### PR TITLE
[SPARK-43276][CONNECT][PYTHON] Migrate Spark Connect Window errors into error class

### DIFF
--- a/python/pyspark/errors/error_classes.py
+++ b/python/pyspark/errors/error_classes.py
@@ -224,6 +224,11 @@ ERROR_CLASSES_JSON = """
       "Argument `<arg_name>` should be a Column, int or str, got <arg_type>."
     ]
   },
+  "NOT_COLUMN_OR_LIST_OR_STR" : {
+    "message" : [
+      "Argument `<arg_name>` should be a Column, list or str, got <arg_type>."
+    ]
+  },
   "NOT_COLUMN_OR_STR" : {
     "message" : [
       "Argument `<arg_name>` should be a Column or str, got <arg_type>."

--- a/python/pyspark/sql/connect/window.py
+++ b/python/pyspark/sql/connect/window.py
@@ -32,6 +32,7 @@ from pyspark.sql.connect.types import (
     JVM_LONG_MAX,
 )
 from pyspark.sql.window import Window as PySparkWindow, WindowSpec as PySparkWindowSpec
+from pyspark.errors import PySparkTypeError
 
 if TYPE_CHECKING:
     from pyspark.sql.connect._typing import ColumnOrName
@@ -94,12 +95,14 @@ class WindowSpec:
                     if isinstance(c, (str, Column)):
                         _cols.append(c)
                     else:
-                        raise TypeError(
-                            f"cols must be str or Column or list, but got {type(c).__name__} {c}"
+                        raise PySparkTypeError(
+                            error_class="NOT_COLUMN_OR_LIST_OR_STR",
+                            message_parameters={"arg_name": "cols", "arg_type": type(c).__name__},
                         )
             else:
-                raise TypeError(
-                    f"cols must be str or Column or list, but got {type(col).__name__} {col}"
+                raise PySparkTypeError(
+                    error_class="NOT_COLUMN_OR_LIST_OR_STR",
+                    message_parameters={"arg_name": "cols", "arg_type": type(col).__name__},
                 )
 
         newPartitionSpec: List[Expression] = []
@@ -125,12 +128,14 @@ class WindowSpec:
                     if isinstance(c, (str, Column)):
                         _cols.append(c)
                     else:
-                        raise TypeError(
-                            f"cols must be str or Column or list, but got {type(c).__name__} {c}"
+                        raise PySparkTypeError(
+                            error_class="NOT_COLUMN_OR_LIST_OR_STR",
+                            message_parameters={"arg_name": "cols", "arg_type": type(c).__name__},
                         )
             else:
-                raise TypeError(
-                    f"cols must be str or Column or list, but got {type(col).__name__} {col}"
+                raise PySparkTypeError(
+                    error_class="NOT_COLUMN_OR_LIST_OR_STR",
+                    message_parameters={"arg_name": "cols", "arg_type": type(col).__name__},
                 )
 
         newOrderSpec: List[SortOrder] = []


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to migrate Spark Connect Window errors into error class


### Why are the changes needed?

To improve PySpark error usability.


### Does this PR introduce _any_ user-facing change?

No API changes.


### How was this patch tested?

The existing CI should pass.
