### PR TITLE
[SPARK-43279][CORE] Cleanup unused members from `SparkHadoopUtil`

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
@@ -21,15 +21,12 @@ import java.io.{ByteArrayInputStream, ByteArrayOutputStream, DataInputStream, Da
 import java.net.InetAddress
 import java.security.PrivilegedExceptionAction
 import java.text.DateFormat
-import java.util.{Arrays, Date, Locale}
+import java.util.{Date, Locale}
 
 import scala.collection.JavaConverters._
-import scala.collection.immutable.Map
 import scala.collection.mutable
 import scala.collection.mutable.HashMap
-import scala.util.control.NonFatal
 
-import com.google.common.primitives.Longs
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs._
 import org.apache.hadoop.mapred.JobConf
@@ -226,21 +223,6 @@ private[spark] class SparkHadoopUtil extends Logging {
     if (baseStatus.isDirectory) recurse(baseStatus) else Seq(baseStatus)
   }
 
-  def listLeafDirStatuses(fs: FileSystem, basePath: Path): Seq[FileStatus] = {
-    listLeafDirStatuses(fs, fs.getFileStatus(basePath))
-  }
-
-  def listLeafDirStatuses(fs: FileSystem, baseStatus: FileStatus): Seq[FileStatus] = {
-    def recurse(status: FileStatus): Seq[FileStatus] = {
-      val (directories, files) = fs.listStatus(status.getPath).partition(_.isDirectory)
-      val leaves = if (directories.isEmpty) Seq(status) else Seq.empty[FileStatus]
-      leaves ++ directories.flatMap(dir => listLeafDirStatuses(fs, dir))
-    }
-
-    assert(baseStatus.isDirectory)
-    recurse(baseStatus)
-  }
-
   def isGlobPath(pattern: Path): Boolean = {
     pattern.toString.exists("{}[]*?\\".toSet.contains)
   }
@@ -263,41 +245,6 @@ private[spark] class SparkHadoopUtil extends Logging {
   def globPathIfNecessary(fs: FileSystem, pattern: Path): Seq[Path] = {
     if (isGlobPath(pattern)) globPath(fs, pattern) else Seq(pattern)
   }
-
-  /**
-   * Lists all the files in a directory with the specified prefix, and does not end with the
-   * given suffix. The returned {{FileStatus}} instances are sorted by the modification times of
-   * the respective files.
-   */
-  def listFilesSorted(
-      remoteFs: FileSystem,
-      dir: Path,
-      prefix: String,
-      exclusionSuffix: String): Array[FileStatus] = {
-    try {
-      val fileStatuses = remoteFs.listStatus(dir,
-        new PathFilter {
-          override def accept(path: Path): Boolean = {
-            val name = path.getName
-            name.startsWith(prefix) && !name.endsWith(exclusionSuffix)
-          }
-        })
-      Arrays.sort(fileStatuses, (o1: FileStatus, o2: FileStatus) =>
-        Longs.compare(o1.getModificationTime, o2.getModificationTime))
-      fileStatuses
-    } catch {
-      case NonFatal(e) =>
-        logWarning("Error while attempting to list files from application staging dir", e)
-        Array.empty
-    }
-  }
-
-  private[spark] def getSuffixForCredentialsPath(credentialsPath: Path): Int = {
-    val fileName = credentialsPath.getName
-    fileName.substring(
-      fileName.lastIndexOf(SparkHadoopUtil.SPARK_YARN_CREDS_COUNTER_DELIM) + 1).toInt
-  }
-
 
   private val HADOOP_CONF_PATTERN = "(\\$\\{hadoopconf-[^\\}\\$\\s]+\\})".r.unanchored
 
@@ -396,10 +343,6 @@ private[spark] class SparkHadoopUtil extends Logging {
 private[spark] object SparkHadoopUtil extends Logging {
 
   private lazy val instance = new SparkHadoopUtil
-
-  val SPARK_YARN_CREDS_TEMP_EXTENSION = ".tmp"
-
-  val SPARK_YARN_CREDS_COUNTER_DELIM = "-"
 
   /**
    * Number of records to update input metrics when reading from HadoopRDDs.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This pr clean up the following unused members from `SparkHadoopUtil`:

- `listLeafDirStatuses`: introduced by SPARK-3928 and no longer used after SPARK-7673
- `listFilesSorted`: introduced by SPARK-5342 and no longer used after SPARK-23361
- `getSuffixForCredentialsPath`: same as `listFilesSorted`
- `SPARK_YARN_CREDS_TEMP_EXTENSION`: same as `listFilesSorted`
- `SPARK_YARN_CREDS_COUNTER_DELIM`: same as `listFilesSorted`


### Why are the changes needed?
Code cleanup


### Does this PR introduce _any_ user-facing change?
No, all cleaned up are internal APIs



### How was this patch tested?
Pass GitHub Action
