### PR TITLE
[SPARK-43280][BUILD] Reimplement the protobuf breaking change checker

### DIFF
--- a/dev/protobuf-breaking-changes-check.sh
+++ b/dev/protobuf-breaking-changes-check.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -15,22 +16,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-if [[ $# -gt 0 ]]; then
+
+if [[ $# -gt 1 ]]; then
   echo "Illegal number of parameters."
-  echo "Usage: ./connector/connect/dev/detect_breaking_changes.sh"
+  echo "Usage: ./dev/protobuf-breaking-changes-check.sh [branch]"
+  echo "the default branch is 'master', available options are 'master', 'branch-3.4', etc"
   exit -1
 fi
 
-
-SPARK_HOME="$(cd "`dirname $0`"/../../..; pwd)"
+SPARK_HOME="$(cd "`dirname $0`"/..; pwd)"
 cd "$SPARK_HOME"
 
-pushd connector/connect/common/src/main
+BRANCH="master"
+if [[ $# -eq 1 ]]; then
+  BRANCH=$1
+fi
 
-buf breaking --against "https://github.com/apache/spark/archive/master.zip#strip_components=1,subdir=connector/connect/common/src/main"
+pushd connector/connect/common/src/main && echo "Start checking against $BRANCH" && buf breaking --against "https://github.com/apache/spark.git#branch=$BRANCH,subdir=connector/connect/common/src/main"
 if [[ $? -ne -0 ]]; then
   echo "Buf detected breaking changes for your Pull Request. Please verify."
-  echo "Please make sure your branch is current against spark/master."
+  echo "Please make sure your branch is current against spark/$BRANCH."
   exit 1
 fi
 

--- a/dev/protobuf-breaking-changes-check.sh
+++ b/dev/protobuf-breaking-changes-check.sh
@@ -32,7 +32,11 @@ if [[ $# -eq 1 ]]; then
   BRANCH=$1
 fi
 
-pushd connector/connect/common/src/main && echo "Start checking against $BRANCH" && buf breaking --against "https://github.com/apache/spark.git#branch=$BRANCH,subdir=connector/connect/common/src/main"
+pushd connector/connect/common/src/main &&
+echo "Start protobuf breaking changes checking against $BRANCH" &&
+buf breaking --against "https://github.com/apache/spark.git#branch=$BRANCH,subdir=connector/connect/common/src/main" &&
+echo "Finsh protobuf breaking changes checking: SUCCESS"
+
 if [[ $? -ne -0 ]]; then
   echo "Buf detected breaking changes for your Pull Request. Please verify."
   echo "Please make sure your branch is current against spark/$BRANCH."

--- a/dev/protobuf-breaking-changes-check.sh
+++ b/dev/protobuf-breaking-changes-check.sh
@@ -16,6 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+set -ex
 
 if [[ $# -gt 1 ]]; then
   echo "Illegal number of parameters."


### PR DESCRIPTION
### What changes were proposed in this pull request?
Refine the script:

1. rename the file name to be more specific;
2. make it work in `SPARK_HOME` dir;
3. add a optional `branch` parameter;


### Why are the changes needed?
```
(spark_dev) ➜  spark git:(master) ./dev/detect_breaking_changes.sh 
./dev/detect_breaking_changes.sh: line 28: pushd: connector/connect/common/src/main: No such file or directory
Failure: failed to enumerate module files: open .Trash: operation not permitted
Buf detected breaking changes for your Pull Request. Please verify.
Please make sure your branch is current against spark/master.
```


### Does this PR introduce _any_ user-facing change?
no, dev-only


### How was this patch tested?
manually tests:

```
(spark_dev) ➜  spark git:(new_breaking_change_script) ✗ ./dev/protobuf-breaking-changes-check.sh
~/Dev/spark/connector/connect/common/src/main ~/Dev/spark
Start protobuf breaking changes checking against master
Finsh protobuf breaking changes checking: SUCCESS
(spark_dev) ➜  spark git:(new_breaking_change_script) ✗ ./dev/protobuf-breaking-changes-check.sh master
~/Dev/spark/connector/connect/common/src/main ~/Dev/spark
Start protobuf breaking changes checking against master
Finsh protobuf breaking changes checking: SUCCESS
(spark_dev) ➜  spark git:(new_breaking_change_script) ✗ ./dev/protobuf-breaking-changes-check.sh branch-3.4    
~/Dev/spark/connector/connect/common/src/main ~/Dev/spark
Start protobuf breaking changes checking against branch-3.4
Finsh protobuf breaking changes checking: SUCCESS
(spark_dev) ➜  spark git:(new_breaking_change_script) ✗ ./dev/protobuf-breaking-changes-check.sh branch-3.4 xyz
Illegal number of parameters.
Usage: ./dev/protobuf-breaking-changes-check.sh [branch]
the default branch is 'master', available options are 'master', 'branch-3.4', etc
(spark_dev) ➜  spark git:(new_breaking_change_script) ✗ ./dev/protobuf-breaking-changes-check.sh branch-3.3    
~/Dev/spark/connector/connect/common/src/main ~/Dev/spark
Start protobuf breaking changes checking against branch-3.3
Failure: no .proto target files found
Buf detected breaking changes for your Pull Request. Please verify.
Please make sure your branch is current against spark/branch-3.3.
```
