### PR TITLE
[SPARK-43156][SPARK-43098][SQL] Extend scalar subquery count bug test with decorrelateInnerQuery disabled

### DIFF
--- a/sql/core/src/test/resources/sql-tests/inputs/subquery/scalar-subquery/scalar-subquery-count-bug.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/subquery/scalar-subquery/scalar-subquery-count-bug.sql
@@ -1,3 +1,6 @@
+--CONFIG_DIM1 spark.sql.optimizer.decorrelateInnerQuery.enabled=true
+--CONFIG_DIM1 spark.sql.optimizer.decorrelateInnerQuery.enabled=false
+
 create temp view l (a, b)
 as values
     (1, 2.0),


### PR DESCRIPTION
### What changes were proposed in this pull request?
Extend a test to test with both the DecorrelateInnerQuery framework on and off, since this came up in both https://github.com/apache/spark/pull/40865 and https://github.com/apache/spark/pull/40811. (The default is on.)

### Why are the changes needed?
Improve test coverage

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Test itself
