### PR TITLE
[SPARK-43284] Switch back to url-encoded strings

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormat.scala
@@ -266,7 +266,7 @@ object FileFormat {
    */
   val BASE_METADATA_EXTRACTORS: Map[String, PartitionedFile => Any] = Map(
     FILE_PATH -> { pf: PartitionedFile => pf.filePath.urlEncoded },
-    FILE_NAME -> { pf: PartitionedFile => new Path(pf.filePath.urlEncoded).getName },
+    FILE_NAME -> { pf: PartitionedFile => new Path(pf.filePath.toUri.getRawPath).getName },
     FILE_SIZE -> { pf: PartitionedFile => pf.fileSize },
     FILE_BLOCK_START -> { pf: PartitionedFile => pf.start },
     FILE_BLOCK_LENGTH -> { pf: PartitionedFile => pf.length },

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormat.scala
@@ -265,7 +265,10 @@ object FileFormat {
    * fields of the [[PartitionedFile]], and do have entries in the file's metadata map.
    */
   val BASE_METADATA_EXTRACTORS: Map[String, PartitionedFile => Any] = Map(
-    FILE_PATH -> { pf: PartitionedFile => pf.filePath.urlEncoded },
+    FILE_PATH -> { pf: PartitionedFile =>
+      // Use new Path(Path.toString).toString as a form of canonicalization
+      new Path(pf.filePath.toPath.toString).toString
+    },
     FILE_NAME -> { pf: PartitionedFile =>
       pf.filePath.toUri.getRawPath.split("/").lastOption.getOrElse("")
     },

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormat.scala
@@ -265,7 +265,7 @@ object FileFormat {
    * fields of the [[PartitionedFile]], and do have entries in the file's metadata map.
    */
   val BASE_METADATA_EXTRACTORS: Map[String, PartitionedFile => Any] = Map(
-    FILE_PATH -> { pf: PartitionedFile => new Path(pf.filePath.urlEncoded).toString },
+    FILE_PATH -> { pf: PartitionedFile => pf.filePath.urlEncoded },
     FILE_NAME -> { pf: PartitionedFile =>
       pf.filePath.toUri.getRawPath.split("/").lastOption.getOrElse("")
     },

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormat.scala
@@ -265,8 +265,8 @@ object FileFormat {
    * fields of the [[PartitionedFile]], and do have entries in the file's metadata map.
    */
   val BASE_METADATA_EXTRACTORS: Map[String, PartitionedFile => Any] = Map(
-    FILE_PATH -> { pf: PartitionedFile => pf.toPath.toString },
-    FILE_NAME -> { pf: PartitionedFile => pf.toPath.getName },
+    FILE_PATH -> { pf: PartitionedFile => pf.filePath.urlEncoded },
+    FILE_NAME -> { pf: PartitionedFile => new Path(pf.filePath.urlEncoded).getName },
     FILE_SIZE -> { pf: PartitionedFile => pf.fileSize },
     FILE_BLOCK_START -> { pf: PartitionedFile => pf.start },
     FILE_BLOCK_LENGTH -> { pf: PartitionedFile => pf.length },

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormat.scala
@@ -266,7 +266,9 @@ object FileFormat {
    */
   val BASE_METADATA_EXTRACTORS: Map[String, PartitionedFile => Any] = Map(
     FILE_PATH -> { pf: PartitionedFile => pf.filePath.urlEncoded },
-    FILE_NAME -> { pf: PartitionedFile => new Path(pf.filePath.toUri.getRawPath).getName },
+    FILE_NAME -> { pf: PartitionedFile =>
+      pf.filePath.toUri.getRawPath.split("/").lastOption.getOrElse("")
+    },
     FILE_SIZE -> { pf: PartitionedFile => pf.fileSize },
     FILE_BLOCK_START -> { pf: PartitionedFile => pf.start },
     FILE_BLOCK_LENGTH -> { pf: PartitionedFile => pf.length },

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormat.scala
@@ -265,7 +265,7 @@ object FileFormat {
    * fields of the [[PartitionedFile]], and do have entries in the file's metadata map.
    */
   val BASE_METADATA_EXTRACTORS: Map[String, PartitionedFile => Any] = Map(
-    FILE_PATH -> { pf: PartitionedFile => pf.filePath.urlEncoded },
+    FILE_PATH -> { pf: PartitionedFile => new Path(pf.filePath.urlEncoded).toString },
     FILE_NAME -> { pf: PartitionedFile =>
       pf.filePath.toUri.getRawPath.split("/").lastOption.getOrElse("")
     },

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileMetadataStructSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileMetadataStructSuite.scala
@@ -82,7 +82,7 @@ class FileMetadataStructSuite extends QueryTest with SharedSparkSession {
 
   private def getMetadataForFile(f: File): Map[String, Any] = {
     Map(
-      METADATA_FILE_PATH -> f.toURI.toString,
+      METADATA_FILE_PATH -> s"file://${f.getCanonicalPath}",
       METADATA_FILE_NAME -> f.getName,
       METADATA_FILE_SIZE -> f.length(),
       // test file is small enough so we would not do splitting files,
@@ -129,7 +129,7 @@ class FileMetadataStructSuite extends QueryTest with SharedSparkSession {
 
           // 2. read both f0 and f1
           val df = spark.read.format(testFileFormat).schema(fileSchema)
-            .load(new File(dir, "data").getCanonicalPath + "/*")
+            .load(s"file://${new File(dir, "data").getCanonicalPath}/*")
 
           val realF0 = new File(dir, "data/f0").listFiles()
             .filter(_.getName.endsWith(s".$testFileFormat")).head
@@ -682,7 +682,7 @@ class FileMetadataStructSuite extends QueryTest with SharedSparkSession {
       val sourceFile = new File(dir, "/source/new-streaming-data").listFiles()
         .filter(_.getName.endsWith(".json")).head
       val sourceFileMetadata = Map(
-        METADATA_FILE_PATH -> sourceFile.toURI.toString,
+        METADATA_FILE_PATH -> s"file://${sourceFile.getCanonicalPath}",
         METADATA_FILE_NAME -> sourceFile.getName,
         METADATA_FILE_SIZE -> sourceFile.length(),
         METADATA_FILE_BLOCK_START -> 0,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileMetadataStructSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileMetadataStructSuite.scala
@@ -22,6 +22,7 @@ import java.sql.Timestamp
 import java.text.SimpleDateFormat
 
 import org.apache.spark.TestUtils
+import org.apache.spark.paths.SparkPath
 import org.apache.spark.sql.{AnalysisException, Column, DataFrame, QueryTest, Row}
 import org.apache.spark.sql.execution.FileSourceScanExec
 import org.apache.spark.sql.functions._
@@ -975,6 +976,36 @@ class FileMetadataStructSuite extends QueryTest with SharedSparkSession {
         val files3 = fileSourceScan3.get.asInstanceOf[FileSourceScanExec].selectedPartitions
         assert(files3.length == 1 && files3.head.files.isEmpty)
         assert(df3.collect().isEmpty)
+      }
+    }
+  }
+
+
+  Seq("parquet", "json", "csv", "text", "orc").foreach { format =>
+    test(s"metadata file path and name are url encoded for format: $format") {
+      val suffix = if (format == "text") ".txt" else s".$format"
+      withTempPath { f =>
+        val dirWithSpace = s"$f/with space"
+        spark.range(10)
+          .selectExpr("cast(id as string) as str")
+          .repartition(1)
+          .write
+          .format(format)
+          .mode("append")
+          .save(dirWithSpace)
+
+        val pathWithSpace = s"$dirWithSpace/file with space.$suffix"
+        new File(dirWithSpace)
+          .listFiles((_, f) => f.endsWith(suffix))
+          .headOption
+          .getOrElse(fail(s"no file with suffix $suffix in $dirWithSpace"))
+          .renameTo(new File(pathWithSpace))
+
+        val encodedPath = SparkPath.fromPathString(pathWithSpace).urlEncoded
+        val encodedName = encodedPath.split("/").last
+        val df = spark.read.format(format).load(dirWithSpace)
+        val metadataName = df.select(METADATA_FILE_NAME).as[String].head()
+        assert(metadataName == encodedName)
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileMetadataStructSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileMetadataStructSuite.scala
@@ -21,6 +21,8 @@ import java.io.File
 import java.sql.Timestamp
 import java.text.SimpleDateFormat
 
+import org.apache.hadoop.fs.Path
+
 import org.apache.spark.TestUtils
 import org.apache.spark.paths.SparkPath
 import org.apache.spark.sql.{AnalysisException, Column, DataFrame, QueryTest, Row}
@@ -422,7 +424,8 @@ class FileMetadataStructSuite extends QueryTest with SharedSparkSession {
 
     assert(partitions.length == 1) // 1 partition
     assert(partitions.head.files.length == 1) // 1 file in that partition
-    assert(partitions.head.files.head.getPath.toString == f0(METADATA_FILE_PATH)) // the file is f0
+    assert(partitions.head.files.head.getPath ==
+        new Path(f0(METADATA_FILE_PATH).toString)) // the file is f0
 
     // check result
     checkAnswer(
@@ -467,7 +470,8 @@ class FileMetadataStructSuite extends QueryTest with SharedSparkSession {
 
     assert(partitions.length == 1) // 1 partition
     assert(partitions.head.files.length == 1) // 1 file in that partition
-    assert(partitions.head.files.head.getPath.toString == f1(METADATA_FILE_PATH)) // the file is f1
+    assert(partitions.head.files.head.getPath ==
+      new Path(f1(METADATA_FILE_PATH).toString)) // the file is f1
 
     // check result
     checkAnswer(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Update `_metadata.file_path` and `_metadata.file_name` to return url-encoded strings, rather than un-encoded strings. This was a regression introduced in Spark 3.4.0.


### Why are the changes needed?
This was an inadvertent behavior change.


### Does this PR introduce _any_ user-facing change?
Yes, fix regression!


### How was this patch tested?
New test added to validate that the `file_path` and `path_name` are returned as encoded strings. 
