### PR TITLE
[DRAFT][SPARK-23607][CORE] Use HDFS extended attributes to store application summary information in SHS

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/History.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/History.scala
@@ -202,6 +202,11 @@ private[spark] object History {
     .stringConf
     .createOptional
 
+  val EVENT_LOG_XATTR_ENABLED = ConfigBuilder("spark.history.fs.eventLog.xattr.enabled")
+    .version("3.3.0")
+    .booleanConf
+    .createWithDefault(false)
+
   val CUSTOM_EXECUTOR_LOG_URL = ConfigBuilder("spark.history.custom.executor.log.url")
     .doc("Specifies custom spark executor log url for supporting external log service instead of " +
       "using cluster managers' application log urls in the history server. Spark will support " +

--- a/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/EventLoggingListener.scala
@@ -299,6 +299,17 @@ private[spark] class EventLoggingListener(
 
 private[spark] object EventLoggingListener extends Logging {
   val DEFAULT_LOG_DIR = "/tmp/spark-events"
+  val USER_XATTR_ENABLED = "user.xattr.enabled"
+  val USER_APP_ID = "user.app.id"
+  val USER_APP_NAME = "user.app.name"
+  val USER_ATTEMPT_ID = "user.attempt.id"
+  val USER_ATTEMPT_STARTTIME = "user.attempt.startTime"
+  val USER_ATTEMPT_SPARKUSER = "user.attempt.sparkUser"
+  val USER_ATTEMPT_APPSPARKVERSION = "user.attempt.appSparkVersion"
+  val USER_ATTEMPT_ENDTIME = "user.attempt.endTime"
+  val USER_ATTEMPT_ACLS = "user.attempt.acls"
+  val XATTRS_APPLICATION_START_LIST = List(USER_APP_ID, USER_APP_NAME, USER_ATTEMPT_ID,
+    USER_ATTEMPT_STARTTIME, USER_ATTEMPT_SPARKUSER, USER_ATTEMPT_APPSPARKVERSION)
   // Dummy stage key used by driver in executor metrics updates
   val DRIVER_STAGE_KEY = (-1, -1)
 


### PR DESCRIPTION
 ### What changes were proposed in this pull request?
Previously, #34829 was raised which was auto closed due to staleness. This is a rework of that by addressing comments raised.

 This PR seeks to improve the performance of serving the application list in History Server by storing the required information of the application as part of HDFS extended attributes instead of parsing the log file each time.

 ### Why are the changes needed?

 Improves the performance of the History Server listing page

Below is the comparison of the  time taken to complete `mergeApplicationListing` call [in FsHistoryProvider](https://github.com/apache/spark/blob/master/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala#L584) that is called for every log file that is updated in the event log directory : 

| Event log size  | Extended Attributes disabled (in ms) | Extended Attributes enabled (in ms) |
| ------------- | ------------- | ------------- |
| 122MB  | 1340 | 137  |
| 10.2MB  | 866 | 135  |
| 5.5MB  | 645  | 136 |
|  0.6MB | 505 | 134 |
| 0.8MB  | 525 | 137  |

As we can see in the comparison above, irrespective of the event log size, the time to build the application listing for the app remains the same. This is hugely beneficial in clusters that have very large event log sizes.

 ### Does this PR introduce _any_ user-facing change?

 No.

 ### How was this patch tested?
 Will add unit tests