### PR TITLE
[SPARK-43257][SQL] Replace the error class _LEGACY_ERROR_TEMP_2022 by an internal error

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -3796,11 +3796,6 @@
       "Couldn't find a primary constructor on <cls>."
     ]
   },
-  "_LEGACY_ERROR_TEMP_2022" : {
-    "message" : [
-      "Unsupported natural join type <joinType>."
-    ]
-  },
   "_LEGACY_ERROR_TEMP_2023" : {
     "message" : [
       "Unresolved encoder expected, but <attr> was found."

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -469,10 +469,9 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase {
       messageParameters = Map("cls" -> cls.toString()))
   }
 
-  def unsupportedNaturalJoinTypeError(joinType: JoinType): SparkRuntimeException = {
-    new SparkRuntimeException(
-      errorClass = "_LEGACY_ERROR_TEMP_2022",
-      messageParameters = Map("joinType" -> joinType.toString()))
+  def unsupportedNaturalJoinTypeError(joinType: JoinType): SparkException = {
+    SparkException.internalError(
+      s"Unsupported natural join type ${joinType.toString}")
   }
 
   def notExpectedUnresolvedEncoderError(attr: AttributeReference): SparkRuntimeException = {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Change the error class_LEGACY_ERROR_TEMP_2022 to internal error as it cannot be accessed.

### Why are the changes needed?

Fix jira issue [SPARK-43257](https://issues.apache.org/jira/browse/SPARK-43257). `ResolveNaturalAndUsingJoin` only handles `UsingJoin` and `NaturalJoin`,  and  all join types supported by `UsingJoin` and `NaturalJoin` are supported by natural join, so `commonNaturalJoinProcessing` will never go to the default branch and throw  `unsupportedNaturalJoinTypeError`. I think this error class could be replaced with internal error.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Already exist tests.