### PR TITLE
[SPARK-43143] [SS] [CONNECT] Scala StreamingQuery awaitTermination()

### DIFF
--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/streaming/StreamingQuery.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/streaming/StreamingQuery.scala
@@ -124,8 +124,8 @@ trait StreamingQuery {
    * the query has terminated with an exception, then the exception will be thrown. Otherwise, it
    * returns whether the query has terminated or not within the `timeoutMs` milliseconds.
    *
-   * If the query has terminated, then all subsequent calls to this method will return
-   * `true` immediately.
+   * If the query has terminated, then all subsequent calls to this method will return `true`
+   * immediately.
    *
    * @since 3.5.0
    */
@@ -186,18 +186,12 @@ class RemoteStreamingQuery(
   }
 
   override def awaitTermination(): Unit = {
-    val awaitTerminationCmd = StreamingQueryCommand.AwaitTerminationCommand
-      .newBuilder()
-      .build()
-    executeQueryCmd(_.setAwaitTermination(awaitTerminationCmd))
+    executeQueryCmd(_.getAwaitTerminationBuilder.build())
   }
 
   override def awaitTermination(timeoutMs: Long): Boolean = {
-    val awaitTerminationCmd = StreamingQueryCommand.AwaitTerminationCommand
-      .newBuilder()
-      .setTimeoutMs(timeoutMs)
-      .build()
-    executeQueryCmd(_.setAwaitTermination(awaitTerminationCmd)).getAwaitTermination.getTerminated
+    executeQueryCmd(
+      _.getAwaitTerminationBuilder.setTimeoutMs(timeoutMs)).getAwaitTermination.getTerminated
   }
 
   override def status: StreamingQueryStatus = {

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/streaming/StreamingQuery.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/streaming/StreamingQuery.scala
@@ -115,11 +115,8 @@ trait StreamingQuery {
    * immediately (if the query was terminated by `stop()`), or throw the exception
    * immediately (if the query has terminated with exception).
    *
-   * @throws StreamingQueryException if the query has terminated with an exception.
-   *
    * @since 3.5.0
    */
-  @throws[StreamingQueryException]
   def awaitTermination(): Unit
 
   /**
@@ -132,11 +129,8 @@ trait StreamingQuery {
    * `true` immediately (if the query was terminated by `stop()`), or throw the exception
    * immediately (if the query has terminated with exception).
    *
-   * @throws StreamingQueryException if the query has terminated with an exception
-   *
    * @since 3.5.0
    */
-  @throws[StreamingQueryException]
   def awaitTermination(timeoutMs: Long): Boolean
 
 

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/streaming/StreamingQuery.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/streaming/StreamingQuery.scala
@@ -108,22 +108,21 @@ trait StreamingQuery {
   def lastProgress: StreamingQueryProgress
 
   /**
-   * Waits for the termination of `this` query, either by `query.stop()` or by an exception.
-   * If the query has terminated with an exception, then the exception will be thrown.
+   * Waits for the termination of `this` query, either by `query.stop()` or by an exception. If
+   * the query has terminated with an exception, then the exception will be thrown.
    *
    * If the query has terminated, then all subsequent calls to this method will either return
-   * immediately (if the query was terminated by `stop()`), or throw the exception
-   * immediately (if the query has terminated with exception).
+   * immediately (if the query was terminated by `stop()`), or throw the exception immediately (if
+   * the query has terminated with exception).
    *
    * @since 3.5.0
    */
   def awaitTermination(): Unit
 
   /**
-   * Waits for the termination of `this` query, either by `query.stop()` or by an exception.
-   * If the query has terminated with an exception, then the exception will be thrown.
-   * Otherwise, it returns whether the query has terminated or not within the `timeoutMs`
-   * milliseconds.
+   * Waits for the termination of `this` query, either by `query.stop()` or by an exception. If
+   * the query has terminated with an exception, then the exception will be thrown. Otherwise, it
+   * returns whether the query has terminated or not within the `timeoutMs` milliseconds.
    *
    * If the query has terminated, then all subsequent calls to this method will either return
    * `true` immediately (if the query was terminated by `stop()`), or throw the exception
@@ -132,7 +131,6 @@ trait StreamingQuery {
    * @since 3.5.0
    */
   def awaitTermination(timeoutMs: Long): Boolean
-
 
   /**
    * Blocks until all available data in the source has been processed and committed to the sink.

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/streaming/StreamingQuery.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/streaming/StreamingQuery.scala
@@ -108,15 +108,15 @@ trait StreamingQuery {
   def lastProgress: StreamingQueryProgress
 
   /**
-   * Waits for the termination of `this` query, either by `query.stop()` or by an exception. If
-   * the query has terminated with an exception, then the exception will be thrown.
+   * Waits for the termination of `this` query, either by `query.stop()` or by an exception.
    *
    * If the query has terminated, then all subsequent calls to this method will either return
-   * immediately (if the query was terminated by `stop()`), or throw the exception immediately (if
-   * the query has terminated with exception).
+   * immediately (if the query was terminated by `stop()`).
    *
    * @since 3.5.0
    */
+  // TODO(SPARK-43299): verity the behavior of this method after JVM client-side error-handling
+  // framework is supported and modify the doc accordingly.
   def awaitTermination(): Unit
 
   /**
@@ -124,12 +124,13 @@ trait StreamingQuery {
    * the query has terminated with an exception, then the exception will be thrown. Otherwise, it
    * returns whether the query has terminated or not within the `timeoutMs` milliseconds.
    *
-   * If the query has terminated, then all subsequent calls to this method will either return
-   * `true` immediately (if the query was terminated by `stop()`), or throw the exception
-   * immediately (if the query has terminated with exception).
+   * If the query has terminated, then all subsequent calls to this method will return
+   * `true` immediately.
    *
    * @since 3.5.0
    */
+  // TODO(SPARK-43299): verity the behavior of this method after JVM client-side error-handling
+  // framework is supported and modify the doc accordingly.
   def awaitTermination(timeoutMs: Long): Boolean
 
   /**

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/streaming/StreamingQuery.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/streaming/StreamingQuery.scala
@@ -159,6 +159,14 @@ class RemoteStreamingQuery(
     executeQueryCmd(_.setStatus(true)).getStatus.getIsActive
   }
 
+  override def awaitTermination(): Unit = {
+    streamingQuery.awaitTermination()
+  }
+
+  override def awaitTermination(timeoutMs: Long): Boolean = {
+    streamingQuery.awaitTermination(timeoutMs)
+  }
+
   override def status: StreamingQueryStatus = {
     val statusResp = executeQueryCmd(_.setStatus(true)).getStatus
     new StreamingQueryStatus(

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/CheckConnectJvmClientCompatibility.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/CheckConnectJvmClientCompatibility.scala
@@ -245,9 +245,6 @@ object CheckConnectJvmClientCompatibility {
 
       // StreamingQuery
       ProblemFilters.exclude[Problem](
-        "org.apache.spark.sql.streaming.StreamingQuery.awaitTermination" // TODO(SPARK-43143)
-      ),
-      ProblemFilters.exclude[Problem](
         "org.apache.spark.sql.streaming.StreamingQueryProgress.*" // TODO(SPARK-43128)
       ),
 

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/streaming/StreamingQuerySuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/streaming/StreamingQuerySuite.scala
@@ -114,4 +114,30 @@ class StreamingQuerySuite extends RemoteSparkSession with SQLHelper {
       }
     }
   }
+
+  test("awaitTermination") {
+    withSQLConf(
+      "spark.sql.shuffle.partitions" -> "1" // Avoid too many reducers.
+    ) {
+      val q = spark.readStream
+        .format("rate")
+        .load()
+        .writeStream
+        .format("memory")
+        .queryName("test")
+        .start()
+
+      val start = System.nanoTime
+      val terminated = q.awaitTermination(500)
+      val end = System.nanoTime
+      assert((end - start) / 1e6 >= 500)
+      assert(!terminated)
+
+      q.stop()
+      // TODO (SPARK-43032): uncomment below
+      // eventually(timeout(1.minute)) {
+      // q.awaitTermination()
+      // }
+    }
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Add the awaitTermination() API to scala client query. Please note that currently it won't throw the exception as it would do in original method. Because the JVM client side error handling is not ready yet. Details in SPARK-43299

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
SS Connect development

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes they can use that now

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
```
Spark session available as 'spark'.
   _____                  __      ______                            __
  / ___/____  ____ ______/ /__   / ____/___  ____  ____  ___  _____/ /_
  \__ \/ __ \/ __ `/ ___/ //_/  / /   / __ \/ __ \/ __ \/ _ \/ ___/ __/
 ___/ / /_/ / /_/ / /  / ,<    / /___/ /_/ / / / / / / /  __/ /__/ /_
/____/ .___/\__,_/_/  /_/|_|   \____/\____/_/ /_/_/ /_/\___/\___/\__/
    /_/

@ val q = spark.readStream.format("rate").load().writeStream.format("memory").queryName("test").start() 
q: org.apache.spark.sql.streaming.StreamingQuery = org.apache.spark.sql.streaming.RemoteStreamingQuery@34eaf9c1

@ q.awaitTermination(500) 
res1: Boolean = false

```
