### PR TITLE
[SPARK-43301][CORE][SHUFFLE] BlockStoreClient getHostLocalDirs RPC supports IOException retry

### DIFF
--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/BlockStoreClient.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/BlockStoreClient.java
@@ -170,7 +170,7 @@ public abstract class BlockStoreClient implements Closeable {
     checkInit();
     int maxRetries = transportConf.maxIORetries();
     int retryWaitTime = transportConf.ioRetryWaitTimeMs();
-    retry(1, maxRetries, retryWaitTime, () -> {
+    retry(0, maxRetries, retryWaitTime, () -> {
       CompletableFuture<Map<String, String[]>> tempHostLocalDirsCompletable =
               new CompletableFuture<>();
       getHostLocalDirsInternal(host, port, execIds, tempHostLocalDirsCompletable);
@@ -228,9 +228,9 @@ public abstract class BlockStoreClient implements Closeable {
               } else {
                 executorService.execute(() -> {
                   logger.info("Retrying ({}/{}) for getting host local dirs after {} ms",
-                          times, maxRetries, delayMs);
+                          times + 1, maxRetries, delayMs);
                   Uninterruptibles.sleepUninterruptibly(delayMs, TimeUnit.MILLISECONDS);
-                  retry(times + 1, maxRetries, delayMs, action, future);
+                  retry(times + 1, maxRetries, enableSaslRetries, delayMs, action, future);
                 });
               }
               return null;

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/BlockStoreClient.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/BlockStoreClient.java
@@ -170,7 +170,7 @@ public abstract class BlockStoreClient implements Closeable {
     checkInit();
     int maxRetries = transportConf.maxIORetries();
     int retryWaitTime = transportConf.ioRetryWaitTimeMs();
-    retry(0, maxRetries, retryWaitTime, () -> {
+    retry(1, maxRetries, retryWaitTime, () -> {
       CompletableFuture<Map<String, String[]>> tempHostLocalDirsCompletable =
               new CompletableFuture<>();
       getHostLocalDirsInternal(host, port, execIds, tempHostLocalDirsCompletable);
@@ -223,7 +223,7 @@ public abstract class BlockStoreClient implements Closeable {
             .exceptionally(e -> {
               boolean isIOException = e instanceof IOException
                       || (e.getCause() != null && e.getCause() instanceof IOException);
-              if (times >= maxRetries || isIOException) {
+              if (times >= maxRetries || !isIOException) {
                 future.completeExceptionally(e);
               } else {
                 executorService.execute(() -> {

--- a/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
@@ -400,7 +400,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       clientConf, null, false, 5000)
     try {
       testExternalBlockStoreClient.init("APP_ID")
-      Seq((0, true), (2, true), (3, false)).foreach { case (maxCnt, success) =>
+      Seq((0, true), (2, true), (3, true), (4, false)).foreach { case (maxCnt, success) =>
         sendRpcThrowIOExceptionIdx = 0
         sendRpcThrowIOExceptionMaxCnt = maxCnt
         val hostLocalDirsCompletable = new CompletableFuture[java.util.Map[String, Array[String]]]

--- a/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
@@ -20,9 +20,10 @@ package org.apache.spark.storage
 import java.io._
 import java.nio.ByteBuffer
 import java.util.UUID
-import java.util.concurrent.{CompletableFuture, Semaphore}
+import java.util.concurrent.{CompletableFuture, ExecutionException, Semaphore}
 import java.util.zip.CheckedInputStream
 
+import scala.collection.JavaConverters._
 import scala.collection.mutable
 // scalastyle:off executioncontextglobal
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -43,8 +44,11 @@ import org.apache.spark.{MapOutputTracker, SparkFunSuite, TaskContext}
 import org.apache.spark.MapOutputTracker.SHUFFLE_PUSH_MAP_ID
 import org.apache.spark.network._
 import org.apache.spark.network.buffer.{FileSegmentManagedBuffer, ManagedBuffer}
+import org.apache.spark.network.client.{RpcResponseCallback, TransportClient, TransportClientFactory}
+import org.apache.spark.network.sasl.SecretKeyHolder
 import org.apache.spark.network.shuffle.{BlockFetchingListener, DownloadFileManager, ExternalBlockStoreClient, MergedBlockMeta, MergedBlocksMetaListener}
-import org.apache.spark.network.util.LimitedInputStream
+import org.apache.spark.network.shuffle.protocol.LocalDirsForExecutors
+import org.apache.spark.network.util.{LimitedInputStream, MapConfigProvider, TransportConf}
 import org.apache.spark.shuffle.{FetchFailedException, ShuffleReadMetricsReporter}
 import org.apache.spark.storage.BlockManagerId.SHUFFLE_MERGER_IDENTIFIER
 import org.apache.spark.storage.ShuffleBlockFetcherIterator._
@@ -354,6 +358,72 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
     // 2 remote blocks are read from the same block manager
     verifyFetchBlocksInvocationCount(1)
     assert(blockManager.hostLocalDirManager.get.getCachedHostLocalDirs.size === 1)
+  }
+
+  test("BlockStoreClient getHostLocalDirs RPC supports IOException retry") {
+    val mockClientFactory = mock(classOf[TransportClientFactory])
+    val mockTransportClient = mock(classOf[TransportClient])
+    val execToDirs = Map("exec-1" ->
+      Array("loc2.1", "loc2.2"))
+
+    var sendRpcThrowIOExceptionIdx = 0
+    var sendRpcThrowIOExceptionMaxCnt = 2
+    when(mockClientFactory.createClient(any(), any())).thenAnswer(_ => {
+      mockTransportClient
+    })
+    when(mockTransportClient.sendRpc(any(), any())).thenAnswer(invocationOnMock => {
+      if (sendRpcThrowIOExceptionIdx < sendRpcThrowIOExceptionMaxCnt) {
+        sendRpcThrowIOExceptionIdx += 1
+        throw new IOException("sendRpc failed " + sendRpcThrowIOExceptionIdx + " times")
+      }
+      val callback = invocationOnMock.getArgument(1).asInstanceOf[RpcResponseCallback]
+      callback.onSuccess(new LocalDirsForExecutors(execToDirs.asJava).toByteBuffer)
+      null
+    })
+
+    class TestExternalBlockStoreClient(
+      conf: TransportConf,
+      secretKeyHolder: SecretKeyHolder,
+      authEnabled: Boolean,
+      registrationTimeoutMs: Long) extends ExternalBlockStoreClient(
+      conf, secretKeyHolder, authEnabled, registrationTimeoutMs) {
+      override def init(appId: String): Unit = {
+        super.init(appId)
+        this.clientFactory = mockClientFactory
+      }
+    }
+
+    val config = new java.util.HashMap[String, String]
+    config.put("spark.shuffle.io.maxRetries", "3")
+    val clientConf: TransportConf = new TransportConf("shuffle", new MapConfigProvider(config))
+    val testExternalBlockStoreClient = new TestExternalBlockStoreClient(
+      clientConf, null, false, 5000)
+    try {
+      testExternalBlockStoreClient.init("APP_ID")
+      Seq((0, true), (2, true), (3, false)).foreach { case (maxCnt, success) =>
+        sendRpcThrowIOExceptionIdx = 0
+        sendRpcThrowIOExceptionMaxCnt = maxCnt
+        val hostLocalDirsCompletable = new CompletableFuture[java.util.Map[String, Array[String]]]
+        testExternalBlockStoreClient.getHostLocalDirs("exec-1", 1,
+          Array("exec-1"), hostLocalDirsCompletable)
+        try {
+          val result = hostLocalDirsCompletable.get()
+          assert(success)
+          assert(result.size() == 1)
+          assert(result.keySet() == execToDirs.asJava.keySet())
+          assert(result.values().iterator().next() sameElements
+            execToDirs.asJava.values().iterator().next())
+        } catch {
+          case e: ExecutionException =>
+            assert(e.getCause.isInstanceOf[IOException])
+            assert(!success)
+        }
+      }
+    } finally {
+      if (testExternalBlockStoreClient != null) {
+        testExternalBlockStoreClient.close()
+      }
+    }
   }
 
   test("error during accessing host local dirs for executors") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Use `CompletableFuture` to implement retry logic, and retry operations are performed asynchronously.

### Why are the changes needed?
`BlockStoreClient#getHostLocalDirs` RPC did not retry when `IOexception` occurred, and then `FetchFailedException` was thrown.

```java
23/04/24 01:24:55,158 [shuffle-client-7-1] WARN ExternalBlockStoreClient: Error while trying to get the host local dirs for [148]
23/04/24 01:24:55,158 [shuffle-client-7-1] ERROR ShuffleBlockFetcherIterator: Error occurred while fetching host local blocks
java.io.IOException: Connection reset by peer
	at sun.nio.ch.FileDispatcherImpl.read0(Native Method)
	at sun.nio.ch.SocketDispatcher.read(SocketDispatcher.java:39)
	at sun.nio.ch.IOUtil.readIntoNativeBuffer(IOUtil.java:223)
	at sun.nio.ch.IOUtil.read(IOUtil.java:192)
	at sun.nio.ch.SocketChannelImpl.read(SocketChannelImpl.java:380)
	at io.netty.buffer.PooledByteBuf.setBytes(PooledByteBuf.java:253)
	at io.netty.buffer.AbstractByteBuf.writeBytes(AbstractByteBuf.java:1132)
	at io.netty.channel.socket.nio.NioSocketChannel.doReadBytes(NioSocketChannel.java:350)
	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:151)
	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:719)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:655)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:581)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:493)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:986)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.lang.Thread.run(Thread.java:745) 
```


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
local test / add UT
