### PR TITLE
[SPARK-43307][PYTHON] Migrate PandasUDF value errors into error class

### DIFF
--- a/python/pyspark/errors/error_classes.py
+++ b/python/pyspark/errors/error_classes.py
@@ -170,6 +170,16 @@ ERROR_CLASSES_JSON = """
       "All items in `<arg_name>` should be in <allowed_types>, got <item_type>."
     ]
   },
+  "INVALID_PANDAS_UDF" : {
+    "message" : [
+      "Invalid function: <detail>"
+    ]
+  },
+  "INVALID_PANDAS_UDF_TYPE" : {
+    "message" : [
+      "`<arg_name>` should be one the values from PandasUDFType, got <arg_type>"
+    ]
+  },
   "INVALID_RETURN_TYPE_FOR_PANDAS_UDF": {
     "message": [
       "Pandas UDF should return StructType for <eval_type>, got <return_type>."

--- a/python/pyspark/sql/tests/pandas/test_pandas_udf.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_udf.py
@@ -133,17 +133,29 @@ class PandasUDFTestsMixin:
                 def foo(x):
                     return x
 
-            with self.assertRaisesRegex(ValueError, "Invalid return type.*None"):
+            with self.assertRaises(PySparkTypeError) as pe:
 
                 @pandas_udf(functionType=PandasUDFType.SCALAR)
                 def foo(x):
                     return x
 
-            with self.assertRaisesRegex(ValueError, "Invalid function"):
+            self.check_error(
+                exception=pe.exception,
+                error_class="CANNOT_BE_NONE",
+                message_parameters={"arg_name": "returnType"},
+            )
+
+            with self.assertRaises(PySparkTypeError) as pe:
 
                 @pandas_udf("double", 100)
                 def foo(x):
                     return x
+
+            self.check_error(
+                exception=pe.exception,
+                error_class="INVALID_PANDAS_UDF_TYPE",
+                message_parameters={"arg_name": "functionType", "arg_type": "100"},
+            )
 
             with self.assertRaisesRegex(ValueError, "0-arg pandas_udfs.*not.*supported"):
                 pandas_udf(lambda: 1, LongType(), PandasUDFType.SCALAR)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to migrate all `ValueError` from pandas UDF into error class.

### Why are the changes needed?

To improve PySpark error


### Does this PR introduce _any_ user-facing change?

No API changes, only error improvement.

### How was this patch tested?

This existing CI should pass.