### PR TITLE
[SPARK-43136][CONNECT][Followup] Adding tests for KeyAs

### DIFF
--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/KeyValueGroupedDatasetE2ETestSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/KeyValueGroupedDatasetE2ETestSuite.scala
@@ -88,8 +88,8 @@ class KeyValueGroupedDatasetE2ETestSuite extends QueryTest with SQLHelper {
       .groupByKey(id => K2(id % 2, id % 4))
       .keyAs[K1]
       .flatMapGroups((_, it) => Seq(it.toSeq.size))
-      .collectAsList()
-    assert(result == Arrays.asList[Int](3, 2, 3, 2))
+      .collect()
+    assert(result.sorted === Seq(2, 2, 3, 3))
   }
 
   test("groupByKey, keyAs, keys - duplicates") {
@@ -101,11 +101,8 @@ class KeyValueGroupedDatasetE2ETestSuite extends QueryTest with SQLHelper {
       .groupByKey(id => K2(id % 2, id % 4))
       .keyAs[K1]
       .keys
-      .collectAsList()
-    assert(result.size() == 4)
-    for (i <- 0 to 3) {
-      assert(result.get(i) == K1(i % 2))
-    }
+      .collect()
+    assert(result.sortBy(_.a) === Seq(K1(0), K1(0), K1(1), K1(1)))
   }
 
   test("keyAs - flatGroupMap") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -675,17 +675,18 @@ class DatasetSuite extends QueryTest
       .groupByKey(id => K2(id % 2, id % 4))
       .keyAs[K1]
       .flatMapGroups((_, it) => Seq(it.toSeq.size))
-    checkDataset(ds, 3, 2, 3, 2)
+    checkDatasetUnorderly(ds, 3, 2, 3, 2)
   }
 
   test("groupByKey, keyAs, keys - duplicates") {
-    val ds = spark
+    val result = spark
       .range(10)
       .as[Long]
       .groupByKey(id => K2(id % 2, id % 4))
       .keyAs[K1]
       .keys
-    checkDataset(ds, K1(0), K1(1), K1(0), K1(1))
+      .collect()
+    assert(result.sortBy(_.a) === Seq(K1(0), K1(0), K1(1), K1(1)))
   }
 
   test("groupBy function, mapValues, flatMap") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -668,6 +668,26 @@ class DatasetSuite extends QueryTest
     )
   }
 
+  test("groupByKey, keyAs - duplicates") {
+    val ds = spark
+      .range(10)
+      .as[Long]
+      .groupByKey(id => K2(id % 2, id % 4))
+      .keyAs[K1]
+      .flatMapGroups((_, it) => Seq(it.toSeq.size))
+    checkDataset(ds, 3, 2, 3, 2)
+  }
+
+  test("groupByKey, keyAs, keys - duplicates") {
+    val ds = spark
+      .range(10)
+      .as[Long]
+      .groupByKey(id => K2(id % 2, id % 4))
+      .keyAs[K1]
+      .keys
+    checkDataset(ds, K1(0), K1(1), K1(0), K1(1))
+  }
+
   test("groupBy function, mapValues, flatMap") {
     val ds = Seq(("a", 10), ("a", 20), ("b", 1), ("b", 2), ("c", 1)).toDS()
     val keyValue = ds.groupByKey(_._1).mapValues(_._2)
@@ -2626,3 +2646,6 @@ case class SpecialCharClass(`field.1`: String, `field 2`: String)
 /** Used to test Java Enums from Scala code */
 case class SaveModeCase(mode: SaveMode)
 case class SaveModeArrayCase(modes: Array[SaveMode])
+
+case class K1(a: Long)
+case class K2(a: Long, b: Long)


### PR DESCRIPTION
### What changes were proposed in this pull request?
The current impl of KeyAs for the Scala client is a purely client side encoder operation. Thus we could end up with duplicates in keys. 

Added the tests both for the Scala Client and for Spark dataset API. It showed the behavior is the same for server and client at this moment.

### Why are the changes needed?
More tests to verify the client and server behavior.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Tests