### PR TITLE
[SPARK-43252][SQL] Rename the error class _LEGACY_ERROR_TEMP_2017 to UNRESOLVED_CUSTOM_CLASS

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -1599,6 +1599,11 @@
     },
     "sqlState" : "42703"
   },
+  "UNRESOLVED_CUSTOM_CLASS": {
+    "message": [
+      "Could not resolve custom collection class. Please ensure that the class name is correct and that the class is available on the classpath."
+    ]
+  },
   "UNRESOLVED_FIELD" : {
     "message" : [
       "A field with name <fieldName> cannot be resolved with the struct-type column <columnPath>."
@@ -3774,11 +3779,6 @@
   "_LEGACY_ERROR_TEMP_2016" : {
     "message" : [
       "Can not interpolate <arg> into code block."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_2017" : {
-    "message" : [
-      "not resolved."
     ]
   },
   "_LEGACY_ERROR_TEMP_2018" : {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -436,7 +436,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase {
 
   def customCollectionClsNotResolvedError(): SparkUnsupportedOperationException = {
     new SparkUnsupportedOperationException(
-      errorClass = "_LEGACY_ERROR_TEMP_2017",
+      errorClass = "UNRESOLVED_CUSTOM_CLASS",
       messageParameters = Map.empty)
   }
 


### PR DESCRIPTION
What changes were proposed in this pull request?
In the PR, I propose to assign the proper name UNRESOLVED_CUSTOM_CLASS to the legacy error class _LEGACY_ERROR_TEMP_2017 , and modify test suite to use checkError() which checks the error class name.

Why are the changes needed?
Proper name improves user experience with Spark.

Does this PR introduce any user-facing change?
Yes, the PR changes an user-facing error message.

How was this patch tested?
By running the modified test suites:

$ build/sbt "testOnly *ObjectExpressionsSuite"