### PR TITLE
[SPARK-43314][CONNECT][PYTHON] Migrate Spark Connect client errors into error class

### DIFF
--- a/python/pyspark/errors/error_classes.py
+++ b/python/pyspark/errors/error_classes.py
@@ -170,6 +170,11 @@ ERROR_CLASSES_JSON = """
       "Invalid call to `<func_name>` on unresolved object."
     ]
   },
+  "INVALID_CONNECT_URL" : {
+    "message" : [
+      "Invalid URL for Spark Connect: <detail>"
+    ]
+  },
   "INVALID_ITEM_FOR_CONTAINER": {
     "message": [
       "All items in `<arg_name>` should be in <allowed_types>, got <item_type>."

--- a/python/pyspark/errors/error_classes.py
+++ b/python/pyspark/errors/error_classes.py
@@ -144,6 +144,11 @@ ERROR_CLASSES_JSON = """
       "Argument `<arg_name>`(type: <arg_type>) should only contain a type in [<allowed_types>], got <return_type>"
     ]
   },
+  "EXCEED_RETRY" : {
+    "message" : [
+      "Retries exceeded but no exception caught."
+    ]
+  },
   "HIGHER_ORDER_FUNCTION_SHOULD_RETURN_COLUMN" : {
     "message" : [
       "Function `<func_name>` should return Column, got <return_type>."
@@ -529,6 +534,16 @@ ERROR_CLASSES_JSON = """
   "UNEXPECTED_RESPONSE_FROM_SERVER" : {
     "message" : [
       "Unexpected response from iterator server."
+    ]
+  },
+  "UNKNOWN_EXPLAIN_MODE" : {
+    "message" : [
+      "Unknown explain mode: <explain_mode>. Accepted explain modes are 'simple', 'extended', 'codegen', 'cost', 'formatted'."
+    ]
+  },
+  "UNKNOWN_RESPONSE" : {
+    "message" : [
+      "Unknown response: <response>."
     ]
   },
   "UNSUPPORTED_DATA_TYPE" : {

--- a/python/pyspark/errors/error_classes.py
+++ b/python/pyspark/errors/error_classes.py
@@ -543,7 +543,7 @@ ERROR_CLASSES_JSON = """
   },
   "UNKNOWN_EXPLAIN_MODE" : {
     "message" : [
-      "Unknown explain mode: <explain_mode>. Accepted explain modes are 'simple', 'extended', 'codegen', 'cost', 'formatted'."
+      "Unknown explain mode: '<explain_mode>'. Accepted explain modes are 'simple', 'extended', 'codegen', 'cost', 'formatted'."
     ]
   },
   "UNKNOWN_RESPONSE" : {

--- a/python/pyspark/sql/connect/client.py
+++ b/python/pyspark/sql/connect/client.py
@@ -170,15 +170,24 @@ class ChannelBuilder:
         """
         # Explicitly check the scheme of the URL.
         if url[:5] != "sc://":
-            raise AttributeError("URL scheme must be set to `sc`.")
+            raise PySparkValueError(
+                error_class="INVALID_CONNECT_URL",
+                message_parameters={
+                    "detail": "URL scheme must be set to `sc`.",
+                },
+            )
         # Rewrite the URL to use http as the scheme so that we can leverage
         # Python's built-in parser.
         tmp_url = "http" + url[2:]
         self.url = urllib.parse.urlparse(tmp_url)
         self.params: Dict[str, str] = {}
         if len(self.url.path) > 0 and self.url.path != "/":
-            raise AttributeError(
-                f"Path component for connection URI must be empty: {self.url.path}"
+            raise PySparkValueError(
+                error_class="INVALID_CONNECT_URL",
+                message_parameters={
+                    "detail": f"Path component for connection URI `{self.url.path}` "
+                    f"must be empty.",
+                },
             )
         self._extract_attributes()
 
@@ -198,7 +207,12 @@ class ChannelBuilder:
             for p in parts:
                 kv = p.split("=")
                 if len(kv) != 2:
-                    raise AttributeError(f"Parameter '{p}' is not a valid parameter key-value pair")
+                    raise PySparkValueError(
+                        error_class="INVALID_CONNECT_URL",
+                        message_parameters={
+                            "detail": f"Parameter '{p}' is not a valid parameter key-value pair.",
+                        },
+                    )
                 self.params[kv[0]] = urllib.parse.unquote(kv[1])
 
         netloc = self.url.netloc.split(":")
@@ -209,8 +223,12 @@ class ChannelBuilder:
             self.host = netloc[0]
             self.port = int(netloc[1])
         else:
-            raise AttributeError(
-                f"Target destination {self.url.netloc} does not match '<host>:<port>' pattern"
+            raise PySparkValueError(
+                error_class="INVALID_CONNECT_URL",
+                message_parameters={
+                    "detail": f"Target destination {self.url.netloc} does not match "
+                    f"'<host>:<port>' pattern.",
+                },
             )
 
     def metadata(self) -> Iterable[Tuple[str, str]]:

--- a/python/pyspark/sql/connect/client.py
+++ b/python/pyspark/sql/connect/client.py
@@ -842,7 +842,7 @@ class SparkConnectClient(object):
                 raise PySparkValueError(
                     error_class="UNKNOWN_EXPLAIN_MODE",
                     message_parameters={
-                        "explain_mode": explain_mode,
+                        "explain_mode": str(explain_mode),
                     },
                 )
             if explain_mode == "simple":

--- a/python/pyspark/sql/connect/client.py
+++ b/python/pyspark/sql/connect/client.py
@@ -842,7 +842,7 @@ class SparkConnectClient(object):
                 raise PySparkValueError(
                     error_class="UNKNOWN_EXPLAIN_MODE",
                     message_parameters={
-                        "explain_mode": "explain_mode",
+                        "explain_mode": explain_mode,
                     },
                 )
             if explain_mode == "simple":

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -3365,7 +3365,7 @@ class ChannelBuilderTests(unittest.TestCase):
             "sc://host/;parm1;param2",
         ]
         for i in invalid:
-            self.assertRaises(AttributeError, ChannelBuilder, i)
+            self.assertRaises(PySparkValueError, ChannelBuilder, i)
 
     def test_sensible_defaults(self):
         chan = ChannelBuilder("sc://host")

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -2073,9 +2073,13 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
         self.assertTrue("Optimized Logical Plan" in plan_str)
         self.assertTrue("Physical Plan" in plan_str)
 
-        with self.assertRaises(ValueError) as context:
+        with self.assertRaises(PySparkValueError) as pe:
             self.connect.sql("SELECT 1")._explain_string(mode="unknown")
-        self.assertTrue("unknown" in str(context.exception))
+        self.check_error(
+            exception=pe.exception,
+            error_class="UNKNOWN_EXPLAIN_MODE",
+            message_parameters={"explain_mode": "unknown"},
+        )
 
     def test_simple_datasource_read(self) -> None:
         writeDf = self.df_text


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to migrate all Spark Connect client errors into error class

### Why are the changes needed?

To improve PySpark error


### Does this PR introduce _any_ user-facing change?

No API changes, only error improvement.

### How was this patch tested?

This existing CI should pass.