### PR TITLE
[SPARK-43332][CONNECT][PYTHON] Make it possible to extend ChannelBuilder for SparkConnectClient

### DIFF
--- a/python/pyspark/sql/connect/client.py
+++ b/python/pyspark/sql/connect/client.py
@@ -532,7 +532,7 @@ class SparkConnectClient(object):
 
     def __init__(
         self,
-        connectionString: str,
+        connection: Union[str, ChannelBuilder],
         userId: Optional[str] = None,
         channelOptions: Optional[List[Tuple[str, Any]]] = None,
         retryPolicy: Optional[Dict[str, Any]] = None,
@@ -542,9 +542,10 @@ class SparkConnectClient(object):
 
         Parameters
         ----------
-        connectionString: Optional[str]
+        connection: Union[str,ChannelBuilder]
             Connection string that is used to extract the connection parameters and configure
-            the GRPC connection. Defaults to `sc://localhost`.
+            the GRPC connection. Or instance of ChannelBuilder that creates GRPC connection.
+            Defaults to `sc://localhost`.
         userId : Optional[str]
             Optional unique user ID that is used to differentiate multiple users and
             isolate their Spark Sessions. If the `user_id` is not set, will default to
@@ -552,7 +553,11 @@ class SparkConnectClient(object):
             takes precedence.
         """
         # Parse the connection string.
-        self._builder = ChannelBuilder(connectionString, channelOptions)
+        self._builder = (
+            connection
+            if isinstance(connection, ChannelBuilder)
+            else ChannelBuilder(connection, channelOptions)
+        )
         self._user_id = None
         self._retry_policy = {
             "max_retries": 15,

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -48,7 +48,7 @@ from pandas.api.types import (  # type: ignore[attr-defined]
 
 from pyspark import SparkContext, SparkConf, __version__
 from pyspark.sql.connect import proto
-from pyspark.sql.connect.client import SparkConnectClient
+from pyspark.sql.connect.client import SparkConnectClient, ChannelBuilder
 from pyspark.sql.connect.conf import RuntimeConf
 from pyspark.sql.connect.dataframe import DataFrame
 from pyspark.sql.connect.plan import SQL, Range, LocalRelation, CachedRelation
@@ -90,6 +90,7 @@ class SparkSession:
 
         def __init__(self) -> None:
             self._options: Dict[str, Any] = {}
+            self._channel_builder: Optional[ChannelBuilder] = None
 
         @overload
         def config(self, key: str, value: Any) -> "SparkSession.Builder":
@@ -123,6 +124,34 @@ class SparkSession:
         def remote(self, location: str = "sc://localhost") -> "SparkSession.Builder":
             return self.config("spark.remote", location)
 
+        def channelBuilder(self, channelBuilder: ChannelBuilder) -> "SparkSession.Builder":
+            """Uses custom :class:`ChannelBuilder` implementation, when there is a need
+            to customize the behavior for creation of GRPC connections.
+
+            .. versionadded:: 3.5.0
+
+            An example to use this class looks like this:
+
+            .. code-block:: python
+
+                from pyspark.sql.connect import SparkSession, ChannelBuilder
+
+                class CustomChannelBuilder(ChannelBuilder):
+                    ...
+
+                custom_channel_builder = CustomChannelBuilder(...)
+                spark = SparkSession.builder().channelBuilder(custom_channel_builder).getOrCreate()
+
+            Returns
+            -------
+            :class:`SparkSession.Builder`
+            """
+            with self._lock:
+                # self._channel_builder is a separate field, because it may hold the state
+                # and cannot be serialized with to_str()
+                self._channel_builder = channelBuilder
+                return self
+
         def enableHiveSupport(self) -> "SparkSession.Builder":
             raise PySparkNotImplementedError(
                 error_class="NOT_IMPLEMENTED",
@@ -133,7 +162,25 @@ class SparkSession:
             global _active_spark_session
             if _active_spark_session is not None:
                 return _active_spark_session
-            _active_spark_session = SparkSession(connectionString=self._options["spark.remote"])
+
+            has_channel_builder = self._channel_builder is not None
+            has_spark_remote = "spark.remote" in self._options
+
+            if has_channel_builder and has_spark_remote:
+                raise ValueError(
+                    "Only one of connection string or channelBuilder "
+                    "can be used to create a new SparkSession."
+                )
+
+            if not has_channel_builder and not has_spark_remote:
+                raise ValueError(
+                    "Needs either connection string or channelBuilder to create a new SparkSession."
+                )
+
+            if has_channel_builder:
+                _active_spark_session = SparkSession(connection=self._channel_builder)
+            else:
+                _active_spark_session = SparkSession(connection=self._options.get("spark.remote"))
             return _active_spark_session
 
     _client: SparkConnectClient
@@ -143,23 +190,23 @@ class SparkSession:
         """Creates a :class:`Builder` for constructing a :class:`SparkSession`."""
         return cls.Builder()
 
-    def __init__(self, connectionString: str, userId: Optional[str] = None):
+    def __init__(self, connection: Union[str, ChannelBuilder], userId: Optional[str] = None):
         """
         Creates a new SparkSession for the Spark Connect interface.
 
         Parameters
         ----------
-        connectionString: str, optional
+        connection: Union[str,ChannelBuilder]
             Connection string that is used to extract the connection parameters and configure
-            the GRPC connection. Defaults to `sc://localhost`.
+            the GRPC connection. Or instance of ChannelBuilder that creates GRPC connection.
+            Defaults to `sc://localhost`.
         userId : str, optional
             Optional unique user ID that is used to differentiate multiple users and
             isolate their Spark Sessions. If the `user_id` is not set, will default to
             the $USER environment. Defining the user ID as part of the connection string
             takes precedence.
         """
-        # Parse the connection string.
-        self._client = SparkConnectClient(connectionString)
+        self._client = SparkConnectClient(connection=connection, userId=userId)
 
     def table(self, tableName: str) -> DataFrame:
         return self.read.table(tableName)

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -178,9 +178,12 @@ class SparkSession:
                 )
 
             if has_channel_builder:
+                assert self._channel_builder is not None
                 _active_spark_session = SparkSession(connection=self._channel_builder)
             else:
-                _active_spark_session = SparkSession(connection=self._options.get("spark.remote"))
+                spark_remote = to_str(self._options.get("spark.remote"))
+                assert spark_remote is not None
+                _active_spark_session = SparkSession(connection=spark_remote)
             return _active_spark_session
 
     _client: SparkConnectClient

--- a/python/pyspark/sql/tests/connect/test_client.py
+++ b/python/pyspark/sql/tests/connect/test_client.py
@@ -18,7 +18,7 @@
 import unittest
 from typing import Optional
 
-from pyspark.sql.connect.client import SparkConnectClient
+from pyspark.sql.connect.client import SparkConnectClient, ChannelBuilder
 import pyspark.sql.connect.proto as proto
 from pyspark.testing.connectutils import should_test_connect
 
@@ -57,6 +57,16 @@ class SparkConnectClientTestCase(unittest.TestCase):
 
         client = SparkConnectClient("sc://foo/")
         self.assertIsNone(client.token)
+
+    def test_channel_builder(self):
+        class CustomChannelBuilder(ChannelBuilder):
+            @property
+            def userId(self) -> Optional[str]:
+                return "abc"
+
+        client = SparkConnectClient(CustomChannelBuilder("sc://foo/"))
+
+        self.assertEqual(client._user_id, "abc")
 
 
 class MockService:

--- a/python/pyspark/sql/tests/connect/test_session.py
+++ b/python/pyspark/sql/tests/connect/test_session.py
@@ -1,0 +1,58 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import unittest
+from typing import Optional
+
+from pyspark.sql.connect.client import ChannelBuilder
+from pyspark.sql.connect.session import SparkSession as RemoteSparkSession
+
+
+class CustomChannelBuilder(ChannelBuilder):
+    @property
+    def userId(self) -> Optional[str]:
+        return "abc"
+
+
+class SparkSessionTestCase(unittest.TestCase):
+    def test_fails_to_create_session_without_remote_and_channel_builder(self):
+        with self.assertRaises(ValueError):
+            RemoteSparkSession.builder.getOrCreate()
+
+    def test_fails_to_create_when_both_remote_and_channel_builder_are_specified(self):
+        with self.assertRaises(ValueError):
+            (
+                RemoteSparkSession.builder.channelBuilder(CustomChannelBuilder("sc://localhost"))
+                .remote("sc://localhost")
+                .getOrCreate()
+            )
+
+    def test_creates_session_with_channel_builder(self):
+        test_session = RemoteSparkSession.builder.channelBuilder(
+            CustomChannelBuilder("sc://other")
+        ).getOrCreate()
+        host = test_session.client.host
+        test_session.stop()
+
+        self.assertEqual("other", host)
+
+    def test_creates_session_with_remote(self):
+        test_session = RemoteSparkSession.builder.remote("sc://other").getOrCreate()
+        host = test_session.client.host
+        test_session.stop()
+
+        self.assertEqual("other", host)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

This PR adds an ability to extend `ChannelBuilder` with extra logic.


### Why are the changes needed?

So that it's possible to extend GRPC options like in the example below:

```python
from pyspark.sql.connect import SparkSession, ChannelBuilder

class CustomChannelBuilder(ChannelBuilder):
    ...

custom_channel_builder = CustomChannelBuilder(...)
spark = SparkSession.builder().channelBuilder(custom_channel_builder).getOrCreate()
```

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
