### PR TITLE
[SPARK-43319][K8S][TEST] Remove usage of deprecated DefaultKubernetesClient

### DIFF
--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/BasicTestsSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/BasicTestsSuite.scala
@@ -58,9 +58,13 @@ private[spark] trait BasicTestsSuite { k8sSuite: KubernetesSuite =>
     // Verify there is no dangling statefulset
     // This depends on the garbage collection happening inside of K8s so give it some time.
     Eventually.eventually(TIMEOUT, INTERVAL) {
-      val sets = kubernetesTestComponents.kubernetesClient.apps().statefulSets().list().getItems
-      val scalaSets = sets.asScala
-      scalaSets.size shouldBe (0)
+      val sets = kubernetesTestComponents.kubernetesClient
+        .apps()
+        .statefulSets()
+        .inNamespace(kubernetesTestComponents.namespace)
+        .list()
+        .getItems
+      sets.asScala.size shouldBe 0
     }
   }
 

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/ClientModeTestsSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/ClientModeTestsSuite.scala
@@ -53,8 +53,7 @@ private[spark] trait ClientModeTestsSuite { k8sSuite: KubernetesSuite =>
           .endSpec()
         .build())
     try {
-      val driverPod = testBackend
-        .getKubernetesClient
+      val driverPod = testBackend.getKubernetesClient
         .pods()
         .inNamespace(kubernetesTestComponents.namespace)
         .create(new PodBuilder()
@@ -98,6 +97,7 @@ private[spark] trait ClientModeTestsSuite { k8sSuite: KubernetesSuite =>
       Eventually.eventually(TIMEOUT, INTERVAL) {
         assert(kubernetesTestComponents.kubernetesClient
           .pods()
+          .inNamespace(kubernetesTestComponents.namespace)
           .withName(driverPodName)
           .getLog
           .contains("Pi is roughly 3"), "The application did not complete.")

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/DecommissionSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/DecommissionSuite.scala
@@ -156,7 +156,10 @@ private[spark] trait DecommissionSuite { k8sSuite: KubernetesSuite =>
             PatienceConfiguration.Timeout(Span(120, Seconds)),
             PatienceConfiguration.Interval(Span(1, Seconds))) {
 
-            val currentPod = client.pods().withName(pod.getMetadata.getName).get
+            val currentPod = client.pods()
+              .inNamespace(kubernetesTestComponents.namespace)
+              .withName(pod.getMetadata.getName)
+              .get
             val labels = currentPod.getMetadata.getLabels.asScala
 
             labels should not be (null)

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/DepsTestsSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/DepsTestsSuite.scala
@@ -129,6 +129,7 @@ private[spark] trait DepsTestsSuite { k8sSuite: KubernetesSuite =>
     Eventually.eventually(TIMEOUT, INTERVAL) (kubernetesTestComponents
       .kubernetesClient
       .services()
+      .inNamespace(kubernetesTestComponents.namespace)
       .create(minioService))
 
     // try until the stateful set of a previous test is deleted
@@ -136,6 +137,7 @@ private[spark] trait DepsTestsSuite { k8sSuite: KubernetesSuite =>
       .kubernetesClient
       .apps()
       .statefulSets()
+      .inNamespace(kubernetesTestComponents.namespace)
       .create(minioStatefulSet))
   }
 
@@ -144,6 +146,7 @@ private[spark] trait DepsTestsSuite { k8sSuite: KubernetesSuite =>
       .kubernetesClient
       .apps()
       .statefulSets()
+      .inNamespace(kubernetesTestComponents.namespace)
       .withName(cName)
       .withGracePeriod(0)
       .delete()
@@ -151,6 +154,7 @@ private[spark] trait DepsTestsSuite { k8sSuite: KubernetesSuite =>
     kubernetesTestComponents
       .kubernetesClient
       .services()
+      .inNamespace(kubernetesTestComponents.namespace)
       .withName(svcName)
       .withGracePeriod(0)
       .delete()

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/KubernetesSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/KubernetesSuite.scala
@@ -81,6 +81,7 @@ class KubernetesSuite extends SparkFunSuite
     logInfo("END DESCRIBE PODS for the application")
     val driverPodOption = kubernetesTestComponents.kubernetesClient
       .pods()
+      .inNamespace(kubernetesTestComponents.namespace)
       .withLabel("spark-app-locator", appLocator)
       .withLabel("spark-role", "driver")
       .list()
@@ -91,12 +92,14 @@ class KubernetesSuite extends SparkFunSuite
       logInfo("BEGIN driver POD log\n" +
         kubernetesTestComponents.kubernetesClient
           .pods()
+          .inNamespace(kubernetesTestComponents.namespace)
           .withName(driverPod.getMetadata.getName)
           .getLog)
       logInfo("END driver POD log")
     }
     kubernetesTestComponents.kubernetesClient
       .pods()
+      .inNamespace(kubernetesTestComponents.namespace)
       .withLabel("spark-app-locator", appLocator)
       .withLabel("spark-role", "executor")
       .list()
@@ -104,6 +107,7 @@ class KubernetesSuite extends SparkFunSuite
         val podLog = try {
           kubernetesTestComponents.kubernetesClient
             .pods()
+            .inNamespace(kubernetesTestComponents.namespace)
             .withName(execPod.getMetadata.getName)
             .getLog
         } catch {
@@ -318,6 +322,7 @@ class KubernetesSuite extends SparkFunSuite
 
     val driverPod = kubernetesTestComponents.kubernetesClient
       .pods()
+      .inNamespace(kubernetesTestComponents.namespace)
       .withLabel("spark-app-locator", appLocator)
       .withLabel("spark-role", "driver")
       .list()
@@ -329,6 +334,7 @@ class KubernetesSuite extends SparkFunSuite
       expectedJVMValue.foreach { e =>
         assert(kubernetesTestComponents.kubernetesClient
           .pods()
+          .inNamespace(kubernetesTestComponents.namespace)
           .withName(driverPod.getMetadata.getName)
           .getLog
           .contains(e), "The application did not complete.")
@@ -385,6 +391,7 @@ class KubernetesSuite extends SparkFunSuite
 
     val execWatcher = kubernetesTestComponents.kubernetesClient
       .pods()
+      .inNamespace(kubernetesTestComponents.namespace)
       .withLabel("spark-app-locator", customAppLocator.getOrElse(appLocator))
       .withLabel("spark-role", "executor")
       .watch(new Watcher[Pod] {
@@ -415,6 +422,7 @@ class KubernetesSuite extends SparkFunSuite
                 Eventually.eventually(TIMEOUT, INTERVAL) {
                   assert(kubernetesTestComponents.kubernetesClient
                     .pods()
+                    .inNamespace(kubernetesTestComponents.namespace)
                     .withName(driverPodName)
                     .getLog
                     .contains("Waiting to give nodes time to finish migration, decom exec 1."),
@@ -425,8 +433,12 @@ class KubernetesSuite extends SparkFunSuite
                 // We set an intentionally long grace period to test that Spark
                 // exits once the blocks are done migrating and doesn't wait for the
                 // entire grace period if it does not need to.
-                kubernetesTestComponents.kubernetesClient.pods()
-                  .withName(name).withGracePeriod(Int.MaxValue).delete()
+                kubernetesTestComponents.kubernetesClient
+                  .pods()
+                  .inNamespace(kubernetesTestComponents.namespace)
+                  .withName(name)
+                  .withGracePeriod(Int.MaxValue)
+                  .delete()
                 logDebug(s"Triggered pod decom/delete: $name deleted")
                 // Make sure this pod is deleted
                 Eventually.eventually(TIMEOUT, INTERVAL) {
@@ -458,6 +470,7 @@ class KubernetesSuite extends SparkFunSuite
 
     val driverPod = kubernetesTestComponents.kubernetesClient
       .pods()
+      .inNamespace(kubernetesTestComponents.namespace)
       .withLabel("spark-app-locator", customAppLocator.getOrElse(appLocator))
       .withLabel("spark-role", "driver")
       .list()
@@ -477,6 +490,7 @@ class KubernetesSuite extends SparkFunSuite
     val execPod: Option[Pod] = if (expectedExecutorLogOnCompletion.nonEmpty) {
       Some(kubernetesTestComponents.kubernetesClient
         .pods()
+        .inNamespace(kubernetesTestComponents.namespace)
         .withLabel("spark-app-locator", appLocator)
         .withLabel("spark-role", "executor")
         .list()
@@ -490,6 +504,7 @@ class KubernetesSuite extends SparkFunSuite
       expectedDriverLogOnCompletion.foreach { e =>
         assert(kubernetesTestComponents.kubernetesClient
           .pods()
+          .inNamespace(kubernetesTestComponents.namespace)
           .withName(driverPod.getMetadata.getName)
           .getLog
           .contains(e),
@@ -498,6 +513,7 @@ class KubernetesSuite extends SparkFunSuite
       expectedExecutorLogOnCompletion.foreach { e =>
         assert(kubernetesTestComponents.kubernetesClient
           .pods()
+          .inNamespace(kubernetesTestComponents.namespace)
           .withName(execPod.get.getMetadata.getName)
           .getLog
           .contains(e),
@@ -589,7 +605,11 @@ class KubernetesSuite extends SparkFunSuite
   }
 
   private def deleteDriverPod(): Unit = {
-    kubernetesTestComponents.kubernetesClient.pods().withName(driverPodName).delete()
+    kubernetesTestComponents.kubernetesClient
+      .pods()
+      .inNamespace(kubernetesTestComponents.namespace)
+      .withName(driverPodName)
+      .delete()
     Eventually.eventually(TIMEOUT, INTERVAL) {
       assert(kubernetesTestComponents.kubernetesClient
         .pods()
@@ -602,12 +622,14 @@ class KubernetesSuite extends SparkFunSuite
     kubernetesTestComponents
       .kubernetesClient
       .pods()
+      .inNamespace(kubernetesTestComponents.namespace)
       .withLabel("spark-app-locator", appLocator)
       .withLabel("spark-role", "executor")
       .delete()
     Eventually.eventually(TIMEOUT, INTERVAL) {
       assert(kubernetesTestComponents.kubernetesClient
         .pods()
+        .inNamespace(kubernetesTestComponents.namespace)
         .withLabel("spark-app-locator", appLocator)
         .withLabel("spark-role", "executor")
         .list()

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/PVTestsSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/PVTestsSuite.scala
@@ -41,6 +41,7 @@ private[spark] trait PVTestsSuite { k8sSuite: KubernetesSuite =>
       kubernetesTestComponents
         .kubernetesClient
         .storage()
+        .v1()
         .storageClasses()
         .create(scBuilder.build())
     } catch {
@@ -98,6 +99,7 @@ private[spark] trait PVTestsSuite { k8sSuite: KubernetesSuite =>
     kubernetesTestComponents
       .kubernetesClient
       .persistentVolumeClaims()
+      .inNamespace(kubernetesTestComponents.namespace)
       .create(pvcBuilder.build())
   }
 
@@ -105,6 +107,7 @@ private[spark] trait PVTestsSuite { k8sSuite: KubernetesSuite =>
     kubernetesTestComponents
       .kubernetesClient
       .persistentVolumeClaims()
+      .inNamespace(kubernetesTestComponents.namespace)
       .withName(PVC_NAME)
       .delete()
 
@@ -117,6 +120,7 @@ private[spark] trait PVTestsSuite { k8sSuite: KubernetesSuite =>
     kubernetesTestComponents
       .kubernetesClient
       .storage()
+      .v1()
       .storageClasses()
       .withName(STORAGE_NAME)
       .delete()

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/SecretsTestsSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/SecretsTestsSuite.scala
@@ -44,6 +44,7 @@ private[spark] trait SecretsTestsSuite { k8sSuite: KubernetesSuite =>
     val sec = kubernetesTestComponents
       .kubernetesClient
       .secrets()
+      .inNamespace(kubernetesTestComponents.namespace)
       .createOrReplace(envSecret)
   }
 
@@ -51,6 +52,7 @@ private[spark] trait SecretsTestsSuite { k8sSuite: KubernetesSuite =>
     kubernetesTestComponents
       .kubernetesClient
       .secrets()
+      .inNamespace(kubernetesTestComponents.namespace)
       .withName(ENV_SECRET_NAME)
       .delete()
   }

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/Utils.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/Utils.scala
@@ -55,6 +55,7 @@ object Utils extends Logging {
     val pod = kubernetesTestComponents
       .kubernetesClient
       .pods()
+      .inNamespace(kubernetesTestComponents.namespace)
       .withName(podName)
     // Avoid timing issues by looking for open/close
     class ReadyListener extends ExecListener {

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/VolcanoTestsSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/VolcanoTestsSuite.scala
@@ -28,7 +28,6 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 import io.fabric8.kubernetes.api.model.{HasMetadata, Pod, Quantity}
-import io.fabric8.kubernetes.client.NamespacedKubernetesClient
 import io.fabric8.volcano.client.VolcanoClient
 import io.fabric8.volcano.scheduling.v1beta1.{Queue, QueueBuilder}
 import org.scalatest.BeforeAndAfterEach
@@ -46,9 +45,6 @@ private[spark] trait VolcanoTestsSuite extends BeforeAndAfterEach { k8sSuite: Ku
   import org.apache.spark.deploy.k8s.integrationtest.KubernetesSuite.{k8sTestTag, INTERVAL, TIMEOUT,
     SPARK_DRIVER_MAIN_CLASS}
 
-  lazy val volcanoClient: VolcanoClient
-    = kubernetesTestComponents.kubernetesClient.adapt(classOf[VolcanoClient])
-  lazy val k8sClient: NamespacedKubernetesClient = kubernetesTestComponents.kubernetesClient
   private val testGroups: mutable.Set[String] = mutable.Set.empty
   private val testYAMLPaths: mutable.Set[String] = mutable.Set.empty
   private val testResources: mutable.Set[HasMetadata] = mutable.Set.empty
@@ -58,9 +54,19 @@ private[spark] trait VolcanoTestsSuite extends BeforeAndAfterEach { k8sSuite: Ku
 
   private def deletePodInTestGroup(): Unit = {
     testGroups.foreach { g =>
-      k8sClient.pods().withLabel("spark-group-locator", g).delete()
+      kubernetesTestComponents.kubernetesClient
+        .pods()
+        .inNamespace(kubernetesTestComponents.namespace)
+        .withLabel("spark-group-locator", g)
+        .delete()
       Eventually.eventually(TIMEOUT, INTERVAL) {
-        assert(k8sClient.pods().withLabel("spark-group-locator", g).list().getItems.isEmpty)
+        assert(kubernetesTestComponents.kubernetesClient
+          .pods()
+          .inNamespace(kubernetesTestComponents.namespace)
+          .withLabel("spark-group-locator", g)
+          .list()
+          .getItems
+          .isEmpty)
       }
     }
     testGroups.clear()
@@ -70,7 +76,10 @@ private[spark] trait VolcanoTestsSuite extends BeforeAndAfterEach { k8sSuite: Ku
     testYAMLPaths.foreach { yaml =>
       deleteYAMLResource(yaml)
       Eventually.eventually(TIMEOUT, INTERVAL) {
-        val resources = k8sClient.load(new FileInputStream(yaml)).fromServer.get.asScala
+        val resources = kubernetesTestComponents.kubernetesClient
+          .load(new FileInputStream(yaml))
+          .inNamespace(kubernetesTestComponents.namespace)
+          .get.asScala
         // Make sure all elements are null (no specific resources in cluster)
         resources.foreach { r => assert(r === null) }
       }
@@ -80,9 +89,15 @@ private[spark] trait VolcanoTestsSuite extends BeforeAndAfterEach { k8sSuite: Ku
 
   private def deleteResources(): Unit = {
     testResources.foreach { _ =>
-      k8sClient.resourceList(testResources.toSeq: _*).delete()
+      kubernetesTestComponents.kubernetesClient
+        .resourceList(testResources.toSeq: _*)
+        .inNamespace(kubernetesTestComponents.namespace)
+        .delete()
       Eventually.eventually(TIMEOUT, INTERVAL) {
-        val resources = k8sClient.resourceList(testResources.toSeq: _*).fromServer.get.asScala
+        val resources = kubernetesTestComponents.kubernetesClient
+          .resourceList(testResources.toSeq: _*)
+          .inNamespace(kubernetesTestComponents.namespace)
+          .get().asScala
         // Make sure all elements are null (no specific resources in cluster)
         resources.foreach { r => assert(r === null) }
       }
@@ -120,7 +135,11 @@ private[spark] trait VolcanoTestsSuite extends BeforeAndAfterEach { k8sSuite: Ku
       priorityClassName: Option[String] = None): Unit = {
     val appId = pod.getMetadata.getLabels.get("spark-app-selector")
     val podGroupName = s"$appId-podgroup"
-    val podGroup = volcanoClient.podGroups().withName(podGroupName).get()
+    val podGroup = kubernetesTestComponents.kubernetesClient.adapt(classOf[VolcanoClient])
+      .podGroups()
+      .inNamespace(kubernetesTestComponents.namespace)
+      .withName(podGroupName)
+      .get()
     assert(podGroup.getMetadata.getOwnerReferences.get(0).getName === pod.getMetadata.getName)
     queue.foreach(q => assert(q === podGroup.getSpec.getQueue))
     priorityClassName.foreach(_ =>
@@ -128,7 +147,10 @@ private[spark] trait VolcanoTestsSuite extends BeforeAndAfterEach { k8sSuite: Ku
   }
 
   private def createOrReplaceResource(resource: Queue): Unit = {
-    volcanoClient.queues().createOrReplace(resource)
+    kubernetesTestComponents.kubernetesClient.adapt(classOf[VolcanoClient])
+      .queues()
+      .inNamespace(kubernetesTestComponents.namespace)
+      .createOrReplace(resource)
     testResources += resource
   }
 
@@ -152,20 +174,27 @@ private[spark] trait VolcanoTestsSuite extends BeforeAndAfterEach { k8sSuite: Ku
   }
 
   private def createOrReplaceYAMLResource(yamlPath: String): Unit = {
-    k8sClient.load(new FileInputStream(yamlPath)).createOrReplace()
+    kubernetesTestComponents.kubernetesClient
+      .load(new FileInputStream(yamlPath))
+      .inNamespace(kubernetesTestComponents.namespace)
+      .createOrReplace()
     testYAMLPaths += yamlPath
   }
 
   private def deleteYAMLResource(yamlPath: String): Unit = {
-    k8sClient.load(new FileInputStream(yamlPath)).delete()
+    kubernetesTestComponents.kubernetesClient
+      .load(new FileInputStream(yamlPath))
+      .inNamespace(kubernetesTestComponents.namespace)
+      .delete()
   }
 
   private def getPods(
       role: String,
       groupLocator: String,
       statusPhase: String): mutable.Buffer[Pod] = {
-    k8sClient
+    kubernetesTestComponents.kubernetesClient
       .pods()
+      .inNamespace(kubernetesTestComponents.namespace)
       .withLabel("spark-group-locator", groupLocator)
       .withLabel("spark-role", role)
       .withField("status.phase", statusPhase)

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/backend/IntegrationTestBackend.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/backend/IntegrationTestBackend.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.deploy.k8s.integrationtest.backend
 
-import io.fabric8.kubernetes.client.DefaultKubernetesClient
+import io.fabric8.kubernetes.client.KubernetesClient
 
 import org.apache.spark.deploy.k8s.integrationtest.ProcessUtils
 import org.apache.spark.deploy.k8s.integrationtest.TestConstants._
@@ -27,7 +27,7 @@ import org.apache.spark.deploy.k8s.integrationtest.backend.minikube.MinikubeTest
 
 private[spark] trait IntegrationTestBackend {
   def initialize(): Unit
-  def getKubernetesClient: DefaultKubernetesClient
+  def getKubernetesClient: KubernetesClient
   def cleanUp(): Unit = {}
   def describePods(labels: String): Seq[String] =
     ProcessUtils.executeProcess(

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/backend/cloud/KubeConfigBackend.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/backend/cloud/KubeConfigBackend.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.spark.deploy.k8s.integrationtest.backend.cloud
 
-import io.fabric8.kubernetes.client.{Config, DefaultKubernetesClient}
+import io.fabric8.kubernetes.client.{Config, KubernetesClient, KubernetesClientBuilder}
 import io.fabric8.kubernetes.client.utils.Utils
 import org.apache.commons.lang3.StringUtils
 
@@ -31,7 +31,7 @@ private[spark] class KubeConfigBackend(var context: String)
     s"${if (context != null) s"context ${context}" else "default context"}" +
     s" from users K8S config file")
 
-  private var defaultClient: DefaultKubernetesClient = _
+  private var defaultClient: KubernetesClient = _
 
   override def initialize(): Unit = {
     // Auto-configure K8S client from K8S config file
@@ -55,7 +55,7 @@ private[spark] class KubeConfigBackend(var context: String)
       }
     }
 
-    defaultClient = new DefaultKubernetesClient(config)
+    defaultClient = new KubernetesClientBuilder().withConfig(config).build()
   }
 
   override def cleanUp(): Unit = {
@@ -65,7 +65,7 @@ private[spark] class KubeConfigBackend(var context: String)
     super.cleanUp()
   }
 
-  override def getKubernetesClient: DefaultKubernetesClient = {
+  override def getKubernetesClient: KubernetesClient = {
     defaultClient
   }
 }

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/backend/minikube/Minikube.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/backend/minikube/Minikube.scala
@@ -16,8 +16,7 @@
  */
 package org.apache.spark.deploy.k8s.integrationtest.backend.minikube
 
-import io.fabric8.kubernetes.client.Config
-import io.fabric8.kubernetes.client.DefaultKubernetesClient
+import io.fabric8.kubernetes.client.{Config, KubernetesClient, KubernetesClientBuilder}
 
 import org.apache.spark.deploy.k8s.integrationtest.ProcessUtils
 import org.apache.spark.internal.Logging
@@ -40,7 +39,7 @@ private[spark] object Minikube extends Logging {
   def logVersion(): Unit =
     logInfo(minikubeVersionString)
 
-  def getKubernetesClient: DefaultKubernetesClient = {
+  def getKubernetesClient: KubernetesClient = {
     // only the three-part version number is matched (the optional suffix like "-beta.0" is dropped)
     val versionArrayOpt = "\\d+\\.\\d+\\.\\d+".r
       .findFirstIn(minikubeVersionString.split(VERSION_PREFIX)(1))
@@ -58,7 +57,7 @@ private[spark] object Minikube extends Logging {
           "non-numeric suffix is intentionally dropped)")
     }
 
-    new DefaultKubernetesClient(Config.autoConfigure("minikube"))
+    new KubernetesClientBuilder().withConfig(Config.autoConfigure("minikube")).build()
   }
 
   def getMinikubeStatus(): MinikubeStatus.Value = {

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/backend/minikube/MinikubeTestBackend.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/backend/minikube/MinikubeTestBackend.scala
@@ -16,13 +16,13 @@
  */
 package org.apache.spark.deploy.k8s.integrationtest.backend.minikube
 
-import io.fabric8.kubernetes.client.DefaultKubernetesClient
+import io.fabric8.kubernetes.client.KubernetesClient
 
 import org.apache.spark.deploy.k8s.integrationtest.backend.IntegrationTestBackend
 
 private[spark] object MinikubeTestBackend extends IntegrationTestBackend {
 
-  private var defaultClient: DefaultKubernetesClient = _
+  private var defaultClient: KubernetesClient = _
 
   override def initialize(): Unit = {
     Minikube.logVersion()
@@ -40,7 +40,7 @@ private[spark] object MinikubeTestBackend extends IntegrationTestBackend {
     super.cleanUp()
   }
 
-  override def getKubernetesClient: DefaultKubernetesClient = {
+  override def getKubernetesClient: KubernetesClient = {
     defaultClient
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Migrate from deprecated `DefaultKubernetesClient` to suggested `KubernetesClient`.

Note: The fabric8io/kubernetes-client changes rapidly, there are still bunches of deprecated API usages in the codebase, would like to migrate them in separated PRs.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

```
/**
 * Class for Default Kubernetes Client implementing KubernetesClient interface.
 * It is thread safe.
 *
 * @deprecated direct usage should no longer be needed. Please use the {@link KubernetesClientBuilder} instead.
 */
@Deprecated
public class DefaultKubernetesClient ...
```

```
public interface StorageAPIGroupDSL extends Client {
  /**
   * DSL entrypoint for storage.k8s.io/v1 StorageClass
   *
   * @deprecated Use <code>client.storage().v1().storageClasses()</code> instead
   * @return {@link NonNamespaceOperation} for StorageClass
   */
  @Deprecated
  NonNamespaceOperation<StorageClass, StorageClassList, Resource<StorageClass>> storageClasses();

  ...
}
```
### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Pass GA.