### PR TITLE
[SPARK-43313][SQL] Adding missing column DEFAULT values for MERGE INSERT actions

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/SupportsCustomSchemaWrite.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/SupportsCustomSchemaWrite.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.write;
+
+import org.apache.spark.annotation.Evolving;
+import org.apache.spark.sql.types.StructType;
+
+/**
+ * Trait for tables that support custom schemas for write operations including INSERT INTO commands
+ * whose target table columns have explicit or implicit default values.
+ *
+ * @since 3.4.0
+ */
+@Evolving
+public interface SupportsCustomSchemaWrite {
+    /**
+     * Represents a table with a custom schema to use for resolving DEFAULT column references when
+     * inserting into the table. For example, this can be useful for excluding hidden pseudocolumns.
+     *
+     * @return the new schema to use for this process.
+     */
+    StructType customSchemaForInserts();
+}

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/SupportsCustomSchemaWrite.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/SupportsCustomSchemaWrite.java
@@ -24,7 +24,7 @@ import org.apache.spark.sql.types.StructType;
  * Trait for tables that support custom schemas for write operations including INSERT INTO commands
  * whose target table columns have explicit or implicit default values.
  *
- * @since 3.4.0
+ * @since 3.4.1
  */
 @Evolving
 public interface SupportsCustomSchemaWrite {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDefaultColumns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDefaultColumns.scala
@@ -570,7 +570,7 @@ case class ResolveDefaultColumns(
    */
   private def getInsertTableSchemaWithoutPartitionColumns(
       enclosingInsert: InsertIntoStatement): Option[StructType] = {
-    val target = getSchemaForTargetTable(enclosingInsert.table).getOrElse(return None)
+    val target: StructType = getSchemaForTargetTable(enclosingInsert.table).getOrElse(return None)
     val schema: StructType = StructType(target.fields.dropRight(enclosingInsert.partitionSpec.size))
     // Rearrange the columns in the result schema to match the order of the explicit column list,
     // if any.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDefaultColumns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDefaultColumns.scala
@@ -233,7 +233,7 @@ case class ResolveDefaultColumns(
       }.getOrElse(action)
     }
     val newNotMatchedActions: Seq[MergeAction] = m.notMatchedActions.map { action: MergeAction =>
-      val expanded = addMissingDefaultValuesForMergeAction(action, m, columnsWithDefaults)
+      val expanded = addMissingDefaultValuesForMergeAction(action, m, columnsWithDefaults.toSeq)
       replaceExplicitDefaultValuesInMergeAction(expanded, columnNamesToExpressions).map { r =>
         replaced = true
         r

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDefaultColumns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDefaultColumns.scala
@@ -24,7 +24,6 @@ import org.apache.spark.sql.catalyst.catalog.UnresolvedCatalogRelation
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules.Rule
-import org.apache.spark.sql.catalyst.util.CustomInsertSchema
 import org.apache.spark.sql.catalyst.util.ResolveDefaultColumns._
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDefaultColumns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDefaultColumns.scala
@@ -620,8 +620,6 @@ case class ResolveDefaultColumns(
 
   /**
    * Returns the schema for the target table of a DML command, looking into the catalog if needed.
-   * Includes a StructType representing the schema as well as a set of column names to exclude from
-   * consideration when performing INSERT INTO commands, if any.
    */
   private def getSchemaForTargetTable(table: LogicalPlan): Option[StructType] = {
     val resolved = table match {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDefaultColumns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDefaultColumns.scala
@@ -25,6 +25,7 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.util.ResolveDefaultColumns._
+import org.apache.spark.sql.connector.write.SupportsCustomSchemaWrite
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.internal.SQLConf
@@ -630,8 +631,8 @@ case class ResolveDefaultColumns(
     resolved.collectFirst {
       case r: UnresolvedCatalogRelation =>
         r.tableMeta.schema
-      case DataSourceV2Relation(table: CustomInsertSchema, _, _, _, _) =>
-        table.customInsertSchema
+      case DataSourceV2Relation(table: SupportsCustomSchemaWrite, _, _, _, _) =>
+        table.customSchemaForInserts
       case r: NamedRelation if !r.skipSchemaResolution =>
         r.schema
       case v: View if v.isTempViewStoringAnalyzedPlan =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ResolveDefaultColumnsUtil.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ResolveDefaultColumnsUtil.scala
@@ -224,7 +224,12 @@ object ResolveDefaultColumns {
       val result = if (analyzed.isInstanceOf[Literal] &&
         !Seq(dataType, analyzed.dataType).exists(_ == BooleanType)) {
         try {
-          Some(Literal(Cast(analyzed, dataType, evalMode = EvalMode.TRY).eval()))
+          val casted = Cast(analyzed, dataType, evalMode = EvalMode.TRY).eval()
+          if (casted != null) {
+            Some(Literal(casted))
+          } else {
+            None
+          }
         } catch {
           case _: SparkThrowable | _: RuntimeException => None
         }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ResolveDefaultColumnsUtil.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ResolveDefaultColumnsUtil.scala
@@ -221,7 +221,8 @@ object ResolveDefaultColumns {
     } else {
       // If the provided default value is a literal of a wider type than the target column, but the
       // literal value fits within the narrower type, just coerce it for convenience.
-      val result = if (analyzed.isInstanceOf[Literal] && analyzed.dataType != BooleanType) {
+      val result = if (analyzed.isInstanceOf[Literal] &&
+        !Seq(dataType, analyzed.dataType).exists(_ == BooleanType)) {
         try {
           Some(Literal(Cast(analyzed, dataType, evalMode = EvalMode.TRY).eval()))
         } catch {
@@ -359,12 +360,8 @@ object ResolveDefaultColumns {
   }
 }
 
-/**
- * Represents a table with an underlying raw schema to use for resolving DEFAULT column references.
- * The 'ignoreColumnsForInserts' field represents a set of column names to exclude from
- * consideration when performing INSERT INTO commands, if any.
- */
-trait TableWithRawSchemaForColumnDefaults {
-  def rawSchema: Option[StructType]
-  def ignoreColumnsForInserts: Set[String]
+trait CustomInsertSchema {
+  // Represents a table with a custom schema to use for resolving DEFAULT column references when
+  // inserting into the table. For example, this can be useful for excluding hidden pseudocolumns.
+  def customInsertSchema: StructType
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ResolveDefaultColumnsUtil.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ResolveDefaultColumnsUtil.scala
@@ -221,10 +221,13 @@ object ResolveDefaultColumns {
     } else {
       // If the provided default value is a literal of a wider type than the target column, but the
       // literal value fits within the narrower type, just coerce it for convenience. Exclude
-      // boolean types from consideration for this type coercion to avoid surprising behavior like
-      // interpreting "false" as integer zero.
+      // boolean/array/struct/map types from consideration for this type coercion to avoid
+      // surprising behavior like interpreting "false" as integer zero.
       val result = if (analyzed.isInstanceOf[Literal] &&
-        !Seq(dataType, analyzed.dataType).exists(_ == BooleanType)) {
+        !Seq(dataType, analyzed.dataType).exists(_ match {
+          case _: BooleanType | _: ArrayType | _: StructType | _: MapType => true
+          case _ => false
+        })) {
         try {
           val casted = Cast(analyzed, dataType, evalMode = EvalMode.TRY).eval()
           if (casted != null) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ResolveDefaultColumnsUtil.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ResolveDefaultColumnsUtil.scala
@@ -365,4 +365,3 @@ object ResolveDefaultColumns {
     }
   }
 }
-

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ResolveDefaultColumnsUtil.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ResolveDefaultColumnsUtil.scala
@@ -358,10 +358,11 @@ object ResolveDefaultColumns {
       v1Catalog.isPersistentFunction(ident.asFunctionIdentifier)
     }
   }
+
+  trait CustomInsertSchema {
+    // Represents a table with a custom schema to use for resolving DEFAULT column references when
+    // inserting into the table. For example, this can be useful for excluding hidden pseudocolumns.
+    def customInsertSchema: StructType
+  }
 }
 
-trait CustomInsertSchema {
-  // Represents a table with a custom schema to use for resolving DEFAULT column references when
-  // inserting into the table. For example, this can be useful for excluding hidden pseudocolumns.
-  def customInsertSchema: StructType
-}

--- a/sql/core/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveDefaultColumnsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveDefaultColumnsSuite.scala
@@ -101,8 +101,8 @@ class ResolveDefaultColumnsSuite extends QueryTest with SharedSparkSession {
         // If the provided default value is a literal of a completely different type than the target
         // column such that no coercion is possible, throw an error.
         assert(intercept[AnalysisException](
-          sql("create table demos.test_ts (id int default 'abc') using parquet"))
-          .getMessage.contains("statement provided a value of incompatible type"))
+          sql("create table demos.test_ts_other (id int default 'abc') using parquet"))
+        .getMessage.contains("statement provided a value of incompatible type"))
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveDefaultColumnsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveDefaultColumnsSuite.scala
@@ -20,8 +20,13 @@ package org.apache.spark.sql.catalyst.analysis
 import org.apache.spark.sql.{AnalysisException, QueryTest}
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.catalyst.util.ResolveDefaultColumns._
+import org.apache.spark.sql.connector.catalog.{Table, TableCapability}
+import org.apache.spark.sql.connector.write.SupportsCustomSchemaWrite
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.test.SharedSparkSession
-import org.apache.spark.sql.types.{IntegerType, StructField, StructType, TimestampType}
+import org.apache.spark.sql.types.{MetadataBuilder, StringType, StructField, StructType, TimestampType}
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 class ResolveDefaultColumnsSuite extends QueryTest with SharedSparkSession {
   val rule = ResolveDefaultColumns(null)
@@ -91,36 +96,110 @@ class ResolveDefaultColumnsSuite extends QueryTest with SharedSparkSession {
         checkAnswer(spark.table("demos.test_ts"),
           sql("select null, timestamp'2023-01-01'"))
       }
+    }
+  }
+
+  test("SPARK-43313: Column default values with implicit coercion from provided values") {
+    withDatabase("demos") {
+      sql("create database demos")
       withTable("demos.test_ts") {
         // If the provided default value is a literal of a wider type than the target column, but
         // the literal value fits within the narrower type, just coerce it for convenience.
-        sql("create table demos.test_ts (id int default 42L) using parquet")
-        sql("insert into demos.test_ts(id) values (default)")
+        sql(
+          """create table demos.test_ts (
+            |a int default 42L,
+            |b timestamp_ntz default '2022-01-02',
+            |c date default '2022-01-03',
+            |f float default 0D
+            |) using parquet""".stripMargin)
+        sql("insert into demos.test_ts(a) values (default)")
         checkAnswer(spark.table("demos.test_ts"),
-          sql("select 42"))
-        // If the provided default value is a literal of a completely different type than the target
-        // column such that no coercion is possible, throw an error.
-        assert(intercept[AnalysisException](
-          sql("create table demos.test_ts_other (id int default 'abc') using parquet"))
-        .getMessage.contains("statement provided a value of incompatible type"))
+          sql("select 42, timestamp_ntz'2022-01-02', date'2022-01-03', 0f"))
+        // If the provided default value is a literal of a different type than the target column
+        // such that no coercion is possible, throw an error.
+        Seq(
+          "create table demos.test_ts_other (a int default 'abc') using parquet",
+          "create table demos.test_ts_other (a timestamp default '2022-01-02') using parquet",
+          "create table demos.test_ts_other (a boolean default 'true') using parquet",
+          "create table demos.test_ts_other (a int default true) using parquet"
+        ).foreach { command =>
+          assert(intercept[AnalysisException](sql(command))
+            .getMessage.contains("statement provided a value of incompatible type"))
+        }
       }
     }
+  }
+
+  /**
+   * This is a new relation type that defines the 'customSchemaForInserts' method.
+   * Its implementation drops the last table column as it represents an internal pseudocolumn.
+   */
+  case class TableWithCustomInsertSchema(output: Seq[Attribute], numMetadataColumns: Int)
+    extends Table with SupportsCustomSchemaWrite {
+    override def name: String = "t"
+    override def schema: StructType = StructType.fromAttributes(output)
+    override def capabilities(): java.util.Set[TableCapability] =
+      new java.util.HashSet[TableCapability]()
+    override def customSchemaForInserts: StructType =
+      StructType(schema.fields.dropRight(numMetadataColumns))
+  }
+
+  /** Helper method to generate a DSV2 relation using the above table type. */
+  private def relationWithCustomInsertSchema(
+      output: Seq[AttributeReference], numMetadataColumns: Int): DataSourceV2Relation = {
+    DataSourceV2Relation(
+      TableWithCustomInsertSchema(output, numMetadataColumns),
+      output,
+      catalog = None,
+      identifier = None,
+      options = CaseInsensitiveStringMap.empty)
   }
 
   test("SPARK-43313: Add missing default values for MERGE INSERT actions") {
     val testRelation = SubqueryAlias(
       "testRelation",
-      LocalRelation(
-        AttributeReference("a", IntegerType)(),
-        AttributeReference("b", IntegerType)(),
-        AttributeReference("c", IntegerType)()))
+      relationWithCustomInsertSchema(Seq(
+        AttributeReference(
+          "a",
+          StringType,
+          true,
+          new MetadataBuilder()
+            .putString(CURRENT_DEFAULT_COLUMN_METADATA_KEY, "'a'")
+            .putString(EXISTS_DEFAULT_COLUMN_METADATA_KEY, "'a'")
+            .build())(),
+        AttributeReference(
+          "b",
+          StringType,
+          true,
+          new MetadataBuilder()
+            .putString(CURRENT_DEFAULT_COLUMN_METADATA_KEY, "'b'")
+            .putString(EXISTS_DEFAULT_COLUMN_METADATA_KEY, "'b'")
+            .build())(),
+        AttributeReference(
+          "c",
+          StringType,
+          true,
+          new MetadataBuilder()
+            .putString(CURRENT_DEFAULT_COLUMN_METADATA_KEY, "'c'")
+            .putString(EXISTS_DEFAULT_COLUMN_METADATA_KEY, "'c'")
+            .build())(),
+        AttributeReference(
+          "pseudocolumn",
+          StringType,
+          true,
+          new MetadataBuilder()
+            .putString(CURRENT_DEFAULT_COLUMN_METADATA_KEY, "'pseudocolumn'")
+            .putString(EXISTS_DEFAULT_COLUMN_METADATA_KEY, "'pseudocolumn'")
+            .build())()),
+        numMetadataColumns = 1))
     val testRelation2 =
       SubqueryAlias(
         "testRelation2",
-        LocalRelation(
-          AttributeReference("d", IntegerType)(),
-          AttributeReference("e", IntegerType)(),
-          AttributeReference("f", IntegerType)()))
+        relationWithCustomInsertSchema(Seq(
+          AttributeReference("d", StringType)(),
+          AttributeReference("e", StringType)(),
+          AttributeReference("f", StringType)()),
+        numMetadataColumns = 0))
     val mergePlan = MergeIntoTable(
       targetTable = testRelation,
       sourceTable = testRelation2,
@@ -135,22 +214,21 @@ class ResolveDefaultColumnsSuite extends QueryTest with SharedSparkSession {
               value = UnresolvedAttribute("DEFAULT")),
             Assignment(
               key = UnresolvedAttribute(Seq("testRelation", "b")),
-              value = Literal(42))))),
+              value = Literal("xyz"))))),
       notMatchedBySourceActions = Seq(DeleteAction(None)))
     // Run the 'addMissingDefaultValuesForMergeAction' method of the 'ResolveDefaultColumns' rule
     // on an MERGE INSERT action with two assignments, one to the target table's column 'a' and
-    // another to the target table's column 'b'. The result should include a new assignment to
-    // the target column 'c' from the unresolved attribute named "DEFAULT", to be replaced later.
+    // another to the target table's column 'b'.
     val columnNamesWithDefaults = Seq("a", "b", "c")
-    val actualMergeAction = rule.addMissingDefaultValuesForMergeAction(
-      mergePlan.notMatchedActions.head, mergePlan, columnNamesWithDefaults)
+    val actualMergeAction =
+      rule.apply(mergePlan).asInstanceOf[MergeIntoTable].notMatchedActions.head
     val expectedMergeAction =
       InsertAction(
         condition = None,
         assignments = Seq(
-          Assignment(key = UnresolvedAttribute("a"), value = UnresolvedAttribute("DEFAULT")),
-          Assignment(key = UnresolvedAttribute(Seq("testRelation", "b")), value = Literal(42)),
-          Assignment(key = UnresolvedAttribute("c"), value = UnresolvedAttribute("DEFAULT"))))
+          Assignment(key = UnresolvedAttribute("a"), value = Literal("a")),
+          Assignment(key = UnresolvedAttribute(Seq("testRelation", "b")), value = Literal("xyz")),
+          Assignment(key = UnresolvedAttribute("c"), value = Literal("c"))))
     assert(expectedMergeAction == actualMergeAction)
     // Run the same method on another MERGE DELETE action. There is no change because this method
     // only operates on MERGE INSERT actions.

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
@@ -1044,8 +1044,8 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
   test("SPARK-38336 INSERT INTO statements with tables with default columns: negative tests") {
     object Errors {
       val COMMON_SUBSTRING = " has a DEFAULT value"
-      val COLUMN_DEFAULT_NOT_FOUND = "The table or view `t` cannot be found"
       val BAD_SUBQUERY = "subquery expressions are not allowed in DEFAULT values"
+      val TARGET_TABLE_NOT_FOUND = "The table or view `t` cannot be found"
     }
     // The default value fails to analyze.
     withTable("t") {
@@ -1096,7 +1096,7 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
     withTable("t") {
       assert(intercept[AnalysisException] {
         sql("insert into t values(false, default)")
-      }.getMessage.contains(Errors.COLUMN_DEFAULT_NOT_FOUND))
+      }.getMessage.contains(Errors.TARGET_TABLE_NOT_FOUND))
     }
     // The default value parses but the type is not coercible.
     withTable("t") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
@@ -1044,7 +1044,7 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
   test("SPARK-38336 INSERT INTO statements with tables with default columns: negative tests") {
     object Errors {
       val COMMON_SUBSTRING = " has a DEFAULT value"
-      val COLUMN_DEFAULT_NOT_FOUND = "`default` cannot be resolved."
+      val COLUMN_DEFAULT_NOT_FOUND = "The table or view `t` cannot be found"
       val BAD_SUBQUERY = "subquery expressions are not allowed in DEFAULT values"
     }
     // The default value fails to analyze.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates column DEFAULT assignment to add missing values for MERGE INSERT actions. This brings the behavior to parity with non-MERGE INSERT commands.

* It also adds a small convenience feature where if the provided default value is a literal of a wider type than the target column, but the literal value fits within the narrower type, just coerce it for convenience. For example, `CREATE TABLE t (col INT DEFAULT 42L)` returns an error before this PR because `42L` has a long integer type which is wider than `col`, but after this PR we just coerce it to `42` since the value fits within the short integer range.
* We also add the `SupportsCustomSchemaWrite` interface which tables may implement to exclude certain pseudocolumns from consideration when resolving column DEFAULT values.

### Why are the changes needed?

These changes make column DEFAULT values more usable in more types of situations.

### Does this PR introduce _any_ user-facing change?

Yes, see above.

### How was this patch tested?

This PR adds new unit test coverage.