### PR TITLE
[SPARK-43323][SQL][PYTHON] Fix DataFrame.toPandas with Arrow enabled to handle exceptions properly

### DIFF
--- a/python/pyspark/errors/exceptions/captured.py
+++ b/python/pyspark/errors/exceptions/captured.py
@@ -14,8 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-from typing import Any, Callable, Dict, Optional, cast
+from contextlib import contextmanager
+from typing import Any, Callable, Dict, Iterator, Optional, cast
 
 import py4j
 from py4j.protocol import Py4JJavaError
@@ -184,6 +184,22 @@ def capture_sql_exception(f: Callable[..., Any]) -> Callable[..., Any]:
                 raise
 
     return deco
+
+
+@contextmanager
+def unwrap_spark_exception() -> Iterator[Any]:
+    assert SparkContext._gateway is not None
+
+    gw = SparkContext._gateway
+    try:
+        yield
+    except Py4JJavaError as e:
+        je: Py4JJavaError = e.java_exception
+        if je is not None and is_instance_of(gw, je, "org.apache.spark.SparkException"):
+            converted = convert_exception(je.getCause())
+            if not isinstance(converted, UnknownException):
+                raise converted from None
+        raise
 
 
 def install_exception_handler() -> None:

--- a/python/pyspark/sql/pandas/conversion.py
+++ b/python/pyspark/sql/pandas/conversion.py
@@ -19,6 +19,7 @@ from collections import Counter
 from typing import List, Optional, Type, Union, no_type_check, overload, TYPE_CHECKING
 from warnings import catch_warnings, simplefilter, warn
 
+from pyspark.errors.exceptions.captured import unwrap_spark_exception
 from pyspark.rdd import _load_from_socket
 from pyspark.sql.pandas.serializers import ArrowCollectSerializer
 from pyspark.sql.types import (
@@ -357,8 +358,6 @@ class PandasConversionMixin:
             else:
                 results = list(batch_stream)
         finally:
-            from pyspark.errors.exceptions.captured import unwrap_spark_exception
-
             with unwrap_spark_exception():
                 # Join serving thread and raise any exceptions from collectAsArrowToPython
                 jsocket_auth_server.getResult()

--- a/python/pyspark/sql/pandas/conversion.py
+++ b/python/pyspark/sql/pandas/conversion.py
@@ -357,8 +357,11 @@ class PandasConversionMixin:
             else:
                 results = list(batch_stream)
         finally:
-            # Join serving thread and raise any exceptions from collectAsArrowToPython
-            jsocket_auth_server.getResult()
+            from pyspark.errors.exceptions.captured import unwrap_spark_exception
+
+            with unwrap_spark_exception():
+                # Join serving thread and raise any exceptions from collectAsArrowToPython
+                jsocket_auth_server.getResult()
 
         # Separate RecordBatches from batch order indices in results
         batches = results[:-1]

--- a/python/pyspark/sql/tests/connect/test_parity_arrow.py
+++ b/python/pyspark/sql/tests/connect/test_parity_arrow.py
@@ -103,6 +103,9 @@ class ArrowParityTests(ArrowTestsMixin, ReusedConnectTestCase):
     def test_timestamp_nat(self):
         self.check_timestamp_nat(True)
 
+    def test_error(self):
+        self.check_error(True)
+
 
 if __name__ == "__main__":
     from pyspark.sql.tests.connect.test_parity_arrow import *  # noqa: F401

--- a/python/pyspark/sql/tests/connect/test_parity_arrow.py
+++ b/python/pyspark/sql/tests/connect/test_parity_arrow.py
@@ -103,8 +103,8 @@ class ArrowParityTests(ArrowTestsMixin, ReusedConnectTestCase):
     def test_timestamp_nat(self):
         self.check_timestamp_nat(True)
 
-    def test_error(self):
-        self.check_error(True)
+    def test_toPandas_error(self):
+        self.check_toPandas_error(True)
 
 
 if __name__ == "__main__":

--- a/python/pyspark/sql/tests/test_arrow.py
+++ b/python/pyspark/sql/tests/test_arrow.py
@@ -873,12 +873,12 @@ class ArrowTestsMixin:
         self.assertEqual([Row(c1=1, c2="string")], df.collect())
         self.assertGreater(self.spark.sparkContext.defaultParallelism, len(pdf))
 
-    def test_error(self):
+    def test_toPandas_error(self):
         for arrow_enabled in [True, False]:
             with self.subTest(arrow_enabled=arrow_enabled):
-                self.check_error(arrow_enabled)
+                self.check_toPandas_error(arrow_enabled)
 
-    def check_error(self, arrow_enabled):
+    def check_toPandas_error(self, arrow_enabled):
         with self.sql_conf(
             {
                 "spark.sql.ansi.enabled": True,


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fixes `DataFrame.toPandas` with Arrow enabled to handle exceptions properly.

```py
>>> spark.conf.set("spark.sql.ansi.enabled", True)
>>> spark.conf.set('spark.sql.execution.arrow.pyspark.enabled', True)
>>> spark.sql("select 1/0").toPandas()
...
Traceback (most recent call last):
...
pyspark.errors.exceptions.captured.ArithmeticException: [DIVIDE_BY_ZERO] Division by zero. Use `try_divide` to tolerate divisor being 0 and return NULL instead. If necessary set "spark.sql.ansi.enabled" to "false" to bypass this error.
== SQL(line 1, position 8) ==
select 1/0
       ^^^

```

### Why are the changes needed?

Currently `DataFrame.toPandas` doesn't capture exceptions happened in Spark properly.

```py
>>> spark.conf.set("spark.sql.ansi.enabled", True)
>>> spark.conf.set('spark.sql.execution.arrow.pyspark.enabled', True)
>>> spark.sql("select 1/0").toPandas()
...
  An error occurred while calling o53.getResult.
: org.apache.spark.SparkException: Exception thrown in awaitResult:
	at org.apache.spark.util.ThreadUtils$.awaitResult(ThreadUtils.scala:322)
...
```

because `jsocket_auth_server.getResult()` always wraps the thrown exceptions with `SparkException` that won't be captured.

Whereas without Arrow:

```py
>>> spark.conf.set("spark.sql.ansi.enabled", True)
>>> spark.conf.set('spark.sql.execution.arrow.pyspark.enabled', False)
>>> spark.sql("select 1/0").toPandas()
Traceback (most recent call last):
...
pyspark.errors.exceptions.captured.ArithmeticException: [DIVIDE_BY_ZERO] Division by zero. Use `try_divide` to tolerate divisor being 0 and return NULL instead. If necessary set "spark.sql.ansi.enabled" to "false" to bypass this error.
== SQL(line 1, position 8) ==
select 1/0
       ^^^
```

### Does this PR introduce _any_ user-facing change?

`DataFrame.toPandas` with Arrow enabled will show a proper exception.

### How was this patch tested?

Added the related test.