### PR TITLE
[SPARK-43328][SS] Add latest timestamp on no-execution trigger for Idle event in streaming query listener

### DIFF
--- a/python/pyspark/sql/streaming/listener.py
+++ b/python/pyspark/sql/streaming/listener.py
@@ -228,6 +228,7 @@ class QueryIdleEvent:
     def __init__(self, jevent: JavaObject) -> None:
         self._id: uuid.UUID = uuid.UUID(jevent.id().toString())
         self._runId: uuid.UUID = uuid.UUID(jevent.runId().toString())
+        self._timestamp: str = jevent.timestamp()
 
     @property
     def id(self) -> uuid.UUID:
@@ -244,6 +245,13 @@ class QueryIdleEvent:
         py:meth:`~pyspark.sql.streaming.StreamingQuery.runId`.
         """
         return self._runId
+
+    @property
+    def timestamp(self) -> str:
+        """
+        The timestamp when the latest no-batch trigger happened.
+        """
+        return self._timestamp
 
 
 class QueryTerminatedEvent:

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/ProgressReporter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/ProgressReporter.scala
@@ -154,8 +154,9 @@ trait ProgressReporter extends Logging {
   }
 
   private def postIdleness(): Unit = {
-    postEvent(new QueryIdleEvent(id, runId))
-    logInfo("Streaming query has been idle and waiting for new data.")
+    postEvent(new QueryIdleEvent(id, runId, formatTimestamp(currentTriggerStartTimestamp)))
+    logInfo(s"Streaming query has been idle and waiting for new data more than " +
+      s"${noDataProgressEventInterval} ms.")
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryListener.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryListener.scala
@@ -140,7 +140,8 @@ object StreamingQueryListener {
   @Evolving
   class QueryIdleEvent private[sql](
       val id: UUID,
-      val runId: UUID) extends Event
+      val runId: UUID,
+      val timestamp: String) extends Event
 
   /**
    * Event representing that termination of a query.

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryListener.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryListener.scala
@@ -135,6 +135,10 @@ object StreamingQueryListener {
 
   /**
    * Event representing that query is idle and waiting for new data to process.
+   *
+   * @param id    A unique query id that persists across restarts. See `StreamingQuery.id()`.
+   * @param runId A query id that is unique for every start/restart. See `StreamingQuery.runId()`.
+   * @param timestamp The timestamp when the latest no-batch trigger happened.
    * @since 3.5.0
    */
   @Evolving


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to add the latest timestamp on no-execution trigger for QueryIdleEvent.

### Why are the changes needed?

This adds a "human readable" timestamp which is useful for user side verification as well as be consistent with other events.

### Does this PR introduce _any_ user-facing change?

Yes, but QueryIdleEvent is not released yet.

### How was this patch tested?

Existing tests.