### PR TITLE
Update ExecutorAllocationManager.scala

### DIFF
--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/ExecutorAllocationManager.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/ExecutorAllocationManager.scala
@@ -102,6 +102,9 @@ private[streaming] class ExecutorAllocationManager(
         logDebug("Killing executors")
         killExecutor()
       }
+      else {
+        logWarning("Cannot Kill Anymore Executors")
+      }
     }
     batchProcTimeSum = 0
     batchProcTimeCount = 0


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fixed minor issues & added a simple statement to ensure the program doesn't allow killing all executors. 



### Why are the changes needed?

The dynamic alloc config hangs when the minexec count is 0 



### Does this PR introduce _any_ user-facing change?

It does, but it does not affect the user in any way, just shows a warning message. 



### How was this patch tested?

This was done on a test cluster. The cluster does run without problems but I feel there are additional safety methods we could add. I'm working on finding a way to calculate and run on an optimal number of clusters so this problem is not repeated. 

