### PR TITLE
[SPARK-432265][CORE][FOLLOW-UP] Add Mima excludes of ErrorInfo and ErrorSubInfo for Scala 2.13

### DIFF
--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -76,6 +76,8 @@ object MimaExcludes {
     ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.SparkException"),
     ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.SparkException$"),
     ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.SparkThrowable"),
+    ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.ErrorInfo$"),
+    ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.ErrorSubInfo$"),
 
     (problem: Problem) => problem match {
       case MissingClassProblem(cls) => !cls.fullName.startsWith("org.sparkproject.jpmml") &&


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/40931 that excludes `org.apache.spark.ErrorInfo$` and `org.apache.spark.ErrorSubInfo$` for binary compatibility in Scala 2.13.

### Why are the changes needed?

This is broken, see https://github.com/apache/spark/actions/runs/4854026308/jobs/8650909982.
This PR recovers the scheduled build.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manually.