### PR TITLE
[MINOR][CONNECT][DOC] Add information on how to regenerate proto for python client

### DIFF
--- a/connector/connect/README.md
+++ b/connector/connect/README.md
@@ -21,16 +21,27 @@ user experience across all languages. Please follow the below guidelines:
 
 Python-specific development guidelines are located in [python/docs/source/development/testing.rst](https://github.com/apache/spark/blob/master/python/docs/source/development/testing.rst) that is published at [Development tab](https://spark.apache.org/docs/latest/api/python/development/index.html) in PySpark documentation.
 
-When adding new proto messages, the python proto code need to be regenerated. To do it, use `dev/connect-gen-protos.sh` script.
-It depends on
-```
-brew install bufbuild/buf/buf
-```
-and python dependencies from
+To generate the Python client code from the proto files,
+
+First, make sure to have a Python environment with the installed dependencies.
+Specifically, install `black` and dependencies from the "Spark Connect python proto generation plugin (optional)" section.
+
+
 ```
 pip install -r dev/requirements.txt
 ```
-(specifically, install `black` and dependencies from "Spark Connect python proto generation plugin (optional)" section)
+
+Install [buf](https://github.com/bufbuild/buf)
+
+```
+brew install bufbuild/buf/buf
+```
+
+Generate the Python files by running:
+
+```
+dev/connect-gen-protos.sh
+```
 
 ### Build with user-defined `protoc` and `protoc-gen-grpc-java`
 

--- a/connector/connect/README.md
+++ b/connector/connect/README.md
@@ -21,7 +21,7 @@ user experience across all languages. Please follow the below guidelines:
 
 Python-specific development guidelines are located in [python/docs/source/development/testing.rst](https://github.com/apache/spark/blob/master/python/docs/source/development/testing.rst) that is published at [Development tab](https://spark.apache.org/docs/latest/api/python/development/index.html) in PySpark documentation.
 
-To generate the Python client code from the proto files,
+To generate the Python client code from the proto files:
 
 First, make sure to have a Python environment with the installed dependencies.
 Specifically, install `black` and dependencies from the "Spark Connect python proto generation plugin (optional)" section.

--- a/connector/connect/README.md
+++ b/connector/connect/README.md
@@ -21,6 +21,17 @@ user experience across all languages. Please follow the below guidelines:
 
 Python-specific development guidelines are located in [python/docs/source/development/testing.rst](https://github.com/apache/spark/blob/master/python/docs/source/development/testing.rst) that is published at [Development tab](https://spark.apache.org/docs/latest/api/python/development/index.html) in PySpark documentation.
 
+When adding new proto messages, the python proto code need to be regenerated. To do it, use `dev/connect-gen-protos.sh` script.
+It depends on
+```
+brew install bufbuild/buf/buf
+```
+and python dependencies from
+```
+pip install -r dev/requirements.txt
+```
+(specifically, install `black` and dependencies from "Spark Connect python proto generation plugin (optional)" section)
+
 ### Build with user-defined `protoc` and `protoc-gen-grpc-java`
 
 When the user cannot use the official `protoc` and `protoc-gen-grpc-java` binary files to build the `connect` module in the compilation environment,


### PR DESCRIPTION
### What changes were proposed in this pull request?

Figuring out how to generate connect grpc proto in python was surprisingly hard to figure out for me (not knowing much about python development though), so adding it to the README.

### Why are the changes needed?

Improving internal documentation.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Not applicable.