### PR TITLE
[SPARK-16484][SQL] Use 8-bit registers for representing DataSketches

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datasketchesExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datasketchesExpressions.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.catalyst.expressions
 
-import org.apache.datasketches.hll.{HllSketch, Union}
+import org.apache.datasketches.hll.{HllSketch, TgtHllType, Union}
 import org.apache.datasketches.memory.Memory
 
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
@@ -76,6 +76,9 @@ case class HllUnion(first: Expression, second: Expression, third: Expression)
     with ExpectsInputTypes
     with NullIntolerant {
 
+  // The default target type (register size) to use.
+  private val targetType = TgtHllType.HLL_8
+
   def this(first: Expression, second: Expression) = {
     this(first, second, Literal(false))
   }
@@ -108,6 +111,6 @@ case class HllUnion(first: Expression, second: Expression, third: Expression)
     val union = new Union(Math.min(sketch1.getLgConfigK, sketch2.getLgConfigK))
     union.update(sketch1)
     union.update(sketch2)
-    union.getResult.toUpdatableByteArray
+    union.getResult(targetType).toUpdatableByteArray
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up PR to #40615.

In this PR we make sure that all sketches produces by the new expressions `hll_sketch_agg`, `hll_union_agg`, and `hll_union` are actually HLL DataSketches represented with 8-bit registers.

Using 8-bit registers improves the performance of the expressions at the expense of using more memory (the current implementation uses 4-bit registers by default, which is the default choice in the DataSketches library).

Note that the register size of the DataSketches HLL sketch does not have any impact on the accuracy of the sketch.

### Why are the changes needed?

To improve the performance of the new HLL-related expressions.

### Does this PR introduce _any_ user-facing change?

No in terms of SQL surface. However, the results of the `hll_sketch_agg`, `hll_union_agg`, and `hll_union` expressions can be different since we are changing the sketch representation. However, since these expressions have not been released yet we are not facing any breaking changes.

### How was this patch tested?

Existing tests suffice.
