### PR TITLE
[SPARK-43349][PS][TEST] Fix flaky test for `DataFrame` creation

### DIFF
--- a/python/pyspark/pandas/tests/test_dataframe.py
+++ b/python/pyspark/pandas/tests/test_dataframe.py
@@ -238,14 +238,22 @@ class DataFrameTestsMixin:
         with ps.option_context("compute.ops_on_diff_frames", True):
             # test with ps.DataFrame and pd.Index
             self.assert_eq(
-                ps.DataFrame(data=psdf, index=pd.Index(["Hello", "Universe", "Databricks"])),
-                pd.DataFrame(data=pdf, index=pd.Index(["Hello", "Universe", "Databricks"])),
+                ps.DataFrame(
+                    data=psdf, index=pd.Index(["Hello", "Universe", "Databricks"])
+                ).sort_index(),
+                pd.DataFrame(
+                    data=pdf, index=pd.Index(["Hello", "Universe", "Databricks"])
+                ).sort_index(),
             )
 
             # test with ps.DataFrame and ps.Index
             self.assert_eq(
-                ps.DataFrame(data=psdf, index=ps.Index(["Hello", "Universe", "Databricks"])),
-                pd.DataFrame(data=pdf, index=pd.Index(["Hello", "Universe", "Databricks"])),
+                ps.DataFrame(
+                    data=psdf, index=ps.Index(["Hello", "Universe", "Databricks"])
+                ).sort_index(),
+                pd.DataFrame(
+                    data=pdf, index=pd.Index(["Hello", "Universe", "Databricks"])
+                ).sort_index(),
             )
 
         # test DatetimeIndex


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to fix DataFrame creating test since it's flaky failing within some envs as below:
```
DataFrame.index values are different (100.0 %)
[left]:  Index(['Databricks', 'Hello', 'Universe'], dtype='object')
[right]: Index(['Hello', 'Universe', 'Databricks'], dtype='object')

Left:
                 x
Databricks  2004.0
Hello       2002.0
Universe       NaN
x    float64
dtype: object

Right:
                 x
Hello       2002.0
Universe       NaN
Databricks  2004.0
x    float64
dtype: object
```


### Why are the changes needed?

Fix flaky test

### Does this PR introduce _any_ user-facing change?

No, test-only

### How was this patch tested?

Manually tested.