### PR TITLE
[SPARK-43350][BUILD] Upgrade `scalafmt` to 3.7.3

### DIFF
--- a/dev/.scalafmt.conf
+++ b/dev/.scalafmt.conf
@@ -32,4 +32,4 @@ fileOverride {
     runner.dialect = scala213
   }
 }
-version = 3.7.2
+version = 3.7.3


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade scalafmt from 3.7.2 to 3.7.3

### Why are the changes needed?
A. Release note:
> https://github.com/scalameta/scalafmt/releases

B. V3.7.2 VS V3.7.3
> https://github.com/scalameta/scalafmt/compare/v3.7.2...v3.7.3

C. Bring bug fix:
<img width="571" alt="image" src="https://user-images.githubusercontent.com/15246973/235818482-83649ebd-a9a5-4036-8457-f3ee108d427c.png">

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA.