### PR TITLE
[SPARK-43357][SQL] Filter date type quote date

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
@@ -880,7 +880,7 @@ private[client] class Shim_v0_13 extends Shim_v0_12 {
         case Literal(value, _: IntegralType) => Some(value.toString)
         case Literal(value, _: StringType) => Some(quoteStringLiteral(value.toString))
         case Literal(value, _: DateType) =>
-          Some(dateFormatter.format(value.asInstanceOf[Int]))
+          Some(quoteStringLiteral(dateFormatter.format(value.asInstanceOf[Int])))
         case _ => None
       }
     }
@@ -933,7 +933,7 @@ private[client] class Shim_v0_13 extends Shim_v0_12 {
 
     object ExtractableDateValues {
       private lazy val valueToLiteralString: PartialFunction[Any, String] = {
-        case value: Int => dateFormatter.format(value)
+        case value: Int => quoteStringLiteral(dateFormatter.format(value))
       }
 
       def unapply(values: Set[Any]): Option[Seq[String]] = {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/FiltersSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/FiltersSuite.scala
@@ -66,17 +66,17 @@ class FiltersSuite extends SparkFunSuite with PlanTest {
 
   filterTest("date filter",
     (a("datecol", DateType) === Literal(Date.valueOf("2019-01-01"))) :: Nil,
-    "datecol = 2019-01-01")
+    "datecol = \"2019-01-01\"")
 
   filterTest("date filter with IN predicate",
     (a("datecol", DateType) in
       (Literal(Date.valueOf("2019-01-01")), Literal(Date.valueOf("2019-01-07")))) :: Nil,
-    "(datecol = 2019-01-01 or datecol = 2019-01-07)")
+    "(datecol = \"2019-01-01\" or datecol = \"2019-01-07\")")
 
   filterTest("date and string filter",
     (Literal(Date.valueOf("2019-01-01")) === a("datecol", DateType)) ::
       (Literal("a") === a("strcol", IntegerType)) :: Nil,
-    "2019-01-01 = datecol and \"a\" = strcol")
+    "\"2019-01-01\" = datecol and \"a\" = strcol")
 
   filterTest("date filter with null",
     (a("datecol", DateType) ===  Literal(null)) :: Nil,
@@ -105,7 +105,7 @@ class FiltersSuite extends SparkFunSuite with PlanTest {
 
   filterTest("NOT: date filter",
     (a("datecol", DateType) =!= Literal(Date.valueOf("2019-01-01"))) :: Nil,
-    "datecol != 2019-01-01")
+    "datecol != \"2019-01-01\"")
 
   filterTest("not-in, string filter",
     (Not(In(a("strcol", StringType), Seq(Literal("a"), Literal("b"))))) :: Nil,
@@ -118,7 +118,7 @@ class FiltersSuite extends SparkFunSuite with PlanTest {
   filterTest("not-in, date filter",
     (Not(In(a("datecol", DateType),
       Seq(Literal(Date.valueOf("2021-01-01")), Literal(Date.valueOf("2021-01-02")))))) :: Nil,
-    """(datecol != 2021-01-01 and datecol != 2021-01-02)""")
+    """(datecol != "2021-01-01" and datecol != "2021-01-02")""")
 
   filterTest("not-in, date filter with null",
     (Not(In(a("datecol", DateType),
@@ -139,7 +139,7 @@ class FiltersSuite extends SparkFunSuite with PlanTest {
     (Not(InSet(a("datecol", DateType),
       Set(Literal(Date.valueOf("2020-01-01")).eval(),
         Literal(Date.valueOf("2020-01-02")).eval())))) :: Nil,
-    """(datecol != 2020-01-01 and datecol != 2020-01-02)""")
+    """(datecol != "2020-01-01" and datecol != "2020-01-02")""")
 
   filterTest("not-inset, date filter with null",
     (Not(InSet(a("datecol", DateType),
@@ -215,7 +215,7 @@ class FiltersSuite extends SparkFunSuite with PlanTest {
       checkConverted(
         InSet(a("datecol", DateType),
           Range(1, 20).map(d => Literal(d, DateType).eval(EmptyRow)).toSet),
-        "(datecol >= 1970-01-02 and datecol <= 1970-01-20)")
+        "(datecol >= \"1970-01-02\" and datecol <= \"1970-01-20\")")
     }
   }
 
@@ -246,7 +246,7 @@ class FiltersSuite extends SparkFunSuite with PlanTest {
       val dateFilter = InSet(a("p", DateType), Set(null,
         Literal(Date.valueOf("2020-01-01")).eval(), Literal(Date.valueOf("2021-01-01")).eval()))
       val dateConverted = shim.convertFilters(testTable, Seq(dateFilter))
-      assert(dateConverted == "(p = 2020-01-01 or p = 2021-01-01)")
+      assert(dateConverted == "(p = \"2020-01-01\" or p = \"2021-01-01\")")
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

In this PR the date value is quoted before being sent to the hive metastore


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Glue for example expects the dates to be quoted, without quotes we get errors.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Changed the result of unit tests, also tested by running the fix against glue