### PR TITLE
[SPARK-43363][SQL][PYTHON] Make to call `astype` to the category type only when the arrow type is not provided

### DIFF
--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -207,6 +207,7 @@ class ArrowStreamPandasSerializer(ArrowStreamSerializer):
             _check_series_convert_timestamps_internal,
             _convert_dict_to_map_items,
         )
+        from pandas.api.types import is_categorical_dtype
 
         # Make input conform to [(series1, type1), (series2, type2), ...]
         if not isinstance(series, (list, tuple)) or (
@@ -225,6 +226,8 @@ class ArrowStreamPandasSerializer(ArrowStreamSerializer):
                 s = _check_series_convert_timestamps_internal(s, self._timezone)
             elif t is not None and pa.types.is_map(t):
                 s = _convert_dict_to_map_items(s)
+            elif t is None and is_categorical_dtype(s.dtype):
+                s = s.astype(s.dtypes.categories.dtype)
             try:
                 array = pa.Array.from_pandas(s, mask=mask, type=t, safe=self._safecheck)
             except TypeError as e:

--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -207,7 +207,6 @@ class ArrowStreamPandasSerializer(ArrowStreamSerializer):
             _check_series_convert_timestamps_internal,
             _convert_dict_to_map_items,
         )
-        from pandas.api.types import is_categorical_dtype
 
         # Make input conform to [(series1, type1), (series2, type2), ...]
         if not isinstance(series, (list, tuple)) or (
@@ -226,9 +225,6 @@ class ArrowStreamPandasSerializer(ArrowStreamSerializer):
                 s = _check_series_convert_timestamps_internal(s, self._timezone)
             elif t is not None and pa.types.is_map(t):
                 s = _convert_dict_to_map_items(s)
-            elif is_categorical_dtype(s.dtype):
-                # Note: This can be removed once minimum pyarrow version is >= 0.16.1
-                s = s.astype(s.dtypes.categories.dtype)
             try:
                 array = pa.Array.from_pandas(s, mask=mask, type=t, safe=self._safecheck)
             except TypeError as e:


### PR DESCRIPTION
### What changes were proposed in this pull request?

Makes to call `astype` to the category type only when the arrow type is not provided.

### Why are the changes needed?

Now that the minimum version of pyarrow is `1.0.0`, a workaround for pandas' categorical type for pyarrow can be removed if the arrow type is provided.

> Note: This can be removed once minimum pyarrow version is >= 0.16.1

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests.