### PR TITLE
[SPARK-43340][CORE] Handle missing stack-trace field in eventlogs

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
@@ -1555,18 +1555,13 @@ private[spark] object JsonProtocol {
   }
 
   def stackTraceFromJson(json: JsonNode): Array[StackTraceElement] = {
-    jsonOption(json)
-      .map(
-        _.extractElements
-          .map { line =>
-            val declaringClass = line.get("Declaring Class").extractString
-            val methodName = line.get("Method Name").extractString
-            val fileName = jsonOption(line.get("File Name")).map(_.extractString).orNull
-            val lineNumber = line.get("Line Number").extractInt
-            new StackTraceElement(declaringClass, methodName, fileName, lineNumber)
-          }
-          .toArray)
-      .getOrElse(Array[StackTraceElement]())
+    jsonOption(json).map(_.extractElements.map { line =>
+      val declaringClass = line.get("Declaring Class").extractString
+      val methodName = line.get("Method Name").extractString
+      val fileName = jsonOption(line.get("File Name")).map(_.extractString).orNull
+      val lineNumber = line.get("Line Number").extractInt
+      new StackTraceElement(declaringClass, methodName, fileName, lineNumber)
+    }.toArray).getOrElse(Array[StackTraceElement]())
   }
 
   def exceptionFromJson(json: JsonNode): Exception = {

--- a/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
@@ -1555,13 +1555,18 @@ private[spark] object JsonProtocol {
   }
 
   def stackTraceFromJson(json: JsonNode): Array[StackTraceElement] = {
-    json.extractElements.map { line =>
-      val declaringClass = line.get("Declaring Class").extractString
-      val methodName = line.get("Method Name").extractString
-      val fileName = jsonOption(line.get("File Name")).map(_.extractString).orNull
-      val lineNumber = line.get("Line Number").extractInt
-      new StackTraceElement(declaringClass, methodName, fileName, lineNumber)
-    }.toArray
+    jsonOption(json)
+      .map(
+        _.extractElements
+          .map { line =>
+            val declaringClass = line.get("Declaring Class").extractString
+            val methodName = line.get("Method Name").extractString
+            val fileName = jsonOption(line.get("File Name")).map(_.extractString).orNull
+            val lineNumber = line.get("Line Number").extractInt
+            new StackTraceElement(declaringClass, methodName, fileName, lineNumber)
+          }
+          .toArray)
+      .getOrElse(Array[StackTraceElement]())
   }
 
   def exceptionFromJson(json: JsonNode): Exception = {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

This PR fixes a regression introduced by #36885 which broke JsonProtocol's ability to handle missing fields from exception field. old eventlogs missing a `Stack Trace` will raise a NPE.  
As a result, SHS misinterprets  failed-jobs/SQLs as `Active/Incomplete` 

This PR solves this problem by checking the JsonNode for null. If it is null, an empty array of `StackTraceElements`


### Why are the changes needed?

Fix a case which prevents the history server from identifying failed jobs if the stacktrace was not set.

Example eventlog

```
{
   "Event":"SparkListenerJobEnd",
   "Job ID":31,
   "Completion Time":1616171909785,
   "Job Result":{
      "Result":"JobFailed",
      "Exception":{
         "Message":"Job aborted"
      }
   }
} 
```

**Original behavior:**

The job is marked as `incomplete`

Error from the SHS logs:

```
23/05/01 21:57:16 INFO FsHistoryProvider: Parsing file:/tmp/nds_q86_fail_test to re-build UI...
23/05/01 21:57:17 ERROR ReplayListenerBus: Exception parsing Spark event log: file:/tmp/nds_q86_fail_test
java.lang.NullPointerException
    at org.apache.spark.util.JsonProtocol$JsonNodeImplicits.extractElements(JsonProtocol.scala:1589)
    at org.apache.spark.util.JsonProtocol$.stackTraceFromJson(JsonProtocol.scala:1558)
    at org.apache.spark.util.JsonProtocol$.exceptionFromJson(JsonProtocol.scala:1569)
    at org.apache.spark.util.JsonProtocol$.jobResultFromJson(JsonProtocol.scala:1423)
    at org.apache.spark.util.JsonProtocol$.jobEndFromJson(JsonProtocol.scala:967)
    at org.apache.spark.util.JsonProtocol$.sparkEventFromJson(JsonProtocol.scala:878)
    at org.apache.spark.util.JsonProtocol$.sparkEventFromJson(JsonProtocol.scala:865)
....
23/05/01 21:57:17 ERROR ReplayListenerBus: Malformed line #24368: {"Event":"SparkListenerJobEnd","Job ID":31,"Completion Time":1616171909785,"Job Result":{"Result":"JobFailed","Exception":
{"Message":"Job aborted"}
}}
```

**After the fix:**

Job 31 is marked as `failedJob`

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Added new unit test in JsonProtocolSuite.