### PR TITLE
[SPARK-43379][DOCS] Deprecate old Java 8 versions prior to 8u371

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -35,7 +35,7 @@ source, visit [Building Spark](building-spark.html).
 Spark runs on both Windows and UNIX-like systems (e.g. Linux, Mac OS), and it should run on any platform that runs a supported version of Java. This should include JVMs on x86_64 and ARM64. It's easy to run locally on one machine --- all you need is to have `java` installed on your system `PATH`, or the `JAVA_HOME` environment variable pointing to a Java installation.
 
 Spark runs on Java 8/11/17, Scala 2.12/2.13, Python 3.8+, and R 3.5+.
-Java 8 prior to version 8u362 support is deprecated as of Spark 3.4.0.
+Java 8 prior to version 8u371 support is deprecated as of Spark 3.5.0.
 When using the Scala API, it is necessary for applications to use the same version of Scala that Spark was compiled for.
 For example, when using Scala 2.13, use Spark compiled for 2.13, and compile code/applications for Scala 2.13 as well.
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to deprecate old Java 8 versions prior to 8u371.

Specifically, it's fixed at Java SE 8u371, 11.0.19, 17.0.7, 20.0.1.

### Why are the changes needed?

To avoid TLS issue
- [OpenJDK: improper connection handling during TLS handshake](https://bugzilla.redhat.com/show_bug.cgi?id=2187435)
- https://www.oracle.com/security-alerts/cpuapr2023.html#AppendixJAVA

Release notes:
- https://www.oracle.com/java/technologies/javase/8u371-relnotes.html
- https://www.oracle.com/java/technologies/javase/11-0-19-relnotes.html
- https://www.oracle.com/java/technologies/javase/17-0-7-relnotes.html
- https://www.oracle.com/java/technologies/javase/20-0-1-relnotes.html

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.