### PR TITLE
[SPARK-43284][SQL][FOLLOWUP] Return URI encoded path, and add a test

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormat.scala
@@ -267,7 +267,7 @@ object FileFormat {
   val BASE_METADATA_EXTRACTORS: Map[String, PartitionedFile => Any] = Map(
     FILE_PATH -> { pf: PartitionedFile =>
       // Use new Path(Path.toString).toString as a form of canonicalization
-      new Path(pf.filePath.toPath.toString).toString
+      new Path(pf.filePath.toPath.toString).toUri.toString
     },
     FILE_NAME -> { pf: PartitionedFile =>
       pf.filePath.toUri.getRawPath.split("/").lastOption.getOrElse("")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormat.scala
@@ -266,7 +266,7 @@ object FileFormat {
    */
   val BASE_METADATA_EXTRACTORS: Map[String, PartitionedFile => Any] = Map(
     FILE_PATH -> { pf: PartitionedFile =>
-      // Use new Path(Path.toString).toString as a form of canonicalization
+      // Use `new Path(Path.toString)` as a form of canonicalization
       new Path(pf.filePath.toPath.toString).toUri.toString
     },
     FILE_NAME -> { pf: PartitionedFile =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileMetadataStructSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileMetadataStructSuite.scala
@@ -982,7 +982,25 @@ class FileMetadataStructSuite extends QueryTest with SharedSparkSession {
 
 
   Seq("parquet", "json", "csv", "text", "orc").foreach { format =>
-    test(s"metadata file path and name are url encoded for format: $format") {
+    test(s"metadata file path is url encoded for format: $format") {
+      withTempPath { f =>
+        val dirWithSpace = s"$f/with space"
+        spark.range(10)
+          .selectExpr("cast(id as string) as str")
+          .repartition(1)
+          .write
+          .format(format)
+          .mode("append")
+          .save(dirWithSpace)
+
+        val encodedPath = SparkPath.fromPathString(dirWithSpace).urlEncoded
+        val df = spark.read.format(format).load(dirWithSpace)
+        val metadataPath = df.select(METADATA_FILE_PATH).as[String].head()
+        assert(metadataPath.contains(encodedPath))
+      }
+    }
+
+    test(s"metadata file name is url encoded for format: $format") {
       val suffix = if (format == "text") ".txt" else s".$format"
       withTempPath { f =>
         val dirWithSpace = s"$f/with space"


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Return URI encoded path, and add a test


### Why are the changes needed?
Fix regression in spark 3.4.


### Does this PR introduce _any_ user-facing change?
Yes, fixes a regression in `_metadata.file_path`.


### How was this patch tested?
New explicit test.
