### PR TITLE
[SPARK-43381][CONNECT] Make 'transformStatCov' lazy

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -68,6 +68,7 @@ import org.apache.spark.sql.execution.command.CreateViewCommand
 import org.apache.spark.sql.execution.datasources.LogicalRelation
 import org.apache.spark.sql.execution.datasources.jdbc.{JDBCOptions, JDBCPartition, JDBCRelation}
 import org.apache.spark.sql.execution.python.UserDefinedPythonFunction
+import org.apache.spark.sql.execution.stat.StatFunctions
 import org.apache.spark.sql.execution.streaming.StreamingQueryWrapper
 import org.apache.spark.sql.internal.CatalogImpl
 import org.apache.spark.sql.streaming.Trigger
@@ -401,13 +402,10 @@ class SparkConnectPlanner(val session: SparkSession) {
   }
 
   private def transformStatCov(rel: proto.StatCov): LogicalPlan = {
-    val cov = Dataset
-      .ofRows(session, transformRelation(rel.getInput))
-      .stat
-      .cov(rel.getCol1, rel.getCol2)
-    LocalRelation.fromProduct(
-      output = AttributeReference("cov", DoubleType, false)() :: Nil,
-      data = Tuple1.apply(cov) :: Nil)
+    val df = Dataset.ofRows(session, transformRelation(rel.getInput))
+    StatFunctions
+      .calculateCovImpl(df, Seq(rel.getCol1, rel.getCol2))
+      .logicalPlan
   }
 
   private def transformStatCorr(rel: proto.StatCorr): LogicalPlan = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/stat/StatFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/stat/StatFunctions.scala
@@ -133,6 +133,10 @@ object StatFunctions extends Logging {
    * @return the covariance of the two columns.
    */
   def calculateCov(df: DataFrame, cols: Seq[String]): Double = {
+    calculateCovImpl(df, cols).head.getDouble(0)
+  }
+
+  private[sql] def calculateCovImpl(df: DataFrame, cols: Seq[String]): DataFrame = {
     require(cols.length == 2,
       "Currently covariance calculation is supported between two columns.")
     val Seq(col1, col2) = cols.map { c =>
@@ -147,7 +151,8 @@ object StatFunctions extends Logging {
     df.select(
       when(isnull(covariance), lit(0.0))
         .otherwise(covariance)
-    ).head.getDouble(0)
+        .as("cov")
+    )
   }
 
   /** Generate a table of frequencies for the elements of two columns. */


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make 'transformStatCov' lazy


### Why are the changes needed?
Existing implementation eagerly compute the `cov`, and return a local relation.

Even through currently `message StatCov` is only used in 'Dataset.stat.cov' which returns a double value, it still should be a bit beneficial if we make 'transformStatCov' lazy, since the creation of local relation is skipped.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
existing UT