### PR TITLE
[SPARK-43346][SQL] Change error class _LEGACY_ERROR_TEMP_1206 to COLUMN_NOT_DEFINED

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -3136,7 +3136,7 @@
       "Expected only partition pruning predicates: <nonPartitionPruningPredicates>."
     ]
   },
-  "_LEGACY_ERROR_TEMP_1206" : {
+  "COLUMN_NOT_DEFINED" : {
     "message" : [
       "<colType> column <colName> is not defined in table <tableName>, defined table columns are: <tableCols>."
     ]

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -2115,7 +2115,7 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase {
   def columnNotDefinedInTableError(
       colType: String, colName: String, tableName: String, tableCols: Seq[String]): Throwable = {
     new AnalysisException(
-      errorClass = "_LEGACY_ERROR_TEMP_1206",
+      errorClass = "COLUMN_NOT_DEFINED",
       messageParameters = Map(
         "colType" -> colType,
         "colName" -> colName,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -534,7 +534,7 @@ abstract class DDLSuite extends QueryTest with DDLSuiteBase {
       exception = intercept[AnalysisException] {
         sql("CREATE TABLE tbl(a int, b string) USING json PARTITIONED BY (c)")
       },
-      errorClass = "_LEGACY_ERROR_TEMP_1206",
+      errorClass = "COLUMN_NOT_DEFINED",
       parameters = Map(
         "colType" -> "partition",
         "colName" -> "c",
@@ -547,7 +547,7 @@ abstract class DDLSuite extends QueryTest with DDLSuiteBase {
       exception = intercept[AnalysisException] {
         sql("CREATE TABLE tbl(a int, b string) USING json CLUSTERED BY (c) INTO 4 BUCKETS")
       },
-      errorClass = "_LEGACY_ERROR_TEMP_1206",
+      errorClass = "COLUMN_NOT_DEFINED",
       parameters = Map(
         "colType" -> "bucket",
         "colName" -> "c",


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to assign the proper name COLUMN_NOT_DEFINED  to the legacy error class _LEGACY_ERROR_TEMP_1206.


### Why are the changes needed?
see [SPARK-43346](https://issues.apache.org/jira/browse/SPARK-43346)

### Does this PR introduce _any_ user-facing change?
No. 

### How was this patch tested?
existing tests. 
