### PR TITLE
[SPARK-43040][SQL][FOLLOWUP] Avoid duplicated conversion

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -493,8 +493,7 @@ object JdbcUtils extends Logging with SQLConfHelper {
       (rs: ResultSet, row: InternalRow, pos: Int) =>
         val t = rs.getTimestamp(pos + 1)
         if (t != null) {
-          row.setLong(pos,
-            DateTimeUtils.localDateTimeToMicros(dialect.convertJavaTimestampToTimestampNTZ(t)))
+          row.setLong(pos, dialect.convertJavaTimestampToTimestampNTZ(t))
         } else {
           row.update(pos, null)
         }

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -111,11 +111,11 @@ abstract class JdbcDialect extends Serializable with Logging {
    * JDBC dialects should override this function to provide implementations that suite their
    * JDBC drivers.
    * @param t Timestamp returned from JDBC driver getTimestamp method.
-   * @return A LocalDateTime representing the same wall clock time as the timestamp in database.
+   * @return A Long value representing the same wall clock time as the timestamp in database.
    */
   @Since("3.5.0")
-  def convertJavaTimestampToTimestampNTZ(t: Timestamp): LocalDateTime = {
-    DateTimeUtils.microsToLocalDateTime(DateTimeUtils.fromJavaTimestampNoRebase(t))
+  def convertJavaTimestampToTimestampNTZ(t: Timestamp): Long = {
+    DateTimeUtils.fromJavaTimestampNoRebase(t)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
@@ -25,6 +25,7 @@ import java.util.Locale
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.SQLConfHelper
 import org.apache.spark.sql.catalyst.analysis.{IndexAlreadyExistsException, NonEmptyNamespaceException, NoSuchIndexException}
+import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.connector.catalog.Identifier
 import org.apache.spark.sql.connector.expressions.NamedReference
 import org.apache.spark.sql.errors.QueryCompilationErrors
@@ -103,8 +104,8 @@ private object PostgresDialect extends JdbcDialect with SQLConfHelper {
     case _ => None
   }
 
-  override def convertJavaTimestampToTimestampNTZ(t: Timestamp): LocalDateTime = {
-    t.toLocalDateTime
+  override def convertJavaTimestampToTimestampNTZ(t: Timestamp): Long = {
+    DateTimeUtils.localDateTimeToMicros(t.toLocalDateTime)
   }
 
   override def convertTimestampNTZToJavaTimestamp(ldt: LocalDateTime): Timestamp = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
https://github.com/apache/spark/pull/40678 adds a dialect parameter to makeGetter for applying dialect specific conversions when reading a Java Timestamp into TimestampNTZType.

But there exists duplicated conversion.
`JdbcDialect` calls `DateTimeUtils.microsToLocalDateTime` first and return `LocalDateTime` to `makeGetter`.
But `makeGetter` calls `DateTimeUtils.localDateTimeToMicros` later.

Personally, I don't think it's necessary to maintain complete symmetry between `convertJavaTimestampToTimestampNTZ` and `convertTimestampNTZToJavaTimestamp`.

### Why are the changes needed?
Simplify code to avoid duplicated conversion.


### Does this PR introduce _any_ user-facing change?
'No'.
New feature.


### How was this patch tested?
Exists test cases.

The micro benchmark.

```
Java HotSpot(TM) 64-Bit Server VM 1.8.0_311-b11 on Mac OS X 10.16
Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
Compare timestamp:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
--------------------------------------------------------------------------------------------------------------------------
Before: convertJavaTimestampToTimestampNTZ              6              7           2         16.8          59.6       1.0X
After: convertJavaTimestampToTimestampNTZ               1              1           0        188.3           5.3      11.2X
```
