### PR TITLE
[SPARK-43496][KUBERNETES] Add configuration for pod memory limits

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -22,6 +22,7 @@ import java.util.concurrent.TimeUnit
 import org.apache.spark.deploy.k8s.Constants._
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config.{ConfigBuilder, PYSPARK_DRIVER_PYTHON, PYSPARK_PYTHON}
+import org.apache.spark.network.util._
 
 private[spark] object Config extends Logging {
 
@@ -280,6 +281,20 @@ private[spark] object Config extends Logging {
       .doc("Specify the hard cpu limit for the driver pod")
       .version("2.3.0")
       .stringConf
+      .createOptional
+
+  val KUBERNETES_DRIVER_LIMIT_MEMORY =
+    ConfigBuilder("spark.kubernetes.driver.limit.memory")
+      .doc("Specify the hard memory limit for the driver pod")
+      .version("3.4.1")
+      .bytesConf(ByteUnit.MiB)
+      .createOptional
+
+  val KUBERNETES_EXECUTOR_LIMIT_MEMORY =
+    ConfigBuilder("spark.kubernetes.executor.limit.memory")
+      .doc("Specify the hard memory limit for the executor pod")
+      .version("3.4.1")
+      .bytesConf(ByteUnit.MiB)
       .createOptional
 
   val KUBERNETES_DRIVER_REQUEST_CORES =

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStep.scala
@@ -117,6 +117,9 @@ private[spark] class BasicExecutorFeatureStep(
       .replaceAll("[^\\w-]+", "_")
 
     val executorMemoryQuantity = new Quantity(s"${execResources.totalMemMiB}Mi")
+    val executorLimitMemoryMiB = kubernetesConf.get(KUBERNETES_EXECUTOR_LIMIT_MEMORY)
+    val executorMemoryLimitQuantity =
+      new Quantity(s"${executorLimitMemoryMiB.getOrElse(execResources.totalMemMiB)}Mi")
     val executorCpuQuantity = new Quantity(executorCoresRequest)
     val executorResourceQuantities =
       buildExecutorResourcesQuantities(execResources.customResources.values.toSet)
@@ -191,8 +194,8 @@ private[spark] class BasicExecutorFeatureStep(
       .withImage(executorContainerImage)
       .withImagePullPolicy(kubernetesConf.imagePullPolicy)
       .editOrNewResources()
-        .addToRequests("memory", executorMemoryQuantity)
-        .addToLimits("memory", executorMemoryQuantity)
+      .addToRequests("memory", executorMemoryQuantity)
+      .addToLimits("memory", executorMemoryLimitQuantity)
         .addToRequests("cpu", executorCpuQuantity)
         .addToLimits(executorResourceQuantities.asJava)
         .endResources()


### PR DESCRIPTION

### What changes were proposed in this pull request?
Adding dedicated configuration for specifying driver/executor memory limits.


### Why are the changes needed?
Separate mem limit for the pod might be needed if sprak JVM launches extrernal processes.
Also, this could be useful in heterogenous loads when some pods may use more memory for bursty operations.


### Does this PR introduce _any_ user-facing change?
Without using new configurations - no


### How was this patch tested?
Unit tested
