### PR TITLE
[SPARK-43391][CORE] Idle connection should be kept when closeIdleConnection is disabled

### DIFF
--- a/common/network-common/src/test/java/org/apache/spark/network/RequestTimeoutIntegrationSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/RequestTimeoutIntegrationSuite.java
@@ -110,7 +110,7 @@ public class RequestTimeoutIntegrationSuite {
       }
     };
 
-    context = new TransportContext(conf, handler);
+    context = new TransportContext(conf, handler, true);
     server = context.createServer();
     clientFactory = context.createClientFactory();
     TransportClient client = clientFactory.createClient(TestUtils.getLocalHost(), server.getPort());
@@ -157,7 +157,7 @@ public class RequestTimeoutIntegrationSuite {
       }
     };
 
-    context = new TransportContext(conf, handler);
+    context = new TransportContext(conf, handler, true);
     server = context.createServer();
     clientFactory = context.createClientFactory();
 
@@ -208,7 +208,7 @@ public class RequestTimeoutIntegrationSuite {
       }
     };
 
-    context = new TransportContext(conf, handler);
+    context = new TransportContext(conf, handler, true);
     server = context.createServer();
     clientFactory = context.createClientFactory();
     TransportClient client = clientFactory.createClient(TestUtils.getLocalHost(), server.getPort());


### PR DESCRIPTION
### What changes were proposed in this pull request?
Not close idle connection when closeIdleConnection is disabled

### Why are the changes needed?
Spark will close idle connection when there're outstanding requests but no traffic for at least `requestTimeoutMs` even with closeIdleConnection is disabled. This will cause all shuffle output on this executor being unregistered when executor has spike IO with long fetch delay.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Manually tested.
