### PR TITLE
[SPARK-43361][PROTOBUF] spark-protobuf: allow serde with enum as ints

### DIFF
--- a/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/ProtobufDataToCatalyst.scala
+++ b/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/ProtobufDataToCatalyst.scala
@@ -76,7 +76,8 @@ private[protobuf] case class ProtobufDataToCatalyst(
       messageDescriptor,
       dataType,
       typeRegistry = typeRegistry,
-      emitDefaultValues = protobufOptions.emitDefaultValues
+      emitDefaultValues = protobufOptions.emitDefaultValues,
+      enumsAsInts = protobufOptions.enumsAsInts
     )
   }
 

--- a/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/ProtobufDeserializer.scala
+++ b/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/ProtobufDeserializer.scala
@@ -260,6 +260,11 @@ private[sql] class ProtobufDeserializer(
       case (ENUM, StringType) =>
         (updater, ordinal, value) => updater.set(ordinal, UTF8String.fromString(value.toString))
 
+      case (ENUM, IntegerType) =>
+        (updater, ordinal, value) => {
+          updater.set(ordinal, protoType.getEnumType.findValueByName(value.toString).getNumber)
+        }
+
       case _ =>
         throw QueryCompilationErrors.cannotConvertProtobufTypeToSqlTypeError(
           toFieldStr(protoPath),

--- a/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/ProtobufDeserializer.scala
+++ b/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/ProtobufDeserializer.scala
@@ -18,10 +18,9 @@ package org.apache.spark.sql.protobuf
 
 import java.util.concurrent.TimeUnit
 
-import com.google.protobuf.{ByteString, DynamicMessage, Message}
+import com.google.protobuf.{ByteString, DynamicMessage, Message, TypeRegistry}
 import com.google.protobuf.Descriptors._
 import com.google.protobuf.Descriptors.FieldDescriptor.JavaType._
-import com.google.protobuf.TypeRegistry
 import com.google.protobuf.util.JsonFormat
 
 import org.apache.spark.sql.AnalysisException
@@ -40,7 +39,8 @@ private[sql] class ProtobufDeserializer(
     rootCatalystType: DataType,
     filters: StructFilters = new NoopFilters,
     typeRegistry: TypeRegistry = TypeRegistry.getEmptyTypeRegistry,
-    emitDefaultValues: Boolean = false) {
+    emitDefaultValues: Boolean = false,
+    enumsAsInts: Boolean = false) {
 
   def this(rootDescriptor: Descriptor, rootCatalystType: DataType) = {
     this(
@@ -79,10 +79,18 @@ private[sql] class ProtobufDeserializer(
   // JsonFormatter used to convert Any fields (if the option is enabled).
   // This keeps original field names and does not include any extra whitespace in JSON.
   // If the runtime type for Any field is not found in the registry, it throws an exception.
-  private val jsonPrinter = JsonFormat.printer
-    .omittingInsignificantWhitespace()
-    .preservingProtoFieldNames()
-    .usingTypeRegistry(typeRegistry)
+  private val jsonPrinter = if (enumsAsInts) {
+    JsonFormat.printer
+      .omittingInsignificantWhitespace()
+      .preservingProtoFieldNames()
+      .printingEnumsAsInts()
+      .usingTypeRegistry(typeRegistry)
+  } else {
+    JsonFormat.printer
+      .omittingInsignificantWhitespace()
+      .preservingProtoFieldNames()
+      .usingTypeRegistry(typeRegistry)
+  }
 
   private def newArrayWriter(
       protoField: FieldDescriptor,
@@ -258,12 +266,14 @@ private[sql] class ProtobufDeserializer(
           updater.set(ordinal, row)
 
       case (ENUM, StringType) =>
-        (updater, ordinal, value) => updater.set(ordinal, UTF8String.fromString(value.toString))
+        (updater, ordinal, value) =>
+          updater.set(
+            ordinal,
+            UTF8String.fromString(value.asInstanceOf[EnumValueDescriptor].getName))
 
       case (ENUM, IntegerType) =>
-        (updater, ordinal, value) => {
-          updater.set(ordinal, protoType.getEnumType.findValueByName(value.toString).getNumber)
-        }
+        (updater, ordinal, value) =>
+          updater.set(ordinal, value.asInstanceOf[EnumValueDescriptor].getNumber)
 
       case _ =>
         throw QueryCompilationErrors.cannotConvertProtobufTypeToSqlTypeError(

--- a/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/ProtobufSerializer.scala
+++ b/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/ProtobufSerializer.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.SpecializedGetters
 import org.apache.spark.sql.catalyst.util.{DateTimeUtils, IntervalUtils}
 import org.apache.spark.sql.catalyst.util.IntervalStringStyles.ANSI_STYLE
-import org.apache.spark.sql.errors.QueryCompilationErrors
+import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
 import org.apache.spark.sql.protobuf.utils.ProtobufUtils
 import org.apache.spark.sql.protobuf.utils.ProtobufUtils.{toFieldStr, ProtoMatchedField}
 import org.apache.spark.sql.types._
@@ -103,7 +103,7 @@ private[sql] class ProtobufSerializer(
         (getter, ordinal) =>
           val data = getter.getUTF8String(ordinal).toString
           if (!enumSymbols.contains(data)) {
-            throw QueryCompilationErrors.cannotConvertCatalystTypeToProtobufEnumTypeError(
+            throw QueryExecutionErrors.cannotConvertCatalystValueToProtobufEnumTypeError(
               catalystPath,
               toFieldStr(protoPath),
               data,
@@ -116,7 +116,7 @@ private[sql] class ProtobufSerializer(
         (getter, ordinal) =>
           val data = getter.getInt(ordinal)
           if (!enumValues.contains(data)) {
-            throw QueryCompilationErrors.cannotConvertCatalystTypeToProtobufEnumTypeError(
+            throw QueryExecutionErrors.cannotConvertCatalystValueToProtobufEnumTypeError(
               catalystPath,
               toFieldStr(protoPath),
               data.toString,

--- a/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/utils/ProtobufOptions.scala
+++ b/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/utils/ProtobufOptions.scala
@@ -141,6 +141,30 @@ private[sql] class ProtobufOptions(
   //      what information is available in a serialized proto.
   val emitDefaultValues: Boolean =
     parameters.getOrElse("emit.default.values", false.toString).toBoolean
+
+  // Whether to render enum fields as their integer values.
+  //
+  // As an example, consider the following message type:
+  // ```
+  // syntax = "proto3";
+  // message Person {
+  //   enum Job {
+  //     NONE = 0;
+  //     ENGINEER = 1;
+  //     DOCTOR = 2;
+  //   }
+  //   Job job = 1;
+  // }
+  // ```
+  //
+  // If we have an instance of this message like `Person(job = ENGINEER)`, then the
+  // default deserialization will be:
+  // `{"job": "ENGINEER"}`
+  //
+  // But with this option set the deserialization will be:
+  // `{"job": 1}`
+  val enumsAsInts: Boolean =
+    parameters.getOrElse("enums.as.ints", false.toString).toBoolean
 }
 
 private[sql] object ProtobufOptions {

--- a/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/utils/ProtobufOptions.scala
+++ b/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/utils/ProtobufOptions.scala
@@ -163,6 +163,9 @@ private[sql] class ProtobufOptions(
   //
   // But with this option set the deserialization will be:
   // `{"job": 1}`
+  //
+  // Please note the output struct type will now contain an int column
+  // instead of string, so use caution if changing existing parsing logic.
   val enumsAsInts: Boolean =
     parameters.getOrElse("enums.as.ints", false.toString).toBoolean
 }

--- a/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/utils/SchemaConverters.scala
+++ b/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/utils/SchemaConverters.scala
@@ -75,7 +75,7 @@ object SchemaConverters extends Logging {
       case BOOLEAN => Some(BooleanType)
       case STRING => Some(StringType)
       case BYTE_STRING => Some(BinaryType)
-      case ENUM => Some(StringType)
+      case ENUM => if (protobufOptions.enumsAsInts) Some(IntegerType) else Some(StringType)
       case MESSAGE
         if (fd.getMessageType.getName == "Duration" &&
           fd.getMessageType.getFields.size() == 2 &&

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -3287,20 +3287,6 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase {
         "protobufType" -> protobufType))
   }
 
-  def cannotConvertCatalystTypeToProtobufEnumTypeError(
-      sqlColumn: Seq[String],
-      protobufColumn: String,
-      data: String,
-      enumString: String): Throwable = {
-    new AnalysisException(
-      errorClass = "CANNOT_CONVERT_SQL_TYPE_TO_PROTOBUF_ENUM_TYPE",
-      messageParameters = Map(
-        "sqlColumn" -> toSQLId(sqlColumn),
-        "protobufColumn" -> protobufColumn,
-        "data" -> data,
-        "enumString" -> enumString))
-  }
-
   def cannotConvertProtobufTypeToCatalystTypeError(
       protobufType: String,
       sqlType: DataType,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -33,6 +33,7 @@ import org.codehaus.commons.compiler.{CompileException, InternalCompilerExceptio
 import org.apache.spark._
 import org.apache.spark.launcher.SparkLauncher
 import org.apache.spark.memory.SparkOutOfMemoryError
+import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.{TableIdentifier, WalkedTypePath}
 import org.apache.spark.sql.catalyst.ScalaReflection.Schema
 import org.apache.spark.sql.catalyst.analysis.UnresolvedGenerator
@@ -2811,5 +2812,19 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase {
       messageParameters = Map(
         "location" -> toSQLValue(location.toString, StringType),
         "identifier" -> toSQLId(tableId.nameParts)))
+  }
+
+  def cannotConvertCatalystValueToProtobufEnumTypeError(
+      sqlColumn: Seq[String],
+      protobufColumn: String,
+      data: String,
+      enumString: String): Throwable = {
+    new AnalysisException(
+      errorClass = "CANNOT_CONVERT_SQL_VALUE_TO_PROTOBUF_ENUM_TYPE",
+      messageParameters = Map(
+        "sqlColumn" -> toSQLId(sqlColumn),
+        "protobufColumn" -> protobufColumn,
+        "data" -> data,
+        "enumString" -> enumString))
   }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SPARK-43361

### What changes were proposed in this pull request?
When deserializing protobuf enum fields, the spark-protobuf library will deserialize them as string values based on the enum name in the proto. E.g. 

```
message Person {
  enum Job {
    NOTHING = 0;
    ENGINEER = 1;
    DOCTOR = 2;
  }
  Job job = 1;
}
```
And we have a message like

```
Person(job=ENGINEER)
```

Then the deserialized value will be:

```
{"job": "ENGINEER"}
```

However it can be useful to deserialize the enum integer value rather than the name, namely:

```
{"job": 1}
```

This commit adds that functionality to spark protobuf via an option, "enums.as.ints". In addition, it also allows serializing such fields back into protobuf via `to_protobuf`.



Examples in other libraries:

- protobuf-java-util JsonFormat: https://javadoc.io/doc/com.google.protobuf/protobuf-java-util/3.10.0/com/google/protobuf/util/JsonFormat.Printer.html#printingEnumsAsInts--
- golang/protobuf jsonpb marshaler https://pkg.go.dev/github.com/golang/protobuf/jsonpb#Marshaler


### Why are the changes needed?
Adds new functionality that exists in other libraries.

### Does this PR introduce _any_ user-facing change?
Yes, adds a new option to from_protobuf.

### How was this patch tested?
Added unit tests confirming this behavior.