### PR TITLE
[SPARK-43396][CORE] Add config to control max ratio of decommissioning executors

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -2576,4 +2576,16 @@ package object config {
       .stringConf
       .toSequence
       .createWithDefault("org.apache.spark.sql.connect.client" :: Nil)
+
+  private[spark] val DECOMMISSION_MAX_RATIO =
+    ConfigBuilder("spark.decommission.maxRatio")
+      .doc("Max ratio of decommissioning executor of running executors. Decommission too many " +
+        s"executors at the same time with shuffle or rdd migration enabled " +
+        s"could hurt performance of shuffle fetch " +
+        s"as shuffle or rdd migration compete network and disk IO with shuffle fetch. " +
+        s"This only affects decommission triggered by driver.")
+      .version("4.0.0")
+      .doubleConf
+      .checkValue(ratio => ratio > 0 && ratio <= 1, "Decommission max ratio should > 0 and <= 1")
+      .createWithDefault(1)
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add config `spark.decommission.maxRatio` to control max ratio of decommissioning executors of running ones

### Why are the changes needed?
Decommission too many executors at the same time with shuffle or rdd migration could severely hurt performance of shuffle fetch. Block manager decommissioner try to migrate shuffle or rdd as soon as possible, this will compete network and disk IO with shuffle fetch in the target executor. This only affects decommission triggered by driver.

### Does this PR introduce _any_ user-facing change?
Yes, added new config `spark.decommission.maxRatio`

### How was this patch tested?
Added test in `ExecutorMonitorSuite`
