### PR TITLE
[SPARK-43397][CORE] Log executor decommission duration in `executorLost` method

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -1086,9 +1086,17 @@ private[spark] class TaskSchedulerImpl(
     case ExecutorKilled =>
       logInfo(s"Executor $executorId on $hostPort killed by driver.")
     case _: ExecutorDecommission =>
-      logInfo(s"Executor $executorId on $hostPort is decommissioned.")
+      logInfo(s"Executor $executorId on $hostPort is decommissioned" +
+        s"${getDecommissionDuration(executorId)}.")
     case _ =>
       logError(s"Lost executor $executorId on $hostPort: $reason")
+  }
+
+  // return decommission duration in string or "" if decommission startTime not exists
+  private def getDecommissionDuration(executorId: String): String = {
+    executorsPendingDecommission.get(executorId)
+      .map(s => s" after ${Utils.msDurationToString(clock.getTimeMillis() - s.startTime)}")
+      .getOrElse("")
   }
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?
Log executor decommission duration

### Why are the changes needed?
Executor decommission duration is important info to understand resource efficiency and troubleshoot decommission issue. 

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Manually tested.
