### PR TITLE
[SPARK-43399][CORE] Add config to control threshold of unregister map ouput when fetch failed

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -948,6 +948,15 @@ package object config {
       .booleanConf
       .createWithDefault(false)
 
+  private[spark] val UNREGISTER_OUTPUT_THRESHOLD_ON_FETCH_FAILURE =
+    ConfigBuilder("spark.files.fetchFailure.unRegisterOutputThreshold")
+      .doc("Times of FetchFailure received to un-register map outputs on the executor." +
+        " Setting to 0 to disable un-register map outputs.")
+      .version("3.5.0")
+      .intConf
+      .checkValue(t => t >= 0, "Fetch failure unregister output threshold should be >= 0")
+      .createWithDefault(1)
+
   private[spark] val LISTENER_BUS_EVENT_QUEUE_CAPACITY =
     ConfigBuilder("spark.scheduler.listenerbus.eventqueue.capacity")
       .doc("The default capacity for event queues. Spark will try to initialize " +


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add the config `spark.files.fetchFailure.unRegisterOutputThreshold` to control the number of fetch failed failures needed for one specific executor to unregister map output on this executor and allow to disable unregister.

### Why are the changes needed?
Spark will unregister map output on the executor when fetch failed from this executor. This might be too aggressive when fetch failed is temporary and recoverable, especially when re-computation is more expensive than retry failed fetch.

### Does this PR introduce _any_ user-facing change?
Yes. Added the config `spark.files.fetchFailure.unRegisterOutputThreshold`

### How was this patch tested?
Added test in `DAGSchedulerSuite`
