### PR TITLE
[MINOR][PYTHON] Remove deprecated use of typing.io

### DIFF
--- a/python/pyspark/broadcast.py
+++ b/python/pyspark/broadcast.py
@@ -24,6 +24,7 @@ import pickle
 from typing import (
     overload,
     Any,
+    BinaryIO,
     Callable,
     Dict,
     Generic,
@@ -35,7 +36,6 @@ from typing import (
     TYPE_CHECKING,
     Union,
 )
-from typing.io import BinaryIO  # type: ignore[import]
 
 from pyspark.java_gateway import local_connect_and_auth
 from pyspark.serializers import ChunkedStream, pickle_protocol


### PR DESCRIPTION
### What changes were proposed in this pull request?
Use `typing.BinaryIO` instead of `typing.io.BinaryIO`. The latter is deprecated and had questionable type checker support, see https://github.com/python/cpython/issues/92871

### Why are the changes needed?
So Spark is unaffected when `typing.io` is removed in Python 3.13

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
Existing unit tests / every import of this module