### PR TITLE
[SPARK-43348][PYTHON][TESTS][FOLLOW-UP] Skip the day-time-interval test only with PyPy 3.8

### DIFF
--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
+import platform
 from decimal import Decimal
 import os
 import pydoc
@@ -1455,7 +1455,10 @@ class DataFrameTestsMixin:
             time.tzset()
 
     # TODO(SPARK-43354): Re-enable test_create_dataframe_from_pandas_with_day_time_interval
-    @unittest.skip("Fails in PyPy Python 3.8, should enable.")
+    @unittest.skipIf(
+        "pypy" in platform.python_implementation().lower(),
+        "Fails in PyPy Python 3.8, should enable.",
+    )
     def test_create_dataframe_from_pandas_with_day_time_interval(self):
         # SPARK-37277: Test DayTimeIntervalType in createDataFrame without Arrow.
         import pandas as pd


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/41024 that skips the test only with PyPy 3.8.

### Why are the changes needed?

To narrow the scope of testing skipped.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

CI in this PR should verify the change.
