### PR TITLE
[MINOR][PYTHON] Fix MyPy linter failure

### DIFF
--- a/python/pyspark/broadcast.py
+++ b/python/pyspark/broadcast.py
@@ -103,7 +103,7 @@ class Broadcast(Generic[T]):
     def __init__(self: "Broadcast[Any]", *, sock_file: str):
         ...
 
-    def __init__(
+    def __init__(  # type: ignore[misc]
         self,
         sc: Optional["SparkContext"] = None,
         value: Optional[T] = None,


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds a skip for the type check being failed in the build https://github.com/apache/spark/actions/runs/4910498665/jobs/8767736542

```
starting mypy annotations test...
annotations failed mypy checks:
python/pyspark/broadcast.py:106: error: Overloaded function implementation does not accept all possible arguments of signature 3  [misc]
Found 1 error in 1 file (checked 511 source files)
```

### Why are the changes needed?

To fix the broken build up.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

CI in this PR should verify them.
