### PR TITLE
[SPARK-43406][SQL] enable spark sql to drop multiple partitions in on…

### DIFF
--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
@@ -145,7 +145,7 @@ statement
     | ALTER TABLE multipartIdentifier
         from=partitionSpec RENAME TO to=partitionSpec                  #renameTablePartition
     | ALTER (TABLE | VIEW) multipartIdentifier
-        DROP (IF EXISTS)? partitionSpec (COMMA partitionSpec)* PURGE?  #dropTablePartitions
+        DROP (IF EXISTS)? dropPartitionSpec (COMMA dropPartitionSpec)* PURGE?  #dropTablePartitions
     | ALTER TABLE multipartIdentifier
         (partitionSpec)? SET locationSpec                              #setTableLocation
     | ALTER TABLE multipartIdentifier RECOVER PARTITIONS               #recoverPartitions
@@ -336,6 +336,20 @@ partitionVal
     : identifier (EQ constant)?
     | identifier EQ DEFAULT
     ;
+
+dropPartitionSpec
+    : PARTITION LEFT_PAREN dropPartitionVal (COMMA dropPartitionVal)* RIGHT_PAREN
+    ;
+
+dropPartitionVal
+    : identifier (dropPartitionComparisonOperator constant)
+    | identifier EQ DEFAULT
+    ;
+
+dropPartitionComparisonOperator
+    : EQ | GTE | GT | LTE | LT | NEQJ
+    ;
+
 
 namespace
     : NAMESPACE

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/v2ResolutionPlans.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/v2ResolutionPlans.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.catalyst.analysis
 
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
+import org.apache.spark.sql.catalyst.catalog.CatalogTypes.{TablePartitionSpec}
 import org.apache.spark.sql.catalyst.expressions.{Attribute, LeafExpression, Unevaluable}
 import org.apache.spark.sql.catalyst.plans.logical.{LeafNode, Statistics}
 import org.apache.spark.sql.catalyst.trees.TreePattern.{TreePattern, UNRESOLVED_FUNC}
@@ -85,6 +85,12 @@ sealed trait PartitionSpec extends LeafExpression with Unevaluable {
     "PartitionSpec.dataType should not be called.")
   override def nullable: Boolean = throw new IllegalStateException(
     "PartitionSpec.nullable should not be called.")
+}
+
+case class UnresolvedDropPartitionSpec(
+    spec: Seq[(String, String, String)],
+    location: Option[String] = None) extends PartitionSpec {
+  override lazy val resolved = false
 }
 
 case class UnresolvedPartitionSpec(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalog.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.catalyst.catalog
 
 import org.apache.spark.sql.catalyst.analysis.{FunctionAlreadyExistsException, NoSuchDatabaseException, NoSuchFunctionException, NoSuchTableException}
+import org.apache.spark.sql.catalyst.catalog.CatalogTypes.DropTablePartitionSpec
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.types.StructType
 
@@ -183,6 +184,14 @@ trait ExternalCatalog {
       table: String,
       parts: Seq[CatalogTablePartition],
       ignoreIfExists: Boolean): Unit
+
+  def dropMutiplePartitions(
+      db: String,
+      table: String,
+      parts: Seq[DropTablePartitionSpec],
+      ignoreIfNotExists: Boolean,
+      purge: Boolean,
+      retainData: Boolean): Unit
 
   def dropPartitions(
       db: String,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogUtils.scala
@@ -18,13 +18,11 @@
 package org.apache.spark.sql.catalyst.catalog
 
 import java.net.URI
-
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.util.Shell
-
 import org.apache.spark.sql.catalyst.analysis.Resolver
-import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
+import org.apache.spark.sql.catalyst.catalog.CatalogTypes.{TablePartitionSpec}
 import org.apache.spark.sql.catalyst.expressions.{And, AttributeReference, BasePredicate, BoundReference, Expression, Predicate}
 import org.apache.spark.sql.catalyst.util.CharVarcharUtils
 import org.apache.spark.sql.errors.QueryCompilationErrors
@@ -204,6 +202,13 @@ object ExternalCatalogUtils {
         isNullPartitionValue(spec2(partitionColumn))
       case (partitionColumn, value) => spec2(partitionColumn) == value
     }
+  }
+
+  def convertNullDropPartitionValues
+    (specs: Seq[(String, String, String)]): Seq[(String, String, String)] = {
+    specs.map(spec =>
+      if (spec._3 == null) (spec._1, spec._2, DEFAULT_PARTITION_NAME)
+      else (spec._1, spec._2, spec._3))
   }
 
   def convertNullPartitionValues(spec: TablePartitionSpec): TablePartitionSpec = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogWithListener.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogWithListener.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.catalyst.catalog
 
+import org.apache.spark.sql.catalyst.catalog.CatalogTypes.DropTablePartitionSpec
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.ListenerBus
@@ -199,6 +200,16 @@ class ExternalCatalogWithListener(delegate: ExternalCatalog)
       parts: Seq[CatalogTablePartition],
       ignoreIfExists: Boolean): Unit = {
     delegate.createPartitions(db, table, parts, ignoreIfExists)
+  }
+
+  override def dropMutiplePartitions(
+      db: String,
+      table: String,
+      partSpecsWithOp: Seq[DropTablePartitionSpec],
+      ignoreIfNotExists: Boolean,
+      purge: Boolean,
+      retainData: Boolean): Unit = {
+    delegate.dropMutiplePartitions(db, table, partSpecsWithOp, ignoreIfNotExists, purge, retainData)
   }
 
   override def dropPartitions(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -774,6 +774,11 @@ case class CatalogDatabase(
 
 object CatalogTypes {
   /**
+   * Specifications of a drop table partition. Mapping column name to operator and column value.
+   */
+  type DropTablePartitionSpec = Seq[(String, String, String)]
+
+  /**
    * Specifications of a table partition. Mapping column name to column value.
    */
   type TablePartitionSpec = Map[String, String]

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -501,6 +501,7 @@ class AstBuilder extends SqlBaseParserBaseVisitor[AnyRef] with SQLConfHelper wit
 
   /**
    * Create a drop partition specification map.
+   *
    */
   override def visitDropPartitionSpec(
       ctx: DropPartitionSpecContext): Seq[(String, String, Option[String])] = withOrigin(ctx) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
@@ -71,6 +71,14 @@ private[sql] object QueryParsingErrors extends QueryErrorsBase {
     new ParseException(errorClass = "NON_LAST_NOT_MATCHED_BY_SOURCE_CLAUSE_OMIT_CONDITION", ctx)
   }
 
+  def emptyPartitionKeyError(key: String, ctx: DropPartitionSpecContext): Throwable = {
+    new ParseException(
+      errorClass = "INVALID_SQL_SYNTAX",
+      messageParameters = Map(
+        "inputString" -> s"Drop Partition key ${toSQLId(key)} must set value (can't be empty)."),
+      ctx)
+  }
+
   def emptyPartitionKeyError(key: String, ctx: PartitionSpecContext): Throwable = {
     new ParseException(
       errorClass = "INVALID_SQL_SYNTAX",

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Implicits.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Implicits.scala
@@ -18,8 +18,7 @@
 package org.apache.spark.sql.execution.datasources.v2
 
 import scala.collection.JavaConverters._
-
-import org.apache.spark.sql.catalyst.analysis.{PartitionSpec, ResolvedPartitionSpec, UnresolvedPartitionSpec}
+import org.apache.spark.sql.catalyst.analysis.{PartitionSpec, ResolvedPartitionSpec, UnresolvedDropPartitionSpec, UnresolvedPartitionSpec}
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, MetadataAttribute}
 import org.apache.spark.sql.connector.catalog.{MetadataColumn, SupportsAtomicPartitionManagement, SupportsDeleteV2, SupportsPartitionManagement, SupportsRead, SupportsWrite, Table, TableCapability, TruncatableTable}
 import org.apache.spark.sql.connector.write.RowLevelOperationTable
@@ -123,6 +122,12 @@ object DataSourceV2Implicits {
       partSpecs.map(_.asInstanceOf[UnresolvedPartitionSpec])
 
     def asResolvedPartitionSpecs: Seq[ResolvedPartitionSpec] =
+      partSpecs.map(_.asInstanceOf[ResolvedPartitionSpec])
+
+    def asUnresolvedDropPartitionSpecs: Seq[UnresolvedDropPartitionSpec] =
+      partSpecs.map(_.asInstanceOf[UnresolvedDropPartitionSpec])
+
+    def asResolvedDropPartitionSpecs: Seq[ResolvedPartitionSpec] =
       partSpecs.map(_.asInstanceOf[ResolvedPartitionSpec])
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
@@ -342,9 +342,9 @@ class ResolveSessionCatalog(val catalogManager: CatalogManager)
 
     case DropPartitions(
         ResolvedV1TableIdentifier(ident), specs, ifExists, purge) =>
-      AlterTableDropPartitionCommand(
+      AlterTableDropMutiplePartitionCommand(
         ident,
-        specs.asUnresolvedPartitionSpecs.map(_.spec),
+        specs.asUnresolvedDropPartitionSpecs.map(_.spec),
         ifExists,
         purge,
         retainData = false)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClient.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClient.scala
@@ -18,10 +18,9 @@
 package org.apache.spark.sql.hive.client
 
 import java.io.PrintStream
-
 import org.apache.spark.sql.catalyst.analysis._
 import org.apache.spark.sql.catalyst.catalog._
-import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
+import org.apache.spark.sql.catalyst.catalog.CatalogTypes.{DropTablePartitionSpec, TablePartitionSpec}
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.types.StructType
 
@@ -168,6 +167,17 @@ private[hive] trait HiveClient {
       table: String,
       parts: Seq[CatalogTablePartition],
       ignoreIfExists: Boolean): Unit
+
+  /**
+   * Drop one or many partitions in the given table, assuming they exist.
+   */
+  def dropMutiplePartitions(
+      db: String,
+      table: String,
+      specs: Seq[DropTablePartitionSpec],
+      ignoreIfNotExists: Boolean,
+      purge: Boolean,
+      retainData: Boolean): Unit
 
   /**
    * Drop one or many partitions in the given table, assuming they exist.

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
@@ -102,6 +102,11 @@ private[client] sealed abstract class Shim {
   def getAllPartitions(hive: Hive, table: Table): Seq[Partition]
 
   def getPartitionsByFilter(
+       hive: Hive,
+       table: Table,
+       filter: String): Seq[Partition]
+
+  def getPartitionsByFilter(
       hive: Hive,
       table: Table,
       predicates: Seq[Expression],
@@ -650,6 +655,14 @@ private[client] class Shim_v0_12 extends Shim with Logging {
       forceCreate: Boolean): Partition = {
     recordHiveCall()
     hive.getPartition(table, partSpec, forceCreate)
+  }
+
+  override def getPartitionsByFilter(
+      hive: Hive,
+      table: Table,
+      filter: String): Seq[Partition] = {
+    recordHiveCall()
+    hive.getPartitionsByFilter(table, filter).asScala.toSeq
   }
 
   override def getPartitions(


### PR DESCRIPTION
Now spark sql cannot drop multiple partitions in one call, so I fix it

With this patch we can drop multiple partitions like this : 

alter table test.table_partition drop partition(dt<='2023-04-02', dt>='2023-03-31')

this is my test demo with hms

1、insert five data into partitioned table test.table_partition
insert into table test.table_partition partition(dt='2023-03-30') values('chenruotao','100');
insert into table test.table_partition partition(dt='2023-03-31') values('chenruotao','100');
insert into table test.table_partition partition(dt='2023-04-01') values('chenruotao','100');
insert into table test.table_partition partition(dt='2023-04-02') values('chenruotao','100');
insert into table test.table_partition partition(dt='2023-04-03') values('chenruotao','100');
<img width="420" alt="image" src="https://user-images.githubusercontent.com/20615138/236775512-d54fa998-7f0b-40d9-ae30-7c2de6e7facc.png">
2、execute sql to  drop multiple partitions：
alter table test.table_partition drop partition(dt<='2023-04-02', dt>='2023-03-31');
<img width="394" alt="image" src="https://user-images.githubusercontent.com/20615138/236775777-2ba14634-0a87-4fee-a819-38774273fb1e.png">
3、execute sql to  drop one partitions：
alter table test.table_partition drop partition(dt='2023-03-30');
<img width="321" alt="image" src="https://user-images.githubusercontent.com/20615138/236775891-ea53f3fb-e670-4cdc-8765-45d56d5d156e.png">


