### PR TITLE
[SPARK-43414][TESTS] Fix flakiness in Kafka RDD suites due to port binding configuration issue

### DIFF
--- a/connector/kafka-0-10/src/test/scala/org/apache/spark/streaming/kafka010/KafkaTestUtils.scala
+++ b/connector/kafka-0-10/src/test/scala/org/apache/spark/streaming/kafka010/KafkaTestUtils.scala
@@ -240,9 +240,7 @@ private[kafka010] class KafkaTestUtils extends Logging {
   private def brokerConfiguration: Properties = {
     val props = new Properties()
     props.put("broker.id", "0")
-    props.put("host.name", localHostNameForURI)
-    props.put("advertised.host.name", localHostNameForURI)
-    props.put("port", brokerPort.toString)
+    props.put("listeners", s"PLAINTEXT://$localHostNameForURI:$brokerPort")
     props.put("log.dir", brokerLogDir)
     props.put("zookeeper.connect", zkAddress)
     props.put("zookeeper.connection.timeout.ms", "60000")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR addresses a test flakiness issue in Kafka connector RDD suites

https://github.com/apache/spark/pull/34089#pullrequestreview-872739182 (Spark 3.4.0) upgraded Spark to Kafka 3.1.0, which requires a different configuration key for configuring the broker listening port. That PR updated the `KafkaTestUtils.scala` used in SQL tests, but there's a near-duplicate of that code in a different `KafkaTestUtils.scala` used by RDD API suites which wasn't updated. As a result, the RDD suites began using Kafka's default port 9092 and this results in flakiness as multiple concurrent suites hit port conflicts when trying to bind to that default port.

This PR fixes that by simply copying the updated configuration from the SQL copy of `KafkaTestUtils.scala`. 


### Why are the changes needed?

Fix test flakiness due to port conflicts.


### Does this PR introduce _any_ user-facing change?

No


### How was this patch tested?

Ran 20 concurrent copies of `org.apache.spark.streaming.kafka010.JavaKafkaRDDSuite` in my CI environment and confirmed that this PR's changes resolve the test flakiness.