### PR TITLE
[SPARK-39420][SQL] Support `ANALYZE TABLE` on Datasource V2 tables

### DIFF
--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/CheckConnectJvmClientCompatibility.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/CheckConnectJvmClientCompatibility.scala
@@ -177,6 +177,7 @@ object CheckConnectJvmClientCompatibility {
         "org.apache.spark.sql.SparkSessionExtensionsProvider"),
       ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.sql.UDTFRegistration"),
       ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.sql.UDFRegistration$"),
+      ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.sql.StatisticsCache"),
 
       // DataFrame Reader & Writer
       ProblemFilters.exclude[Problem]("org.apache.spark.sql.DataFrameReader.json"), // rdd

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -1454,8 +1454,16 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
       messageParameters = Map("cmd" -> toSQLStmt(cmd)))
   }
 
-  def analyzeTableNotSupportedForV2TablesError(): Throwable = {
-    notSupportedForV2TablesError("ANALYZE TABLE")
+  def analyzeTableForColumnsNotSupportedForV2TablesError(): Throwable = {
+    notSupportedForV2TablesError("ANALYZE TABLE ... FOR [ALL] COLUMNS ...")
+  }
+
+  def analyzeTablePartitionNotSupportedForV2TablesError(): Throwable = {
+    notSupportedForV2TablesError("ANALYZE TABLE ... PARTITION ...")
+  }
+
+  def analyzeTableNoScanNotSupportedForV2TablesError(): Throwable = {
+    notSupportedForV2TablesError("ANALYZE TABLE ... NOSCAN")
   }
 
   def alterTableRecoverPartitionsNotSupportedForV2TablesError(): Throwable = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/StatisticsCache.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/StatisticsCache.scala
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+import scala.collection.mutable
+
+import org.apache.spark.sql.catalyst.analysis.ResolvedIdentifier
+import org.apache.spark.sql.connector.read.Statistics
+
+/**
+ * A cache for statistics of Datasource v2.
+ */
+private[sql] class StatisticsCache {
+
+  private val cache = mutable.HashMap[ResolvedIdentifier, Statistics]()
+
+  def put(resolvedIdentifier: ResolvedIdentifier, statistics: Statistics): Unit = {
+    cache.put(resolvedIdentifier, statistics)
+  }
+
+  def get(resolvedIdentifier: ResolvedIdentifier): Option[Statistics] = {
+    cache.get(resolvedIdentifier)
+  }
+
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AnalyzeTableExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AnalyzeTableExec.scala
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2
+
+import org.apache.spark.sql.StatisticsCache
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.analysis.{ResolvedIdentifier, ResolvedTable}
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.connector.catalog.SupportsRead
+import org.apache.spark.sql.connector.read.SupportsReportStatistics
+import org.apache.spark.sql.errors.QueryCompilationErrors
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+/**
+ * Physical plan node for analyze table from a data source v2.
+ */
+case class AnalyzeTableExec(
+    resolvedTable: ResolvedTable,
+    statisticsCache: StatisticsCache) extends LeafV2CommandExec {
+  override protected def run(): Seq[InternalRow] = {
+    val colStats = resolvedTable.table match {
+      case read: SupportsRead =>
+        read.newScanBuilder(CaseInsensitiveStringMap.empty()).build() match {
+          case s: SupportsReportStatistics =>
+            s.estimateStatistics()
+          case _ => throw QueryCompilationErrors.unsupportedTableOperationError(
+            resolvedTable.catalog, resolvedTable.identifier, "ANALYZE TABLE")
+        }
+      case _ => throw QueryCompilationErrors.unsupportedTableOperationError(resolvedTable.catalog,
+        resolvedTable.identifier, "ANALYZE TABLE")
+    }
+    statisticsCache.put(ResolvedIdentifier(resolvedTable.catalog,
+      resolvedTable.identifier), colStats)
+    Seq.empty
+  }
+  override def output: Seq[Attribute] = Seq.empty
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala
@@ -260,6 +260,10 @@ abstract class BaseSessionStateBuilder(
     }
   }
 
+  protected def statisticsCache: StatisticsCache = {
+    new StatisticsCache
+  }
+
   /**
    * Custom operator optimization rules to add to the Optimizer. Prefer overriding this instead
    * of creating your own Optimizer.
@@ -373,6 +377,7 @@ abstract class BaseSessionStateBuilder(
       sqlParser,
       () => analyzer,
       () => optimizer,
+      () => statisticsCache,
       planner,
       () => streamingQueryManager,
       listenerManager,

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SessionState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SessionState.scala
@@ -76,6 +76,7 @@ private[sql] class SessionState(
     val sqlParser: ParserInterface,
     analyzerBuilder: () => Analyzer,
     optimizerBuilder: () => Optimizer,
+    statisticsCacheBuilder: () => StatisticsCache,
     val planner: SparkPlanner,
     val streamingQueryManagerBuilder: () => StreamingQueryManager,
     val listenerManager: ExecutionListenerManager,
@@ -92,6 +93,8 @@ private[sql] class SessionState(
   lazy val analyzer: Analyzer = analyzerBuilder()
 
   lazy val optimizer: Optimizer = optimizerBuilder()
+
+  lazy val statisticsCache: StatisticsCache = statisticsCacheBuilder()
 
   lazy val resourceLoader: SessionResourceLoader = resourceLoaderBuilder()
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -2271,8 +2271,12 @@ class DataSourceV2SQLSuiteV1Filter
     val t = "testcat.ns1.ns2.tbl"
     withTable(t) {
       spark.sql(s"CREATE TABLE $t (id bigint, data string) USING foo")
-      testNotSupportedV2Command("ANALYZE TABLE", s"$t COMPUTE STATISTICS")
-      testNotSupportedV2Command("ANALYZE TABLE", s"$t COMPUTE STATISTICS FOR ALL COLUMNS")
+      checkError(
+        exception = intercept[AnalysisException] {
+          sql(s"ANALYZE TABLE $t COMPUTE STATISTICS FOR ALL COLUMNS")
+        },
+        errorClass = "NOT_SUPPORTED_COMMAND_FOR_V2_TABLE",
+        parameters = Map("cmd" -> "ANALYZE TABLE ... FOR [ALL] COLUMNS ..."))
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Support ANALYZE TABLE on v2 tables.

Through this PR, users can use the `ANALYZE TABLE` statement on Datasourcev2 to analyze the table. Since the API of Datasourcev2 does not support the `NOSCAN` and `PARTITION` features, currently using the Analyze table with `PARTITION`, `COLUMNS` and `NOSCAN` statements will report an error.

The statistics obtained through the analysis will be stored in the `SessionState` to be used by statements of the `DESC EXTENDED`. In the future, the data in the `SessionState` can be provided to `DataSourceV2Relation` to reduce repeated statistics.

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
`ANALYZE TABLE` syntax for aligning Datasourcev1 and v2

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
No
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
Add new test
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
