### PR TITLE
[SPARK-43434][CONNECT][PYTHON][TESTS] Disable flaky doctest `pyspark.sql.connect.dataframe.DataFrame.writeStream`

### DIFF
--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -2171,6 +2171,9 @@ def _test() -> None:
     # TODO(SPARK-41888): Support StreamingQueryListener for DataFrame.observe
     del pyspark.sql.connect.dataframe.DataFrame.observe.__doc__
 
+    # TODO(SPARK-43435): should reenable this test
+    del pyspark.sql.connect.dataframe.DataFrame.writeStream.__doc__
+
     globs["spark"] = (
         PySparkSession.builder.appName("sql.connect.dataframe tests")
         .remote("local[4]")


### PR DESCRIPTION
### What changes were proposed in this pull request?
Disable flaky doctest `pyspark.sql.connect.dataframe.DataFrame.writeStream`


### Why are the changes needed?
This test is unstable, see https://github.com/apache/spark/pull/40586#issuecomment-1524690074 and https://github.com/apache/spark/pull/40586#discussion_r1182411427


### Does this PR introduce _any_ user-facing change?
No, dev-only


### How was this patch tested?
updated UT