### PR TITLE
[SPARK-38467][CORE] Use error classes in org.apache.spark.memory

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -824,6 +824,12 @@
     ],
     "sqlState" : "XX000"
   },
+  "INTERNAL_ERROR_MEMORY" : {
+    "message" : [
+      "<message>"
+    ],
+    "sqlState" : "XX000"
+  },
   "INTERVAL_ARITHMETIC_OVERFLOW" : {
     "message" : [
       "<message>.<alternative>"
@@ -870,11 +876,23 @@
     ],
     "sqlState" : "42000"
   },
+  "INVALID_DRIVER_MEMORY" : {
+    "message" : [
+      "System memory <systemMemory> must be at least <minSystemMemory>. Please increase heap size using the --driver-memory option or <config> in Spark configuration."
+    ],
+    "sqlState" : "F0000"
+  },
   "INVALID_EMPTY_LOCATION" : {
     "message" : [
       "The location name cannot be empty string, but `<location>` was given."
     ],
     "sqlState" : "42K05"
+  },
+  "INVALID_EXECUTOR_MEMORY" : {
+    "message" : [
+      "Executor memory <executorMemory> must be at least <minSystemMemory>. Please increase executor memory using the --executor-memory option or <config> in Spark configuration."
+    ],
+    "sqlState" : "F0000"
   },
   "INVALID_EXTRACT_BASE_FIELD_TYPE" : {
     "message" : [

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -878,7 +878,7 @@
   },
   "INVALID_DRIVER_MEMORY" : {
     "message" : [
-      "System memory <systemMemory> must be at least <minSystemMemory>. Please increase heap size using the --driver-memory option or <config> in Spark configuration."
+      "System memory <systemMemory> must be at least <minSystemMemory>. Please increase heap size using the --driver-memory option or \"<config>\" in Spark configuration."
     ],
     "sqlState" : "F0000"
   },
@@ -890,7 +890,7 @@
   },
   "INVALID_EXECUTOR_MEMORY" : {
     "message" : [
-      "Executor memory <executorMemory> must be at least <minSystemMemory>. Please increase executor memory using the --executor-memory option or <config> in Spark configuration."
+      "Executor memory <executorMemory> must be at least <minSystemMemory>. Please increase executor memory using the --executor-memory option or \"<config>\" in Spark configuration."
     ],
     "sqlState" : "F0000"
   },

--- a/core/src/main/scala/org/apache/spark/memory/StorageMemoryPool.scala
+++ b/core/src/main/scala/org/apache/spark/memory/StorageMemoryPool.scala
@@ -19,6 +19,7 @@ package org.apache.spark.memory
 
 import javax.annotation.concurrent.GuardedBy
 
+import org.apache.spark.SparkException
 import org.apache.spark.internal.Logging
 import org.apache.spark.storage.BlockId
 import org.apache.spark.storage.memory.MemoryStore
@@ -50,7 +51,7 @@ private[memory] class StorageMemoryPool(
   private var _memoryStore: MemoryStore = _
   def memoryStore: MemoryStore = {
     if (_memoryStore == null) {
-      throw new IllegalStateException("memory store not initialized yet")
+      throw SparkException.internalError("memory store not initialized yet", category = "MEMORY")
     }
     _memoryStore
   }

--- a/core/src/main/scala/org/apache/spark/memory/UnifiedMemoryManager.scala
+++ b/core/src/main/scala/org/apache/spark/memory/UnifiedMemoryManager.scala
@@ -216,7 +216,8 @@ object UnifiedMemoryManager {
       if (conf.contains(IS_TESTING)) 0 else RESERVED_SYSTEM_MEMORY_BYTES)
     val minSystemMemory = (reservedMemory * 1.5).ceil.toLong
     if (systemMemory < minSystemMemory) {
-      throw new SparkIllegalArgumentException(errorClass = "INVALID_DRIVER_MEMORY",
+      throw new SparkIllegalArgumentException(
+        errorClass = "INVALID_DRIVER_MEMORY",
         messageParameters = Map(
           "systemMemory" -> systemMemory.toString,
           "minSystemMemory" -> minSystemMemory.toString,
@@ -226,7 +227,8 @@ object UnifiedMemoryManager {
     if (conf.contains(config.EXECUTOR_MEMORY)) {
       val executorMemory = conf.getSizeAsBytes(config.EXECUTOR_MEMORY.key)
       if (executorMemory < minSystemMemory) {
-        throw new SparkIllegalArgumentException(errorClass = "INVALID_EXECUTOR_MEMORY",
+        throw new SparkIllegalArgumentException(
+          errorClass = "INVALID_EXECUTOR_MEMORY",
           messageParameters = Map(
             "executorMemory" -> executorMemory.toString,
             "minSystemMemory" -> minSystemMemory.toString,

--- a/core/src/main/scala/org/apache/spark/memory/UnifiedMemoryManager.scala
+++ b/core/src/main/scala/org/apache/spark/memory/UnifiedMemoryManager.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.memory
 
-import org.apache.spark.SparkConf
+import org.apache.spark.{SparkConf, SparkIllegalArgumentException}
 import org.apache.spark.internal.config
 import org.apache.spark.internal.config.Tests._
 import org.apache.spark.storage.BlockId
@@ -216,17 +216,21 @@ object UnifiedMemoryManager {
       if (conf.contains(IS_TESTING)) 0 else RESERVED_SYSTEM_MEMORY_BYTES)
     val minSystemMemory = (reservedMemory * 1.5).ceil.toLong
     if (systemMemory < minSystemMemory) {
-      throw new IllegalArgumentException(s"System memory $systemMemory must " +
-        s"be at least $minSystemMemory. Please increase heap size using the --driver-memory " +
-        s"option or ${config.DRIVER_MEMORY.key} in Spark configuration.")
+      throw new SparkIllegalArgumentException(errorClass = "INVALID_DRIVER_MEMORY",
+        messageParameters = Map(
+          "systemMemory" -> systemMemory.toString,
+          "minSystemMemory" -> minSystemMemory.toString,
+          "config" -> config.DRIVER_MEMORY.key))
     }
     // SPARK-12759 Check executor memory to fail fast if memory is insufficient
     if (conf.contains(config.EXECUTOR_MEMORY)) {
       val executorMemory = conf.getSizeAsBytes(config.EXECUTOR_MEMORY.key)
       if (executorMemory < minSystemMemory) {
-        throw new IllegalArgumentException(s"Executor memory $executorMemory must be at least " +
-          s"$minSystemMemory. Please increase executor memory using the " +
-          s"--executor-memory option or ${config.EXECUTOR_MEMORY.key} in Spark configuration.")
+        throw new SparkIllegalArgumentException(errorClass = "INVALID_EXECUTOR_MEMORY",
+          messageParameters = Map(
+            "executorMemory" -> executorMemory.toString,
+            "minSystemMemory" -> minSystemMemory.toString,
+            "config" -> config.EXECUTOR_MEMORY.key))
       }
     }
     val usableMemory = systemMemory - reservedMemory


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to change exceptions created in package org.apache.spark.memory to use error class. This also adds an error class INTERNAL_ERROR_MEMORY and uses that for the internal errors in the package.

### Why are the changes needed?
This is to move exceptions created in package org.apache.spark.memory to error class.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Existing unit tests.
