### PR TITLE
[SPARK-43441][CORE] `makeDotNode` should not fail when DeterministicLevel is absent

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/scope/RDDOperationGraph.scala
+++ b/core/src/main/scala/org/apache/spark/ui/scope/RDDOperationGraph.scala
@@ -258,6 +258,7 @@ private[spark] object RDDOperationGraph extends Logging {
       case DeterministicLevel.DETERMINATE => ""
       case DeterministicLevel.INDETERMINATE => " [Indeterminate]"
       case DeterministicLevel.UNORDERED => " [Unordered]"
+      case _ => ""
     }
     val escapedCallsite = Utility.escape(node.callsite)
     val label = s"${node.name} [${node.id}]$isCached$isBarrier$outputDeterministicLevel" +

--- a/core/src/test/scala/org/apache/spark/ui/scope/RDDOperationGraphSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/scope/RDDOperationGraphSuite.scala
@@ -17,10 +17,12 @@
 
 package org.apache.spark.ui.scope
 
+import org.scalatest.PrivateMethodTester
+
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.rdd.DeterministicLevel
 
-class RDDOperationGraphSuite extends SparkFunSuite {
+class RDDOperationGraphSuite extends SparkFunSuite with PrivateMethodTester {
   test("Test simple cluster equals") {
     // create a 2-cluster chain with a child
     val c1 = new RDDOperationCluster("1", false, "Bender")
@@ -35,5 +37,11 @@ class RDDOperationGraphSuite extends SparkFunSuite {
     c1copy.attachChildCluster(c2copy)
 
     assert(c1 == c1copy)
+  }
+
+  test("SPARK-XXXXX: makeDotNode should not fail when DeterministicLevel is absent") {
+    val node = new RDDOperationNode(0, "", false, false, "", null)
+    val _makeDotNode = PrivateMethod[String](Symbol("makeDotNode"))
+    RDDOperationGraph.invokePrivate(_makeDotNode(node))
   }
 }

--- a/core/src/test/scala/org/apache/spark/ui/scope/RDDOperationGraphSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/scope/RDDOperationGraphSuite.scala
@@ -39,7 +39,7 @@ class RDDOperationGraphSuite extends SparkFunSuite with PrivateMethodTester {
     assert(c1 == c1copy)
   }
 
-  test("SPARK-XXXXX: makeDotNode should not fail when DeterministicLevel is absent") {
+  test("SPARK-43441: makeDotNode should not fail when DeterministicLevel is absent") {
     val node = new RDDOperationNode(0, "", false, false, "", null)
     val _makeDotNode = PrivateMethod[String](Symbol("makeDotNode"))
     RDDOperationGraph.invokePrivate(_makeDotNode(node))


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to make `makeDotNode` method handle the missing `DeterministicLevel`.

### Why are the changes needed?

Some old Spark generated data do not have that field.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs with newly added test case.