### PR TITLE
[SPARK-43447][R] Support R 4.3.0

### DIFF
--- a/dev/appveyor-install-dependencies.ps1
+++ b/dev/appveyor-install-dependencies.ps1
@@ -129,7 +129,7 @@ $env:PATH = "$env:HADOOP_HOME\bin;" + $env:PATH
 Pop-Location
 
 # ========================== R
-$rVer = "4.2.0"
+$rVer = "4.3.0"
 $rToolsVer = "4.0.2"
 
 InstallR


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support R 4.3.0 officially in Apache Spark 3.5.0 by upgrading AppVeyor to 4.3.0.

### Why are the changes needed?

R 4.3.0 is released on April 21th, 2023.
- https://stat.ethz.ch/pipermail/r-announce/2023/000691.html

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

I verified locally.
```
$ R --version
R version 4.3.0 (2023-04-21) -- "Already Tomorrow"
Copyright (C) 2023 The R Foundation for Statistical Computing
Platform: aarch64-apple-darwin20 (64-bit)

R is free software and comes with ABSOLUTELY NO WARRANTY.
You are welcome to redistribute it under the terms of the
GNU General Public License versions 2 or 3.
For more information about these matters see
https://www.gnu.org/licenses/.

$ build/sbt package -Psparkr

$ R/install-dev.sh; R/run-tests.sh
...
Tests passed.
```