### PR TITLE
[SPARK-43302][SQL][FOLLOWUP] Code cleanup for PythonUDAF

### DIFF
--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -69,6 +69,10 @@ def _to_java_column(col: "ColumnOrName") -> JavaObject:
     return jcol
 
 
+def _to_java_expr(col: "ColumnOrName") -> JavaObject:
+    return _to_java_column(col).expr()
+
+
 def _to_seq(
     sc: SparkContext,
     cols: Iterable["ColumnOrName"],

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -422,7 +422,7 @@ class UserDefinedFunction:
                 func.__signature__ = inspect.signature(f)  # type: ignore[attr-defined]
                 judf = self._create_judf(func)
                 jPythonUDF = judf.apply(_to_seq(sc, cols, _to_java_column))
-                id = self._get_UDF_id(jPythonUDF.expr())
+                id = self._get_udf_id(jPythonUDF.expr())
                 sc.profiler_collector.add_profiler(id, profiler)
             else:  # memory_profiler_enabled
                 f = self.func
@@ -439,14 +439,14 @@ class UserDefinedFunction:
                 func.__signature__ = inspect.signature(f)  # type: ignore[attr-defined]
                 judf = self._create_judf(func)
                 jPythonUDF = judf.apply(_to_seq(sc, cols, _to_java_column))
-                id = self._get_UDF_id(jPythonUDF.expr())
+                id = self._get_udf_id(jPythonUDF.expr())
                 sc.profiler_collector.add_profiler(id, memory_profiler)
         else:
             judf = self._judf
             jPythonUDF = judf.apply(_to_seq(sc, cols, _to_java_column))
         return Column(jPythonUDF)
 
-    def _get_UDF_id(self, jexpr: JavaObject) -> int:
+    def _get_udf_id(self, jexpr: JavaObject) -> int:
         if is_instance_of(
             sc._gateway,
             jexpr,

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -453,7 +453,7 @@ class UserDefinedFunction:
             "org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression",
         ):
             return jexpr.child().resultId().id() # PythonUDAF
-        else
+        else:
             return jexpr.resultId().id() # PythonUDF
 
     # This function is for improving the online help system in the interactive interpreter.

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -452,9 +452,9 @@ class UserDefinedFunction:
             jexpr,
             "org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression",
         ):
-            return jexpr.child().resultId().id() # PythonUDAF
+            return jexpr.child().resultId().id()  # PythonUDAF
         else:
-            return jexpr.resultId().id() # PythonUDF
+            return jexpr.resultId().id()  # PythonUDF
 
     # This function is for improving the online help system in the interactive interpreter.
     # For example, the built-in help / pydoc.help. It wraps the UDF with the docstring and

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -422,7 +422,7 @@ class UserDefinedFunction:
                 func.__signature__ = inspect.signature(f)  # type: ignore[attr-defined]
                 judf = self._create_judf(func)
                 jPythonUDF = judf.apply(_to_seq(sc, cols, _to_java_column))
-                id = jPythonUDF.expr().resultId().id()
+                id = self._get_UDF_id(jPythonUDF.expr())
                 sc.profiler_collector.add_profiler(id, profiler)
             else:  # memory_profiler_enabled
                 f = self.func
@@ -439,12 +439,22 @@ class UserDefinedFunction:
                 func.__signature__ = inspect.signature(f)  # type: ignore[attr-defined]
                 judf = self._create_judf(func)
                 jPythonUDF = judf.apply(_to_seq(sc, cols, _to_java_column))
-                id = jPythonUDF.expr().resultId().id()
+                id = self._get_UDF_id(jPythonUDF.expr())
                 sc.profiler_collector.add_profiler(id, memory_profiler)
         else:
             judf = self._judf
             jPythonUDF = judf.apply(_to_seq(sc, cols, _to_java_column))
         return Column(jPythonUDF)
+
+    def _get_UDF_id(self, jexpr: JavaObject) -> int:
+        if is_instance_of(
+            sc._gateway,
+            jexpr,
+            "org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression",
+        ):
+            return jexpr.child().resultId().id() # PythonUDAF
+        else
+            return jexpr.resultId().id() # PythonUDF
 
     # This function is for improving the online help system in the interactive interpreter.
     # For example, the built-in help / pydoc.help. It wraps the UDF with the docstring and

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -421,7 +421,8 @@ class UserDefinedFunction:
 
                 func.__signature__ = inspect.signature(f)  # type: ignore[attr-defined]
                 judf = self._create_judf(func)
-                jPythonUDF = judf.builder(_to_seq(sc, cols, _to_java_expr))
+                jUDFExpr = judf.builder(_to_seq(sc, cols, _to_java_expr))
+                jPythonUDF = judf.fromUDFExpr(jUDFExpr)
                 id = jPythonUDF.resultId().id()
                 sc.profiler_collector.add_profiler(id, profiler)
             else:  # memory_profiler_enabled
@@ -438,7 +439,8 @@ class UserDefinedFunction:
 
                 func.__signature__ = inspect.signature(f)  # type: ignore[attr-defined]
                 judf = self._create_judf(func)
-                jPythonUDF = judf.builder(_to_seq(sc, cols, _to_java_expr))
+                jUDFExpr = judf.builder(_to_seq(sc, cols, _to_java_expr))
+                jPythonUDF = judf.fromUDFExpr(jUDFExpr)
                 id = jPythonUDF.resultId().id()
                 sc.profiler_collector.add_profiler(id, memory_profiler)
         else:

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -423,7 +423,7 @@ class UserDefinedFunction:
                 judf = self._create_judf(func)
                 jUDFExpr = judf.builder(_to_seq(sc, cols, _to_java_expr))
                 jPythonUDF = judf.fromUDFExpr(jUDFExpr)
-                id = jPythonUDF.resultId().id()
+                id = jUDFExpr.resultId().id()
                 sc.profiler_collector.add_profiler(id, profiler)
             else:  # memory_profiler_enabled
                 f = self.func
@@ -441,7 +441,7 @@ class UserDefinedFunction:
                 judf = self._create_judf(func)
                 jUDFExpr = judf.builder(_to_seq(sc, cols, _to_java_expr))
                 jPythonUDF = judf.fromUDFExpr(jUDFExpr)
-                id = jPythonUDF.resultId().id()
+                id = jUDFExpr.resultId().id()
                 sc.profiler_collector.add_profiler(id, memory_profiler)
         else:
             judf = self._judf

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/PythonUDF.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/PythonUDF.scala
@@ -22,7 +22,7 @@ import org.apache.spark.api.python.{PythonEvalType, PythonFunction}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateFunction
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, ExprCode}
-import org.apache.spark.sql.catalyst.trees.TreePattern.{PYTHON_UDAF, PYTHON_UDF, TreePattern}
+import org.apache.spark.sql.catalyst.trees.TreePattern.{PYTHON_UDF, TreePattern}
 import org.apache.spark.sql.catalyst.util.toPrettySQL
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.types.{DataType, StructType}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
@@ -76,7 +76,6 @@ object TreePattern extends Enumeration  {
   val PARAMETERIZED_QUERY: Value = Value
   val PIVOT: Value = Value
   val PLAN_EXPRESSION: Value = Value
-  val PYTHON_UDAF: Value = Value
   val PYTHON_UDF: Value = Value
   val REGEXP_EXTRACT_FAMILY: Value = Value
   val REGEXP_REPLACE: Value = Value

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/UserDefinedPythonFunction.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/UserDefinedPythonFunction.scala
@@ -42,9 +42,16 @@ case class UserDefinedPythonFunction(
 
   /** Returns a [[Column]] that will evaluate to calling this UDF with the given input. */
   def apply(exprs: Column*): Column = {
-    builder(exprs.map(_.expr)) match {
+    fromUDFExpr(builder(exprs.map(_.expr)))
+  }
+
+  /**
+   * Returns a [[Column]] that will evaluate the UDF expression with the given input.
+   */
+  def fromUDFExpr(expr: Expression): Column = {
+    expr match {
       case udaf: PythonUDAF => Column(udaf.toAggregateExpression())
-      case udf => Column(udf)
+      case _ => Column(expr)
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This is a followup of https://github.com/apache/spark/pull/40739 to do some code cleanup
1. remove the pattern `PYTHON_UDAF` as it's not used by any rule.
2. add `PythonFuncExpression.evalType` for convenience: catalyst rules (including third-party extensions) may want to get the eval type of a python function, no matter it's UDF or UDAF.
3. update the python profile to use `PythonUDAF.resultId` instead of `AggregateExpression.resultId`, to be consistent with `PythonUDF`

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  4. If you fix a bug, you can clarify why it is a bug.
-->
code cleanup

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
no

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
existing tests