### PR TITLE
[SPARK-43482][SS] Expand QueryTerminatedEvent to contain error class if it exists in exception

### DIFF
--- a/python/pyspark/sql/streaming/listener.py
+++ b/python/pyspark/sql/streaming/listener.py
@@ -271,10 +271,9 @@ class QueryTerminatedEvent:
         jexception = jevent.exception()
         self._exception: Optional[str] = jexception.get() if jexception.isDefined() else None
         jerrorclass = jevent.errorClassOnException()
-        if jerrorclass.isDefined():
-            self._errorClassOnException: Optional[str] = jerrorclass.get()
-        else:
-            self._errorClassOnException: Optional[str] = None
+        self._errorClassOnException: Optional[str] = (
+            jerrorclass.get() if jerrorclass.isDefined() else None
+        )
 
     @property
     def id(self) -> uuid.UUID:

--- a/python/pyspark/sql/streaming/listener.py
+++ b/python/pyspark/sql/streaming/listener.py
@@ -311,6 +311,7 @@ class QueryTerminatedEvent:
         """
         return self._errorClassOnException
 
+
 class StreamingQueryProgress:
     """
     .. versionadded:: 3.4.0

--- a/python/pyspark/sql/streaming/listener.py
+++ b/python/pyspark/sql/streaming/listener.py
@@ -307,6 +307,8 @@ class QueryTerminatedEvent:
         If the query was terminated without an exception, or the
         exception is not a part of error class framework, it will be
         `None`.
+
+        .. versionadded:: 3.5.0
         """
         return self._errorClassOnException
 

--- a/python/pyspark/sql/streaming/listener.py
+++ b/python/pyspark/sql/streaming/listener.py
@@ -270,6 +270,11 @@ class QueryTerminatedEvent:
         self._runId: uuid.UUID = uuid.UUID(jevent.runId().toString())
         jexception = jevent.exception()
         self._exception: Optional[str] = jexception.get() if jexception.isDefined() else None
+        jerrorclass = jevent.errorClassOnException()
+        if jerrorclass.isDefined():
+            self._errorClassOnException: Optional[str] = jerrorclass.get()
+        else:
+            self._errorClassOnException: Optional[str] = None
 
     @property
     def id(self) -> uuid.UUID:
@@ -295,6 +300,16 @@ class QueryTerminatedEvent:
         """
         return self._exception
 
+    @property
+    def errorClassOnException(self) -> Optional[str]:
+        """
+        The error class from the exception if the query was terminated
+        with an exception which is a part of error class framework.
+        If the query was terminated without an exception, or the
+        exception is not a part of error class framework, it will be
+        `None`.
+        """
+        return self._errorClassOnException
 
 class StreamingQueryProgress:
     """

--- a/python/pyspark/sql/tests/streaming/test_streaming_listener.py
+++ b/python/pyspark/sql/tests/streaming/test_streaming_listener.py
@@ -149,6 +149,7 @@ class StreamingListenerTests(ReusedSQLTestCase):
         self.assertTrue(isinstance(event.runId, uuid.UUID))
         # TODO: Needs a test for exception.
         self.assertEquals(event.exception, None)
+        self.assertEquals(event.errorClassOnException, None)
 
     def check_streaming_query_progress(self, progress):
         """Check StreamingQueryProgress"""

--- a/python/pyspark/sql/tests/streaming/test_streaming_listener.py
+++ b/python/pyspark/sql/tests/streaming/test_streaming_listener.py
@@ -65,7 +65,7 @@ class StreamingListenerTests(ReusedSQLTestCase):
             get_number_of_public_methods(
                 "org.apache.spark.sql.streaming.StreamingQueryListener$QueryTerminatedEvent"
             ),
-            13,
+            14,
             msg,
         )
         self.assertEquals(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
@@ -31,7 +31,7 @@ import scala.util.control.NonFatal
 import com.google.common.util.concurrent.UncheckedExecutionException
 import org.apache.hadoop.fs.Path
 
-import org.apache.spark.{SparkContext, SparkException}
+import org.apache.spark.{SparkContext, SparkException, SparkThrowable}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
@@ -353,8 +353,15 @@ abstract class StreamExecution(
 
         // Notify others
         sparkSession.streams.notifyQueryTermination(StreamExecution.this)
+        val errorClassOpt = exception.flatMap {
+          _.cause match {
+            case t: SparkThrowable => Some(t.getErrorClass)
+            case _ => None
+          }
+        }
         postEvent(
-          new QueryTerminatedEvent(id, runId, exception.map(_.cause).map(Utils.exceptionString)))
+          new QueryTerminatedEvent(id, runId, exception.map(_.cause).map(Utils.exceptionString),
+            errorClassOpt))
 
         // Delete the temp checkpoint when either force delete enabled or the query didn't fail
         if (deleteCheckpointOnStop &&

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryListener.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryListener.scala
@@ -166,5 +166,10 @@ object StreamingQueryListener {
       val id: UUID,
       val runId: UUID,
       val exception: Option[String],
-      val errorClassOnException: Option[String]) extends Event
+      val errorClassOnException: Option[String]) extends Event {
+    // compatibility with versions in prior to 3.5.0
+    def this(id: UUID, runId: UUID, exception: Option[String]) = {
+      this(id, runId, exception, None)
+    }
+  }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryListener.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryListener.scala
@@ -154,11 +154,17 @@ object StreamingQueryListener {
    * @param runId A query id that is unique for every start/restart. See `StreamingQuery.runId()`.
    * @param exception The exception message of the query if the query was terminated
    *                  with an exception. Otherwise, it will be `None`.
+   * @param errorClassOnException The error class from the exception if the query was terminated
+   *                              with an exception which is a part of error class framework.
+   *                              If the query was terminated without an exception, or the
+   *                              exception is not a part of error class framework, it will be
+   *                              `None`.
    * @since 2.1.0
    */
   @Evolving
   class QueryTerminatedEvent private[sql](
       val id: UUID,
       val runId: UUID,
-      val exception: Option[String]) extends Event
+      val exception: Option[String],
+      val errorClassOnException: Option[String]) extends Event
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryListenerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryListenerSuite.scala
@@ -165,6 +165,8 @@ class StreamingQueryListenerSuite extends StreamTest with BeforeAndAfter {
             listeners.foreach(listener => assert(listener.terminationEvent.id === query.id))
             listeners.foreach(listener => assert(listener.terminationEvent.runId === query.runId))
             listeners.foreach(listener => assert(listener.terminationEvent.exception === None))
+            listeners.foreach(listener => assert(listener.terminationEvent.errorClassOnException
+              === None))
           }
           listeners.foreach(listener => listener.checkAsyncErrors())
           listeners.foreach(listener => listener.reset())
@@ -190,6 +192,8 @@ class StreamingQueryListenerSuite extends StreamTest with BeforeAndAfter {
             listeners.foreach(listener => assert(listener.terminationEvent.id === query.id))
             listeners.foreach(listener => assert(listener.terminationEvent.runId === query.runId))
             listeners.foreach(listener => assert(listener.terminationEvent.exception === None))
+            listeners.foreach(listener => assert(listener.terminationEvent.errorClassOnException
+              === None))
           }
           listeners.foreach(listener => listener.checkAsyncErrors())
           listeners.foreach(listener => listener.reset())
@@ -280,11 +284,13 @@ class StreamingQueryListenerSuite extends StreamTest with BeforeAndAfter {
       assert(newEvent.id === event.id)
       assert(newEvent.runId === event.runId)
       assert(newEvent.exception === event.exception)
+      assert(newEvent.errorClassOnException === event.errorClassOnException)
     }
 
-    val exception = new RuntimeException("exception")
+    val exception = SparkException.internalError("testpurpose")
     testSerialization(
-      new QueryTerminatedEvent(UUID.randomUUID, UUID.randomUUID, Some(exception.getMessage)))
+      new QueryTerminatedEvent(UUID.randomUUID, UUID.randomUUID,
+        Some(exception.getMessage), Some(exception.getErrorClass)))
   }
 
   test("only one progress event per interval when no data") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/ui/StreamingQueryStatusListenerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/ui/StreamingQueryStatusListenerSuite.scala
@@ -104,7 +104,7 @@ class StreamingQueryStatusListenerSuite extends StreamTest {
     }
 
     // handle terminate event
-    val terminateEvent = new StreamingQueryListener.QueryTerminatedEvent(id, runId, None)
+    val terminateEvent = new StreamingQueryListener.QueryTerminatedEvent(id, runId, None, None)
     listener.onQueryTerminated(terminateEvent)
 
     assert(!queryStore.allQueryUIData.filterNot(_.summary.isActive).head.summary.isActive)
@@ -126,7 +126,7 @@ class StreamingQueryStatusListenerSuite extends StreamTest {
     listener.onQueryStarted(startEvent0)
 
     // handle terminate event
-    val terminateEvent0 = new StreamingQueryListener.QueryTerminatedEvent(id, runId0, None)
+    val terminateEvent0 = new StreamingQueryListener.QueryTerminatedEvent(id, runId0, None, None)
     listener.onQueryTerminated(terminateEvent0)
 
     // handle second time start
@@ -178,19 +178,19 @@ class StreamingQueryStatusListenerSuite extends StreamTest {
     val (id3, runId3) = addNewQuery()
     assert(queryStore.allQueryUIData.count(!_.summary.isActive) == 0)
 
-    val terminateEvent1 = new StreamingQueryListener.QueryTerminatedEvent(id1, runId1, None)
+    val terminateEvent1 = new StreamingQueryListener.QueryTerminatedEvent(id1, runId1, None, None)
     listener.onQueryTerminated(terminateEvent1)
     checkInactiveQueryStatus(1, Seq(id1))
     // SPARK-41972: having a short sleep here to make sure the end time of query 2 is larger than
     // query 1.
     Thread.sleep(20)
-    val terminateEvent2 = new StreamingQueryListener.QueryTerminatedEvent(id2, runId2, None)
+    val terminateEvent2 = new StreamingQueryListener.QueryTerminatedEvent(id2, runId2, None, None)
     listener.onQueryTerminated(terminateEvent2)
     checkInactiveQueryStatus(2, Seq(id1, id2))
     // SPARK-41972: having a short sleep here to make sure the end time of query 3 is larger than
     // query 2.
     Thread.sleep(20)
-    val terminateEvent3 = new StreamingQueryListener.QueryTerminatedEvent(id3, runId3, None)
+    val terminateEvent3 = new StreamingQueryListener.QueryTerminatedEvent(id3, runId3, None, None)
     listener.onQueryTerminated(terminateEvent3)
     checkInactiveQueryStatus(2, Seq(id2, id3))
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This adds a new field in QueryTerminatedEvent about "error class" if the information exists in the exception. Note that it doesn't retrieve the information from StreamingQueryException, because it is marked as it's own error class and we want to know the causing exception.

### Why are the changes needed?

Custom streaming query listeners can get the "categorized" error as cause of the query termination, which can be used to determine trends of the errors, aggregation, etc.

### Does this PR introduce _any_ user-facing change?

Yes, users having customer streaming query listener will have additional information in termination event.

### How was this patch tested?

Modified UTs.