### PR TITLE
[SPARK-43483][SQL][DOCS] Adds SQL references for OFFSET clause.

### DIFF
--- a/docs/sql-ref-syntax-qry-select-case.md
+++ b/docs/sql-ref-syntax-qry-select-case.md
@@ -105,6 +105,7 @@ SELECT * FROM person
 * [SORT BY Clause](sql-ref-syntax-qry-select-sortby.html)
 * [DISTRIBUTE BY Clause](sql-ref-syntax-qry-select-distribute-by.html)
 * [LIMIT Clause](sql-ref-syntax-qry-select-limit.html)
+* [OFFSET Clause](sql-ref-syntax-qry-select-offset.html)
 * [PIVOT Clause](sql-ref-syntax-qry-select-pivot.html)
 * [UNPIVOT Clause](sql-ref-syntax-qry-select-unpivot.html)
 * [LATERAL VIEW Clause](sql-ref-syntax-qry-select-lateral-view.html)

--- a/docs/sql-ref-syntax-qry-select-clusterby.md
+++ b/docs/sql-ref-syntax-qry-select-clusterby.md
@@ -99,6 +99,7 @@ SELECT age, name FROM person CLUSTER BY age;
 * [SORT BY Clause](sql-ref-syntax-qry-select-sortby.html)
 * [DISTRIBUTE BY Clause](sql-ref-syntax-qry-select-distribute-by.html)
 * [LIMIT Clause](sql-ref-syntax-qry-select-limit.html)
+* [OFFSET Clause](sql-ref-syntax-qry-select-offset.html)
 * [CASE Clause](sql-ref-syntax-qry-select-case.html)
 * [PIVOT Clause](sql-ref-syntax-qry-select-pivot.html)
 * [UNPIVOT Clause](sql-ref-syntax-qry-select-unpivot.html)

--- a/docs/sql-ref-syntax-qry-select-distribute-by.md
+++ b/docs/sql-ref-syntax-qry-select-distribute-by.md
@@ -94,6 +94,7 @@ SELECT age, name FROM person DISTRIBUTE BY age;
 * [SORT BY Clause](sql-ref-syntax-qry-select-sortby.html)
 * [CLUSTER BY Clause](sql-ref-syntax-qry-select-clusterby.html)
 * [LIMIT Clause](sql-ref-syntax-qry-select-limit.html)
+* [OFFSET Clause](sql-ref-syntax-qry-select-offset.html)
 * [CASE Clause](sql-ref-syntax-qry-select-case.html)
 * [PIVOT Clause](sql-ref-syntax-qry-select-pivot.html)
 * [UNPIVOT Clause](sql-ref-syntax-qry-select-unpivot.html)

--- a/docs/sql-ref-syntax-qry-select-groupby.md
+++ b/docs/sql-ref-syntax-qry-select-groupby.md
@@ -314,6 +314,7 @@ SELECT FIRST(age IGNORE NULLS), LAST(id), SUM(id) FROM person;
 * [CLUSTER BY Clause](sql-ref-syntax-qry-select-clusterby.html)
 * [DISTRIBUTE BY Clause](sql-ref-syntax-qry-select-distribute-by.html)
 * [LIMIT Clause](sql-ref-syntax-qry-select-limit.html)
+* [OFFSET Clause](sql-ref-syntax-qry-select-offset.html)
 * [CASE Clause](sql-ref-syntax-qry-select-case.html)
 * [PIVOT Clause](sql-ref-syntax-qry-select-pivot.html)
 * [UNPIVOT Clause](sql-ref-syntax-qry-select-unpivot.html)

--- a/docs/sql-ref-syntax-qry-select-having.md
+++ b/docs/sql-ref-syntax-qry-select-having.md
@@ -125,6 +125,7 @@ SELECT sum(quantity) AS sum FROM dealer HAVING sum(quantity) > 10;
 * [CLUSTER BY Clause](sql-ref-syntax-qry-select-clusterby.html)
 * [DISTRIBUTE BY Clause](sql-ref-syntax-qry-select-distribute-by.html)
 * [LIMIT Clause](sql-ref-syntax-qry-select-limit.html)
+* [OFFSET Clause](sql-ref-syntax-qry-select-offset.html)
 * [CASE Clause](sql-ref-syntax-qry-select-case.html)
 * [PIVOT Clause](sql-ref-syntax-qry-select-pivot.html)
 * [UNPIVOT Clause](sql-ref-syntax-qry-select-unpivot.html)

--- a/docs/sql-ref-syntax-qry-select-lateral-view.md
+++ b/docs/sql-ref-syntax-qry-select-lateral-view.md
@@ -121,6 +121,7 @@ SELECT * FROM person
 * [SORT BY Clause](sql-ref-syntax-qry-select-sortby.html)
 * [DISTRIBUTE BY Clause](sql-ref-syntax-qry-select-distribute-by.html)
 * [LIMIT Clause](sql-ref-syntax-qry-select-limit.html)
+* [OFFSET Clause](sql-ref-syntax-qry-select-offset.html)
 * [CASE Clause](sql-ref-syntax-qry-select-case.html)
 * [PIVOT Clause](sql-ref-syntax-qry-select-pivot.html)
 * [UNPIVOT Clause](sql-ref-syntax-qry-select-unpivot.html)

--- a/docs/sql-ref-syntax-qry-select-limit.md
+++ b/docs/sql-ref-syntax-qry-select-limit.md
@@ -91,21 +91,7 @@ SELECT name, age FROM person ORDER BY name LIMIT length('SPARK');
 
 -- A non-foldable expression as an input to LIMIT is not allowed.
 SELECT name, age FROM person ORDER BY name LIMIT length(name);
-org.apache.spark.sql.AnalysisException
-{
-  "errorClass" : "_LEGACY_ERROR_TEMP_2400",
-  "messageParameters" : {
-    "limitExpr" : "length(person.name)",
-    "name" : "limit"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 50,
-    "stopIndex" : 61,
-    "fragment" : "length(name)"
-  } ]
-}
+org.apache.spark.sql.AnalysisException: The limit expression must evaluate to a constant value ...
 ```
 
 ### Related Statements

--- a/docs/sql-ref-syntax-qry-select-offset.md
+++ b/docs/sql-ref-syntax-qry-select-offset.md
@@ -81,21 +81,7 @@ SELECT name, age FROM person ORDER BY name OFFSET length('SPARK');
 
 -- A non-foldable expression as an input to OFFSET is not allowed.
 SELECT name, age FROM person ORDER BY name OFFSET length(name);
-org.apache.spark.sql.AnalysisException
-{
-  "errorClass" : "_LEGACY_ERROR_TEMP_2400",
-  "messageParameters" : {
-    "limitExpr" : "length(person.name)",
-    "name" : "offset"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 51,
-    "stopIndex" : 62,
-    "fragment" : "length(name)"
-  } ]
-}
+org.apache.spark.sql.AnalysisException: The offset expression must evaluate to a constant value ...
 ```
 
 ### Related Statements

--- a/docs/sql-ref-syntax-qry-select-offset.md
+++ b/docs/sql-ref-syntax-qry-select-offset.md
@@ -1,7 +1,7 @@
 ---
 layout: global
-title: LIMIT Clause
-displayTitle: LIMIT Clause
+title: OFFSET Clause
+displayTitle: OFFSET Clause
 license: |
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -21,23 +21,18 @@ license: |
 
 ### Description
 
-The `LIMIT` clause is used to constrain the number of rows returned by
-the [SELECT](sql-ref-syntax-qry-select.html) statement. In general, this clause
+The `OFFSET` clause is used to specify the number of rows to skip before beginning to return rows
+returned by the [SELECT](sql-ref-syntax-qry-select.html) statement. In general, this clause
 is used in conjunction with [ORDER BY](sql-ref-syntax-qry-select-orderby.html) to
 ensure that the results are deterministic.
 
 ### Syntax
 
 ```sql
-LIMIT { ALL | integer_expression }
+OFFSET integer_expression
 ```
 
 ### Parameters
-
-* **ALL**
-
-    If specified, the query returns all the rows. In other words, no limit is applied if this
-    option is specified.
 
 * **integer_expression**
 
@@ -55,54 +50,49 @@ INSERT INTO person VALUES
     ('John A', 18),
     ('Jack N', 16);
 
--- Select the first two rows.
-SELECT name, age FROM person ORDER BY name LIMIT 2;
-+------+---+
-|  name|age|
-+------+---+
-|Anil B| 18|
-|Jack N| 16|
-+------+---+
-
--- Specifying ALL option on LIMIT returns all the rows.
-SELECT name, age FROM person ORDER BY name LIMIT ALL;
+-- Skip the first two rows.
+SELECT name, age FROM person ORDER BY name OFFSET 2;
 +-------+---+
 |   name|age|
 +-------+---+
-| Anil B| 18|
-| Jack N| 16|
 | John A| 18|
 | Mike A| 25|
 |Shone S| 16|
 |Zen Hui| 25|
 +-------+---+
 
--- A function expression as an input to LIMIT.
-SELECT name, age FROM person ORDER BY name LIMIT length('SPARK');
+-- Skip the first two rows and returns the next three rows.
+SELECT name, age FROM person ORDER BY name LIMIT 3 OFFSET 2;
 +-------+---+
 |   name|age|
 +-------+---+
-| Anil B| 18|
-| Jack N| 16|
 | John A| 18|
 | Mike A| 25|
 |Shone S| 16|
 +-------+---+
 
--- A non-foldable expression as an input to LIMIT is not allowed.
-SELECT name, age FROM person ORDER BY name LIMIT length(name);
+-- A function expression as an input to OFFSET.
+SELECT name, age FROM person ORDER BY name OFFSET length('SPARK');
++-------+---+
+|   name|age|
++-------+---+
+|Zen Hui| 25|
++-------+---+
+
+-- A non-foldable expression as an input to OFFSET is not allowed.
+SELECT name, age FROM person ORDER BY name OFFSET length(name);
 org.apache.spark.sql.AnalysisException
 {
   "errorClass" : "_LEGACY_ERROR_TEMP_2400",
   "messageParameters" : {
     "limitExpr" : "length(person.name)",
-    "name" : "limit"
+    "name" : "offset"
   },
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",
-    "startIndex" : 50,
-    "stopIndex" : 61,
+    "startIndex" : 51,
+    "stopIndex" : 62,
     "fragment" : "length(name)"
   } ]
 }
@@ -118,7 +108,7 @@ org.apache.spark.sql.AnalysisException
 * [SORT BY Clause](sql-ref-syntax-qry-select-sortby.html)
 * [CLUSTER BY Clause](sql-ref-syntax-qry-select-clusterby.html)
 * [DISTRIBUTE BY Clause](sql-ref-syntax-qry-select-distribute-by.html)
-* [OFFSET Clause](sql-ref-syntax-qry-select-offset.html)
+* [LIMIT Clause](sql-ref-syntax-qry-select-limit.html)
 * [CASE Clause](sql-ref-syntax-qry-select-case.html)
 * [PIVOT Clause](sql-ref-syntax-qry-select-pivot.html)
 * [UNPIVOT Clause](sql-ref-syntax-qry-select-unpivot.html)

--- a/docs/sql-ref-syntax-qry-select-orderby.md
+++ b/docs/sql-ref-syntax-qry-select-orderby.md
@@ -143,6 +143,7 @@ SELECT * FROM person ORDER BY name ASC, age DESC;
 * [CLUSTER BY Clause](sql-ref-syntax-qry-select-clusterby.html)
 * [DISTRIBUTE BY Clause](sql-ref-syntax-qry-select-distribute-by.html)
 * [LIMIT Clause](sql-ref-syntax-qry-select-limit.html)
+* [OFFSET Clause](sql-ref-syntax-qry-select-offset.html)
 * [CASE Clause](sql-ref-syntax-qry-select-case.html)
 * [PIVOT Clause](sql-ref-syntax-qry-select-pivot.html)
 * [UNPIVOT Clause](sql-ref-syntax-qry-select-unpivot.html)

--- a/docs/sql-ref-syntax-qry-select-pivot.md
+++ b/docs/sql-ref-syntax-qry-select-pivot.md
@@ -97,6 +97,7 @@ SELECT * FROM person
 * [SORT BY Clause](sql-ref-syntax-qry-select-sortby.html)
 * [DISTRIBUTE BY Clause](sql-ref-syntax-qry-select-distribute-by.html)
 * [LIMIT Clause](sql-ref-syntax-qry-select-limit.html)
+* [OFFSET Clause](sql-ref-syntax-qry-select-offset.html)
 * [CASE Clause](sql-ref-syntax-qry-select-case.html)
 * [UNPIVOT Clause](sql-ref-syntax-qry-select-unpivot.html)
 * [LATERAL VIEW Clause](sql-ref-syntax-qry-select-lateral-view.html)

--- a/docs/sql-ref-syntax-qry-select-sortby.md
+++ b/docs/sql-ref-syntax-qry-select-sortby.md
@@ -176,6 +176,7 @@ SELECT /*+ REPARTITION(zip_code) */ name, age, zip_code FROM person
 * [CLUSTER BY Clause](sql-ref-syntax-qry-select-clusterby.html)
 * [DISTRIBUTE BY Clause](sql-ref-syntax-qry-select-distribute-by.html)
 * [LIMIT Clause](sql-ref-syntax-qry-select-limit.html)
+* [OFFSET Clause](sql-ref-syntax-qry-select-offset.html)
 * [CASE Clause](sql-ref-syntax-qry-select-case.html)
 * [PIVOT Clause](sql-ref-syntax-qry-select-pivot.html)
 * [UNPIVOT Clause](sql-ref-syntax-qry-select-unpivot.html)

--- a/docs/sql-ref-syntax-qry-select-transform.md
+++ b/docs/sql-ref-syntax-qry-select-transform.md
@@ -261,6 +261,7 @@ WHERE zip_code > 94500;
 * [SORT BY Clause](sql-ref-syntax-qry-select-sortby.html)
 * [DISTRIBUTE BY Clause](sql-ref-syntax-qry-select-distribute-by.html)
 * [LIMIT Clause](sql-ref-syntax-qry-select-limit.html)
+* [OFFSET Clause](sql-ref-syntax-qry-select-offset.html)
 * [CASE Clause](sql-ref-syntax-qry-select-case.html)
 * [PIVOT Clause](sql-ref-syntax-qry-select-pivot.html)
 * [UNPIVOT Clause](sql-ref-syntax-qry-select-unpivot.html)

--- a/docs/sql-ref-syntax-qry-select-unpivot.md
+++ b/docs/sql-ref-syntax-qry-select-unpivot.md
@@ -138,6 +138,7 @@ SELECT * FROM sales_quarterly
 * [SORT BY Clause](sql-ref-syntax-qry-select-sortby.html)
 * [DISTRIBUTE BY Clause](sql-ref-syntax-qry-select-distribute-by.html)
 * [LIMIT Clause](sql-ref-syntax-qry-select-limit.html)
+* [OFFSET Clause](sql-ref-syntax-qry-select-offset.html)
 * [CASE Clause](sql-ref-syntax-qry-select-case.html)
 * [PIVOT Clause](sql-ref-syntax-qry-select-pivot.html)
 * [LATERAL VIEW Clause](sql-ref-syntax-qry-select-lateral-view.html)

--- a/docs/sql-ref-syntax-qry-select-where.md
+++ b/docs/sql-ref-syntax-qry-select-where.md
@@ -125,6 +125,7 @@ SELECT * FROM person AS parent
 * [CLUSTER BY Clause](sql-ref-syntax-qry-select-clusterby.html)
 * [DISTRIBUTE BY Clause](sql-ref-syntax-qry-select-distribute-by.html)
 * [LIMIT Clause](sql-ref-syntax-qry-select-limit.html)
+* [OFFSET Clause](sql-ref-syntax-qry-select-offset.html)
 * [CASE Clause](sql-ref-syntax-qry-select-case.html)
 * [PIVOT Clause](sql-ref-syntax-qry-select-pivot.html)
 * [UNPIVOT Clause](sql-ref-syntax-qry-select-unpivot.html)

--- a/docs/sql-ref-syntax-qry-select.md
+++ b/docs/sql-ref-syntax-qry-select.md
@@ -185,6 +185,7 @@ SELECT [ hints , ... ] [ ALL | DISTINCT ] { [ [ named_expression | regex_column_
 * [CLUSTER BY Clause](sql-ref-syntax-qry-select-clusterby.html)
 * [DISTRIBUTE BY Clause](sql-ref-syntax-qry-select-distribute-by.html)
 * [LIMIT Clause](sql-ref-syntax-qry-select-limit.html)
+* [OFFSET Clause](sql-ref-syntax-qry-select-offset.html)
 * [Common Table Expression](sql-ref-syntax-qry-select-cte.html)
 * [Hints](sql-ref-syntax-qry-select-hints.html)
 * [Inline Table](sql-ref-syntax-qry-select-inline-table.html)

--- a/docs/sql-ref-syntax.md
+++ b/docs/sql-ref-syntax.md
@@ -70,6 +70,7 @@ ability to generate logical and physical plan for a given query using
    * [JOIN](sql-ref-syntax-qry-select-join.html)
    * [LIKE Predicate](sql-ref-syntax-qry-select-like.html)
    * [LIMIT Clause](sql-ref-syntax-qry-select-limit.html)
+   * [OFFSET Clause](sql-ref-syntax-qry-select-offset.html)
    * [ORDER BY Clause](sql-ref-syntax-qry-select-orderby.html)
    * [Set Operators](sql-ref-syntax-qry-select-setops.html)
    * [SORT BY Clause](sql-ref-syntax-qry-select-sortby.html)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Spark 3.4.0 released the new syntax: `OFFSET clause`.
But the SQL reference missing the description for it.


### Why are the changes needed?
Adds SQL reference for `OFFSET` clause.

### Does this PR introduce _any_ user-facing change?
'Yes'.
Users could find out the SQL reference for `OFFSET` clause.


### How was this patch tested?
Manual verify.
![image](https://github.com/apache/spark/assets/8486025/55398194-5193-45eb-ac04-10f5f0793f7f)
![image](https://github.com/apache/spark/assets/8486025/fef0abc1-7dfa-44e2-b2e0-a56fa82a0817)
![image](https://github.com/apache/spark/assets/8486025/5ab9dc39-6812-45b4-a758-85668ab040f1)
![image](https://github.com/apache/spark/assets/8486025/b726abd4-daae-4de4-a78e-45120573e699)


