### PR TITLE
[SPARK-43487][SQL] Fix Nested CTE error message

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -5,6 +5,13 @@
     ],
     "sqlState" : "42710"
   },
+  "AMBIGUOUS_ALIAS_IN_NESTED_CTE" : {
+    "message" : [
+      "Name <name> is ambiguous in nested CTE.",
+      "Please set <config> to \"CORRECTED\" so that name defined in inner CTE takes precedence. If set it to \"LEGACY\", outer CTE definitions will take precedence.",
+      "See '<docroot>/sql-migration-guide.html#query-engine'."
+    ]
+  },
   "AMBIGUOUS_COLUMN_OR_FIELD" : {
     "message" : [
       "Column or field <name> is ambiguous and has <n> matches."
@@ -3781,12 +3788,6 @@
   "_LEGACY_ERROR_TEMP_1347" : {
     "message" : [
       "Failed to execute command because subquery expressions are not allowed in DEFAULT values."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_1348" : {
-    "message" : [
-      "Name <name> is ambiguous in nested CTE.",
-      "Please set <config> to CORRECTED so that name defined in inner CTE takes precedence. If set it to LEGACY, outer CTE definitions will take precedence. See more details in SPARK-28228."
     ]
   },
   "_LEGACY_ERROR_TEMP_2000" : {

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -3783,6 +3783,12 @@
       "Failed to execute command because subquery expressions are not allowed in DEFAULT values."
     ]
   },
+  "_LEGACY_ERROR_TEMP_1348" : {
+    "message" : [
+      "Name <name> is ambiguous in nested CTE.",
+      "Please set <config> to CORRECTED so that name defined in inner CTE takes precedence. If set it to LEGACY, outer CTE definitions will take precedence. See more details in SPARK-28228."
+    ]
+  },
   "_LEGACY_ERROR_TEMP_2000" : {
     "message" : [
       "<message>. If necessary set <ansiConfig> to false to bypass this error."

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -3225,14 +3225,6 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase {
       messageParameters = Map.empty)
   }
 
-  def ambiguousRelationAliasNameInNestedCTEError(name: String): Throwable = {
-    new AnalysisException(
-      errorClass = "_LEGACY_ERROR_TEMP_1348",
-      messageParameters = Map(
-        "name" -> name,
-        "config" -> LEGACY_CTE_PRECEDENCE_POLICY.key))
-  }
-
   def nullableColumnOrFieldError(name: Seq[String]): Throwable = {
     new AnalysisException(
       errorClass = "NULLABLE_COLUMN_OR_FIELD",
@@ -3440,6 +3432,15 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase {
           messageParameters = Map("funcName" -> toSQLId(funcName)),
           cause = Option(other))
     }
+  }
+
+  def ambiguousRelationAliasNameInNestedCTEError(name: String): Throwable = {
+    new AnalysisException(
+      errorClass = "AMBIGUOUS_ALIAS_IN_NESTED_CTE",
+      messageParameters = Map(
+        "name" -> toSQLId(name),
+        "config" -> toSQLConf(LEGACY_CTE_PRECEDENCE_POLICY.key),
+        "docroot" -> SPARK_DOC_ROOT))
   }
 
   def ambiguousLateralColumnAliasError(name: String, numOfMatches: Int): Throwable = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -2050,14 +2050,6 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase {
         "inputTypesLen" -> bound.inputTypes().length.toString))
   }
 
-  def ambiguousRelationAliasNameInNestedCTEError(name: String): Throwable = {
-    new AnalysisException(
-      errorClass = "_LEGACY_ERROR_TEMP_1200",
-      messageParameters = Map(
-        "name" -> name,
-        "config" -> LEGACY_CTE_PRECEDENCE_POLICY.key))
-  }
-
   def commandUnsupportedInV2TableError(name: String): Throwable = {
     new AnalysisException(
       errorClass = "_LEGACY_ERROR_TEMP_1200",
@@ -3231,6 +3223,14 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase {
     new AnalysisException(
       errorClass = "_LEGACY_ERROR_TEMP_1347",
       messageParameters = Map.empty)
+  }
+
+  def ambiguousRelationAliasNameInNestedCTEError(name: String): Throwable = {
+    new AnalysisException(
+      errorClass = "_LEGACY_ERROR_TEMP_1348",
+      messageParameters = Map(
+        "name" -> name,
+        "config" -> LEGACY_CTE_PRECEDENCE_POLICY.key))
   }
 
   def nullableColumnOrFieldError(name: Seq[String]): Throwable = {

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/cte-nested.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/cte-nested.sql.out
@@ -95,10 +95,11 @@ SELECT * FROM t2
 -- !query analysis
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1200",
+  "errorClass" : "AMBIGUOUS_ALIAS_IN_NESTED_CTE",
   "messageParameters" : {
-    "config" : "spark.sql.legacy.ctePrecedencePolicy",
-    "name" : "t"
+    "config" : "\"spark.sql.legacy.ctePrecedencePolicy\"",
+    "docroot" : "https://spark.apache.org/docs/latest",
+    "name" : "`t`"
   }
 }
 
@@ -157,10 +158,11 @@ SELECT * FROM t2
 -- !query analysis
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1200",
+  "errorClass" : "AMBIGUOUS_ALIAS_IN_NESTED_CTE",
   "messageParameters" : {
-    "config" : "spark.sql.legacy.ctePrecedencePolicy",
-    "name" : "t"
+    "config" : "\"spark.sql.legacy.ctePrecedencePolicy\"",
+    "docroot" : "https://spark.apache.org/docs/latest",
+    "name" : "`t`"
   }
 }
 
@@ -263,10 +265,11 @@ SELECT (
 -- !query analysis
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1200",
+  "errorClass" : "AMBIGUOUS_ALIAS_IN_NESTED_CTE",
   "messageParameters" : {
-    "config" : "spark.sql.legacy.ctePrecedencePolicy",
-    "name" : "t"
+    "config" : "\"spark.sql.legacy.ctePrecedencePolicy\"",
+    "docroot" : "https://spark.apache.org/docs/latest",
+    "name" : "`t`"
   }
 }
 
@@ -282,10 +285,11 @@ SELECT (
 -- !query analysis
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1200",
+  "errorClass" : "AMBIGUOUS_ALIAS_IN_NESTED_CTE",
   "messageParameters" : {
-    "config" : "spark.sql.legacy.ctePrecedencePolicy",
-    "name" : "t"
+    "config" : "\"spark.sql.legacy.ctePrecedencePolicy\"",
+    "docroot" : "https://spark.apache.org/docs/latest",
+    "name" : "`t`"
   }
 }
 
@@ -302,10 +306,11 @@ SELECT (
 -- !query analysis
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1200",
+  "errorClass" : "AMBIGUOUS_ALIAS_IN_NESTED_CTE",
   "messageParameters" : {
-    "config" : "spark.sql.legacy.ctePrecedencePolicy",
-    "name" : "t"
+    "config" : "\"spark.sql.legacy.ctePrecedencePolicy\"",
+    "docroot" : "https://spark.apache.org/docs/latest",
+    "name" : "`t`"
   }
 }
 
@@ -320,10 +325,11 @@ WHERE c IN (
 -- !query analysis
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1200",
+  "errorClass" : "AMBIGUOUS_ALIAS_IN_NESTED_CTE",
   "messageParameters" : {
-    "config" : "spark.sql.legacy.ctePrecedencePolicy",
-    "name" : "t"
+    "config" : "\"spark.sql.legacy.ctePrecedencePolicy\"",
+    "docroot" : "https://spark.apache.org/docs/latest",
+    "name" : "`t`"
   }
 }
 
@@ -367,10 +373,11 @@ SELECT * FROM t
 -- !query analysis
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1200",
+  "errorClass" : "AMBIGUOUS_ALIAS_IN_NESTED_CTE",
   "messageParameters" : {
-    "config" : "spark.sql.legacy.ctePrecedencePolicy",
-    "name" : "aBc"
+    "config" : "\"spark.sql.legacy.ctePrecedencePolicy\"",
+    "docroot" : "https://spark.apache.org/docs/latest",
+    "name" : "`aBc`"
   }
 }
 
@@ -384,10 +391,11 @@ SELECT (
 -- !query analysis
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1200",
+  "errorClass" : "AMBIGUOUS_ALIAS_IN_NESTED_CTE",
   "messageParameters" : {
-    "config" : "spark.sql.legacy.ctePrecedencePolicy",
-    "name" : "aBc"
+    "config" : "\"spark.sql.legacy.ctePrecedencePolicy\"",
+    "docroot" : "https://spark.apache.org/docs/latest",
+    "name" : "`aBc`"
   }
 }
 

--- a/sql/core/src/test/resources/sql-tests/results/cte-nested.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/cte-nested.sql.out
@@ -74,7 +74,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1200",
+  "errorClass" : "_LEGACY_ERROR_TEMP_1348",
   "messageParameters" : {
     "config" : "spark.sql.legacy.ctePrecedencePolicy",
     "name" : "t"
@@ -117,7 +117,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1200",
+  "errorClass" : "_LEGACY_ERROR_TEMP_1348",
   "messageParameters" : {
     "config" : "spark.sql.legacy.ctePrecedencePolicy",
     "name" : "t"
@@ -177,7 +177,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1200",
+  "errorClass" : "_LEGACY_ERROR_TEMP_1348",
   "messageParameters" : {
     "config" : "spark.sql.legacy.ctePrecedencePolicy",
     "name" : "t"
@@ -198,7 +198,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1200",
+  "errorClass" : "_LEGACY_ERROR_TEMP_1348",
   "messageParameters" : {
     "config" : "spark.sql.legacy.ctePrecedencePolicy",
     "name" : "t"
@@ -220,7 +220,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1200",
+  "errorClass" : "_LEGACY_ERROR_TEMP_1348",
   "messageParameters" : {
     "config" : "spark.sql.legacy.ctePrecedencePolicy",
     "name" : "t"
@@ -240,7 +240,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1200",
+  "errorClass" : "_LEGACY_ERROR_TEMP_1348",
   "messageParameters" : {
     "config" : "spark.sql.legacy.ctePrecedencePolicy",
     "name" : "t"
@@ -275,7 +275,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1200",
+  "errorClass" : "_LEGACY_ERROR_TEMP_1348",
   "messageParameters" : {
     "config" : "spark.sql.legacy.ctePrecedencePolicy",
     "name" : "aBc"
@@ -294,7 +294,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1200",
+  "errorClass" : "_LEGACY_ERROR_TEMP_1348",
   "messageParameters" : {
     "config" : "spark.sql.legacy.ctePrecedencePolicy",
     "name" : "aBc"

--- a/sql/core/src/test/resources/sql-tests/results/cte-nested.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/cte-nested.sql.out
@@ -74,10 +74,11 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1348",
+  "errorClass" : "AMBIGUOUS_ALIAS_IN_NESTED_CTE",
   "messageParameters" : {
-    "config" : "spark.sql.legacy.ctePrecedencePolicy",
-    "name" : "t"
+    "config" : "\"spark.sql.legacy.ctePrecedencePolicy\"",
+    "docroot" : "https://spark.apache.org/docs/latest",
+    "name" : "`t`"
   }
 }
 
@@ -117,10 +118,11 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1348",
+  "errorClass" : "AMBIGUOUS_ALIAS_IN_NESTED_CTE",
   "messageParameters" : {
-    "config" : "spark.sql.legacy.ctePrecedencePolicy",
-    "name" : "t"
+    "config" : "\"spark.sql.legacy.ctePrecedencePolicy\"",
+    "docroot" : "https://spark.apache.org/docs/latest",
+    "name" : "`t`"
   }
 }
 
@@ -177,10 +179,11 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1348",
+  "errorClass" : "AMBIGUOUS_ALIAS_IN_NESTED_CTE",
   "messageParameters" : {
-    "config" : "spark.sql.legacy.ctePrecedencePolicy",
-    "name" : "t"
+    "config" : "\"spark.sql.legacy.ctePrecedencePolicy\"",
+    "docroot" : "https://spark.apache.org/docs/latest",
+    "name" : "`t`"
   }
 }
 
@@ -198,10 +201,11 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1348",
+  "errorClass" : "AMBIGUOUS_ALIAS_IN_NESTED_CTE",
   "messageParameters" : {
-    "config" : "spark.sql.legacy.ctePrecedencePolicy",
-    "name" : "t"
+    "config" : "\"spark.sql.legacy.ctePrecedencePolicy\"",
+    "docroot" : "https://spark.apache.org/docs/latest",
+    "name" : "`t`"
   }
 }
 
@@ -220,10 +224,11 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1348",
+  "errorClass" : "AMBIGUOUS_ALIAS_IN_NESTED_CTE",
   "messageParameters" : {
-    "config" : "spark.sql.legacy.ctePrecedencePolicy",
-    "name" : "t"
+    "config" : "\"spark.sql.legacy.ctePrecedencePolicy\"",
+    "docroot" : "https://spark.apache.org/docs/latest",
+    "name" : "`t`"
   }
 }
 
@@ -240,10 +245,11 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1348",
+  "errorClass" : "AMBIGUOUS_ALIAS_IN_NESTED_CTE",
   "messageParameters" : {
-    "config" : "spark.sql.legacy.ctePrecedencePolicy",
-    "name" : "t"
+    "config" : "\"spark.sql.legacy.ctePrecedencePolicy\"",
+    "docroot" : "https://spark.apache.org/docs/latest",
+    "name" : "`t`"
   }
 }
 
@@ -275,10 +281,11 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1348",
+  "errorClass" : "AMBIGUOUS_ALIAS_IN_NESTED_CTE",
   "messageParameters" : {
-    "config" : "spark.sql.legacy.ctePrecedencePolicy",
-    "name" : "aBc"
+    "config" : "\"spark.sql.legacy.ctePrecedencePolicy\"",
+    "docroot" : "https://spark.apache.org/docs/latest",
+    "name" : "`aBc`"
   }
 }
 
@@ -294,10 +301,11 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1348",
+  "errorClass" : "AMBIGUOUS_ALIAS_IN_NESTED_CTE",
   "messageParameters" : {
-    "config" : "spark.sql.legacy.ctePrecedencePolicy",
-    "name" : "aBc"
+    "config" : "\"spark.sql.legacy.ctePrecedencePolicy\"",
+    "docroot" : "https://spark.apache.org/docs/latest",
+    "name" : "`aBc`"
   }
 }
 


### PR DESCRIPTION

### What changes were proposed in this pull request?
The batch of errors migrated to error classes as part of spark-40540 contains an error that got mixed up with the wrong error message:

[ambiguousRelationAliasNameInNestedCTEError](https://github.com/apache/spark/commit/43a6b932759865c45ccf36f3e9cf6898c1b762da#diff-744ac13f6fe074fddeab09b407404bffa2386f54abc83c501e6e1fe618f6db56R1983) uses the same error message as the following commandUnsupportedInV2TableError:

WITH t AS (SELECT 1), t2 AS ( WITH t AS (SELECT 2) SELECT * FROM t) SELECT * FROM t2;
AnalysisException: t is not supported for v2 tables

The error should be:

AnalysisException: Name tis ambiguous in nested CTE.
Please set spark.sql.legacy.ctePrecedencePolicy to CORRECTED so that name defined in inner CTE takes precedence. If set it to LEGACY, outer CTE definitions will take precedence. See more details in SPARK-28228.

### Does this PR introduce _any_ user-facing change?
Fix user-facing error message for ambiguous name in nested CTEs.


### How was this patch tested?
