### PR TITLE
[SPARK-41971][PYTHON][FOLLOWUP] Fix toPandas to support empty columns

### DIFF
--- a/python/pyspark/sql/connect/client.py
+++ b/python/pyspark/sql/connect/client.py
@@ -713,31 +713,32 @@ class SparkConnectClient(object):
         pdf = table.rename_columns([f"col_{i}" for i in range(table.num_columns)]).to_pandas()
         pdf.columns = schema.names
 
-        timezone: Optional[str] = None
-        struct_in_pandas: Optional[str] = None
-        error_on_duplicated_field_names: bool = False
-        if any(_has_type(f.dataType, (StructType, TimestampType)) for f in schema.fields):
-            timezone, struct_in_pandas = self.get_configs(
-                "spark.sql.session.timeZone", "spark.sql.execution.pandas.structHandlingMode"
+        if len(pdf.columns) > 0:
+            timezone: Optional[str] = None
+            struct_in_pandas: Optional[str] = None
+            error_on_duplicated_field_names: bool = False
+            if any(_has_type(f.dataType, (StructType, TimestampType)) for f in schema.fields):
+                timezone, struct_in_pandas = self.get_configs(
+                    "spark.sql.session.timeZone", "spark.sql.execution.pandas.structHandlingMode"
+                )
+
+                if struct_in_pandas == "legacy":
+                    error_on_duplicated_field_names = True
+                    struct_in_pandas = "dict"
+
+            pdf = pd.concat(
+                [
+                    _create_converter_to_pandas(
+                        field.dataType,
+                        field.nullable,
+                        timezone=timezone,
+                        struct_in_pandas=struct_in_pandas,
+                        error_on_duplicated_field_names=error_on_duplicated_field_names,
+                    )(pser)
+                    for (_, pser), field, pa_field in zip(pdf.items(), schema.fields, table.schema)
+                ],
+                axis="columns",
             )
-
-            if struct_in_pandas == "legacy":
-                error_on_duplicated_field_names = True
-                struct_in_pandas = "dict"
-
-        pdf = pd.concat(
-            [
-                _create_converter_to_pandas(
-                    field.dataType,
-                    field.nullable,
-                    timezone=timezone,
-                    struct_in_pandas=struct_in_pandas,
-                    error_on_duplicated_field_names=error_on_duplicated_field_names,
-                )(pser)
-                for (_, pser), field, pa_field in zip(pdf.items(), schema.fields, table.schema)
-            ],
-            axis="columns",
-        )
 
         if len(metrics) > 0:
             pdf.attrs["metrics"] = metrics

--- a/python/pyspark/sql/pandas/conversion.py
+++ b/python/pyspark/sql/pandas/conversion.py
@@ -85,8 +85,6 @@ class PandasConversionMixin:
         import pandas as pd
 
         jconf = self.sparkSession._jconf
-        timezone = jconf.sessionLocalTimeZone()
-        struct_in_pandas = jconf.pandasStructHandlingMode()
 
         if jconf.arrowPySparkEnabled():
             use_arrow = True
@@ -159,24 +157,30 @@ class PandasConversionMixin:
                     else:
                         pdf = pd.DataFrame(columns=self.columns)
 
-                    error_on_duplicated_field_names = False
-                    if struct_in_pandas == "legacy":
-                        error_on_duplicated_field_names = True
-                        struct_in_pandas = "dict"
+                    if len(pdf.columns) > 0:
+                        timezone = jconf.sessionLocalTimeZone()
+                        struct_in_pandas = jconf.pandasStructHandlingMode()
 
-                    return pd.concat(
-                        [
-                            _create_converter_to_pandas(
-                                field.dataType,
-                                field.nullable,
-                                timezone=timezone,
-                                struct_in_pandas=struct_in_pandas,
-                                error_on_duplicated_field_names=error_on_duplicated_field_names,
-                            )(pser)
-                            for (_, pser), field in zip(pdf.items(), self.schema.fields)
-                        ],
-                        axis="columns",
-                    )
+                        error_on_duplicated_field_names = False
+                        if struct_in_pandas == "legacy":
+                            error_on_duplicated_field_names = True
+                            struct_in_pandas = "dict"
+
+                        return pd.concat(
+                            [
+                                _create_converter_to_pandas(
+                                    field.dataType,
+                                    field.nullable,
+                                    timezone=timezone,
+                                    struct_in_pandas=struct_in_pandas,
+                                    error_on_duplicated_field_names=error_on_duplicated_field_names,
+                                )(pser)
+                                for (_, pser), field in zip(pdf.items(), self.schema.fields)
+                            ],
+                            axis="columns",
+                        )
+                    else:
+                        return pdf
                 except Exception as e:
                     # We might have to allow fallback here as well but multiple Spark jobs can
                     # be executed. So, simply fail in this case for now.
@@ -192,21 +196,32 @@ class PandasConversionMixin:
                     raise
 
         # Below is toPandas without Arrow optimization.
-        pdf = pd.DataFrame.from_records(self.collect(), columns=self.columns)
-
-        return pd.concat(
-            [
-                _create_converter_to_pandas(
-                    field.dataType,
-                    field.nullable,
-                    timezone=timezone,
-                    struct_in_pandas=("row" if struct_in_pandas == "legacy" else struct_in_pandas),
-                    error_on_duplicated_field_names=False,
-                )(pser)
-                for (_, pser), field in zip(pdf.items(), self.schema.fields)
-            ],
-            axis="columns",
+        rows = self.collect()
+        pdf = pd.DataFrame.from_records(
+            rows, index=range(len(rows)), columns=self.columns  # type: ignore[arg-type]
         )
+
+        if len(pdf.columns) > 0:
+            timezone = jconf.sessionLocalTimeZone()
+            struct_in_pandas = jconf.pandasStructHandlingMode()
+
+            return pd.concat(
+                [
+                    _create_converter_to_pandas(
+                        field.dataType,
+                        field.nullable,
+                        timezone=timezone,
+                        struct_in_pandas=(
+                            "row" if struct_in_pandas == "legacy" else struct_in_pandas
+                        ),
+                        error_on_duplicated_field_names=False,
+                    )(pser)
+                    for (_, pser), field in zip(pdf.items(), self.schema.fields)
+                ],
+                axis="columns",
+            )
+        else:
+            return pdf
 
     def _collect_as_arrow(self, split_batches: bool = False) -> List["pa.RecordBatch"]:
         """

--- a/python/pyspark/sql/pandas/conversion.py
+++ b/python/pyspark/sql/pandas/conversion.py
@@ -197,9 +197,12 @@ class PandasConversionMixin:
 
         # Below is toPandas without Arrow optimization.
         rows = self.collect()
-        pdf = pd.DataFrame.from_records(
-            rows, index=range(len(rows)), columns=self.columns  # type: ignore[arg-type]
-        )
+        if len(rows) > 0:
+            pdf = pd.DataFrame.from_records(
+                rows, index=range(len(rows)), columns=self.columns  # type: ignore[arg-type]
+            )
+        else:
+            pdf = pd.DataFrame(columns=self.columns)
 
         if len(pdf.columns) > 0:
             timezone = jconf.sessionLocalTimeZone()

--- a/python/pyspark/sql/tests/connect/test_parity_arrow.py
+++ b/python/pyspark/sql/tests/connect/test_parity_arrow.py
@@ -109,6 +109,9 @@ class ArrowParityTests(ArrowTestsMixin, ReusedConnectTestCase):
     def test_toPandas_duplicate_field_names(self):
         self.check_toPandas_duplicate_field_names(True)
 
+    def test_toPandas_empty_columns(self):
+        self.check_toPandas_empty_columns(True)
+
 
 if __name__ == "__main__":
     from pyspark.sql.tests.connect.test_parity_arrow import *  # noqa: F401

--- a/python/pyspark/sql/tests/test_arrow.py
+++ b/python/pyspark/sql/tests/test_arrow.py
@@ -948,6 +948,17 @@ class ArrowTestsMixin:
                             expected = pd.DataFrame.from_records(data, columns=schema.names)
                         assert_frame_equal(df.toPandas(), expected)
 
+    def test_toPandas_empty_columns(self):
+        for arrow_enabled in [True, False]:
+            with self.subTest(arrow_enabled=arrow_enabled):
+                self.check_toPandas_empty_columns(arrow_enabled)
+
+    def check_toPandas_empty_columns(self, arrow_enabled):
+        df = self.spark.range(2).select([])
+
+        with self.sql_conf({"spark.sql.execution.arrow.pyspark.enabled": arrow_enabled}):
+            assert_frame_equal(df.toPandas(), pd.DataFrame(index=range(2)))
+
 
 @unittest.skipIf(
     not have_pandas or not have_pyarrow,


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up of #40988.

Fixes `df.toPandas` to support empty columns.

The result will be no-column, same-length dataframe.

```py
>>> spark.range(2).select([]).toPandas()
Empty DataFrame
Columns: []
Index: [0, 1]
```

### Why are the changes needed?

Currently `df.toPandas()` fails if the columns are empty:

```py
>>> spark.range(2).select([]).toPandas()
Traceback (most recent call last):
...
ValueError: No objects to concatenate
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Added the related test.