### PR TITLE
[SPARK-43487][SQL] Fix wrong error message used for `ambiguousRelationAliasNameInNestedCTEError`

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -29,6 +29,11 @@
     ],
     "sqlState" : "42000"
   },
+  "AMBIGUOUS_RELATION_ALIAS" : {
+    "message" : [
+      "Name <name> is ambiguous in nested CTE. Please set <configKey> to CORRECTED so that name defined in inner CTE takes precedence. If set it to LEGACY, outer CTE definitions will take precedence. See more details in SPARK-28228."
+    ]
+  },
   "ARITHMETIC_OVERFLOW" : {
     "message" : [
       "<message>.<alternative> If necessary set <config> to \"false\" to bypass this error."

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -2052,10 +2052,10 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase {
 
   def ambiguousRelationAliasNameInNestedCTEError(name: String): Throwable = {
     new AnalysisException(
-      errorClass = "_LEGACY_ERROR_TEMP_1200",
+      errorClass = "AMBIGUOUS_RELATION_ALIAS",
       messageParameters = Map(
         "name" -> name,
-        "config" -> LEGACY_CTE_PRECEDENCE_POLICY.key))
+        "configKey" -> LEGACY_CTE_PRECEDENCE_POLICY.key))
   }
 
   def commandUnsupportedInV2TableError(name: String): Throwable = {

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/cte-nested.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/cte-nested.sql.out
@@ -95,9 +95,9 @@ SELECT * FROM t2
 -- !query analysis
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1200",
+  "errorClass" : "AMBIGUOUS_RELATION_ALIAS",
   "messageParameters" : {
-    "config" : "spark.sql.legacy.ctePrecedencePolicy",
+    "configKey" : "spark.sql.legacy.ctePrecedencePolicy",
     "name" : "t"
   }
 }
@@ -157,9 +157,9 @@ SELECT * FROM t2
 -- !query analysis
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1200",
+  "errorClass" : "AMBIGUOUS_RELATION_ALIAS",
   "messageParameters" : {
-    "config" : "spark.sql.legacy.ctePrecedencePolicy",
+    "configKey" : "spark.sql.legacy.ctePrecedencePolicy",
     "name" : "t"
   }
 }
@@ -263,9 +263,9 @@ SELECT (
 -- !query analysis
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1200",
+  "errorClass" : "AMBIGUOUS_RELATION_ALIAS",
   "messageParameters" : {
-    "config" : "spark.sql.legacy.ctePrecedencePolicy",
+    "configKey" : "spark.sql.legacy.ctePrecedencePolicy",
     "name" : "t"
   }
 }
@@ -282,9 +282,9 @@ SELECT (
 -- !query analysis
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1200",
+  "errorClass" : "AMBIGUOUS_RELATION_ALIAS",
   "messageParameters" : {
-    "config" : "spark.sql.legacy.ctePrecedencePolicy",
+    "configKey" : "spark.sql.legacy.ctePrecedencePolicy",
     "name" : "t"
   }
 }
@@ -302,9 +302,9 @@ SELECT (
 -- !query analysis
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1200",
+  "errorClass" : "AMBIGUOUS_RELATION_ALIAS",
   "messageParameters" : {
-    "config" : "spark.sql.legacy.ctePrecedencePolicy",
+    "configKey" : "spark.sql.legacy.ctePrecedencePolicy",
     "name" : "t"
   }
 }
@@ -320,9 +320,9 @@ WHERE c IN (
 -- !query analysis
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1200",
+  "errorClass" : "AMBIGUOUS_RELATION_ALIAS",
   "messageParameters" : {
-    "config" : "spark.sql.legacy.ctePrecedencePolicy",
+    "configKey" : "spark.sql.legacy.ctePrecedencePolicy",
     "name" : "t"
   }
 }
@@ -367,9 +367,9 @@ SELECT * FROM t
 -- !query analysis
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1200",
+  "errorClass" : "AMBIGUOUS_RELATION_ALIAS",
   "messageParameters" : {
-    "config" : "spark.sql.legacy.ctePrecedencePolicy",
+    "configKey" : "spark.sql.legacy.ctePrecedencePolicy",
     "name" : "aBc"
   }
 }
@@ -384,9 +384,9 @@ SELECT (
 -- !query analysis
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1200",
+  "errorClass" : "AMBIGUOUS_RELATION_ALIAS",
   "messageParameters" : {
-    "config" : "spark.sql.legacy.ctePrecedencePolicy",
+    "configKey" : "spark.sql.legacy.ctePrecedencePolicy",
     "name" : "aBc"
   }
 }

--- a/sql/core/src/test/resources/sql-tests/results/cte-nested.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/cte-nested.sql.out
@@ -74,9 +74,9 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1200",
+  "errorClass" : "AMBIGUOUS_RELATION_ALIAS",
   "messageParameters" : {
-    "config" : "spark.sql.legacy.ctePrecedencePolicy",
+    "configKey" : "spark.sql.legacy.ctePrecedencePolicy",
     "name" : "t"
   }
 }
@@ -117,9 +117,9 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1200",
+  "errorClass" : "AMBIGUOUS_RELATION_ALIAS",
   "messageParameters" : {
-    "config" : "spark.sql.legacy.ctePrecedencePolicy",
+    "configKey" : "spark.sql.legacy.ctePrecedencePolicy",
     "name" : "t"
   }
 }
@@ -177,9 +177,9 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1200",
+  "errorClass" : "AMBIGUOUS_RELATION_ALIAS",
   "messageParameters" : {
-    "config" : "spark.sql.legacy.ctePrecedencePolicy",
+    "configKey" : "spark.sql.legacy.ctePrecedencePolicy",
     "name" : "t"
   }
 }
@@ -198,9 +198,9 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1200",
+  "errorClass" : "AMBIGUOUS_RELATION_ALIAS",
   "messageParameters" : {
-    "config" : "spark.sql.legacy.ctePrecedencePolicy",
+    "configKey" : "spark.sql.legacy.ctePrecedencePolicy",
     "name" : "t"
   }
 }
@@ -220,9 +220,9 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1200",
+  "errorClass" : "AMBIGUOUS_RELATION_ALIAS",
   "messageParameters" : {
-    "config" : "spark.sql.legacy.ctePrecedencePolicy",
+    "configKey" : "spark.sql.legacy.ctePrecedencePolicy",
     "name" : "t"
   }
 }
@@ -240,9 +240,9 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1200",
+  "errorClass" : "AMBIGUOUS_RELATION_ALIAS",
   "messageParameters" : {
-    "config" : "spark.sql.legacy.ctePrecedencePolicy",
+    "configKey" : "spark.sql.legacy.ctePrecedencePolicy",
     "name" : "t"
   }
 }
@@ -275,9 +275,9 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1200",
+  "errorClass" : "AMBIGUOUS_RELATION_ALIAS",
   "messageParameters" : {
-    "config" : "spark.sql.legacy.ctePrecedencePolicy",
+    "configKey" : "spark.sql.legacy.ctePrecedencePolicy",
     "name" : "aBc"
   }
 }
@@ -294,9 +294,9 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_1200",
+  "errorClass" : "AMBIGUOUS_RELATION_ALIAS",
   "messageParameters" : {
-    "config" : "spark.sql.legacy.ctePrecedencePolicy",
+    "configKey" : "spark.sql.legacy.ctePrecedencePolicy",
     "name" : "aBc"
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
@@ -857,6 +857,18 @@ class QueryCompilationErrorsSuite
       )
     }
   }
+
+  test("ambiguous relation alias name in nested CTE") {
+    checkError(
+      exception = intercept[AnalysisException] {
+        sql("WITH t AS (SELECT 1), t2 AS ( WITH t AS (SELECT 2) SELECT * FROM t) SELECT * FROM t2")
+      },
+      errorClass = "AMBIGUOUS_RELATION_ALIAS",
+      parameters = Map(
+        "name" -> "t",
+        "configKey" -> "spark.sql.legacy.ctePrecedencePolicy")
+    )
+  }
 }
 
 class MyCastToString extends SparkUserDefinedFunction(


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to fix  wrong error message used for `ambiguousRelationAliasNameInNestedCTEError`.

### Why are the changes needed?
Fix bug.


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA.