### PR TITLE
[SPARK-43491][SQL] In expression should act as same as EqualTo when elements in IN expression have same DataType.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -517,7 +517,9 @@ case class In(value: Expression, list: Seq[Expression]) extends Predicate {
            |  $tmpResult = $HAS_NULL; // ${ev.isNull} = true;
            |}
          """.stripMargin
-      val codeElseIf =
+      val codeElseIf = {
+        // When x.isNull is a variable name or false, the else if branch needs to keep,
+        // and only when isNull is set to true the branch just no need to generate.
         if (!java.lang.Boolean.parseBoolean(x.isNull.toString)) {
           s"""
              | else if (${ctx.genEqual(value.dataType, valueArg, x.value)}) {
@@ -526,6 +528,7 @@ case class In(value: Expression, list: Seq[Expression]) extends Predicate {
              |}
            """.stripMargin
         } else ""
+      }
       codeIf + codeElseIf
     }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -517,9 +517,9 @@ case class In(value: Expression, list: Seq[Expression]) extends Predicate {
            |  $tmpResult = $HAS_NULL; // ${ev.isNull} = true;
            |}
          """.stripMargin
-      val codeElseIf = {
+      val codeElseIf =
         // When x.isNull is a variable name or false, the else if branch needs to keep,
-        // and only when isNull is set to true the branch just no need to generate.
+        // and only when isNull is true the branch just no need to generate.
         if (!java.lang.Boolean.parseBoolean(x.isNull.toString)) {
           s"""
              | else if (${ctx.genEqual(value.dataType, valueArg, x.value)}) {
@@ -528,7 +528,6 @@ case class In(value: Expression, list: Seq[Expression]) extends Predicate {
              |}
            """.stripMargin
         } else ""
-      }
       codeIf + codeElseIf
     }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4238,6 +4238,13 @@ object SQLConf {
       .checkValue(_ >= 0, "The threshold of cached local relations must not be negative")
       .createWithDefault(64 * 1024 * 1024)
 
+  val LEGACY_IN_EXPRESSION_COMPATIBLE_WITH_EQUAL_TO_ENABLED =
+    buildConf("spark.sql.legacy.inExpressionCompatibleWithEqualTo.enabled")
+      .internal()
+      .doc("When true, we will try to support In expression compatible with EqualTo expression.")
+      .booleanConf
+      .createWithDefault(false)
+
   /**
    * Holds information about keys that have been deprecated.
    *
@@ -5074,6 +5081,9 @@ class SQLConf extends Serializable with Logging {
     getConf(SQLConf.ALLOW_TEMP_VIEW_CREATION_WITH_MULTIPLE_NAME_PARTS)
 
   def usePartitionEvaluator: Boolean = getConf(SQLConf.USE_PARTITION_EVALUATOR)
+
+  def inExpressionCompatibleWithEqualToEnabled: Boolean =
+    getConf(LEGACY_IN_EXPRESSION_COMPATIBLE_WITH_EQUAL_TO_ENABLED)
 
   /** ********************** SQLConf functionality methods ************ */
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionSuite.scala
@@ -1550,6 +1550,24 @@ class TypeCoercionSuite extends TypeCoercionSuiteBase {
       In(Cast(Literal("a"), StringType),
         Seq(Cast(Literal(1), StringType), Cast(Literal("b"), StringType)))
     )
+    // Casts String to Integer as same as EqualTo
+    withSQLConf(
+      "spark.sql.legacy.inExpressionCompatibleWithEqualTo.enabled" -> "true") {
+      ruleTest(inConversion,
+        In(Literal(0), Seq(Literal("00"), Literal("15"), Literal("30"), Literal("45"))),
+        In(Literal(0), Seq(Cast(Literal("00"), IntegerType), Cast(Literal("15"), IntegerType),
+          Cast(Literal("30"), IntegerType), Cast(Literal("45"), IntegerType)))
+      )
+    }
+    withSQLConf(
+      "spark.sql.legacy.inExpressionCompatibleWithEqualTo.enabled" -> "false") {
+      ruleTest(inConversion,
+        In(Literal(0), Seq(Literal("00"), Literal("15"), Literal("30"), Literal("45"))),
+        In(Cast(Literal(0), StringType), Seq(Cast(Literal("00"), StringType),
+          Cast(Literal("15"), StringType), Cast(Literal("30"), StringType),
+          Cast(Literal("45"), StringType)))
+      )
+    }
   }
 
   test("SPARK-15776 Divide expression's dataType should be casted to Double or Decimal " +


### PR DESCRIPTION
### What changes were proposed in this pull request?
See [SPARK-43491](https://issues.apache.org/jira/browse/SPARK-43491).
The query results of `in ('00')` and `= '00'`  are inconsistent. 
![image](https://github.com/apache/spark/assets/132866841/007cc156-625a-4d0d-a0d4-6a0442cfc8f6)

We do this work to ensure when dataTypes of elements in `In` expression are the same, it will behaviour as same as BinaryComparison expression like `EqualTo` when the switch is open(`spark.sql.legacy.inExpressionCompatibleWithEqualTo.enabled=true`).
```scala
// test data and content: 
// test.json
// {"name":"Michael","age":0}
spark.read().json("examples/src/main/resources/test.json").createOrReplaceTempView("t");
```
**Before change (see Filter node in Analyzed Logical Plan)**
```
spark.sql("select * from t where age in ('00')").explain(true);
== Parsed Logical Plan ==
'Project [*]
+- 'Filter 'age IN (00)
   +- 'UnresolvedRelation [t], [], false

== Analyzed Logical Plan ==
age: bigint, name: string
Project [age#7L, name#8]
+- Filter cast(age#7L as string) IN (cast(00 as string))
   +- SubqueryAlias t
	  +- Relation[age#7L,name#8] json

== Optimized Logical Plan ==
Filter (isnotnull(age#7L) AND (cast(age#7L as string) = 00))
+- Relation[age#7L,name#8] json

== Physical Plan ==
*(1) Filter (isnotnull(age#7L) AND (cast(age#7L as string) = 00))
+- FileScan json [age#7L,name#8] Batched: false, DataFilters: [isnotnull(age#7L), (cast(age#7L as string) = 00)], Format: JSON, Location: InMemoryFileIndex[file:/D:/code/spark/examples/src/main/resources/test.json], PartitionFilters: [], PushedFilters: [IsNotNull(age)], ReadSchema: struct<age:bigint,name:string>

+---+----+
|age|name|
+---+----+
+---+----+

```
**After change (see Filter node in Analyzed Logical Plan)**
```
spark.sql("select * from t where age in ('00')").explain(true);
== Parsed Logical Plan ==
'Project [*]
+- 'Filter 'age IN (00)
   +- 'UnresolvedRelation [t], [], false

== Analyzed Logical Plan ==
age: bigint, name: string
Project [age#7L, name#8]
+- Filter cast(age#7L as bigint) IN (cast(00 as bigint))
   +- SubqueryAlias t
	  +- Relation[age#7L,name#8] json

== Optimized Logical Plan ==
Filter (isnotnull(age#7L) AND (age#7L = 0))
+- Relation[age#7L,name#8] json

== Physical Plan ==
*(1) Filter (isnotnull(age#7L) AND (age#7L = 0))
+- FileScan json [age#7L,name#8] Batched: false, DataFilters: [isnotnull(age#7L), (age#7L = 0)], Format: JSON, Location: InMemoryFileIndex[file:/D:/code/spark/examples/src/main/resources/test.json], PartitionFilters: [], PushedFilters: [IsNotNull(age), EqualTo(age,0)], ReadSchema: struct<age:bigint,name:string>

+---+-------+
|age|   name|
+---+-------+
|  0|Michael|
+---+-------+
```

### Why are the changes needed?
The query results of Spark SQL and Hive SQL are inconsistent with same sql. Spark SQL calculates `0 in ('00') ` as false in 3.1.1, which act different from `=` keyword, but Hive calculates true in 3.1.0 and false in 2.3.3. Hive has fixed the `in` keyword in 3.1.0, but SparkSQL does not.
for example, this two query sql should have same result, how ever, the query result is different:
```
scala> spark.sql("select 1 as test where 0 in ('00')").show;
+----+
|test|
+----+
+----+


scala> spark.sql("select 1 as test where 0 = '00'").show;
+----+                                                                          
|test|
+----+
|   1|
+----+

```

hive 2.3.3
![image](https://github.com/apache/spark/assets/132866841/417768c8-3dda-49a4-9629-aba5fca39e3e)

hive 3.1.0
![image](https://github.com/apache/spark/assets/132866841/65edf7fd-0c1c-457b-97f3-c2fb399156b3)




### Does this PR introduce _any_ user-facing change?
We add a switch to support `In` expression compatible with `EqualTo` expression with false as default value, to make sure it will not change default behavior of Spark SQL.

### How was this patch tested?
By set spark.sql.legacy.inExpressionCompatibleWithEqualTo.enabled=true/false, to check whether the analyzed logical plan will cast expression as expected. For true, it will generate same Cast logical plan as EqualTo, and false will keep the old Cast logical plan solution.