### PR TITLE
[SPARK-43494][CORE] Directly call `replicate()` for `HdfsDataOutputStreamBuilder` instead of reflection in `SparkHadoopUtil#createFile`

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
@@ -30,6 +30,7 @@ import scala.language.existentials
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs._
+import org.apache.hadoop.hdfs.DistributedFileSystem.HdfsDataOutputStreamBuilder
 import org.apache.hadoop.mapred.JobConf
 import org.apache.hadoop.security.{Credentials, UserGroupInformation}
 import org.apache.hadoop.security.token.{Token, TokenIdentifier}
@@ -566,24 +567,16 @@ private[spark] object SparkHadoopUtil extends Logging {
     if (allowEC) {
       fs.create(path)
     } else {
-      try {
-        // the builder api does not resolve relative paths, nor does it create parent dirs, while
-        // the old api does.
-        if (!fs.mkdirs(path.getParent())) {
-          throw new IOException(s"Failed to create parents of $path")
-        }
-        val qualifiedPath = fs.makeQualified(path)
-        val builder = fs.createFile(qualifiedPath)
-        val builderCls = builder.getClass()
-        // this may throw a NoSuchMethodException if the path is not on hdfs
-        val replicateMethod = builderCls.getMethod("replicate")
-        val buildMethod = builderCls.getMethod("build")
-        val b2 = replicateMethod.invoke(builder)
-        buildMethod.invoke(b2).asInstanceOf[FSDataOutputStream]
-      } catch {
-        case  _: NoSuchMethodException =>
-          // No replicate() method, so just create a file with old apis.
-          fs.create(path)
+      // the builder api does not resolve relative paths, nor does it create parent dirs, while
+      // the old api does.
+      if (!fs.mkdirs(path.getParent())) {
+        throw new IOException(s"Failed to create parents of $path")
+      }
+      val qualifiedPath = fs.makeQualified(path)
+      val builder = fs.createFile(qualifiedPath)
+      builder match {
+        case hb: HdfsDataOutputStreamBuilder => hb.replicate().build()
+        case _ => fs.create(path)
       }
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
As discussed in https://github.com/apache/spark/pull/40945#discussion_r1191804004 and https://github.com/apache/spark/pull/40945#discussion_r1191804004, `replicate()` is a very private method of `HdfsDataOutputStreamBuilder`, so this pr uses case match to further remove the use of reflection in `SparkHadoopUtil#createFile`.

### Why are the changes needed?
Code simplification: remove reflection calls used for compatibility with Hadoop2.



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions