### PR TITLE
[SPARK-40189][SQL] Add `json_array_get` function

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -797,6 +797,7 @@ object FunctionRegistry {
     expression[SchemaOfJson]("schema_of_json"),
     expression[LengthOfJsonArray]("json_array_length"),
     expression[JsonObjectKeys]("json_object_keys"),
+    expression[JsonArrayGet]("json_array_get"),
 
     // cast
     expression[Cast]("cast"),

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
@@ -1010,6 +1010,7 @@ case class JsonObjectKeys(child: Expression) extends UnaryExpression with Codege
 // scalastyle:on line.size.limit line.contains.tab
 case class JsonArrayGet(child: Expression, index: Expression) extends BinaryExpression
   with CodegenFallback
+  with NullIntolerant
   with ExpectsInputTypes {
 
   override def inputTypes: Seq[DataType] = Seq(StringType, IntegerType)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/JsonExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/JsonExpressionsSuite.scala
@@ -880,6 +880,29 @@ class JsonExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper with 
     }
   }
 
+  test("Use specified index get value from JSON array") {
+    Seq(
+      ("", 1, null),
+      ("[1,2,3]", 2, "3"),
+      ("[]", 0, null),
+      ("[[1],[2,3],[]]", 4, null),
+      ("""[1,2,3,4,5""", 1, null),
+      ("""[1,2,3,4,5]""", 1, "2"),
+      ("""["k1","k2","k3","k4","k5"]""", 1, "k2"),
+      ("Random String", 1, null),
+      ("""{"key":"not a json array"}""", 1, null),
+      ("""{"key": 25}""", 1, null),
+      ("[[1],[2,3],[]]", 2, "[]"),
+      ("[[1],[2,3],{}]", 2, "{}"),
+      ("""[{"a":123},{"b":"hello"}]""", 1, """{"b":"hello"}"""),
+      ("""[1,2,3,[33,44],{"key":[2,3,4]}]""", 4, """{"key":[2,3,4]}"""),
+      ("""[1,2,3,{"f1":1,"f2":[5,6]},4]""", 3, """{"f1":1,"f2":[5,6]}""")
+    ).foreach {
+      case (literal, index, expectedValue) =>
+        checkEvaluation(JsonArrayGet(Literal(literal), Literal(index)), expectedValue)
+    }
+  }
+
   test("SPARK-35320: from_json should fail with a key type different of StringType") {
     Seq(
       (MapType(IntegerType, StringType), """{"1": "test"}"""),

--- a/sql/core/src/test/resources/sql-functions/sql-expression-schema.md
+++ b/sql/core/src/test/resources/sql-functions/sql-expression-schema.md
@@ -164,6 +164,7 @@
 | org.apache.spark.sql.catalyst.expressions.IsNaN | isnan | SELECT isnan(cast('NaN' as double)) | struct<isnan(CAST(NaN AS DOUBLE)):boolean> |
 | org.apache.spark.sql.catalyst.expressions.IsNotNull | isnotnull | SELECT isnotnull(1) | struct<(1 IS NOT NULL):boolean> |
 | org.apache.spark.sql.catalyst.expressions.IsNull | isnull | SELECT isnull(1) | struct<(1 IS NULL):boolean> |
+| org.apache.spark.sql.catalyst.expressions.JsonArrayGet | json_array_get | SELECT json_array_get('[]', 1) | struct<json_array_get([], 1):string> |
 | org.apache.spark.sql.catalyst.expressions.JsonObjectKeys | json_object_keys | SELECT json_object_keys('{}') | struct<json_object_keys({}):array<string>> |
 | org.apache.spark.sql.catalyst.expressions.JsonToStructs | from_json | SELECT from_json('{"a":1, "b":0.8}', 'a INT, b DOUBLE') | struct<from_json({"a":1, "b":0.8}):struct<a:int,b:double>> |
 | org.apache.spark.sql.catalyst.expressions.JsonTuple | json_tuple | SELECT json_tuple('{"a":1, "b":2}', 'a', 'b') | struct<c0:string,c1:string> |

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/json-functions.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/json-functions.sql.out
@@ -719,6 +719,97 @@ Project [json_object_keys([1, 2, 3]) AS json_object_keys([1, 2, 3])#x]
 
 
 -- !query
+select json_array_get("",1)
+-- !query analysis
+Project [json_array_get(, 1) AS json_array_get(, 1)#x]
++- OneRowRelation
+
+
+-- !query
+select json_array_get("[1,2,3]", 2)
+-- !query analysis
+Project [json_array_get([1,2,3], 2) AS json_array_get([1,2,3], 2)#x]
++- OneRowRelation
+
+
+-- !query
+select json_array_get("[]", 0)
+-- !query analysis
+Project [json_array_get([], 0) AS json_array_get([], 0)#x]
++- OneRowRelation
+
+
+-- !query
+select json_array_get("[[1],[2,3],[]]", 4)
+-- !query analysis
+Project [json_array_get([[1],[2,3],[]], 4) AS json_array_get([[1],[2,3],[]], 4)#x]
++- OneRowRelation
+
+
+-- !query
+select json_array_get("[1,2,3,4,5", 1)
+-- !query analysis
+Project [json_array_get([1,2,3,4,5, 1) AS json_array_get([1,2,3,4,5, 1)#x]
++- OneRowRelation
+
+
+-- !query
+select json_array_get("[1,2,3,4,5]", 1)
+-- !query analysis
+Project [json_array_get([1,2,3,4,5], 1) AS json_array_get([1,2,3,4,5], 1)#x]
++- OneRowRelation
+
+
+-- !query
+select json_array_get('["k1","k2","k3","k4","k5"]', 1)
+-- !query analysis
+Project [json_array_get(["k1","k2","k3","k4","k5"], 1) AS json_array_get(["k1","k2","k3","k4","k5"], 1)#x]
++- OneRowRelation
+
+
+-- !query
+select json_array_get("Random String", 1)
+-- !query analysis
+Project [json_array_get(Random String, 1) AS json_array_get(Random String, 1)#x]
++- OneRowRelation
+
+
+-- !query
+select json_array_get('{"key":"not a json array"}', 1)
+-- !query analysis
+Project [json_array_get({"key":"not a json array"}, 1) AS json_array_get({"key":"not a json array"}, 1)#x]
++- OneRowRelation
+
+
+-- !query
+select json_array_get('{"key": 25}', 1)
+-- !query analysis
+Project [json_array_get({"key": 25}, 1) AS json_array_get({"key": 25}, 1)#x]
++- OneRowRelation
+
+
+-- !query
+select json_array_get("[[1],[2,3],[]]", 2)
+-- !query analysis
+Project [json_array_get([[1],[2,3],[]], 2) AS json_array_get([[1],[2,3],[]], 2)#x]
++- OneRowRelation
+
+
+-- !query
+select json_array_get('[{"a":123},{"b":"hello"}]', 1)
+-- !query analysis
+Project [json_array_get([{"a":123},{"b":"hello"}], 1) AS json_array_get([{"a":123},{"b":"hello"}], 1)#x]
++- OneRowRelation
+
+
+-- !query
+select json_array_get('[1,2,3,[33,44],{"key":[2,3,4]}]', 4)
+-- !query analysis
+Project [json_array_get([1,2,3,[33,44],{"key":[2,3,4]}], 4) AS json_array_get([1,2,3,[33,44],{"key":[2,3,4]}], 4)#x]
++- OneRowRelation
+
+
+-- !query
 DROP VIEW IF EXISTS jsonTable
 -- !query analysis
 DropTempViewCommand jsonTable

--- a/sql/core/src/test/resources/sql-tests/inputs/json-functions.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/json-functions.sql
@@ -107,5 +107,20 @@ select json_object_keys('{[1,2]}');
 select json_object_keys('{"key": 45, "random_string"}');
 select json_object_keys('[1, 2, 3]');
 
+-- json_array_get
+select json_array_get("",1);
+select json_array_get("[1,2,3]", 2);
+select json_array_get("[]", 0);
+select json_array_get("[[1],[2,3],[]]", 4);
+select json_array_get("[1,2,3,4,5", 1);
+select json_array_get("[1,2,3,4,5]", 1);
+select json_array_get('["k1","k2","k3","k4","k5"]', 1);
+select json_array_get("Random String", 1);
+select json_array_get('{"key":"not a json array"}', 1);
+select json_array_get('{"key": 25}', 1);
+select json_array_get("[[1],[2,3],[]]", 2);
+select json_array_get('[{"a":123},{"b":"hello"}]', 1);
+select json_array_get('[1,2,3,[33,44],{"key":[2,3,4]}]', 4);
+
 -- Clean up
 DROP VIEW IF EXISTS jsonTable;

--- a/sql/core/src/test/resources/sql-tests/results/json-functions.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/json-functions.sql.out
@@ -816,6 +816,110 @@ NULL
 
 
 -- !query
+select json_array_get("",1)
+-- !query schema
+struct<json_array_get(, 1):string>
+-- !query output
+NULL
+
+
+-- !query
+select json_array_get("[1,2,3]", 2)
+-- !query schema
+struct<json_array_get([1,2,3], 2):string>
+-- !query output
+3
+
+
+-- !query
+select json_array_get("[]", 0)
+-- !query schema
+struct<json_array_get([], 0):string>
+-- !query output
+NULL
+
+
+-- !query
+select json_array_get("[[1],[2,3],[]]", 4)
+-- !query schema
+struct<json_array_get([[1],[2,3],[]], 4):string>
+-- !query output
+NULL
+
+
+-- !query
+select json_array_get("[1,2,3,4,5", 1)
+-- !query schema
+struct<json_array_get([1,2,3,4,5, 1):string>
+-- !query output
+NULL
+
+
+-- !query
+select json_array_get("[1,2,3,4,5]", 1)
+-- !query schema
+struct<json_array_get([1,2,3,4,5], 1):string>
+-- !query output
+2
+
+
+-- !query
+select json_array_get('["k1","k2","k3","k4","k5"]', 1)
+-- !query schema
+struct<json_array_get(["k1","k2","k3","k4","k5"], 1):string>
+-- !query output
+k2
+
+
+-- !query
+select json_array_get("Random String", 1)
+-- !query schema
+struct<json_array_get(Random String, 1):string>
+-- !query output
+NULL
+
+
+-- !query
+select json_array_get('{"key":"not a json array"}', 1)
+-- !query schema
+struct<json_array_get({"key":"not a json array"}, 1):string>
+-- !query output
+NULL
+
+
+-- !query
+select json_array_get('{"key": 25}', 1)
+-- !query schema
+struct<json_array_get({"key": 25}, 1):string>
+-- !query output
+NULL
+
+
+-- !query
+select json_array_get("[[1],[2,3],[]]", 2)
+-- !query schema
+struct<json_array_get([[1],[2,3],[]], 2):string>
+-- !query output
+[]
+
+
+-- !query
+select json_array_get('[{"a":123},{"b":"hello"}]', 1)
+-- !query schema
+struct<json_array_get([{"a":123},{"b":"hello"}], 1):string>
+-- !query output
+{"b":"hello"}
+
+
+-- !query
+select json_array_get('[1,2,3,[33,44],{"key":[2,3,4]}]', 4)
+-- !query schema
+struct<json_array_get([1,2,3,[33,44],{"key":[2,3,4]}], 4):string>
+-- !query output
+{"key":[2,3,4]}
+
+
+-- !query
 DROP VIEW IF EXISTS jsonTable
 -- !query schema
 struct<>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
At the moment we do not have any function to get value of JSON array by use specified index.
I add a `json_array_get` function which will return the value of JSON array by use specified index.

- This function will return value of JSON array, if JSON array is valid.

```sql

select json_array_get('[{"a":123},{"b":"hello"}]', 1);

+--------------------------------------------+
|json_array_get([{"a":123},{"b":"hello"}], 1)|
+--------------------------------------------+
|                               {"b":"hello"}|
+--------------------------------------------+
```

- In case of any other valid JSON string, the specified index does not exist, invalid JSON string or null array or NULL input , NULL will be returned.

```sql

select json_array_get("[[1],[2,3],[]]", 4);

+---------------------------------+
|json_array_get([[1],[2,3],[]], 4)|
+---------------------------------+
|                             NULL|
+---------------------------------+
```

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
- As mentioned in JIRA, this function is supported by presto
- For better user experience and ease of use.


<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
Yes, now users can get value of a json array by using `json_array_get`.

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
Add new test
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
