### PR TITLE
[SPARK-43454][CORE] support substitution for SparkConf's get and getAllWithPrefix

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkConf.scala
+++ b/core/src/main/scala/org/apache/spark/SparkConf.scala
@@ -385,12 +385,12 @@ class SparkConf(loadDefaults: Boolean) extends Cloneable with Logging with Seria
 
   /** Get a parameter as an Option */
   def getOption(key: String): Option[String] = {
-    Option(settings.get(key)).orElse(getDeprecatedConfig(key, settings))
+    getWithSubstitution(key)
   }
 
   /** Get an optional value, applying variable substitution. */
   private[spark] def getWithSubstitution(key: String): Option[String] = {
-    getOption(key).map(reader.substitute)
+    Option(settings.get(key)).orElse(getDeprecatedConfig(key, settings)).map(reader.substitute)
   }
 
   /** Get all parameters as a list of pairs */
@@ -403,7 +403,7 @@ class SparkConf(loadDefaults: Boolean) extends Cloneable with Logging with Seria
    */
   def getAllWithPrefix(prefix: String): Array[(String, String)] = {
     getAll.filter { case (k, v) => k.startsWith(prefix) }
-      .map { case (k, v) => (k.substring(prefix.length), v) }
+      .map { case (k, v) => (k.substring(prefix.length), reader.substitute(v)) }
   }
 
   /**

--- a/core/src/test/scala/org/apache/spark/SparkConfSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkConfSuite.scala
@@ -502,7 +502,7 @@ class SparkConfSuite extends SparkFunSuite with LocalSparkContext with ResetSyst
   test("SPARK-43454: getOption and getAllWithPrefix should be substituted") {
     val conf = new SparkConfWithEnv(Map(
       "ENV_A" -> "a",
-      "ENV_B" -> "b",
+      "ENV_B" -> "b"
     ))
     conf.set("spark.executorEnv.A", "${env:ENV_A}")
     conf.set("spark.executorEnv.B", "${env:ENV_B}")


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. sparkConf's getOption/get supports substitution for raw keys
2. sparkConf's getAllWithPrefix supports substitution for values

### Why are the changes needed?
To be consistent between `sparkConf.get(CONFIG_ENTRY_A)` and `sparkConf.get(CONFIG_ENTRY_A.key)`. 
It's also a todo left for: https://github.com/apache/spark/pull/18394#discussion_r126241078


### Does this PR introduce _any_ user-facing change?
Yes. Some values contain env/sys variables, such as `${env:xxx}`, `${sys:yyy}` might be substituted by the real one. 
However I doubt that's rarely possibel


### How was this patch tested?
Added new UTs.