### PR TITLE
[SPARK-43508][DOC] Replace the link related to hadoop version 2 with hadoop version 3

### DIFF
--- a/docs/streaming-programming-guide.md
+++ b/docs/streaming-programming-guide.md
@@ -748,7 +748,7 @@ of the store is consistent with that expected by Spark Streaming. It may be
 that writing directly into a destination directory is the appropriate strategy for
 streaming data via the chosen object store.
 
-For more details on this topic, consult the [Hadoop Filesystem Specification](https://hadoop.apache.org/docs/stable2/hadoop-project-dist/hadoop-common/filesystem/introduction.html).
+For more details on this topic, consult the [Hadoop Filesystem Specification](https://hadoop.apache.org/docs/stable3/hadoop-project-dist/hadoop-common/filesystem/introduction.html).
 
 #### Streams based on Custom Receivers
 {:.no_toc}


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to replace the link related to hadoop version 2 with hadoop version 3

### Why are the changes needed?
Because [SPARK-40651](https://issues.apache.org/jira/browse/SPARK-40651) Drop Hadoop2 binary distribtuion from release process and [SPARK-42447](https://issues.apache.org/jira/browse/SPARK-42447) Remove Hadoop 2 GitHub Action job.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Manual test.