### PR TITLE
[SPARK-43359][SQL] Delete from Hive table should throw "UNSUPPORTED_FEATURE.TABLE_OPERATION"

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveStrategies.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.catalog._
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.planning._
-import org.apache.spark.sql.catalyst.plans.logical.{InsertIntoDir, InsertIntoStatement, LogicalPlan, ScriptTransformation, Statistics}
+import org.apache.spark.sql.catalyst.plans.logical.{DeleteFromTable, InsertIntoDir, InsertIntoStatement, LogicalPlan, ScriptTransformation, Statistics, SubqueryAlias}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.execution._
@@ -178,6 +178,11 @@ object HiveAnalysis extends Rule[LogicalPlan] {
       if (overwrite) DDLUtils.verifyNotReadPath(child, outputPath)
 
       InsertIntoHiveDirCommand(isLocal, storage, child, overwrite, child.output.map(_.name))
+
+    case DeleteFromTable(SubqueryAlias(_, HiveTableRelation(table, _, _, _, _)), _) =>
+      throw QueryCompilationErrors.unsupportedTableOperationError(
+        table.identifier,
+        "DELETE")
   }
 }
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -3102,9 +3102,9 @@ class HiveDDLSuite
   test("SPARK-43359: Delete table not allowed") {
     val tbl = "T1"
     withTable(tbl) {
-      sql("CREATE TABLE T1(c1 INT)")
+      sql(s"CREATE TABLE $tbl(c1 INT)")
       val e = intercept[AnalysisException] {
-        sql("DELETE FROM T1 WHERE c1 = 1")
+        sql(s"DELETE FROM $tbl WHERE c1 = 1")
       }
       checkError(e,
         errorClass = "UNSUPPORTED_FEATURE.TABLE_OPERATION",

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -3100,7 +3100,7 @@ class HiveDDLSuite
   }
 
   test("SPARK-43359: Delete table not allowed") {
-    val tbl = "T1"
+    val tbl = "t1"
     withTable(tbl) {
       sql(s"CREATE TABLE $tbl(c1 INT)")
       val e = intercept[AnalysisException] {
@@ -3109,7 +3109,7 @@ class HiveDDLSuite
       checkError(e,
         errorClass = "UNSUPPORTED_FEATURE.TABLE_OPERATION",
         parameters = Map(
-          "tableName" -> "`spark_catalog`.`default`.`t1`",
+          "tableName" -> s"`spark_catalog`.`default`.`$tbl`",
           "operation" -> "DELETE")
       )
     }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -3098,4 +3098,20 @@ class HiveDDLSuite
       "CREATE TABLE tab (c1 int) PARTITIONED BY (c1) STORED AS PARQUET",
       "Cannot use all columns for partition columns")
   }
+
+  test("SPARK-43359: Delete table not allowed") {
+    val tbl = "T1"
+    withTable(tbl) {
+      sql("CREATE TABLE T1(c1 INT)")
+      val e = intercept[AnalysisException] {
+        sql("DELETE FROM T1 WHERE c1 = 1")
+      }
+      checkError(e,
+        errorClass = "UNSUPPORTED_FEATURE.TABLE_OPERATION",
+        parameters = Map(
+          "tableName" -> "`spark_catalog`.`default`.`t1`",
+          "operation" -> "DELETE")
+      )
+    }
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to fix error exception about 'DELETE from Hive table'

### Why are the changes needed?
Proper names of error classes should improve user experience with Spark SQL.

**BEFORE**
```
scala> sql("delete from t")
org.apache.spark.SparkException: [INTERNAL_ERROR] Unexpected table relation: HiveTableRelation [`spark_catalog`.`default`.`t`, org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe, Data Cols: [a#0], Partition Cols: []]
```

**AFTER**
```
scala> sql("delete from t")
org.apache.spark.sql.AnalysisException: [UNSUPPORTED_FEATURE.TABLE_OPERATION] The feature is not supported: Table `spark_catalog`.`default`.`t` does not support DELETE. Please check the current catalog and namespace to make sure the qualified table name is expected, and also check the catalog implementation which is configured by "spark.sql.catalog".
```

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA & Add new UT.