### PR TITLE
[SPARK-43510][YARN] Fix YarnAllocator internal state when adding running executor after processing completed containers

### DIFF
--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
@@ -796,8 +796,7 @@ private[yarn] class YarnAllocator(
     }
   }
 
-  // visible for testing
-  private[yarn] def updateInternalState(rpId: Int, executorId: String,
+  private def updateInternalState(rpId: Int, executorId: String,
     container: Container): Unit = synchronized {
     val containerId = container.getId
     if (!completedContainerIds.contains(containerId)) {

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnAllocatorSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnAllocatorSuite.scala
@@ -33,6 +33,7 @@ import org.mockito.ArgumentCaptor
 import org.mockito.Mockito._
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
+import org.scalatest.PrivateMethodTester
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.matchers.should.Matchers._
 
@@ -60,7 +61,7 @@ class MockResolver extends SparkRackResolver(SparkHadoopUtil.get.conf) {
 
 }
 
-class YarnAllocatorSuite extends SparkFunSuite with Matchers {
+class YarnAllocatorSuite extends SparkFunSuite with Matchers with PrivateMethodTester {
   val conf = new YarnConfiguration()
   val sparkConf = new SparkConf()
   sparkConf.set(DRIVER_HOST_ADDRESS, "localhost")
@@ -848,7 +849,8 @@ class YarnAllocatorSuite extends SparkFunSuite with Matchers {
     val status = ContainerStatus.newInstance(
       container.getId, ContainerState.COMPLETE, "Finished", 0)
     handler.processCompletedContainers(Seq(status))
-    handler.updateInternalState(0, "1", container)
+    val updateInternalState = PrivateMethod[Unit](Symbol("updateInternalState"))
+    handler.invokePrivate(updateInternalState(0, "1", container))
     handler.getNumExecutorsRunning should be(0)
   }
 }

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnAllocatorSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnAllocatorSuite.scala
@@ -19,8 +19,11 @@ package org.apache.spark.deploy.yarn
 
 import java.util
 import java.util.Collections
+import java.util.concurrent.atomic.AtomicInteger
+
 import scala.collection.JavaConverters._
 import scala.collection.mutable
+
 import org.apache.hadoop.net.{Node, NodeBase}
 import org.apache.hadoop.yarn.api.protocolrecords.AllocateResponse
 import org.apache.hadoop.yarn.api.records._
@@ -34,6 +37,7 @@ import org.mockito.stubbing.Answer
 import org.scalatest.PrivateMethodTester
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.matchers.should.Matchers._
+
 import org.apache.spark.{SecurityManager, SparkConf, SparkFunSuite}
 import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.deploy.yarn.ResourceRequestHelper._
@@ -46,8 +50,6 @@ import org.apache.spark.rpc.RpcEndpointRef
 import org.apache.spark.scheduler.SplitInfo
 import org.apache.spark.scheduler.cluster.CoarseGrainedClusterMessages.DecommissionExecutorsOnHost
 import org.apache.spark.util.ManualClock
-
-import java.util.concurrent.atomic.AtomicInteger
 
 class MockResolver extends SparkRackResolver(SparkHadoopUtil.get.conf) {
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Keep track of completed container ids in YarnAllocator and don't update internal state of a container if it's already completed.


### Why are the changes needed?
YarnAllocator updates internal state adding running executors after executor launch in a separate thread. That can happen after the containers are already completed (e.g. preempted) and processed by YarnAllocator. Then YarnAllocator mistakenly thinks there are still running executors which are already lost. As a result, application hangs without any running executors.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Added UT.
