### PR TITLE
[SPARK-43512][SS][TESTS] Update StateStoreOperationsBenchmark to reflect updates to RocksDB usage as state store provider

### DIFF
--- a/sql/core/benchmarks/StateStoreBasicOperationsBenchmark-jdk11-results.txt
+++ b/sql/core/benchmarks/StateStoreBasicOperationsBenchmark-jdk11-results.txt
@@ -2,182 +2,109 @@
 put rows
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1035-azure
+OpenJDK 64-Bit Server VM 11.0.19+7 on Linux 5.15.0-1037-azure
 Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 putting 10000 rows (10000 rows to overwrite - rate 100):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                            9             11           1          1.2         869.5       1.0X
-RocksDB (trackTotalNumberOfRows: true)                              55             59           1          0.2        5544.5       0.2X
-RocksDB (trackTotalNumberOfRows: false)                             15             17           1          0.7        1466.2       0.6X
+In-memory                                                            9             10           1          1.1         894.3       1.0X
+RocksDB (trackTotalNumberOfRows: true)                              70             75           3          0.1        6964.6       0.1X
+RocksDB (trackTotalNumberOfRows: false)                             23             26           1          0.4        2342.7       0.4X
 
-OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1035-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
-putting 10000 rows (7500 rows to overwrite - rate 75):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
--------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                          9             10           1          1.2         851.0       1.0X
-RocksDB (trackTotalNumberOfRows: true)                            52             55           1          0.2        5168.1       0.2X
-RocksDB (trackTotalNumberOfRows: false)                           15             17           1          0.7        1521.9       0.6X
-
-OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1035-azure
+OpenJDK 64-Bit Server VM 11.0.19+7 on Linux 5.15.0-1037-azure
 Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 putting 10000 rows (5000 rows to overwrite - rate 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                          9             10           1          1.2         864.1       1.0X
-RocksDB (trackTotalNumberOfRows: true)                            46             49           1          0.2        4568.5       0.2X
-RocksDB (trackTotalNumberOfRows: false)                           16             17           1          0.6        1561.6       0.6X
+In-memory                                                          9             10           1          1.1         882.4       1.0X
+RocksDB (trackTotalNumberOfRows: true)                            57             63           3          0.2        5712.7       0.2X
+RocksDB (trackTotalNumberOfRows: false)                           23             26           2          0.4        2299.9       0.4X
 
-OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1035-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
-putting 10000 rows (2500 rows to overwrite - rate 25):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
--------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                          9             10           1          1.2         862.7       1.0X
-RocksDB (trackTotalNumberOfRows: true)                            40             43           1          0.3        3968.2       0.2X
-RocksDB (trackTotalNumberOfRows: false)                           15             17           1          0.7        1519.9       0.6X
-
-OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1035-azure
+OpenJDK 64-Bit Server VM 11.0.19+7 on Linux 5.15.0-1037-azure
 Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 putting 10000 rows (1000 rows to overwrite - rate 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                          8             10           1          1.2         842.5       1.0X
-RocksDB (trackTotalNumberOfRows: true)                            36             38           1          0.3        3579.8       0.2X
-RocksDB (trackTotalNumberOfRows: false)                           15             17           1          0.6        1542.7       0.5X
+In-memory                                                          8             10           1          1.2         840.5       1.0X
+RocksDB (trackTotalNumberOfRows: true)                            46             50           3          0.2        4554.6       0.2X
+RocksDB (trackTotalNumberOfRows: false)                           22             25           2          0.4        2223.1       0.4X
 
-OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1035-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
-putting 10000 rows (500 rows to overwrite - rate 5):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                        8             10           1          1.2         839.7       1.0X
-RocksDB (trackTotalNumberOfRows: true)                          34             37           1          0.3        3400.6       0.2X
-RocksDB (trackTotalNumberOfRows: false)                         15             17           1          0.7        1530.3       0.5X
-
-OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1035-azure
+OpenJDK 64-Bit Server VM 11.0.19+7 on Linux 5.15.0-1037-azure
 Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 putting 10000 rows (0 rows to overwrite - rate 0):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                      8             10           1          1.2         834.5       1.0X
-RocksDB (trackTotalNumberOfRows: true)                        33             36           1          0.3        3316.0       0.3X
-RocksDB (trackTotalNumberOfRows: false)                       15             17           1          0.7        1517.5       0.5X
+In-memory                                                      8             10           1          1.2         821.2       1.0X
+RocksDB (trackTotalNumberOfRows: true)                        42             47           2          0.2        4208.4       0.2X
+RocksDB (trackTotalNumberOfRows: false)                       22             25           1          0.4        2229.2       0.4X
 
 
 ================================================================================================
 delete rows
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1035-azure
+OpenJDK 64-Bit Server VM 11.0.19+7 on Linux 5.15.0-1037-azure
 Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 trying to delete 10000 rows from 10000 rows(10000 rows are non-existing - rate 100):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                        1              1           0         11.5          86.6       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                          31             33           1          0.3        3076.2       0.0X
-RocksDB (trackTotalNumberOfRows: false)                                                         13             15           1          0.8        1318.3       0.1X
+In-memory                                                                                        1              1           0         16.0          62.6       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                          42             46           2          0.2        4168.6       0.0X
+RocksDB (trackTotalNumberOfRows: false)                                                         22             24           2          0.5        2203.7       0.0X
 
-OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1035-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
-trying to delete 10000 rows from 10000 rows(7500 rows are non-existing - rate 75):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                      6              7           1          1.7         584.6       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                        37             39           1          0.3        3655.3       0.2X
-RocksDB (trackTotalNumberOfRows: false)                                                       13             14           1          0.8        1303.6       0.4X
-
-OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1035-azure
+OpenJDK 64-Bit Server VM 11.0.19+7 on Linux 5.15.0-1037-azure
 Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 trying to delete 10000 rows from 10000 rows(5000 rows are non-existing - rate 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                      6              8           1          1.6         638.9       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                        42             45           1          0.2        4235.6       0.2X
-RocksDB (trackTotalNumberOfRows: false)                                                       13             14           1          0.8        1311.7       0.5X
+In-memory                                                                                      6              7           1          1.6         616.9       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                        55             59           2          0.2        5479.9       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                                       22             24           1          0.5        2165.7       0.3X
 
-OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1035-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
-trying to delete 10000 rows from 10000 rows(2500 rows are non-existing - rate 25):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                      7              8           1          1.5         684.3       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                        48             51           1          0.2        4824.4       0.1X
-RocksDB (trackTotalNumberOfRows: false)                                                       13             14           1          0.8        1309.5       0.5X
-
-OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1035-azure
+OpenJDK 64-Bit Server VM 11.0.19+7 on Linux 5.15.0-1037-azure
 Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 trying to delete 10000 rows from 10000 rows(1000 rows are non-existing - rate 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                      7              8           1          1.4         722.9       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                        52             54           1          0.2        5160.7       0.1X
-RocksDB (trackTotalNumberOfRows: false)                                                       13             14           1          0.8        1301.6       0.6X
+In-memory                                                                                      7              8           1          1.4         703.1       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                        65             70           3          0.2        6455.5       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                                       22             24           1          0.5        2183.6       0.3X
 
-OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1035-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
-trying to delete 10000 rows from 10000 rows(500 rows are non-existing - rate 5):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
----------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                    7              9           1          1.4         729.8       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                      52             56           1          0.2        5232.5       0.1X
-RocksDB (trackTotalNumberOfRows: false)                                                     13             15           1          0.8        1314.2       0.6X
-
-OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1035-azure
+OpenJDK 64-Bit Server VM 11.0.19+7 on Linux 5.15.0-1037-azure
 Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 trying to delete 10000 rows from 10000 rows(0 rows are non-existing - rate 0):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                  7              9           1          1.4         719.8       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                    52             56           1          0.2        5242.8       0.1X
-RocksDB (trackTotalNumberOfRows: false)                                                   13             14           1          0.8        1255.1       0.6X
+In-memory                                                                                  7              8           1          1.4         725.6       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                    66             73           3          0.2        6631.7       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                                   22             24           1          0.5        2154.2       0.3X
 
 
 ================================================================================================
 evict rows
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1035-azure
+OpenJDK 64-Bit Server VM 11.0.19+7 on Linux 5.15.0-1037-azure
 Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 evicting 10000 rows (maxTimestampToEvictInMillis: 9999) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                            7              8           1          1.4         702.5       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                              51             54           1          0.2        5067.6       0.1X
-RocksDB (trackTotalNumberOfRows: false)                                             12             14           0          0.8        1234.6       0.6X
+In-memory                                                                            7              8           1          1.4         717.1       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                              68             74           3          0.1        6806.7       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                             23             26           2          0.4        2298.4       0.3X
 
-OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1035-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
-evicting 7500 rows (maxTimestampToEvictInMillis: 7499) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                           7              8           1          1.5         670.3       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                             39             42           1          0.3        3934.1       0.2X
-RocksDB (trackTotalNumberOfRows: false)                                            11             12           0          0.9        1065.4       0.6X
-
-OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1035-azure
+OpenJDK 64-Bit Server VM 11.0.19+7 on Linux 5.15.0-1037-azure
 Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 evicting 5000 rows (maxTimestampToEvictInMillis: 4999) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                           6              7           1          1.6         621.9       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                             28             30           1          0.4        2763.8       0.2X
-RocksDB (trackTotalNumberOfRows: false)                                             9             10           0          1.1         901.2       0.7X
+In-memory                                                                           6              7           1          1.7         605.3       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                             36             40           2          0.3        3591.4       0.2X
+RocksDB (trackTotalNumberOfRows: false)                                            13             15           1          0.7        1335.0       0.5X
 
-OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1035-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
-evicting 2500 rows (maxTimestampToEvictInMillis: 2499) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                           6              7           0          1.7         573.7       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                             16             17           0          0.6        1640.5       0.3X
-RocksDB (trackTotalNumberOfRows: false)                                             7              8           0          1.5         683.8       0.8X
-
-OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1035-azure
+OpenJDK 64-Bit Server VM 11.0.19+7 on Linux 5.15.0-1037-azure
 Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 evicting 1000 rows (maxTimestampToEvictInMillis: 999) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                          5              6           0          1.9         532.8       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                            10             10           0          1.0         954.0       0.6X
-RocksDB (trackTotalNumberOfRows: false)                                            6              6           0          1.8         561.2       0.9X
+In-memory                                                                          5              6           1          1.9         513.0       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                            11             13           1          0.9        1100.6       0.5X
+RocksDB (trackTotalNumberOfRows: false)                                            7              8           1          1.5         668.5       0.8X
 
-OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1035-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
-evicting 500 rows (maxTimestampToEvictInMillis: 499) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
-----------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                         5              6           0          1.9         533.4       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                            7              8           0          1.4         734.9       0.7X
-RocksDB (trackTotalNumberOfRows: false)                                           5              6           0          2.0         503.3       1.1X
-
-OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1035-azure
+OpenJDK 64-Bit Server VM 11.0.19+7 on Linux 5.15.0-1037-azure
 Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 evicting 0 rows (maxTimestampToEvictInMillis: -1) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                      1              1           0         12.3          81.3       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                         5              6           0          2.0         499.2       0.2X
-RocksDB (trackTotalNumberOfRows: false)                                        5              6           0          2.0         490.6       0.2X
-
+In-memory                                                                      1              1           0         13.9          71.8       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                         5              6           1          2.1         482.4       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                        5              6           1          2.1         474.3       0.2X
 

--- a/sql/core/benchmarks/StateStoreBasicOperationsBenchmark-jdk17-results.txt
+++ b/sql/core/benchmarks/StateStoreBasicOperationsBenchmark-jdk17-results.txt
@@ -2,182 +2,109 @@
 put rows
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1035-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 17.0.7+7 on Linux 5.15.0-1037-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 putting 10000 rows (10000 rows to overwrite - rate 100):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                            8              9           1          1.2         804.5       1.0X
-RocksDB (trackTotalNumberOfRows: true)                              50             52           1          0.2        5047.1       0.2X
-RocksDB (trackTotalNumberOfRows: false)                             13             14           0          0.8        1313.9       0.6X
+In-memory                                                            9             10           1          1.2         862.1       1.0X
+RocksDB (trackTotalNumberOfRows: true)                              60             63           1          0.2        6048.9       0.1X
+RocksDB (trackTotalNumberOfRows: false)                             20             21           0          0.5        1993.6       0.4X
 
-OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1035-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
-putting 10000 rows (7500 rows to overwrite - rate 75):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
--------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                          8              9           0          1.2         816.7       1.0X
-RocksDB (trackTotalNumberOfRows: true)                            46             47           1          0.2        4563.5       0.2X
-RocksDB (trackTotalNumberOfRows: false)                           13             13           0          0.8        1270.7       0.6X
-
-OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1035-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 17.0.7+7 on Linux 5.15.0-1037-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 putting 10000 rows (5000 rows to overwrite - rate 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                          8              9           0          1.2         818.3       1.0X
-RocksDB (trackTotalNumberOfRows: true)                            41             42           1          0.2        4050.7       0.2X
-RocksDB (trackTotalNumberOfRows: false)                           13             14           0          0.8        1286.8       0.6X
+In-memory                                                          9              9           1          1.1         873.8       1.0X
+RocksDB (trackTotalNumberOfRows: true)                            50             52           1          0.2        5041.4       0.2X
+RocksDB (trackTotalNumberOfRows: false)                           20             21           0          0.5        2041.0       0.4X
 
-OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1035-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
-putting 10000 rows (2500 rows to overwrite - rate 25):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
--------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                          8              9           1          1.2         813.6       1.0X
-RocksDB (trackTotalNumberOfRows: true)                            35             37           1          0.3        3537.0       0.2X
-RocksDB (trackTotalNumberOfRows: false)                           13             14           0          0.8        1285.6       0.6X
-
-OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1035-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 17.0.7+7 on Linux 5.15.0-1037-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 putting 10000 rows (1000 rows to overwrite - rate 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                          8              9           0          1.2         806.3       1.0X
-RocksDB (trackTotalNumberOfRows: true)                            32             33           1          0.3        3196.0       0.3X
-RocksDB (trackTotalNumberOfRows: false)                           13             14           0          0.8        1279.3       0.6X
+In-memory                                                          8              9           1          1.2         832.2       1.0X
+RocksDB (trackTotalNumberOfRows: true)                            41             42           1          0.2        4069.5       0.2X
+RocksDB (trackTotalNumberOfRows: false)                           20             21           0          0.5        1984.3       0.4X
 
-OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1035-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
-putting 10000 rows (500 rows to overwrite - rate 5):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                        8              9           0          1.2         808.0       1.0X
-RocksDB (trackTotalNumberOfRows: true)                          31             32           1          0.3        3077.1       0.3X
-RocksDB (trackTotalNumberOfRows: false)                         13             14           0          0.8        1269.1       0.6X
-
-OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1035-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 17.0.7+7 on Linux 5.15.0-1037-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 putting 10000 rows (0 rows to overwrite - rate 0):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                      8              9           0          1.2         806.4       1.0X
-RocksDB (trackTotalNumberOfRows: true)                        30             31           0          0.3        2981.7       0.3X
-RocksDB (trackTotalNumberOfRows: false)                       13             13           0          0.8        1277.3       0.6X
+In-memory                                                      8              9           1          1.2         826.6       1.0X
+RocksDB (trackTotalNumberOfRows: true)                        38             39           1          0.3        3804.5       0.2X
+RocksDB (trackTotalNumberOfRows: false)                       20             21           0          0.5        1972.5       0.4X
 
 
 ================================================================================================
 delete rows
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1035-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 17.0.7+7 on Linux 5.15.0-1037-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 trying to delete 10000 rows from 10000 rows(10000 rows are non-existing - rate 100):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                        1              1           0         15.2          65.7       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                          28             29           0          0.4        2800.2       0.0X
-RocksDB (trackTotalNumberOfRows: false)                                                         11             12           0          0.9        1142.8       0.1X
+In-memory                                                                                        1              1           0         17.6          56.8       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                          38             39           0          0.3        3782.8       0.0X
+RocksDB (trackTotalNumberOfRows: false)                                                         20             20           0          0.5        1986.1       0.0X
 
-OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1035-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
-trying to delete 10000 rows from 10000 rows(7500 rows are non-existing - rate 75):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                      6              6           0          1.7         581.8       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                        33             34           1          0.3        3306.0       0.2X
-RocksDB (trackTotalNumberOfRows: false)                                                       11             12           0          0.9        1128.5       0.5X
-
-OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1035-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 17.0.7+7 on Linux 5.15.0-1037-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 trying to delete 10000 rows from 10000 rows(5000 rows are non-existing - rate 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                      6              7           0          1.6         639.9       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                        38             40           1          0.3        3802.8       0.2X
-RocksDB (trackTotalNumberOfRows: false)                                                       11             12           0          0.9        1126.0       0.6X
+In-memory                                                                                      6              7           0          1.6         641.8       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                        50             51           0          0.2        4968.6       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                                       20             20           0          0.5        1968.3       0.3X
 
-OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1035-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
-trying to delete 10000 rows from 10000 rows(2500 rows are non-existing - rate 25):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                      7              7           1          1.5         674.3       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                        43             45           1          0.2        4325.7       0.2X
-RocksDB (trackTotalNumberOfRows: false)                                                       11             12           0          0.9        1135.1       0.6X
-
-OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1035-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 17.0.7+7 on Linux 5.15.0-1037-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 trying to delete 10000 rows from 10000 rows(1000 rows are non-existing - rate 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                      7              7           0          1.5         689.2       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                        46             48           1          0.2        4606.9       0.1X
-RocksDB (trackTotalNumberOfRows: false)                                                       11             12           0          0.9        1125.4       0.6X
+In-memory                                                                                      7              8           0          1.4         713.9       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                        59             60           1          0.2        5868.8       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                                       20             20           0          0.5        1971.1       0.4X
 
-OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1035-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
-trying to delete 10000 rows from 10000 rows(500 rows are non-existing - rate 5):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
----------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                    7              8           1          1.4         702.6       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                      47             49           1          0.2        4708.5       0.1X
-RocksDB (trackTotalNumberOfRows: false)                                                     11             12           0          0.9        1129.9       0.6X
-
-OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1035-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 17.0.7+7 on Linux 5.15.0-1037-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 trying to delete 10000 rows from 10000 rows(0 rows are non-existing - rate 0):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                  7              7           0          1.5         681.0       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                    48             49           1          0.2        4793.6       0.1X
-RocksDB (trackTotalNumberOfRows: false)                                                   11             12           0          0.9        1103.6       0.6X
+In-memory                                                                                  7              8           0          1.4         716.9       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                    61             62           1          0.2        6053.0       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                                   20             20           0          0.5        1954.3       0.4X
 
 
 ================================================================================================
 evict rows
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1035-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 17.0.7+7 on Linux 5.15.0-1037-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 evicting 10000 rows (maxTimestampToEvictInMillis: 9999) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                            7              7           0          1.5         681.5       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                              46             48           1          0.2        4637.0       0.1X
-RocksDB (trackTotalNumberOfRows: false)                                             12             12           0          0.9        1155.1       0.6X
+In-memory                                                                            7              8           0          1.4         712.5       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                              60             62           1          0.2        6016.9       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                             20             20           0          0.5        2003.4       0.4X
 
-OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1035-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
-evicting 7500 rows (maxTimestampToEvictInMillis: 7499) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                           7              7           0          1.5         661.3       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                             36             37           1          0.3        3600.1       0.2X
-RocksDB (trackTotalNumberOfRows: false)                                            10             11           0          1.0        1008.5       0.7X
-
-OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1035-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 17.0.7+7 on Linux 5.15.0-1037-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 evicting 5000 rows (maxTimestampToEvictInMillis: 4999) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                           6              7           0          1.6         619.4       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                             26             26           1          0.4        2571.1       0.2X
-RocksDB (trackTotalNumberOfRows: false)                                             8              9           0          1.2         848.0       0.7X
+In-memory                                                                           6              7           0          1.5         646.0       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                             32             33           1          0.3        3152.2       0.2X
+RocksDB (trackTotalNumberOfRows: false)                                            12             12           0          0.9        1171.4       0.6X
 
-OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1035-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
-evicting 2500 rows (maxTimestampToEvictInMillis: 2499) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                           6              6           0          1.7         572.6       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                             15             16           0          0.6        1548.5       0.4X
-RocksDB (trackTotalNumberOfRows: false)                                             7              7           0          1.5         688.2       0.8X
-
-OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1035-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 17.0.7+7 on Linux 5.15.0-1037-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 evicting 1000 rows (maxTimestampToEvictInMillis: 999) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                          5              6           0          1.9         540.1       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                             9             10           0          1.1         940.6       0.6X
-RocksDB (trackTotalNumberOfRows: false)                                            6              6           0          1.7         595.9       0.9X
+In-memory                                                                          6              6           0          1.8         558.3       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                            10             10           0          1.0         963.9       0.6X
+RocksDB (trackTotalNumberOfRows: false)                                            6              6           0          1.8         568.1       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1035-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
-evicting 500 rows (maxTimestampToEvictInMillis: 499) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
-----------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                         5              6           0          1.9         533.3       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                            7              7           0          1.4         738.8       0.7X
-RocksDB (trackTotalNumberOfRows: false)                                           6              6           0          1.8         565.4       0.9X
-
-OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1035-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 17.0.7+7 on Linux 5.15.0-1037-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 evicting 0 rows (maxTimestampToEvictInMillis: -1) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                      1              1           0         16.8          59.6       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                         5              5           0          1.9         524.8       0.1X
-RocksDB (trackTotalNumberOfRows: false)                                        5              5           0          1.9         522.9       0.1X
-
+In-memory                                                                      1              1           0         14.8          67.5       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                         4              4           0          2.5         403.0       0.2X
+RocksDB (trackTotalNumberOfRows: false)                                        4              4           0          2.5         401.5       0.2X
 

--- a/sql/core/benchmarks/StateStoreBasicOperationsBenchmark-results.txt
+++ b/sql/core/benchmarks/StateStoreBasicOperationsBenchmark-results.txt
@@ -2,182 +2,109 @@
 put rows
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1035-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1037-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 putting 10000 rows (10000 rows to overwrite - rate 100):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                            8              9           1          1.3         776.2       1.0X
-RocksDB (trackTotalNumberOfRows: true)                              50             52           1          0.2        5024.8       0.2X
-RocksDB (trackTotalNumberOfRows: false)                             13             14           0          0.8        1290.8       0.6X
+In-memory                                                            8              9           1          1.3         788.9       1.0X
+RocksDB (trackTotalNumberOfRows: true)                              60             63           3          0.2        6043.3       0.1X
+RocksDB (trackTotalNumberOfRows: false)                             21             22           1          0.5        2105.1       0.4X
 
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1035-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
-putting 10000 rows (7500 rows to overwrite - rate 75):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
--------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                          8              9           1          1.2         800.0       1.0X
-RocksDB (trackTotalNumberOfRows: true)                            47             48           1          0.2        4667.5       0.2X
-RocksDB (trackTotalNumberOfRows: false)                           13             15           0          0.8        1316.2       0.6X
-
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1035-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1037-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 putting 10000 rows (5000 rows to overwrite - rate 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                          8              9           1          1.3         786.1       1.0X
-RocksDB (trackTotalNumberOfRows: true)                            42             43           1          0.2        4157.9       0.2X
-RocksDB (trackTotalNumberOfRows: false)                           13             15           0          0.7        1345.1       0.6X
+In-memory                                                          8             10           1          1.2         823.9       1.0X
+RocksDB (trackTotalNumberOfRows: true)                            52             54           2          0.2        5182.9       0.2X
+RocksDB (trackTotalNumberOfRows: false)                           21             23           1          0.5        2138.7       0.4X
 
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1035-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
-putting 10000 rows (2500 rows to overwrite - rate 25):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
--------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                          8              9           1          1.3         755.5       1.0X
-RocksDB (trackTotalNumberOfRows: true)                            36             38           1          0.3        3638.3       0.2X
-RocksDB (trackTotalNumberOfRows: false)                           13             14           0          0.8        1308.7       0.6X
-
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1035-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1037-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 putting 10000 rows (1000 rows to overwrite - rate 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                          8              9           1          1.3         763.5       1.0X
-RocksDB (trackTotalNumberOfRows: true)                            32             34           1          0.3        3238.4       0.2X
-RocksDB (trackTotalNumberOfRows: false)                           13             14           0          0.8        1323.3       0.6X
+In-memory                                                          7              8           1          1.4         722.7       1.0X
+RocksDB (trackTotalNumberOfRows: true)                            42             43           1          0.2        4188.7       0.2X
+RocksDB (trackTotalNumberOfRows: false)                           21             22           1          0.5        2103.1       0.3X
 
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1035-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
-putting 10000 rows (500 rows to overwrite - rate 5):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                        8              9           1          1.3         783.1       1.0X
-RocksDB (trackTotalNumberOfRows: true)                          31             33           1          0.3        3142.9       0.2X
-RocksDB (trackTotalNumberOfRows: false)                         13             14           0          0.8        1316.3       0.6X
-
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1035-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1037-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 putting 10000 rows (0 rows to overwrite - rate 0):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                      8              9           1          1.3         751.9       1.0X
-RocksDB (trackTotalNumberOfRows: true)                        30             32           1          0.3        3020.2       0.2X
-RocksDB (trackTotalNumberOfRows: false)                       13             14           0          0.8        1325.2       0.6X
+In-memory                                                      7              8           1          1.4         720.2       1.0X
+RocksDB (trackTotalNumberOfRows: true)                        40             41           1          0.3        3958.8       0.2X
+RocksDB (trackTotalNumberOfRows: false)                       21             23           2          0.5        2109.9       0.3X
 
 
 ================================================================================================
 delete rows
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1035-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1037-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 trying to delete 10000 rows from 10000 rows(10000 rows are non-existing - rate 100):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                        1              1           0         17.0          58.8       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                          27             28           0          0.4        2725.2       0.0X
-RocksDB (trackTotalNumberOfRows: false)                                                         12             12           0          0.9        1162.0       0.1X
+In-memory                                                                                        0              1           0         21.3          47.0       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                          40             42           2          0.3        3989.6       0.0X
+RocksDB (trackTotalNumberOfRows: false)                                                         20             21           1          0.5        2045.9       0.0X
 
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1035-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
-trying to delete 10000 rows from 10000 rows(7500 rows are non-existing - rate 75):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                      5              6           0          1.9         535.8       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                        32             34           1          0.3        3243.5       0.2X
-RocksDB (trackTotalNumberOfRows: false)                                                       11             12           0          0.9        1148.5       0.5X
-
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1035-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1037-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 trying to delete 10000 rows from 10000 rows(5000 rows are non-existing - rate 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                      6              7           0          1.7         595.5       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                        38             39           0          0.3        3762.3       0.2X
-RocksDB (trackTotalNumberOfRows: false)                                                       12             13           1          0.9        1153.6       0.5X
+In-memory                                                                                      6              7           1          1.7         596.9       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                        51             52           1          0.2        5127.4       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                                       21             22           1          0.5        2123.1       0.3X
 
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1035-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
-trying to delete 10000 rows from 10000 rows(2500 rows are non-existing - rate 25):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                      7              8           1          1.5         671.6       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                        42             44           0          0.2        4242.7       0.2X
-RocksDB (trackTotalNumberOfRows: false)                                                       12             13           0          0.9        1171.3       0.6X
-
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1035-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1037-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 trying to delete 10000 rows from 10000 rows(1000 rows are non-existing - rate 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                      7              8           1          1.5         671.7       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                        45             47           1          0.2        4521.7       0.1X
-RocksDB (trackTotalNumberOfRows: false)                                                       12             13           0          0.9        1161.1       0.6X
+In-memory                                                                                      6              8           1          1.6         631.9       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                        59             61           2          0.2        5876.7       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                                       21             22           1          0.5        2089.2       0.3X
 
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1035-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
-trying to delete 10000 rows from 10000 rows(500 rows are non-existing - rate 5):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
----------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                    7              8           1          1.5         680.3       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                      46             48           1          0.2        4632.1       0.1X
-RocksDB (trackTotalNumberOfRows: false)                                                     12             13           0          0.9        1169.2       0.6X
-
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1035-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1037-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 trying to delete 10000 rows from 10000 rows(0 rows are non-existing - rate 0):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                  7              8           1          1.5         683.8       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                    46             48           1          0.2        4640.5       0.1X
-RocksDB (trackTotalNumberOfRows: false)                                                   11             12           0          0.9        1132.0       0.6X
+In-memory                                                                                  6              7           1          1.5         647.1       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                    60             62           1          0.2        6034.9       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                                   21             22           1          0.5        2063.4       0.3X
 
 
 ================================================================================================
 evict rows
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1035-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1037-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 evicting 10000 rows (maxTimestampToEvictInMillis: 9999) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                            6              7           1          1.5         649.2       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                              44             46           1          0.2        4402.8       0.1X
-RocksDB (trackTotalNumberOfRows: false)                                             10             10           0          1.0         979.8       0.7X
+In-memory                                                                            6              7           0          1.6         625.7       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                              60             61           2          0.2        5950.1       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                             22             23           1          0.5        2194.1       0.3X
 
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1035-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
-evicting 7500 rows (maxTimestampToEvictInMillis: 7499) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                           6              7           0          1.6         610.0       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                             34             35           0          0.3        3402.0       0.2X
-RocksDB (trackTotalNumberOfRows: false)                                             8              9           0          1.2         825.0       0.7X
-
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1035-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1037-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 evicting 5000 rows (maxTimestampToEvictInMillis: 4999) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                           6              6           0          1.8         565.1       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                             24             25           0          0.4        2383.2       0.2X
-RocksDB (trackTotalNumberOfRows: false)                                             7              7           0          1.5         665.8       0.8X
+In-memory                                                                           6              7           1          1.7         586.7       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                             31             33           1          0.3        3146.3       0.2X
+RocksDB (trackTotalNumberOfRows: false)                                            13             13           0          0.8        1260.5       0.5X
 
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1035-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
-evicting 2500 rows (maxTimestampToEvictInMillis: 2499) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                           5              6           0          1.9         520.1       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                             14             14           0          0.7        1370.5       0.4X
-RocksDB (trackTotalNumberOfRows: false)                                             5              5           1          2.0         508.8       1.0X
-
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1035-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1037-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 evicting 1000 rows (maxTimestampToEvictInMillis: 999) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                          5              6           0          2.0         496.2       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                             8              8           0          1.3         759.3       0.7X
-RocksDB (trackTotalNumberOfRows: false)                                            4              4           0          2.4         418.6       1.2X
+In-memory                                                                          5              5           0          2.2         463.0       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                             9              9           0          1.1         925.8       0.5X
+RocksDB (trackTotalNumberOfRows: false)                                            6              6           0          1.8         552.6       0.8X
 
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1035-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
-evicting 500 rows (maxTimestampToEvictInMillis: 499) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
-----------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                         5              6           0          2.0         488.8       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                            6              6           0          1.8         560.2       0.9X
-RocksDB (trackTotalNumberOfRows: false)                                           4              4           0          2.6         388.5       1.3X
-
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1035-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1037-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 evicting 0 rows (maxTimestampToEvictInMillis: -1) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                      1              1           0         15.0          66.7       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                         4              4           0          2.8         357.2       0.2X
-RocksDB (trackTotalNumberOfRows: false)                                        4              4           0          2.8         357.3       0.2X
-
+In-memory                                                                      1              1           0         18.4          54.4       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                         4              4           0          2.8         351.8       0.2X
+RocksDB (trackTotalNumberOfRows: false)                                        3              4           0          2.9         342.9       0.2X
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/StateStoreBasicOperationsBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/StateStoreBasicOperationsBenchmark.scala
@@ -80,7 +80,7 @@ object StateStoreBasicOperationsBenchmark extends SqlBasedBenchmark {
 
     runBenchmark("put rows") {
       val numOfRows = Seq(10000)
-      val overwriteRates = Seq(100, 75, 50, 25, 10, 5, 0)
+      val overwriteRates = Seq(100, 50, 10, 0)
 
       numOfRows.foreach { numOfRow =>
         val testData = constructRandomizedTestData(numOfRow,
@@ -114,7 +114,7 @@ object StateStoreBasicOperationsBenchmark extends SqlBasedBenchmark {
 
           val benchmark = new Benchmark(s"putting $numOfRow rows " +
             s"($numOfRowsToOverwrite rows to overwrite - rate $overwriteRate)",
-            numOfRow, minNumIters = 10000, output = output)
+            numOfRow, minNumIters = 1000, output = output)
 
           registerPutBenchmarkCase(benchmark, "In-memory", inMemoryProvider,
             committedInMemoryVersion, rowsToPut)
@@ -153,7 +153,7 @@ object StateStoreBasicOperationsBenchmark extends SqlBasedBenchmark {
 
     runBenchmark("delete rows") {
       val numOfRows = Seq(10000)
-      val nonExistRates = Seq(100, 75, 50, 25, 10, 5, 0)
+      val nonExistRates = Seq(100, 50, 10, 0)
       numOfRows.foreach { numOfRow =>
         val testData = constructRandomizedTestData(numOfRow,
           (1 to numOfRow).map(_ * 1000L).toList, 0)
@@ -187,7 +187,7 @@ object StateStoreBasicOperationsBenchmark extends SqlBasedBenchmark {
           val benchmark = new Benchmark(s"trying to delete $numOfRow rows " +
             s"from $numOfRow rows" +
             s"($numOfRowsNonExist rows are non-existing - rate $nonExistRate)",
-            numOfRow, minNumIters = 10000, output = output)
+            numOfRow, minNumIters = 1000, output = output)
 
           registerDeleteBenchmarkCase(benchmark, "In-memory", inMemoryProvider,
             committedInMemoryVersion, keysToDelete)
@@ -228,7 +228,7 @@ object StateStoreBasicOperationsBenchmark extends SqlBasedBenchmark {
 
     runBenchmark("evict rows") {
       val numOfRows = Seq(10000)
-      val numOfEvictionRates = Seq(100, 75, 50, 25, 10, 5, 0)
+      val numOfEvictionRates = Seq(100, 50, 10, 0)
 
       numOfRows.foreach { numOfRow =>
         val timestampsInMicros = (0L until numOfRow).map(ts => ts * 1000L).toList
@@ -253,7 +253,7 @@ object StateStoreBasicOperationsBenchmark extends SqlBasedBenchmark {
           val benchmark = new Benchmark(s"evicting $numOfRowsToEvict rows " +
             s"(maxTimestampToEvictInMillis: $maxTimestampToEvictInMillis) " +
             s"from $numOfRow rows",
-            numOfRow, minNumIters = 10000, output = output)
+            numOfRow, minNumIters = 1000, output = output)
 
           registerEvictBenchmarkCase(benchmark, "In-memory", inMemoryProvider,
             committedInMemoryVersion, maxTimestampToEvictInMillis, numOfRowsToEvict)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Update StateStoreOperationsBenchmark to reflect updates to RocksDB usage as state store provider


### Why are the changes needed?
Need the changes to unblock RocksDB JNI upgrade

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Ran it locally and using Github Actions. Run now takes ~40-50mins
