### PR TITLE
[SPARK-43516][ML][PYTHON][CONNECT] Base interfaces of sparkML for spark3.5: estimator/transformer/model/evaluator

### DIFF
--- a/dev/infra/Dockerfile
+++ b/dev/infra/Dockerfile
@@ -71,4 +71,4 @@ RUN python3.9 -m pip install numpy pyarrow 'pandas<=1.5.3' scipy unittest-xml-re
 RUN python3.9 -m pip install grpcio protobuf googleapis-common-protos grpcio-status
 
 # Add torch as a testing dependency for TorchDistributor
-RUN python3.9 -m pip install torch torchvision
+RUN python3.9 -m pip install torch torchvision torcheval

--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -63,3 +63,5 @@ grpc-stubs==1.24.11
 # TorchDistributor dependencies
 torch
 torchvision
+torcheval
+

--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -606,6 +606,9 @@ pyspark_ml = Module(
         "pyspark.ml.torch.tests.test_distributor",
         "pyspark.ml.torch.tests.test_log_communication",
         "pyspark.ml.torch.tests.test_data_loader",
+        "pyspark.mlv2.tests.test_summarizer",
+        "pyspark.mlv2.tests.test_evaluation",
+        "pyspark.mlv2.tests.test_feature",
     ],
     excluded_python_implementations=[
         "PyPy"  # Skip these tests under PyPy since they require numpy and it isn't available there
@@ -786,6 +789,9 @@ pyspark_connect = Module(
         "pyspark.ml.tests.connect.test_connect_function",
         "pyspark.ml.tests.connect.test_parity_torch_distributor",
         "pyspark.ml.tests.connect.test_parity_torch_data_loader",
+        "pyspark.mlv2.tests.connect.test_parity_summarizer",
+        "pyspark.mlv2.tests.connect.test_parity_evaluation",
+        "pyspark.mlv2.tests.connect.test_parity_feature",
     ],
     excluded_python_implementations=[
         "PyPy"  # Skip these tests under PyPy since they require numpy, pandas, and pyarrow and

--- a/python/mypy.ini
+++ b/python/mypy.ini
@@ -85,6 +85,9 @@ disallow_untyped_defs = False
 [mypy-pyspark.ml.tests.*]
 ignore_errors = True
 
+[mypy-pyspark.mlv2.tests.*]
+ignore_errors = True
+
 [mypy-pyspark.ml.torch.tests.*]
 ignore_errors = True
 

--- a/python/pyspark/mlv2/__init__.py
+++ b/python/pyspark/mlv2/__init__.py
@@ -1,0 +1,16 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/python/pyspark/mlv2/__init__.py
+++ b/python/pyspark/mlv2/__init__.py
@@ -18,7 +18,6 @@
 from pyspark.mlv2.base import (
     Estimator,
     Transformer,
-    Evaluator,
     Model,
 )
 

--- a/python/pyspark/mlv2/__init__.py
+++ b/python/pyspark/mlv2/__init__.py
@@ -14,3 +14,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+from pyspark.mlv2.base import (
+    Estimator,
+    Transformer,
+    Evaluator,
+    Model,
+)
+
+from pyspark.mlv2 import (
+    feature,
+    evaluation,
+)
+
+__all__ = [
+    "Estimator",
+    "Transformer",
+    "Estimator",
+    "Model",
+    "feature",
+    "evaluation",
+]

--- a/python/pyspark/mlv2/base.py
+++ b/python/pyspark/mlv2/base.py
@@ -129,8 +129,8 @@ class Transformer(Params, metaclass=ABCMeta):
 
     def _get_transform_fn(self):
         """
-        Return a transformation function that accepts an instance of `pd.Series` as input and returns
-        transformed result as an instance of `pd.Series` or `pd.DataFrame`
+        Return a transformation function that accepts an instance of `pd.Series` as input and
+        returns transformed result as an instance of `pd.Series` or `pd.DataFrame`
         """
         raise NotImplementedError()
 

--- a/python/pyspark/mlv2/base.py
+++ b/python/pyspark/mlv2/base.py
@@ -16,10 +16,12 @@
 #
 
 from abc import ABCMeta, abstractmethod
+from collections.abc import Callable
 
 import pandas as pd
 
 from typing import (
+    Any,
     Generic,
     List,
     Optional,
@@ -38,7 +40,6 @@ from pyspark.mlv2.util import transform_dataframe_column
 if TYPE_CHECKING:
     from pyspark.ml._typing import ParamMap
 
-T = TypeVar("T")
 M = TypeVar("M", bound="Transformer")
 
 
@@ -114,20 +115,20 @@ class Transformer(Params, metaclass=ABCMeta):
     Abstract class for transformers that transform one dataset into another.
     """
 
-    def _input_column_name(self):
+    def _input_column_name(self) -> str:
         """
         Return the name of the input column that is transformed.
         """
         raise NotImplementedError()
 
-    def _output_columns(self):
+    def _output_columns(self) -> list[str]:
         """
         Return a list of output transformed columns, each elements in the list
         is a tuple of (column_name, column_spark_type)
         """
         raise NotImplementedError()
 
-    def _get_transform_fn(self):
+    def _get_transform_fn(self) -> Callable[["pd.Series"], Any]:
         """
         Return a transformation function that accepts an instance of `pd.Series` as input and
         returns transformed result as an instance of `pd.Series` or `pd.DataFrame`
@@ -172,7 +173,7 @@ class Evaluator(Params, metaclass=ABCMeta):
     """
 
     @abstractmethod
-    def _evaluate(self, dataset: DataFrame) -> float:
+    def _evaluate(self, dataset: Union["DataFrame", "pd.DataFrame"]) -> float:
         """
         Evaluates the output.
 

--- a/python/pyspark/mlv2/base.py
+++ b/python/pyspark/mlv2/base.py
@@ -123,7 +123,7 @@ class Transformer(Params, metaclass=ABCMeta):
         """
         raise NotImplementedError()
 
-    def _output_columns(self) -> list[str]:
+    def _output_columns(self) -> list[tuple[str, str]]:
         """
         Return a list of output transformed columns, each elements in the list
         is a tuple of (column_name, column_spark_type)

--- a/python/pyspark/mlv2/base.py
+++ b/python/pyspark/mlv2/base.py
@@ -1,0 +1,277 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from abc import ABCMeta, abstractmethod
+
+import copy
+import threading
+import pandas as pd
+
+from typing import (
+    Any,
+    Callable,
+    Generic,
+    Iterator,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    TypeVar,
+    Union,
+    cast,
+    overload,
+    TYPE_CHECKING,
+)
+
+from pyspark import since
+from pyspark.ml.param import P
+from pyspark.ml.common import inherit_doc
+from pyspark.ml.param.shared import (
+    HasInputCols,
+    HasOutputCols,
+    HasLabelCol,
+    HasFeaturesCol,
+    HasPredictionCol,
+)
+from pyspark.sql.dataframe import DataFrame
+from pyspark.sql.functions import udf
+from pyspark.sql.types import DataType, StructField, StructType
+from pyspark.ml.param import Param, Params, TypeConverters
+from pyspark.sql.functions import col, pandas_udf, struct
+import pickle
+
+if TYPE_CHECKING:
+    from pyspark.ml._typing import ParamMap
+
+T = TypeVar("T")
+M = TypeVar("M", bound="Transformer")
+
+
+@inherit_doc
+class Estimator(Params, Generic[M], metaclass=ABCMeta):
+    """
+    Abstract class for estimators that fit models to data.
+
+    .. versionadded:: 1.3.0
+    """
+
+    @abstractmethod
+    def _fit(self, dataset: Union[DataFrame, pd.DataFrame]) -> M:
+        """
+        Fits a model to the input dataset. This is called by the default implementation of fit.
+
+
+        Parameters
+        ----------
+        dataset : :py:class:`pyspark.sql.DataFrame`
+            input dataset
+
+        Returns
+        -------
+        :class:`Transformer`
+            fitted model
+        """
+        raise NotImplementedError()
+
+    def fit(
+            self,
+            dataset: Union[DataFrame, pd.DataFrame],
+            params: Optional["ParamMap"] = None,
+    ) -> Union[M, List[M]]:
+        """
+        Fits a model to the input dataset with optional parameters.
+
+        .. versionadded:: 1.3.0
+
+        Parameters
+        ----------
+        dataset : :py:class:`pyspark.sql.DataFrame` or py:class:`pandas.DataFrame`
+            input dataset, it can be either pandas dataframe or spark dataframe.
+        params : a dict of param values, optional
+            an optional param map that overrides embedded params.
+
+        Returns
+        -------
+        :py:class:`Transformer`
+            fitted model
+        """
+        if params is None:
+            params = dict()
+
+        if isinstance(params, dict):
+            if params:
+                return self.copy(params)._fit(dataset)
+            else:
+                return self._fit(dataset)
+        else:
+            raise TypeError(
+                "Params must be either a param map or a list/tuple of param maps, "
+                "but got %s." % type(params)
+            )
+
+
+_SPARKML_TRANSFORMER_TMP_OUTPUT_COLNAME = "_sparkML_transformer_tmp_output"
+
+
+@inherit_doc
+class Transformer(Params, HasInputCols, HasOutputCols, metaclass=ABCMeta):
+    """
+    Abstract class for transformers that transform one dataset into another.
+    """
+    def _get_transform_func_and_output_schema(self):
+        """
+        Returns a function defined like:
+        `transform_func(input: pd.DataFrame) -> pd.DataFrame`
+        the transforming function accepts a pandas DataFrame input,
+        the input columns must be consistent with "inputCols" param,
+        and generate a new pandas DataFrame as transformation results,
+        output columns must be consistent with "outputCols" param.
+        and returns an output pyspark schema for the output columns.
+        """
+        raise NotImplementedError()
+
+    def transform(self, dataset: Union[DataFrame, pd.DataFrame]) -> Union[DataFrame, pd.DataFrame]:
+        """
+        Transforms the input dataset.
+        The dataset can be either pandas dataframe or spark dataframe,
+        if it is pandas dataframe, transforms the dataframe locally without creating spark jobs.
+
+        Parameters
+        ----------
+        dataset : :py:class:`pyspark.sql.DataFrame` or py:class:`pandas.DataFrame`
+            input dataset.
+
+        Returns
+        -------
+        :py:class:`pyspark.sql.DataFrame` or py:class:`pandas.DataFrame`
+            transformed dataset, the type of output dataframe is consistent with
+            input dataframe.
+        """
+        transform_func, output_spark_schema = self._get_transform_func_and_output_schema()
+
+        if isinstance(dataset, pd.DataFrame):
+            input_cols = self.getInputCols()
+            selected_dataset = dataset[input_cols]
+            return transform_func(selected_dataset)
+
+        @pandas_udf(returnType=output_spark_schema)
+        def pyspark_transform_udf(s: pd.DataFrame) -> pd.DataFrame:
+            return transform_func(s)
+
+        return dataset.withColumn(
+            _SPARKML_TRANSFORMER_TMP_OUTPUT_COLNAME,
+            pyspark_transform_udf(struct(*self.getInputCols()))
+        ).withColumn(
+            [f"{_SPARKML_TRANSFORMER_TMP_OUTPUT_COLNAME}.{output_col}"]
+            for output_col in self.getOutputCols()
+        ).drop(_SPARKML_TRANSFORMER_TMP_OUTPUT_COLNAME)
+
+
+@inherit_doc
+class Evaluator(Params, metaclass=ABCMeta):
+    """
+    Abstract class for Evaluators
+    """
+    def _get_input_col_map(self):
+        """
+        Return a dict that maps raw input column name to column name that metric
+        function needed.
+
+        e.g., for metric like `accuracy`, it requires `label` column and `prediction` column as
+        input, supposing user input DataFrame contains 3 columns:
+         abc_features, def_label, xyz_prediction
+        then this function should return a dict of:
+        {"def_label": "label", "xyz_prediction", "prediction"
+        and the `update_status` function returned by `_get_metric_functions` must accept a
+        pandas DataFrame containing columns of "label" and "prediction".
+        """
+        raise NotImplementedError()
+
+    def _get_metric_functions(self):
+        """
+        Returns a tuple of functions: (init_status, update_status, merge_status, status_to_metric),
+        the `init_status` function must have signature like:
+        `def init_status() -> XX_METRIC_EVAL_STATUS`
+
+        the `update_status` function must have signature like:
+        `def update_status(status: XX_METRIC_EVAL_STATUS, input: pd.DataFrame)`
+        `update_status` function is an in-place op
+
+        the `merge_status` function must have signature like:
+        `def merge_status(x: XX_METRIC_EVAL_STATUS, y: XX_METRIC_EVAL_STATUS)
+        `merge_status` function is an in-place op, i.e., status `y` is merged to status `x`.
+        and status must be and pickle-able.
+
+        the `status_to_metric` function must have signature like:
+        `def status_to_metric(status: XX_METRIC_EVAL_STATUS) -> METRIC_VALUE_TYPE`
+        """
+        raise NotImplementedError()
+
+    def evaluate(self, dataset: Union[DataFrame, pd.DataFrame]) -> Any:
+        """
+        Evaluate metric over a spark DataFrame.
+        return metric value.
+        """
+        if isinstance(dataset, pd.DataFrame):
+            input_col_map = self._get_input_col_map()
+            input_cols = list(input_col_map.keys())
+
+            dataset = dataset[input_cols].rename(input_col_map)
+
+            init_status, update_status, merge_status, status_to_metric = self._get_metric_functions()
+
+            status = init_status()
+            update_status(status, dataset)
+            return status_to_metric(status)
+
+        dataset = dataset.select(
+            **[col(raw_input_col).alias(input_col)
+               for raw_input_col, input_col in self._get_input_col_map()]
+        )
+
+        init_status, update_status, merge_status, status_to_metric = self._get_metric_functions()
+
+        def compute_status(iterator):
+            status = init_status()
+
+            for pdf in iterator:
+                update_status(status, pdf)
+
+            return pd.DataFrame({'status': [pickle.dumps(status)]})
+
+        result_pdf = dataset.mapInPandas(compute_status, schema='status binary').toPandas()
+
+        merged_status = None
+        for s in result_pdf.status:
+            s = pickle.loads(s)
+            if merged_status is None:
+                merged_status = s
+            else:
+                merge_status(merged_status, s)
+
+        return status_to_metric(merged_status)
+
+
+@inherit_doc
+class Model(Transformer, metaclass=ABCMeta):
+    """
+    Abstract class for models that are fitted by estimators.
+
+    .. versionadded:: 1.4.0
+    """
+
+    pass

--- a/python/pyspark/mlv2/base.py
+++ b/python/pyspark/mlv2/base.py
@@ -69,9 +69,9 @@ class Estimator(Params, Generic[M], metaclass=ABCMeta):
         raise NotImplementedError()
 
     def fit(
-            self,
-            dataset: Union[DataFrame, pd.DataFrame],
-            params: Optional["ParamMap"] = None,
+        self,
+        dataset: Union[DataFrame, pd.DataFrame],
+        params: Optional["ParamMap"] = None,
     ) -> Union[M, List[M]]:
         """
         Fits a model to the input dataset with optional parameters.
@@ -159,7 +159,7 @@ class Transformer(Params, metaclass=ABCMeta):
             dataset,
             input_col_name=input_col_name,
             transform_fn=transform_fn,
-            output_cols=output_cols
+            output_cols=output_cols,
         )
 
 

--- a/python/pyspark/mlv2/base.py
+++ b/python/pyspark/mlv2/base.py
@@ -130,7 +130,7 @@ _SPARKML_TRANSFORMER_TMP_OUTPUT_COLNAME = "_sparkML_transformer_tmp_output"
 
 
 @inherit_doc
-class Transformer(Params, HasInputCols, HasOutputCols, metaclass=ABCMeta):
+class Transformer(Params, metaclass=ABCMeta):
     """
     Abstract class for transformers that transform one dataset into another.
     """

--- a/python/pyspark/mlv2/base.py
+++ b/python/pyspark/mlv2/base.py
@@ -17,42 +17,21 @@
 
 from abc import ABCMeta, abstractmethod
 
-import copy
-import threading
 import pandas as pd
 
 from typing import (
-    Any,
-    Callable,
     Generic,
-    Iterator,
     List,
     Optional,
-    Sequence,
-    Tuple,
     TypeVar,
     Union,
-    cast,
-    overload,
     TYPE_CHECKING,
 )
 
 from pyspark import since
-from pyspark.ml.param import P
 from pyspark.ml.common import inherit_doc
-from pyspark.ml.param.shared import (
-    HasInputCols,
-    HasOutputCols,
-    HasLabelCol,
-    HasFeaturesCol,
-    HasPredictionCol,
-)
 from pyspark.sql.dataframe import DataFrame
-from pyspark.sql.functions import udf
-from pyspark.sql.types import DataType, StructField, StructType
-from pyspark.ml.param import Param, Params, TypeConverters
-from pyspark.sql.functions import col, pandas_udf, struct
-import pickle
+from pyspark.ml.param import Params
 
 from pyspark.mlv2.util import transform_dataframe_column
 
@@ -68,7 +47,7 @@ class Estimator(Params, Generic[M], metaclass=ABCMeta):
     """
     Abstract class for estimators that fit models to data.
 
-    .. versionadded:: 1.3.0
+    .. versionadded:: 3.5.0
     """
 
     @abstractmethod
@@ -97,7 +76,7 @@ class Estimator(Params, Generic[M], metaclass=ABCMeta):
         """
         Fits a model to the input dataset with optional parameters.
 
-        .. versionadded:: 1.3.0
+        .. versionadded:: 3.5.0
 
         Parameters
         ----------
@@ -213,7 +192,7 @@ class Evaluator(Params, metaclass=ABCMeta):
         """
         Evaluates the output with optional parameters.
 
-        .. versionadded:: 1.4.0
+        .. versionadded:: 3.5.0
 
         Parameters
         ----------
@@ -252,7 +231,7 @@ class Model(Transformer, metaclass=ABCMeta):
     """
     Abstract class for models that are fitted by estimators.
 
-    .. versionadded:: 1.4.0
+    .. versionadded:: 3.5.0
     """
 
     pass

--- a/python/pyspark/mlv2/base.py
+++ b/python/pyspark/mlv2/base.py
@@ -113,6 +113,8 @@ _SPARKML_TRANSFORMER_TMP_OUTPUT_COLNAME = "_sparkML_transformer_tmp_output"
 class Transformer(Params, metaclass=ABCMeta):
     """
     Abstract class for transformers that transform one dataset into another.
+
+    .. versionadded:: 3.5.0
     """
 
     def _input_column_name(self) -> str:

--- a/python/pyspark/mlv2/evaluation.py
+++ b/python/pyspark/mlv2/evaluation.py
@@ -20,7 +20,6 @@ from pyspark.mlv2.base import Evaluator
 from pyspark.ml.param import Param, Params, TypeConverters
 from pyspark.ml.param.shared import HasLabelCol, HasPredictionCol
 from pyspark.mlv2.util import aggregate_dataframe
-from pyspark.sql.functions import col
 
 import torch
 import torcheval.metrics as torchmetrics

--- a/python/pyspark/mlv2/evaluation.py
+++ b/python/pyspark/mlv2/evaluation.py
@@ -26,7 +26,6 @@ import torcheval.metrics as torchmetrics
 
 
 class RegressionEvaluator(Evaluator, HasLabelCol, HasPredictionCol):
-
     def __init__(self, metricName, labelCol, predictionCol):
         super().__init__()
         self._set(metricName=metricName, labelCol=labelCol, predictionCol=predictionCol)

--- a/python/pyspark/mlv2/evaluation.py
+++ b/python/pyspark/mlv2/evaluation.py
@@ -33,6 +33,7 @@ class RegressionEvaluator(Evaluator, HasLabelCol, HasPredictionCol):
 
     .. versionadded:: 3.5.0
     """
+
     def __init__(self, metricName: str, labelCol: str, predictionCol: str) -> None:
         super().__init__()
         self._set(metricName=metricName, labelCol=labelCol, predictionCol=predictionCol)
@@ -55,7 +56,6 @@ class RegressionEvaluator(Evaluator, HasLabelCol, HasPredictionCol):
         raise ValueError(f"Unsupported regressor evaluator metric name: {metric_name}")
 
     def _evaluate(self, dataset: Union["DataFrame", "pd.DataFrame"]) -> float:
-
         prediction_col = self.getPredictionCol()
         label_col = self.getLabelCol()
 

--- a/python/pyspark/mlv2/evaluation.py
+++ b/python/pyspark/mlv2/evaluation.py
@@ -1,0 +1,74 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from pyspark.mlv2.base import Evaluator
+
+from pyspark.ml.param import Param, Params, TypeConverters
+from pyspark.ml.param.shared import HasLabelCol, HasPredictionCol
+from pyspark.mlv2.util import aggregate_dataframe
+from pyspark.sql.functions import col
+
+import torch
+import torcheval.metrics as torchmetrics
+
+
+class RegressionEvaluator(Evaluator, HasLabelCol, HasPredictionCol):
+
+    metricName: Param[str] = Param(
+        Params._dummy(),
+        "metricName",
+        "metric name for the regression evaluator.",
+        typeConverter=TypeConverters.toString,
+    )
+
+    def _get_torch_metric(self):
+        metric_name = self.getOrDefault(self.metricName)
+
+        if metric_name == "mse":
+            return torchmetrics.MeanSquaredError()
+        if metric_name == "r2":
+            return torchmetrics.R2Score()
+
+        raise ValueError(f"Unsupported regressor evaluator metric name: {metric_name}")
+
+    def _evaluate(self, dataset):
+
+        prediction_col = self.getPredictionCol()
+        label_col = self.getLabelCol()
+
+        torch_metric = self._get_torch_metric()
+
+        def local_agg_fn(pandas_df):
+            preds_tensor = torch.tensor(pandas_df[prediction_col].values)
+            labels_tensor = torch.tensor(pandas_df[label_col].values)
+            torch_metric.update(preds_tensor, labels_tensor)
+            return torch_metric
+
+        def merge_agg_status(state1, state2):
+            state1.merge_state([state2])
+            return state1
+
+        def agg_status_to_result(state):
+            return state.compute().item()
+
+        return aggregate_dataframe(
+            dataset,
+            [prediction_col, label_col],
+            local_agg_fn,
+            merge_agg_status,
+            agg_status_to_result,
+        )

--- a/python/pyspark/mlv2/evaluation.py
+++ b/python/pyspark/mlv2/evaluation.py
@@ -15,12 +15,14 @@
 # limitations under the License.
 #
 
+import pandas as pd
 from typing import Any, Union
 
-from pyspark.mlv2.base import Evaluator
 from pyspark.ml.param import Param, Params, TypeConverters
 from pyspark.ml.param.shared import HasLabelCol, HasPredictionCol
+from pyspark.mlv2.base import Evaluator
 from pyspark.mlv2.util import aggregate_dataframe
+from pyspark.sql import DataFrame
 
 import torch
 import torcheval.metrics as torchmetrics

--- a/python/pyspark/mlv2/evaluation.py
+++ b/python/pyspark/mlv2/evaluation.py
@@ -63,12 +63,12 @@ class RegressionEvaluator(Evaluator, HasLabelCol, HasPredictionCol):
                 torch_metric.update(preds_tensor, labels_tensor)
                 return torch_metric
 
-        def merge_agg_status(state1, state2):
+        def merge_agg_state(state1, state2):
             with torch.inference_mode():
                 state1.merge_state([state2])
                 return state1
 
-        def agg_status_to_result(state):
+        def agg_state_to_result(state):
             with torch.inference_mode():
                 return state.compute().item()
 
@@ -76,6 +76,6 @@ class RegressionEvaluator(Evaluator, HasLabelCol, HasPredictionCol):
             dataset,
             [prediction_col, label_col],
             local_agg_fn,
-            merge_agg_status,
-            agg_status_to_result,
+            merge_agg_state,
+            agg_state_to_result,
         )

--- a/python/pyspark/mlv2/evaluation.py
+++ b/python/pyspark/mlv2/evaluation.py
@@ -28,10 +28,14 @@ import torcheval.metrics as torchmetrics
 
 class RegressionEvaluator(Evaluator, HasLabelCol, HasPredictionCol):
 
+    def __init__(self, metricName, labelCol, predictionCol):
+        super().__init__()
+        self._set(metricName=metricName, labelCol=labelCol, predictionCol=predictionCol)
+
     metricName: Param[str] = Param(
         Params._dummy(),
         "metricName",
-        "metric name for the regression evaluator.",
+        "metric name for the regression evaluator, valid values are 'mse' and 'r2'",
         typeConverter=TypeConverters.toString,
     )
 

--- a/python/pyspark/mlv2/feature.py
+++ b/python/pyspark/mlv2/feature.py
@@ -1,0 +1,75 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import numpy as np
+import pandas as pd
+
+from pyspark.sql.functions import col, pandas_udf
+
+from pyspark.mlv2.base import Estimator, Model, Transformer
+from pyspark.mlv2.summarizer import summarize_dataframe
+from pyspark.ml.param.shared import HasInputCol, HasOutputCol
+from pyspark.ml.functions import array_to_vector
+
+
+class MaxAbsScaler(Estimator, HasInputCol, HasOutputCol):
+    """
+    Rescale each feature individually to range [-1, 1] by dividing through the largest maximum
+    absolute value in each feature. It does not shift/center the data, and thus does not destroy
+    any sparsity.
+    """
+
+    def _fit(self, dataset):
+        input_col = self.getInputCol()
+
+        dataset = dataset.withColumn(input_col, array_to_vector(col(input_col)))
+
+        min_max_res = summarize_dataframe(dataset, input_col, ["min", "max"])
+        min_values = min_max_res["min"]
+        max_values = min_max_res["max"]
+
+        max_abs_values = np.maximum(np.abs(min_values), np.abs(max_values))
+
+        return self._copyValues(MaxAbsScalerModel(max_abs_values))
+
+
+class MaxAbsScalerModel(Transformer, HasInputCol, HasOutputCol):
+
+    def __init__(self, max_abs_values):
+        self.max_abs_values = max_abs_values
+
+    def transform(self, dataset):
+
+        input_col = self.getInputCol()
+        output_col = self.getOutputCol()
+
+        max_abs_values = self.max_abs_values
+        max_abs_values_zero_cond = (max_abs_values == 0.0)
+
+        def transform_pandas_series(series):
+            def map_value(x):
+                return max_abs_values.where(max_abs_values_zero_cond, 0.0, x / max_abs_values)
+
+            return series.apply(map_value)
+
+        if isinstance(dataset, pd.DataFrame):
+            result_series = transform_pandas_series(dataset[input_col])
+            return pd.DataFrame({output_col: result_series})
+
+        transform_pandas_series_udf = pandas_udf(transform_pandas_series, returnType="array<double>")
+
+        return dataset.withColumn(output_col, transform_pandas_series_udf(col(input_col)))

--- a/python/pyspark/mlv2/feature.py
+++ b/python/pyspark/mlv2/feature.py
@@ -21,6 +21,7 @@ import pandas as pd
 from pyspark.sql.functions import col, pandas_udf
 
 from pyspark.mlv2.base import Estimator, Model, Transformer
+from pyspark.mlv2.util import transform_dataframe_column
 from pyspark.mlv2.summarizer import summarize_dataframe
 from pyspark.ml.param.shared import HasInputCol, HasOutputCol
 from pyspark.ml.functions import array_to_vector
@@ -66,10 +67,10 @@ class MaxAbsScalerModel(Transformer, HasInputCol, HasOutputCol):
 
             return series.apply(map_value)
 
-        if isinstance(dataset, pd.DataFrame):
-            result_series = transform_pandas_series(dataset[input_col])
-            return pd.DataFrame({output_col: result_series})
-
-        transform_pandas_series_udf = pandas_udf(transform_pandas_series, returnType="array<double>")
-
-        return dataset.withColumn(output_col, transform_pandas_series_udf(col(input_col)))
+        return transform_dataframe_column(
+            dataset,
+            input_col_name=input_col,
+            transform_fn=transform_pandas_series,
+            result_col_name=output_col,
+            result_col_spark_type='double'
+        )

--- a/python/pyspark/mlv2/feature.py
+++ b/python/pyspark/mlv2/feature.py
@@ -16,15 +16,10 @@
 #
 
 import numpy as np
-import pandas as pd
 
-from pyspark.sql.functions import col, pandas_udf
-
-from pyspark.mlv2.base import Estimator, Model, Transformer
-from pyspark.mlv2.util import transform_dataframe_column
+from pyspark.mlv2.base import Estimator, Model
 from pyspark.mlv2.summarizer import summarize_dataframe
 from pyspark.ml.param.shared import HasInputCol, HasOutputCol
-from pyspark.ml.functions import vector_to_array
 
 
 class MaxAbsScaler(Estimator, HasInputCol, HasOutputCol):
@@ -53,7 +48,7 @@ class MaxAbsScaler(Estimator, HasInputCol, HasOutputCol):
         return self._copyValues(model)
 
 
-class MaxAbsScalerModel(Transformer, HasInputCol, HasOutputCol):
+class MaxAbsScalerModel(Model, HasInputCol, HasOutputCol):
 
     def __init__(self, max_abs_values):
         super().__init__()
@@ -101,7 +96,7 @@ class StandardScaler(Estimator, HasInputCol, HasOutputCol):
         return self._copyValues(model)
 
 
-class StandardScalerModel(Transformer, HasInputCol, HasOutputCol):
+class StandardScalerModel(Model, HasInputCol, HasOutputCol):
 
     def __init__(self, mean_values, std_values):
         super().__init__()

--- a/python/pyspark/mlv2/feature.py
+++ b/python/pyspark/mlv2/feature.py
@@ -49,7 +49,6 @@ class MaxAbsScaler(Estimator, HasInputCol, HasOutputCol):
 
 
 class MaxAbsScalerModel(Model, HasInputCol, HasOutputCol):
-
     def __init__(self, max_abs_values):
         super().__init__()
         self.max_abs_values = max_abs_values
@@ -62,7 +61,7 @@ class MaxAbsScalerModel(Model, HasInputCol, HasOutputCol):
 
     def _get_transform_fn(self):
         max_abs_values = self.max_abs_values
-        max_abs_values_zero_cond = (max_abs_values == 0.0)
+        max_abs_values_zero_cond = max_abs_values == 0.0
 
         def transform_fn(series):
             def map_value(x):
@@ -97,7 +96,6 @@ class StandardScaler(Estimator, HasInputCol, HasOutputCol):
 
 
 class StandardScalerModel(Model, HasInputCol, HasOutputCol):
-
     def __init__(self, mean_values, std_values):
         super().__init__()
         self.mean_values = mean_values

--- a/python/pyspark/mlv2/feature.py
+++ b/python/pyspark/mlv2/feature.py
@@ -84,6 +84,11 @@ class StandardScaler(Estimator, HasInputCol, HasOutputCol):
     statistics on the samples in the training set.
     """
 
+    def __init__(self, inputCol, outputCol):
+        super().__init__()
+        self.set(self.inputCol, inputCol)
+        self.set(self.outputCol, outputCol)
+
     def _fit(self, dataset):
         input_col = self.getInputCol()
 
@@ -91,7 +96,7 @@ class StandardScaler(Estimator, HasInputCol, HasOutputCol):
         mean_values = min_max_res["mean"]
         std_values = min_max_res["std"]
 
-        model = MaxAbsScalerModel(mean_values, std_values)
+        model = StandardScalerModel(mean_values, std_values)
         model._resetUid(self.uid)
         return self._copyValues(model)
 
@@ -99,6 +104,7 @@ class StandardScaler(Estimator, HasInputCol, HasOutputCol):
 class StandardScalerModel(Transformer, HasInputCol, HasOutputCol):
 
     def __init__(self, mean_values, std_values):
+        super().__init__()
         self.mean_values = mean_values
         self.std_values = std_values
 

--- a/python/pyspark/mlv2/feature.py
+++ b/python/pyspark/mlv2/feature.py
@@ -33,12 +33,12 @@ class MaxAbsScaler(Estimator, HasInputCol, HasOutputCol):
     any sparsity.
     """
 
-    def __init__(self, inputCol, outputCol):
+    def __init__(self, inputCol: str, outputCol: str) -> None:
         super().__init__()
         self.set(self.inputCol, inputCol)
         self.set(self.outputCol, outputCol)
 
-    def _fit(self, dataset):
+    def _fit(self, dataset: Union["pd.DataFrame", "DataFrame"]) -> "MaxAbsScalerModel":
         input_col = self.getInputCol()
 
         min_max_res = summarize_dataframe(dataset, input_col, ["min", "max"])
@@ -60,15 +60,15 @@ class MaxAbsScalerModel(Model, HasInputCol, HasOutputCol):
     def _input_column_name(self) -> str:
         return self.getInputCol()
 
-    def _output_columns(self) -> list[str]:
+    def _output_columns(self) -> list[tuple[str, str]]:
         return [(self.getOutputCol(), "array<double>")]
 
     def _get_transform_fn(self) -> Callable[["pd.Series"], Any]:
         max_abs_values = self.max_abs_values
         max_abs_values_zero_cond = max_abs_values == 0.0
 
-        def transform_fn(series):
-            def map_value(x):
+        def transform_fn(series: "pd.Series") -> Any:
+            def map_value(x: "np.ndarray") -> "np.ndarray":
                 return np.where(max_abs_values_zero_cond, 0.0, x / max_abs_values)
 
             return series.apply(map_value)
@@ -87,7 +87,7 @@ class StandardScaler(Estimator, HasInputCol, HasOutputCol):
         self.set(self.inputCol, inputCol)
         self.set(self.outputCol, outputCol)
 
-    def _fit(self, dataset: Union[DataFrame, pd.DataFrame]):
+    def _fit(self, dataset: Union[DataFrame, pd.DataFrame]) -> "StandardScalerModel":
         input_col = self.getInputCol()
 
         min_max_res = summarize_dataframe(dataset, input_col, ["mean", "std"])
@@ -108,15 +108,15 @@ class StandardScalerModel(Model, HasInputCol, HasOutputCol):
     def _input_column_name(self) -> str:
         return self.getInputCol()
 
-    def _output_columns(self) -> list[str]:
+    def _output_columns(self) -> list[tuple[str, str]]:
         return [(self.getOutputCol(), "array<double>")]
 
     def _get_transform_fn(self) -> Callable[["pd.Series"], Any]:
         mean_values = self.mean_values
         std_values = self.std_values
 
-        def transform_fn(series: "pd.Series") -> "pd.Series":
-            def map_value(x):
+        def transform_fn(series: "pd.Series") -> Any:
+            def map_value(x: "np.ndarray") -> "np.ndarray":
                 return (x - mean_values) / std_values
 
             return series.apply(map_value)

--- a/python/pyspark/mlv2/summarizer.py
+++ b/python/pyspark/mlv2/summarizer.py
@@ -56,6 +56,8 @@ class SummarizerAggStatus:
             if metric == "mean":
                 result["mean"] = self.sum_values / self.count
             if metric == "std":
+                if self.count <= 1:
+                    raise ValueError("Standard deviation evaluation requires more than one row data.")
                 result["std"] = np.sqrt(
                     ((self.square_sum_values / self.count) - np.square(self.sum_values / self.count))
                     * (self.count / (self.count - 1))

--- a/python/pyspark/mlv2/summarizer.py
+++ b/python/pyspark/mlv2/summarizer.py
@@ -26,7 +26,7 @@ class SummarizerAggState:
         self.max_values = input_array.copy()
         self.count = 1
         self.sum_values = np.array(input_array.copy())
-        self.square_sum_values = np.square(input_array)
+        self.square_sum_values = np.square(input_array.copy())
 
     def update(self, input_array):
         self.count += 1
@@ -89,7 +89,7 @@ def summarize_dataframe(dataframe, column, metrics):
 
     def local_agg_fn(pandas_df):
         state = None
-        for value_array in pandas_df[column].values:
+        for _, value_array in pandas_df[column].iteritems():
             if state is None:
                 state = SummarizerAggState(value_array)
             else:

--- a/python/pyspark/mlv2/summarizer.py
+++ b/python/pyspark/mlv2/summarizer.py
@@ -26,16 +26,19 @@ class SummarizerAggStatus:
         self.max_values = input_array.copy()
         self.count = 1
         self.sum_values = np.array(input_array.copy())
+        self.square_sum_values = np.square(input_array)
 
     def update(self, input_array):
         self.count += 1
         self.sum_values += input_array
+        self.square_sum_values += np.square(input_array)
         self.min_values = np.minimum(self.min_values, input_array)
         self.max_values = np.maximum(self.max_values, input_array)
 
     def merge(self, status):
         self.count += status.count
         self.sum_values += status.sum_values
+        self.square_sum_values += status.square_sum_values
         self.min_values = np.minimum(self.min_values, status.min_values)
         self.max_values = np.maximum(self.max_values, status.max_values)
         return self
@@ -52,6 +55,10 @@ class SummarizerAggStatus:
                 result["sum"] = self.sum_values.copy()
             if metric == "mean":
                 result["mean"] = self.sum_values / self.count
+            if metric == "std":
+                result["std"] = np.sqrt(
+                    (self.square_sum_values / self.count) - np.square(self.sum_values / self.count)
+                ) * (self.count / (self.count - 1))
 
         return result
 

--- a/python/pyspark/mlv2/summarizer.py
+++ b/python/pyspark/mlv2/summarizer.py
@@ -56,7 +56,7 @@ class SummarizerAggStatus:
         return result
 
 
-def summarize(dataframe, column, metrics):
+def summarize_dataframe(dataframe, column, metrics):
     """
     Summarize an array type column over a spark dataframe or a pandas dataframe
 

--- a/python/pyspark/mlv2/summarizer.py
+++ b/python/pyspark/mlv2/summarizer.py
@@ -72,9 +72,7 @@ class SummarizerAggState:
 
 
 def summarize_dataframe(
-        dataframe: Union["DataFrame", "pd.DataFrame"],
-        column: str,
-        metrics: list[str]
+    dataframe: Union["DataFrame", "pd.DataFrame"], column: str, metrics: list[str]
 ) -> dict[str, Any]:
     """
     Summarize an array type column over a spark dataframe or a pandas dataframe

--- a/python/pyspark/mlv2/summarizer.py
+++ b/python/pyspark/mlv2/summarizer.py
@@ -16,7 +16,10 @@
 #
 
 import numpy as np
+import pandas as pd
 from typing import Any, Union
+
+from pyspark.sql import DataFrame
 from pyspark.mlv2.util import aggregate_dataframe
 
 

--- a/python/pyspark/mlv2/summarizer.py
+++ b/python/pyspark/mlv2/summarizer.py
@@ -57,8 +57,9 @@ class SummarizerAggStatus:
                 result["mean"] = self.sum_values / self.count
             if metric == "std":
                 result["std"] = np.sqrt(
-                    (self.square_sum_values / self.count) - np.square(self.sum_values / self.count)
-                ) * (self.count / (self.count - 1))
+                    ((self.square_sum_values / self.count) - np.square(self.sum_values / self.count))
+                    * (self.count / (self.count - 1))
+                )
 
         return result
 

--- a/python/pyspark/mlv2/summarizer.py
+++ b/python/pyspark/mlv2/summarizer.py
@@ -20,7 +20,6 @@ from pyspark.mlv2.util import aggregate_dataframe
 
 
 class SummarizerAggState:
-
     def __init__(self, input_array):
         self.min_values = input_array.copy()
         self.max_values = input_array.copy()
@@ -57,9 +56,14 @@ class SummarizerAggState:
                 result["mean"] = self.sum_values / self.count
             if metric == "std":
                 if self.count <= 1:
-                    raise ValueError("Standard deviation evaluation requires more than one row data.")
+                    raise ValueError(
+                        "Standard deviation evaluation requires more than one row data."
+                    )
                 result["std"] = np.sqrt(
-                    ((self.square_sum_values / self.count) - np.square(self.sum_values / self.count))
+                    (
+                        (self.square_sum_values / self.count)
+                        - np.square(self.sum_values / self.count)
+                    )
                     * (self.count / (self.count - 1))
                 )
 

--- a/python/pyspark/mlv2/summarizer.py
+++ b/python/pyspark/mlv2/summarizer.py
@@ -1,0 +1,98 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import numpy as np
+from pyspark.mlv2.util import aggregate_dataframe
+
+
+class SummarizerAggStatus:
+
+    def __init__(self, input_array):
+        self.min_values = input_array.copy()
+        self.max_values = input_array.copy()
+        self.count = 1
+        self.sum_values = np.array(input_array.copy())
+
+    def update(self, input_array):
+        self.count += 1
+        self.sum_values += input_array
+        self.min_values = np.minimum(self.min_values, input_array)
+        self.max_values = np.maximum(self.max_values, input_array)
+
+    def merge(self, status):
+        self.count += status.count
+        self.sum_values += status.sum_values
+        self.min_values = np.minimum(self.min_values, status.min_values)
+        self.max_values = np.maximum(self.max_values, status.max_values)
+        return self
+
+    def to_result(self, metrics):
+        result = {}
+
+        for metric in metrics:
+            if metric == "min":
+                result["min"] = self.min_values.copy()
+            if metric == "max":
+                result["max"] = self.max_values.copy()
+            if metric == "sum":
+                result["sum"] = self.sum_values.copy()
+            if metric == "mean":
+                result["mean"] = self.sum_values / self.count
+
+        return result
+
+
+def summarize(dataframe, column, metrics):
+    """
+    Summarize an array type column over a spark dataframe or a pandas dataframe
+
+    Parameters
+    ----------
+    dataframe : :py:class:`pyspark.sql.DataFrame` or py:class:`pandas.DataFrame`
+        input dataset, it can be either pandas dataframe or spark dataframe.
+
+    column:
+        The name of the column to be summarized, it must be an array type column
+        and all values in the column must have the same length.
+    metrics:
+        The metrics to be summarized, available metrics are:
+        "min", "max",  "sum", "mean"
+
+    Returns
+    -------
+    Summary results as a dict, the keys in the dict are the metrics being summarized.
+    """
+
+    def local_agg_fn(pandas_df):
+        status = None
+        for value_array in pandas_df[column].values:
+            if status is None:
+                status = SummarizerAggStatus(value_array)
+            else:
+                status.update(value_array)
+
+        return status
+
+    def merge_agg_status(status1, status2):
+        return status1.merge(status2)
+
+    def agg_status_to_result(status):
+        return status.to_result(metrics)
+
+    return aggregate_dataframe(
+        dataframe, [column], local_agg_fn, merge_agg_status, agg_status_to_result
+    )

--- a/python/pyspark/mlv2/tests/connect/test_parity_evaluation.py
+++ b/python/pyspark/mlv2/tests/connect/test_parity_evaluation.py
@@ -15,20 +15,25 @@
 # limitations under the License.
 #
 
+import unittest
 from pyspark.sql import SparkSession
-from pyspark.mlv2.tests.test_evaluation import EvaluationTests
+from pyspark.mlv2.tests.test_evaluation import EvaluationTestsMixin
 
 
-class EvaluationTestsOnConnect(EvaluationTests):
+class EvaluationTestsOnConnect(EvaluationTestsMixin, unittest.TestCase):
+
     def setUp(self) -> None:
         self.spark = (
             SparkSession.builder.remote("local[2]")
                 .getOrCreate()
         )
 
+    def tearDown(self) -> None:
+        self.spark.stop()
+
 
 if __name__ == "__main__":
-    from pyspark.mlv2.tests.test_evaluation import *  # noqa: F401,F403
+    from pyspark.mlv2.tests.connect.test_parity_evaluation import *  # noqa: F401,F403
 
     try:
         import xmlrunner

--- a/python/pyspark/mlv2/tests/connect/test_parity_evaluation.py
+++ b/python/pyspark/mlv2/tests/connect/test_parity_evaluation.py
@@ -19,7 +19,14 @@ import unittest
 from pyspark.sql import SparkSession
 from pyspark.mlv2.tests.test_evaluation import EvaluationTestsMixin
 
+have_torcheval = True
+try:
+    import torcheval  # noqa: F401
+except ImportError:
+    have_torcheval = False
 
+
+@unittest.skipIf(not have_torcheval, "torcheval is required")
 class EvaluationTestsOnConnect(EvaluationTestsMixin, unittest.TestCase):
     def setUp(self) -> None:
         self.spark = SparkSession.builder.remote("local[2]").getOrCreate()

--- a/python/pyspark/mlv2/tests/connect/test_parity_evaluation.py
+++ b/python/pyspark/mlv2/tests/connect/test_parity_evaluation.py
@@ -39,7 +39,7 @@ if __name__ == "__main__":
     from pyspark.mlv2.tests.connect.test_parity_evaluation import *  # noqa: F401,F403
 
     try:
-        import xmlrunner
+        import xmlrunner  # type: ignore[import]
 
         testRunner = xmlrunner.XMLTestRunner(output="target/test-reports", verbosity=2)
     except ImportError:

--- a/python/pyspark/mlv2/tests/connect/test_parity_evaluation.py
+++ b/python/pyspark/mlv2/tests/connect/test_parity_evaluation.py
@@ -21,12 +21,8 @@ from pyspark.mlv2.tests.test_evaluation import EvaluationTestsMixin
 
 
 class EvaluationTestsOnConnect(EvaluationTestsMixin, unittest.TestCase):
-
     def setUp(self) -> None:
-        self.spark = (
-            SparkSession.builder.remote("local[2]")
-                .getOrCreate()
-        )
+        self.spark = SparkSession.builder.remote("local[2]").getOrCreate()
 
     def tearDown(self) -> None:
         self.spark.stop()

--- a/python/pyspark/mlv2/tests/connect/test_parity_evaluation.py
+++ b/python/pyspark/mlv2/tests/connect/test_parity_evaluation.py
@@ -1,0 +1,39 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from pyspark.sql import SparkSession
+from pyspark.mlv2.tests.test_evaluation import EvaluationTests
+
+
+class EvaluationTestsOnConnect(EvaluationTests):
+    def setUp(self) -> None:
+        self.spark = (
+            SparkSession.builder.remote("local[2]")
+                .getOrCreate()
+        )
+
+
+if __name__ == "__main__":
+    from pyspark.mlv2.tests.test_evaluation import *  # noqa: F401,F403
+
+    try:
+        import xmlrunner
+
+        testRunner = xmlrunner.XMLTestRunner(output="target/test-reports", verbosity=2)
+    except ImportError:
+        testRunner = None
+    unittest.main(testRunner=testRunner, verbosity=2)

--- a/python/pyspark/mlv2/tests/connect/test_parity_feature.py
+++ b/python/pyspark/mlv2/tests/connect/test_parity_feature.py
@@ -1,0 +1,39 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from pyspark.sql import SparkSession
+from pyspark.mlv2.tests.test_feature import FeatureTests
+
+
+class EvaluationTestsOnConnect(FeatureTests):
+    def setUp(self) -> None:
+        self.spark = (
+            SparkSession.builder.remote("local[2]")
+                .getOrCreate()
+        )
+
+
+if __name__ == "__main__":
+    from pyspark.mlv2.tests.test_feature import *  # noqa: F401,F403
+
+    try:
+        import xmlrunner
+
+        testRunner = xmlrunner.XMLTestRunner(output="target/test-reports", verbosity=2)
+    except ImportError:
+        testRunner = None
+    unittest.main(testRunner=testRunner, verbosity=2)

--- a/python/pyspark/mlv2/tests/connect/test_parity_feature.py
+++ b/python/pyspark/mlv2/tests/connect/test_parity_feature.py
@@ -32,7 +32,7 @@ if __name__ == "__main__":
     from pyspark.mlv2.tests.connect.test_parity_feature import *  # noqa: F401,F403
 
     try:
-        import xmlrunner
+        import xmlrunner  # type: ignore[import]
 
         testRunner = xmlrunner.XMLTestRunner(output="target/test-reports", verbosity=2)
     except ImportError:

--- a/python/pyspark/mlv2/tests/connect/test_parity_feature.py
+++ b/python/pyspark/mlv2/tests/connect/test_parity_feature.py
@@ -21,12 +21,8 @@ from pyspark.mlv2.tests.test_feature import FeatureTestsMixin
 
 
 class FeatureTestsOnConnect(FeatureTestsMixin, unittest.TestCase):
-
     def setUp(self) -> None:
-        self.spark = (
-            SparkSession.builder.remote("local[2]")
-                .getOrCreate()
-        )
+        self.spark = SparkSession.builder.remote("local[2]").getOrCreate()
 
     def tearDown(self) -> None:
         self.spark.stop()

--- a/python/pyspark/mlv2/tests/connect/test_parity_feature.py
+++ b/python/pyspark/mlv2/tests/connect/test_parity_feature.py
@@ -15,20 +15,25 @@
 # limitations under the License.
 #
 
+import unittest
 from pyspark.sql import SparkSession
-from pyspark.mlv2.tests.test_feature import FeatureTests
+from pyspark.mlv2.tests.test_feature import FeatureTestsMixin
 
 
-class EvaluationTestsOnConnect(FeatureTests):
+class FeatureTestsOnConnect(FeatureTestsMixin, unittest.TestCase):
+
     def setUp(self) -> None:
         self.spark = (
             SparkSession.builder.remote("local[2]")
                 .getOrCreate()
         )
 
+    def tearDown(self) -> None:
+        self.spark.stop()
+
 
 if __name__ == "__main__":
-    from pyspark.mlv2.tests.test_feature import *  # noqa: F401,F403
+    from pyspark.mlv2.tests.connect.test_parity_feature import *  # noqa: F401,F403
 
     try:
         import xmlrunner

--- a/python/pyspark/mlv2/tests/connect/test_parity_summarizer.py
+++ b/python/pyspark/mlv2/tests/connect/test_parity_summarizer.py
@@ -15,20 +15,24 @@
 # limitations under the License.
 #
 
+import unittest
 from pyspark.sql import SparkSession
-from pyspark.mlv2.tests.test_summarizer import SummarizerTests
+from pyspark.mlv2.tests.test_summarizer import SummarizerTestsMixin
 
 
-class EvaluationTestsOnConnect(SummarizerTests):
+class SummarizerTestsOnConnect(SummarizerTestsMixin, unittest.TestCase):
     def setUp(self) -> None:
         self.spark = (
             SparkSession.builder.remote("local[2]")
                 .getOrCreate()
         )
 
+    def tearDown(self) -> None:
+        self.spark.stop()
+
 
 if __name__ == "__main__":
-    from pyspark.mlv2.tests.test_summarizer import *  # noqa: F401,F403
+    from pyspark.mlv2.tests.connect.test_parity_summarizer import *  # noqa: F401,F403
 
     try:
         import xmlrunner

--- a/python/pyspark/mlv2/tests/connect/test_parity_summarizer.py
+++ b/python/pyspark/mlv2/tests/connect/test_parity_summarizer.py
@@ -32,7 +32,7 @@ if __name__ == "__main__":
     from pyspark.mlv2.tests.connect.test_parity_summarizer import *  # noqa: F401,F403
 
     try:
-        import xmlrunner
+        import xmlrunner  # type: ignore[import]
 
         testRunner = xmlrunner.XMLTestRunner(output="target/test-reports", verbosity=2)
     except ImportError:

--- a/python/pyspark/mlv2/tests/connect/test_parity_summarizer.py
+++ b/python/pyspark/mlv2/tests/connect/test_parity_summarizer.py
@@ -22,10 +22,7 @@ from pyspark.mlv2.tests.test_summarizer import SummarizerTestsMixin
 
 class SummarizerTestsOnConnect(SummarizerTestsMixin, unittest.TestCase):
     def setUp(self) -> None:
-        self.spark = (
-            SparkSession.builder.remote("local[2]")
-                .getOrCreate()
-        )
+        self.spark = SparkSession.builder.remote("local[2]").getOrCreate()
 
     def tearDown(self) -> None:
         self.spark.stop()

--- a/python/pyspark/mlv2/tests/connect/test_parity_summarizer.py
+++ b/python/pyspark/mlv2/tests/connect/test_parity_summarizer.py
@@ -1,0 +1,39 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from pyspark.sql import SparkSession
+from pyspark.mlv2.tests.test_summarizer import SummarizerTests
+
+
+class EvaluationTestsOnConnect(SummarizerTests):
+    def setUp(self) -> None:
+        self.spark = (
+            SparkSession.builder.remote("local[2]")
+                .getOrCreate()
+        )
+
+
+if __name__ == "__main__":
+    from pyspark.mlv2.tests.test_summarizer import *  # noqa: F401,F403
+
+    try:
+        import xmlrunner
+
+        testRunner = xmlrunner.XMLTestRunner(output="target/test-reports", verbosity=2)
+    except ImportError:
+        testRunner = None
+    unittest.main(testRunner=testRunner, verbosity=2)

--- a/python/pyspark/mlv2/tests/test_evaluation.py
+++ b/python/pyspark/mlv2/tests/test_evaluation.py
@@ -22,6 +22,13 @@ from pyspark.mlv2.evaluation import RegressionEvaluator
 from pyspark.sql import SparkSession
 
 
+have_torcheval = True
+try:
+    import torcheval  # noqa: F401
+except ImportError:
+    have_torcheval = False
+
+
 class EvaluationTestsMixin:
     def test_regressor_evaluator(self):
         df1 = self.spark.createDataFrame(
@@ -60,6 +67,7 @@ class EvaluationTestsMixin:
         np.testing.assert_almost_equal(r2_local, expected_r2)
 
 
+@unittest.skipIf(not have_torcheval, "torcheval is required")
 class EvaluationTests(EvaluationTestsMixin, unittest.TestCase):
     def setUp(self) -> None:
         self.spark = SparkSession.builder.master("local[2]").getOrCreate()
@@ -69,7 +77,7 @@ class EvaluationTests(EvaluationTestsMixin, unittest.TestCase):
 
 
 if __name__ == "__main__":
-    from pyspark.mlv2.tests.test_evaluation import *  # noqa: F401
+    from pyspark.mlv2.tests.test_evaluation import *  # noqa: F401,F403
 
     try:
         import xmlrunner

--- a/python/pyspark/mlv2/tests/test_evaluation.py
+++ b/python/pyspark/mlv2/tests/test_evaluation.py
@@ -80,7 +80,7 @@ if __name__ == "__main__":
     from pyspark.mlv2.tests.test_evaluation import *  # noqa: F401,F403
 
     try:
-        import xmlrunner
+        import xmlrunner  # type: ignore[import]
 
         testRunner = xmlrunner.XMLTestRunner(output="target/test-reports", verbosity=2)
     except ImportError:

--- a/python/pyspark/mlv2/tests/test_evaluation.py
+++ b/python/pyspark/mlv2/tests/test_evaluation.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import unittest
+import numpy as np
+
+from pyspark.ml.linalg import DenseVector, SparseVector, Vectors
+from pyspark.sql import Row
+from pyspark.testing.utils import QuietTest
+from pyspark.testing.mlutils import check_params, SparkSessionTestCase
+
+from pyspark.mlv2.evaluation import RegressionEvaluator
+
+
+class EvaluationTests(SparkSessionTestCase):
+
+    def test_regressor_evaluator(self):
+        df1 = self.spark.createDataFrame([
+            (0.5, 1.0),
+            (-0.5, -0.8),
+            (2.0, 3.0),
+        ], schema=['label', 'prediction'])
+
+        local_df1 = df1.toPandas()
+
+        mse_evaluator = RegressionEvaluator(
+            metricName="mse",
+            labelCol="label",
+            predictionCol="prediction",
+        )
+
+        expected_mse = 0.4466666877269745
+        mse = mse_evaluator.evaluate(df1)
+        mse_local = mse_evaluator.evaluate(local_df1)
+        np.testing.assert_almost_equal(mse, expected_mse)
+        np.testing.assert_almost_equal(mse_local, expected_mse)
+
+        r2_evaluator = RegressionEvaluator(
+            metricName="r2",
+            labelCol="label",
+            predictionCol="prediction",
+        )
+
+        expected_r2 = 0.5768420696258545
+        r2 = r2_evaluator.evaluate(df1)
+        r2_local = r2_evaluator.evaluate(local_df1)
+        np.testing.assert_almost_equal(r2, expected_r2)
+        np.testing.assert_almost_equal(r2_local, expected_r2)
+
+
+if __name__ == "__main__":
+    from pyspark.mlv2.tests.test_evaluation import *  # noqa: F401
+
+    try:
+        import xmlrunner
+
+        testRunner = xmlrunner.XMLTestRunner(output="target/test-reports", verbosity=2)
+    except ImportError:
+        testRunner = None
+    unittest.main(testRunner=testRunner, verbosity=2)

--- a/python/pyspark/mlv2/tests/test_evaluation.py
+++ b/python/pyspark/mlv2/tests/test_evaluation.py
@@ -22,16 +22,7 @@ from pyspark.mlv2.evaluation import RegressionEvaluator
 from pyspark.sql import SparkSession
 
 
-class EvaluationTests(unittest.TestCase):
-
-    def setUp(self) -> None:
-        self.spark = (
-            SparkSession.builder.master("local[2]")
-                .getOrCreate()
-        )
-
-    def tearDown(self) -> None:
-        self.spark.stop()
+class EvaluationTestsMixin:
 
     def test_regressor_evaluator(self):
         df1 = self.spark.createDataFrame([
@@ -65,6 +56,18 @@ class EvaluationTests(unittest.TestCase):
         r2_local = r2_evaluator.evaluate(local_df1)
         np.testing.assert_almost_equal(r2, expected_r2)
         np.testing.assert_almost_equal(r2_local, expected_r2)
+
+
+class EvaluationTests(EvaluationTestsMixin, unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.spark = (
+            SparkSession.builder.master("local[2]")
+                .getOrCreate()
+        )
+
+    def tearDown(self) -> None:
+        self.spark.stop()
 
 
 if __name__ == "__main__":

--- a/python/pyspark/mlv2/tests/test_evaluation.py
+++ b/python/pyspark/mlv2/tests/test_evaluation.py
@@ -23,13 +23,15 @@ from pyspark.sql import SparkSession
 
 
 class EvaluationTestsMixin:
-
     def test_regressor_evaluator(self):
-        df1 = self.spark.createDataFrame([
-            (0.5, 1.0),
-            (-0.5, -0.8),
-            (2.0, 3.0),
-        ], schema=['label', 'prediction'])
+        df1 = self.spark.createDataFrame(
+            [
+                (0.5, 1.0),
+                (-0.5, -0.8),
+                (2.0, 3.0),
+            ],
+            schema=["label", "prediction"],
+        )
 
         local_df1 = df1.toPandas()
 
@@ -59,12 +61,8 @@ class EvaluationTestsMixin:
 
 
 class EvaluationTests(EvaluationTestsMixin, unittest.TestCase):
-
     def setUp(self) -> None:
-        self.spark = (
-            SparkSession.builder.master("local[2]")
-                .getOrCreate()
-        )
+        self.spark = SparkSession.builder.master("local[2]").getOrCreate()
 
     def tearDown(self) -> None:
         self.spark.stop()

--- a/python/pyspark/mlv2/tests/test_evaluation.py
+++ b/python/pyspark/mlv2/tests/test_evaluation.py
@@ -18,15 +18,20 @@
 import unittest
 import numpy as np
 
-from pyspark.ml.linalg import DenseVector, SparseVector, Vectors
-from pyspark.sql import Row
-from pyspark.testing.utils import QuietTest
-from pyspark.testing.mlutils import check_params, SparkSessionTestCase
-
 from pyspark.mlv2.evaluation import RegressionEvaluator
+from pyspark.sql import SparkSession
 
 
-class EvaluationTests(SparkSessionTestCase):
+class EvaluationTests(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.spark = (
+            SparkSession.builder.master("local[2]")
+                .getOrCreate()
+        )
+
+    def tearDown(self) -> None:
+        self.spark.stop()
 
     def test_regressor_evaluator(self):
         df1 = self.spark.createDataFrame([

--- a/python/pyspark/mlv2/tests/test_feature.py
+++ b/python/pyspark/mlv2/tests/test_feature.py
@@ -27,19 +27,19 @@ from pyspark.sql import SparkSession
 
 class FeatureTestsMixin:
     def test_max_abs_scaler(self):
-        df1 = self.spark.createDataFrame([
-            (Vectors.dense([2.0, 3.5, 1.5]),),
-            (Vectors.dense([-3.0, -0.5, -2.5]),),
-        ], schema=['features'])
+        df1 = self.spark.createDataFrame(
+            [
+                (Vectors.dense([2.0, 3.5, 1.5]),),
+                (Vectors.dense([-3.0, -0.5, -2.5]),),
+            ],
+            schema=["features"],
+        )
 
-        scaler = MaxAbsScaler(inputCol='features', outputCol='scaled_features')
+        scaler = MaxAbsScaler(inputCol="features", outputCol="scaled_features")
         model = scaler.fit(df1)
         result = model.transform(df1).toPandas()
 
-        expected_result = [
-            [2.0 / 3, 1.0, 0.6],
-            [-1.0, -1.0 / 7, -1.0]
-        ]
+        expected_result = [[2.0 / 3, 1.0, 0.6], [-1.0, -1.0 / 7, -1.0]]
 
         np.testing.assert_allclose(list(result.scaled_features), expected_result)
 
@@ -47,25 +47,26 @@ class FeatureTestsMixin:
         local_fit_model = scaler.fit(local_df1)
         local_transform_result = local_fit_model.transform(local_df1)
 
-        np.testing.assert_allclose(
-            list(local_transform_result.scaled_features), expected_result
-        )
+        np.testing.assert_allclose(list(local_transform_result.scaled_features), expected_result)
 
     def test_standard_scaler(self):
-        df1 = self.spark.createDataFrame([
-            (Vectors.dense([2.0, 3.5, 1.5]),),
-            (Vectors.dense([-3.0, -0.5, -2.5]),),
-            (Vectors.dense([1.0, -1.5, 0.5]),),
-        ], schema=['features'])
+        df1 = self.spark.createDataFrame(
+            [
+                (Vectors.dense([2.0, 3.5, 1.5]),),
+                (Vectors.dense([-3.0, -0.5, -2.5]),),
+                (Vectors.dense([1.0, -1.5, 0.5]),),
+            ],
+            schema=["features"],
+        )
 
-        scaler = StandardScaler(inputCol='features', outputCol='scaled_features')
+        scaler = StandardScaler(inputCol="features", outputCol="scaled_features")
         model = scaler.fit(df1)
         result = model.transform(df1).toPandas()
 
         expected_result = [
             [0.7559289460184544, 1.1338934190276817, 0.8006407690254358],
             [-1.1338934190276817, -0.3779644730092272, -1.1208970766356101],
-            [0.3779644730092272, -0.7559289460184544, 0.32025630761017426]
+            [0.3779644730092272, -0.7559289460184544, 0.32025630761017426],
         ]
 
         np.testing.assert_allclose(list(result.scaled_features), expected_result)
@@ -74,18 +75,12 @@ class FeatureTestsMixin:
         local_fit_model = scaler.fit(local_df1)
         local_transform_result = local_fit_model.transform(local_df1)
 
-        np.testing.assert_allclose(
-            list(local_transform_result.scaled_features), expected_result
-        )
+        np.testing.assert_allclose(list(local_transform_result.scaled_features), expected_result)
 
 
 class FeatureTests(FeatureTestsMixin, unittest.TestCase):
-
     def setUp(self) -> None:
-        self.spark = (
-            SparkSession.builder.master("local[2]")
-                .getOrCreate()
-        )
+        self.spark = SparkSession.builder.master("local[2]").getOrCreate()
 
     def tearDown(self) -> None:
         self.spark.stop()

--- a/python/pyspark/mlv2/tests/test_feature.py
+++ b/python/pyspark/mlv2/tests/test_feature.py
@@ -24,7 +24,7 @@ from pyspark.sql import Row
 from pyspark.testing.utils import QuietTest
 from pyspark.testing.mlutils import check_params, SparkSessionTestCase
 
-from pyspark.mlv2.feature import MaxAbsScaler
+from pyspark.mlv2.feature import MaxAbsScaler, StandardScaler
 
 
 class FeatureTests(SparkSessionTestCase):
@@ -51,6 +51,33 @@ class FeatureTests(SparkSessionTestCase):
         expected_result = [
             [2.0 / 3, 1.0, 0.6],
             [-1.0, -1.0 / 7, -1.0]
+        ]
+
+        np.testing.assert_allclose(list(result.scaled_features), expected_result)
+
+        local_df1 = df1.toPandas()
+        local_fit_model = scaler.fit(local_df1)
+        local_transform_result = local_fit_model.transform(local_df1)
+
+        np.testing.assert_allclose(
+            list(local_transform_result.scaled_features), expected_result
+        )
+
+    def test_standard_scaler(self):
+        df1 = self.spark.createDataFrame([
+            (Vectors.dense([2.0, 3.5, 1.5]),),
+            (Vectors.dense([-3.0, -0.5, -2.5]),),
+            (Vectors.dense([1.0, -1.5, 0.5]),),
+        ], schema=['features'])
+
+        scaler = StandardScaler(inputCol='features', outputCol='scaled_features')
+        model = scaler.fit(df1)
+        result = model.transform(df1).toPandas()
+
+        expected_result = [
+            [0.7559289460184544, 1.1338934190276817, 0.8006407690254358],
+            [-1.1338934190276817, -0.3779644730092272, -1.1208970766356101],
+            [0.3779644730092272, -0.7559289460184544, 0.32025630761017426]
         ]
 
         np.testing.assert_allclose(list(result.scaled_features), expected_result)

--- a/python/pyspark/mlv2/tests/test_feature.py
+++ b/python/pyspark/mlv2/tests/test_feature.py
@@ -87,7 +87,7 @@ class FeatureTests(FeatureTestsMixin, unittest.TestCase):
 
 
 if __name__ == "__main__":
-    from pyspark.mlv2.tests.test_feature import *  # noqa: F401
+    from pyspark.mlv2.tests.test_feature import *  # noqa: F401,F403
 
     try:
         import xmlrunner

--- a/python/pyspark/mlv2/tests/test_feature.py
+++ b/python/pyspark/mlv2/tests/test_feature.py
@@ -90,7 +90,7 @@ if __name__ == "__main__":
     from pyspark.mlv2.tests.test_feature import *  # noqa: F401,F403
 
     try:
-        import xmlrunner   # type: ignore[import]
+        import xmlrunner  # type: ignore[import]
 
         testRunner = xmlrunner.XMLTestRunner(output="target/test-reports", verbosity=2)
     except ImportError:

--- a/python/pyspark/mlv2/tests/test_feature.py
+++ b/python/pyspark/mlv2/tests/test_feature.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import unittest
+import numpy as np
+
+from pyspark.ml.linalg import DenseVector, SparseVector, Vectors
+from pyspark.sql import Row
+from pyspark.testing.utils import QuietTest
+from pyspark.testing.mlutils import check_params, SparkSessionTestCase
+
+from pyspark.mlv2.feature import MaxAbsScaler
+
+
+class FeatureTests(SparkSessionTestCase):
+
+    @classmethod
+    def conf(cls):
+        """
+        Override this in subclasses to supply a more specific conf
+        """
+        base_conf = super().conf()
+        base_conf.set("spark.task.maxFailures", "1")
+        return base_conf
+
+    def test_max_abs_scaler(self):
+        df1 = self.spark.createDataFrame([
+            (Vectors.dense([2.0, 3.5, 1.5]),),
+            (Vectors.dense([-3.0, -0.5, -2.5]),),
+        ], schema=['features'])
+
+        scaler = MaxAbsScaler(inputCol='features', outputCol='scaled_features')
+        model = scaler.fit(df1)
+        result = model.transform(df1).toPandas()
+
+        expected_result = [
+            [2.0 / 3, 1.0, 0.6],
+            [-1.0, -1.0 / 7, -1.0]
+        ]
+
+        np.testing.assert_allclose(list(result.scaled_features), expected_result)
+
+        local_df1 = df1.toPandas()
+        local_fit_model = scaler.fit(local_df1)
+        local_transform_result = local_fit_model.transform(local_df1)
+
+        np.testing.assert_allclose(
+            list(local_transform_result.scaled_features), expected_result
+        )
+
+
+if __name__ == "__main__":
+    from pyspark.mlv2.tests.test_feature import *  # noqa: F401
+
+    try:
+        import xmlrunner
+
+        testRunner = xmlrunner.XMLTestRunner(output="target/test-reports", verbosity=2)
+    except ImportError:
+        testRunner = None
+    unittest.main(testRunner=testRunner, verbosity=2)

--- a/python/pyspark/mlv2/tests/test_feature.py
+++ b/python/pyspark/mlv2/tests/test_feature.py
@@ -19,24 +19,21 @@
 import unittest
 import numpy as np
 
-from pyspark.ml.linalg import DenseVector, SparseVector, Vectors
-from pyspark.sql import Row
-from pyspark.testing.utils import QuietTest
-from pyspark.testing.mlutils import check_params, SparkSessionTestCase
-
+from pyspark.ml.linalg import Vectors
 from pyspark.mlv2.feature import MaxAbsScaler, StandardScaler
+from pyspark.sql import SparkSession
 
 
-class FeatureTests(SparkSessionTestCase):
+class FeatureTests(unittest.TestCase):
 
-    @classmethod
-    def conf(cls):
-        """
-        Override this in subclasses to supply a more specific conf
-        """
-        base_conf = super().conf()
-        base_conf.set("spark.task.maxFailures", "1")
-        return base_conf
+    def setUp(self) -> None:
+        self.spark = (
+            SparkSession.builder.master("local[2]")
+                .getOrCreate()
+        )
+
+    def tearDown(self) -> None:
+        self.spark.stop()
 
     def test_max_abs_scaler(self):
         df1 = self.spark.createDataFrame([

--- a/python/pyspark/mlv2/tests/test_feature.py
+++ b/python/pyspark/mlv2/tests/test_feature.py
@@ -90,7 +90,7 @@ if __name__ == "__main__":
     from pyspark.mlv2.tests.test_feature import *  # noqa: F401,F403
 
     try:
-        import xmlrunner
+        import xmlrunner   # type: ignore[import]
 
         testRunner = xmlrunner.XMLTestRunner(output="target/test-reports", verbosity=2)
     except ImportError:

--- a/python/pyspark/mlv2/tests/test_summarizer.py
+++ b/python/pyspark/mlv2/tests/test_summarizer.py
@@ -72,7 +72,7 @@ if __name__ == "__main__":
     from pyspark.mlv2.tests.test_summarizer import *  # noqa: F401,F403
 
     try:
-        import xmlrunner
+        import xmlrunner  # type: ignore[import]
 
         testRunner = xmlrunner.XMLTestRunner(output="target/test-reports", verbosity=2)
     except ImportError:

--- a/python/pyspark/mlv2/tests/test_summarizer.py
+++ b/python/pyspark/mlv2/tests/test_summarizer.py
@@ -19,16 +19,21 @@
 import unittest
 import numpy as np
 
-from pyspark.ml.linalg import DenseVector, SparseVector, Vectors
-from pyspark.sql import Row
-from pyspark.testing.utils import QuietTest
-from pyspark.testing.mlutils import check_params, SparkSessionTestCase
-
+from pyspark.ml.linalg import Vectors
 from pyspark.mlv2.summarizer import summarize_dataframe
-from pyspark.ml.stat import Summarizer
+from pyspark.sql import SparkSession
 
 
-class SummarizerTests(SparkSessionTestCase):
+class SummarizerTests(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.spark = (
+            SparkSession.builder.master("local[2]")
+                .getOrCreate()
+        )
+
+    def tearDown(self) -> None:
+        self.spark.stop()
 
     def test_summarize_dataframe(self):
         df1 = self.spark.createDataFrame([

--- a/python/pyspark/mlv2/tests/test_summarizer.py
+++ b/python/pyspark/mlv2/tests/test_summarizer.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import unittest
+import numpy as np
+
+from pyspark.ml.linalg import DenseVector, SparseVector, Vectors
+from pyspark.sql import Row
+from pyspark.testing.utils import QuietTest
+from pyspark.testing.mlutils import check_params, SparkSessionTestCase
+
+from pyspark.mlv2.summarizer import summarize_dataframe
+from pyspark.ml.stat import Summarizer
+
+
+class SummarizerTests(SparkSessionTestCase):
+
+    def test_summarize_dataframe(self):
+        df1 = self.spark.createDataFrame([
+            (Vectors.dense([2.0, -1.5]),),
+            (Vectors.dense([-3.0, 0.5]),),
+            (Vectors.dense([1.0, 3.5]),),
+        ], schema=["features"])
+
+        df1_local = df1.toPandas()
+
+        result = summarize_dataframe(df1, "features", ["min", "max", "sum", "mean", "std"])
+        result_local = summarize_dataframe(
+            df1_local, "features", ["min", "max", "sum", "mean", "std"]
+        )
+        expected_result = {
+            'min': [-3., -1.5],
+            'max': [2., 3.5],
+            'sum': [0., 2.5],
+            'mean': [0., 0.83333333],
+            'std': [2.64575131, 2.51661148],
+        }
+
+        def assert_dict_allclose(dict1, dict2):
+            assert set(dict1.keys()) == set(dict2.keys())
+
+            for key in dict1:
+                np.testing.assert_allclose(dict1[key], dict2[key])
+
+        assert_dict_allclose(result, expected_result)
+        assert_dict_allclose(result_local, expected_result)
+
+
+if __name__ == "__main__":
+    from pyspark.mlv2.tests.test_summarizer import *  # noqa: F401
+
+    try:
+        import xmlrunner
+
+        testRunner = xmlrunner.XMLTestRunner(output="target/test-reports", verbosity=2)
+    except ImportError:
+        testRunner = None
+    unittest.main(testRunner=testRunner, verbosity=2)

--- a/python/pyspark/mlv2/tests/test_summarizer.py
+++ b/python/pyspark/mlv2/tests/test_summarizer.py
@@ -27,11 +27,14 @@ from pyspark.sql import SparkSession
 
 class SummarizerTestsMixin:
     def test_summarize_dataframe(self):
-        df1 = self.spark.createDataFrame([
-            (Vectors.dense([2.0, -1.5]),),
-            (Vectors.dense([-3.0, 0.5]),),
-            (Vectors.dense([1.0, 3.5]),),
-        ], schema=["features"])
+        df1 = self.spark.createDataFrame(
+            [
+                (Vectors.dense([2.0, -1.5]),),
+                (Vectors.dense([-3.0, 0.5]),),
+                (Vectors.dense([1.0, 3.5]),),
+            ],
+            schema=["features"],
+        )
 
         df1_local = df1.withColumn("features", vector_to_array("features")).toPandas()
 
@@ -40,11 +43,11 @@ class SummarizerTestsMixin:
             df1_local, "features", ["min", "max", "sum", "mean", "std"]
         )
         expected_result = {
-            'min': [-3., -1.5],
-            'max': [2., 3.5],
-            'sum': [0., 2.5],
-            'mean': [0., 0.83333333],
-            'std': [2.64575131, 2.51661148],
+            "min": [-3.0, -1.5],
+            "max": [2.0, 3.5],
+            "sum": [0.0, 2.5],
+            "mean": [0.0, 0.83333333],
+            "std": [2.64575131, 2.51661148],
         }
 
         def assert_dict_allclose(dict1, dict2):
@@ -58,12 +61,8 @@ class SummarizerTestsMixin:
 
 
 class SummarizerTests(SummarizerTestsMixin, unittest.TestCase):
-
     def setUp(self) -> None:
-        self.spark = (
-            SparkSession.builder.master("local[2]")
-                .getOrCreate()
-        )
+        self.spark = SparkSession.builder.master("local[2]").getOrCreate()
 
     def tearDown(self) -> None:
         self.spark.stop()

--- a/python/pyspark/mlv2/tests/test_summarizer.py
+++ b/python/pyspark/mlv2/tests/test_summarizer.py
@@ -69,7 +69,7 @@ class SummarizerTests(SummarizerTestsMixin, unittest.TestCase):
 
 
 if __name__ == "__main__":
-    from pyspark.mlv2.tests.test_summarizer import *  # noqa: F401
+    from pyspark.mlv2.tests.test_summarizer import *  # noqa: F401,F403
 
     try:
         import xmlrunner

--- a/python/pyspark/mlv2/util.py
+++ b/python/pyspark/mlv2/util.py
@@ -66,18 +66,15 @@ def aggregate_dataframe(
 
     col_types = dict(dataframe.dtypes)
 
-    input_cols = []
     for col_name in input_col_names:
-        input_col = col(col_name)
         col_type = col_types[col_name]
         if col_type == "vector":
             from pyspark.ml.functions import vector_to_array
             # pandas UDF does not support vector type for now,
             # we convert it into vector type
-            input_col = vector_to_array(input_col).alias(col_name)
-        input_cols.append(input_col)
+            dataframe = dataframe.withColumn(col_name, vector_to_array(col_name))
 
-    dataframe = dataframe.select(*input_cols)
+    dataframe = dataframe.select(*input_col_names)
 
     def compute_state(iterator):
         state = None
@@ -179,7 +176,7 @@ def transform_dataframe_column(
         from pyspark.ml.functions import vector_to_array
         # pandas UDF does not support vector type for now,
         # we convert it into vector type
-        input_col = vector_to_array(input_col).alias(input_col_name)
+        input_col = vector_to_array(input_col)
 
     result_spark_df = dataframe.withColumn(
         output_col_name, transform_fn_pandas_udf(input_col)

--- a/python/pyspark/mlv2/util.py
+++ b/python/pyspark/mlv2/util.py
@@ -17,7 +17,7 @@
 
 import pandas as pd
 import cloudpickle  # type: ignore[import]
-from collections.abc import Callable, Iterator, Iterable
+from collections.abc import Callable, Iterable
 from typing import Any, Union
 
 from pyspark.sql import DataFrame

--- a/python/pyspark/mlv2/util.py
+++ b/python/pyspark/mlv2/util.py
@@ -1,0 +1,89 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pandas as pd
+import cloudpickle
+
+
+def aggregate_dataframe(
+        dataframe,
+        cols,
+        local_agg_fn,
+        merge_agg_status,
+        agg_status_to_result
+):
+    """
+    The function can be used to run arbitrary aggregation logic on a spark dataframe
+    or a pandas dataframe.
+
+    Parameters
+    ----------
+    dataframe :
+        A spark dataframe or a pandas dataframe
+
+    cols :
+        The name of columns that are used in aggregation
+
+    local_agg_fn :
+        A user-defined function that converts a pandas dataframe to an object holding
+        aggregation status. The aggregation status object must be pickle-able by
+        `cloudpickle`.
+
+    merge_agg_status :
+        A user-defined function that merges 2 aggregation status objects into one and
+        return the merged status. Either in-place modifying the first input status object
+        and returning it or creating a new status object are acceptable.
+
+    agg_status_to_result :
+        A user-defined function that converts aggregation status object to final aggregation
+        result.
+
+    Returns
+    -------
+    Aggregation result.
+    """
+
+    if isinstance(dataframe, pd.DataFrame):
+        dataframe = dataframe[list(cols)]
+        agg_status = local_agg_fn(dataframe)
+        return agg_status_to_result(agg_status)
+
+    dataframe = dataframe.select(*cols)
+
+    def compute_status(iterator):
+        status = None
+
+        for batch_pandas_df in iterator:
+            new_batch_status = local_agg_fn(batch_pandas_df)
+            if status is None:
+                status = new_batch_status
+            else:
+                status = merge_agg_status(status, new_batch_status)
+
+        return pd.DataFrame({'status': [cloudpickle.dumps(status)]})
+
+    result_pdf = dataframe.mapInPandas(compute_status, schema='status binary').toPandas()
+
+    merged_status = None
+    for status in result_pdf.status:
+        status = cloudpickle.loads(status)
+        if merged_status is None:
+            merged_status = status
+        else:
+            merged_status = merge_agg_status(merged_status, status)
+
+    return agg_status_to_result(merged_status)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?


 - Defines basic interfaces of Evaluator / Transformer / Model / Evaluator, these interfaces are designed to support both spark connect and legacy spark mode, and are designed to support train / transform / evaluate over either spark dataframe or pandas dataframe
 - Implement a feature transformer `MaxAbsScaler`, `ScalerScaler`
 - Implement a regressor evaluator `RegressorEvaluator` that supports MSE and R2 metric evaluation
 - Implement a summarizer via pure python code that can summarize array type columns on spark dataframe.
 - Some utility methods.


### Why are the changes needed?

Project: Distributed ML <> spark connect


### Does this PR introduce _any_ user-facing change?
Yes.


### How was this patch tested?
Unit tests.
