### PR TITLE
[SPARK-43518][SQL] Convert `_LEGACY_ERROR_TEMP_2029` to INTERNAL_ERROR

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -3873,11 +3873,6 @@
       "This line should be unreachable<err>."
     ]
   },
-  "_LEGACY_ERROR_TEMP_2029" : {
-    "message" : [
-      "Not supported rounding mode: <roundMode>."
-    ]
-  },
   "_LEGACY_ERROR_TEMP_2030" : {
     "message" : [
       "Can not handle nested schema yet...  plan <plan>."

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -514,10 +514,8 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase {
       messageParameters = Map("err" -> err))
   }
 
-  def unsupportedRoundingMode(roundMode: BigDecimal.RoundingMode.Value): SparkRuntimeException = {
-    new SparkRuntimeException(
-      errorClass = "_LEGACY_ERROR_TEMP_2029",
-      messageParameters = Map("roundMode" -> roundMode.toString()))
+  def unsupportedRoundingMode(roundMode: BigDecimal.RoundingMode.Value): SparkException = {
+    SparkException.internalError(s"Not supported rounding mode: ${roundMode.toString}.")
   }
 
   def resolveCannotHandleNestedSchema(plan: LogicalPlan): SparkRuntimeException = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DecimalSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DecimalSuite.scala
@@ -303,7 +303,7 @@ class DecimalSuite extends SparkFunSuite with PrivateMethodTester with SQLHelper
     }
   }
 
-  test("Not supported rounding mode: UNNECESSARY") {
+  test("Not supported rounding mode: HALF_DOWN") {
     val d = Decimal(10000L, 100, 80)
     checkError(
       exception = intercept[SparkException] {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DecimalSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DecimalSuite.scala
@@ -303,6 +303,17 @@ class DecimalSuite extends SparkFunSuite with PrivateMethodTester with SQLHelper
     }
   }
 
+  test("Not supported rounding mode: UNNECESSARY") {
+    val d = Decimal(10000L, 100, 80)
+    checkError(
+      exception = intercept[SparkException] {
+        d.toPrecision(5, 50, BigDecimal.RoundingMode.UNNECESSARY)
+      },
+      errorClass = "INTERNAL_ERROR",
+      parameters = Map("message" -> "Not supported rounding mode: UNNECESSARY.")
+    )
+  }
+
   test("SPARK-20341: support BigInt's value does not fit in long value range") {
     val bigInt = scala.math.BigInt("9223372036854775808")
     val decimal = Decimal.apply(bigInt)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DecimalSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DecimalSuite.scala
@@ -307,10 +307,10 @@ class DecimalSuite extends SparkFunSuite with PrivateMethodTester with SQLHelper
     val d = Decimal(10000L, 100, 80)
     checkError(
       exception = intercept[SparkException] {
-        d.toPrecision(5, 50, BigDecimal.RoundingMode.UNNECESSARY)
+        d.toPrecision(5, 50, BigDecimal.RoundingMode.HALF_DOWN)
       },
       errorClass = "INTERNAL_ERROR",
-      parameters = Map("message" -> "Not supported rounding mode: UNNECESSARY.")
+      parameters = Map("message" -> "Not supported rounding mode: HALF_DOWN.")
     )
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to convert _LEGACY_ERROR_TEMP_2029 to INTERNAL_ERROR.

### Why are the changes needed?
1. I found that it can only be triggered it with the parameter value: UP,DOWN,HALF_DOWN,UNNECESSARY, but from a user's perspective, it is impossible (the internal code limits its value to only: HALF_UP,HALF_EVEN,CEILING,FLOOR), so we should convert it to an internal error.
2. The changes improve the error framework.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
1. Update existed UT.
2. Pass GA.
