### PR TITLE
[SPARK-43520][BUILD][TESTS] Upgrade `mysql-connector-java` to 8.0.33

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1181,7 +1181,7 @@
       <dependency>
         <groupId>com.mysql</groupId>
         <artifactId>mysql-connector-j</artifactId>
-        <version>8.0.32</version>
+        <version>8.0.33</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade mysql-connector-java from 8.0.32 to 8.0.33
`Version 8.0.33 is the latest General Availability release of the 8.0 series of MySQL Connector/J. It is suitable for use with MySQL Server versions 8.0 and 5.7. It supports the Java Database Connectivity (JDBC) 4.2 API, and implements the X DevAPI.`

### Why are the changes needed?
1.This version brings some bugs fixes, the release note as follows:
https://dev.mysql.com/doc/relnotes/connector-j/8.0/en/news-8-0-33.html

2.Bugs Fixed(https://dev.mysql.com/doc/relnotes/connector-j/8.0/en/news-8-0-33.html#connector-j-8-0-33-bug), eg:

- When connecting to MySQL Server 5.7 and earlier with Connector/J 8.0.32, Connector/J sometimes hung after the prepare phase of a server-side prepared statement. (Bug #109864, Bug #35034666)
References: This issue is a regression of: Bug #33968169.

- Results returned by the getPrimaryKeys() method of the DatabaseMetadata interface were not sorted by COLUMN_NAME as required by the JDBC specification. (Bug #109808, Bug #35021038)

- Results returned by the getTypeInfo() method of the DatabaseMetadata interface were not sorted by DATA_TYPE as required by the JDBC specification. (Bug #109807, Bug #35021014)

- Rewriting of batched statements failed when a closing parenthesis was found within a VALUES clause. It was because QueryInfo failed to parse the prepared statement properly in that case. With this fix, the parser of VALUES clauses is improved, so that Connector/J is now able to recognize rewritability of statements that contain function calls or multiple VALUES lists, and it also handles well the cases when the string "value" is part of a table name, a column name, or a keyword. (Bug #109377, Bug #34900156, Bug #107577, Bug #34325361)

- Before executing a query with Statement.executeQuery(query), Connector/J checks if the query is going to produce results and rejects it if it cannot. The check wrongly rejected queries that had a WITH clause in which there was no space after the comma between two common table expressions. (Bug #109243, Bug #34852047)


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA.