### PR TITLE
[SPARK-42604][CONNECT][FOLLOWUP] Remove `typedlit/typedLit` `ProblemFilters.exclude` rule from mima check

### DIFF
--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/CheckConnectJvmClientCompatibility.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/CheckConnectJvmClientCompatibility.scala
@@ -177,8 +177,6 @@ object CheckConnectJvmClientCompatibility {
       ProblemFilters.exclude[Problem]("org.apache.spark.sql.functions.callUDF"),
       ProblemFilters.exclude[Problem]("org.apache.spark.sql.functions.unwrap_udt"),
       ProblemFilters.exclude[Problem]("org.apache.spark.sql.functions.udaf"),
-      ProblemFilters.exclude[Problem]("org.apache.spark.sql.functions.typedlit"),
-      ProblemFilters.exclude[Problem]("org.apache.spark.sql.functions.typedLit"),
 
       // KeyValueGroupedDataset
       ProblemFilters.exclude[Problem](


### PR DESCRIPTION
### What changes were proposed in this pull request?
https://github.com/apache/spark/pull/40355 has implemented the `functions#typedlit ` and `functions#typedLit `, so this pr remove the corresponding `ProblemFilters.exclude` rule from `CheckConnectJvmClientCompatibility`


### Why are the changes needed?
Remove `unnecessary` `ProblemFilters.exclude` rule.



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Manual check `dev/connect-jvm-client-mima-check` passed

