### PR TITLE
[SPARK-43527][PYTHON] Fix `catalog.listCatalogs` in PySpark

### DIFF
--- a/python/pyspark/sql/catalog.py
+++ b/python/pyspark/sql/catalog.py
@@ -128,12 +128,19 @@ class Catalog:
         -------
         list
             A list of :class:`CatalogMetadata`.
+
+        Examples
+        --------
+        >>> spark.catalog.listCatalogs()
+        [CatalogMetadata(name='spark_catalog', description=None)]
         """
         iter = self._jcatalog.listCatalogs().toLocalIterator()
         catalogs = []
         while iter.hasNext():
             jcatalog = iter.next()
-            catalogs.append(CatalogMetadata(name=jcatalog.name, description=jcatalog.description))
+            catalogs.append(
+                CatalogMetadata(name=jcatalog.name(), description=jcatalog.description())
+            )
         return catalogs
 
     def currentDatabase(self) -> str:


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix `catalog.listCatalogs` in PySpark


### Why are the changes needed?
existing implementation outputs incorrect results

### Does this PR introduce _any_ user-facing change?
yes

before this PR:
```
In [1]: spark.catalog.listCatalogs()
Out[1]: [CatalogMetadata(name=<py4j.java_gateway.JavaMember object at 0x1031f08b0>, description=<py4j.java_gateway.JavaMember object at 0x1049ac2e0>)]
```

after this PR:
```
In [1]: spark.catalog.listCatalogs()
Out[1]: [CatalogMetadata(name='spark_catalog', description=None)]
```

### How was this patch tested?
added doctest