### PR TITLE
[SPARK-43528][SQL][PYTHON] Support duplicated field names in createDataFrame with pandas DataFrame

### DIFF
--- a/python/pyspark/sql/connect/conversion.py
+++ b/python/pyspark/sql/connect/conversion.py
@@ -44,7 +44,7 @@ from pyspark.sql.types import (
 from pyspark.storagelevel import StorageLevel
 from pyspark.sql.connect.types import to_arrow_schema
 import pyspark.sql.connect.proto as pb2
-from pyspark.sql.pandas.types import _dedup_names
+from pyspark.sql.pandas.types import _dedup_names, _deduplicate_field_names
 
 from typing import (
     Any,
@@ -481,29 +481,3 @@ def proto_to_storage_level(storage_level: pb2.StorageLevel) -> StorageLevel:
         deserialized=storage_level.deserialized,
         replication=storage_level.replication,
     )
-
-
-def _deduplicate_field_names(dt: DataType) -> DataType:
-    if isinstance(dt, StructType):
-        dedup_field_names = _dedup_names(dt.names)
-
-        return StructType(
-            [
-                StructField(
-                    dedup_field_names[i],
-                    _deduplicate_field_names(field.dataType),
-                    nullable=field.nullable,
-                )
-                for i, field in enumerate(dt.fields)
-            ]
-        )
-    elif isinstance(dt, ArrayType):
-        return ArrayType(_deduplicate_field_names(dt.elementType), containsNull=dt.containsNull)
-    elif isinstance(dt, MapType):
-        return MapType(
-            _deduplicate_field_names(dt.keyType),
-            _deduplicate_field_names(dt.valueType),
-            valueContainsNull=dt.valueContainsNull,
-        )
-    else:
-        return dt

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -54,7 +54,7 @@ from pyspark.sql.connect.plan import SQL, Range, LocalRelation, CachedRelation
 from pyspark.sql.connect.readwriter import DataFrameReader
 from pyspark.sql.connect.streaming import DataStreamReader, StreamingQueryManager
 from pyspark.sql.pandas.serializers import ArrowStreamPandasSerializer
-from pyspark.sql.pandas.types import to_arrow_schema, to_arrow_type
+from pyspark.sql.pandas.types import to_arrow_schema, to_arrow_type, _deduplicate_field_names
 from pyspark.sql.session import classproperty, SparkSession as PySparkSession
 from pyspark.sql.types import (
     _infer_schema,
@@ -330,7 +330,7 @@ class SparkSession:
             # Determine arrow types to coerce data when creating batches
             arrow_schema: Optional[pa.Schema] = None
             if isinstance(schema, StructType):
-                arrow_schema = to_arrow_schema(schema)
+                arrow_schema = to_arrow_schema(cast(StructType, _deduplicate_field_names(schema)))
                 arrow_types = [field.type for field in arrow_schema]
                 _cols = [str(x) if not isinstance(x, str) else x for x in schema.fieldNames()]
             elif isinstance(schema, DataType):
@@ -361,7 +361,9 @@ class SparkSession:
 
             if isinstance(schema, StructType):
                 assert arrow_schema is not None
-                _table = _table.rename_columns(schema.names).cast(arrow_schema)
+                _table = _table.rename_columns(
+                    cast(StructType, _deduplicate_field_names(schema)).names
+                ).cast(arrow_schema)
 
         elif isinstance(data, np.ndarray):
             if _cols is None:

--- a/python/pyspark/sql/tests/connect/test_parity_arrow.py
+++ b/python/pyspark/sql/tests/connect/test_parity_arrow.py
@@ -109,6 +109,9 @@ class ArrowParityTests(ArrowTestsMixin, ReusedConnectTestCase):
     def test_toPandas_duplicate_field_names(self):
         self.check_toPandas_duplicate_field_names(True)
 
+    def test_createDataFrame_duplicate_field_names(self):
+        self.check_createDataFrame_duplicate_field_names(True)
+
     def test_toPandas_empty_columns(self):
         self.check_toPandas_empty_columns(True)
 

--- a/python/pyspark/sql/tests/test_arrow.py
+++ b/python/pyspark/sql/tests/test_arrow.py
@@ -974,6 +974,34 @@ class ArrowTestsMixin:
                             expected = pd.DataFrame.from_records(data, columns=schema.names)
                         assert_frame_equal(df.toPandas(), expected)
 
+    def test_createDataFrame_duplicate_field_names(self):
+        for arrow_enabled in [True, False]:
+            with self.subTest(arrow_enabled=arrow_enabled):
+                self.check_createDataFrame_duplicate_field_names(arrow_enabled)
+
+    def check_createDataFrame_duplicate_field_names(self, arrow_enabled):
+        schema = (
+            StructType()
+            .add("struct", StructType().add("x", StringType()).add("x", IntegerType()))
+            .add(
+                "struct",
+                StructType()
+                .add("a", IntegerType())
+                .add("x", IntegerType())
+                .add("x", StringType())
+                .add("y", IntegerType())
+                .add("y", StringType()),
+            )
+        )
+
+        data = [Row(Row("a", 1), Row(2, 3, "b", 4, "c")), Row(Row("x", 6), Row(7, 8, "y", 9, "z"))]
+        pdf = pd.DataFrame.from_records(data, columns=schema.names)
+
+        with self.sql_conf({"spark.sql.execution.arrow.pyspark.enabled": arrow_enabled}):
+            df = self.spark.createDataFrame(pdf, schema)
+
+        self.assertEqual(df.collect(), data)
+
     def test_toPandas_empty_columns(self):
         for arrow_enabled in [True, False]:
             with self.subTest(arrow_enabled=arrow_enabled):

--- a/sql/core/src/main/scala/org/apache/spark/sql/api/r/SQLUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/api/r/SQLUtils.scala
@@ -247,7 +247,7 @@ private[sql] object SQLUtils extends Logging {
     val timeZoneId = sparkSession.sessionState.conf.sessionLocalTimeZone
     val rdd = arrowBatchRDD.rdd.mapPartitions { iter =>
       val context = TaskContext.get()
-      ArrowConverters.fromBatchIterator(iter, schema, timeZoneId, context)
+      ArrowConverters.fromBatchIterator(iter, schema, timeZoneId, true, context)
     }
     sparkSession.internalCreateDataFrame(rdd.setName("arrow"), schema)
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/arrow/ArrowConvertersSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/arrow/ArrowConvertersSuite.scala
@@ -1382,7 +1382,7 @@ class ArrowConvertersSuite extends SharedSparkSession {
 
     val ctx = TaskContext.empty()
     val batchIter = ArrowConverters.toBatchIterator(inputRows.iterator, schema, 5, null, true, ctx)
-    val outputRowIter = ArrowConverters.fromBatchIterator(batchIter, schema, null, ctx)
+    val outputRowIter = ArrowConverters.fromBatchIterator(batchIter, schema, null, true, ctx)
 
     var count = 0
     outputRowIter.zipWithIndex.foreach { case (row, i) =>
@@ -1415,7 +1415,7 @@ class ArrowConvertersSuite extends SharedSparkSession {
     // Read Arrow stream into batches, then convert back to rows
     val in = new ByteArrayReadableSeekableByteChannel(out.toByteArray)
     val readBatches = ArrowConverters.getBatchesFromStream(in)
-    val outputRowIter = ArrowConverters.fromBatchIterator(readBatches, schema, null, ctx)
+    val outputRowIter = ArrowConverters.fromBatchIterator(readBatches, schema, null, true, ctx)
 
     var count = 0
     outputRowIter.zipWithIndex.foreach { case (row, i) =>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Support duplicated field names in `createDataFrame` with pandas DataFrame.

For with Arrow, without Arrow, and Spark Connect:

```py
>>> spark.createDataFrame(pdf, schema).show()
+--------+---------------+
|struct_0|       struct_1|
+--------+---------------+
|  {a, 1}|{2, 3, b, 4, c}|
|  {x, 6}|{7, 8, y, 9, z}|
+--------+---------------+
```

### Why are the changes needed?

If there are duplicated field names, `createDataFrame` with pandas DataFrame fallbacks to without Arrow, or fails in Spark Connect.

```py
>>> import pandas as pd
>>> from pyspark.sql.types import *
>>>
>>> schema = (
...     StructType()
...     .add("struct_0", StructType().add("x", StringType()).add("x", IntegerType()))
...     .add(
...         "struct_1",
...         StructType()
...         .add("a", IntegerType())
...         .add("x", IntegerType())
...         .add("x", StringType())
...         .add("y", IntegerType())
...         .add("y", StringType()),
...     )
... )
>>>
>>> data = [Row(Row("a", 1), Row(2, 3, "b", 4, "c")), Row(Row("x", 6), Row(7, 8, "y", 9, "z"))]
>>> pdf = pd.DataFrame.from_records(data, columns=schema.names)
```

- Without Arrow:

Works fine.

```py
>>> spark.createDataFrame(pdf, schema).show()
+--------+---------------+
|struct_0|       struct_1|
+--------+---------------+
|  {a, 1}|{2, 3, b, 4, c}|
|  {x, 6}|{7, 8, y, 9, z}|
+--------+---------------+
```

- With Arrow:

Works with fallback.

```py
>>> spark.conf.set('spark.sql.execution.arrow.pyspark.enabled', True)
>>> spark.createDataFrame(pdf, schema).show()
/.../pyspark/sql/pandas/conversion.py:347: UserWarning: createDataFrame attempted Arrow optimization because 'spark.sql.execution.arrow.pyspark.enabled' is set to true; however, failed by the reason below:
  [DUPLICATED_FIELD_NAME_IN_ARROW_STRUCT] Duplicated field names in Arrow Struct are not allowed, got [x, x].
Attempting non-optimization as 'spark.sql.execution.arrow.pyspark.fallback.enabled' is set to true.
  warn(msg)
+--------+---------------+
|struct_0|       struct_1|
+--------+---------------+
|  {a, 1}|{2, 3, b, 4, c}|
|  {x, 6}|{7, 8, y, 9, z}|
+--------+---------------+
```

- Spark Connect

Fails.

```py
>>> spark.createDataFrame(pdf, schema).show()
...
Traceback (most recent call last):
...
pyspark.errors.exceptions.connect.IllegalArgumentException: not all nodes and buffers were consumed. ...
```

### Does this PR introduce _any_ user-facing change?

The duplicated field names will work.

### How was this patch tested?

Added the related test.