### PR TITLE
[SPARK-43531][CONNECT][PYTHON][TESTS] Enable more parity tests for Pandas UDFs

### DIFF
--- a/python/pyspark/sql/tests/connect/test_parity_pandas_cogrouped_map.py
+++ b/python/pyspark/sql/tests/connect/test_parity_pandas_cogrouped_map.py
@@ -21,53 +21,30 @@ from pyspark.testing.connectutils import ReusedConnectTestCase
 
 
 class CogroupedApplyInPandasTests(CogroupedApplyInPandasTestsMixin, ReusedConnectTestCase):
-    @unittest.skip(
-        "Spark Connect does not support sc._jvm.org.apache.log4j but the test depends on it."
-    )
+    @unittest.skip("Fails in Spark Connect, should enable.")
     def test_different_group_key_cardinality(self):
-        super().test_different_group_key_cardinality()
+        self.check_different_group_key_cardinality()
 
-    @unittest.skip(
-        "Spark Connect does not support sc._jvm.org.apache.log4j but the test depends on it."
-    )
-    def test_apply_in_pandas_returning_incompatible_type(self):
-        super().test_apply_in_pandas_returning_incompatible_type()
-
-    @unittest.skip(
-        "Spark Connect does not support sc._jvm.org.apache.log4j but the test depends on it."
-    )
+    @unittest.skip("Fails in Spark Connect, should enable.")
     def test_wrong_args(self):
-        super().test_wrong_args()
+        self.check_wrong_args()
 
-    @unittest.skip(
-        "Spark Connect does not support sc._jvm.org.apache.log4j but the test depends on it."
-    )
     def test_apply_in_pandas_not_returning_pandas_dataframe(self):
-        super().test_apply_in_pandas_not_returning_pandas_dataframe()
+        self.check_apply_in_pandas_not_returning_pandas_dataframe()
 
-    @unittest.skip(
-        "Spark Connect does not support sc._jvm.org.apache.log4j but the test depends on it."
-    )
     def test_apply_in_pandas_returning_wrong_column_names(self):
-        super().test_apply_in_pandas_returning_wrong_column_names()
+        self.check_apply_in_pandas_returning_wrong_column_names()
 
-    @unittest.skip(
-        "Spark Connect does not support sc._jvm.org.apache.log4j but the test depends on it."
-    )
     def test_apply_in_pandas_returning_no_column_names_and_wrong_amount(self):
-        super().test_apply_in_pandas_returning_no_column_names_and_wrong_amount()
+        self.check_apply_in_pandas_returning_no_column_names_and_wrong_amount()
 
-    @unittest.skip(
-        "Spark Connect does not support sc._jvm.org.apache.log4j but the test depends on it."
-    )
+    @unittest.skip("Fails in Spark Connect, should enable.")
     def test_apply_in_pandas_returning_incompatible_type(self):
-        super().test_apply_in_pandas_returning_incompatible_type()
+        self.check_apply_in_pandas_returning_incompatible_type()
 
-    @unittest.skip(
-        "Spark Connect does not support sc._jvm.org.apache.log4j but the test depends on it."
-    )
+    @unittest.skip("Fails in Spark Connect, should enable.")
     def test_wrong_return_type(self):
-        super().test_wrong_return_type()
+        self.check_wrong_return_type()
 
 
 if __name__ == "__main__":

--- a/python/pyspark/sql/tests/connect/test_parity_pandas_grouped_map.py
+++ b/python/pyspark/sql/tests/connect/test_parity_pandas_grouped_map.py
@@ -21,69 +21,41 @@ from pyspark.testing.connectutils import ReusedConnectTestCase
 
 
 class GroupedApplyInPandasTests(GroupedApplyInPandasTestsMixin, ReusedConnectTestCase):
-    # TODO(SPARK-42822): Fix ambiguous reference for case-insensitive grouping column
-    @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_case_insensitive_grouping_column(self):
-        super().test_case_insensitive_grouping_column()
-
     # TODO(SPARK-42857): Support CreateDataFrame from Decimal128
     @unittest.skip("Fails in Spark Connect, should enable.")
     def test_supported_types(self):
         super().test_supported_types()
 
-    @unittest.skip(
-        "Spark Connect does not support sc._jvm.org.apache.log4j but the test depends on it."
-    )
+    @unittest.skip("Fails in Spark Connect, should enable.")
     def test_wrong_return_type(self):
-        super().test_wrong_return_type()
+        self.check_wrong_return_type()
 
-    @unittest.skip(
-        "Spark Connect does not support sc._jvm.org.apache.log4j but the test depends on it."
-    )
+    @unittest.skip("Fails in Spark Connect, should enable.")
     def test_wrong_args(self):
-        super().test_wrong_args()
+        self.check_wrong_args()
 
-    @unittest.skip(
-        "Spark Connect does not support sc._jvm.org.apache.log4j but the test depends on it."
-    )
+    @unittest.skip("Fails in Spark Connect, should enable.")
     def test_unsupported_types(self):
-        super().test_unsupported_types()
+        self.check_unsupported_types()
 
-    @unittest.skip(
-        "Spark Connect does not support sc._jvm.org.apache.log4j but the test depends on it."
-    )
     def test_register_grouped_map_udf(self):
-        super().test_register_grouped_map_udf()
+        self.check_register_grouped_map_udf()
 
-    @unittest.skip(
-        "Spark Connect does not support sc._jvm.org.apache.log4j but the test depends on it."
-    )
     def test_column_order(self):
-        super().test_column_order()
+        self.check_column_order()
 
-    @unittest.skip(
-        "Spark Connect does not support sc._jvm.org.apache.log4j but the test depends on it."
-    )
     def test_apply_in_pandas_returning_wrong_column_names(self):
-        super().test_apply_in_pandas_returning_wrong_column_names()
+        self.check_apply_in_pandas_returning_wrong_column_names()
 
-    @unittest.skip(
-        "Spark Connect does not support sc._jvm.org.apache.log4j but the test depends on it."
-    )
     def test_apply_in_pandas_returning_no_column_names_and_wrong_amount(self):
-        super().test_apply_in_pandas_returning_no_column_names_and_wrong_amount()
+        self.check_apply_in_pandas_returning_no_column_names_and_wrong_amount()
 
-    @unittest.skip(
-        "Spark Connect does not support sc._jvm.org.apache.log4j but the test depends on it."
-    )
+    @unittest.skip("Fails in Spark Connect, should enable.")
     def test_apply_in_pandas_returning_incompatible_type(self):
-        super().test_apply_in_pandas_returning_incompatible_type()
+        self.check_apply_in_pandas_returning_incompatible_type()
 
-    @unittest.skip(
-        "Spark Connect does not support sc._jvm.org.apache.log4j but the test depends on it."
-    )
     def test_apply_in_pandas_not_returning_pandas_dataframe(self):
-        super().test_apply_in_pandas_not_returning_pandas_dataframe()
+        self.check_apply_in_pandas_not_returning_pandas_dataframe()
 
     @unittest.skip("Spark Connect doesn't support RDD but the test depends on it.")
     def test_grouped_with_empty_partition(self):

--- a/python/pyspark/sql/tests/connect/test_parity_pandas_udf.py
+++ b/python/pyspark/sql/tests/connect/test_parity_pandas_udf.py
@@ -24,15 +24,8 @@ from pyspark.testing.connectutils import ReusedConnectTestCase
 
 
 class PandasUDFParityTests(PandasUDFTestsMixin, ReusedConnectTestCase):
-    @unittest.skip(
-        "Spark Connect does not support sc._jvm.org.apache.log4j but the test depends on it."
-    )
     def test_udf_wrong_arg(self):
-        super().test_udf_wrong_arg()
-
-    @unittest.skip("Spark Connect does not support spark.conf but the test depends on it.")
-    def test_pandas_udf_timestamp_ntz(self):
-        super().test_pandas_udf_timestamp_ntz()
+        self.check_udf_wrong_arg()
 
     def test_pandas_udf_decorator_with_return_type_string(self):
         @pandas_udf("v double", PandasUDFType.GROUPED_MAP)

--- a/python/pyspark/sql/tests/pandas/test_pandas_cogrouped_map.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_cogrouped_map.py
@@ -133,22 +133,29 @@ class CogroupedApplyInPandasTestsMixin:
         self._test_merge(self.data1, self.data2, by=[])
 
     def test_different_group_key_cardinality(self):
+        with QuietTest(self.sc):
+            self.check_different_group_key_cardinality()
+
+    def check_different_group_key_cardinality(self):
         left = self.data1
         right = self.data2
 
         def merge_pandas(lft, _):
             return lft
 
-        with QuietTest(self.sc):
-            with self.assertRaisesRegex(
-                IllegalArgumentException,
-                "requirement failed: Cogroup keys must have same size: 2 != 1",
-            ):
-                (left.groupby("id", "k").cogroup(right.groupby("id"))).applyInPandas(
-                    merge_pandas, "id long, k int, v int"
-                )
+        with self.assertRaisesRegex(
+            IllegalArgumentException,
+            "requirement failed: Cogroup keys must have same size: 2 != 1",
+        ):
+            (left.groupby("id", "k").cogroup(right.groupby("id"))).applyInPandas(
+                merge_pandas, "id long, k int, v int"
+            )
 
     def test_apply_in_pandas_not_returning_pandas_dataframe(self):
+        with QuietTest(self.sc):
+            self.check_apply_in_pandas_not_returning_pandas_dataframe()
+
+    def check_apply_in_pandas_not_returning_pandas_dataframe(self):
         self._test_merge_error(
             fn=lambda lft, rgt: lft.size + rgt.size,
             error_class=PythonException,
@@ -178,6 +185,10 @@ class CogroupedApplyInPandasTestsMixin:
         self._test_merge(fn=merge_pandas)
 
     def test_apply_in_pandas_returning_wrong_column_names(self):
+        with QuietTest(self.sc):
+            self.check_apply_in_pandas_returning_wrong_column_names()
+
+    def check_apply_in_pandas_returning_wrong_column_names(self):
         def merge_pandas(lft, rgt):
             if 0 in lft["id"] and lft["id"][0] % 2 == 0:
                 lft["add"] = 0
@@ -193,6 +204,10 @@ class CogroupedApplyInPandasTestsMixin:
         )
 
     def test_apply_in_pandas_returning_no_column_names_and_wrong_amount(self):
+        with QuietTest(self.sc):
+            self.check_apply_in_pandas_returning_no_column_names_and_wrong_amount()
+
+    def check_apply_in_pandas_returning_no_column_names_and_wrong_amount(self):
         def merge_pandas(lft, rgt):
             if 0 in lft["id"] and lft["id"][0] % 2 == 0:
                 lft[3] = 0
@@ -220,10 +235,14 @@ class CogroupedApplyInPandasTestsMixin:
         self._test_merge_empty(fn=merge_pandas)
 
     def test_apply_in_pandas_returning_incompatible_type(self):
+        with QuietTest(self.sc):
+            self.check_apply_in_pandas_returning_incompatible_type()
+
+    def check_apply_in_pandas_returning_incompatible_type(self):
         for safely in [True, False]:
             with self.subTest(convertToArrowArraySafely=safely), self.sql_conf(
                 {"spark.sql.execution.pandas.convertToArrowArraySafely": safely}
-            ), QuietTest(self.sc):
+            ):
                 # sometimes we see ValueErrors
                 with self.subTest(convert="string to double"):
                     expected = (
@@ -307,6 +326,10 @@ class CogroupedApplyInPandasTestsMixin:
         assert_frame_equal(expected, result)
 
     def test_wrong_return_type(self):
+        with QuietTest(self.sc):
+            self.check_wrong_return_type()
+
+    def check_wrong_return_type(self):
         # Test that we get a sensible exception invalid values passed to apply
         self._test_merge_error(
             fn=lambda l, r: l,
@@ -316,6 +339,10 @@ class CogroupedApplyInPandasTestsMixin:
         )
 
     def test_wrong_args(self):
+        with QuietTest(self.sc):
+            self.check_wrong_args()
+
+    def check_wrong_args(self):
         self.__test_merge_error(
             fn=lambda: 1,
             output_schema=StructType([StructField("d", DoubleType())]),
@@ -533,9 +560,8 @@ class CogroupedApplyInPandasTestsMixin:
         output_schema="id long, k int, v int, v2 int",
     ):
         # Test fn as is, cf. _test_merge_error
-        with QuietTest(self.sc):
-            with self.assertRaisesRegex(error_class, error_message_regex):
-                self.__test_merge(left, right, by, fn, output_schema)
+        with self.assertRaisesRegex(error_class, error_message_regex):
+            self.__test_merge(left, right, by, fn, output_schema)
 
 
 class CogroupedApplyInPandasTests(CogroupedApplyInPandasTestsMixin, ReusedSQLTestCase):

--- a/python/pyspark/sql/tests/pandas/test_pandas_grouped_map.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_grouped_map.py
@@ -210,19 +210,23 @@ class GroupedApplyInPandasTestsMixin:
         assert_frame_equal(expected, result)
 
     def test_register_grouped_map_udf(self):
-        foo_udf = pandas_udf(lambda x: x, "id long", PandasUDFType.GROUPED_MAP)
         with QuietTest(self.sc):
-            with self.assertRaises(PySparkTypeError) as pe:
-                self.spark.catalog.registerFunction("foo_udf", foo_udf)
+            self.check_register_grouped_map_udf()
 
-            self.check_error(
-                exception=pe.exception,
-                error_class="INVALID_UDF_EVAL_TYPE",
-                message_parameters={
-                    "eval_type": "SQL_BATCHED_UDF, SQL_ARROW_BATCHED_UDF, SQL_SCALAR_PANDAS_UDF, "
-                    "SQL_SCALAR_PANDAS_ITER_UDF or SQL_GROUPED_AGG_PANDAS_UDF"
-                },
-            )
+    def check_register_grouped_map_udf(self):
+        foo_udf = pandas_udf(lambda x: x, "id long", PandasUDFType.GROUPED_MAP)
+
+        with self.assertRaises(PySparkTypeError) as pe:
+            self.spark.catalog.registerFunction("foo_udf", foo_udf)
+
+        self.check_error(
+            exception=pe.exception,
+            error_class="INVALID_UDF_EVAL_TYPE",
+            message_parameters={
+                "eval_type": "SQL_BATCHED_UDF, SQL_ARROW_BATCHED_UDF, SQL_SCALAR_PANDAS_UDF, "
+                "SQL_SCALAR_PANDAS_ITER_UDF or SQL_GROUPED_AGG_PANDAS_UDF"
+            },
+        )
 
     def test_decorator(self):
         df = self.data
@@ -277,12 +281,15 @@ class GroupedApplyInPandasTestsMixin:
 
     def test_apply_in_pandas_not_returning_pandas_dataframe(self):
         with QuietTest(self.sc):
-            with self.assertRaisesRegex(
-                PythonException,
-                "Return type of the user-defined function should be pandas.DataFrame, "
-                "but is <class 'tuple'>",
-            ):
-                self._test_apply_in_pandas(lambda key, pdf: key)
+            self.check_apply_in_pandas_not_returning_pandas_dataframe()
+
+    def check_apply_in_pandas_not_returning_pandas_dataframe(self):
+        with self.assertRaisesRegex(
+            PythonException,
+            "Return type of the user-defined function should be pandas.DataFrame, "
+            "but is <class 'tuple'>",
+        ):
+            self._test_apply_in_pandas(lambda key, pdf: key)
 
     @staticmethod
     def stats_with_column_names(key, pdf):
@@ -311,36 +318,46 @@ class GroupedApplyInPandasTestsMixin:
 
     def test_apply_in_pandas_returning_wrong_column_names(self):
         with QuietTest(self.sc):
-            with self.assertRaisesRegex(
-                PythonException,
-                "Column names of the returned pandas.DataFrame do not match specified schema. "
-                "Missing: mean. Unexpected: median, std.\n",
-            ):
-                self._test_apply_in_pandas(
-                    lambda key, pdf: pd.DataFrame(
-                        [key + (pdf.v.median(), pdf.v.std())], columns=["id", "median", "std"]
-                    )
+            self.check_apply_in_pandas_returning_wrong_column_names()
+
+    def check_apply_in_pandas_returning_wrong_column_names(self):
+        with self.assertRaisesRegex(
+            PythonException,
+            "Column names of the returned pandas.DataFrame do not match specified schema. "
+            "Missing: mean. Unexpected: median, std.\n",
+        ):
+            self._test_apply_in_pandas(
+                lambda key, pdf: pd.DataFrame(
+                    [key + (pdf.v.median(), pdf.v.std())], columns=["id", "median", "std"]
                 )
+            )
 
     def test_apply_in_pandas_returning_no_column_names_and_wrong_amount(self):
         with QuietTest(self.sc):
-            with self.assertRaisesRegex(
-                PythonException,
-                "Number of columns of the returned pandas.DataFrame doesn't match "
-                "specified schema. Expected: 2 Actual: 3\n",
-            ):
-                self._test_apply_in_pandas(
-                    lambda key, pdf: pd.DataFrame([key + (pdf.v.mean(), pdf.v.std())])
-                )
+            self.check_apply_in_pandas_returning_no_column_names_and_wrong_amount()
+
+    def check_apply_in_pandas_returning_no_column_names_and_wrong_amount(self):
+        with self.assertRaisesRegex(
+            PythonException,
+            "Number of columns of the returned pandas.DataFrame doesn't match "
+            "specified schema. Expected: 2 Actual: 3\n",
+        ):
+            self._test_apply_in_pandas(
+                lambda key, pdf: pd.DataFrame([key + (pdf.v.mean(), pdf.v.std())])
+            )
 
     def test_apply_in_pandas_returning_empty_dataframe(self):
         self._test_apply_in_pandas_returning_empty_dataframe(pd.DataFrame())
 
     def test_apply_in_pandas_returning_incompatible_type(self):
+        with QuietTest(self.sc):
+            self.check_apply_in_pandas_returning_incompatible_type()
+
+    def check_apply_in_pandas_returning_incompatible_type(self):
         for safely in [True, False]:
             with self.subTest(convertToArrowArraySafely=safely), self.sql_conf(
                 {"spark.sql.execution.pandas.convertToArrowArraySafely": safely}
-            ), QuietTest(self.sc):
+            ):
                 # sometimes we see ValueErrors
                 with self.subTest(convert="string to double"):
                     expected = (
@@ -387,38 +404,44 @@ class GroupedApplyInPandasTestsMixin:
 
     def test_wrong_return_type(self):
         with QuietTest(self.sc):
-            with self.assertRaisesRegex(
-                NotImplementedError,
-                "Invalid return type.*grouped map Pandas UDF.*ArrayType.*TimestampType",
-            ):
-                pandas_udf(
-                    lambda pdf: pdf, "id long, v array<timestamp>", PandasUDFType.GROUPED_MAP
-                )
+            self.check_wrong_return_type()
+
+    def check_wrong_return_type(self):
+        with self.assertRaisesRegex(
+            NotImplementedError,
+            "Invalid return type.*grouped map Pandas UDF.*ArrayType.*TimestampType",
+        ):
+            pandas_udf(lambda pdf: pdf, "id long, v array<timestamp>", PandasUDFType.GROUPED_MAP)
 
     def test_wrong_args(self):
+        with QuietTest(self.sc):
+            self.check_wrong_args()
+
+    def check_wrong_args(self):
         df = self.data
 
-        with QuietTest(self.sc):
-            with self.assertRaisesRegex(ValueError, "Invalid udf"):
-                df.groupby("id").apply(lambda x: x)
-            with self.assertRaisesRegex(ValueError, "Invalid udf"):
-                df.groupby("id").apply(udf(lambda x: x, DoubleType()))
-            with self.assertRaisesRegex(ValueError, "Invalid udf"):
-                df.groupby("id").apply(sum(df.v))
-            with self.assertRaisesRegex(ValueError, "Invalid udf"):
-                df.groupby("id").apply(df.v + 1)
-            with self.assertRaisesRegex(ValueError, "Invalid function"):
-                df.groupby("id").apply(
-                    pandas_udf(lambda: 1, StructType([StructField("d", DoubleType())]))
-                )
-            with self.assertRaisesRegex(ValueError, "Invalid udf"):
-                df.groupby("id").apply(pandas_udf(lambda x, y: x, DoubleType()))
-            with self.assertRaisesRegex(ValueError, "Invalid udf.*GROUPED_MAP"):
-                df.groupby("id").apply(
-                    pandas_udf(lambda x, y: x, DoubleType(), PandasUDFType.SCALAR)
-                )
+        with self.assertRaisesRegex(ValueError, "Invalid udf"):
+            df.groupby("id").apply(lambda x: x)
+        with self.assertRaisesRegex(ValueError, "Invalid udf"):
+            df.groupby("id").apply(udf(lambda x: x, DoubleType()))
+        with self.assertRaisesRegex(ValueError, "Invalid udf"):
+            df.groupby("id").apply(sum(df.v))
+        with self.assertRaisesRegex(ValueError, "Invalid udf"):
+            df.groupby("id").apply(df.v + 1)
+        with self.assertRaisesRegex(ValueError, "Invalid function"):
+            df.groupby("id").apply(
+                pandas_udf(lambda: 1, StructType([StructField("d", DoubleType())]))
+            )
+        with self.assertRaisesRegex(ValueError, "Invalid udf"):
+            df.groupby("id").apply(pandas_udf(lambda x, y: x, DoubleType()))
+        with self.assertRaisesRegex(ValueError, "Invalid udf.*GROUPED_MAP"):
+            df.groupby("id").apply(pandas_udf(lambda x, y: x, DoubleType(), PandasUDFType.SCALAR))
 
     def test_unsupported_types(self):
+        with QuietTest(self.sc):
+            self.check_unsupported_types()
+
+    def check_unsupported_types(self):
         common_err_msg = "Invalid return type.*grouped map Pandas UDF.*"
         unsupported_types = [
             StructField("arr_ts", ArrayType(TimestampType())),
@@ -427,9 +450,9 @@ class GroupedApplyInPandasTestsMixin:
 
         for unsupported_type in unsupported_types:
             schema = StructType([StructField("id", LongType(), True), unsupported_type])
-            with QuietTest(self.sc):
-                with self.assertRaisesRegex(NotImplementedError, common_err_msg):
-                    pandas_udf(lambda x: x, schema, PandasUDFType.GROUPED_MAP)
+
+            with self.assertRaisesRegex(NotImplementedError, common_err_msg):
+                pandas_udf(lambda x: x, schema, PandasUDFType.GROUPED_MAP)
 
     # Regression test for SPARK-23314
     def test_timestamp_dst(self):
@@ -526,6 +549,10 @@ class GroupedApplyInPandasTestsMixin:
         assert_frame_equal(expected4, result4)
 
     def test_column_order(self):
+        with QuietTest(self.sc):
+            self.check_column_order()
+
+    def check_column_order(self):
 
         # Helper function to set column names from a list
         def rename_pdf(pdf, names):
@@ -593,15 +620,14 @@ class GroupedApplyInPandasTestsMixin:
             return pd.DataFrame([(1, datetime.date(2020, 10, 5))])
 
         with self.sql_conf({"spark.sql.execution.pandas.convertToArrowArraySafely": False}):
-            with QuietTest(self.sc):
-                with self.assertRaisesRegex(
-                    PythonException,
-                    "Column names of the returned pandas.DataFrame do not match "
-                    "specified schema. Missing: id. Unexpected: iid.\n",
-                ):
-                    grouped_df.apply(column_name_typo).collect()
-                with self.assertRaisesRegex(Exception, "[D|d]ecimal.*got.*date"):
-                    grouped_df.apply(invalid_positional_types).collect()
+            with self.assertRaisesRegex(
+                PythonException,
+                "Column names of the returned pandas.DataFrame do not match "
+                "specified schema. Missing: id. Unexpected: iid.\n",
+            ):
+                grouped_df.apply(column_name_typo).collect()
+            with self.assertRaisesRegex(Exception, "[D|d]ecimal.*got.*date"):
+                grouped_df.apply(invalid_positional_types).collect()
 
     def test_positional_assignment_conf(self):
         with self.sql_conf(

--- a/python/pyspark/sql/tests/pandas/test_pandas_udf.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_udf.py
@@ -127,55 +127,13 @@ class PandasUDFTestsMixin:
 
     def test_udf_wrong_arg(self):
         with QuietTest(self.sc):
+            self.check_udf_wrong_arg()
+
             with self.assertRaises(ParseException):
 
                 @pandas_udf("blah")
                 def foo(x):
                     return x
-
-            with self.assertRaises(PySparkTypeError) as pe:
-
-                @pandas_udf(functionType=PandasUDFType.SCALAR)
-                def foo(x):
-                    return x
-
-            self.check_error(
-                exception=pe.exception,
-                error_class="CANNOT_BE_NONE",
-                message_parameters={"arg_name": "returnType"},
-            )
-
-            with self.assertRaises(PySparkTypeError) as pe:
-
-                @pandas_udf("double", 100)
-                def foo(x):
-                    return x
-
-            self.check_error(
-                exception=pe.exception,
-                error_class="INVALID_PANDAS_UDF_TYPE",
-                message_parameters={"arg_name": "functionType", "arg_type": "100"},
-            )
-
-            with self.assertRaisesRegex(ValueError, "0-arg pandas_udfs.*not.*supported"):
-                pandas_udf(lambda: 1, LongType(), PandasUDFType.SCALAR)
-            with self.assertRaisesRegex(ValueError, "0-arg pandas_udfs.*not.*supported"):
-
-                @pandas_udf(LongType(), PandasUDFType.SCALAR)
-                def zero_with_type():
-                    return 1
-
-            with self.assertRaises(PySparkTypeError) as pe:
-
-                @pandas_udf(returnType=PandasUDFType.GROUPED_MAP)
-                def foo(df):
-                    return df
-
-            self.check_error(
-                exception=pe.exception,
-                error_class="NOT_DATATYPE_OR_STR",
-                message_parameters={"arg_name": "returnType", "arg_type": "int"},
-            )
 
             with self.assertRaises(PySparkTypeError) as pe:
 
@@ -198,6 +156,51 @@ class PandasUDFTestsMixin:
                 @pandas_udf(returnType="k int, v double", functionType=PandasUDFType.GROUPED_MAP)
                 def foo(k, v, w):
                     return k
+
+    def check_udf_wrong_arg(self):
+        with self.assertRaises(PySparkTypeError) as pe:
+
+            @pandas_udf(functionType=PandasUDFType.SCALAR)
+            def foo(x):
+                return x
+
+        self.check_error(
+            exception=pe.exception,
+            error_class="CANNOT_BE_NONE",
+            message_parameters={"arg_name": "returnType"},
+        )
+
+        with self.assertRaises(PySparkTypeError) as pe:
+
+            @pandas_udf("double", 100)
+            def foo(x):
+                return x
+
+        self.check_error(
+            exception=pe.exception,
+            error_class="INVALID_PANDAS_UDF_TYPE",
+            message_parameters={"arg_name": "functionType", "arg_type": "100"},
+        )
+
+        with self.assertRaisesRegex(ValueError, "0-arg pandas_udfs.*not.*supported"):
+            pandas_udf(lambda: 1, LongType(), PandasUDFType.SCALAR)
+        with self.assertRaisesRegex(ValueError, "0-arg pandas_udfs.*not.*supported"):
+
+            @pandas_udf(LongType(), PandasUDFType.SCALAR)
+            def zero_with_type():
+                return 1
+
+        with self.assertRaises(PySparkTypeError) as pe:
+
+            @pandas_udf(returnType=PandasUDFType.GROUPED_MAP)
+            def foo(df):
+                return df
+
+        self.check_error(
+            exception=pe.exception,
+            error_class="NOT_DATATYPE_OR_STR",
+            message_parameters={"arg_name": "returnType", "arg_type": "int"},
+        )
 
     def test_stopiteration_in_udf(self):
         def foo(x):


### PR DESCRIPTION
### What changes were proposed in this pull request?

Enables more parity tests for Pandas UDFs.

### Why are the changes needed?

There are still many tests disabled for some reasons.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Enabled tests.