### PR TITLE
[SPARK-43532][BUILD][TESTS] Upgrade `jdbc` related test dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1187,31 +1187,31 @@
       <dependency>
         <groupId>org.mariadb.jdbc</groupId>
         <artifactId>mariadb-java-client</artifactId>
-        <version>2.7.4</version>
+        <version>2.7.9</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.postgresql</groupId>
         <artifactId>postgresql</artifactId>
-        <version>42.5.1</version>
+        <version>42.6.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>com.ibm.db2</groupId>
         <artifactId>jcc</artifactId>
-        <version>11.5.6.0</version>
+        <version>11.5.8.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>com.microsoft.sqlserver</groupId>
         <artifactId>mssql-jdbc</artifactId>
-        <version>9.4.0.jre8</version>
+        <version>9.4.1.jre8</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>com.oracle.database.jdbc</groupId>
         <artifactId>ojdbc8</artifactId>
-        <version>21.3.0.0</version>
+        <version>23.2.0.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade `jdbc` related test dependencies, include:
- org.mariadb.jdbc:mariadb-java-client from 2.7.4 to 2.7.9
- org.postgresql:postgresql from 42.5.1 to 42.6.0
- com.ibm.db2:jcc from 11.5.6.0 to 11.5.8.0
- com.microsoft.sqlserver:mssql-jdbc from 9.4.0.jre8 to 9.4.1.jre8
- com.oracle.database.jdbc:ojdbc8 from 21.3.0.0 to 23.2.0.0 

### Why are the changes needed?
Routine upgrade.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA.