### PR TITLE
[MINOR][DOC] Refine doc for `Column.over`

### DIFF
--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -1366,13 +1366,19 @@ class Column:
         Examples
         --------
         >>> from pyspark.sql import Window
-        >>> window = Window.partitionBy("name").orderBy("age") \
-                .rowsBetween(Window.unboundedPreceding, Window.currentRow)
+        >>> window = (
+        ...     Window.partitionBy("name")
+        ...     .orderBy("age")
+        ...     .rowsBetween(Window.unboundedPreceding, Window.currentRow)
+        ... )
         >>> from pyspark.sql.functions import rank, min, desc
         >>> df = spark.createDataFrame(
         ...      [(2, "Alice"), (5, "Bob")], ["age", "name"])
-        >>> df.withColumn("rank", rank().over(window)) \
-                .withColumn("min", min('age').over(window)).sort(desc("age")).show()
+        >>> df.withColumn(
+        ...      "rank", rank().over(window)
+        ... ).withColumn(
+        ...      "min", min('age').over(window)
+        ... ).sort(desc("age")).show()
         +---+-----+----+---+
         |age| name|rank|min|
         +---+-----+----+---+


### PR DESCRIPTION
### What changes were proposed in this pull request?
reformat the docstring of  `Column.over`

### Why are the changes needed?
[existing doc](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.Column.over.html#pyspark.sql.Column.over) is not properly rendered


### Does this PR introduce _any_ user-facing change?
doc-only

before:
![image](https://github.com/apache/spark/assets/7322292/c73cb1ed-9291-480c-8765-475b0bc451d3)


after:
![image](https://github.com/apache/spark/assets/7322292/f6dee714-ad4c-4ee2-8973-3a91c105652f)


### How was this patch tested?
CI