### PR TITLE
[SPARK-43539][SQL] Assign a name to the error class _LEGACY_ERROR_TEMP_0003

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -180,6 +180,11 @@
     ],
     "sqlState" : "22003"
   },
+  "COLUMN_ALIASES_IS_NOT_ALLOWED" : {
+    "message" : [
+      "Columns aliases are not allowed in <op>."
+    ]
+  },
   "COLUMN_ALREADY_EXISTS" : {
     "message" : [
       "The column <columnName> already exists. Consider to choose another name or rename the existing column."
@@ -2133,11 +2138,6 @@
   "_LEGACY_ERROR_TEMP_0002" : {
     "message" : [
       "INSERT OVERWRITE DIRECTORY is not supported."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_0003" : {
-    "message" : [
-      "Columns aliases are not allowed in <op>."
     ]
   },
   "_LEGACY_ERROR_TEMP_0004" : {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
@@ -43,7 +43,7 @@ private[sql] object QueryParsingErrors extends QueryErrorsBase {
   def columnAliasInOperationNotAllowedError(op: String, ctx: TableAliasContext): Throwable = {
     new ParseException(
       errorClass = "COLUMN_ALIASES_IS_NOT_ALLOWED",
-      messageParameters = Map("op" -> toSQLId(op)),
+      messageParameters = Map("op" -> toSQLStmt(op)),
       ctx.identifierList())
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
@@ -42,7 +42,7 @@ private[sql] object QueryParsingErrors extends QueryErrorsBase {
 
   def columnAliasInOperationNotAllowedError(op: String, ctx: TableAliasContext): Throwable = {
     new ParseException(
-      errorClass = "_LEGACY_ERROR_TEMP_0003",
+      errorClass = "COLUMN_ALIASES_IS_NOT_ALLOWED",
       messageParameters = Map("op" -> op),
       ctx.identifierList())
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
@@ -43,7 +43,7 @@ private[sql] object QueryParsingErrors extends QueryErrorsBase {
   def columnAliasInOperationNotAllowedError(op: String, ctx: TableAliasContext): Throwable = {
     new ParseException(
       errorClass = "COLUMN_ALIASES_IS_NOT_ALLOWED",
-      messageParameters = Map("op" -> op),
+      messageParameters = Map("op" -> toSQLId(op)),
       ctx.identifierList())
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
@@ -1687,7 +1687,7 @@ class DDLParserSuite extends AnalysisTest {
     val sql = "DELETE FROM testcat.ns1.ns2.tbl AS t(a,b,c,d) WHERE d = 2"
     checkError(
       exception = parseException(sql),
-      errorClass = "_LEGACY_ERROR_TEMP_0003",
+      errorClass = "COLUMN_ALIASES_IS_NOT_ALLOWED",
       parameters = Map("op" -> "DELETE"),
       context = ExpectedContext(
         fragment = sql,
@@ -1729,7 +1729,7 @@ class DDLParserSuite extends AnalysisTest {
         |WHERE d=2""".stripMargin
     checkError(
       exception = parseException(sql),
-      errorClass = "_LEGACY_ERROR_TEMP_0003",
+      errorClass = "COLUMN_ALIASES_IS_NOT_ALLOWED",
       parameters = Map("op" -> "UPDATE"),
       context = ExpectedContext(
         fragment = sql,
@@ -1929,7 +1929,7 @@ class DDLParserSuite extends AnalysisTest {
           .stripMargin
         checkError(
           exception = parseException(sql),
-          errorClass = "_LEGACY_ERROR_TEMP_0003",
+          errorClass = "COLUMN_ALIASES_IS_NOT_ALLOWED",
           parameters = Map("op" -> "MERGE"),
           context = ExpectedContext(
             fragment = sql,

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
@@ -1688,7 +1688,7 @@ class DDLParserSuite extends AnalysisTest {
     checkError(
       exception = parseException(sql),
       errorClass = "COLUMN_ALIASES_IS_NOT_ALLOWED",
-      parameters = Map("op" -> "DELETE"),
+      parameters = Map("op" -> "`DELETE`"),
       context = ExpectedContext(
         fragment = sql,
         start = 0,
@@ -1730,7 +1730,7 @@ class DDLParserSuite extends AnalysisTest {
     checkError(
       exception = parseException(sql),
       errorClass = "COLUMN_ALIASES_IS_NOT_ALLOWED",
-      parameters = Map("op" -> "UPDATE"),
+      parameters = Map("op" -> "`UPDATE`"),
       context = ExpectedContext(
         fragment = sql,
         start = 0,
@@ -1930,7 +1930,7 @@ class DDLParserSuite extends AnalysisTest {
         checkError(
           exception = parseException(sql),
           errorClass = "COLUMN_ALIASES_IS_NOT_ALLOWED",
-          parameters = Map("op" -> "MERGE"),
+          parameters = Map("op" -> "`MERGE`"),
           context = ExpectedContext(
             fragment = sql,
             start = 0,

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
@@ -1688,7 +1688,7 @@ class DDLParserSuite extends AnalysisTest {
     checkError(
       exception = parseException(sql),
       errorClass = "COLUMN_ALIASES_IS_NOT_ALLOWED",
-      parameters = Map("op" -> "`DELETE`"),
+      parameters = Map("op" -> "DELETE"),
       context = ExpectedContext(
         fragment = sql,
         start = 0,
@@ -1730,7 +1730,7 @@ class DDLParserSuite extends AnalysisTest {
     checkError(
       exception = parseException(sql),
       errorClass = "COLUMN_ALIASES_IS_NOT_ALLOWED",
-      parameters = Map("op" -> "`UPDATE`"),
+      parameters = Map("op" -> "UPDATE"),
       context = ExpectedContext(
         fragment = sql,
         start = 0,
@@ -1930,7 +1930,7 @@ class DDLParserSuite extends AnalysisTest {
         checkError(
           exception = parseException(sql),
           errorClass = "COLUMN_ALIASES_IS_NOT_ALLOWED",
-          parameters = Map("op" -> "`MERGE`"),
+          parameters = Map("op" -> "MERGE"),
           context = ExpectedContext(
             fragment = sql,
             start = 0,


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to assign a name to the error class _LEGACY_ERROR_TEMP_0003.

### Why are the changes needed?
The changes improve the error framework.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA.