### PR TITLE
[SPARK-43413][SQL][FOLLOWUP] Show a directional message in ListQuery nullability assertion

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/subquery.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/subquery.scala
@@ -373,7 +373,7 @@ case class ListQuery(
     // Consider using ListQuery.childOutputs.exists(_.nullable)
     if (!SQLConf.get.getConf(SQLConf.LEGACY_IN_SUBQUERY_NULLABILITY)) {
       assert(false, "ListQuery nullability is not defined. To restore the legacy behavior before " +
-        "Spark 3.5.0, set " + SQLConf.LEGACY_IN_SUBQUERY_NULLABILITY.key + " = true")
+        s"Spark 3.5.0, set ${SQLConf.LEGACY_IN_SUBQUERY_NULLABILITY.key}=true")
     }
     false
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/subquery.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/subquery.scala
@@ -372,8 +372,8 @@ case class ListQuery(
     // ListQuery can't be executed alone so its nullability is not defined.
     // Consider using ListQuery.childOutputs.exists(_.nullable)
     if (!SQLConf.get.getConf(SQLConf.LEGACY_IN_SUBQUERY_NULLABILITY)) {
-      assert(false, "ListQuery nullability is not defined. This assert can be disabled using " +
-        "conf spark.sql.legacy.inSubqueryNullability = true")
+      assert(false, "ListQuery nullability is not defined. To restore the legacy behavior before " +
+        "Spark 3.5.0, set " + SQLConf.LEGACY_IN_SUBQUERY_NULLABILITY.key + " = true")
     }
     false
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/subquery.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/subquery.scala
@@ -372,7 +372,8 @@ case class ListQuery(
     // ListQuery can't be executed alone so its nullability is not defined.
     // Consider using ListQuery.childOutputs.exists(_.nullable)
     if (!SQLConf.get.getConf(SQLConf.LEGACY_IN_SUBQUERY_NULLABILITY)) {
-      assert(false, "ListQuery nullability is not defined")
+      assert(false, "ListQuery nullability is not defined. This assert can be disabled using " +
+        "conf spark.sql.legacy.inSubqueryNullability = true")
     }
     false
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
In case the assert for the call to ListQuery.nullable is hit, mention in the assert error message the conf flag that can be used to disable the assert. Follow-up to https://github.com/apache/spark/pull/41094#discussion_r1195438179

### Why are the changes needed?
Improve error message.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Unit tests