### PR TITLE
[SPARK-16484][SQL] Update hll function type checks to also check for non-foldable inputs

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -476,6 +476,11 @@
           "Parameter <paramIndex> requires the <requiredType> type, however <inputSql> has the type <inputType>."
         ]
       },
+      "UNEXPECTED_INPUT_FOLDABLE_VALUE" : {
+        "message" : [
+          "Parameter <paramIndex> requires a foldable value of <requiredFoldable>, however <inputSql> has a foldable value of <inputFoldable>."
+        ]
+      },
       "UNEXPECTED_NULL" : {
         "message" : [
           "The <exprName> must not be null."

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -471,14 +471,14 @@
           "class <className> not found."
         ]
       },
-      "UNEXPECTED_INPUT_TYPE" : {
-        "message" : [
-          "Parameter <paramIndex> requires the <requiredType> type, however <inputSql> has the type <inputType>."
-        ]
-      },
       "UNEXPECTED_INPUT_FOLDABLE_VALUE" : {
         "message" : [
           "Parameter <paramIndex> requires a foldable value of <requiredFoldable>, however <inputSql> has a foldable value of <inputFoldable>."
+        ]
+      },
+      "UNEXPECTED_INPUT_TYPE" : {
+        "message" : [
+          "Parameter <paramIndex> requires the <requiredType> type, however <inputSql> has the type <inputType>."
         ]
       },
       "UNEXPECTED_NULL" : {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ExpectsInputTypes.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ExpectsInputTypes.scala
@@ -98,18 +98,15 @@ object ExpectsInputTypesAndFoldable extends QueryErrorsBase {
   def checkInputIsFoldable(
       inputs: Seq[Expression],
       inputIsFoldable: Seq[Option[Boolean]]): TypeCheckResult = {
-    val mismatch = inputs.zip(inputIsFoldable).zipWithIndex.filter {
-      case ((_, Some(_)), _) => true
-      case _ => false
-    }.collectFirst {
-        case ((input, expected), idx) if input.foldable != expected.get =>
-          DataTypeMismatch(
-            errorSubClass = "UNEXPECTED_INPUT_FOLDABLE_VALUE",
-            messageParameters = Map(
-              "paramIndex" -> (idx + 1).toString,
-              "inputSql" -> toSQLExpr(input),
-              "inputFoldable" -> input.foldable.toString,
-              "requiredFoldable" -> expected.get.toString))
+   val mismatch = inputs.zip(inputIsFoldable).zipWithIndex.collectFirst {
+      case ((input, Some(expected)), idx) if input.foldable != expected =>
+        DataTypeMismatch(
+          errorSubClass = "UNEXPECTED_INPUT_FOLDABLE_VALUE",
+          messageParameters = Map(
+            "paramIndex" -> (idx + 1).toString,
+            "inputSql" -> toSQLExpr(input),
+            "inputFoldable" -> input.foldable.toString,
+            "requiredFoldable" -> expected.toString))
     }
 
     mismatch.getOrElse(TypeCheckResult.TypeCheckSuccess)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datasketchesExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datasketchesExpressions.scala
@@ -20,9 +20,6 @@ package org.apache.spark.sql.catalyst.expressions
 import org.apache.datasketches.hll.{HllSketch, TgtHllType, Union}
 import org.apache.datasketches.memory.Memory
 
-import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
-import org.apache.spark.sql.catalyst.analysis.TypeCheckResult.{DataTypeMismatch, TypeCheckSuccess}
-import org.apache.spark.sql.catalyst.expressions.Cast.{toSQLExpr, toSQLType}
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
 import org.apache.spark.sql.types.{AbstractDataType, BinaryType, BooleanType, DataType, LongType}
 
@@ -76,7 +73,7 @@ case class HllSketchEstimate(child: Expression)
 case class HllUnion(first: Expression, second: Expression, third: Expression)
   extends TernaryExpression
     with CodegenFallback
-    with ExpectsInputTypes
+    with ExpectsInputTypesAndFoldable
     with NullIntolerant {
 
   // The default target type (register size) to use.
@@ -94,27 +91,11 @@ case class HllUnion(first: Expression, second: Expression, third: Expression)
     newFirst: Expression, newSecond: Expression, newThird: Expression):
   HllUnion = copy(first = newFirst, second = newSecond, third = newThird)
 
-  override def checkInputDataTypes(): TypeCheckResult = {
-    val defaultCheck = super.checkInputDataTypes()
-    if (defaultCheck.isFailure) {
-      defaultCheck
-    } else if (!third.foldable) {
-      DataTypeMismatch(
-        errorSubClass = "NON_FOLDABLE_INPUT",
-        messageParameters = Map(
-          "inputName" -> "allowDifferentLgConfigK",
-          "inputType" -> toSQLType(third.dataType),
-          "inputExpr" -> toSQLExpr(third)
-        )
-      )
-    } else {
-      TypeCheckSuccess
-    }
-  }
-
   override def prettyName: String = "hll_union"
 
   override def inputTypes: Seq[AbstractDataType] = Seq(BinaryType, BinaryType, BooleanType)
+
+  override def inputIsFoldable: Seq[Option[Boolean]] = Seq(None, None, Some(true))
 
   override def dataType: DataType = BinaryType
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
@@ -1876,6 +1876,49 @@ class DataFrameAggregateSuite extends QueryTest
       checkAnswer(res, Nil)
     }
     assert(error7.toString contains "UnsupportedOperationException")
+
+    // validate specific args require foldable = true
+    val error8 = intercept[AnalysisException] {
+      val res = sql(
+        """with cte as (
+          |select * from values
+          | (1, 12)
+          | as tab(col, logk)
+          |)
+          |select hll_sketch_agg(col, logk) from cte
+          |""".stripMargin
+      )
+      checkAnswer(res, Nil)
+    }
+    assert(error8.toString contains "NON_FOLDABLE_INPUT")
+
+    val error9 = intercept[AnalysisException] {
+      val res = sql(
+        """with cte as (
+          |select * from values
+          | (binary(1), true)
+          | as tab(col, allow_different_lgconfigk)
+          |)
+          |select hll_union_agg(col, allow_different_lgconfigk) from cte
+          |""".stripMargin
+      )
+      checkAnswer(res, Nil)
+    }
+    assert(error9.toString contains "NON_FOLDABLE_INPUT")
+
+    val error10 = intercept[AnalysisException] {
+      val res = sql(
+        """with cte as (
+          |select * from values
+          | (binary(1), binary(1), true)
+          | as tab(col1, col2, allow_different_lgconfigk)
+          |)
+          |select hll_union(col1, col2, allow_different_lgconfigk) from cte
+          |""".stripMargin
+      )
+      checkAnswer(res, Nil)
+    }
+    assert(error10.toString contains "NON_FOLDABLE_INPUT")
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
@@ -1890,7 +1890,7 @@ class DataFrameAggregateSuite extends QueryTest
       )
       checkAnswer(res, Nil)
     }
-    assert(error8.toString contains "NON_FOLDABLE_INPUT")
+    assert(error8.toString contains "UNEXPECTED_INPUT_FOLDABLE_VALUE")
 
     val error9 = intercept[AnalysisException] {
       val res = sql(
@@ -1904,7 +1904,7 @@ class DataFrameAggregateSuite extends QueryTest
       )
       checkAnswer(res, Nil)
     }
-    assert(error9.toString contains "NON_FOLDABLE_INPUT")
+    assert(error9.toString contains "UNEXPECTED_INPUT_FOLDABLE_VALUE")
 
     val error10 = intercept[AnalysisException] {
       val res = sql(
@@ -1918,7 +1918,7 @@ class DataFrameAggregateSuite extends QueryTest
       )
       checkAnswer(res, Nil)
     }
-    assert(error10.toString contains "NON_FOLDABLE_INPUT")
+    assert(error10.toString contains "UNEXPECTED_INPUT_FOLDABLE_VALUE")
   }
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR fixes a null pointer thrown when non-foldable values are provided to the lgConfigK or allowDifferentLgConfigK arguments of the hll_sketch_agg, hll_union_agg, or hll_union functions.


### Why are the changes needed?
We should be handling this error gracefully, rather than throwing a null pointer exception.


### Does this PR introduce _any_ user-facing change?
This PR introduces two new error messages, replacing what would be null pointer exceptions.


### How was this patch tested?
Three new negative test cases have been added to the 'SPARK-16484: hll_*_agg + hll_union negative tests' test of the DataframeAggregateSuite.
