### PR TITLE
[SPARK-43509][PYTHON][CONNECT][FOLLOW-UP] Set SPARK_CONNECT_MODE_ENABLED when running pyspark shell with remote is local

### DIFF
--- a/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
@@ -363,6 +363,7 @@ class SparkSubmitCommandBuilder extends AbstractCommandBuilder {
     }
     if (remoteStr != null) {
       env.put("SPARK_REMOTE", remoteStr);
+      env.put("SPARK_CONNECT_MODE_ENABLED", "1");
     }
 
     if (!isEmpty(pyOpts)) {

--- a/python/pyspark/shell.py
+++ b/python/pyspark/shell.py
@@ -100,10 +100,11 @@ print(
     % (platform.python_version(), platform.python_build()[0], platform.python_build()[1])
 )
 if is_remote():
-    print(
-        "Client connected to the Spark Connect server at %s"
-        % urlparse(os.environ["SPARK_REMOTE"]).netloc
-    )
+    url = os.environ.get("SPARK_REMOTE", None)
+    assert url is not None
+    if url.startswith("local"):
+        url = "sc://localhost"  # only for display in the console.
+    print("Client connected to the Spark Connect server at %s" % urlparse(url).netloc)
 else:
     print("Spark context Web UI available at %s" % (sc.uiWebUrl))  # type: ignore[union-attr]
     print(


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/41013 that sets `SPARK_CONNECT_MODE_ENABLED` when running PySpark shell via `bin/pyspark --remote=local` so it works.

### Why are the changes needed?

It is broken after the PR:

```bash
./bin/pyspark --remote local
```

```python
...
Traceback (most recent call last):
  File "/.../python/pyspark/shell.py", line 78, in <module>
    sc = spark.sparkContext
  File "/.../python/pyspark/sql/connect/session.py", line 567, in sparkContext
    raise PySparkNotImplementedError(
pyspark.errors.exceptions.base.PySparkNotImplementedError: [NOT_IMPLEMENTED] sparkContext() is not implemented.
```


### Does this PR introduce _any_ user-facing change?

No to end users.

Yes to the dev as described above.


### How was this patch tested?

Manually tested via `./bin/pyspark --remote local`