### PR TITLE
[3.4][SPARK-43547][PS][DOCS] Update "Supported Pandas API" page to point out the proper pandas docs

### DIFF
--- a/python/pyspark/pandas/supported_api_gen.py
+++ b/python/pyspark/pandas/supported_api_gen.py
@@ -65,8 +65,8 @@ If there is non-implemented pandas API or parameter you want, you can create an 
 JIRA <https://issues.apache.org/jira/projects/SPARK/summary>`__ to request or to contribute by
 your own.
 
-The API list is updated based on the `latest pandas official API reference
-<https://pandas.pydata.org/docs/reference/index.html#>`__.
+The API list is updated based on the `pandas 1.5 official API reference
+<https://pandas.pydata.org/pandas-docs/version/1.5/reference/index.html>`__.
 
 """
 

--- a/python/pyspark/pandas/supported_api_gen.py
+++ b/python/pyspark/pandas/supported_api_gen.py
@@ -65,8 +65,7 @@ If there is non-implemented pandas API or parameter you want, you can create an 
 JIRA <https://issues.apache.org/jira/projects/SPARK/summary>`__ to request or to contribute by
 your own.
 
-The API list is updated based on the `pandas 1.5 official API reference
-<https://pandas.pydata.org/pandas-docs/version/1.5/reference/index.html>`__.
+The API list is updated based on the pandas 2.0.0 pre-release.
 
 """
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to fix [Supported pandas API](https://spark.apache.org/docs/latest/api/python/user_guide/pandas_on_spark/supported_pandas_api.html#supported-pandas-api)  page to point out the proper pandas version.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Currently we're supporting pandas 1.5, but it says we support latest pandas which is 2.0.1.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No, it's document change

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

The existing CI should pass.