### PR TITLE
[SPARK-43548][SS] Remove workaround for HADOOP-16255

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/CheckpointFileManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/CheckpointFileManager.scala
@@ -370,20 +370,6 @@ class FileContextBasedCheckpointFileManager(path: Path, hadoopConf: Configuratio
   override def renameTempFile(srcPath: Path, dstPath: Path, overwriteIfPossible: Boolean): Unit = {
     import Options.Rename._
     fc.rename(srcPath, dstPath, if (overwriteIfPossible) OVERWRITE else NONE)
-    // TODO: this is a workaround of HADOOP-16255 - remove this when HADOOP-16255 is resolved
-    mayRemoveCrcFile(srcPath)
-  }
-
-  private def mayRemoveCrcFile(path: Path): Unit = {
-    try {
-      val checksumFile = new Path(path.getParent, s".${path.getName}.crc")
-      if (exists(checksumFile)) {
-        // checksum file exists, deleting it
-        delete(checksumFile)
-      }
-    } catch {
-      case NonFatal(_) => // ignore, we are removing crc file as "best-effort"
-    }
   }
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to remove workaround for HADOOP-16255.
https://issues.apache.org/jira/browse/HADOOP-16255

### Why are the changes needed?
- Because HADOOP-16255 has been fix after hadoop version  3.1.2. Spark support hadoop version: >= 3.2.2 or >= 3.3.1
- Make code clean.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA.
