### PR TITLE
[SPARK-43569][SQL] Remove workaround for HADOOP-14067

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -60,11 +60,6 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
   import HiveExternalCatalog._
   import CatalogTableType._
 
-  // SPARK-32256: Make sure `VersionInfo` is initialized before touching the isolated classloader.
-  // This is a workaround for HADOOP-14067, to ensure Hive can get the Hadoop version when using
-  // the isolated classloader.
-  org.apache.hadoop.util.VersionInfo.getVersion()
-
   /**
    * A Hive client used to interact with the metastore.
    */


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to remove workaround for HADOOP-14067.
https://issues.apache.org/jira/browse/HADOOP-14067
https://issues.apache.org/jira/browse/SPARK-32256

### Why are the changes needed?
1.According to the PR description, this doesn't happen in Hadoop 3.1.0 and above; Now spark support hadoop version: 3.2.2+ and 3.3.1+
2.Make code clean.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA.