### PR TITLE
[SPARK-43383][SQL][FOLLOWUP] LocalRelation should not report row count in tests

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LocalRelation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LocalRelation.scala
@@ -81,7 +81,7 @@ case class LocalRelation(
 
   override def computeStats(): Statistics = {
     val rowCount: Option[BigInt] = if (Utils.isTesting &&
-      conf.getConfString("spark.sql.test.localRelationRowCount") != "true") {
+      conf.getConfString("spark.sql.test.localRelationRowCount", "false") != "true") {
       // LocalRelation is heavily used in tests and we should not report row count by default in
       // tests to keep the test coverage, in case the plan is overly optimized.
       None

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LocalRelation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LocalRelation.scala
@@ -24,6 +24,7 @@ import org.apache.spark.sql.catalyst.expressions.{Attribute, Literal}
 import org.apache.spark.sql.catalyst.plans.logical.statsEstimation.EstimationUtils
 import org.apache.spark.sql.catalyst.trees.TreePattern.{LOCAL_RELATION, TreePattern}
 import org.apache.spark.sql.types.{StructField, StructType}
+import org.apache.spark.util.Utils
 
 object LocalRelation {
   def apply(output: Attribute*): LocalRelation = new LocalRelation(output)
@@ -78,9 +79,18 @@ case class LocalRelation(
     }
   }
 
-  override def computeStats(): Statistics =
-    Statistics(sizeInBytes = EstimationUtils.getSizePerRow(output) * data.length,
-      rowCount = Some(data.length))
+  override def computeStats(): Statistics = {
+    val rowCount: Option[BigInt] = if (Utils.isTesting &&
+      conf.getConfString("spark.sql.test.localRelationRowCount") != "true") {
+      // LocalRelation is heavily used in tests and we should not report row count by default in
+      // tests to keep the test coverage, in case the plan is overly optimized.
+      None
+    } else {
+      Some(data.length)
+    }
+    Statistics(
+      sizeInBytes = EstimationUtils.getSizePerRow(output) * data.length, rowCount = rowCount)
+  }
 
   def toSQL(inlineTableName: String): String = {
     require(data.nonEmpty)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/joinReorder/JoinReorderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/joinReorder/JoinReorderSuite.scala
@@ -228,16 +228,17 @@ class JoinReorderSuite extends JoinReorderPlanTestBase with StatsEstimationTestB
   }
 
   test("SPARK-26352: join reordering should not change the order of attributes") {
+    // This test case does not rely on CBO.
     // It's similar to the test case above, but catches a reordering bug that the one above doesn't
     val tab1 = LocalRelation($"x".int, $"y".int)
     val tab2 = LocalRelation($"i".int, $"j".int)
     val tab3 = LocalRelation($"a".int, $"b".int)
     val original =
       tab1.join(tab2, Cross)
-          .join(tab3, Inner, Some($"a" === $"x"))
+          .join(tab3, Inner, Some($"a" === $"x" && $"b" === $"i"))
     val expected =
       tab1.join(tab3, Inner, Some($"a" === $"x"))
-          .join(tab2, Cross)
+          .join(tab2, Cross, Some($"b" === $"i"))
           .select(outputsOf(tab1, tab2, tab3): _*)
 
     assertEqualJoinPlans(Optimize, original, expected)

--- a/sql/core/src/test/scala/org/apache/spark/sql/StatisticsCollectionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/StatisticsCollectionSuite.scala
@@ -851,11 +851,13 @@ class StatisticsCollectionSuite extends StatisticsCollectionTestBase with Shared
   }
 
   test("SPARK-43383: Add rowCount statistics to LocalRelation") {
-    val optimizedPlan = spark.sql("select * from values(1),(2),(3),(4),(5),(6)")
-      .queryExecution.optimizedPlan
-    assert(optimizedPlan.isInstanceOf[LocalRelation])
+    withSQLConf("spark.sql.test.localRelationRowCount" -> "true") {
+      val optimizedPlan = spark.sql("select * from values(1),(2),(3),(4),(5),(6)")
+        .queryExecution.optimizedPlan
+      assert(optimizedPlan.isInstanceOf[LocalRelation])
 
-    val stats = optimizedPlan.stats
-    assert(stats.rowCount.isDefined && stats.rowCount.get == 6)
+      val stats = optimizedPlan.stats
+      assert(stats.rowCount.isDefined && stats.rowCount.get == 6)
+    }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This is a follow-up of https://github.com/apache/spark/pull/41064 . `LocalRelaton` is heavily used in tests and it's better to not report row count in tests to avoid the query being optimized too well which may hurt test coverage.

This PR updates `LocalRelaton` to not report row count in tests, and adds a test-only config to still enable it in tests.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
keep test coverage

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
existing tests