### PR TITLE
[SPARK-43577][BUILD] Upgrade cyclonedx-maven-plugin to 2.7.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3410,7 +3410,7 @@
       <plugin>
         <groupId>org.cyclonedx</groupId>
         <artifactId>cyclonedx-maven-plugin</artifactId>
-        <version>2.7.6</version>
+        <version>2.7.9</version>
         <executions>
           <execution>
             <phase>package</phase>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR upgrades `cyclonedx-maven-plugin` to 2.7.9.

### Why are the changes needed?

1. Fix compile errors running on Java 20+:
   ```
   Error:  Failed to execute goal org.cyclonedx:cyclonedx-maven-plugin:2.7.6:makeBom (default) on project spark-tags_2.12: Execution default of goal org.cyclonedx:cyclonedx-maven-plugin:2.7.6:makeBom failed: Unsupported class file major version 64 -> [Help 1]
   ```
   The issue fixed by `cyclonedx-maven-plugin` 2.7.7. Please see: https://github.com/CycloneDX/cyclonedx-maven-plugin/issues/326.
2. 2.7.9 contains other bug fixes and improvements:
   https://github.com/CycloneDX/cyclonedx-maven-plugin/releases/tag/cyclonedx-maven-plugin-2.7.9
   https://github.com/CycloneDX/cyclonedx-maven-plugin/releases/tag/cyclonedx-maven-plugin-2.7.8
   https://github.com/CycloneDX/cyclonedx-maven-plugin/releases/tag/cyclonedx-maven-plugin-2.7.7

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

manual test.
