### PR TITLE
[SPARK-43541][SQL][3.4] Propagate all `Project` tags in resolving of expressions and missing columns

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ColumnResolutionHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ColumnResolutionHelper.scala
@@ -58,7 +58,9 @@ trait ColumnResolutionHelper extends Logging {
           // If some attributes used by expressions are resolvable only on the rewritten child
           // plan, we need to add them into original projection.
           val missingAttrs = (AttributeSet(newExprs) -- p.outputSet).intersect(newChild.outputSet)
-          (newExprs, Project(p.projectList ++ missingAttrs, newChild))
+          val newProject = Project(p.projectList ++ missingAttrs, newChild)
+          newProject.copyTagsFrom(p)
+          (newExprs, newProject)
 
         case a @ Aggregate(groupExprs, aggExprs, child) =>
           val maybeResolvedExprs = exprs.map(resolveExpressionByPlanOutput(_, a))

--- a/sql/core/src/test/resources/sql-tests/inputs/using-join.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/using-join.sql
@@ -86,3 +86,10 @@ SELECT nt2.k AS key FROM nt1 inner join nt2 using (k) ORDER BY key;
 SELECT k, nt1.k FROM nt1 inner join nt2 using (k);
 
 SELECT k, nt2.k FROM nt1 inner join nt2 using (k);
+
+WITH
+  t1 AS (select key from values ('a') t(key)),
+  t2 AS (select key from values ('a') t(key))
+SELECT t1.key
+FROM t1 FULL OUTER JOIN t2 USING (key)
+WHERE t1.key NOT LIKE 'bb.%';

--- a/sql/core/src/test/resources/sql-tests/results/using-join.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/using-join.sql.out
@@ -432,3 +432,16 @@ struct<k:string,k:string>
 one	one
 one	one
 two	two
+
+
+-- !query
+WITH
+  t1 AS (select key from values ('a') t(key)),
+  t2 AS (select key from values ('a') t(key))
+SELECT t1.key
+FROM t1 FULL OUTER JOIN t2 USING (key)
+WHERE t1.key NOT LIKE 'bb.%'
+-- !query schema
+struct<key:string>
+-- !query output
+a


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to propagate all tags in a `Project` while resolving of expressions and missing columns in `ColumnResolutionHelper.resolveExprsAndAddMissingAttrs()`.

This is a backport of https://github.com/apache/spark/pull/41204.

### Why are the changes needed?
To fix the bug reproduced by the query below:
```sql
spark-sql (default)> WITH
                   >   t1 AS (select key from values ('a') t(key)),
                   >   t2 AS (select key from values ('a') t(key))
                   > SELECT t1.key
                   > FROM t1 FULL OUTER JOIN t2 USING (key)
                   > WHERE t1.key NOT LIKE 'bb.%';
[UNRESOLVED_COLUMN.WITH_SUGGESTION] A column or function parameter with name `t1`.`key` cannot be resolved. Did you mean one of the following? [`key`].; line 4 pos 7;
```

### Does this PR introduce _any_ user-facing change?
No. It fixes a bug, and outputs the expected result: `a`.

### How was this patch tested?
By new test added to `using-join.sql`:
```
$ PYSPARK_PYTHON=python3 build/sbt "sql/testOnly org.apache.spark.sql.SQLQueryTestSuite -- -z using-join.sql"
```
and the related test suites:
```
$ build/sbt -Phive-2.3 -Phive-thriftserver "test:testOnly org.apache.spark.sql.hive.HiveContextCompatibilitySuite"
```

Authored-by: Max Gekk <max.gekk@gmail.com>
Signed-off-by: Max Gekk <max.gekk@gmail.com>
(cherry picked from commit 09d5742a8679839d0846f50e708df98663a6d64c)