### PR TITLE
[SPARK-43580][PYTHON][TESTS] Add `https://dlcdn.apache.org/` to default_sites of get_preferred_mirrors

### DIFF
--- a/python/pyspark/install.py
+++ b/python/pyspark/install.py
@@ -179,6 +179,7 @@ def get_preferred_mirrors():
             pass
 
     default_sites = [
+        "https://dlcdn.apache.org/",
         "https://archive.apache.org/dist",
         "https://dist.apache.org/repos/dist/release",
     ]

--- a/python/pyspark/install.py
+++ b/python/pyspark/install.py
@@ -183,7 +183,7 @@ def get_preferred_mirrors():
         "https://archive.apache.org/dist",
         "https://dist.apache.org/repos/dist/release",
     ]
-    return list(set(mirror_urls)) + default_sites
+    return list(set(mirror_urls)) + [x for x in default_sites if x not in mirror_urls]
 
 
 def download_to_file(response, path, chunk_size=1024 * 1024):


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `https://dlcdn.apache.org/` to the default mirror site list during python installation tests.

### Why are the changes needed?

This is a preferred mirror. So, even if `https://www.apache.org/dyn/closer.lua` is inaccessible, we will download from `https://dlcdn.apache.org/`.
```
$ curl https://www.apache.org/dyn/closer.lua\?preferred\=true
https://dlcdn.apache.org/
```

Although we try to get this programmatically, sometimes `https://www.apache.org/dyn/closer.lua` seems to fail.
https://github.com/apache/spark/blob/acad77d56112f2cab2ce5adca913b75ce659add5/python/pyspark/install.py#L169C2-L179

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.