### PR TITLE
[SPARK-43582][BUILD] Upgrade `sbt-pom-reader` to 2.4.0

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -31,7 +31,7 @@ import sbt.Keys._
 import sbt.librarymanagement.{ VersionNumber, SemanticSelector }
 import com.etsy.sbt.checkstyle.CheckstylePlugin.autoImport._
 import com.simplytyped.Antlr4Plugin._
-import com.typesafe.sbt.pom.{PomBuild, SbtPomKeys}
+import sbtpomreader.{PomBuild, SbtPomKeys}
 import com.typesafe.tools.mima.plugin.MimaKeys
 import org.scalastyle.sbt.ScalastylePlugin.autoImport._
 import org.scalastyle.sbt.Tasks
@@ -1123,7 +1123,7 @@ object OldDeps {
 
   lazy val project = Project("oldDeps", file("dev"))
     .settings(oldDepsSettings)
-    .disablePlugins(com.typesafe.sbt.pom.PomReaderPlugin)
+    .disablePlugins(sbtpomreader.PomReaderPlugin)
 
   lazy val allPreviousArtifactKeys = Def.settingDyn[Seq[Set[ModuleID]]] {
     SparkBuild.mimaProjects

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -43,6 +43,6 @@ libraryDependencies += "org.ow2.asm"  % "asm-commons" % "9.4"
 
 addSbtPlugin("com.simplytyped" % "sbt-antlr4" % "0.8.3")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-pom-reader" % "2.2.0")
+addSbtPlugin("com.github.sbt" % "sbt-pom-reader" % "2.4.0")
 
 addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.6")


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to upgrade `sbt-pom-reader` from 2.2.0 to 2.4.0.

### Why are the changes needed?
Since v2.3.0, organization has moved from `com.typesafe.sbt` to `com.github.sbt`
- https://github.com/sbt/sbt-pom-reader/releases/tag/v2.4.0
- https://github.com/sbt/sbt-pom-reader/releases/tag/v2.3.0

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA.