### PR TITLE
[SPARK-43583][CORE] get MergedBlockedMetaReqHandler from the delegate instead of the SaslRpcHandler instance

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/crypto/AuthRpcHandler.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/crypto/AuthRpcHandler.java
@@ -139,8 +139,4 @@ class AuthRpcHandler extends AbstractAuthRpcHandler {
     return true;
   }
 
-  @Override
-  public MergedBlockMetaReqHandler getMergedBlockMetaReqHandler() {
-    return saslHandler.getMergedBlockMetaReqHandler();
-  }
 }

--- a/common/network-common/src/test/java/org/apache/spark/network/crypto/AuthIntegrationSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/crypto/AuthIntegrationSuite.java
@@ -149,6 +149,14 @@ public class AuthIntegrationSuite {
     assertEquals(testErrorMessageLength, messageEnd - messageStart);
   }
 
+  @Test
+  public void testValidMergedBlockMetaReqHandler() throws Exception {
+    ctx = new AuthTestCtx();
+    ctx.createServer("secret");
+    ctx.createClient("secret");
+    assertNotNull(ctx.authRpcHandler.getMergedBlockMetaReqHandler());
+  }
+
   private static class AuthTestCtx {
 
     private final String appId = "testAppId";


### PR DESCRIPTION
### What changes were proposed in this pull request?
This change fixes a bug with push-based shuffle when encryption is enabled on the server. The meta requests for push-merged blocks for an application which doesn't have encryption enabled, fails with NPE:
```
java.lang.RuntimeException: java.lang.NullPointerException
	at org.apache.spark.network.server.AbstractAuthRpcHandler.getMergedBlockMetaReqHandler(AbstractAuthRpcHandler.java:110)
	at org.apache.spark.network.crypto.AuthRpcHandler.getMergedBlockMetaReqHandler(AuthRpcHandler.java:144)
	at org.apache.spark.network.server.TransportRequestHandler.processMergedBlockMetaRequest(TransportRequestHandler.java:275)
	at org.apache.spark.network.server.TransportRequestHandler.handle(TransportRequestHandler.java:117)
	at org.apache.spark.network.server.TransportChannelHandler.channelRead0(TransportChannelHandler.java:140)
	at org.apache.spark.network.server.TransportChannelHandler.channelRead0(TransportChannelHandler.java:53)
	at org.sparkproject.io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:99)
	at org.sparkproject.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at org.sparkproject.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at org.sparkproject.io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at org.sparkproject.io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:286) 
```
The change here fixes this issue.

### Why are the changes needed?
It is a bug fix for push-based shuffle.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Added a simple UT. Verified manually.