### PR TITLE
[SPARK-43584][BUILD] Update `sbt-assembly`, `sbt-revolver`, `sbt-mima-plugin` plugins

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -25,17 +25,17 @@ libraryDependencies += "com.puppycrawl.tools" % "checkstyle" % "9.3"
 // checkstyle uses guava 31.0.1-jre.
 libraryDependencies += "com.google.guava" % "guava" % "31.0.1-jre"
 
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.1.0")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.1.1")
 
 addSbtPlugin("com.github.sbt" % "sbt-eclipse" % "6.0.0")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 
-addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.0")
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.2")
 
 addSbtPlugin("com.github.sbt" % "sbt-unidoc" % "0.5.0")
 
-addSbtPlugin("io.spray" % "sbt-revolver" % "0.9.1")
+addSbtPlugin("io.spray" % "sbt-revolver" % "0.10.0")
 
 libraryDependencies += "org.ow2.asm"  % "asm" % "9.4"
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to update some sbt plugins to newest version. include:
- sbt-assembly from 2.1.0 to 2.1.1
- sbt-mima-plugin from 1.1.0 to 1.1.2
- sbt-revolver from 0.9.1 to 0.10.0

### Why are the changes needed?
Routine upgrade.


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA.