### PR TITLE
[SPARK-43587][CORE][TESTS] Run `HealthTrackerIntegrationSuite` in a dedicated JVM

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -549,6 +549,7 @@ object SparkParallelTestGrouping {
 
   private val testsWhichShouldRunInTheirOwnDedicatedJvm = Set(
     "org.apache.spark.DistributedSuite",
+    "org.apache.spark.scheduler.HealthTrackerIntegrationSuite",
     "org.apache.spark.sql.catalyst.expressions.DateExpressionsSuite",
     "org.apache.spark.sql.catalyst.expressions.HashExpressionsSuite",
     "org.apache.spark.sql.catalyst.expressions.CastSuite",


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to run `HealthTrackerIntegrationSuite` in a dedicated JVM to mitigate a flaky tests.

### Why are the changes needed?

`HealthTrackerIntegrationSuite` has been flaky and SPARK-25400 and SPARK-37384 increased the timeout `from 1s to 10s` and `10s to 20s`, respectively. The usual suspect of this flakiness is some unknown side-effect like GCs. In this PR, we aims to run this in a separate JVM instead of increasing the timeout more.

https://github.com/apache/spark/blob/abc140263303c409f8d4b9632645c5c6cbc11d20/core/src/test/scala/org/apache/spark/scheduler/SchedulerIntegrationSuite.scala#L56-L58

This is the recent failure.
- https://github.com/apache/spark/actions/runs/5020505360/jobs/9002039817
```
[info] HealthTrackerIntegrationSuite:
[info] - If preferred node is bad, without excludeOnFailure job will fail (92 milliseconds)
[info] - With default settings, job can succeed despite multiple bad executors on node (3 seconds, 163 milliseconds)
[info] - Bad node with multiple executors, job will still succeed with the right confs *** FAILED *** (20 seconds, 43 milliseconds)
[info]   java.util.concurrent.TimeoutException: Futures timed out after [20 seconds]
[info]   at scala.concurrent.impl.Promise$DefaultPromise.ready(Promise.scala:259)
[info]   at scala.concurrent.impl.Promise$DefaultPromise.ready(Promise.scala:187)
[info]   at org.apache.spark.util.ThreadUtils$.awaitReady(ThreadUtils.scala:355)
[info]   at org.apache.spark.scheduler.SchedulerIntegrationSuite.awaitJobTermination(SchedulerIntegrationSuite.scala:276)
[info]   at org.apache.spark.scheduler.HealthTrackerIntegrationSuite.$anonfun$new$9(HealthTrackerIntegrationSuite.scala:92)
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.