### PR TITLE
[SPARK-43586][SQL] Use the smaller value of `Range.numElements` and `Range.numSlices` as `numSlices` of `RangeExec`

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -421,7 +421,7 @@ case class RangeExec(range: org.apache.spark.sql.catalyst.plans.logical.Range)
   val step: Long = range.step
   val numElements: BigInt = range.numElements
   val numSlices: Int =
-    math.min(range.numSlices.getOrElse(session.leafNodeDefaultParallelism), numElements.longValue())
+    math.min(range.numSlices.getOrElse(session.leafNodeDefaultParallelism), numElements.longValue)
       .intValue()
   val isEmptyRange: Boolean = start == end || (start < end ^ 0 < step)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -419,8 +419,10 @@ case class RangeExec(range: org.apache.spark.sql.catalyst.plans.logical.Range)
   val start: Long = range.start
   val end: Long = range.end
   val step: Long = range.step
-  val numSlices: Int = range.numSlices.getOrElse(session.leafNodeDefaultParallelism)
   val numElements: BigInt = range.numElements
+  val numSlices: Int =
+    math.min(range.numSlices.getOrElse(session.leafNodeDefaultParallelism), numElements.longValue())
+      .intValue()
   val isEmptyRange: Boolean = start == end || (start < end ^ 0 < step)
 
   override val output: Seq[Attribute] = range.output

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/QueryExecutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/QueryExecutionSuite.scala
@@ -41,22 +41,22 @@ case class QueryExecutionTestRecord(
 class QueryExecutionSuite extends SharedSparkSession {
   import testImplicits._
 
-  def checkDumpedPlans(path: String, expected: Int): Unit = Utils.tryWithResource(
+  def checkDumpedPlans(path: String, end: Int, finalSplits: Int = 2): Unit = Utils.tryWithResource(
     Source.fromFile(path)) { source =>
     assert(source.getLines.toList
       .takeWhile(_ != "== Whole Stage Codegen ==") == List(
       "== Parsed Logical Plan ==",
-      s"Range (0, $expected, step=1, splits=Some(2))",
+      s"Range (0, $end, step=1, splits=Some(2))",
       "",
       "== Analyzed Logical Plan ==",
       "id: bigint",
-      s"Range (0, $expected, step=1, splits=Some(2))",
+      s"Range (0, $end, step=1, splits=Some(2))",
       "",
       "== Optimized Logical Plan ==",
-      s"Range (0, $expected, step=1, splits=Some(2))",
+      s"Range (0, $end, step=1, splits=Some(2))",
       "",
       "== Physical Plan ==",
-      s"*(1) Range (0, $expected, step=1, splits=2)",
+      s"*(1) Range (0, $end, step=1, splits=$finalSplits)",
       ""))
   }
 
@@ -66,7 +66,7 @@ class QueryExecutionSuite extends SharedSparkSession {
       val df = spark.range(0, 10)
       df.queryExecution.debug.toFile(path)
 
-      checkDumpedPlans(path, expected = 10)
+      checkDumpedPlans(path, end = 10)
     }
   }
 
@@ -78,7 +78,7 @@ class QueryExecutionSuite extends SharedSparkSession {
 
       val df2 = spark.range(0, 1)
       df2.queryExecution.debug.toFile(path)
-      checkDumpedPlans(path, expected = 1)
+      checkDumpedPlans(path, end = 1, finalSplits = 1)
     }
   }
 
@@ -87,7 +87,7 @@ class QueryExecutionSuite extends SharedSparkSession {
       val path = dir.getCanonicalPath + "/newfolder/plans.txt"
       val df = spark.range(0, 100)
       df.queryExecution.debug.toFile(path)
-      checkDumpedPlans(path, expected = 100)
+      checkDumpedPlans(path, end = 100)
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr change `RangeExec#numSlices ` to use smaller value in `Range.numElements` and `Range.numSlices` to avoid scheduling unnecessary tasks.


### Why are the changes needed?
Avoid scheduling unnecessary tasks when `Range.numSlices` > `Range.numElements`.


### Does this PR introduce _any_ user-facing change?
Yes, when `Range.numSlices` > `Range.numElements` is, for the result of `queryExecution.debug`, the `splits` value in the printed Physical Plan will change.


### How was this patch tested?
- Existing UT
- Manual check:

start a spark-shell with ``--master "local[100]"``, then run 

```
spark.range(10).map(_ + 1).reduce(_ + _)
```

**Before**

<img width="1718" alt="image" src="https://github.com/apache/spark/assets/1475305/ce8317f3-46b6-4bc0-a8f8-10d7e8f33e4f">


**After**

<img width="1720" alt="image" src="https://github.com/apache/spark/assets/1475305/711a9c24-0f79-4714-8984-532bc8132a03">
