### PR TITLE
[SPARK-43588][BUILD] Upgrade ASM to 9.5

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -247,7 +247,7 @@ tink/1.9.0//tink-1.9.0.jar
 transaction-api/1.1//transaction-api-1.1.jar
 univocity-parsers/2.9.1//univocity-parsers-2.9.1.jar
 wildfly-openssl/1.1.3.Final//wildfly-openssl-1.1.3.Final.jar
-xbean-asm9-shaded/4.22//xbean-asm9-shaded-4.22.jar
+xbean-asm9-shaded/4.23//xbean-asm9-shaded-4.23.jar
 xz/1.9//xz-1.9.jar
 zjsonpatch/0.3.0//zjsonpatch-0.3.0.jar
 zookeeper-jute/3.6.3//zookeeper-jute-3.6.3.jar

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
     <maven.version>3.8.8</maven.version>
     <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
     <sbt.project.name>spark</sbt.project.name>
-    <asm.version>9.4</asm.version>
+    <asm.version>9.5</asm.version>
     <slf4j.version>2.0.7</slf4j.version>
     <log4j.version>2.20.0</log4j.version>
     <!-- make sure to update IsolatedClientLoader whenever this version is changed -->
@@ -461,7 +461,7 @@
       <dependency>
         <groupId>org.apache.xbean</groupId>
         <artifactId>xbean-asm9-shaded</artifactId>
-        <version>4.22</version>
+        <version>4.23</version>
       </dependency>
 
       <!-- Shaded deps marked as provided. These are promoted to compile scope

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -37,9 +37,9 @@ addSbtPlugin("com.github.sbt" % "sbt-unidoc" % "0.5.0")
 
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.9.1")
 
-libraryDependencies += "org.ow2.asm"  % "asm" % "9.4"
+libraryDependencies += "org.ow2.asm"  % "asm" % "9.5"
 
-libraryDependencies += "org.ow2.asm"  % "asm-commons" % "9.4"
+libraryDependencies += "org.ow2.asm"  % "asm-commons" % "9.5"
 
 addSbtPlugin("com.simplytyped" % "sbt-antlr4" % "0.8.3")
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to upgrade ASM to 9.5.




### Why are the changes needed?
xbean-asm9-shaded 4.25 upgrade to use ASM 9.5 and ASM 9.5 is for Java 21:

- https://asm.ow2.io/versions.html
- https://issues.apache.org/jira/browse/XBEAN-339 | https://github.com/apache/geronimo-xbean/pull/36


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions