### PR TITLE
[SPARK-42958][CONNECT][FOLLOWUP] Correct the parameter passed to `checkMiMaCompatibilityWithAvroModule` to `avroJar`

### DIFF
--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/CheckConnectJvmClientCompatibility.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/CheckConnectJvmClientCompatibility.scala
@@ -71,7 +71,7 @@ object CheckConnectJvmClientCompatibility {
         "Sql")
 
       val avroJar: File = findJar("connector/avro", "spark-avro", "spark-avro")
-      val problemsWithAvroModule = checkMiMaCompatibilityWithAvroModule(clientJar, sqlJar)
+      val problemsWithAvroModule = checkMiMaCompatibilityWithAvroModule(clientJar, avroJar)
       appendMimaCheckErrorMessageIfNeeded(
         resultWriter,
         problemsWithAvroModule,

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/CheckConnectJvmClientCompatibility.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/CheckConnectJvmClientCompatibility.scala
@@ -246,11 +246,11 @@ object CheckConnectJvmClientCompatibility {
    */
   private def checkMiMaCompatibility(
       clientJar: File,
-      sqlJar: File,
+      targetJar: File,
       includedRules: Seq[IncludeByName],
       excludeRules: Seq[ProblemFilter]): List[Problem] = {
-    val mima = new MiMaLib(Seq(clientJar, sqlJar))
-    val allProblems = mima.collectProblems(sqlJar, clientJar, List.empty)
+    val mima = new MiMaLib(Seq(clientJar, targetJar))
+    val allProblems = mima.collectProblems(targetJar, clientJar, List.empty)
     val problems = allProblems
       .filter { p =>
         includedRules.exists(rule => rule(p))


### PR DESCRIPTION
### What changes were proposed in this pull request?
This is a bug fix for `CheckConnectJvmClientCompatibility`: correct the parameter passed to `checkMiMaCompatibilityWithAvroModule` from `sqlJar` to `avroJar`.

In addition, this pr rename the 2rd parameter of the `checkMiMaCompatibility` from `sqlJar` to `targetJar`.



### Why are the changes needed?
Bug fix for `CheckConnectJvmClientCompatibility`, `checkMiMaCompatibilityWithAvroModule` should compare `clientJar` and `avroJar`


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass GitHub Actions
- Manually constructed the incompatibility between `connect client` and `avro`, and the check results met expectations
