### PR TITLE
[SPARK-43589][SQL][3.3] Fix `cannotBroadcastTableOverMaxTableBytesError` to use `bytesToString`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -59,7 +59,7 @@ import org.apache.spark.sql.streaming.OutputMode
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.array.ByteArrayMethods
 import org.apache.spark.unsafe.types.UTF8String
-import org.apache.spark.util.CircularBuffer
+import org.apache.spark.util.{CircularBuffer, Utils}
 
 /**
  * Object for grouping error messages from (most) exceptions thrown during query execution.
@@ -1828,7 +1828,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase {
   def cannotBroadcastTableOverMaxTableBytesError(
       maxBroadcastTableBytes: Long, dataSize: Long): Throwable = {
     new SparkException("Cannot broadcast the table that is larger than" +
-      s" ${maxBroadcastTableBytes >> 30}GB: ${dataSize >> 30} GB")
+      s" ${Utils.bytesToString(maxBroadcastTableBytes)}: ${Utils.bytesToString(dataSize)}")
   }
 
   def notEnoughMemoryToBuildAndBroadcastTableError(oe: OutOfMemoryError): Throwable = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
@@ -311,4 +311,11 @@ class QueryExecutionErrorsSuite extends QueryTest
       assert(e.getMessage.matches("Invalid bucket file: .+"))
     }
   }
+
+  test("SPARK-43589: Use bytesToString instead of shift operation") {
+    val m = QueryExecutionErrors.cannotBroadcastTableOverMaxTableBytesError(
+      maxBroadcastTableBytes = 1024 * 1024 * 1024,
+      dataSize = 2 * 1024 * 1024 * 1024 - 1).getMessage
+    assert(m === "Cannot broadcast the table that is larger than 1024.0 MiB: 2048.0 MiB")
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a logical backporting of #41232 

This PR aims to fix `cannotBroadcastTableOverMaxTableBytesError` to use `bytesToString` instead of shift operations.

### Why are the changes needed?

To avoid user confusion by giving more accurate values. For example, `maxBroadcastTableBytes` is 1GB and `dataSize` is `2GB - 1 byte`.

**BEFORE**
```
Cannot broadcast the table that is larger than 1GB: 1 GB.
```

**AFTER**
```
Cannot broadcast the table that is larger than 1024.0 MiB: 2048.0 MiB.
```

### Does this PR introduce _any_ user-facing change?

Yes, but only error message.

### How was this patch tested?

Pass the CIs with newly added test case.