### PR TITLE
[SPARK-43590][CONNECT] Make `connect-jvm-client-mima-check` to support mima check with `protobuf` module

### DIFF
--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/CheckConnectJvmClientCompatibility.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/CheckConnectJvmClientCompatibility.scala
@@ -79,6 +79,17 @@ object CheckConnectJvmClientCompatibility {
         avroJar,
         "Avro")
 
+      val protobufJar: File =
+        findJar("connector/protobuf", "spark-protobuf-assembly", "spark-protobuf")
+      val problemsWithProtobufModule =
+        checkMiMaCompatibilityWithProtobufModule(clientJar, protobufJar)
+      appendMimaCheckErrorMessageIfNeeded(
+        resultWriter,
+        problemsWithProtobufModule,
+        clientJar,
+        protobufJar,
+        "Protobuf")
+
       val incompatibleApis = checkDatasetApiCompatibility(clientJar, sqlJar)
       appendIncompatibleDatasetApisErrorMessageIfNeeded(resultWriter, incompatibleApis)
     } catch {
@@ -98,6 +109,14 @@ object CheckConnectJvmClientCompatibility {
     val includedRules = Seq(IncludeByName("org.apache.spark.sql.avro.functions.*"))
     val excludeRules = Seq.empty
     checkMiMaCompatibility(clientJar, avroJar, includedRules, excludeRules)
+  }
+
+  private def checkMiMaCompatibilityWithProtobufModule(
+      clientJar: File,
+      protobufJar: File): List[Problem] = {
+    val includedRules = Seq(IncludeByName("org.apache.spark.sql.protobuf.functions.*"))
+    val excludeRules = Seq.empty
+    checkMiMaCompatibility(clientJar, protobufJar, includedRules, excludeRules)
   }
 
   private def checkMiMaCompatibilityWithSqlModule(

--- a/dev/connect-jvm-client-mima-check
+++ b/dev/connect-jvm-client-mima-check
@@ -35,7 +35,7 @@ fi
 rm -f .connect-mima-check-result
 
 echo "Build required modules..."
-build/sbt "sql/package;connect-client-jvm/assembly;connect-client-jvm/Test/package;avro/package"
+build/sbt "sql/package;connect-client-jvm/assembly;connect-client-jvm/Test/package;avro/package;protobuf/package"
 
 CONNECT_TEST_CLASSPATH="$(build/sbt -DcopyDependencies=false "export connect-client-jvm/Test/fullClasspath" | grep jar | tail -n1)"
 SQL_CLASSPATH="$(build/sbt -DcopyDependencies=false "export sql/fullClasspath" | grep jar | tail -n1)"


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr make `connect-jvm-client-mima-check`  to support mima check between `connect-client-jvm` and `protobuf` module.


### Why are the changes needed?
Do mima check between `connect-client-jvm` and `protobuf` module.



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?

- Pass Github Actions
- Manually constructed the incompatibility between `connect client` and `protobuf`, and the check results met expectations