### PR TITLE
[WIP][SPARK-43593][SQL] Support the minimum number of range shuffle partitions

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3316,7 +3316,7 @@ object SQLConf {
     buildConf("spark.sql.rangePartitioning.minPartitionNum")
       .doc(s"Support the minimum number of range shuffle partitions when this value is greater " +
         s"than 0")
-      .version("3.4.1")
+      .version("3.5.0")
       .intConf
       .createWithDefault(-1)
 
@@ -3629,7 +3629,7 @@ object SQLConf {
     .checkValue(mode => Set("SIMPLE", "EXTENDED", "CODEGEN", "COST", "FORMATTED").contains(mode),
       "Invalid value for 'spark.sql.ui.explainMode'. Valid values are 'simple', 'extended', " +
       "'codegen', 'cost' and 'formatted'.")
-    .createWithDefault("formatted")
+    .createWithDefault("extended")
 
   val SOURCES_BINARY_FILE_MAX_LENGTH = buildConf("spark.sql.sources.binaryFile.maxLength")
     .doc("The max length of a file that can be read by the binary file data source. " +

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3313,7 +3313,7 @@ object SQLConf {
       .createWithDefault(ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH)
 
   val RANGE_PARTITIONING_MIN_PARTITION_NUM =
-    buildConf("spark.sql.adaptive.rangePartitioning.minPartitionNum")
+    buildConf("spark.sql.rangePartitioning.minPartitionNum")
       .doc(s"Support the minimum number of range shuffle partitions when this value is greater " +
         s"than 0")
       .version("3.4.1")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3312,6 +3312,14 @@ object SQLConf {
       .intConf
       .createWithDefault(ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH)
 
+  val RANGE_PARTITIONING_MIN_PARTITION_NUM =
+    buildConf("spark.sql.adaptive.rangePartitioning.minPartitionNum")
+      .doc(s"Support the minimum number of range shuffle partitions when this value is greater " +
+        s"than 0")
+      .version("3.4.1")
+      .intConf
+      .createWithDefault(-1)
+
   object Deprecated {
     val MAPRED_REDUCE_TASKS = "mapred.reduce.tasks"
   }
@@ -4618,6 +4626,8 @@ class SQLConf extends Serializable with Logging {
   def sortBeforeRepartition: Boolean = getConf(SORT_BEFORE_REPARTITION)
 
   def topKSortFallbackThreshold: Int = getConf(TOP_K_SORT_FALLBACK_THRESHOLD)
+
+  def rangePartitionMinPartitionNum: Int = getConf(RANGE_PARTITIONING_MIN_PARTITION_NUM)
 
   def fastHashAggregateRowMaxCapacityBit: Int = getConf(FAST_HASH_AGGREGATE_MAX_ROWS_CAPACITY_BIT)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala
@@ -309,7 +309,9 @@ object ShuffleExchangeExec {
         rangeSortingExprs = Some(sortingExpressions)
         val partitioner = prepareRangePartitioner(sortingExpressions)
         val minPartitionNum = SQLConf.get.rangePartitionMinPartitionNum
-        if (minPartitionNum > 0 && partitioner.numPartitions < minPartitionNum) {
+        if (minPartitionNum > 0 &&
+          !newPartitioning.asInstanceOf[RangePartitioning].needClusteredDistribution &&
+          partitioner.numPartitions < minPartitionNum) {
           rangeSortingExprs =
             Some(sortingExpressions :+ SortOrder(Rand(Utils.random.nextLong), Ascending))
           prepareRangePartitioner(rangeSortingExprs.get)

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DistributionAndOrderingSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DistributionAndOrderingSuiteBase.scala
@@ -56,8 +56,9 @@ abstract class DistributionAndOrderingSuiteBase
         partitionValues)
     case PartitioningCollection(partitionings) =>
       PartitioningCollection(partitionings.map(resolvePartitioning(_, plan)))
-    case RangePartitioning(ordering, numPartitions) =>
-      RangePartitioning(ordering.map(resolveAttrs(_, plan).asInstanceOf[SortOrder]), numPartitions)
+    case RangePartitioning(ordering, numPartitions, needClusteredDistribution) =>
+      RangePartitioning(ordering.map(resolveAttrs(_, plan).asInstanceOf[SortOrder]), numPartitions,
+        needClusteredDistribution)
     case p @ SinglePartition =>
       p
     case p: UnknownPartitioning =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
@@ -993,7 +993,7 @@ class PlannerSuite extends SharedSparkSession with AdaptiveSparkPlanHelper {
 
       val projects = collect(planned) { case p: ProjectExec => p }
       assert(projects.exists(_.outputPartitioning match {
-        case RangePartitioning(Seq(SortOrder(ar: AttributeReference, _, _, _)), _) =>
+        case RangePartitioning(Seq(SortOrder(ar: AttributeReference, _, _, _)), _, _) =>
           ar.name == "id1"
         case _ => false
       }))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -2841,6 +2841,22 @@ class AdaptiveQueryExecSuite
       }
     }
   }
+
+  test("SPARK-43593: Support the minimum number of range shuffle partitions") {
+    withSQLConf(
+      SQLConf.COALESCE_PARTITIONS_ENABLED.key -> "false",
+      SQLConf.RANGE_PARTITIONING_MIN_PARTITION_NUM.key -> "4") {
+      // The number of RangePartitioner changed from 3 to 5
+      val df = sql(
+        s"""SELECT * FROM (
+           |  SELECT case when id < 500 then 500 else 1000 end as key, id as value
+           |  FROM RANGE(1000) t
+           |) tt
+           |ORDER BY key
+           |""".stripMargin)
+      assert(df.rdd.partitions.length == 5)
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

If there are few distinct values in the RangePartitioner, there will be very few partitions that could be very large. We can append a random expression to increase the number of partitions.

### Why are the changes needed?

To optimize RangePartitioner, for example, the following query can be optimized from 2.9 hours to 3.2 mins.

![range_partitioner](https://github.com/apache/spark/assets/3626747/a99f7092-d38f-43e4-8881-96ee6d6ed75d)


### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Added UT