### PR TITLE
[SPARK-43597][SQL] Assign a name to the error class _LEGACY_ERROR_TEMP_0017

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -904,6 +904,11 @@
     ],
     "sqlState" : "42K05"
   },
+  "INVALID_ESC" : {
+    "message" : [
+      "Invalid escape string. Escape string must contain only one character."
+    ]
+  },
   "INVALID_EXECUTOR_MEMORY" : {
     "message" : [
       "Executor memory <executorMemory> must be at least <minSystemMemory>. Please increase executor memory using the --executor-memory option or \"<config>\" in Spark configuration."
@@ -2188,11 +2193,6 @@
   "_LEGACY_ERROR_TEMP_0016" : {
     "message" : [
       "<bytesStr> is not a valid byte length literal, expected syntax: DIGIT+ ('B' | 'K' | 'M' | 'G')."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_0017" : {
-    "message" : [
-      "Invalid escape string. Escape string must contain only one character."
     ]
   },
   "_LEGACY_ERROR_TEMP_0018" : {

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -906,7 +906,7 @@
   },
   "INVALID_ESC" : {
     "message" : [
-      "Invalid escape string. Escape string must contain only one character."
+      "Found an invalid escape string: <invalidEscape>. The escape string must contain only one character."
     ]
   },
   "INVALID_EXECUTOR_MEMORY" : {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -1865,7 +1865,7 @@ class AstBuilder extends SqlBaseParserBaseVisitor[AnyRef] with SQLConfHelper wit
             val escapeChar = Option(ctx.escapeChar)
               .map(stringLitCtx => string(visitStringLit(stringLitCtx))).map { str =>
               if (str.length != 1) {
-                throw QueryParsingErrors.invalidEscapeStringError(ctx)
+                throw QueryParsingErrors.invalidEscapeStringError(str, ctx)
               }
               str.charAt(0)
             }.getOrElse('\\')

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
@@ -191,7 +191,7 @@ private[sql] object QueryParsingErrors extends QueryErrorsBase {
   def invalidEscapeStringError(invalidEscape: String, ctx: PredicateContext): Throwable = {
     new ParseException(
       errorClass = "INVALID_ESC",
-      messageParameters = Map("invalidEscape" -> toSQLConf(invalidEscape)),
+      messageParameters = Map("invalidEscape" -> toSQLValue(invalidEscape, StringType)),
       ctx)
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
@@ -189,7 +189,7 @@ private[sql] object QueryParsingErrors extends QueryErrorsBase {
   }
 
   def invalidEscapeStringError(ctx: PredicateContext): Throwable = {
-    new ParseException(errorClass = "_LEGACY_ERROR_TEMP_0017", ctx)
+    new ParseException(errorClass = "INVALID_ESC", ctx)
   }
 
   def trimOptionUnsupportedError(trimOption: Int, ctx: TrimContext): Throwable = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
@@ -188,8 +188,11 @@ private[sql] object QueryParsingErrors extends QueryErrorsBase {
       ctx)
   }
 
-  def invalidEscapeStringError(ctx: PredicateContext): Throwable = {
-    new ParseException(errorClass = "INVALID_ESC", ctx)
+  def invalidEscapeStringError(invalidEscape: String, ctx: PredicateContext): Throwable = {
+    new ParseException(
+      errorClass = "INVALID_ESC",
+      messageParameters = Map("invalidEscape" -> toSQLConf(invalidEscape)),
+      ctx)
   }
 
   def trimOptionUnsupportedError(trimOption: Int, ctx: TrimContext): Throwable = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ExpressionParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ExpressionParserSuite.scala
@@ -199,7 +199,7 @@ class ExpressionParserSuite extends AnalysisTest {
     checkError(
       exception = parseException("a like 'pattern%' escape '##'"),
       errorClass = "INVALID_ESC",
-      parameters = Map("invalidEscape" -> "\"##\""),
+      parameters = Map("invalidEscape" -> "'##'"),
       context = ExpectedContext(
         fragment = "like 'pattern%' escape '##'",
         start = 2,
@@ -208,7 +208,7 @@ class ExpressionParserSuite extends AnalysisTest {
     checkError(
       exception = parseException("a like 'pattern%' escape ''"),
       errorClass = "INVALID_ESC",
-      parameters = Map("invalidEscape" -> "\"\""),
+      parameters = Map("invalidEscape" -> "''"),
       context = ExpectedContext(
         fragment = "like 'pattern%' escape ''",
         start = 2,
@@ -220,7 +220,7 @@ class ExpressionParserSuite extends AnalysisTest {
     checkError(
       exception = parseException("a not like 'pattern%' escape '\"/'"),
       errorClass = "INVALID_ESC",
-      parameters = Map("invalidEscape" -> "\"\"/\""),
+      parameters = Map("invalidEscape" -> "'\"/'"),
       context = ExpectedContext(
         fragment = "not like 'pattern%' escape '\"/'",
         start = 2,
@@ -229,7 +229,7 @@ class ExpressionParserSuite extends AnalysisTest {
     checkError(
       exception = parseException("a not like 'pattern%' escape ''"),
       errorClass = "INVALID_ESC",
-      parameters = Map("invalidEscape" -> "\"\""),
+      parameters = Map("invalidEscape" -> "''"),
       context = ExpectedContext(
         fragment = "not like 'pattern%' escape ''",
         start = 2,

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ExpressionParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ExpressionParserSuite.scala
@@ -193,14 +193,13 @@ class ExpressionParserSuite extends AnalysisTest {
   }
 
   test("like escape expressions") {
-    val message = "Escape string must contain only one character."
     assertEqual("a like 'pattern%' escape '#'", $"a".like("pattern%", '#'))
     assertEqual("a like 'pattern%' escape '\"'", $"a".like("pattern%", '\"'))
 
     checkError(
       exception = parseException("a like 'pattern%' escape '##'"),
       errorClass = "INVALID_ESC",
-      parameters = Map.empty,
+      parameters = Map("invalidEscape" -> "\"##\""),
       context = ExpectedContext(
         fragment = "like 'pattern%' escape '##'",
         start = 2,
@@ -209,7 +208,7 @@ class ExpressionParserSuite extends AnalysisTest {
     checkError(
       exception = parseException("a like 'pattern%' escape ''"),
       errorClass = "INVALID_ESC",
-      parameters = Map.empty,
+      parameters = Map("invalidEscape" -> "\"\""),
       context = ExpectedContext(
         fragment = "like 'pattern%' escape ''",
         start = 2,
@@ -221,7 +220,7 @@ class ExpressionParserSuite extends AnalysisTest {
     checkError(
       exception = parseException("a not like 'pattern%' escape '\"/'"),
       errorClass = "INVALID_ESC",
-      parameters = Map.empty,
+      parameters = Map("invalidEscape" -> "\"\"/\""),
       context = ExpectedContext(
         fragment = "not like 'pattern%' escape '\"/'",
         start = 2,
@@ -230,7 +229,7 @@ class ExpressionParserSuite extends AnalysisTest {
     checkError(
       exception = parseException("a not like 'pattern%' escape ''"),
       errorClass = "INVALID_ESC",
-      parameters = Map.empty,
+      parameters = Map("invalidEscape" -> "\"\""),
       context = ExpectedContext(
         fragment = "not like 'pattern%' escape ''",
         start = 2,

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ExpressionParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ExpressionParserSuite.scala
@@ -199,7 +199,7 @@ class ExpressionParserSuite extends AnalysisTest {
 
     checkError(
       exception = parseException("a like 'pattern%' escape '##'"),
-      errorClass = "_LEGACY_ERROR_TEMP_0017",
+      errorClass = "INVALID_ESC",
       parameters = Map.empty,
       context = ExpectedContext(
         fragment = "like 'pattern%' escape '##'",
@@ -208,7 +208,7 @@ class ExpressionParserSuite extends AnalysisTest {
 
     checkError(
       exception = parseException("a like 'pattern%' escape ''"),
-      errorClass = "_LEGACY_ERROR_TEMP_0017",
+      errorClass = "INVALID_ESC",
       parameters = Map.empty,
       context = ExpectedContext(
         fragment = "like 'pattern%' escape ''",
@@ -220,7 +220,7 @@ class ExpressionParserSuite extends AnalysisTest {
 
     checkError(
       exception = parseException("a not like 'pattern%' escape '\"/'"),
-      errorClass = "_LEGACY_ERROR_TEMP_0017",
+      errorClass = "INVALID_ESC",
       parameters = Map.empty,
       context = ExpectedContext(
         fragment = "not like 'pattern%' escape '\"/'",
@@ -229,7 +229,7 @@ class ExpressionParserSuite extends AnalysisTest {
 
     checkError(
       exception = parseException("a not like 'pattern%' escape ''"),
-      errorClass = "_LEGACY_ERROR_TEMP_0017",
+      errorClass = "INVALID_ESC",
       parameters = Map.empty,
       context = ExpectedContext(
         fragment = "not like 'pattern%' escape ''",

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
@@ -620,4 +620,15 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession {
       sqlState = "42601",
       parameters = Map("error" -> "'>'", "hint" -> ""))
   }
+
+  test("INVALID_ESC: Escape string must contain only one character") {
+    checkError(
+      exception = parseException("select * from test where test.t like 'pattern%' escape '##'"),
+      errorClass = "INVALID_ESC",
+      parameters = Map.empty,
+      context = ExpectedContext(
+        fragment = "like 'pattern%' escape '##'",
+        start = 32,
+        stop = 58))
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
@@ -625,7 +625,7 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession {
     checkError(
       exception = parseException("select * from test where test.t like 'pattern%' escape '##'"),
       errorClass = "INVALID_ESC",
-      parameters = Map.empty,
+      parameters = Map("invalidEscape" -> "\"##\""),
       context = ExpectedContext(
         fragment = "like 'pattern%' escape '##'",
         start = 32,

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
@@ -625,7 +625,7 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession {
     checkError(
       exception = parseException("select * from test where test.t like 'pattern%' escape '##'"),
       errorClass = "INVALID_ESC",
-      parameters = Map("invalidEscape" -> "\"##\""),
+      parameters = Map("invalidEscape" -> "'##'"),
       context = ExpectedContext(
         fragment = "like 'pattern%' escape '##'",
         start = 32,


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to assign a name to the error class _LEGACY_ERROR_TEMP_0017.

### Why are the changes needed?
The changes improve the error framework.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Update existed UT.
Pass GA.