### PR TITLE
[SPARK-43600][K8S][DOCS] Update K8s doc to recommend K8s 1.24+

### DIFF
--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -44,7 +44,7 @@ Cluster administrators should use [Pod Security Policies](https://kubernetes.io/
 
 # Prerequisites
 
-* A running Kubernetes cluster at version >= 1.22 with access configured to it using
+* A running Kubernetes cluster at version >= 1.24 with access configured to it using
 [kubectl](https://kubernetes.io/docs/user-guide/prereqs/).  If you do not already have a working Kubernetes cluster,
 you may set up a test cluster on your local machine using
 [minikube](https://kubernetes.io/docs/getting-started-guides/minikube/).


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update K8s doc to recommend K8s 1.24+.

### Why are the changes needed?

**1. Default K8s Version in Public Cloud environments**

As of today (2023 May), the default K8s versions of public cloud providers moved on to K8s 1.24+ already.

- EKS: v1.26 (Default)
- GKE: v1.24 (Stable), v1.25 (Regular), v1.27 (Rapid)

**2. End Of Support**

In addition, K8s 1.23 and olders are going to reach EOL when Apache Spark 3.5.0 arrives. K8s 1.24 also will reach EOL in some cloud providers.

| K8s  |   AKS   |   GKE   |   EKS   |
| ---- | ------- | ------- | ------- |
| 1.23 | 2023-03 | 2023-07 | 2023-10 |
| 1.24 | 2023-07 | 2023-10 | 2024-01 |

- [AKS EOL Schedule](https://docs.microsoft.com/en-us/azure/aks/supported-kubernetes-versions?tabs=azure-cli#aks-kubernetes-release-calendar)
- [GKE EOL Schedule](https://cloud.google.com/kubernetes-engine/docs/release-schedule)
- [EKS EOL Schedule](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html)

### Does this PR introduce _any_ user-facing change?

No, this is a documentation-only change about K8s versions.

### How was this patch tested?

Manual review.