### PR TITLE
[SPARK-43601][INFRA] Remove the upper bound of `matplotlib` in requirements

### DIFF
--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -9,7 +9,7 @@ scipy
 plotly
 mlflow>=2.3.1
 scikit-learn
-matplotlib<3.3.0
+matplotlib
 memory-profiler==0.60.0
 
 # PySpark test dependencies


### PR DESCRIPTION
### What changes were proposed in this pull request?
Remove the upper bound of `matplotlib` in requirements


### Why are the changes needed?
1, actually, `matplotlib` is not pinned in CI;
2, `matplotlib<3.3.0` fails `pip install -U -r dev/requirements.txt` in some cases, e.g. in `ubuntu 18.04`
```
      gcc -pthread -B /home/ruifeng.zheng/miniconda3/compiler_compat -Wno-unused-result -Wsign-compare -DNDEBUG -fwrapv -O2 -Wall -fPIC -O2 -isystem /home/ruifeng.zheng/miniconda3/include -fPIC -O2 -isystem /home/ruifeng.zheng/miniconda3/include -fPIC -DFREETYPE_BUILD_TYPE=system -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib_ft2font_ARRAY_API -DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION -D__STDC_FORMAT_MACROS=1 -Iextern/agg24-svn/include -I/home/ruifeng.zheng/miniconda3/lib/python3.10/site-packages/numpy/core/include -I/home/ruifeng.zheng/miniconda3/include/python3.10 -c src/checkdep_freetype2.c -o build/temp.linux-x86_64-cpython-310/src/checkdep_freetype2.o
      src/checkdep_freetype2.c:3:6: error: #error "FreeType version 2.3 or higher is required. You may set the MPLLOCALFREETYPE environment variable to 1 to let Matplotlib download it."
           #error "FreeType version 2.3 or higher is required. \
            ^~~~~
      src/checkdep_freetype2.c:10:10: error: #include expects "FILENAME" or <FILENAME>
       #include FT_FREETYPE_H
                ^~~~~~~~~~~~~
      src/checkdep_freetype2.c:15:9: note: #pragma message: Compiling with FreeType version FREETYPE_MAJOR.FREETYPE_MINOR.FREETYPE_PATCH.
       #pragma message("Compiling with FreeType version " \
               ^~~~~~~
      src/checkdep_freetype2.c:18:4: error: #error "FreeType version 2.3 or higher is required. You may set the MPLLOCALFREETYPE environment variable to 1 to let Matplotlib download it."
         #error "FreeType version 2.3 or higher is required. \
          ^~~~~
      error: command '/usr/bin/gcc' failed with exit code 1
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: legacy-install-failure

× Encountered error while trying to install package.
╰─> matplotlib
```



### Does this PR introduce _any_ user-facing change?
no, dev-only


### How was this patch tested?
manually test
