### PR TITLE
[SPARK-43612][CONNECT][PYTHON] Implement SparkSession.addArtifact(s) in Python client

### DIFF
--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -755,7 +755,6 @@ pyspark_connect = Module(
         "pyspark.sql.connect.streaming.readwriter",
         "pyspark.sql.connect.streaming.query",
         # sql unittests
-        "pyspark.sql.tests.connect.test_client",
         "pyspark.sql.tests.connect.test_connect_plan",
         "pyspark.sql.tests.connect.test_connect_basic",
         "pyspark.sql.tests.connect.test_connect_function",
@@ -778,6 +777,8 @@ pyspark_connect = Module(
         "pyspark.sql.tests.connect.test_parity_arrow_map",
         "pyspark.sql.tests.connect.test_parity_pandas_grouped_map",
         "pyspark.sql.tests.connect.test_parity_pandas_cogrouped_map",
+        "pyspark.sql.tests.connect.client.test_artifact",
+        "pyspark.sql.tests.connect.client.test_client",
         "pyspark.sql.tests.connect.streaming.test_parity_streaming",
         "pyspark.sql.tests.connect.streaming.test_parity_foreach",
         "pyspark.sql.tests.connect.test_parity_pandas_grouped_map_with_state",

--- a/python/pyspark/sql/connect/client/__init__.py
+++ b/python/pyspark/sql/connect/client/__init__.py
@@ -1,0 +1,22 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from pyspark.sql.connect.utils import check_dependencies
+
+check_dependencies(__name__)
+
+from pyspark.sql.connect.client.core import *  # noqa: F401,F403

--- a/python/pyspark/sql/connect/client/artifact.py
+++ b/python/pyspark/sql/connect/client/artifact.py
@@ -122,8 +122,9 @@ class ArtifactManager:
     CHUNK_SIZE: int = 32 * 1024
 
     def __init__(self, user_id: Optional[str], session_id: str, channel: grpc.Channel):
-        assert user_id is not None
-        self._user_context = proto.UserContext(user_id=user_id)
+        self._user_context = proto.UserContext()
+        if user_id is not None:
+            self._user_context.user_id = user_id
         self._stub = grpc_lib.SparkConnectServiceStub(channel)
         self._session_id = session_id
 

--- a/python/pyspark/sql/connect/client/artifact.py
+++ b/python/pyspark/sql/connect/client/artifact.py
@@ -1,0 +1,269 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from pyspark.sql.connect.utils import check_dependencies
+
+check_dependencies(__name__)
+
+import os
+import zlib
+from itertools import chain
+from typing import List, Iterable, BinaryIO, Iterator, Optional
+import abc
+from pathlib import Path
+from urllib.parse import urlparse
+from urllib.request import url2pathname
+from functools import cached_property
+
+import grpc
+
+import pyspark.sql.connect.proto as proto
+import pyspark.sql.connect.proto.base_pb2_grpc as grpc_lib
+
+
+JAR_PREFIX: str = "jars"
+
+
+class LocalData(metaclass=abc.ABCMeta):
+    """
+    Payload stored on this machine.
+    """
+
+    @cached_property
+    @abc.abstractmethod
+    def stream(self) -> BinaryIO:
+        pass
+
+    @cached_property
+    @abc.abstractmethod
+    def size(self) -> int:
+        pass
+
+
+class LocalFile(LocalData):
+    """
+    Payload stored in a local file.
+    """
+
+    def __init__(self, path: str):
+        self.path = path
+        self._size: int
+        self._stream: int
+
+    @cached_property
+    def size(self) -> int:
+        return os.path.getsize(self.path)
+
+    @cached_property
+    def stream(self) -> BinaryIO:
+        return open(self.path, "rb")
+
+
+class Artifact:
+    """
+    Payload stored in memory.
+    """
+
+    def __init__(self, path: str, storage: LocalData):
+        assert not Path(path).is_absolute(), f"Bad path: {path}"
+        self.path = path
+        self.storage = storage
+
+    @cached_property
+    def size(self) -> int:
+        if isinstance(self.storage, LocalData):
+            return self.storage.size
+        else:
+            raise RuntimeError(f"Unsupported storage {type(self.storage)}")
+
+
+def new_jar_artifact(file_name: str, storage: LocalData) -> Artifact:
+    return _new_artifact(JAR_PREFIX, ".jar", file_name, storage)
+
+
+def _new_artifact(
+    prefix: str, required_suffix: str, file_name: str, storage: LocalData
+) -> Artifact:
+    assert not Path(file_name).is_absolute()
+    assert file_name.endswith(required_suffix)
+    return Artifact(os.path.join(prefix, file_name), storage)
+
+
+class ArtifactManager:
+    """
+    The Artifact Manager is responsible for handling and transferring artifacts from the local
+    client to the server (local/remote).
+
+    Parameters
+    ----------
+    user_id : str, optional
+        User ID.
+    session_id: str
+        An unique identifier of the session which the artifact manager belongs to.
+    channel: grpc.Channel
+        GRPC Channel instance.
+    """
+
+    # Using the midpoint recommendation of 32KiB for chunk size as specified in
+    # https://github.com/grpc/grpc.github.io/issues/371.
+    CHUNK_SIZE: int = 32 * 1024
+
+    def __init__(self, user_id: Optional[str], session_id: str, channel: grpc.Channel):
+        assert user_id is not None
+        self._user_context = proto.UserContext(user_id=user_id)
+        self._stub = grpc_lib.SparkConnectServiceStub(channel)
+        self._session_id = session_id
+
+    def _parse_artifacts(self, path_or_uri: str) -> List[Artifact]:
+        # Currently only local files with .jar extension is supported.
+        uri = path_or_uri
+        if urlparse(path_or_uri).scheme == "":  # Is path?
+            uri = Path(path_or_uri).absolute().as_uri()
+        parsed = urlparse(uri)
+        if parsed.scheme == "file":
+            local_path = url2pathname(parsed.path)
+            name = Path(local_path).name
+            if name.endswith(".jar"):
+                artifact = new_jar_artifact(name, LocalFile(local_path))
+            else:
+                raise RuntimeError(f"Unsupported file format: {local_path}")
+            return [artifact]
+        raise RuntimeError(f"Unsupported scheme: {uri}")
+
+    def _create_requests(self, *path: str) -> Iterator[proto.AddArtifactsRequest]:
+        """Separated for the testing purpose."""
+        return self._add_artifacts(chain(*(self._parse_artifacts(p) for p in path)))
+
+    def _retrieve_responses(
+        self, requests: Iterator[proto.AddArtifactsRequest]
+    ) -> proto.AddArtifactsResponse:
+        """Separated for the testing purpose."""
+        return self._stub.AddArtifacts(requests)
+
+    def add_artifacts(self, *path: str) -> None:
+        """
+        Add a single artifact to the session.
+        Currently only local files with .jar extension is supported.
+        """
+        requests: Iterator[proto.AddArtifactsRequest] = self._create_requests(*path)
+        response: proto.AddArtifactsResponse = self._retrieve_responses(requests)
+        summaries: List[proto.AddArtifactsResponse.ArtifactSummary] = []
+
+        for summary in response.artifacts:
+            summaries.append(summary)
+            # TODO(SPARK-42658): Handle responses containing CRC failures.
+
+    def _add_artifacts(self, artifacts: Iterable[Artifact]) -> Iterator[proto.AddArtifactsRequest]:
+        """
+        Add a number of artifacts to the session.
+        """
+
+        current_batch: List[Artifact] = []
+        current_batch_size = 0
+
+        def add_to_batch(dep: Artifact, size: int) -> None:
+            nonlocal current_batch
+            nonlocal current_batch_size
+
+            current_batch.append(dep)
+            current_batch_size += size
+
+        def write_batch() -> Iterator[proto.AddArtifactsRequest]:
+            nonlocal current_batch
+            nonlocal current_batch_size
+
+            yield from self._add_batched_artifacts(current_batch)
+            current_batch = []
+            current_batch_size = 0
+
+        for artifact in artifacts:
+            data = artifact.storage
+            size = data.size
+            if size > ArtifactManager.CHUNK_SIZE:
+                # Payload can either be a batch OR a single chunked artifact.
+                # Write batch if non-empty before chunking current artifact.
+                if len(current_batch) > 0:
+                    yield from write_batch()
+                yield from self._add_chunked_artifact(artifact)
+            else:
+                if current_batch_size + size > ArtifactManager.CHUNK_SIZE:
+                    yield from write_batch()
+                add_to_batch(artifact, size)
+
+        if len(current_batch) > 0:
+            yield from write_batch()
+
+    def _add_batched_artifacts(
+        self, artifacts: Iterable[Artifact]
+    ) -> Iterator[proto.AddArtifactsRequest]:
+        """
+        Add a batch of artifacts to the stream. All the artifacts in this call are packaged into a
+        single :class:`proto.AddArtifactsRequest`.
+        """
+        artifact_chunks = []
+
+        for artifact in artifacts:
+            binary = artifact.storage.stream.read()
+            crc32 = zlib.crc32(binary)
+            data = proto.AddArtifactsRequest.ArtifactChunk(data=binary, crc=crc32)
+            artifact_chunks.append(
+                proto.AddArtifactsRequest.SingleChunkArtifact(name=artifact.path, data=data)
+            )
+
+        # Write the request once
+        yield proto.AddArtifactsRequest(
+            session_id=self._session_id,
+            user_context=self._user_context,
+            batch=proto.AddArtifactsRequest.Batch(artifacts=artifact_chunks),
+        )
+
+    def _add_chunked_artifact(self, artifact: Artifact) -> Iterator[proto.AddArtifactsRequest]:
+        """
+        Add a artifact in chunks to the stream. The artifact's data is spread out over multiple
+        :class:`proto.AddArtifactsRequest requests`.
+        """
+        initial_batch = True
+        # Integer division that rounds up to the nearest whole number.
+        get_num_chunks = int(
+            (artifact.size + (ArtifactManager.CHUNK_SIZE - 1)) / ArtifactManager.CHUNK_SIZE
+        )
+
+        # Consume stream in chunks until there is no data left to read.
+        for chunk in iter(lambda: artifact.storage.stream.read(ArtifactManager.CHUNK_SIZE), b""):
+            if initial_batch:
+                # First RPC contains the `BeginChunkedArtifact` payload (`begin_chunk`).
+                yield proto.AddArtifactsRequest(
+                    session_id=self._session_id,
+                    user_context=self._user_context,
+                    begin_chunk=proto.AddArtifactsRequest.BeginChunkedArtifact(
+                        name=artifact.path,
+                        total_bytes=artifact.size,
+                        num_chunks=get_num_chunks,
+                        initial_chunk=proto.AddArtifactsRequest.ArtifactChunk(
+                            data=chunk, crc=zlib.crc32(chunk)
+                        ),
+                    ),
+                )
+                initial_batch = False
+            else:
+                # Subsequent RPCs contains the `ArtifactChunk` payload (`chunk`).
+                yield proto.AddArtifactsRequest(
+                    session_id=self._session_id,
+                    user_context=self._user_context,
+                    chunk=proto.AddArtifactsRequest.ArtifactChunk(
+                        data=chunk, crc=zlib.crc32(chunk)
+                    ),
+                )

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -60,6 +60,7 @@ from google.rpc import error_details_pb2
 
 from pyspark.version import __version__
 from pyspark.resource.information import ResourceInformation
+from pyspark.sql.connect.client.artifact import ArtifactManager
 from pyspark.sql.connect.conversion import storage_level_to_proto, proto_to_storage_level
 import pyspark.sql.connect.proto as pb2
 import pyspark.sql.connect.proto.base_pb2_grpc as grpc_lib
@@ -594,6 +595,7 @@ class SparkConnectClient(object):
 
         self._channel = self._builder.toChannel()
         self._stub = grpc_lib.SparkConnectServiceStub(self._channel)
+        self._artifact_manager = ArtifactManager(self._user_id, self._session_id, self._channel)
         # Configure logging for the SparkConnect client.
 
     def register_udf(
@@ -758,6 +760,7 @@ class SparkConnectClient(object):
     def _proto_to_string(self, p: google.protobuf.message.Message) -> str:
         """
         Helper method to generate a one line string representation of the plan.
+
         Parameters
         ----------
         p : google.protobuf.message.Message
@@ -1233,6 +1236,9 @@ class SparkConnectClient(object):
             raise SparkConnectGrpcException(status.message) from None
         else:
             raise SparkConnectGrpcException(str(rpc_error)) from None
+
+    def add_artifacts(self, *path: str) -> None:
+        self._artifact_manager.add_artifacts(*path)
 
 
 class RetryState:

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -617,11 +617,28 @@ class SparkSession:
         """
         Gives access to the Spark Connect client. In normal cases this is not necessary to be used
         and only relevant for testing.
+
         Returns
         -------
         :class:`SparkConnectClient`
         """
         return self._client
+
+    def addArtifacts(self, *path: str) -> None:
+        """
+        Add artifact(s) to the client session. Currently only local files with .jar extension is
+        supported.
+
+        .. versionadded:: 3.5.0
+
+        Parameters
+        ----------
+        *path : tuple of str
+            Artifact's URIs to add.
+        """
+        self._client.add_artifacts(*path)
+
+    addArtifact = addArtifacts
 
     @staticmethod
     def _start_connect_server(master: str, opts: Dict[str, Any]) -> None:

--- a/python/pyspark/sql/tests/connect/client/__init__.py
+++ b/python/pyspark/sql/tests/connect/client/__init__.py
@@ -1,0 +1,16 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/python/pyspark/sql/tests/connect/client/test_artifact.py
+++ b/python/pyspark/sql/tests/connect/client/test_artifact.py
@@ -1,0 +1,213 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import unittest
+import os
+
+from pyspark.testing.connectutils import ReusedConnectTestCase, should_test_connect
+from pyspark.testing.utils import SPARK_HOME
+
+if should_test_connect:
+    from pyspark.sql.connect.client.artifact import ArtifactManager
+
+
+class ArtifactTests(ReusedConnectTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(ArtifactTests, cls).setUpClass()
+        cls.artifact_manager: ArtifactManager = cls.spark._client._artifact_manager
+        cls.base_resource_dir = os.path.join(
+            SPARK_HOME, "connector", "connect", "common", "src", "test", "resources"
+        )
+        cls.artifact_file_path = os.path.join(
+            cls.base_resource_dir,
+            "artifact-tests",
+        )
+        cls.artifact_crc_path = os.path.join(
+            cls.artifact_file_path,
+            "crc",
+        )
+
+    def test_basic_requests(self):
+        file_name = "smallJar"
+        small_jar_path = os.path.join(self.artifact_file_path, f"{file_name}.jar")
+        response = self.artifact_manager._retrieve_responses(
+            self.artifact_manager._create_requests(small_jar_path)
+        )
+        self.assertTrue(response.artifacts[0].name.endswith(f"{file_name}.jar"))
+
+    def test_single_chunk_artifact(self):
+        file_name = "smallJar"
+        small_jar_path = os.path.join(self.artifact_file_path, f"{file_name}.jar")
+        small_jar_crc_path = os.path.join(self.artifact_crc_path, f"{file_name}.txt")
+
+        requests = list(self.artifact_manager._create_requests(small_jar_path))
+        self.assertEqual(len(requests), 1)
+
+        request = requests[0]
+        self.assertIsNotNone(request.batch)
+
+        batch = request.batch
+        self.assertEqual(len(batch.artifacts), 1)
+
+        single_artifact = batch.artifacts[0]
+        self.assertTrue(single_artifact.name.endswith(".jar"))
+
+        self.assertEqual(os.path.join("jars", f"{file_name}.jar"), single_artifact.name)
+        with open(small_jar_crc_path) as f1, open(small_jar_path, "rb") as f2:
+            self.assertEqual(single_artifact.data.crc, int(f1.readline()))
+            self.assertEqual(single_artifact.data.data, f2.read())
+
+    def test_chunked_artifacts(self):
+        file_name = "junitLargeJar"
+        large_jar_path = os.path.join(self.artifact_file_path, f"{file_name}.jar")
+        large_jar_crc_path = os.path.join(self.artifact_crc_path, f"{file_name}.txt")
+
+        requests = list(self.artifact_manager._create_requests(large_jar_path))
+        # Expected chunks = roundUp( file_size / chunk_size) = 12
+        # File size of `junitLargeJar.jar` is 384581 bytes.
+        large_jar_size = os.path.getsize(large_jar_path)
+        expected_chunks = int(
+            (large_jar_size + (ArtifactManager.CHUNK_SIZE - 1)) / ArtifactManager.CHUNK_SIZE
+        )
+        self.assertEqual(len(requests), expected_chunks)
+        request = requests[0]
+        self.assertIsNotNone(request.begin_chunk)
+        begin_chunk = request.begin_chunk
+        self.assertEqual(begin_chunk.name, os.path.join("jars", f"{file_name}.jar"))
+        self.assertEqual(begin_chunk.total_bytes, large_jar_size)
+        self.assertEqual(begin_chunk.num_chunks, expected_chunks)
+        other_requests = requests[1:]
+        data_chunks = [begin_chunk.initial_chunk] + [req.chunk for req in other_requests]
+
+        with open(large_jar_crc_path) as f1, open(large_jar_path, "rb") as f2:
+            cscs = [chunk.crc for chunk in data_chunks]
+            expected_cscs = [int(line.rstrip()) for line in f1]
+            self.assertEqual(cscs, expected_cscs)
+
+            binaries = [chunk.data for chunk in data_chunks]
+            expected_binaries = list(iter(lambda: f2.read(ArtifactManager.CHUNK_SIZE), b""))
+            self.assertEqual(binaries, expected_binaries)
+
+    def test_batched_artifacts(self):
+        file_name = "smallJar"
+        small_jar_path = os.path.join(self.artifact_file_path, f"{file_name}.jar")
+        small_jar_crc_path = os.path.join(self.artifact_crc_path, f"{file_name}.txt")
+
+        requests = list(self.artifact_manager._create_requests(small_jar_path, small_jar_path))
+        # Single request containing 2 artifacts.
+        self.assertEqual(len(requests), 1)
+
+        request = requests[0]
+        self.assertIsNotNone(request.batch)
+
+        batch = request.batch
+        self.assertEqual(len(batch.artifacts), 2)
+
+        artifact1 = batch.artifacts[0]
+        self.assertTrue(artifact1.name.endswith(".jar"))
+        artifact2 = batch.artifacts[1]
+        self.assertTrue(artifact2.name.endswith(".jar"))
+
+        self.assertEqual(os.path.join("jars", f"{file_name}.jar"), artifact1.name)
+        with open(small_jar_crc_path) as f1, open(small_jar_path, "rb") as f2:
+            crc = int(f1.readline())
+            data = f2.read()
+            self.assertEqual(artifact1.data.crc, crc)
+            self.assertEqual(artifact1.data.data, data)
+            self.assertEqual(artifact2.data.crc, crc)
+            self.assertEqual(artifact2.data.data, data)
+
+    def test_single_chunked_and_chunked_artifact(self):
+        file_name1 = "smallJar"
+        file_name2 = "junitLargeJar"
+        small_jar_path = os.path.join(self.artifact_file_path, f"{file_name1}.jar")
+        small_jar_crc_path = os.path.join(self.artifact_crc_path, f"{file_name1}.txt")
+        large_jar_path = os.path.join(self.artifact_file_path, f"{file_name2}.jar")
+        large_jar_crc_path = os.path.join(self.artifact_crc_path, f"{file_name2}.txt")
+        large_jar_size = os.path.getsize(large_jar_path)
+
+        requests = list(
+            self.artifact_manager._create_requests(
+                small_jar_path, large_jar_path, small_jar_path, small_jar_path
+            )
+        )
+        # There are a total of 14 requests.
+        # The 1st request contains a single artifact - smallJar.jar (There are no
+        # other artifacts batched with it since the next one is large multi-chunk artifact)
+        # Requests 2-13 (1-indexed) belong to the transfer of junitLargeJar.jar. This includes
+        # the first "beginning chunk" and the subsequent data chunks.
+        # The last request (14) contains two smallJar.jar batched
+        # together.
+        self.assertEqual(len(requests), 1 + 12 + 1)
+
+        first_req_batch = requests[0].batch.artifacts
+        self.assertEqual(len(first_req_batch), 1)
+        self.assertEqual(first_req_batch[0].name, os.path.join("jars", f"{file_name1}.jar"))
+        with open(small_jar_crc_path) as f1, open(small_jar_path, "rb") as f2:
+            self.assertEqual(first_req_batch[0].data.crc, int(f1.readline()))
+            self.assertEqual(first_req_batch[0].data.data, f2.read())
+
+        second_req_batch = requests[1]
+        self.assertIsNotNone(second_req_batch.begin_chunk)
+        begin_chunk = second_req_batch.begin_chunk
+        self.assertEqual(begin_chunk.name, os.path.join("jars", f"{file_name2}.jar"))
+        self.assertEqual(begin_chunk.total_bytes, large_jar_size)
+        self.assertEqual(begin_chunk.num_chunks, 12)
+        other_requests = requests[2:-1]
+        data_chunks = [begin_chunk.initial_chunk] + [req.chunk for req in other_requests]
+
+        with open(large_jar_crc_path) as f1, open(large_jar_path, "rb") as f2:
+            cscs = [chunk.crc for chunk in data_chunks]
+            expected_cscs = [int(line.rstrip()) for line in f1]
+            self.assertEqual(cscs, expected_cscs)
+
+            binaries = [chunk.data for chunk in data_chunks]
+            expected_binaries = list(iter(lambda: f2.read(ArtifactManager.CHUNK_SIZE), b""))
+            self.assertEqual(binaries, expected_binaries)
+
+        last_request = requests[-1]
+        self.assertIsNotNone(last_request.batch)
+
+        batch = last_request.batch
+        self.assertEqual(len(batch.artifacts), 2)
+
+        artifact1 = batch.artifacts[0]
+        self.assertTrue(artifact1.name.endswith(".jar"))
+        artifact2 = batch.artifacts[1]
+        self.assertTrue(artifact2.name.endswith(".jar"))
+
+        self.assertEqual(os.path.join("jars", f"{file_name1}.jar"), artifact1.name)
+        with open(small_jar_crc_path) as f1, open(small_jar_path, "rb") as f2:
+            crc = int(f1.readline())
+            data = f2.read()
+            self.assertEqual(artifact1.data.crc, crc)
+            self.assertEqual(artifact1.data.data, data)
+            self.assertEqual(artifact2.data.crc, crc)
+            self.assertEqual(artifact2.data.data, data)
+
+
+if __name__ == "__main__":
+    from pyspark.sql.tests.connect.client.test_artifact import *  # noqa: F401
+
+    try:
+        import xmlrunner  # type: ignore
+
+        testRunner = xmlrunner.XMLTestRunner(output="target/test-reports", verbosity=2)
+    except ImportError:
+        testRunner = None
+    unittest.main(testRunner=testRunner, verbosity=2)

--- a/python/pyspark/sql/tests/connect/client/test_client.py
+++ b/python/pyspark/sql/tests/connect/client/test_client.py
@@ -20,13 +20,14 @@ from typing import Optional
 
 from pyspark.sql.connect.client import SparkConnectClient, ChannelBuilder
 import pyspark.sql.connect.proto as proto
-from pyspark.testing.connectutils import should_test_connect
+from pyspark.testing.connectutils import should_test_connect, connect_requirement_message
 
 if should_test_connect:
     import pandas as pd
     import pyarrow as pa
 
 
+@unittest.skipIf(not should_test_connect, connect_requirement_message)
 class SparkConnectClientTestCase(unittest.TestCase):
     def test_user_agent_passthrough(self):
         client = SparkConnectClient("sc://foo/;user_agent=bar")
@@ -115,4 +116,12 @@ class MockService:
 
 
 if __name__ == "__main__":
-    unittest.main()
+    from pyspark.sql.tests.connect.client.test_client import *  # noqa: F401
+
+    try:
+        import xmlrunner  # type: ignore
+
+        testRunner = xmlrunner.XMLTestRunner(output="target/test-reports", verbosity=2)
+    except ImportError:
+        testRunner = None
+    unittest.main(testRunner=testRunner, verbosity=2)

--- a/python/pyspark/sql/tests/connect/streaming/__init__.py
+++ b/python/pyspark/sql/tests/connect/streaming/__init__.py
@@ -1,0 +1,16 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -74,7 +74,7 @@ if should_test_connect:
     from pyspark.sql.connect.dataframe import DataFrame as CDataFrame
     from pyspark.sql import functions as SF
     from pyspark.sql.connect import functions as CF
-    from pyspark.sql.connect.client import Retrying
+    from pyspark.sql.connect.client.core import Retrying
 
 
 class SparkConnectSQLTestCase(ReusedConnectTestCase, SQLTestUtils, PandasOnSparkTestUtils):


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR implements `SparkSession.addArtifact(s)`. The logic is basically translated from Scala (https://github.com/apache/spark/pull/40256) to Python here.

One difference is that, it does not support `class` files and `cache` (https://github.com/apache/spark/pull/40827) because it's not realistic for Python client to add `class` files. For `cache`, this implementation will be used as a base work.

This PR is also a base work to implement sending py-files and archive files

### Why are the changes needed?

For feature parity w/ Scala client. In addition, this is also base work for `cache` implementation, and Python dependency management (https://www.databricks.com/blog/2020/12/22/how-to-manage-python-dependencies-in-pyspark.html)

### Does this PR introduce _any_ user-facing change?

Yes, this exposes an API `SparkSession.addArtifact(s)`.

### How was this patch tested?

Unittests were added. Also manually tested.
