### PR TITLE
[SPARK-43649][SPARK-43650][SPARK-43651][SQL] Assign names to the error class _LEGACY_ERROR_TEMP_240[1-3]

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -1040,6 +1040,33 @@
     ],
     "sqlState" : "42613"
   },
+  "INVALID_LIMIT_LIKE_EXPRESSION" : {
+    "message" : [
+      "The limit like expression <expr> is invalid."
+    ],
+    "subClass" : {
+      "DATA_TYPE" : {
+        "message" : [
+          "The <name> expression must be integer type, but got <dataType>."
+        ]
+      },
+      "IS_NEGATIVE" : {
+        "message" : [
+          "The <name> expression must be equal to or greater than 0, but got <v>."
+        ]
+      },
+      "IS_NULL" : {
+        "message" : [
+          "The evaluated <name> expression must not be null."
+        ]
+      },
+      "IS_UNFOLDABLE" : {
+        "message" : [
+          "The <name> expression must evaluate to a constant value."
+        ]
+      }
+    }
+  },
   "INVALID_OPTIONS" : {
     "message" : [
       "Invalid options:"
@@ -1209,33 +1236,6 @@
       "PARTITION_SIZE_WITH_UNSPECIFIED_DISTRIBUTION" : {
         "message" : [
           "The advisory partition size can't be specified with unspecified distribution."
-        ]
-      }
-    }
-  },
-  "INVALID_LIMIT_LIKE_EXPRESSION" : {
-    "message" : [
-      "The limit like expression <expr> is invalid."
-    ],
-    "subClass" : {
-      "IS_UNFOLDABLE" : {
-        "message" : [
-          "The <name> expression must evaluate to a constant value."
-        ]
-      },
-      "DATA_TYPE" : {
-        "message" : [
-          "The <name> expression must be integer type, but got <dataType>."
-        ]
-      },
-      "IS_NEGATIVE" : {
-        "message" : [
-          "The <name> expression must be equal to or greater than 0, but got <v>."
-        ]
-      },
-      "IS_NULL" : {
-        "message" : [
-          "The evaluated <name> expression must not be null."
         ]
       }
     }

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -904,6 +904,11 @@
     ],
     "sqlState" : "42000"
   },
+  "INVALID_DATA_TYPE_FOR_LIMIT_LIKE_EXPRESSION" : {
+    "message" : [
+      "The <name> expression must be integer type, but got <dataType>."
+    ]
+  },
   "INVALID_DRIVER_MEMORY" : {
     "message" : [
       "System memory <systemMemory> must be at least <minSystemMemory>. Please increase heap size using the --driver-memory option or \"<config>\" in Spark configuration."
@@ -1212,6 +1217,16 @@
         ]
       }
     }
+  },
+  "LIMIT_LIKE_EXPRESSION_IS_NEGATIVE" : {
+    "message" : [
+      "The <name> expression must be equal to or greater than 0, but got <v>."
+    ]
+  },
+  "LIMIT_LIKE_EXPRESSION_IS_NULL" : {
+    "message" : [
+      "The evaluated <name> expression must not be null, but got <limitExpr>."
+    ]
   },
   "LIMIT_LIKE_EXPRESSION_IS_UNFOLDABLE" : {
     "message" : [
@@ -5219,21 +5234,6 @@
   "_LEGACY_ERROR_TEMP_2331" : {
     "message" : [
       "failed to evaluate expression <sqlExpr>: <msg>"
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_2401" : {
-    "message" : [
-      "The <name> expression must be integer type, but got <dataType>."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_2402" : {
-    "message" : [
-      "The evaluated <name> expression must not be null, but got <limitExpr>."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_2403" : {
-    "message" : [
-      "The <name> expression must be equal to or greater than 0, but got <v>."
     ]
   },
   "_LEGACY_ERROR_TEMP_2404" : {

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -904,11 +904,6 @@
     ],
     "sqlState" : "42000"
   },
-  "INVALID_DATA_TYPE_FOR_LIMIT_LIKE_EXPRESSION" : {
-    "message" : [
-      "The <name> expression must be integer type, but got <dataType>."
-    ]
-  },
   "INVALID_DRIVER_MEMORY" : {
     "message" : [
       "System memory <systemMemory> must be at least <minSystemMemory>. Please increase heap size using the --driver-memory option or \"<config>\" in Spark configuration."
@@ -1218,20 +1213,32 @@
       }
     }
   },
-  "LIMIT_LIKE_EXPRESSION_IS_NEGATIVE" : {
+  "INVALID_LIMIT_LIKE_EXPRESSION" : {
     "message" : [
-      "The <name> expression must be equal to or greater than 0, but got <v>."
-    ]
-  },
-  "LIMIT_LIKE_EXPRESSION_IS_NULL" : {
-    "message" : [
-      "The evaluated <name> expression must not be null, but got <limitExpr>."
-    ]
-  },
-  "LIMIT_LIKE_EXPRESSION_IS_UNFOLDABLE" : {
-    "message" : [
-      "The <name> expression must evaluate to a constant value, but got <limitExpr>."
-    ]
+      "The limit like expression <expr> is invalid."
+    ],
+    "subClass" : {
+      "IS_UNFOLDABLE" : {
+        "message" : [
+          "The <name> expression must evaluate to a constant value."
+        ]
+      },
+      "DATA_TYPE" : {
+        "message" : [
+          "The <name> expression must be integer type, but got <dataType>."
+        ]
+      },
+      "IS_NEGATIVE" : {
+        "message" : [
+          "The <name> expression must be equal to or greater than 0, but got <v>."
+        ]
+      },
+      "IS_NULL" : {
+        "message" : [
+          "The evaluated <name> expression must not be null."
+        ]
+      }
+    }
   },
   "LOCATION_ALREADY_EXISTS" : {
     "message" : [

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -85,26 +85,28 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
   private def checkLimitLikeClause(name: String, limitExpr: Expression): Unit = {
     limitExpr match {
       case e if !e.foldable => limitExpr.failAnalysis(
-        errorClass = "LIMIT_LIKE_EXPRESSION_IS_UNFOLDABLE",
+        errorClass = "INVALID_LIMIT_LIKE_EXPRESSION.IS_UNFOLDABLE",
         messageParameters = Map(
           "name" -> name,
-          "limitExpr" -> toSQLExpr(limitExpr)))
+          "expr" -> toSQLExpr(limitExpr)))
       case e if e.dataType != IntegerType => limitExpr.failAnalysis(
-        errorClass = "INVALID_DATA_TYPE_FOR_LIMIT_LIKE_EXPRESSION",
+        errorClass = "INVALID_LIMIT_LIKE_EXPRESSION.DATA_TYPE",
         messageParameters = Map(
           "name" -> name,
+          "expr" -> toSQLExpr(limitExpr),
           "dataType" -> e.dataType.catalogString))
       case e =>
         e.eval() match {
           case null => limitExpr.failAnalysis(
-            errorClass = "LIMIT_LIKE_EXPRESSION_IS_NULL",
+            errorClass = "INVALID_LIMIT_LIKE_EXPRESSION.IS_NULL",
             messageParameters = Map(
               "name" -> name,
-              "limitExpr" -> toSQLExpr(limitExpr)))
+              "expr" -> toSQLExpr(limitExpr)))
           case v: Int if v < 0 => limitExpr.failAnalysis(
-            errorClass = "LIMIT_LIKE_EXPRESSION_IS_NEGATIVE",
+            errorClass = "INVALID_LIMIT_LIKE_EXPRESSION.IS_NEGATIVE",
             messageParameters = Map(
               "name" -> name,
+              "expr" -> toSQLExpr(limitExpr),
               "v" -> v.toString))
           case _ => // OK
         }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -94,7 +94,7 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
         messageParameters = Map(
           "name" -> name,
           "expr" -> toSQLExpr(limitExpr),
-          "dataType" -> e.dataType.catalogString))
+          "dataType" -> toSQLType(e.dataType)))
       case e =>
         e.eval() match {
           case null => limitExpr.failAnalysis(
@@ -107,7 +107,7 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
             messageParameters = Map(
               "name" -> name,
               "expr" -> toSQLExpr(limitExpr),
-              "v" -> v.toString))
+              "v" -> toSQLValue(v, IntegerType)))
           case _ => // OK
         }
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -90,19 +90,19 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
           "name" -> name,
           "limitExpr" -> toSQLExpr(limitExpr)))
       case e if e.dataType != IntegerType => limitExpr.failAnalysis(
-        errorClass = "_LEGACY_ERROR_TEMP_2401",
+        errorClass = "INVALID_DATA_TYPE_FOR_LIMIT_LIKE_EXPRESSION",
         messageParameters = Map(
           "name" -> name,
           "dataType" -> e.dataType.catalogString))
       case e =>
         e.eval() match {
           case null => limitExpr.failAnalysis(
-            errorClass = "_LEGACY_ERROR_TEMP_2402",
+            errorClass = "LIMIT_LIKE_EXPRESSION_IS_NULL",
             messageParameters = Map(
               "name" -> name,
-              "limitExpr" -> limitExpr.sql))
+              "limitExpr" -> toSQLExpr(limitExpr)))
           case v: Int if v < 0 => limitExpr.failAnalysis(
-            errorClass = "_LEGACY_ERROR_TEMP_2403",
+            errorClass = "LIMIT_LIKE_EXPRESSION_IS_NEGATIVE",
             messageParameters = Map(
               "name" -> name,
               "v" -> v.toString))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
@@ -626,42 +626,90 @@ class AnalysisErrorSuite extends AnalysisTest {
     "The generator is not supported: outside the SELECT clause, found: Sort" :: Nil
   )
 
-  errorTest(
+  errorClassTest(
+    "an evaluated limit class must not be string",
+    testRelation.limit(Literal(UTF8String.fromString("abc"), StringType)),
+    "INVALID_LIMIT_LIKE_EXPRESSION.DATA_TYPE",
+    Map(
+      "name" -> "limit",
+      "expr" -> "\"abc\"",
+      "dataType" -> "\"STRING\""
+    )
+  )
+
+  errorClassTest(
+    "an evaluated limit class must not be long",
+    testRelation.limit(Literal(10L, LongType)),
+    "INVALID_LIMIT_LIKE_EXPRESSION.DATA_TYPE",
+    Map(
+      "name" -> "limit",
+      "expr" -> "\"10\"",
+      "dataType" -> "\"BIGINT\""
+    )
+  )
+
+  errorClassTest(
     "an evaluated limit class must not be null",
     testRelation.limit(Literal(null, IntegerType)),
-    "The limit like expression \"NULL\" is invalid. " +
-      "The evaluated limit expression must not be null." :: Nil
+    "INVALID_LIMIT_LIKE_EXPRESSION.IS_NULL",
+    Map(
+      "name" -> "limit",
+      "expr" -> "\"NULL\""
+    )
   )
 
-  errorTest(
+  errorClassTest(
     "num_rows in limit clause must be equal to or greater than 0",
     listRelation.limit(-1),
-    "The limit expression must be equal to or greater than 0, but got -1" :: Nil
+    "INVALID_LIMIT_LIKE_EXPRESSION.IS_NEGATIVE",
+    Map(
+      "name" -> "limit",
+      "expr" -> "\"-1\"",
+      "v" -> "-1"
+    )
   )
 
-  errorTest(
+  errorClassTest(
     "an evaluated offset class must not be string",
     testRelation.offset(Literal(UTF8String.fromString("abc"), StringType)),
-    "The offset expression must be integer type, but got string" :: Nil
+    "INVALID_LIMIT_LIKE_EXPRESSION.DATA_TYPE",
+    Map(
+      "name" -> "offset",
+      "expr" -> "\"abc\"",
+      "dataType" -> "\"STRING\""
+    )
   )
 
-  errorTest(
+  errorClassTest(
     "an evaluated offset class must not be long",
     testRelation.offset(Literal(10L, LongType)),
-    "The offset expression must be integer type, but got bigint" :: Nil
+    "INVALID_LIMIT_LIKE_EXPRESSION.DATA_TYPE",
+    Map(
+      "name" -> "offset",
+      "expr" -> "\"10\"",
+      "dataType" -> "\"BIGINT\""
+    )
   )
 
-  errorTest(
+  errorClassTest(
     "an evaluated offset class must not be null",
     testRelation.offset(Literal(null, IntegerType)),
-    "The limit like expression \"NULL\" is invalid. " +
-      "The evaluated offset expression must not be null." :: Nil
+    "INVALID_LIMIT_LIKE_EXPRESSION.IS_NULL",
+    Map(
+      "name" -> "offset",
+      "expr" -> "\"NULL\""
+    )
   )
 
-  errorTest(
+  errorClassTest(
     "num_rows in offset clause must be equal to or greater than 0",
     testRelation.offset(-1),
-    "The offset expression must be equal to or greater than 0, but got -1" :: Nil
+    "INVALID_LIMIT_LIKE_EXPRESSION.IS_NEGATIVE",
+    Map(
+      "name" -> "offset",
+      "expr" -> "\"-1\"",
+      "v" -> "-1"
+    )
   )
 
   errorClassTest(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
@@ -629,7 +629,8 @@ class AnalysisErrorSuite extends AnalysisTest {
   errorTest(
     "an evaluated limit class must not be null",
     testRelation.limit(Literal(null, IntegerType)),
-    "The evaluated limit expression must not be null, but got " :: Nil
+    "The limit like expression \"NULL\" is invalid. " +
+      "The evaluated limit expression must not be null." :: Nil
   )
 
   errorTest(
@@ -653,7 +654,8 @@ class AnalysisErrorSuite extends AnalysisTest {
   errorTest(
     "an evaluated offset class must not be null",
     testRelation.offset(Literal(null, IntegerType)),
-    "The evaluated offset expression must not be null, but got " :: Nil
+    "The limit like expression \"NULL\" is invalid. " +
+      "The evaluated offset expression must not be null." :: Nil
   )
 
   errorTest(

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/limit.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/limit.sql.out
@@ -54,7 +54,7 @@ SELECT * FROM testdata LIMIT -1
 -- !query analysis
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_2403",
+  "errorClass" : "LIMIT_LIKE_EXPRESSION_IS_NEGATIVE",
   "messageParameters" : {
     "name" : "limit",
     "v" : "-1"
@@ -74,7 +74,7 @@ SELECT * FROM testData TABLESAMPLE (-1 ROWS)
 -- !query analysis
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_2403",
+  "errorClass" : "LIMIT_LIKE_EXPRESSION_IS_NEGATIVE",
   "messageParameters" : {
     "name" : "limit",
     "v" : "-1"
@@ -104,9 +104,9 @@ SELECT * FROM testdata LIMIT CAST(NULL AS INT)
 -- !query analysis
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_2402",
+  "errorClass" : "LIMIT_LIKE_EXPRESSION_IS_NULL",
   "messageParameters" : {
-    "limitExpr" : "CAST(NULL AS INT)",
+    "limitExpr" : "\"CAST(NULL AS INT)\"",
     "name" : "limit"
   },
   "queryContext" : [ {
@@ -144,7 +144,7 @@ SELECT * FROM testdata LIMIT true
 -- !query analysis
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_2401",
+  "errorClass" : "INVALID_DATA_TYPE_FOR_LIMIT_LIKE_EXPRESSION",
   "messageParameters" : {
     "dataType" : "boolean",
     "name" : "limit"
@@ -157,7 +157,7 @@ SELECT * FROM testdata LIMIT 'a'
 -- !query analysis
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_2401",
+  "errorClass" : "INVALID_DATA_TYPE_FOR_LIMIT_LIKE_EXPRESSION",
   "messageParameters" : {
     "dataType" : "string",
     "name" : "limit"

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/limit.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/limit.sql.out
@@ -54,8 +54,9 @@ SELECT * FROM testdata LIMIT -1
 -- !query analysis
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "LIMIT_LIKE_EXPRESSION_IS_NEGATIVE",
+  "errorClass" : "INVALID_LIMIT_LIKE_EXPRESSION.IS_NEGATIVE",
   "messageParameters" : {
+    "expr" : "\"-1\"",
     "name" : "limit",
     "v" : "-1"
   },
@@ -74,8 +75,9 @@ SELECT * FROM testData TABLESAMPLE (-1 ROWS)
 -- !query analysis
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "LIMIT_LIKE_EXPRESSION_IS_NEGATIVE",
+  "errorClass" : "INVALID_LIMIT_LIKE_EXPRESSION.IS_NEGATIVE",
   "messageParameters" : {
+    "expr" : "\"-1\"",
     "name" : "limit",
     "v" : "-1"
   },
@@ -104,9 +106,9 @@ SELECT * FROM testdata LIMIT CAST(NULL AS INT)
 -- !query analysis
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "LIMIT_LIKE_EXPRESSION_IS_NULL",
+  "errorClass" : "INVALID_LIMIT_LIKE_EXPRESSION.IS_NULL",
   "messageParameters" : {
-    "limitExpr" : "\"CAST(NULL AS INT)\"",
+    "expr" : "\"CAST(NULL AS INT)\"",
     "name" : "limit"
   },
   "queryContext" : [ {
@@ -124,9 +126,9 @@ SELECT * FROM testdata LIMIT key > 3
 -- !query analysis
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "LIMIT_LIKE_EXPRESSION_IS_UNFOLDABLE",
+  "errorClass" : "INVALID_LIMIT_LIKE_EXPRESSION.IS_UNFOLDABLE",
   "messageParameters" : {
-    "limitExpr" : "\"(key > 3)\"",
+    "expr" : "\"(key > 3)\"",
     "name" : "limit"
   },
   "queryContext" : [ {
@@ -144,9 +146,10 @@ SELECT * FROM testdata LIMIT true
 -- !query analysis
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "INVALID_DATA_TYPE_FOR_LIMIT_LIKE_EXPRESSION",
+  "errorClass" : "INVALID_LIMIT_LIKE_EXPRESSION.DATA_TYPE",
   "messageParameters" : {
     "dataType" : "boolean",
+    "expr" : "\"true\"",
     "name" : "limit"
   }
 }
@@ -157,9 +160,10 @@ SELECT * FROM testdata LIMIT 'a'
 -- !query analysis
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "INVALID_DATA_TYPE_FOR_LIMIT_LIKE_EXPRESSION",
+  "errorClass" : "INVALID_LIMIT_LIKE_EXPRESSION.DATA_TYPE",
   "messageParameters" : {
     "dataType" : "string",
+    "expr" : "\"a\"",
     "name" : "limit"
   },
   "queryContext" : [ {

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/limit.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/limit.sql.out
@@ -148,7 +148,7 @@ org.apache.spark.sql.AnalysisException
 {
   "errorClass" : "INVALID_LIMIT_LIKE_EXPRESSION.DATA_TYPE",
   "messageParameters" : {
-    "dataType" : "boolean",
+    "dataType" : "\"BOOLEAN\"",
     "expr" : "\"true\"",
     "name" : "limit"
   }
@@ -162,7 +162,7 @@ org.apache.spark.sql.AnalysisException
 {
   "errorClass" : "INVALID_LIMIT_LIKE_EXPRESSION.DATA_TYPE",
   "messageParameters" : {
-    "dataType" : "string",
+    "dataType" : "\"STRING\"",
     "expr" : "\"a\"",
     "name" : "limit"
   },

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/postgreSQL/limit.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/postgreSQL/limit.sql.out
@@ -141,9 +141,9 @@ select * from int8_tbl limit (case when random() < 0.5 then bigint(null) end)
 -- !query analysis
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "LIMIT_LIKE_EXPRESSION_IS_UNFOLDABLE",
+  "errorClass" : "INVALID_LIMIT_LIKE_EXPRESSION.IS_UNFOLDABLE",
   "messageParameters" : {
-    "limitExpr" : "\"CASE WHEN (_nondeterministic < 0.5) THEN NULL END\"",
+    "expr" : "\"CASE WHEN (_nondeterministic < 0.5) THEN NULL END\"",
     "name" : "limit"
   },
   "queryContext" : [ {
@@ -161,9 +161,9 @@ select * from int8_tbl offset (case when random() < 0.5 then bigint(null) end)
 -- !query analysis
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "LIMIT_LIKE_EXPRESSION_IS_UNFOLDABLE",
+  "errorClass" : "INVALID_LIMIT_LIKE_EXPRESSION.IS_UNFOLDABLE",
   "messageParameters" : {
-    "limitExpr" : "\"CASE WHEN (_nondeterministic < 0.5) THEN NULL END\"",
+    "expr" : "\"CASE WHEN (_nondeterministic < 0.5) THEN NULL END\"",
     "name" : "offset"
   },
   "queryContext" : [ {

--- a/sql/core/src/test/resources/sql-tests/results/limit.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/limit.sql.out
@@ -151,7 +151,7 @@ org.apache.spark.sql.AnalysisException
 {
   "errorClass" : "INVALID_LIMIT_LIKE_EXPRESSION.DATA_TYPE",
   "messageParameters" : {
-    "dataType" : "boolean",
+    "dataType" : "\"BOOLEAN\"",
     "expr" : "\"true\"",
     "name" : "limit"
   }
@@ -167,7 +167,7 @@ org.apache.spark.sql.AnalysisException
 {
   "errorClass" : "INVALID_LIMIT_LIKE_EXPRESSION.DATA_TYPE",
   "messageParameters" : {
-    "dataType" : "string",
+    "dataType" : "\"STRING\"",
     "expr" : "\"a\"",
     "name" : "limit"
   },

--- a/sql/core/src/test/resources/sql-tests/results/limit.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/limit.sql.out
@@ -51,8 +51,9 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "LIMIT_LIKE_EXPRESSION_IS_NEGATIVE",
+  "errorClass" : "INVALID_LIMIT_LIKE_EXPRESSION.IS_NEGATIVE",
   "messageParameters" : {
+    "expr" : "\"-1\"",
     "name" : "limit",
     "v" : "-1"
   },
@@ -73,8 +74,9 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "LIMIT_LIKE_EXPRESSION_IS_NEGATIVE",
+  "errorClass" : "INVALID_LIMIT_LIKE_EXPRESSION.IS_NEGATIVE",
   "messageParameters" : {
+    "expr" : "\"-1\"",
     "name" : "limit",
     "v" : "-1"
   },
@@ -103,9 +105,9 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "LIMIT_LIKE_EXPRESSION_IS_NULL",
+  "errorClass" : "INVALID_LIMIT_LIKE_EXPRESSION.IS_NULL",
   "messageParameters" : {
-    "limitExpr" : "\"CAST(NULL AS INT)\"",
+    "expr" : "\"CAST(NULL AS INT)\"",
     "name" : "limit"
   },
   "queryContext" : [ {
@@ -125,9 +127,9 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "LIMIT_LIKE_EXPRESSION_IS_UNFOLDABLE",
+  "errorClass" : "INVALID_LIMIT_LIKE_EXPRESSION.IS_UNFOLDABLE",
   "messageParameters" : {
-    "limitExpr" : "\"(key > 3)\"",
+    "expr" : "\"(key > 3)\"",
     "name" : "limit"
   },
   "queryContext" : [ {
@@ -147,9 +149,10 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "INVALID_DATA_TYPE_FOR_LIMIT_LIKE_EXPRESSION",
+  "errorClass" : "INVALID_LIMIT_LIKE_EXPRESSION.DATA_TYPE",
   "messageParameters" : {
     "dataType" : "boolean",
+    "expr" : "\"true\"",
     "name" : "limit"
   }
 }
@@ -162,9 +165,10 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "INVALID_DATA_TYPE_FOR_LIMIT_LIKE_EXPRESSION",
+  "errorClass" : "INVALID_LIMIT_LIKE_EXPRESSION.DATA_TYPE",
   "messageParameters" : {
     "dataType" : "string",
+    "expr" : "\"a\"",
     "name" : "limit"
   },
   "queryContext" : [ {

--- a/sql/core/src/test/resources/sql-tests/results/limit.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/limit.sql.out
@@ -51,7 +51,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_2403",
+  "errorClass" : "LIMIT_LIKE_EXPRESSION_IS_NEGATIVE",
   "messageParameters" : {
     "name" : "limit",
     "v" : "-1"
@@ -73,7 +73,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_2403",
+  "errorClass" : "LIMIT_LIKE_EXPRESSION_IS_NEGATIVE",
   "messageParameters" : {
     "name" : "limit",
     "v" : "-1"
@@ -103,9 +103,9 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_2402",
+  "errorClass" : "LIMIT_LIKE_EXPRESSION_IS_NULL",
   "messageParameters" : {
-    "limitExpr" : "CAST(NULL AS INT)",
+    "limitExpr" : "\"CAST(NULL AS INT)\"",
     "name" : "limit"
   },
   "queryContext" : [ {
@@ -147,7 +147,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_2401",
+  "errorClass" : "INVALID_DATA_TYPE_FOR_LIMIT_LIKE_EXPRESSION",
   "messageParameters" : {
     "dataType" : "boolean",
     "name" : "limit"
@@ -162,7 +162,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_2401",
+  "errorClass" : "INVALID_DATA_TYPE_FOR_LIMIT_LIKE_EXPRESSION",
   "messageParameters" : {
     "dataType" : "string",
     "name" : "limit"

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/limit.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/limit.sql.out
@@ -132,9 +132,9 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "LIMIT_LIKE_EXPRESSION_IS_UNFOLDABLE",
+  "errorClass" : "INVALID_LIMIT_LIKE_EXPRESSION.IS_UNFOLDABLE",
   "messageParameters" : {
-    "limitExpr" : "\"CASE WHEN (_nondeterministic < 0.5) THEN NULL END\"",
+    "expr" : "\"CASE WHEN (_nondeterministic < 0.5) THEN NULL END\"",
     "name" : "limit"
   },
   "queryContext" : [ {
@@ -154,9 +154,9 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "LIMIT_LIKE_EXPRESSION_IS_UNFOLDABLE",
+  "errorClass" : "INVALID_LIMIT_LIKE_EXPRESSION.IS_UNFOLDABLE",
   "messageParameters" : {
-    "limitExpr" : "\"CASE WHEN (_nondeterministic < 0.5) THEN NULL END\"",
+    "expr" : "\"CASE WHEN (_nondeterministic < 0.5) THEN NULL END\"",
     "name" : "offset"
   },
   "queryContext" : [ {


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to assign a name to the error class _LEGACY_ERROR_TEMP_240[1-3].

### Why are the changes needed?
Improve the error framework.


### Does this PR introduce _any_ user-facing change?
'No'.


### How was this patch tested?
Exists test cases.
