### PR TITLE
[SPARK-43604][SQL] Refactor `INVALID_SQL_SYNTAX ` for avoiding to embed error's text in source code

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -1151,8 +1151,85 @@
   },
   "INVALID_SQL_SYNTAX" : {
     "message" : [
-      "Invalid SQL syntax: <inputString>."
+      "Invalid SQL syntax:"
     ],
+    "subClass" : {
+      "CREATE_FUNC_WITH_IF_NOT_EXISTS_AND_REPLACE" : {
+        "message" : [
+          "CREATE FUNCTION with both IF NOT EXISTS and REPLACE is not allowed."
+        ]
+      },
+      "CREATE_TEMP_FUNC_WITH_DATABASE" : {
+        "message" : [
+          "CREATE TEMPORARY FUNCTION with specifying a database(<database>) is not allowed."
+        ]
+      },
+      "CREATE_TEMP_FUNC_WITH_IF_NOT_EXISTS" : {
+        "message" : [
+          "CREATE TEMPORARY FUNCTION with IF NOT EXISTS is not allowed."
+        ]
+      },
+      "EMPTY_PARTITION_VALUE" : {
+        "message" : [
+          "Partition key <partKey> must set value."
+        ]
+      },
+      "INVALID_COLUMN_REFERENCE" : {
+        "message" : [
+          "Expected a column reference for transform <transform>: <expr>."
+        ]
+      },
+      "INVALID_TABLE_VALUED_FUNC_NAME" : {
+        "message" : [
+          "Table valued function cannot specify database name: <funcName>."
+        ]
+      },
+      "INVALID_WINDOW_REFERENCE" : {
+        "message" : [
+          "Window reference <windowName> is not a window specification."
+        ]
+      },
+      "LATERAL_WITHOUT_SUBQUERY_OR_TABLE_VALUED_FUNC" : {
+        "message" : [
+          "LATERAL can only be used with subquery and table-valued functions."
+        ]
+      },
+      "MULTI_PART_NAME" : {
+        "message" : [
+          "<statement> with multiple part function name(<funcName>) is not allowed."
+        ]
+      },
+      "REPETITIVE_WINDOW_DEFINITION" : {
+        "message" : [
+          "The definition of window <windowName> is repetitive."
+        ]
+      },
+      "SHOW_FUNCTIONS_INVALID_PATTERN" : {
+        "message" : [
+          "Invalid pattern in SHOW FUNCTIONS: <pattern>. It must be a \"STRING\" literal."
+        ]
+      },
+      "SHOW_FUNCTIONS_INVALID_SCOPE" : {
+        "message" : [
+          "SHOW <scope> FUNCTIONS not supported."
+        ]
+      },
+      "TRANSFORM_WRONG_NUM_ARGS" : {
+        "message" : [
+          "The transform<transform> requires <expectedNum> parameters but the actual number is <actualNum>."
+        ]
+      },
+      "UNRESOLVED_WINDOW_REFERENCE" : {
+        "message" : [
+          "Cannot resolve window reference <windowName>."
+        ]
+      },
+      "UNSUPPORTED_FUNC_NAME" : {
+        "message" : [
+          "Unsupported function name <funcName>."
+        ]
+      }
+    },
     "sqlState" : "42000"
   },
   "INVALID_SUBQUERY_EXPRESSION" : {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -3341,7 +3341,7 @@ class AstBuilder extends SqlBaseParserBaseVisitor[AnyRef] with SQLConfHelper wit
         arguments: Seq[V2Expression]): FieldReference = {
       lazy val name: String = ctx.identifier.getText
       if (arguments.size > 1) {
-        throw QueryParsingErrors.tooManyArgumentsForTransformError(name, ctx)
+        throw QueryParsingErrors.wrongNumberArgumentsForTransformError(name, arguments.size, ctx)
       } else if (arguments.isEmpty) {
         throw new IllegalStateException(s"Not enough arguments for transform $name")
       } else {
@@ -4387,7 +4387,7 @@ class AstBuilder extends SqlBaseParserBaseVisitor[AnyRef] with SQLConfHelper wit
         visitPartitionSpec(ctx.partitionSpec).map {
           case (key, Some(value)) => key -> value
           case (key, _) =>
-            throw QueryParsingErrors.incompletePartitionSpecificationError(key, ctx)
+            throw QueryParsingErrors.emptyPartitionKeyError(key, ctx.partitionSpec)
         }
       } else {
         Map.empty[String, String]

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
@@ -73,9 +73,8 @@ private[sql] object QueryParsingErrors extends QueryErrorsBase {
 
   def emptyPartitionKeyError(key: String, ctx: PartitionSpecContext): Throwable = {
     new ParseException(
-      errorClass = "INVALID_SQL_SYNTAX",
-      messageParameters = Map(
-        "inputString" -> s"Partition key ${toSQLId(key)} must set value (can't be empty)."),
+      errorClass = "INVALID_SQL_SYNTAX.EMPTY_PARTITION_VALUE",
+      messageParameters = Map("partKey" -> toSQLId(key)),
       ctx)
   }
 
@@ -129,34 +128,28 @@ private[sql] object QueryParsingErrors extends QueryErrorsBase {
 
   def invalidLateralJoinRelationError(ctx: RelationPrimaryContext): Throwable = {
     new ParseException(
-      errorClass = "INVALID_SQL_SYNTAX",
-      messageParameters = Map(
-        "inputString" ->
-          s"${toSQLStmt("LATERAL")} can only be used with subquery and table-valued functions."),
+      errorClass = "INVALID_SQL_SYNTAX.LATERAL_WITHOUT_SUBQUERY_OR_TABLE_VALUED_FUNC",
       ctx)
   }
 
   def repetitiveWindowDefinitionError(name: String, ctx: WindowClauseContext): Throwable = {
     new ParseException(
-      errorClass = "INVALID_SQL_SYNTAX",
-      messageParameters = Map(
-        "inputString" -> s"The definition of window ${toSQLId(name)} is repetitive."),
+      errorClass = "INVALID_SQL_SYNTAX.REPETITIVE_WINDOW_DEFINITION",
+      messageParameters = Map("windowName" -> toSQLId(name)),
       ctx)
   }
 
   def invalidWindowReferenceError(name: String, ctx: WindowClauseContext): Throwable = {
     new ParseException(
-      errorClass = "INVALID_SQL_SYNTAX",
-      messageParameters = Map(
-        "inputString" -> s"Window reference ${toSQLId(name)} is not a window specification."),
+      errorClass = "INVALID_SQL_SYNTAX.INVALID_WINDOW_REFERENCE",
+      messageParameters = Map("windowName" -> toSQLId(name)),
       ctx)
   }
 
   def cannotResolveWindowReferenceError(name: String, ctx: WindowClauseContext): Throwable = {
     new ParseException(
-      errorClass = "INVALID_SQL_SYNTAX",
-      messageParameters = Map(
-        "inputString" -> s"Cannot resolve window reference ${toSQLId(name)}."),
+      errorClass = "INVALID_SQL_SYNTAX.UNRESOLVED_WINDOW_REFERENCE",
+      messageParameters = Map("windowName" -> toSQLId(name)),
       ctx)
   }
 
@@ -201,9 +194,8 @@ private[sql] object QueryParsingErrors extends QueryErrorsBase {
 
   def functionNameUnsupportedError(functionName: String, ctx: ParserRuleContext): Throwable = {
     new ParseException(
-      errorClass = "INVALID_SQL_SYNTAX",
-      messageParameters = Map(
-        "inputString" -> s"Unsupported function name ${toSQLId(functionName)}"),
+      errorClass = "INVALID_SQL_SYNTAX.UNSUPPORTED_FUNC_NAME",
+      messageParameters = Map("funcName" -> toSQLId(functionName)),
       ctx)
   }
 
@@ -308,20 +300,23 @@ private[sql] object QueryParsingErrors extends QueryErrorsBase {
   }
 
   def partitionTransformNotExpectedError(
-      name: String, describe: String, ctx: ApplyTransformContext): Throwable = {
+      name: String, expr: String, ctx: ApplyTransformContext): Throwable = {
     new ParseException(
-      errorClass = "INVALID_SQL_SYNTAX",
+      errorClass = "INVALID_SQL_SYNTAX.INVALID_COLUMN_REFERENCE",
       messageParameters = Map(
-        "inputString" ->
-          s"Expected a column reference for transform ${toSQLId(name)}: $describe"),
+        "transform" -> toSQLId(name),
+        "expr" -> expr),
       ctx)
   }
 
-  def tooManyArgumentsForTransformError(name: String, ctx: ApplyTransformContext): Throwable = {
+  def wrongNumberArgumentsForTransformError(
+      name: String, actualNum: Int, ctx: ApplyTransformContext): Throwable = {
     new ParseException(
-      errorClass = "INVALID_SQL_SYNTAX",
+      errorClass = "INVALID_SQL_SYNTAX.TRANSFORM_WRONG_NUM_ARGS",
       messageParameters = Map(
-        "inputString" -> s"Too many arguments for transform ${toSQLId(name)}"),
+        "transform" -> toSQLId(name),
+      "expectedNum" -> "1",
+      "actualNum" -> actualNum.toString),
       ctx)
   }
 
@@ -396,15 +391,6 @@ private[sql] object QueryParsingErrors extends QueryErrorsBase {
       ctx)
   }
 
-  def incompletePartitionSpecificationError(
-      key: String, ctx: DescribeRelationContext): Throwable = {
-    new ParseException(
-      errorClass = "INVALID_SQL_SYNTAX",
-      messageParameters = Map(
-        "inputString" -> s"PARTITION specification is incomplete: ${toSQLId(key)}"),
-      ctx)
-  }
-
   def computeStatisticsNotExpectedError(ctx: IdentifierContext): Throwable = {
     new ParseException(
       errorClass = "_LEGACY_ERROR_TEMP_0036",
@@ -422,20 +408,15 @@ private[sql] object QueryParsingErrors extends QueryErrorsBase {
 
   def showFunctionsUnsupportedError(identifier: String, ctx: IdentifierContext): Throwable = {
     new ParseException(
-      errorClass = "INVALID_SQL_SYNTAX",
-      messageParameters = Map(
-        "inputString" ->
-          s"${toSQLStmt("SHOW")} ${toSQLId(identifier)} ${toSQLStmt("FUNCTIONS")} not supported"),
+      errorClass = "INVALID_SQL_SYNTAX.SHOW_FUNCTIONS_INVALID_SCOPE",
+      messageParameters = Map("scope" -> toSQLId(identifier)),
       ctx)
   }
 
   def showFunctionsInvalidPatternError(pattern: String, ctx: ParserRuleContext): Throwable = {
     new ParseException(
-      errorClass = "INVALID_SQL_SYNTAX",
-      messageParameters = Map(
-        "inputString" ->
-          (s"Invalid pattern in ${toSQLStmt("SHOW FUNCTIONS")}: ${toSQLId(pattern)}. " +
-          s"It must be a ${toSQLType(StringType)} literal.")),
+      errorClass = "INVALID_SQL_SYNTAX.SHOW_FUNCTIONS_INVALID_PATTERN",
+      messageParameters = Map("pattern" -> toSQLId(pattern)),
       ctx)
   }
 
@@ -555,29 +536,22 @@ private[sql] object QueryParsingErrors extends QueryErrorsBase {
 
   def createFuncWithBothIfNotExistsAndReplaceError(ctx: CreateFunctionContext): Throwable = {
     new ParseException(
-      errorClass = "INVALID_SQL_SYNTAX",
-      messageParameters = Map(
-        "inputString" ->
-          (s"${toSQLStmt("CREATE FUNCTION")} with both ${toSQLStmt("IF NOT EXISTS")} " +
-          s"and ${toSQLStmt("REPLACE")} is not allowed.")),
+      errorClass = "INVALID_SQL_SYNTAX.CREATE_FUNC_WITH_IF_NOT_EXISTS_AND_REPLACE",
       ctx)
   }
 
   def defineTempFuncWithIfNotExistsError(ctx: CreateFunctionContext): Throwable = {
     new ParseException(
-      errorClass = "INVALID_SQL_SYNTAX",
-      messageParameters = Map(
-        "inputString" ->
-          (s"It is not allowed to define a ${toSQLStmt("TEMPORARY FUNCTION")}" +
-          s" with ${toSQLStmt("IF NOT EXISTS")}.")),
+      errorClass = "INVALID_SQL_SYNTAX.CREATE_TEMP_FUNC_WITH_IF_NOT_EXISTS",
       ctx)
   }
 
   def unsupportedFunctionNameError(funcName: Seq[String], ctx: CreateFunctionContext): Throwable = {
     new ParseException(
-      errorClass = "INVALID_SQL_SYNTAX",
+      errorClass = "INVALID_SQL_SYNTAX.MULTI_PART_NAME",
       messageParameters = Map(
-        "inputString" -> s"Unsupported function name ${toSQLId(funcName)}"),
+        "statement" -> toSQLStmt("CREATE TEMPORARY FUNCTION"),
+        "funcName" -> toSQLId(funcName)),
       ctx)
   }
 
@@ -585,11 +559,8 @@ private[sql] object QueryParsingErrors extends QueryErrorsBase {
       databaseName: String,
       ctx: CreateFunctionContext): Throwable = {
     new ParseException(
-      errorClass = "INVALID_SQL_SYNTAX",
-      messageParameters = Map(
-        "inputString" ->
-          (s"Specifying a database in ${toSQLStmt("CREATE TEMPORARY FUNCTION")} is not allowed: " +
-          toSQLId(databaseName))),
+      errorClass = "INVALID_SQL_SYNTAX.CREATE_TEMP_FUNC_WITH_DATABASE",
+      messageParameters = Map("database" -> toSQLId(databaseName)),
       ctx)
   }
 
@@ -597,10 +568,8 @@ private[sql] object QueryParsingErrors extends QueryErrorsBase {
       name: Seq[String],
       ctx: TableValuedFunctionContext): Throwable = {
     new ParseException(
-      errorClass = "INVALID_SQL_SYNTAX",
-      messageParameters = Map(
-        "inputString" ->
-          ("table valued function cannot specify database name: " + toSQLId(name))),
+      errorClass = "INVALID_SQL_SYNTAX.INVALID_TABLE_VALUED_FUNC_NAME",
+      messageParameters = Map("funcName" -> toSQLId(name)),
       ctx)
   }
 
@@ -622,11 +591,10 @@ private[sql] object QueryParsingErrors extends QueryErrorsBase {
 
   def invalidNameForDropTempFunc(name: Seq[String], ctx: ParserRuleContext): Throwable = {
     new ParseException(
-      errorClass = "INVALID_SQL_SYNTAX",
+      errorClass = "INVALID_SQL_SYNTAX.MULTI_PART_NAME",
       messageParameters = Map(
-        "inputString" ->
-          (s"${toSQLStmt("DROP TEMPORARY FUNCTION")} requires a single part name but got: " +
-          toSQLId(name))),
+        "statement" -> toSQLStmt("DROP TEMPORARY FUNCTION"),
+        "funcName" -> toSQLId(name)),
       ctx)
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
@@ -862,9 +862,8 @@ class PlanParserSuite extends AnalysisTest {
     val fragment1 = "default.range(2)"
     checkError(
       exception = parseException(sql1),
-      errorClass = "INVALID_SQL_SYNTAX",
-      parameters = Map(
-        "inputString" -> "table valued function cannot specify database name: `default`.`range`"),
+      errorClass = "INVALID_SQL_SYNTAX.INVALID_TABLE_VALUED_FUNC_NAME",
+      parameters = Map("funcName" -> "`default`.`range`"),
       context = ExpectedContext(
         fragment = fragment1,
         start = 14,
@@ -872,13 +871,11 @@ class PlanParserSuite extends AnalysisTest {
 
     // SPARK-38957
     val sql2 = "select * from spark_catalog.default.range(2)"
-    val value2 = "table valued function cannot specify database name: " +
-      "`spark_catalog`.`default`.`range`"
     val fragment2 = "spark_catalog.default.range(2)"
     checkError(
       exception = parseException(sql2),
-      errorClass = "INVALID_SQL_SYNTAX",
-      parameters = Map("inputString" -> value2),
+      errorClass = "INVALID_SQL_SYNTAX.INVALID_TABLE_VALUED_FUNC_NAME",
+      parameters = Map("funcName" -> "`spark_catalog`.`default`.`range`"),
       context = ExpectedContext(
         fragment = fragment2,
         start = 14,

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/describe.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/describe.sql.out
@@ -161,10 +161,10 @@ DESC t PARTITION (c='Us', d)
 -- !query analysis
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "INVALID_SQL_SYNTAX",
+  "errorClass" : "INVALID_SQL_SYNTAX.EMPTY_PARTITION_VALUE",
   "sqlState" : "42000",
   "messageParameters" : {
-    "inputString" : "PARTITION specification is incomplete: `d`"
+    "partKey" : "`d`"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/window.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/window.sql.out
@@ -967,10 +967,10 @@ ORDER BY salary DESC
 -- !query analysis
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "INVALID_SQL_SYNTAX",
+  "errorClass" : "INVALID_SQL_SYNTAX.REPETITIVE_WINDOW_DEFINITION",
   "sqlState" : "42000",
   "messageParameters" : {
-    "inputString" : "The definition of window `w` is repetitive."
+    "windowName" : "`w`"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/results/describe.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/describe.sql.out
@@ -395,10 +395,10 @@ struct<>
 -- !query output
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "INVALID_SQL_SYNTAX",
+  "errorClass" : "INVALID_SQL_SYNTAX.EMPTY_PARTITION_VALUE",
   "sqlState" : "42000",
   "messageParameters" : {
-    "inputString" : "PARTITION specification is incomplete: `d`"
+    "partKey" : "`d`"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/results/window.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/window.sql.out
@@ -1026,10 +1026,10 @@ struct<>
 -- !query output
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "INVALID_SQL_SYNTAX",
+  "errorClass" : "INVALID_SQL_SYNTAX.REPETITIVE_WINDOW_DEFINITION",
   "sqlState" : "42000",
   "messageParameters" : {
-    "inputString" : "The definition of window `w` is repetitive."
+    "windowName" : "`w`"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
@@ -159,7 +159,7 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession {
         start = 0,
         stop = 97))
   }
-  
+
   test("INVALID_SQL_SYNTAX.TRANSFORM_WRONG_NUM_ARGS: Wrong number arguments for transform") {
     checkError(
       exception = parseException("CREATE TABLE table(col int) PARTITIONED BY (years(col,col))"),

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLParserSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLParserSuite.scala
@@ -718,9 +718,8 @@ class DDLParserSuite extends AnalysisTest with SharedSparkSession {
     val sql1 = "DROP TEMPORARY FUNCTION a.b"
     checkError(
       exception = parseException(sql1),
-      errorClass = "INVALID_SQL_SYNTAX",
-      parameters = Map(
-        "inputString" -> "DROP TEMPORARY FUNCTION requires a single part name but got: `a`.`b`"),
+      errorClass = "INVALID_SQL_SYNTAX.MULTI_PART_NAME",
+      parameters = Map("statement" -> "DROP TEMPORARY FUNCTION", "funcName" -> "`a`.`b`"),
       context = ExpectedContext(
         fragment = sql1,
         start = 0,
@@ -729,9 +728,8 @@ class DDLParserSuite extends AnalysisTest with SharedSparkSession {
     val sql2 = "DROP TEMPORARY FUNCTION IF EXISTS a.b"
     checkError(
       exception = parseException(sql2),
-      errorClass = "INVALID_SQL_SYNTAX",
-      parameters = Map(
-        "inputString" -> "DROP TEMPORARY FUNCTION requires a single part name but got: `a`.`b`"),
+      errorClass = "INVALID_SQL_SYNTAX.MULTI_PART_NAME",
+      parameters = Map("statement" -> "DROP TEMPORARY FUNCTION", "funcName" -> "`a`.`b`"),
       context = ExpectedContext(
         fragment = sql2,
         start = 0,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowPartitionsParserSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowPartitionsParserSuite.scala
@@ -47,9 +47,9 @@ class ShowPartitionsParserSuite extends AnalysisTest {
   test("empty values in non-optional partition specs") {
     checkError(
       exception = parseException(parsePlan)("SHOW PARTITIONS dbx.tab1 PARTITION (a='1', b)"),
-      errorClass = "INVALID_SQL_SYNTAX",
+      errorClass = "INVALID_SQL_SYNTAX.EMPTY_PARTITION_VALUE",
       sqlState = "42000",
-      parameters = Map("inputString" -> "Partition key `b` must set value (can't be empty)."),
+      parameters = Map("partKey" -> "`b`"),
       context = ExpectedContext(
         fragment = "PARTITION (a='1', b)",
         start = 25,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/TruncateTableParserSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/TruncateTableParserSuite.scala
@@ -47,9 +47,9 @@ class TruncateTableParserSuite extends AnalysisTest {
   test("empty values in non-optional partition specs") {
     checkError(
       exception = parseException(parsePlan)("TRUNCATE TABLE dbx.tab1 PARTITION (a='1', b)"),
-      errorClass = "INVALID_SQL_SYNTAX",
+      errorClass = "INVALID_SQL_SYNTAX.EMPTY_PARTITION_VALUE",
       sqlState = "42000",
-      parameters = Map("inputString" -> "Partition key `b` must set value (can't be empty)."),
+      parameters = Map("partKey" -> "`b`"),
       context = ExpectedContext(
         fragment = "PARTITION (a='1', b)",
         start = 24,


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to refactor `INVALID_SQL_SYNTAX` for avoiding to embed error's text in source code.

### Why are the changes needed?
The changes improve the error framework.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
- Update UT.
- Pass GA