### PR TITLE
[SPARK-43714][SQL][TESTS] When formatting `error-classes.json` file with `SparkThrowableSuite` , the last line of the file should be empty line

### DIFF
--- a/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
@@ -21,6 +21,8 @@ import java.io.File
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 
+import scala.util.Properties.lineSeparator
+
 import com.fasterxml.jackson.annotation.JsonInclude.Include
 import com.fasterxml.jackson.core.JsonParser.Feature.STRICT_DUPLICATE_DETECTION
 import com.fasterxml.jackson.core.`type`.TypeReference
@@ -92,7 +94,10 @@ class SparkThrowableSuite extends SparkFunSuite {
         val errorClassesFile = errorJsonFilePath.toFile
         logInfo(s"Regenerating error class file $errorClassesFile")
         Files.delete(errorClassesFile.toPath)
-        FileUtils.writeStringToFile(errorClassesFile, rewrittenString, StandardCharsets.UTF_8)
+        FileUtils.writeStringToFile(
+          errorClassesFile,
+          rewrittenString + lineSeparator,
+          StandardCharsets.UTF_8)
       }
     } else {
       assert(rewrittenString.trim == errorClassFileContents.trim)


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to generate a blank line when formatting `error-classes.json` file using `SparkThrowableSuite`.

### Why are the changes needed?
- When I format `error-classes.json` file using `SparkThrowableSuite`, I found the last blank line of the file will be erased, which does not comply with universal underlying code specifications, similar:
python: https://www.flake8rules.com/rules/W391.html

- Promote developer experience.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Manual testing.