### PR TITLE
[SPARK-43657][K8S]: reuse config map for executor when running on k8s-cluster mode

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -165,6 +165,16 @@ private[spark] object Config extends Logging {
       .checkValue(_ <= 1048576, "Must have at most 1048576 bytes")
       .createWithDefault(1048576) // 1.0 MiB
 
+  val SPARK_CONF_DIR_CONFIG_MAP_NAME =
+    ConfigBuilder("spark.kubernetes.sparkConfDir.configMapName")
+      .internal()
+      .doc("Name of the config map that would be mounted as driver and executor's " +
+        "spark conf dir. This is used internally and propagated from spark-submit client to " +
+        "driver pod.")
+      .version("3.5.0")
+      .stringConf
+      .createOptional
+
   val EXECUTOR_ROLL_INTERVAL =
     ConfigBuilder("spark.kubernetes.executor.rollInterval")
       .doc("Interval between executor roll operations. To disable, set 0 (default)")
@@ -378,7 +388,9 @@ private[spark] object Config extends Logging {
 
   val KUBERNETES_EXECUTOR_DISABLE_CONFIGMAP =
     ConfigBuilder("spark.kubernetes.executor.disableConfigMap")
-      .doc("If true, disable ConfigMap creation for executors.")
+      .doc("If true, disable ConfigMap creation for executors. Deprecated since 3.5.0 as spark " +
+        "will propagate config map from the driver pod to executor pod, which wouldn't create " +
+        "new config map.")
       .version("3.2.0")
       .booleanConf
       .createWithDefault(false)

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -388,9 +388,7 @@ private[spark] object Config extends Logging {
 
   val KUBERNETES_EXECUTOR_DISABLE_CONFIGMAP =
     ConfigBuilder("spark.kubernetes.executor.disableConfigMap")
-      .doc("If true, disable ConfigMap creation for executors. Deprecated since 3.5.0 as spark " +
-        "will propagate config map from the driver pod to executor pod, which wouldn't create " +
-        "new config map.")
+      .doc("If true, disable ConfigMap creation for executors.")
       .version("3.2.0")
       .booleanConf
       .createWithDefault(false)

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientApplication.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientApplication.scala
@@ -103,8 +103,10 @@ private[spark] class Client(
   def run(): Unit = {
     val resolvedDriverSpec = builder.buildFromFeatures(conf, kubernetesClient)
     val configMapName = KubernetesClientUtils.configMapNameDriver
+    // propagate the config map name to the driver pod
+    val additionalSystemProperties = Map(SPARK_CONF_DIR_CONFIG_MAP_NAME.key -> configMapName)
     val confFilesMap = KubernetesClientUtils.buildSparkConfDirFilesMap(configMapName,
-      conf.sparkConf, resolvedDriverSpec.systemProperties)
+      conf.sparkConf, resolvedDriverSpec.systemProperties ++ additionalSystemProperties)
     val configMap = KubernetesClientUtils.buildConfigMap(configMapName, confFilesMap +
         (KUBERNETES_NAMESPACE.key -> conf.namespace))
 

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackend.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackend.scala
@@ -110,7 +110,8 @@ private[spark] class KubernetesClusterSchedulerBackend(
     lifecycleEventHandler.start(this)
     watchEvents.start(applicationId())
     pollEvents.start(applicationId())
-    if (!conf.get(KUBERNETES_DRIVER_SUBMIT_CHECK)) {
+    if (!conf.get(KUBERNETES_DRIVER_SUBMIT_CHECK) &&
+      !conf.get(KUBERNETES_EXECUTOR_DISABLE_CONFIGMAP)) {
       // this spark app is submitted as k8s-client, the spark conf dir config map should be
       // created and mounted
       setUpExecutorConfigMap(podAllocator.driverPod)
@@ -160,7 +161,8 @@ private[spark] class KubernetesClusterSchedulerBackend(
 
       podAllocator.stop(applicationId())
 
-      if (!conf.get(KUBERNETES_EXECUTOR_DISABLE_CONFIGMAP)) {
+      if (!conf.get(KUBERNETES_DRIVER_SUBMIT_CHECK) &&
+        !conf.get(KUBERNETES_EXECUTOR_DISABLE_CONFIGMAP)) {
         Utils.tryLogNonFatalError {
           kubernetesClient
             .configMaps()

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackend.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackend.scala
@@ -110,7 +110,9 @@ private[spark] class KubernetesClusterSchedulerBackend(
     lifecycleEventHandler.start(this)
     watchEvents.start(applicationId())
     pollEvents.start(applicationId())
-    if (!conf.get(KUBERNETES_EXECUTOR_DISABLE_CONFIGMAP)) {
+    if (!conf.get(KUBERNETES_DRIVER_SUBMIT_CHECK)) {
+      // this spark app is submitted as k8s-client, the spark conf dir config map should be
+      // created and mounted
       setUpExecutorConfigMap(podAllocator.driverPod)
     }
   }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackend.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackend.scala
@@ -110,8 +110,8 @@ private[spark] class KubernetesClusterSchedulerBackend(
     lifecycleEventHandler.start(this)
     watchEvents.start(applicationId())
     pollEvents.start(applicationId())
-    if (!conf.get(KUBERNETES_DRIVER_SUBMIT_CHECK) &&
-      !conf.get(KUBERNETES_EXECUTOR_DISABLE_CONFIGMAP)) {
+    if (!conf.get(KUBERNETES_EXECUTOR_DISABLE_CONFIGMAP) &&
+      !conf.get(KUBERNETES_DRIVER_SUBMIT_CHECK)) {
       // this spark app is submitted as k8s-client, the spark conf dir config map should be
       // created and mounted
       setUpExecutorConfigMap(podAllocator.driverPod)
@@ -161,8 +161,8 @@ private[spark] class KubernetesClusterSchedulerBackend(
 
       podAllocator.stop(applicationId())
 
-      if (!conf.get(KUBERNETES_DRIVER_SUBMIT_CHECK) &&
-        !conf.get(KUBERNETES_EXECUTOR_DISABLE_CONFIGMAP)) {
+      if (!conf.get(KUBERNETES_EXECUTOR_DISABLE_CONFIGMAP) &&
+        !conf.get(KUBERNETES_DRIVER_SUBMIT_CHECK)) {
         Utils.tryLogNonFatalError {
           kubernetesClient
             .configMaps()

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/SecretVolumeUtils.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/SecretVolumeUtils.scala
@@ -28,6 +28,14 @@ private[spark] object SecretVolumeUtils {
     }
   }
 
+  def podHasConfigMapVolume(pod: Pod, volumeName: String, configMapName: String): Boolean = {
+    pod.getSpec.getVolumes.asScala.exists { volume =>
+      volume.getName == volumeName &&
+        volume.getConfigMap != null &&
+        volume.getConfigMap.getName == configMapName
+    }
+  }
+
   def containerHasVolume(container: Container, volumeName: String, mountPath: String): Boolean = {
     container.getVolumeMounts.asScala.exists { volumeMount =>
       volumeMount.getName == volumeName && volumeMount.getMountPath == mountPath

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStepSuite.scala
@@ -356,7 +356,7 @@ class BasicExecutorFeatureStepSuite extends SparkFunSuite with BeforeAndAfter {
     assert(SecretVolumeUtils.podHasVolume(podConfigured.pod, SPARK_CONF_VOLUME_EXEC))
   }
 
-  test("SPARK-34316 Disable configmap volume on executor pod's container") {
+  ignore("SPARK-34316 Disable configmap volume on executor pod's container") {
     baseConf.set(KUBERNETES_EXECUTOR_DISABLE_CONFIGMAP, true)
     val baseDriverPod = SparkPod.initialPod()
     val step = new BasicExecutorFeatureStep(newExecutorConf(), new SecurityManager(baseConf),
@@ -377,7 +377,7 @@ class BasicExecutorFeatureStepSuite extends SparkFunSuite with BeforeAndAfter {
     assert(SecretVolumeUtils.podHasVolume(podConfigured.pod, SPARK_CONF_VOLUME_EXEC))
   }
 
-  test("SPARK-40065 Disable configmap volume on executor pod's container (non-default profile)") {
+  ignore("SPARK-40065 Disable configmap volume on executor pod's container (non-default profile)") {
     baseConf.set(KUBERNETES_EXECUTOR_DISABLE_CONFIGMAP, true)
     val baseDriverPod = SparkPod.initialPod()
     val rp = new ResourceProfileBuilder().build()

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/ClientSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/ClientSuite.scala
@@ -33,7 +33,7 @@ import org.scalatestplus.mockito.MockitoSugar._
 
 import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.deploy.k8s.{Config, _}
-import org.apache.spark.deploy.k8s.Config._
+import org.apache.spark.deploy.k8s.Config.{SPARK_CONF_DIR_CONFIG_MAP_NAME, WAIT_FOR_APP_COMPLETION}
 import org.apache.spark.deploy.k8s.Constants._
 import org.apache.spark.deploy.k8s.Fabric8Aliases._
 import org.apache.spark.deploy.k8s.submit.Client.submissionId


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. reuse SPARK_CONF_DIR config map for executor pods when the cm is already created for driver pod
2. deprecated `spark.kubernetes.executor.disableConfigMap` as it may not be needed any more
3. create config map for executor when running on k8s-client only

### Why are the changes needed?
1. avoid unnecessary config map creation and reduce overhead to K8S
2. code optimize to avoid unnecessary disk file scan to create spark conf config map

### Does this PR introduce _any_ user-facing change?
Yes.  `spark.kubernetes.executor.disableConfigMap` is deprecated and may not be necessary.

### How was this patch tested?
Added UTs.