### PR TITLE
[SPARK-43719][WEBUI] Handle `missing row.excludedInStages` field

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/executorspage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/executorspage.js
@@ -45,7 +45,7 @@ function formatStatus(status, type, row) {
   }
 
   if (status) {
-    if (row.excludedInStages.length == 0) {
+    if (typeof row.excludedInStages === "undefined" || row.excludedInStages.length == 0) {
       return "Active"
     }
     return "Active (Excluded in Stages: [" + row.excludedInStages.join(", ") + "])";


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to handle a corner case when `row.excludedInStages` field is missing.

### Why are the changes needed?

To fix the following type error when Spark loads some very old 2.4.x or 3.0.x logs.

![missing](https://github.com/apache/spark/assets/9700541/f402df10-bf92-4c9f-8bd1-ec9b98a67966)

We have two places and this PR protects both places.
```
$ git grep row.excludedInStages
core/src/main/resources/org/apache/spark/ui/static/executorspage.js:    if (typeof row.excludedInStages === "undefined" || row.excludedInStages.length == 0) {
core/src/main/resources/org/apache/spark/ui/static/executorspage.js:    return "Active (Excluded in Stages: [" + row.excludedInStages.join(", ") + "])";
```

### Does this PR introduce _any_ user-facing change?

No, this will remove the error case only.

### How was this patch tested?

Manual review.