### PR TITLE
[SPARK-43718][SQL] Set nullable correctly for keys in USING joins

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -3433,18 +3433,21 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
     // the output list looks like: join keys, columns from left, columns from right
     val (projectList, hiddenList) = joinType match {
       case LeftOuter =>
-        (leftKeys ++ lUniqueOutput ++ rUniqueOutput.map(_.withNullability(true)), rightKeys)
+        (leftKeys ++ lUniqueOutput ++ rUniqueOutput.map(_.withNullability(true)),
+          rightKeys.map(_.withNullability(true)))
       case LeftExistence(_) =>
         (leftKeys ++ lUniqueOutput, Seq.empty)
       case RightOuter =>
-        (rightKeys ++ lUniqueOutput.map(_.withNullability(true)) ++ rUniqueOutput, leftKeys)
+        (rightKeys ++ lUniqueOutput.map(_.withNullability(true)) ++ rUniqueOutput,
+          leftKeys.map(_.withNullability(true)))
       case FullOuter =>
         // in full outer join, joinCols should be non-null if there is.
         val joinedCols = joinPairs.map { case (l, r) => Alias(Coalesce(Seq(l, r)), l.name)() }
         (joinedCols ++
           lUniqueOutput.map(_.withNullability(true)) ++
           rUniqueOutput.map(_.withNullability(true)),
-          leftKeys ++ rightKeys)
+          leftKeys.map(_.withNullability(true)) ++
+          rightKeys.map(_.withNullability(true)))
       case _ : InnerLike =>
         (leftKeys ++ lUniqueOutput ++ rUniqueOutput, rightKeys)
       case _ =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
@@ -1491,7 +1491,7 @@ class JoinSuite extends QueryTest with SharedSparkSession with AdaptiveSparkPlan
     dupStreamSideColTest("SHUFFLE_HASH", check)
   }
 
-  test("Using with references to key columns: Full Outer") {
+  test("SPARK-43718: USING with references to key columns: Full Outer") {
     withTempView("t1", "t2") {
       sql("create or replace temp view t1 as values (1), (2), (3) as (c1)")
       sql("create or replace temp view t2 as values (2), (3), (4) as (c1)")
@@ -1508,7 +1508,8 @@ class JoinSuite extends QueryTest with SharedSparkSession with AdaptiveSparkPlan
       checkAnswer(sql(query), expected)
     }
   }
-  test("Using with references to key columns: Left Outer") {
+
+  test("SPARK-43718: USING with references to key columns: Left Outer") {
     withTempView("t1", "t2") {
       sql("create or replace temp view t1 as values (1), (2), (3) as (c1)")
       sql("create or replace temp view t2 as values (2), (3), (4) as (c1)")
@@ -1526,7 +1527,7 @@ class JoinSuite extends QueryTest with SharedSparkSession with AdaptiveSparkPlan
     }
   }
 
-  test("Using with references to key columns: Right Outer") {
+  test("SPARK-43718: USING with references to key columns: Right Outer") {
     withTempView("t1", "t2") {
       sql("create or replace temp view t1 as values (1), (2), (3) as (c1)")
       sql("create or replace temp view t2 as values (2), (3), (4) as (c1)")

--- a/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
@@ -1490,4 +1490,57 @@ class JoinSuite extends QueryTest with SharedSparkSession with AdaptiveSparkPlan
     }
     dupStreamSideColTest("SHUFFLE_HASH", check)
   }
+
+  test("Using with references to key columns: Full Outer") {
+    withTempView("t1", "t2") {
+      sql("create or replace temp view t1 as values (1), (2), (3) as (c1)")
+      sql("create or replace temp view t2 as values (2), (3), (4) as (c1)")
+
+      val query =
+        """select explode(array(t1.c1, t2.c1)) as x1
+          |from t1
+          |full outer join t2
+          |using (c1)
+          |""".stripMargin
+
+      val expected = Seq(Row(1), Row(2), Row(2), Row(3), Row(3), Row(4), Row(null), Row(null))
+
+      checkAnswer(sql(query), expected)
+    }
+  }
+  test("Using with references to key columns: Left Outer") {
+    withTempView("t1", "t2") {
+      sql("create or replace temp view t1 as values (1), (2), (3) as (c1)")
+      sql("create or replace temp view t2 as values (2), (3), (4) as (c1)")
+
+      val query =
+        """select explode(array(t1.c1, t2.c1)) as x1
+          |from t1
+          |left outer join t2
+          |using (c1)
+          |""".stripMargin
+
+      val expected = Seq(Row(1), Row(2), Row(2), Row(3), Row(3), Row(null))
+
+      checkAnswer(sql(query), expected)
+    }
+  }
+
+  test("Using with references to key columns: Right Outer") {
+    withTempView("t1", "t2") {
+      sql("create or replace temp view t1 as values (1), (2), (3) as (c1)")
+      sql("create or replace temp view t2 as values (2), (3), (4) as (c1)")
+
+      val query =
+        """select explode(array(t1.c1, t2.c1)) as x1
+          |from t1
+          |right outer join t2
+          |using (c1)
+          |""".stripMargin
+
+      val expected = Seq(Row(2), Row(2), Row(3), Row(3), Row(4), Row(null))
+
+      checkAnswer(sql(query), expected)
+    }
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

In `Anaylzer#commonNaturalJoinProcessing`, set nullable correctly when adding the join keys to the Project's hidden_output tag.

### Why are the changes needed?

The value of the hidden_output tag will be used for resolution of attributes in parent operators, so incorrect nullabilty can cause problems.

For example, assume this data:
```
create or replace temp view t1 as values (1), (2), (3) as (c1);
create or replace temp view t2 as values (2), (3), (4) as (c1);
```
The following query produces incorrect results:
```
spark-sql (default)> select explode(array(t1.c1, t2.c1)) as x1
from t1
full outer join t2
using (c1);
1
-1      <== should be null
2
2
3
3
-1      <== should be null
4
Time taken: 0.663 seconds, Fetched 8 row(s)
spark-sql (default)> 
```
Similar issues occur with right outer join and left outer join.

`t1.c1` and `t2.c1` have the wrong nullability at the time the array is resolved, so the array's `containsNull` value is incorrect.

`UpdateNullability` will update the nullability of `t1.c1` and `t2.c1` in the `CreateArray` arguments, but will not update `containsNull` in the function's data type.

Queries that don't use arrays also can get wrong results. Assume this data:
```
create or replace temp view t1 as values (0), (1), (2) as (c1);
create or replace temp view t2 as values (1), (2), (3) as (c1);
create or replace temp view t3 as values (1, 2), (3, 4), (4, 5) as (a, b);
```
The following query produces incorrect results:
```
select t1.c1 as t1_c1, t2.c1 as t2_c1, b
from t1
full outer join t2
using (c1),
lateral (
  select b
  from t3
  where a = coalesce(t2.c1, 1)
) lt3;
1	1	2
NULL	3	4
Time taken: 2.395 seconds, Fetched 2 row(s)
spark-sql (default)> 
```
The result should be the following:
```
0	NULL	2
1	1	2
NULL	3	4
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

New tests.
