### PR TITLE
[SPARK-43737][BUILD] Upgrade zstd-jni to 1.5.5-3

### DIFF
--- a/core/benchmarks/ZStandardBenchmark-jdk11-results.txt
+++ b/core/benchmarks/ZStandardBenchmark-jdk11-results.txt
@@ -2,26 +2,26 @@
 Benchmark ZStandardCompressionCodec
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1036-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 11.0.19+7 on Linux 5.15.0-1037-azure
+Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 Benchmark ZStandardCompressionCodec:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------
-Compression 10000 times at level 1 without buffer pool           1074           1076           3          0.0      107421.2       1.0X
-Compression 10000 times at level 2 without buffer pool           1056           1056           0          0.0      105604.6       1.0X
-Compression 10000 times at level 3 without buffer pool           1297           1298           1          0.0      129748.3       0.8X
-Compression 10000 times at level 1 with buffer pool               305            317          13          0.0       30513.4       3.5X
-Compression 10000 times at level 2 with buffer pool               386            408          17          0.0       38550.2       2.8X
-Compression 10000 times at level 3 with buffer pool               603            605           2          0.0       60250.7       1.8X
+Compression 10000 times at level 1 without buffer pool            803            814          14          0.0       80302.2       1.0X
+Compression 10000 times at level 2 without buffer pool            677            688          17          0.0       67706.0       1.2X
+Compression 10000 times at level 3 without buffer pool            929            943          23          0.0       92943.2       0.9X
+Compression 10000 times at level 1 with buffer pool               360            371           8          0.0       36037.2       2.2X
+Compression 10000 times at level 2 with buffer pool               451            463          11          0.0       45141.1       1.8X
+Compression 10000 times at level 3 with buffer pool               684            697          11          0.0       68384.5       1.2X
 
-OpenJDK 64-Bit Server VM 11.0.18+10 on Linux 5.15.0-1036-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 11.0.19+7 on Linux 5.15.0-1037-azure
+Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 Benchmark ZStandardCompressionCodec:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------
-Decompression 10000 times from level 1 without buffer pool           1321           1330          14          0.0      132085.8       1.0X
-Decompression 10000 times from level 2 without buffer pool           1291           1308          25          0.0      129084.5       1.0X
-Decompression 10000 times from level 3 without buffer pool           1291           1291           0          0.0      129085.2       1.0X
-Decompression 10000 times from level 1 with buffer pool               966            966           0          0.0       96569.8       1.4X
-Decompression 10000 times from level 2 with buffer pool               970            984          13          0.0       96992.1       1.4X
-Decompression 10000 times from level 3 with buffer pool               965           1007          37          0.0       96530.0       1.4X
+Decompression 10000 times from level 1 without buffer pool            769            779          15          0.0       76920.7       1.0X
+Decompression 10000 times from level 2 without buffer pool            758            775          19          0.0       75783.4       1.0X
+Decompression 10000 times from level 3 without buffer pool            762            776          20          0.0       76180.9       1.0X
+Decompression 10000 times from level 1 with buffer pool               533            548          11          0.0       53271.9       1.4X
+Decompression 10000 times from level 2 with buffer pool               521            523           2          0.0       52073.6       1.5X
+Decompression 10000 times from level 3 with buffer pool               515            525           8          0.0       51469.0       1.5X
 
 

--- a/core/benchmarks/ZStandardBenchmark-jdk17-results.txt
+++ b/core/benchmarks/ZStandardBenchmark-jdk17-results.txt
@@ -2,26 +2,26 @@
 Benchmark ZStandardCompressionCodec
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1036-azure
+OpenJDK 64-Bit Server VM 17.0.7+7 on Linux 5.15.0-1037-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Benchmark ZStandardCompressionCodec:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------
-Compression 10000 times at level 1 without buffer pool           2285           2286           1          0.0      228515.4       1.0X
-Compression 10000 times at level 2 without buffer pool           2206           2540         473          0.0      220612.4       1.0X
-Compression 10000 times at level 3 without buffer pool           2396           2402           8          0.0      239645.1       1.0X
-Compression 10000 times at level 1 with buffer pool              2054           2056           2          0.0      205401.6       1.1X
-Compression 10000 times at level 2 with buffer pool              2104           2107           5          0.0      210352.6       1.1X
-Compression 10000 times at level 3 with buffer pool              2302           2306           6          0.0      230178.4       1.0X
+Compression 10000 times at level 1 without buffer pool           2289           2293           5          0.0      228903.7       1.0X
+Compression 10000 times at level 2 without buffer pool           2184           2260         107          0.0      218405.7       1.0X
+Compression 10000 times at level 3 without buffer pool           2393           2394           2          0.0      239296.0       1.0X
+Compression 10000 times at level 1 with buffer pool              1965           1966           2          0.0      196462.2       1.2X
+Compression 10000 times at level 2 with buffer pool              2031           2032           3          0.0      203063.0       1.1X
+Compression 10000 times at level 3 with buffer pool              2222           2224           2          0.0      222247.8       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.6+10 on Linux 5.15.0-1036-azure
+OpenJDK 64-Bit Server VM 17.0.7+7 on Linux 5.15.0-1037-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Benchmark ZStandardCompressionCodec:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------
-Decompression 10000 times from level 1 without buffer pool           2120           2124           5          0.0      212043.2       1.0X
-Decompression 10000 times from level 2 without buffer pool           2126           2130           6          0.0      212560.3       1.0X
-Decompression 10000 times from level 3 without buffer pool           2122           2124           3          0.0      212227.1       1.0X
-Decompression 10000 times from level 1 with buffer pool              1958           1959           2          0.0      195798.8       1.1X
-Decompression 10000 times from level 2 with buffer pool              1959           1960           2          0.0      195918.1       1.1X
-Decompression 10000 times from level 3 with buffer pool              1965           1968           3          0.0      196533.7       1.1X
+Decompression 10000 times from level 1 without buffer pool           2120           2121           1          0.0      211953.8       1.0X
+Decompression 10000 times from level 2 without buffer pool           2118           2123           7          0.0      211828.0       1.0X
+Decompression 10000 times from level 3 without buffer pool           2126           2127           1          0.0      212600.3       1.0X
+Decompression 10000 times from level 1 with buffer pool              1955           1956           2          0.0      195464.7       1.1X
+Decompression 10000 times from level 2 with buffer pool              1956           1956           0          0.0      195566.8       1.1X
+Decompression 10000 times from level 3 with buffer pool              1958           1960           2          0.0      195813.0       1.1X
 
 

--- a/core/benchmarks/ZStandardBenchmark-results.txt
+++ b/core/benchmarks/ZStandardBenchmark-results.txt
@@ -2,26 +2,26 @@
 Benchmark ZStandardCompressionCodec
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1036-azure
-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1037-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Benchmark ZStandardCompressionCodec:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------
-Compression 10000 times at level 1 without buffer pool            815            854          39          0.0       81531.3       1.0X
-Compression 10000 times at level 2 without buffer pool            744            750           5          0.0       74444.2       1.1X
-Compression 10000 times at level 3 without buffer pool           1005           1009           5          0.0      100524.4       0.8X
-Compression 10000 times at level 1 with buffer pool               384            388           3          0.0       38388.7       2.1X
-Compression 10000 times at level 2 with buffer pool               480            494          12          0.0       48017.6       1.7X
-Compression 10000 times at level 3 with buffer pool               732            753          26          0.0       73192.6       1.1X
+Compression 10000 times at level 1 without buffer pool            391            524         152          0.0       39064.0       1.0X
+Compression 10000 times at level 2 without buffer pool            448            451           2          0.0       44798.2       0.9X
+Compression 10000 times at level 3 without buffer pool            637            644           5          0.0       63736.0       0.6X
+Compression 10000 times at level 1 with buffer pool               194            197           3          0.1       19357.1       2.0X
+Compression 10000 times at level 2 with buffer pool               245            251           4          0.0       24535.1       1.6X
+Compression 10000 times at level 3 with buffer pool               414            426           7          0.0       41389.3       0.9X
 
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1036-azure
-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1037-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Benchmark ZStandardCompressionCodec:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------
-Decompression 10000 times from level 1 without buffer pool            800            808           8          0.0       79950.8       1.0X
-Decompression 10000 times from level 2 without buffer pool            808            821          18          0.0       80750.5       1.0X
-Decompression 10000 times from level 3 without buffer pool            820            831          11          0.0       82019.0       1.0X
-Decompression 10000 times from level 1 with buffer pool               550            561           9          0.0       54984.8       1.5X
-Decompression 10000 times from level 2 with buffer pool               554            560           5          0.0       55370.0       1.4X
-Decompression 10000 times from level 3 with buffer pool               553            569          14          0.0       55272.1       1.4X
+Decompression 10000 times from level 1 without buffer pool            684            685           2          0.0       68350.8       1.0X
+Decompression 10000 times from level 2 without buffer pool            682            683           2          0.0       68170.9       1.0X
+Decompression 10000 times from level 3 without buffer pool            680            683           2          0.0       68002.2       1.0X
+Decompression 10000 times from level 1 with buffer pool               493            495           1          0.0       49339.8       1.4X
+Decompression 10000 times from level 2 with buffer pool               493            495           1          0.0       49283.2       1.4X
+Decompression 10000 times from level 3 with buffer pool               494            495           1          0.0       49350.3       1.4X
 
 

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -252,4 +252,4 @@ xz/1.9//xz-1.9.jar
 zjsonpatch/0.3.0//zjsonpatch-0.3.0.jar
 zookeeper-jute/3.6.3//zookeeper-jute-3.6.3.jar
 zookeeper/3.6.3//zookeeper-3.6.3.jar
-zstd-jni/1.5.5-2//zstd-jni-1.5.5-2.jar
+zstd-jni/1.5.5-3//zstd-jni-1.5.5-3.jar

--- a/pom.xml
+++ b/pom.xml
@@ -781,7 +781,7 @@
       <dependency>
         <groupId>com.github.luben</groupId>
         <artifactId>zstd-jni</artifactId>
-        <version>1.5.5-2</version>
+        <version>1.5.5-3</version>
       </dependency>
       <dependency>
         <groupId>com.clearspring.analytics</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims upgrade `zstd-jni` from 1.5.5-2 to 1.5.5-3.

### Why are the changes needed?
New version includes some improvement & bug fixed, eg
- https://github.com/luben/zstd-jni/pull/258
- https://github.com/luben/zstd-jni/pull/262
- https://github.com/luben/zstd-jni/issues/253
    
Other changes as follows:
- https://github.com/luben/zstd-jni/compare/v1.5.5-2...v1.5.5-3

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Pass GA.