### PR TITLE
[SPARK-43738][BUILD] Upgrade dropwizard metrics 4.2.18

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -177,11 +177,11 @@ log4j-slf4j2-impl/2.20.0//log4j-slf4j2-impl-2.20.0.jar
 logging-interceptor/3.12.12//logging-interceptor-3.12.12.jar
 lz4-java/1.8.0//lz4-java-1.8.0.jar
 mesos/1.4.3/shaded-protobuf/mesos-1.4.3-shaded-protobuf.jar
-metrics-core/4.2.17//metrics-core-4.2.17.jar
-metrics-graphite/4.2.17//metrics-graphite-4.2.17.jar
-metrics-jmx/4.2.17//metrics-jmx-4.2.17.jar
-metrics-json/4.2.17//metrics-json-4.2.17.jar
-metrics-jvm/4.2.17//metrics-jvm-4.2.17.jar
+metrics-core/4.2.18//metrics-core-4.2.18.jar
+metrics-graphite/4.2.18//metrics-graphite-4.2.18.jar
+metrics-jmx/4.2.18//metrics-jmx-4.2.18.jar
+metrics-json/4.2.18//metrics-json-4.2.18.jar
+metrics-jvm/4.2.18//metrics-jvm-4.2.18.jar
 minlog/1.3.0//minlog-1.3.0.jar
 netty-all/4.1.92.Final//netty-all-4.1.92.Final.jar
 netty-buffer/4.1.92.Final//netty-buffer-4.1.92.Final.jar

--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
     If you changes codahale.metrics.version, you also need to change
     the link to metrics.dropwizard.io in docs/monitoring.md.
     -->
-    <codahale.metrics.version>4.2.17</codahale.metrics.version>
+    <codahale.metrics.version>4.2.18</codahale.metrics.version>
     <!-- Should be consistent with SparkBuild.scala and docs -->
     <avro.version>1.11.1</avro.version>
     <aws.kinesis.client.version>1.12.0</aws.kinesis.client.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims upgrade dropwizard metrics to 4.2.18.

### Why are the changes needed?
- 4.2.17 VS 4.2.18: https://github.com/dropwizard/metrics/compare/v4.2.17...v4.2.18
- This version relies on jetty9 v9.4.51.v20230217 for compilation, and Spark is currently using this version as well
[Update jetty9.version to v9.4.51.v20230217](https://github.com/dropwizard/metrics/commit/245c516ada98986026ebf505f8c2698737207cb2)

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA.