### PR TITLE
[SPARK-43739][BUILD] Upgrade commons-io to 2.12.0

### DIFF
--- a/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
+++ b/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.avro
 
 import java.io._
 import java.net.URL
-import java.nio.file.{Files, Paths, StandardCopyOption}
+import java.nio.file.{Files, NoSuchFileException, Paths, StandardCopyOption}
 import java.sql.{Date, Timestamp}
 import java.util.{Locale, UUID}
 
@@ -1349,7 +1349,7 @@ abstract class AvroSuite
       spark.read.format("avro").load("*/*/*/*/*/*/*/something.avro")
     }
 
-    intercept[IOException] {
+    intercept[NoSuchFileException] {
       withTempPath { dir =>
         FileUtils.touch(new File(dir, "test"))
         withSQLConf(AvroFileFormat.IgnoreFilesWithoutExtensionProperty -> "true") {
@@ -1358,7 +1358,7 @@ abstract class AvroSuite
       }
     }
 
-    intercept[IOException] {
+    intercept[NoSuchFileException] {
       withTempPath { dir =>
         FileUtils.touch(new File(dir, "test"))
 

--- a/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
+++ b/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
@@ -1349,7 +1349,7 @@ abstract class AvroSuite
       spark.read.format("avro").load("*/*/*/*/*/*/*/something.avro")
     }
 
-    intercept[FileNotFoundException] {
+    intercept[IOException] {
       withTempPath { dir =>
         FileUtils.touch(new File(dir, "test"))
         withSQLConf(AvroFileFormat.IgnoreFilesWithoutExtensionProperty -> "true") {
@@ -1358,7 +1358,7 @@ abstract class AvroSuite
       }
     }
 
-    intercept[FileNotFoundException] {
+    intercept[IOException] {
       withTempPath { dir =>
         FileUtils.touch(new File(dir, "test"))
 

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -41,9 +41,9 @@ commons-collections/3.2.2//commons-collections-3.2.2.jar
 commons-collections4/4.4//commons-collections4-4.4.jar
 commons-compiler/3.1.9//commons-compiler-3.1.9.jar
 commons-compress/1.23.0//commons-compress-1.23.0.jar
-commons-crypto/1.1.0//commons-crypto-1.1.0.jar
+commons-crypto/1.2.0//commons-crypto-1.2.0.jar
 commons-dbcp/1.4//commons-dbcp-1.4.jar
-commons-io/2.11.0//commons-io-2.11.0.jar
+commons-io/2.12.0//commons-io-2.12.0.jar
 commons-lang/2.6//commons-lang-2.6.jar
 commons-lang3/3.12.0//commons-lang3-3.12.0.jar
 commons-logging/1.1.3//commons-logging-1.1.3.jar

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -41,7 +41,7 @@ commons-collections/3.2.2//commons-collections-3.2.2.jar
 commons-collections4/4.4//commons-collections4-4.4.jar
 commons-compiler/3.1.9//commons-compiler-3.1.9.jar
 commons-compress/1.23.0//commons-compress-1.23.0.jar
-commons-crypto/1.2.0//commons-crypto-1.2.0.jar
+commons-crypto/1.1.0//commons-crypto-1.1.0.jar
 commons-dbcp/1.4//commons-dbcp-1.4.jar
 commons-io/2.12.0//commons-io-2.12.0.jar
 commons-lang/2.6//commons-lang-2.6.jar

--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,7 @@
     <netlib.ludovic.dev.version>3.0.3</netlib.ludovic.dev.version>
     <commons-codec.version>1.15</commons-codec.version>
     <commons-compress.version>1.23.0</commons-compress.version>
-    <commons-io.version>2.11.0</commons-io.version>
+    <commons-io.version>2.12.0</commons-io.version>
     <!-- org.apache.commons/commons-lang/-->
     <commons-lang2.version>2.6</commons-lang2.version>
     <!-- org.apache.commons/commons-lang3/-->


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade common-io from 2.11.0 to 2.12.0.


### Why are the changes needed?
common-io new version includes some improvement & bug fixed, eg
- https://github.com/apache/commons-io/pull/450
- https://github.com/apache/commons-io/pull/368
- [Add PathUtils.touch(Path)](https://github.com/apache/commons-io/commit/fd7c8182d2117d01f43ccc9fe939105f834ba672) The error exception of the FileUtils.touch method has been changed from `java.io.FileNotFoundException` to `java.nio.file.NoSuchFileException`
- common-io 2.11.0 VS 2.12.0
https://github.com/apache/commons-io/compare/rel/commons-io-2.11.0...rel/commons-io-2.12.0


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA.