### PR TITLE
[SPARK-43743][SQL] Port HIVE-12188(DoAs does not work properly in non-kerberos secured HS2)

### DIFF
--- a/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/thrift/ThriftCLIService.java
+++ b/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/thrift/ThriftCLIService.java
@@ -383,7 +383,7 @@ public abstract class ThriftCLIService extends AbstractService implements TCLISe
       return cliService.getDelegationTokenFromMetaStore(userName);
     } catch (UnsupportedOperationException e) {
       // The delegation token is not applicable in the given deployment mode
-      // such as HMS is not kerberos secured 
+      // such as HMS is not kerberos secured
     }
     return null;
   }

--- a/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/thrift/ThriftCLIService.java
+++ b/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/thrift/ThriftCLIService.java
@@ -379,14 +379,11 @@ public abstract class ThriftCLIService extends AbstractService implements TCLISe
 
   private String getDelegationToken(String userName)
       throws HiveSQLException, LoginException, IOException {
-    if (userName == null || !cliService.getHiveConf().getVar(ConfVars.HIVE_SERVER2_AUTHENTICATION)
-        .equalsIgnoreCase(HiveAuthFactory.AuthTypes.KERBEROS.toString())) {
-      return null;
-    }
     try {
       return cliService.getDelegationTokenFromMetaStore(userName);
     } catch (UnsupportedOperationException e) {
       // The delegation token is not applicable in the given deployment mode
+      // such as HMS is not kerberos secured 
     }
     return null;
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR port [HIVE-12188](https://issues.apache.org/jira/browse/HIVE-12188)(DoAs does not work properly in non-kerberos secure HS2) to Spark.

### Why are the changes needed?

The case with following settings is valid but it seems still not work correctly in current HS2(Copied from HIVE-12188's description):
```
hive.server2.authentication=NONE (or LDAP)
hive.server2.enable.doAs=true
hive.metastore.sasl.enabled=true (with HMS Kerberos enabled)
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual test.
