### PR TITLE
[SPARK-38464][CORE] Use error classes in org.apache.spark.io

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -189,7 +189,12 @@
   },
   "CODEC_NOT_AVAILABLE" : {
     "message" : [
-      "Codec [<codecName>] is not available. Consider setting <configKey>=<configVal>"
+      "The codec <codecName> is not available. Consider to set the config <configKey> to <configVal>."
+    ]
+  },
+  "CODEC_SHORT_NAME_NOT_FOUND" : {
+    "message" : [
+      "Cannot find a short name for the codec <codecName>."
     ]
   },
   "COLUMN_ALIASES_IS_NOT_ALLOWED" : {
@@ -1388,11 +1393,6 @@
   "NO_HANDLER_FOR_UDAF" : {
     "message" : [
       "No handler for UDAF '<functionName>'. Use sparkSession.udf.register(...) instead."
-    ]
-  },
-  "NO_SHORT_NAME_FOR_CODEC" : {
-    "message" : [
-      "No short name for codec <codecName>."
     ]
   },
   "NO_SQL_TYPE_IN_PROTOBUF_SCHEMA" : {

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -187,6 +187,11 @@
     ],
     "sqlState" : "22003"
   },
+  "CODEC_NOT_AVAILABLE" : {
+    "message" : [
+      "Codec [<codecName>] is not available. Consider setting <configKey>=<configVal>"
+    ]
+  },
   "COLUMN_ALIASES_IS_NOT_ALLOWED" : {
     "message" : [
       "Columns aliases are not allowed in <op>."
@@ -1383,6 +1388,11 @@
   "NO_HANDLER_FOR_UDAF" : {
     "message" : [
       "No handler for UDAF '<functionName>'. Use sparkSession.udf.register(...) instead."
+    ]
+  },
+  "NO_SHORT_NAME_FOR_CODEC" : {
+    "message" : [
+      "No short name for codec <codecName>."
     ]
   },
   "NO_SQL_TYPE_IN_PROTOBUF_SCHEMA" : {

--- a/core/src/main/scala/org/apache/spark/errors/SparkCoreErrors.scala
+++ b/core/src/main/scala/org/apache/spark/errors/SparkCoreErrors.scala
@@ -466,4 +466,16 @@ private[spark] object SparkCoreErrors {
         "requestedBytes" -> requestedBytes.toString,
         "receivedBytes" -> receivedBytes.toString).asJava)
   }
+
+  private def quoteByDefault(elem: String): String = {
+    "\"" + elem + "\""
+  }
+
+  def toConf(conf: String): String = {
+    quoteByDefault(conf)
+  }
+
+  def toConfVal(conf: String): String = {
+    quoteByDefault(conf)
+  }
 }

--- a/core/src/main/scala/org/apache/spark/io/CompressionCodec.scala
+++ b/core/src/main/scala/org/apache/spark/io/CompressionCodec.scala
@@ -107,7 +107,7 @@ private[spark] object CompressionCodec {
       shortCompressionCodecNames
         .collectFirst { case (k, v) if v == codecName => k }
         .getOrElse { throw new SparkIllegalArgumentException(
-          errorClass = "NO_SHORT_NAME_FOR_CODEC",
+          errorClass = "CODEC_SHORT_NAME_NOT_FOUND",
           messageParameters = Map("codecName" -> codecName))}
     }
   }

--- a/core/src/main/scala/org/apache/spark/io/CompressionCodec.scala
+++ b/core/src/main/scala/org/apache/spark/io/CompressionCodec.scala
@@ -28,6 +28,7 @@ import org.xerial.snappy.{Snappy, SnappyInputStream, SnappyOutputStream}
 
 import org.apache.spark.{SparkConf, SparkIllegalArgumentException}
 import org.apache.spark.annotation.DeveloperApi
+import org.apache.spark.errors.SparkCoreErrors.{toConf, toConfVal}
 import org.apache.spark.internal.config._
 import org.apache.spark.util.Utils
 
@@ -92,8 +93,8 @@ private[spark] object CompressionCodec {
       errorClass = "CODEC_NOT_AVAILABLE",
       messageParameters = Map(
         "codecName" -> codecName,
-        "configKey" -> configKey,
-        "configVal" -> FALLBACK_COMPRESSION_CODEC)))
+        "configKey" -> toConf(configKey),
+        "configVal" -> toConfVal(FALLBACK_COMPRESSION_CODEC))))
   }
 
   /**

--- a/core/src/test/scala/org/apache/spark/io/CompressionCodecSuite.scala
+++ b/core/src/test/scala/org/apache/spark/io/CompressionCodecSuite.scala
@@ -134,8 +134,8 @@ class CompressionCodecSuite extends SparkFunSuite {
       errorClass = "CODEC_NOT_AVAILABLE",
       parameters = Map(
         "codecName" -> "foobar",
-        "configKey" -> "spark.io.compression.codec",
-        "configVal" -> "snappy"
+        "configKey" -> "\"spark.io.compression.codec\"",
+        "configVal" -> "\"snappy\""
       )
     )
   }

--- a/core/src/test/scala/org/apache/spark/io/CompressionCodecSuite.scala
+++ b/core/src/test/scala/org/apache/spark/io/CompressionCodecSuite.scala
@@ -21,7 +21,7 @@ import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
 
 import com.google.common.io.ByteStreams
 
-import org.apache.spark.{SparkConf, SparkFunSuite}
+import org.apache.spark.{SparkConf, SparkFunSuite, SparkIllegalArgumentException}
 import org.apache.spark.internal.config.IO_COMPRESSION_ZSTD_BUFFERPOOL_ENABLED
 
 class CompressionCodecSuite extends SparkFunSuite {
@@ -127,9 +127,10 @@ class CompressionCodecSuite extends SparkFunSuite {
   }
 
   test("bad compression codec") {
-    intercept[IllegalArgumentException] {
+    val e = intercept[SparkIllegalArgumentException] {
       CompressionCodec.createCodec(conf, "foobar")
     }
+    assert(e.getErrorClass == "CODEC_NOT_AVAILABLE")
   }
 
   private def testConcatenationOfSerializedStreams(codec: CompressionCodec): Unit = {

--- a/core/src/test/scala/org/apache/spark/io/CompressionCodecSuite.scala
+++ b/core/src/test/scala/org/apache/spark/io/CompressionCodecSuite.scala
@@ -127,10 +127,17 @@ class CompressionCodecSuite extends SparkFunSuite {
   }
 
   test("bad compression codec") {
-    val e = intercept[SparkIllegalArgumentException] {
-      CompressionCodec.createCodec(conf, "foobar")
-    }
-    assert(e.getErrorClass == "CODEC_NOT_AVAILABLE")
+    checkError(
+      exception = intercept[SparkIllegalArgumentException] {
+        CompressionCodec.createCodec(conf, "foobar")
+      },
+      errorClass = "CODEC_NOT_AVAILABLE",
+      parameters = Map(
+        "codecName" -> "foobar",
+        "configKey" -> "spark.io.compression.codec",
+        "configVal" -> "snappy"
+      )
+    )
   }
 
   private def testConcatenationOfSerializedStreams(codec: CompressionCodec): Unit = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to change exceptions created in package org.apache.spark.io to use error class.

This PR also adds `toConf` and `toConfVal` in `SparkCoreErrors`.


### Why are the changes needed?
This is to move exceptions created in package org.apache.spark.io to error class.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Updated existing tests.