### PR TITLE
[SPARK-43747][PYTHON][CONNECT] Implement the pyfile support in SparkSession.addArtifacts

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -1407,8 +1407,8 @@ class SparkConnectPlanner(val session: SparkSession) {
       command = fun.getCommand.toByteArray,
       // Empty environment variables
       envVars = Maps.newHashMap(),
-      // No imported Python libraries
-      pythonIncludes = Lists.newArrayList(),
+      pythonIncludes =
+        SparkConnectArtifactManager.getOrCreateArtifactManager.getSparkConnectPythonIncludes.asJava,
       pythonExec = pythonExec,
       pythonVer = fun.getPythonVer,
       // Empty broadcast variables

--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/artifact/ArtifactManagerSuite.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/artifact/ArtifactManagerSuite.scala
@@ -134,4 +134,15 @@ class ArtifactManagerSuite extends SharedSparkSession with ResourceHelper {
       }
     }
   }
+
+  test("Check Python includes when zipped package is added") {
+    withTempPath { path =>
+      val stagingPath = path.toPath
+      Files.write(path.toPath, "test".getBytes(StandardCharsets.UTF_8))
+      val session = sessionHolder()
+      val remotePath = Paths.get("pyfiles/abc.zip")
+      artifactManager.addArtifact(session, remotePath, stagingPath)
+      assert(artifactManager.getSparkConnectPythonIncludes == Seq("abc.zip"))
+    }
+  }
 }

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -1237,8 +1237,8 @@ class SparkConnectClient(object):
         else:
             raise SparkConnectGrpcException(str(rpc_error)) from None
 
-    def add_artifacts(self, *path: str) -> None:
-        self._artifact_manager.add_artifacts(*path)
+    def add_artifacts(self, *path: str, pyfile: bool) -> None:
+        self._artifact_manager.add_artifacts(*path, pyfile=pyfile)
 
 
 class RetryState:

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -618,16 +618,17 @@ class SparkSession:
         Gives access to the Spark Connect client. In normal cases this is not necessary to be used
         and only relevant for testing.
 
+        .. versionadded:: 3.4.0
+
         Returns
         -------
         :class:`SparkConnectClient`
         """
         return self._client
 
-    def addArtifacts(self, *path: str) -> None:
+    def addArtifacts(self, *path: str, pyfile: bool = False) -> None:
         """
-        Add artifact(s) to the client session. Currently only local files with .jar extension is
-        supported.
+        Add artifact(s) to the client session. Currently only local files are supported.
 
         .. versionadded:: 3.5.0
 
@@ -635,8 +636,10 @@ class SparkSession:
         ----------
         *path : tuple of str
             Artifact's URIs to add.
+        pyfile : bool
+            Whether to add them as Python dependencies such as .py, .egg, .zip or .jar files.
         """
-        self._client.add_artifacts(*path)
+        self._client.add_artifacts(*path, pyfile=pyfile)
 
     addArtifact = addArtifacts
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to add the support of pyfiles (`.zip`, `.py`, `.jar`, `.egg` files) in `SparkSession.addArtifacts`.

### Why are the changes needed?

In order for end users to add the dependencies in Python Spark Connect client.

### Does this PR introduce _any_ user-facing change?

Yes, it adds the support of pyfiles (`.zip`, `.py`, `.jar`, `.egg` files) in `SparkSession.addArtifacts`.

### How was this patch tested?

Manually tested via `local-cluster`.

```bash
./sbin/start-connect-server.sh --jars `ls connector/connect/server/target/**/spark-connect*SNAPSHOT.jar` --master "local-cluster[2,2,1024]"
./bin/pyspark --remote "sc://localhost:15002"
```

```python
import os
import tempfile
from pyspark.sql.functions import udf
import shutil

with tempfile.TemporaryDirectory() as d:
    package_path = os.path.join(d, "my_zipfile")
    os.mkdir(package_path)
    pyfile_path = os.path.join(package_path, "__init__.py")
    with open(pyfile_path, "w") as f:
        _ = f.write("my_func = lambda: 5")
    shutil.make_archive(package_path, 'zip', d, "my_zipfile")
    @udf("long")
    def func(x):
        import my_zipfile
        return my_zipfile.my_func()
    spark.addArtifacts(f"{package_path}.zip", pyfile=True)
    spark.range(1).select(func("id")).show()

```

Also added a couple of unittests.
