### PR TITLE
[SPARK-43749][SPARK-43750][SQL] Assign names to the error class _LEGACY_ERROR_TEMP_240[4-5]

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -1156,6 +1156,23 @@
     },
     "sqlState" : "22023"
   },
+  "INVALID_PARTITION_OPERATION" : {
+    "message" : [
+      "The partition command is invalid."
+    ],
+    "subClass" : {
+      "PARTITION_MANAGEMENT_IS_UNSUPPORTED" : {
+        "message" : [
+          "Table <name> does not support partition management."
+        ]
+      },
+      "PARTITION_SCHEMA_IS_EMPTY" : {
+        "message" : [
+          "Table <name> is not partitioned."
+        ]
+      }
+    }
+  },
   "INVALID_PROPERTY_KEY" : {
     "message" : [
       "<key> is an invalid property key, please use quotes, e.g. SET <key>=<value>."
@@ -5367,16 +5384,6 @@
   "_LEGACY_ERROR_TEMP_2331" : {
     "message" : [
       "failed to evaluate expression <sqlExpr>: <msg>"
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_2404" : {
-    "message" : [
-      "Table <name> is not partitioned."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_2405" : {
-    "message" : [
-      "Table <name> does not support partition management."
     ]
   },
   "_LEGACY_ERROR_TEMP_2406" : {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -212,12 +212,12 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
               if (t.partitionSchema.isEmpty) {
                 r.failAnalysis(
                   errorClass = "INVALID_PARTITION_OPERATION.PARTITION_SCHEMA_IS_EMPTY",
-                  messageParameters = Map("name" -> r.name))
+                  messageParameters = Map("name" -> toSQLId(r.name)))
               }
             case _ =>
               r.failAnalysis(
                 errorClass = "INVALID_PARTITION_OPERATION.PARTITION_MANAGEMENT_IS_UNSUPPORTED",
-                messageParameters = Map("name" -> r.name))
+                messageParameters = Map("name" -> toSQLId(r.name)))
           }
           case _ =>
         }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -211,12 +211,12 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
             case t: SupportsPartitionManagement =>
               if (t.partitionSchema.isEmpty) {
                 r.failAnalysis(
-                  errorClass = "_LEGACY_ERROR_TEMP_2404",
+                  errorClass = "INVALID_PARTITION_OPERATION.PARTITION_SCHEMA_IS_EMPTY",
                   messageParameters = Map("name" -> r.name))
               }
             case _ =>
               r.failAnalysis(
-                errorClass = "_LEGACY_ERROR_TEMP_2405",
+                errorClass = "INVALID_PARTITION_OPERATION.PARTITION_MANAGEMENT_IS_UNSUPPORTED",
                 messageParameters = Map("name" -> r.name))
           }
           case _ =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowPartitionsSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowPartitionsSuiteBase.scala
@@ -18,6 +18,8 @@
 package org.apache.spark.sql.execution.command
 
 import org.apache.spark.sql.{AnalysisException, QueryTest, Row, SaveMode}
+import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
+import org.apache.spark.sql.catalyst.util.quoteIdentifier
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{StringType, StructType}
 
@@ -69,9 +71,11 @@ trait ShowPartitionsSuiteBase extends QueryTest with DDLCommandTestUtils {
       val errMsg = intercept[AnalysisException] {
         sql(s"SHOW PARTITIONS $t")
       }.getMessage
+      lazy val tableName =
+        UnresolvedAttribute.parseAttributeName(t).map(quoteIdentifier).mkString(".")
       assert(errMsg.contains("not allowed on a table that is not partitioned") ||
         // V2 error message.
-        errMsg.contains(s"Table $t is not partitioned"))
+        errMsg.contains(s"Table $tableName is not partitioned"))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowPartitionsSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowPartitionsSuiteBase.scala
@@ -18,8 +18,6 @@
 package org.apache.spark.sql.execution.command
 
 import org.apache.spark.sql.{AnalysisException, QueryTest, Row, SaveMode}
-import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
-import org.apache.spark.sql.catalyst.util.quoteIdentifier
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{StringType, StructType}
 
@@ -63,20 +61,6 @@ trait ShowPartitionsSuiteBase extends QueryTest with DDLCommandTestUtils {
       .format(format)
       .mode(SaveMode.Overwrite)
       .saveAsTable(table)
-  }
-
-  test("show partitions of non-partitioned table") {
-    withNamespaceAndTable("ns", "not_partitioned_table") { t =>
-      sql(s"CREATE TABLE $t (col1 int) $defaultUsing")
-      val errMsg = intercept[AnalysisException] {
-        sql(s"SHOW PARTITIONS $t")
-      }.getMessage
-      lazy val tableName =
-        UnresolvedAttribute.parseAttributeName(t).map(quoteIdentifier).mkString(".")
-      assert(errMsg.contains("not allowed on a table that is not partitioned") ||
-        // V2 error message.
-        errMsg.contains(s"Table $tableName is not partitioned"))
-    }
   }
 
   test("non-partitioning columns") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowPartitionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowPartitionsSuite.scala
@@ -117,6 +117,17 @@ class ShowPartitionsSuite extends ShowPartitionsSuiteBase with CommandSuiteBase 
     }
   }
 
+  test("show partitions of non-partitioned table") {
+    withNamespaceAndTable("ns", "not_partitioned_table") { t =>
+      sql(s"CREATE TABLE $t (col1 int) $defaultUsing")
+      val errMsg = intercept[AnalysisException] {
+        sql(s"SHOW PARTITIONS $t")
+      }.getMessage
+
+      assert(errMsg.contains("not allowed on a table that is not partitioned"))
+    }
+  }
+
   test("SPARK-33904: null and empty string as partition values") {
     withNamespaceAndTable("ns", "tbl") { t =>
       createNullPartTable(t, "parquet")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/AlterTableAddPartitionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/AlterTableAddPartitionSuite.scala
@@ -19,7 +19,8 @@ package org.apache.spark.sql.execution.command.v2
 
 import org.apache.spark.SparkNumberFormatException
 import org.apache.spark.sql.{AnalysisException, Row}
-import org.apache.spark.sql.catalyst.analysis.PartitionsAlreadyExistException
+import org.apache.spark.sql.catalyst.analysis.{PartitionsAlreadyExistException, UnresolvedAttribute}
+import org.apache.spark.sql.catalyst.util.quoteIdentifier
 import org.apache.spark.sql.execution.command
 import org.apache.spark.sql.internal.SQLConf
 
@@ -38,7 +39,8 @@ class AlterTableAddPartitionSuite
       val errMsg = intercept[AnalysisException] {
         sql(s"ALTER TABLE $t ADD PARTITION (id=1)")
       }.getMessage
-      assert(errMsg.contains(s"Table $t does not support partition management"))
+      val tableName = UnresolvedAttribute.parseAttributeName(t).map(quoteIdentifier).mkString(".")
+      assert(errMsg.contains(s"Table $tableName does not support partition management"))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/AlterTableAddPartitionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/AlterTableAddPartitionSuite.scala
@@ -36,11 +36,19 @@ class AlterTableAddPartitionSuite
   test("SPARK-33650: add partition into a table which doesn't support partition management") {
     withNamespaceAndTable("ns", "tbl", s"non_part_$catalog") { t =>
       sql(s"CREATE TABLE $t (id bigint, data string) $defaultUsing")
-      val errMsg = intercept[AnalysisException] {
-        sql(s"ALTER TABLE $t ADD PARTITION (id=1)")
-      }.getMessage
       val tableName = UnresolvedAttribute.parseAttributeName(t).map(quoteIdentifier).mkString(".")
-      assert(errMsg.contains(s"Table $tableName does not support partition management"))
+      val sqlText = s"ALTER TABLE $t ADD PARTITION (id=1)"
+
+      checkError(
+        exception = intercept[AnalysisException] {
+          sql(sqlText)
+        },
+        errorClass = "INVALID_PARTITION_OPERATION.PARTITION_MANAGEMENT_IS_UNSUPPORTED",
+        parameters = Map("name" -> tableName),
+        context = ExpectedContext(
+          fragment = t,
+          start = 12,
+          stop = 39))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/AlterTableDropPartitionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/AlterTableDropPartitionSuite.scala
@@ -18,6 +18,8 @@
 package org.apache.spark.sql.execution.command.v2
 
 import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
+import org.apache.spark.sql.catalyst.util.quoteIdentifier
 import org.apache.spark.sql.execution.command
 
 /**
@@ -36,7 +38,8 @@ class AlterTableDropPartitionSuite
       val errMsg = intercept[AnalysisException] {
         sql(s"ALTER TABLE $t DROP PARTITION (id=1)")
       }.getMessage
-      assert(errMsg.contains(s"Table $t does not support partition management"))
+      val tableName = UnresolvedAttribute.parseAttributeName(t).map(quoteIdentifier).mkString(".")
+      assert(errMsg.contains(s"Table $tableName does not support partition management"))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowPartitionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowPartitionsSuite.scala
@@ -18,6 +18,8 @@
 package org.apache.spark.sql.execution.command.v2
 
 import org.apache.spark.sql.{AnalysisException, Row}
+import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
+import org.apache.spark.sql.catalyst.util.quoteIdentifier
 import org.apache.spark.sql.execution.command
 
 /**
@@ -33,7 +35,9 @@ class ShowPartitionsSuite extends command.ShowPartitionsSuiteBase with CommandSu
       val errMsg = intercept[AnalysisException] {
         sql(s"SHOW PARTITIONS $table")
       }.getMessage
-      assert(errMsg.contains(s"Table $table does not support partition management"))
+      val tableName =
+        UnresolvedAttribute.parseAttributeName(table).map(quoteIdentifier).mkString(".")
+      assert(errMsg.contains(s"Table $tableName does not support partition management"))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/TruncateTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/TruncateTableSuite.scala
@@ -36,7 +36,7 @@ class TruncateTableSuite extends command.TruncateTableSuiteBase with CommandSuit
         sql(s"TRUNCATE TABLE $t PARTITION (c0=1)")
       }.getMessage
       assert(errMsg.contains(
-        "Table non_part_test_catalog.ns.tbl does not support partition management"))
+        "Table `non_part_test_catalog`.`ns`.`tbl` does not support partition management"))
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to assign a name to the error class _LEGACY_ERROR_TEMP_240[4-5].


### Why are the changes needed?
Improve the error framework.


### Does this PR introduce _any_ user-facing change?
'No'.


### How was this patch tested?
N/A
