### PR TITLE
[SPARK-43759][SQL][PYTHON] Expose TimestampNTZType in pyspark.sql.types

### DIFF
--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -68,6 +68,7 @@ __all__ = [
     "BooleanType",
     "DateType",
     "TimestampType",
+    "TimestampNTZType",
     "DecimalType",
     "DoubleType",
     "FloatType",


### PR DESCRIPTION
### What changes were proposed in this pull request?

Exposes `TimestampNTZType` in `pyspark.sql.types`.

```py
>>> from pyspark.sql.types import *
>>>
>>> TimestampNTZType()
TimestampNTZType()
```

### Why are the changes needed?

`TimestampNTZType` is missing in `_all_` list in `pyspark.sql.types`.

```py
>>> from pyspark.sql.types import *
>>>
>>> TimestampNTZType()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
NameError: name 'TimestampNTZType' is not defined
```

### Does this PR introduce _any_ user-facing change?

Users won't need to explicitly import `TimestampNTZType` but wildcard will work.

### How was this patch tested?

Existing tests.