### PR TITLE
[MINOR][CORE] Fix default value of daemonExitValue in eofExceptionWhileReadPortNumberError

### DIFF
--- a/core/src/main/scala/org/apache/spark/errors/SparkCoreErrors.scala
+++ b/core/src/main/scala/org/apache/spark/errors/SparkCoreErrors.scala
@@ -43,7 +43,7 @@ private[spark] object SparkCoreErrors {
 
   def eofExceptionWhileReadPortNumberError(
       daemonModule: String,
-      daemonExitValue: Option[Int] = null): Throwable = {
+      daemonExitValue: Option[Int] = None): Throwable = {
     new SparkException(
       errorClass = "_LEGACY_ERROR_TEMP_3001",
       messageParameters = Map(


### PR DESCRIPTION
### What changes were proposed in this pull request?
Change the default value of `daemonExitValue` from `null` to `None` in `eofExceptionWhileReadPortNumberError` to avoid a NPE.  This is possible `PythonWorkerFactory` can call this method without a value for `daemonExitValue` (https://github.com/apache/spark/blob/06648efddb43166577269400e73cd56210e15728/core/src/main/scala/org/apache/spark/api/python/PythonWorkerFactory.scala#L229-L230).


### Why are the changes needed?
If no value is provided for `daemonExitValue`, the expected behavior is to still throw an exception, but without an additional message.  Currently, this results in a NPE.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
N/A
