### PR TITLE
[SPARK-43767][SQL][TESTS] Fix bug in AvroSuite for 'reading from invalid path throws exception'

### DIFF
--- a/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
+++ b/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
@@ -1351,6 +1351,7 @@ abstract class AvroSuite
 
     intercept[FileNotFoundException] {
       withTempPath { dir =>
+        dir.mkdirs()
         FileUtils.touch(new File(dir, "test"))
         withSQLConf(AvroFileFormat.IgnoreFilesWithoutExtensionProperty -> "true") {
           spark.read.format("avro").load(dir.toString)
@@ -1360,6 +1361,7 @@ abstract class AvroSuite
 
     intercept[FileNotFoundException] {
       withTempPath { dir =>
+        dir.mkdirs()
         FileUtils.touch(new File(dir, "test"))
 
         spark

--- a/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
+++ b/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
@@ -1350,8 +1350,7 @@ abstract class AvroSuite
     }
 
     intercept[FileNotFoundException] {
-      withTempPath { dir =>
-        dir.mkdirs()
+      withTempDir { dir =>
         FileUtils.touch(new File(dir, "test"))
         withSQLConf(AvroFileFormat.IgnoreFilesWithoutExtensionProperty -> "true") {
           spark.read.format("avro").load(dir.toString)
@@ -1360,8 +1359,7 @@ abstract class AvroSuite
     }
 
     intercept[FileNotFoundException] {
-      withTempPath { dir =>
-        dir.mkdirs()
+      withTempDir { dir =>
         FileUtils.touch(new File(dir, "test"))
 
         spark


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to fix bug in AvroSuite for 'reading from invalid path throws exception'.

### Why are the changes needed?
- As discussed and analyzed in [41271](https://github.com/apache/spark/pull/41271#issuecomment-1560355918)

- There is a problem with this UT. Its original intention was to test if there is no file with .avro extensions in the directory, and the read should fail. However, this UT triggered the error as FileUtils.touch instead of spark.read.format("avro").load(dir.toString).The root cause for the failure of this case is that the parent directory was not created. When FileUtils.touch is called in version 1.11.0, it just throws java.io.FileNotFoundException, which covers the error.



### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA.