### PR TITLE
[SPARK-43758][BUILD][FOLLOWUP][3.4] Update Hadoop 2 dependency manifest

### DIFF
--- a/dev/deps/spark-deps-hadoop-2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2-hive-2.3
@@ -248,7 +248,7 @@ scala-xml_2.12/2.1.0//scala-xml_2.12-2.1.0.jar
 shims/0.9.38//shims-0.9.38.jar
 slf4j-api/2.0.6//slf4j-api-2.0.6.jar
 snakeyaml/1.33//snakeyaml-1.33.jar
-snappy-java/1.1.9.1//snappy-java-1.1.9.1.jar
+snappy-java/1.1.10.0//snappy-java-1.1.10.0.jar
 spire-macros_2.12/0.17.0//spire-macros_2.12-0.17.0.jar
 spire-platform_2.12/0.17.0//spire-platform_2.12-0.17.0.jar
 spire-util_2.12/0.17.0//spire-util_2.12-0.17.0.jar


### PR DESCRIPTION
### What changes were proposed in this pull request?

This Is a follow-up of https://github.com/apache/spark/pull/41285.

### Why are the changes needed?

When merging to branch-3.4, `hadoop-2` dependency manifest is missed.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.