### PR TITLE
[SPARK-43771][BUILD][CONNECT] Upgrade mima-core from 1.1.0 to 1.1.2

### DIFF
--- a/connector/connect/client/jvm/pom.xml
+++ b/connector/connect/client/jvm/pom.xml
@@ -34,7 +34,7 @@
     <sbt.project.name>connect-client-jvm</sbt.project.name>
     <guava.version>31.0.1-jre</guava.version>
     <guava.failureaccess.version>1.0.1</guava.failureaccess.version>
-    <mima.version>1.1.0</mima.version>
+    <mima.version>1.1.2</mima.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade mima-core from 1.1.0 to 1.1.2.

### Why are the changes needed?
- New version includes bug fixed, eg:
1.Handle POM-only modules by creating empty Definitions by @rossabaker in https://github.com/lightbend/mima/pull/743

- Release note:
1.https://github.com/lightbend/mima/releases/tag/1.1.2
2.https://github.com/lightbend/mima/releases/tag/1.1.1

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA.