### PR TITLE
[SPARK-43549][SQL] Convert _LEGACY_ERROR_TEMP_0036 to INVALID_SQL_SYNTAX.ANALYZE_TABLE_UNEXPECTED_NOSCAN

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -1198,6 +1198,11 @@
       "Invalid SQL syntax:"
     ],
     "subClass" : {
+      "ANALYZE_TABLE_UNEXPECTED_NOSCAN" : {
+        "message" : [
+          "ANALYZE TABLE ... COMPUTE STATISTICS ... <ctx> must be 'NOSCAN'"
+        ]
+      },
       "CREATE_FUNC_WITH_IF_NOT_EXISTS_AND_REPLACE" : {
         "message" : [
           "CREATE FUNCTION with both IF NOT EXISTS and REPLACE is not allowed."

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -1210,7 +1210,7 @@
     "subClass" : {
       "ANALYZE_TABLE_UNEXPECTED_NOSCAN" : {
         "message" : [
-          "ANALYZE TABLE ... COMPUTE STATISTICS ... <ctx> must be 'NOSCAN'"
+          "ANALYZE TABLE(S) ... COMPUTE STATISTICS ... <ctx> must be either NOSCAN or empty"
         ]
       },
       "CREATE_FUNC_WITH_IF_NOT_EXISTS_AND_REPLACE" : {

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -1210,7 +1210,7 @@
     "subClass" : {
       "ANALYZE_TABLE_UNEXPECTED_NOSCAN" : {
         "message" : [
-          "ANALYZE TABLE(S) ... COMPUTE STATISTICS ... <ctx> must be either NOSCAN or empty"
+          "ANALYZE TABLE(S) ... COMPUTE STATISTICS ... <ctx> must be either NOSCAN or empty."
         ]
       },
       "CREATE_FUNC_WITH_IF_NOT_EXISTS_AND_REPLACE" : {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
@@ -396,8 +396,8 @@ private[sql] object QueryParsingErrors extends QueryErrorsBase {
 
   def computeStatisticsNotExpectedError(ctx: IdentifierContext): Throwable = {
     new ParseException(
-      errorClass = "_LEGACY_ERROR_TEMP_0036",
-      messageParameters = Map("ctx" -> ctx.getText),
+      errorClass = "INVALID_SQL_SYNTAX.ANALYZE_TABLE_UNEXPECTED_NOSCAN",
+      messageParameters = Map("ctx" -> toSQLStmt(ctx.getText)),
       ctx)
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
@@ -2142,8 +2142,8 @@ class DDLParserSuite extends AnalysisTest {
     val sql1 = "analyze table a.b.c compute statistics xxxx"
     checkError(
       exception = parseException(sql1),
-      errorClass = "_LEGACY_ERROR_TEMP_0036",
-      parameters = Map("ctx" -> "xxxx"),
+      errorClass = "INVALID_SQL_SYNTAX.ANALYZE_TABLE_UNEXPECTED_NOSCAN",
+      parameters = Map("ctx" -> "XXXX"),
       context = ExpectedContext(
         fragment = sql1,
         start = 0,
@@ -2152,8 +2152,8 @@ class DDLParserSuite extends AnalysisTest {
     val sql2 = "analyze table a.b.c partition (a) compute statistics xxxx"
     checkError(
       exception = parseException(sql2),
-      errorClass = "_LEGACY_ERROR_TEMP_0036",
-      parameters = Map("ctx" -> "xxxx"),
+      errorClass = "INVALID_SQL_SYNTAX.ANALYZE_TABLE_UNEXPECTED_NOSCAN",
+      parameters = Map("ctx" -> "XXXX"),
       context = ExpectedContext(
         fragment = sql2,
         start = 0,
@@ -2169,8 +2169,8 @@ class DDLParserSuite extends AnalysisTest {
     val sql = "ANALYZE TABLES IN a.b.c COMPUTE STATISTICS xxxx"
     checkError(
       exception = parseException(sql),
-      errorClass = "_LEGACY_ERROR_TEMP_0036",
-      parameters = Map("ctx" -> "xxxx"),
+      errorClass = "INVALID_SQL_SYNTAX.ANALYZE_TABLE_UNEXPECTED_NOSCAN",
+      parameters = Map("ctx" -> "XXXX"),
       context = ExpectedContext(
         fragment = sql,
         start = 0,


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to Convert `_LEGACY_ERROR_TEMP_0036` to INVALID_SQL_SYNTAX.ANALYZE_TABLE_UNEXPECTED_NOSCAN

### Why are the changes needed?
The changes improve the error framework.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA & Update UT.