### PR TITLE
[SPARK-43785][SQL][DOC] Improve the document of GenTPCDSData, so that developers could easy to generate TPCDS table data.

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/GenTPCDSData.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/GenTPCDSData.scala
@@ -412,6 +412,10 @@ class GenTPCDSDataConfig(args: Array[String]) {
  * {{{
  *   build/sbt "sql/Test/runMain <this class> --dsdgenDir <path> --location <path> --scaleFactor 1"
  * }}}
+ *
+ * Note: if users specify a small scale factor, GenTPCDSData works good. Otherwise, may encounter
+ * OOM and cause failure. Users can retry by setting a larger value for the environment variable
+ * HEAP_SIZE(the default size is 4g), e.g. export HEAP_SIZE=10g.
  */
 object GenTPCDSData {
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
https://github.com/apache/spark/pull/41212 added the new environment variable `HEAP_SIZE`. It let developers could fix some OOM issues.

This PR want improve the document of `GenTPCDSData`, so that developers could easy to generate TPCDS table data.


### Why are the changes needed?
Make `GenTPCDSData` could easy to use.


### Does this PR introduce _any_ user-facing change?
'No'.
This change is relationed to developers.


### How was this patch tested?
N/A
