### PR TITLE
[SPARK-43692][SPARK-43693][SPARK-43694][SPARK-43695][PS] Fix `StringOps` for Spark Connect

### DIFF
--- a/python/pyspark/pandas/data_type_ops/string_ops.py
+++ b/python/pyspark/pandas/data_type_ops/string_ops.py
@@ -22,7 +22,7 @@ from pandas.api.types import CategoricalDtype
 
 from pyspark.sql import functions as F
 from pyspark.sql.types import IntegralType, StringType
-from pyspark.sql.utils import is_remote
+from pyspark.sql.utils import pyspark_column_op
 
 from pyspark.pandas._typing import Dtype, IndexOpsLike, SeriesOrIndex
 from pyspark.pandas.base import column_op, IndexOpsMixin
@@ -35,7 +35,6 @@ from pyspark.pandas.data_type_ops.base import (
 )
 from pyspark.pandas.spark import functions as SF
 from pyspark.pandas.typedef import extension_dtypes, pandas_on_spark_type
-from pyspark.sql import Column as PySparkColumn
 from pyspark.sql.types import BooleanType
 
 
@@ -105,52 +104,20 @@ class StringOps(DataTypeOps):
             raise TypeError("Multiplication can not be applied to given types.")
 
     def lt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        from pyspark.pandas.base import column_op
-
         _sanitize_list_like(right)
-        if is_remote():
-            from pyspark.sql.connect.column import Column as ConnectColumn
-
-            Column = ConnectColumn
-        else:
-            Column = PySparkColumn  # type: ignore[assignment]
-        return column_op(Column.__lt__)(left, right)
+        return pyspark_column_op("__lt__")(left, right)
 
     def le(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        from pyspark.pandas.base import column_op
-
         _sanitize_list_like(right)
-        if is_remote():
-            from pyspark.sql.connect.column import Column as ConnectColumn
-
-            Column = ConnectColumn
-        else:
-            Column = PySparkColumn  # type: ignore[assignment]
-        return column_op(Column.__le__)(left, right)  # type: ignore[arg-type]
+        return pyspark_column_op("__le__")(left, right)
 
     def ge(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        from pyspark.pandas.base import column_op
-
         _sanitize_list_like(right)
-        if is_remote():
-            from pyspark.sql.connect.column import Column as ConnectColumn
-
-            Column = ConnectColumn
-        else:
-            Column = PySparkColumn  # type: ignore[assignment]
-        return column_op(Column.__ge__)(left, right)  # type: ignore[arg-type]
+        return pyspark_column_op("__ge__")(left, right)
 
     def gt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        from pyspark.pandas.base import column_op
-
         _sanitize_list_like(right)
-        if is_remote():
-            from pyspark.sql.connect.column import Column as ConnectColumn
-
-            Column = ConnectColumn
-        else:
-            Column = PySparkColumn  # type: ignore[assignment]
-        return column_op(Column.__gt__)(left, right)  # type: ignore[arg-type]
+        return pyspark_column_op("__gt__")(left, right)
 
     def astype(self, index_ops: IndexOpsLike, dtype: Union[str, type, Dtype]) -> IndexOpsLike:
         dtype, spark_type = pandas_on_spark_type(dtype)

--- a/python/pyspark/pandas/data_type_ops/string_ops.py
+++ b/python/pyspark/pandas/data_type_ops/string_ops.py
@@ -22,6 +22,7 @@ from pandas.api.types import CategoricalDtype
 
 from pyspark.sql import functions as F
 from pyspark.sql.types import IntegralType, StringType
+from pyspark.sql.utils import is_remote
 
 from pyspark.pandas._typing import Dtype, IndexOpsLike, SeriesOrIndex
 from pyspark.pandas.base import column_op, IndexOpsMixin
@@ -34,7 +35,7 @@ from pyspark.pandas.data_type_ops.base import (
 )
 from pyspark.pandas.spark import functions as SF
 from pyspark.pandas.typedef import extension_dtypes, pandas_on_spark_type
-from pyspark.sql import Column
+from pyspark.sql import Column as PySparkColumn
 from pyspark.sql.types import BooleanType
 
 
@@ -107,25 +108,49 @@ class StringOps(DataTypeOps):
         from pyspark.pandas.base import column_op
 
         _sanitize_list_like(right)
+        if is_remote():
+            from pyspark.sql.connect.column import Column as ConnectColumn
+
+            Column = ConnectColumn
+        else:
+            Column = PySparkColumn  # type: ignore[assignment]
         return column_op(Column.__lt__)(left, right)
 
     def le(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         from pyspark.pandas.base import column_op
 
         _sanitize_list_like(right)
-        return column_op(Column.__le__)(left, right)
+        if is_remote():
+            from pyspark.sql.connect.column import Column as ConnectColumn
+
+            Column = ConnectColumn
+        else:
+            Column = PySparkColumn  # type: ignore[assignment]
+        return column_op(Column.__le__)(left, right)  # type: ignore[arg-type]
 
     def ge(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         from pyspark.pandas.base import column_op
 
         _sanitize_list_like(right)
-        return column_op(Column.__ge__)(left, right)
+        if is_remote():
+            from pyspark.sql.connect.column import Column as ConnectColumn
+
+            Column = ConnectColumn
+        else:
+            Column = PySparkColumn  # type: ignore[assignment]
+        return column_op(Column.__ge__)(left, right)  # type: ignore[arg-type]
 
     def gt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         from pyspark.pandas.base import column_op
 
         _sanitize_list_like(right)
-        return column_op(Column.__gt__)(left, right)
+        if is_remote():
+            from pyspark.sql.connect.column import Column as ConnectColumn
+
+            Column = ConnectColumn
+        else:
+            Column = PySparkColumn  # type: ignore[assignment]
+        return column_op(Column.__gt__)(left, right)  # type: ignore[arg-type]
 
     def astype(self, index_ops: IndexOpsLike, dtype: Union[str, type, Dtype]) -> IndexOpsLike:
         dtype, spark_type = pandas_on_spark_type(dtype)

--- a/python/pyspark/pandas/tests/connect/data_type_ops/test_parity_string_ops.py
+++ b/python/pyspark/pandas/tests/connect/data_type_ops/test_parity_string_ops.py
@@ -34,19 +34,15 @@ class StringOpsParityTests(
     def test_astype(self):
         super().test_astype()
 
-    @unittest.skip("TODO(SPARK-43692): Fix StringOps.ge to work with Spark Connect.")
     def test_ge(self):
         super().test_ge()
 
-    @unittest.skip("TODO(SPARK-43693): Fix StringOps.gt to work with Spark Connect.")
     def test_gt(self):
         super().test_gt()
 
-    @unittest.skip("TODO(SPARK-43694): Fix StringOps.le to work with Spark Connect.")
     def test_le(self):
         super().test_le()
 
-    @unittest.skip("TODO(SPARK-43695): Fix StringOps.lt to work with Spark Connect.")
     def test_lt(self):
         super().test_lt()
 

--- a/python/pyspark/pandas/tests/connect/data_type_ops/test_parity_string_ops.py
+++ b/python/pyspark/pandas/tests/connect/data_type_ops/test_parity_string_ops.py
@@ -34,18 +34,6 @@ class StringOpsParityTests(
     def test_astype(self):
         super().test_astype()
 
-    def test_ge(self):
-        super().test_ge()
-
-    def test_gt(self):
-        super().test_gt()
-
-    def test_le(self):
-        super().test_le()
-
-    def test_lt(self):
-        super().test_lt()
-
     @unittest.skip(
         "TODO(SPARK-43621): Enable pyspark.pandas.spark.functions.repeat in Spark Connect."
     )


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to fix `StringOps` test for pandas API on Spark with Spark Connect.

This includes SPARK-43692, SPARK-43693, SPARK-43694, SPARK-43695 at once, because they are all related similar modifications in single file.


### Why are the changes needed?

To support all features for pandas API on Spark with Spark Connect.


### Does this PR introduce _any_ user-facing change?

Yes, `StringOps.lt`,  `StringOps.le`, `StringOps.ge`, `StringOps.gt` are now working as expected on Spark Connect.


### How was this patch tested?

Uncomment the UTs, and tested manually.
