### PR TITLE
[MINOR][DOCS][PS] Move a few `Frame` functions to correct categories

### DIFF
--- a/python/docs/source/reference/pyspark.pandas/frame.rst
+++ b/python/docs/source/reference/pyspark.pandas/frame.rst
@@ -62,7 +62,6 @@ Conversion
    DataFrame.isnull
    DataFrame.notna
    DataFrame.notnull
-   DataFrame.pad
    DataFrame.bool
 
 Indexing, iteration
@@ -77,6 +76,7 @@ Indexing, iteration
    DataFrame.idxmin
    DataFrame.loc
    DataFrame.iloc
+   DataFrame.insert
    DataFrame.items
    DataFrame.iteritems
    DataFrame.iterrows
@@ -164,6 +164,7 @@ Computations / Descriptive Stats
    DataFrame.prod
    DataFrame.product
    DataFrame.quantile
+   DataFrame.rank
    DataFrame.nunique
    DataFrame.sem
    DataFrame.skew
@@ -197,6 +198,8 @@ Reindexing / Selection / Label manipulation
    DataFrame.first
    DataFrame.head
    DataFrame.last
+   DataFrame.reindex
+   DataFrame.reindex_like
    DataFrame.rename
    DataFrame.rename_axis
    DataFrame.reset_index
@@ -222,6 +225,7 @@ Missing data handling
    DataFrame.bfill
    DataFrame.ffill
    DataFrame.interpolate
+   DataFrame.pad
 
 Reshaping, sorting, transposing
 -------------------------------
@@ -241,9 +245,6 @@ Reshaping, sorting, transposing
    DataFrame.squeeze
    DataFrame.T
    DataFrame.transpose
-   DataFrame.reindex
-   DataFrame.reindex_like
-   DataFrame.rank
 
 Combining / joining / merging
 -----------------------------
@@ -255,7 +256,6 @@ Combining / joining / merging
    DataFrame.merge
    DataFrame.join
    DataFrame.update
-   DataFrame.insert
 
 Time series-related
 -------------------


### PR DESCRIPTION
### What changes were proposed in this pull request?
Following `Frame` functions in https://spark.apache.org/docs/latest/api/python/reference/pyspark.pandas/frame.html were in wrong categories:

- pad
- insert
- rank
- reindex
- reindex_like


### Why are the changes needed?
should be consistent with https://pandas.pydata.org/docs/reference/frame.html#dataframe

### Does this PR introduce _any_ user-facing change?
yes, doc changes


### How was this patch tested?
existing CI