### PR TITLE
[SPARK-43798][SQL][PYTHON] Support Python user-defined table functions

### DIFF
--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/CheckConnectJvmClientCompatibility.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/CheckConnectJvmClientCompatibility.scala
@@ -225,6 +225,7 @@ object CheckConnectJvmClientCompatibility {
       ProblemFilters.exclude[Problem]("org.apache.spark.sql.SparkSession.listenerManager"),
       ProblemFilters.exclude[Problem]("org.apache.spark.sql.SparkSession.experimental"),
       ProblemFilters.exclude[Problem]("org.apache.spark.sql.SparkSession.udf"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.SparkSession.udtf"),
       ProblemFilters.exclude[Problem]("org.apache.spark.sql.SparkSession.streams"),
       ProblemFilters.exclude[Problem]("org.apache.spark.sql.SparkSession.createDataFrame"),
       ProblemFilters.exclude[Problem](

--- a/core/src/main/scala/org/apache/spark/api/python/PythonRunner.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRunner.scala
@@ -56,6 +56,8 @@ private[spark] object PythonEvalType {
   val SQL_MAP_ARROW_ITER_UDF = 207
   val SQL_GROUPED_MAP_PANDAS_UDF_WITH_STATE = 208
 
+  val SQL_TABLE_UDF = 300
+
   def toString(pythonEvalType: Int): String = pythonEvalType match {
     case NON_UDF => "NON_UDF"
     case SQL_BATCHED_UDF => "SQL_BATCHED_UDF"
@@ -69,6 +71,7 @@ private[spark] object PythonEvalType {
     case SQL_COGROUPED_MAP_PANDAS_UDF => "SQL_COGROUPED_MAP_PANDAS_UDF"
     case SQL_MAP_ARROW_ITER_UDF => "SQL_MAP_ARROW_ITER_UDF"
     case SQL_GROUPED_MAP_PANDAS_UDF_WITH_STATE => "SQL_GROUPED_MAP_PANDAS_UDF_WITH_STATE"
+    case SQL_TABLE_UDF => "SQL_TABLE_UDF"
   }
 }
 

--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -456,6 +456,7 @@ pyspark_sql = Module(
         "pyspark.sql.streaming.readwriter",
         "pyspark.sql.streaming.listener",
         "pyspark.sql.udf",
+        "pyspark.sql.udtf",
         "pyspark.sql.window",
         "pyspark.sql.avro.functions",
         "pyspark.sql.protobuf.functions",
@@ -501,6 +502,7 @@ pyspark_sql = Module(
         "pyspark.sql.tests.test_types",
         "pyspark.sql.tests.test_udf",
         "pyspark.sql.tests.test_udf_profiler",
+        "pyspark.sql.tests.test_udtf",
         "pyspark.sql.tests.test_utils",
     ],
 )

--- a/python/docs/source/reference/pyspark.sql/core_classes.rst
+++ b/python/docs/source/reference/pyspark.sql/core_classes.rst
@@ -39,4 +39,6 @@ Core Classes
     DataFrameWriter
     DataFrameWriterV2
     UDFRegistration
+    UDTFRegistration
     udf.UserDefinedFunction
+    udtf.UserDefinedTableFunction

--- a/python/docs/source/reference/pyspark.sql/functions.rst
+++ b/python/docs/source/reference/pyspark.sql/functions.rst
@@ -367,6 +367,7 @@ UDF
     call_udf
     pandas_udf
     udf
+    udtf
     unwrap_udt
 
 Misc Functions

--- a/python/docs/source/reference/pyspark.sql/index.rst
+++ b/python/docs/source/reference/pyspark.sql/index.rst
@@ -40,4 +40,5 @@ This page gives an overview of all public Spark SQL API.
     avro
     observation
     udf
+    udtf
     protobuf

--- a/python/docs/source/reference/pyspark.sql/spark_session.rst
+++ b/python/docs/source/reference/pyspark.sql/spark_session.rst
@@ -51,4 +51,5 @@ See also :class:`SparkSession`.
     SparkSession.streams
     SparkSession.table
     SparkSession.udf
+    SparkSession.udtf
     SparkSession.version

--- a/python/docs/source/reference/pyspark.sql/udtf.rst
+++ b/python/docs/source/reference/pyspark.sql/udtf.rst
@@ -1,0 +1,30 @@
+..  Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+..    http://www.apache.org/licenses/LICENSE-2.0
+
+..  Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+
+====
+UDTF
+====
+
+.. currentmodule:: pyspark.sql
+
+.. autosummary::
+    :toctree: api/
+
+    udtf.UserDefinedTableFunction.asNondeterministic
+    udtf.UserDefinedTableFunction.returnType
+    UDTFRegistration.register

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -152,6 +152,8 @@ class PythonEvalType:
     SQL_MAP_ARROW_ITER_UDF: "ArrowMapIterUDFType" = 207
     SQL_GROUPED_MAP_PANDAS_UDF_WITH_STATE: "PandasGroupedMapUDFWithStateType" = 208
 
+    SQL_TABLE_UDF = 300
+
 
 def portable_hash(x: Hashable) -> int:
     """

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -110,7 +110,13 @@ if TYPE_CHECKING:
     )
     from pyspark.sql.dataframe import DataFrame
     from pyspark.sql.types import AtomicType, StructType
-    from pyspark.sql._typing import AtomicValue, RowLike, SQLArrowBatchedUDFType, SQLBatchedUDFType
+    from pyspark.sql._typing import (
+        AtomicValue,
+        RowLike,
+        SQLArrowBatchedUDFType,
+        SQLBatchedUDFType,
+        SQLTableUDFType,
+    )
 
     from py4j.java_gateway import JavaObject
     from py4j.java_collections import JavaArray
@@ -152,7 +158,7 @@ class PythonEvalType:
     SQL_MAP_ARROW_ITER_UDF: "ArrowMapIterUDFType" = 207
     SQL_GROUPED_MAP_PANDAS_UDF_WITH_STATE: "PandasGroupedMapUDFWithStateType" = 208
 
-    SQL_TABLE_UDF = 300
+    SQL_TABLE_UDF: "SQLTableUDFType" = 300
 
 
 def portable_hash(x: Hashable) -> int:

--- a/python/pyspark/sql/__init__.py
+++ b/python/pyspark/sql/__init__.py
@@ -40,7 +40,7 @@ Important classes of Spark SQL and DataFrames:
       For working with window functions.
 """
 from pyspark.sql.types import Row
-from pyspark.sql.context import SQLContext, HiveContext, UDFRegistration
+from pyspark.sql.context import SQLContext, HiveContext, UDFRegistration, UDTFRegistration
 from pyspark.sql.session import SparkSession
 from pyspark.sql.column import Column
 from pyspark.sql.catalog import Catalog
@@ -57,6 +57,7 @@ __all__ = [
     "SQLContext",
     "HiveContext",
     "UDFRegistration",
+    "UDTFRegistration",
     "DataFrame",
     "GroupedData",
     "Column",

--- a/python/pyspark/sql/_typing.pyi
+++ b/python/pyspark/sql/_typing.pyi
@@ -58,6 +58,7 @@ RowLike = TypeVar("RowLike", List[Any], Tuple[Any, ...], pyspark.sql.types.Row)
 
 SQLBatchedUDFType = Literal[100]
 SQLArrowBatchedUDFType = Literal[101]
+SQLTableUDFType = Literal[300]
 
 class SupportsOpen(Protocol):
     def open(self, partition_id: int, epoch_id: int) -> bool: ...

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -579,7 +579,7 @@ class SparkSession:
             raise PySparkAttributeError(
                 error_class="JVM_ATTRIBUTE_NOT_SUPPORTED", message_parameters={"attr_name": name}
             )
-        elif name in ["newSession", "sparkContext"]:
+        elif name in ["newSession", "sparkContext", "udtf"]:
             raise PySparkNotImplementedError(
                 error_class="NOT_IMPLEMENTED", message_parameters={"feature": f"{name}()"}
             )

--- a/python/pyspark/sql/context.py
+++ b/python/pyspark/sql/context.py
@@ -41,6 +41,7 @@ from pyspark.sql.dataframe import DataFrame
 from pyspark.sql.readwriter import DataFrameReader
 from pyspark.sql.streaming import DataStreamReader
 from pyspark.sql.udf import UDFRegistration  # noqa: F401
+from pyspark.sql.udtf import UDTFRegistration
 from pyspark.errors.exceptions.captured import install_exception_handler
 from pyspark.context import SparkContext
 from pyspark.rdd import RDD
@@ -227,6 +228,18 @@ class SQLContext:
         :class:`UDFRegistration`
         """
         return self.sparkSession.udf
+
+    @property
+    def udtf(self) -> UDTFRegistration:
+        """Returns a :class:`UDTFRegistration` for UDTF registration.
+
+        .. versionadded:: 3.5.0
+
+        Returns
+        -------
+        :class:`UDTFRegistration`
+        """
+        return self.sparkSession.udtf
 
     def range(
         self,

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -11178,22 +11178,26 @@ def udtf(
 
     Examples
     --------
-    Implement the UDTF class.
+    Implement the UDTF class
+
     >>> class TestUDTF:
     ...     def eval(self, *args: Any):
     ...         yield "hello", "world"
 
     Create the UDTF
+
     >>> from pyspark.sql.functions import udtf
     >>> test_udtf = udtf(TestUDTF, returnType="c1: string, c2: string")
 
     Create the UDTF using the decorator
+
     >>> @udtf(returnType="c1: int, c2: int")
     ... class PlusOne:
     ...     def eval(self, x: int):
     ...         yield x, x + 1
 
     Invoke the UDTF
+
     >>> test_udtf().show()
     +-----+-----+
     |   c1|   c2|
@@ -11202,6 +11206,7 @@ def udtf(
     +-----+-----+
 
     Invoke the UDTF with parameters
+
     >>> from pyspark.sql.functions import lit
     >>> PlusOne(lit(1)).show()
     +---+---+
@@ -11212,7 +11217,7 @@ def udtf(
 
     Notes
     -----
-    User-defined table functions are considered deterministic by default.
+    User-defined table functions (UDTFs) are considered deterministic by default.
     Use `asNondeterministic()` to mark a function as non-deterministic. E.g.:
 
     >>> import random
@@ -11220,6 +11225,17 @@ def udtf(
     ...     def eval(self, a: int):
     ...         yield a * int(random.random() * 100),
     >>> random_udtf = udtf(RandomUDTF, returnType="r: int").asNondeterministic()
+
+    Use "yield" to produce one row for the UDTF result relation as many times
+    as needed. In the context of a lateral join, each such result row will be
+    associated with the most recent input row consumed from the "eval" method.
+    Or, use "return" to produce multiple rows for the UDTF result relation at
+    once.
+
+    >>> class TestUDTF:
+    ...     def eval(self, a: int):
+    ...         return [(a, a + 1), (a, a + 2)]
+    >>> test_udtf = udtf(TestUDTF, returnType="x: int, y: int")
 
     User-defined table functions are considered opaque to the optimizer by default.
     As a result, operations like filters from WHERE clauses or limits from

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -32,6 +32,7 @@ from typing import (
     overload,
     Optional,
     Tuple,
+    Type,
     TYPE_CHECKING,
     Union,
     ValuesView,
@@ -47,6 +48,7 @@ from pyspark.sql.types import ArrayType, DataType, StringType, StructType, _from
 
 # Keep UserDefinedFunction import for backwards compatible import; moved in SPARK-22409
 from pyspark.sql.udf import UserDefinedFunction, _create_py_udf  # noqa: F401
+from pyspark.sql.udtf import UserDefinedTableFunction, _create_udtf
 
 # Keep pandas_udf and PandasUDFType import for backwards compatible import; moved in SPARK-28264
 from pyspark.sql.pandas.functions import pandas_udf, PandasUDFType  # noqa: F401
@@ -11155,6 +11157,15 @@ def udf(
         )
     else:
         return _create_py_udf(f=f, returnType=returnType, useArrow=useArrow)
+
+
+def udtf(
+    f: Optional[Type] = None, *, returnType: Union[StructType, str], name: Optional[str] = None
+) -> Union[UserDefinedTableFunction, functools.partial]:
+    if f is None:
+        return functools.partial(_create_udtf, returnType=returnType, name=name)
+    else:
+        return _create_udtf(f=f, returnType=returnType, name=name)
 
 
 def _test() -> None:

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -11160,8 +11160,9 @@ def udf(
 
 
 def udtf(
-    f: Optional[Type] = None,
-    returnType: Union[StructType, str] = None,
+    cls: Optional[Type] = None,
+    *,
+    returnType: Union[StructType, str],
 ) -> Union[UserDefinedTableFunction, functools.partial]:
     """Creates a user defined table function (UDTF).
 
@@ -11169,7 +11170,7 @@ def udtf(
 
     Parameters
     ----------
-    f : class
+    cls : class
         the Python user-defined table function handler class.
     returnType : :class:`pyspark.sql.types.StructType` or str
         the return type of the user-defined table function. The value can be either a
@@ -11177,29 +11178,30 @@ def udtf(
 
     Examples
     --------
-    >>> # Implement the UDTF class
+    Implement the UDTF class.
     >>> class TestUDTF:
-    >>>     def eval(self, *args):
-    >>>         yield "hello", "world"
-    >>>
-    >>> # Create the UDTF
+    ...     def eval(self, *args: Any):
+    ...         yield "hello", "world"
+
+    Create the UDTF
     >>> from pyspark.sql.functions import udtf
     >>> test_udtf = udtf(TestUDTF, returnType="c1: string, c2: string")
-    >>>
-    >>> # Create the UDTF using the decorator
+
+    Create the UDTF using the decorator
     >>> @udtf(returnType="c1: int, c2: int")
-    >>> class PlusOne:
-    >>>     def eval(self, x: int):
-    >>>         yield x, x + 1
-    >>>
-    >>> # Invoke the UDTF
+    ... class PlusOne:
+    ...     def eval(self, x: int):
+    ...         yield x, x + 1
+
+    Invoke the UDTF
     >>> test_udtf().show()
     +-----+-----+
     |   c1|   c2|
     +-----+-----+
     |hello|world|
     +-----+-----+
-    >>> # Invoke the UDTF with parameters
+
+    Invoke the UDTF with parameters
     >>> from pyspark.sql.functions import lit
     >>> PlusOne(lit(1)).show()
     +---+---+
@@ -11215,8 +11217,8 @@ def udtf(
 
     >>> import random
     >>> class RandomUDTF:
-    >>>     def eval(self, a: int):
-    >>>         yield a * int(random.random() * 100)
+    ...     def eval(self, a: int):
+    ...         yield a * int(random.random() * 100),
     >>> random_udtf = udtf(RandomUDTF, "r: int").asNondeterministic()
 
     User-defined table functions are considered opaque to the optimizer by default.
@@ -11229,10 +11231,10 @@ def udtf(
 
     User-defined table functions do not accept keyword arguments on the calling side.
     """
-    if f is None:
+    if cls is None:
         return functools.partial(_create_udtf, returnType=returnType)
     else:
-        return _create_udtf(f=f, returnType=returnType)
+        return _create_udtf(cls=cls, returnType=returnType)
 
 
 def _test() -> None:

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -11219,7 +11219,7 @@ def udtf(
     >>> class RandomUDTF:
     ...     def eval(self, a: int):
     ...         yield a * int(random.random() * 100),
-    >>> random_udtf = udtf(RandomUDTF, "r: int").asNondeterministic()
+    >>> random_udtf = udtf(RandomUDTF, returnType="r: int").asNondeterministic()
 
     User-defined table functions are considered opaque to the optimizer by default.
     As a result, operations like filters from WHERE clauses or limits from

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -72,6 +72,7 @@ if TYPE_CHECKING:
     from pyspark.sql.pandas._typing import ArrayLike, DataFrameLike as PandasDataFrameLike
     from pyspark.sql.streaming import StreamingQueryManager
     from pyspark.sql.udf import UDFRegistration
+    from pyspark.sql.udtf import UDTFRegistration
 
 
 __all__ = ["SparkSession"]
@@ -791,6 +792,20 @@ class SparkSession(SparkConversionMixin):
         from pyspark.sql.udf import UDFRegistration
 
         return UDFRegistration(self)
+
+    @property
+    def udtf(self) -> "UDTFRegistration":
+        """Returns a :class:`UDTFRegistration` for UDTF registration.
+
+        .. versionadded:: 3.5.0
+
+        Returns
+        -------
+        :class:`UDTFRegistration`
+        """
+        from pyspark.sql.udtf import UDTFRegistration
+
+        return UDTFRegistration(self)
 
     def range(
         self,

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -3169,7 +3169,7 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
         self.check_error(
             exception=e.exception,
             error_class="NOT_IMPLEMENTED",
-            message_parameters={"feature": "udtf()"}
+            message_parameters={"feature": "udtf()"},
         )
 
     def test_unsupported_jvm_attribute(self):

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -25,6 +25,7 @@ from collections import defaultdict
 
 from pyspark.errors import (
     PySparkAttributeError,
+    PySparkNotImplementedError,
     PySparkTypeError,
     PySparkException,
     PySparkValueError,
@@ -3160,6 +3161,16 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
         row_count = 100 * 1000
         rows = [cols] * row_count
         self.assertEqual(row_count, self.connect.createDataFrame(data=rows).count())
+
+    def test_unsupported_udtf(self):
+        with self.assertRaises(PySparkNotImplementedError) as e:
+            self.connect.udtf.register()
+
+        self.check_error(
+            exception=e.exception,
+            error_class="NOT_IMPLEMENTED",
+            message_parameters={"feature": "udtf()"}
+        )
 
     def test_unsupported_jvm_attribute(self):
         # Unsupported jvm attributes for Spark session.

--- a/python/pyspark/sql/tests/test_udtf.py
+++ b/python/pyspark/sql/tests/test_udtf.py
@@ -1,0 +1,209 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import unittest
+
+from typing import Any, Iterator
+
+from py4j.protocol import Py4JJavaError
+
+from pyspark.errors import PythonException
+from pyspark.sql.functions import lit, udtf
+from pyspark.sql.types import Row
+from pyspark.testing.sqlutils import ReusedSQLTestCase
+
+
+class UDTFTestsMixin(ReusedSQLTestCase):
+
+    def test_udtf_single_col(self):
+        class TestUDTF:
+            def eval(self, a: int):
+                yield a,
+
+        func = udtf(TestUDTF, returnType="a: int")
+        rows = func(lit(1)).collect()
+        self.assertEqual(rows, [Row(a=1)])
+
+    def test_udtf_multi_col(self):
+        class TestUDTF:
+            def eval(self, a: int):
+                yield a, a + 1
+
+        func = udtf(TestUDTF, returnType="a: int, b: int")
+        rows = func(lit(1)).collect()
+        self.assertEqual(rows, [Row(a=1, b=2)])
+
+    def test_udtf_multi_row(self):
+        class TestUDTF:
+            def eval(self, a: int, b: int):
+                yield a, b, a + b
+                yield a, b, a - b
+                yield a, b, b - a
+
+        func = udtf(TestUDTF, returnType="a: int, b: int, c: int")
+        rows = func(lit(1), lit(2)).collect()
+        self.assertEqual(rows, [Row(a=1, b=2, c=3), Row(a=1, b=2, c=-1), Row(a=1, b=2, c=1)])
+
+    def test_udtf_zero_row(self):
+        class TestUDTF:
+            def eval(self, a: int):
+                yield
+
+        func = udtf(TestUDTF, returnType="c: int")
+        with self.assertRaisesRegex(Py4JJavaError, "java.lang.NullPointerException"):
+            func(lit(1)).collect()
+
+    def test_udtf_decorator(self):
+        @udtf(returnType="a: int, b: int")
+        class TestUDTF:
+            def eval(self, a: int):
+                yield a, a + 1
+
+        rows = TestUDTF(lit(1)).collect()
+        self.assertEqual(rows, [Row(a=1, b=2)])
+
+    def test_udtf_registration(self):
+        class TestUDTF:
+            def eval(self, a: int, b: int):
+                yield a, b, a + b
+                yield a, b, a - b
+                yield a, b, b - a
+
+        func = udtf(TestUDTF, returnType="a: int, b: int, c: int")
+        self.spark.udtf.register("testUDTF", func)
+        df = self.spark.sql("SELECT * FROM testUDTF(1, 2)")
+        rows = df.collect()
+        self.assertEqual(rows, [Row(a=1, b=2, c=3), Row(a=1, b=2, c=-1), Row(a=1, b=2, c=1)])
+
+    def test_udtf_with_lateral_join(self):
+        class TestUDTF:
+            def eval(self, a: int, b: int) -> Iterator:
+                yield a, b, a + b
+                yield a, b, a - b
+
+        func = udtf(TestUDTF, returnType="a: int, b: int, c: int")
+        self.spark.udtf.register("testUDTF", func)
+        df = self.spark.sql(
+            "SELECT f.* FROM values (0, 1), (1, 2) t(a, b), LATERAL testUDTF(a, b) f"
+        )
+        expected = self.spark.createDataFrame(
+            [(0, 1, 1), (0, 1, -1), (1, 2, 3), (1, 2, -1)], schema=["a", "b", "c"]
+        )
+        self.assertEqual(df.collect(), expected.collect())
+
+    def test_udtf_with_none_output(self):
+        @udtf(returnType="a: int")
+        class TestUDTF:
+            def eval(self, a: int):
+                yield a,
+                yield None,
+
+        self.assertEqual(TestUDTF(lit(1)).collect(), [Row(a=1), Row(a=None)])
+        df = self.spark.createDataFrame([(0, 1), (1, 2)], schema=["a", "b"])
+        self.assertEqual(TestUDTF(lit(1)).join(df, "a", "inner").collect(), [Row(a=1, b=2)])
+        self.assertEqual(
+            TestUDTF(lit(1)).join(df, "a", "left").collect(), [Row(a=None, b=None), Row(a=1, b=2)]
+        )
+
+    def test_udtf_with_none_input(self):
+        @udtf(returnType="a: int")
+        class TestUDTF:
+            def eval(self, a: int):
+                yield a,
+
+        self.assertEqual(TestUDTF(lit(None)).collect(), [Row(a=None)])
+        self.spark.udtf.register("testUDTF", TestUDTF)
+        df = self.spark.sql("SELECT * FROM testUDTF(null)")
+        self.assertEqual(df.collect(), [Row(a=None)])
+
+    def test_udtf_init(self):
+        @udtf(returnType="a: int, b: int, c: string")
+        class TestUDTF:
+            def __init__(self):
+                self.key = "test"
+
+            def eval(self, a: int):
+                yield a, a + 1, self.key
+
+        rows = TestUDTF(lit(1)).collect()
+        self.assertEqual(rows, [Row(a=1, b=2, c="test")])
+
+    def test_udtf_terminate(self):
+        @udtf(returnType="a: int, b: int")
+        class TestUDTF:
+            def eval(self, a: int):
+                yield a, a + 1
+
+            def terminate(self):
+                raise ValueError("terminate")
+
+        with self.assertRaisesRegex(PythonException, "Failed to terminate UDTF: terminate"):
+            TestUDTF(lit(1)).collect()
+
+    # Invalid cases
+
+    def test_udtf_no_eval(self):
+        @udtf(returnType="a: int, b: int")
+        class TestUDTF:
+            def run(self, a: int):
+                yield a, a + 1
+
+        with self.assertRaisesRegex(PythonException, "Python UDTF must implement the eval method"):
+            TestUDTF(lit(1)).collect()
+
+    def test_udtf_eval_returning_non_tuple(self):
+        class TestUDTF:
+            def eval(self, a: int):
+                yield a
+
+        func = udtf(TestUDTF, returnType="a: int")
+        with self.assertRaisesRegex(PythonException, "Unexpected tuple 1 with StructType"):
+            func(lit(1)).collect()
+
+    def test_udtf_eval_with_return_stmt(self):
+        class TestUDTF:
+            def eval(self, a: int):
+                return a,
+
+        func = udtf(TestUDTF, returnType="a: int")
+        with self.assertRaisesRegex(PythonException, "Unexpected tuple 1 with StructType"):
+            func(lit(1)).collect()
+
+    def test_udtf_no_handler(self):
+        with self.assertRaisesRegex(TypeError, "the function handler must be a class"):
+            @udtf(returnType="a: int")
+            def eval(a: int):
+                yield a,
+
+
+class UDTFTests(UDTFTestsMixin, ReusedSQLTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(UDTFTests, cls).setUpClass()
+        cls.spark.conf.set("spark.sql.execution.pythonUDF.arrow.enabled", "false")
+
+
+if __name__ == "__main__":
+    from pyspark.sql.tests.test_udtf import *  # noqa: F401
+
+    try:
+        import xmlrunner  # type: ignore
+
+        testRunner = xmlrunner.XMLTestRunner(output="target/test-reports", verbosity=2)
+    except ImportError:
+        testRunner = None
+    unittest.main(testRunner=testRunner, verbosity=2)

--- a/python/pyspark/sql/tests/test_udtf.py
+++ b/python/pyspark/sql/tests/test_udtf.py
@@ -148,6 +148,7 @@ class UDTFTestsMixin(ReusedSQLTestCase):
             def eval(self, a: int):
                 ...
 
+        # TODO(SPARK-43967): Support Python UDTFs with empty return values
         with self.assertRaisesRegex(
             PythonException, "TypeError: 'NoneType' object is not iterable"
         ):
@@ -306,7 +307,7 @@ class UDTFTestsMixin(ReusedSQLTestCase):
                 yield a * int(random.random() * 100),
 
         random_udtf = udtf(RandomUDTF, returnType="x: int").asNondeterministic()
-        # TODO: support non-deterministic UDTFs
+        # TODO(SPARK-43966): support non-deterministic UDTFs
         with self.assertRaisesRegex(AnalysisException, "nondeterministic expressions"):
             random_udtf(lit(1)).collect()
 
@@ -318,7 +319,7 @@ class UDTFTestsMixin(ReusedSQLTestCase):
             def eval(self, a: int):
                 yield a + 1,
 
-        # TODO: support non-deterministic UDTFs
+        # TODO(SPARK-43966): support non-deterministic UDTFs
         with self.assertRaisesRegex(AnalysisException, "nondeterministic expressions"):
             TestUDTF(rand(0) * 100).collect()
 

--- a/python/pyspark/sql/tests/test_udtf.py
+++ b/python/pyspark/sql/tests/test_udtf.py
@@ -290,10 +290,10 @@ class UDTFTestsMixin(ReusedSQLTestCase):
         self.assertEqual(
             df.collect(),
             [
-                Row(id=0, key="count", value=5.0),
-                Row(id=0, key="avg", value=2.0),
-                Row(id=0, key="count", value=5.0),
-                Row(id=0, key="avg", value=7.0),
+                Row(id=4, key="count", value=5.0),
+                Row(id=4, key="avg", value=2.0),
+                Row(id=9, key="count", value=5.0),
+                Row(id=9, key="avg", value=7.0),
             ],
         )
 

--- a/python/pyspark/sql/udtf.py
+++ b/python/pyspark/sql/udtf.py
@@ -1,0 +1,209 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+User-defined table function related classes and functions
+"""
+import sys
+from typing import Type, TYPE_CHECKING, Optional, Union
+
+from py4j.java_gateway import JavaObject
+
+from pyspark.sql.column import _to_java_column, _to_seq
+from pyspark.sql.types import StructType, _parse_datatype_string
+from pyspark.sql.udf import _wrap_function
+
+if TYPE_CHECKING:
+    from pyspark.sql._typing import ColumnOrName
+    from pyspark.sql.dataframe import DataFrame
+    from pyspark.sql.session import SparkSession
+
+__all__ = ["UDTFRegistration"]
+
+
+def _create_udtf(
+    f: Type,
+    returnType: Union[StructType, str],
+    name: Optional[str] = None,
+    deterministic: bool = True,
+) -> "UserDefinedTableFunction":
+    """Create a Python UDTF."""
+    udtf_obj = UserDefinedTableFunction(
+        f, returnType=returnType, name=name, deterministic=deterministic
+    )
+    return udtf_obj
+
+
+class UserDefinedTableFunction:
+    """
+    User-defined table function in Python
+
+    .. versionadded:: 3.5
+
+    Notes
+    -----
+    The constructor of this class is not supposed to be directly called.
+    Use :meth:`pyspark.sql.functions.udtf` to create this instance.
+
+    This API is evolving.
+    """
+
+    def __init__(
+        self,
+        func: Type,
+        returnType: Union[StructType, str],
+        name: Optional[str] = None,
+        deterministic: bool = True,
+    ):
+        if not isinstance(func, type):
+            raise TypeError(
+                f"Invalid user-defined table function: the function handler "
+                f"must be a class, but got {type(func)}."
+            )
+
+        # TODO: add more checks for invalid user-defined table functions.
+
+        self.func = func
+        self._returnType = returnType
+        self._returnType_placeholder: Optional[StructType] = None
+        self._inputTypes_placeholder = None
+        self._judtf_placeholder = None
+        self._name = name or func.__name__
+        self.deterministic = deterministic
+
+    @property
+    def returnType(self) -> StructType:
+        # `_parse_datatype_string` accesses to JVM for parsing a DDL formatted string.
+        # This makes sure this is called after SparkContext is initialized.
+        if self._returnType_placeholder is None:
+            if isinstance(self._returnType, StructType):
+                self._returnType_placeholder = self._returnType
+            else:
+                assert isinstance(self._returnType, str)
+                parsed = _parse_datatype_string(self._returnType)
+                if not isinstance(parsed, StructType):
+                    raise TypeError(
+                        f"Invalid function return type string: {self._returnType}. "
+                        f"The return type of a UDTF must be a struct type."
+                    )
+                self._returnType_placeholder = parsed
+        return self._returnType_placeholder
+
+    @property
+    def _judtf(self) -> JavaObject:
+        if self._judtf_placeholder is None:
+            self._judtf_placeholder = self._create_judtf(self.func)
+        return self._judtf_placeholder
+
+    def _create_judtf(self, func: Type) -> JavaObject:
+        from pyspark.sql import SparkSession
+
+        spark = SparkSession._getActiveSessionOrCreate()
+        sc = spark.sparkContext
+
+        wrapped_func = _wrap_function(sc, func, self.returnType)
+        jdt = spark._jsparkSession.parseDataType(self.returnType.json())
+        assert sc._jvm is not None
+        judtf = sc._jvm.org.apache.spark.sql.execution.python.UserDefinedPythonTableFunction(
+            self._name, wrapped_func, jdt, self.deterministic
+        )
+        return judtf
+
+    def __call__(self, *cols: "ColumnOrName") -> "DataFrame":
+        from pyspark.sql import DataFrame, SparkSession
+
+        spark = SparkSession._getActiveSessionOrCreate()
+        sc = spark.sparkContext
+
+        judtf = self._judtf
+        jPythonUDTF = judtf.apply(spark._jsparkSession, _to_seq(sc, cols, _to_java_column))
+        return DataFrame(jPythonUDTF, spark)
+
+    def asNondeterministic(self) -> "UserDefinedTableFunction":
+        """
+        Updates UserDefinedTableFunction to nondeterministic.
+        """
+        # Explicitly clean the cache to create a JVM UDTF instance.
+        self._judtf_placeholder = None
+        self.deterministic = False
+        return self
+
+
+class UDTFRegistration:
+    """
+    Wrapper for user-defined table function registration. This instance can be accessed by
+    :attr:`spark.udtf` or :attr:`sqlContext.udtf`.
+
+    .. versionadded:: 3.5
+    """
+
+    def __init__(self, sparkSession: "SparkSession"):
+        self.sparkSession = sparkSession
+
+    def register(
+        self,
+        name: str,
+        f: UserDefinedTableFunction,
+    ) -> UserDefinedTableFunction:
+        """Register a Python user-defined table function as a SQL table function.
+
+        .. versionadded:: 3.5
+
+        Parameters
+        ----------
+        name : str,
+            name of the user-defined table function in SQL statements.
+        f : function, :meth:`pyspark.sql.functions.udtf` a user-defined table function.
+
+        Returns
+        -------
+        function
+            a user-defined table function
+
+        Notes
+        -----
+        To register a nondeterministic Python table function, users need to first build
+        a nondeterministic user-defined table function and then register it as a SQL function.
+        """
+        register_udtf = _create_udtf(
+            f.func,
+            returnType=f.returnType,
+            name=name,
+            deterministic=f.deterministic,
+        )
+        return_udtf = f
+        self.sparkSession._jsparkSession.udtf().registerPython(name, register_udtf._judtf)
+        return return_udtf
+
+
+def _test() -> None:
+    import doctest
+    from pyspark.sql import SparkSession
+    import pyspark.sql.udf
+
+    globs = pyspark.sql.udtf.__dict__.copy()
+    spark = SparkSession.builder.master("local[4]").appName("sql.udtf tests").getOrCreate()
+    globs["spark"] = spark
+    (failure_count, test_count) = doctest.testmod(
+        pyspark.sql.udtf, globs=globs, optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE
+    )
+    spark.stop()
+    if failure_count:
+        sys.exit(-1)
+
+
+if __name__ == "__main__":
+    _test()

--- a/python/pyspark/sql/udtf.py
+++ b/python/pyspark/sql/udtf.py
@@ -74,7 +74,7 @@ class UserDefinedTableFunction:
                 f"must be a class, but got {type(func)}."
             )
 
-        # TODO: add more checks for invalid user-defined table functions.
+        # TODO(SPARK-43968): add more compile time checks for UDTFs
 
         self.func = func
         self._returnType = returnType

--- a/python/pyspark/sql/udtf.py
+++ b/python/pyspark/sql/udtf.py
@@ -193,7 +193,7 @@ class UDTFRegistration:
         ... class PlusOne:
         ...     def eval(self, x: int):
         ...         yield x, x + 1
-        >>> spark.udtf.register(name="plus_one", f=PlusOne)
+        >>> _ = spark.udtf.register(name="plus_one", f=PlusOne)
         >>> spark.sql("SELECT * FROM plus_one(1)").collect()
         [Row(c1=1, c2=2)]
 

--- a/python/pyspark/sql/udtf.py
+++ b/python/pyspark/sql/udtf.py
@@ -35,14 +35,14 @@ __all__ = ["UDTFRegistration"]
 
 
 def _create_udtf(
-    f: Type,
+    cls: Type,
     returnType: Union[StructType, str],
     name: Optional[str] = None,
     deterministic: bool = True,
 ) -> "UserDefinedTableFunction":
     """Create a Python UDTF."""
     udtf_obj = UserDefinedTableFunction(
-        f, returnType=returnType, name=name, deterministic=deterministic
+        cls, returnType=returnType, name=name, deterministic=deterministic
     )
     return udtf_obj
 
@@ -185,14 +185,14 @@ class UDTFRegistration:
         --------
         >>> from pyspark.sql.functions import udtf
         >>> @udtf(returnType="c1: int, c2: int")
-        >>> class PlusOne:
-        >>>     def eval(self, x: int):
-        >>>         yield x, x + 1
+        ... class PlusOne:
+        ...     def eval(self, x: int):
+        ...         yield x, x + 1
         >>> spark.udtf.register(name="plus_one", f=PlusOne)
         >>> spark.sql("SELECT * FROM plus_one(1)").collect()
         [Row(c1=1, c2=2)]
 
-        >>> # Use it with lateral join
+        Use it with lateral join
         >>> spark.sql("SELECT * FROM VALUES (0, 1), (1, 2) t(x, y), LATERAL plus_one(x)").collect()
         [Row(x=0, y=1, c1=0, c2=1), Row(x=1, y=2, c1=1, c2=2)]
         """

--- a/python/pyspark/sql/udtf.py
+++ b/python/pyspark/sql/udtf.py
@@ -51,7 +51,7 @@ class UserDefinedTableFunction:
     """
     User-defined table function in Python
 
-    .. versionadded:: 3.5
+    .. versionadded:: 3.5.0
 
     Notes
     -----
@@ -147,7 +147,7 @@ class UDTFRegistration:
     Wrapper for user-defined table function registration. This instance can be accessed by
     :attr:`spark.udtf` or :attr:`sqlContext.udtf`.
 
-    .. versionadded:: 3.5
+    .. versionadded:: 3.5.0
     """
 
     def __init__(self, sparkSession: "SparkSession"):
@@ -160,7 +160,7 @@ class UDTFRegistration:
     ) -> UserDefinedTableFunction:
         """Register a Python user-defined table function as a SQL table function.
 
-        .. versionadded:: 3.5
+        .. versionadded:: 3.5.0
 
         Parameters
         ----------
@@ -175,8 +175,26 @@ class UDTFRegistration:
 
         Notes
         -----
+        Spark uses the return type of the given user-defined table function as the return
+        type of the registered user-defined function.
+
         To register a nondeterministic Python table function, users need to first build
         a nondeterministic user-defined table function and then register it as a SQL function.
+
+        Examples
+        --------
+        >>> from pyspark.sql.functions import udtf
+        >>> @udtf(returnType="c1: int, c2: int")
+        >>> class PlusOne:
+        >>>     def eval(self, x: int):
+        >>>         yield x, x + 1
+        >>> spark.udtf.register(name="plus_one", f=PlusOne)
+        >>> spark.sql("SELECT * FROM plus_one(1)").collect()
+        [Row(c1=1, c2=2)]
+
+        >>> # Use it with lateral join
+        >>> spark.sql("SELECT * FROM VALUES (0, 1), (1, 2) t(x, y), LATERAL plus_one(x)").collect()
+        [Row(x=0, y=1, c1=0, c2=1), Row(x=1, y=2, c1=1, c2=2)]
         """
         register_udtf = _create_udtf(
             f.func,

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/ExpressionInfo.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/ExpressionInfo.java
@@ -48,7 +48,8 @@ public class ExpressionInfo {
             "window_funcs", "xml_funcs", "table_funcs", "url_funcs"));
 
     private static final Set<String> validSources =
-            new HashSet<>(Arrays.asList("built-in", "hive", "python_udf", "scala_udf", "java_udf"));
+            new HashSet<>(Arrays.asList("built-in", "hive", "python_udf", "scala_udf",
+                    "java_udf", "python_udtf"));
 
     public String getClassName() {
         return className;

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/PlanHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/PlanHelper.scala
@@ -48,7 +48,8 @@ object PlanHelper {
                plan.isInstanceOf[CollectMetrics] ||
                onlyInLateralSubquery(plan)) => e
         case e: Generator
-          if !plan.isInstanceOf[Generate] => e
+          if !(plan.isInstanceOf[Generate] ||
+               plan.isInstanceOf[BaseEvalPythonUDTF]) => e
       }
     }
     invalidExpressions

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/pythonLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/pythonLogicalOperators.scala
@@ -188,6 +188,12 @@ case class ArrowEvalPython(
 
 /**
  * A logical plan that evaluates a [[PythonUDTF]].
+ *
+ * @param udtf the user-defined Python function
+ * @param requiredChildOutput the required output of the child plan. It's used for omitting data
+ *                            generation that will be discarded next by a projection.
+ * @param resultAttrs the output schema of the Python UDTF.
+ * @param child the child plan
  */
 case class BatchEvalPythonUDTF(
     udtf: PythonUDTF,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/pythonLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/pythonLogicalOperators.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.catalyst.plans.logical
 
-import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeSet, Expression, PythonUDF}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeSet, Expression, PythonUDF, PythonUDTF}
 import org.apache.spark.sql.catalyst.trees.TreePattern._
 import org.apache.spark.sql.catalyst.util.truncatedString
 import org.apache.spark.sql.streaming.{GroupStateTimeout, OutputMode}
@@ -148,6 +148,21 @@ trait BaseEvalPython extends UnaryNode {
   final override val nodePatterns: Seq[TreePattern] = Seq(EVAL_PYTHON_UDF)
 }
 
+trait BaseEvalPythonUDTF extends UnaryNode {
+
+  def udtf: PythonUDTF
+
+  def requiredChildOutput: Seq[Attribute]
+
+  def resultAttrs: Seq[Attribute]
+
+  override def output: Seq[Attribute] = requiredChildOutput ++ resultAttrs
+
+  override def producedAttributes: AttributeSet = AttributeSet(resultAttrs)
+
+  final override val nodePatterns: Seq[TreePattern] = Seq(EVAL_PYTHON_UDTF)
+}
+
 /**
  * A logical plan that evaluates a [[PythonUDF]]
  */
@@ -168,6 +183,18 @@ case class ArrowEvalPython(
     child: LogicalPlan,
     evalType: Int) extends BaseEvalPython {
   override protected def withNewChildInternal(newChild: LogicalPlan): ArrowEvalPython =
+    copy(child = newChild)
+}
+
+/**
+ * A logical plan that evaluates a [[PythonUDTF]].
+ */
+case class BatchEvalPythonUDTF(
+    udtf: PythonUDTF,
+    requiredChildOutput: Seq[Attribute],
+    resultAttrs: Seq[Attribute],
+    child: LogicalPlan) extends BaseEvalPythonUDTF {
+  override protected def withNewChildInternal(newChild: LogicalPlan): BatchEvalPythonUDTF =
     copy(child = newChild)
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
@@ -106,6 +106,7 @@ object TreePattern extends Enumeration  {
   val CTE: Value = Value
   val DISTINCT_LIKE: Value = Value
   val EVAL_PYTHON_UDF: Value = Value
+  val EVAL_PYTHON_UDTF: Value = Value
   val EVENT_TIME_WATERMARK: Value = Value
   val EXCEPT: Value = Value
   val FILTER: Value = Value

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -225,6 +225,8 @@ class SparkSession private(
    */
   def udf: UDFRegistration = sessionState.udfRegistration
 
+  def udtf: UDTFRegistration = sessionState.udtfRegistration
+
   /**
    * Returns a `StreamingQueryManager` that allows managing all the
    * `StreamingQuery`s active on `this`.

--- a/sql/core/src/main/scala/org/apache/spark/sql/UDTFRegistration.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/UDTFRegistration.scala
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+import org.apache.spark.annotation.Evolving
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.catalyst.analysis.TableFunctionRegistry
+import org.apache.spark.sql.execution.python.UserDefinedPythonTableFunction
+
+/**
+ * Functions for registering user-defined table functions. Use `SparkSession.udtf` to access this.
+ *
+ * @since 3.5.0
+ */
+@Evolving
+class UDTFRegistration private[sql] (tableFunctionRegistry: TableFunctionRegistry)
+  extends Logging {
+
+  protected[sql] def registerPython(name: String, udtf: UserDefinedPythonTableFunction): Unit = {
+    log.debug(
+      s"""
+         | Registering new PythonUDTF:
+         | name: $name
+         | command: ${udtf.func.command}
+         | envVars: ${udtf.func.envVars}
+         | pythonIncludes: ${udtf.func.pythonIncludes}
+         | pythonExec: ${udtf.func.pythonExec}
+         | returnType: ${udtf.returnType}
+         | udfDeterministic: ${udtf.udfDeterministic}
+      """.stripMargin)
+
+    tableFunctionRegistry.createOrReplaceTempFunction(name, udtf.builder, "python_udtf")
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkOptimizer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkOptimizer.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.connector.catalog.CatalogManager
 import org.apache.spark.sql.execution.datasources.{PruneFileSourcePartitions, SchemaPruning, V1Writes}
 import org.apache.spark.sql.execution.datasources.v2.{GroupBasedRowLevelOperationScanPlanning, OptimizeMetadataOnlyDeleteFromTable, V2ScanPartitioningAndOrdering, V2ScanRelationPushDown, V2Writes}
 import org.apache.spark.sql.execution.dynamicpruning.{CleanupDynamicPruningFilters, PartitionPruning, RowLevelOperationRuntimeGroupFiltering}
-import org.apache.spark.sql.execution.python.{ExtractGroupingPythonUDFFromAggregate, ExtractPythonUDFFromAggregate, ExtractPythonUDFs}
+import org.apache.spark.sql.execution.python.{ExtractGroupingPythonUDFFromAggregate, ExtractPythonUDFFromAggregate, ExtractPythonUDFs, ExtractPythonUDTFs}
 
 class SparkOptimizer(
     catalogManager: CatalogManager,
@@ -77,6 +77,7 @@ class SparkOptimizer(
       // This must be executed after `ExtractPythonUDFFromAggregate` and before `ExtractPythonUDFs`.
       ExtractGroupingPythonUDFFromAggregate,
       ExtractPythonUDFs,
+      ExtractPythonUDTFs,
       // The eval-python node may be between Project/Filter and the scan node, which breaks
       // column pruning and filter push-down. Here we rerun the related optimizer rules.
       ColumnPruning,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -747,6 +747,8 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
         ArrowEvalPythonExec(udfs, output, planLater(child), evalType) :: Nil
       case BatchEvalPython(udfs, output, child) =>
         BatchEvalPythonExec(udfs, output, planLater(child)) :: Nil
+      case BatchEvalPythonUDTF(udtf, requiredChildOutput, resultAttrs, child) =>
+        BatchEvalPythonUDTFExec(udtf, requiredChildOutput, resultAttrs, planLater(child)) :: Nil
       case _ =>
         Nil
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/BatchEvalPythonExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/BatchEvalPythonExec.scala
@@ -42,39 +42,8 @@ case class BatchEvalPythonExec(udfs: Seq[PythonUDF], resultAttrs: Seq[Attribute]
       context: TaskContext): Iterator[InternalRow] = {
     EvaluatePython.registerPicklers()  // register pickler for Row
 
-    val dataTypes = schema.map(_.dataType)
-    val needConversion = dataTypes.exists(EvaluatePython.needConversionInPython)
-
-    // enable memo iff we serialize the row with schema (schema and class should be memorized)
-    // pyrolite 4.21+ can lookup objects in its cache by value, but `GenericRowWithSchema` objects,
-    // that we pass from JVM to Python, don't define their `equals()` to take the type of the
-    // values or the schema of the row into account. This causes like
-    // `GenericRowWithSchema(Array(1.0, 1.0),
-    //    StructType(Seq(StructField("_1", DoubleType), StructField("_2", DoubleType))))`
-    // and
-    // `GenericRowWithSchema(Array(1, 1),
-    //    StructType(Seq(StructField("_1", IntegerType), StructField("_2", IntegerType))))`
-    // to be `equal()` and so we need to disable this feature explicitly (`valueCompare=false`).
-    // Please note that cache by reference is still enabled depending on `needConversion`.
-    val pickle = new Pickler(/* useMemo = */ needConversion,
-      /* valueCompare = */ false)
-    // Input iterator to Python: input rows are grouped so we send them in batches to Python.
-    // For each row, add it to the queue.
-    val inputIterator = iter.map { row =>
-      if (needConversion) {
-        EvaluatePython.toJava(row, schema)
-      } else {
-        // fast path for these types that does not need conversion in Python
-        val fields = new Array[Any](row.numFields)
-        var i = 0
-        while (i < row.numFields) {
-          val dt = dataTypes(i)
-          fields(i) = EvaluatePython.toJava(row.get(i, dt), dt)
-          i += 1
-        }
-        fields
-      }
-    }.grouped(100).map(x => pickle.dumps(x.toArray))
+    // Input iterator to Python.
+    val inputIterator = BatchEvalPythonExec.getInputIterator(iter, schema)
 
     // Output iterator for results from Python.
     val outputIterator =
@@ -108,4 +77,44 @@ case class BatchEvalPythonExec(udfs: Seq[PythonUDF], resultAttrs: Seq[Attribute]
 
   override protected def withNewChildInternal(newChild: SparkPlan): BatchEvalPythonExec =
     copy(child = newChild)
+}
+
+object BatchEvalPythonExec {
+  def getInputIterator(
+      iter: Iterator[InternalRow],
+      schema: StructType): Iterator[Array[Byte]] = {
+    val dataTypes = schema.map(_.dataType)
+    val needConversion = dataTypes.exists(EvaluatePython.needConversionInPython)
+
+    // enable memo iff we serialize the row with schema (schema and class should be memorized)
+    // pyrolite 4.21+ can lookup objects in its cache by value, but `GenericRowWithSchema` objects,
+    // that we pass from JVM to Python, don't define their `equals()` to take the type of the
+    // values or the schema of the row into account. This causes like
+    // `GenericRowWithSchema(Array(1.0, 1.0),
+    //    StructType(Seq(StructField("_1", DoubleType), StructField("_2", DoubleType))))`
+    // and
+    // `GenericRowWithSchema(Array(1, 1),
+    //    StructType(Seq(StructField("_1", IntegerType), StructField("_2", IntegerType))))`
+    // to be `equal()` and so we need to disable this feature explicitly (`valueCompare=false`).
+    // Please note that cache by reference is still enabled depending on `needConversion`.
+    val pickle = new Pickler(/* useMemo = */ needConversion,
+      /* valueCompare = */ false)
+    // Input iterator to Python: input rows are grouped so we send them in batches to Python.
+    // For each row, add it to the queue.
+    iter.map { row =>
+      if (needConversion) {
+        EvaluatePython.toJava(row, schema)
+      } else {
+        // fast path for these types that does not need conversion in Python
+        val fields = new Array[Any](row.numFields)
+        var i = 0
+        while (i < row.numFields) {
+          val dt = dataTypes(i)
+          fields(i) = EvaluatePython.toJava(row.get(i, dt), dt)
+          i += 1
+        }
+        fields
+      }
+    }.grouped(100).map(x => pickle.dumps(x.toArray))
+  }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/BatchEvalPythonUDTFExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/BatchEvalPythonUDTFExec.scala
@@ -17,20 +17,25 @@
 
 package org.apache.spark.sql.execution.python
 
+import java.io.File
+
 import scala.collection.JavaConverters._
+import scala.collection.mutable.ArrayBuffer
 
 import net.razorvine.pickle.Unpickler
 
-import org.apache.spark.TaskContext
+import org.apache.spark.{ContextAwareIterator, SparkEnv, TaskContext}
 import org.apache.spark.api.python.{ChainedPythonFunctions, PythonEvalType}
+import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.util.GenericArrayData
-import org.apache.spark.sql.execution.SparkPlan
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.execution.{SparkPlan, UnaryExecNode}
+import org.apache.spark.sql.types.{DataType, StructField, StructType}
+import org.apache.spark.util.Utils
 
 /**
- * A physical plan that evaluates a [[PythonUDTF]].
+ * A physical plan that evaluates a [[PythonUDTF]]. This is similar to [[BatchEvalPythonExec]].
  *
  * @param udtf the user-defined Python function
  * @param requiredChildOutput the required output of the child plan. It's used for omitting data
@@ -43,10 +48,83 @@ case class BatchEvalPythonUDTFExec(
     requiredChildOutput: Seq[Attribute],
     resultAttrs: Seq[Attribute],
     child: SparkPlan)
-  extends EvalPythonUDTFExec with PythonSQLMetrics {
+  extends UnaryExecNode with PythonSQLMetrics {
 
-  protected override def evaluate(
-      funcs: Seq[ChainedPythonFunctions],
+  override def output: Seq[Attribute] = requiredChildOutput ++ resultAttrs
+
+  override def producedAttributes: AttributeSet = AttributeSet(resultAttrs)
+
+  protected override def doExecute(): RDD[InternalRow] = {
+    val inputRDD = child.execute().map(_.copy())
+
+    inputRDD.mapPartitions { iter =>
+      val context = TaskContext.get()
+      val contextAwareIterator = new ContextAwareIterator(context, iter)
+
+      // The queue used to buffer input rows so we can drain it to
+      // combine input with output from Python.
+      val queue = HybridRowQueue(context.taskMemoryManager(),
+        new File(Utils.getLocalDir(SparkEnv.get.conf)), child.output.length)
+      context.addTaskCompletionListener[Unit] { ctx =>
+        queue.close()
+      }
+
+      val inputs = Seq(udtf.children)
+
+      // flatten all the arguments
+      val allInputs = new ArrayBuffer[Expression]
+      val dataTypes = new ArrayBuffer[DataType]
+      val argOffsets = inputs.map { input =>
+        input.map { e =>
+          if (allInputs.exists(_.semanticEquals(e))) {
+            allInputs.indexWhere(_.semanticEquals(e))
+          } else {
+            allInputs += e
+            dataTypes += e.dataType
+            allInputs.length - 1
+          }
+        }.toArray
+      }.toArray
+      val projection = MutableProjection.create(allInputs.toSeq, child.output)
+      projection.initialize(context.partitionId())
+      val schema = StructType(dataTypes.zipWithIndex.map { case (dt, i) =>
+        StructField(s"_$i", dt)
+      }.toArray)
+
+      // Add rows to the queue to join later with the result.
+      // Also keep track of the number rows added to the queue.
+      var count = 0L
+      val projectedRowIter = contextAwareIterator.map { inputRow =>
+        queue.add(inputRow.asInstanceOf[UnsafeRow])
+        count += 1
+        projection(inputRow)
+      }
+
+      val outputRowIterator = evaluate(udtf, argOffsets, projectedRowIter, schema, context)
+
+      val pruneChildForResult: InternalRow => InternalRow =
+        if (child.outputSet == AttributeSet(requiredChildOutput)) {
+          identity
+        } else {
+          UnsafeProjection.create(requiredChildOutput, child.output)
+        }
+
+      val joined = new JoinedRow
+      val resultProj = UnsafeProjection.create(output, output)
+
+      outputRowIterator.flatMap { outputRows =>
+        if (count > 0) {
+          val left = queue.remove()
+          count -= 1
+          joined.withLeft(pruneChildForResult(left))
+        }
+        outputRows.map(r => resultProj(joined.withRight(r)))
+      }
+    }
+  }
+
+  private def evaluate(
+      udtf: PythonUDTF,
       argOffsets: Array[Array[Int]],
       iter: Iterator[InternalRow],
       schema: StructType,
@@ -57,6 +135,7 @@ case class BatchEvalPythonUDTFExec(
     val inputIterator = BatchEvalPythonExec.getInputIterator(iter, schema)
 
     // Output iterator for results from Python.
+    val funcs = Seq(ChainedPythonFunctions(Seq(udtf.func)))
     val outputIterator =
       new PythonUDFRunner(funcs, PythonEvalType.SQL_TABLE_UDF, argOffsets, pythonMetrics)
         .compute(inputIterator, context.partitionId(), context)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/BatchEvalPythonUDTFExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/BatchEvalPythonUDTFExec.scala
@@ -31,6 +31,12 @@ import org.apache.spark.sql.types.StructType
 
 /**
  * A physical plan that evaluates a [[PythonUDTF]].
+ *
+ * @param udtf the user-defined Python function
+ * @param requiredChildOutput the required output of the child plan. It's used for omitting data
+ *                            generation that will be discarded next by a projection.
+ * @param resultAttrs the output schema of the Python UDTF.
+ * @param child the child plan
  */
 case class BatchEvalPythonUDTFExec(
     udtf: PythonUDTF,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/BatchEvalPythonUDTFExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/BatchEvalPythonUDTFExec.scala
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.python
+
+import scala.collection.JavaConverters._
+
+import net.razorvine.pickle.Unpickler
+
+import org.apache.spark.TaskContext
+import org.apache.spark.api.python.{ChainedPythonFunctions, PythonEvalType}
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.util.GenericArrayData
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.types.StructType
+
+/**
+ * A physical plan that evaluates a [[PythonUDTF]].
+ */
+case class BatchEvalPythonUDTFExec(
+    udtf: PythonUDTF,
+    requiredChildOutput: Seq[Attribute],
+    resultAttrs: Seq[Attribute],
+    child: SparkPlan)
+  extends EvalPythonUDTFExec with PythonSQLMetrics {
+
+  protected override def evaluate(
+      funcs: Seq[ChainedPythonFunctions],
+      argOffsets: Array[Array[Int]],
+      iter: Iterator[InternalRow],
+      schema: StructType,
+      context: TaskContext): Iterator[Iterator[InternalRow]] = {
+    EvaluatePython.registerPicklers()  // register pickler for Row
+
+    // Input iterator to Python.
+    val inputIterator = BatchEvalPythonExec.getInputIterator(iter, schema)
+
+    // Output iterator for results from Python.
+    val outputIterator =
+      new PythonUDFRunner(funcs, PythonEvalType.SQL_TABLE_UDF, argOffsets, pythonMetrics)
+        .compute(inputIterator, context.partitionId(), context)
+
+    val unpickle = new Unpickler
+
+    // The return type of a UDTF is an array of struct.
+    val resultType = udtf.dataType
+    val fromJava = EvaluatePython.makeFromJava(resultType)
+
+    outputIterator.flatMap { pickedResult =>
+      val unpickledBatch = unpickle.loads(pickedResult)
+      unpickledBatch.asInstanceOf[java.util.ArrayList[Any]].asScala
+    }.map { results =>
+      assert(results.getClass.isArray)
+      val res = results.asInstanceOf[Array[_]]
+      pythonMetrics("pythonNumRowsReceived") += res.length
+      fromJava(results).asInstanceOf[GenericArrayData]
+        .array.map(_.asInstanceOf[InternalRow]).toIterator
+    }
+  }
+
+  override protected def withNewChildInternal(newChild: SparkPlan): BatchEvalPythonUDTFExec =
+    copy(child = newChild)
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ExtractPythonUDFs.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ExtractPythonUDFs.scala
@@ -305,3 +305,19 @@ object ExtractPythonUDFs extends Rule[LogicalPlan] {
     }
   }
 }
+
+/**
+ * Extracts PythonUDTFs from operators, rewriting the query plan so that UDTFs can be evaluated.
+ */
+object ExtractPythonUDTFs extends Rule[LogicalPlan] {
+  def apply(plan: LogicalPlan): LogicalPlan = plan match {
+    // A correlated subquery will be rewritten into join later, and will go through this rule
+    // eventually. Here we skip subquery, as Python UDTFs only need to be extracted once.
+    case s: Subquery if s.correlated => plan
+
+    case _ => plan.transformUpWithPruning(_.containsPattern(GENERATE)) {
+      case g @ Generate(func: PythonUDTF, _, _, _, _, child) =>
+        BatchEvalPythonUDTF(func, g.requiredChildOutput, g.generatorOutput, child)
+    }
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala
@@ -175,6 +175,8 @@ abstract class BaseSessionStateBuilder(
    */
   protected def udfRegistration: UDFRegistration = new UDFRegistration(functionRegistry)
 
+  protected def udtfRegistration: UDTFRegistration = new UDTFRegistration(tableFunctionRegistry)
+
   /**
    * Logical query plan analyzer for resolving unresolved attributes and relations.
    *
@@ -365,6 +367,7 @@ abstract class BaseSessionStateBuilder(
       functionRegistry,
       tableFunctionRegistry,
       udfRegistration,
+      udtfRegistration,
       () => catalog,
       sqlParser,
       () => analyzer,

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SessionState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SessionState.scala
@@ -46,6 +46,8 @@ import org.apache.spark.util.{DependencyUtils, Utils}
  * @param experimentalMethods Interface to add custom planning strategies and optimizers.
  * @param functionRegistry Internal catalog for managing functions registered by the user.
  * @param udfRegistration Interface exposed to the user for registering user-defined functions.
+ * @param udtfRegistration Interface exposed to the user for registering user-defined
+ *                         table functions.
  * @param catalogBuilder a function to create an internal catalog for managing table and database
  *                       states.
  * @param sqlParser Parser that extracts expressions, plans, table identifiers etc. from SQL texts.
@@ -69,6 +71,7 @@ private[sql] class SessionState(
     val functionRegistry: FunctionRegistry,
     val tableFunctionRegistry: TableFunctionRegistry,
     val udfRegistration: UDFRegistration,
+    val udtfRegistration: UDTFRegistration,
     catalogBuilder: () => SessionCatalog,
     val sqlParser: ParserInterface,
     analyzerBuilder: () => Analyzer,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonUDTFSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonUDTFSuite.scala
@@ -49,17 +49,13 @@ class PythonUDTFSuite extends QueryTest with SharedSparkSession {
     createUserDefinedPythonTableFunction("SimpleUDTF", pythonScript, returnType)
 
   test("Simple PythonUDTF") {
-    // scalastyle:off assume
     assume(shouldTestPythonUDFs)
-    // scalastyle:on assume
     val df = pythonUDTF(spark, lit(1), lit(2))
     checkAnswer(df, Seq(Row(1, 2, -1), Row(1, 2, 1), Row(1, 2, 3)))
   }
 
   test("PythonUDTF with lateral join") {
-    // scalastyle:off assume
     assume(shouldTestPythonUDFs)
-    // scalastyle:on assume
     withTempView("t") {
       spark.udtf.registerPython("testUDTF", pythonUDTF)
       Seq((0, 1), (1, 2)).toDF("a", "b").createOrReplaceTempView("t")
@@ -70,9 +66,7 @@ class PythonUDTFSuite extends QueryTest with SharedSparkSession {
   }
 
   test("PythonUDTF in correlated subquery") {
-    // scalastyle:off assume
     assume(shouldTestPythonUDFs)
-    // scalastyle:on assume
     withTempView("t") {
       spark.udtf.registerPython("testUDTF", pythonUDTF)
       Seq((0, 1), (1, 2)).toDF("a", "b").createOrReplaceTempView("t")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonUDTFSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonUDTFSuite.scala
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.python
+
+import org.apache.spark.sql.{IntegratedUDFTestUtils, QueryTest, Row}
+import org.apache.spark.sql.functions.lit
+import org.apache.spark.sql.test.SharedSparkSession
+
+class PythonUDTFSuite extends QueryTest with SharedSparkSession {
+
+  import testImplicits._
+
+  import IntegratedUDFTestUtils._
+
+  val pythonTestUDTF = TestPythonUDTF(name = "pyUDTF")
+
+  test("Simple PythonUDTF") {
+    // scalastyle:off assume
+    assume(shouldTestPythonUDFs)
+    // scalastyle:on assume
+    val df = pythonTestUDTF(spark, lit(1), lit(2))
+    checkAnswer(df, Seq(Row(1, 2, -1), Row(1, 2, 1), Row(1, 2, 3)))
+  }
+
+  test("PythonUDTF with lateral join") {
+    // scalastyle:off assume
+    assume(shouldTestPythonUDFs)
+    // scalastyle:on assume
+    withTempView("t") {
+      val func = createUserDefinedPythonTableFunction("testUDTF")
+      spark.udtf.registerPython("testUDTF", func)
+      Seq((0, 1), (1, 2)).toDF("a", "b").createOrReplaceTempView("t")
+      checkAnswer(
+        sql("SELECT f.* FROM t, LATERAL testUDTF(a, b) f"),
+        sql("SELECT * FROM t, LATERAL explode(array(a + b, a - b, b - a)) t(c)")
+      )
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR adds the initial support for Python user-defined table functions. It allows users to create UDTFs in PySpark and use them in PySpark and SQL.

Here are examples of creating and using Python UDTFs:
```python
# Implement the UDTF class
class TestUDTF:
  def __init__(self):
    ...

  def eval(self, *args):
    yield "hello", "world"  
  
  def terminate(self):
    ...

# Create the UDTF
from pyspark.sql.functions import udtf

test_udtf = udtf(TestUDTF, returnType="c1: string, c2: string")

# Invoke the UDTF
test_udtf().show()
+-----+-----+
|   c1|   c2|
+-----+-----+
|hello|world|
+-----+-----+

# Register the UDTF
spark.udtf.register(name="test_udtf", f=test_udtf)

# Invoke the UDTF in SQL
spark.sql("SELECT * FROM test_udtf()").show()
+-----+-----+
|   c1|   c2|
+-----+-----+
|hello|world|
+-----+-----+
```

Please note that this is the initial PR, and there will be subsequent follow-up work to make it more user-friendly and performant.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To support another type of user-defined function in PySpark.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. After this PR, users can create Python user-defined table functions.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New unit tests.