### PR TITLE
[SPARK-43803] [SS] [CONNECT] Improve awaitTermination() to handle client disconnects

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -2577,16 +2577,13 @@ class SparkConnectPlanner(val session: SparkSession) extends Logging {
         }
 
       case StreamingQueryCommand.CommandCase.AWAIT_TERMINATION =>
-        if (command.getAwaitTermination.hasTimeoutMs) {
-          val terminated = handleStreamingAwaitTermination(query,
-            Some(command.getAwaitTermination.getTimeoutMs))
-          respBuilder.getAwaitTerminationBuilder
-            .setTerminated(terminated)
+        val timeout = if (command.getAwaitTermination.hasTimeoutMs) {
+          Some(command.getAwaitTermination.getTimeoutMs)
         } else {
-          handleStreamingAwaitTermination(query, None)
-          respBuilder.getAwaitTerminationBuilder
-            .setTerminated(true)
+          None
         }
+        val terminated = handleStreamingAwaitTermination(query, timeout)
+        respBuilder.getAwaitTerminationBuilder.setTerminated(terminated)
 
       case StreamingQueryCommand.CommandCase.COMMAND_NOT_SET =>
         throw new IllegalArgumentException("Missing command in StreamingQueryCommand")

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -21,7 +21,7 @@ import scala.collection.JavaConverters._
 import scala.collection.mutable
 
 import com.google.common.collect.{Lists, Maps}
-import com.google.protobuf.{ByteString, Any => ProtoAny}
+import com.google.protobuf.{Any => ProtoAny, ByteString}
 import io.grpc.{Context, Status, StatusRuntimeException}
 import io.grpc.stub.StreamObserver
 import org.apache.commons.lang3.exception.ExceptionUtils

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -2601,9 +2601,12 @@ class SparkConnectPlanner(val session: SparkSession) extends Logging {
    * A helper function to handle streaming awaitTermination(). awaitTermination() can be a long
    * running command. In this function, we periodically check if the RPC call has been cancelled.
    * If so, we can stop the operation and release resources early.
-   * @param query the query waits to be terminated
-   * @param timeoutOptionMs optional. Timeout to wait for termination. If None, no timeout is set
-   * @return if the query has terminated
+   * @param query
+   *   the query waits to be terminated
+   * @param timeoutOptionMs
+   *   optional. Timeout to wait for termination. If None, no timeout is set
+   * @return
+   *   if the query has terminated
    */
   private def handleStreamingAwaitTermination(
       query: StreamingQuery,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Streaming awaitTermination() is a long running API. Currently, it keeps running on server even if client disconnects. This change periodically checks if client has disconnected. If so, we can stop the operation and release resources.

We use gRPC Context.isCancelled() to determine if client has disconnected and response cannot be returned to the client. [Here is the reference of of isCancelled()](https://grpc.github.io/grpc/cpp/classgrpc_1_1_server_context.html#af2d0f087805b4b475d01b12d73508f09): 

> Return whether this RPC failed before the server could provide its status back to the client.

> This could be because of explicit API cancellation from the client-side or server-side, because of deadline exceeded, network connection reset, HTTP/2 parameter configuration (e.g., max message size, max connection age), etc. It does NOT include failure due to a non-OK status return from the server application's request handler, including [Status::CANCELLED](https://grpc.github.io/grpc/cpp/classgrpc_1_1_status.html#a9994ffe95a0495915d82481c2ec594ab).

> IsCancelled is always safe to call when using sync or callback API. When using async API, it is only safe to call IsCancelled after the AsyncNotifyWhenDone tag has been delivered. Thread-safe.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
The change improves handling of awaitTermination(). It avoids resource waste of server side.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Existing unit tests.
Manually tested on local with:
1. start spark connect 
2. create a streaming query
3. call query.awaitTermination()
4. exit() the client to disconnect it
5. check that an error (RPC context is cancelled when executing awaitTermination()) is logged on server. It proves that awaitTermination() is exited on the server side when client disconnects

```
>>> query = (
...  spark
...  .readStream
...  .format("rate")
...  .option("numPartitions", "1")
...  .load()
...  .writeStream
...  .format("memory")
...  .queryName("tableName_35")
...  .start()
... )

>>>
>>> query.awaitTermination()
...
>>> exit()
```
