### PR TITLE
[SPARK-43804][PYTHON][TESTS] Test on nested structs support in Pandas UDF

### DIFF
--- a/python/pyspark/sql/tests/connect/test_parity_pandas_udf.py
+++ b/python/pyspark/sql/tests/connect/test_parity_pandas_udf.py
@@ -14,11 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-import os
-import time
-import unittest
-
 from pyspark.sql.connect.types import UnparsedDataType
 from pyspark.sql.functions import pandas_udf, PandasUDFType
 from pyspark.sql.tests.pandas.test_pandas_udf import PandasUDFTestsMixin

--- a/python/pyspark/sql/tests/connect/test_parity_pandas_udf.py
+++ b/python/pyspark/sql/tests/connect/test_parity_pandas_udf.py
@@ -26,27 +26,6 @@ from pyspark.testing.connectutils import ReusedConnectTestCase
 
 
 class PandasUDFParityTests(PandasUDFTestsMixin, ReusedConnectTestCase):
-    @classmethod
-    def setUpClass(cls):
-        ReusedConnectTestCase.setUpClass()
-
-        # Synchronize default timezone between Python and Java
-        cls.tz_prev = os.environ.get("TZ", None)  # save current tz if set
-        tz = "America/Los_Angeles"
-        os.environ["TZ"] = tz
-        time.tzset()
-
-        cls.sc.environment["TZ"] = tz
-        cls.spark.conf.set("spark.sql.session.timeZone", tz)
-
-    @classmethod
-    def tearDownClass(cls):
-        del os.environ["TZ"]
-        if cls.tz_prev is not None:
-            os.environ["TZ"] = cls.tz_prev
-        time.tzset()
-        ReusedConnectTestCase.tearDownClass()
-
     def test_udf_wrong_arg(self):
         self.check_udf_wrong_arg()
 

--- a/python/pyspark/sql/tests/connect/test_parity_pandas_udf.py
+++ b/python/pyspark/sql/tests/connect/test_parity_pandas_udf.py
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+import os
+import time
 import unittest
 
 from pyspark.sql.connect.types import UnparsedDataType
@@ -24,6 +26,27 @@ from pyspark.testing.connectutils import ReusedConnectTestCase
 
 
 class PandasUDFParityTests(PandasUDFTestsMixin, ReusedConnectTestCase):
+    @classmethod
+    def setUpClass(cls):
+        ReusedConnectTestCase.setUpClass()
+
+        # Synchronize default timezone between Python and Java
+        cls.tz_prev = os.environ.get("TZ", None)  # save current tz if set
+        tz = "America/Los_Angeles"
+        os.environ["TZ"] = tz
+        time.tzset()
+
+        cls.sc.environment["TZ"] = tz
+        cls.spark.conf.set("spark.sql.session.timeZone", tz)
+
+    @classmethod
+    def tearDownClass(cls):
+        del os.environ["TZ"]
+        if cls.tz_prev is not None:
+            os.environ["TZ"] = cls.tz_prev
+        time.tzset()
+        ReusedConnectTestCase.tearDownClass()
+
     def test_udf_wrong_arg(self):
         self.check_udf_wrong_arg()
 

--- a/python/pyspark/sql/tests/pandas/test_pandas_udf_scalar.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_udf_scalar.py
@@ -97,6 +97,51 @@ class ScalarPandasUDFTestsMixin:
         random_udf = random_udf.asNondeterministic()
         return random_udf
 
+    @property
+    def df_with_nested_structs(self):
+        schema = StructType(
+            [
+                StructField("id", IntegerType(), False),
+                StructField(
+                    "info",
+                    StructType(
+                        [
+                            StructField("name", StringType(), False),
+                            StructField("age", IntegerType(), False),
+                            StructField(
+                                "details",
+                                StructType(
+                                    [
+                                        StructField("field1", StringType(), False),
+                                        StructField("field2", IntegerType(), False),
+                                    ]
+                                ),
+                                False,
+                            ),
+                        ]
+                    ),
+                    False,
+                ),
+            ]
+        )
+        data = [(1, ("John", 30, ("Value1", 10)))]
+        df = self.spark.createDataFrame(data, schema)
+        return df
+
+    @property
+    def df_with_nested_maps(self):
+        schema = StructType(
+            [
+                StructField("id", StringType(), True),
+                StructField(
+                    "attributes", MapType(StringType(), MapType(StringType(), StringType())), True
+                ),
+            ]
+        )
+        data = [("1", {"personal": {"name": "John", "city": "New York"}})]
+        df = self.spark.createDataFrame(data, schema)
+        return df
+
     def test_pandas_udf_tokenize(self):
         tokenize = pandas_udf(
             lambda s: s.apply(lambda str: str.split(" ")), ArrayType(StringType())
@@ -115,31 +160,28 @@ class ScalarPandasUDFTestsMixin:
         result = df.select(tokenize("vals").alias("hi"))
         self.assertEqual([Row(hi=[["hi", "boo"]]), Row(hi=[["bye", "boo"]])], result.collect())
 
-    def test_pandas_udf_nested_maps(self):
-        schema = StructType(
-            [
-                StructField("id", StringType(), True),
-                StructField(
-                    "attributes", MapType(StringType(), MapType(StringType(), StringType())), True
-                ),
-            ]
-        )
-        data = [("1", {"personal": {"name": "John", "city": "New York"}})]
-        df = self.spark.createDataFrame(data, schema)
+    def test_input_nested_structs(self):
+        df = self.df_with_nested_structs
 
-        @pandas_udf(StringType())
-        def f(s: pd.Series) -> pd.Series:
-            return s.astype(str)
+        str_repr = pandas_udf(
+            lambda s: s.astype(str), "struct<name:string,age:string,details:string>"
+        )
 
         self.assertEquals(
-            df.select(f(df.attributes).alias("res")).first(),
+            df.select(str_repr(df.info).alias("res")).first(),
+            Row(res=Row(name="John", age="30", details="{'field1': 'Value1', 'field2': 10}")),
+        )
+
+    def test_input_nested_maps(self):
+        df = self.df_with_nested_maps
+
+        str_repr = pandas_udf(lambda s: s.astype(str), StringType())
+        self.assertEquals(
+            df.select(str_repr(df.attributes).alias("res")).first(),
             Row(res="{'personal': {'name': 'John', 'city': 'New York'}}"),
         )
 
-        @pandas_udf(StringType())
-        def extract_name(s: pd.Series) -> pd.Series:
-            return s.apply(lambda x: x["personal"]["name"])
-
+        extract_name = pandas_udf(lambda s: s.apply(lambda x: x["personal"]["name"]), StringType())
         self.assertEquals(
             df.select(extract_name(df.attributes).alias("res")).first(),
             Row(res="John"),


### PR DESCRIPTION
### What changes were proposed in this pull request?
Test on nested structs support in Pandas UDF. That support is newly enabled (compared to Spark 3.4).

### Why are the changes needed?
Test coverage.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Unit tests.
