### PR TITLE
[SPARK-43893][PYTHON][CONNECT] Non-atomic data type support in Arrow-optimized Python UDF

### DIFF
--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -20,7 +20,6 @@ Serializers for PyArrow and pandas conversions. See `pyspark.serializers` for mo
 """
 
 from pyspark.errors import PySparkTypeError, PySparkValueError
-from pyspark.rdd import PythonEvalType
 from pyspark.serializers import Serializer, read_int, write_int, UTF8Deserializer, CPickleSerializer
 from pyspark.sql.pandas.types import (
     from_arrow_type,

--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -315,11 +315,7 @@ class ArrowStreamPandasUDFSerializer(ArrowStreamPandasSerializer):
     def arrow_to_pandas(self, arrow_column):
         import pyarrow.types as types
 
-        if (
-            self._struct_in_pandas == "dict"
-            and self._df_for_struct
-            and types.is_struct(arrow_column.type)
-        ):
+        if self._df_for_struct and types.is_struct(arrow_column.type):
             import pandas as pd
 
             series = [

--- a/python/pyspark/sql/tests/test_arrow_python_udf.py
+++ b/python/pyspark/sql/tests/test_arrow_python_udf.py
@@ -52,10 +52,11 @@ class PythonUDFArrowTestsMixin(BaseUDFTestsMixin):
     def test_complex_input_types(self):
         row = (
             self.spark.range(1)
-            .selectExpr("array(1, 2, 3) as array", "map('a', 'b') as map")
+            .selectExpr("array(1, 2, 3) as array", "map('a', 'b') as map", "struct(1, 2) as struct")
             .select(
                 udf(lambda x: str(x))("array"),
                 udf(lambda x: str(x))("map"),
+                udf(lambda x: str(x))("struct"),
             )
             .first()
         )
@@ -63,6 +64,7 @@ class PythonUDFArrowTestsMixin(BaseUDFTestsMixin):
         # The input is NumPy array when the optimization is on.
         self.assertEquals(row[0], "[1 2 3]")
         self.assertEquals(row[1], "{'a': 'b'}")
+        self.assertEquals(row[2], "Row(col1=1, col2=2)")
 
     def test_use_arrow(self):
         # useArrow=True

--- a/python/pyspark/sql/tests/test_arrow_python_udf.py
+++ b/python/pyspark/sql/tests/test_arrow_python_udf.py
@@ -45,9 +45,10 @@ class PythonUDFArrowTestsMixin(BaseUDFTestsMixin):
     def test_register_java_udaf(self):
         super(PythonUDFArrowTests, self).test_register_java_udaf()
 
-    @unittest.skip("Struct input types are not supported with Arrow optimization")
-    def test_udf_input_serialization_valuecompare_disabled(self):
-        super(PythonUDFArrowTests, self).test_udf_input_serialization_valuecompare_disabled()
+    # TODO(SPARK-43903): Standardize ArrayType conversion for Python UDF
+    @unittest.skip("Inconsistent ArrayType conversion with/without Arrow.")
+    def test_nested_array(self):
+        super(PythonUDFArrowTests, self).test_nested_array()
 
     def test_complex_input_types(self):
         row = (

--- a/python/pyspark/sql/tests/test_arrow_python_udf.py
+++ b/python/pyspark/sql/tests/test_arrow_python_udf.py
@@ -49,12 +49,6 @@ class PythonUDFArrowTestsMixin(BaseUDFTestsMixin):
     def test_udf_input_serialization_valuecompare_disabled(self):
         super(PythonUDFArrowTests, self).test_udf_input_serialization_valuecompare_disabled()
 
-    def test_nested_input_error(self):
-        with self.assertRaisesRegexp(Exception, "[NotImplementedError]"):
-            self.spark.range(1).selectExpr("struct(1, 2) as struct").select(
-                udf(lambda x: x)("struct")
-            ).collect()
-
     def test_complex_input_types(self):
         row = (
             self.spark.range(1)

--- a/python/pyspark/sql/tests/test_udf.py
+++ b/python/pyspark/sql/tests/test_udf.py
@@ -872,6 +872,21 @@ class UDFInitializationTests(unittest.TestCase):
         ):
             udf(lambda x: x, "integer")
 
+    def test_nested_structs(self):
+        df = self.spark.range(1).selectExpr(
+            "struct(1, struct('John', 30, ('value', 10))) as nested_struct"
+        )
+        # Input
+        row = df.select(udf(lambda x: str(x))("nested_struct")).first()
+        self.assertEquals(
+            row[0], "Row(col1=1, col2=Row(col1='John', col2=30, col3=Row(col1='value', col2=10)))"
+        )
+        # Output
+        row = df.select(udf(lambda x: x, returnType=df.dtypes[0][1])("nested_struct")).first()
+        self.assertEquals(
+            row[0], Row(col1=1, col2=Row(col1="John", col2=30, col3=Row(col1="value", col2=10)))
+        )
+
 
 if __name__ == "__main__":
     from pyspark.sql.tests.test_udf import *  # noqa: F401

--- a/python/pyspark/sql/tests/test_udf.py
+++ b/python/pyspark/sql/tests/test_udf.py
@@ -858,6 +858,7 @@ class BaseUDFTestsMixin(object):
         row = df.select(udf(lambda x: str(x))("nested_map")).first()
         self.assertEquals(row[0], "{'a': {'b': 'c'}}")
         # Output
+
         @udf(returnType=df.dtypes[0][1])
         def f(x):
             x["a"]["b"] = "d"
@@ -872,6 +873,7 @@ class BaseUDFTestsMixin(object):
         row = df.select(udf(lambda x: str(x))("nested_array")).first()
         self.assertEquals(row[0], "[[1, 2], [3, 4]]")
         # Output
+
         @udf(returnType=df.dtypes[0][1])
         def f(x):
             x.append([4, 5])

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -134,9 +134,8 @@ def _create_py_udf(
         is_func_with_args = len(getfullargspec(f).args) > 0
     except TypeError:
         is_func_with_args = False
-    is_output_atomic_or_struct = (
-        not isinstance(return_type, MapType)
-        and not isinstance(return_type, ArrayType)
+    is_output_atomic_or_struct = not isinstance(return_type, MapType) and not isinstance(
+        return_type, ArrayType
     )
     if is_arrow_enabled:
         if is_output_atomic_or_struct and is_func_with_args:

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -129,16 +129,12 @@ def _create_py_udf(
             else useArrow
         )
     regular_udf = _create_udf(f, returnType, PythonEvalType.SQL_BATCHED_UDF)
-    return_type = regular_udf.returnType
     try:
         is_func_with_args = len(getfullargspec(f).args) > 0
     except TypeError:
         is_func_with_args = False
-    is_output_atomic_or_struct = not isinstance(return_type, MapType) and not isinstance(
-        return_type, ArrayType
-    )
     if is_arrow_enabled:
-        if is_output_atomic_or_struct and is_func_with_args:
+        if is_func_with_args:
             return _create_arrow_py_udf(regular_udf)
         else:
             warnings.warn(

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -32,10 +32,8 @@ from pyspark.profiler import Profiler
 from pyspark.rdd import _prepare_for_python_RDD, PythonEvalType
 from pyspark.sql.column import Column, _to_java_column, _to_java_expr, _to_seq
 from pyspark.sql.types import (
-    ArrayType,
     BinaryType,
     DataType,
-    MapType,
     StringType,
     StructType,
     _parse_datatype_string,

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -175,11 +175,6 @@ def _create_arrow_py_udf(regular_udf):  # type: ignore
         result_func = lambda r: bytes(r) if r is not None else r  # noqa: E731
 
     def vectorized_udf(*args: pd.Series) -> pd.Series:
-        if any(map(lambda arg: isinstance(arg, pd.DataFrame), args)):
-            raise PySparkNotImplementedError(
-                error_class="UNSUPPORTED_WITH_ARROW_OPTIMIZATION",
-                message_parameters={"feature": "Struct input type"},
-            )
         return pd.Series(result_func(f(*a)) for a in zip(*args))
 
     # Regular UDFs can take callable instances too.

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -134,13 +134,12 @@ def _create_py_udf(
         is_func_with_args = len(getfullargspec(f).args) > 0
     except TypeError:
         is_func_with_args = False
-    is_output_atomic_type = (
-        not isinstance(return_type, StructType)
-        and not isinstance(return_type, MapType)
+    is_output_atomic_or_struct = (
+        not isinstance(return_type, MapType)
         and not isinstance(return_type, ArrayType)
     )
     if is_arrow_enabled:
-        if is_output_atomic_type and is_func_with_args:
+        if is_output_atomic_or_struct and is_func_with_args:
             return _create_arrow_py_udf(regular_udf)
         else:
             warnings.warn(

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -517,7 +517,7 @@ def read_udfs(pickleSer, infile, eval_type):
                 or eval_type == PythonEvalType.SQL_MAP_PANDAS_ITER_UDF
             )
             ser = ArrowStreamPandasUDFSerializer(
-                timezone, safecheck, assign_cols_by_name(runner_conf), df_for_struct
+                timezone, safecheck, assign_cols_by_name(runner_conf), df_for_struct, eval_type
             )
     else:
         ser = BatchedSerializer(CPickleSerializer(), 100)

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -511,11 +511,11 @@ def read_udfs(pickleSer, infile, eval_type):
             # Scalar Pandas UDF handles struct type arguments as pandas DataFrames instead of
             # pandas Series. See SPARK-27240.
             df_for_struct = (
-                eval_type == PythonEvalType.SQL_ARROW_BATCHED_UDF
-                or eval_type == PythonEvalType.SQL_SCALAR_PANDAS_UDF
+                eval_type == PythonEvalType.SQL_SCALAR_PANDAS_UDF
                 or eval_type == PythonEvalType.SQL_SCALAR_PANDAS_ITER_UDF
                 or eval_type == PythonEvalType.SQL_MAP_PANDAS_ITER_UDF
             )
+            # Arrow-optimized Python UDF takes a struct type argument as a Row
             struct_in_pandas = (
                 "row" if eval_type == PythonEvalType.SQL_ARROW_BATCHED_UDF else "dict"
             )

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -516,8 +516,15 @@ def read_udfs(pickleSer, infile, eval_type):
                 or eval_type == PythonEvalType.SQL_SCALAR_PANDAS_ITER_UDF
                 or eval_type == PythonEvalType.SQL_MAP_PANDAS_ITER_UDF
             )
+            struct_in_pandas = (
+                "row" if eval_type == PythonEvalType.SQL_ARROW_BATCHED_UDF else "dict"
+            )
             ser = ArrowStreamPandasUDFSerializer(
-                timezone, safecheck, assign_cols_by_name(runner_conf), df_for_struct, eval_type
+                timezone,
+                safecheck,
+                assign_cols_by_name(runner_conf),
+                df_for_struct,
+                struct_in_pandas,
             )
     else:
         ser = BatchedSerializer(CPickleSerializer(), 100)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support non-atomic data types in input and output of Arrow-optimized Python UDF.

Non-atomic data types refer to: ArrayType, MapType, and StructType.

### Why are the changes needed?
Parity with pickled Python UDFs.

### Does this PR introduce _any_ user-facing change?
Non-atomic data types are accepted as both input and output of Arrow-optimized Python UDF.

For example,
```py
>>> df = spark.range(1).selectExpr("struct(1, struct('John', 30, ('value', 10))) as nested_struct")
>>> df.select(udf(lambda x: str(x))("nested_struct")).first()
Row(<lambda>(nested_struct)="Row(col1=1, col2=Row(col1='John', col2=30, col3=Row(col1='value', col2=10)))")
```

### How was this patch tested?
Unit tests.

SPARK-40307
