### PR TITLE
[WIP][SPARK-42298] Assign name to _LEGACY_ERROR_TEMP_2132

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -1576,7 +1576,7 @@
   },
   "PARSE_JSON_STRUCTS_FORBIDDEN" : {
     "message" : [
-      "Parsing JSON arrays as structs is forbidden."
+      "Parsing JSON arrays as structs is not allowed."
     ],
     "sqlState": "2203G"
   },

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -875,6 +875,12 @@
     ],
     "sqlState" : "XX000"
   },
+  "INTERNAL_ERROR_PARSE_JSON_STRUCTS" : {
+    "message" : [
+      "Parsing JSON arrays as structs is not allowed."
+    ],
+    "sqlState": "XX000"
+  },
   "INTERVAL_ARITHMETIC_OVERFLOW" : {
     "message" : [
       "<message>.<alternative>"
@@ -1573,12 +1579,6 @@
       "Syntax error, unexpected empty statement."
     ],
     "sqlState" : "42617"
-  },
-  "PARSE_JSON_STRUCTS_FORBIDDEN" : {
-    "message" : [
-      "Parsing JSON arrays as structs is not allowed."
-    ],
-    "sqlState": "2203G"
   },
   "PARSE_SYNTAX_ERROR" : {
     "message" : [

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -1574,6 +1574,11 @@
     ],
     "sqlState" : "42617"
   },
+  "PARSE_JSON_STRUCTS_FORBIDDEN" : {
+    "message" : [
+      "Parsing JSON arrays as structs is forbidden."
+    ]
+  },
   "PARSE_SYNTAX_ERROR" : {
     "message" : [
       "Syntax error at or near <error><hint>."
@@ -4513,11 +4518,6 @@
   "_LEGACY_ERROR_TEMP_2131" : {
     "message" : [
       "Exception when registering StreamingQueryListener."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_2132" : {
-    "message" : [
-      "Parsing JSON arrays as structs is forbidden."
     ]
   },
   "_LEGACY_ERROR_TEMP_2133" : {

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -1577,7 +1577,8 @@
   "PARSE_JSON_STRUCTS_FORBIDDEN" : {
     "message" : [
       "Parsing JSON arrays as structs is forbidden."
-    ]
+    ],
+    "sqlState": "00T"
   },
   "PARSE_SYNTAX_ERROR" : {
     "message" : [

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -1578,7 +1578,7 @@
     "message" : [
       "Parsing JSON arrays as structs is forbidden."
     ],
-    "sqlState": "00T"
+    "sqlState": "2203G"
   },
   "PARSE_SYNTAX_ERROR" : {
     "message" : [

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -1418,7 +1418,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase {
 
   def cannotParseJsonArraysAsStructsError(): SparkRuntimeException = {
     new SparkRuntimeException(
-      errorClass = "_LEGACY_ERROR_TEMP_2132",
+      errorClass = "PARSE_JSON_STRUCTS_FORBIDDEN",
       messageParameters = Map.empty)
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -1418,7 +1418,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase {
 
   def cannotParseJsonArraysAsStructsError(): SparkRuntimeException = {
     new SparkRuntimeException(
-      errorClass = "PARSE_JSON_STRUCTS_FORBIDDEN",
+      errorClass = "INTERNAL_ERROR_PARSE_JSON_STRUCTS",
       messageParameters = Map.empty)
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
The PR assigns a more descriptive name to the error class _LEGACY_ERROR_TEMP_2132.


### Why are the changes needed?
This change Improves the error framework by making the error name more descriptive.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Tested with existing test cases.
