### PR TITLE
[SPARK-16484][SPARK-42527][CONNECT][FOLLOWUP] Simplify functions API by reuse existent functions.

### DIFF
--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/functions.scala
@@ -1188,8 +1188,7 @@ object functions {
    * @group window_funcs
    * @since 3.4.0
    */
-  def nth_value(e: Column, offset: Int): Column =
-    Column.fn("nth_value", e, lit(offset))
+  def nth_value(e: Column, offset: Int): Column = nth_value(e, offset, false)
 
   /**
    * Window function: returns the ntile group id (from 1 to `n` inclusive) in an ordered window
@@ -2713,7 +2712,27 @@ object functions {
    * @since 3.5.0
    */
   def hll_sketch_estimate(columnName: String): Column =
-    Column.fn("hll_sketch_estimate", Column(columnName))
+    hll_sketch_estimate(Column(columnName))
+
+  /**
+   * Merges two binary representations of Datasketches HllSketch objects, using a Datasketches
+   * Union object. Throws an exception if sketches have different lgConfigK values.
+   *
+   * @group misc_funcs
+   * @since 3.5.0
+   */
+  def hll_union(c1: Column, c2: Column): Column =
+    Column.fn("hll_union", c1, c2)
+
+  /**
+   * Merges two binary representations of Datasketches HllSketch objects, using a Dataskethes
+   * Union object. Throws an exception if sketches have different lgConfigK values.
+   *
+   * @group misc_funcs
+   * @since 3.5.0
+   */
+  def hll_union(columnName1: String, columnName2: String): Column =
+    hll_union(Column(columnName1), Column(columnName2))
 
   /**
    * Merges two binary representations of Datasketches HllSketch objects, using a Datasketches
@@ -2738,27 +2757,7 @@ object functions {
       columnName1: String,
       columnName2: String,
       allowDifferentLgConfigK: Boolean): Column =
-    Column.fn("hll_union", Column(columnName1), Column(columnName2), lit(allowDifferentLgConfigK))
-
-  /**
-   * Merges two binary representations of Datasketches HllSketch objects, using a Datasketches
-   * Union object. Throws an exception if sketches have different lgConfigK values.
-   *
-   * @group misc_funcs
-   * @since 3.5.0
-   */
-  def hll_union(c1: Column, c2: Column): Column =
-    Column.fn("hll_union", c1, c2)
-
-  /**
-   * Merges two binary representations of Datasketches HllSketch objects, using a Dataskethes
-   * Union object. Throws an exception if sketches have different lgConfigK values.
-   *
-   * @group misc_funcs
-   * @since 3.5.0
-   */
-  def hll_union(columnName1: String, columnName2: String): Column =
-    Column.fn("hll_union", Column(columnName1), Column(columnName2))
+    hll_union(Column(columnName1), Column(columnName2), allowDifferentLgConfigK)
 
   //////////////////////////////////////////////////////////////////////////////////////////////
   // String functions
@@ -2888,13 +2887,6 @@ object functions {
   def lower(e: Column): Column = Column.fn("lower", e)
 
   /**
-   * Computes the Levenshtein distance of the two given string columns.
-   * @group string_funcs
-   * @since 3.4.0
-   */
-  def levenshtein(l: Column, r: Column): Column = Column.fn("levenshtein", l, r)
-
-  /**
    * Computes the Levenshtein distance of the two given string columns if it's less than or equal
    * to a given threshold.
    * @return
@@ -2904,6 +2896,13 @@ object functions {
    */
   def levenshtein(l: Column, r: Column, threshold: Int): Column =
     Column.fn("levenshtein", l, r, lit(threshold))
+
+  /**
+   * Computes the Levenshtein distance of the two given string columns.
+   * @group string_funcs
+   * @since 3.4.0
+   */
+  def levenshtein(l: Column, r: Column): Column = Column.fn("levenshtein", l, r)
 
   /**
    * Locate the position of the first occurrence of substr.

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/functions.scala
@@ -588,7 +588,7 @@ object functions {
    * @since 3.5.0
    */
   def hll_sketch_agg(columnName: String, lgConfigK: Int): Column =
-    Column.fn("hll_sketch_agg", Column(columnName), lit(lgConfigK))
+    hll_sketch_agg(Column(columnName), lgConfigK)
 
   /**
    * Aggregate function: returns the updatable binary representation of the Datasketches HllSketch
@@ -608,7 +608,7 @@ object functions {
    * @since 3.5.0
    */
   def hll_sketch_agg(columnName: String): Column =
-    Column.fn("hll_sketch_agg", Column(columnName))
+    hll_sketch_agg(Column(columnName))
 
   /**
    * Aggregate function: returns the updatable binary representation of the Datasketches
@@ -632,7 +632,7 @@ object functions {
    * @since 3.5.0
    */
   def hll_union_agg(columnName: String, allowDifferentLgConfigK: Boolean): Column =
-    Column.fn("hll_union_agg", Column(columnName), lit(allowDifferentLgConfigK))
+    hll_union_agg(Column(columnName), allowDifferentLgConfigK)
 
   /**
    * Aggregate function: returns the updatable binary representation of the Datasketches
@@ -653,8 +653,7 @@ object functions {
    * @group agg_funcs
    * @since 3.5.0
    */
-  def hll_union_agg(columnName: String): Column =
-    Column.fn("hll_union_agg", Column(columnName))
+  def hll_union_agg(columnName: String): Column = hll_union_agg(Column(columnName))
 
   /**
    * Aggregate function: returns the kurtosis of the values in a group.

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/functions.scala
@@ -607,8 +607,7 @@ object functions {
    * @group agg_funcs
    * @since 3.5.0
    */
-  def hll_sketch_agg(columnName: String): Column =
-    hll_sketch_agg(Column(columnName))
+  def hll_sketch_agg(columnName: String): Column = hll_sketch_agg(Column(columnName))
 
   /**
    * Aggregate function: returns the updatable binary representation of the Datasketches


### PR DESCRIPTION
### What changes were proposed in this pull request?
https://github.com/apache/spark/pull/40615 added the `hll_union_agg` into Spark and Spark connect project. and https://github.com/apache/spark/pull/40120 added the `nth_value` into Spark connect project.
But `hll_union_agg` and `nth_value` in connect functions API are defined one by one.
In fact, we can simplify the `hll_union_agg` and `nth_value` by reuse functions.

Another minor change is we should keep a consistent API order with functions API in SQL.


### Why are the changes needed?
Simplify the `hll_union_agg` by reuse functions.


### Does this PR introduce _any_ user-facing change?
'No'.
Just update the inner implementation.


### How was this patch tested?
Exists test cases.
