### PR TITLE
[SPARK-43841][SQL] Handle candidate attributes with no prefix in `StringUtils#orderSuggestedIdentifiersBySimilarity`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/StringUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/StringUtils.scala
@@ -109,7 +109,7 @@ object StringUtils extends Logging {
         sorted.map(_._2)
       } else {
         // More than one relation
-        sorted.map(x => s"${x._1}.${x._2}")
+        sorted.map(x => if (x._1.isEmpty) s"${x._2}" else s"${x._1}.${x._2}")
       }
     }
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/StringUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/StringUtilsSuite.scala
@@ -138,4 +138,11 @@ class StringUtilsSuite extends SparkFunSuite with SQLHelper {
     assert(quoteIfNeeded("_") === "_")
     assert(quoteIfNeeded("") === "``")
   }
+
+  test("mix of multipart and single-part identifiers") {
+    val baseString = "b"
+    val testStrings = Seq("c1", "v1.c2", "v2.c2") // mix of multipart and single-part
+    val expectedOutput = Seq("c1", "v1.c2", "v2.c2")
+    assert(orderSuggestedIdentifiersBySimilarity(baseString, testStrings) === expectedOutput)
+  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/StringUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/StringUtilsSuite.scala
@@ -139,7 +139,7 @@ class StringUtilsSuite extends SparkFunSuite with SQLHelper {
     assert(quoteIfNeeded("") === "``")
   }
 
-  test("mix of multipart and single-part identifiers") {
+  test("SPARK-43841: mix of multipart and single-part identifiers") {
     val baseString = "b"
     val testStrings = Seq("c1", "v1.c2", "v2.c2") // mix of multipart and single-part
     val expectedOutput = Seq("c1", "v1.c2", "v2.c2")

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
@@ -885,7 +885,7 @@ class QueryCompilationErrorsSuite
     }
   }
 
-  test("Unresolved attribute in select of USING join") {
+  test("SPARK-43841: Unresolved attribute in select of full outer join with USING") {
     withTempView("v1", "v2") {
       sql("create or replace temp view v1 as values (1, 2) as (c1, c2)")
       sql("create or replace temp view v2 as values (2, 3) as (c1, c2)")

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
@@ -891,7 +891,7 @@ class QueryCompilationErrorsSuite
       sql("create or replace temp view v2 as values (2, 3) as (c1, c2)")
 
       val query =
-        """select v1.c1, v1.c2, v2.c1, v2.c2, b
+        """select b
           |from v1
           |full outer join v2
           |using (c1)
@@ -907,7 +907,7 @@ class QueryCompilationErrorsSuite
           "objectName" -> "`b`"),
         context = ExpectedContext(
           fragment = "b",
-          start = 35, stop = 35)
+          start = 7, stop = 7)
       )
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

In `StringUtils#orderSuggestedIdentifiersBySimilarity`, handle the case where the candidate attributes have a mix of empty and non-empty prefixes.

### Why are the changes needed?

The following query throws a `StringIndexOutOfBoundsException`:
```
with v1 as (
 select * from values (1, 2) as (c1, c2)
),
v2 as (
  select * from values (2, 3) as (c1, c2)
)
select v1.c1, v1.c2, v2.c1, v2.c2, b
from v1
full outer join v2
using (c1);
```
The query should fail anyway, since `b` refers to a non-existent column. But it should fail with a helpful error message, not with a `StringIndexOutOfBoundsException`.

`StringUtils#orderSuggestedIdentifiersBySimilarity` assumes that a list of suggested attributes with a mix of prefixes will never have an attribute name with an empty prefix. But in this case it does (`c1` from the `coalesce` has no prefix, since it is not associated with any relation or subquery):
```
+- 'Project [c1#5, c2#6, c1#7, c2#8, 'b]
   +- Project [coalesce(c1#5, c1#7) AS c1#9, c2#6, c2#8] <== c1#9 has no prefix, unlike c2#6 (v1.c2) or c2#8 (v2.c2)
      +- Join FullOuter, (c1#5 = c1#7)
         :- SubqueryAlias v1
         :  +- CTERelationRef 0, true, [c1#5, c2#6]
         +- SubqueryAlias v2
            +- CTERelationRef 1, true, [c1#7, c2#8]
```
Because of this, `orderSuggestedIdentifiersBySimilarity` returns a sorted list of suggestions like this:
```
ArrayBuffer(.c1, v1.c2, v2.c2)
```
`UnresolvedAttribute.parseAttributeName` chokes on an attribute name that starts with a '.'.


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

New unit tests.
