### PR TITLE
[SPARK-43845][INFRA] Setup Scala 2.12 Daily GitHub Action Job

### DIFF
--- a/.github/workflows/build_scala212.yml
+++ b/.github/workflows/build_scala212.yml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-name: "Build (master, Scala 2.13, Hadoop 3, JDK 8)"
+name: "Build (master, Scala 2.12, Hadoop 3, JDK 8)"
 
 on:
   schedule:
@@ -36,7 +36,7 @@ jobs:
       hadoop: hadoop3
       envs: >-
         {
-          "SCALA_PROFILE": "scala2.13"
+          "SCALA_PROFILE": "scala2.12"
         }
       jobs: >-
         {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to setup Scala 2.12 Daily GitHub Action Job by converting Scala 2.13 Daily Job.
- Rename `build_scala213.yml` file to `.github/workflows/build_scala212.yml`.
- Rename job name
```
-name: "Build (master, Scala 2.13, Hadoop 3, JDK 8)"
+name: "Build (master, Scala 2.12, Hadoop 3, JDK 8)"
```
- Switch SCALA_PROFILE from `scala2.13` to `scala2.12`.

### Why are the changes needed?

To keep the Scala 2.12 test coverage

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

This is a daily job. We need to check after merging.