### PR TITLE
[SPARK-43846][SQL][TESTS] Use checkError() to check Exception in SessionCatalogSuite

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
@@ -116,10 +116,13 @@ abstract class SessionCatalogSuite extends AnalysisTest with Eventually {
     // non ascii characters are not allowed in the source code, so we disable the scalastyle.
     val name = "砖"
     // scalastyle:on
-    val e = intercept[AnalysisException] {
-      func(name)
-    }.getMessage
-    assert(e.contains(s"`$name` is not a valid name for tables/databases."))
+    checkError(
+      exception = intercept[AnalysisException] {
+        func(name)
+      },
+      errorClass = "_LEGACY_ERROR_TEMP_1065",
+      parameters = Map("name" -> name)
+    )
   }
 
   test("create table with default columns") {
@@ -580,11 +583,13 @@ abstract class SessionCatalogSuite extends AnalysisTest with Eventually {
     withBasicCatalog { sessionCatalog =>
       sessionCatalog.createTable(newTable("t1", "default"), ignoreIfExists = false)
       val oldTab = sessionCatalog.externalCatalog.getTable("default", "t1")
-      val e = intercept[AnalysisException] {
-        sessionCatalog.alterTableDataSchema(
-          TableIdentifier("t1", Some("default")), StructType(oldTab.dataSchema.drop(1)))
-      }.getMessage
-      assert(e.contains("We don't support dropping columns yet."))
+      checkError(
+        exception = intercept[AnalysisException] {
+          sessionCatalog.alterTableDataSchema(
+            TableIdentifier("t1", Some("default")), StructType(oldTab.dataSchema.drop(1)))
+        },
+        errorClass = "_LEGACY_ERROR_TEMP_1071",
+        parameters = Map("nonExistentColumnNames" -> "[col1]"))
     }
   }
 
@@ -807,13 +812,20 @@ abstract class SessionCatalogSuite extends AnalysisTest with Eventually {
   test("getTempViewOrPermanentTableMetadata on temporary views") {
     withBasicCatalog { catalog =>
       val tempTable = Range(1, 10, 2, 10)
-      intercept[NoSuchTableException] {
-        catalog.getTempViewOrPermanentTableMetadata(TableIdentifier("view1"))
-      }.getMessage
-
-      intercept[NoSuchTableException] {
-        catalog.getTempViewOrPermanentTableMetadata(TableIdentifier("view1", Some("default")))
-      }.getMessage
+      checkError(
+        exception = intercept[NoSuchTableException] {
+          catalog.getTempViewOrPermanentTableMetadata(TableIdentifier("view1"))
+        },
+        errorClass = "TABLE_OR_VIEW_NOT_FOUND",
+        parameters = Map("relationName" -> "`default`.`view1`")
+      )
+      checkError(
+        exception = intercept[NoSuchTableException] {
+          catalog.getTempViewOrPermanentTableMetadata(TableIdentifier("view1", Some("default")))
+        },
+        errorClass = "TABLE_OR_VIEW_NOT_FOUND",
+        parameters = Map("relationName" -> "`default`.`view1`")
+      )
 
       createTempView(catalog, "view1", tempTable, overrideIfExists = false)
       assert(catalog.getTempViewOrPermanentTableMetadata(
@@ -821,9 +833,13 @@ abstract class SessionCatalogSuite extends AnalysisTest with Eventually {
       assert(catalog.getTempViewOrPermanentTableMetadata(
         TableIdentifier("view1")).schema(0).name == "id")
 
-      intercept[NoSuchTableException] {
-        catalog.getTempViewOrPermanentTableMetadata(TableIdentifier("view1", Some("default")))
-      }.getMessage
+      checkError(
+        exception = intercept[NoSuchTableException] {
+          catalog.getTempViewOrPermanentTableMetadata(TableIdentifier("view1", Some("default")))
+        },
+        errorClass = "TABLE_OR_VIEW_NOT_FOUND",
+        parameters = Map("relationName" -> "`default`.`view1`")
+      )
     }
   }
 
@@ -977,34 +993,48 @@ abstract class SessionCatalogSuite extends AnalysisTest with Eventually {
 
   test("create partitions with invalid part spec") {
     withBasicCatalog { catalog =>
-      var e = intercept[AnalysisException] {
-        catalog.createPartitions(
-          TableIdentifier("tbl2", Some("db2")),
-          Seq(part1, partWithLessColumns), ignoreIfExists = false)
-      }
-      assert(e.getMessage.contains("Partition spec is invalid. The spec (a) must match " +
-        s"the partition spec (a, b) defined in table '`$SESSION_CATALOG_NAME`.`db2`.`tbl2`'"))
-      e = intercept[AnalysisException] {
-        catalog.createPartitions(
-          TableIdentifier("tbl2", Some("db2")),
-          Seq(part1, partWithMoreColumns), ignoreIfExists = true)
-      }
-      assert(e.getMessage.contains("Partition spec is invalid. The spec (a, b, c) must match " +
-        s"the partition spec (a, b) defined in table '`$SESSION_CATALOG_NAME`.`db2`.`tbl2`'"))
-      e = intercept[AnalysisException] {
-        catalog.createPartitions(
-          TableIdentifier("tbl2", Some("db2")),
-          Seq(partWithUnknownColumns, part1), ignoreIfExists = true)
-      }
-      assert(e.getMessage.contains("Partition spec is invalid. The spec (a, unknown) must match " +
-        s"the partition spec (a, b) defined in table '`$SESSION_CATALOG_NAME`.`db2`.`tbl2`'"))
-      e = intercept[AnalysisException] {
-        catalog.createPartitions(
-          TableIdentifier("tbl2", Some("db2")),
-          Seq(partWithEmptyValue, part1), ignoreIfExists = true)
-      }
-      assert(e.getMessage.contains("Partition spec is invalid. The spec ([a=3, b=]) contains an " +
-        "empty partition column value"))
+      checkError(
+        exception = intercept[AnalysisException] {
+          catalog.createPartitions(
+            TableIdentifier("tbl2", Some("db2")),
+            Seq(part1, partWithLessColumns), ignoreIfExists = false)
+        },
+        errorClass = "_LEGACY_ERROR_TEMP_1232",
+        parameters = Map(
+          "specKeys" -> "a",
+          "partitionColumnNames" -> "a, b",
+          "tableName" -> s"`$SESSION_CATALOG_NAME`.`db2`.`tbl2`"))
+      checkError(
+        exception = intercept[AnalysisException] {
+          catalog.createPartitions(
+            TableIdentifier("tbl2", Some("db2")),
+            Seq(part1, partWithMoreColumns), ignoreIfExists = true)
+        },
+        errorClass = "_LEGACY_ERROR_TEMP_1232",
+        parameters = Map(
+          "specKeys" -> "a, b, c",
+          "partitionColumnNames" -> "a, b",
+          "tableName" -> s"`$SESSION_CATALOG_NAME`.`db2`.`tbl2`"))
+      checkError(
+        exception = intercept[AnalysisException] {
+          catalog.createPartitions(
+            TableIdentifier("tbl2", Some("db2")),
+            Seq(partWithUnknownColumns, part1), ignoreIfExists = true)
+        },
+        errorClass = "_LEGACY_ERROR_TEMP_1232",
+        parameters = Map(
+          "specKeys" -> "a, unknown",
+          "partitionColumnNames" -> "a, b",
+          "tableName" -> s"`$SESSION_CATALOG_NAME`.`db2`.`tbl2`"))
+      checkError(
+        exception = intercept[AnalysisException] {
+          catalog.createPartitions(
+            TableIdentifier("tbl2", Some("db2")),
+            Seq(partWithEmptyValue, part1), ignoreIfExists = true)
+        },
+        errorClass = "_LEGACY_ERROR_TEMP_1076",
+        parameters = Map(
+          "details" -> "The spec ([a=3, b=]) contains an empty partition column value"))
     }
   }
 
@@ -1086,38 +1116,44 @@ abstract class SessionCatalogSuite extends AnalysisTest with Eventually {
 
   test("drop partitions with invalid partition spec") {
     withBasicCatalog { catalog =>
-      var e = intercept[AnalysisException] {
-        catalog.dropPartitions(
-          TableIdentifier("tbl2", Some("db2")),
-          Seq(partWithMoreColumns.spec),
-          ignoreIfNotExists = false,
-          purge = false,
-          retainData = false)
-      }
-      assert(e.getMessage.contains(
-        "Partition spec is invalid. The spec (a, b, c) must be contained within " +
-          s"the partition spec (a, b) defined in table '`$SESSION_CATALOG_NAME`.`db2`.`tbl2`'"))
-      e = intercept[AnalysisException] {
-        catalog.dropPartitions(
-          TableIdentifier("tbl2", Some("db2")),
-          Seq(partWithUnknownColumns.spec),
-          ignoreIfNotExists = false,
-          purge = false,
-          retainData = false)
-      }
-      assert(e.getMessage.contains(
-        "Partition spec is invalid. The spec (a, unknown) must be contained within " +
-          s"the partition spec (a, b) defined in table '`$SESSION_CATALOG_NAME`.`db2`.`tbl2`'"))
-      e = intercept[AnalysisException] {
-        catalog.dropPartitions(
-          TableIdentifier("tbl2", Some("db2")),
-          Seq(partWithEmptyValue.spec, part1.spec),
-          ignoreIfNotExists = false,
-          purge = false,
-          retainData = false)
-      }
-      assert(e.getMessage.contains("Partition spec is invalid. The spec ([a=3, b=]) contains an " +
-        "empty partition column value"))
+      checkError(
+        exception = intercept[AnalysisException] {
+          catalog.dropPartitions(
+            TableIdentifier("tbl2", Some("db2")),
+            Seq(partWithMoreColumns.spec),
+            ignoreIfNotExists = false,
+            purge = false,
+            retainData = false)
+        },
+        errorClass = "_LEGACY_ERROR_TEMP_1076",
+        parameters = Map(
+          "details" -> ("The spec (a, b, c) must be contained within the partition " +
+            s"spec (a, b) defined in table '`$SESSION_CATALOG_NAME`.`db2`.`tbl2`'")))
+      checkError(
+        exception = intercept[AnalysisException] {
+          catalog.dropPartitions(
+            TableIdentifier("tbl2", Some("db2")),
+            Seq(partWithUnknownColumns.spec),
+            ignoreIfNotExists = false,
+            purge = false,
+            retainData = false)
+        },
+        errorClass = "_LEGACY_ERROR_TEMP_1076",
+        parameters = Map(
+          "details" -> ("The spec (a, unknown) must be contained within the partition " +
+            s"spec (a, b) defined in table '`$SESSION_CATALOG_NAME`.`db2`.`tbl2`'")))
+      checkError(
+        exception = intercept[AnalysisException] {
+          catalog.dropPartitions(
+            TableIdentifier("tbl2", Some("db2")),
+            Seq(partWithEmptyValue.spec, part1.spec),
+            ignoreIfNotExists = false,
+            purge = false,
+            retainData = false)
+        },
+        errorClass = "_LEGACY_ERROR_TEMP_1076",
+        parameters = Map(
+          "details" -> "The spec ([a=3, b=]) contains an empty partition column value"))
     }
   }
 
@@ -1151,26 +1187,40 @@ abstract class SessionCatalogSuite extends AnalysisTest with Eventually {
 
   test("get partition with invalid partition spec") {
     withBasicCatalog { catalog =>
-      var e = intercept[AnalysisException] {
-        catalog.getPartition(TableIdentifier("tbl1", Some("db2")), partWithLessColumns.spec)
-      }
-      assert(e.getMessage.contains("Partition spec is invalid. The spec (a) must match " +
-        s"the partition spec (a, b) defined in table '`$SESSION_CATALOG_NAME`.`db2`.`tbl1`'"))
-      e = intercept[AnalysisException] {
-        catalog.getPartition(TableIdentifier("tbl1", Some("db2")), partWithMoreColumns.spec)
-      }
-      assert(e.getMessage.contains("Partition spec is invalid. The spec (a, b, c) must match " +
-        s"the partition spec (a, b) defined in table '`$SESSION_CATALOG_NAME`.`db2`.`tbl1`'"))
-      e = intercept[AnalysisException] {
-        catalog.getPartition(TableIdentifier("tbl1", Some("db2")), partWithUnknownColumns.spec)
-      }
-      assert(e.getMessage.contains("Partition spec is invalid. The spec (a, unknown) must match " +
-        s"the partition spec (a, b) defined in table '`$SESSION_CATALOG_NAME`.`db2`.`tbl1`'"))
-      e = intercept[AnalysisException] {
-        catalog.getPartition(TableIdentifier("tbl1", Some("db2")), partWithEmptyValue.spec)
-      }
-      assert(e.getMessage.contains("Partition spec is invalid. The spec ([a=3, b=]) contains an " +
-        "empty partition column value"))
+      checkError(
+        exception = intercept[AnalysisException] {
+          catalog.getPartition(TableIdentifier("tbl1", Some("db2")), partWithLessColumns.spec)
+        },
+        errorClass = "_LEGACY_ERROR_TEMP_1232",
+        parameters = Map(
+          "specKeys" -> "a",
+          "partitionColumnNames" -> "a, b",
+          "tableName" -> s"`$SESSION_CATALOG_NAME`.`db2`.`tbl1`"))
+      checkError(
+        exception = intercept[AnalysisException] {
+          catalog.getPartition(TableIdentifier("tbl1", Some("db2")), partWithMoreColumns.spec)
+        },
+        errorClass = "_LEGACY_ERROR_TEMP_1232",
+        parameters = Map(
+          "specKeys" -> "a, b, c",
+          "partitionColumnNames" -> "a, b",
+          "tableName" -> s"`$SESSION_CATALOG_NAME`.`db2`.`tbl1`"))
+      checkError(
+        exception = intercept[AnalysisException] {
+          catalog.getPartition(TableIdentifier("tbl1", Some("db2")), partWithUnknownColumns.spec)
+        },
+        errorClass = "_LEGACY_ERROR_TEMP_1232",
+        parameters = Map(
+          "specKeys" -> "a, unknown",
+          "partitionColumnNames" -> "a, b",
+          "tableName" -> s"`$SESSION_CATALOG_NAME`.`db2`.`tbl1`"))
+      checkError(
+        exception = intercept[AnalysisException] {
+          catalog.getPartition(TableIdentifier("tbl1", Some("db2")), partWithEmptyValue.spec)
+        },
+        errorClass = "_LEGACY_ERROR_TEMP_1076",
+        parameters = Map(
+          "details" -> "The spec ([a=3, b=]) contains an empty partition column value"))
     }
   }
 
@@ -1220,34 +1270,48 @@ abstract class SessionCatalogSuite extends AnalysisTest with Eventually {
 
   test("rename partition with invalid partition spec") {
     withBasicCatalog { catalog =>
-      var e = intercept[AnalysisException] {
-        catalog.renamePartitions(
-          TableIdentifier("tbl1", Some("db2")),
-          Seq(part1.spec), Seq(partWithLessColumns.spec))
-      }
-      assert(e.getMessage.contains("Partition spec is invalid. The spec (a) must match " +
-        s"the partition spec (a, b) defined in table '`$SESSION_CATALOG_NAME`.`db2`.`tbl1`'"))
-      e = intercept[AnalysisException] {
-        catalog.renamePartitions(
-          TableIdentifier("tbl1", Some("db2")),
-          Seq(part1.spec), Seq(partWithMoreColumns.spec))
-      }
-      assert(e.getMessage.contains("Partition spec is invalid. The spec (a, b, c) must match " +
-        s"the partition spec (a, b) defined in table '`$SESSION_CATALOG_NAME`.`db2`.`tbl1`'"))
-      e = intercept[AnalysisException] {
-        catalog.renamePartitions(
-          TableIdentifier("tbl1", Some("db2")),
-          Seq(part1.spec), Seq(partWithUnknownColumns.spec))
-      }
-      assert(e.getMessage.contains("Partition spec is invalid. The spec (a, unknown) must match " +
-        s"the partition spec (a, b) defined in table '`$SESSION_CATALOG_NAME`.`db2`.`tbl1`'"))
-      e = intercept[AnalysisException] {
-        catalog.renamePartitions(
-          TableIdentifier("tbl1", Some("db2")),
-          Seq(part1.spec), Seq(partWithEmptyValue.spec))
-      }
-      assert(e.getMessage.contains("Partition spec is invalid. The spec ([a=3, b=]) contains an " +
-        "empty partition column value"))
+      checkError(
+        exception = intercept[AnalysisException] {
+          catalog.renamePartitions(
+            TableIdentifier("tbl1", Some("db2")),
+            Seq(part1.spec), Seq(partWithLessColumns.spec))
+        },
+        errorClass = "_LEGACY_ERROR_TEMP_1232",
+        parameters = Map(
+          "specKeys" -> "a",
+          "partitionColumnNames" -> "a, b",
+          "tableName" -> s"`$SESSION_CATALOG_NAME`.`db2`.`tbl1`"))
+      checkError(
+        exception = intercept[AnalysisException] {
+          catalog.renamePartitions(
+            TableIdentifier("tbl1", Some("db2")),
+            Seq(part1.spec), Seq(partWithMoreColumns.spec))
+        },
+        errorClass = "_LEGACY_ERROR_TEMP_1232",
+        parameters = Map(
+          "specKeys" -> "a, b, c",
+          "partitionColumnNames" -> "a, b",
+          "tableName" -> s"`$SESSION_CATALOG_NAME`.`db2`.`tbl1`"))
+      checkError(
+        exception = intercept[AnalysisException] {
+          catalog.renamePartitions(
+            TableIdentifier("tbl1", Some("db2")),
+            Seq(part1.spec), Seq(partWithUnknownColumns.spec))
+        },
+        errorClass = "_LEGACY_ERROR_TEMP_1232",
+        parameters = Map(
+          "specKeys" -> "a, unknown",
+          "partitionColumnNames" -> "a, b",
+          "tableName" -> s"`$SESSION_CATALOG_NAME`.`db2`.`tbl1`"))
+      checkError(
+        exception = intercept[AnalysisException] {
+          catalog.renamePartitions(
+            TableIdentifier("tbl1", Some("db2")),
+            Seq(part1.spec), Seq(partWithEmptyValue.spec))
+        },
+        errorClass = "_LEGACY_ERROR_TEMP_1076",
+        parameters = Map(
+          "details" -> "The spec ([a=3, b=]) contains an empty partition column value"))
     }
   }
 
@@ -1295,26 +1359,40 @@ abstract class SessionCatalogSuite extends AnalysisTest with Eventually {
 
   test("alter partition with invalid partition spec") {
     withBasicCatalog { catalog =>
-      var e = intercept[AnalysisException] {
-        catalog.alterPartitions(TableIdentifier("tbl1", Some("db2")), Seq(partWithLessColumns))
-      }
-      assert(e.getMessage.contains("Partition spec is invalid. The spec (a) must match " +
-        s"the partition spec (a, b) defined in table '`$SESSION_CATALOG_NAME`.`db2`.`tbl1`'"))
-      e = intercept[AnalysisException] {
-        catalog.alterPartitions(TableIdentifier("tbl1", Some("db2")), Seq(partWithMoreColumns))
-      }
-      assert(e.getMessage.contains("Partition spec is invalid. The spec (a, b, c) must match " +
-        s"the partition spec (a, b) defined in table '`$SESSION_CATALOG_NAME`.`db2`.`tbl1`'"))
-      e = intercept[AnalysisException] {
-        catalog.alterPartitions(TableIdentifier("tbl1", Some("db2")), Seq(partWithUnknownColumns))
-      }
-      assert(e.getMessage.contains("Partition spec is invalid. The spec (a, unknown) must match " +
-        s"the partition spec (a, b) defined in table '`$SESSION_CATALOG_NAME`.`db2`.`tbl1`'"))
-      e = intercept[AnalysisException] {
-        catalog.alterPartitions(TableIdentifier("tbl1", Some("db2")), Seq(partWithEmptyValue))
-      }
-      assert(e.getMessage.contains("Partition spec is invalid. The spec ([a=3, b=]) contains an " +
-        "empty partition column value"))
+      checkError(
+        exception = intercept[AnalysisException] {
+          catalog.alterPartitions(TableIdentifier("tbl1", Some("db2")), Seq(partWithLessColumns))
+        },
+        errorClass = "_LEGACY_ERROR_TEMP_1232",
+        parameters = Map(
+          "specKeys" -> "a",
+          "partitionColumnNames" -> "a, b",
+          "tableName" -> s"`$SESSION_CATALOG_NAME`.`db2`.`tbl1`"))
+      checkError(
+        exception = intercept[AnalysisException] {
+          catalog.alterPartitions(TableIdentifier("tbl1", Some("db2")), Seq(partWithMoreColumns))
+        },
+        errorClass = "_LEGACY_ERROR_TEMP_1232",
+        parameters = Map(
+          "specKeys" -> "a, b, c",
+          "partitionColumnNames" -> "a, b",
+          "tableName" -> s"`$SESSION_CATALOG_NAME`.`db2`.`tbl1`"))
+      checkError(
+        exception = intercept[AnalysisException] {
+          catalog.alterPartitions(TableIdentifier("tbl1", Some("db2")), Seq(partWithUnknownColumns))
+        },
+        errorClass = "_LEGACY_ERROR_TEMP_1232",
+        parameters = Map(
+          "specKeys" -> "a, unknown",
+          "partitionColumnNames" -> "a, b",
+          "tableName" -> s"`$SESSION_CATALOG_NAME`.`db2`.`tbl1`"))
+      checkError(
+        exception = intercept[AnalysisException] {
+          catalog.alterPartitions(TableIdentifier("tbl1", Some("db2")), Seq(partWithEmptyValue))
+        },
+        errorClass = "_LEGACY_ERROR_TEMP_1076",
+        parameters = Map(
+          "details" -> "The spec ([a=3, b=]) contains an empty partition column value"))
     }
   }
 
@@ -1339,26 +1417,32 @@ abstract class SessionCatalogSuite extends AnalysisTest with Eventually {
 
   test("list partition names with invalid partial partition spec") {
     withBasicCatalog { catalog =>
-      var e = intercept[AnalysisException] {
-        catalog.listPartitionNames(TableIdentifier("tbl2", Some("db2")),
-          Some(partWithMoreColumns.spec))
-      }
-      assert(e.getMessage.contains("Partition spec is invalid. The spec (a, b, c) must be " +
-        "contained within the partition spec (a, b) defined in table " +
-        s"'`$SESSION_CATALOG_NAME`.`db2`.`tbl2`'"))
-      e = intercept[AnalysisException] {
-        catalog.listPartitionNames(TableIdentifier("tbl2", Some("db2")),
-          Some(partWithUnknownColumns.spec))
-      }
-      assert(e.getMessage.contains("Partition spec is invalid. The spec (a, unknown) must be " +
-        "contained within the partition spec (a, b) defined in table " +
-        s"'`$SESSION_CATALOG_NAME`.`db2`.`tbl2`'"))
-      e = intercept[AnalysisException] {
-        catalog.listPartitionNames(TableIdentifier("tbl2", Some("db2")),
-          Some(partWithEmptyValue.spec))
-      }
-      assert(e.getMessage.contains("Partition spec is invalid. The spec ([a=3, b=]) contains an " +
-        "empty partition column value"))
+      checkError(
+        exception = intercept[AnalysisException] {
+          catalog.listPartitionNames(TableIdentifier("tbl2", Some("db2")),
+            Some(partWithMoreColumns.spec))
+        },
+        errorClass = "_LEGACY_ERROR_TEMP_1076",
+        parameters = Map(
+          "details" -> ("The spec (a, b, c) must be contained within the partition spec (a, b) " +
+            s"defined in table '`$SESSION_CATALOG_NAME`.`db2`.`tbl2`'")))
+      checkError(
+        exception = intercept[AnalysisException] {
+          catalog.listPartitionNames(TableIdentifier("tbl2", Some("db2")),
+            Some(partWithUnknownColumns.spec))
+        },
+        errorClass = "_LEGACY_ERROR_TEMP_1076",
+        parameters = Map(
+          "details" -> ("The spec (a, unknown) must be contained within the partition " +
+            s"spec (a, b) defined in table '`$SESSION_CATALOG_NAME`.`db2`.`tbl2`'")))
+      checkError(
+        exception = intercept[AnalysisException] {
+          catalog.listPartitionNames(TableIdentifier("tbl2", Some("db2")),
+            Some(partWithEmptyValue.spec))
+        },
+        errorClass = "_LEGACY_ERROR_TEMP_1076",
+        parameters = Map(
+          "details" -> "The spec ([a=3, b=]) contains an empty partition column value"))
     }
   }
 
@@ -1381,24 +1465,32 @@ abstract class SessionCatalogSuite extends AnalysisTest with Eventually {
 
   test("list partitions with invalid partial partition spec") {
     withBasicCatalog { catalog =>
-      var e = intercept[AnalysisException] {
-        catalog.listPartitions(TableIdentifier("tbl2", Some("db2")), Some(partWithMoreColumns.spec))
-      }
-      assert(e.getMessage.contains("Partition spec is invalid. The spec (a, b, c) must be " +
-        "contained within the partition spec (a, b) defined in table " +
-        s"'`$SESSION_CATALOG_NAME`.`db2`.`tbl2`'"))
-      e = intercept[AnalysisException] {
-        catalog.listPartitions(TableIdentifier("tbl2", Some("db2")),
-          Some(partWithUnknownColumns.spec))
-      }
-      assert(e.getMessage.contains("Partition spec is invalid. The spec (a, unknown) must be " +
-        "contained within the partition spec (a, b) defined in table " +
-        s"'`$SESSION_CATALOG_NAME`.`db2`.`tbl2`'"))
-      e = intercept[AnalysisException] {
-        catalog.listPartitions(TableIdentifier("tbl2", Some("db2")), Some(partWithEmptyValue.spec))
-      }
-      assert(e.getMessage.contains("Partition spec is invalid. The spec ([a=3, b=]) contains an " +
-        "empty partition column value"))
+      checkError(
+        exception = intercept[AnalysisException] {
+          catalog.listPartitions(TableIdentifier("tbl2", Some("db2")),
+            Some(partWithMoreColumns.spec))
+        },
+        errorClass = "_LEGACY_ERROR_TEMP_1076",
+        parameters = Map(
+          "details" -> ("The spec (a, b, c) must be contained within the partition spec (a, b) " +
+            s"defined in table '`$SESSION_CATALOG_NAME`.`db2`.`tbl2`'")))
+      checkError(
+        exception = intercept[AnalysisException] {
+          catalog.listPartitions(TableIdentifier("tbl2", Some("db2")),
+            Some(partWithUnknownColumns.spec))
+        },
+        errorClass = "_LEGACY_ERROR_TEMP_1076",
+        parameters = Map(
+          "details" -> ("The spec (a, unknown) must be contained within the partition " +
+            s"spec (a, b) defined in table '`$SESSION_CATALOG_NAME`.`db2`.`tbl2`'")))
+      checkError(
+        exception = intercept[AnalysisException] {
+          catalog.listPartitions(TableIdentifier("tbl2", Some("db2")),
+            Some(partWithEmptyValue.spec))
+        },
+        errorClass = "_LEGACY_ERROR_TEMP_1076",
+        parameters = Map(
+          "details" -> "The spec ([a=3, b=]) contains an empty partition column value"))
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to use `checkError()` to check Exception in `SessionCatalogSuite`.

### Why are the changes needed?
Migration on `checkError()` will make the tests independent from the text of error messages.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA.