### PR TITLE
[SPARK-43849][BUILD] Enable unused imports check for Scala 2.13

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -31,13 +31,9 @@ import org.apache.spark.connect.proto
 import org.apache.spark.connect.proto.{ExecutePlanResponse, SqlCommand, StreamingQueryCommand, StreamingQueryCommandResult, StreamingQueryInstanceId, WriteStreamOperationStart, WriteStreamOperationStartResult}
 import org.apache.spark.connect.proto.ExecutePlanResponse.SqlCommandResult
 import org.apache.spark.connect.proto.Parse.ParseFormat
-import org.apache.spark.connect.proto.StreamingQueryCommand
-import org.apache.spark.connect.proto.StreamingQueryCommandResult
-import org.apache.spark.connect.proto.StreamingQueryInstanceId
 import org.apache.spark.connect.proto.StreamingQueryManagerCommand
 import org.apache.spark.connect.proto.StreamingQueryManagerCommandResult
 import org.apache.spark.connect.proto.StreamingQueryManagerCommandResult.StreamingQueryInstance
-import org.apache.spark.connect.proto.WriteStreamOperationStart
 import org.apache.spark.connect.proto.WriteStreamOperationStart.TriggerCase
 import org.apache.spark.ml.{functions => MLFunctions}
 import org.apache.spark.sql.{Column, Dataset, Encoders, ForeachWriter, RelationalGroupedDataset, SparkSession}

--- a/pom.xml
+++ b/pom.xml
@@ -2855,10 +2855,7 @@
               <arg>-explaintypes</arg>
               <arg>-target:jvm-1.8</arg>
               <arg>-Wconf:cat=deprecation:wv,any:e</arg>
-              <!--
-                TODO(SPARK-33805): Undo the corresponding deprecated usage suppression rule after fixed
-                <arg>-Wunused:imports</arg>
-              -->
+              <arg>-Wunused:imports</arg>
               <arg>-Wconf:cat=scaladoc:wv</arg>
               <arg>-Wconf:cat=lint-multiarg-infix:wv</arg>
               <arg>-Wconf:cat=other-nullary-override:wv</arg>
@@ -2891,6 +2888,13 @@
               <arg>-Wconf:cat=unchecked&amp;msg=outer reference:s</arg>
               <arg>-Wconf:cat=unchecked&amp;msg=eliminated by erasure:s</arg>
               <arg>-Wconf:msg=^(?=.*?a value of type)(?=.*?cannot also be).+$:s</arg>
+
+              <!--
+                TODO(SPARK-43850): Remove the following suppression rules and remove `import scala.language.higherKinds`
+                from the corresponding files when Scala 2.12 is no longer supported.
+              -->
+              <arg>-Wconf:cat=unused-imports&amp;src=org\/apache\/spark\/graphx\/impl\/VertexPartitionBase.scala:s</arg>
+              <arg>-Wconf:cat=unused-imports&amp;src=org\/apache\/spark\/graphx\/impl\/VertexPartitionBaseOps.scala:s</arg>
             </args>
             <jvmArgs>
               <jvmArg>-Xss128m</jvmArg>

--- a/pom.xml
+++ b/pom.xml
@@ -2856,6 +2856,9 @@
               <arg>-target:jvm-1.8</arg>
               <arg>-Wconf:cat=deprecation:wv,any:e</arg>
               <arg>-Wunused:imports</arg>
+              <!--
+                TODO(SPARK-33805): Undo the corresponding deprecated usage suppression rule after fixed
+              -->
               <arg>-Wconf:cat=scaladoc:wv</arg>
               <arg>-Wconf:cat=lint-multiarg-infix:wv</arg>
               <arg>-Wconf:cat=other-nullary-override:wv</arg>

--- a/pom.xml
+++ b/pom.xml
@@ -2891,7 +2891,6 @@
               <arg>-Wconf:cat=unchecked&amp;msg=outer reference:s</arg>
               <arg>-Wconf:cat=unchecked&amp;msg=eliminated by erasure:s</arg>
               <arg>-Wconf:msg=^(?=.*?a value of type)(?=.*?cannot also be).+$:s</arg>
-
               <!--
                 TODO(SPARK-43850): Remove the following suppression rules and remove `import scala.language.higherKinds`
                 from the corresponding files when Scala 2.12 is no longer supported.

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -286,8 +286,8 @@ object SparkBuild extends PomBuild {
           "-Wconf:msg=^(?=.*?a value of type)(?=.*?cannot also be).+$:s",
           // TODO(SPARK-43850): Remove the following suppression rules and remove `import scala.language.higherKinds`
           // from the corresponding files when Scala 2.12 is no longer supported.
-          "-Wconf:cat=unused-imports&amp;src=org\\/apache\\/spark\\/graphx\\/impl\\/VertexPartitionBase.scala:s",
-          "-Wconf:cat=unused-imports&amp;src=org\\/apache\\/spark\\/graphx\\/impl\\/VertexPartitionBaseOps.scala:s"
+          "-Wconf:cat=unused-imports&src=org\\/apache\\/spark\\/graphx\\/impl\\/VertexPartitionBase.scala:s",
+          "-Wconf:cat=unused-imports&src=org\\/apache\\/spark\\/graphx\\/impl\\/VertexPartitionBaseOps.scala:s"
         )
       }
     }

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -256,7 +256,6 @@ object SparkBuild extends PomBuild {
           // see `scalac -Wconf:help` for details
           "-Wconf:cat=deprecation:wv,any:e",
           // 2.13-specific warning hits to be muted (as narrowly as possible) and addressed separately
-          // TODO(SPARK-33499): Enable this option when Scala 2.12 is no longer supported.
           "-Wunused:imports",
           "-Wconf:cat=lint-multiarg-infix:wv",
           "-Wconf:cat=other-nullary-override:wv",

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -257,7 +257,7 @@ object SparkBuild extends PomBuild {
           "-Wconf:cat=deprecation:wv,any:e",
           // 2.13-specific warning hits to be muted (as narrowly as possible) and addressed separately
           // TODO(SPARK-33499): Enable this option when Scala 2.12 is no longer supported.
-          // "-Wunused:imports",
+          "-Wunused:imports",
           "-Wconf:cat=lint-multiarg-infix:wv",
           "-Wconf:cat=other-nullary-override:wv",
           "-Wconf:cat=other-match-analysis&site=org.apache.spark.sql.catalyst.catalog.SessionCatalog.lookupFunction.catalogFunction:wv",
@@ -283,7 +283,11 @@ object SparkBuild extends PomBuild {
           // 4. `fruitless type test: a value of TypeA cannot also be a TypeB`
           "-Wconf:cat=unchecked&msg=outer reference:s",
           "-Wconf:cat=unchecked&msg=eliminated by erasure:s",
-          "-Wconf:msg=^(?=.*?a value of type)(?=.*?cannot also be).+$:s"
+          "-Wconf:msg=^(?=.*?a value of type)(?=.*?cannot also be).+$:s",
+          // TODO(SPARK-43850): Remove the following suppression rules and remove `import scala.language.higherKinds`
+          // from the corresponding files when Scala 2.12 is no longer supported.
+          "-Wconf:cat=unused-imports&amp;src=org\\/apache\\/spark\\/graphx\\/impl\\/VertexPartitionBase.scala:s",
+          "-Wconf:cat=unused-imports&amp;src=org\\/apache\\/spark\\/graphx\\/impl\\/VertexPartitionBaseOps.scala:s"
         )
       }
     }

--- a/sql/catalyst/src/main/scala-2.13/org/apache/spark/sql/catalyst/expressions/ExpressionSet.scala
+++ b/sql/catalyst/src/main/scala-2.13/org/apache/spark/sql/catalyst/expressions/ExpressionSet.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.catalyst.expressions
 
-import scala.collection.{mutable, IterableFactory, IterableOps}
+import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
 object ExpressionSet {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to enable `unused imports` check for Scala 2.13.

There is an exception here for `import scala.language.higherKinds`（Scala 2.13 does not need to import them , while Scala 2.12 must import them）, so this pr add two new suppression rules for it.


### Why are the changes needed?
Enable `unused imports` check for Scala 2.13.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass Github Actions