### PR TITLE
[SPARK-43858][INFRA] Make benchmark Github Action task use Scala 2.13 as default

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -33,7 +33,7 @@ on:
       scala:
         description: 'Scala version: 2.12 or 2.13'
         required: true
-        default: '2.12'
+        default: '2.13'
       failfast:
         description: 'Failfast: true or false'
         required: true


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to make the benchmark Github Action task use Scala 2.13 as default.


### Why are the changes needed?
Spark 3.5.0 already change to use Scala 2.13 as default 


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Manual checked:

<img width="353" alt="image" src="https://github.com/apache/spark/assets/1475305/6bc9190d-0a84-40e7-8c97-7c1d5a6fdd7d">
