### PR TITLE
[SPARK-43859][SQL] Override toString in LateralColumnAliasReference

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/namedExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/namedExpressions.scala
@@ -459,6 +459,7 @@ case class LateralColumnAliasReference(ne: NamedExpression, nameParts: Seq[Strin
   override def dataType: DataType = ne.dataType
   override def prettyName: String = "lateralAliasReference"
   override def sql: String = s"$prettyName($name)"
+  override def toString: String = sql
 
   final override val nodePatterns: Seq[TreePattern] = Seq(LATERAL_COLUMN_ALIAS_REFERENCE)
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR makes it override `toString` in `LateralColumnAliasReference`.

### Why are the changes needed?

Improve the readability of logical plans.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual test:
```sql
select id + 1 as a1, a1 + 2 as a3 from range(10);
```
Before this PR:
```
Project [(id#2L + 1) AS a1#0, (lateralAliasReference('a1, a1, 'a1) + 2) AS a3#1]
+- Range (0, 10, step=1, splits=None)
```

After this  PR:
```
Project [(id#2L + 1) AS a1#0, (lateralAliasReference(a1) + 2) AS a3#1]
+- Range (0, 10, step=1, splits=None)
```