### PR TITLE
[SPARK-43860][SQL] Enable tail-recursion wherever possible

### DIFF
--- a/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/common/LiteralValueProtoConverter.scala
+++ b/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/common/LiteralValueProtoConverter.scala
@@ -102,6 +102,7 @@ object LiteralValueProtoConverter {
     }
   }
 
+  @scala.annotation.tailrec
   def toLiteralProtoBuilder(
       literal: Any,
       dataType: DataType): proto.Expression.Literal.Builder = {

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -1694,6 +1694,7 @@ class SparkConnectPlanner(val session: SparkSession) {
     case other => throw InvalidPlanInput(s"$field should be a literal string, but got $other")
   }
 
+  @scala.annotation.tailrec
   private def extractMapData(expr: Expression, field: String): Map[String, String] = expr match {
     case map: CreateMap => ExprUtils.convertToMapData(map)
     case UnresolvedFunction(Seq("map"), args, _, _, _) => extractMapData(CreateMap(args), field)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/InterpretedUnsafeProjection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/InterpretedUnsafeProjection.scala
@@ -288,6 +288,7 @@ object InterpretedUnsafeProjection {
    * portion of the array object. Primitives take up to 8 bytes, depending on the size of the
    * underlying data type.
    */
+  @scala.annotation.tailrec
   private def getElementSize(dataType: DataType): Int = dataType match {
     case NullType | StringType | BinaryType | CalendarIntervalType |
          _: DecimalType | _: StructType | _: ArrayType | _: MapType => 8


### PR DESCRIPTION
### What changes were proposed in this pull request
Similar to SPARK-41316, this pr adds `@scala.annotation.tailrec` inspected by IDE (IntelliJ),  these are new cases after Spark 3.4.


### Why are the changes needed?
To improve performance.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GItHub Actions