### PR TITLE
[SPARK-43687][SPARK-43688][SPARK-43689][SPARK-43690][PS] Fix `NumOps` for Spark Connect

### DIFF
--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -216,7 +216,7 @@ class NumericOps(DataTypeOps):
     def lt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         _sanitize_list_like(right)
         result = pyspark_column_op("__lt__")(left, right)
-        if is_remote:
+        if is_remote():
             # In Spark Connect, it returns None instead of False, so we manually cast it.
             result = result.fillna(False)
         return result
@@ -224,7 +224,7 @@ class NumericOps(DataTypeOps):
     def le(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         _sanitize_list_like(right)
         result = pyspark_column_op("__le__")(left, right)
-        if is_remote:
+        if is_remote():
             # In Spark Connect, it returns None instead of False, so we manually cast it.
             result = result.fillna(False)
         return result
@@ -232,7 +232,7 @@ class NumericOps(DataTypeOps):
     def ge(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         _sanitize_list_like(right)
         result = pyspark_column_op("__ge__")(left, right)
-        if is_remote:
+        if is_remote():
             # In Spark Connect, it returns None instead of False, so we manually cast it.
             result = result.fillna(False)
         return result
@@ -240,7 +240,7 @@ class NumericOps(DataTypeOps):
     def gt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         _sanitize_list_like(right)
         result = pyspark_column_op("__gt__")(left, right)
-        if is_remote:
+        if is_remote():
             # In Spark Connect, it returns None instead of False, so we manually cast it.
             result = result.fillna(False)
         return result

--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -217,7 +217,7 @@ class NumericOps(DataTypeOps):
         _sanitize_list_like(right)
         result = pyspark_column_op("__lt__")(left, right)
         if is_remote():
-            # In Spark Connect, it returns None instead of False, so we manually cast it.
+            # TODO(SPARK-43877): Fix behavior difference for compare binary functions.
             result = result.fillna(False)
         return result
 
@@ -225,7 +225,7 @@ class NumericOps(DataTypeOps):
         _sanitize_list_like(right)
         result = pyspark_column_op("__le__")(left, right)
         if is_remote():
-            # In Spark Connect, it returns None instead of False, so we manually cast it.
+            # TODO(SPARK-43877): Fix behavior difference for compare binary functions.
             result = result.fillna(False)
         return result
 
@@ -233,7 +233,7 @@ class NumericOps(DataTypeOps):
         _sanitize_list_like(right)
         result = pyspark_column_op("__ge__")(left, right)
         if is_remote():
-            # In Spark Connect, it returns None instead of False, so we manually cast it.
+            # TODO(SPARK-43877): Fix behavior difference for compare binary functions.
             result = result.fillna(False)
         return result
 
@@ -241,7 +241,7 @@ class NumericOps(DataTypeOps):
         _sanitize_list_like(right)
         result = pyspark_column_op("__gt__")(left, right)
         if is_remote():
-            # In Spark Connect, it returns None instead of False, so we manually cast it.
+            # TODO(SPARK-43877): Fix behavior difference for compare binary functions.
             result = result.fillna(False)
         return result
 

--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -53,7 +53,7 @@ from pyspark.sql.types import (
 from pyspark.errors import PySparkValueError
 
 # For Supporting Spark Connect
-from pyspark.sql.utils import is_remote
+from pyspark.sql.utils import is_remote, pyspark_column_op
 
 
 def _non_fractional_astype(
@@ -215,43 +215,35 @@ class NumericOps(DataTypeOps):
 
     def lt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         _sanitize_list_like(right)
-        if is_remote():
-            from pyspark.sql.connect.column import Column as ConnectColumn
-
-            Column = ConnectColumn
-        else:
-            Column = PySparkColumn  # type: ignore[assignment]
-        return column_op(Column.__lt__)(left, right)  # type: ignore[arg-type]
+        result = pyspark_column_op("__lt__")(left, right)
+        if is_remote:
+            # In Spark Connect, it returns None instead of False, so we manually cast it.
+            result = result.fillna(False)
+        return result
 
     def le(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         _sanitize_list_like(right)
-        if is_remote():
-            from pyspark.sql.connect.column import Column as ConnectColumn
-
-            Column = ConnectColumn
-        else:
-            Column = PySparkColumn  # type: ignore[assignment]
-        return column_op(Column.__le__)(left, right)  # type: ignore[arg-type]
+        result = pyspark_column_op("__le__")(left, right)
+        if is_remote:
+            # In Spark Connect, it returns None instead of False, so we manually cast it.
+            result = result.fillna(False)
+        return result
 
     def ge(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         _sanitize_list_like(right)
-        if is_remote():
-            from pyspark.sql.connect.column import Column as ConnectColumn
-
-            Column = ConnectColumn
-        else:
-            Column = PySparkColumn  # type: ignore[assignment]
-        return column_op(Column.__ge__)(left, right)  # type: ignore[arg-type]
+        result = pyspark_column_op("__ge__")(left, right)
+        if is_remote:
+            # In Spark Connect, it returns None instead of False, so we manually cast it.
+            result = result.fillna(False)
+        return result
 
     def gt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         _sanitize_list_like(right)
-        if is_remote():
-            from pyspark.sql.connect.column import Column as ConnectColumn
-
-            Column = ConnectColumn
-        else:
-            Column = PySparkColumn  # type: ignore[assignment]
-        return column_op(Column.__gt__)(left, right)  # type: ignore[arg-type]
+        result = pyspark_column_op("__gt__")(left, right)
+        if is_remote:
+            # In Spark Connect, it returns None instead of False, so we manually cast it.
+            result = result.fillna(False)
+        return result
 
 
 class IntegralOps(NumericOps):

--- a/python/pyspark/pandas/tests/connect/data_type_ops/test_parity_num_ops.py
+++ b/python/pyspark/pandas/tests/connect/data_type_ops/test_parity_num_ops.py
@@ -38,22 +38,6 @@ class NumOpsParityTests(
     def test_eq(self):
         super().test_eq()
 
-    @unittest.skip("TODO(SPARK-43687): Enable NumOpsParityTests.test_ge.")
-    def test_ge(self):
-        super().test_ge()
-
-    @unittest.skip("TODO(SPARK-43688): Enable NumOpsParityTests.test_gt.")
-    def test_gt(self):
-        super().test_gt()
-
-    @unittest.skip("TODO(SPARK-43689): Enable NumOpsParityTests.test_le.")
-    def test_le(self):
-        super().test_le()
-
-    @unittest.skip("TODO(SPARK-43690): Enable NumOpsParityTests.test_lt.")
-    def test_lt(self):
-        super().test_lt()
-
     @unittest.skip(
         "TODO(SPARK-43621): Enable pyspark.pandas.spark.functions.repeat in Spark Connect."
     )


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to fix `NullOps` test for pandas API on Spark with Spark Connect.

This includes SPARK-43687, SPARK-43688, SPARK-43689, SPARK-43690 at once, because they are all related similar modifications in single file.


### Why are the changes needed?

To support all features for pandas API on Spark with Spark Connect.


### Does this PR introduce _any_ user-facing change?

Yes, `NumOps.lt`,  `NumOps.le`, `NumOps.ge`, `NumOps.gt` are now working as expected on Spark Connect.


### How was this patch tested?

Uncomment the UTs, and tested manually.
