### PR TITLE
[SPARK-43852][SPARK-43853][SPARK-43854][SPARK-43855][SPARK-43856] Assign names to the error class _LEGACY_ERROR_TEMP_2418-2425

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -1,7 +1,7 @@
 {
   "AGGREGATE_FUNCTION_WITH_NONDETERMINISTIC_EXPRESSION" : {
     "message" : [
-      "nondeterministic expression <sqlExpr> should not appear in the arguments of an aggregate function."
+      "Non-deterministic expression <sqlExpr> should not appear in the arguments of an aggregate function."
     ]
   },
   "ALTER_TABLE_COLUMN_DESCRIPTOR_DUPLICATE" : {
@@ -54,12 +54,12 @@
     "subClass" : {
       "TOLERANCE_IS_NON_NEGATIVE" : {
         "message" : [
-          "Input argument tolerance must be non-negative."
+          "The input argument `tolerance` must be non-negative."
         ]
       },
       "TOLERANCE_IS_UNFOLDABLE" : {
         "message" : [
-          "Input argument tolerance must be a constant."
+          "The input argument `tolerance` must be a constant."
         ]
       }
     }
@@ -727,7 +727,7 @@
   },
   "GROUP_EXPRESSION_TYPE_IS_NOT_ORDERABLE" : {
     "message" : [
-      "expression <sqlExpr> cannot be used as a grouping expression because its data type <dataType> is not an orderable data type."
+      "The expression <sqlExpr> cannot be used as a grouping expression because its data type <dataType> is not an orderable data type."
     ]
   },
   "IDENTIFIER_TOO_MANY_NAME_PARTS" : {
@@ -1845,7 +1845,7 @@
   },
   "SCALAR_SUBQUERY_IS_IN_GROUP_BY_OR_AGGREGATE_FUNCTION" : {
     "message" : [
-      "Correlated scalar subquery '<sqlExpr>' is neither present in the group by, nor in an aggregate function. Add it to group by using ordinal position or wrap it in first() (or first_value) if you don't care which value you get."
+      "The correlated scalar subquery '<sqlExpr>' is neither present in GROUP BY, nor in an aggregate function. Add it to GROUP BY using ordinal position or wrap it in `first()` (or `first_value`) if you don't care which value you get."
     ]
   },
   "SCALAR_SUBQUERY_TOO_MANY_ROWS" : {

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -49,7 +49,7 @@
   },
   "AS_OF_JOIN" : {
     "message" : [
-      "Generic Spark Connect error."
+      "Invalid as-of join."
     ],
     "subClass" : {
       "TOLERANCE_IS_NON_NEGATIVE" : {

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -1,4 +1,9 @@
 {
+  "AGGREGATE_FUNCTION_WITH_NONDETERMINISTIC_EXPRESSION" : {
+    "message" : [
+      "nondeterministic expression <sqlExpr> should not appear in the arguments of an aggregate function."
+    ]
+  },
   "ALTER_TABLE_COLUMN_DESCRIPTOR_DUPLICATE" : {
     "message" : [
       "ALTER TABLE <type> column <columnName> specifies descriptor \"<optionName>\" more than once, which is invalid."
@@ -41,6 +46,23 @@
       "<message>.<alternative> If necessary set <config> to \"false\" to bypass this error."
     ],
     "sqlState" : "22003"
+  },
+  "AS_OF_JOIN" : {
+    "message" : [
+      "Generic Spark Connect error."
+    ],
+    "subClass" : {
+      "TOLERANCE_IS_NON_NEGATIVE" : {
+        "message" : [
+          "Input argument tolerance must be non-negative."
+        ]
+      },
+      "TOLERANCE_IS_UNFOLDABLE" : {
+        "message" : [
+          "Input argument tolerance must be a constant."
+        ]
+      }
+    }
   },
   "BINARY_ARITHMETIC_OVERFLOW" : {
     "message" : [
@@ -702,6 +724,11 @@
       "GROUP BY position <index> is not in select list (valid range is [1, <size>])."
     ],
     "sqlState" : "42805"
+  },
+  "GROUP_EXPRESSION_TYPE_IS_NOT_ORDERABLE" : {
+    "message" : [
+      "expression <sqlExpr> cannot be used as a grouping expression because its data type <dataType> is not an orderable data type."
+    ]
   },
   "IDENTIFIER_TOO_MANY_NAME_PARTS" : {
     "message" : [
@@ -1815,6 +1842,11 @@
       "To tolerate the error on drop use DROP FUNCTION IF EXISTS."
     ],
     "sqlState" : "42883"
+  },
+  "SCALAR_SUBQUERY_IS_IN_GROUP_BY_OR_AGGREGATE_FUNCTION" : {
+    "message" : [
+      "Correlated scalar subquery '<sqlExpr>' is neither present in the group by, nor in an aggregate function. Add it to group by using ordinal position or wrap it in first() (or first_value) if you don't care which value you get."
+    ]
   },
   "SCALAR_SUBQUERY_TOO_MANY_ROWS" : {
     "message" : [
@@ -5470,31 +5502,6 @@
   "_LEGACY_ERROR_TEMP_2331" : {
     "message" : [
       "failed to evaluate expression <sqlExpr>: <msg>"
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_2418" : {
-    "message" : [
-      "Input argument tolerance must be a constant."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_2419" : {
-    "message" : [
-      "Input argument tolerance must be non-negative."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_2421" : {
-    "message" : [
-      "nondeterministic expression <sqlExpr> should not appear in the arguments of an aggregate function."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_2423" : {
-    "message" : [
-      "Correlated scalar subquery '<sqlExpr>' is neither present in the group by, nor in an aggregate function. Add it to group by using ordinal position or wrap it in first() (or first_value) if you don't care which value you get."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_2425" : {
-    "message" : [
-      "expression <sqlExpr> cannot be used as a grouping expression because its data type <dataType> is not an orderable data type."
     ]
   },
   "_LEGACY_ERROR_TEMP_2426" : {

--- a/python/pyspark/sql/tests/pandas/test_pandas_udf_scalar.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_udf_scalar.py
@@ -967,9 +967,9 @@ class ScalarPandasUDFTestsMixin:
             self.nondeterministic_vectorized_udf,
             self.nondeterministic_vectorized_iter_udf,
         ]:
-            with self.assertRaisesRegex(AnalysisException, "nondeterministic"):
+            with self.assertRaisesRegex(AnalysisException, "Non-deterministic"):
                 df.groupby(df.id).agg(sum(random_udf(df.id))).collect()
-            with self.assertRaisesRegex(AnalysisException, "nondeterministic"):
+            with self.assertRaisesRegex(AnalysisException, "Non-deterministic"):
                 df.agg(sum(random_udf(df.id))).collect()
 
     def test_register_vectorized_udf_basic(self):

--- a/python/pyspark/sql/tests/test_udf.py
+++ b/python/pyspark/sql/tests/test_udf.py
@@ -174,9 +174,9 @@ class BaseUDFTestsMixin(object):
         udf_random_col = udf(lambda: int(100 * random.random()), "int").asNondeterministic()
         df = self.spark.range(10)
 
-        with self.assertRaisesRegex(AnalysisException, "nondeterministic"):
+        with self.assertRaisesRegex(AnalysisException, "Non-deterministic"):
             df.groupby("id").agg(sum(udf_random_col())).collect()
-        with self.assertRaisesRegex(AnalysisException, "nondeterministic"):
+        with self.assertRaisesRegex(AnalysisException, "Non-deterministic"):
             df.agg(sum(udf_random_col())).collect()
 
     def test_chained_udf(self):

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -403,12 +403,12 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
           case j @ AsOfJoin(_, _, _, _, _, _, Some(toleranceAssertion)) =>
             if (!toleranceAssertion.foldable) {
               j.failAnalysis(
-                errorClass = "_LEGACY_ERROR_TEMP_2418",
+                errorClass = "AS_OF_JOIN.TOLERANCE_IS_UNFOLDABLE",
                 messageParameters = Map.empty)
             }
             if (!toleranceAssertion.eval().asInstanceOf[Boolean]) {
               j.failAnalysis(
-                errorClass = "_LEGACY_ERROR_TEMP_2419",
+                errorClass = "AS_OF_JOIN.TOLERANCE_IS_NON_NEGATIVE",
                 messageParameters = Map.empty)
             }
 
@@ -427,8 +427,8 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
 
                   if (!child.deterministic) {
                     child.failAnalysis(
-                      errorClass = "_LEGACY_ERROR_TEMP_2421",
-                      messageParameters = Map("sqlExpr" -> expr.sql))
+                      errorClass = "AGGREGATE_FUNCTION_WITH_NONDETERMINISTIC_EXPRESSION",
+                      messageParameters = Map("sqlExpr" -> toSQLExpr(expr)))
                   }
                 }
               case _: Attribute if groupingExprs.isEmpty =>
@@ -440,8 +440,8 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
               case s: ScalarSubquery
                   if s.children.nonEmpty && !groupingExprs.exists(_.semanticEquals(s)) =>
                 s.failAnalysis(
-                  errorClass = "_LEGACY_ERROR_TEMP_2423",
-                  messageParameters = Map("sqlExpr" -> s.sql))
+                  errorClass = "SCALAR_SUBQUERY_IS_IN_GROUP_BY_OR_AGGREGATE_FUNCTION",
+                  messageParameters = Map("sqlExpr" -> toSQLExpr(s)))
               case e if groupingExprs.exists(_.semanticEquals(e)) => // OK
               // There should be no Window in Aggregate - this case will fail later check anyway.
               // Perform this check for special case of lateral column alias, when the window
@@ -463,10 +463,10 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
               // Check if the data type of expr is orderable.
               if (!RowOrdering.isOrderable(expr.dataType)) {
                 expr.failAnalysis(
-                  errorClass = "_LEGACY_ERROR_TEMP_2425",
+                  errorClass = "GROUP_EXPRESSION_TYPE_IS_NOT_ORDERABLE",
                   messageParameters = Map(
-                    "sqlExpr" -> expr.sql,
-                    "dataType" -> expr.dataType.catalogString))
+                    "sqlExpr" -> toSQLExpr(expr),
+                    "dataType" -> toSQLType(expr.dataType)))
               }
 
               if (!expr.deterministic) {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
@@ -790,7 +790,8 @@ class AnalysisErrorSuite extends AnalysisTest {
   }
 
   test("check grouping expression data types") {
-    def checkDataType(dataType: DataType, shouldSuccess: Boolean): Unit = {
+    def checkDataType(
+        dataType: DataType, shouldSuccess: Boolean, dataTypeMsg: String = ""): Unit = {
       val plan =
         Aggregate(
           AttributeReference("a", dataType)(exprId = ExprId(2)) :: Nil,
@@ -802,7 +803,14 @@ class AnalysisErrorSuite extends AnalysisTest {
       if (shouldSuccess) {
         assertAnalysisSuccess(plan, true)
       } else {
-        assertAnalysisError(plan, "expression a cannot be used as a grouping expression" :: Nil)
+        assertAnalysisErrorClass(
+          inputPlan = plan,
+          expectedErrorClass = "GROUP_EXPRESSION_TYPE_IS_NOT_ORDERABLE",
+          expectedMessageParameters = Map(
+            "sqlExpr" -> "\"a\"",
+            "dataType" -> dataTypeMsg
+          )
+        )
       }
     }
 
@@ -830,8 +838,11 @@ class AnalysisErrorSuite extends AnalysisTest {
         .add("f1", FloatType, nullable = true)
         .add("f2", MapType(StringType, LongType), nullable = true),
       new UngroupableUDT())
-    unsupportedDataTypes.foreach { dataType =>
-      checkDataType(dataType, shouldSuccess = false)
+    val expectedDataTypeParameters =
+      Seq("\"MAP<STRING, BIGINT>\"", "\"STRUCT<f1: FLOAT, f2: MAP<STRING, BIGINT>>\"")
+    unsupportedDataTypes.zip(expectedDataTypeParameters).foreach {
+      case (dataType, dataTypeMsg) =>
+        checkDataType(dataType, shouldSuccess = false, dataTypeMsg)
     }
   }
 
@@ -1025,10 +1036,11 @@ class AnalysisErrorSuite extends AnalysisTest {
           Filter($"t1.c1" === $"t2.c1",
             t.as("t2")))
       ).as("sub") :: Nil, t.as("t1"))
-    assertAnalysisError(plan, "Correlated scalar subquery 'scalarsubquery(t1.c1)' is " +
-      "neither present in the group by, nor in an aggregate function. Add it to group by " +
-      "using ordinal position or wrap it in first() (or first_value) if you don't care " +
-      "which value you get." :: Nil)
+    assertAnalysisErrorClass(
+      plan,
+      expectedErrorClass =
+        "SCALAR_SUBQUERY_IS_IN_GROUP_BY_OR_AGGREGATE_FUNCTION",
+      expectedMessageParameters = Map("sqlExpr" -> "\"scalarsubquery(c1)\""))
   }
 
   errorTest(

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAsOfJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAsOfJoinSuite.scala
@@ -98,22 +98,27 @@ class DataFrameAsOfJoinSuite extends QueryTest
 
   test("as-of join - tolerance should be a constant") {
     val (df1, df2) = prepareForAsOfJoin()
-    val errMsg = intercept[AnalysisException] {
-      df1.joinAsOf(
-        df2, df1.col("a"), df2.col("a"), usingColumns = Seq.empty,
-        joinType = "inner", tolerance = df1.col("b"), allowExactMatches = true,
-        direction = "backward")
-    }.getMessage
-    assert(errMsg.contains("Input argument tolerance must be a constant."))
+    checkError(
+      exception = intercept[AnalysisException] {
+        df1.joinAsOf(
+          df2, df1.col("a"), df2.col("a"), usingColumns = Seq.empty,
+          joinType = "inner", tolerance = df1.col("b"), allowExactMatches = true,
+          direction = "backward")
+      },
+      errorClass = "AS_OF_JOIN.TOLERANCE_IS_UNFOLDABLE",
+      parameters = Map.empty)
   }
 
   test("as-of join - tolerance should be non-negative") {
     val (df1, df2) = prepareForAsOfJoin()
-    val errMsg = intercept[AnalysisException] {
-      df1.joinAsOf(df2, df1.col("a"), df2.col("a"), usingColumns = Seq.empty,
-        joinType = "inner", tolerance = lit(-1), allowExactMatches = true, direction = "backward")
-    }.getMessage
-    assert(errMsg.contains("Input argument tolerance must be non-negative."))
+    checkError(
+      exception = intercept[AnalysisException] {
+        df1.joinAsOf(df2, df1.col("a"), df2.col("a"), usingColumns = Seq.empty,
+          joinType = "inner", tolerance = lit(-1), allowExactMatches = true,
+          direction = "backward")
+      },
+      errorClass = "AS_OF_JOIN.TOLERANCE_IS_NON_NEGATIVE",
+      parameters = Map.empty)
   }
 
   test("as-of join - allowExactMatches = false") {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/AggregationQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/AggregationQuerySuite.scala
@@ -517,16 +517,21 @@ abstract class AggregationQuerySuite extends QueryTest with SQLTestUtils with Te
   }
 
   test("non-deterministic children expressions of UDAF") {
-    val e = intercept[AnalysisException] {
-      spark.sql(
-        """
-          |SELECT mydoublesum(value + 1.5 * key + rand())
-          |FROM agg1
-          |GROUP BY key
-        """.stripMargin)
-    }.getMessage
-    assert(Seq("nondeterministic expression",
-      "should not appear in the arguments of an aggregate function").forall(e.contains))
+    checkError(
+      exception = intercept[AnalysisException] {
+        spark.sql(
+          """
+            |SELECT mydoublesum(value + 1.5 * key + rand())
+            |FROM agg1
+            |GROUP BY key
+          """.stripMargin)
+      },
+      errorClass = "AGGREGATE_FUNCTION_WITH_NONDETERMINISTIC_EXPRESSION",
+      parameters = Map("sqlExpr" -> "\"mydoublesum(((value + (1.5 * key)) + rand()))\""),
+      context = ExpectedContext(
+        fragment = "value + 1.5 * key + rand()",
+        start = 20,
+        stop = 45))
   }
 
   test("interpreted aggregate function") {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/UDAQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/UDAQuerySuite.scala
@@ -225,16 +225,21 @@ abstract class UDAQuerySuite extends QueryTest with SQLTestUtils with TestHiveSi
   }
 
   test("non-deterministic children expressions of aggregator") {
-    val e = intercept[AnalysisException] {
-      spark.sql(
-        """
-          |SELECT mydoublesum(value + 1.5 * key + rand())
-          |FROM agg1
-          |GROUP BY key
-        """.stripMargin)
-    }.getMessage
-    assert(Seq("nondeterministic expression",
-      "should not appear in the arguments of an aggregate function").forall(e.contains))
+    checkError(
+      exception = intercept[AnalysisException] {
+        spark.sql(
+          """
+            |SELECT mydoublesum(value + 1.5 * key + rand())
+            |FROM agg1
+            |GROUP BY key
+          """.stripMargin)
+      },
+      errorClass = "AGGREGATE_FUNCTION_WITH_NONDETERMINISTIC_EXPRESSION",
+      parameters = Map("sqlExpr" -> "\"mydoublesum(((value + (1.5 * key)) + rand()))\""),
+      context = ExpectedContext(
+        fragment = "value + 1.5 * key + rand()",
+        start = 20,
+        stop = 45))
   }
 
   test("interpreted aggregate function") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to assign a name to the error class `_LEGACY_ERROR_TEMP_[2418-2425]`.


### Why are the changes needed?
Improve the error framework.


### Does this PR introduce _any_ user-facing change?
'No'.


### How was this patch tested?
Exists test cases.
