### PR TITLE
[SPARK-43858][INFRA][FOLLOWUP] Restore the Scala version to 2.13 after run benchmark

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -182,7 +182,7 @@ jobs:
           "`find . -name 'spark-core*-SNAPSHOT-tests.jar'`" \
           "${{ github.event.inputs.class }}"
         # Revert to default Scala version to clean up unnecessary git diff
-        dev/change-scala-version.sh 2.12
+        dev/change-scala-version.sh 2.13
         # To keep the directory structure and file permissions, tar them
         # See also https://github.com/actions/upload-artifact#maintaining-file-permissions-and-case-sensitive-files
         echo "Preparing the benchmark results:"


### PR DESCRIPTION
### What changes were proposed in this pull request?
This is a followup of https://github.com/apache/spark/pull/41358, this pr change to restore Scala version to 2.13 after running benchmark to avoid containing changed `pom.xml` in the results tarball.


### Why are the changes needed?
After running benchmark, should restore Scala to default version to results tarball includes changed `pom.xml`.




### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions
