### PR TITLE
[SPARK-43696][SPARK-43697][SPARK-43698][SPARK-43699][PS] Fix `TimedeltaOps` for Spark Connect

### DIFF
--- a/python/pyspark/pandas/data_type_ops/timedelta_ops.py
+++ b/python/pyspark/pandas/data_type_ops/timedelta_ops.py
@@ -37,6 +37,7 @@ from pyspark.pandas.data_type_ops.base import (
     _sanitize_list_like,
 )
 from pyspark.pandas.typedef import pandas_on_spark_type
+from pyspark.sql.utils import pyspark_column_op
 
 
 class TimedeltaOps(DataTypeOps):
@@ -89,25 +90,17 @@ class TimedeltaOps(DataTypeOps):
             raise TypeError("Timedelta subtraction can only be applied to timedelta series.")
 
     def lt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        from pyspark.pandas.base import column_op
-
         _sanitize_list_like(right)
-        return column_op(Column.__lt__)(left, right)
+        return pyspark_column_op("__lt__")(left, right)
 
     def le(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        from pyspark.pandas.base import column_op
-
         _sanitize_list_like(right)
-        return column_op(Column.__le__)(left, right)
+        return pyspark_column_op("__le__")(left, right)
 
     def ge(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        from pyspark.pandas.base import column_op
-
         _sanitize_list_like(right)
-        return column_op(Column.__ge__)(left, right)
+        return pyspark_column_op("__ge__")(left, right)
 
     def gt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
-        from pyspark.pandas.base import column_op
-
         _sanitize_list_like(right)
-        return column_op(Column.__gt__)(left, right)
+        return pyspark_column_op("__gt__")(left, right)

--- a/python/pyspark/pandas/tests/connect/data_type_ops/test_parity_timedelta_ops.py
+++ b/python/pyspark/pandas/tests/connect/data_type_ops/test_parity_timedelta_ops.py
@@ -29,22 +29,6 @@ class TimedeltaOpsParityTests(
     def test_astype(self):
         super().test_astype()
 
-    @unittest.skip("TODO(SPARK-43696): Fix TimedeltaOps.ge to work with Spark Connect.")
-    def test_ge(self):
-        super().test_ge()
-
-    @unittest.skip("TODO(SPARK-43697): Fix TimedeltaOps.gt to work with Spark Connect.")
-    def test_gt(self):
-        super().test_gt()
-
-    @unittest.skip("TODO(SPARK-43698): Fix TimedeltaOps.le to work with Spark Connect.")
-    def test_le(self):
-        super().test_le()
-
-    @unittest.skip("TODO(SPARK-43699): Fix TimedeltaOps.lt to work with Spark Connect.")
-    def test_lt(self):
-        super().test_lt()
-
     @unittest.skip("TODO(SPARK-43700): Fix TimedeltaOps.rsub to work with Spark Connect.")
     def test_rsub(self):
         super().test_rsub()


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to fix `TimedeltaOps` test for pandas API on Spark with Spark Connect.

This includes SPARK-43696, SPARK-43697, SPARK-43698, SPARK-43699 at once, because they are all related similar modifications in single file.


### Why are the changes needed?

To support all features for pandas API on Spark with Spark Connect.


### Does this PR introduce _any_ user-facing change?

Yes, `TimedeltaOps.lt`,  `TimedeltaOps.le`, `TimedeltaOps.ge`, `TimedeltaOps.gt` are now working as expected on Spark Connect.


### How was this patch tested?

Uncomment the UTs, and tested manually.
