### PR TITLE
[SPARK-43680][PS][FOLLOWUP] Fix wrong usage for `is_remote`

### DIFF
--- a/python/pyspark/pandas/data_type_ops/null_ops.py
+++ b/python/pyspark/pandas/data_type_ops/null_ops.py
@@ -47,7 +47,7 @@ class NullOps(DataTypeOps):
         _sanitize_list_like(right)
         result = pyspark_column_op("__lt__")(left, right)
         if is_remote():
-            # In Spark Connect, it returns None instead of False, so we manually cast it.
+            # TODO(SPARK-43877): Fix behavior difference for compare binary functions.
             result = result.fillna(False)
         return result
 
@@ -55,7 +55,7 @@ class NullOps(DataTypeOps):
         _sanitize_list_like(right)
         result = pyspark_column_op("__le__")(left, right)
         if is_remote():
-            # In Spark Connect, it returns None instead of False, so we manually cast it.
+            # TODO(SPARK-43877): Fix behavior difference for compare binary functions.
             result = result.fillna(False)
         return result
 
@@ -63,7 +63,7 @@ class NullOps(DataTypeOps):
         _sanitize_list_like(right)
         result = pyspark_column_op("__ge__")(left, right)
         if is_remote():
-            # In Spark Connect, it returns None instead of False, so we manually cast it.
+            # TODO(SPARK-43877): Fix behavior difference for compare binary functions.
             result = result.fillna(False)
         return result
 
@@ -71,7 +71,7 @@ class NullOps(DataTypeOps):
         _sanitize_list_like(right)
         result = pyspark_column_op("__gt__")(left, right)
         if is_remote():
-            # In Spark Connect, it returns None instead of False, so we manually cast it.
+            # TODO(SPARK-43877): Fix behavior difference for compare binary functions.
             result = result.fillna(False)
         return result
 

--- a/python/pyspark/pandas/data_type_ops/null_ops.py
+++ b/python/pyspark/pandas/data_type_ops/null_ops.py
@@ -46,7 +46,7 @@ class NullOps(DataTypeOps):
     def lt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         _sanitize_list_like(right)
         result = pyspark_column_op("__lt__")(left, right)
-        if is_remote:
+        if is_remote():
             # In Spark Connect, it returns None instead of False, so we manually cast it.
             result = result.fillna(False)
         return result
@@ -54,7 +54,7 @@ class NullOps(DataTypeOps):
     def le(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         _sanitize_list_like(right)
         result = pyspark_column_op("__le__")(left, right)
-        if is_remote:
+        if is_remote():
             # In Spark Connect, it returns None instead of False, so we manually cast it.
             result = result.fillna(False)
         return result
@@ -62,7 +62,7 @@ class NullOps(DataTypeOps):
     def ge(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         _sanitize_list_like(right)
         result = pyspark_column_op("__ge__")(left, right)
-        if is_remote:
+        if is_remote():
             # In Spark Connect, it returns None instead of False, so we manually cast it.
             result = result.fillna(False)
         return result
@@ -70,7 +70,7 @@ class NullOps(DataTypeOps):
     def gt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
         _sanitize_list_like(right)
         result = pyspark_column_op("__gt__")(left, right)
-        if is_remote:
+        if is_remote():
             # In Spark Connect, it returns None instead of False, so we manually cast it.
             result = result.fillna(False)
         return result


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR follow up for https://github.com/apache/spark/pull/41361 to fix misusage for `is_remote` on `if` clause.

### Why are the changes needed?

To fix the wrong function call

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manually tested.