### PR TITLE
[SPARK-43878][BUILD] Upgrade `cyclonedx-maven-plugin` from 2.7.6 to 2.7.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3438,7 +3438,7 @@
       <plugin>
         <groupId>org.cyclonedx</groupId>
         <artifactId>cyclonedx-maven-plugin</artifactId>
-        <version>2.7.6</version>
+        <version>2.7.9</version>
         <executions>
           <execution>
             <phase>package</phase>


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade `cyclonedx-maven-plugin` from 2.7.6 to 2.7.9.

### Why are the changes needed?
The release notes as follows:
- https://github.com/CycloneDX/cyclonedx-maven-plugin/releases/tag/cyclonedx-maven-plugin-2.7.9
- https://github.com/CycloneDX/cyclonedx-maven-plugin/releases/tag/cyclonedx-maven-plugin-2.7.8
- https://github.com/CycloneDX/cyclonedx-maven-plugin/releases/tag/cyclonedx-maven-plugin-2.7.7

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA.