### PR TITLE
[SPARK-43879][CONNECT] Decouple handle command and send response on server side

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectStreamHandler.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectStreamHandler.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.connect.service
 
 import scala.collection.JavaConverters._
+import scala.collection.mutable
 import scala.util.control.NonFatal
 
 import com.google.protobuf.ByteString
@@ -113,11 +114,13 @@ class SparkConnectStreamHandler(responseObserver: StreamObserver[ExecutePlanResp
   private def handleCommand(session: SparkSession, request: ExecutePlanRequest): Unit = {
     val command = request.getPlan.getCommand
     val planner = new SparkConnectPlanner(session)
+    val responses = mutable.ArrayBuffer.empty[ExecutePlanResponse]
     planner.process(
       command = command,
       userId = request.getUserContext.getUserId,
       sessionId = request.getSessionId,
-      responseObserver = responseObserver)
+      responses = responses)
+    responses.foreach(responseObserver.onNext(_))
     responseObserver.onCompleted()
   }
 }

--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectPlannerSuite.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectPlannerSuite.scala
@@ -20,11 +20,9 @@ package org.apache.spark.sql.connect.planner
 import scala.collection.JavaConverters._
 
 import com.google.protobuf.ByteString
-import io.grpc.stub.StreamObserver
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.connect.proto
-import org.apache.spark.connect.proto.ExecutePlanResponse
 import org.apache.spark.connect.proto.Expression.{Alias, ExpressionString, UnresolvedStar}
 import org.apache.spark.sql.{AnalysisException, Dataset, Row}
 import org.apache.spark.sql.catalyst.InternalRow
@@ -44,18 +42,12 @@ import org.apache.spark.unsafe.types.UTF8String
  */
 trait SparkConnectPlanTest extends SharedSparkSession {
 
-  class MockObserver extends StreamObserver[proto.ExecutePlanResponse] {
-    override def onNext(value: ExecutePlanResponse): Unit = {}
-    override def onError(t: Throwable): Unit = {}
-    override def onCompleted(): Unit = {}
-  }
-
   def transform(rel: proto.Relation): logical.LogicalPlan = {
     new SparkConnectPlanner(spark).transformRelation(rel)
   }
 
   def transform(cmd: proto.Command): Unit = {
-    new SparkConnectPlanner(spark).process(cmd, "clientId", "sessionId", new MockObserver())
+    new SparkConnectPlanner(spark).process(cmd, "clientId", "sessionId")
   }
 
   def readRel: proto.Relation =

--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/plugin/SparkConnectPluginRegistrySuite.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/plugin/SparkConnectPluginRegistrySuite.scala
@@ -195,7 +195,7 @@ class SparkConnectPluginRegistrySuite extends SharedSparkSession with SparkConne
               .build()))
         .build()
 
-      new SparkConnectPlanner(spark).process(plan, "clientId", "sessionId", new MockObserver())
+      new SparkConnectPlanner(spark).process(plan, "clientId", "sessionId")
       assert(spark.sparkContext.getLocalProperty("testingProperty").equals("Martin"))
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
`SparkConnectStreamHandler` treats the proto requests from connect client and send the responses back to connect client. `SparkConnectStreamHandler` holds a component `StreamObserver` to send responses.
So I think we should keep the `StreamObserver` could be accessed only with `SparkConnectStreamHandler`.

This PR want decouple the process handle commands and the other process send responses on server side.
After this PR, we can remove `MockObserver` which seems is not useful.


### Why are the changes needed?
Decouple handle command and send response on server side.


### Does this PR introduce _any_ user-facing change?
'No'.
Just update the inner implementation.


### How was this patch tested?
Exists test cases.
