### PR TITLE
[SPARK-43297][ML]Use scala parallel collection ParVector to accelarate LocalKMeans.

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/KMeans.scala
@@ -449,8 +449,9 @@ class KMeans private (
 
       bcCenters.destroy()
 
+      val driverCores = data.conf.getOption("spark.driver.cores").getOrElse("1").toInt
       val myWeights = distinctCenters.indices.map(countMap.getOrElse(_, 0L).toDouble).toArray
-      LocalKMeans.kMeansPlusPlus(0, distinctCenters, myWeights, k, 30)
+      LocalKMeans.kMeansPlusPlus(0, distinctCenters, myWeights, k, 30, driverCores)
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
In mllib module, the kMeansPlusPlus is a local method which run in a single thread.
I use scala parallel collections to change the array to ParVector, which supports parallel calculating.


### Why are the changes needed?
The kMeansPlusPlus method runs in spark driver in a single thread. 
If the input vectors are very large, it will take a long time to calculate the distance between every points.
If we change this single-thread method to run in parallel, it will reduce a lot of time. 


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
All unit test cases passed.
