### PR TITLE
[SPARK-43894][PYTHON] Fix bug in df.cache()

### DIFF
--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -1826,9 +1826,7 @@ class DataFrame:
     def cache(self) -> "DataFrame":
         if self._plan is None:
             raise Exception("Cannot cache on empty plan.")
-        relation = self._plan.plan(self._session.client)
-        self._session.client._analyze(method="persist", relation=relation)
-        return self
+        return self.persist(storageLevel=StorageLevel.MEMORY_AND_DISK)
 
     cache.__doc__ = PySparkDataFrame.cache.__doc__
 

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -1826,7 +1826,7 @@ class DataFrame:
     def cache(self) -> "DataFrame":
         if self._plan is None:
             raise Exception("Cannot cache on empty plan.")
-        return self.persist(storageLevel=StorageLevel.MEMORY_AND_DISK)
+        return self.persist()
 
     cache.__doc__ = PySparkDataFrame.cache.__doc__
 

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -3212,7 +3212,7 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
         df = self.connect.range(10)
         df.cache()
         self.assert_eq(10, df.count())
-        self.assertTrue(df.is_cached())
+        self.assertTrue(df.is_cached)
 
 
 class SparkConnectSessionTests(ReusedConnectTestCase):

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -3208,6 +3208,12 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
             message_parameters={"attr_name": "_jreader"},
         )
 
+    def test_df_caache(self):
+        df = self.connect.range(10)
+        df.cache()
+        self.assert_eq(10, df.count())
+        self.assertTrue(df.is_cached())
+
 
 class SparkConnectSessionTests(ReusedConnectTestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
### What changes were proposed in this pull request?
Previously calling `df.cache()` would result in an invalid plan input exception because we did not invoke `persist()` with the right arguments. This patch simplifies the logic and makes it compatible to the behavior in Spark itself.

### Why are the changes needed?
Bug

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Added UT
