### PR TITLE
[SPARK-43896][TESTS][PS][CONNECT] Enable `test_iterrows` and `test_itertuples` on Connect

### DIFF
--- a/python/pyspark/pandas/tests/connect/indexes/test_parity_indexing.py
+++ b/python/pyspark/pandas/tests/connect/indexes/test_parity_indexing.py
@@ -27,14 +27,6 @@ class FrameParityIndexingTests(FrameIndexingMixin, PandasOnSparkTestUtils, Reuse
     def psdf(self):
         return ps.from_pandas(self.pdf)
 
-    @unittest.skip("TODO(SPARK-41876): Implement DataFrame `toLocalIterator`")
-    def test_iterrows(self):
-        super().test_iterrows()
-
-    @unittest.skip("TODO(SPARK-41876): Implement DataFrame `toLocalIterator`")
-    def test_itertuples(self):
-        super().test_itertuples()
-
 
 if __name__ == "__main__":
     from pyspark.pandas.tests.connect.indexes.test_parity_indexing import *  # noqa: F401


### PR DESCRIPTION
### What changes were proposed in this pull request?
`toLocalIterator` had been implemented in https://issues.apache.org/jira/browse/SPARK-41876, this PR enables `test_iterrows` and `test_itertuples` on Connect


### Why are the changes needed?
for better test coverage


### Does this PR introduce _any_ user-facing change?
No, test-only


### How was this patch tested?
CI
