### PR TITLE
[SPARK-41593][FOLLOW-UP][ML] Torch distributor log streaming server: Avoid duplicated log to stdout redirection 

### DIFF
--- a/python/pyspark/ml/torch/distributor.py
+++ b/python/pyspark/ml/torch/distributor.py
@@ -443,7 +443,7 @@ class TorchDistributor(Distributor):
     def _execute_command(
         cmd: List[str],
         _prctl: bool = True,
-        redirect_to_stdout: bool = None,
+        redirect_to_stdout: bool = True,
         log_streaming_client: Optional[LogStreamingClient] = None,
     ) -> None:
         _TAIL_LINES_TO_KEEP = 100

--- a/python/pyspark/ml/torch/distributor.py
+++ b/python/pyspark/ml/torch/distributor.py
@@ -443,7 +443,7 @@ class TorchDistributor(Distributor):
     def _execute_command(
         cmd: List[str],
         _prctl: bool = True,
-        redirect_to_stdout: bool = True,
+        redirect_to_stdout: bool = None,
         log_streaming_client: Optional[LogStreamingClient] = None,
     ) -> None:
         _TAIL_LINES_TO_KEEP = 100
@@ -462,7 +462,18 @@ class TorchDistributor(Distributor):
                 decoded = line.decode()
                 tail.append(decoded)
                 if redirect_to_stdout:
-                    sys.stdout.write(decoded)
+                    if log_streaming_client and not log_streaming_client.failed and (
+                        log_streaming_client.sock.getsockname()[0] ==
+                        log_streaming_client.sock.getpeername()[0]
+                    ):
+                        # If log_streaming_client and log_stream_server are in the same
+                        # node (typical case is spark local mode),
+                        # server side will redirect the log to STDOUT,
+                        # to avoid STDOUT outputs duplication, skip redirecting
+                        # logs to STDOUT in client side.
+                        pass
+                    else:
+                        sys.stdout.write(decoded)
                 if log_streaming_client:
                     log_streaming_client.send(decoded.rstrip())
             task.wait()

--- a/python/pyspark/ml/torch/distributor.py
+++ b/python/pyspark/ml/torch/distributor.py
@@ -462,9 +462,13 @@ class TorchDistributor(Distributor):
                 decoded = line.decode()
                 tail.append(decoded)
                 if redirect_to_stdout:
-                    if log_streaming_client and not log_streaming_client.failed and (
-                        log_streaming_client.sock.getsockname()[0] ==
-                        log_streaming_client.sock.getpeername()[0]
+                    if (
+                        log_streaming_client
+                        and not log_streaming_client.failed
+                        and (
+                            log_streaming_client.sock.getsockname()[0]
+                            == log_streaming_client.sock.getpeername()[0]
+                        )
                     ):
                         # If log_streaming_client and log_stream_server are in the same
                         # node (typical case is spark local mode),

--- a/python/pyspark/ml/torch/log_communication.py
+++ b/python/pyspark/ml/torch/log_communication.py
@@ -52,15 +52,9 @@ class WriteLogToStdout(socketserver.StreamRequestHandler):
     def handle(self) -> None:
         self.request.setblocking(0)  # non-blocking mode
         for bline in self._read_bline():
-            # To avoid printing duplicated logs to stdout,
-            # if the handler socket local addr equals to peer addr,
-            # it means remote task runs on the same node with log server,
-            # in this case, we should skip redirect log to stdout
-            # because remote task already does that.
-            if self.request.getsockname()[0] != self.request.getpeername()[0]:
-                with _get_log_print_lock():
-                    sys.stderr.write(bline.decode("utf-8") + "\n")
-                    sys.stderr.flush()
+            with _get_log_print_lock():
+                sys.stderr.write(bline.decode("utf-8") + "\n")
+                sys.stderr.flush()
 
 
 # What is run on the local driver

--- a/python/pyspark/ml/torch/log_communication.py
+++ b/python/pyspark/ml/torch/log_communication.py
@@ -52,9 +52,15 @@ class WriteLogToStdout(socketserver.StreamRequestHandler):
     def handle(self) -> None:
         self.request.setblocking(0)  # non-blocking mode
         for bline in self._read_bline():
-            with _get_log_print_lock():
-                sys.stderr.write(bline.decode("utf-8") + "\n")
-                sys.stderr.flush()
+            # To avoid printing duplicated logs to stdout,
+            # if the handler socket local addr equals to peer addr,
+            # it means remote task runs on the same node with log server,
+            # in this case, we should skip redirect log to stdout
+            # because remote task already does that.
+            if self.request.getsockname()[0] != self.request.getpeername()[0]:
+                with _get_log_print_lock():
+                    sys.stderr.write(bline.decode("utf-8") + "\n")
+                    sys.stderr.flush()
 
 
 # What is run on the local driver


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Torch distributor log streaming server: Avoid duplicated log to stdout redirection.

In some cases (typically spark local mode), the remote tasks runs on the same node with spark driver,
in this case, both torch process created by spark task and driver side torch distributor log streaming server redirect logs to STDOUT, then it causes STDOUT prints duplicate logs. This PR fixes the case.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
In some cases (typically spark local mode), the remote tasks runs on the same node with spark driver,
in this case, both torch process created by spark task and driver side torch distributor log streaming server redirect logs to STDOUT, then it causes STDOUT prints duplicate logs. This PR fixes the case.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
UT.