### PR TITLE
[SPARK-43899][BUILD] Upgrade protobuf-java to 3.23.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
     <!-- make sure to update IsolatedClientLoader whenever this version is changed -->
     <hadoop.version>3.3.5</hadoop.version>
     <!-- SPARK-41247: When updating `protobuf.version`, also need to update `protoVersion` in `SparkBuild.scala` -->
-    <protobuf.version>3.22.3</protobuf.version>
+    <protobuf.version>3.23.2</protobuf.version>
     <protoc-jar-maven-plugin.version>3.11.4</protoc-jar-maven-plugin.version>
     <yarn.version>${hadoop.version}</yarn.version>
     <zookeeper.version>3.6.3</zookeeper.version>

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -89,7 +89,7 @@ object BuildCommons {
 
   // Google Protobuf version used for generating the protobuf.
   // SPARK-41247: needs to be consistent with `protobuf.version` in `pom.xml`.
-  val protoVersion = "3.22.3"
+  val protoVersion = "3.23.2"
   // GRPC version used for Spark Connect.
   val gprcVersion = "1.47.0"
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims upgrade protobuf-java from 3.22.3 to 3.23.2.


### Why are the changes needed?
The new version bring some bug fix like:  

- https://github.com/protocolbuffers/protobuf/issues/11393 / https://github.com/protocolbuffers/protobuf/pull/12023
- https://github.com/protocolbuffers/protobuf/pull/12020
- 


The full release notes as follows:

- https://github.com/protocolbuffers/protobuf/releases/tag/v23.0
- https://github.com/protocolbuffers/protobuf/releases/tag/v23.1
- https://github.com/protocolbuffers/protobuf/releases/tag/v23.2
- https://github.com/protocolbuffers/protobuf/compare/v3.22.3...v3.23.2

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions
