### PR TITLE
[SPARK-43901][SQL] Avro to Support custom decimal type backed by Long

### DIFF
--- a/connector/avro/src/main/java/org/apache/spark/sql/avro/CustomDecimal.scala
+++ b/connector/avro/src/main/java/org/apache/spark/sql/avro/CustomDecimal.scala
@@ -22,7 +22,9 @@ import org.apache.avro.Schema
 
 import org.apache.spark.sql.types.DecimalType
 
-object CustomDecimal { val TYPE_NAME = "custom-decimal" }
+object CustomDecimal {
+  val TYPE_NAME = "custom-decimal"
+}
 
 // A customized logical type, which will be registered to Avro. This logical type is similar to
 // Avro's builtin Decimal type, but is meant to be registered for long type. It indicates that
@@ -69,5 +71,6 @@ private class CustomDecimal(schema: Schema) extends LogicalType(CustomDecimal.TY
         s"precision: $precision)");
     }
   }
-  override def toString: String = s"${CustomDecimal.TYPE_NAME}<scale: $scale, precision: $precision>"
+  override def toString: String =
+    s"${CustomDecimal.TYPE_NAME}<scale: $scale, precision: $precision>"
 }

--- a/connector/avro/src/main/java/org/apache/spark/sql/avro/CustomDecimal.scala
+++ b/connector/avro/src/main/java/org/apache/spark/sql/avro/CustomDecimal.scala
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.avro
+
+import org.apache.avro.LogicalType
+import org.apache.avro.Schema
+
+import org.apache.spark.sql.types.DecimalType
+
+object CustomDecimal { val TYPE_NAME = "custom-decimal" }
+class CustomDecimal(schema: Schema) extends LogicalType(CustomDecimal.TYPE_NAME) {
+  val scale : Int = {
+    val obj = schema.getObjectProp("scale")
+    obj match {
+      case null =>
+        throw new IllegalArgumentException("Invalid long-decimal: missing scale");
+      case i : Integer =>
+        i
+      case other =>
+        throw new IllegalArgumentException("Expected int long-decimal:scale")
+    }
+  }
+  val precision : Int = {
+    val obj = schema.getObjectProp("precision")
+    if (obj == null) {
+      throw new IllegalArgumentException("Invalid long-decimal: missing precision");
+    }
+    obj.asInstanceOf[Int]
+  }
+  val className : String = schema.getProp("className")
+
+  override def validate(schema: Schema): Unit = {
+    super.validate(schema)
+    if (schema.getType != Schema.Type.LONG) {
+      throw new IllegalArgumentException(
+        "long-decimal can only be used with an underlying long type")
+    }
+    if (precision <= 0) {
+      throw new IllegalArgumentException(s"Invalid decimal precision: $precision" +
+        " (must be positive)");
+    } else if (precision > DecimalType.MAX_PRECISION) {
+      throw new IllegalArgumentException(
+        s"cannot store $precision digits (max ${DecimalType.MAX_PRECISION})")
+    }
+    if (scale < 0) {
+      throw new IllegalArgumentException(s"Invalid decimal scale: $scale" +
+        " (must be positive)");
+    } else if (scale > precision) {
+      throw new IllegalArgumentException(s"Invalid decimal scale: $scale (greater than " +
+        s"precision: $precision)");
+    }
+  }
+  override def toString: String = s"${CustomDecimal.TYPE_NAME}<scale: $scale, precision: $precision>"
+}

--- a/connector/avro/src/main/java/org/apache/spark/sql/avro/CustomDecimal.scala
+++ b/connector/avro/src/main/java/org/apache/spark/sql/avro/CustomDecimal.scala
@@ -43,10 +43,15 @@ private class CustomDecimal(schema: Schema) extends LogicalType(CustomDecimal.TY
   }
   val precision : Int = {
     val obj = schema.getObjectProp("precision")
-    if (obj == null) {
-      throw new IllegalArgumentException(s"Invalid ${CustomDecimal.TYPE_NAME}: missing precision");
+    obj match {
+      case null =>
+        throw new IllegalArgumentException(
+          s"Invalid ${CustomDecimal.TYPE_NAME}: missing precision");
+      case i: Integer =>
+        i
+      case other =>
+        throw new IllegalArgumentException(s"Expected int ${CustomDecimal.TYPE_NAME}:precision")
     }
-    obj.asInstanceOf[Int]
   }
   val className : String = schema.getProp("className")
 
@@ -71,6 +76,4 @@ private class CustomDecimal(schema: Schema) extends LogicalType(CustomDecimal.TY
         s"precision: $precision)");
     }
   }
-  override def toString: String =
-    s"${CustomDecimal.TYPE_NAME}<scale: $scale, precision: $precision>"
 }

--- a/connector/avro/src/main/scala/org/apache/spark/sql/avro/AvroDeserializer.scala
+++ b/connector/avro/src/main/scala/org/apache/spark/sql/avro/AvroDeserializer.scala
@@ -137,6 +137,11 @@ private[sql] class AvroDeserializer(
             updater.setBoolean(ordinal, value.asInstanceOf[Boolean])
           case _ => throw new IncompatibleSchemaException(incompatibleMsg)
         }
+
+      case (LONG, _: DecimalType) => (updater, ordinal, value) =>
+        val d = avroType.getLogicalType.asInstanceOf[CustomDecimal]
+        updater.setDecimal(ordinal, Decimal(value.asInstanceOf[Long], d.precision, d.scale))
+
       case INT =>
         (logicalDataType, catalystType) match {
           case (IntegerType, IntegerType) => (updater, ordinal, value) =>

--- a/connector/avro/src/main/scala/org/apache/spark/sql/avro/AvroDeserializer.scala
+++ b/connector/avro/src/main/scala/org/apache/spark/sql/avro/AvroDeserializer.scala
@@ -138,10 +138,6 @@ private[sql] class AvroDeserializer(
           case _ => throw new IncompatibleSchemaException(incompatibleMsg)
         }
 
-      case (LONG, _: DecimalType) => (updater, ordinal, value) =>
-        val d = avroType.getLogicalType.asInstanceOf[CustomDecimal]
-        updater.setDecimal(ordinal, Decimal(value.asInstanceOf[Long], d.precision, d.scale))
-
       case INT =>
         (logicalDataType, catalystType) match {
           case (IntegerType, IntegerType) => (updater, ordinal, value) =>
@@ -211,6 +207,9 @@ private[sql] class AvroDeserializer(
               logicalDataType.catalogString, catalystType.catalogString, confKey.key)
           case (_: DayTimeIntervalType, DateType) => (updater, ordinal, value) =>
             updater.setInt(ordinal, (value.asInstanceOf[Long] / MILLIS_PER_DAY).toInt)
+          case (_, dt: DecimalType) => (updater, ordinal, value) =>
+            val d = avroType.getLogicalType.asInstanceOf[CustomDecimal]
+            updater.setDecimal(ordinal, Decimal(value.asInstanceOf[Long], d.precision, d.scale))
           case _ if !preventReadingIncorrectType => (updater, ordinal, value) =>
             updater.setLong(ordinal, value.asInstanceOf[Long])
           case _ => throw new IncompatibleSchemaException(incompatibleMsg)

--- a/connector/avro/src/main/scala/org/apache/spark/sql/avro/AvroFileFormat.scala
+++ b/connector/avro/src/main/scala/org/apache/spark/sql/avro/AvroFileFormat.scala
@@ -171,6 +171,7 @@ private[sql] class AvroFileFormat extends FileFormat
 private[avro] object AvroFileFormat {
   val IgnoreFilesWithoutExtensionProperty = "avro.mapred.ignore.inputs.without.extension"
 
+  // Register the customized decimal type backed by long.
   LogicalTypes.register(CustomDecimal.TYPE_NAME, new LogicalTypes.LogicalTypeFactory {
     override def fromSchema(schema: Schema): LogicalType = {
       new CustomDecimal(schema)

--- a/connector/avro/src/main/scala/org/apache/spark/sql/avro/AvroFileFormat.scala
+++ b/connector/avro/src/main/scala/org/apache/spark/sql/avro/AvroFileFormat.scala
@@ -21,6 +21,8 @@ import java.io._
 
 import scala.util.control.NonFatal
 
+import org.apache.avro.{LogicalTypes, Schema}
+import org.apache.avro.LogicalType
 import org.apache.avro.file.DataFileReader
 import org.apache.avro.generic.{GenericDatumReader, GenericRecord}
 import org.apache.avro.mapred.FsInput
@@ -168,4 +170,10 @@ private[sql] class AvroFileFormat extends FileFormat
 
 private[avro] object AvroFileFormat {
   val IgnoreFilesWithoutExtensionProperty = "avro.mapred.ignore.inputs.without.extension"
+
+  LogicalTypes.register(CustomDecimal.TYPE_NAME, new LogicalTypes.LogicalTypeFactory {
+    override def fromSchema(schema: Schema): LogicalType = {
+      new CustomDecimal(schema)
+    }
+  })
 }

--- a/connector/avro/src/main/scala/org/apache/spark/sql/avro/SchemaConverters.scala
+++ b/connector/avro/src/main/scala/org/apache/spark/sql/avro/SchemaConverters.scala
@@ -89,6 +89,8 @@ object SchemaConverters {
       case DOUBLE => SchemaType(DoubleType, nullable = false)
       case FLOAT => SchemaType(FloatType, nullable = false)
       case LONG => avroSchema.getLogicalType match {
+        case d: CustomDecimal =>
+          SchemaType(DecimalType(d.precision, d.scale), nullable = false)
         case _: TimestampMillis | _: TimestampMicros => SchemaType(TimestampType, nullable = false)
         case _: LocalTimestampMillis | _: LocalTimestampMicros =>
           SchemaType(TimestampNTZType, nullable = false)

--- a/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroLogicalTypeSuite.scala
+++ b/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroLogicalTypeSuite.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.{QueryTest, Row}
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
-import org.apache.spark.sql.types.{StructField, StructType, TimestampNTZType, TimestampType}
+import org.apache.spark.sql.types.{DecimalType, LongType, StructField, StructType, TimestampNTZType, TimestampType}
 
 abstract class AvroLogicalTypeSuite extends QueryTest with SharedSparkSession {
   import testImplicits._
@@ -444,6 +444,97 @@ abstract class AvroLogicalTypeSuite extends QueryTest with SharedSparkSession {
           "scale" -> "2",
           "config" -> "\"spark.sql.ansi.enabled\"")
       )
+    }
+  }
+
+  test("LogicalType: Decimal for Long Type") {
+    val schema =
+      new Schema.Parser().parse("""{
+        "namespace": "logical",
+        "type": "record",
+        "name": "test",
+        "fields": [
+         {
+           "name": "field1",
+           "type": {"type": "long", "logicalType": "custom-decimal", "scale": 2, "precision": 38}
+         },
+         {
+           "name": "field2",
+           "type": {"type": "long", "logicalType": "custom-decimal", "scale": 9, "precision": 33}
+         },
+         {
+           "name": "field3",
+           "type": "long"
+         }]
+        }""")
+
+    withTempDir { dir =>
+      val datumWriter = new GenericDatumWriter[GenericRecord](schema)
+      val dataFileWriter = new DataFileWriter[GenericRecord](datumWriter)
+      dataFileWriter.create(schema, new File(s"$dir.avro"))
+      val avroRec = new GenericData.Record(schema)
+      avroRec.put("field1", 123456789L)
+      avroRec.put("field2", 123456789L)
+      avroRec.put("field3", 123456789L)
+      dataFileWriter.append(avroRec)
+      dataFileWriter.flush()
+      dataFileWriter.close()
+      val df = spark
+        .read
+        .format("avro")
+        .load(s"$dir.avro")
+      assertResult(DecimalType(38, 2))(df.schema.head.dataType)
+      val firstRow = df.take(1)(0)
+      assertResult(java.math.BigDecimal.valueOf(123456789L, 2))(firstRow.getAs("field1"))
+      assertResult(java.math.BigDecimal.valueOf(123456789L, 9))(firstRow.getAs("field2"))
+      assertResult(123456789L)(firstRow.getAs("field3"))
+    }
+  }
+  test("LogicalType: Decimal for Long Type Exception Cases") {
+    // Avro appears to catch all exceptions when creating a customized logical type and turn the
+    // logical null and we can't distinguish with the case where the logical type isn't given.
+    Seq(
+      """ "type": "long", "logicalType": "custom-decimal", "scale": 2, "precision": 50 """,
+      """ "type": "long", "logicalType": "custom-decimal", "scale": -2, "precision": 30 """,
+      """ "type": "long", "logicalType": "custom-decimal", "scale": 2, "precision": -30 """,
+      """ "type": "long", "logicalType": "custom-decimal", "scale": 30, "precision": 20 """,
+      """ "type": "long", "logicalType": "custom-decimal", "scale": "2", "precision": 30 """,
+      """ "type": "long", "logicalType": "custom-decimal", "scale": "xx", "precision": 30 """,
+      """ "type": "long", "logicalType": "custom-decimal", "scale": 2, "precision": "30" """,
+      """ "type": "long", "logicalType": "custom-decimal", "scale": 2, "precision": "xx" """,
+      """ "type": "long", "logicalType": "custom-decimal", "precision": 30 """,
+      """ "type": "long", "logicalType": "custom-decimal", "scale": 2 """,
+      """ "type": "long", "logicalType": "custom-decimal" """
+    ).foreach { d =>
+      val schema =
+        new Schema.Parser().parse(
+          s"""{
+            "namespace": "logical",
+            "type": "record",
+            "name": "test",
+            "fields": [
+            {
+              "name": "field",
+              "type": {$d}
+             }]
+          }""")
+
+      withTempDir { dir =>
+        val datumWriter = new GenericDatumWriter[GenericRecord](schema)
+        val dataFileWriter = new DataFileWriter[GenericRecord](datumWriter)
+        dataFileWriter.create(schema, new File(s"$dir.avro"))
+        val avroRec = new GenericData.Record(schema)
+        avroRec.put("field", 123456789L)
+        dataFileWriter.append(avroRec)
+        dataFileWriter.flush()
+        dataFileWriter.close()
+          val df = spark.read
+            .format("avro")
+            .load(s"$dir.avro")
+        assertResult(LongType)(df.schema.head.dataType)
+        val firstRow = df.take(1)(0)
+        assertResult(123456789L)(firstRow.getAs("field"))
+      }
     }
   }
 }

--- a/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroLogicalTypeSuite.scala
+++ b/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroLogicalTypeSuite.scala
@@ -491,7 +491,7 @@ abstract class AvroLogicalTypeSuite extends QueryTest with SharedSparkSession {
     }
   }
 
-  test("SPARK-43901:LogicalType: Decimal for Long Type Exception Cases") {
+  test("SPARK-43901: LogicalType: Decimal for Long Type Exception Cases") {
     // Avro appears to catch all exceptions when creating a customized logical type and turn the
     // logical null and we can't distinguish with the case where the logical type isn't given.
     Seq(

--- a/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroLogicalTypeSuite.scala
+++ b/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroLogicalTypeSuite.scala
@@ -447,7 +447,7 @@ abstract class AvroLogicalTypeSuite extends QueryTest with SharedSparkSession {
     }
   }
 
-  test("LogicalType: Decimal for Long Type") {
+  test("SPARK-43901: LogicalType: Custom Decimal for Long Type") {
     val schema =
       new Schema.Parser().parse("""{
         "namespace": "logical",
@@ -490,7 +490,8 @@ abstract class AvroLogicalTypeSuite extends QueryTest with SharedSparkSession {
       assertResult(123456789L)(firstRow.getAs("field3"))
     }
   }
-  test("LogicalType: Decimal for Long Type Exception Cases") {
+
+  test("SPARK-43901:LogicalType: Decimal for Long Type Exception Cases") {
     // Avro appears to catch all exceptions when creating a customized logical type and turn the
     // logical null and we can't distinguish with the case where the logical type isn't given.
     Seq(


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add a logical type "custom-decimal" in Avro, which can only be backed by physical type long, and will be convert into decimal type.

### Why are the changes needed?
A user would like to represent currency (for money) after loading Avro into SQL type. However, there isn't a good way to represent it in Avro. This custom type will allow them to do that.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Added several unit test cases to test the new "custom-decimal" to be loaded successfully and also exception cases.
