### PR TITLE
[SPARK-43902][SS] Use keyMayExist to check if key is absent and avoid gets while tracking metrics using RocksDB state store provider

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -176,7 +176,7 @@ class RocksDB(
   }
 
   /**
-   * Check if the check exists in the database.
+   * Check if the key exists in the database.
    */
   private def keyExists(key: Array[Byte]): Boolean = {
     if (!db.keyMayExist(readOptions, key, null)) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -176,13 +176,22 @@ class RocksDB(
   }
 
   /**
+   * Check if the check exists in the database.
+   */
+  private def keyExists(key: Array[Byte]): Boolean = {
+    if (!db.keyMayExist(readOptions, key, null)) {
+      false
+    } else {
+      db.get(readOptions, key) != null
+    }
+  }
+
+  /**
    * Put the given value for the given key.
-   * @note This update is not committed to disk until commit() is called.
    */
   def put(key: Array[Byte], value: Array[Byte]): Unit = {
     if (conf.trackTotalNumberOfRows) {
-      val oldValue = db.get(readOptions, key)
-      if (oldValue == null) {
+      if (!keyExists(key)) {
         numKeysOnWritingVersion += 1
       }
     }
@@ -191,12 +200,10 @@ class RocksDB(
 
   /**
    * Remove the key if present.
-   * @note This update is not committed to disk until commit() is called.
    */
   def remove(key: Array[Byte]): Unit = {
     if (conf.trackTotalNumberOfRows) {
-      val value = db.get(readOptions, key)
-      if (value != null) {
+      if (keyExists(key)) {
         numKeysOnWritingVersion -= 1
       }
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Use keyMayExist to check if key is absent and avoid gets while tracking metrics using RocksDB state store provider

### Why are the changes needed?
Small change to use lighter weight check for key existence

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Ran all relevant unit tests
- RocksDBSuite
- RocksDBStateStoreSuite
- RocksDBStateStoreIntegrationSuite

```
[info] Run completed in 41 seconds, 621 milliseconds.
[info] Total number of tests run: 33
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 33, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.

[info] Run completed in 54 seconds, 675 milliseconds.
[info] Total number of tests run: 73
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 73, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.

[info] Run completed in 14 seconds, 892 milliseconds.
[info] Total number of tests run: 5
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 5, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
```