### PR TITLE
[SPARK-43910][SQL] Strip `__auto_generated_subquery_name` from ids in errors

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryErrorsBase.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryErrorsBase.scala
@@ -71,7 +71,11 @@ private[sql] trait QueryErrorsBase {
   }
 
   def toSQLId(parts: Seq[String]): String = {
-    parts.map(quoteIdentifier).mkString(".")
+    val cleaned = parts match {
+      case "__auto_generated_subquery_name" :: rest if rest != Nil => rest
+      case other => other
+    }
+    cleaned.map(quoteIdentifier).mkString(".")
   }
 
   def toSQLId(parts: String): String = {

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/natural-join.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/natural-join.sql.out
@@ -494,7 +494,7 @@ org.apache.spark.sql.AnalysisException
   "sqlState" : "42703",
   "messageParameters" : {
     "objectName" : "`nt2`.`k`",
-    "proposal" : "`__auto_generated_subquery_name`.`k`, `__auto_generated_subquery_name`.`v1`, `__auto_generated_subquery_name`.`v2`"
+    "proposal" : "`k`, `v1`, `v2`"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/pivot.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/pivot.sql.out
@@ -743,7 +743,7 @@ org.apache.spark.sql.AnalysisException
   "errorClass" : "INCOMPARABLE_PIVOT_COLUMN",
   "sqlState" : "42818",
   "messageParameters" : {
-    "columnName" : "`__auto_generated_subquery_name`.`m`"
+    "columnName" : "`m`"
   }
 }
 

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/udf/udf-pivot.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/udf/udf-pivot.sql.out
@@ -683,7 +683,7 @@ org.apache.spark.sql.AnalysisException
   "errorClass" : "INCOMPARABLE_PIVOT_COLUMN",
   "sqlState" : "42818",
   "messageParameters" : {
-    "columnName" : "`__auto_generated_subquery_name`.`m`"
+    "columnName" : "`m`"
   }
 }
 

--- a/sql/core/src/test/resources/sql-tests/results/identifier-clause.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/identifier-clause.sql.out
@@ -535,7 +535,7 @@ Catalog Name	spark_catalog
 Comment	some comment
 Location [not included in comparison]/{warehouse_dir}/someloc
 Namespace Name	ident
-Owner	runner
+Owner	maximgekk
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/identifier-clause.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/identifier-clause.sql.out
@@ -535,7 +535,7 @@ Catalog Name	spark_catalog
 Comment	some comment
 Location [not included in comparison]/{warehouse_dir}/someloc
 Namespace Name	ident
-Owner	maximgekk
+Owner	runner
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/natural-join.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/natural-join.sql.out
@@ -254,7 +254,7 @@ org.apache.spark.sql.AnalysisException
   "sqlState" : "42703",
   "messageParameters" : {
     "objectName" : "`nt2`.`k`",
-    "proposal" : "`__auto_generated_subquery_name`.`k`, `__auto_generated_subquery_name`.`v1`, `__auto_generated_subquery_name`.`v2`"
+    "proposal" : "`k`, `v1`, `v2`"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/results/pivot.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/pivot.sql.out
@@ -521,7 +521,7 @@ org.apache.spark.sql.AnalysisException
   "errorClass" : "INCOMPARABLE_PIVOT_COLUMN",
   "sqlState" : "42818",
   "messageParameters" : {
-    "columnName" : "`__auto_generated_subquery_name`.`m`"
+    "columnName" : "`m`"
   }
 }
 

--- a/sql/core/src/test/resources/sql-tests/results/udf/udf-pivot.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udf/udf-pivot.sql.out
@@ -487,7 +487,7 @@ org.apache.spark.sql.AnalysisException
   "errorClass" : "INCOMPARABLE_PIVOT_COLUMN",
   "sqlState" : "42818",
   "messageParameters" : {
-    "columnName" : "`__auto_generated_subquery_name`.`m`"
+    "columnName" : "`m`"
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
@@ -486,13 +486,14 @@ class QueryCompilationErrorsSuite
         sqlState = None,
         parameters = Map(
           "objectName" -> "`v`.`i`",
-          "proposal" -> "`__auto_generated_subquery_name`.`i`"),
+          "proposal" -> "`i`"),
         context = ExpectedContext(
           fragment = "v.i",
           start = 7,
           stop = 9))
 
       checkAnswer(sql("SELECT __auto_generated_subquery_name.i from (SELECT i FROM v)"), Row(1))
+      checkAnswer(sql("SELECT i from (SELECT i FROM v)"), Row(1))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
@@ -420,7 +420,7 @@ class QueryExecutionErrorsSuite
     checkError(
       exception = e,
       errorClass = "INCOMPARABLE_PIVOT_COLUMN",
-      parameters = Map("columnName" -> "`__auto_generated_subquery_name`.`map`"),
+      parameters = Map("columnName" -> "`map`"),
       sqlState = "42818")
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose the drop the prefix `__auto_generated_subquery_name` from SQL ids in errors.

### Why are the changes needed?
The changes should improve user experience with Spark SQL by making error messages shorter and more clear.

### Does this PR introduce _any_ user-facing change?
Should not.

### How was this patch tested?
By running the affected test suites:
```
$ PYSPARK_PYTHON=python3 build/sbt "sql/testOnly org.apache.spark.sql.SQLQueryTestSuite"
$ build/sbt "test:testOnly *QueryCompilationErrorsSuite"
$ build/sbt "sql/testOnly *QueryExecutionErrorsSuite"
```