### PR TITLE
[SPARK-43905][CORE] Consolidate BlockId parsing and creation

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -78,6 +78,7 @@ CORE:
   - "common/network-shuffle/**/*"
   - "python/pyspark/*.py"
   - "python/pyspark/tests/**/*.py"
+  - "common/storage-common/**/*"
 SPARK SUBMIT:
   - "bin/spark-submit*"
 SPARK SHELL:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -143,7 +143,7 @@ jobs:
           - >-
             core, unsafe, kvstore, avro,
             network-common, network-shuffle, repl, launcher,
-            examples, sketch, graphx
+            examples, sketch, graphx, storage-common
           - >-
             catalyst, hive-thriftserver
           - >-

--- a/common/network-yarn/pom.xml
+++ b/common/network-yarn/pom.xml
@@ -99,9 +99,7 @@
             <includes>
               <include>*:*</include>
             </includes>
-            <excludes>
-              <exclude>org.scala-lang:scala-library</exclude>
-            </excludes>
+            <!-- scala-library is needed because network-yarn depends on ExternalBlockHandler which depends on BlockId -->
           </artifactSet>
           <filters>
             <filter>

--- a/common/storage-common/pom.xml
+++ b/common/storage-common/pom.xml
@@ -26,62 +26,25 @@
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
-  <artifactId>spark-network-shuffle_2.12</artifactId>
+  <artifactId>spark-storage-common_2.12</artifactId>
   <packaging>jar</packaging>
-  <name>Spark Project Shuffle Streaming Service</name>
+  <name>Spark Project Storage Common</name>
   <url>https://spark.apache.org/</url>
   <properties>
-    <sbt.project.name>network-shuffle</sbt.project.name>
+    <sbt.project.name>storage-common</sbt.project.name>
   </properties>
 
   <dependencies>
-    <!-- Core dependencies -->
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-storage-common_${scala.binary.version}</artifactId>
+      <artifactId>spark-common-utils_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.spark</groupId>
-      <artifactId>spark-network-common_${scala.binary.version}</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>io.dropwizard.metrics</groupId>
-      <artifactId>metrics-core</artifactId>
     </dependency>
 
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-tags_${scala.binary.version}</artifactId>
     </dependency>
-
-    <!-- Provided dependencies -->
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.roaringbitmap</groupId>
-      <artifactId>RoaringBitmap</artifactId>
-    </dependency>
-
-    <!-- Test dependencies -->
-    <dependency>
-      <groupId>org.apache.spark</groupId>
-      <artifactId>spark-network-common_${scala.binary.version}</artifactId>
-      <version>${project.version}</version>
-      <type>test-jar</type>
-      <scope>test</scope>
-    </dependency>
-
     <!--
       This spark-tags test-dep is needed even though it isn't used in this module, otherwise testing-cmds that exclude
       them will yield errors.
@@ -92,42 +55,11 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
-
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-1.2-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j2-impl</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
-
   <build>
     <outputDirectory>target/scala-${scala.binary.version}/classes</outputDirectory>
     <testOutputDirectory>target/scala-${scala.binary.version}/test-classes</testOutputDirectory>
+    <plugins>
+    </plugins>
   </build>
 </project>

--- a/common/storage-common/src/test/scala/org/apache/spark/storage/BlockIdSuite.scala
+++ b/common/storage-common/src/test/scala/org/apache/spark/storage/BlockIdSuite.scala
@@ -19,9 +19,9 @@ package org.apache.spark.storage
 
 import java.util.UUID
 
-import org.apache.spark.SparkFunSuite
+import org.scalatest.funsuite.AnyFunSuite // scalastyle:ignore funsuite
 
-class BlockIdSuite extends SparkFunSuite {
+class BlockIdSuite extends AnyFunSuite { // scalastyle:ignore funsuite
   def assertSame(id1: BlockId, id2: BlockId): Unit = {
     assert(id1.name === id2.name)
     assert(id1.hashCode === id2.hashCode)

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -111,6 +111,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-storage-common_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>javax.activation</groupId>
       <artifactId>activation</artifactId>
     </dependency>

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -1196,8 +1196,8 @@ private[spark] object SparkSubmitUtils extends Logging {
   // spark-streaming utility components. Underscore is there to differentiate between
   // spark-streaming_2.1x and spark-streaming-kafka-0-10-assembly_2.1x
   val IVY_DEFAULT_EXCLUDES = Seq("catalyst_", "core_", "graphx_", "kvstore_", "launcher_", "mllib_",
-    "mllib-local_", "network-common_", "network-shuffle_", "repl_", "sketch_", "sql_", "streaming_",
-    "tags_", "unsafe_")
+    "mllib-local_", "network-common_", "network-shuffle_", "repl_", "sketch_", "sql_",
+    "storage-common_", "streaming_", "tags_", "unsafe_")
 
   /**
    * Represents a Maven Coordinate

--- a/core/src/test/scala/org/apache/spark/network/netty/NettyBlockTransferServiceSuite.scala
+++ b/core/src/test/scala/org/apache/spark/network/netty/NettyBlockTransferServiceSuite.scala
@@ -125,7 +125,7 @@ class NettyBlockTransferServiceSuite
     clientFactoryField.set(service0, clientFactory)
 
     service0.fetchBlocks("localhost", port, "exec1",
-      Array("block1"), listener, mock(classOf[DownloadFileManager]))
+      Array("rdd_0_0"), listener, mock(classOf[DownloadFileManager]))
     assert(createClientCount === 1)
     assert(hitExecutorDeadException)
   }

--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -135,9 +135,20 @@ network_common = Module(
     ],
 )
 
+storage_common = Module(
+    name="storage-common",
+    dependencies=[tags],
+    source_file_regexes=[
+        "common/storage-common/",
+    ],
+    sbt_test_goals=[
+        "storage-common/test",
+    ],
+)
+
 network_shuffle = Module(
     name="network-shuffle",
-    dependencies=[tags],
+    dependencies=[tags, storage_common],
     source_file_regexes=[
         "common/network-shuffle/",
     ],
@@ -170,7 +181,7 @@ launcher = Module(
 
 core = Module(
     name="core",
-    dependencies=[kvstore, network_common, network_shuffle, unsafe, launcher],
+    dependencies=[kvstore, network_common, network_shuffle, unsafe, launcher, storage_common],
     source_file_regexes=[
         "core/",
     ],

--- a/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
@@ -148,6 +148,7 @@ abstract class AbstractCommandBuilder {
         "common/network-shuffle",
         "common/network-yarn",
         "common/sketch",
+        "common/storage-common",
         "common/tags",
         "common/unsafe",
         "core",

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,7 @@
   <modules>
     <module>common/sketch</module>
     <module>common/kvstore</module>
+    <module>common/storage-common</module>
     <module>common/network-common</module>
     <module>common/network-shuffle</module>
     <module>common/unsafe</module>

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -73,7 +73,42 @@ object MimaExcludes {
     ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.sql.AnalysisException$"),
     // [SPARK-44535][CONNECT][SQL] Move required Streaming API to sql/api
     ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.sql.streaming.GroupStateTimeout"),
-    ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.sql.streaming.OutputMode")
+    ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.sql.streaming.OutputMode"),
+    // [SPARK-43905][CORE] Consolidate BlockId parsing and creation
+    // These classes have all been moved to the common-storage module
+    ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.storage.BlockId"),
+    ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.storage.BlockId$"),
+    ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.storage.BroadcastBlockId"),
+    ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.storage.BroadcastBlockId$"),
+    ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.storage.RDDBlockId"),
+    ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.storage.RDDBlockId$"),
+    ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.storage.ShuffleBlockBatchId"),
+    ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.storage.ShuffleBlockBatchId$"),
+    ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.storage.ShuffleBlockChunkId"),
+    ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.storage.ShuffleBlockChunkId$"),
+    ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.storage.ShuffleBlockId"),
+    ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.storage.ShuffleBlockId$"),
+    ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.storage.ShuffleChecksumBlockId"),
+    ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.storage.ShuffleChecksumBlockId$"),
+    ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.storage.ShuffleDataBlockId"),
+    ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.storage.ShuffleDataBlockId$"),
+    ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.storage.ShuffleIndexBlockId"),
+    ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.storage.ShuffleIndexBlockId$"),
+    ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.storage.ShuffleMergedBlockId"),
+    ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.storage.ShuffleMergedBlockId$"),
+    ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.storage.ShuffleMergedDataBlockId"),
+    ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.storage.ShuffleMergedDataBlockId$"),
+    ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.storage.ShuffleMergedIndexBlockId"),
+    ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.storage.ShuffleMergedIndexBlockId$"),
+    ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.storage.ShuffleMergedMetaBlockId"),
+    ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.storage.ShuffleMergedMetaBlockId$"),
+    ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.storage.ShufflePushBlockId"),
+    ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.storage.ShufflePushBlockId$"),
+    ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.storage.StreamBlockId"),
+    ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.storage.StreamBlockId$"),
+    ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.storage.TaskResultBlockId"),
+    ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.storage.TaskResultBlockId$"),
+    ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.storage.UnrecognizedBlockId")
   )
 
   // Default exclude rules

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -58,10 +58,10 @@ object BuildCommons {
 
   val allProjects@Seq(
     core, graphx, mllib, mllibLocal, repl, networkCommon, networkShuffle, launcher, unsafe, tags, sketch, kvstore,
-    commonUtils, sqlApi, _*
+    commonUtils, sqlApi, storageCommon, _*
   ) = Seq(
     "core", "graphx", "mllib", "mllib-local", "repl", "network-common", "network-shuffle", "launcher", "unsafe",
-    "tags", "sketch", "kvstore", "common-utils", "sql-api"
+    "tags", "sketch", "kvstore", "common-utils", "sql-api", "storage-common"
   ).map(ProjectRef(buildLocation, _)) ++ sqlProjects ++ streamingProjects ++ Seq(connectCommon, connect, connectClient)
 
   val optionallyEnabledProjects@Seq(kubernetes, mesos, yarn,
@@ -416,7 +416,7 @@ object SparkBuild extends PomBuild {
     Seq(
       spark, hive, hiveThriftServer, repl, networkCommon, networkShuffle, networkYarn,
       unsafe, tags, tokenProviderKafka010, sqlKafka010, connectCommon, connect, connectClient,
-      commonUtils, sqlApi
+      commonUtils, sqlApi, storageCommon
     ).contains(x)
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Consolidating BlockId parsing and handling helps to cut down on errors arising from parsing the BlockId and also eliminates the need to manually synchronize the code across different places that parse the BlockIds.

Most of the offending code was in common/network-shuffle and it looks like the reason was because BlockId was in core/ so it wasn't usable by common/network-shuffle. So this patch moves BlockId.scala into common/storage-common to make it accessible everywhere.

Validated that there are no further instances of manual BlockId parsing or creation by running the following commands:

```
git grep -i 'split("_")' **.scala | grep -v "/test/"
core/src/main/scala/org/apache/spark/deploy/history/EventLogFileWriters.scala:    val index = eventLogFileName.stripPrefix(EVENT_LOG_FILE_NAME_PREFIX).split("_")(0)

git grep -i 'split("_")' **.java | grep -v "/test/"
common/network-common/src/main/java/org/apache/spark/network/server/OneForOneStreamManager.java:    String[] array = streamChunkId.split("_");


git grep '"_" +' **.scala | grep -v "BlockId.scala:" | grep -v "/test/" | grep -v '("_" + _)'
core/src/main/scala/org/apache/spark/deploy/history/EventLogFileWriters.scala:      base + "_" + Utils.sanitizeDirName(appAttemptId.get)
core/src/main/scala/org/apache/spark/util/logging/DriverLogger.scala:  val DRIVER_LOG_FILE_SUFFIX = "_" + DRIVER_LOG_FILE
mllib/src/main/scala/org/apache/spark/ml/Pipeline.scala:      val stageDir = idxFormat.format(stageIdx) + "_" + stageUid
mllib/src/main/scala/org/apache/spark/ml/feature/VectorAssembler.scala:                attr.withName(c + "_" + attr.name.get)
mllib/src/main/scala/org/apache/spark/ml/feature/VectorAssembler.scala:                attr.withName(c + "_" + i)
mllib/src/main/scala/org/apache/spark/ml/feature/VectorAssembler.scala:              NumericAttribute.defaultAttr.withName(c + "_" + i)
mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala:      Array.tabulate[String](origModel.numFeatures)((x: Int) => model.getFeaturesCol + "_" + x)
mllib/src/main/scala/org/apache/spark/ml/util/Identifiable.scala:    prefix + "_" + UUID.randomUUID().toString.takeRight(12)
sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala:            stringValue + "_" + suffix
sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala:          aggregates.map(agg => AttributeReference(value + "_" + agg.sql, agg.dataType)())
sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/HiveTempPath.scala:        new Path(stagingPathName + "_" + executionId + "-" + TaskRunner.getTaskRunnerID))
sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/HiveTempPath.scala:    "hive_" + format.format(new Date) + "_" + Math.abs(rand.nextLong)

git grep '"_" +' **.java | grep -v "/test/"
common/network-yarn/src/main/java/org/apache/spark/network/yarn/YarnShuffleServiceMetrics.java:      baseName + "_" + valueName,


git grep 'String\.format(.*_' **.java | grep -v "/test/"
common/network-common/src/main/java/org/apache/spark/network/sasl/SparkSaslServer.java:    String qop = alwaysEncrypt ? QOP_AUTH_CONF : String.format("%s,%s", QOP_AUTH_CONF, QOP_AUTH);
common/network-common/src/main/java/org/apache/spark/network/server/OneForOneStreamManager.java:    return String.format("%d_%d", streamId, chunkId);
common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java:      return String.format("Application %s_%s", appId, attemptId);
common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java:      return String.format("Application %s_%s shuffleId %s shuffleMergeId %s",
common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java:      return String.format("Application %s_%s shuffleId %s shuffleMergeId %s reduceId %s",
launcher/src/main/java/org/apache/spark/launcher/InProcessAppHandle.java:    app.setName(String.format(THREAD_NAME_FMT, THREAD_IDS.incrementAndGet(), appName));


git grep '\${.*}_\${.*}_' **.scala | grep -v "/test/" | grep -v "BlockId.scala:"
sql/core/src/main/scala/org/apache/spark/sql/streaming/ui/StreamingQueryStatusListener.scala:    s"${runId}_${batchId}_$timestamp"
```

The only hits from these commands are not related to BlockId parsing or creation.


### Why are the changes needed?

These changes are needed to cut down on bugs that arise from manual BlockId parsing, creation, and manual synchronization of that code.


### Does this PR introduce _any_ user-facing change?

No


### How was this patch tested?

```
mvn clean install
```