### PR TITLE
[SPARK-43523][CORE] Fix Spark UI LiveTask memory leak

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/Status.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/Status.scala
@@ -53,6 +53,12 @@ private[spark] object Status {
     .intConf
     .createWithDefault(100000)
 
+  val MAX_REFRESHED_TASKS = ConfigBuilder("spark.ui.refreshedTasks")
+    .doc("The maximum number of live tasks that are refreshed at any given time in the UI view.")
+    .version("3.5.0")
+    .intConf
+    .createWithDefault(Int.MaxValue)
+
   val MAX_RETAINED_DEAD_EXECUTORS = ConfigBuilder("spark.ui.retainedDeadExecutors")
     .version("2.0.0")
     .intConf


### PR DESCRIPTION
### What changes were proposed in this pull request?
Limit the number of LiveTask objects in AppStatusListener to avoid a memory leak.
Change the type of liveTasks map (used to refresh the state of the UI kvstore) from HashMap to LinkedHashMap and remove the eldest entries from the map after each put as long as the map size exceeds the new int property spark.ui.refreshedTasks.

### Why are the changes needed?
When the rate of Spark events is very high, some of the events may be dropped from the event queue that AppStatusListener is subscribed to since the listener can't keep up. When an event of type onTaskEnd is dropped, the LiveTask object associated to that task remains forever in the liveTasks map of AppStatusListener. This can lead to a memory leak since these LiveTask objects keep adding up in the map (even though the corresponding tasks are finished) and can't be garbage collected.
For more information check the discussion on the jira thread : https://issues.apache.org/jira/browse/SPARK-43523.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
I have performed performance tests before and after the fix. I have used Spark in standalone mode. I have used Spark shell to submit the queries. I have deliberately reduced the event queue capacity to 10 to be able to reproduce the memory leak quickly. I have generated a heap dump of the driver's JVM after each test and analyzed it using Eclipse Memory Analyzer.
*N.B: if no onTaskEnd events were dropped there would be 0 LiveTask objects in the AppStatusListener.liveTasks map at the end of the test.*
#### Setup :
- Cluster (spark-env.sh) :
```
SPARK_WORKER_MEMORY=1g
SPARK_WORKER_INSTANCES=4
SPARK_WORKER_CORES=32 
``` 
- Code submitted using spark-shell :
```
import Array._
import spark.implicits._
val uuid = udf(() => java.util.UUID.randomUUID().toString)
(1 to 100).foreach(x => sc.parallelize(range(x, 10000)).toDF("id")
 .repartition(1000)
 .withColumn("uuid", uuid())
 .withColumn("key", substring(col("uuid"), 0, 2))
 .groupBy("key")
 .agg(count("id").alias("c"))
 .sort(col("c").desc)
 .filter(x => x.getAs[Long](1) % 3 == 0)
 .count()) 
```

#### Pre-fix test :
- Spark shell command :
```
./bin/spark-shell --master spark://DESKTOP-UMJ5H4Q.localdomain:7077 --conf spark.scheduler.listenerbus.eventqueue.capacity=10 --conf spark.executor.memory=512m --conf spark.executor.instances=3
```
- Relevant logs :
```
23/05/20 16:44:04 ERROR AsyncEventQueue: Dropping event from queue appStatus. This likely means one of the listeners is too slow and cannot keep up with the rate at which tasks are being started by the scheduler.
23/05/20 16:45:04 WARN AsyncEventQueue: Dropped 2560 events from appStatus since Sat May 20 16:44:04 CEST 2023.
23/05/20 16:46:04 WARN AsyncEventQueue: Dropped 8797 events from appStatus since Sat May 20 16:45:04 CEST 2023.
23/05/20 16:47:04 WARN AsyncEventQueue: Dropped 15909 events from appStatus since Sat May 20 16:46:04 CEST 2023.
23/05/20 16:48:04 WARN AsyncEventQueue: Dropped 20031 events from appStatus since Sat May 20 16:47:04 CEST 2023.
```
- Duration of test : 5 minutes
- Driver Heap dump relevant facts :
	- **AppStatusListener estimated retained heap size is 95 MB.**
	- **LiveTask objects count is 19k.**

#### Post-fix test :
- Spark shell command (introduced the new property spark.ui.refreshedTasks) :
```
./bin/spark-shell --master spark://DESKTOP-UMJ5H4Q.localdomain:7077 --conf spark.scheduler.listenerbus.eventqueue.capacity=10 --conf spark.executor.memory=512m --conf spark.executor.instances=3 --conf spark.ui.refreshedTasks=1000
```
- Relevant logs :
```
23/06/01 13:19:53 ERROR AsyncEventQueue: Dropping event from queue appStatus. This likely means one of the listeners is too slow and cannot keep up with the rate at which tasks are being started by the scheduler.
23/06/01 13:19:53 WARN AsyncEventQueue: Dropped 1 events from appStatus since the application started.
23/06/01 13:20:53 WARN AsyncEventQueue: Dropped 3289 events from appStatus since Thu Jun 01 13:19:53 CEST 2023.
23/06/01 13:21:54 WARN AsyncEventQueue: Dropped 10969 events from appStatus since Thu Jun 01 13:20:53 CEST 2023.
23/06/01 13:22:54 WARN AsyncEventQueue: Dropped 13010 events from appStatus since Thu Jun 01 13:21:54 CEST 2023.
23/06/01 13:23:54 WARN AsyncEventQueue: Dropped 16818 events from appStatus since Thu Jun 01 13:22:54 CEST 2023.
```
- Duration of test : 5 minutes
- Driver Heap dump relevant facts :
	- **AppStatusListener estimated retained heap size is 11 MB.**
	- **LiveTask objects count is 888.**
