### PR TITLE
[SPARK-43913][SQL] Assign names to the error class _LEGACY_ERROR_TEMP_[2426-2432]

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -646,7 +646,7 @@
   },
   "EXPRESSION_TYPE_IS_NOT_ORDERABLE" : {
     "message" : [
-      "sorting is not supported for columns of type <type>."
+      "Column expression <expr> cannot be sorted because its type <exprType> is not orderable."
     ]
   },
   "FAILED_EXECUTE_UDF" : {
@@ -735,11 +735,6 @@
       "GROUP BY position <index> is not in select list (valid range is [1, <size>])."
     ],
     "sqlState" : "42805"
-  },
-  "GROUP_EXPRESSION_IS_NON_DETERMINISTIC" : {
-    "message" : [
-      "nondeterministic expression <sqlExpr> should not appear in grouping expression."
-    ]
   },
   "GROUP_EXPRESSION_TYPE_IS_NOT_ORDERABLE" : {
     "message" : [
@@ -1753,11 +1748,6 @@
     ],
     "sqlState" : "428FT"
   },
-  "PARTITION_WITH_NESTED_COLUMN_IS_UNSUPPORTED" : {
-    "message" : [
-      "Invalid partitioning: <cols> is missing or is in a map or array."
-    ]
-  },
   "PATH_ALREADY_EXISTS" : {
     "message" : [
       "Path <outputPath> already exists. Set mode as \"overwrite\" to overwrite the existing path."
@@ -2290,6 +2280,11 @@
       "PARAMETER_MARKER_IN_UNEXPECTED_STATEMENT" : {
         "message" : [
           "Parameter markers in unexpected statement: <statement>. Parameter markers must only be used in a query, or DML statement."
+        ]
+      },
+      "PARTITION_WITH_NESTED_COLUMN_IS_UNSUPPORTED" : {
+        "message" : [
+          "Invalid partitioning: <cols> is missing or is in a map or array."
         ]
       },
       "PIVOT_AFTER_GROUP_BY" : {

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -644,6 +644,11 @@
       "The event time <eventName> has the invalid type <eventType>, but expected \"TIMESTAMP\"."
     ]
   },
+  "EXPRESSION_TYPE_IS_NOT_ORDERABLE" : {
+    "message" : [
+      "sorting is not supported for columns of type <type>."
+    ]
+  },
   "FAILED_EXECUTE_UDF" : {
     "message" : [
       "Failed to execute user defined function (<functionName>: (<signature>) => <result>)."
@@ -730,6 +735,11 @@
       "GROUP BY position <index> is not in select list (valid range is [1, <size>])."
     ],
     "sqlState" : "42805"
+  },
+  "GROUP_EXPRESSION_IS_NON_DETERMINISTIC" : {
+    "message" : [
+      "nondeterministic expression <sqlExpr> should not appear in grouping expression."
+    ]
   },
   "GROUP_EXPRESSION_TYPE_IS_NOT_ORDERABLE" : {
     "message" : [
@@ -1743,6 +1753,11 @@
     ],
     "sqlState" : "428FT"
   },
+  "PARTITION_WITH_NESTED_COLUMN_IS_UNSUPPORTED" : {
+    "message" : [
+      "Invalid partitioning: <cols> is missing or is in a map or array."
+    ]
+  },
   "PATH_ALREADY_EXISTS" : {
     "message" : [
       "Path <outputPath> already exists. Set mode as \"overwrite\" to overwrite the existing path."
@@ -1834,6 +1849,11 @@
     ],
     "sqlState" : "42K05"
   },
+  "RESOLVED_ATTRIBUTE_MISSING_FROM_INPUT" : {
+    "message" : [
+      "<msg>"
+    ]
+  },
   "ROUTINE_ALREADY_EXISTS" : {
     "message" : [
       "Cannot create the function <routineName> because it already exists.",
@@ -1917,6 +1937,11 @@
   "STREAM_FAILED" : {
     "message" : [
       "Query [id = <id>, runId = <runId>] terminated with exception: <message>"
+    ]
+  },
+  "SUM_OF_LIMIT_AND_OFFSET_EXCEEDS_MAX_INT" : {
+    "message" : [
+      "The sum of the LIMIT clause and the OFFSET clause must not be greater than the maximum 32-bit integer value (2,147,483,647) but found limit = <limit>, offset = <offset>."
     ]
   },
   "TABLE_OR_VIEW_ALREADY_EXISTS" : {
@@ -5505,31 +5530,6 @@
   "_LEGACY_ERROR_TEMP_2331" : {
     "message" : [
       "failed to evaluate expression <sqlExpr>: <msg>"
-    ]
-  },
-  "GROUP_EXPRESSION_IS_NON_DETERMINISTIC" : {
-    "message" : [
-      "nondeterministic expression <sqlExpr> should not appear in grouping expression."
-    ]
-  },
-  "EXPRESSION_TYPE_IS_NOT_ORDERABLE" : {
-    "message" : [
-      "sorting is not supported for columns of type <type>."
-    ]
-  },
-  "SUM_OF_LIMIT_AND_OFFSET_EXCEEDS_MAX_INT" : {
-    "message" : [
-      "The sum of the LIMIT clause and the OFFSET clause must not be greater than the maximum 32-bit integer value (2,147,483,647) but found limit = <limit>, offset = <offset>."
-    ]
-  },
-  "PARTITION_WITH_NESTED_COLUMN_IS_UNSUPPORTED" : {
-    "message" : [
-      "Invalid partitioning: <cols> is missing or is in a map or array."
-    ]
-  },
-  "RESOLVED_ATTRIBUTE_MISSING_FROM_INPUT" : {
-    "message" : [
-      "<msg>"
     ]
   },
   "_LEGACY_ERROR_TEMP_2433" : {

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -1527,19 +1527,18 @@
   },
   "MISSING_ATTRIBUTES" : {
     "message" : [
-      "Operator missing attributes."
+      "Resolved attribute(s) <missingAttributes> missing from <input> in operator <operator>."
     ],
     "subClass" : {
       "RESOLVED_ATTRIBUTE_APPEAR_IN_OPERATION" : {
         "message" : [
-          "Resolved attribute(s) <missingAttributes> missing from <input> in operator <operator>.",
           "Attribute(s) with the same name appear in the operation: <operation>.",
           "Please check if the right attribute(s) are used."
         ]
       },
       "RESOLVED_ATTRIBUTE_MISSING_FROM_INPUT" : {
         "message" : [
-          "Resolved attribute(s) <missingAttributes> missing from <input> in operator <operator>."
+          ""
         ]
       }
     }

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -5507,27 +5507,27 @@
       "failed to evaluate expression <sqlExpr>: <msg>"
     ]
   },
-  "_LEGACY_ERROR_TEMP_2426" : {
+  "GROUP_EXPRESSION_IS_NON_DETERMINISTIC" : {
     "message" : [
       "nondeterministic expression <sqlExpr> should not appear in grouping expression."
     ]
   },
-  "_LEGACY_ERROR_TEMP_2427" : {
+  "EXPRESSION_TYPE_IS_NOT_ORDERABLE" : {
     "message" : [
       "sorting is not supported for columns of type <type>."
     ]
   },
-  "_LEGACY_ERROR_TEMP_2428" : {
+  "SUM_OF_LIMIT_AND_OFFSET_EXCEEDS_MAX_INT" : {
     "message" : [
       "The sum of the LIMIT clause and the OFFSET clause must not be greater than the maximum 32-bit integer value (2,147,483,647) but found limit = <limit>, offset = <offset>."
     ]
   },
-  "_LEGACY_ERROR_TEMP_2431" : {
+  "PARTITION_WITH_NESTED_COLUMN_IS_UNSUPPORTED" : {
     "message" : [
       "Invalid partitioning: <cols> is missing or is in a map or array."
     ]
   },
-  "_LEGACY_ERROR_TEMP_2432" : {
+  "RESOLVED_ATTRIBUTE_MISSING_FROM_INPUT" : {
     "message" : [
       "<msg>"
     ]

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -1525,6 +1525,25 @@
     ],
     "sqlState" : "42803"
   },
+  "MISSING_ATTRIBUTES" : {
+    "message" : [
+      "Operator missing attributes."
+    ],
+    "subClass" : {
+      "RESOLVED_ATTRIBUTE_APPEAR_IN_OPERATION" : {
+        "message" : [
+          "Resolved attribute(s) <missingAttributes> missing from <input> in operator <operator>.",
+          "Attribute(s) with the same name appear in the operation: <operation>.",
+          "Please check if the right attribute(s) are used."
+        ]
+      },
+      "RESOLVED_ATTRIBUTE_MISSING_FROM_INPUT" : {
+        "message" : [
+          "Resolved attribute(s) <missingAttributes> missing from <input> in operator <operator>."
+        ]
+      }
+    }
+  },
   "MISSING_GROUP_BY" : {
     "message" : [
       "The query does not include a GROUP BY clause. Add GROUP BY or turn it into the window functions using OVER clauses."
@@ -1838,11 +1857,6 @@
       "<sessionCatalog> requires a single-part namespace, but got <namespace>."
     ],
     "sqlState" : "42K05"
-  },
-  "RESOLVED_ATTRIBUTE_MISSING_FROM_INPUT" : {
-    "message" : [
-      "<msg>"
-    ]
   },
   "ROUTINE_ALREADY_EXISTS" : {
     "message" : [

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -474,9 +474,11 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
                 // This is just a sanity check, our analysis rule PullOutNondeterministic should
                 // already pull out those nondeterministic expressions and evaluate them in
                 // a Project node.
-                expr.failAnalysis(
-                  errorClass = "GROUP_EXPRESSION_IS_NON_DETERMINISTIC",
-                  messageParameters = Map("sqlExpr" -> toSQLExpr(expr)))
+                throw SparkException.internalError(
+                  msg = s"Non-deterministic expression '${toSQLExpr(expr)}' should not appear in " +
+                    "grouping expression.",
+                  context = expr.origin.getQueryContext,
+                  summary = expr.origin.context.summary)
               }
             }
 
@@ -546,7 +548,7 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
               if (!RowOrdering.isOrderable(order.dataType)) {
                 order.failAnalysis(
                   errorClass = "EXPRESSION_TYPE_IS_NOT_ORDERABLE",
-                  messageParameters = Map("type" -> toSQLType(order.dataType)))
+                  messageParameters = Map("exprType" -> toSQLType(order.dataType)))
               }
             }
 
@@ -624,7 +626,7 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
 
             if (badReferences.nonEmpty) {
               create.failAnalysis(
-                errorClass = "PARTITION_WITH_NESTED_COLUMN_IS_UNSUPPORTED",
+                errorClass = "UNSUPPORTED_FEATURE.PARTITION_WITH_NESTED_COLUMN_IS_UNSUPPORTED",
                 messageParameters = Map("cols" -> badReferences.map(r => s"`$r`").mkString(", ")))
             }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -645,7 +645,7 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
         operator match {
           case o if o.children.nonEmpty && o.missingInput.nonEmpty =>
             val missingAttributes = o.missingInput.map(attr => toSQLExpr(attr)).mkString(",")
-            val input = o.inputSet.map(attr => toSQLExpr(attr)).mkString(",")
+            val input = o.inputSet.map(attr => toSQLExpr(attr)).mkString(", ")
 
             val resolver = plan.conf.resolver
             val attrsWithSameName = o.missingInput.filter { missing =>
@@ -653,7 +653,7 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
             }
 
             if (attrsWithSameName.nonEmpty) {
-              val sameNames = attrsWithSameName.map(attr => toSQLExpr(attr)).mkString(",")
+              val sameNames = attrsWithSameName.map(attr => toSQLExpr(attr)).mkString(", ")
               o.failAnalysis(
                 errorClass = "MISSING_ATTRIBUTES.RESOLVED_ATTRIBUTE_APPEAR_IN_OPERATION",
                 messageParameters = Map(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -475,8 +475,8 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
                 // already pull out those nondeterministic expressions and evaluate them in
                 // a Project node.
                 expr.failAnalysis(
-                  errorClass = "_LEGACY_ERROR_TEMP_2426",
-                  messageParameters = Map("sqlExpr" -> expr.sql))
+                  errorClass = "GROUP_EXPRESSION_IS_NON_DETERMINISTIC",
+                  messageParameters = Map("sqlExpr" -> toSQLExpr(expr)))
               }
             }
 
@@ -545,8 +545,8 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
             orders.foreach { order =>
               if (!RowOrdering.isOrderable(order.dataType)) {
                 order.failAnalysis(
-                  errorClass = "_LEGACY_ERROR_TEMP_2427",
-                  messageParameters = Map("type" -> order.dataType.catalogString))
+                  errorClass = "EXPRESSION_TYPE_IS_NOT_ORDERABLE",
+                  messageParameters = Map("type" -> toSQLType(order.dataType)))
               }
             }
 
@@ -560,7 +560,7 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
                 val offset = offsetExpr.eval().asInstanceOf[Int]
                 if (Int.MaxValue - limit < offset) {
                   child.failAnalysis(
-                    errorClass = "_LEGACY_ERROR_TEMP_2428",
+                    errorClass = "SUM_OF_LIMIT_AND_OFFSET_EXCEEDS_MAX_INT",
                     messageParameters = Map(
                       "limit" -> limit.toString,
                       "offset" -> offset.toString))
@@ -624,8 +624,8 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
 
             if (badReferences.nonEmpty) {
               create.failAnalysis(
-                errorClass = "_LEGACY_ERROR_TEMP_2431",
-                messageParameters = Map("cols" -> badReferences.mkString(", ")))
+                errorClass = "PARTITION_WITH_NESTED_COLUMN_IS_UNSUPPORTED",
+                messageParameters = Map("cols" -> badReferences.map(r => s"`$r`").mkString(", ")))
             }
 
             create.tableSchema.foreach(f => TypeUtils.failWithIntervalType(f.dataType))
@@ -660,7 +660,7 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
             }
 
             o.failAnalysis(
-              errorClass = "_LEGACY_ERROR_TEMP_2432",
+              errorClass = "RESOLVED_ATTRIBUTE_MISSING_FROM_INPUT",
               messageParameters = Map("msg" -> msg))
 
           case p @ Project(exprs, _) if containsMultipleGenerators(exprs) =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -644,7 +644,7 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
 
         operator match {
           case o if o.children.nonEmpty && o.missingInput.nonEmpty =>
-            val missingAttributes = o.missingInput.map(attr => toSQLExpr(attr)).mkString(",")
+            val missingAttributes = o.missingInput.map(attr => toSQLExpr(attr)).mkString(", ")
             val input = o.inputSet.map(attr => toSQLExpr(attr)).mkString(", ")
 
             val resolver = plan.conf.resolver

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
@@ -770,14 +770,16 @@ class AnalysisErrorSuite extends AnalysisTest {
 
     assert(plan.resolved)
 
-    val resolved = s"${attrA.toString},${attrC.toString}"
-
-    val errorMsg = s"Resolved attribute(s) $resolved missing from ${otherA.toString} " +
-                     s"in operator !Aggregate [${aliases.mkString(", ")}]. " +
-                     s"Attribute(s) with the same name appear in the operation: a. " +
-                     "Please check if the right attribute(s) are used."
-
-    assertAnalysisError(plan, errorMsg :: Nil)
+    assertAnalysisErrorClass(
+      inputPlan = plan,
+      expectedErrorClass = "MISSING_ATTRIBUTES.RESOLVED_ATTRIBUTE_APPEAR_IN_OPERATION",
+      expectedMessageParameters = Map(
+        "missingAttributes" -> "\"a\",\"c\"",
+        "input" -> "\"a\"",
+        "operator" -> s"!Aggregate [${aliases.mkString(", ")}]",
+        "operation" -> "\"a\""
+      )
+    )
   }
 
   test("error test for self-join") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
@@ -774,7 +774,7 @@ class AnalysisErrorSuite extends AnalysisTest {
       inputPlan = plan,
       expectedErrorClass = "MISSING_ATTRIBUTES.RESOLVED_ATTRIBUTE_APPEAR_IN_OPERATION",
       expectedMessageParameters = Map(
-        "missingAttributes" -> "\"a\",\"c\"",
+        "missingAttributes" -> "\"a\", \"c\"",
         "input" -> "\"a\"",
         "operator" -> s"!Aggregate [${aliases.mkString(", ")}]",
         "operation" -> "\"a\""

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
@@ -721,7 +721,7 @@ class AnalysisErrorSuite extends AnalysisTest {
   errorClassTest(
     "the sum of num_rows in limit clause and num_rows in offset clause less than Int.MaxValue",
     testRelation.offset(Literal(2000000000, IntegerType)).limit(Literal(1000000000, IntegerType)),
-    "_LEGACY_ERROR_TEMP_2428",
+    "SUM_OF_LIMIT_AND_OFFSET_EXCEEDS_MAX_INT",
     Map("limit" -> "1000000000", "offset" -> "2000000000"))
 
   errorTest(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/CreateTablePartitioningValidationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/CreateTablePartitioningValidationSuite.scala
@@ -42,7 +42,7 @@ class CreateTablePartitioningValidationSuite extends AnalysisTest {
     assert(!plan.resolved)
     assertAnalysisError(plan, Seq(
       "Invalid partitioning",
-      "does_not_exist is missing or is in a map or array"))
+      "`does_not_exist` is missing or is in a map or array"))
   }
 
   test("CreateTableAsSelect: fail missing top-level column nested reference") {
@@ -59,7 +59,7 @@ class CreateTablePartitioningValidationSuite extends AnalysisTest {
     assert(!plan.resolved)
     assertAnalysisError(plan, Seq(
       "Invalid partitioning",
-      "does_not_exist.z is missing or is in a map or array"))
+      "`does_not_exist.z` is missing or is in a map or array"))
   }
 
   test("CreateTableAsSelect: fail missing nested column") {
@@ -76,7 +76,7 @@ class CreateTablePartitioningValidationSuite extends AnalysisTest {
     assert(!plan.resolved)
     assertAnalysisError(plan, Seq(
       "Invalid partitioning",
-      "point.z is missing or is in a map or array"))
+      "`point.z` is missing or is in a map or array"))
   }
 
   test("CreateTableAsSelect: fail with multiple errors") {
@@ -92,8 +92,8 @@ class CreateTablePartitioningValidationSuite extends AnalysisTest {
 
     assert(!plan.resolved)
     assertAnalysisErrorClass(plan,
-      expectedErrorClass = "_LEGACY_ERROR_TEMP_2431",
-      expectedMessageParameters = Map("cols" -> "does_not_exist, point.z"))
+      expectedErrorClass = "PARTITION_WITH_NESTED_COLUMN_IS_UNSUPPORTED",
+      expectedMessageParameters = Map("cols" -> "`does_not_exist`, `point.z`"))
   }
 
   test("CreateTableAsSelect: success with top-level column") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/CreateTablePartitioningValidationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/CreateTablePartitioningValidationSuite.scala
@@ -40,9 +40,9 @@ class CreateTablePartitioningValidationSuite extends AnalysisTest {
       ignoreIfExists = false)
 
     assert(!plan.resolved)
-    assertAnalysisError(plan, Seq(
-      "Invalid partitioning",
-      "`does_not_exist` is missing or is in a map or array"))
+    assertAnalysisErrorClass(plan,
+      expectedErrorClass = "UNSUPPORTED_FEATURE.PARTITION_WITH_NESTED_COLUMN_IS_UNSUPPORTED",
+      expectedMessageParameters = Map("cols" -> "`does_not_exist`"))
   }
 
   test("CreateTableAsSelect: fail missing top-level column nested reference") {
@@ -57,9 +57,9 @@ class CreateTablePartitioningValidationSuite extends AnalysisTest {
       ignoreIfExists = false)
 
     assert(!plan.resolved)
-    assertAnalysisError(plan, Seq(
-      "Invalid partitioning",
-      "`does_not_exist.z` is missing or is in a map or array"))
+    assertAnalysisErrorClass(plan,
+      expectedErrorClass = "UNSUPPORTED_FEATURE.PARTITION_WITH_NESTED_COLUMN_IS_UNSUPPORTED",
+      expectedMessageParameters = Map("cols" -> "`does_not_exist.z`"))
   }
 
   test("CreateTableAsSelect: fail missing nested column") {
@@ -74,9 +74,9 @@ class CreateTablePartitioningValidationSuite extends AnalysisTest {
       ignoreIfExists = false)
 
     assert(!plan.resolved)
-    assertAnalysisError(plan, Seq(
-      "Invalid partitioning",
-      "`point.z` is missing or is in a map or array"))
+    assertAnalysisErrorClass(plan,
+      expectedErrorClass = "UNSUPPORTED_FEATURE.PARTITION_WITH_NESTED_COLUMN_IS_UNSUPPORTED",
+      expectedMessageParameters = Map("cols" -> "`point.z`"))
   }
 
   test("CreateTableAsSelect: fail with multiple errors") {
@@ -92,7 +92,7 @@ class CreateTablePartitioningValidationSuite extends AnalysisTest {
 
     assert(!plan.resolved)
     assertAnalysisErrorClass(plan,
-      expectedErrorClass = "PARTITION_WITH_NESTED_COLUMN_IS_UNSUPPORTED",
+      expectedErrorClass = "UNSUPPORTED_FEATURE.PARTITION_WITH_NESTED_COLUMN_IS_UNSUPPORTED",
       expectedMessageParameters = Map("cols" -> "`does_not_exist`, `point.z`"))
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/CreateTablePartitioningValidationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/CreateTablePartitioningValidationSuite.scala
@@ -59,7 +59,7 @@ class CreateTablePartitioningValidationSuite extends AnalysisTest {
     assert(!plan.resolved)
     assertAnalysisErrorClass(plan,
       expectedErrorClass = "UNSUPPORTED_FEATURE.PARTITION_WITH_NESTED_COLUMN_IS_UNSUPPORTED",
-      expectedMessageParameters = Map("cols" -> "`does_not_exist.z`"))
+      expectedMessageParameters = Map("cols" -> "`does_not_exist`.`z`"))
   }
 
   test("CreateTableAsSelect: fail missing nested column") {
@@ -76,7 +76,7 @@ class CreateTablePartitioningValidationSuite extends AnalysisTest {
     assert(!plan.resolved)
     assertAnalysisErrorClass(plan,
       expectedErrorClass = "UNSUPPORTED_FEATURE.PARTITION_WITH_NESTED_COLUMN_IS_UNSUPPORTED",
-      expectedMessageParameters = Map("cols" -> "`point.z`"))
+      expectedMessageParameters = Map("cols" -> "`point`.`z`"))
   }
 
   test("CreateTableAsSelect: fail with multiple errors") {
@@ -93,7 +93,7 @@ class CreateTablePartitioningValidationSuite extends AnalysisTest {
     assert(!plan.resolved)
     assertAnalysisErrorClass(plan,
       expectedErrorClass = "UNSUPPORTED_FEATURE.PARTITION_WITH_NESTED_COLUMN_IS_UNSUPPORTED",
-      expectedMessageParameters = Map("cols" -> "`does_not_exist`, `point.z`"))
+      expectedMessageParameters = Map("cols" -> "`does_not_exist`, `point`.`z`"))
   }
 
   test("CreateTableAsSelect: success with top-level column") {

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/subquery/negative-cases/invalid-correlation.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/subquery/negative-cases/invalid-correlation.sql.out
@@ -76,7 +76,7 @@ WHERE  t1a IN (SELECT   min(t2a)
 -- !query analysis
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_2432",
+  "errorClass" : "RESOLVED_ATTRIBUTE_MISSING_FROM_INPUT",
   "messageParameters" : {
     "msg" : "Resolved attribute(s) t2b#x missing from min(t2a)#x,t2c#x in operator !Filter t2c#x IN (list#x [t2b#x])."
   },

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/subquery/negative-cases/invalid-correlation.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/subquery/negative-cases/invalid-correlation.sql.out
@@ -76,9 +76,11 @@ WHERE  t1a IN (SELECT   min(t2a)
 -- !query analysis
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "RESOLVED_ATTRIBUTE_MISSING_FROM_INPUT",
+  "errorClass" : "MISSING_ATTRIBUTES.RESOLVED_ATTRIBUTE_MISSING_FROM_INPUT",
   "messageParameters" : {
-    "msg" : "Resolved attribute(s) t2b#x missing from min(t2a)#x,t2c#x in operator !Filter t2c#x IN (list#x [t2b#x])."
+    "input" : "\"min(t2a)\",\"t2c\"",
+    "missingAttributes" : "\"t2b\"",
+    "operator" : "!Filter t2c#x IN (list#x [t2b#x])"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/subquery/negative-cases/invalid-correlation.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/subquery/negative-cases/invalid-correlation.sql.out
@@ -78,7 +78,7 @@ org.apache.spark.sql.AnalysisException
 {
   "errorClass" : "MISSING_ATTRIBUTES.RESOLVED_ATTRIBUTE_MISSING_FROM_INPUT",
   "messageParameters" : {
-    "input" : "\"min(t2a)\",\"t2c\"",
+    "input" : "\"min(t2a)\", \"t2c\"",
     "missingAttributes" : "\"t2b\"",
     "operator" : "!Filter t2c#x IN (list#x [t2b#x])"
   },

--- a/sql/core/src/test/resources/sql-tests/results/subquery/negative-cases/invalid-correlation.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/subquery/negative-cases/invalid-correlation.sql.out
@@ -73,7 +73,7 @@ org.apache.spark.sql.AnalysisException
 {
   "errorClass" : "MISSING_ATTRIBUTES.RESOLVED_ATTRIBUTE_MISSING_FROM_INPUT",
   "messageParameters" : {
-    "input" : "\"min(t2a)\",\"t2c\"",
+    "input" : "\"min(t2a)\", \"t2c\"",
     "missingAttributes" : "\"t2b\"",
     "operator" : "!Filter t2c#x IN (list#x [t2b#x])"
   },

--- a/sql/core/src/test/resources/sql-tests/results/subquery/negative-cases/invalid-correlation.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/subquery/negative-cases/invalid-correlation.sql.out
@@ -71,9 +71,11 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "RESOLVED_ATTRIBUTE_MISSING_FROM_INPUT",
+  "errorClass" : "MISSING_ATTRIBUTES.RESOLVED_ATTRIBUTE_MISSING_FROM_INPUT",
   "messageParameters" : {
-    "msg" : "Resolved attribute(s) t2b#x missing from min(t2a)#x,t2c#x in operator !Filter t2c#x IN (list#x [t2b#x])."
+    "input" : "\"min(t2a)\",\"t2c\"",
+    "missingAttributes" : "\"t2b\"",
+    "operator" : "!Filter t2c#x IN (list#x [t2b#x])"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/results/subquery/negative-cases/invalid-correlation.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/subquery/negative-cases/invalid-correlation.sql.out
@@ -71,7 +71,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_2432",
+  "errorClass" : "RESOLVED_ATTRIBUTE_MISSING_FROM_INPUT",
   "messageParameters" : {
     "msg" : "Resolved attribute(s) t2b#x missing from min(t2a)#x,t2c#x in operator !Filter t2c#x IN (list#x [t2b#x])."
   },


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to assign names to the error class `_LEGACY_ERROR_TEMP_[2426-2432]`.


### Why are the changes needed?
Improve the error framework.


### Does this PR introduce _any_ user-facing change?
'No'.


### How was this patch tested?
Exists test cases.
