### PR TITLE
[SPARK-43945][SQL][TESTS] Fix bug for `SQLQueryTestSuite` when run on local env

### DIFF
--- a/sql/core/src/test/resources/sql-tests/results/identifier-clause.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/identifier-clause.sql.out
@@ -535,7 +535,7 @@ Catalog Name	spark_catalog
 Comment	some comment
 Location [not included in comparison]/{warehouse_dir}/someloc
 Namespace Name	ident
-Owner	runner
+Owner [not included in comparison]
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/identifier-clause.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/identifier-clause.sql.out
@@ -535,7 +535,7 @@ Catalog Name	spark_catalog
 Comment	some comment
 Location [not included in comparison]/{warehouse_dir}/someloc
 Namespace Name	ident
-Owner [not included in comparison]
+Owner	[not included in comparison]
 
 
 -- !query

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestHelper.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestHelper.scala
@@ -49,7 +49,7 @@ trait SQLQueryTestHelper extends Logging {
       .replaceAll("Created By.*", s"Created By $notIncludedMsg")
       .replaceAll("Created Time.*", s"Created Time $notIncludedMsg")
       .replaceAll("Last Access.*", s"Last Access $notIncludedMsg")
-      .replaceAll("Owner.*", s"Owner $notIncludedMsg")
+      .replaceAll("Owner\t.*", s"Owner\t$notIncludedMsg")
       .replaceAll("Partition Statistics\t\\d+", s"Partition Statistics\t$notIncludedMsg")
       .replaceAll("CTERelationDef \\d+,", s"CTERelationDef xxxx,")
       .replaceAll("CTERelationRef \\d+,", s"CTERelationRef xxxx,")

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestHelper.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestHelper.scala
@@ -49,6 +49,7 @@ trait SQLQueryTestHelper extends Logging {
       .replaceAll("Created By.*", s"Created By $notIncludedMsg")
       .replaceAll("Created Time.*", s"Created Time $notIncludedMsg")
       .replaceAll("Last Access.*", s"Last Access $notIncludedMsg")
+      .replaceAll("Owner.*", s"Owner $notIncludedMsg")
       .replaceAll("Partition Statistics\t\\d+", s"Partition Statistics\t$notIncludedMsg")
       .replaceAll("CTERelationDef \\d+,", s"CTERelationDef xxxx,")
       .replaceAll("CTERelationRef \\d+,", s"CTERelationRef xxxx,")

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
@@ -837,15 +837,11 @@ class SQLQueryTestSuite extends QueryTest with SharedSparkSession with SQLHelper
         s"Schema did not match for query #$i\n${expected.sql}: $output") {
         output.schema
       }
-      assertResult(normalizeOwner(expected.output), s"Result did not match" +
+      assertResult(expected.output, s"Result did not match" +
         s" for query #$i\n${expected.sql}") {
         output.output
       }
     }
-  }
-
-  private def normalizeOwner(plan: String): String = {
-    plan.replaceAll("""Owner\t\{runner}""", "Owner\t" + Utils.getCurrentUserName)
   }
 
   /** A single SQL query's output. */

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
@@ -595,7 +595,6 @@ class SQLQueryTestSuite extends QueryTest with SharedSparkSession with SQLHelper
         file.getAbsolutePath.replace(inputFilePath, analyzerGoldenFilePath) + ".out"
       val absPath = file.getAbsolutePath
       val testCaseName = absPath.stripPrefix(inputFilePath).stripPrefix(File.separator)
-      val analyzerTestCaseName = s"${testCaseName}_analyzer_test"
 
       // Create test cases of test types that depend on the input filename.
       val newTestCases: Seq[TestCase] = if (file.getAbsolutePath.startsWith(
@@ -838,11 +837,15 @@ class SQLQueryTestSuite extends QueryTest with SharedSparkSession with SQLHelper
         s"Schema did not match for query #$i\n${expected.sql}: $output") {
         output.schema
       }
-      assertResult(expected.output, s"Result did not match" +
+      assertResult(normalizeOwner(expected.output), s"Result did not match" +
         s" for query #$i\n${expected.sql}") {
         output.output
       }
     }
+  }
+
+  private def normalizeOwner(plan: String): String = {
+    plan.replaceAll("""Owner\t\{runner}""", "Owner\t" + Utils.getCurrentUserName)
   }
 
   /** A single SQL query's output. */

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
@@ -595,6 +595,7 @@ class SQLQueryTestSuite extends QueryTest with SharedSparkSession with SQLHelper
         file.getAbsolutePath.replace(inputFilePath, analyzerGoldenFilePath) + ".out"
       val absPath = file.getAbsolutePath
       val testCaseName = absPath.stripPrefix(inputFilePath).stripPrefix(File.separator)
+      val analyzerTestCaseName = s"${testCaseName}_analyzer_test"
 
       // Create test cases of test types that depend on the input filename.
       val newTestCases: Seq[TestCase] = if (file.getAbsolutePath.startsWith(


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to fix bug for SQLQueryTestSuite when run on local env.
When SQLQueryTestSuite runs `identifier-clause.sql` in various different environments, the statement `DESCRIBE SCHEMA IDENTIFIER('id' || 'ent')` will generate different `Owner` values. Currently, this value(`runner`) is OK when runs on GA, but it will fail on local. In order to be compatible with the results of various different environments, the `Owner` value is removed for comparison.

### Why are the changes needed?
Fix bugs and compatibility.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
- Manually test.
- Pass GA.