### PR TITLE
[SPARK-43063][SQL][FOLLOWUP] Add a space between `->` and value

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ToStringBase.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ToStringBase.scala
@@ -100,7 +100,7 @@ trait ToStringBase { self: UnaryExpression with TimeZoneAwareExpression =>
           builder.append(keyToUTF8String(keyArray.get(0, kt)).asInstanceOf[UTF8String])
           builder.append(" ->")
           if (valueArray.isNullAt(0)) {
-            if (nullString.nonEmpty) builder.append(nullString)
+            if (nullString.nonEmpty) builder.append(" " + nullString)
           } else {
             builder.append(" ")
             builder.append(valueToUTF8String(valueArray.get(0, vt)).asInstanceOf[UTF8String])


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up of #40922. This PR aims to add a space between `->` and value.

It seems to be missed here because the original PR already have the same code pattern in other place.

https://github.com/apache/spark/blob/74b04eeffdc4765f56fe3a9e97165b15ed4e2c73/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ToStringBase.scala#L114

### Why are the changes needed?

**BEFORE**
```
scala> sql("select map('k', null)").show()
+------------+
|map(k, NULL)|
+------------+
|  {k ->NULL}|
+------------+
```

**AFTER**
```
 scala> sql("select map('k', null)").show()
+------------+
|map(k, NULL)|
+------------+
| {k -> NULL}|
+------------+
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?
Manual review.