### PR TITLE
[SPARK-43954][BUILD] Upgrade sbt from 1.8.3 to 1.9.0

### DIFF
--- a/dev/appveyor-install-dependencies.ps1
+++ b/dev/appveyor-install-dependencies.ps1
@@ -97,7 +97,7 @@ if (!(Test-Path $tools)) {
 # ========================== SBT
 Push-Location $tools
 
-$sbtVer = "1.8.3"
+$sbtVer = "1.9.0"
 Start-FileDownload "https://github.com/sbt/sbt/releases/download/v$sbtVer/sbt-$sbtVer.zip" "sbt.zip"
 
 # extract

--- a/project/build.properties
+++ b/project/build.properties
@@ -15,4 +15,4 @@
 # limitations under the License.
 #
 # Please update the version in appveyor-install-dependencies.ps1 together.
-sbt.version=1.8.3
+sbt.version=1.9.0


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to upgrade sbt from 1.8.3 to 1.9.0

### Why are the changes needed?
Release notes: https://github.com/sbt/sbt/releases/tag/v1.9.0
- Deprecates IntegrationTest configuration.
- Updates underlying Coursier to 2.1.2 by [@eed3si9n](https://github.com/eed3si9n).

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA.