### PR TITLE
[SPARK-43955][BUILD] Upgrade `scalafmt` from 3.7.3 to 3.7.4

### DIFF
--- a/dev/.scalafmt.conf
+++ b/dev/.scalafmt.conf
@@ -32,4 +32,4 @@ fileOverride {
     runner.dialect = scala213
   }
 }
-version = 3.7.3
+version = 3.7.4


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade scalafmt from 3.7.3 to 3.7.4

### Why are the changes needed?
A. Release note:
> https://github.com/scalameta/scalafmt/releases

B. V3.7.3 VS V3.7.4
> https://github.com/scalameta/scalafmt/compare/v3.7.3...v3.7.4

C. Bring bug fix:
- SortModifiers: do not sort using
- RedundantBraces: don't remove parens in Init args
- Router: apply fewer braces to new anonymous, too
- Router: undo entire indent for fewerBraces

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA.