### PR TITLE
[SPARK-43957][SQL][TESTS] Use `checkError()` to check `Exception` in `*Insert*Suite`

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLInsertTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLInsertTestSuite.scala
@@ -17,8 +17,8 @@
 
 package org.apache.spark.sql
 
-import org.apache.spark.SparkNumberFormatException
 import org.apache.spark.SparkConf
+import org.apache.spark.SparkNumberFormatException
 import org.apache.spark.sql.catalyst.expressions.Hex
 import org.apache.spark.sql.connector.catalog.InMemoryPartitionTableCatalog
 import org.apache.spark.sql.internal.SQLConf

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLInsertTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLInsertTestSuite.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql
 
+import org.apache.spark.SparkNumberFormatException
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.catalyst.expressions.Hex
 import org.apache.spark.sql.connector.catalog.InMemoryPartitionTableCatalog
@@ -181,16 +182,28 @@ trait SQLInsertTestSuite extends QueryTest with SQLTestUtils {
   }
 
   test("insert with column list - mismatched column list size") {
-    val msgs = Seq("Cannot write to table due to mismatched user specified column size",
-      "expected 3 columns but found")
     def test: Unit = {
       withTable("t1") {
         val cols = Seq("c1", "c2", "c3")
         createTable("t1", cols, Seq("int", "long", "string"))
-        val e1 = intercept[AnalysisException](sql(s"INSERT INTO t1 (c1, c2) values(1, 2, 3)"))
-        assert(e1.getMessage.contains(msgs(0)) || e1.getMessage.contains(msgs(1)))
-        val e2 = intercept[AnalysisException](sql(s"INSERT INTO t1 (c1, c2, c3) values(1, 2)"))
-        assert(e2.getMessage.contains(msgs(0)) || e2.getMessage.contains(msgs(1)))
+        checkError(
+          exception = intercept[AnalysisException] {
+            sql(s"INSERT INTO t1 (c1, c2) values(1, 2, 3)")
+          },
+          sqlState = None,
+          errorClass = "_LEGACY_ERROR_TEMP_1038",
+          parameters = Map("columnSize" -> "2", "outputSize" -> "3"),
+          context = ExpectedContext("values(1, 2, 3)", 24, 38)
+        )
+        checkError(
+          exception = intercept[AnalysisException] {
+            sql(s"INSERT INTO t1 (c1, c2, c3) values(1, 2)")
+          },
+          sqlState = None,
+          errorClass = "_LEGACY_ERROR_TEMP_1038",
+          parameters = Map("columnSize" -> "3", "outputSize" -> "2"),
+          context = ExpectedContext("values(1, 2)", 28, 39)
+        )
       }
     }
     withSQLConf(SQLConf.ENABLE_DEFAULT_COLUMNS.key -> "false") {
@@ -259,10 +272,15 @@ trait SQLInsertTestSuite extends QueryTest with SQLTestUtils {
     "checking duplicate static partition columns should respect case sensitive conf") {
     withTable("t") {
       sql(s"CREATE TABLE t(i STRING, c string) USING PARQUET PARTITIONED BY (c)")
-      val e = intercept[AnalysisException] {
-        sql("INSERT OVERWRITE t PARTITION (c='2', C='3') VALUES (1)")
-      }
-      assert(e.getMessage.contains("Found duplicate keys `c`"))
+      checkError(
+        exception = intercept[AnalysisException] {
+          sql("INSERT OVERWRITE t PARTITION (c='2', C='3') VALUES (1)")
+        },
+        sqlState = None,
+        errorClass = "DUPLICATE_KEY",
+        parameters = Map("keyColumn" -> "`c`"),
+        context = ExpectedContext("PARTITION (c='2', C='3')", 19, 42)
+      )
     }
     // The following code is skipped for Hive because columns stored in Hive Metastore is always
     // case insensitive and we cannot create such table in Hive Metastore.
@@ -297,11 +315,19 @@ trait SQLInsertTestSuite extends QueryTest with SQLTestUtils {
         withTable("t") {
           sql("create table t(a int, b string) using parquet partitioned by (a)")
           if (shouldThrowException(policy)) {
-            val errorMsg = intercept[NumberFormatException] {
-              sql("insert into t partition(a='ansi') values('ansi')")
-            }.getMessage
-            assert(errorMsg.contains(
-              """The value 'ansi' of the type "STRING" cannot be cast to "INT""""))
+            checkError(
+              exception = intercept[SparkNumberFormatException] {
+                sql("insert into t partition(a='ansi') values('ansi')")
+              },
+              errorClass = "CAST_INVALID_INPUT",
+              parameters = Map(
+                "expression" -> "'ansi'",
+                "sourceType" -> "\"STRING\"",
+                "targetType" -> "\"INT\"",
+                "ansiConfig" -> "\"spark.sql.ansi.enabled\""
+              ),
+              context = ExpectedContext("insert into t partition(a='ansi')", 0, 32)
+            )
           } else {
             sql("insert into t partition(a='ansi') values('ansi')")
             checkAnswer(sql("select * from t"), Row("ansi", null) :: Nil)
@@ -340,8 +366,17 @@ trait SQLInsertTestSuite extends QueryTest with SQLTestUtils {
         ).foreach { query =>
           checkAnswer(sql(query), Seq(Row("a", 10, "08")))
         }
-        val e = intercept[AnalysisException](sql("alter table t drop partition(dt='8')"))
-        assert(e.getMessage.contains("PARTITIONS_NOT_FOUND"))
+        checkError(
+          exception = intercept[AnalysisException] {
+            sql("alter table t drop partition(dt='8')")
+          },
+          errorClass = "PARTITIONS_NOT_FOUND",
+          sqlState = None,
+          parameters = Map(
+            "partitionList" -> "PARTITION \\(`dt` = 8\\)",
+            "tableName" -> ".*`t`"),
+          matchPVals = true
+        )
       }
     }
 
@@ -351,8 +386,17 @@ trait SQLInsertTestSuite extends QueryTest with SQLTestUtils {
         sql("insert into t partition(dt=08) values('a', 10)")
         checkAnswer(sql("select * from t where dt='08'"), sql("select * from t where dt='07'"))
         checkAnswer(sql("select * from t where dt=08"), Seq(Row("a", 10, "8")))
-        val e = intercept[AnalysisException](sql("alter table t drop partition(dt='08')"))
-        assert(e.getMessage.contains("PARTITIONS_NOT_FOUND"))
+        checkError(
+          exception = intercept[AnalysisException] {
+            sql("alter table t drop partition(dt='08')")
+          },
+          errorClass = "PARTITIONS_NOT_FOUND",
+          sqlState = None,
+          parameters = Map(
+            "partitionList" -> "PARTITION \\(`dt` = 08\\)",
+            "tableName" -> ".*.`t`"),
+          matchPVals = true
+        )
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedUpdateAsDeleteAndInsertTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedUpdateAsDeleteAndInsertTableSuite.scala
@@ -35,10 +35,13 @@ class DeltaBasedUpdateAsDeleteAndInsertTableSuite extends UpdateTableSuiteBase {
         |{ "pk": 3, "salary": 120, "dep": 'hr' }
         |""".stripMargin)
 
-    val exception = intercept[AnalysisException] {
-      sql(s"UPDATE $tableNameAsString SET salary = -1 WHERE pk = 1")
-    }
-    assert(exception.message.contains("Row ID attributes cannot be nullable"))
+    checkErrorMatchPVals(
+      exception = intercept[AnalysisException] {
+        sql(s"UPDATE $tableNameAsString SET salary = -1 WHERE pk = 1")
+      },
+      errorClass = "NULLABLE_ROW_ID_ATTRIBUTES",
+      parameters = Map("nullableRowIdAttrs" -> "pk#\\d+")
+    )
   }
 
   test("update with assignments to row ID") {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/InsertSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/InsertSuite.scala
@@ -346,20 +346,30 @@ class InsertSuite extends QueryTest with TestHiveSingleton with BeforeAndAfter
   }
 
   testPartitionedTable("partitionBy() can't be used together with insertInto()") { tableName =>
-    val cause = intercept[AnalysisException] {
-      Seq((1, 2, 3, 4)).toDF("a", "b", "c", "d").write.partitionBy("b", "c").insertInto(tableName)
-    }
-
-    assert(cause.getMessage.contains("insertInto() can't be used together with partitionBy()."))
+    checkError(
+      exception = intercept[AnalysisException] {
+        Seq((1, 2, 3, 4)).toDF("a", "b", "c", "d").write.partitionBy("b", "c").insertInto(tableName)
+      },
+      errorClass = "_LEGACY_ERROR_TEMP_1309",
+      parameters = Map.empty
+    )
   }
 
   testPartitionedTable(
     "SPARK-16036: better error message when insert into a table with mismatch schema") {
     tableName =>
-      val e = intercept[AnalysisException] {
-        sql(s"INSERT INTO TABLE $tableName PARTITION(b=1, c=2) SELECT 1, 2, 3")
-      }
-      assert(e.message.contains("Cannot write to") && e.message.contains("too many data columns"))
+      checkError(
+        exception = intercept[AnalysisException] {
+          sql(s"INSERT INTO TABLE $tableName PARTITION(b=1, c=2) SELECT 1, 2, 3")
+        },
+        errorClass = "INSERT_PARTITION_COLUMN_ARITY_MISMATCH",
+        parameters = Map(
+          "staticPartCols" -> "'b', 'c'",
+          "tableColumns" -> "'a', 'd', 'b', 'c'",
+          "reason" -> "too many data columns",
+          "dataColumns" -> "'1', '2', '3'",
+          "tableName" -> s"`spark_catalog`.`default`.`$tableName`")
+      )
   }
 
   testPartitionedTable("SPARK-16037: INSERT statement should match columns by position") {
@@ -841,16 +851,18 @@ class InsertSuite extends QueryTest with TestHiveSingleton with BeforeAndAfter
           |PARTITIONED BY (d string)
           """.stripMargin)
 
-      val e = intercept[AnalysisException] {
-        spark.sql(
-          """
-            |INSERT OVERWRITE TABLE t1 PARTITION(d='')
-            |SELECT 1
-          """.stripMargin)
-      }.getMessage
-
-      assert(!e.contains("get partition: Value for key d is null or empty"))
-      assert(e.contains("Partition spec is invalid"))
+      checkError(
+        exception = intercept[AnalysisException] {
+          spark.sql(
+            """
+              |INSERT OVERWRITE TABLE t1 PARTITION(d='')
+              |SELECT 1
+            """.stripMargin)
+        },
+        errorClass = "_LEGACY_ERROR_TEMP_1076",
+        parameters = Map(
+          "details" -> "The spec ([d=Some()]) contains an empty partition column value")
+      )
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to use `checkError()` to check `Exception` in `*Insert*Suite`, include:
- sql/core/src/test/scala/org/apache/spark/sql/SQLInsertTestSuite
- sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedUpdateAsDeleteAndInsertTableSuite
- sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite
- sql/hive/src/test/scala/org/apache/spark/sql/hive/InsertSuite

#### Note:
But this pr does not include some of these cases, which directly throw AnalysisExecution, such as:
https://github.com/apache/spark/blob/898ad77900d887ac64800a616bd382def816eea6/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/rules.scala#L505-L515
After this PR, I will refactor these, assign them a name, and use the error framework. As these tasks are completed, all exceptions checks in `*Insert*Suite` will eventually be migrated to `checkError`.

### Why are the changes needed?
Migration on checkError() will make the tests independent from the text of error messages.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
- Manually test.
- Pass GA.