### PR TITLE
[SPARK-44077] Session Configs were not getting honored in RDDs

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -683,6 +683,15 @@ abstract class CSVSuite
     assert(results.toSeq.map(_.toSeq) === expected)
   }
 
+  test("Config not getting popluated in RDD") {
+    spark.conf.set("spark.sql.legacy.timeParserPolicy", "legacy")
+    spark.read
+      .option("dateFormat", "dd/MM/yy")
+      .schema("date date")
+      .csv(Seq("2/6/18").toDS())
+      .rdd.collect()
+  }
+
   test("load date types via custom date format") {
     val customSchema = new StructType(Array(StructField("date", DateType, true)))
     val options = Map(


### PR DESCRIPTION
What changes were proposed in this pull request?
Spark SQL configs are not honored in case of RDD actions.

When calling SQLConf.get on executors, the configs are read from the local properties on the TaskContext. The local properties are populated driver-side when scheduling the job, using the properties found in sparkContext.localProperties. For RDD actions, local properties were not getting populated.

How was this patch tested?
UT.