### PR TITLE
[SPARK-43970][PYTHON][CONNECT] Hide unsupported dataframe methods from auto-completion

### DIFF
--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -1572,6 +1572,18 @@ class DataFrame:
             raise PySparkAttributeError(
                 error_class="JVM_ATTRIBUTE_NOT_SUPPORTED", message_parameters={"attr_name": name}
             )
+        elif name in [
+            "rdd",
+            "toJSON",
+            "foreach",
+            "foreachPartition",
+            "checkpoint",
+            "localCheckpoint",
+        ]:
+            raise PySparkNotImplementedError(
+                error_class="NOT_IMPLEMENTED",
+                message_parameters={"feature": f"{name}()"},
+            )
         return self[name]
 
     @overload
@@ -1817,12 +1829,6 @@ class DataFrame:
 
     createOrReplaceGlobalTempView.__doc__ = PySparkDataFrame.createOrReplaceGlobalTempView.__doc__
 
-    def rdd(self, *args: Any, **kwargs: Any) -> None:
-        raise PySparkNotImplementedError(
-            error_class="NOT_IMPLEMENTED",
-            message_parameters={"feature": "RDD Support for Spark Connect"},
-        )
-
     def cache(self) -> "DataFrame":
         if self._plan is None:
             raise Exception("Cannot cache on empty plan.")
@@ -1870,18 +1876,6 @@ class DataFrame:
     def is_cached(self) -> bool:
         return self.storageLevel != StorageLevel.NONE
 
-    def foreach(self, *args: Any, **kwargs: Any) -> None:
-        raise PySparkNotImplementedError(
-            error_class="NOT_IMPLEMENTED",
-            message_parameters={"feature": "foreach()"},
-        )
-
-    def foreachPartition(self, *args: Any, **kwargs: Any) -> None:
-        raise PySparkNotImplementedError(
-            error_class="NOT_IMPLEMENTED",
-            message_parameters={"feature": "foreachPartition()"},
-        )
-
     def toLocalIterator(self, prefetchPartitions: bool = False) -> Iterator[Row]:
         from pyspark.sql.connect.conversion import ArrowTableToRowsConversion
 
@@ -1904,18 +1898,6 @@ class DataFrame:
                 yield from ArrowTableToRowsConversion.convert(table, schema)
 
     toLocalIterator.__doc__ = PySparkDataFrame.toLocalIterator.__doc__
-
-    def checkpoint(self, *args: Any, **kwargs: Any) -> None:
-        raise PySparkNotImplementedError(
-            error_class="NOT_IMPLEMENTED",
-            message_parameters={"feature": "checkpoint()"},
-        )
-
-    def localCheckpoint(self, *args: Any, **kwargs: Any) -> None:
-        raise PySparkNotImplementedError(
-            error_class="NOT_IMPLEMENTED",
-            message_parameters={"feature": "localCheckpoint()"},
-        )
 
     def to_pandas_on_spark(
         self, index_col: Optional[Union[str, List[str]]] = None
@@ -2000,12 +1982,6 @@ class DataFrame:
         return DataStreamWriter(plan=self._plan, session=self._session)
 
     writeStream.__doc__ = PySparkDataFrame.writeStream.__doc__
-
-    def toJSON(self, *args: Any, **kwargs: Any) -> None:
-        raise PySparkNotImplementedError(
-            error_class="NOT_IMPLEMENTED",
-            message_parameters={"feature": "toJSON()"},
-        )
 
     def sameSemantics(self, other: "DataFrame") -> bool:
         assert self._plan is not None


### PR DESCRIPTION
### What changes were proposed in this pull request?
Hide unsupported dataframe methods from auto-completion


### Why are the changes needed?

for better UX

before
<img width="507" alt="image" src="https://github.com/apache/spark/assets/7322292/8f4f228c-e30e-4027-8d52-768f1657f19e">


after
<img width="892" alt="image" src="https://github.com/apache/spark/assets/7322292/1d308937-dd57-4ca6-b37a-29b09348bda5">



### Does this PR introduce _any_ user-facing change?
yes


### How was this patch tested?
manually check in ipython