### PR TITLE
[SPARK-43976][CORE] Handle the case where modifiedConfigs doesn't exist in event logs

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/ExecutionPage.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/ExecutionPage.scala
@@ -84,15 +84,14 @@ class ExecutionPage(parent: SQLTab) extends WebUIPage("execution") with Logging 
 
       val metrics = sqlStore.executionMetrics(executionId)
       val graph = sqlStore.planGraph(executionId)
+      val configs = Option(executionUIData.modifiedConfigs).getOrElse(Map.empty)
 
       summary ++
         planVisualization(request, metrics, graph) ++
         physicalPlanDescription(executionUIData.physicalPlanDescription) ++
-        modifiedConfigs(
-          executionUIData.modifiedConfigs.filterKeys(
-            !_.startsWith(pandasOnSparkConfPrefix)).toMap) ++
+        modifiedConfigs(configs.filterKeys(!_.startsWith(pandasOnSparkConfPrefix)).toMap) ++
         modifiedPandasOnSparkConfigs(
-          executionUIData.modifiedConfigs.filterKeys(_.startsWith(pandasOnSparkConfPrefix)).toMap)
+          configs.filterKeys(_.startsWith(pandasOnSparkConfPrefix)).toMap)
     }.getOrElse {
       <div>No information to display for query {executionId}</div>
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This prevents NPE by handling the case where `modifiedConfigs` doesn't exist in event logs.

### Why are the changes needed?

Basically, this is the same solution for that case.
- https://github.com/apache/spark/pull/34907

The new code was added here, but we missed the corner case.

- https://github.com/apache/spark/pull/35972

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.