### PR TITLE
[SPARK-43977][CONNECT] Fix unexpected check result of `dev/connect-jvm-client-mima-check`

### DIFF
--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/CheckConnectJvmClientCompatibility.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/CheckConnectJvmClientCompatibility.scala
@@ -95,7 +95,7 @@ object CheckConnectJvmClientCompatibility {
     } catch {
       case e: Throwable =>
         println(e.getMessage)
-        resultWriter.write(s"ERROR: ${e.getMessage}")
+        resultWriter.write(s"ERROR: ${e.getMessage}\n")
     } finally {
       if (resultWriter != null) {
         resultWriter.close()

--- a/dev/connect-jvm-client-mima-check
+++ b/dev/connect-jvm-client-mima-check
@@ -35,7 +35,7 @@ fi
 rm -f .connect-mima-check-result
 
 echo "Build required modules..."
-build/sbt "sql/package;connect-client-jvm/assembly;connect-client-jvm/Test/package;avro/package;protobuf/package"
+build/sbt "sql/package;connect-client-jvm/assembly;connect-client-jvm/Test/package;avro/package;protobuf/assembly"
 
 CONNECT_TEST_CLASSPATH="$(build/sbt -DcopyDependencies=false "export connect-client-jvm/Test/fullClasspath" | grep jar | tail -n1)"
 SQL_CLASSPATH="$(build/sbt -DcopyDependencies=false "export sql/fullClasspath" | grep jar | tail -n1)"


### PR DESCRIPTION
### What changes were proposed in this pull request?
There is an unexpected check scenario of `dev/connect-jvm-client-mima-check` as follows:

1. run `build/sbt "protobuf/clean"`
2. run `dev/connect-jvm-client-mima-check`

Then  is a strange check result

```
Failed to find the jar: spark-protobuf-assembly(.*).jar or spark-protobuf(.*)3.5.0-SNAPSHOT.jar inside folder: /Users/yangjie01/SourceCode/git/spark-mine-sbt/connector/protobuf/target. This file can be generated by similar to the following command: build/sbt package|assembly
finish connect-client-jvm module mima check ...
connect-client-jvm module mima check passed.
```

There are both error messages and checks successful as above.

So this pr do the following changes to fix this unexpected check scenario:

1. Add a line break after write error message in `CheckConnectJvmClientCompatibility` to avoid `RESULT_SIZE` being considered as `0`:

after this change, run the above commands, the check result result is expected:

```
Do connect-client-jvm module mima check ...
Failed to find the jar: spark-protobuf-assembly(.*).jar or spark-protobuf(.*)3.5.0-SNAPSHOT.jar inside folder: /Users/yangjie01/SourceCode/git/spark-mine-sbt/connector/protobuf/target. This file can be generated by similar to the following command: build/sbt package|assembly
finish connect-client-jvm module mima check ...
ERROR: Failed to find the jar: spark-protobuf-assembly(.*).jar or spark-protobuf(.*)3.5.0-SNAPSHOT.jar inside folder: /Users/yangjie01/SourceCode/git/spark-mine-sbt/connector/protobuf/target. This file can be generated by similar to the following command: build/sbt package|assembly
connect-client-jvm module mima check failed.
```

2. Change `protobuf/package` to `protobuf/assembly` to ensure spark-protobuf uber jar always present

after this change, run the above commands, the check result result is successful:

```
Do connect-client-jvm module mima check ...
finish connect-client-jvm module mima check ...
connect-client-jvm module mima check passed.
```


### Why are the changes needed?
Fix wrong check result of `dev/connect-jvm-client-mima-check`


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass GitHub Actions
- Do manual checks as pr description 
