### PR TITLE
[SPARK-43914][SQL] Assign names to the error class _LEGACY_ERROR_TEMP_[2433-2437]

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -5667,40 +5667,6 @@
       "Cannot change nullable column to non-nullable: <fieldName>."
     ]
   },
-  "_LEGACY_ERROR_TEMP_2433" : {
-    "message" : [
-      "Only a single table generating function is allowed in a SELECT clause, found:",
-      "<sqlExprs>."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_2434" : {
-    "message" : [
-      "Failure when resolving conflicting references in Join:",
-      "<plan>",
-      "Conflicting attributes: <conflictingAttributes>."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_2435" : {
-    "message" : [
-      "Failure when resolving conflicting references in Intersect:",
-      "<plan>",
-      "Conflicting attributes: <conflictingAttributes>."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_2436" : {
-    "message" : [
-      "Failure when resolving conflicting references in Except:",
-      "<plan>",
-      "Conflicting attributes: <conflictingAttributes>."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_2437" : {
-    "message" : [
-      "Failure when resolving conflicting references in AsOfJoin:",
-      "<plan>",
-      "Conflicting attributes: <conflictingAttributes>."
-    ]
-  },
   "_LEGACY_ERROR_TEMP_2446" : {
     "message" : [
       "Operation not allowed: <cmd> only works on table with location provided: <tableIdentWithDB>"

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -1978,13 +1978,6 @@
     ],
     "sqlState" : "42K05"
   },
-  "RESOLVED_PLAN_HAVE_CONFLICTING_ATTRS" : {
-    "message" : [
-      "Failure when resolving conflicting references in <nodeName>:",
-      "<plan>",
-      "Conflicting attributes: <conflictingAttributes>."
-    ]
-  },
   "ROUTINE_ALREADY_EXISTS" : {
     "message" : [
       "Cannot create the function <routineName> because it already exists.",

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -1978,6 +1978,13 @@
     ],
     "sqlState" : "42K05"
   },
+  "RESOLVED_PLAN_HAVE_CONFLICTING_ATTRS" : {
+    "message" : [
+      "Failure when resolving conflicting references in <nodeName>:",
+      "<plan>",
+      "Conflicting attributes: <conflictingAttributes>."
+    ]
+  },
   "ROUTINE_ALREADY_EXISTS" : {
     "message" : [
       "Cannot create the function <routineName> because it already exists.",

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -694,7 +694,7 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
               msg = s"""
                        |Failure when resolving conflicting references in ${j.nodeName}:
                        |${plan.toString}
-                       |Conflicting attributes: $conflictingAttributes.""",
+                       |Conflicting attributes: $conflictingAttributes.""".stripMargin,
               context = j.origin.getQueryContext,
               summary = j.origin.context.summary)
 
@@ -705,7 +705,7 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
               msg = s"""
                        |Failure when resolving conflicting references in ${i.nodeName}:
                        |${plan.toString}
-                       |Conflicting attributes: $conflictingAttributes.""",
+                       |Conflicting attributes: $conflictingAttributes.""".stripMargin,
               context = i.origin.getQueryContext,
               summary = i.origin.context.summary)
 
@@ -716,7 +716,7 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
               msg = s"""
                        |Failure when resolving conflicting references in ${e.nodeName}:
                        |${plan.toString}
-                       |Conflicting attributes: $conflictingAttributes.""",
+                       |Conflicting attributes: $conflictingAttributes.""".stripMargin,
               context = e.origin.getQueryContext,
               summary = e.origin.context.summary)
 
@@ -727,7 +727,7 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
               msg = s"""
                        |Failure when resolving conflicting references in ${j.nodeName}:
                        |${plan.toString}
-                       |Conflicting attributes: $conflictingAttributes.""",
+                       |Conflicting attributes: $conflictingAttributes.""".stripMargin,
               context = j.origin.getQueryContext,
               summary = j.origin.context.summary)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -693,7 +693,7 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
             throw SparkException.internalError(
               msg = s"""
                        |Failure when resolving conflicting references in ${j.nodeName}:
-                       |${plan.toString}
+                       |${planToString(plan)}
                        |Conflicting attributes: $conflictingAttributes.""".stripMargin,
               context = j.origin.getQueryContext,
               summary = j.origin.context.summary)
@@ -704,7 +704,7 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
             throw SparkException.internalError(
               msg = s"""
                        |Failure when resolving conflicting references in ${i.nodeName}:
-                       |${plan.toString}
+                       |${planToString(plan)}
                        |Conflicting attributes: $conflictingAttributes.""".stripMargin,
               context = i.origin.getQueryContext,
               summary = i.origin.context.summary)
@@ -715,7 +715,7 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
             throw SparkException.internalError(
               msg = s"""
                        |Failure when resolving conflicting references in ${e.nodeName}:
-                       |${plan.toString}
+                       |${planToString(plan)}
                        |Conflicting attributes: $conflictingAttributes.""".stripMargin,
               context = e.origin.getQueryContext,
               summary = e.origin.context.summary)
@@ -726,7 +726,7 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
             throw SparkException.internalError(
               msg = s"""
                        |Failure when resolving conflicting references in ${j.nodeName}:
-                       |${plan.toString}
+                       |${planToString(plan)}
                        |Conflicting attributes: $conflictingAttributes.""".stripMargin,
               context = j.origin.getQueryContext,
               summary = j.origin.context.summary)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -688,40 +688,48 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
             })
 
           case j: Join if !j.duplicateResolved =>
-            val conflictingAttributes = j.left.outputSet.intersect(j.right.outputSet)
-            j.failAnalysis(
-              errorClass = "RESOLVED_PLAN_HAVE_CONFLICTING_ATTRS",
-              messageParameters = Map(
-                "nodeName" -> j.nodeName,
-                "plan" -> planToString(plan),
-                "conflictingAttributes" -> conflictingAttributes.map(toSQLExpr(_)).mkString(", ")))
+            val conflictingAttributes =
+              j.left.outputSet.intersect(j.right.outputSet).map(toSQLExpr(_)).mkString(", ")
+            throw SparkException.internalError(
+              msg = s"""
+                       |Failure when resolving conflicting references in ${j.nodeName}:
+                       |${plan.toString}
+                       |Conflicting attributes: $conflictingAttributes.""",
+              context = j.origin.getQueryContext,
+              summary = j.origin.context.summary)
 
           case i: Intersect if !i.duplicateResolved =>
-            val conflictingAttributes = i.left.outputSet.intersect(i.right.outputSet)
-            i.failAnalysis(
-              errorClass = "RESOLVED_PLAN_HAVE_CONFLICTING_ATTRS",
-              messageParameters = Map(
-                "nodeName" -> i.nodeName,
-                "plan" -> planToString(plan),
-                "conflictingAttributes" -> conflictingAttributes.map(toSQLExpr(_)).mkString(", ")))
+            val conflictingAttributes =
+              i.left.outputSet.intersect(i.right.outputSet).map(toSQLExpr(_)).mkString(", ")
+            throw SparkException.internalError(
+              msg = s"""
+                       |Failure when resolving conflicting references in ${i.nodeName}:
+                       |${plan.toString}
+                       |Conflicting attributes: $conflictingAttributes.""",
+              context = i.origin.getQueryContext,
+              summary = i.origin.context.summary)
 
           case e: Except if !e.duplicateResolved =>
-            val conflictingAttributes = e.left.outputSet.intersect(e.right.outputSet)
-            e.failAnalysis(
-              errorClass = "RESOLVED_PLAN_HAVE_CONFLICTING_ATTRS",
-              messageParameters = Map(
-                "nodeName" -> e.nodeName,
-                "plan" -> planToString(plan),
-                "conflictingAttributes" -> conflictingAttributes.map(toSQLExpr(_)).mkString(", ")))
+            val conflictingAttributes =
+              e.left.outputSet.intersect(e.right.outputSet).map(toSQLExpr(_)).mkString(", ")
+            throw SparkException.internalError(
+              msg = s"""
+                       |Failure when resolving conflicting references in ${e.nodeName}:
+                       |${plan.toString}
+                       |Conflicting attributes: $conflictingAttributes.""",
+              context = e.origin.getQueryContext,
+              summary = e.origin.context.summary)
 
           case j: AsOfJoin if !j.duplicateResolved =>
-            val conflictingAttributes = j.left.outputSet.intersect(j.right.outputSet)
-            j.failAnalysis(
-              errorClass = "RESOLVED_PLAN_HAVE_CONFLICTING_ATTRS",
-              messageParameters = Map(
-                "nodeName" -> j.nodeName,
-                "plan" -> planToString(plan),
-                "conflictingAttributes" -> conflictingAttributes.map(toSQLExpr(_)).mkString(",")))
+            val conflictingAttributes =
+              j.left.outputSet.intersect(j.right.outputSet).map(toSQLExpr(_)).mkString(", ")
+            throw SparkException.internalError(
+              msg = s"""
+                       |Failure when resolving conflicting references in ${j.nodeName}:
+                       |${plan.toString}
+                       |Conflicting attributes: $conflictingAttributes.""",
+              context = j.origin.getQueryContext,
+              summary = j.origin.context.summary)
 
           // TODO: although map type is not orderable, technically map type should be able to be
           // used in equality comparison, remove this type check once we support it.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -693,7 +693,7 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
               errorClass = "RESOLVED_PLAN_HAVE_CONFLICTING_ATTRS",
               messageParameters = Map(
                 "nodeName" -> j.nodeName,
-                "plan" -> plan.toString,
+                "plan" -> planToString(plan),
                 "conflictingAttributes" -> conflictingAttributes.map(toSQLExpr(_)).mkString(", ")))
 
           case i: Intersect if !i.duplicateResolved =>
@@ -702,7 +702,7 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
               errorClass = "RESOLVED_PLAN_HAVE_CONFLICTING_ATTRS",
               messageParameters = Map(
                 "nodeName" -> i.nodeName,
-                "plan" -> plan.toString,
+                "plan" -> planToString(plan),
                 "conflictingAttributes" -> conflictingAttributes.map(toSQLExpr(_)).mkString(", ")))
 
           case e: Except if !e.duplicateResolved =>
@@ -711,7 +711,7 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
               errorClass = "RESOLVED_PLAN_HAVE_CONFLICTING_ATTRS",
               messageParameters = Map(
                 "nodeName" -> e.nodeName,
-                "plan" -> plan.toString,
+                "plan" -> planToString(plan),
                 "conflictingAttributes" -> conflictingAttributes.map(toSQLExpr(_)).mkString(", ")))
 
           case j: AsOfJoin if !j.duplicateResolved =>
@@ -720,7 +720,7 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
               errorClass = "RESOLVED_PLAN_HAVE_CONFLICTING_ATTRS",
               messageParameters = Map(
                 "nodeName" -> j.nodeName,
-                "plan" -> plan.toString,
+                "plan" -> planToString(plan),
                 "conflictingAttributes" -> conflictingAttributes.map(toSQLExpr(_)).mkString(",")))
 
           // TODO: although map type is not orderable, technically map type should be able to be

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -674,11 +674,8 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
             }
 
           case p @ Project(exprs, _) if containsMultipleGenerators(exprs) =>
-            throw SparkException.internalError(
-              msg = "Only a single table generating function is allowed in a SELECT clause, " +
-                s"found: ${exprs.map(toSQLExpr(_)).mkString(", ")}.",
-              context = p.origin.getQueryContext,
-              summary = p.origin.context.summary)
+            val generators = exprs.filter(expr => expr.exists(_.isInstanceOf[Generator]))
+            throw QueryCompilationErrors.moreThanOneGeneratorError(generators, "SELECT")
 
           case p @ Project(projectList, _) =>
             projectList.foreach(_.transformDownWithPruning(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
@@ -781,31 +781,53 @@ class AnalysisErrorSuite extends AnalysisTest {
 
   test("error test for self-join") {
     val join = Join(testRelation, testRelation, Cross, None, JoinHint.NONE)
-    val error = intercept[SparkException] {
-      SimpleAnalyzer.checkAnalysis(join)
-    }
-    assert(error.getMessage.contains("Failure when resolving conflicting references in Join"))
-    assert(error.getMessage.contains("Conflicting attributes"))
+    checkError(
+      exception = intercept[SparkException] {
+        SimpleAnalyzer.checkAnalysis(join)
+      },
+      errorClass = "INTERNAL_ERROR",
+      parameters = Map("message" ->
+        """
+          |Failure when resolving conflicting references in Join:
+          |'Join Cross
+          |:- LocalRelation <empty>, [a#0]
+          |+- LocalRelation <empty>, [a#0]
+          |
+          |Conflicting attributes: "a".""".stripMargin))
   }
 
   test("error test for self-intersect") {
     val intersect = Intersect(testRelation, testRelation, true)
-    val error = intercept[SparkException] {
-      SimpleAnalyzer.checkAnalysis(intersect)
-    }
-    assert(error.getMessage.contains(
-      "Failure when resolving conflicting references in Intersect All"))
-    assert(error.getMessage.contains("Conflicting attributes"))
+    checkError(
+      exception = intercept[SparkException] {
+        SimpleAnalyzer.checkAnalysis(intersect)
+      },
+      errorClass = "INTERNAL_ERROR",
+      parameters = Map("message" ->
+        """
+          |Failure when resolving conflicting references in Intersect All:
+          |'Intersect All true
+          |:- LocalRelation <empty>, [a#0]
+          |+- LocalRelation <empty>, [a#0]
+          |
+          |Conflicting attributes: "a".""".stripMargin))
   }
 
   test("error test for self-except") {
     val except = Except(testRelation, testRelation, true)
-    val error = intercept[SparkException] {
-      SimpleAnalyzer.checkAnalysis(except)
-    }
-    assert(error.getMessage.contains(
-      "Failure when resolving conflicting references in Except All"))
-    assert(error.getMessage.contains("Conflicting attributes"))
+    checkError(
+      exception = intercept[SparkException] {
+        SimpleAnalyzer.checkAnalysis(except)
+      },
+      errorClass = "INTERNAL_ERROR",
+      parameters = Map("message" ->
+        """
+          |Failure when resolving conflicting references in Except All:
+          |'Except All true
+          |:- LocalRelation <empty>, [a#0]
+          |+- LocalRelation <empty>, [a#0]
+          |
+          |Conflicting attributes: "a".""".stripMargin))
   }
 
   test("error test for self-asOfJoin") {
@@ -813,11 +835,19 @@ class AnalysisErrorSuite extends AnalysisTest {
       AsOfJoin(testRelation, testRelation, testRelation.output(0), testRelation.output(0),
       None, Inner, tolerance = None, allowExactMatches = true,
       direction = AsOfJoinDirection("backward"))
-    val error = intercept[SparkException] {
-      SimpleAnalyzer.checkAnalysis(asOfJoin)
-    }
-    assert(error.getMessage.contains("Failure when resolving conflicting references in AsOfJoin"))
-    assert(error.getMessage.contains("Conflicting attributes"))
+    checkError(
+      exception = intercept[SparkException] {
+        SimpleAnalyzer.checkAnalysis(asOfJoin)
+      },
+      errorClass = "INTERNAL_ERROR",
+      parameters = Map("message" ->
+        """
+          |Failure when resolving conflicting references in AsOfJoin:
+          |'AsOfJoin (a#0 >= a#0), Inner
+          |:- LocalRelation <empty>, [a#0]
+          |+- LocalRelation <empty>, [a#0]
+          |
+          |Conflicting attributes: "a".""".stripMargin))
   }
 
   test("check grouping expression data types") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
@@ -789,7 +789,7 @@ class AnalysisErrorSuite extends AnalysisTest {
       errorClass = "RESOLVED_PLAN_HAVE_CONFLICTING_ATTRS",
       parameters = Map(
         "nodeName" -> "Join",
-        "plan" -> "'Join Cross\n:- LocalRelation <empty>, [a#0]\n+- LocalRelation <empty>, [a#0]\n",
+        "plan" -> "'Join Cross\n:- LocalRelation <empty>, [a#x]\n+- LocalRelation <empty>, [a#x]\n",
         "conflictingAttributes" -> "\"a\""
       )
     )
@@ -806,7 +806,7 @@ class AnalysisErrorSuite extends AnalysisTest {
       parameters = Map(
         "nodeName" -> "Intersect All",
         "plan" ->
-          "'Intersect All true\n:- LocalRelation <empty>, [a#0]\n+- LocalRelation <empty>, [a#0]\n",
+          "'Intersect All true\n:- LocalRelation <empty>, [a#x]\n+- LocalRelation <empty>, [a#x]\n",
         "conflictingAttributes" -> "\"a\""
       )
     )
@@ -823,7 +823,7 @@ class AnalysisErrorSuite extends AnalysisTest {
       parameters = Map(
         "nodeName" -> "Except All",
         "plan" ->
-          "'Except All true\n:- LocalRelation <empty>, [a#0]\n+- LocalRelation <empty>, [a#0]\n",
+          "'Except All true\n:- LocalRelation <empty>, [a#x]\n+- LocalRelation <empty>, [a#x]\n",
         "conflictingAttributes" -> "\"a\""
       )
     )
@@ -837,8 +837,8 @@ class AnalysisErrorSuite extends AnalysisTest {
     val error = intercept[AnalysisException] {
       SimpleAnalyzer.checkAnalysis(asOfJoin)
     }
-    val expectedPlan = "'AsOfJoin (a#0 >= a#0), " +
-      "Inner\n:- LocalRelation <empty>, [a#0]\n+- LocalRelation <empty>, [a#0]\n"
+    val expectedPlan = "'AsOfJoin (a#x >= a#x), " +
+      "Inner\n:- LocalRelation <empty>, [a#x]\n+- LocalRelation <empty>, [a#x]\n"
     checkError(
       exception = error,
       errorClass = "RESOLVED_PLAN_HAVE_CONFLICTING_ATTRS",

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
@@ -790,8 +790,8 @@ class AnalysisErrorSuite extends AnalysisTest {
         """
           |Failure when resolving conflicting references in Join:
           |'Join Cross
-          |:- LocalRelation <empty>, [a#0]
-          |+- LocalRelation <empty>, [a#0]
+          |:- LocalRelation <empty>, [a#x]
+          |+- LocalRelation <empty>, [a#x]
           |
           |Conflicting attributes: "a".""".stripMargin))
   }
@@ -807,8 +807,8 @@ class AnalysisErrorSuite extends AnalysisTest {
         """
           |Failure when resolving conflicting references in Intersect All:
           |'Intersect All true
-          |:- LocalRelation <empty>, [a#0]
-          |+- LocalRelation <empty>, [a#0]
+          |:- LocalRelation <empty>, [a#x]
+          |+- LocalRelation <empty>, [a#x]
           |
           |Conflicting attributes: "a".""".stripMargin))
   }
@@ -824,8 +824,8 @@ class AnalysisErrorSuite extends AnalysisTest {
         """
           |Failure when resolving conflicting references in Except All:
           |'Except All true
-          |:- LocalRelation <empty>, [a#0]
-          |+- LocalRelation <empty>, [a#0]
+          |:- LocalRelation <empty>, [a#x]
+          |+- LocalRelation <empty>, [a#x]
           |
           |Conflicting attributes: "a".""".stripMargin))
   }
@@ -843,9 +843,9 @@ class AnalysisErrorSuite extends AnalysisTest {
       parameters = Map("message" ->
         """
           |Failure when resolving conflicting references in AsOfJoin:
-          |'AsOfJoin (a#0 >= a#0), Inner
-          |:- LocalRelation <empty>, [a#0]
-          |+- LocalRelation <empty>, [a#0]
+          |'AsOfJoin (a#x >= a#x), Inner
+          |:- LocalRelation <empty>, [a#x]
+          |+- LocalRelation <empty>, [a#x]
           |
           |Conflicting attributes: "a".""".stripMargin))
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -364,6 +364,20 @@ class DataFrameSuite extends QueryTest
       Row("a", Seq("a"), 1) :: Nil)
   }
 
+  test("more than one generator in SELECT clause") {
+    val df = Seq((Array("a"), 1)).toDF("a", "b")
+
+    checkError(
+      exception = intercept[AnalysisException] {
+        df.select(explode($"a").as("a"), explode($"a").as("b"))
+      },
+      errorClass = "UNSUPPORTED_GENERATOR.MULTI_GENERATOR",
+      parameters = Map(
+        "clause" -> "SELECT",
+        "num" -> "2",
+        "generators" -> "\"explode(a)\", \"explode(a)\""))
+  }
+
   test("sort after generate with join=true") {
     val df = Seq((Array("a"), 1)).toDF("a", "b")
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to assign names to the error class _LEGACY_ERROR_TEMP_[2433-2437].


### Why are the changes needed?
Improve the error framework.


### Does this PR introduce _any_ user-facing change?
'No'.


### How was this patch tested?
Exists test cases updated.
