### PR TITLE
Use pandas ExtensionDtype for integral Series with nulls 

### DIFF
--- a/python/pyspark/sql/pandas/types.py
+++ b/python/pyspark/sql/pandas/types.py
@@ -495,6 +495,7 @@ def _create_converter_to_pandas(
     error_on_duplicated_field_names: bool = True,
     timestamp_utc_localized: bool = True,
     ndarray_as_list: bool = False,
+    null_int_float: bool = True,
 ) -> Callable[["pd.Series"], "pd.Series"]:
     """
     Create a converter of pandas Series that is created from Spark's Python objects,
@@ -523,6 +524,8 @@ def _create_converter_to_pandas(
         whereas the ones from `df.collect()` are localized to the local timezone.
     ndarray_as_list : bool, optional
         Whether `np.ndarray` is converted to a list or not (default ``False``).
+    null_int_float : bool, optional
+        Whether the int Series with nulls will be converted to float Series or not.
 
     Returns
     -------
@@ -544,7 +547,7 @@ def _create_converter_to_pandas(
 
             def correct_dtype(pser: pd.Series) -> pd.Series:
                 if pser.isnull().any():
-                    return pser.astype(np.float64, copy=False)
+                    return pser.astype(np.float64, copy=False) if null_int_float else pser
                 else:
                     return pser.astype(pandas_type, copy=False)
 

--- a/python/pyspark/sql/tests/pandas/test_pandas_udf_scalar.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_udf_scalar.py
@@ -27,7 +27,7 @@ from typing import cast
 
 from pyspark import TaskContext
 from pyspark.rdd import PythonEvalType
-from pyspark.sql import Column
+from pyspark.sql import Column, Row
 from pyspark.sql.functions import array, col, expr, lit, sum, struct, udf, pandas_udf, PandasUDFType
 from pyspark.sql.pandas.utils import pyarrow_version_less_than_minimum
 from pyspark.sql.types import (
@@ -348,6 +348,13 @@ class ScalarPandasUDFTestsMixin:
             int_f = pandas_udf(lambda x: x, IntegerType(), udf_type)
             res = df.select(int_f(col("int")))
             self.assertEqual(df.collect(), res.collect())
+            str_f = pandas_udf(lambda x: x.astype(str), StringType(), udf_type)
+            res = df.select(str_f(col("int")))
+            expected = (
+                "[Row(<lambda>(int)='<NA>'), Row(<lambda>(int)='2'), "
+                "Row(<lambda>(int)='3'), Row(<lambda>(int)='4')]"
+            )
+            self.assertEqual(expected, res.collect())
 
     def test_vectorized_udf_null_long(self):
         data = [(None,), (2,), (3,), (4,)]

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -584,13 +584,18 @@ def read_udfs(pickleSer, infile, eval_type):
                 or eval_type == PythonEvalType.SQL_SCALAR_PANDAS_ITER_UDF
                 or eval_type == PythonEvalType.SQL_MAP_PANDAS_ITER_UDF
             )
-            # Arrow-optimized Python UDF takes a struct type argument as a Row
-            struct_in_pandas = (
-                "row" if eval_type == PythonEvalType.SQL_ARROW_BATCHED_UDF else "dict"
-            )
-            ndarray_as_list = eval_type == PythonEvalType.SQL_ARROW_BATCHED_UDF
-            # Arrow-optimized Python UDF uses explicit Arrow cast for type coercion
-            arrow_cast = eval_type == PythonEvalType.SQL_ARROW_BATCHED_UDF
+
+            if eval_type == PythonEvalType.SQL_ARROW_BATCHED_UDF:
+                struct_in_pandas = "row"
+                ndarray_as_list = True
+                arrow_cast = True
+                null_int_float = False
+            else:
+                struct_in_pandas = "dict"
+                ndarray_as_list = False
+                arrow_cast = False
+                null_int_float = True
+
             ser = ArrowStreamPandasUDFSerializer(
                 timezone,
                 safecheck,
@@ -599,6 +604,7 @@ def read_udfs(pickleSer, infile, eval_type):
                 struct_in_pandas,
                 ndarray_as_list,
                 arrow_cast,
+                null_int_float,
             )
     else:
         ser = BatchedSerializer(CPickleSerializer(), 100)


### PR DESCRIPTION
### What changes were proposed in this pull request?
In Arrow Python UDF, use pandas ExtensionDtype for integral Series with Nulls after Arrow to Pandas conversion.


### Why are the changes needed?
More reasonable results after Arrow to Pandas conversion.


### Does this PR introduce _any_ user-facing change?
No behavior changes, only the `na` in the string representation becomes `<NA>`.

```py
df = spark.createDataFrame([1, None], schema='int')

# FROM
>>> df.select(udf(lambda x: str(x), 'string', useArrow=True)('value')).show()
+---------------+                                                               
|<lambda>(value)|
+---------------+
|              1|
|            nan|
+---------------+

# TO
>>> df.select(udf(lambda x: str(x), 'string', useArrow=True)('value')).show()
+---------------+
|<lambda>(value)|
+---------------+
|              1|
|           <NA>|
+---------------+
```

### How was this patch tested?
Unit tests.
