### PR TITLE
[SPARK-43991][CORE] Use the value of spark.eventLog.compression.codec set by user when write compact file

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/EventLogFileCompactor.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/EventLogFileCompactor.scala
@@ -222,19 +222,15 @@ private class CompactedEventLogFileWriter(
     hadoopConf: Configuration)
   extends SingleEventLogFileWriter(appId, appAttemptId, logBaseDir, sparkConf, hadoopConf) {
 
-  override val shouldCompress = EventLogFileWriter.codecName(originalFilePath) match {
-    case Some(_) => true
-    case _ => false
-  }
+  override val shouldCompress = EventLogFileWriter.codecName(originalFilePath).isDefined
 
-  override val compressionCodec = {
-    val originalCodecName = EventLogFileWriter.codecName(originalFilePath).getOrElse("")
+  override val compressionCodec =
     if (shouldCompress) {
+      val originalCodecName = EventLogFileWriter.codecName(originalFilePath).getOrElse("")
       Some(CompressionCodec.createCodec(sparkConf, originalCodecName))
     } else {
       None
     }
-  }
 
   override def logPath: String = originalFilePath.toUri.toString + EventLogFileWriter.COMPACTED
 }

--- a/core/src/main/scala/org/apache/spark/deploy/history/EventLogFileCompactor.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/EventLogFileCompactor.scala
@@ -222,12 +222,13 @@ private class CompactedEventLogFileWriter(
     hadoopConf: Configuration)
   extends SingleEventLogFileWriter(appId, appAttemptId, logBaseDir, sparkConf, hadoopConf) {
 
-  override val shouldCompress = EventLogFileWriter.codecName(originalFilePath).isDefined
+  private val originalCodecName = EventLogFileWriter.codecName(originalFilePath)
+
+  override val shouldCompress = originalCodecName.isDefined
 
   override val compressionCodec =
     if (shouldCompress) {
-      val originalCodecName = EventLogFileWriter.codecName(originalFilePath).getOrElse("")
-      Some(CompressionCodec.createCodec(sparkConf, originalCodecName))
+      Some(CompressionCodec.createCodec(sparkConf, originalCodecName.get))
     } else {
       None
     }

--- a/core/src/main/scala/org/apache/spark/deploy/history/EventLogFileWriters.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/EventLogFileWriters.scala
@@ -65,7 +65,7 @@ abstract class EventLogFileWriter(
       None
     }
 
-  private[history] val compressionCodecName = compressionCodec.map { c =>
+  private[history] lazy val compressionCodecName = compressionCodec.map { c =>
     CompressionCodec.getShortName(c.getClass.getName)
   }
 
@@ -212,7 +212,7 @@ class SingleEventLogFileWriter(
     hadoopConf: Configuration)
   extends EventLogFileWriter(appId, appAttemptId, logBaseDir, sparkConf, hadoopConf) {
 
-  override val logPath: String = SingleEventLogFileWriter.getLogPath(logBaseDir, appId,
+  override def logPath: String = SingleEventLogFileWriter.getLogPath(logBaseDir, appId,
     appAttemptId, compressionCodecName)
 
   protected def inProgressPath = logPath + EventLogFileWriter.IN_PROGRESS

--- a/core/src/test/scala/org/apache/spark/deploy/history/EventLogFileCompactorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/EventLogFileCompactorSuite.scala
@@ -284,7 +284,7 @@ class EventLogFileCompactorSuite extends SparkFunSuite {
     }
   }
 
-  test("Use the value of spark.eventLog.compression.codec set by user") {
+  test("SPARK-43991: should follow the event log compress configuration set by user") {
     withTempDir { dir =>
       val fs = new Path(dir.getAbsolutePath).getFileSystem(hadoopConf)
 
@@ -296,8 +296,10 @@ class EventLogFileCompactorSuite extends SparkFunSuite {
         (1 to 10).map(_ => testEvent): _*)
       val fileToCompact = fileStatuses.head.getPath
 
+      val sparkConf = new SparkConf()
+      sparkConf.set(EVENT_LOG_COMPRESS, false)
       val writer = new CompactedEventLogFileWriter(fileToCompact, "dummy", None,
-        fileToCompact.getParent.toUri, conf, hadoopConf)
+        fileToCompact.getParent.toUri, sparkConf, hadoopConf)
       assert(writer.compressionCodecName === Some("lz4"))
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Use the compression codec set by the user when write compact log.

### Why are the changes needed?
Currently, if enable rolling log in SHS, only `originalFilePath` is used to determine the path of compact file.

    override val logPath: String = originalFilePath.toUri.toString + EventLogFileWriter.COMPACTED


If the user set `spark.eventLog.compression.codec` in sparkConf and it is different from the default value of spark conf, when the log compact logic is triggered, the old event log file will be compacted and use the default value of spark conf.

    protected val compressionCodec =
      if (shouldCompress) {
      Some(CompressionCodec.createCodec(sparkConf, sparkConf.get(EVENT_LOG_COMPRESSION_CODEC)))
    } else {
      None
    }

    private[history] val compressionCodecName = compressionCodec.map { c =>
      CompressionCodec.getShortName(c.getClass.getName)
    }


However, The compression codec used by `EventLogFileReader` to read log is split from the log path, this will lead to EventLogFileReader can not read the compacted log file normally.

    def codecName(log: Path): Option[String] = {
      // Compression codec is encoded as an extension, e.g. app_123.lzf
      // Since we sanitize the app ID to not include periods, it is safe to split on it
      val logName = log.getName.stripSuffix(COMPACTED).stripSuffix(IN_PROGRESS)
      logName.split("\\.").tail.lastOption
    }


So we should override the `shouldCompress` and `compressionCodec` variable in class `CompactedEventLogFileWriter`, use the compression codec set by the user.
### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?
Add unit test.
