### PR TITLE
[MINOR][PS][DOCS] Add `DataFrame.{from_dict, to_orc}` to API references

### DIFF
--- a/python/docs/source/reference/pyspark.pandas/frame.rst
+++ b/python/docs/source/reference/pyspark.pandas/frame.rst
@@ -37,6 +37,7 @@ Attributes and underlying data
    :toctree: api/
 
    DataFrame.index
+   DataFrame.info
    DataFrame.columns
    DataFrame.empty
 
@@ -272,13 +273,14 @@ Serialization / IO / Conversion
 .. autosummary::
    :toctree: api/
 
+   DataFrame.from_dict
    DataFrame.from_records
-   DataFrame.info
    DataFrame.to_table
    DataFrame.to_delta
    DataFrame.to_parquet
    DataFrame.to_spark_io
    DataFrame.to_csv
+   DataFrame.to_orc
    DataFrame.to_pandas
    DataFrame.to_html
    DataFrame.to_numpy


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add `DataFrame.{from_dict, to_orc}` to API references
Move `DataFrame.info` to attributes according to https://pandas.pydata.org/docs/reference/frame.html#attributes-and-underlying-data


### Why are the changes needed?
add missing doc


### Does this PR introduce _any_ user-facing change?
yes, doc updated


### How was this patch tested?
CI and manually check
