### PR TITLE
[SPARK-43994][BUILD] Upgrade zstd-jni to 1.5.5-4

### DIFF
--- a/core/benchmarks/ZStandardBenchmark-jdk11-results.txt
+++ b/core/benchmarks/ZStandardBenchmark-jdk11-results.txt
@@ -2,26 +2,26 @@
 Benchmark ZStandardCompressionCodec
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.19+7 on Linux 5.15.0-1037-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.19+7 on Linux 5.15.0-1038-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Benchmark ZStandardCompressionCodec:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------
-Compression 10000 times at level 1 without buffer pool            803            814          14          0.0       80302.2       1.0X
-Compression 10000 times at level 2 without buffer pool            677            688          17          0.0       67706.0       1.2X
-Compression 10000 times at level 3 without buffer pool            929            943          23          0.0       92943.2       0.9X
-Compression 10000 times at level 1 with buffer pool               360            371           8          0.0       36037.2       2.2X
-Compression 10000 times at level 2 with buffer pool               451            463          11          0.0       45141.1       1.8X
-Compression 10000 times at level 3 with buffer pool               684            697          11          0.0       68384.5       1.2X
+Compression 10000 times at level 1 without buffer pool            531            598          80          0.0       53076.5       1.0X
+Compression 10000 times at level 2 without buffer pool            594            594           0          0.0       59383.7       0.9X
+Compression 10000 times at level 3 without buffer pool            792            806          18          0.0       79199.0       0.7X
+Compression 10000 times at level 1 with buffer pool               333            334           1          0.0       33294.3       1.6X
+Compression 10000 times at level 2 with buffer pool               397            399           2          0.0       39743.5       1.3X
+Compression 10000 times at level 3 with buffer pool               588            588           0          0.0       58806.3       0.9X
 
-OpenJDK 64-Bit Server VM 11.0.19+7 on Linux 5.15.0-1037-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.19+7 on Linux 5.15.0-1038-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Benchmark ZStandardCompressionCodec:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------
-Decompression 10000 times from level 1 without buffer pool            769            779          15          0.0       76920.7       1.0X
-Decompression 10000 times from level 2 without buffer pool            758            775          19          0.0       75783.4       1.0X
-Decompression 10000 times from level 3 without buffer pool            762            776          20          0.0       76180.9       1.0X
-Decompression 10000 times from level 1 with buffer pool               533            548          11          0.0       53271.9       1.4X
-Decompression 10000 times from level 2 with buffer pool               521            523           2          0.0       52073.6       1.5X
-Decompression 10000 times from level 3 with buffer pool               515            525           8          0.0       51469.0       1.5X
+Decompression 10000 times from level 1 without buffer pool            721            722           2          0.0       72112.3       1.0X
+Decompression 10000 times from level 2 without buffer pool            718            719           1          0.0       71807.7       1.0X
+Decompression 10000 times from level 3 without buffer pool            721            722           0          0.0       72103.6       1.0X
+Decompression 10000 times from level 1 with buffer pool               529            530           2          0.0       52856.1       1.4X
+Decompression 10000 times from level 2 with buffer pool               529            529           0          0.0       52850.4       1.4X
+Decompression 10000 times from level 3 with buffer pool               529            529           0          0.0       52878.5       1.4X
 
 

--- a/core/benchmarks/ZStandardBenchmark-jdk17-results.txt
+++ b/core/benchmarks/ZStandardBenchmark-jdk17-results.txt
@@ -2,26 +2,26 @@
 Benchmark ZStandardCompressionCodec
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.7+7 on Linux 5.15.0-1037-azure
+OpenJDK 64-Bit Server VM 17.0.7+7 on Linux 5.15.0-1039-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Benchmark ZStandardCompressionCodec:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------
-Compression 10000 times at level 1 without buffer pool           2289           2293           5          0.0      228903.7       1.0X
-Compression 10000 times at level 2 without buffer pool           2184           2260         107          0.0      218405.7       1.0X
-Compression 10000 times at level 3 without buffer pool           2393           2394           2          0.0      239296.0       1.0X
-Compression 10000 times at level 1 with buffer pool              1965           1966           2          0.0      196462.2       1.2X
-Compression 10000 times at level 2 with buffer pool              2031           2032           3          0.0      203063.0       1.1X
-Compression 10000 times at level 3 with buffer pool              2222           2224           2          0.0      222247.8       1.0X
+Compression 10000 times at level 1 without buffer pool           2281           2288          10          0.0      228093.0       1.0X
+Compression 10000 times at level 2 without buffer pool           2213           2282          98          0.0      221314.5       1.0X
+Compression 10000 times at level 3 without buffer pool           2377           2379           3          0.0      237678.5       1.0X
+Compression 10000 times at level 1 with buffer pool              2053           2058           6          0.0      205331.4       1.1X
+Compression 10000 times at level 2 with buffer pool              2115           2123          11          0.0      211512.9       1.1X
+Compression 10000 times at level 3 with buffer pool              2288           2291           3          0.0      228832.4       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.7+7 on Linux 5.15.0-1037-azure
+OpenJDK 64-Bit Server VM 17.0.7+7 on Linux 5.15.0-1039-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Benchmark ZStandardCompressionCodec:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------
-Decompression 10000 times from level 1 without buffer pool           2120           2121           1          0.0      211953.8       1.0X
-Decompression 10000 times from level 2 without buffer pool           2118           2123           7          0.0      211828.0       1.0X
-Decompression 10000 times from level 3 without buffer pool           2126           2127           1          0.0      212600.3       1.0X
-Decompression 10000 times from level 1 with buffer pool              1955           1956           2          0.0      195464.7       1.1X
-Decompression 10000 times from level 2 with buffer pool              1956           1956           0          0.0      195566.8       1.1X
-Decompression 10000 times from level 3 with buffer pool              1958           1960           2          0.0      195813.0       1.1X
+Decompression 10000 times from level 1 without buffer pool           2101           2105           6          0.0      210130.8       1.0X
+Decompression 10000 times from level 2 without buffer pool           2104           2105           2          0.0      210381.8       1.0X
+Decompression 10000 times from level 3 without buffer pool           2105           2106           2          0.0      210502.2       1.0X
+Decompression 10000 times from level 1 with buffer pool              1945           1946           1          0.0      194513.0       1.1X
+Decompression 10000 times from level 2 with buffer pool              1947           1947           0          0.0      194670.9       1.1X
+Decompression 10000 times from level 3 with buffer pool              1947           1947           0          0.0      194663.1       1.1X
 
 

--- a/core/benchmarks/ZStandardBenchmark-results.txt
+++ b/core/benchmarks/ZStandardBenchmark-results.txt
@@ -2,26 +2,26 @@
 Benchmark ZStandardCompressionCodec
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1037-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 1.8.0_372-b07 on Linux 5.15.0-1038-azure
+Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 Benchmark ZStandardCompressionCodec:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------
-Compression 10000 times at level 1 without buffer pool            391            524         152          0.0       39064.0       1.0X
-Compression 10000 times at level 2 without buffer pool            448            451           2          0.0       44798.2       0.9X
-Compression 10000 times at level 3 without buffer pool            637            644           5          0.0       63736.0       0.6X
-Compression 10000 times at level 1 with buffer pool               194            197           3          0.1       19357.1       2.0X
-Compression 10000 times at level 2 with buffer pool               245            251           4          0.0       24535.1       1.6X
-Compression 10000 times at level 3 with buffer pool               414            426           7          0.0       41389.3       0.9X
+Compression 10000 times at level 1 without buffer pool            462            596         154          0.0       46182.3       1.0X
+Compression 10000 times at level 2 without buffer pool            532            544          11          0.0       53213.2       0.9X
+Compression 10000 times at level 3 without buffer pool            777            785          10          0.0       77733.9       0.6X
+Compression 10000 times at level 1 with buffer pool               252            256           5          0.0       25152.3       1.8X
+Compression 10000 times at level 2 with buffer pool               331            343           7          0.0       33129.1       1.4X
+Compression 10000 times at level 3 with buffer pool               563            579          13          0.0       56340.4       0.8X
 
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1037-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 1.8.0_372-b07 on Linux 5.15.0-1038-azure
+Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
 Benchmark ZStandardCompressionCodec:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------
-Decompression 10000 times from level 1 without buffer pool            684            685           2          0.0       68350.8       1.0X
-Decompression 10000 times from level 2 without buffer pool            682            683           2          0.0       68170.9       1.0X
-Decompression 10000 times from level 3 without buffer pool            680            683           2          0.0       68002.2       1.0X
-Decompression 10000 times from level 1 with buffer pool               493            495           1          0.0       49339.8       1.4X
-Decompression 10000 times from level 2 with buffer pool               493            495           1          0.0       49283.2       1.4X
-Decompression 10000 times from level 3 with buffer pool               494            495           1          0.0       49350.3       1.4X
+Decompression 10000 times from level 1 without buffer pool            722            744          22          0.0       72246.4       1.0X
+Decompression 10000 times from level 2 without buffer pool            726            745          19          0.0       72557.0       1.0X
+Decompression 10000 times from level 3 without buffer pool            743            751          10          0.0       74300.3       1.0X
+Decompression 10000 times from level 1 with buffer pool               521            530           6          0.0       52097.1       1.4X
+Decompression 10000 times from level 2 with buffer pool               521            529           6          0.0       52119.5       1.4X
+Decompression 10000 times from level 3 with buffer pool               532            540           7          0.0       53232.3       1.4X
 
 

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -252,4 +252,4 @@ xz/1.9//xz-1.9.jar
 zjsonpatch/0.3.0//zjsonpatch-0.3.0.jar
 zookeeper-jute/3.6.3//zookeeper-jute-3.6.3.jar
 zookeeper/3.6.3//zookeeper-3.6.3.jar
-zstd-jni/1.5.5-3//zstd-jni-1.5.5-3.jar
+zstd-jni/1.5.5-4//zstd-jni-1.5.5-4.jar

--- a/pom.xml
+++ b/pom.xml
@@ -781,7 +781,7 @@
       <dependency>
         <groupId>com.github.luben</groupId>
         <artifactId>zstd-jni</artifactId>
-        <version>1.5.5-3</version>
+        <version>1.5.5-4</version>
       </dependency>
       <dependency>
         <groupId>com.clearspring.analytics</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims upgrade `zstd-jni` from 1.5.5-3 to 1.5.5-4.

### Why are the changes needed?
New version includes a bug fixed
[Fix bug in ZstdBufferDecompressingStream when array backing ByteBuffer](https://github.com/luben/zstd-jni/commit/355b8511a2967d097a619047a579930cac2ccd9d)
    
Other changes as follows:
- https://github.com/luben/zstd-jni/compare/v1.5.5-3...v1.5.5-4

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Pass GA.