### PR TITLE
[SPARK-44002][CONNECT] Fix the artifact statuses handler

### DIFF
--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientE2ETestSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientE2ETestSuite.scala
@@ -945,9 +945,11 @@ class ClientE2ETestSuite extends RemoteSparkSession with SQLHelper with PrivateM
       val suffix = "abcdef"
       val str = scala.util.Random.alphanumeric.take(1024 * 1024).mkString + suffix
       val data = Seq.tabulate(count)(i => (i, str))
-      val df = spark.createDataFrame(data)
-      assert(df.count() === count)
-      assert(!df.filter(df("_2").endsWith(suffix)).isEmpty)
+      for (_ <- 0 until 2) {
+        val df = spark.createDataFrame(data)
+        assert(df.count() === count)
+        assert(!df.filter(df("_2").endsWith(suffix)).isEmpty)
+      }
     }
   }
 

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectArtifactStatusesHandler.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectArtifactStatusesHandler.scala
@@ -33,7 +33,7 @@ class SparkConnectArtifactStatusesHandler(
       .getOrCreateIsolatedSession(userId, sessionId)
       .session
     val blockManager = session.sparkContext.env.blockManager
-    blockManager.get(CacheId(userId, sessionId, hash)).isDefined
+    blockManager.getStatus(CacheId(userId, sessionId, hash)).isDefined
   }
 
   def handle(request: proto.ArtifactStatusesRequest): Unit = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to invoke `getStatus()` instead of `get()` of `BlockManager` in `SparkConnectArtifactStatusesHandler` because `get()` acquires a lock on the given block. Apparently, the next request of artifact status freezes w/o the fix. Comparing to `get()` the `getStatus()` method doesn't lock the given block.

### Why are the changes needed?
To fix a bug.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By running the modified test suite:
```
$ build/sbt "test:testOnly *.ClientE2ETestSuite"
```