### PR TITLE
[SPARK-43712][SPARK-43713][CONNECT][PS] Enable parity test: `test_line_plot`, `test_pie_plot`.

### DIFF
--- a/python/pyspark/pandas/tests/connect/plot/test_parity_series_plot_matplotlib.py
+++ b/python/pyspark/pandas/tests/connect/plot/test_parity_series_plot_matplotlib.py
@@ -36,14 +36,6 @@ class SeriesPlotMatplotlibParityTests(
     def test_kde_plot(self):
         super().test_kde_plot()
 
-    @unittest.skip("TODO(SPARK-43712): Enable SeriesPlotMatplotlibParityTests.test_line_plot.")
-    def test_line_plot(self):
-        super().test_line_plot()
-
-    @unittest.skip("TODO(SPARK-43713): Enable SeriesPlotMatplotlibParityTests.test_pie_plot.")
-    def test_pie_plot(self):
-        super().test_pie_plot()
-
     @unittest.skip("TODO(SPARK-43711): Fix Transformer.transform to work with Spark Connect.")
     def test_single_value_hist(self):
         super().test_single_value_hist()


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to enable parity test for pandas API on Spark with Spark connect.


### Why are the changes needed?

To test pandas API on Spark with Spark Connect properly.


### Does this PR introduce _any_ user-facing change?

No, test-only.


### How was this patch tested?

This uncommented tests should be passed CI.
