### PR TITLE
[SPARK-43613][PS][CONNECT] Enable `pyspark.pandas.spark.functions.covar` in Spark Connect

### DIFF
--- a/python/pyspark/pandas/spark/functions.py
+++ b/python/pyspark/pandas/spark/functions.py
@@ -64,7 +64,13 @@ def covar(col1: Column, col2: Column, ddof: int) -> Column:
     if is_remote():
         from pyspark.sql.connect.functions import _invoke_function_over_columns, lit
 
-        return _invoke_function_over_columns("pandas_covar", col1, col2, lit(ddof))
+        return _invoke_function_over_columns(  # type: ignore[return-value]
+            "pandas_covar",
+            col1,  # type: ignore[arg-type]
+            col2,  # type: ignore[arg-type]
+            lit(ddof),
+        )
+
     else:
         sc = SparkContext._active_spark_context
         return Column(sc._jvm.PythonSQLUtils.pandasCovar(col1._jc, col2._jc, ddof))

--- a/python/pyspark/pandas/tests/connect/computation/test_parity_cov.py
+++ b/python/pyspark/pandas/tests/connect/computation/test_parity_cov.py
@@ -27,12 +27,6 @@ class FrameParityCovTests(FrameCovMixin, PandasOnSparkTestUtils, ReusedConnectTe
     def psdf(self):
         return ps.from_pandas(self.pdf)
 
-    @unittest.skip(
-        "TODO(SPARK-43613): Enable pyspark.pandas.spark.functions.covar in Spark Connect."
-    )
-    def test_cov(self):
-        super().test_cov()
-
 
 if __name__ == "__main__":
     from pyspark.pandas.tests.connect.computation.test_parity_cov import *  # noqa: F401

--- a/python/pyspark/pandas/tests/connect/series/test_parity_stat.py
+++ b/python/pyspark/pandas/tests/connect/series/test_parity_stat.py
@@ -23,12 +23,6 @@ from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 class SeriesParityStatTests(SeriesStatMixin, PandasOnSparkTestUtils, ReusedConnectTestCase):
     @unittest.skip(
-        "TODO(SPARK-43613): Enable pyspark.pandas.spark.functions.covar in Spark Connect."
-    )
-    def test_cov(self):
-        super().test_cov()
-
-    @unittest.skip(
         "TODO(SPARK-43616): Enable pyspark.pandas.spark.functions.mode in Spark Connect."
     )
     def test_mode(self):

--- a/python/pyspark/pandas/tests/connect/test_parity_ops_on_diff_frames_slow.py
+++ b/python/pyspark/pandas/tests/connect/test_parity_ops_on_diff_frames_slow.py
@@ -25,12 +25,6 @@ class OpsOnDiffFramesEnabledSlowParityTests(
     OpsOnDiffFramesEnabledSlowTestsMixin, PandasOnSparkTestUtils, ReusedConnectTestCase
 ):
     @unittest.skip(
-        "TODO(SPARK-43613): Enable pyspark.pandas.spark.functions.covar in Spark Connect."
-    )
-    def test_cov(self):
-        super().test_cov()
-
-    @unittest.skip(
         "TODO(SPARK-43611): Fix unexpected `AnalysisException` from Spark Connect client."
     )
     def test_diff(self):


### PR DESCRIPTION
### What changes were proposed in this pull request?
Enable `pyspark.pandas.spark.functions.covar` in Spark Connect


### Why are the changes needed?
to support pandas dedicated expression


### Does this PR introduce _any_ user-facing change?
yes


### How was this patch tested?
enabled tests