### PR TITLE
[SPARK-44007][SQL] Unresolved hint cause query failure

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -273,6 +273,8 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
     Batch("Hints", fixedPoint,
       ResolveHints.ResolveJoinStrategyHints,
       ResolveHints.ResolveCoalesceHints),
+    Batch("Remove Unresolved Hints", Once,
+      new ResolveHints.RemoveAllHints),
     Batch("Simple Sanity Check", Once,
       LookupFunctions),
     Batch("Keep Legacy Outputs", Once,
@@ -330,8 +332,6 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
     Batch("Post-Hoc Resolution", Once,
       Seq(ResolveCommandsWithIfExists) ++
       postHocResolutionRules: _*),
-    Batch("Remove Unresolved Hints", Once,
-      new ResolveHints.RemoveAllHints),
     Batch("Nondeterministic", Once,
       PullOutNondeterministic),
     Batch("UDF", Once,
@@ -974,7 +974,6 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
 
     def apply(plan: LogicalPlan): LogicalPlan = plan.resolveOperatorsDownWithPruning(
       AlwaysProcess.fn, ruleId) {
-      case hint: UnresolvedHint => hint
       // Add metadata output to all node types
       case node if node.children.nonEmpty && node.resolved && hasMetadataCol(node) =>
         val inputAttrs = AttributeSet(node.children.flatMap(_.output))


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
After the Resolve Hints Rules are completed, immediately remove unknown Hints to avoid query errors caused by Unresolved Hints.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
```
// create t0,t1
CREATE TABLE t0(c0 bigint) USING PARQUET 
CREATE TABLE t1(c1 bigint) USING PARQUET

// query with unknown hint
 with w0 as (select * from t0),
 w1 as (select c0 from w0 group by c0),
 w2 as (select  /*+ userHint(t1) */  c1 from t1 ),
 w3 as (
 select w2.c1, w0.c0, w1.c0
 from w2 
 join w0 on w2.c1 = w0.c0
 join w1 on w2.c1 = w1.c0
 )
 select * from w3;

23/06/08 17:25:23 WARN HintErrorLogger: Unrecognized hint: userHint(t1)
[UNRESOLVED_COLUMN.WITH_SUGGESTION] A column or function parameter with name `w2`.`c1` cannot be resolved. Did you mean one of the following? [`w2`.`c1`, `w0`.`c0`].; line 8 pos 11;
'WithCTE
:- CTERelationDef 4, false
:  +- SubqueryAlias w0
:     +- Project [c0#0L]
:        +- SubqueryAlias spark_catalog.default.t0
:           +- Relation spark_catalog.default.t0[c0#0L] parquet
:- CTERelationDef 5, false
:  +- SubqueryAlias w1
:     +- Aggregate [c0#0L], [c0#0L]
:        +- SubqueryAlias w0
:           +- CTERelationRef 4, true, [c0#0L]
:- CTERelationDef 6, false
:  +- SubqueryAlias w2
:     +- Project [c1#1L]
:        +- SubqueryAlias spark_catalog.default.t1
:           +- Relation spark_catalog.default.t1[c1#1L] parquet
:- 'CTERelationDef 7, false
:  +- 'SubqueryAlias w3
:     +- 'Project ['w2.c1, 'w0.c0, 'w1.c0]
:        +- 'Join Inner, ('w2.c1 = 'w1.c0)
:           :- Join Inner, (c1#1L = c0#0L)
:           :  :- SubqueryAlias w2
:           :  :  +- CTERelationRef 6, true, [c1#1L]
:           :  +- SubqueryAlias w0
:           :     +- CTERelationRef 4, true, [c0#0L]
:           +- SubqueryAlias w1
:              +- CTERelationRef 5, true, [c0#0L]
+- 'Project [*]
   +- 'SubqueryAlias w3
      +- 'CTERelationRef 7, false


// query without unknown hint
 with w0 as (select * from t0),
 w1 as (select * from w0 group by c0),
 w2 as (select c1 from t1 ),
 w3 as (
 select w2.c1, w0.c0, w1.c0
 from w2 
 join w0 on w2.c1 = w0.c0
 join w1 on w2.c1 = w1.c0
 )
 select * from w3;  
Time taken: 12.666 seconds
```

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
NO

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
add test