### PR TITLE
[MINOR][SQL][TESTS] Move ResolveDefaultColumnsSuite to 'o.a.s.sql'

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/ResolveDefaultColumnsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ResolveDefaultColumnsSuite.scala
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql.catalyst.analysis
+package org.apache.spark.sql
 
-import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
 import org.apache.spark.sql.test.SharedSparkSession
 
 class ResolveDefaultColumnsSuite extends QueryTest with SharedSparkSession {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR moves `ResolveDefaultColumnsSuite` from `catalyst/analysis` package to `sql` package.

### Why are the changes needed?

To fix the code layout.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?


Pass the CI