### PR TITLE
[SPARK-43380][SQL][FOLLOWUP] Fix conversion of Avro logical timestamp type to Long

### DIFF
--- a/connector/avro/src/main/scala/org/apache/spark/sql/avro/AvroDeserializer.scala
+++ b/connector/avro/src/main/scala/org/apache/spark/sql/avro/AvroDeserializer.scala
@@ -162,6 +162,8 @@ private[sql] class AvroDeserializer(
             updater.setLong(ordinal, value.asInstanceOf[Long])
           case (TimestampType, LongType) => (updater, ordinal, value) =>
             updater.setLong(ordinal, value.asInstanceOf[Long])
+          case (TimestampNTZType, LongType) => (updater, ordinal, value) =>
+            updater.setLong(ordinal, value.asInstanceOf[Long])
           case (LongType, TimestampType)
                | (TimestampType, TimestampType)
                |(TimestampNTZType, TimestampType) => avroType.getLogicalType match {

--- a/connector/avro/src/main/scala/org/apache/spark/sql/avro/AvroDeserializer.scala
+++ b/connector/avro/src/main/scala/org/apache/spark/sql/avro/AvroDeserializer.scala
@@ -160,13 +160,8 @@ private[sql] class AvroDeserializer(
         (logicalDataType, catalystType) match {
           case (LongType, LongType) => (updater, ordinal, value) =>
             updater.setLong(ordinal, value.asInstanceOf[Long])
-          case (_, LongType) => avroType.getLogicalType match {
-            case _: TimestampMicros | _: TimestampMillis |
-                 _: LocalTimestampMillis | _: LocalTimestampMicros => (updater, ordinal, value) =>
-              updater.setLong(ordinal, value.asInstanceOf[Long])
-            case other => throw new IncompatibleSchemaException(errorPrefix +
-              s"Avro logical type $other cannot be converted to SQL type ${TimestampType.sql}.")
-          }
+          case (TimestampType, LongType) => (updater, ordinal, value) =>
+            updater.setLong(ordinal, value.asInstanceOf[Long])
           case (LongType, TimestampType)
                | (TimestampType, TimestampType)
                |(TimestampNTZType, TimestampType) => avroType.getLogicalType match {

--- a/connector/avro/src/main/scala/org/apache/spark/sql/avro/AvroDeserializer.scala
+++ b/connector/avro/src/main/scala/org/apache/spark/sql/avro/AvroDeserializer.scala
@@ -158,7 +158,7 @@ private[sql] class AvroDeserializer(
         }
       case LONG =>
         (logicalDataType, catalystType) match {
-          case (LongType, LongType) => (updater, ordinal, value) =>
+          case (_, LongType) => (updater, ordinal, value) =>
             updater.setLong(ordinal, value.asInstanceOf[Long])
           case (LongType, TimestampType)
                | (TimestampType, TimestampType)

--- a/connector/avro/src/main/scala/org/apache/spark/sql/avro/AvroDeserializer.scala
+++ b/connector/avro/src/main/scala/org/apache/spark/sql/avro/AvroDeserializer.scala
@@ -24,7 +24,7 @@ import scala.collection.JavaConverters._
 
 import org.apache.avro.{LogicalTypes, Schema, SchemaBuilder}
 import org.apache.avro.Conversions.DecimalConversion
-import org.apache.avro.LogicalTypes.{LocalTimestampMicros, LocalTimestampMillis, TimeMicros, TimeMillis, TimestampMicros, TimestampMillis}
+import org.apache.avro.LogicalTypes.{LocalTimestampMicros, LocalTimestampMillis, TimestampMicros, TimestampMillis}
 import org.apache.avro.Schema.Type._
 import org.apache.avro.generic._
 import org.apache.avro.util.Utf8
@@ -162,8 +162,7 @@ private[sql] class AvroDeserializer(
             updater.setLong(ordinal, value.asInstanceOf[Long])
           case (_, LongType) => avroType.getLogicalType match {
             case _: TimestampMicros | _: TimestampMillis |
-                 _: LocalTimestampMillis | _: LocalTimestampMicros |
-                 _: TimeMicros | _: TimeMillis => (updater, ordinal, value) =>
+                 _: LocalTimestampMillis | _: LocalTimestampMicros => (updater, ordinal, value) =>
               updater.setLong(ordinal, value.asInstanceOf[Long])
             case other => throw new IncompatibleSchemaException(errorPrefix +
               s"Avro logical type $other cannot be converted to SQL type ${TimestampType.sql}.")

--- a/connector/avro/src/main/scala/org/apache/spark/sql/avro/AvroDeserializer.scala
+++ b/connector/avro/src/main/scala/org/apache/spark/sql/avro/AvroDeserializer.scala
@@ -24,7 +24,7 @@ import scala.collection.JavaConverters._
 
 import org.apache.avro.{LogicalTypes, Schema, SchemaBuilder}
 import org.apache.avro.Conversions.DecimalConversion
-import org.apache.avro.LogicalTypes.{LocalTimestampMicros, LocalTimestampMillis, TimestampMicros, TimestampMillis, TimeMicros, TimeMillis}
+import org.apache.avro.LogicalTypes.{LocalTimestampMicros, LocalTimestampMillis, TimeMicros, TimeMillis, TimestampMicros, TimestampMillis}
 import org.apache.avro.Schema.Type._
 import org.apache.avro.generic._
 import org.apache.avro.util.Utf8

--- a/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
+++ b/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
@@ -950,6 +950,7 @@ abstract class AvroSuite
     "time-millis",
     "time-micros",
     "timestamp-micros",
+    "timestamp-millis",
     "local-timestamp-millis",
     "local-timestamp-micros"
   ).foreach { timeLogicalType =>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix conversion of Avro logical timestamp type to Long

### Why are the changes needed?
The fix in https://github.com/apache/spark/pull/41052 cause regression when trying to convert logical timestamp type to Long type and it's not covered by existing test suite. Fix it and add a test for it.

### Does this PR introduce _any_ user-facing change?
NO

### How was this patch tested?
New unit test