### PR TITLE
[SPARK-43621][PS][CONNECT] Enable `pyspark.pandas.spark.functions.repeat` in Spark Connect

### DIFF
--- a/python/pyspark/pandas/spark/functions.py
+++ b/python/pyspark/pandas/spark/functions.py
@@ -20,6 +20,7 @@ Additional Spark functions used in pandas-on-Spark.
 from typing import Union, no_type_check
 
 from pyspark import SparkContext
+import pyspark.sql.functions as F
 from pyspark.sql.column import (
     Column,
     _to_java_column,
@@ -90,22 +91,8 @@ def repeat(col: Column, n: Union[int, Column]) -> Column:
     """
     Repeats a string column n times, and returns it as a new string column.
     """
-    if is_remote():
-        from pyspark.sql.connect.functions import lit, call_udf
-
-        if isinstance(n, int):
-            n = lit(n)  # type: ignore[assignment]
-
-        return call_udf(  # type: ignore[return-value]
-            "repeat",
-            col,  # type: ignore[arg-type]
-            n,  # type: ignore[arg-type]
-        )
-
-    else:
-        sc = SparkContext._active_spark_context
-        n = _to_java_column(n) if isinstance(n, Column) else _create_column_from_literal(n)
-        return _call_udf(sc, "repeat", _to_java_column(col), n)
+    _n = F.lit(n) if isinstance(n, int) else n
+    return F.call_udf("repeat", col, _n)
 
 
 def date_part(field: Union[str, Column], source: Column) -> Column:

--- a/python/pyspark/pandas/spark/functions.py
+++ b/python/pyspark/pandas/spark/functions.py
@@ -90,9 +90,22 @@ def repeat(col: Column, n: Union[int, Column]) -> Column:
     """
     Repeats a string column n times, and returns it as a new string column.
     """
-    sc = SparkContext._active_spark_context
-    n = _to_java_column(n) if isinstance(n, Column) else _create_column_from_literal(n)
-    return _call_udf(sc, "repeat", _to_java_column(col), n)
+    if is_remote():
+        from pyspark.sql.connect.functions import lit, call_udf
+
+        if isinstance(n, int):
+            n = lit(n)  # type: ignore[assignment]
+
+        return call_udf(  # type: ignore[return-value]
+            "repeat",
+            col,  # type: ignore[arg-type]
+            n,  # type: ignore[arg-type]
+        )
+
+    else:
+        sc = SparkContext._active_spark_context
+        n = _to_java_column(n) if isinstance(n, Column) else _create_column_from_literal(n)
+        return _call_udf(sc, "repeat", _to_java_column(col), n)
 
 
 def date_part(field: Union[str, Column], source: Column) -> Column:

--- a/python/pyspark/pandas/tests/connect/computation/test_parity_binary_ops.py
+++ b/python/pyspark/pandas/tests/connect/computation/test_parity_binary_ops.py
@@ -27,12 +27,6 @@ class FrameParityBinaryOpsTests(FrameBinaryOpsMixin, PandasOnSparkTestUtils, Reu
     def psdf(self):
         return ps.from_pandas(self.pdf)
 
-    @unittest.skip(
-        "TODO(SPARK-43616): Enable pyspark.pandas.spark.functions.repeat in Spark Connect."
-    )
-    def test_binary_operator_multiply(self):
-        super().test_binary_operator_multiply()
-
 
 if __name__ == "__main__":
     from pyspark.pandas.tests.connect.computation.test_parity_binary_ops import *  # noqa: F401

--- a/python/pyspark/pandas/tests/connect/data_type_ops/test_parity_num_ops.py
+++ b/python/pyspark/pandas/tests/connect/data_type_ops/test_parity_num_ops.py
@@ -38,12 +38,6 @@ class NumOpsParityTests(
     def test_eq(self):
         super().test_eq()
 
-    @unittest.skip(
-        "TODO(SPARK-43621): Enable pyspark.pandas.spark.functions.repeat in Spark Connect."
-    )
-    def test_mul(self):
-        super().test_mul()
-
     @unittest.skip("TODO(SPARK-43691): Enable NumOpsParityTests.test_ne.")
     def test_ne(self):
         super().test_ne()

--- a/python/pyspark/pandas/tests/connect/data_type_ops/test_parity_string_ops.py
+++ b/python/pyspark/pandas/tests/connect/data_type_ops/test_parity_string_ops.py
@@ -34,18 +34,6 @@ class StringOpsParityTests(
     def test_astype(self):
         super().test_astype()
 
-    @unittest.skip(
-        "TODO(SPARK-43621): Enable pyspark.pandas.spark.functions.repeat in Spark Connect."
-    )
-    def test_mul(self):
-        super().test_mul()
-
-    @unittest.skip(
-        "TODO(SPARK-43621): Enable pyspark.pandas.spark.functions.repeat in Spark Connect."
-    )
-    def test_rmul(self):
-        super().test_rmul()
-
 
 if __name__ == "__main__":
     from pyspark.pandas.tests.connect.data_type_ops.test_parity_string_ops import *  # noqa: F401

--- a/python/pyspark/pandas/tests/connect/test_parity_series_string.py
+++ b/python/pyspark/pandas/tests/connect/test_parity_series_string.py
@@ -24,11 +24,7 @@ from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 class SeriesStringParityTests(
     SeriesStringTestsMixin, PandasOnSparkTestUtils, ReusedConnectTestCase
 ):
-    @unittest.skip(
-        "TODO(SPARK-43621): Enable pyspark.pandas.spark.functions.repeat in Spark Connect."
-    )
-    def test_string_repeat(self):
-        super().test_string_repeat()
+    pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### What changes were proposed in this pull request?
Enable `pyspark.pandas.spark.functions.repeat` in Spark Connect


### Why are the changes needed?
feature parity

### Does this PR introduce _any_ user-facing change?
yes, new method enabled


### How was this patch tested?
enabled UTs