### PR TITLE
[SPARK-44012][SS] KafkaDataConsumer to print some read status

### DIFF
--- a/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/consumer/KafkaDataConsumer.scala
+++ b/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/consumer/KafkaDataConsumer.scala
@@ -260,6 +260,8 @@ private[kafka010] class KafkaDataConsumer(
 
   // Total duration spent on reading from Kafka
   private var totalTimeReadNanos: Long = 0
+  // Number of times we poll Kafka consumers.
+  private var numPolls: Long = 0
   // Total number of records fetched from Kafka
   private var totalRecordsRead: Long = 0
   // Starting timestamp when the consumer is created.
@@ -383,7 +385,7 @@ private[kafka010] class KafkaDataConsumer(
     val walTime = System.nanoTime() - startTimestampNano
 
     logInfo(
-      s"From Kafka $kafkaMeta read $totalRecordsRead records, " +
+      s"From Kafka $kafkaMeta read $totalRecordsRead records through $numPolls polls, " +
       s"taking $totalTimeReadNanos nanos, during time span of $walTime nanos."
     )
 
@@ -573,6 +575,7 @@ private[kafka010] class KafkaDataConsumer(
     val (records, offsetAfterPoll, range) = timeNanos {
       consumer.fetch(offset, pollTimeoutMs)
     }
+    numPolls += 1
     fetchedData.withNewPoll(records.listIterator, offsetAfterPoll, range)
   }
 

--- a/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/consumer/KafkaDataConsumer.scala
+++ b/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/consumer/KafkaDataConsumer.scala
@@ -262,6 +262,8 @@ private[kafka010] class KafkaDataConsumer(
   private var totalTimeReadNanos: Long = 0
   // Number of times we poll Kafka consumers.
   private var numPolls: Long = 0
+  // Number of times we poll Kafka consumers.
+  private var numRecordsPolled: Long = 0
   // Total number of records fetched from Kafka
   private var totalRecordsRead: Long = 0
   // Starting timestamp when the consumer is created.
@@ -385,8 +387,9 @@ private[kafka010] class KafkaDataConsumer(
     val walTime = System.nanoTime() - startTimestampNano
 
     logInfo(
-      s"From Kafka $kafkaMeta read $totalRecordsRead records through $numPolls polls, " +
-      s"taking $totalTimeReadNanos nanos, during time span of $walTime nanos."
+      s"From Kafka $kafkaMeta read $totalRecordsRead records through $numPolls polls (polled " +
+      s" out $numRecordsPolled records), taking $totalTimeReadNanos nanos, during time span of " +
+      s"$walTime nanos."
     )
 
     releaseConsumer()
@@ -576,6 +579,7 @@ private[kafka010] class KafkaDataConsumer(
       consumer.fetch(offset, pollTimeoutMs)
     }
     numPolls += 1
+    numRecordsPolled += records.size
     fetchedData.withNewPoll(records.listIterator, offsetAfterPoll, range)
   }
 
@@ -602,6 +606,7 @@ private[kafka010] class KafkaDataConsumer(
     startTimestampNano = System.nanoTime()
     totalTimeReadNanos = 0
     numPolls = 0
+    numRecordsPolled = 0
     totalRecordsRead = 0
 
     require(_consumer.isDefined, "borrowing consumer from pool must always succeed.")

--- a/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/consumer/KafkaDataConsumer.scala
+++ b/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/consumer/KafkaDataConsumer.scala
@@ -601,6 +601,7 @@ private[kafka010] class KafkaDataConsumer(
     }
     startTimestampNano = System.nanoTime()
     totalTimeReadNanos = 0
+    numPolls = 0
     totalRecordsRead = 0
 
     require(_consumer.isDefined, "borrowing consumer from pool must always succeed.")


### PR DESCRIPTION

### What changes were proposed in this pull request?
In the end of each KafkaDataConsumer, it logs some stats. Here is an sample log line:

23/06/08 23:48:14 INFO KafkaDataConsumer: From Kafka topicPartition=topic-121-2 groupId=spark-kafka-source-623fa0a8-04a5-4f34-a9ad-adbf31494e85-711383366-executor read 1 records, taking 504554479 nanos, during time span of 504620999 nanos

### Why are the changes needed?
For each task, Kafka source should report fraction of time spent in KafkaConsumer to fetch records. It should also report overall read bandwidth (bytes or records read / time spent fetching).

This will be useful in verifying if fetching is the bottleneck.


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
1. Run unit tests and validate log line is correct
2. Run some benchmarks and see it doesn't show up much in CPU profiling.
