### PR TITLE
[SPARK-43971][CONNECT][PYTHON] Support Python's createDataFrame in streaming manner

### DIFF
--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -1257,6 +1257,9 @@ class SparkConnectClient(object):
     def copy_from_local_to_fs(self, local_path: str, dest_path: str) -> None:
         self._artifact_manager._add_forward_to_fs_artifacts(local_path, dest_path)
 
+    def cache_artifact(self, blob: bytes) -> str:
+        return self._artifact_manager.cache_artifact(blob)
+
 
 class RetryState:
     """

--- a/python/pyspark/sql/connect/plan.py
+++ b/python/pyspark/sql/connect/plan.py
@@ -390,7 +390,8 @@ class CachedLocalRelation(LogicalPlan):
         plan = self._create_proto_relation()
         clr = plan.cached_local_relation
 
-        clr.userId = session._user_id
+        if session._user_id:
+            clr.userId = session._user_id
         clr.sessionId = session._session_id
         clr.hash = self._hash
 

--- a/python/pyspark/sql/connect/plan.py
+++ b/python/pyspark/sql/connect/plan.py
@@ -377,10 +377,7 @@ class LocalRelation(LogicalPlan):
 class CachedLocalRelation(LogicalPlan):
     """Creates a CachedLocalRelation plan object based on a hash of a LocalRelation."""
 
-    def __init__(
-        self,
-        hash: str
-    ) -> None:
+    def __init__(self, hash: str) -> None:
         super().__init__(None)
 
         self._hash = hash

--- a/python/pyspark/sql/connect/plan.py
+++ b/python/pyspark/sql/connect/plan.py
@@ -362,6 +362,10 @@ class LocalRelation(LogicalPlan):
         if self._schema is not None:
             plan.local_relation.schema = self._schema
         return plan
+    
+    def serialize(self, session: "SparkConnectClient") -> bytes:
+        p = self.plan(session)
+        return bytes(p.local_relation.SerializeToString())
 
     def print(self, indent: int = 0) -> str:
         return f"{' ' * indent}<LocalRelation>\n"

--- a/python/pyspark/sql/connect/plan.py
+++ b/python/pyspark/sql/connect/plan.py
@@ -362,7 +362,7 @@ class LocalRelation(LogicalPlan):
         if self._schema is not None:
             plan.local_relation.schema = self._schema
         return plan
-    
+
     def serialize(self, session: "SparkConnectClient") -> bytes:
         p = self.plan(session)
         return bytes(p.local_relation.SerializeToString())

--- a/python/pyspark/sql/connect/plan.py
+++ b/python/pyspark/sql/connect/plan.py
@@ -374,6 +374,38 @@ class LocalRelation(LogicalPlan):
         """
 
 
+class CachedLocalRelation(LogicalPlan):
+    """Creates a CachedLocalRelation plan object based on a hash of a LocalRelation."""
+
+    def __init__(
+        self,
+        hash: str
+    ) -> None:
+        super().__init__(None)
+
+        self._hash = hash
+
+    def plan(self, session: "SparkConnectClient") -> proto.Relation:
+        plan = self._create_proto_relation()
+        clr = plan.cached_local_relation
+
+        clr.userId = session._user_id
+        clr.sessionId = session._session_id
+        clr.hash = self._hash
+
+        return plan
+
+    def print(self, indent: int = 0) -> str:
+        return f"{' ' * indent}<CachedLocalRelation>\n"
+
+    def _repr_html_(self) -> str:
+        return """
+        <ul>
+            <li><b>CachedLocalRelation</b></li>
+        </ul>
+        """
+
+
 class ShowString(LogicalPlan):
     def __init__(
         self, child: Optional["LogicalPlan"], num_rows: int, truncate: int, vertical: bool

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -358,8 +358,7 @@ class SparkSession:
                 arrow_types = [to_arrow_type(dt) if dt is not None else None for dt in spark_types]
 
             timezone, safecheck = self._client.get_configs(
-                "spark.sql.session.timeZone",
-                "spark.sql.execution.pandas.convertToArrowArraySafely"
+                "spark.sql.session.timeZone", "spark.sql.execution.pandas.convertToArrowArraySafely"
             )
 
             ser = ArrowStreamPandasSerializer(cast(str, timezone), safecheck == "true")

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -477,9 +477,9 @@ class SparkSession:
         else:
             local_relation = LocalRelation(_table)
 
-        cacheThreshold = self._client.get_configs("spark.sql.session.localRelationCacheThreshold")
+        cache_threshold = self._client.get_configs("spark.sql.session.localRelationCacheThreshold")
         plan: LogicalPlan = local_relation
-        if cacheThreshold[0] is not None and int(cacheThreshold[0]) <= _table.nbytes:
+        if cache_threshold[0] is not None and int(cache_threshold[0]) <= _table.nbytes:
             plan = CachedLocalRelation(self._cache_local_relation(local_relation))
 
         df = DataFrame.withPlan(plan, self)

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -657,7 +657,6 @@ class SparkSession:
         serialized = localRelation.serialize(self._client)
         return self._client.cache_artifact(serialized)
 
-
     def copyFromLocalToFs(self, local_path: str, dest_path: str) -> None:
         """
         Copy file from local to cloud storage file system.

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -473,14 +473,14 @@ class SparkSession:
             )
 
         if _schema is not None:
-            localRelation = LocalRelation(_table, schema=_schema.json())
+            local_relation = LocalRelation(_table, schema=_schema.json())
         else:
-            localRelation = LocalRelation(_table)
+            local_relation = LocalRelation(_table)
 
         cacheThreshold = self._client.get_configs("spark.sql.session.localRelationCacheThreshold")
-        plan: LogicalPlan = localRelation
+        plan: LogicalPlan = local_relation
         if cacheThreshold[0] is not None and int(cacheThreshold[0]) <= _table.nbytes:
-            plan = CachedLocalRelation(self._cacheLocalRelation(localRelation))
+            plan = CachedLocalRelation(self._cache_local_relation(local_relation))
 
         df = DataFrame.withPlan(plan, self)
         if _cols is not None and len(_cols) > 0:
@@ -656,11 +656,11 @@ class SparkSession:
 
     addArtifact = addArtifacts
 
-    def _cacheLocalRelation(self, localRelation: LocalRelation) -> str:
+    def _cache_local_relation(self, local_relation: LocalRelation) -> str:
         """
         Cache the local relation at the server side if it has not been cached yet.
         """
-        serialized = localRelation.serialize(self._client)
+        serialized = local_relation.serialize(self._client)
         return self._client.cache_artifact(serialized)
 
     def copyFromLocalToFs(self, local_path: str, dest_path: str) -> None:

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -474,7 +474,7 @@ class SparkSession:
         if cacheThreshold[0] is None or _table.nbytes < int(cacheThreshold[0]):
             plan = localRelation
         else:
-            plan = CachedLocalRelation(hash=self.cacheLocalRelation(localRelation))
+            plan = CachedLocalRelation(hash=self._cacheLocalRelation(localRelation))
 
         df = DataFrame.withPlan(plan, self)
         if _cols is not None and len(_cols) > 0:
@@ -649,6 +649,14 @@ class SparkSession:
         self._client.add_artifacts(*path, pyfile=pyfile, archive=archive, file=file)
 
     addArtifact = addArtifacts
+
+    def _cacheLocalRelation(self, localRelation: LocalRelation) -> str:
+        """
+        Cache the local relation at the server side if it has not been cached yet.
+        """
+        serialized = localRelation.serialize(self._client)
+        return self._client.cache_artifact(serialized)
+
 
     def copyFromLocalToFs(self, local_path: str, dest_path: str) -> None:
         """

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -652,15 +652,16 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
             self.assert_eq(sdf.toPandas(), cdf.toPandas())
 
     def test_streaming_local_relation(self):
-        threshold = 64 * 1024 * 1024
+        threshold = 1024 * 1024
         with self.sql_conf({"spark.sql.session.localRelationCacheThreshold": threshold}):
             suffix = "abcdef"
             letters = string.ascii_lowercase
             str = "".join(random.choice(letters) for i in range(threshold)) + suffix
             data = [[0, str], [1, str]]
-            cdf = self.connect.createDataFrame(data, ["a", "b"])
-            self.assert_eq(cdf.count(), len(data))
-            self.assert_eq(cdf.filter(f"endsWith(b, '{suffix}')").isEmpty(), False)
+            for i in range(0, 2):
+                cdf = self.connect.createDataFrame(data, ["a", "b"])
+                self.assert_eq(cdf.count(), len(data))
+                self.assert_eq(cdf.filter(f"endsWith(b, '{suffix}')").isEmpty(), False)
 
     def test_with_atom_type(self):
         for data in [[(1), (2), (3)], [1, 2, 3]]:

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -652,7 +652,7 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
             self.assert_eq(sdf.toPandas(), cdf.toPandas())
 
     def test_streaming_local_relation(self):
-        threshold = 1024 * 1024
+        threshold = 64 * 1024 * 1024
         with self.sql_conf({"spark.sql.session.localRelationCacheThreshold": threshold}):
             suffix = "abcdef"
             letters = string.ascii_lowercase


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to transfer a local relation from **the Python connect client** to the server in streaming way when it exceeds some size which is defined by the SQL config `spark.sql.session.localRelationCacheThreshold`. The implementation is similar to https://github.com/apache/spark/pull/40827.  In particular:
1. The client applies the `sha256` function over **the proto form** of the local relation;
2. It checks presents of the relation at the server side by sending the relation hash to the server;
3. If the server doesn't have the local relation, the client transfers the local relation as an artefact with the name `cache/<sha256>`;
4. As soon as the relation has presented at the server already, or transferred recently, the client transform the logical plan by replacing the `LocalRelation` node by `CachedLocalRelation` with the hash.
5. On another hand, the server converts `CachedLocalRelation` back to `LocalRelation` by retrieving the relation body from the local cache.

### Why are the changes needed?
To fix the issues of creating a large dataframe from a local collection:
```python
pyspark.errors.exceptions.connect.SparkConnectGrpcException: <_MultiThreadedRendezvous of RPC that terminated with:
	status = StatusCode.RESOURCE_EXHAUSTED
	details = "Sent message larger than max (134218508 vs. 134217728)"
	debug_error_string = "UNKNOWN:Error received from peer localhost:50982 {grpc_message:"Sent message larger than max (134218508 vs. 134217728)", grpc_status:8, created_time:"2023-06-09T15:34:08.362797+03:00"}
```

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By running new test:
```
$ python/run-tests --parallelism=1 --testnames 'pyspark.sql.tests.connect.test_connect_basic SparkConnectBasicTests.test_streaming_local_relation'
```