### PR TITLE
[SPARK-43594][SQL] Add LocalDateTime to anyToMicros

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -211,12 +211,13 @@ object DateTimeUtils {
   /**
    * Converts an Java object to microseconds.
    *
-   * @param obj Either an object of `java.sql.Timestamp` or `java.time.Instant`.
+   * @param obj Either an object of `java.sql.Timestamp` or `java.time.{Instant,LocalDateTime}`.
    * @return The number of micros since the epoch.
    */
   def anyToMicros(obj: Any): Long = obj match {
     case t: Timestamp => fromJavaTimestamp(t)
     case i: Instant => instantToMicros(i)
+    case ldt: LocalDateTime => localDateTimeToMicros(ldt)
   }
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?

Small change to `anyToMicros` to also accept `LocalDateTime` that's being returned when working with `TIMESTAMP_NTZ`. This simplifies some code at the Iceberg side.

### Why are the changes needed?

With the introduction of the TIMESTAMP_NTZ it is convient to also accept LocalDateTime

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Very trivial change, no test needed.

Closes #41238 from Fokko/fd-add-local-date-time.

Authored-by: Fokko Driesprong <fokko@tabular.io>
