### PR TITLE
[SPARK-44018][SQL] Improve the hashCode and toString for some DS V2 Expression

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/GeneralScalarExpression.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/GeneralScalarExpression.java
@@ -18,7 +18,6 @@
 package org.apache.spark.sql.connector.expressions;
 
 import java.util.Arrays;
-import java.util.Objects;
 
 import org.apache.spark.annotation.Evolving;
 import org.apache.spark.sql.connector.expressions.filter.Predicate;
@@ -441,12 +440,17 @@ public class GeneralScalarExpression extends ExpressionWithToString {
   public boolean equals(Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
+
     GeneralScalarExpression that = (GeneralScalarExpression) o;
-    return Objects.equals(name, that.name) && Arrays.equals(children, that.children);
+
+    if (!name.equals(that.name)) return false;
+    return Arrays.equals(children, that.children);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name) * 31 + Arrays.hashCode(children);
+    int result = name.hashCode();
+    result = 31 * result + Arrays.hashCode(children);
+    return result;
   }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/GeneralScalarExpression.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/GeneralScalarExpression.java
@@ -447,6 +447,6 @@ public class GeneralScalarExpression extends ExpressionWithToString {
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, children);
+    return Objects.hash(name) * 31 + Arrays.hashCode(children);
   }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/UserDefinedScalarFunc.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/UserDefinedScalarFunc.java
@@ -58,6 +58,6 @@ public class UserDefinedScalarFunc extends ExpressionWithToString {
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, canonicalName, children);
+    return Objects.hash(name, canonicalName) * 31 + Arrays.hashCode(children);
   }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/UserDefinedScalarFunc.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/UserDefinedScalarFunc.java
@@ -18,7 +18,6 @@
 package org.apache.spark.sql.connector.expressions;
 
 import java.util.Arrays;
-import java.util.Objects;
 
 import org.apache.spark.annotation.Evolving;
 import org.apache.spark.sql.internal.connector.ExpressionWithToString;
@@ -51,13 +50,19 @@ public class UserDefinedScalarFunc extends ExpressionWithToString {
   public boolean equals(Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
+
     UserDefinedScalarFunc that = (UserDefinedScalarFunc) o;
-    return Objects.equals(name, that.name) && Objects.equals(canonicalName, that.canonicalName) &&
-      Arrays.equals(children, that.children);
+
+    if (!name.equals(that.name)) return false;
+    if (!canonicalName.equals(that.canonicalName)) return false;
+    return Arrays.equals(children, that.children);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, canonicalName) * 31 + Arrays.hashCode(children);
+    int result = name.hashCode();
+    result = 31 * result + canonicalName.hashCode();
+    result = 31 * result + Arrays.hashCode(children);
+    return result;
   }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/aggregate/GeneralAggregateFunc.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/aggregate/GeneralAggregateFunc.java
@@ -18,7 +18,6 @@
 package org.apache.spark.sql.connector.expressions.aggregate;
 
 import java.util.Arrays;
-import java.util.Objects;
 
 import org.apache.spark.annotation.Evolving;
 import org.apache.spark.sql.connector.expressions.Expression;
@@ -68,13 +67,19 @@ public final class GeneralAggregateFunc extends ExpressionWithToString implement
   public boolean equals(Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
+
     GeneralAggregateFunc that = (GeneralAggregateFunc) o;
-    return Objects.equals(name, that.name) && isDistinct == that.isDistinct &&
-      Arrays.equals(children, that.children);
+
+    if (isDistinct != that.isDistinct) return false;
+    if (!name.equals(that.name)) return false;
+    return Arrays.equals(children, that.children);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, isDistinct) * 31 + Arrays.hashCode(children);
+    int result = name.hashCode();
+    result = 31 * result + (isDistinct ? 1 : 0);
+    result = 31 * result + Arrays.hashCode(children);
+    return result;
   }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/aggregate/GeneralAggregateFunc.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/aggregate/GeneralAggregateFunc.java
@@ -69,12 +69,12 @@ public final class GeneralAggregateFunc extends ExpressionWithToString implement
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     GeneralAggregateFunc that = (GeneralAggregateFunc) o;
-    return Objects.equals(name, that.name) && Objects.equals(isDistinct, that.isDistinct) &&
+    return Objects.equals(name, that.name) && isDistinct == that.isDistinct &&
       Arrays.equals(children, that.children);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name) * 31 + Arrays.hashCode(children);
+    return Objects.hash(name, isDistinct) * 31 + Arrays.hashCode(children);
   }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/aggregate/GeneralAggregateFunc.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/aggregate/GeneralAggregateFunc.java
@@ -17,6 +17,9 @@
 
 package org.apache.spark.sql.connector.expressions.aggregate;
 
+import java.util.Arrays;
+import java.util.Objects;
+
 import org.apache.spark.annotation.Evolving;
 import org.apache.spark.sql.connector.expressions.Expression;
 import org.apache.spark.sql.internal.connector.ExpressionWithToString;
@@ -60,4 +63,18 @@ public final class GeneralAggregateFunc extends ExpressionWithToString implement
 
   @Override
   public Expression[] children() { return children; }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    GeneralAggregateFunc that = (GeneralAggregateFunc) o;
+    return Objects.equals(name, that.name) && Objects.equals(isDistinct, that.isDistinct) &&
+      Arrays.equals(children, that.children);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name) * 31 + Arrays.hashCode(children);
+  }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/aggregate/UserDefinedAggregateFunc.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/aggregate/UserDefinedAggregateFunc.java
@@ -60,11 +60,11 @@ public class UserDefinedAggregateFunc extends ExpressionWithToString implements 
     if (o == null || getClass() != o.getClass()) return false;
     UserDefinedAggregateFunc that = (UserDefinedAggregateFunc) o;
     return Objects.equals(name, that.name) && Objects.equals(canonicalName, that.canonicalName) &&
-      Arrays.equals(children, that.children);
+      isDistinct == that.isDistinct && Arrays.equals(children, that.children);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, canonicalName) * 31 + Arrays.hashCode(children);
+    return Objects.hash(name, canonicalName, isDistinct) * 31 + Arrays.hashCode(children);
   }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/aggregate/UserDefinedAggregateFunc.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/aggregate/UserDefinedAggregateFunc.java
@@ -17,6 +17,9 @@
 
 package org.apache.spark.sql.connector.expressions.aggregate;
 
+import java.util.Arrays;
+import java.util.Objects;
+
 import org.apache.spark.annotation.Evolving;
 import org.apache.spark.sql.connector.expressions.Expression;
 import org.apache.spark.sql.internal.connector.ExpressionWithToString;
@@ -50,4 +53,18 @@ public class UserDefinedAggregateFunc extends ExpressionWithToString implements 
 
   @Override
   public Expression[] children() { return children; }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    UserDefinedAggregateFunc that = (UserDefinedAggregateFunc) o;
+    return Objects.equals(name, that.name) && Objects.equals(canonicalName, that.canonicalName) &&
+      Arrays.equals(children, that.children);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, canonicalName) * 31 + Arrays.hashCode(children);
+  }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/aggregate/UserDefinedAggregateFunc.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/aggregate/UserDefinedAggregateFunc.java
@@ -18,7 +18,6 @@
 package org.apache.spark.sql.connector.expressions.aggregate;
 
 import java.util.Arrays;
-import java.util.Objects;
 
 import org.apache.spark.annotation.Evolving;
 import org.apache.spark.sql.connector.expressions.Expression;
@@ -58,13 +57,21 @@ public class UserDefinedAggregateFunc extends ExpressionWithToString implements 
   public boolean equals(Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
+
     UserDefinedAggregateFunc that = (UserDefinedAggregateFunc) o;
-    return Objects.equals(name, that.name) && Objects.equals(canonicalName, that.canonicalName) &&
-      isDistinct == that.isDistinct && Arrays.equals(children, that.children);
+
+    if (isDistinct != that.isDistinct) return false;
+    if (!name.equals(that.name)) return false;
+    if (!canonicalName.equals(that.canonicalName)) return false;
+    return Arrays.equals(children, that.children);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, canonicalName, isDistinct) * 31 + Arrays.hashCode(children);
+    int result = name.hashCode();
+    result = 31 * result + canonicalName.hashCode();
+    result = 31 * result + (isDistinct ? 1 : 0);
+    result = 31 * result + Arrays.hashCode(children);
+    return result;
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
The `hashCode() `of `UserDefinedScalarFunc` and `GeneralScalarExpression` is not good enough. Take for example, `GeneralScalarExpression` uses `Objects.hash(name, children)`, it adopt the hash code of `name` and `children`'s reference and then combine them together as the `GeneralScalarExpression`'s hash code.
In fact, we should adopt the hash code for each element in `children`.

Because `UserDefinedAggregateFunc` and `GeneralAggregateFunc` missing `hashCode()`, this PR also want add them.

This PR also improve the toString for `UserDefinedAggregateFunc` and `GeneralAggregateFunc` by using bool primitive comparison instead `Objects.equals`. Because the performance of bool primitive comparison better than `Objects.equals`.


### Why are the changes needed?
Improve the hash code for some DS V2 Expression.


### Does this PR introduce _any_ user-facing change?
'Yes'.


### How was this patch tested?
N/A
