### PR TITLE
[SPARK-44021][SQL] Add spark.sql.files.maxPartitionNum

### DIFF
--- a/docs/sql-performance-tuning.md
+++ b/docs/sql-performance-tuning.md
@@ -96,6 +96,17 @@ that these options will be deprecated in future release as more optimizations ar
     <td>3.1.0</td>
   </tr>
   <tr>
+    <td><code>spark.sql.files.maxPartitionNum</code></td>
+    <td>None</td>
+    <td>
+      The suggested (not guaranteed) maximum number of split file partitions. If it is set,
+      Spark will rescale each partition to make the number of partitions is close to this
+      value if the initial number of partitions exceeds this value. This configuration is
+      effective only when using file-based sources such as Parquet, JSON and ORC.
+    </td>
+    <td>3.5.0</td>
+  </tr>
+  <tr>
     <td><code>spark.sql.broadcastTimeout</code></td>
     <td>300</td>
     <td>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1751,7 +1751,7 @@ object SQLConf {
 
   val FILES_MAX_PARTITION_NUM = buildConf("spark.sql.files.maxPartitionNum")
     .doc("The suggested (not guaranteed) maximum number of split file partitions. If it is set, " +
-      "Spark will reorganize each partition to make the number of partitions is close to this " +
+      "Spark will rescale each partition to make the number of partitions is close to this " +
       "value if the initial number of partitions exceeds this value. This configuration is " +
       "effective only when using file-based sources such as Parquet, JSON and ORC.")
     .version("3.5.0")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1749,6 +1749,16 @@ object SQLConf {
     .checkValue(v => v > 0, "The min partition number must be a positive integer.")
     .createOptional
 
+  val FILES_MAX_PARTITION_NUM = buildConf("spark.sql.files.maxPartitionNum")
+    .doc("The suggested (not guaranteed) maximum number of split file partitions. If it is set, " +
+      "Spark will reorganize each partition to make the number of partitions is close to this " +
+      "value if the initial number of partitions exceeds this value. This configuration is " +
+      "effective only when using file-based sources such as Parquet, JSON and ORC.")
+    .version("3.5.0")
+    .intConf
+    .checkValue(v => v > 0, "The maximum number of partitions must be a positive integer.")
+    .createOptional
+
   val IGNORE_CORRUPT_FILES = buildConf("spark.sql.files.ignoreCorruptFiles")
     .doc("Whether to ignore corrupt files. If true, the Spark jobs will continue to run when " +
       "encountering corrupted files and the contents that have been read will still be returned. " +
@@ -4508,6 +4518,8 @@ class SQLConf extends Serializable with Logging {
   def filesOpenCostInBytes: Long = getConf(FILES_OPEN_COST_IN_BYTES)
 
   def filesMinPartitionNum: Option[Int] = getConf(FILES_MIN_PARTITION_NUM)
+
+  def filesMaxPartitionNum: Option[Int] = getConf(FILES_MAX_PARTITION_NUM)
 
   def ignoreCorruptFiles: Boolean = getConf(IGNORE_CORRUPT_FILES)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR add a new SQL config: `spark.sql.files.maxPartitionNum`. User can set it to avoid generating too many partitions when reading file-based sources. Too many partitions will increase the various overheads of the driver and cause Shuffle service OOM.

The following is the GC log of the Shuffle service:
```
2023-06-08T01:41:01.871-0700: 7303.965: [Full GC (Allocation Failure) 2023-06-08T01:41:01.871-0700: 7303.965: [CMS: 4194304K->4194304K(4194304K), 7.4010107 secs]2023-06-08T01:41:09.272-0700: 7311.366: [Class Histogram (after full gc):
 num     #instances         #bytes  class name
----------------------------------------------
   1:       7110660     2334927400  [C
   2:      19465810      467514416  [I
   3:       6754570      270182800  org.apache.spark.network.protocol.ChunkFetchRequest
   4:       6661155      266446200  org.sparkproject.io.netty.channel.DefaultChannelPromise
   5:       6639056      265562240  org.apache.spark.network.buffer.FileSegmentManagedBuffer
   6:       6639055      265562200  org.apache.spark.network.protocol.RequestTraceInfo
   7:       6663764      213240448  org.sparkproject.io.netty.util.Recycler$DefaultHandle
   8:       6659382      213100224  org.sparkproject.io.netty.channel.AbstractChannelHandlerContext$WriteTask
   9:       6659218      213094976  org.apache.spark.network.server.ChunkFetchRequestHandler$$Lambda$156/886274988
  10:       6640444      212494208  java.io.File
...
```

### Why are the changes needed?

1. The PR aims to selectively rescale large RDDs only, while keeping the existing behavior in the same way in small RDDs. So directly increasing `spark.sql.files.maxPartitionBytes` is not acceptable:
   1. There are multiple data sources in one SQL, setting `spark.sql.files.maxPartitionBytes` will affect all data sources.
   2. We don't know how much `spark.sql.files.maxPartitionBytes` should be set to, sometimes it may be very large(More than 20GiB).


2. To make it do not generate too many partitions if it is very large partitioned and bucketed table as it is not always use bucket scan since [SPARK-32859](https://issues.apache.org/jira/browse/SPARK-32859).
   
   Before SPARK-32859 | After SPARK-32859
   --- | ---
   <img width="400" src="https://github.com/apache/spark/assets/5399861/5e14932b-aa3d-4b14-b80c-e3ff348958c4"> | <img width="400" src="https://github.com/apache/spark/assets/5399861/170311a0-c086-408a-9d95-17031e21e16a">

3. Avoid generating too many partitions if these are lots of small files.

### Does this PR introduce _any_ user-facing change?

No. Unless the user sets `spark.sql.files.maxPartitionNum`.

### How was this patch tested?

Unit test and manual testing:

Before this PR | After this PR and `set spark.sql.files.maxPartitionNum=20000`
-- | --
<img width="400" src="https://github.com/apache/spark/assets/5399861/ffda1850-cd4a-4970-a4e5-e1e43177135a"> | <img width="330" src="https://github.com/apache/spark/assets/5399861/1df7cac7-fe82-4af3-b3ec-91aa23c79a8b">
