### PR TITLE
[SPARK-43617][PS][CONNECT] Enable `pyspark.pandas.spark.functions.product` in Spark Connect

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -1634,6 +1634,11 @@ class SparkConnectPlanner(val session: SparkSession) extends Logging {
       case "distributed_sequence_id" if fun.getArgumentsCount == 0 =>
         Some(DistributedSequenceID())
 
+      case "pandas_product" if fun.getArgumentsCount == 2 =>
+        val children = fun.getArgumentsList.asScala.map(transformExpression)
+        val dropna = extractBoolean(children(1), "dropna")
+        Some(aggregate.PandasProduct(children(0), dropna).toAggregateExpression(false))
+
       case "pandas_covar" if fun.getArgumentsCount == 3 =>
         val children = fun.getArgumentsList.asScala.map(transformExpression)
         val ddof = extractInteger(children(2), "ddof")

--- a/python/pyspark/pandas/tests/connect/computation/test_parity_compute.py
+++ b/python/pyspark/pandas/tests/connect/computation/test_parity_compute.py
@@ -43,12 +43,6 @@ class FrameParityComputeTests(FrameComputeMixin, PandasOnSparkTestUtils, ReusedC
     def test_pct_change(self):
         super().test_pct_change()
 
-    @unittest.skip(
-        "TODO(SPARK-43617): Enable pyspark.pandas.spark.functions.product in Spark Connect."
-    )
-    def test_product(self):
-        super().test_product()
-
     @unittest.skip("TODO(SPARK-43618): Fix pyspark.sq.column._unary_op to work with Spark Connect.")
     def test_rank(self):
         super().test_rank()

--- a/python/pyspark/pandas/tests/connect/groupby/test_parity_stat.py
+++ b/python/pyspark/pandas/tests/connect/groupby/test_parity_stat.py
@@ -29,12 +29,6 @@ class GroupbyParityStatTests(GroupbyStatMixin, PandasOnSparkTestUtils, ReusedCon
         super().test_basic_stat_funcs()
 
     @unittest.skip(
-        "TODO(SPARK-43617): Enable pyspark.pandas.spark.functions.product in Spark Connect."
-    )
-    def test_prod(self):
-        super().test_prod()
-
-    @unittest.skip(
         "TODO(SPARK-43645): Enable pyspark.pandas.spark.functions.stddev in Spark Connect."
     )
     def test_ddof(self):

--- a/python/pyspark/pandas/tests/connect/series/test_parity_stat.py
+++ b/python/pyspark/pandas/tests/connect/series/test_parity_stat.py
@@ -28,12 +28,6 @@ class SeriesParityStatTests(SeriesStatMixin, PandasOnSparkTestUtils, ReusedConne
     def test_pct_change(self):
         super().test_pct_change()
 
-    @unittest.skip(
-        "TODO(SPARK-43617): Enable pyspark.pandas.spark.functions.product in Spark Connect."
-    )
-    def test_product(self):
-        super().test_product()
-
     @unittest.skip("TODO(SPARK-43618): Fix pyspark.sq.column._unary_op to work with Spark Connect.")
     def test_rank(self):
         super().test_rank()

--- a/python/pyspark/pandas/tests/connect/test_parity_generic_functions.py
+++ b/python/pyspark/pandas/tests/connect/test_parity_generic_functions.py
@@ -28,15 +28,7 @@ class GenericFunctionsParityTests(
     def test_interpolate(self):
         super().test_interpolate()
 
-    @unittest.skip(
-        "TODO(SPARK-43617): Enable pyspark.pandas.spark.functions.product in Spark Connect."
-    )
-    def test_prod_precision(self):
-        super().test_prod_precision()
-
-    @unittest.skip(
-        "TODO(SPARK-43617): Enable pyspark.pandas.spark.functions.product in Spark Connect."
-    )
+    @unittest.skip("TODO(SPARK-43645): Enable pyspark.pandas.spark.functions.std in Spark Connect.")
     def test_stat_functions(self):
         super().test_stat_functions()
 

--- a/python/pyspark/pandas/tests/connect/test_parity_stats.py
+++ b/python/pyspark/pandas/tests/connect/test_parity_stats.py
@@ -29,12 +29,6 @@ class StatsParityTests(StatsTestsMixin, PandasOnSparkTestUtils, ReusedConnectTes
         super().test_axis_on_dataframe()
 
     @unittest.skip(
-        "TODO(SPARK-43617): Enable pyspark.pandas.spark.functions.product in Spark Connect."
-    )
-    def test_product(self):
-        super().test_product()
-
-    @unittest.skip(
         "TODO(SPARK-43627): Enable pyspark.pandas.spark.functions.skew in Spark Connect."
     )
     def test_skew_kurt_numerical_stability(self):
@@ -52,21 +46,15 @@ class StatsParityTests(StatsTestsMixin, PandasOnSparkTestUtils, ReusedConnectTes
     def test_stat_functions_multiindex_column(self):
         super().test_stat_functions_multiindex_column()
 
-    @unittest.skip(
-        "TODO(SPARK-43617): Enable pyspark.pandas.spark.functions.product in Spark Connect."
-    )
+    @unittest.skip("TODO(SPARK-43622): Enable pyspark.pandas.spark.functions.var in Spark Connect.")
     def test_stats_on_boolean_dataframe(self):
         super().test_stats_on_boolean_dataframe()
 
-    @unittest.skip(
-        "TODO(SPARK-43617): Enable pyspark.pandas.spark.functions.product in Spark Connect."
-    )
+    @unittest.skip("TODO(SPARK-43622): Enable pyspark.pandas.spark.functions.var in Spark Connect.")
     def test_stats_on_boolean_series(self):
         super().test_stats_on_boolean_series()
 
-    @unittest.skip(
-        "TODO(SPARK-43617): Enable pyspark.pandas.spark.functions.product in Spark Connect."
-    )
+    @unittest.skip("TODO(SPARK-43622): Enable pyspark.pandas.spark.functions.var in Spark Connect.")
     def test_stats_on_non_numeric_columns_should_be_discarded_if_numeric_only_is_true(self):
         super().test_stats_on_non_numeric_columns_should_be_discarded_if_numeric_only_is_true()
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Enable `pyspark.pandas.spark.functions.product` in Spark Connect


### Why are the changes needed?
for parity

### Does this PR introduce _any_ user-facing change?
yes, new methods enabled

### How was this patch tested?
enabled UTs