### PR TITLE
[SPARK-43915][SQL] Assign names to the error class _LEGACY_ERROR_TEMP_[2438-2445]

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -2467,9 +2467,9 @@
           "<property> is a reserved namespace property, <msg>."
         ]
       },
-      "SET_OPERATION_ON_MAP_TYPE_UNSUPPORTED" : {
+      "SET_OPERATION_ON_MAP_TYPE" : {
         "message" : [
-          "Cannot have map type columns in DataFrame which calls set operations(intersect, except, etc.), but the type of column <colName> is <dataType>."
+          "Cannot have MAP type columns in DataFrame which calls set operations (INTERSECT, EXCEPT, etc.), but the type of column <colName> is <dataType>."
         ]
       },
       "SET_PROPERTIES_AND_DBPROPERTIES" : {

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -1526,7 +1526,7 @@
   },
   "INVALID_UDF_IMPLEMENTATION" : {
     "message" : [
-      "Function '<funcName>' does not implement ScalarFunction or AggregateFunction."
+      "Function <funcName> does not implement ScalarFunction or AggregateFunction."
     ]
   },
   "INVALID_URL" : {

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -643,6 +643,11 @@
     ],
     "sqlState" : "23505"
   },
+  "DUPLICATED_OBSERVED_METRICS_NAME" : {
+    "message" : [
+      "Multiple definitions of observed metrics named '<name>': <plan>."
+    ]
+  },
   "DUPLICATE_CLAUSES" : {
     "message" : [
       "Found duplicate clauses: <clauseName>. Please, remove one of them."
@@ -1237,6 +1242,13 @@
       }
     }
   },
+  "INVALID_NON_DETERMINISTIC_EXPRESSIONS" : {
+    "message" : [
+      "nondeterministic expressions are only allowed in Project, Filter, Aggregate or Window, found:",
+      "<sqlExprs>",
+      "in operator <operator>."
+    ]
+  },
   "INVALID_NUMERIC_LITERAL_RANGE" : {
     "message" : [
       "Numeric literal <rawStrippedQualifier> is outside the valid range for <typeName> with minimum value of <minValue> and maximum value of <maxValue>. Please adjust the value accordingly."
@@ -1511,6 +1523,11 @@
       "The value of the typed literal <valueType> is invalid: <value>."
     ],
     "sqlState" : "42604"
+  },
+  "INVALID_UDF_IMPLEMENTATION" : {
+    "message" : [
+      "Function '<funcName>' does not implement ScalarFunction or AggregateFunction."
+    ]
   },
   "INVALID_URL" : {
     "message" : [
@@ -2014,6 +2031,11 @@
   "SEED_EXPRESSION_IS_UNFOLDABLE" : {
     "message" : [
       "The seed expression <seedExpr> of the expression <exprWithSeed> must be foldable."
+    ]
+  },
+  "SET_OPERATION_ON_MAP_TYPE_UNSUPPORTED" : {
+    "message" : [
+      "Cannot have map type columns in DataFrame which calls set operations(intersect, except, etc.), but the type of column <colName> is <dataType>."
     ]
   },
   "SORT_BY_WITHOUT_BUCKETING" : {
@@ -5651,33 +5673,6 @@
       "Failure when resolving conflicting references in AsOfJoin:",
       "<plan>",
       "Conflicting attributes: <conflictingAttributes>."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_2438" : {
-    "message" : [
-      "Cannot have map type columns in DataFrame which calls set operations(intersect, except, etc.), but the type of column <colName> is <dataType>."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_2439" : {
-    "message" : [
-      "nondeterministic expressions are only allowed in Project, Filter, Aggregate or Window, found:",
-      "<sqlExprs>",
-      "in operator <operator>."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_2443" : {
-    "message" : [
-      "Multiple definitions of observed metrics named '<name>': <plan>."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_2444" : {
-    "message" : [
-      "Function '<funcName>' does not implement ScalarFunction or AggregateFunction."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_2445" : {
-    "message" : [
-      "grouping() can only be used with GroupingSets/Cube/Rollup."
     ]
   },
   "_LEGACY_ERROR_TEMP_2446" : {

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -643,9 +643,9 @@
     ],
     "sqlState" : "23505"
   },
-  "DUPLICATED_OBSERVED_METRICS_NAME" : {
+  "DUPLICATED_METRICS_NAME" : {
     "message" : [
-      "Multiple definitions of observed metrics named '<name>': <plan>."
+      "The metric name is not unique: <metricName>. The same name cannot be used for metrics with different results. However multiple instances of metrics with with same result and name are allowed (e.g. self-joins)."
     ]
   },
   "DUPLICATE_CLAUSES" : {
@@ -1244,9 +1244,7 @@
   },
   "INVALID_NON_DETERMINISTIC_EXPRESSIONS" : {
     "message" : [
-      "nondeterministic expressions are only allowed in Project, Filter, Aggregate or Window, found:",
-      "<sqlExprs>",
-      "in operator <operator>."
+      "The operator expects a deterministic expression, but the actual expression is <sqlExprs>."
     ]
   },
   "INVALID_NUMERIC_LITERAL_RANGE" : {
@@ -2033,11 +2031,6 @@
       "The seed expression <seedExpr> of the expression <exprWithSeed> must be foldable."
     ]
   },
-  "SET_OPERATION_ON_MAP_TYPE_UNSUPPORTED" : {
-    "message" : [
-      "Cannot have map type columns in DataFrame which calls set operations(intersect, except, etc.), but the type of column <colName> is <dataType>."
-    ]
-  },
   "SORT_BY_WITHOUT_BUCKETING" : {
     "message" : [
       "sortBy must be used together with bucketBy."
@@ -2472,6 +2465,11 @@
       "SET_NAMESPACE_PROPERTY" : {
         "message" : [
           "<property> is a reserved namespace property, <msg>."
+        ]
+      },
+      "SET_OPERATION_ON_MAP_TYPE_UNSUPPORTED" : {
+        "message" : [
+          "Cannot have map type columns in DataFrame which calls set operations(intersect, except, etc.), but the type of column <colName> is <dataType>."
         ]
       },
       "SET_PROPERTIES_AND_DBPROPERTIES" : {

--- a/python/pyspark/sql/tests/test_udtf.py
+++ b/python/pyspark/sql/tests/test_udtf.py
@@ -350,7 +350,9 @@ class UDTFTestsMixin(ReusedSQLTestCase):
 
         random_udtf = udtf(RandomUDTF, returnType="x: int").asNondeterministic()
         # TODO(SPARK-43966): support non-deterministic UDTFs
-        with self.assertRaisesRegex(AnalysisException, "nondeterministic expressions"):
+        with self.assertRaisesRegex(
+            AnalysisException, "The operator expects a deterministic expression"
+        ):
             random_udtf(lit(1)).collect()
 
     def test_udtf_with_nondeterministic_input(self):
@@ -362,7 +364,9 @@ class UDTFTestsMixin(ReusedSQLTestCase):
                 yield a + 1,
 
         # TODO(SPARK-43966): support non-deterministic UDTFs
-        with self.assertRaisesRegex(AnalysisException, "nondeterministic expressions"):
+        with self.assertRaisesRegex(
+            AnalysisException, " The operator expects a deterministic expression"
+        ):
             TestUDTF(rand(0) * 100).collect()
 
     def test_udtf_no_eval(self):

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -2326,8 +2326,8 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
           processV2AggregateFunction(aggFunc, arguments, u)
         case _ =>
           failAnalysis(
-            errorClass = "_LEGACY_ERROR_TEMP_2444",
-            messageParameters = Map("funcName" -> bound.name()))
+            errorClass = "INVALID_UDF_IMPLEMENTATION",
+            messageParameters = Map("funcName" -> toSQLId(bound.name())))
       }
     }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -1060,7 +1060,7 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
                   errorClass = "DUPLICATED_OBSERVED_METRICS_NAME",
                   messageParameters = Map(
                     "name" -> name,
-                    "plan" -> plan.toString))
+                    "plan" -> planToString(plan)))
               }
             case None =>
               metricsMap.put(name, metrics)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -722,9 +722,9 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
           case o if mapColumnInSetOperation(o).isDefined =>
             val mapCol = mapColumnInSetOperation(o).get
             o.failAnalysis(
-              errorClass = "UNSUPPORTED_FEATURE.SET_OPERATION_ON_MAP_TYPE_UNSUPPORTED",
+              errorClass = "UNSUPPORTED_FEATURE.SET_OPERATION_ON_MAP_TYPE",
               messageParameters = Map(
-                "colName" -> toSQLExpr(mapCol),
+                "colName" -> toSQLId(mapCol.name),
                 "dataType" -> toSQLType(mapCol.dataType)))
 
           case o if o.expressions.exists(!_.deterministic) &&

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -738,7 +738,7 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
               errorClass = "INVALID_NON_DETERMINISTIC_EXPRESSIONS",
               messageParameters = Map(
                 "sqlExprs" -> o.expressions.map(toSQLExpr(_)).mkString(", "),
-                "operator" -> operator.simpleString(SQLConf.get.maxToStringFields)))
+                "operator" -> planToString(operator)))
 
           case _: UnresolvedHint => throw new IllegalStateException(
             "Logical hint operator should be removed during analysis.")
@@ -869,6 +869,7 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
   private def scrubOutIds(string: String): String =
     string.replaceAll("#\\d+", "#x")
       .replaceAll("operator id = \\d+", "operator id = #x")
+      .replaceAll("rand\\(-?\\d+\\)", "rand(number)")
 
   private def planToString(plan: LogicalPlan): String = {
     if (Utils.isTesting) scrubOutIds(plan.toString) else plan.toString

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -722,7 +722,7 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
           case o if mapColumnInSetOperation(o).isDefined =>
             val mapCol = mapColumnInSetOperation(o).get
             o.failAnalysis(
-              errorClass = "SET_OPERATION_ON_MAP_TYPE_UNSUPPORTED",
+              errorClass = "UNSUPPORTED_FEATURE.SET_OPERATION_ON_MAP_TYPE_UNSUPPORTED",
               messageParameters = Map(
                 "colName" -> toSQLExpr(mapCol),
                 "dataType" -> toSQLType(mapCol.dataType)))
@@ -736,9 +736,8 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
             // The rule above is used to check Aggregate operator.
             o.failAnalysis(
               errorClass = "INVALID_NON_DETERMINISTIC_EXPRESSIONS",
-              messageParameters = Map(
-                "sqlExprs" -> o.expressions.map(toSQLExpr(_)).mkString(", "),
-                "operator" -> planToString(operator)))
+              messageParameters = Map("sqlExprs" -> o.expressions.map(toSQLExpr(_)).mkString(", "))
+            )
 
           case _: UnresolvedHint => throw new IllegalStateException(
             "Logical hint operator should be removed during analysis.")
@@ -1058,10 +1057,8 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
               // of a CTE that is used multiple times or a self join.
               if (!simplifiedMetrics.sameResult(simplifiedOther)) {
                 failAnalysis(
-                  errorClass = "DUPLICATED_OBSERVED_METRICS_NAME",
-                  messageParameters = Map(
-                    "name" -> name,
-                    "plan" -> planToString(plan)))
+                  errorClass = "DUPLICATED_METRICS_NAME",
+                  messageParameters = Map("metricName" -> name))
               }
             case None =>
               metricsMap.put(name, metrics)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
@@ -825,16 +825,8 @@ class AnalysisSuite extends AnalysisTest with Matchers {
       Union(
         CollectMetrics("evt1", count :: Nil, testRelation) ::
           CollectMetrics("evt1", sum :: Nil, testRelation) :: Nil),
-      expectedErrorClass = "DUPLICATED_OBSERVED_METRICS_NAME",
-      expectedMessageParameters = Map(
-        "name" -> "evt1",
-        "plan" ->
-         """Union false, false
-           |:- CollectMetrics evt1, [count(1) AS cnt#xL]
-           |:  +- LocalRelation <empty>, [a#x]
-           |+- CollectMetrics evt1, [sum(a#x) AS sum#xL]
-           |   +- LocalRelation <empty>, [a#x]
-           |""".stripMargin)
+      expectedErrorClass = "DUPLICATED_METRICS_NAME",
+      expectedMessageParameters = Map("metricName" -> "evt1")
     )
 
     // Different children, same metrics - fail
@@ -844,17 +836,8 @@ class AnalysisSuite extends AnalysisTest with Matchers {
       Union(
         CollectMetrics("evt1", count :: Nil, testRelation) ::
           CollectMetrics("evt1", count :: Nil, tblB) :: Nil),
-      expectedErrorClass = "DUPLICATED_OBSERVED_METRICS_NAME",
-      expectedMessageParameters = Map(
-        "name" -> "evt1",
-        "plan" ->
-          """Union false, false
-            |:- Project [cast(a#x as string) AS a#x]
-            |:  +- CollectMetrics evt1, [count(1) AS cnt#xL]
-            |:     +- LocalRelation <empty>, [a#x]
-            |+- CollectMetrics evt1, [count(1) AS cnt#xL]
-            |   +- LocalRelation <empty>, [b#x]
-            |""".stripMargin)
+      expectedErrorClass = "DUPLICATED_METRICS_NAME",
+      expectedMessageParameters = Map("metricName" -> "evt1")
     )
 
     // Subquery different tree - fail
@@ -864,17 +847,8 @@ class AnalysisSuite extends AnalysisTest with Matchers {
       CollectMetrics("evt1", count :: Nil, tblB))
     assertAnalysisErrorClass(
       query,
-      expectedErrorClass = "DUPLICATED_OBSERVED_METRICS_NAME",
-      expectedMessageParameters = Map(
-        "name" -> "evt1",
-        "plan" ->
-          """Project [b#x, scalar-subquery#x [] AS sum#xL]
-            |:  +- Aggregate [sum(a#x) AS sum#xL]
-            |:     +- CollectMetrics evt1, [count(1) AS cnt#xL]
-            |:        +- LocalRelation <empty>, [a#x]
-            |+- CollectMetrics evt1, [count(1) AS cnt#xL]
-            |   +- LocalRelation <empty>, [b#x]
-            |""".stripMargin)
+      expectedErrorClass = "DUPLICATED_METRICS_NAME",
+      expectedMessageParameters = Map("metricName" -> "evt1")
     )
 
     // Aggregate with filter predicate - fail

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
@@ -830,10 +830,10 @@ class AnalysisSuite extends AnalysisTest with Matchers {
         "name" -> "evt1",
         "plan" ->
          """Union false, false
-           |:- CollectMetrics evt1, [count(1) AS cnt#23L]
-           |:  +- LocalRelation <empty>, [a#0]
-           |+- CollectMetrics evt1, [sum(a#25) AS sum#21L]
-           |   +- LocalRelation <empty>, [a#25]
+           |:- CollectMetrics evt1, [count(1) AS cnt#xL]
+           |:  +- LocalRelation <empty>, [a#x]
+           |+- CollectMetrics evt1, [sum(a#x) AS sum#xL]
+           |   +- LocalRelation <empty>, [a#x]
            |""".stripMargin)
     )
 
@@ -849,11 +849,11 @@ class AnalysisSuite extends AnalysisTest with Matchers {
         "name" -> "evt1",
         "plan" ->
           """Union false, false
-            |:- Project [cast(a#0 as string) AS a#27]
-            |:  +- CollectMetrics evt1, [count(1) AS cnt#23L]
-            |:     +- LocalRelation <empty>, [a#0]
-            |+- CollectMetrics evt1, [count(1) AS cnt#23L]
-            |   +- LocalRelation <empty>, [b#26]
+            |:- Project [cast(a#x as string) AS a#x]
+            |:  +- CollectMetrics evt1, [count(1) AS cnt#xL]
+            |:     +- LocalRelation <empty>, [a#x]
+            |+- CollectMetrics evt1, [count(1) AS cnt#xL]
+            |   +- LocalRelation <empty>, [b#x]
             |""".stripMargin)
     )
 
@@ -868,12 +868,12 @@ class AnalysisSuite extends AnalysisTest with Matchers {
       expectedMessageParameters = Map(
         "name" -> "evt1",
         "plan" ->
-          """Project [b#26, scalar-subquery#28 [] AS sum#29L]
-            |:  +- Aggregate [sum(a#0) AS sum#21L]
-            |:     +- CollectMetrics evt1, [count(1) AS cnt#23L]
-            |:        +- LocalRelation <empty>, [a#0]
-            |+- CollectMetrics evt1, [count(1) AS cnt#23L]
-            |   +- LocalRelation <empty>, [b#26]
+          """Project [b#x, scalar-subquery#x [] AS sum#xL]
+            |:  +- Aggregate [sum(a#x) AS sum#xL]
+            |:     +- CollectMetrics evt1, [count(1) AS cnt#xL]
+            |:        +- LocalRelation <empty>, [a#x]
+            |+- CollectMetrics evt1, [count(1) AS cnt#xL]
+            |   +- LocalRelation <empty>, [b#x]
             |""".stripMargin)
     )
 

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/group-analytics.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/group-analytics.sql.out
@@ -332,7 +332,7 @@ SELECT course, year, GROUPING(course) FROM courseSales GROUP BY course, year
 -- !query analysis
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_2445",
+  "errorClass" : "UNSUPPORTED_GROUPING_EXPRESSION",
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/join-lateral.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/join-lateral.sql.out
@@ -480,7 +480,7 @@ org.apache.spark.sql.AnalysisException
   "errorClass" : "UNSUPPORTED_SUBQUERY_EXPRESSION_CATEGORY.NON_DETERMINISTIC_LATERAL_SUBQUERIES",
   "sqlState" : "0A000",
   "messageParameters" : {
-    "treeNode" : "LateralJoin lateral-subquery#x [c1#x && c2#x], Inner\n:  +- SubqueryAlias __auto_generated_subquery_name\n:     +- Project [(cast((outer(c1#x) + outer(c2#x)) as double) + rand(0)) AS c3#x]\n:        +- OneRowRelation\n+- SubqueryAlias spark_catalog.default.t1\n   +- View (`spark_catalog`.`default`.`t1`, [c1#x,c2#x])\n      +- Project [cast(col1#x as int) AS c1#x, cast(col2#x as int) AS c2#x]\n         +- LocalRelation [col1#x, col2#x]\n"
+    "treeNode" : "LateralJoin lateral-subquery#x [c1#x && c2#x], Inner\n:  +- SubqueryAlias __auto_generated_subquery_name\n:     +- Project [(cast((outer(c1#x) + outer(c2#x)) as double) + rand(number)) AS c3#x]\n:        +- OneRowRelation\n+- SubqueryAlias spark_catalog.default.t1\n   +- View (`spark_catalog`.`default`.`t1`, [c1#x,c2#x])\n      +- Project [cast(col1#x as int) AS c1#x, cast(col2#x as int) AS c2#x]\n         +- LocalRelation [col1#x, col2#x]\n"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -500,7 +500,7 @@ org.apache.spark.sql.AnalysisException
   "errorClass" : "UNSUPPORTED_SUBQUERY_EXPRESSION_CATEGORY.NON_DETERMINISTIC_LATERAL_SUBQUERIES",
   "sqlState" : "0A000",
   "messageParameters" : {
-    "treeNode" : "LateralJoin lateral-subquery#x [], Inner\n:  +- SubqueryAlias __auto_generated_subquery_name\n:     +- Project [rand(0) AS rand(0)#x]\n:        +- SubqueryAlias spark_catalog.default.t2\n:           +- View (`spark_catalog`.`default`.`t2`, [c1#x,c2#x])\n:              +- Project [cast(col1#x as int) AS c1#x, cast(col2#x as int) AS c2#x]\n:                 +- LocalRelation [col1#x, col2#x]\n+- SubqueryAlias spark_catalog.default.t1\n   +- View (`spark_catalog`.`default`.`t1`, [c1#x,c2#x])\n      +- Project [cast(col1#x as int) AS c1#x, cast(col2#x as int) AS c2#x]\n         +- LocalRelation [col1#x, col2#x]\n"
+    "treeNode" : "LateralJoin lateral-subquery#x [], Inner\n:  +- SubqueryAlias __auto_generated_subquery_name\n:     +- Project [rand(number) AS rand(number)#x]\n:        +- SubqueryAlias spark_catalog.default.t2\n:           +- View (`spark_catalog`.`default`.`t2`, [c1#x,c2#x])\n:              +- Project [cast(col1#x as int) AS c1#x, cast(col2#x as int) AS c2#x]\n:                 +- LocalRelation [col1#x, col2#x]\n+- SubqueryAlias spark_catalog.default.t1\n   +- View (`spark_catalog`.`default`.`t1`, [c1#x,c2#x])\n      +- Project [cast(col1#x as int) AS c1#x, cast(col2#x as int) AS c2#x]\n         +- LocalRelation [col1#x, col2#x]\n"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/udf/udf-group-analytics.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/udf/udf-group-analytics.sql.out
@@ -205,7 +205,7 @@ SELECT course, udf(year), GROUPING(course) FROM courseSales GROUP BY course, udf
 -- !query analysis
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_2445",
+  "errorClass" : "UNSUPPORTED_GROUPING_EXPRESSION",
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",

--- a/sql/core/src/test/resources/sql-tests/results/group-analytics.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/group-analytics.sql.out
@@ -466,7 +466,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_2445",
+  "errorClass" : "UNSUPPORTED_GROUPING_EXPRESSION",
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",

--- a/sql/core/src/test/resources/sql-tests/results/join-lateral.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/join-lateral.sql.out
@@ -360,7 +360,7 @@ org.apache.spark.sql.AnalysisException
   "errorClass" : "UNSUPPORTED_SUBQUERY_EXPRESSION_CATEGORY.NON_DETERMINISTIC_LATERAL_SUBQUERIES",
   "sqlState" : "0A000",
   "messageParameters" : {
-    "treeNode" : "LateralJoin lateral-subquery#x [c1#x && c2#x], Inner\n:  +- SubqueryAlias __auto_generated_subquery_name\n:     +- Project [(cast((outer(c1#x) + outer(c2#x)) as double) + rand(0)) AS c3#x]\n:        +- OneRowRelation\n+- SubqueryAlias spark_catalog.default.t1\n   +- View (`spark_catalog`.`default`.`t1`, [c1#x,c2#x])\n      +- Project [cast(col1#x as int) AS c1#x, cast(col2#x as int) AS c2#x]\n         +- LocalRelation [col1#x, col2#x]\n"
+    "treeNode" : "LateralJoin lateral-subquery#x [c1#x && c2#x], Inner\n:  +- SubqueryAlias __auto_generated_subquery_name\n:     +- Project [(cast((outer(c1#x) + outer(c2#x)) as double) + rand(number)) AS c3#x]\n:        +- OneRowRelation\n+- SubqueryAlias spark_catalog.default.t1\n   +- View (`spark_catalog`.`default`.`t1`, [c1#x,c2#x])\n      +- Project [cast(col1#x as int) AS c1#x, cast(col2#x as int) AS c2#x]\n         +- LocalRelation [col1#x, col2#x]\n"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -382,7 +382,7 @@ org.apache.spark.sql.AnalysisException
   "errorClass" : "UNSUPPORTED_SUBQUERY_EXPRESSION_CATEGORY.NON_DETERMINISTIC_LATERAL_SUBQUERIES",
   "sqlState" : "0A000",
   "messageParameters" : {
-    "treeNode" : "LateralJoin lateral-subquery#x [], Inner\n:  +- SubqueryAlias __auto_generated_subquery_name\n:     +- Project [rand(0) AS rand(0)#x]\n:        +- SubqueryAlias spark_catalog.default.t2\n:           +- View (`spark_catalog`.`default`.`t2`, [c1#x,c2#x])\n:              +- Project [cast(col1#x as int) AS c1#x, cast(col2#x as int) AS c2#x]\n:                 +- LocalRelation [col1#x, col2#x]\n+- SubqueryAlias spark_catalog.default.t1\n   +- View (`spark_catalog`.`default`.`t1`, [c1#x,c2#x])\n      +- Project [cast(col1#x as int) AS c1#x, cast(col2#x as int) AS c2#x]\n         +- LocalRelation [col1#x, col2#x]\n"
+    "treeNode" : "LateralJoin lateral-subquery#x [], Inner\n:  +- SubqueryAlias __auto_generated_subquery_name\n:     +- Project [rand(number) AS rand(number)#x]\n:        +- SubqueryAlias spark_catalog.default.t2\n:           +- View (`spark_catalog`.`default`.`t2`, [c1#x,c2#x])\n:              +- Project [cast(col1#x as int) AS c1#x, cast(col2#x as int) AS c2#x]\n:                 +- LocalRelation [col1#x, col2#x]\n+- SubqueryAlias spark_catalog.default.t1\n   +- View (`spark_catalog`.`default`.`t1`, [c1#x,c2#x])\n      +- Project [cast(col1#x as int) AS c1#x, cast(col2#x as int) AS c2#x]\n         +- LocalRelation [col1#x, col2#x]\n"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/results/udf/udf-group-analytics.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udf/udf-group-analytics.sql.out
@@ -208,7 +208,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_2445",
+  "errorClass" : "UNSUPPORTED_GROUPING_EXPRESSION",
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSetOperationsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSetOperationsSuite.scala
@@ -354,21 +354,21 @@ class DataFrameSetOperationsSuite extends QueryTest with SharedSparkSession {
     val df = spark.range(1).select(map(lit("key"), $"id").as("m"))
     checkError(
       exception = intercept[AnalysisException](df.intersect(df)),
-      errorClass = "SET_OPERATION_ON_MAP_TYPE_UNSUPPORTED",
+      errorClass = "UNSUPPORTED_FEATURE.SET_OPERATION_ON_MAP_TYPE_UNSUPPORTED",
       parameters = Map(
         "colName" -> "\"m\"",
         "dataType" -> "\"MAP<STRING, BIGINT>\"")
     )
     checkError(
       exception = intercept[AnalysisException](df.except(df)),
-      errorClass = "SET_OPERATION_ON_MAP_TYPE_UNSUPPORTED",
+      errorClass = "UNSUPPORTED_FEATURE.SET_OPERATION_ON_MAP_TYPE_UNSUPPORTED",
       parameters = Map(
         "colName" -> "\"m\"",
         "dataType" -> "\"MAP<STRING, BIGINT>\"")
     )
     checkError(
       exception = intercept[AnalysisException](df.distinct()),
-      errorClass = "SET_OPERATION_ON_MAP_TYPE_UNSUPPORTED",
+      errorClass = "UNSUPPORTED_FEATURE.SET_OPERATION_ON_MAP_TYPE_UNSUPPORTED",
       parameters = Map(
         "colName" -> "\"m\"",
         "dataType" -> "\"MAP<STRING, BIGINT>\"")
@@ -377,7 +377,7 @@ class DataFrameSetOperationsSuite extends QueryTest with SharedSparkSession {
       df.createOrReplaceTempView("v")
       checkError(
         exception = intercept[AnalysisException](sql("SELECT DISTINCT m FROM v")),
-        errorClass = "SET_OPERATION_ON_MAP_TYPE_UNSUPPORTED",
+        errorClass = "UNSUPPORTED_FEATURE.SET_OPERATION_ON_MAP_TYPE_UNSUPPORTED",
         parameters = Map(
           "colName" -> "\"m\"",
           "dataType" -> "\"MAP<STRING, BIGINT>\""),

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSetOperationsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSetOperationsSuite.scala
@@ -354,32 +354,32 @@ class DataFrameSetOperationsSuite extends QueryTest with SharedSparkSession {
     val df = spark.range(1).select(map(lit("key"), $"id").as("m"))
     checkError(
       exception = intercept[AnalysisException](df.intersect(df)),
-      errorClass = "UNSUPPORTED_FEATURE.SET_OPERATION_ON_MAP_TYPE_UNSUPPORTED",
+      errorClass = "UNSUPPORTED_FEATURE.SET_OPERATION_ON_MAP_TYPE",
       parameters = Map(
-        "colName" -> "\"m\"",
+        "colName" -> "`m`",
         "dataType" -> "\"MAP<STRING, BIGINT>\"")
     )
     checkError(
       exception = intercept[AnalysisException](df.except(df)),
-      errorClass = "UNSUPPORTED_FEATURE.SET_OPERATION_ON_MAP_TYPE_UNSUPPORTED",
+      errorClass = "UNSUPPORTED_FEATURE.SET_OPERATION_ON_MAP_TYPE",
       parameters = Map(
-        "colName" -> "\"m\"",
+        "colName" -> "`m`",
         "dataType" -> "\"MAP<STRING, BIGINT>\"")
     )
     checkError(
       exception = intercept[AnalysisException](df.distinct()),
-      errorClass = "UNSUPPORTED_FEATURE.SET_OPERATION_ON_MAP_TYPE_UNSUPPORTED",
+      errorClass = "UNSUPPORTED_FEATURE.SET_OPERATION_ON_MAP_TYPE",
       parameters = Map(
-        "colName" -> "\"m\"",
+        "colName" -> "`m`",
         "dataType" -> "\"MAP<STRING, BIGINT>\"")
     )
     withTempView("v") {
       df.createOrReplaceTempView("v")
       checkError(
         exception = intercept[AnalysisException](sql("SELECT DISTINCT m FROM v")),
-        errorClass = "UNSUPPORTED_FEATURE.SET_OPERATION_ON_MAP_TYPE_UNSUPPORTED",
+        errorClass = "UNSUPPORTED_FEATURE.SET_OPERATION_ON_MAP_TYPE",
         parameters = Map(
-          "colName" -> "\"m\"",
+          "colName" -> "`m`",
           "dataType" -> "\"MAP<STRING, BIGINT>\""),
         context = ExpectedContext(
           fragment = "SELECT DISTINCT m FROM v",

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSetOperationsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSetOperationsSuite.scala
@@ -352,20 +352,40 @@ class DataFrameSetOperationsSuite extends QueryTest with SharedSparkSession {
 
   test("SPARK-19893: cannot run set operations with map type") {
     val df = spark.range(1).select(map(lit("key"), $"id").as("m"))
-    val e = intercept[AnalysisException](df.intersect(df))
-    assert(e.message.contains(
-      "Cannot have map type columns in DataFrame which calls set operations"))
-    val e2 = intercept[AnalysisException](df.except(df))
-    assert(e2.message.contains(
-      "Cannot have map type columns in DataFrame which calls set operations"))
-    val e3 = intercept[AnalysisException](df.distinct())
-    assert(e3.message.contains(
-      "Cannot have map type columns in DataFrame which calls set operations"))
+    checkError(
+      exception = intercept[AnalysisException](df.intersect(df)),
+      errorClass = "SET_OPERATION_ON_MAP_TYPE_UNSUPPORTED",
+      parameters = Map(
+        "colName" -> "\"m\"",
+        "dataType" -> "\"MAP<STRING, BIGINT>\"")
+    )
+    checkError(
+      exception = intercept[AnalysisException](df.except(df)),
+      errorClass = "SET_OPERATION_ON_MAP_TYPE_UNSUPPORTED",
+      parameters = Map(
+        "colName" -> "\"m\"",
+        "dataType" -> "\"MAP<STRING, BIGINT>\"")
+    )
+    checkError(
+      exception = intercept[AnalysisException](df.distinct()),
+      errorClass = "SET_OPERATION_ON_MAP_TYPE_UNSUPPORTED",
+      parameters = Map(
+        "colName" -> "\"m\"",
+        "dataType" -> "\"MAP<STRING, BIGINT>\"")
+    )
     withTempView("v") {
       df.createOrReplaceTempView("v")
-      val e4 = intercept[AnalysisException](sql("SELECT DISTINCT m FROM v"))
-      assert(e4.message.contains(
-        "Cannot have map type columns in DataFrame which calls set operations"))
+      checkError(
+        exception = intercept[AnalysisException](sql("SELECT DISTINCT m FROM v")),
+        errorClass = "SET_OPERATION_ON_MAP_TYPE_UNSUPPORTED",
+        parameters = Map(
+          "colName" -> "\"m\"",
+          "dataType" -> "\"MAP<STRING, BIGINT>\""),
+        context = ExpectedContext(
+          fragment = "SELECT DISTINCT m FROM v",
+          start = 0,
+          stop = 23)
+      )
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2FunctionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2FunctionSuite.scala
@@ -446,8 +446,17 @@ class DataSourceV2FunctionSuite extends DatasourceV2SQLBase {
     catalog("testcat").asInstanceOf[SupportsNamespaces].createNamespace(Array("ns"), emptyProps)
     addFunction(Identifier.of(Array("ns"), "strlen"), StrLen(BadBoundFunction))
 
-    assert(intercept[AnalysisException](sql("SELECT testcat.ns.strlen('abc')"))
-      .getMessage.contains("does not implement ScalarFunction or AggregateFunction"))
+    checkError(
+      exception = intercept[AnalysisException](
+        sql("SELECT testcat.ns.strlen('abc')")),
+      errorClass = "INVALID_UDF_IMPLEMENTATION",
+      parameters = Map(
+        "funcName" -> "`bad_bound_func`"),
+      context = ExpectedContext(
+        fragment = "testcat.ns.strlen('abc')",
+        start = 7,
+        stop = 30)
+    )
   }
 
   test("aggregate function: lookup int average") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DeleteFromTableSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DeleteFromTableSuiteBase.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.connector
 
-import org.apache.spark.sql.{AnalysisException, Row}
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.execution.datasources.v2.{DeleteFromTableExec, ReplaceDataExec, WriteDeltaExec}
 
 abstract class DeleteFromTableSuiteBase extends RowLevelOperationSuiteBase {
@@ -447,19 +447,6 @@ abstract class DeleteFromTableSuiteBase extends RowLevelOperationSuiteBase {
         checkAnswer(sql("SELECT * FROM temp"), Nil)
       }
     }
-  }
-
-  test("delete with nondeterministic conditions") {
-    createAndInitTable("pk INT NOT NULL, id INT, dep STRING",
-      """{ "pk": 1, "id": 1, "dep": "hr" }
-        |{ "pk": 2, "id": 2, "dep": "software" }
-        |{ "pk": 3, "id": 3, "dep": "hr" }
-        |""".stripMargin)
-
-    val e = intercept[AnalysisException] {
-      sql(s"DELETE FROM $tableNameAsString WHERE id <= 1 AND rand() > 0.5")
-    }
-    assert(e.message.contains("nondeterministic expressions are only allowed"))
   }
 
   test("delete without condition executed as delete with filters") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedDeleteFromTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedDeleteFromTableSuite.scala
@@ -39,11 +39,7 @@ class DeltaBasedDeleteFromTableSuite extends DeleteFromTableSuiteBase {
         sql(s"DELETE FROM $tableNameAsString WHERE id <= 1 AND rand() > 0.5")),
       errorClass = "INVALID_NON_DETERMINISTIC_EXPRESSIONS",
       parameters = Map(
-        "sqlExprs" -> "\"((id <= 1) AND (rand() > 0.5))\"",
-        "operator" ->
-          """
-            |WriteDelta RelationV2[pk#2810, id#2811, dep#2812] cat.ns1.test_table cat.ns1.test_table
-            |""".stripMargin.replaceAll("\n", "")),
+        "sqlExprs" -> "\"((id <= 1) AND (rand() > 0.5))\""),
       context = ExpectedContext(
         fragment = "DELETE FROM cat.ns1.test_table WHERE id <= 1 AND rand() > 0.5",
         start = 0,

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedDeleteFromTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedDeleteFromTableSuite.scala
@@ -27,6 +27,30 @@ class DeltaBasedDeleteFromTableSuite extends DeleteFromTableSuiteBase {
     props
   }
 
+  test("delete with nondeterministic conditions") {
+    createAndInitTable("pk INT NOT NULL, id INT, dep STRING",
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |{ "pk": 2, "id": 2, "dep": "software" }
+        |{ "pk": 3, "id": 3, "dep": "hr" }
+        |""".stripMargin)
+
+    checkError(
+      exception = intercept[AnalysisException](
+        sql(s"DELETE FROM $tableNameAsString WHERE id <= 1 AND rand() > 0.5")),
+      errorClass = "INVALID_NON_DETERMINISTIC_EXPRESSIONS",
+      parameters = Map(
+        "sqlExprs" -> "\"((id <= 1) AND (rand() > 0.5))\"",
+        "operator" ->
+          """
+            |WriteDelta RelationV2[pk#2810, id#2811, dep#2812] cat.ns1.test_table cat.ns1.test_table
+            |""".stripMargin.replaceAll("\n", "")),
+      context = ExpectedContext(
+        fragment = "DELETE FROM cat.ns1.test_table WHERE id <= 1 AND rand() > 0.5",
+        start = 0,
+        stop = 60)
+    )
+  }
+
   test("nullable row ID attrs") {
     createAndInitTable("pk INT, salary INT, dep STRING",
       """{ "pk": 1, "salary": 300, "dep": 'hr' }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/GroupBasedDeleteFromTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/GroupBasedDeleteFromTableSuite.scala
@@ -31,20 +31,12 @@ class GroupBasedDeleteFromTableSuite extends DeleteFromTableSuiteBase {
         |{ "pk": 3, "id": 3, "dep": "hr" }
         |""".stripMargin)
 
-    // scalastyle:off line.size.limit
-    val expectedOperator =
-      """ReplaceData RelationV2[pk#x, id#x, dep#x] cat.ns1.test_table cat.ns1.test_table
-        |+- Filter NOT (((id#x <= 1) AND (rand(number) > cast(0.5 as double))) <=> true)
-        |   +- RelationV2[pk#x, id#x, dep#x, _partition#x] cat.ns1.test_table cat.ns1.test_table
-        |""".stripMargin
-    // scalastyle:on line.size.limit
     checkError(
       exception = intercept[AnalysisException](
         sql(s"DELETE FROM $tableNameAsString WHERE id <= 1 AND rand() > 0.5")),
       errorClass = "INVALID_NON_DETERMINISTIC_EXPRESSIONS",
       parameters = Map(
-        "sqlExprs" -> "\"((id <= 1) AND (rand() > 0.5))\", \"((id <= 1) AND (rand() > 0.5))\"",
-        "operator" -> expectedOperator),
+        "sqlExprs" -> "\"((id <= 1) AND (rand() > 0.5))\", \"((id <= 1) AND (rand() > 0.5))\""),
       context = ExpectedContext(
         fragment = "DELETE FROM cat.ns1.test_table WHERE id <= 1 AND rand() > 0.5",
         start = 0,

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/GroupBasedDeleteFromTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/GroupBasedDeleteFromTableSuite.scala
@@ -31,16 +31,15 @@ class GroupBasedDeleteFromTableSuite extends DeleteFromTableSuiteBase {
         |{ "pk": 3, "id": 3, "dep": "hr" }
         |""".stripMargin)
 
+    val expectedOperator =
+      "ReplaceData RelationV2[pk#3435, id#3436, dep#3437] cat.ns1.test_table cat.ns1.test_table"
     checkError(
       exception = intercept[AnalysisException](
         sql(s"DELETE FROM $tableNameAsString WHERE id <= 1 AND rand() > 0.5")),
       errorClass = "INVALID_NON_DETERMINISTIC_EXPRESSIONS",
       parameters = Map(
         "sqlExprs" -> "\"((id <= 1) AND (rand() > 0.5))\"",
-        "operator" ->
-          """
-            |ReplaceData RelationV2[pk#3435, id#3436, dep#3437] cat.ns1.test_table cat.ns1.test_table
-            |""".stripMargin.replaceAll("\n", "")),
+        "operator" -> expectedOperator),
       context = ExpectedContext(
         fragment = "DELETE FROM cat.ns1.test_table WHERE id <= 1 AND rand() > 0.5",
         start = 0,

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/GroupBasedDeleteFromTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/GroupBasedDeleteFromTableSuite.scala
@@ -31,14 +31,19 @@ class GroupBasedDeleteFromTableSuite extends DeleteFromTableSuiteBase {
         |{ "pk": 3, "id": 3, "dep": "hr" }
         |""".stripMargin)
 
+    // scalastyle:off line.size.limit
     val expectedOperator =
-      "ReplaceData RelationV2[pk#3435, id#3436, dep#3437] cat.ns1.test_table cat.ns1.test_table"
+      """ReplaceData RelationV2[pk#x, id#x, dep#x] cat.ns1.test_table cat.ns1.test_table
+        |+- Filter NOT (((id#x <= 1) AND (rand(number) > cast(0.5 as double))) <=> true)
+        |   +- RelationV2[pk#x, id#x, dep#x, _partition#x] cat.ns1.test_table cat.ns1.test_table
+        |""".stripMargin
+    // scalastyle:on line.size.limit
     checkError(
       exception = intercept[AnalysisException](
         sql(s"DELETE FROM $tableNameAsString WHERE id <= 1 AND rand() > 0.5")),
       errorClass = "INVALID_NON_DETERMINISTIC_EXPRESSIONS",
       parameters = Map(
-        "sqlExprs" -> "\"((id <= 1) AND (rand() > 0.5))\"",
+        "sqlExprs" -> "\"((id <= 1) AND (rand() > 0.5))\", \"((id <= 1) AND (rand() > 0.5))\"",
         "operator" -> expectedOperator),
       context = ExpectedContext(
         fragment = "DELETE FROM cat.ns1.test_table WHERE id <= 1 AND rand() > 0.5",

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/GroupBasedDeleteFromTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/GroupBasedDeleteFromTableSuite.scala
@@ -17,12 +17,36 @@
 
 package org.apache.spark.sql.connector
 
-import org.apache.spark.sql.Row
+import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.internal.SQLConf
 
 class GroupBasedDeleteFromTableSuite extends DeleteFromTableSuiteBase {
 
   import testImplicits._
+
+  test("delete with nondeterministic conditions") {
+    createAndInitTable("pk INT NOT NULL, id INT, dep STRING",
+      """{ "pk": 1, "id": 1, "dep": "hr" }
+        |{ "pk": 2, "id": 2, "dep": "software" }
+        |{ "pk": 3, "id": 3, "dep": "hr" }
+        |""".stripMargin)
+
+    checkError(
+      exception = intercept[AnalysisException](
+        sql(s"DELETE FROM $tableNameAsString WHERE id <= 1 AND rand() > 0.5")),
+      errorClass = "INVALID_NON_DETERMINISTIC_EXPRESSIONS",
+      parameters = Map(
+        "sqlExprs" -> "\"((id <= 1) AND (rand() > 0.5))\"",
+        "operator" ->
+          """
+            |ReplaceData RelationV2[pk#3435, id#3436, dep#3437] cat.ns1.test_table cat.ns1.test_table
+            |""".stripMargin.replaceAll("\n", "")),
+      context = ExpectedContext(
+        fragment = "DELETE FROM cat.ns1.test_table WHERE id <= 1 AND rand() > 0.5",
+        start = 0,
+        stop = 60)
+    )
+  }
 
   test("delete with IN predicate and runtime group filtering") {
     createAndInitTable("id INT, salary INT, dep STRING",

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/UpdateTableSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/UpdateTableSuiteBase.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.connector
 
 import org.apache.spark.SparkException
-import org.apache.spark.sql.{AnalysisException, Row}
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.connector.catalog.{Column, ColumnDefaultValue}
 import org.apache.spark.sql.connector.expressions.LiteralValue
 import org.apache.spark.sql.types.{IntegerType, StringType}
@@ -526,19 +526,6 @@ abstract class UpdateTableSuiteBase extends RowLevelOperationSuiteBase {
     checkAnswer(
       sql(s"SELECT count(*) FROM $tableNameAsString WHERE value < 2.0"),
       Row(2) :: Nil)
-  }
-
-  test("update with nondeterministic conditions") {
-    createAndInitTable("pk INT NOT NULL, id INT, dep STRING",
-      """{ "pk": 1, "id": 1, "dep": "hr" }
-        |{ "pk": 2, "id": 2, "dep": "software" }
-        |{ "pk": 3, "id": 3, "dep": "hr" }
-        |""".stripMargin)
-
-    val e = intercept[AnalysisException] {
-      sql(s"UPDATE $tableNameAsString SET dep = 'invalid' WHERE id <= 1 AND rand() > 0.5")
-    }
-    assert(e.message.contains("The operator expects a deterministic expression"))
   }
 
   test("update with default values") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/UpdateTableSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/UpdateTableSuiteBase.scala
@@ -538,7 +538,7 @@ abstract class UpdateTableSuiteBase extends RowLevelOperationSuiteBase {
     val e = intercept[AnalysisException] {
       sql(s"UPDATE $tableNameAsString SET dep = 'invalid' WHERE id <= 1 AND rand() > 0.5")
     }
-    assert(e.message.contains("nondeterministic expressions are only allowed"))
+    assert(e.message.contains("The operator expects a deterministic expression"))
   }
 
   test("update with default values") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to assign names to the error class _LEGACY_ERROR_TEMP_[2438-2445].


### Why are the changes needed?
Improve the error framework.



### Does this PR introduce _any_ user-facing change?
'No'.


### How was this patch tested?
Exists test cases updated.
