### PR TITLE
[SPARK-44031][BUILD] Upgrade silencer to 1.7.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2896,7 +2896,7 @@
               <compilerPlugin>
                 <groupId>com.github.ghik</groupId>
                 <artifactId>silencer-plugin_${scala.version}</artifactId>
-                <version>1.7.10</version>
+                <version>1.7.13</version>
               </compilerPlugin>
             </compilerPlugins>
           </configuration>

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -226,12 +226,12 @@ object SparkBuild extends PomBuild {
   // Silencer: Scala compiler plugin for warning suppression
   // Aim: enable fatal warnings, but suppress ones related to using of deprecated APIs
   // depends on scala version:
-  // <2.13.2 - silencer 1.7.12 and compiler settings to enable fatal warnings
+  // <2.13.2 - silencer 1.7.13 and compiler settings to enable fatal warnings
   // 2.13.2+ - no silencer and configured warnings to achieve the same
   lazy val compilerWarningSettings: Seq[sbt.Def.Setting[_]] = Seq(
     libraryDependencies ++= {
       if (VersionNumber(scalaVersion.value).matchesSemVer(SemanticSelector("<2.13.2"))) {
-        val silencerVersion = "1.7.12"
+        val silencerVersion = "1.7.13"
         Seq(
           "org.scala-lang.modules" %% "scala-collection-compat" % "2.2.0",
           compilerPlugin("com.github.ghik" % "silencer-plugin" % silencerVersion cross CrossVersion.full),


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `silencer` to 1.7.13.

### Why are the changes needed?

`silencer` 1.7.13 supports `Scala 2.12.18 & 2.13.11`.
- https://github.com/ghik/silencer/releases/tag/v1.7.13

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?
Pass the CIs.