### PR TITLE
[SPARK-43663][CONNECT][PS] Enable `SeriesParityTests.test_compare`

### DIFF
--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -4018,15 +4018,10 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         >>> ps.DataFrame({}, index=list('abc')).empty
         True
         """
-        # RDD is not supported in Spark Connect, so we use the DataFrame.isEmpty function instead.
-        # We currently do not introduce any additional aliases since these two functions return the
-        # same result, and only have internal differences in their behavior.
-        is_empty = (
-            self._internal.resolved_copy.spark_frame.isEmpty()
-            if is_remote()
-            else self._internal.resolved_copy.spark_frame.rdd.isEmpty()
+        return (
+            len(self._internal.column_labels) == 0
+            or self._internal.resolved_copy.spark_frame.isEmpty()
         )
-        return len(self._internal.column_labels) == 0 or is_empty
 
     @property
     def style(self) -> "Styler":

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -4018,10 +4018,15 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         >>> ps.DataFrame({}, index=list('abc')).empty
         True
         """
-        return (
-            len(self._internal.column_labels) == 0
-            or self._internal.resolved_copy.spark_frame.rdd.isEmpty()
+        # RDD is not supported in Spark Connect, so we use the DataFrame.isEmpty function instead.
+        # We currently do not introduce any additional aliases since these two functions return the
+        # same result, and only have internal differences in their behavior.
+        is_empty = (
+            self._internal.resolved_copy.spark_frame.isEmpty()
+            if is_remote
+            else self._internal.resolved_copy.spark_frame.rdd.isEmpty()
         )
+        return len(self._internal.column_labels) == 0 or is_empty
 
     @property
     def style(self) -> "Styler":

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -4023,7 +4023,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         # same result, and only have internal differences in their behavior.
         is_empty = (
             self._internal.resolved_copy.spark_frame.isEmpty()
-            if is_remote
+            if is_remote()
             else self._internal.resolved_copy.spark_frame.rdd.isEmpty()
         )
         return len(self._internal.column_labels) == 0 or is_empty

--- a/python/pyspark/pandas/tests/connect/series/test_parity_compute.py
+++ b/python/pyspark/pandas/tests/connect/series/test_parity_compute.py
@@ -22,10 +22,6 @@ from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
 class SeriesParityComputeTests(SeriesComputeMixin, PandasOnSparkTestUtils, ReusedConnectTestCase):
-    @unittest.skip("TODO(SPARK-43663): Enable SeriesParityTests.test_compare.")
-    def test_compare(self):
-        super().test_compare()
-
     @unittest.skip(
         "TODO(SPARK-43611): Fix unexpected `AnalysisException` from Spark Connect client."
     )


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to enable `SeriesParityTests.test_compare` for Spark Connect.


### Why are the changes needed?

We should support the existing pandas-on-Spark APIs for Spark Connect as much as possible.


### Does this PR introduce _any_ user-facing change?

Yes, `Series.compare` is now available on Spark Connect.


### How was this patch tested?

Reusing the existing UT.