### PR TITLE
[SPARK-44016][CONNECT] Prevent processing of artifacts that contain invalid paths (absolute, parent, sibling, nephew)

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/artifact/util/ArtifactUtils.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/artifact/util/ArtifactUtils.scala
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connect.artifact.util
+
+import java.nio.file.{Path, Paths}
+
+object ArtifactUtils {
+
+  private[connect] def concatenatePaths(basePath: Path, otherPath: Path): Path = {
+    require(!otherPath.isAbsolute)
+    // We avoid using the `.resolve()` method here to ensure that we're concatenating the two
+    // paths.
+    val concatenatedPath = Paths.get(basePath.toString + "/" + otherPath.toString)
+    // Note: The normalized resulting path may still reference parent directories if the
+    // `otherPath` contains sufficient number of parent operators (i.e "..").
+    // Example: `basePath` = "/base", `otherPath` = "subdir/../../file.txt"
+    // Then, `concatenatedPath` = "/base/subdir/../../file.txt"
+    // and `normalizedPath` = "/base/file.txt".
+    val normalizedPath = concatenatedPath.normalize()
+    // Verify that the prefix of the `normalizedPath` starts with `basePath/`.
+    require(normalizedPath != basePath && normalizedPath.startsWith(basePath + "/"))
+    normalizedPath
+  }
+
+  private[connect] def concatenatePaths(basePath: Path, otherPath: String): Path = {
+    concatenatePaths(basePath, Paths.get(otherPath))
+  }
+}

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectAddArtifactsHandler.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectAddArtifactsHandler.scala
@@ -170,14 +170,16 @@ class SparkConnectAddArtifactsHandler(val responseObserver: StreamObserver[AddAr
       }
 
     val path: Path = Paths.get(canonicalFileName)
-    val stagedPath: Path = try {
-      ArtifactUtils.concatenatePaths(stagingDir, path)
-    } catch {
-      case _: IllegalArgumentException =>
-        throw new IllegalArgumentException(s"Artifact with name: $name is invalid. The `name` " +
-          s"must be a relative path and cannot reference parent/sibling/nephew directories.")
-      case NonFatal(e) => throw e
-    }
+    val stagedPath: Path =
+      try {
+        ArtifactUtils.concatenatePaths(stagingDir, path)
+      } catch {
+        case _: IllegalArgumentException =>
+          throw new IllegalArgumentException(
+            s"Artifact with name: $name is invalid. The `name` " +
+              s"must be a relative path and cannot reference parent/sibling/nephew directories.")
+        case NonFatal(e) => throw e
+      }
 
     Files.createDirectories(stagedPath.getParent)
 

--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/service/AddArtifactsHandlerSuite.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/service/AddArtifactsHandlerSuite.scala
@@ -368,7 +368,7 @@ class AddArtifactsHandlerSuite extends SharedSparkSession with ResourceHelper {
       val name = "/absolute/path/"
       val request = createDummyArtifactRequests(name)
       request.foreach { req =>
-        intercept[IllegalArgumentException]{
+        intercept[IllegalArgumentException] {
           handler.onNext(req)
         }
       }
@@ -385,7 +385,7 @@ class AddArtifactsHandlerSuite extends SharedSparkSession with ResourceHelper {
       val names = Seq("..", "../sibling", "../nephew/directory", "a/../../b", "x/../y/../..")
       val request = names.flatMap(createDummyArtifactRequests)
       request.foreach { req =>
-        intercept[IllegalArgumentException]{
+        intercept[IllegalArgumentException] {
           handler.onNext(req)
         }
       }

--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/service/AddArtifactsHandlerSuite.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/service/AddArtifactsHandlerSuite.scala
@@ -314,4 +314,85 @@ class AddArtifactsHandlerSuite extends SharedSparkSession with ResourceHelper {
       handler.forceCleanUp()
     }
   }
+
+  private def createDummyArtifactRequests(name: String): Seq[proto.AddArtifactsRequest] = {
+    val bytes = ByteString.EMPTY
+    val context = proto.UserContext
+      .newBuilder()
+      .setUserId("c1")
+      .build()
+
+    val singleChunkArtifact = proto.AddArtifactsRequest.SingleChunkArtifact
+      .newBuilder()
+      .setName(name)
+      .setData(
+        proto.AddArtifactsRequest.ArtifactChunk
+          .newBuilder()
+          .setData(bytes)
+          // Set a dummy CRC value
+          .setCrc(12345)
+          .build())
+      .build()
+
+    val singleChunkArtifactRequest = AddArtifactsRequest
+      .newBuilder()
+      .setSessionId("abc")
+      .setUserContext(context)
+      .setBatch(
+        proto.AddArtifactsRequest.Batch.newBuilder().addArtifacts(singleChunkArtifact).build())
+      .build()
+
+    val beginChunkedArtifact = proto.AddArtifactsRequest.BeginChunkedArtifact
+      .newBuilder()
+      .setName(name)
+      .setNumChunks(1)
+      .setTotalBytes(1)
+      .setInitialChunk(
+        proto.AddArtifactsRequest.ArtifactChunk.newBuilder().setData(bytes).setCrc(12345).build())
+      .build()
+
+    val beginChunkArtifactRequest = AddArtifactsRequest
+      .newBuilder()
+      .setSessionId("abc")
+      .setUserContext(context)
+      .setBeginChunk(beginChunkedArtifact)
+      .build()
+
+    Seq(singleChunkArtifactRequest, beginChunkArtifactRequest)
+  }
+
+  test("Artifacts names are not allowed to be absolute paths") {
+    val promise = Promise[AddArtifactsResponse]
+    val handler = new TestAddArtifactsHandler(new DummyStreamObserver(promise))
+    try {
+      val name = "/absolute/path/"
+      val request = createDummyArtifactRequests(name)
+      request.foreach { req =>
+        intercept[IllegalArgumentException]{
+          handler.onNext(req)
+        }
+      }
+      handler.onCompleted()
+    } finally {
+      handler.forceCleanUp()
+    }
+  }
+
+  test("Artifact name/paths cannot reference parent/sibling/nephew directories") {
+    val promise = Promise[AddArtifactsResponse]
+    val handler = new TestAddArtifactsHandler(new DummyStreamObserver(promise))
+    try {
+      val names = Seq("..", "../sibling", "../nephew/directory", "a/../../b", "x/../y/../..")
+      val request = names.flatMap(createDummyArtifactRequests)
+      request.foreach { req =>
+        intercept[IllegalArgumentException]{
+          handler.onNext(req)
+        }
+      }
+      handler.onCompleted()
+    } finally {
+      handler.forceCleanUp()
+    }
+  }
+
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR ensures that all path concatenation operations (i.e `resolve()` operations) with user-giver paths use a custom `concatenatePaths` method that verifies that the resultant path is a sub-directory of the base path. 
 In specific, three conditions are checked:

- The user-given path must not be absolute.
- The final resultant path must not reference parent/nephew/sibling files or directories.
- The final resultant path is not the same as the base path (e.g if the user-given path was empty or normalizes to empty like in "."/"a/..").

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This change is needed to prevent an artifact from overwriting another file on the driver during processing (when the user given path references absolute/parent/sibling/nephew locations) 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes. The user could previously use any type of path when creating the `AddArtifactsRequest` manually but this was unintentional. The [documentation](https://github.com/apache/spark/blob/master/connector/connect/common/src/main/protobuf/spark/connect/base.proto#L499) for the proto mentioned relative paths and thus, this change enforces the expected type of path.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

New unit tests in `AddArtifactsHandlerSuite.scala` that check various types of paths like `"/absolute/path", "..", "../sibling", "../nephew/directory", "a/../../b", "x/../y/../..")`
