### PR TITLE
[SPARK-44044][SS] Improve Error message for Window functions with streaming

### DIFF
--- a/common/utils/src/main/resources/error/error-classes.json
+++ b/common/utils/src/main/resources/error/error-classes.json
@@ -1769,6 +1769,11 @@
     ],
     "sqlState" : "42000"
   },
+  "NON_TIME_WINDOW_NOT_SUPPORTED_IN_STREAMING" : {
+    "message" : [
+      "Window function is not supported in <windowFuncs> on streaming DataFrames/Datasets. Structured Streaming only supports time-window aggregation using the `window` function. (window specification: '<windowSpec>')"
+    ]
+  },
   "NOT_ALLOWED_IN_FROM" : {
     "message" : [
       "Not allowed in the FROM clause:"
@@ -1890,11 +1895,6 @@
   "NO_UDF_INTERFACE" : {
     "message" : [
       "UDF class <className> doesn't implement any UDF interface."
-    ]
-  },
-  "NON_TIME_WINDOW_NOT_SUPPORTED_IN_STREAMING" : {
-    "message" : [
-      "Window function is not supported in <windowFuncs> on streaming DataFrames/Datasets. Structured Streaming only supports time-window aggregation using the `window` function. (window specification: '<windowSpec>')"
     ]
   },
   "NULLABLE_COLUMN_OR_FIELD" : {

--- a/common/utils/src/main/resources/error/error-classes.json
+++ b/common/utils/src/main/resources/error/error-classes.json
@@ -1892,6 +1892,11 @@
       "UDF class <className> doesn't implement any UDF interface."
     ]
   },
+  "NON_TIME_WINDOW_NOT_SUPPORTED_IN_STREAMING" : {
+    "message" : [
+      "Window function is not supported in <windowFuncs> on streaming DataFrames/Datasets. Structured Streaming only supports time-window aggregation using the `window` function. (window specification: '<windowSpec>')"
+    ]
+  },
   "NULLABLE_COLUMN_OR_FIELD" : {
     "message" : [
       "Column or field <name> is nullable while it's required to be non-nullable."

--- a/common/utils/src/main/resources/error/error-classes.json
+++ b/common/utils/src/main/resources/error/error-classes.json
@@ -1771,7 +1771,7 @@
   },
   "NON_TIME_WINDOW_NOT_SUPPORTED_IN_STREAMING" : {
     "message" : [
-      "Window function is not supported in <windowFunc> on streaming DataFrames/Datasets. Structured Streaming only supports time-window aggregation using the WINDOW function. (window specification: <windowSpec>)"
+      "Window function is not supported in '<windowFunc>' (as column '<columnName>') on streaming DataFrames/Datasets. Structured Streaming only supports time-window aggregation using the WINDOW function. (window specification: <windowSpec>)"
     ]
   },
   "NOT_ALLOWED_IN_FROM" : {

--- a/common/utils/src/main/resources/error/error-classes.json
+++ b/common/utils/src/main/resources/error/error-classes.json
@@ -1771,7 +1771,7 @@
   },
   "NON_TIME_WINDOW_NOT_SUPPORTED_IN_STREAMING" : {
     "message" : [
-      "Window function is not supported in '<windowFunc>' (as column '<columnName>') on streaming DataFrames/Datasets. Structured Streaming only supports time-window aggregation using the WINDOW function. (window specification: <windowSpec>)"
+      "Window function is not supported in <windowFunc> (as column <columnName>) on streaming DataFrames/Datasets. Structured Streaming only supports time-window aggregation using the WINDOW function. (window specification: <windowSpec>)"
     ]
   },
   "NOT_ALLOWED_IN_FROM" : {

--- a/common/utils/src/main/resources/error/error-classes.json
+++ b/common/utils/src/main/resources/error/error-classes.json
@@ -1771,7 +1771,7 @@
   },
   "NON_TIME_WINDOW_NOT_SUPPORTED_IN_STREAMING" : {
     "message" : [
-      "Window function is not supported in <windowFuncs> on streaming DataFrames/Datasets. Structured Streaming only supports time-window aggregation using the `window` function. (window specification: '<windowSpec>')"
+      "Window function is not supported in <windowFunc> on streaming DataFrames/Datasets. Structured Streaming only supports time-window aggregation using the `window` function. (window specification: <windowSpec>)"
     ]
   },
   "NOT_ALLOWED_IN_FROM" : {

--- a/common/utils/src/main/resources/error/error-classes.json
+++ b/common/utils/src/main/resources/error/error-classes.json
@@ -1771,7 +1771,7 @@
   },
   "NON_TIME_WINDOW_NOT_SUPPORTED_IN_STREAMING" : {
     "message" : [
-      "Window function is not supported in <windowFunc> on streaming DataFrames/Datasets. Structured Streaming only supports time-window aggregation using the `window` function. (window specification: <windowSpec>)"
+      "Window function is not supported in <windowFunc> on streaming DataFrames/Datasets. Structured Streaming only supports time-window aggregation using the WINDOW function. (window specification: <windowSpec>)"
     ]
   },
   "NOT_ALLOWED_IN_FROM" : {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationChecker.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationChecker.scala
@@ -514,7 +514,7 @@ object UnsupportedOperationChecker extends Logging {
             e.collect {
               case we: WindowExpression =>
                 s"'${we.windowFunction}' as column '${e.toAttribute.sql}'"
-            }
+              }
           }.mkString(", ")
           val windowSpec = windowExpression.flatMap { e =>
             e.collect {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationChecker.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationChecker.scala
@@ -511,12 +511,12 @@ object UnsupportedOperationChecker extends Logging {
         case Window(_, _, _, child) if child.isStreaming =>
           val windowFuncs = subPlan.asInstanceOf[Window].windowExpressions.flatMap { e =>
             e.collect {
-              case we: WindowExpression => s"${we.windowFunction} AS ${e.toAttribute.sql}"
+              case we: WindowExpression => s"${we.windowFunction} as column ${e.toAttribute.sql}"
             }
           }.mkString(", ")
           throw new AnalysisException(
-            s"Unsupported window function found in column '$windowFuncs'. Structured " +
-            "streaming only supports time-window aggregation using the `window` function.",
+            s"Unsupported window function in '$windowFuncs'. Structured " +
+            "Streaming only supports time-window aggregation using the `window` function.",
             subPlan.origin.line,
             subPlan.origin.startPosition)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationChecker.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationChecker.scala
@@ -509,7 +509,7 @@ object UnsupportedOperationChecker extends Logging {
           throwError("Sampling is not supported on streaming DataFrames/Datasets")
 
         case Window(_, _, _, child) if child.isStreaming =>
-          val windowFuncs = subPlan.asInstanceOf[Window].projectList.flatMap { e =>
+          val windowFuncs = subPlan.asInstanceOf[Window].windowExpressions.flatMap { e =>
             e.collect {
               case we: WindowExpression => s"${we.windowFunction} AS ${e.toAttribute.sql}"
             }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationChecker.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationChecker.scala
@@ -522,9 +522,9 @@ object UnsupportedOperationChecker extends Logging {
             }
           }.mkString(", ")
           throw new AnalysisException(
-            s"Unsupported window function in $windowFuncs. Structured " +
-            "Streaming only supports time-window aggregation using the `window` function. " +
-            s"(window specification: '$windowSpec')",
+            s"Window function is not supported in $windowFuncs on streaming DataFrames/Datasets. " +
+            "Structured Streaming only supports time-window aggregation using the `window` " +
+            s"function. (window specification: '$windowSpec')",
             subPlan.origin.line,
             subPlan.origin.startPosition)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -725,13 +725,15 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase {
   }
 
   def nonTimeWindowNotSupportedInStreamingError(
-      windowFuncs: String,
+      windowFunc: String,
       windowSpec: String,
       origin: Origin): AnalysisException = {
     new AnalysisException(
       errorClass = "NON_TIME_WINDOW_NOT_SUPPORTED_IN_STREAMING",
-      messageParameters = Map("windowFuncs" -> windowFuncs, "windowSpec" -> windowSpec),
-      origin = origin)
+      messageParameters = Map(
+        "windowFunc" -> windowFunc,
+        "windowSpec" -> toSQLValue(windowSpec, StringType)),
+        origin = origin)
   }
 
   def multiplePathsSpecifiedError(allPaths: Seq[String]): SparkIllegalArgumentException = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -726,13 +726,15 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase {
 
   def nonTimeWindowNotSupportedInStreamingError(
       windowFunc: String,
+      columnName: String,
       windowSpec: String,
       origin: Origin): AnalysisException = {
     new AnalysisException(
       errorClass = "NON_TIME_WINDOW_NOT_SUPPORTED_IN_STREAMING",
       messageParameters = Map(
         "windowFunc" -> windowFunc,
-        "windowSpec" -> toSQLStmt(windowSpec)),
+        "columnName" -> columnName,
+        "windowSpec" -> windowSpec),
         origin = origin)
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -725,16 +725,16 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase {
   }
 
   def nonTimeWindowNotSupportedInStreamingError(
-      windowFunc: String,
-      columnName: String,
-      windowSpec: String,
+      windowFuncList: Seq[String],
+      columnNameList: Seq[String],
+      windowSpecList: Seq[String],
       origin: Origin): AnalysisException = {
     new AnalysisException(
       errorClass = "NON_TIME_WINDOW_NOT_SUPPORTED_IN_STREAMING",
       messageParameters = Map(
-        "windowFunc" -> windowFunc,
-        "columnName" -> columnName,
-        "windowSpec" -> windowSpec),
+        "windowFunc" -> windowFuncList.map(toSQLStmt(_)).mkString(","),
+        "columnName" -> columnNameList.map(toSQLId(_)).mkString(","),
+        "windowSpec" -> windowSpecList.map(toSQLStmt(_)).mkString(",")),
         origin = origin)
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -732,7 +732,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase {
       errorClass = "NON_TIME_WINDOW_NOT_SUPPORTED_IN_STREAMING",
       messageParameters = Map(
         "windowFunc" -> windowFunc,
-        "windowSpec" -> toSQLValue(windowSpec, StringType)),
+        "windowSpec" -> toSQLStmt(windowSpec)),
         origin = origin)
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -43,7 +43,7 @@ import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.catalyst.plans.JoinType
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.plans.logical.statsEstimation.ValueInterval
-import org.apache.spark.sql.catalyst.trees.{SQLQueryContext, TreeNode}
+import org.apache.spark.sql.catalyst.trees.{Origin, SQLQueryContext, TreeNode}
 import org.apache.spark.sql.catalyst.util.{sideBySide, BadRecordException, DateTimeUtils, FailFastMode}
 import org.apache.spark.sql.connector.catalog.{CatalogNotFoundException, Table, TableProvider}
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
@@ -722,6 +722,16 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase {
     new SparkUnsupportedOperationException(
       errorClass = "_LEGACY_ERROR_TEMP_2049",
       messageParameters = Map("className" -> className, "operator" -> operator))
+  }
+
+  def nonTimeWindowNotSupportedInStreamingError(
+      windowFuncs: String,
+      windowSpec: String,
+      origin: Origin): AnalysisException = {
+    new AnalysisException(
+      errorClass = "NON_TIME_WINDOW_NOT_SUPPORTED_IN_STREAMING",
+      messageParameters = Map("windowFuncs" -> windowFuncs, "windowSpec" -> windowSpec),
+      origin = origin)
   }
 
   def multiplePathsSpecifiedError(allPaths: Seq[String]): SparkIllegalArgumentException = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationsSuite.scala
@@ -738,7 +738,10 @@ class UnsupportedOperationsSuite extends SparkFunSuite with SQLHelper {
   testUnaryOperatorInStreamingPlan(
     "sample", Sample(0.1, 1, true, 1L, _), expectedMsg = "sampling")
   testUnaryOperatorInStreamingPlan(
-    "window", Window(Nil, Nil, Nil, _), expectedMsg = "non-time-based windows")
+    "window",
+    Window(Nil, Nil, Nil, _),
+    expectedMsg =
+      "Structured Streaming only supports time-window aggregation using the `window` function")
 
   // Output modes with aggregation and non-aggregation plans
   testOutputMode(Append, shouldSupportAggregation = false, shouldSupportNonAggregation = true)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationsSuite.scala
@@ -36,7 +36,7 @@ import org.apache.spark.sql.types.{IntegerType, LongType, MetadataBuilder}
 /** A dummy command for testing unsupported operations. */
 case class DummyCommand() extends LeafCommand
 
-  class UnsupportedOperationsSuite extends SparkFunSuite with SQLHelper {
+class UnsupportedOperationsSuite extends SparkFunSuite with SQLHelper {
 
   val attribute = AttributeReference("a", IntegerType, nullable = true)()
   val watermarkMetadata = new MetadataBuilder()

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
@@ -703,7 +703,7 @@ class StreamSuite extends StreamTest {
         .start()
     }
   assert(e.getMessage.contains(
-    "Unsupported window function in 'row_number()' as column 'rn_col'"))
+    "Window function is not supported in 'row_number()' as column 'rn_col'"))
   }
 
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
@@ -42,6 +42,7 @@ import org.apache.spark.sql.execution.command.ExplainCommand
 import org.apache.spark.sql.execution.streaming._
 import org.apache.spark.sql.execution.streaming.sources.{ContinuousMemoryStream, MemorySink}
 import org.apache.spark.sql.execution.streaming.state.{StateStore, StateStoreConf, StateStoreId, StateStoreProvider}
+import org.apache.spark.sql.expressions.Window
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.sources.StreamSourceProvider
@@ -685,6 +686,26 @@ class StreamSuite extends StreamTest {
     query.stop()
     assert(query.exception.isEmpty)
   }
+
+  test("SPARK-44044: non-time-window") {
+    val inputData = MemoryStream[(Int, Int)]
+    val e = intercept[AnalysisException] {
+      val agg = inputData
+        .toDF()
+        .selectExpr("CAST(_1 AS timestamp) AS col1", "_2 AS col2")
+        .withWatermark("col1", "10 seconds")
+        .withColumn("rn_col", row_number().over(Window
+          .partitionBy("col1")
+          .orderBy(col("col2"))))
+        .select("rn_col", "col1", "col2")
+        .writeStream
+        .format("console")
+        .start()
+    }
+  assert(e.getMessage.contains(
+    "Unsupported window function found in column 'row_number() AS rn_col'"))
+  }
+
 
   test("SPARK-19873: streaming aggregation with change in number of partitions") {
     val inputData = MemoryStream[(Int, Int)]

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
@@ -706,10 +706,11 @@ class StreamSuite extends StreamTest {
       e,
       "NON_TIME_WINDOW_NOT_SUPPORTED_IN_STREAMING",
       parameters = Map(
-        "windowFunc" -> "'row_number()' as column 'rn_col'",
+        "windowFunc" -> "ROW_NUMBER()",
+        "columnName" -> "`rn_col`",
         "windowSpec" ->
-          ("'(PARTITION BY col1 ORDER BY col2 ASC NULLS FIRST ROWS BETWEEN UNBOUNDED PRECEDING " +
-          "AND CURRENT ROW)'")))
+          ("(PARTITION BY COL1 ORDER BY COL2 ASC NULLS FIRST ROWS BETWEEN UNBOUNDED PRECEDING " +
+          "AND CURRENT ROW)")))
   }
 
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
@@ -702,8 +702,14 @@ class StreamSuite extends StreamTest {
         .format("console")
         .start()
     }
-  assert(e.getMessage.contains(
-    "Window function is not supported in 'row_number()' as column 'rn_col'"))
+    checkError(
+      e,
+      "NON_TIME_WINDOW_NOT_SUPPORTED_IN_STREAMING",
+      parameters = Map(
+        "windowFunc" -> "'row_number()' as column 'rn_col'",
+        "windowSpec" ->
+          ("'(PARTITION BY col1 ORDER BY col2 ASC NULLS FIRST ROWS BETWEEN UNBOUNDED PRECEDING " +
+          "AND CURRENT ROW)'")))
   }
 
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
@@ -703,7 +703,7 @@ class StreamSuite extends StreamTest {
         .start()
     }
   assert(e.getMessage.contains(
-    "Unsupported window function found in column 'row_number() AS rn_col'"))
+    "Unsupported window function in 'row_number()' as column 'rn_col'"))
   }
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Replace existing error message when non-time window function is used with streaming to include aggregation function and column. The error message looks like following now:

org.apache.spark.sql.AnalysisException: Window function is not supported in 'row_number()' as column 'rn_col' on streaming DataFrames/Datasets. Structured Streaming only supports time-window aggregation using the `window` unction. (window specification: '(PARTITION BY col1 ORDER BY col2 ASC NULLS FIRST ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)')

Note that the message is a little bit unnatural as the existing unit test requires the exception follows the pattern that it includes "not supported", "streaming" "DataFrames" and "Dataset".

### Why are the changes needed?
The exiting error message is vague and a full logical plan is included. A user reports that they aren't able to identify what the problem is.

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Added a unit test
