### PR TITLE
[SPARK-44045][SQL][TESTS] Mark `WholeStageCodegenSparkSubmitSuite` as `ExtendedSQLTest`

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSparkSubmitSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSparkSubmitSuite.scala
@@ -27,10 +27,12 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{QueryTest, Row, SparkSession}
 import org.apache.spark.sql.functions.{array, col, count, lit}
 import org.apache.spark.sql.types.IntegerType
+import org.apache.spark.tags.ExtendedSQLTest
 import org.apache.spark.unsafe.Platform
 import org.apache.spark.util.ResetSystemProperties
 
 // Due to the need to set driver's extraJavaOptions, this test needs to use actual SparkSubmit.
+@ExtendedSQLTest
 class WholeStageCodegenSparkSubmitSuite extends SparkSubmitTestUtils
   with Matchers
   with BeforeAndAfterEach


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to move `WholeStageCodegenSparkSubmitSuite` to `sql - slow` pipeline to mitigate the recent `sql - others` pipeline's flakiness.

### Why are the changes needed?

`WholeStageCodegenSparkSubmitSuite` is the only test suite using `SparkSubmitTestUtils` in `sql` module.

```
$ git grep 'SparkSubmitTestUtils' | grep sql/core
sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSparkSubmitSuite.scala:import org.apache.spark.deploy.SparkSubmitTestUtils
sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSparkSubmitSuite.scala:class WholeStageCodegenSparkSubmitSuite extends SparkSubmitTestUtils
```

Like the following, this test case contributes the flakiness.

- https://github.com/wangyum/spark/actions/runs/5253058423/jobs/9489919333


```
2023-06-13T11:05:31.3387316Z [0m[[0m[0minfo[0m] [0m[0m[32mWholeStageCodegenSparkSubmitSuite:[0m[0m
2023-06-13T11:05:36.6680896Z 2023-06-13 04:05:36.667 - stderr> 23/06/13 11:05:36 INFO SparkContext: Running Spark version 3.5.0-SNAPSHOT
...
2023-06-13T11:06:47.4402222Z 2023-06-13 04:06:47.408 - stderr> 23/06/13 11:06:47 INFO TaskSetManager: Finished task 52.0 in stage 2.0 (TID 63) in 148 ms on 127.0.0.1 (executor 0) (60/200)
2023-06-13T11:06:48.1484169Z 
2023-06-13T11:06:48.8633864Z ##[error]The runner has received a shutdown signal. This can happen when the runner service is stopped, or a manually started runner is canceled.
2023-06-13T11:06:48.9660849Z Session terminated, killing shell...
2023-06-13T11:06:49.2756183Z ##[error]The operation was canceled.
2023-06-13T11:06:49.4597252Z Cleaning up orphan processes
2023-06-13T11:06:49.6684941Z Terminate orphan process: pid (4061) (java)
2023-06-13T11:06:49.7698091Z Terminate orphan process: pid (661115) (java)
```

### Does this PR introduce _any_ user-facing change?

No.


### How was this patch tested?
Pass the CIs.