### PR TITLE
[SPARK-39979][SQL][FOLLOW-UP] Make `spark.sql.execution.arrow.useLargeVarTypes` as an internal configuration

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2841,8 +2841,9 @@ object SQLConf {
       .doc("When using Apache Arrow, use large variable width vectors for string and binary " +
         "types. Regular string and binary types have a 2GiB limit for a column in a single " +
         "record batch. Large variable types remove this limitation at the cost of higher memory " +
-        "usage per value.")
+        "usage per value. Note that this only works for DataFrame.mapInArrow.")
       .version("3.5.0")
+      .internal()
       .booleanConf
       .createWithDefault(false)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/39572 that hides the `spark.sql.execution.arrow.useLargeVarTypes` configuration as an internal configuration.


### Why are the changes needed?

As described in https://github.com/apache/spark/pull/41569, this feature only works for `mapInArrow`, and other cases cannot be completely supported because of Arrow side limitation, see https://github.com/apache/arrow/issues/35289. Therefore, this PR hides this configuration as an internal one for now.

### Does this PR introduce _any_ user-facing change?

No, this configuration was not released out yet.

### How was this patch tested?

Ran the Scala linter.