### PR TITLE
[WIP][SPARK-43654][SPARK-43655][CONNECT] Ensure that Spark Connect assigns correct column name

### DIFF
--- a/python/pyspark/pandas/tests/connect/test_parity_internal.py
+++ b/python/pyspark/pandas/tests/connect/test_parity_internal.py
@@ -24,9 +24,7 @@ from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 class InternalFrameParityTests(
     InternalFrameTestsMixin, PandasOnSparkTestUtils, ReusedConnectTestCase
 ):
-    @unittest.skip("TODO(SPARK-43654): Enable InternalFrameParityTests.test_from_pandas.")
-    def test_from_pandas(self):
-        super().test_from_pandas()
+    pass
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/connect/test_parity_namespace.py
+++ b/python/pyspark/pandas/tests/connect/test_parity_namespace.py
@@ -34,10 +34,6 @@ class NamespaceParityTests(NamespaceTestsMixin, PandasOnSparkTestUtils, ReusedCo
     def test_concat_multiindex_sort(self):
         super().test_concat_multiindex_sort()
 
-    @unittest.skip("TODO(SPARK-43655): Enable NamespaceParityTests.test_get_index_map.")
-    def test_get_index_map(self):
-        super().test_get_index_map()
-
 
 if __name__ == "__main__":
     from pyspark.pandas.tests.connect.test_parity_namespace import *  # noqa: F401

--- a/python/pyspark/pandas/utils.py
+++ b/python/pyspark/pandas/utils.py
@@ -36,7 +36,6 @@ from typing import (
     overload,
 )
 import warnings
-import re
 
 from pyspark.sql import functions as F, Column, DataFrame as PySparkDataFrame, SparkSession
 from pyspark.sql.types import DoubleType

--- a/python/pyspark/pandas/utils.py
+++ b/python/pyspark/pandas/utils.py
@@ -965,14 +965,7 @@ def spark_column_equals(left: Column, right: Column) -> bool:
                 error_class="NOT_COLUMN",
                 message_parameters={"arg_name": "right", "arg_type": type(right).__name__},
             )
-        # In Spark Connect, column name is surrounded by backticks.
-        # e.g. "Column<'`name`'>" in Spark Connect whereas "Column<'name'>" in vanilla PySpark.
-        # Therefore, we need to use regular expressions to extract the actual column name
-        # excluding the backticks, in order to check if they have the same name.
-        pattern = r"['`]([^'`]+)['`]"
-        left_col_name = re.search(pattern, repr(left)).group(1)
-        right_col_name = re.search(pattern, repr(right)).group(1)
-        return left_col_name == right_col_name
+        return left._expr == right._expr
     else:
         return left._jc.equals(right._jc)
 

--- a/python/pyspark/sql/connect/expressions.py
+++ b/python/pyspark/sql/connect/expressions.py
@@ -457,7 +457,11 @@ class ColumnReference(Expression):
     def __init__(self, unparsed_identifier: str, plan_id: Optional[int] = None) -> None:
         super().__init__()
         assert isinstance(unparsed_identifier, str)
-        self._unparsed_identifier = unparsed_identifier
+        # To ensure that only the column name without the surrounding backticks is recognized
+        # when the column name is enclosed in backticks, we need to replace the backticks here.
+        # Otherwise, Spark Connect assign wrong column name such as "Column<'`name`'>",
+        # whereas "Column<'name'>" in vanilla PySpark.
+        self._unparsed_identifier = unparsed_identifier.replace("`", "")
 
         assert plan_id is None or isinstance(plan_id, int)
         self._plan_id = plan_id


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to fix Spark Connect Column work properly when assigning the column name.

### Why are the changes needed?

To match the behavior between vanilla PySpark <> Spark Connect.

In Spark Connect, when a column name is enclosed in backticks, it is used as the column name as it is.

```python
>>> sdf = spark.range(10)
>>> sdf["`id`"]
Column<'`id`'>
```

Whereas vanilla PySpark excludes the backticks:

```python
>>> sdf = spark.range(10)
>>> sdf["`id`"]
Column<'id'>
```
### Does this PR introduce _any_ user-facing change?

Yes, now the Spark Connect Column assigns its name as the same as vanilla PySpark.

### How was this patch tested?

Reusing the existing UT.