### PR TITLE
[SPARK-44054][CORE][TESTS]  Make test cases inherit `SparkFunSuite` have a default timeout

### DIFF
--- a/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaSinkSuite.scala
+++ b/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaSinkSuite.scala
@@ -27,7 +27,6 @@ import org.apache.kafka.clients.producer.ProducerConfig
 import org.apache.kafka.clients.producer.internals.DefaultPartitioner
 import org.apache.kafka.common.Cluster
 import org.apache.kafka.common.serialization.ByteArraySerializer
-import org.scalatest.concurrent.TimeLimits.failAfter
 import org.scalatest.time.SpanSugar._
 
 import org.apache.spark.{SparkConf, SparkContext, SparkException, TestUtils}

--- a/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaSinkSuite.scala
+++ b/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaSinkSuite.scala
@@ -286,12 +286,13 @@ abstract class KafkaSinkStreamingSuiteBase extends KafkaSinkSuiteBase {
 class KafkaSinkMicroBatchStreamingSuite extends KafkaSinkStreamingSuiteBase {
   import testImplicits._
 
-  override val streamingTimeout = 30.seconds
+  override val streamingTimeout = 10.milliseconds
 
   override protected def createMemoryStream(): MemoryStreamBase[String] = MemoryStream[String]
 
   override protected def verifyResult(writer: StreamingQuery)(verifyFn: => Unit): Unit = {
     failAfter(streamingTimeout) {
+      Thread.sleep(20)
       writer.processAllAvailable()
     }
     verifyFn

--- a/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaSinkSuite.scala
+++ b/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaSinkSuite.scala
@@ -286,13 +286,12 @@ abstract class KafkaSinkStreamingSuiteBase extends KafkaSinkSuiteBase {
 class KafkaSinkMicroBatchStreamingSuite extends KafkaSinkStreamingSuiteBase {
   import testImplicits._
 
-  override val streamingTimeout = 10.milliseconds
+  override val streamingTimeout = 30.seconds
 
   override protected def createMemoryStream(): MemoryStreamBase[String] = MemoryStream[String]
 
   override protected def verifyResult(writer: StreamingQuery)(verifyFn: => Unit): Unit = {
     failAfter(streamingTimeout) {
-      Thread.sleep(20)
       writer.processAllAvailable()
     }
     verifyFn

--- a/core/src/test/scala/org/apache/spark/SparkFunSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkFunSuite.scala
@@ -35,6 +35,7 @@ import org.scalactic.source.Position
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, BeforeAndAfterEach, Failed, Outcome, Tag}
 import org.scalatest.concurrent.TimeLimits
 import org.scalatest.funsuite.AnyFunSuite // scalastyle:ignore funsuite
+import org.scalatest.time.SpanSugar._ // scalastyle:ignore
 
 import org.apache.spark.deploy.LocalSparkCluster
 import org.apache.spark.internal.Logging
@@ -149,7 +150,6 @@ abstract class SparkFunSuite
     if (excluded.contains(testName)) {
       ignore(s"$testName (excluded)")(testBody)
     } else {
-      import org.scalatest.time.SpanSugar._
       super.test(testName, testTags: _*)(
         failAfter(10.minutes)(testBody)
       )

--- a/core/src/test/scala/org/apache/spark/SparkFunSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkFunSuite.scala
@@ -33,6 +33,7 @@ import org.apache.logging.log4j.core.appender.AbstractAppender
 import org.apache.logging.log4j.core.config.Property
 import org.scalactic.source.Position
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, BeforeAndAfterEach, Failed, Outcome, Tag}
+import org.scalatest.concurrent.TimeLimits
 import org.scalatest.funsuite.AnyFunSuite // scalastyle:ignore funsuite
 
 import org.apache.spark.deploy.LocalSparkCluster
@@ -69,6 +70,7 @@ abstract class SparkFunSuite
   with BeforeAndAfterAll
   with BeforeAndAfterEach
   with ThreadAudit
+  with TimeLimits
   with Logging {
 // scalastyle:on
 
@@ -147,7 +149,10 @@ abstract class SparkFunSuite
     if (excluded.contains(testName)) {
       ignore(s"$testName (excluded)")(testBody)
     } else {
-      super.test(testName, testTags: _*)(testBody)
+      import org.scalatest.time.SpanSugar._
+      super.test(testName, testTags: _*)(
+        failAfter(10.minutes)(testBody)
+      )
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/SparkFunSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkFunSuite.scala
@@ -35,7 +35,7 @@ import org.scalactic.source.Position
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, BeforeAndAfterEach, Failed, Outcome, Tag}
 import org.scalatest.concurrent.TimeLimits
 import org.scalatest.funsuite.AnyFunSuite // scalastyle:ignore funsuite
-import org.scalatest.time.SpanSugar._ // scalastyle:ignore
+import org.scalatest.time._ // scalastyle:ignore
 
 import org.apache.spark.deploy.LocalSparkCluster
 import org.apache.spark.internal.Logging
@@ -150,8 +150,9 @@ abstract class SparkFunSuite
     if (excluded.contains(testName)) {
       ignore(s"$testName (excluded)")(testBody)
     } else {
+      val timeout = sys.props.getOrElse("spark.test.timeout", "20").toLong
       super.test(testName, testTags: _*)(
-        failAfter(10.minutes)(testBody)
+        failAfter(Span(timeout, Minutes))(testBody)
       )
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr use `failAfter` to wrap the `testBody` of `SparkFunSuite#test` to control the test timeout, and add an un-document config `spark.test.timeout` with default value 20 minutes in this pr, the test inherit `SparkFunSuite` will fail with `TestFailedDueToTimeoutException` when test timeout.


### Why are the changes needed?
Avoid GA task times out due to test case blocks.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass Github Actions
- manual checked.
