### PR TITLE
[SPARK-43415][Connect] Alternative mapValues for KeyValueGroupedDS#agg using withContext

### DIFF
--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -1242,7 +1242,10 @@ class Dataset[T] private[sql] (
    */
   @scala.annotation.varargs
   def groupBy(cols: Column*): RelationalGroupedDataset = {
-    new RelationalGroupedDataset(toDF(), cols, proto.Aggregate.GroupType.GROUP_TYPE_GROUPBY)
+    new RelationalGroupedDataset(
+      toDF(),
+      cols.map(_.expr),
+      proto.Aggregate.GroupType.GROUP_TYPE_GROUPBY)
   }
 
   /**
@@ -1270,7 +1273,7 @@ class Dataset[T] private[sql] (
     val colNames: Seq[String] = col1 +: cols
     new RelationalGroupedDataset(
       toDF(),
-      colNames.map(colName => Column(colName)),
+      colNames.map(colName => Column(colName).expr),
       proto.Aggregate.GroupType.GROUP_TYPE_GROUPBY)
   }
 
@@ -1351,7 +1354,10 @@ class Dataset[T] private[sql] (
    */
   @scala.annotation.varargs
   def rollup(cols: Column*): RelationalGroupedDataset = {
-    new RelationalGroupedDataset(toDF(), cols, proto.Aggregate.GroupType.GROUP_TYPE_ROLLUP)
+    new RelationalGroupedDataset(
+      toDF(),
+      cols.map(_.expr),
+      proto.Aggregate.GroupType.GROUP_TYPE_ROLLUP)
   }
 
   /**
@@ -1381,7 +1387,7 @@ class Dataset[T] private[sql] (
     val colNames: Seq[String] = col1 +: cols
     new RelationalGroupedDataset(
       toDF(),
-      colNames.map(colName => Column(colName)),
+      colNames.map(colName => Column(colName).expr),
       proto.Aggregate.GroupType.GROUP_TYPE_ROLLUP)
   }
 
@@ -1406,7 +1412,10 @@ class Dataset[T] private[sql] (
    */
   @scala.annotation.varargs
   def cube(cols: Column*): RelationalGroupedDataset = {
-    new RelationalGroupedDataset(toDF(), cols, proto.Aggregate.GroupType.GROUP_TYPE_CUBE)
+    new RelationalGroupedDataset(
+      toDF(),
+      cols.map(_.expr),
+      proto.Aggregate.GroupType.GROUP_TYPE_CUBE)
   }
 
   /**
@@ -1435,7 +1444,7 @@ class Dataset[T] private[sql] (
     val colNames: Seq[String] = col1 +: cols
     new RelationalGroupedDataset(
       toDF(),
-      colNames.map(colName => Column(colName)),
+      colNames.map(colName => Column(colName).expr),
       proto.Aggregate.GroupType.GROUP_TYPE_CUBE)
   }
 

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
@@ -37,7 +37,7 @@ import org.apache.spark.connect.proto
  */
 class RelationalGroupedDataset private[sql] (
     private[sql] val df: DataFrame,
-    private[sql] val groupingExprs: Seq[Column],
+    private[sql] val groupingExprs: Seq[proto.Expression],
     groupType: proto.Aggregate.GroupType,
     pivot: Option[proto.Aggregate.Pivot] = None) {
 
@@ -45,7 +45,7 @@ class RelationalGroupedDataset private[sql] (
     df.sparkSession.newDataFrame { builder =>
       builder.getAggregateBuilder
         .setInput(df.plan.getRoot)
-        .addAllGroupingExpressions(groupingExprs.map(_.expr).asJava)
+        .addAllGroupingExpressions(groupingExprs.asJava)
         .addAllAggregateExpressions(aggExprs.map(e => e.expr).asJava)
 
       groupType match {

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -2001,11 +2001,41 @@ class SparkConnectPlanner(val session: SparkSession) extends Logging {
 
   private def transformKeyValueGroupedAggregate(rel: proto.Aggregate): LogicalPlan = {
     val input = transformRelation(rel.getInput)
-    val ds = UntypedKeyValueGroupedDataset(input, rel.getGroupingExpressionsList, Seq.empty)
+    var ds = UntypedKeyValueGroupedDataset(input, rel.getGroupingExpressionsList, Seq.empty)
+
+    val aggExprs: Seq[proto.Expression] = rel.getAggregateExpressionsList.asScala.toSeq match {
+      case Seq(expr)
+          if expr.hasUnresolvedFunction &&
+            expr.getUnresolvedFunction.getFunctionName == "map_values" =>
+        // Apply mapValue functions before handling agg expressions
+        if (expr.getUnresolvedFunction.getArgumentsCount < 2) {
+          throw InvalidPlanInput("map_values requires at least two child expressions")
+        }
+        val args = expr.getUnresolvedFunction.getArgumentsList.asScala.toSeq
+        val mapValueFunc = TypedScalaUdf(args.head)
+
+        // Recompute the dataset's logical plan and data attributes after applying the mapFunc.
+        val withNewData = AppendColumns(
+          mapValueFunc.function,
+          mapValueFunc.inEnc,
+          mapValueFunc.outEnc,
+          ds.analyzed,
+          ds.dataAttributes)
+
+        val projected = Project(withNewData.newColumns ++ ds.groupingAttributes, withNewData)
+        val analyzed = session.sessionState.executePlan(projected).analyzed
+        ds = ds.copy(
+          vEncoder = mapValueFunc.outEnc,
+          analyzed = analyzed,
+          dataAttributes = withNewData.newColumns)
+        args.drop(1)
+      case e => e
+    }
 
     val keyColumn = TypedAggUtils.aggKeyColumn(ds.kEncoder, ds.groupingAttributes)
-    val namedColumns = rel.getAggregateExpressionsList.asScala.toSeq
-      .map(expr => transformExpressionWithTypedReduceExpression(expr, input))
+    val namedColumns = aggExprs
+      .map(expr =>
+        transformExpressionWithTypedReduceExpression(expr, input, Some(ds.dataAttributes)))
       .map(toNamedExpression)
     logical.Aggregate(ds.groupingAttributes, keyColumn +: namedColumns, ds.analyzed)
   }
@@ -2097,12 +2127,16 @@ class SparkConnectPlanner(val session: SparkSession) extends Logging {
 
   private def transformExpressionWithTypedReduceExpression(
       expr: proto.Expression,
-      plan: LogicalPlan): Expression = {
+      plan: LogicalPlan,
+      dataAttribute: Option[Seq[Attribute]] = None): Expression = {
     expr.getExprTypeCase match {
       case proto.Expression.ExprTypeCase.UNRESOLVED_FUNCTION
           if expr.getUnresolvedFunction.getFunctionName == "reduce" =>
         // The reduce func needs the input data attribute, thus handle it specially here
-        transformTypedReduceExpression(expr.getUnresolvedFunction, plan.output)
+        transformTypedReduceExpression(
+          expr.getUnresolvedFunction,
+          dataAttribute.getOrElse(plan.output)
+        ) // if not yet computed, obtain it from the plan
       case _ => transformExpression(expr)
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
The `KVGDS#agg` and `reduceGroups` was not able to chain mapValues functions directly with columns. This PR add the a new unresolved func `withContext` to carry the mapValues func from the client to the server.

The `withContext` can also be used to provide the missing encoders for KVGDS created via RelationalGroupedDS#as.

Reverted the changes to `RelationalGroupedDataset` to use expression instead of columns.
Refactored the code in `SparkConnectPlanner` to always create `TypedUdf` via `ScalaUDF`.

### Why are the changes needed?
Missing functionality for the KVGDS.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
E2E