### PR TITLE
[SPARK-44055][CORE] Remove redundant `override` functions from `CheckpointRDD`

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/CheckpointRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/CheckpointRDD.scala
@@ -19,7 +19,7 @@ package org.apache.spark.rdd
 
 import scala.reflect.ClassTag
 
-import org.apache.spark.{Partition, SparkContext, TaskContext}
+import org.apache.spark.{Partition, SparkContext}
 
 /**
  * An RDD partition used to recover checkpointed data.
@@ -36,12 +36,4 @@ private[spark] abstract class CheckpointRDD[T: ClassTag](sc: SparkContext)
   override def doCheckpoint(): Unit = { }
   override def checkpoint(): Unit = { }
   override def localCheckpoint(): this.type = this
-
-  // Note: There is a bug in MiMa that complains about `AbstractMethodProblem`s in the
-  // base [[org.apache.spark.rdd.RDD]] class if we do not override the following methods.
-  // scalastyle:off
-  protected override def getPartitions: Array[Partition] = ???
-  override def compute(p: Partition, tc: TaskContext): Iterator[T] = ???
-  // scalastyle:on
-
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to remove redundant `override` functions (`getPartitions` and `compute`) from `CheckpointRDD` due to the bug mentioned in the comment for mima check no longer exists.


### Why are the changes needed?
Code Cleanup.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass GitHub Actions
- Manual checked:

```
dev/mima
```

and 

```
dev/change-scala-version.sh 2.13
dev/mima -Pscala-2.13
```

All passed.