### PR TITLE
[SPARK-43975][SQL] DataSource V2: Handle UPDATE commands for group-based sources

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteUpdateTable.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteUpdateTable.scala
@@ -17,10 +17,9 @@
 
 package org.apache.spark.sql.catalyst.analysis
 
-import org.apache.spark.sql.AnalysisException
-import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeReference, Expression, Literal, MetadataAttribute}
+import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeReference, EqualNullSafe, Expression, If, Literal, MetadataAttribute, Not, SubqueryExpression}
 import org.apache.spark.sql.catalyst.expressions.Literal.TrueLiteral
-import org.apache.spark.sql.catalyst.plans.logical.{Assignment, Expand, Filter, LogicalPlan, Project, UpdateTable, WriteDelta}
+import org.apache.spark.sql.catalyst.plans.logical.{Assignment, Expand, Filter, LogicalPlan, Project, ReplaceData, Union, UpdateTable, WriteDelta}
 import org.apache.spark.sql.catalyst.util.RowDeltaUtils._
 import org.apache.spark.sql.connector.catalog.SupportsRowLevelOperations
 import org.apache.spark.sql.connector.write.{RowLevelOperationTable, SupportsDelta}
@@ -47,13 +46,93 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
           table.operation match {
             case _: SupportsDelta =>
               buildWriteDeltaPlan(r, table, assignments, updateCond)
+            case _ if SubqueryExpression.hasSubquery(updateCond) =>
+              buildReplaceDataWithUnionPlan(r, table, assignments, updateCond)
             case _ =>
-              throw new AnalysisException("Group-based UPDATE commands are not supported yet")
+              buildReplaceDataPlan(r, table, assignments, updateCond)
           }
 
         case _ =>
           u
       }
+  }
+
+  // build a rewrite plan for sources that support replacing groups of data (e.g. files, partitions)
+  // if the condition does NOT contain a subquery
+  private def buildReplaceDataPlan(
+      relation: DataSourceV2Relation,
+      operationTable: RowLevelOperationTable,
+      assignments: Seq[Assignment],
+      cond: Expression): ReplaceData = {
+
+    // resolve all required metadata attrs that may be used for grouping data on write
+    val metadataAttrs = resolveRequiredMetadataAttrs(relation, operationTable.operation)
+
+    // construct a read relation and include all required metadata columns
+    val readRelation = buildRelationWithAttrs(relation, operationTable, metadataAttrs)
+
+    // build a plan with updated and copied over records
+    val updatedAndRemainingRowsPlan = buildReplaceDataUpdateProjection(
+      readRelation, assignments, cond)
+
+    // build a plan to replace read groups in the table
+    val writeRelation = relation.copy(table = operationTable)
+    ReplaceData(writeRelation, cond, updatedAndRemainingRowsPlan, relation, Some(cond))
+  }
+
+  // build a rewrite plan for sources that support replacing groups of data (e.g. files, partitions)
+  // if the condition contains a subquery
+  private def buildReplaceDataWithUnionPlan(
+      relation: DataSourceV2Relation,
+      operationTable: RowLevelOperationTable,
+      assignments: Seq[Assignment],
+      cond: Expression): ReplaceData = {
+
+    // resolve all required metadata attrs that may be used for grouping data on write
+    val metadataAttrs = resolveRequiredMetadataAttrs(relation, operationTable.operation)
+
+    // construct a read relation and include all required metadata columns
+    // the same read relation will be used to read records that must be updated and copied over
+    // the analyzer will take care of duplicated attr IDs
+    val readRelation = buildRelationWithAttrs(relation, operationTable, metadataAttrs)
+
+    // build a plan for updated records that match the condition
+    val matchedRowsPlan = Filter(cond, readRelation)
+    val updatedRowsPlan = buildReplaceDataUpdateProjection(matchedRowsPlan, assignments)
+
+    // build a plan that contains unmatched rows in matched groups that must be copied over
+    val remainingRowFilter = Not(EqualNullSafe(cond, Literal.TrueLiteral))
+    val remainingRowsPlan = Filter(remainingRowFilter, readRelation)
+
+    // the new state is a union of updated and copied over records
+    val updatedAndRemainingRowsPlan = Union(updatedRowsPlan, remainingRowsPlan)
+
+    // build a plan to replace read groups in the table
+    val writeRelation = relation.copy(table = operationTable)
+    ReplaceData(writeRelation, cond, updatedAndRemainingRowsPlan, relation, Some(cond))
+  }
+
+  // this method assumes the assignments have been already aligned before
+  private def buildReplaceDataUpdateProjection(
+      plan: LogicalPlan,
+      assignments: Seq[Assignment],
+      cond: Expression = TrueLiteral): LogicalPlan = {
+
+    // the plan output may include immutable metadata columns at the end
+    // that's why the number of assignments may not match the number of plan output columns
+    val assignedValues = assignments.map(_.value)
+    val updatedValues = plan.output.zipWithIndex.map { case (attr, index) =>
+      if (index < assignments.size) {
+        val assignedExpr = assignedValues(index)
+        val updatedValue = If(cond, assignedExpr, attr)
+        Alias(updatedValue, attr.name)()
+      } else {
+        assert(MetadataAttribute.isValid(attr.metadata))
+        attr
+      }
+    }
+
+    Project(updatedValues, plan)
   }
 
   // build a rewrite plan for sources that support row deltas
@@ -78,7 +157,7 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
     val rowDeltaPlan = if (operation.representUpdateAsDeleteAndInsert) {
       buildDeletesAndInserts(matchedRowsPlan, assignments, rowIdAttrs)
     } else {
-      buildUpdateProjection(matchedRowsPlan, assignments, rowIdAttrs)
+      buildWriteDeltaUpdateProjection(matchedRowsPlan, assignments, rowIdAttrs)
     }
 
     // build a plan to write the row delta to the table
@@ -88,7 +167,7 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
   }
 
   // this method assumes the assignments have been already aligned before
-  private def buildUpdateProjection(
+  private def buildWriteDeltaUpdateProjection(
       plan: LogicalPlan,
       assignments: Seq[Assignment],
       rowIdAttrs: Seq[Attribute]): LogicalPlan = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/GroupBasedRowLevelOperationScanPlanning.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/GroupBasedRowLevelOperationScanPlanning.scala
@@ -61,8 +61,9 @@ object GroupBasedRowLevelOperationScanPlanning extends Rule[LogicalPlan] with Pr
          """.stripMargin)
 
       // replace DataSourceV2Relation with DataSourceV2ScanRelation for the row operation table
+      // there may be multiple read relations for UPDATEs that are rewritten as UNION
       rd transform {
-        case r: DataSourceV2Relation if r eq relation =>
+        case r: DataSourceV2Relation if r.table eq table =>
           DataSourceV2ScanRelation(r, scan, PushDownUtils.toOutputAttrs(scan.readSchema(), r))
       }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/GroupBasedUpdateTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/GroupBasedUpdateTableSuite.scala
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.catalyst.expressions.DynamicPruningExpression
+import org.apache.spark.sql.execution.{InSubqueryExec, ReusedSubqueryExec}
+import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
+import org.apache.spark.sql.internal.SQLConf
+
+class GroupBasedUpdateTableSuite extends UpdateTableSuiteBase {
+
+  import testImplicits._
+
+  test("update runtime group filtering (DPP enabled)") {
+    withSQLConf(SQLConf.DYNAMIC_PARTITION_PRUNING_ENABLED.key -> "true") {
+      checkUpdateRuntimeGroupFiltering()
+    }
+  }
+
+  test("update runtime group filtering (DPP disabled)") {
+    withSQLConf(SQLConf.DYNAMIC_PARTITION_PRUNING_ENABLED.key -> "false") {
+      checkUpdateRuntimeGroupFiltering()
+    }
+  }
+
+  test("update runtime group filtering (AQE enabled)") {
+    withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true") {
+      checkUpdateRuntimeGroupFiltering()
+    }
+  }
+
+  test("update runtime group filtering (AQE disabled)") {
+    withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false") {
+      checkUpdateRuntimeGroupFiltering()
+    }
+  }
+
+  private def checkUpdateRuntimeGroupFiltering(): Unit = {
+    withTempView("deleted_id") {
+      createAndInitTable("id INT, salary INT, dep STRING",
+        """{ "id": 1, "salary": 300, "dep": 'hr' }
+          |{ "id": 2, "salary": 150, "dep": 'software' }
+          |{ "id": 3, "salary": 120, "dep": 'hr' }
+          |""".stripMargin)
+
+      val deletedIdDF = Seq(Some(1), None).toDF()
+      deletedIdDF.createOrReplaceTempView("deleted_id")
+
+      executeAndCheckScans(
+        s"UPDATE $tableNameAsString SET salary = -1 WHERE id IN (SELECT * FROM deleted_id)",
+        primaryScanSchema = "id INT, salary INT, dep STRING, _partition STRING",
+        groupFilterScanSchema = Some("id INT, dep STRING"))
+
+      checkAnswer(
+        sql(s"SELECT * FROM $tableNameAsString"),
+        Row(1, -1, "hr") :: Row(2, 150, "software") :: Row(3, 120, "hr") :: Nil)
+
+      checkReplacedPartitions(Seq("hr"))
+    }
+  }
+
+  test("update runtime filter subquery reuse (AQE enabled)") {
+    withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true") {
+      checkUpdateRuntimeFilterSubqueryReuse()
+    }
+  }
+
+  test("update runtime filter subquery reuse (AQE disabled)") {
+    withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false") {
+      checkUpdateRuntimeFilterSubqueryReuse()
+    }
+  }
+
+  private def checkUpdateRuntimeFilterSubqueryReuse(): Unit = {
+    withTempView("deleted_id") {
+      createAndInitTable("id INT, salary INT, dep STRING",
+        """{ "id": 1, "salary": 300, "dep": 'hr' }
+          |{ "id": 2, "salary": 150, "dep": 'software' }
+          |{ "id": 3, "salary": 120, "dep": 'hr' }
+          |""".stripMargin)
+
+      val deletedIdDF = Seq(Some(1), None).toDF()
+      deletedIdDF.createOrReplaceTempView("deleted_id")
+
+      val plan = executeAndKeepPlan {
+        sql(s"UPDATE $tableNameAsString SET salary = -1 WHERE id IN (SELECT * FROM deleted_id)")
+      }
+
+      val runtimePredicates = flatMap(plan) {
+        case s: BatchScanExec =>
+          val dynamicPruningExprs = s.runtimeFilters.asInstanceOf[Seq[DynamicPruningExpression]]
+          dynamicPruningExprs.map(_.child)
+        case _ =>
+          Nil
+      }
+      val isSubqueryReused = runtimePredicates.exists {
+        case InSubqueryExec(_, _: ReusedSubqueryExec, _, _, _, _) => true
+        case _ => false
+      }
+      assert(isSubqueryReused, "runtime filter subquery must be reused")
+
+      checkAnswer(
+        sql(s"SELECT * FROM $tableNameAsString"),
+        Row(1, -1, "hr") :: Row(2, 150, "software") :: Row(3, 120, "hr") :: Nil)
+
+      checkReplacedPartitions(Seq("hr"))
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR adds support for group-based data sources in `RewriteUpdateTable` and builds on top of the existing logic.

The UPDATE command for group-based is executed differently based on whether there is a subquery in the condition. If there is no subquery, there is simply a projection to update matching rows. If there is a subquery, the rule would assign a union of two scans: one to find matching rows and one to carry over unmatched records in matched groups. The union is required so that subqueries can be rewritten as joins via `RewritePredicateSubquery`. In the future, we may provide a more optimized execution if the subquery is small. That said, the current approach would scale better and should be the default.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

These changes are needed per SPIP SPARK-35801.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

This PR comes with tests. There are more tests in `AlignUpdateAssignmentsSuite`, which was merged earlier.