### PR TITLE
[SPARK-44057][SQL][TESTS] Mark all `local-cluster`-based tests as `ExtendedSQLTest`

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionBuilderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionBuilderSuite.scala
@@ -30,11 +30,13 @@ import org.apache.spark.internal.config.UI.UI_ENABLED
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.StaticSQLConf._
 import org.apache.spark.sql.util.ExecutionListenerBus
+import org.apache.spark.tags.ExtendedSQLTest
 import org.apache.spark.util.ThreadUtils
 
 /**
  * Test cases for the builder pattern of [[SparkSession]].
  */
+@ExtendedSQLTest
 class SparkSessionBuilderSuite extends SparkFunSuite with Eventually {
 
   override def afterEach(): Unit = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/BroadcastExchangeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/BroadcastExchangeSuite.scala
@@ -29,7 +29,9 @@ import org.apache.spark.sql.execution.joins.HashedRelation
 import org.apache.spark.sql.functions.broadcast
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.tags.ExtendedSQLTest
 
+@ExtendedSQLTest
 class BroadcastExchangeSuite extends SparkPlanTest
   with SharedSparkSession
   with AdaptiveSparkPlanHelper {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetCommitterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetCommitterSuite.scala
@@ -27,10 +27,12 @@ import org.apache.spark.{LocalSparkContext, SparkFunSuite}
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SQLTestUtils
+import org.apache.spark.tags.ExtendedSQLTest
 
 /**
  * Test logic related to choice of output committers.
  */
+@ExtendedSQLTest
 class ParquetCommitterSuite extends SparkFunSuite with SQLTestUtils
   with LocalSparkContext {
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/BroadcastJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/BroadcastJoinSuite.scala
@@ -35,6 +35,7 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SQLTestUtils
 import org.apache.spark.sql.types.{LongType, ShortType}
+import org.apache.spark.tags.ExtendedSQLTest
 
 /**
  * Test various broadcast join operators.
@@ -674,6 +675,8 @@ abstract class BroadcastJoinSuiteBase extends QueryTest with SQLTestUtils
   }
 }
 
+@ExtendedSQLTest
 class BroadcastJoinSuite extends BroadcastJoinSuiteBase with DisableAdaptiveExecutionSuite
 
+@ExtendedSQLTest
 class BroadcastJoinSuiteAE extends BroadcastJoinSuiteBase with EnableAdaptiveExecutionSuite

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreRDDSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreRDDSuite.scala
@@ -32,8 +32,10 @@ import org.apache.spark.sql.LocalSparkSession._
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.util.quietly
 import org.apache.spark.sql.execution.streaming.StatefulOperatorStateInfo
+import org.apache.spark.tags.ExtendedSQLTest
 import org.apache.spark.util.{CompletionIterator, Utils}
 
+@ExtendedSQLTest
 class StateStoreRDDSuite extends SparkFunSuite with BeforeAndAfter {
 
   import StateStoreTestsHelper._

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/ExecutorSideSQLConfSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/ExecutorSideSQLConfSuite.scala
@@ -32,7 +32,9 @@ import org.apache.spark.sql.execution.adaptive.DisableAdaptiveExecution
 import org.apache.spark.sql.execution.debug.codegenStringSeq
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.test.SQLTestUtils
+import org.apache.spark.tags.ExtendedSQLTest
 
+@ExtendedSQLTest
 class ExecutorSideSQLConfSuite extends SparkFunSuite with SQLTestUtils {
   import testImplicits._
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to mark all `local-cluster`-based tests as `ExtendedSQLTest`.

```
$ git grep local-cluster sql/core/
sql/core/src/test/scala/org/apache/spark/sql/SparkSessionBuilderSuite.scala:    val session = SparkSession.builder().master("local-cluster[3, 1, 1024]").getOrCreate()
sql/core/src/test/scala/org/apache/spark/sql/SparkSessionBuilderSuite.scala:    val session = SparkSession.builder().master("local-cluster[3, 1, 1024]").getOrCreate()
sql/core/src/test/scala/org/apache/spark/sql/execution/BroadcastExchangeSuite.scala:// Additional tests run in 'local-cluster' mode.
sql/core/src/test/scala/org/apache/spark/sql/execution/BroadcastExchangeSuite.scala:      .setMaster("local-cluster[2,1,1024]")
sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSparkSubmitSuite.scala:      "--master", "local-cluster[1,1,1024]",
sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetCommitterSuite.scala:   * Create a new [[SparkSession]] running in local-cluster mode with unsafe and codegen enabled.
sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetCommitterSuite.scala:      .master("local-cluster[2,1,1024]")
sql/core/src/test/scala/org/apache/spark/sql/execution/joins/BroadcastJoinSuite.scala: * Tests in this suite we need to run Spark in local-cluster mode. In particular, the use of
sql/core/src/test/scala/org/apache/spark/sql/execution/joins/BroadcastJoinSuite.scala:   * Create a new [[SparkSession]] running in local-cluster mode with unsafe and codegen enabled.
sql/core/src/test/scala/org/apache/spark/sql/execution/joins/BroadcastJoinSuite.scala:      .master("local-cluster[2,1,512]")
sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreRDDSuite.scala:          .config(sparkConf.setMaster("local-cluster[2, 1, 1024]"))
sql/core/src/test/scala/org/apache/spark/sql/internal/ExecutorSideSQLConfSuite.scala:  // Create a new [[SparkSession]] running in local-cluster mode.
sql/core/src/test/scala/org/apache/spark/sql/internal/ExecutorSideSQLConfSuite.scala:      .master("local-cluster[2,1,1024]")
```

### Why are the changes needed?

1. Like the following, we still see instability at `sql - others` pipeline. `ExecutorSideSQLConfSuite`-like suite are launching `local-cluster`.
- https://github.com/apache/spark/actions/runs/5264282377/jobs/9518640298

```
2023-06-14T12:32:17.9695374Z [0m[[0m[0minfo[0m] [0m[0m[32mExecutorSideSQLConfSuite:[0m[0m
2023-06-14T12:32:33.7423897Z [0m[[0m[0minfo[0m] [0m[0m[32m- ReadOnlySQLConf is correctly created at the executor side (15 seconds, 433 milliseconds)[0m[0m
...
2023-06-14T12:33:09.1262815Z 
2023-06-14T12:33:09.4014734Z ##[error]The runner has received a shutdown signal. This can happen when the runner service is stopped, or a manually started runner is canceled.
2023-06-14T12:33:09.4599817Z Session terminated, killing shell...
2023-06-14T12:33:09.4999238Z ##[error]Process completed with exit code 143.
2023-06-14T12:33:09.7944983Z Cleaning up orphan processes
2023-06-14T12:33:09.9209125Z Terminate orphan process: pid (4095) (java)
2023-06-14T12:33:09.9911496Z Terminate orphan process: pid (628352) (java)
```

2. In addition, this PR balances two SQL pipelines.
- https://github.com/apache/spark/actions/runs/5263147272/jobs/9513024519 (`sql - slow tests` took 1h 26m 55s)
- https://github.com/apache/spark/actions/runs/5263147272/jobs/9513024582 (`sql - other tests` took 2h 22m 20s)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs