### PR TITLE
[SPARK-43903][PYTHON][CONNECT] Improve ArrayType input support in Arrow Python UDF

### DIFF
--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -174,7 +174,7 @@ class DataFrame:
     select.__doc__ = PySparkDataFrame.select.__doc__
 
     def selectExpr(self, *expr: Union[str, List[str]]) -> "DataFrame":
-        sql_expr = []
+        sql_expr = []python/pyspark/sql/pandas/types.py
         if len(expr) == 1 and isinstance(expr[0], list):
             expr = expr[0]  # type: ignore[assignment]
         for element in expr:

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -174,7 +174,7 @@ class DataFrame:
     select.__doc__ = PySparkDataFrame.select.__doc__
 
     def selectExpr(self, *expr: Union[str, List[str]]) -> "DataFrame":
-        sql_expr = []python/pyspark/sql/pandas/types.py
+        sql_expr = []
         if len(expr) == 1 and isinstance(expr[0], list):
             expr = expr[0]  # type: ignore[assignment]
         for element in expr:

--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -172,7 +172,7 @@ class ArrowStreamPandasSerializer(ArrowStreamSerializer):
         self._timezone = timezone
         self._safecheck = safecheck
 
-    def arrow_to_pandas(self, arrow_column, struct_in_pandas="dict"):
+    def arrow_to_pandas(self, arrow_column, struct_in_pandas="dict", ndarray_as_list=False):
         # If the given column is a date type column, creates a series of datetime.date directly
         # instead of creating datetime64[ns] as intermediate data to avoid overflow caused by
         # datetime64[ns] type handling.
@@ -186,6 +186,7 @@ class ArrowStreamPandasSerializer(ArrowStreamSerializer):
             timezone=self._timezone,
             struct_in_pandas=struct_in_pandas,
             error_on_duplicated_field_names=True,
+            ndarray_as_list=ndarray_as_list,
         )
         return converter(s)
 
@@ -317,11 +318,13 @@ class ArrowStreamPandasUDFSerializer(ArrowStreamPandasSerializer):
         assign_cols_by_name,
         df_for_struct=False,
         struct_in_pandas="dict",
+        ndarray_as_list=False,
     ):
         super(ArrowStreamPandasUDFSerializer, self).__init__(timezone, safecheck)
         self._assign_cols_by_name = assign_cols_by_name
         self._df_for_struct = df_for_struct
         self._struct_in_pandas = struct_in_pandas
+        self._ndarray_as_list = ndarray_as_list
 
     def arrow_to_pandas(self, arrow_column):
         import pyarrow.types as types
@@ -331,14 +334,14 @@ class ArrowStreamPandasUDFSerializer(ArrowStreamPandasSerializer):
 
             series = [
                 super(ArrowStreamPandasUDFSerializer, self)
-                .arrow_to_pandas(column, self._struct_in_pandas)
+                .arrow_to_pandas(column, self._struct_in_pandas, self._ndarray_as_list)
                 .rename(field.name)
                 for column, field in zip(arrow_column.flatten(), arrow_column.type)
             ]
             s = pd.concat(series, axis=1)
         else:
             s = super(ArrowStreamPandasUDFSerializer, self).arrow_to_pandas(
-                arrow_column, self._struct_in_pandas
+                arrow_column, self._struct_in_pandas, self._ndarray_as_list
             )
         return s
 

--- a/python/pyspark/sql/pandas/types.py
+++ b/python/pyspark/sql/pandas/types.py
@@ -585,7 +585,7 @@ def _create_converter_to_pandas(
                     return None
                 elif isinstance(value, np.ndarray):
                     # `pyarrow.Table.to_pandas` uses `np.ndarray`.
-                    if ndarray_as_list:
+                    if _ndarray_as_list:
                         # In Arrow Python UDF, ArrayType is converted to `np.ndarray`
                         # whereas a list is expected.
                         return [_element_conv(v) for v in value]

--- a/python/pyspark/sql/pandas/types.py
+++ b/python/pyspark/sql/pandas/types.py
@@ -588,7 +588,7 @@ def _create_converter_to_pandas(
                     else:
                         # In Arrow Python UDF, ArrayType is converted to `np.ndarray`
                         # whereas a list is expected.
-                        return [_element_conv(v) for v in value]
+                        return [_element_conv(v) for v in value]  # type: ignore[misc]
 
                 return convert_array_ndarray_as_list
             else:

--- a/python/pyspark/sql/pandas/types.py
+++ b/python/pyspark/sql/pandas/types.py
@@ -579,37 +579,28 @@ def _create_converter_to_pandas(
             _element_conv = _converter(dt.elementType, _struct_in_pandas, _ndarray_as_list)
 
             if _ndarray_as_list:
+                if _element_conv is None:
+                    _element_conv = lambda x: x
 
                 def convert_array_ndarray_as_list(value: Any) -> Any:
                     if value is None:
                         return None
-                    elif isinstance(value, np.ndarray):
+                    else:
                         # In Arrow Python UDF, ArrayType is converted to `np.ndarray`
                         # whereas a list is expected.
-                        return (
-                            [_element_conv(v) for v in value]
-                            if _element_conv is not None
-                            else [v for v in value]
-                        )
-                    else:
-                        assert isinstance(value, list)
-                        # otherwise, `list` should be used.
-                        return [_element_conv(v) for v in value]  # type: ignore[misc]
+                        return [_element_conv(v) for v in value]
 
                 return convert_array_ndarray_as_list
             else:
+                if _element_conv is None:
+                    return None
 
                 def convert_array_ndarray_as_ndarray(value: Any) -> Any:
                     if value is None:
                         return None
                     elif isinstance(value, np.ndarray):
                         # `pyarrow.Table.to_pandas` uses `np.ndarray`.
-                        element_list = (
-                            [_element_conv(v) for v in value]
-                            if _element_conv is not None
-                            else [v for v in value]
-                        )
-                        return np.array(element_list)  # type: # ignore[misc]
+                        return np.array([_element_conv(v) for v in value])  # type: # ignore[misc]
                     else:
                         assert isinstance(value, list)
                         # otherwise, `list` should be used.

--- a/python/pyspark/sql/pandas/types.py
+++ b/python/pyspark/sql/pandas/types.py
@@ -714,7 +714,7 @@ def _create_converter_to_pandas(
         elif isinstance(dt, UserDefinedType):
             udt: UserDefinedType = dt
 
-            conv = _converter(udt.sqlType(), _struct_in_pandas="row", _ndarray_as_list=False) or (
+            conv = _converter(udt.sqlType(), _struct_in_pandas="row", _ndarray_as_list=True) or (
                 lambda x: x
             )
 

--- a/python/pyspark/sql/pandas/types.py
+++ b/python/pyspark/sql/pandas/types.py
@@ -580,7 +580,7 @@ def _create_converter_to_pandas(
 
             if _ndarray_as_list:
                 if _element_conv is None:
-                    _element_conv = lambda x: x
+                    _element_conv = lambda x: x  # noqa: E731
 
                 def convert_array_ndarray_as_list(value: Any) -> Any:
                     if value is None:
@@ -600,7 +600,7 @@ def _create_converter_to_pandas(
                         return None
                     elif isinstance(value, np.ndarray):
                         # `pyarrow.Table.to_pandas` uses `np.ndarray`.
-                        return np.array([_element_conv(v) for v in value])  # type: # ignore[misc]
+                        return np.array([_element_conv(v) for v in value])  # type: ignore[misc]
                     else:
                         assert isinstance(value, list)
                         # otherwise, `list` should be used.

--- a/python/pyspark/sql/tests/test_arrow_python_udf.py
+++ b/python/pyspark/sql/tests/test_arrow_python_udf.py
@@ -62,8 +62,7 @@ class PythonUDFArrowTestsMixin(BaseUDFTestsMixin):
             .first()
         )
 
-        # The input is NumPy array when the optimization is on.
-        self.assertEquals(row[0], "[1 2 3]")
+        self.assertEquals(row[0], "[1, 2, 3]")
         self.assertEquals(row[1], "{'a': 'b'}")
         self.assertEquals(row[2], "Row(col1=1, col2=2)")
 
@@ -92,8 +91,7 @@ class PythonUDFArrowTestsMixin(BaseUDFTestsMixin):
             .first()
         )
 
-        # The input is a NumPy array when the Arrow optimization is on.
-        self.assertEquals(row_true[0], row_none[0])  # "[1 2 3]"
+        self.assertEquals(row_true[0], row_none[0])  # "[1, 2, 3]"
 
         # useArrow=False
         row_false = (
@@ -125,7 +123,7 @@ class PythonUDFArrowTestsMixin(BaseUDFTestsMixin):
         # To verify that Arrow optimization is on
         self.assertEquals(
             df.selectExpr("str_repr(array) AS str_id").first()[0],
-            "[1 2 3]",  # The input is a NumPy array when the Arrow optimization is on
+            "[1, 2, 3]",  # The input is a NumPy array when the Arrow optimization is on
         )
 
         # To verify that a UserDefinedFunction is returned

--- a/python/pyspark/sql/tests/test_arrow_python_udf.py
+++ b/python/pyspark/sql/tests/test_arrow_python_udf.py
@@ -132,6 +132,15 @@ class PythonUDFArrowTestsMixin(BaseUDFTestsMixin):
             df.select(str_repr_func("array").alias("str_id")).collect(),
         )
 
+    def test_nested_array_input(self):
+        df = self.spark.range(1).selectExpr("array(array(1, 2), array(3, 4)) as nested_array")
+        self.assertEquals(
+            df.select(
+                udf(lambda x: str(x), returnType="string", useArrow=True)("nested_array")
+            ).first()[0],
+            "[[1, 2], [3, 4]]",
+        )
+
 
 class PythonUDFArrowTests(PythonUDFArrowTestsMixin, ReusedSQLTestCase):
     @classmethod

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -597,12 +597,14 @@ def read_udfs(pickleSer, infile, eval_type):
             struct_in_pandas = (
                 "row" if eval_type == PythonEvalType.SQL_ARROW_BATCHED_UDF else "dict"
             )
+            ndarray_as_list = eval_type == PythonEvalType.SQL_ARROW_BATCHED_UDF
             ser = ArrowStreamPandasUDFSerializer(
                 timezone,
                 safecheck,
                 assign_cols_by_name(runner_conf),
                 df_for_struct,
                 struct_in_pandas,
+                ndarray_as_list,
             )
     else:
         ser = BatchedSerializer(CPickleSerializer(), 100)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Improve ArrayType input support in Arrow Python UDF.

Previously, ArrayType is mapped to a 'np.array'; now it is mapped to a `list` following Pickled Python UDF.


### Why are the changes needed?
Reach parity with Pickled Python UDF.


### Does this PR introduce _any_ user-facing change?
Yes.

FROM
```py
>>> df = spark.range(1).selectExpr("array(array(1, 2), array(3, 4)) as nested_array")
>>> df.select(udf(lambda x: str(x), returnType='string', useArrow=True)("nested_array")).first()
Row(<lambda>(nested_array)='[array([1, 2], dtype=int32) array([3, 4], dtype=int32)]')
```

TO
```py
>>> df = spark.range(1).selectExpr("array(array(1, 2), array(3, 4)) as nested_array"
>>> df.select(udf(lambda x: str(x), returnType='string', useArrow=True)("nested_array")).first()
Row(<lambda>(nested_array)='[[1, 2], [3, 4]]')
```


### How was this patch tested?
Unit tests.

SPARK-40307
