### PR TITLE
[SPARK-43627][SPARK-43626][PS][CONNECT] Enable `pyspark.pandas.spark.functions.{kurt, skew}` in Spark Connect.

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -1644,6 +1644,14 @@ class SparkConnectPlanner(val session: SparkSession) extends Logging {
         val ddof = extractInteger(children(1), "ddof")
         Some(aggregate.PandasStddev(children(0), ddof).toAggregateExpression(false))
 
+      case "pandas_skew" if fun.getArgumentsCount == 1 =>
+        val children = fun.getArgumentsList.asScala.map(transformExpression)
+        Some(aggregate.PandasSkewness(children(0)).toAggregateExpression(false))
+
+      case "pandas_kurt" if fun.getArgumentsCount == 1 =>
+        val children = fun.getArgumentsList.asScala.map(transformExpression)
+        Some(aggregate.PandasKurtosis(children(0)).toAggregateExpression(false))
+
       case "pandas_var" if fun.getArgumentsCount == 2 =>
         val children = fun.getArgumentsList.asScala.map(transformExpression)
         val ddof = extractInteger(children(1), "ddof")

--- a/python/pyspark/pandas/spark/functions.py
+++ b/python/pyspark/pandas/spark/functions.py
@@ -79,13 +79,33 @@ def var(col: Column, ddof: int) -> Column:
 
 
 def skew(col: Column) -> Column:
-    sc = SparkContext._active_spark_context
-    return Column(sc._jvm.PythonSQLUtils.pandasSkewness(col._jc))
+    if is_remote():
+        from pyspark.sql.connect.functions import _invoke_function_over_columns
+
+        return _invoke_function_over_columns(  # type: ignore[return-value]
+            "pandas_skew",
+            col,  # type: ignore[arg-type]
+        )
+
+    else:
+
+        sc = SparkContext._active_spark_context
+        return Column(sc._jvm.PythonSQLUtils.pandasSkewness(col._jc))
 
 
 def kurt(col: Column) -> Column:
-    sc = SparkContext._active_spark_context
-    return Column(sc._jvm.PythonSQLUtils.pandasKurtosis(col._jc))
+    if is_remote():
+        from pyspark.sql.connect.functions import _invoke_function_over_columns
+
+        return _invoke_function_over_columns(  # type: ignore[return-value]
+            "pandas_kurt",
+            col,  # type: ignore[arg-type]
+        )
+
+    else:
+
+        sc = SparkContext._active_spark_context
+        return Column(sc._jvm.PythonSQLUtils.pandasKurtosis(col._jc))
 
 
 def mode(col: Column, dropna: bool) -> Column:

--- a/python/pyspark/pandas/tests/connect/test_parity_expanding.py
+++ b/python/pyspark/pandas/tests/connect/test_parity_expanding.py
@@ -31,7 +31,7 @@ class ExpandingParityTests(
         super().test_expanding_count()
 
     @unittest.skip(
-        "TODO(SPARK-43626): Enable pyspark.pandas.spark.functions.kurt in Spark Connect."
+        "TODO(SPARK-43611): Fix unexpected `AnalysisException` from Spark Connect client."
     )
     def test_expanding_kurt(self):
         super().test_expanding_kurt()
@@ -61,7 +61,7 @@ class ExpandingParityTests(
         super().test_expanding_quantile()
 
     @unittest.skip(
-        "TODO(SPARK-43627): Enable pyspark.pandas.spark.functions.skew in Spark Connect."
+        "TODO(SPARK-43611): Fix unexpected `AnalysisException` from Spark Connect client."
     )
     def test_expanding_skew(self):
         super().test_expanding_skew()
@@ -91,7 +91,7 @@ class ExpandingParityTests(
         super().test_groupby_expanding_count()
 
     @unittest.skip(
-        "TODO(SPARK-43626): Enable pyspark.pandas.spark.functions.kurt in Spark Connect."
+        "TODO(SPARK-43611): Fix unexpected `AnalysisException` from Spark Connect client."
     )
     def test_groupby_expanding_kurt(self):
         super().test_groupby_expanding_kurt()
@@ -121,7 +121,7 @@ class ExpandingParityTests(
         super().test_groupby_expanding_quantile()
 
     @unittest.skip(
-        "TODO(SPARK-43627): Enable pyspark.pandas.spark.functions.skew in Spark Connect."
+        "TODO(SPARK-43611): Fix unexpected `AnalysisException` from Spark Connect client."
     )
     def test_groupby_expanding_skew(self):
         super().test_groupby_expanding_skew()

--- a/python/pyspark/pandas/tests/connect/test_parity_generic_functions.py
+++ b/python/pyspark/pandas/tests/connect/test_parity_generic_functions.py
@@ -28,12 +28,6 @@ class GenericFunctionsParityTests(
     def test_interpolate(self):
         super().test_interpolate()
 
-    @unittest.skip(
-        "TODO(SPARK-43627): Enable pyspark.pandas.spark.functions.skew in Spark Connect."
-    )
-    def test_stat_functions(self):
-        super().test_stat_functions()
-
 
 if __name__ == "__main__":
     from pyspark.pandas.tests.connect.test_parity_generic_functions import *  # noqa: F401

--- a/python/pyspark/pandas/tests/connect/test_parity_rolling.py
+++ b/python/pyspark/pandas/tests/connect/test_parity_rolling.py
@@ -31,7 +31,7 @@ class RollingParityTests(
         super().test_groupby_rolling_count()
 
     @unittest.skip(
-        "TODO(SPARK-43626): Enable pyspark.pandas.spark.functions.kurt in Spark Connect."
+        "TODO(SPARK-43611): Fix unexpected `AnalysisException` from Spark Connect client."
     )
     def test_groupby_rolling_kurt(self):
         super().test_groupby_rolling_kurt()
@@ -61,7 +61,7 @@ class RollingParityTests(
         super().test_groupby_rolling_quantile()
 
     @unittest.skip(
-        "TODO(SPARK-43627): Enable pyspark.pandas.spark.functions.skew in Spark Connect."
+        "TODO(SPARK-43611): Fix unexpected `AnalysisException` from Spark Connect client."
     )
     def test_groupby_rolling_skew(self):
         super().test_groupby_rolling_skew()
@@ -91,7 +91,7 @@ class RollingParityTests(
         super().test_rolling_count()
 
     @unittest.skip(
-        "TODO(SPARK-43626): Enable pyspark.pandas.spark.functions.kurt in Spark Connect."
+        "TODO(SPARK-43611): Fix unexpected `AnalysisException` from Spark Connect client."
     )
     def test_rolling_kurt(self):
         super().test_rolling_kurt()
@@ -121,7 +121,7 @@ class RollingParityTests(
         super().test_rolling_quantile()
 
     @unittest.skip(
-        "TODO(SPARK-43627): Enable pyspark.pandas.spark.functions.skew in Spark Connect."
+        "TODO(SPARK-43611): Fix unexpected `AnalysisException` from Spark Connect client."
     )
     def test_rolling_skew(self):
         super().test_rolling_skew()

--- a/python/pyspark/pandas/tests/connect/test_parity_stats.py
+++ b/python/pyspark/pandas/tests/connect/test_parity_stats.py
@@ -22,35 +22,7 @@ from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
 class StatsParityTests(StatsTestsMixin, PandasOnSparkTestUtils, ReusedConnectTestCase):
-    @unittest.skip(
-        "TODO(SPARK-43626): Enable pyspark.pandas.spark.functions.kurt in Spark Connect."
-    )
-    def test_axis_on_dataframe(self):
-        super().test_axis_on_dataframe()
-
-    @unittest.skip(
-        "TODO(SPARK-43627): Enable pyspark.pandas.spark.functions.skew in Spark Connect."
-    )
-    def test_skew_kurt_numerical_stability(self):
-        super().test_skew_kurt_numerical_stability()
-
-    @unittest.skip(
-        "TODO(SPARK-43627): Enable pyspark.pandas.spark.functions.skew in Spark Connect."
-    )
-    def test_stat_functions(self):
-        super().test_stat_functions()
-
-    @unittest.skip(
-        "TODO(SPARK-43627): Enable pyspark.pandas.spark.functions.skew in Spark Connect."
-    )
-    def test_stat_functions_multiindex_column(self):
-        super().test_stat_functions_multiindex_column()
-
-    @unittest.skip(
-        "TODO(SPARK-43626): Enable pyspark.pandas.spark.functions.kurt in Spark Connect."
-    )
-    def test_stats_on_non_numeric_columns_should_be_discarded_if_numeric_only_is_true(self):
-        super().test_stats_on_non_numeric_columns_should_be_discarded_if_numeric_only_is_true()
+    pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### What changes were proposed in this pull request?
Enable `pyspark.pandas.spark.functions.{kurt, skew}` in Spark Connect.


### Why are the changes needed?
feature parity


### Does this PR introduce _any_ user-facing change?
yes, new functions enabled

### How was this patch tested?
enabled UTs