### PR TITLE
Revert "[SPARK-44047][CONNECT][BUILD] Upgrade google guava for connect from 31.0.1-jre to 32.0.1-jre"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -278,7 +278,7 @@
     <spark.test.docker.removePulledImage>true</spark.test.docker.removePulledImage>
 
     <!-- Version used in Connect -->
-    <connect.guava.version>32.0.1-jre</connect.guava.version>
+    <connect.guava.version>31.0.1-jre</connect.guava.version>
     <guava.failureaccess.version>1.0.1</guava.failureaccess.version>
     <io.grpc.version>1.47.0</io.grpc.version>
     <mima.version>1.1.2</mima.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to reverts commit b4766ff65c204051caad216bb39e6acbbca824b8.


### Why are the changes needed?
Let me revert it first, I will Investigate the root cause.

SPARK_GENERATE_GOLDEN_FILES=1 build/sbt "connect-client-jvm/testOnly org.apache.spark.sql.PlanGenerationTestSuite"

<img width="1417" alt="image" src="https://github.com/apache/spark/assets/15246973/1d162c19-8bee-42e0-bfae-6f0d1afe84d0">


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA.