### PR TITLE
[SPARK-44065][SQL] Optimize BroadcastHashJoin skew in OptimizeSkewedJoin

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeShuffleWithLocalRead.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeShuffleWithLocalRead.scala
@@ -139,7 +139,7 @@ object OptimizeShuffleWithLocalRead extends AQEShuffleReadRule {
   def canUseLocalShuffleRead(plan: SparkPlan): Boolean = plan match {
     case s: ShuffleQueryStageExec =>
       s.mapStats.isDefined && isSupported(s.shuffle)
-    case AQEShuffleReadExec(s: ShuffleQueryStageExec, _) =>
+    case a @ AQEShuffleReadExec(s: ShuffleQueryStageExec, _) if !a.hasSkewedPartition =>
       s.mapStats.isDefined && isSupported(s.shuffle) &&
         s.shuffle.shuffleOrigin == ENSURE_REQUIREMENTS
     case _ => false

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeShuffleWithLocalRead.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeShuffleWithLocalRead.scala
@@ -139,7 +139,7 @@ object OptimizeShuffleWithLocalRead extends AQEShuffleReadRule {
   def canUseLocalShuffleRead(plan: SparkPlan): Boolean = plan match {
     case s: ShuffleQueryStageExec =>
       s.mapStats.isDefined && isSupported(s.shuffle)
-    case a @ AQEShuffleReadExec(s: ShuffleQueryStageExec, _) if !a.hasSkewedPartition =>
+    case AQEShuffleReadExec(s: ShuffleQueryStageExec, _) =>
       s.mapStats.isDefined && isSupported(s.shuffle) &&
         s.shuffle.shuffleOrigin == ENSURE_REQUIREMENTS
     case _ => false

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeSkewInRebalancePartitions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeSkewInRebalancePartitions.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.execution.adaptive
 
-import org.apache.spark.sql.execution.{CoalescedPartitionSpec, ShufflePartitionSpec, SparkPlan}
+import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.exchange.{REBALANCE_PARTITIONS_BY_COL, REBALANCE_PARTITIONS_BY_NONE, ShuffleOrigin}
 import org.apache.spark.sql.internal.SQLConf
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeSkewInRebalancePartitions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeSkewInRebalancePartitions.scala
@@ -39,7 +39,6 @@ object OptimizeSkewInRebalancePartitions extends AQEShuffleReadRule {
   override val supportedShuffleOrigins: Seq[ShuffleOrigin] =
     Seq(REBALANCE_PARTITIONS_BY_NONE, REBALANCE_PARTITIONS_BY_COL)
 
-
   private def tryOptimizeSkewedPartitions(shuffle: ShuffleQueryStageExec): SparkPlan = {
     val defaultAdvisorySize = conf.getConf(SQLConf.ADVISORY_PARTITION_SIZE_IN_BYTES)
     val advisorySize = shuffle.advisoryPartitionSize.getOrElse(defaultAdvisorySize)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeSkewedJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeSkewedJoin.scala
@@ -219,35 +219,39 @@ case class OptimizeSkewedJoin(ensureRequirements: EnsureRequirements)
     }
   }
 
-  def optimizeSkewJoin(plan: SparkPlan): SparkPlan = plan.transformUp {
-    case smj @ SortMergeJoinExec(_, _, joinType, _,
-        s1 @ SortExec(_, _, ShuffleStage(left: ShuffleQueryStageExec), _),
-        s2 @ SortExec(_, _, ShuffleStage(right: ShuffleQueryStageExec), _), false) =>
-      tryOptimizeJoinChildren(left, right, joinType).map {
-        case (newLeft, newRight) =>
-          smj.copy(
-            left = s1.copy(child = newLeft), right = s2.copy(child = newRight), isSkewJoin = true)
-      }.getOrElse(smj)
+  def optimizeSkewJoin(plan: SparkPlan): SparkPlan = {
+    val localShuffleReaderEnabled = conf.getConf(SQLConf.LOCAL_SHUFFLE_READER_ENABLED)
+    plan.transformUp {
+      case smj @ SortMergeJoinExec(_, _, joinType, _,
+          s1 @ SortExec(_, _, ShuffleStage(left: ShuffleQueryStageExec), _),
+          s2 @ SortExec(_, _, ShuffleStage(right: ShuffleQueryStageExec), _), false) =>
+        tryOptimizeJoinChildren(left, right, joinType).map {
+          case (newLeft, newRight) =>
+            smj.copy(
+              left = s1.copy(child = newLeft), right = s2.copy(child = newRight), isSkewJoin = true)
+        }.getOrElse(smj)
 
-    case shj @ ShuffledHashJoinExec(_, _, joinType, _, _,
-        ShuffleStage(left: ShuffleQueryStageExec),
-        ShuffleStage(right: ShuffleQueryStageExec), false) =>
-      tryOptimizeJoinChildren(left, right, joinType).map {
-        case (newLeft, newRight) =>
-          shj.copy(left = newLeft, right = newRight, isSkewJoin = true)
-      }.getOrElse(shj)
+      case shj @ ShuffledHashJoinExec(_, _, joinType, _, _,
+          ShuffleStage(left: ShuffleQueryStageExec),
+          ShuffleStage(right: ShuffleQueryStageExec), false) =>
+        tryOptimizeJoinChildren(left, right, joinType).map {
+          case (newLeft, newRight) =>
+            shj.copy(left = newLeft, right = newRight, isSkewJoin = true)
+        }.getOrElse(shj)
 
-    case bhj @ BroadcastHashJoinExec(_, _, _, BuildRight, _,
-        ShuffleStage(left: ShuffleQueryStageExec), _, _, false) =>
-      tryOptimizeBroadcastHashJoinStreamedPlan(left).map {
-        case newLeft => bhj.copy(left = newLeft, isSkewJoin = true)
-      }.getOrElse(bhj)
-
-    case bhj @ BroadcastHashJoinExec(_, _, _, BuildLeft, _, _,
-        ShuffleStage(right: ShuffleQueryStageExec), _, false) =>
-      tryOptimizeBroadcastHashJoinStreamedPlan(right).map {
-        case newRight => bhj.copy(right = newRight, isSkewJoin = true)
-      }.getOrElse(bhj)
+      // When localShuffleReader is disabled, the streamedPlan of BroadcastHashJoin may be skewed,
+      // so we try to optimize it.
+      case bhj @ BroadcastHashJoinExec(_, _, _, BuildRight, _,
+          ShuffleStage(left: ShuffleQueryStageExec), _, _, false) if !localShuffleReaderEnabled =>
+        tryOptimizeBroadcastHashJoinStreamedPlan(left).map {
+          case newLeft => bhj.copy(left = newLeft, isSkewJoin = true)
+        }.getOrElse(bhj)
+      case bhj @ BroadcastHashJoinExec(_, _, _, BuildLeft, _, _,
+          ShuffleStage(right: ShuffleQueryStageExec), _, false) if !localShuffleReaderEnabled =>
+        tryOptimizeBroadcastHashJoinStreamedPlan(right).map {
+          case newRight => bhj.copy(right = newRight, isSkewJoin = true)
+        }.getOrElse(bhj)
+    }
   }
 
   override def apply(plan: SparkPlan): SparkPlan = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeSkewedJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeSkewedJoin.scala
@@ -252,12 +252,12 @@ case class OptimizeSkewedJoin(ensureRequirements: EnsureRequirements)
           shj.copy(left = newLeft, right = newRight, isSkewJoin = true)
       }.getOrElse(shj)
 
-    // Try to optimize BroadcastHashJoin skew when localShuffleReader is disabled.
     case bhj @ BroadcastHashJoinExec(_, _, _, BuildRight, _,
         ShuffleStage(left: ShuffleQueryStageExec), _, _, _) =>
       tryOptimizeBroadcastHashJoinStreamedPlan(left).map {
         case newLeft => bhj.copy(left = newLeft, isSkewJoin = true)
       }.getOrElse(bhj)
+
     case bhj @ BroadcastHashJoinExec(_, _, _, BuildLeft, _, _,
         ShuffleStage(right: ShuffleQueryStageExec), _, _) =>
       tryOptimizeBroadcastHashJoinStreamedPlan(right).map {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeSkewedJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeSkewedJoin.scala
@@ -23,12 +23,13 @@ import org.apache.spark.SparkUnsupportedOperationException
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, SortOrder}
+import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight}
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.exchange.{ENSURE_REQUIREMENTS, EnsureRequirements, ValidateRequirements}
-import org.apache.spark.sql.execution.joins.{ShuffledHashJoinExec, SortMergeJoinExec}
+import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, ShuffledHashJoinExec, SortMergeJoinExec}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.util.Utils
 
@@ -197,23 +198,72 @@ case class OptimizeSkewedJoin(ensureRequirements: EnsureRequirements)
     }
   }
 
-  def optimizeSkewJoin(plan: SparkPlan): SparkPlan = plan.transformUp {
-    case smj @ SortMergeJoinExec(_, _, joinType, _,
-        s1 @ SortExec(_, _, ShuffleStage(left: ShuffleQueryStageExec), _),
-        s2 @ SortExec(_, _, ShuffleStage(right: ShuffleQueryStageExec), _), false) =>
-      tryOptimizeJoinChildren(left, right, joinType).map {
-        case (newLeft, newRight) =>
-          smj.copy(
-            left = s1.copy(child = newLeft), right = s2.copy(child = newRight), isSkewJoin = true)
-      }.getOrElse(smj)
+  /**
+   * Split the skewed partition of the BroadcastHashJoin streamPlan.
+   */
+  private def tryOptimizeBroadcastHashJoinStreamedPlan(
+      shuffle: ShuffleQueryStageExec): Option[SparkPlan] = {
+    val advisorySize = conf.getConf(SQLConf.ADVISORY_PARTITION_SIZE_IN_BYTES)
+    shuffle.mapStats.flatMap(mapStats => {
+      val bytesByPartitionId = mapStats.bytesByPartitionId
+      val newPartitionsSpec = bytesByPartitionId.indices.flatMap { reduceIndex =>
+        val bytes = bytesByPartitionId(reduceIndex)
+        val shuffleId = mapStats.shuffleId
+        if (bytes > advisorySize) {
+          val newPartitionSpec = ShufflePartitionsUtil.createSkewPartitionSpecs(
+            shuffleId, reduceIndex, advisorySize)
+          if (newPartitionSpec.isEmpty) {
+            CoalescedPartitionSpec(reduceIndex, reduceIndex + 1, bytes) :: Nil
+          } else {
+            logDebug(s"For shuffle $shuffleId, partition $reduceIndex is skew, " +
+              s"split it into ${newPartitionSpec.get.size} parts.")
+            newPartitionSpec.get
+          }
+        } else {
+          CoalescedPartitionSpec(reduceIndex, reduceIndex + 1, bytes) :: Nil
+        }
+      }
+      // return origin plan if we can not optimize partitions
+      if (newPartitionsSpec.length == bytesByPartitionId.length) {
+        None
+      } else {
+        Some(SkewJoinChildWrapper(AQEShuffleReadExec(shuffle, newPartitionsSpec)))
+      }
+    })
+  }
 
-    case shj @ ShuffledHashJoinExec(_, _, joinType, _, _,
-        ShuffleStage(left: ShuffleQueryStageExec),
-        ShuffleStage(right: ShuffleQueryStageExec), false) =>
-      tryOptimizeJoinChildren(left, right, joinType).map {
-        case (newLeft, newRight) =>
-          shj.copy(left = newLeft, right = newRight, isSkewJoin = true)
-      }.getOrElse(shj)
+  def optimizeSkewJoin(plan: SparkPlan): SparkPlan = {
+    val localShuffleReaderEnabled = conf.getConf(SQLConf.LOCAL_SHUFFLE_READER_ENABLED)
+    plan.transformUp {
+      case smj @ SortMergeJoinExec(_, _, joinType, _,
+          s1 @ SortExec(_, _, ShuffleStage(left: ShuffleQueryStageExec), _),
+          s2 @ SortExec(_, _, ShuffleStage(right: ShuffleQueryStageExec), _), false) =>
+        tryOptimizeJoinChildren(left, right, joinType).map {
+          case (newLeft, newRight) =>
+            smj.copy(
+              left = s1.copy(child = newLeft), right = s2.copy(child = newRight), isSkewJoin = true)
+        }.getOrElse(smj)
+
+      case shj @ ShuffledHashJoinExec(_, _, joinType, _, _,
+          ShuffleStage(left: ShuffleQueryStageExec),
+          ShuffleStage(right: ShuffleQueryStageExec), false) =>
+        tryOptimizeJoinChildren(left, right, joinType).map {
+          case (newLeft, newRight) =>
+            shj.copy(left = newLeft, right = newRight, isSkewJoin = true)
+        }.getOrElse(shj)
+
+      // Try to optimize BroadcastHashJoin skew when localShuffleReader is disabled.
+      case bhj @ BroadcastHashJoinExec(_, _, _, BuildRight, _,
+          ShuffleStage(left: ShuffleQueryStageExec), _, _) if !localShuffleReaderEnabled =>
+        tryOptimizeBroadcastHashJoinStreamedPlan(left).map {
+          case newLeft => bhj.copy(left = newLeft)
+        }.getOrElse(bhj)
+      case bhj @ BroadcastHashJoinExec(_, _, _, BuildLeft, _, _,
+          ShuffleStage(right: ShuffleQueryStageExec), _) if !localShuffleReaderEnabled =>
+        tryOptimizeBroadcastHashJoinStreamedPlan(right).map {
+          case newRight => bhj.copy(right = newRight)
+        }.getOrElse(bhj)
+    }
   }
 
   override def apply(plan: SparkPlan): SparkPlan = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeSkewedJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeSkewedJoin.scala
@@ -203,67 +203,66 @@ case class OptimizeSkewedJoin(ensureRequirements: EnsureRequirements)
    */
   private def tryOptimizeBroadcastHashJoinStreamedPlan(
       shuffle: ShuffleQueryStageExec): Option[SparkPlan] = {
-    val advisorySize = conf.getConf(SQLConf.ADVISORY_PARTITION_SIZE_IN_BYTES)
-    shuffle.mapStats.flatMap(mapStats => {
-      val bytesByPartitionId = mapStats.bytesByPartitionId
-      val newPartitionsSpec = bytesByPartitionId.indices.flatMap { reduceIndex =>
-        val bytes = bytesByPartitionId(reduceIndex)
-        val shuffleId = mapStats.shuffleId
-        if (bytes > advisorySize) {
-          val newPartitionSpec = ShufflePartitionsUtil.createSkewPartitionSpecs(
-            shuffleId, reduceIndex, advisorySize)
-          if (newPartitionSpec.isEmpty) {
-            CoalescedPartitionSpec(reduceIndex, reduceIndex + 1, bytes) :: Nil
-          } else {
-            logDebug(s"For shuffle $shuffleId, partition $reduceIndex is skew, " +
-              s"split it into ${newPartitionSpec.get.size} parts.")
-            newPartitionSpec.get
-          }
-        } else {
+    val mapStats = shuffle.mapStats.get
+    val bytesByPartitionId = mapStats.bytesByPartitionId
+    val medSize = Utils.median(bytesByPartitionId, false)
+    val skewThreshold = getSkewThreshold(medSize)
+    val streamedPlanTargetSize = targetSize(bytesByPartitionId, skewThreshold)
+
+    val newPartitionsSpec = bytesByPartitionId.indices.flatMap { reduceIndex =>
+      val bytes = bytesByPartitionId(reduceIndex)
+      val shuffleId = mapStats.shuffleId
+      if (bytes > skewThreshold) {
+        val newPartitionSpec = ShufflePartitionsUtil.createSkewPartitionSpecs(
+          shuffleId, reduceIndex, streamedPlanTargetSize)
+        if (newPartitionSpec.isEmpty) {
           CoalescedPartitionSpec(reduceIndex, reduceIndex + 1, bytes) :: Nil
+        } else {
+          logDebug(s"For shuffle $shuffleId, partition $reduceIndex is skew, " +
+            s"split it into ${newPartitionSpec.get.size} parts.")
+          newPartitionSpec.get
         }
-      }
-      // return origin plan if we can not optimize partitions
-      if (newPartitionsSpec.length == bytesByPartitionId.length) {
-        None
       } else {
-        Some(SkewJoinChildWrapper(AQEShuffleReadExec(shuffle, newPartitionsSpec)))
+        CoalescedPartitionSpec(reduceIndex, reduceIndex + 1, bytes) :: Nil
       }
-    })
+    }
+    // return origin plan if we can not optimize partitions
+    if (newPartitionsSpec.length == bytesByPartitionId.length) {
+      None
+    } else {
+      Some(SkewJoinChildWrapper(AQEShuffleReadExec(shuffle, newPartitionsSpec)))
+    }
   }
 
-  def optimizeSkewJoin(plan: SparkPlan): SparkPlan = {
-    val localShuffleReaderEnabled = conf.getConf(SQLConf.LOCAL_SHUFFLE_READER_ENABLED)
-    plan.transformUp {
-      case smj @ SortMergeJoinExec(_, _, joinType, _,
-          s1 @ SortExec(_, _, ShuffleStage(left: ShuffleQueryStageExec), _),
-          s2 @ SortExec(_, _, ShuffleStage(right: ShuffleQueryStageExec), _), false) =>
-        tryOptimizeJoinChildren(left, right, joinType).map {
-          case (newLeft, newRight) =>
-            smj.copy(
-              left = s1.copy(child = newLeft), right = s2.copy(child = newRight), isSkewJoin = true)
-        }.getOrElse(smj)
+  def optimizeSkewJoin(plan: SparkPlan): SparkPlan = plan.transformUp {
+    case smj @ SortMergeJoinExec(_, _, joinType, _,
+        s1 @ SortExec(_, _, ShuffleStage(left: ShuffleQueryStageExec), _),
+        s2 @ SortExec(_, _, ShuffleStage(right: ShuffleQueryStageExec), _), false) =>
+      tryOptimizeJoinChildren(left, right, joinType).map {
+        case (newLeft, newRight) =>
+          smj.copy(
+            left = s1.copy(child = newLeft), right = s2.copy(child = newRight), isSkewJoin = true)
+      }.getOrElse(smj)
 
-      case shj @ ShuffledHashJoinExec(_, _, joinType, _, _,
-          ShuffleStage(left: ShuffleQueryStageExec),
-          ShuffleStage(right: ShuffleQueryStageExec), false) =>
-        tryOptimizeJoinChildren(left, right, joinType).map {
-          case (newLeft, newRight) =>
-            shj.copy(left = newLeft, right = newRight, isSkewJoin = true)
-        }.getOrElse(shj)
+    case shj @ ShuffledHashJoinExec(_, _, joinType, _, _,
+        ShuffleStage(left: ShuffleQueryStageExec),
+        ShuffleStage(right: ShuffleQueryStageExec), false) =>
+      tryOptimizeJoinChildren(left, right, joinType).map {
+        case (newLeft, newRight) =>
+          shj.copy(left = newLeft, right = newRight, isSkewJoin = true)
+      }.getOrElse(shj)
 
-      // Try to optimize BroadcastHashJoin skew when localShuffleReader is disabled.
-      case bhj @ BroadcastHashJoinExec(_, _, _, BuildRight, _,
-          ShuffleStage(left: ShuffleQueryStageExec), _, _) if !localShuffleReaderEnabled =>
-        tryOptimizeBroadcastHashJoinStreamedPlan(left).map {
-          case newLeft => bhj.copy(left = newLeft)
-        }.getOrElse(bhj)
-      case bhj @ BroadcastHashJoinExec(_, _, _, BuildLeft, _, _,
-          ShuffleStage(right: ShuffleQueryStageExec), _) if !localShuffleReaderEnabled =>
-        tryOptimizeBroadcastHashJoinStreamedPlan(right).map {
-          case newRight => bhj.copy(right = newRight)
-        }.getOrElse(bhj)
-    }
+    // Try to optimize BroadcastHashJoin skew when localShuffleReader is disabled.
+    case bhj @ BroadcastHashJoinExec(_, _, _, BuildRight, _,
+        ShuffleStage(left: ShuffleQueryStageExec), _, _, _) =>
+      tryOptimizeBroadcastHashJoinStreamedPlan(left).map {
+        case newLeft => bhj.copy(left = newLeft, isSkewJoin = true)
+      }.getOrElse(bhj)
+    case bhj @ BroadcastHashJoinExec(_, _, _, BuildLeft, _, _,
+        ShuffleStage(right: ShuffleQueryStageExec), _, _) =>
+      tryOptimizeBroadcastHashJoinStreamedPlan(right).map {
+        case newRight => bhj.copy(right = newRight, isSkewJoin = true)
+      }.getOrElse(bhj)
   }
 
   override def apply(plan: SparkPlan): SparkPlan = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeSkewedJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeSkewedJoin.scala
@@ -209,23 +209,8 @@ case class OptimizeSkewedJoin(ensureRequirements: EnsureRequirements)
     val skewThreshold = getSkewThreshold(medSize)
     val streamedPlanTargetSize = targetSize(bytesByPartitionId, skewThreshold)
 
-    val newPartitionsSpec = bytesByPartitionId.indices.flatMap { reduceIndex =>
-      val bytes = bytesByPartitionId(reduceIndex)
-      val shuffleId = mapStats.shuffleId
-      if (bytes > skewThreshold) {
-        val newPartitionSpec = ShufflePartitionsUtil.createSkewPartitionSpecs(
-          shuffleId, reduceIndex, streamedPlanTargetSize)
-        if (newPartitionSpec.isEmpty) {
-          CoalescedPartitionSpec(reduceIndex, reduceIndex + 1, bytes) :: Nil
-        } else {
-          logDebug(s"For shuffle $shuffleId, partition $reduceIndex is skew, " +
-            s"split it into ${newPartitionSpec.get.size} parts.")
-          newPartitionSpec.get
-        }
-      } else {
-        CoalescedPartitionSpec(reduceIndex, reduceIndex + 1, bytes) :: Nil
-      }
-    }
+    val newPartitionsSpec = ShufflePartitionsUtil.optimizeSkewedPartitions(mapStats.shuffleId,
+      bytesByPartitionId, skewThreshold, streamedPlanTargetSize)
     // return origin plan if we can not optimize partitions
     if (newPartitionsSpec.length == bytesByPartitionId.length) {
       None
@@ -253,13 +238,13 @@ case class OptimizeSkewedJoin(ensureRequirements: EnsureRequirements)
       }.getOrElse(shj)
 
     case bhj @ BroadcastHashJoinExec(_, _, _, BuildRight, _,
-        ShuffleStage(left: ShuffleQueryStageExec), _, _, _) =>
+        ShuffleStage(left: ShuffleQueryStageExec), _, _, false) =>
       tryOptimizeBroadcastHashJoinStreamedPlan(left).map {
         case newLeft => bhj.copy(left = newLeft, isSkewJoin = true)
       }.getOrElse(bhj)
 
     case bhj @ BroadcastHashJoinExec(_, _, _, BuildLeft, _, _,
-        ShuffleStage(right: ShuffleQueryStageExec), _, _) =>
+        ShuffleStage(right: ShuffleQueryStageExec), _, false) =>
       tryOptimizeBroadcastHashJoinStreamedPlan(right).map {
         case newRight => bhj.copy(right = newRight, isSkewJoin = true)
       }.getOrElse(bhj)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/PlanAdaptiveDynamicPruningFilters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/PlanAdaptiveDynamicPruningFilters.scala
@@ -53,9 +53,9 @@ case class PlanAdaptiveDynamicPruningFilters(
 
         val canReuseExchange = conf.exchangeReuseEnabled && buildKeys.nonEmpty &&
           find(rootPlan) {
-            case BroadcastHashJoinExec(_, _, _, BuildLeft, _, left, _, _) =>
+            case BroadcastHashJoinExec(_, _, _, BuildLeft, _, left, _, _, _) =>
               left.sameResult(exchange)
-            case BroadcastHashJoinExec(_, _, _, BuildRight, _, _, right, _) =>
+            case BroadcastHashJoinExec(_, _, _, BuildRight, _, _, right, _, _) =>
               right.sameResult(exchange)
             case _ => false
           }.isDefined

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/ShufflePartitionsUtil.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/ShufflePartitionsUtil.scala
@@ -425,4 +425,33 @@ object ShufflePartitionsUtil extends Logging {
       None
     }
   }
+
+  /**
+   * Splits the skewed partition based on the map size and the target partition size
+   * after split. Create a list of `PartialReducerPartitionSpec` for skewed partition and
+   * create `CoalescedPartition` for normal partition.
+   */
+  def optimizeSkewedPartitions(
+      shuffleId: Int,
+      bytesByPartitionId: Array[Long],
+      skewThreshold: Long,
+      targetSize: Long,
+      smallPartitionFactor: Double = SMALL_PARTITION_FACTOR): Seq[ShufflePartitionSpec] = {
+    bytesByPartitionId.indices.flatMap { reduceIndex =>
+      val bytes = bytesByPartitionId(reduceIndex)
+      if (bytes > skewThreshold) {
+        val newPartitionSpec = createSkewPartitionSpecs(
+          shuffleId, reduceIndex, targetSize, smallPartitionFactor)
+        if (newPartitionSpec.isEmpty) {
+          CoalescedPartitionSpec(reduceIndex, reduceIndex + 1, bytes) :: Nil
+        } else {
+          logDebug(s"For shuffle $shuffleId, partition $reduceIndex is skew, " +
+            s"split it into ${newPartitionSpec.get.size} parts.")
+          newPartitionSpec.get
+        }
+      } else {
+        CoalescedPartitionSpec(reduceIndex, reduceIndex + 1, bytes) :: Nil
+      }
+    }
+  }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/simpleCosting.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/simpleCosting.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.execution.adaptive
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.exchange.ShuffleExchangeLike
-import org.apache.spark.sql.execution.joins.ShuffledJoin
+import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, ShuffledJoin}
 
 /**
  * A simple implementation of [[Cost]], which takes a number of [[Long]] as the cost value.
@@ -48,6 +48,7 @@ case class SimpleCostEvaluator(forceOptimizeSkewedJoin: Boolean) extends CostEva
     if (forceOptimizeSkewedJoin) {
       val numSkewJoins = plan.collect {
         case j: ShuffledJoin if j.isSkewJoin => j
+        case j: BroadcastHashJoinExec if j.isSkewJoin => j
       }.size
       // We put `-numSkewJoins` in the first 32 bits of the long value, so that it's compared first
       // when comparing the cost, and larger `numSkewJoins` means lower cost.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/PlanDynamicPruningFilters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/PlanDynamicPruningFilters.scala
@@ -60,9 +60,9 @@ case class PlanDynamicPruningFilters(sparkSession: SparkSession) extends Rule[Sp
         // the first to be applied (apart from `InsertAdaptiveSparkPlan`).
         val canReuseExchange = conf.exchangeReuseEnabled && buildKeys.nonEmpty &&
           plan.exists {
-            case BroadcastHashJoinExec(_, _, _, BuildLeft, _, left, _, _) =>
+            case BroadcastHashJoinExec(_, _, _, BuildLeft, _, left, _, _, _) =>
               left.sameResult(sparkPlan)
-            case BroadcastHashJoinExec(_, _, _, BuildRight, _, _, right, _) =>
+            case BroadcastHashJoinExec(_, _, _, BuildRight, _, _, right, _, _) =>
               right.sameResult(sparkPlan)
             case _ => false
           }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BroadcastHashJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BroadcastHashJoinExec.scala
@@ -45,8 +45,13 @@ case class BroadcastHashJoinExec private(
     condition: Option[Expression],
     left: SparkPlan,
     right: SparkPlan,
-    isNullAwareAntiJoin: Boolean = false)
+    isNullAwareAntiJoin: Boolean = false,
+    isSkewJoin: Boolean = false)
   extends HashJoin {
+
+  override def nodeName: String = {
+    if (isSkewJoin) super.nodeName + "(skew=true)" else super.nodeName
+  }
 
   if (isNullAwareAntiJoin) {
     require(leftKeys.length == 1, "leftKeys length should be 1")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BroadcastHashJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BroadcastHashJoinExec.scala
@@ -260,7 +260,8 @@ object BroadcastHashJoinExec extends JoinSelectionHelper {
       condition: Option[Expression],
       left: SparkPlan,
       right: SparkPlan,
-      isNullAwareAntiJoin: Boolean = false): BroadcastHashJoinExec = {
+      isNullAwareAntiJoin: Boolean = false,
+      isSkewJoin: Boolean = false): BroadcastHashJoinExec = {
     val (normalizedLeftKeys, normalizedRightKeys) = HashJoin.normalizeJoinKeys(leftKeys, rightKeys)
 
     new BroadcastHashJoinExec(
@@ -271,6 +272,7 @@ object BroadcastHashJoinExec extends JoinSelectionHelper {
       condition,
       left,
       right,
-      isNullAwareAntiJoin)
+      isNullAwareAntiJoin,
+      isSkewJoin)
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
@@ -345,7 +345,7 @@ abstract class DynamicPartitionPruningSuiteBase
        """.stripMargin)
 
       val found = df.queryExecution.executedPlan.exists {
-        case BroadcastHashJoinExec(_, _, p: ExistenceJoin, _, _, _, _, _) => true
+        case BroadcastHashJoinExec(_, _, p: ExistenceJoin, _, _, _, _, _, _) => true
         case _ => false
       }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
@@ -813,8 +813,8 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
       val distinctWithId = baseTable.distinct().withColumn("id", monotonically_increasing_id())
         .join(baseTable, "idx")
       assert(distinctWithId.queryExecution.executedPlan.exists {
-        case WholeStageCodegenExec(
-          ProjectExec(_, BroadcastHashJoinExec(_, _, _, _, _, _: HashAggregateExec, _, _))) => true
+        case WholeStageCodegenExec(ProjectExec(_,
+          BroadcastHashJoinExec(_, _, _, _, _, _: HashAggregateExec, _, _, _))) => true
         case _ => false
       })
       checkAnswer(distinctWithId, Seq(Row(1, 0), Row(1, 0)))
@@ -825,8 +825,8 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
         baseTable.groupBy("idx").sum().withColumn("id", monotonically_increasing_id())
         .join(baseTable, "idx")
       assert(groupByWithId.queryExecution.executedPlan.exists {
-        case WholeStageCodegenExec(
-          ProjectExec(_, BroadcastHashJoinExec(_, _, _, _, _, _: HashAggregateExec, _, _))) => true
+        case WholeStageCodegenExec(ProjectExec(_,
+          BroadcastHashJoinExec(_, _, _, _, _, _: HashAggregateExec, _, _, _))) => true
         case _ => false
       })
       checkAnswer(groupByWithId, Seq(Row(1, 2, 0), Row(1, 2, 0)))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -3482,17 +3482,10 @@ class AdaptiveQueryExecSuite
             val bhjs = findTopLevelBroadcastHashJoin(plan)
             assert(bhjs.nonEmpty)
 
-            if (localShuffleReader) {
-              val localShuffleReaders = collect(plan) {
-                case c: AQEShuffleReadExec if c.isLocalRead => c
-              }
-              assert(localShuffleReaders.nonEmpty)
-            } else {
-              val skewedShuffleReaders = collect(plan) {
-                case c: AQEShuffleReadExec if c.hasSkewedPartition => c
-              }
-              assert(skewedShuffleReaders.nonEmpty)
+            val skewedShuffleReaders = collect(plan) {
+              case c: AQEShuffleReadExec if c.hasSkewedPartition => c
             }
+            assert(skewedShuffleReaders.nonEmpty)
           }
         }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -3456,12 +3456,12 @@ class AdaptiveQueryExecSuite
   test("SPARK-44065: Optimize BroadcastHashJoin skew when localShuffleReader is disabled") {
     withSQLConf(
       SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
-      SQLConf.ADAPTIVE_FORCE_OPTIMIZE_SKEWED_JOIN.key -> "true",
       SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1",
       SQLConf.ADAPTIVE_AUTO_BROADCASTJOIN_THRESHOLD.key -> "1000",
       SQLConf.LOCAL_SHUFFLE_READER_ENABLED.key -> "false",
       SQLConf.SHUFFLE_PARTITIONS.key -> "10",
-      SQLConf.ADVISORY_PARTITION_SIZE_IN_BYTES.key -> "1000") {
+      SQLConf.SKEW_JOIN_SKEWED_PARTITION_THRESHOLD.key -> "600",
+      SQLConf.ADVISORY_PARTITION_SIZE_IN_BYTES.key -> "600") {
       withTempView("skewData", "smallData") {
         spark
           .range(0, 1000, 1, 10)
@@ -3472,20 +3472,45 @@ class AdaptiveQueryExecSuite
           .selectExpr("id key2", "id as value2")
           .createOrReplaceTempView("smallData")
 
-        val sqlText =
-          s"""
-             |select * from skewData1 a join smallData b on a.key1 = b.key2
-             |""".stripMargin
+        Seq(true, false).foreach { localShuffleReader =>
+          withSQLConf(SQLConf.LOCAL_SHUFFLE_READER_ENABLED.key -> localShuffleReader.toString) {
+            val sqlText =
+              s"""
+                 |select * from skewData1 a join smallData b on a.key1 = b.key2
+                 |""".stripMargin
+            val (_, plan) = runAdaptiveAndVerifyResult(sqlText)
+            val bhjs = findTopLevelBroadcastHashJoin(plan)
+            assert(bhjs.nonEmpty)
 
-        val (_, plan) = runAdaptiveAndVerifyResult(sqlText)
-
-        val bhjs = findTopLevelBroadcastHashJoin(plan)
-        assert(bhjs.nonEmpty)
-
-        val skewedShuffleReaders = collect(plan) {
-          case c: AQEShuffleReadExec if c.hasSkewedPartition => c
+            if (localShuffleReader) {
+              val localShuffleReaders = collect(plan) {
+                case c: AQEShuffleReadExec if c.isLocalRead => c
+              }
+              assert(localShuffleReaders.nonEmpty)
+            } else {
+              val skewedShuffleReaders = collect(plan) {
+                case c: AQEShuffleReadExec if c.hasSkewedPartition => c
+              }
+              assert(skewedShuffleReaders.nonEmpty)
+            }
+          }
         }
-        assert(skewedShuffleReaders.nonEmpty)
+
+        withSQLConf(SQLConf.ADAPTIVE_FORCE_OPTIMIZE_SKEWED_JOIN.key -> "true") {
+          val sqlText =
+            s"""
+               |select a.key1, count(*) from skewData1 a join smallData b
+               | on a.key1 = b.key2 group by a.key1
+               |""".stripMargin
+          val (_, plan) = runAdaptiveAndVerifyResult(sqlText)
+          val bhjs = findTopLevelBroadcastHashJoin(plan)
+          assert(bhjs.nonEmpty)
+
+          val skewedBroadcastHashJoins = collect(plan) {
+            case c: BroadcastHashJoinExec if c.isSkewJoin => c
+          }
+          assert(skewedBroadcastHashJoins.nonEmpty)
+        }
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -3482,10 +3482,17 @@ class AdaptiveQueryExecSuite
             val bhjs = findTopLevelBroadcastHashJoin(plan)
             assert(bhjs.nonEmpty)
 
-            val skewedShuffleReaders = collect(plan) {
-              case c: AQEShuffleReadExec if c.hasSkewedPartition => c
+            if (localShuffleReader) {
+              val localShuffleReaders = collect(plan) {
+                case c: AQEShuffleReadExec if c.isLocalRead => c
+              }
+              assert(localShuffleReaders.nonEmpty)
+            } else {
+              val skewedShuffleReaders = collect(plan) {
+                case c: AQEShuffleReadExec if c.hasSkewedPartition => c
+              }
+              assert(skewedShuffleReaders.nonEmpty)
             }
-            assert(skewedShuffleReaders.nonEmpty)
           }
         }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -3453,7 +3453,7 @@ class AdaptiveQueryExecSuite
     }
   }
 
-  test("SPARK-44065: Optimize BroadcastHashJoin skew when localShuffleReader is disabled") {
+  test("SPARK-44065: Optimize BroadcastHashJoin skew") {
     withSQLConf(
       SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
       SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1",

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -3452,6 +3452,43 @@ class AdaptiveQueryExecSuite
       }
     }
   }
+
+  test("SPARK-44065: Optimize BroadcastHashJoin skew when localShuffleReader is disabled") {
+    withSQLConf(
+      SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
+      SQLConf.ADAPTIVE_FORCE_OPTIMIZE_SKEWED_JOIN.key -> "true",
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1",
+      SQLConf.ADAPTIVE_AUTO_BROADCASTJOIN_THRESHOLD.key -> "1000",
+      SQLConf.LOCAL_SHUFFLE_READER_ENABLED.key -> "false",
+      SQLConf.SHUFFLE_PARTITIONS.key -> "10",
+      SQLConf.ADVISORY_PARTITION_SIZE_IN_BYTES.key -> "1000") {
+      withTempView("skewData", "smallData") {
+        spark
+          .range(0, 1000, 1, 10)
+          .selectExpr("if(id >= 5, 5, id) as key1", "id as value1")
+          .createOrReplaceTempView("skewData1")
+        spark
+          .range(0, 5, 1, 10)
+          .selectExpr("id key2", "id as value2")
+          .createOrReplaceTempView("smallData")
+
+        val sqlText =
+          s"""
+             |select * from skewData1 a join smallData b on a.key1 = b.key2
+             |""".stripMargin
+
+        val (_, plan) = runAdaptiveAndVerifyResult(sqlText)
+
+        val bhjs = findTopLevelBroadcastHashJoin(plan)
+        assert(bhjs.nonEmpty)
+
+        val skewedShuffleReaders = collect(plan) {
+          case c: AQEShuffleReadExec if c.hasSkewedPartition => c
+        }
+        assert(skewedShuffleReaders.nonEmpty)
+      }
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Split the skewed partitions of BroadcastHashJoin streamPlan when localShuffleReader is disabled.

+ Add `isSkewJoin` attribute in BroadcastHashJoinExec.
+ Handle skewed BroadcastHashJoinExec  in `OptimizeSkewedJoin`.
+ Calculate skewed BroadcastHashJoinExec in `SimpleCostEvaluator.evaluateCost`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
In RemoteShuffleService services such as uniffle and celeborn, it is recommended to disable localShuffleReader by default for better performance, but it may make BroadcastHashJoin skew again.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
new unit test
