### PR TITLE
[SPARK-44060][SQL] Code-gen for build side outer shuffled hash join

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2182,6 +2182,15 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
+  val ENABLE_BUILD_SIDE_OUTER_SHUFFLED_HASH_JOIN_CODEGEN =
+    buildConf("spark.sql.codegen.join.buildSideOuterShuffledHashJoin.enabled")
+      .internal()
+      .doc("When true, enable code-gen for an OUTER shuffled hash join where outer side" +
+        " is the build side.")
+      .version("3.5.0")
+      .booleanConf
+      .createWithDefault(true)
+
   val ENABLE_FULL_OUTER_SORT_MERGE_JOIN_CODEGEN =
     buildConf("spark.sql.codegen.join.fullOuterSortMergeJoin.enabled")
       .internal()

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/ShuffledHashJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/ShuffledHashJoinExec.scala
@@ -594,10 +594,9 @@ case class ShuffledHashJoinExec(
          |
          |  if (!$foundMatch) {
          |    $buildRow = null;
-         |  }
-         |
-         |  if ($isFullOuterJoin) {
-         |    $consumeFullOuterJoinRow();
+         |    if ($isFullOuterJoin) {
+         |      $consumeFullOuterJoinRow();
+         |    }
          |  }
          |
          |  if (shouldStop()) return;

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/ShuffledHashJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/ShuffledHashJoinExec.scala
@@ -496,12 +496,8 @@ case class ShuffledHashJoinExec(
          |    }
          |  }
          |
-         |  if ($foundMatch) {
+         |  if ($foundMatch || $isFullOuterJoin) {
          |    $consumeFullOuterJoinRow();
-         |  } else {
-         |    if ($isFullOuterJoin) {
-         |      $consumeFullOuterJoinRow();
-         |    }
          |  }
          |
          |  if (shouldStop()) return;

--- a/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
@@ -1315,78 +1315,82 @@ class JoinSuite extends QueryTest with SharedSparkSession with AdaptiveSparkPlan
 
   test("SPARK-36612: Support left outer join build left or right outer join build right in " +
     "shuffled hash join") {
-    val inputDFs = Seq(
-      // Test unique join key
-      (spark.range(10).selectExpr("id as k1"),
-        spark.range(30).selectExpr("id as k2"),
-        $"k1" === $"k2"),
-      // Test non-unique join key
-      (spark.range(10).selectExpr("id % 5 as k1"),
-        spark.range(30).selectExpr("id % 5 as k2"),
-        $"k1" === $"k2"),
-      // Test empty build side
-      (spark.range(10).selectExpr("id as k1").filter("k1 < -1"),
-        spark.range(30).selectExpr("id as k2"),
-        $"k1" === $"k2"),
-      // Test empty stream side
-      (spark.range(10).selectExpr("id as k1"),
-        spark.range(30).selectExpr("id as k2").filter("k2 < -1"),
-        $"k1" === $"k2"),
-      // Test empty build and stream side
-      (spark.range(10).selectExpr("id as k1").filter("k1 < -1"),
-        spark.range(30).selectExpr("id as k2").filter("k2 < -1"),
-        $"k1" === $"k2"),
-      // Test string join key
-      (spark.range(10).selectExpr("cast(id * 3 as string) as k1"),
-        spark.range(30).selectExpr("cast(id as string) as k2"),
-        $"k1" === $"k2"),
-      // Test build side at right
-      (spark.range(30).selectExpr("cast(id / 3 as string) as k1"),
-        spark.range(10).selectExpr("cast(id as string) as k2"),
-        $"k1" === $"k2"),
-      // Test NULL join key
-      (spark.range(10).map(i => if (i % 2 == 0) i else null).selectExpr("value as k1"),
-        spark.range(30).map(i => if (i % 4 == 0) i else null).selectExpr("value as k2"),
-        $"k1" === $"k2"),
-      (spark.range(10).map(i => if (i % 3 == 0) i else null).selectExpr("value as k1"),
-        spark.range(30).map(i => if (i % 5 == 0) i else null).selectExpr("value as k2"),
-        $"k1" === $"k2"),
-      // Test multiple join keys
-      (spark.range(10).map(i => if (i % 2 == 0) i else null).selectExpr(
-        "value as k1", "cast(value % 5 as short) as k2", "cast(value * 3 as long) as k3"),
-        spark.range(30).map(i => if (i % 3 == 0) i else null).selectExpr(
-          "value as k4", "cast(value % 5 as short) as k5", "cast(value * 3 as long) as k6"),
-        $"k1" === $"k4" && $"k2" === $"k5" && $"k3" === $"k6")
-    )
+    withSQLConf(SQLConf.ENABLE_BUILD_SIDE_OUTER_SHUFFLED_HASH_JOIN_CODEGEN.key -> "false") {
+      val inputDFs = Seq(
+        // Test unique join key
+        (spark.range(10).selectExpr("id as k1"),
+          spark.range(30).selectExpr("id as k2"),
+          $"k1" === $"k2"),
+        // Test non-unique join key
+        (spark.range(10).selectExpr("id % 5 as k1"),
+          spark.range(30).selectExpr("id % 5 as k2"),
+          $"k1" === $"k2"),
+        // Test empty build side
+        (spark.range(10).selectExpr("id as k1").filter("k1 < -1"),
+          spark.range(30).selectExpr("id as k2"),
+          $"k1" === $"k2"),
+        // Test empty stream side
+        (spark.range(10).selectExpr("id as k1"),
+          spark.range(30).selectExpr("id as k2").filter("k2 < -1"),
+          $"k1" === $"k2"),
+        // Test empty build and stream side
+        (spark.range(10).selectExpr("id as k1").filter("k1 < -1"),
+          spark.range(30).selectExpr("id as k2").filter("k2 < -1"),
+          $"k1" === $"k2"),
+        // Test string join key
+        (spark.range(10).selectExpr("cast(id * 3 as string) as k1"),
+          spark.range(30).selectExpr("cast(id as string) as k2"),
+          $"k1" === $"k2"),
+        // Test build side at right
+        (spark.range(30).selectExpr("cast(id / 3 as string) as k1"),
+          spark.range(10).selectExpr("cast(id as string) as k2"),
+          $"k1" === $"k2"),
+        // Test NULL join key
+        (spark.range(10).map(i => if (i % 2 == 0) i else null).selectExpr("value as k1"),
+          spark.range(30).map(i => if (i % 4 == 0) i else null).selectExpr("value as k2"),
+          $"k1" === $"k2"),
+        (spark.range(10).map(i => if (i % 3 == 0) i else null).selectExpr("value as k1"),
+          spark.range(30).map(i => if (i % 5 == 0) i else null).selectExpr("value as k2"),
+          $"k1" === $"k2"),
+        // Test multiple join keys
+        (spark.range(10).map(i => if (i % 2 == 0) i else null).selectExpr(
+          "value as k1", "cast(value % 5 as short) as k2", "cast(value * 3 as long) as k3"),
+          spark.range(30).map(i => if (i % 3 == 0) i else null).selectExpr(
+            "value as k4", "cast(value % 5 as short) as k5", "cast(value * 3 as long) as k6"),
+          $"k1" === $"k4" && $"k2" === $"k5" && $"k3" === $"k6")
+      )
 
-    // test left outer with left side build
-    inputDFs.foreach { case (df1, df2, joinExprs) =>
-      val smjDF = df1.hint("SHUFFLE_MERGE").join(df2, joinExprs, "leftouter")
-      assert(collect(smjDF.queryExecution.executedPlan) {
-        case _: SortMergeJoinExec => true }.size === 1)
-      val smjResult = smjDF.collect()
+      // test left outer with left side build
+      inputDFs.foreach { case (df1, df2, joinExprs) =>
+        val smjDF = df1.hint("SHUFFLE_MERGE").join(df2, joinExprs, "leftouter")
+        assert(collect(smjDF.queryExecution.executedPlan) {
+          case _: SortMergeJoinExec => true
+        }.size === 1)
+        val smjResult = smjDF.collect()
 
-      val shjDF = df1.hint("SHUFFLE_HASH").join(df2, joinExprs, "leftouter")
-      assert(collect(shjDF.queryExecution.executedPlan) {
-        case _: ShuffledHashJoinExec => true
-      }.size === 1)
-      // Same result between shuffled hash join and sort merge join
-      checkAnswer(shjDF, smjResult)
-    }
+        val shjDF = df1.hint("SHUFFLE_HASH").join(df2, joinExprs, "leftouter")
+        assert(collect(shjDF.queryExecution.executedPlan) {
+          case _: ShuffledHashJoinExec => true
+        }.size === 1)
+        // Same result between shuffled hash join and sort merge join
+        checkAnswer(shjDF, smjResult)
+      }
 
-    // test right outer with right side build
-    inputDFs.foreach { case (df2, df1, joinExprs) =>
-      val smjDF = df2.join(df1.hint("SHUFFLE_MERGE"), joinExprs, "rightouter")
-      assert(collect(smjDF.queryExecution.executedPlan) {
-        case _: SortMergeJoinExec => true }.size === 1)
-      val smjResult = smjDF.collect()
+      // test right outer with right side build
+      inputDFs.foreach { case (df2, df1, joinExprs) =>
+        val smjDF = df2.join(df1.hint("SHUFFLE_MERGE"), joinExprs, "rightouter")
+        assert(collect(smjDF.queryExecution.executedPlan) {
+          case _: SortMergeJoinExec => true
+        }.size === 1)
+        val smjResult = smjDF.collect()
 
-      val shjDF = df2.join(df1.hint("SHUFFLE_HASH"), joinExprs, "rightouter")
-      assert(collect(shjDF.queryExecution.executedPlan) {
-        case _: ShuffledHashJoinExec => true
-      }.size === 1)
-      // Same result between shuffled hash join and sort merge join
-      checkAnswer(shjDF, smjResult)
+        val shjDF = df2.join(df1.hint("SHUFFLE_HASH"), joinExprs, "rightouter")
+        assert(collect(shjDF.queryExecution.executedPlan) {
+          case _: ShuffledHashJoinExec => true
+        }.size === 1)
+        // Same result between shuffled hash join and sort merge join
+        checkAnswer(shjDF, smjResult)
+      }
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
@@ -1444,7 +1444,6 @@ class JoinSuite extends QueryTest with SharedSparkSession with AdaptiveSparkPlan
     }
   }
 
-
   test("SPARK-34593: Preserve broadcast nested loop join partitioning and ordering") {
     withTable("t1", "t2", "t3", "t4", "t5") {
       spark.range(15).toDF("k").write.bucketBy(4, "k").saveAsTable("t1")

--- a/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
@@ -1315,81 +1315,83 @@ class JoinSuite extends QueryTest with SharedSparkSession with AdaptiveSparkPlan
 
   test("SPARK-36612: Support left outer join build left or right outer join build right in " +
     "shuffled hash join") {
-    withSQLConf(SQLConf.ENABLE_BUILD_SIDE_OUTER_SHUFFLED_HASH_JOIN_CODEGEN.key -> "false") {
-      val inputDFs = Seq(
-        // Test unique join key
-        (spark.range(10).selectExpr("id as k1"),
-          spark.range(30).selectExpr("id as k2"),
-          $"k1" === $"k2"),
-        // Test non-unique join key
-        (spark.range(10).selectExpr("id % 5 as k1"),
-          spark.range(30).selectExpr("id % 5 as k2"),
-          $"k1" === $"k2"),
-        // Test empty build side
-        (spark.range(10).selectExpr("id as k1").filter("k1 < -1"),
-          spark.range(30).selectExpr("id as k2"),
-          $"k1" === $"k2"),
-        // Test empty stream side
-        (spark.range(10).selectExpr("id as k1"),
-          spark.range(30).selectExpr("id as k2").filter("k2 < -1"),
-          $"k1" === $"k2"),
-        // Test empty build and stream side
-        (spark.range(10).selectExpr("id as k1").filter("k1 < -1"),
-          spark.range(30).selectExpr("id as k2").filter("k2 < -1"),
-          $"k1" === $"k2"),
-        // Test string join key
-        (spark.range(10).selectExpr("cast(id * 3 as string) as k1"),
-          spark.range(30).selectExpr("cast(id as string) as k2"),
-          $"k1" === $"k2"),
-        // Test build side at right
-        (spark.range(30).selectExpr("cast(id / 3 as string) as k1"),
-          spark.range(10).selectExpr("cast(id as string) as k2"),
-          $"k1" === $"k2"),
-        // Test NULL join key
-        (spark.range(10).map(i => if (i % 2 == 0) i else null).selectExpr("value as k1"),
-          spark.range(30).map(i => if (i % 4 == 0) i else null).selectExpr("value as k2"),
-          $"k1" === $"k2"),
-        (spark.range(10).map(i => if (i % 3 == 0) i else null).selectExpr("value as k1"),
-          spark.range(30).map(i => if (i % 5 == 0) i else null).selectExpr("value as k2"),
-          $"k1" === $"k2"),
-        // Test multiple join keys
-        (spark.range(10).map(i => if (i % 2 == 0) i else null).selectExpr(
-          "value as k1", "cast(value % 5 as short) as k2", "cast(value * 3 as long) as k3"),
-          spark.range(30).map(i => if (i % 3 == 0) i else null).selectExpr(
-            "value as k4", "cast(value % 5 as short) as k5", "cast(value * 3 as long) as k6"),
-          $"k1" === $"k4" && $"k2" === $"k5" && $"k3" === $"k6")
-      )
+    Seq("true", "false").foreach{ codegen =>
+      withSQLConf(SQLConf.ENABLE_BUILD_SIDE_OUTER_SHUFFLED_HASH_JOIN_CODEGEN.key -> codegen) {
+        val inputDFs = Seq(
+          // Test unique join key
+          (spark.range(10).selectExpr("id as k1"),
+            spark.range(30).selectExpr("id as k2"),
+            $"k1" === $"k2"),
+          // Test non-unique join key
+          (spark.range(10).selectExpr("id % 5 as k1"),
+            spark.range(30).selectExpr("id % 5 as k2"),
+            $"k1" === $"k2"),
+          // Test empty build side
+          (spark.range(10).selectExpr("id as k1").filter("k1 < -1"),
+            spark.range(30).selectExpr("id as k2"),
+            $"k1" === $"k2"),
+          // Test empty stream side
+          (spark.range(10).selectExpr("id as k1"),
+            spark.range(30).selectExpr("id as k2").filter("k2 < -1"),
+            $"k1" === $"k2"),
+          // Test empty build and stream side
+          (spark.range(10).selectExpr("id as k1").filter("k1 < -1"),
+            spark.range(30).selectExpr("id as k2").filter("k2 < -1"),
+            $"k1" === $"k2"),
+          // Test string join key
+          (spark.range(10).selectExpr("cast(id * 3 as string) as k1"),
+            spark.range(30).selectExpr("cast(id as string) as k2"),
+            $"k1" === $"k2"),
+          // Test build side at right
+          (spark.range(30).selectExpr("cast(id / 3 as string) as k1"),
+            spark.range(10).selectExpr("cast(id as string) as k2"),
+            $"k1" === $"k2"),
+          // Test NULL join key
+          (spark.range(10).map(i => if (i % 2 == 0) i else null).selectExpr("value as k1"),
+            spark.range(30).map(i => if (i % 4 == 0) i else null).selectExpr("value as k2"),
+            $"k1" === $"k2"),
+          (spark.range(10).map(i => if (i % 3 == 0) i else null).selectExpr("value as k1"),
+            spark.range(30).map(i => if (i % 5 == 0) i else null).selectExpr("value as k2"),
+            $"k1" === $"k2"),
+          // Test multiple join keys
+          (spark.range(10).map(i => if (i % 2 == 0) i else null).selectExpr(
+            "value as k1", "cast(value % 5 as short) as k2", "cast(value * 3 as long) as k3"),
+            spark.range(30).map(i => if (i % 3 == 0) i else null).selectExpr(
+              "value as k4", "cast(value % 5 as short) as k5", "cast(value * 3 as long) as k6"),
+            $"k1" === $"k4" && $"k2" === $"k5" && $"k3" === $"k6")
+        )
 
-      // test left outer with left side build
-      inputDFs.foreach { case (df1, df2, joinExprs) =>
-        val smjDF = df1.hint("SHUFFLE_MERGE").join(df2, joinExprs, "leftouter")
-        assert(collect(smjDF.queryExecution.executedPlan) {
-          case _: SortMergeJoinExec => true
-        }.size === 1)
-        val smjResult = smjDF.collect()
+        // test left outer with left side build
+        inputDFs.foreach { case (df1, df2, joinExprs) =>
+          val smjDF = df1.hint("SHUFFLE_MERGE").join(df2, joinExprs, "leftouter")
+          assert(collect(smjDF.queryExecution.executedPlan) {
+            case _: SortMergeJoinExec => true
+          }.size === 1)
+          val smjResult = smjDF.collect()
 
-        val shjDF = df1.hint("SHUFFLE_HASH").join(df2, joinExprs, "leftouter")
-        assert(collect(shjDF.queryExecution.executedPlan) {
-          case _: ShuffledHashJoinExec => true
-        }.size === 1)
-        // Same result between shuffled hash join and sort merge join
-        checkAnswer(shjDF, smjResult)
-      }
+          val shjDF = df1.hint("SHUFFLE_HASH").join(df2, joinExprs, "leftouter")
+          assert(collect(shjDF.queryExecution.executedPlan) {
+            case _: ShuffledHashJoinExec => true
+          }.size === 1)
+          // Same result between shuffled hash join and sort merge join
+          checkAnswer(shjDF, smjResult)
+        }
 
-      // test right outer with right side build
-      inputDFs.foreach { case (df2, df1, joinExprs) =>
-        val smjDF = df2.join(df1.hint("SHUFFLE_MERGE"), joinExprs, "rightouter")
-        assert(collect(smjDF.queryExecution.executedPlan) {
-          case _: SortMergeJoinExec => true
-        }.size === 1)
-        val smjResult = smjDF.collect()
+        // test right outer with right side build
+        inputDFs.foreach { case (df2, df1, joinExprs) =>
+          val smjDF = df2.join(df1.hint("SHUFFLE_MERGE"), joinExprs, "rightouter")
+          assert(collect(smjDF.queryExecution.executedPlan) {
+            case _: SortMergeJoinExec => true
+          }.size === 1)
+          val smjResult = smjDF.collect()
 
-        val shjDF = df2.join(df1.hint("SHUFFLE_HASH"), joinExprs, "rightouter")
-        assert(collect(shjDF.queryExecution.executedPlan) {
-          case _: ShuffledHashJoinExec => true
-        }.size === 1)
-        // Same result between shuffled hash join and sort merge join
-        checkAnswer(shjDF, smjResult)
+          val shjDF = df2.join(df1.hint("SHUFFLE_HASH"), joinExprs, "rightouter")
+          assert(collect(shjDF.queryExecution.executedPlan) {
+            case _: ShuffledHashJoinExec => true
+          }.size === 1)
+          // Same result between shuffled hash join and sort merge join
+          checkAnswer(shjDF, smjResult)
+        }
       }
     }
   }
@@ -1441,6 +1443,7 @@ class JoinSuite extends QueryTest with SharedSparkSession with AdaptiveSparkPlan
       }
     }
   }
+
 
   test("SPARK-34593: Preserve broadcast nested loop join partitioning and ordering") {
     withTable("t1", "t2", "t3", "t4", "t5") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
@@ -931,43 +931,6 @@ class KeyGroupedPartitioningSuite extends DistributionAndOrderingSuiteBase {
     }
   }
 
-  test("szehon-test") {
-    val tbl1 = "tbl1"
-    val tbl2 = "tbl2"
-    val partitions = Array(identity("id"), identity("data"))
-    createTable("tbl1", schema, partitions)
-
-    sql(s"INSERT INTO testcat.ns.$items VALUES " +
-      "(1, 'aa', cast('2020-01-01' as timestamp)), " +
-      "(2, 'bb', cast('2020-01-02' as timestamp)), " +
-      "(3, 'cc', cast('2020-02-03' as timestamp))")
-
-    val purchases_partitions = Array(identity("item_id"), identity("name"))
-    createTable(purchases, purchases_schema, purchases_partitions)
-    sql(s"INSERT INTO testcat.ns.$purchases VALUES " +
-      "(1, 42.0, cast('2020-01-01' as timestamp)), " +
-      "(2, 19.5, cast('2020-02-01' as timestamp)), " +
-      "(4, 30.0, cast('2020-02-01' as timestamp))")
-
-    Seq(true, false).foreach { pushDownValues =>
-      withSQLConf(SQLConf.V2_BUCKETING_PUSH_PART_VALUES_ENABLED.key -> pushDownValues.toString) {
-        val df = sql("SELECT id, name, i.price as purchase_price, p.price as sale_price " +
-          s"FROM testcat.ns.$items i JOIN testcat.ns.$purchases p " +
-          "ON i.id = p.item_id ORDER BY id, purchase_price, sale_price")
-
-        val shuffles = collectShuffles(df.queryExecution.executedPlan)
-        if (pushDownValues) {
-          assert(shuffles.isEmpty, "should not add shuffle when partition values mismatch")
-        } else {
-          assert(shuffles.nonEmpty, "should add shuffle when partition values mismatch, and " +
-            "pushing down partition values is not enabled")
-        }
-
-        checkAnswer(df, Seq(Row(1, "aa", 40.0, 42.0), Row(2, "bb", 10.0, 19.5)))
-      }
-    }
-  }
-
   test("data source partitioning + dynamic partition filtering") {
     withSQLConf(
         SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1",

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
@@ -238,84 +238,86 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
     val df2 = spark.range(1, 11).select($"id".as("k2"))
     val df3 = spark.range(2, 5).select($"id".as("k3"))
 
-    Seq("SHUFFLE_HASH", "SHUFFLE_MERGE").foreach { hint =>
-      // test right join with unique key from build side
-      val rightJoinUniqueDf = df1.join(df2.hint(hint), $"k1" === $"k2", "right_outer")
-      assert(rightJoinUniqueDf.queryExecution.executedPlan.collect {
-        case WholeStageCodegenExec(_ : ShuffledHashJoinExec) if hint == "SHUFFLE_HASH" => true
-        case WholeStageCodegenExec(_ : SortMergeJoinExec) if hint == "SHUFFLE_MERGE" => true
-      }.size === 1)
-      checkAnswer(rightJoinUniqueDf, Seq(Row(1, 1), Row(2, 2), Row(3, 3), Row(4, 4),
-        Row(null, 5), Row(null, 6), Row(null, 7), Row(null, 8), Row(null, 9),
-        Row(null, 10)))
-      assert(rightJoinUniqueDf.count() === 10)
+    withSQLConf(SQLConf.ENABLE_BUILD_SIDE_OUTER_SHUFFLED_HASH_JOIN_CODEGEN.key -> "true") {
+      Seq("SHUFFLE_HASH", "SHUFFLE_MERGE").foreach { hint =>
+        // test right join with unique key from build side
+        val rightJoinUniqueDf = df1.join(df2.hint(hint), $"k1" === $"k2", "right_outer")
+        assert(rightJoinUniqueDf.queryExecution.executedPlan.collect {
+          case WholeStageCodegenExec(_: ShuffledHashJoinExec) if hint == "SHUFFLE_HASH" => true
+          case WholeStageCodegenExec(_: SortMergeJoinExec) if hint == "SHUFFLE_MERGE" => true
+        }.size === 1)
+        checkAnswer(rightJoinUniqueDf, Seq(Row(1, 1), Row(2, 2), Row(3, 3), Row(4, 4),
+          Row(null, 5), Row(null, 6), Row(null, 7), Row(null, 8), Row(null, 9),
+          Row(null, 10)))
+        assert(rightJoinUniqueDf.count() === 10)
 
-      // test left join with unique key from build side
-      val leftJoinUniqueDf = df1.hint(hint).join(df2, $"k1" === $"k2", "left_outer")
-      assert(leftJoinUniqueDf.queryExecution.executedPlan.collect {
-        case WholeStageCodegenExec(_ : ShuffledHashJoinExec) if hint == "SHUFFLE_HASH" => true
-        case WholeStageCodegenExec(_ : SortMergeJoinExec) if hint == "SHUFFLE_MERGE" => true
-      }.size === 1)
-      checkAnswer(leftJoinUniqueDf, Seq(Row(0, null), Row(1, 1), Row(2, 2), Row(3, 3), Row(4, 4)))
-      assert(leftJoinUniqueDf.count() === 5)
+        // test left join with unique key from build side
+        val leftJoinUniqueDf = df1.hint(hint).join(df2, $"k1" === $"k2", "left_outer")
+        assert(leftJoinUniqueDf.queryExecution.executedPlan.collect {
+          case WholeStageCodegenExec(_: ShuffledHashJoinExec) if hint == "SHUFFLE_HASH" => true
+          case WholeStageCodegenExec(_: SortMergeJoinExec) if hint == "SHUFFLE_MERGE" => true
+        }.size === 1)
+        checkAnswer(leftJoinUniqueDf, Seq(Row(0, null), Row(1, 1), Row(2, 2), Row(3, 3), Row(4, 4)))
+        assert(leftJoinUniqueDf.count() === 5)
 
-      // test right join with non-unique key from build side
-      val rightJoinNonUniqueDf = df1.join(df2.hint(hint), $"k1" === $"k2" % 3, "right_outer")
-      assert(rightJoinNonUniqueDf.queryExecution.executedPlan.collect {
-        case WholeStageCodegenExec(_ : ShuffledHashJoinExec) if hint == "SHUFFLE_HASH" => true
-        case WholeStageCodegenExec(_ : SortMergeJoinExec) if hint == "SHUFFLE_MERGE" => true
-      }.size === 1)
-      checkAnswer(rightJoinNonUniqueDf, Seq(Row(0, 3), Row(0, 6), Row(0, 9), Row(1, 1),
-        Row(1, 4), Row(1, 7), Row(1, 10), Row(2, 2), Row(2, 5), Row(2, 8)))
+        // test right join with non-unique key from build side
+        val rightJoinNonUniqueDf = df1.join(df2.hint(hint), $"k1" === $"k2" % 3, "right_outer")
+        assert(rightJoinNonUniqueDf.queryExecution.executedPlan.collect {
+          case WholeStageCodegenExec(_: ShuffledHashJoinExec) if hint == "SHUFFLE_HASH" => true
+          case WholeStageCodegenExec(_: SortMergeJoinExec) if hint == "SHUFFLE_MERGE" => true
+        }.size === 1)
+        checkAnswer(rightJoinNonUniqueDf, Seq(Row(0, 3), Row(0, 6), Row(0, 9), Row(1, 1),
+          Row(1, 4), Row(1, 7), Row(1, 10), Row(2, 2), Row(2, 5), Row(2, 8)))
 
-      // test left join with non-unique key from build side
-      val leftJoinNonUniqueDf = df1.hint(hint).join(df2, $"k1" === $"k2" % 3, "left_outer")
-      assert(leftJoinNonUniqueDf.queryExecution.executedPlan.collect {
-        case WholeStageCodegenExec(_ : ShuffledHashJoinExec) if hint == "SHUFFLE_HASH" => true
-        case WholeStageCodegenExec(_ : SortMergeJoinExec) if hint == "SHUFFLE_MERGE" => true
-      }.size === 1)
-      checkAnswer(leftJoinNonUniqueDf, Seq(Row(0, 3), Row(0, 6), Row(0, 9), Row(1, 1),
-        Row(1, 4), Row(1, 7), Row(1, 10), Row(2, 2), Row(2, 5), Row(2, 8), Row(3, null),
-        Row(4, null)))
+        // test left join with non-unique key from build side
+        val leftJoinNonUniqueDf = df1.hint(hint).join(df2, $"k1" === $"k2" % 3, "left_outer")
+        assert(leftJoinNonUniqueDf.queryExecution.executedPlan.collect {
+          case WholeStageCodegenExec(_: ShuffledHashJoinExec) if hint == "SHUFFLE_HASH" => true
+          case WholeStageCodegenExec(_: SortMergeJoinExec) if hint == "SHUFFLE_MERGE" => true
+        }.size === 1)
+        checkAnswer(leftJoinNonUniqueDf, Seq(Row(0, 3), Row(0, 6), Row(0, 9), Row(1, 1),
+          Row(1, 4), Row(1, 7), Row(1, 10), Row(2, 2), Row(2, 5), Row(2, 8), Row(3, null),
+          Row(4, null)))
 
-      // test right join with non-equi condition
-      val rightJoinWithNonEquiDf = df1.join(df2.hint(hint),
-        $"k1" === $"k2" % 3 && $"k1" + 3 =!= $"k2", "right_outer")
-      assert(rightJoinWithNonEquiDf.queryExecution.executedPlan.collect {
-        case WholeStageCodegenExec(_ : ShuffledHashJoinExec) if hint == "SHUFFLE_HASH" => true
-        case WholeStageCodegenExec(_ : SortMergeJoinExec) if hint == "SHUFFLE_MERGE" => true
-      }.size === 1)
-      checkAnswer(rightJoinWithNonEquiDf, Seq(Row(0, 6), Row(0, 9), Row(1, 1), Row(1, 7),
-        Row(1, 10), Row(2, 2), Row(2, 8), Row(null, 3), Row(null, 4), Row(null, 5)))
+        // test right join with non-equi condition
+        val rightJoinWithNonEquiDf = df1.join(df2.hint(hint),
+          $"k1" === $"k2" % 3 && $"k1" + 3 =!= $"k2", "right_outer")
+        assert(rightJoinWithNonEquiDf.queryExecution.executedPlan.collect {
+          case WholeStageCodegenExec(_: ShuffledHashJoinExec) if hint == "SHUFFLE_HASH" => true
+          case WholeStageCodegenExec(_: SortMergeJoinExec) if hint == "SHUFFLE_MERGE" => true
+        }.size === 1)
+        checkAnswer(rightJoinWithNonEquiDf, Seq(Row(0, 6), Row(0, 9), Row(1, 1), Row(1, 7),
+          Row(1, 10), Row(2, 2), Row(2, 8), Row(null, 3), Row(null, 4), Row(null, 5)))
 
-      // test left join with non-equi condition
-      val leftJoinWithNonEquiDf = df1.hint(hint).join(df2,
-        $"k1" === $"k2" % 3 && $"k1" + 3 =!= $"k2", "left_outer")
-      assert(leftJoinWithNonEquiDf.queryExecution.executedPlan.collect {
-        case WholeStageCodegenExec(_ : ShuffledHashJoinExec) if hint == "SHUFFLE_HASH" => true
-        case WholeStageCodegenExec(_ : SortMergeJoinExec) if hint == "SHUFFLE_MERGE" => true
-      }.size === 1)
-      checkAnswer(leftJoinWithNonEquiDf, Seq(Row(0, 6), Row(0, 9), Row(1, 1), Row(1, 7),
-        Row(1, 10), Row(2, 2), Row(2, 8), Row(3, null), Row(4, null)))
+        // test left join with non-equi condition
+        val leftJoinWithNonEquiDf = df1.hint(hint).join(df2,
+          $"k1" === $"k2" % 3 && $"k1" + 3 =!= $"k2", "left_outer")
+        assert(leftJoinWithNonEquiDf.queryExecution.executedPlan.collect {
+          case WholeStageCodegenExec(_: ShuffledHashJoinExec) if hint == "SHUFFLE_HASH" => true
+          case WholeStageCodegenExec(_: SortMergeJoinExec) if hint == "SHUFFLE_MERGE" => true
+        }.size === 1)
+        checkAnswer(leftJoinWithNonEquiDf, Seq(Row(0, 6), Row(0, 9), Row(1, 1), Row(1, 7),
+          Row(1, 10), Row(2, 2), Row(2, 8), Row(3, null), Row(4, null)))
 
-      // test two right joins
-      val twoRightJoinsDf = df1.join(df2.hint(hint), $"k1" === $"k2", "right_outer")
-        .join(df3.hint(hint), $"k1" === $"k3" && $"k1" + $"k3" =!= 2, "right_outer")
-      assert(twoRightJoinsDf.queryExecution.executedPlan.collect {
-        case WholeStageCodegenExec(_ : ShuffledHashJoinExec) if hint == "SHUFFLE_HASH" => true
-        case WholeStageCodegenExec(_ : SortMergeJoinExec) if hint == "SHUFFLE_MERGE" => true
-      }.size === 2)
-      checkAnswer(twoRightJoinsDf, Seq(Row(2, 2, 2), Row(3, 3, 3), Row(4, 4, 4)))
+        // test two right joins
+        val twoRightJoinsDf = df1.join(df2.hint(hint), $"k1" === $"k2", "right_outer")
+          .join(df3.hint(hint), $"k1" === $"k3" && $"k1" + $"k3" =!= 2, "right_outer")
+        assert(twoRightJoinsDf.queryExecution.executedPlan.collect {
+          case WholeStageCodegenExec(_: ShuffledHashJoinExec) if hint == "SHUFFLE_HASH" => true
+          case WholeStageCodegenExec(_: SortMergeJoinExec) if hint == "SHUFFLE_MERGE" => true
+        }.size === 2)
+        checkAnswer(twoRightJoinsDf, Seq(Row(2, 2, 2), Row(3, 3, 3), Row(4, 4, 4)))
 
-      // test two left joins
-      val twoLeftJoinsDf = df1.hint(hint).join(df2, $"k1" === $"k2", "left_outer").hint(hint)
-        .join(df3, $"k1" === $"k3" && $"k1" + $"k3" =!= 2, "left_outer")
-      assert(twoLeftJoinsDf.queryExecution.executedPlan.collect {
-        case WholeStageCodegenExec(_ : ShuffledHashJoinExec) if hint == "SHUFFLE_HASH" => true
-        case WholeStageCodegenExec(_ : SortMergeJoinExec) if hint == "SHUFFLE_MERGE" => true
-      }.size === 2)
-      checkAnswer(twoLeftJoinsDf,
-        Seq(Row(0, null, null), Row(1, 1, null), Row(2, 2, 2), Row(3, 3, 3), Row(4, 4, 4)))
+        // test two left joins
+        val twoLeftJoinsDf = df1.hint(hint).join(df2, $"k1" === $"k2", "left_outer").hint(hint)
+          .join(df3, $"k1" === $"k3" && $"k1" + $"k3" =!= 2, "left_outer")
+        assert(twoLeftJoinsDf.queryExecution.executedPlan.collect {
+          case WholeStageCodegenExec(_: ShuffledHashJoinExec) if hint == "SHUFFLE_HASH" => true
+          case WholeStageCodegenExec(_: SortMergeJoinExec) if hint == "SHUFFLE_MERGE" => true
+        }.size === 2)
+        checkAnswer(twoLeftJoinsDf,
+          Seq(Row(0, null, null), Row(1, 1, null), Row(2, 2, 2), Row(3, 3, 3), Row(4, 4, 4)))
+      }
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
@@ -233,8 +233,7 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
   }
 
 
-  test("Build-side Outer ShuffledHashJoin and SortMergeJoin should be included " +
-    "in WholeStageCodegen") {
+  test("SPARK-44060 Code-gen for build side outer shuffled hash join") {
     val df1 = spark.range(0, 5).select($"id".as("k1"))
     val df2 = spark.range(1, 11).select($"id".as("k2"))
     val df3 = spark.range(2, 5).select($"id".as("k3"))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
@@ -232,6 +232,94 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
     }
   }
 
+
+  test("Build-side Outer ShuffledHashJoin and SortMergeJoin should be included " +
+    "in WholeStageCodegen") {
+    val df1 = spark.range(0, 5).select($"id".as("k1"))
+    val df2 = spark.range(1, 11).select($"id".as("k2"))
+    val df3 = spark.range(2, 5).select($"id".as("k3"))
+
+    Seq("SHUFFLE_HASH", "SHUFFLE_MERGE").foreach { hint =>
+      // test right join with unique key from build side
+      val rightJoinUniqueDf = df1.join(df2.hint(hint), $"k1" === $"k2", "right_outer")
+      assert(rightJoinUniqueDf.queryExecution.executedPlan.collect {
+        case WholeStageCodegenExec(_ : ShuffledHashJoinExec) if hint == "SHUFFLE_HASH" => true
+        case WholeStageCodegenExec(_ : SortMergeJoinExec) if hint == "SHUFFLE_MERGE" => true
+      }.size === 1)
+      checkAnswer(rightJoinUniqueDf, Seq(Row(1, 1), Row(2, 2), Row(3, 3), Row(4, 4),
+        Row(null, 5), Row(null, 6), Row(null, 7), Row(null, 8), Row(null, 9),
+        Row(null, 10)))
+      assert(rightJoinUniqueDf.count() === 10)
+
+      // test left join with unique key from build side
+      val leftJoinUniqueDf = df1.hint(hint).join(df2, $"k1" === $"k2", "left_outer")
+      assert(leftJoinUniqueDf.queryExecution.executedPlan.collect {
+        case WholeStageCodegenExec(_ : ShuffledHashJoinExec) if hint == "SHUFFLE_HASH" => true
+        case WholeStageCodegenExec(_ : SortMergeJoinExec) if hint == "SHUFFLE_MERGE" => true
+      }.size === 1)
+      checkAnswer(leftJoinUniqueDf, Seq(Row(0, null), Row(1, 1), Row(2, 2), Row(3, 3), Row(4, 4)))
+      assert(leftJoinUniqueDf.count() === 5)
+
+      // test right join with non-unique key from build side
+      val rightJoinNonUniqueDf = df1.join(df2.hint(hint), $"k1" === $"k2" % 3, "right_outer")
+      assert(rightJoinNonUniqueDf.queryExecution.executedPlan.collect {
+        case WholeStageCodegenExec(_ : ShuffledHashJoinExec) if hint == "SHUFFLE_HASH" => true
+        case WholeStageCodegenExec(_ : SortMergeJoinExec) if hint == "SHUFFLE_MERGE" => true
+      }.size === 1)
+      checkAnswer(rightJoinNonUniqueDf, Seq(Row(0, 3), Row(0, 6), Row(0, 9), Row(1, 1),
+        Row(1, 4), Row(1, 7), Row(1, 10), Row(2, 2), Row(2, 5), Row(2, 8)))
+
+      // test left join with non-unique key from build side
+      val leftJoinNonUniqueDf = df1.hint(hint).join(df2, $"k1" === $"k2" % 3, "left_outer")
+      assert(leftJoinNonUniqueDf.queryExecution.executedPlan.collect {
+        case WholeStageCodegenExec(_ : ShuffledHashJoinExec) if hint == "SHUFFLE_HASH" => true
+        case WholeStageCodegenExec(_ : SortMergeJoinExec) if hint == "SHUFFLE_MERGE" => true
+      }.size === 1)
+      checkAnswer(leftJoinNonUniqueDf, Seq(Row(0, 3), Row(0, 6), Row(0, 9), Row(1, 1),
+        Row(1, 4), Row(1, 7), Row(1, 10), Row(2, 2), Row(2, 5), Row(2, 8), Row(3, null),
+        Row(4, null)))
+
+      // test right join with non-equi condition
+      val rightJoinWithNonEquiDf = df1.join(df2.hint(hint),
+        $"k1" === $"k2" % 3 && $"k1" + 3 =!= $"k2", "right_outer")
+      assert(rightJoinWithNonEquiDf.queryExecution.executedPlan.collect {
+        case WholeStageCodegenExec(_ : ShuffledHashJoinExec) if hint == "SHUFFLE_HASH" => true
+        case WholeStageCodegenExec(_ : SortMergeJoinExec) if hint == "SHUFFLE_MERGE" => true
+      }.size === 1)
+      checkAnswer(rightJoinWithNonEquiDf, Seq(Row(0, 6), Row(0, 9), Row(1, 1), Row(1, 7),
+        Row(1, 10), Row(2, 2), Row(2, 8), Row(null, 3), Row(null, 4), Row(null, 5)))
+
+      // test left join with non-equi condition
+      val leftJoinWithNonEquiDf = df1.hint(hint).join(df2,
+        $"k1" === $"k2" % 3 && $"k1" + 3 =!= $"k2", "left_outer")
+      assert(leftJoinWithNonEquiDf.queryExecution.executedPlan.collect {
+        case WholeStageCodegenExec(_ : ShuffledHashJoinExec) if hint == "SHUFFLE_HASH" => true
+        case WholeStageCodegenExec(_ : SortMergeJoinExec) if hint == "SHUFFLE_MERGE" => true
+      }.size === 1)
+      checkAnswer(leftJoinWithNonEquiDf, Seq(Row(0, 6), Row(0, 9), Row(1, 1), Row(1, 7),
+        Row(1, 10), Row(2, 2), Row(2, 8), Row(3, null), Row(4, null)))
+
+      // test two right joins
+      val twoRightJoinsDf = df1.join(df2.hint(hint), $"k1" === $"k2", "right_outer")
+        .join(df3.hint(hint), $"k1" === $"k3" && $"k1" + $"k3" =!= 2, "right_outer")
+      assert(twoRightJoinsDf.queryExecution.executedPlan.collect {
+        case WholeStageCodegenExec(_ : ShuffledHashJoinExec) if hint == "SHUFFLE_HASH" => true
+        case WholeStageCodegenExec(_ : SortMergeJoinExec) if hint == "SHUFFLE_MERGE" => true
+      }.size === 2)
+      checkAnswer(twoRightJoinsDf, Seq(Row(2, 2, 2), Row(3, 3, 3), Row(4, 4, 4)))
+
+      // test two left joins
+      val twoLeftJoinsDf = df1.hint(hint).join(df2, $"k1" === $"k2", "left_outer").hint(hint)
+        .join(df3, $"k1" === $"k3" && $"k1" + $"k3" =!= 2, "left_outer")
+      assert(twoLeftJoinsDf.queryExecution.executedPlan.collect {
+        case WholeStageCodegenExec(_ : ShuffledHashJoinExec) if hint == "SHUFFLE_HASH" => true
+        case WholeStageCodegenExec(_ : SortMergeJoinExec) if hint == "SHUFFLE_MERGE" => true
+      }.size === 2)
+      checkAnswer(twoLeftJoinsDf,
+        Seq(Row(0, null, null), Row(1, 1, null), Row(2, 2, 2), Row(3, 3, 3), Row(4, 4, 4)))
+    }
+  }
+
   test("Left/Right Outer SortMergeJoin should be included in WholeStageCodegen") {
     val df1 = spark.range(10).select($"id".as("k1"))
     val df2 = spark.range(4).select($"id".as("k2"))


### PR DESCRIPTION
 ### What changes were proposed in this pull request?
Codegen of shuffled hash join of build side outer join (ie, left outer join build left or right outer join build right)

 ### Why are the changes needed?
The implementation of https://github.com/apache/spark/pull/41398 was only for non-codegen version, and codegen was disabled in this scenario.

 ### Does this PR introduce _any_ user-facing change?
No

 ### How was this patch tested?
New unit test in WholeStageCodegenSuite