### PR TITLE
[SPARK-44041][BUILD] Upgrade Ammonite to 2.5.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -218,7 +218,7 @@
     ./python/pyspark/sql/pandas/utils.py, and ./python/setup.py too.
     -->
     <arrow.version>12.0.0</arrow.version>
-    <ammonite.version>2.5.8</ammonite.version>
+    <ammonite.version>2.5.9</ammonite.version>
 
     <!-- org.fusesource.leveldbjni will be used except on arm64 platform. -->
     <leveldbjni.group>org.fusesource.leveldbjni</leveldbjni.group>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr is aim to upgrade ammonite from 2.5.8 to 2.5.9. 

### Why are the changes needed?
Ammonite 2.5.9  is used to support Scala 2.12.18 and Scala 2.13.11:
- https://github.com/com-lihaoyi/Ammonite/compare/2.5.8...2.5.9


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions
