### PR TITLE
[SPARK-38230][SQL] InsertIntoHadoopFsRelationCommand unnecessarily fetches details of partitions

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalog.scala
@@ -262,6 +262,20 @@ trait ExternalCatalog {
       partialSpec: Option[TablePartitionSpec] = None): Seq[CatalogTablePartition]
 
   /**
+   * List the metadata of all partitions that belong to the specified table
+   * and the giving part names,assuming it exists.
+   *
+   * @param db database name
+   * @param table table name
+   * @param partitionNames partNames e.g.  ('a=1/b=1', 'a=1/b=2')
+   * @return
+   */
+  def listPartitionsByNames(
+      db: String,
+      table: String,
+      partNames: Seq[String]): Seq[CatalogTablePartition]
+
+  /**
    * List the metadata of partitions that belong to the specified table, assuming it exists, that
    * satisfy the given partition-pruning predicate expressions.
    *

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalog.scala
@@ -267,13 +267,13 @@ trait ExternalCatalog {
    *
    * @param db database name
    * @param table table name
-   * @param partitionNames partNames e.g.  ('a=1/b=1', 'a=1/b=2')
+   * @param parts partition names e.g. ('a=1/b=1', 'a=1/b=2')
    * @return
    */
   def listPartitionsByNames(
       db: String,
       table: String,
-      partNames: Seq[String]): Seq[CatalogTablePartition]
+      parts: Seq[String]): Seq[CatalogTablePartition]
 
   /**
    * List the metadata of partitions that belong to the specified table, assuming it exists, that

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogWithListener.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogWithListener.scala
@@ -257,8 +257,8 @@ class ExternalCatalogWithListener(delegate: ExternalCatalog)
   override def listPartitionsByNames(
       db: String,
       table: String,
-      partitionNames: Seq[String]): Seq[CatalogTablePartition] = {
-    delegate.listPartitionsByNames(db, table, partitionNames)
+      parts: Seq[String]): Seq[CatalogTablePartition] = {
+    delegate.listPartitionsByNames(db, table, parts)
   }
 
   override def listPartitionsByFilter(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogWithListener.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogWithListener.scala
@@ -254,6 +254,13 @@ class ExternalCatalogWithListener(delegate: ExternalCatalog)
     delegate.listPartitions(db, table, partialSpec)
   }
 
+  override def listPartitionsByNames(
+      db: String,
+      table: String,
+      partitionNames: Seq[String]): Seq[CatalogTablePartition] = {
+    delegate.listPartitionsByNames(db, table, partitionNames)
+  }
+
   override def listPartitionsByFilter(
       db: String,
       table: String,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
@@ -594,6 +594,17 @@ class InMemoryCatalog(
     }
   }
 
+  def listPartitionsByNames(
+      db: String,
+      table: String,
+      partitionNames: Seq[String]): Seq[CatalogTablePartition] = synchronized {
+    requireTableExists(db, table)
+
+    catalog(db).tables(table).partitions.filter { case (spec, _) =>
+      partitionNames.contains(spec.map(v => v._1 + "=" + v._2).toSeq.mkString("/"))
+    }.values.toSeq
+  }
+
   override def listPartitionsByFilter(
       db: String,
       table: String,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
@@ -597,11 +597,11 @@ class InMemoryCatalog(
   def listPartitionsByNames(
       db: String,
       table: String,
-      partitionNames: Seq[String]): Seq[CatalogTablePartition] = synchronized {
+      parts: Seq[String]): Seq[CatalogTablePartition] = synchronized {
     requireTableExists(db, table)
 
     catalog(db).tables(table).partitions.filter { case (spec, _) =>
-      partitionNames.contains(spec.map(v => v._1 + "=" + v._2).toSeq.mkString("/"))
+      parts.contains(spec.map { case (k, v) => s"$k=$v" }.toSeq.mkString("/"))
     }.values.toSeq
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -1288,6 +1288,20 @@ class SessionCatalog(
   }
 
   /**
+   * List the metadata of partitions that belong to the specified table and
+   * the giving list of part names. e.g. ('a=1/b=1', 'a=1/b=2'), assuming it exists.
+   */
+  def listPartitionsByNames(
+      tableName: TableIdentifier,
+      partNames: Seq[String]): Seq[CatalogTablePartition] = {
+    val qualifiedIdent = qualifyIdentifier(tableName)
+    val db = qualifiedIdent.database.get
+    requireDbExists(db)
+    requireTableExists(qualifiedIdent)
+    externalCatalog.listPartitionsByNames(db, qualifiedIdent.table, partNames)
+  }
+
+  /**
    * List the metadata of partitions that belong to the specified table, assuming it exists, that
    * satisfy the given partition-pruning predicate expressions.
    */

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogSuite.scala
@@ -475,6 +475,17 @@ abstract class ExternalCatalogSuite extends SparkFunSuite {
     assert(catalog.listPartitions("db2", "tbl2", Some(Map("a" -> "unknown"))).isEmpty)
   }
 
+  test("list partitions by partNames") {
+    val catalog = newBasicCatalog()
+
+    val parts = catalog.listPartitionsByNames("db2", "tbl2", List("a=1/b=2", "a=3/b=4"))
+    assert(parts.length == 2)
+
+    // if no partition is matched for the given partition spec, an empty list should be returned.
+    assert(catalog.listPartitionsByNames("db2", "tbl2", List("a=unknown/b=1")).isEmpty)
+    assert(catalog.listPartitionsByNames("db2", "tbl2", List("a=unknown")).isEmpty)
+  }
+
   test("SPARK-21457: list partitions with special chars") {
     val catalog = newBasicCatalog()
     assert(catalog.listPartitions("db2", "tbl1").isEmpty)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelationCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelationCommand.scala
@@ -57,7 +57,7 @@ case class InsertIntoHadoopFsRelationCommand(
     catalogTable: Option[CatalogTable],
     fileIndex: Option[FileIndex],
     outputColumnNames: Seq[String])
-    extends V1WriteCommand {
+  extends V1WriteCommand {
 
   private lazy val parameters = CaseInsensitiveMap(options)
 
@@ -126,7 +126,7 @@ case class InsertIntoHadoopFsRelationCommand(
           committer = committer,
           outputSpec = FileFormatWriter.OutputSpec(
             committerOutputPath.toString,
-            customPartitionLocations,
+            Map.empty,
             outputColumns),
           hadoopConf = hadoopConf,
           partitionColumns = partitionColumns,
@@ -332,5 +332,5 @@ case class InsertIntoHadoopFsRelationCommand(
   }
 
   override protected def withNewChildInternal(
-      newChild: LogicalPlan): InsertIntoHadoopFsRelationCommand = copy(query = newChild)
+    newChild: LogicalPlan): InsertIntoHadoopFsRelationCommand = copy(query = newChild)
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelationCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelationCommand.scala
@@ -116,7 +116,6 @@ case class InsertIntoHadoopFsRelationCommand(
     // When partitions are tracked by the catalog, compute all custom partition locations that
     // may be relevant to the insertion job.
     if (partitionsTrackedByCatalog) {
-
       matchingPartitions = if (dynamicPartitionOverwrite) {
         // Get the matching partitions from the written path instead of pull all
         // partitions from metastore, avoiding heavy pressures
@@ -197,7 +196,7 @@ case class InsertIntoHadoopFsRelationCommand(
           // The `customPartitionLocations` is getting from writing paths. Hence, it need to move
           // files from `qualifiedOutputPath` to custom location.
           if (updatedPartitions.nonEmpty && dynamicPartitionOverwrite) {
-            overWriteCustomParttions(
+            overwriteCustomPartitions(
               fs,
               catalogTable.get,
               qualifiedOutputPath,
@@ -314,13 +313,13 @@ case class InsertIntoHadoopFsRelationCommand(
    * Deletes all partition files that match the custom locations and copy files from the dynamic
    * writing paths
    */
-  private def overWriteCustomParttions(
+  private def overwriteCustomPartitions(
       fs: FileSystem,
       table: CatalogTable,
       qualifiedOutputPath: Path,
       committer: FileCommitProtocol,
-      customPatitions: Map[TablePartitionSpec, String]) = {
-    for ((spec, customLoc) <- customPatitions) {
+      customPartitions: Map[TablePartitionSpec, String]) = {
+    customPartitions.foreach { case (spec, customLoc) =>
       val defaultLocation = qualifiedOutputPath.suffix(
         "/" + PartitioningUtils.getPathFragment(spec, table.partitionSchema))
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -1283,6 +1283,15 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
     }
   }
 
+  override def listPartitionsByNames(
+     db: String,
+     table: String,
+     partNames: Seq[String]): Seq[CatalogTablePartition] = withClient {
+    val partColNameMap = buildLowerCasePartColNameMap(getTable(db, table))
+    client.getPartitionsByNames(db, table, partNames.map(_.toLowerCase()))
+      .map { part => part.copy(spec = restorePartitionSpec(part.spec, partColNameMap))}
+  }
+
   override def listPartitionsByFilter(
       db: String,
       table: String,

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -1286,9 +1286,9 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
   override def listPartitionsByNames(
      db: String,
      table: String,
-     partNames: Seq[String]): Seq[CatalogTablePartition] = withClient {
+     parts: Seq[String]): Seq[CatalogTablePartition] = withClient {
     val partColNameMap = buildLowerCasePartColNameMap(getTable(db, table))
-    client.getPartitionsByNames(db, table, partNames.map(_.toLowerCase()))
+    client.getPartitionsByNames(db, table, parts.map(_.toLowerCase()))
       .map { part => part.copy(spec = restorePartitionSpec(part.spec, partColNameMap))}
   }
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClient.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClient.scala
@@ -241,6 +241,9 @@ private[hive] trait HiveClient {
       partialSpec: Option[TablePartitionSpec]): Seq[CatalogTablePartition]
 
 
+  /**
+   * Returns the partitions for the given table that match the supplied partition names.
+   */
   def getPartitionsByNames(
       db: String,
       table: String,

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClient.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClient.scala
@@ -240,6 +240,12 @@ private[hive] trait HiveClient {
       table: String,
       partialSpec: Option[TablePartitionSpec]): Seq[CatalogTablePartition]
 
+
+  def getPartitionsByNames(
+      db: String,
+      table: String,
+      partNames: Seq[String]): Seq[CatalogTablePartition]
+
   /** Returns partitions filtered by predicates for the given table. */
   def getPartitionsByFilter(
       catalogTable: RawHiveTable,

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -790,6 +790,20 @@ private[hive] class HiveClientImpl(
     getPartitions(hiveTable, spec)
   }
 
+  override def getPartitionsByNames(
+      db: String,
+      table: String,
+      partNames: Seq[String]): Seq[CatalogTablePartition] = {
+    val hiveTable = withHiveState {
+      getRawTableOption(db, table).getOrElse(throw new NoSuchTableException(db, table))
+    }
+    val parts = shim
+      .getPartitionsByNames(client, hiveTable, partNames.asJava)
+      .map(fromHivePartition)
+    HiveCatalogMetrics.incrementFetchedPartitions(parts.length)
+    parts.toSeq
+  }
+
   private def getPartitions(
       hiveTable: HiveTable,
       spec: Option[TablePartitionSpec]): Seq[CatalogTablePartition] = withHiveState {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
@@ -148,6 +148,11 @@ private[client] sealed abstract class Shim {
       table: Table,
       partSpec: JMap[String, String]): Seq[Partition]
 
+  def getPartitionsByNames(
+      hive: Hive,
+      table: Table,
+      partNames: JList[String]): Seq[Partition]
+
   def getPartitionNames(
       hive: Hive,
       dbName: String,
@@ -658,6 +663,14 @@ private[client] class Shim_v0_12 extends Shim with Logging {
       partSpec: JMap[String, String]): Seq[Partition] = {
     recordHiveCall()
     hive.getPartitions(table, partSpec).asScala.toSeq
+  }
+
+  override def getPartitionsByNames(
+      hive: Hive,
+      table: Table,
+      partNames: JList[String]): Seq[Partition] = {
+    recordHiveCall()
+    hive.getPartitionsByNames(table, partNames).asScala.toSeq
   }
 
   override def getPartitionNames(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

When using partition writing with InsertIntoHadoopFsRelationCommand, `listPartitions` will fetch all partition metadata, which causes huge pressure on metadata service. Therefore, this pull request generates the file paths first when writing with dynamic partition, and then retrieves metadata, reducing the pressure on metadata service.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
1. `listPartitions` fetches all metadata where using dynamic partition writing.
2. When dynamically writing partitions, the number of partition written is generally much smaller than the total number of partitions in the table.
3. Therefore, when writing with dynamic partitioning, the file is first written and get the `updatedPartitionPaths` from `FileFormatWriter.write`. 
4. Partition information is obtained through `listPartitionsByNames` by using `updatedPartitionPaths`.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
1. Create table
```scala
-- hive sql
create table test.table(id String, name String) partitioned by(dt string) stored as orc;
```
2. Generate 100k partitions sql
```shell
for i in {1..100000}; do
  echo "ALTER TABLE test.table ADD IF NOT EXISTS PARTITION (dt=${i});" >> add_partition.sql
done
```
3. Add partitions to hive
```shell
hive -f add_partition.sql
```
4. Run sql in spark
```scala
val df = sc.parallelize(1 to 100).map(i=>(i, i, "2023-06-13")).toDF("id","name","dt")
df.write.mode("overwrite").insertInto("test.table")
```

5. Test Result
*  before the patch, sql run fail because timeout after 5min 
<img width="900" alt="image" src="https://github.com/apache/spark/assets/3426093/d16e12a1-a304-4cd9-ac1e-70cb0231a40c">
<img width="1398" alt="image" src="https://github.com/apache/spark/assets/3426093/0350f889-1ac3-45bf-808b-36335083a472">



* after the patch, sql finish in 4s 
<img width="1114" alt="image" src="https://github.com/apache/spark/assets/3426093/f73b468a-4e0b-4bcb-90e4-b67b48af4895">



