### PR TITLE
[SPARK-44080][SQL] Support overriding SQL configurations for new connections

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/webui.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/webui.js
@@ -102,6 +102,7 @@ $(function() {
   collapseTablePageLoad('collapse-aggregated-sqlsessionstat','aggregated-sqlsessionstat');
   collapseTablePageLoad('collapse-aggregated-activeQueries','aggregated-activeQueries');
   collapseTablePageLoad('collapse-aggregated-completedQueries','aggregated-completedQueries');
+  collapseTablePageLoad('collapse-override-sql-configurations','override-sql-configurations');
 });
 
 $(function() {

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLSessionManager.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLSessionManager.scala
@@ -64,10 +64,10 @@ private[hive] class SparkSQLSessionManager(hiveServer: HiveServer2, sqlContext: 
         sqlContext.newSession()
       }
       ctx.setConf(SQLConf.DATETIME_JAVA8API_ENABLED, true)
+      HiveThriftServer2.uiTab.foreach(uiTab => setConfMap(ctx, uiTab.overriddenSQLConf))
       val hiveSessionState = session.getSessionState
       setConfMap(ctx, hiveSessionState.getOverriddenConfigurations)
       setConfMap(ctx, hiveSessionState.getHiveVariables)
-      HiveThriftServer2.uiTab.foreach(uiTab => setConfMap(ctx, uiTab.updatedSQLConf))
       if (sessionConf != null && sessionConf.containsKey("use:database")) {
         ctx.sql(s"use ${sessionConf.get("use:database")}")
       }

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLSessionManager.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLSessionManager.scala
@@ -67,6 +67,7 @@ private[hive] class SparkSQLSessionManager(hiveServer: HiveServer2, sqlContext: 
       val hiveSessionState = session.getSessionState
       setConfMap(ctx, hiveSessionState.getOverriddenConfigurations)
       setConfMap(ctx, hiveSessionState.getHiveVariables)
+      HiveThriftServer2.uiTab.foreach(uiTab => setConfMap(ctx, uiTab.updatedSQLConf))
       if (sessionConf != null && sessionConf.containsKey("use:database")) {
         ctx.sql(s"use ${sessionConf.get("use:database")}")
       }

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/ui/ThriftServerPage.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/ui/ThriftServerPage.scala
@@ -47,7 +47,8 @@ private[ui] class ThriftServerPage(parent: ThriftServerTab) extends WebUIPage(""
           SQL statement(s)
         </h4> ++
         generateSessionStatsTable(request) ++
-        generateSQLStatsTable(request)
+        generateSQLStatsTable(request) ++
+        generateUpdateSQLConf()
     }
     UIUtils.headerSparkPage(request, "JDBC/ODBC Server", content, parent)
   }
@@ -158,6 +159,30 @@ private[ui] class ThriftServerPage(parent: ThriftServerTab) extends WebUIPage(""
       </div>
 
     content
+  }
+
+  private def generateUpdateSQLConf(): Seq[Node] = {
+    <h4>
+      <span class="collapse-table-arrow arrow-open"></span>
+      <a>Update Spark SQL configuration default values for new connections</a>
+    </h4>
+    <span>
+      <div style="width:50%">
+        <form action="/sqlserver/updatesqlconf/" method="POST">
+          <div class="form-group">
+            <label>SQL Conf key:</label>
+            <input type="text" class="form-control" id="key" name="key" required="true"
+                   maxlength="200" pattern="spark.sql.+" placeholder="Enter SQL Conf key"/>
+          </div>
+          <div class="form-group">
+            <label>SQL Conf value:</label>
+            <input type="text" class="form-control" id="value"  name="value" required="true"
+                   maxlength="200" placeholder="Enter SQL Conf value"/>
+          </div>
+          <button type="submit" class="btn btn-primary">Update</button>
+        </form>
+      </div>
+    </span>
   }
 }
 

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/ui/ThriftServerPage.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/ui/ThriftServerPage.scala
@@ -168,16 +168,16 @@ private[ui] class ThriftServerPage(parent: ThriftServerTab) extends WebUIPage(""
     </h4>
     <span>
       <div style="width:50%">
-        <form action="/sqlserver/updatesqlconf/" method="POST">
+        <form action="updatesqlconf/" method="GET"> <!-- Use GET method to support YARN proxy -->
           <div class="form-group">
-            <label>SQL Conf key:</label>
+            <label>SQL configuration key:</label>
             <input type="text" class="form-control" id="key" name="key" required="true"
-                   maxlength="200" pattern="spark.sql.+" placeholder="Enter SQL Conf key"/>
+                   maxlength="200" pattern="spark.sql.+" placeholder="Enter spark.sql.+"/>
           </div>
           <div class="form-group">
-            <label>SQL Conf value:</label>
-            <input type="text" class="form-control" id="value"  name="value" required="true"
-                   maxlength="200" placeholder="Enter SQL Conf value"/>
+            <label>SQL configuration value:</label>
+            <input type="text" class="form-control" id="value" name="value" required="true"
+                   maxlength="200" placeholder="Enter boolean, number or string"/>
           </div>
           <button type="submit" class="btn btn-primary">Update</button>
         </form>

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/ui/ThriftServerPage.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/ui/ThriftServerPage.scala
@@ -182,7 +182,7 @@ private[ui] class ThriftServerPage(parent: ThriftServerTab) extends WebUIPage(""
           <div class="form-group">
             <label>SQL configuration value:</label>
             <input type="text" class="form-control" style="width:50%" id="value" name="value"
-                   required="true" maxlength="200" placeholder="Enter boolean, number or string"/>
+                   required="true" maxlength="5000" placeholder="Enter boolean, number or string"/>
           </div>
           <button type="submit" class="btn btn-primary">Override</button>
         </form>

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/ui/ThriftServerTab.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/ui/ThriftServerTab.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.hive.thriftserver.ui
 
+import java.util.HashMap
 import javax.servlet.http.{HttpServlet, HttpServletRequest, HttpServletResponse}
 
 import org.apache.spark.SparkContext
@@ -37,6 +38,7 @@ private[thriftserver] class ThriftServerTab(
 
   val parent = sparkUI
   val startTime = sparkUI.store.applicationInfo().attempts.head.startTime
+  private[thriftserver] val updatedSQLConf = new HashMap[String, String]
 
   attachPage(new ThriftServerPage(this))
   attachPage(new ThriftServerSessionPage(this))
@@ -45,18 +47,15 @@ private[thriftserver] class ThriftServerTab(
     override def doPost(req: HttpServletRequest, resp: HttpServletResponse): Unit = {
       val key = req.getParameter("key")
       val value = req.getParameter("value")
+      resp.setContentType("text/html; charset=UTF-8");
       try {
         SQLConf.get.setConfString(key, value) // Used to check if the value is valid.
-        parent.conf.set(key, value)
-        logInfo(s"Successfully updated ${key} to ${value}.")
-        resp.setContentType("text/html; charset=UTF-8");
+        updatedSQLConf.put(key, value)
         // scalastyle:off println
-        resp.getWriter
-          .println("<script>window.location.replace(document.referrer);</script>")
+        resp.getWriter.println("<script>window.location.replace(document.referrer);</script>")
         // scalastyle:on println
       } catch {
         case e: Throwable =>
-          resp.setContentType("text/html; charset=UTF-8");
           val msg = s"Failed to update SQL configuration: ${e.getMessage}."
           logWarning(msg)
           // scalastyle:off println

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/ui/ThriftServerTab.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/ui/ThriftServerTab.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.sql.hive.thriftserver.ui
 
-import java.util.HashMap
 import javax.servlet.http.{HttpServlet, HttpServletRequest, HttpServletResponse}
 
 import org.apache.spark.SparkContext
@@ -38,25 +37,25 @@ private[thriftserver] class ThriftServerTab(
 
   val parent = sparkUI
   val startTime = sparkUI.store.applicationInfo().attempts.head.startTime
-  private[thriftserver] val updatedSQLConf = new HashMap[String, String]
+  private[thriftserver] val overriddenSQLConf = new java.util.HashMap[String, String]
 
   attachPage(new ThriftServerPage(this))
   attachPage(new ThriftServerSessionPage(this))
   parent.attachTab(this)
-  parent.attachHandler(createServletHandler("/sqlserver/updatesqlconf", new HttpServlet {
+  parent.attachHandler(createServletHandler("/sqlserver/overridesqlconf", new HttpServlet {
     override def doPost(req: HttpServletRequest, resp: HttpServletResponse): Unit = {
+      resp.setContentType("text/html; charset=UTF-8");
       val key = req.getParameter("key")
       val value = req.getParameter("value")
-      resp.setContentType("text/html; charset=UTF-8");
       try {
         SQLConf.get.setConfString(key, value) // Used to check if the value is valid.
-        updatedSQLConf.put(key, value)
+        overriddenSQLConf.put(key, value)
         // scalastyle:off println
         resp.getWriter.println("<script>window.location.replace(document.referrer);</script>")
         // scalastyle:on println
       } catch {
         case e: Throwable =>
-          val msg = s"Failed to update SQL configuration: ${e.getMessage}."
+          val msg = s"Failed to override SQL configuration: ${e.getMessage}."
           logWarning(msg)
           // scalastyle:off println
           resp.getWriter

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/ui/ThriftServerTab.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/ui/ThriftServerTab.scala
@@ -49,20 +49,19 @@ private[thriftserver] class ThriftServerTab(
         SQLConf.get.setConfString(key, value) // Used to check if the value is valid.
         parent.conf.set(key, value)
         logInfo(s"Successfully updated ${key} to ${value}.")
-        resp.sendRedirect("/sqlserver/")
+        resp.setContentType("text/html; charset=UTF-8");
+        // scalastyle:off println
+        resp.getWriter
+          .println("<script>window.location.replace(document.referrer);</script>")
+        // scalastyle:on println
       } catch {
         case e: Throwable =>
           resp.setContentType("text/html; charset=UTF-8");
-          val msg = s"Failed to update SQL config: ${e.getMessage}."
+          val msg = s"Failed to update SQL configuration: ${e.getMessage}."
           logWarning(msg)
           // scalastyle:off println
-          resp.getWriter.println(
-            s"""
-              |<script>
-              |  alert('$msg');
-              |  window.location.replace('/sqlserver/');
-              |</script>
-              |""".stripMargin)
+          resp.getWriter
+            .println(s"<script>alert('$msg');window.location.replace(document.referrer);</script>")
           // scalastyle:on println
       }
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds a ServletHandler to support overriding SQL configurations for new connections.

### Why are the changes needed?

To support overriding the SQL config default value for new connections without restart SparkContext. The use cases:
1. Disable a newly introduced feature if it has a bug.
2. Fine-tune the value of some configurations. For example: `spark.sql.files.maxPartitionNum` ,`spark.sql.parquet.pushdown.inFilterThreshold`.


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual test.

1. Test function as expected:
```
yumwang@LM-SHC-16508156 spark % bin/beeline -u "jdbc:hive2://localhost:10000/" -e "set spark.sql.cbo.enabled;"              
...
+------------------------+--------+
|          key           | value  |
+------------------------+--------+
| spark.sql.cbo.enabled  | false  |
+------------------------+--------+
1 row selected (0.14 seconds)

yumwang@LM-SHC-16508156 spark % curl "http://localhost:4040/sqlserver/overridesqlconf/?key=spark.sql.cbo.enabled&value=true" 

yumwang@LM-SHC-16508156 spark % bin/beeline -u "jdbc:hive2://localhost:10000/" -e "set spark.sql.cbo.enabled;"             
...
+------------------------+--------+
|          key           | value  |
+------------------------+--------+
| spark.sql.cbo.enabled  | true   |
+------------------------+--------+
1 row selected (0.115 seconds)
```
3. Test UI:

<img width="994" alt="image" src="https://github.com/apache/spark/assets/5399861/502a0f91-9b80-4676-ac2e-dc4f83e33540">

<img width="852" alt="image" src="https://github.com/apache/spark/assets/5399861/902aa35c-aac2-463a-97e8-f0b75fefb9b3">
