### PR TITLE
[SPARK-44081] Simplify PartitionedFileUtil API a little

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/PartitionedFileUtil.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/PartitionedFileUtil.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.execution
 
-import org.apache.hadoop.fs.{BlockLocation, FileStatus, LocatedFileStatus, Path}
+import org.apache.hadoop.fs.{BlockLocation, FileStatus, LocatedFileStatus}
 
 import org.apache.spark.paths.SparkPath
 import org.apache.spark.sql.SparkSession
@@ -28,7 +28,6 @@ object PartitionedFileUtil {
   def splitFiles(
       sparkSession: SparkSession,
       file: FileStatusWithMetadata,
-      filePath: Path,
       isSplitable: Boolean,
       maxSplitBytes: Long,
       partitionValues: InternalRow): Seq[PartitionedFile] = {
@@ -37,20 +36,19 @@ object PartitionedFileUtil {
         val remaining = file.getLen - offset
         val size = if (remaining > maxSplitBytes) maxSplitBytes else remaining
         val hosts = getBlockHosts(getBlockLocations(file.fileStatus), offset, size)
-        PartitionedFile(partitionValues, SparkPath.fromPath(filePath), offset, size, hosts,
+        PartitionedFile(partitionValues, SparkPath.fromPath(file.getPath), offset, size, hosts,
           file.getModificationTime, file.getLen, file.metadata)
       }
     } else {
-      Seq(getPartitionedFile(file, filePath, partitionValues))
+      Seq(getPartitionedFile(file, partitionValues))
     }
   }
 
   def getPartitionedFile(
       file: FileStatusWithMetadata,
-      filePath: Path,
       partitionValues: InternalRow): PartitionedFile = {
     val hosts = getBlockHosts(getBlockLocations(file.fileStatus), 0, file.getLen)
-    PartitionedFile(partitionValues, SparkPath.fromPath(filePath), 0, file.getLen, hosts,
+    PartitionedFile(partitionValues, SparkPath.fromPath(file.getPath), 0, file.getLen, hosts,
       file.getModificationTime, file.getLen, file.metadata)
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileIndex.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileIndex.scala
@@ -30,7 +30,8 @@ import org.apache.spark.sql.types.StructType
  */
 case class FileStatusWithMetadata(fileStatus: FileStatus, metadata: Map[String, Any] = Map.empty) {
   // Wrapper methods to improve source compatibility in code that still expects a [[FileStatus]].
-  def getPath: Path = fileStatus.getPath
+  // NOTE: getPath() is very expensive, so we only want to call it once (if accessed at all).
+  lazy val getPath: Path = fileStatus.getPath
   def getLen: Long = fileStatus.getLen
   def getModificationTime: Long = fileStatus.getModificationTime
   def isDirectory: Boolean = fileStatus.isDirectory

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileScan.scala
@@ -150,12 +150,10 @@ trait FileScan extends Scan
         partition.values
       }
       partition.files.flatMap { file =>
-        val filePath = file.getPath
         PartitionedFileUtil.splitFiles(
           sparkSession = sparkSession,
           file = file,
-          filePath = filePath,
-          isSplitable = isSplitable(filePath),
+          isSplitable = isSplitable(file.getPath),
           maxSplitBytes = maxSplitBytes,
           partitionValues = partitionValues
         )


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Utility methods in `PartitionedFileUtil` take both `file: FileStatusWithMetadata` and `filePath: Path`, even tho the latter can be obtained easily from the former.

This was originally done for performance reasons, so callers can pass a memoized `Path` and thus avoid the cost of an additional `FileStatus.getPath` call.

Now that we have `FileStatusWithMetadata`, the redundancy is no longer needed -- the new class can simply capture the path as a lazy val.

### Why are the changes needed?

Simpler code (and eliminates risk of passing a mismatched path).

### Does this PR introduce _any_ user-facing change?

No. Internal API change.

### How was this patch tested?

Small refactor, existing unit tests suffice.