### PR TITLE
[SPARK-44082][SQL] Generate operator does not update reference set properly

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -296,6 +296,8 @@ case class Generate(
 
   override protected def withNewChildInternal(newChild: LogicalPlan): Generate =
     copy(child = newChild)
+
+  override lazy val references: AttributeSet = generator.references
 }
 
 case class Filter(condition: Expression, child: LogicalPlan)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -296,8 +296,6 @@ case class Generate(
 
   override protected def withNewChildInternal(newChild: LogicalPlan): Generate =
     copy(child = newChild)
-
-  override lazy val references: AttributeSet = generator.references
 }
 
 case class Filter(condition: Expression, child: LogicalPlan)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Before
```
== Optimized Logical Plan ==
Project [col1#2, col2#19](https://issues.apache.org/jira/browse/SPARK-44082#2,%20col2#19)
+- Generate replicaterows(sum#17L, col1#2, col2#3), [2], false, [col1#2, col2#3](https://issues.apache.org/jira/browse/SPARK-44082#2,%20col2#3)
+- Filter (isnotnull(sum#17L) AND (sum#17L > 0))
+- Aggregate [col1#2, col2#19](https://issues.apache.org/jira/browse/SPARK-44082#2,%20col2#19), [col1#2, col2#19, sum(vcol#14L) AS sum#17L](https://issues.apache.org/jira/browse/SPARK-44082#2,%20col2#19,%20sum(vcol#14L)%20AS%20sum#17L)
+- Union false, false
:- Aggregate [col1#2](https://issues.apache.org/jira/browse/SPARK-44082#2), [1 AS vcol#14L, col1#2, first(col2#3, false) AS col2#19](https://issues.apache.org/jira/browse/SPARK-44082#14L,%20col1#2,%20first(col2#3,%20false)%20AS%20col2#19)
: +- LogicalRDD [col1#2, col2#3](https://issues.apache.org/jira/browse/SPARK-44082#2,%20col2#3), false
+- Project [-1 AS vcol#15L, col1#8, col2#9](https://issues.apache.org/jira/browse/SPARK-44082#15L,%20col1#8,%20col2#9)
+- LogicalRDD [col1#8, col2#9](https://issues.apache.org/jira/browse/SPARK-44082#8,%20col2#9), false
```

During the execution `Generate replicaterows(sum#17L, col1#2, col2#3), [2], false, [col1#2, col2#3]` couldn't find `col2#3` in `[col1#2,col2#19,sum#17L]`. So we need generate to update the reference attributes properly.

after this fix the plan is correct now
```
== Optimized Logical Plan ==
Project [col1#2, col2#19](https://issues.apache.org/jira/browse/SPARK-44082#2,%20col2#19)
+- Generate replicaterows(sum#17L, col1#2, col2#19), [2], false, [col1#2, col2#19](https://issues.apache.org/jira/browse/SPARK-44082#2,%20col2#19)
+- Filter (isnotnull(sum#17L) AND (sum#17L > 0))
+- Aggregate [col1#2, col2#19](https://issues.apache.org/jira/browse/SPARK-44082#2,%20col2#19), [col1#2, col2#19, sum(vcol#14L) AS sum#17L](https://issues.apache.org/jira/browse/SPARK-44082#2,%20col2#19,%20sum(vcol#14L)%20AS%20sum#17L)
+- Union false, false
:- Aggregate [col1#2](https://issues.apache.org/jira/browse/SPARK-44082#2), [1 AS vcol#14L, col1#2, first(col2#3, false) AS col2#19](https://issues.apache.org/jira/browse/SPARK-44082#14L,%20col1#2,%20first(col2#3,%20false)%20AS%20col2#19)
: +- LogicalRDD [col1#2, col2#3](https://issues.apache.org/jira/browse/SPARK-44082#2,%20col2#3), false
+- Project [-1 AS vcol#15L, col1#8, col2#9](https://issues.apache.org/jira/browse/SPARK-44082#15L,%20col1#8,%20col2#9)
+- LogicalRDD [col1#8, col2#9](https://issues.apache.org/jira/browse/SPARK-44082#8,%20col2#9), false
```


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Bug fix

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
UT