### PR TITLE
[MINOR][PYTHON][PS][TESTS] Rename `k_res` to `ps_res` (drop Koalas reference)

### DIFF
--- a/python/pyspark/pandas/tests/computation/test_combine.py
+++ b/python/pyspark/pandas/tests/computation/test_combine.py
@@ -148,11 +148,11 @@ class FrameCombineMixin:
             },
             columns=["rkey", "value", "y"],
         )
-        right_ps = pd.Series(list("defghi"), name="x", index=[5, 6, 7, 8, 9, 10])
+        right_pser = pd.Series(list("defghi"), name="x", index=[5, 6, 7, 8, 9, 10])
 
         left_psdf = ps.from_pandas(left_pdf)
         right_psdf = ps.from_pandas(right_pdf)
-        right_psser = ps.from_pandas(right_ps)
+        right_psser = ps.from_pandas(right_pser)
 
         def check(op, right_psdf=right_psdf, right_pdf=right_pdf):
             ps_res = op(left_psdf, right_psdf)
@@ -218,23 +218,25 @@ class FrameCombineMixin:
         )
 
         # Test Series on the right
-        check(lambda left, right: left.merge(right), right_psser, right_ps)
+        check(lambda left, right: left.merge(right), right_psser, right_pser)
         check(
-            lambda left, right: left.merge(right, left_on="x", right_on="x"), right_psser, right_ps
+            lambda left, right: left.merge(right, left_on="x", right_on="x"),
+            right_psser,
+            right_pser,
         )
         check(
             lambda left, right: left.set_index("x").merge(right, left_index=True, right_on="x"),
             right_psser,
-            right_ps,
+            right_pser,
         )
 
         # Test join types with Series
         for how in ["inner", "left", "right", "outer"]:
-            check(lambda left, right: left.merge(right, how=how), right_psser, right_ps)
+            check(lambda left, right: left.merge(right, how=how), right_psser, right_pser)
             check(
                 lambda left, right: left.merge(right, left_on="x", right_on="x", how=how),
                 right_psser,
-                right_ps,
+                right_pser,
             )
 
         # suffix with Series
@@ -247,7 +249,7 @@ class FrameCombineMixin:
                 right_index=True,
             ),
             right_psser,
-            right_ps,
+            right_pser,
         )
 
         # multi-index columns

--- a/python/pyspark/pandas/tests/computation/test_combine.py
+++ b/python/pyspark/pandas/tests/computation/test_combine.py
@@ -155,14 +155,14 @@ class FrameCombineMixin:
         right_psser = ps.from_pandas(right_ps)
 
         def check(op, right_psdf=right_psdf, right_pdf=right_pdf):
-            k_res = op(left_psdf, right_psdf)
-            k_res = k_res._to_pandas()
-            k_res = k_res.sort_values(by=list(k_res.columns))
-            k_res = k_res.reset_index(drop=True)
+            ps_res = op(left_psdf, right_psdf)
+            ps_res = ps_res._to_pandas()
+            ps_res = ps_res.sort_values(by=list(ps_res.columns))
+            ps_res = ps_res.reset_index(drop=True)
             p_res = op(left_pdf, right_pdf)
             p_res = p_res.sort_values(by=list(p_res.columns))
             p_res = p_res.reset_index(drop=True)
-            self.assert_eq(k_res, p_res)
+            self.assert_eq(ps_res, p_res)
 
         check(lambda left, right: left.merge(right))
         check(lambda left, right: left.merge(right, on="value"))


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Rename `k_res` to `ps_res` and `ps` to `pser` in `test_combine.py`. There is no functional change; it's purely stylistic/for consistency.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
As a reader, the variable names are confusing and inconsistent. I only thought that the `k_` prefix meant Koalas because I've contributed to Koalas in the past.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Existing tests should continue to pass; no new tests necessary
