### PR TITLE
[SPARK-43928][SQL][PYTHON][CONNECT][FOLLOWUP] Update `excludedSqlFunctions` of `DataFrameFunctionsSuite`

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
@@ -77,7 +77,6 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSparkSession {
       "random",
       "array_agg", "char_length", "character_length",
       "lcase", "position", "printf", "substr", "ucase", "day", "cardinality", "sha",
-      "getbit",
       // aliases for existing functions
       "reflect", "java_method" // Only needed in SQL
     )


### PR DESCRIPTION
### What changes were proposed in this pull request?
https://github.com/apache/spark/pull/41608 add bit operations to Scala, Python and Connect API, but missing the test for `DataFrameFunctionsSuite`.


### Why are the changes needed?
Fix missing tests


### Does this PR introduce _any_ user-facing change?
'No'.
New feature.


### How was this patch tested?
N/A
