### PR TITLE
[SPARK-44085][BUILD] Update some maven plugins to newest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
     <!-- dont update scala-maven-plugin to version 4.8.1 SPARK-42809 and SPARK-43595 -->   
     <scala-maven-plugin.version>4.8.0</scala-maven-plugin.version>
     <maven.scaladoc.skip>false</maven.scaladoc.skip>
-    <versions-maven-plugin.version>2.15.0</versions-maven-plugin.version>
+    <versions-maven-plugin.version>2.16.0</versions-maven-plugin.version>
     <!-- for now, not running scalafmt as part of default verify pipeline -->
     <scalafmt.skip>true</scalafmt.skip>
     <scalafmt.validateOnly>true</scalafmt.validateOnly>
@@ -2921,7 +2921,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.1.0</version>
+          <version>3.1.2</version>
           <!-- Note config is repeated in scalatest config -->
           <configuration>
             <includes>
@@ -3040,7 +3040,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-source-plugin</artifactId>
-          <version>3.2.1</version>
+          <version>3.3.0</version>
           <configuration>
             <attach>true</attach>
           </configuration>
@@ -3167,7 +3167,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>3.5.0</version>
+          <version>3.6.0</version>
           <executions>
             <execution>
               <id>default-cli</id>


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to update some maven plugins to newest version. include:
- versions-maven-plugin from 2.15.0 to 2.16.0
- maven-source-plugin from 3.2.1 to 3.3.0
- maven-surefire-plugin from 3.1.0 to 3.1.2
- maven-dependency-plugin from 3.5.0 to 3.6.0

### Why are the changes needed?
- versions-maven-plugin
1.Release Notes: https://github.com/mojohaus/versions/releases/tag/2.16.0
2.Bug Fix:
Resolves: display-dependency-updates only shows updates from the most major allowed segment (https://github.com/mojohaus/versions/pull/966) @ajarmoniuk
Resolves https://github.com/mojohaus/versions/issues/931: Fixing problems with encoding in UseDepVersion and PomHelper (https://github.com/mojohaus/versions/pull/932) @ajarmoniuk
Resolves https://github.com/mojohaus/versions/issues/916: Partially reverted https://github.com/mojohaus/versions/pull/799. (https://github.com/mojohaus/versions/pull/924) @ajarmoniuk
Resolves https://github.com/mojohaus/versions/issues/954: Excluded plexus-container-default (https://github.com/mojohaus/versions/pull/955) @ajarmoniuk
Resolves https://github.com/mojohaus/versions/issues/951: DefaultArtifactVersion::getVersion can be null (https://github.com/mojohaus/versions/pull/952) @ajarmoniuk
BoundArtifactVersion.toString() to work with NumericVersionComparator (https://github.com/mojohaus/versions/pull/930) @ajarmoniuk
Issue https://github.com/mojohaus/versions/issues/925: Protect against an NPE if a dependency version is defined in dependencyManagement (https://github.com/mojohaus/versions/pull/926) @ajarmoniuk

- maven-source-plugin
v3.2.1 VS v3.3.0: https://github.com/apache/maven-source-plugin/compare/maven-source-plugin-3.2.1...maven-source-plugin-3.3.0

- maven-surefire-plugin
Release Notes: https://github.com/apache/maven-surefire/releases/tag/surefire-3.1.2

- maven-dependency-plugin
v3.5.0 VS v3.6.0: https://github.com/apache/maven-dependency-plugin/compare/maven-dependency-plugin-3.5.0...maven-dependency-plugin-3.6.0

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA.