### PR TITLE
[SPARK-44086][SQL][TESTS] Move `DataFrameFunctionsSuite` to `sql - slow`

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
@@ -36,10 +36,12 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
+import org.apache.spark.tags.ExtendedSQLTest
 
 /**
  * Test suite for functions in [[org.apache.spark.sql.functions]].
  */
+@ExtendedSQLTest
 class DataFrameFunctionsSuite extends QueryTest with SharedSparkSession {
   import testImplicits._
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Move `DataFrameFunctionsSuite` to `sql - slow`

### Why are the changes needed?
1, recently `DataFrameFunctionsSuite` is frequently updated for the new functions, while `sql - other` is quite flaky and it's likely to get stuck or failed before `DataFrameFunctionsSuite` is actually tested (see https://github.com/apache/spark/commit/61a195d33936d6059933de017fa251dac961021e and https://github.com/apache/spark/commit/37f9beaba7e8bdf9f417453d7dab0b7773b55200), so it is hard for the reviewers to judge whether all related tests pass;
2, `sql - other` is actually much slower than `sql - slow`, so I think it is fine to move a suite to `sql - slow`;


### Does this PR introduce _any_ user-facing change?
no, test-only

### How was this patch tested?
updated GA