### PR TITLE
[SPARK-44088][BUILD] Remove `jdk.incubator.foreign` usage in Java 21

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -331,7 +331,13 @@ object SparkBuild extends PomBuild {
     javaOptions ++= {
       val versionParts = System.getProperty("java.version").split("[+.\\-]+", 3)
       var major = versionParts(0).toInt
-      if (major >= 16) Seq("--add-modules=jdk.incubator.vector,jdk.incubator.foreign", "-Dforeign.restricted=warn") else Seq.empty
+      if (major >= 21) {
+        Seq("--add-modules=jdk.incubator.vector", "-Dforeign.restricted=warn")
+      } else if (major >= 16) {
+        Seq("--add-modules=jdk.incubator.vector,jdk.incubator.foreign", "-Dforeign.restricted=warn")
+      } else {
+        Seq.empty
+      }
     },
 
     (Compile / doc / javacOptions) ++= {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove `jdk.incubator.foreign` usage in Java 21.

### Why are the changes needed?

Java 21 moved `jdk.incubator.foreign` to `java.lang.foreign` and it causes a boot layer failure.
https://bugs.openjdk.org/browse/JDK-8280527


```
$ jshell -J--add-modules=jdk.incubator.vector,jdk.incubator.foreign
Error occurred during initialization of boot layer
java.lang.module.FindException: Module jdk.incubator.foreign not found
```

```
$ build/sbt "unsafe/test"
Using /Users/dongjoon/.jenv/versions/21-ea as default JAVA_HOME.
Note, this will be overridden by -java-home if it is set.
...
Error occurred during initialization of boot layer
java.lang.module.FindException: Module jdk.incubator.foreign not found
...
[error] (unsafe / Test / test) sbt.TestsFailedException: Tests unsuccessful
[error] Total time: 0 s, completed Jun 17, 2023, 9:53:26 PM
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs and manually Java 21 testing.


```
$ java -version
openjdk version "21-ea" 2023-09-19
OpenJDK Runtime Environment (build 21-ea+27-2343)
OpenJDK 64-Bit Server VM (build 21-ea+27-2343, mixed mode, sharing)

$ build/sbt "unsafe/test"
Using /Users/dongjoon/.jenv/versions/21-ea as default JAVA_HOME.
Note, this will be overridden by -java-home if it is set.
Using SPARK_LOCAL_IP=localhost
[info] welcome to sbt 1.9.0 (Oracle Corporation Java 21-ea)
...
[info] UTF8StringPropertyCheckSuite:
[info] - toString (27 milliseconds)
[info] - numChars (2 milliseconds)
[info] - startsWith (5 milliseconds)
[info] - endsWith (4 milliseconds)
[info] - toUpperCase (2 milliseconds)
[info] - toLowerCase (1 millisecond)
[info] - compare (3 milliseconds)
[info] - substring (14 milliseconds)
[info] - contains (10 milliseconds)
[info] - trim, trimLeft, trimRight (4 milliseconds)
[info] - reverse (1 millisecond)
[info] - indexOf (7 milliseconds)
[info] - repeat (2 milliseconds)
[info] - lpad, rpad (4 milliseconds)
[info] - concat (8 milliseconds)
[info] - concatWs (6 milliseconds)
[info] - split !!! IGNORED !!!
[info] - levenshteinDistance (2 milliseconds)
[info] - hashCode (1 millisecond)
[info] - equals (1 millisecond)
[info] Run completed in 582 milliseconds.
[info] Total number of tests run: 19
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 19, failed 0, canceled 0, ignored 1, pending 0
[info] All tests passed.
[success] Total time: 1 s, completed Jun 17, 2023, 9:51:55 PM
```