### PR TITLE
[SPARK-44093][SQL][TESTS] Make `catalyst` module passes in Java 21

### DIFF
--- a/sql/catalyst/src/test/java/org/apache/spark/sql/catalyst/expressions/ExpressionImplUtilsSuite.scala
+++ b/sql/catalyst/src/test/java/org/apache/spark/sql/catalyst/expressions/ExpressionImplUtilsSuite.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.catalyst.expressions
 
+import org.apache.commons.lang3.{JavaVersion, SystemUtils}
+
 import org.apache.spark.{SparkFunSuite, SparkRuntimeException}
 import org.apache.spark.unsafe.types.UTF8String
 
@@ -285,6 +287,12 @@ class ExpressionImplUtilsSuite extends SparkFunSuite {
     }
   }
 
+  // JDK-8267125 changes tag error message at Java 18
+  val msg_tag_mismatch = if (SystemUtils.isJavaVersionAtMost(JavaVersion.JAVA_17)) {
+    "Tag mismatch!"
+  } else {
+    "Tag mismatch"
+  }
   val corruptedCiphertexts = Seq(
     // This is truncated
     TestCase(
@@ -310,7 +318,7 @@ class ExpressionImplUtilsSuite extends SparkFunSuite {
       errorParamsMap = Map(
         "parameter" -> "`expr`, `key`",
         "functionName" -> "`aes_encrypt`/`aes_decrypt`",
-        "detailMessage" -> "Tag mismatch!"
+        "detailMessage" -> msg_tag_mismatch
       )
     ),
     // Valid ciphertext, wrong AAD
@@ -324,7 +332,7 @@ class ExpressionImplUtilsSuite extends SparkFunSuite {
       errorParamsMap = Map(
         "parameter" -> "`expr`, `key`",
         "functionName" -> "`aes_encrypt`/`aes_decrypt`",
-        "detailMessage" -> "Tag mismatch!"
+        "detailMessage" -> msg_tag_mismatch
       )
     )
   )

--- a/sql/catalyst/src/test/java/org/apache/spark/sql/catalyst/expressions/ExpressionImplUtilsSuite.scala
+++ b/sql/catalyst/src/test/java/org/apache/spark/sql/catalyst/expressions/ExpressionImplUtilsSuite.scala
@@ -288,7 +288,7 @@ class ExpressionImplUtilsSuite extends SparkFunSuite {
   }
 
   // JDK-8267125 changes tag error message at Java 18
-  val msg_tag_mismatch = if (SystemUtils.isJavaVersionAtMost(JavaVersion.JAVA_17)) {
+  val msgTagMismatch = if (SystemUtils.isJavaVersionAtMost(JavaVersion.JAVA_17)) {
     "Tag mismatch!"
   } else {
     "Tag mismatch"
@@ -318,7 +318,7 @@ class ExpressionImplUtilsSuite extends SparkFunSuite {
       errorParamsMap = Map(
         "parameter" -> "`expr`, `key`",
         "functionName" -> "`aes_encrypt`/`aes_decrypt`",
-        "detailMessage" -> msg_tag_mismatch
+        "detailMessage" -> msgTagMismatch
       )
     ),
     // Valid ciphertext, wrong AAD
@@ -332,7 +332,7 @@ class ExpressionImplUtilsSuite extends SparkFunSuite {
       errorParamsMap = Map(
         "parameter" -> "`expr`, `key`",
         "functionName" -> "`aes_encrypt`/`aes_decrypt`",
-        "detailMessage" -> msg_tag_mismatch
+        "detailMessage" -> msgTagMismatch
       )
     )
   )


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to make `catalyst` module passes in Java 21.

### Why are the changes needed?

https://bugs.openjdk.org/browse/JDK-8267125 changes the error message at Java 18.

**JAVA**
```
$ java -version
openjdk version "21-ea" 2023-09-19
OpenJDK Runtime Environment (build 21-ea+27-2343)
OpenJDK 64-Bit Server VM (build 21-ea+27-2343, mixed mode, sharing)
```

**BEFORE**
```
$ build/sbt "catalyst/test"
...
[info] *** 1 TEST FAILED ***
[error] Failed: Total 7122, Failed 1, Errors 0, Passed 7121, Ignored 5, Canceled 1
[error] Failed tests:
[error] 	org.apache.spark.sql.catalyst.expressions.ExpressionImplUtilsSuite
[error] (catalyst / Test / test) sbt.TestsFailedException: Tests unsuccessful
[error] Total time: 212 s (03:32), completed Jun 18, 2023, 1:11:17 AM
```
 
**AFTER**
```
$ build/sbt "catalyst/test"
...
[info] All tests passed.
[info] Passed: Total 7122, Failed 0, Errors 0, Passed 7122, Ignored 5, Canceled 1
[success] Total time: 213 s (03:33), completed Jun 18, 2023, 1:15:37 AM
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs and manual test on Java 21.