### PR TITLE
[MINOR][PYTHON][DOCS] Make mapInPandas example copy-pastable

### DIFF
--- a/python/pyspark/sql/pandas/map_ops.py
+++ b/python/pyspark/sql/pandas/map_ops.py
@@ -73,6 +73,7 @@ class PandasMapOpsMixin:
         >>> def filter_func(iterator):
         ...     for pdf in iterator:
         ...         yield pdf[pdf.id == 1]
+        ...
         >>> df.mapInPandas(filter_func, df.schema).show()  # doctest: +SKIP
         +---+---+
         | id|age|


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to add one newline into the example of `mapInPandas`.

### Why are the changes needed?

You copy and paste the example:

![Screenshot 2023-06-19 at 4 23 25 PM](https://github.com/apache/spark/assets/6477701/56c4693d-63c8-4858-8324-6bfea6628ef7)

and it does not work:

```
>>> def filter_func(iterator):
...     for pdf in iterator:
...         yield pdf[pdf.id == 1]
... df.mapInPandas(filter_func, df.schema).show()
  File "<stdin>", line 4
    df.mapInPandas(filter_func, df.schema).show()
    ^
```

We should add one more line to match 


### Does this PR introduce _any_ user-facing change?

Yes, it changes the example of `mapInPandas` copy-pastable

### How was this patch tested?

Manually tested.