### PR TITLE
[SPARK-43944][SQL][CONNECT][PYTHON][FOLLOW-UP] Make `startswith` & `endswith` support binary type

### DIFF
--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/functions.scala
@@ -3945,8 +3945,8 @@ object functions {
 
   /**
    * Returns a boolean. The value is True if str ends with suffix. Returns NULL if either input
-   * expression is NULL. Otherwise, returns False. Both str or suffix must be of STRING or
-   * BINARY type.
+   * expression is NULL. Otherwise, returns False. Both str or suffix must be of STRING or BINARY
+   * type.
    *
    * @group string_funcs
    * @since 3.5.0
@@ -3956,8 +3956,8 @@ object functions {
 
   /**
    * Returns a boolean. The value is True if str starts with prefix. Returns NULL if either input
-   * expression is NULL. Otherwise, returns False. Both str or prefix must be of STRING or
-   * BINARY type.
+   * expression is NULL. Otherwise, returns False. Both str or prefix must be of STRING or BINARY
+   * type.
    *
    * @group string_funcs
    * @since 3.5.0

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/functions.scala
@@ -3947,10 +3947,6 @@ object functions {
    * Returns a boolean. The value is True if str ends with suffix. Returns NULL if either input
    * expression is NULL. Otherwise, returns False. Both str or suffix must be of STRING type.
    *
-   * @note
-   *   Only STRING type is supported in this function, while `endswith` in SQL supports both
-   *   STRING and BINARY.
-   *
    * @group string_funcs
    * @since 3.5.0
    */
@@ -3960,10 +3956,6 @@ object functions {
   /**
    * Returns a boolean. The value is True if str starts with prefix. Returns NULL if either input
    * expression is NULL. Otherwise, returns False. Both str or prefix must be of STRING type.
-   *
-   * @note
-   *   Only STRING type is supported in this function, while `startswith` in SQL supports both
-   *   STRING and BINARY.
    *
    * @group string_funcs
    * @since 3.5.0

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/functions.scala
@@ -3945,7 +3945,8 @@ object functions {
 
   /**
    * Returns a boolean. The value is True if str ends with suffix. Returns NULL if either input
-   * expression is NULL. Otherwise, returns False. Both str or suffix must be of STRING type.
+   * expression is NULL. Otherwise, returns False. Both str or suffix must be of STRING or
+   * BINARY type.
    *
    * @group string_funcs
    * @since 3.5.0
@@ -3955,7 +3956,8 @@ object functions {
 
   /**
    * Returns a boolean. The value is True if str starts with prefix. Returns NULL if either input
-   * expression is NULL. Otherwise, returns False. Both str or prefix must be of STRING type.
+   * expression is NULL. Otherwise, returns False. Both str or prefix must be of STRING or
+   * BINARY type.
    *
    * @group string_funcs
    * @since 3.5.0

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -9535,11 +9535,6 @@ def endswith(str: "ColumnOrName", suffix: "ColumnOrName") -> Column:
 
     .. versionadded:: 3.5.0
 
-    Notes
-    -----
-    Only STRING type is supported in this function,
-    while `startswith` in SQL supports both STRING and BINARY.
-
     Parameters
     ----------
     str : :class:`~pyspark.sql.Column` or str
@@ -9552,6 +9547,19 @@ def endswith(str: "ColumnOrName", suffix: "ColumnOrName") -> Column:
     >>> df = spark.createDataFrame([("Spark SQL", "Spark",)], ["a", "b"])
     >>> df.select(endswith(df.a, df.b).alias('r')).collect()
     [Row(r=False)]
+
+    >>> df = spark.createDataFrame([("414243", "4243",)], ["e", "f"])
+    >>> df = df.select(to_binary("e").alias("e"), to_binary("f").alias("f"))
+    >>> df.printSchema()
+    root
+     |-- e: binary (nullable = true)
+     |-- f: binary (nullable = true)
+    >>> df.select(endswith("e", "f"), endswith("f", "e")).show()
+    +--------------+--------------+
+    |endswith(e, f)|endswith(f, e)|
+    +--------------+--------------+
+    |          true|         false|
+    +--------------+--------------+
     """
     return _invoke_function_over_columns("endswith", str, suffix)
 
@@ -9565,11 +9573,6 @@ def startswith(str: "ColumnOrName", prefix: "ColumnOrName") -> Column:
 
     .. versionadded:: 3.5.0
 
-    Notes
-    -----
-    Only STRING type is supported in this function,
-    while `startswith` in SQL supports both STRING and BINARY.
-
     Parameters
     ----------
     str : :class:`~pyspark.sql.Column` or str
@@ -9582,6 +9585,19 @@ def startswith(str: "ColumnOrName", prefix: "ColumnOrName") -> Column:
     >>> df = spark.createDataFrame([("Spark SQL", "Spark",)], ["a", "b"])
     >>> df.select(startswith(df.a, df.b).alias('r')).collect()
     [Row(r=True)]
+
+    >>> df = spark.createDataFrame([("414243", "4142",)], ["e", "f"])
+    >>> df = df.select(to_binary("e").alias("e"), to_binary("f").alias("f"))
+    >>> df.printSchema()
+    root
+     |-- e: binary (nullable = true)
+     |-- f: binary (nullable = true)
+    >>> df.select(startswith("e", "f"), startswith("f", "e")).show()
+    +----------------+----------------+
+    |startswith(e, f)|startswith(f, e)|
+    +----------------+----------------+
+    |            true|           false|
+    +----------------+----------------+
     """
     return _invoke_function_over_columns("startswith", str, prefix)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -4048,15 +4048,13 @@ object functions {
    * Returns NULL if either input expression is NULL. Otherwise, returns False.
    * Both str or suffix must be of STRING type.
    *
-   * @note
-   *   Only STRING type is supported in this function, while `endswith` in SQL supports both
-   *   STRING and BINARY.
-   *
    * @group string_funcs
    * @since 3.5.0
    */
-  def endswith(str: Column, suffix: Column): Column = withExpr {
-    EndsWith(str.expr, suffix.expr)
+  def endswith(str: Column, suffix: Column): Column = {
+    // 'EndsWith' expression only supports StringType,
+    // use 'call_udf' to support both StringType and BinaryType.
+    call_udf("endswith", str, suffix)
   }
 
   /**
@@ -4064,15 +4062,13 @@ object functions {
    * Returns NULL if either input expression is NULL. Otherwise, returns False.
    * Both str or prefix must be of STRING type.
    *
-   * @note
-   *   Only STRING type is supported in this function, while `endswith` in SQL supports both
-   *   STRING and BINARY.
-   *
    * @group string_funcs
    * @since 3.5.0
    */
-  def startswith(str: Column, prefix: Column): Column = withExpr {
-    StartsWith(str.expr, prefix.expr)
+  def startswith(str: Column, prefix: Column): Column = {
+    // 'StartsWith' expression only supports StringType,
+    // use 'call_udf' to support both StringType and BinaryType.
+    call_udf("startswith", str, prefix)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -4046,7 +4046,7 @@ object functions {
   /**
    * Returns a boolean. The value is True if str ends with suffix.
    * Returns NULL if either input expression is NULL. Otherwise, returns False.
-   * Both str or suffix must be of STRING type.
+   * Both str or suffix must be of STRING or BINARY type.
    *
    * @group string_funcs
    * @since 3.5.0
@@ -4060,7 +4060,7 @@ object functions {
   /**
    * Returns a boolean. The value is True if str starts with prefix.
    * Returns NULL if either input expression is NULL. Otherwise, returns False.
-   * Both str or prefix must be of STRING type.
+   * Both str or prefix must be of STRING or BINARY type.
    *
    * @group string_funcs
    * @since 3.5.0

--- a/sql/core/src/test/scala/org/apache/spark/sql/StringFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/StringFunctionsSuite.scala
@@ -1118,7 +1118,7 @@ class StringFunctionsSuite extends QueryTest with SharedSparkSession {
 
     // test binary
     checkAnswer(df.selectExpr("endswith(c, d)"), Row(true))
-    checkAnswer(df.select(endswith(col("a"), col("b"))), Row(false))
+    checkAnswer(df.select(endswith(col("c"), col("d"))), Row(true))
   }
 
   test("startswith") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/StringFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/StringFunctionsSuite.scala
@@ -1113,8 +1113,8 @@ class StringFunctionsSuite extends QueryTest with SharedSparkSession {
     val df = Seq(("Spark SQL", "Spark", Array[Byte](1, 2, 3, 4), Array[Byte](3, 4)))
       .toDF("a", "b", "c", "d")
 
-    checkAnswer(df.selectExpr("endswith(c, d)"), Row(true))
-    checkAnswer(df.select(endswith(col("c"), col("d"))), Row(true))
+    checkAnswer(df.selectExpr("endswith(a, b)"), Row(false))
+    checkAnswer(df.select(endswith(col("a"), col("b"))), Row(false))
 
     // test binary
     checkAnswer(df.selectExpr("endswith(c, d)"), Row(true))
@@ -1124,6 +1124,9 @@ class StringFunctionsSuite extends QueryTest with SharedSparkSession {
   test("startswith") {
     val df = Seq(("Spark SQL", "Spark", Array[Byte](1, 2, 3, 4), Array[Byte](1, 2)))
       .toDF("a", "b", "c", "d")
+
+    checkAnswer(df.selectExpr("startswith(a, b)"), Row(true))
+    checkAnswer(df.select(startswith(col("a"), col("b"))), Row(true))
 
     // test binary
     checkAnswer(df.selectExpr("startswith(c, d)"), Row(true))

--- a/sql/core/src/test/scala/org/apache/spark/sql/StringFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/StringFunctionsSuite.scala
@@ -1110,16 +1110,23 @@ class StringFunctionsSuite extends QueryTest with SharedSparkSession {
   }
 
   test("endswith") {
-    val df = Seq(("Spark SQL", "Spark")).toDF("a", "b")
+    val df = Seq(("Spark SQL", "Spark", Array[Byte](1, 2, 3, 4), Array[Byte](3, 4)))
+      .toDF("a", "b", "c", "d")
 
-    checkAnswer(df.selectExpr("endswith(a, b)"), Row(false))
+    checkAnswer(df.selectExpr("endswith(c, d)"), Row(true))
+    checkAnswer(df.select(endswith(col("c"), col("d"))), Row(true))
+
+    // test binary
+    checkAnswer(df.selectExpr("endswith(c, d)"), Row(true))
     checkAnswer(df.select(endswith(col("a"), col("b"))), Row(false))
   }
 
   test("startswith") {
-    val df = Seq(("Spark SQL", "Spark")).toDF("a", "b")
+    val df = Seq(("Spark SQL", "Spark", Array[Byte](1, 2, 3, 4), Array[Byte](1, 2)))
+      .toDF("a", "b", "c", "d")
 
-    checkAnswer(df.selectExpr("startswith(a, b)"), Row(true))
-    checkAnswer(df.select(startswith(col("a"), col("b"))), Row(true))
+    // test binary
+    checkAnswer(df.selectExpr("startswith(c, d)"), Row(true))
+    checkAnswer(df.select(startswith(col("c"), col("d"))), Row(true))
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make `startswith`, `endswith` support binary type:
1, in Connect API, `startswith` & `endswith` actually already support binary type;
2, in vanilla API, support binary type via `call_udf`


### Why are the changes needed?
for parity


### Does this PR introduce _any_ user-facing change?
yes


### How was this patch tested?
added ut