### PR TITLE
[SPARK-43624][PS][CONNECT] Add `EWM` to SparkConnectPlanner.

### DIFF
--- a/python/pyspark/pandas/tests/connect/test_parity_ewm.py
+++ b/python/pyspark/pandas/tests/connect/test_parity_ewm.py
@@ -22,11 +22,15 @@ from pyspark.testing.pandasutils import PandasOnSparkTestUtils, TestUtils
 
 
 class EWMParityTests(EWMTestsMixin, PandasOnSparkTestUtils, ReusedConnectTestCase, TestUtils):
-    @unittest.skip("TODO(SPARK-43624): Enable ExponentialMovingLike.mean with Spark Connect.")
+    @unittest.skip(
+        "TODO(SPARK-43611): Fix unexpected `AnalysisException` from Spark Connect client."
+    )
     def test_ewm_mean(self):
         super().test_ewm_mean()
 
-    @unittest.skip("TODO(SPARK-43624): Enable ExponentialMovingLike.mean with Spark Connect.")
+    @unittest.skip(
+        "TODO(SPARK-43611): Fix unexpected `AnalysisException` from Spark Connect client."
+    )
     def test_groupby_ewm_func(self):
         super().test_groupby_ewm_func()
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to add `EWM` for SparkConnectPlanner.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

To increase pandas API coverage

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No, we added `EWM` to SparkConnectPlanner, but there is still unresolved `AnalysisException` issues(SPARK-43611) that need to be addressed in follow-up work.


### How was this patch tested?

Manually checked the plan was created with EWM properly.
