### PR TITLE
[SPARK-44099][INFRA] Support both java-8-openjdk-amd64 and java-8-openjdk-arm64 in `spark-rm` Dockerfile

### DIFF
--- a/dev/create-release/spark-rm/Dockerfile
+++ b/dev/create-release/spark-rm/Dockerfile
@@ -63,7 +63,7 @@ RUN apt-get clean && apt-get update && $APT_INSTALL gnupg ca-certificates && \
   apt-get update && \
   # Install openjdk 8.
   $APT_INSTALL openjdk-8-jdk && \
-  update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java && \
+  update-alternatives --set java $(ls /usr/lib/jvm/java-8-openjdk-*/jre/bin/java) && \
   # Install build / source control tools
   $APT_INSTALL curl wget git maven ivy subversion make gcc lsof libffi-dev \
     pandoc pandoc-citeproc libssl-dev libcurl4-openssl-dev libxml2-dev && \


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support both amd64 and arm64 Java8 installation in `spark-rm` image.

### Why are the changes needed?

The `spark-rm` image uses a hard-coded `/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java` currently.

If we extend it to accept a different arch installation like the following. This helps the release manager test steps.
```
root@34fa8aae9142:/# ls -al /usr/lib/jvm/
total 20
drwxr-xr-x 3 root root 4096 Jun 19 20:47 .
drwxr-xr-x 1 root root 4096 Jun 19 20:46 ..
-rw-r--r-- 1 root root 2670 May  6 10:53 .java-1.8.0-openjdk-arm64.jinfo
lrwxrwxrwx 1 root root   20 May  6 10:53 java-1.8.0-openjdk-arm64 -> java-8-openjdk-arm64
drwxr-xr-x 7 root root 4096 Jun 19 20:47 java-8-openjdk-arm64
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

