### PR TITLE
[SPARK-43944][SPARK-43942][SQL][FOLLOWUP] Directly leverage `UnresolvedFunction` for functions `startswith`/`endswith`/`contains`

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -4051,10 +4051,8 @@ object functions {
    * @group string_funcs
    * @since 3.5.0
    */
-  def endswith(str: Column, suffix: Column): Column = {
-    // 'EndsWith' expression only supports StringType,
-    // use 'call_udf' to support both StringType and BinaryType.
-    call_udf("endswith", str, suffix)
+  def endswith(str: Column, suffix: Column): Column = withExpr {
+    UnresolvedFunction(Seq("endswith"), Seq(str.expr, suffix.expr), isDistinct = false)
   }
 
   /**
@@ -4065,10 +4063,8 @@ object functions {
    * @group string_funcs
    * @since 3.5.0
    */
-  def startswith(str: Column, prefix: Column): Column = {
-    // 'StartsWith' expression only supports StringType,
-    // use 'call_udf' to support both StringType and BinaryType.
-    call_udf("startswith", str, prefix)
+  def startswith(str: Column, prefix: Column): Column = withExpr {
+    UnresolvedFunction(Seq("startswith"), Seq(str.expr, prefix.expr), isDistinct = false)
   }
 
   /**
@@ -4145,10 +4141,8 @@ object functions {
    * @group string_funcs
    * @since 3.5.0
    */
-  def contains(left: Column, right: Column): Column = {
-    // 'Contains' expression only supports StringType
-    // use 'call_udf' to support both StringType and BinaryType.
-    call_udf("contains", left, right)
+  def contains(left: Column, right: Column): Column = withExpr {
+    UnresolvedFunction(Seq("contains"), Seq(left.expr, right.expr), isDistinct = false)
   }
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?
Directly leverage UnresolvedFunction for `startswith`/`endswith`/`contains`


### Why are the changes needed?
to be more consistent with existing functions, like [ceil](https://github.com/apache/spark/blob/6b36a9368d6e97f7f1f94c4ca7f6ee76dcd0015f/sql/core/src/main/scala/org/apache/spark/sql/functions.scala#L2242-L2260), [floor](https://github.com/apache/spark/blob/6b36a9368d6e97f7f1f94c4ca7f6ee76dcd0015f/sql/core/src/main/scala/org/apache/spark/sql/functions.scala#L2397-L2416), [lpad](https://github.com/apache/spark/blob/6b36a9368d6e97f7f1f94c4ca7f6ee76dcd0015f/sql/core/src/main/scala/org/apache/spark/sql/functions.scala#L3454-L3463)

### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
existing GA
