### PR TITLE
[SPARK-44104][BUILD] Enabled `protobuf` module mima check for Spark 3.5.0

### DIFF
--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -93,6 +93,10 @@ object MimaExcludes {
     ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.ErrorInfo$"),
     ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.ErrorSubInfo$"),
 
+    // SPARK-44104: shaded protobuf code and Apis with parameters relocated
+    ProblemFilters.exclude[Problem]("org.sparkproject.spark_protobuf.protobuf.*"),
+    ProblemFilters.exclude[Problem]("org.apache.spark.sql.protobuf.utils.SchemaConverters.*"),
+
     (problem: Problem) => problem match {
       case MissingClassProblem(cls) => !cls.fullName.startsWith("org.sparkproject.jpmml") &&
           !cls.fullName.startsWith("org.sparkproject.dmg.pmml")

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -415,7 +415,7 @@ object SparkBuild extends PomBuild {
   val mimaProjects = allProjects.filterNot { x =>
     Seq(
       spark, hive, hiveThriftServer, repl, networkCommon, networkShuffle, networkYarn,
-      unsafe, tags, tokenProviderKafka010, sqlKafka010, connectCommon, connect, connectClient, protobuf,
+      unsafe, tags, tokenProviderKafka010, sqlKafka010, connect, connectClient,
       commonUtils, sqlApi
     ).contains(x)
   }

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -415,7 +415,7 @@ object SparkBuild extends PomBuild {
   val mimaProjects = allProjects.filterNot { x =>
     Seq(
       spark, hive, hiveThriftServer, repl, networkCommon, networkShuffle, networkYarn,
-      unsafe, tags, tokenProviderKafka010, sqlKafka010, connect, connectClient,
+      unsafe, tags, tokenProviderKafka010, sqlKafka010, connectCommon, connect, connectClient,
       commonUtils, sqlApi
     ).contains(x)
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr adds a mima check for the `protobuf` module for Apache Spark 3.5.0


### Why are the changes needed?
The `protobuf` module is a new module introduced in Spark 3.4.0, which includes some client APIs, so it should be added to Spark 3.5.0's mima check


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass GitHub Actions
- Manual checked:

```
dev/mima
```

and 

```
dev/change-scala-version.sh 2.13
dev/mima -Pscala-2.13
```