### PR TITLE
[SPARK-44105][SQL] `LastNonNull` should be lazily resolved

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/windowExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/windowExpressions.scala
@@ -1164,19 +1164,19 @@ case class LastNonNull(input: Expression)
 
   override def dataType: DataType = input.dataType
 
-  private val last = AttributeReference("last", dataType, nullable = true)()
+  private lazy val last = AttributeReference("last", dataType, nullable = true)()
 
   override def aggBufferAttributes: Seq[AttributeReference] = last :: Nil
 
-  override val initialValues: Seq[Expression] = Seq(Literal.create(null, dataType))
+  override lazy val initialValues: Seq[Expression] = Seq(Literal.create(null, dataType))
 
-  override val updateExpressions: Seq[Expression] = {
+  override lazy val updateExpressions: Seq[Expression] = {
     Seq(
       /* last = */ If(IsNull(input), last, input)
     )
   }
 
-  override val evaluateExpression: Expression = last
+  override lazy val evaluateExpression: Expression = last
 
   override def prettyName: String = "last_non_null"
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
`LastNonNull` should be lazily resolved


### Why are the changes needed?
to fix https://github.com/apache/spark/pull/41670/files#r1234805869


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
existing GA and manually check