### PR TITLE
[SPARK-44107][CONNECT][PYTHON] Hide unsupported Column methods from auto-completion

### DIFF
--- a/python/pyspark/sql/connect/column.py
+++ b/python/pyspark/sql/connect/column.py
@@ -478,12 +478,6 @@ class Column:
 
     __bool__ = __nonzero__
 
-    @property
-    def _jc(self) -> None:
-        raise PySparkAttributeError(
-            error_class="JVM_ATTRIBUTE_NOT_SUPPORTED", message_parameters={"attr_name": "_jc"}
-        )
-
 
 Column.__doc__ = PySparkColumn.__doc__
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Hide unsupported Column method `_jc` from auto-completion, it is already handled in `__getattr__`, see https://github.com/apache/spark/blob/e6c6d444ae07f1ece127cea6332cce906b5aa1c5/python/pyspark/sql/connect/column.py#L445-L454


### Why are the changes needed?
no need to show unsupported methods


### Does this PR introduce _any_ user-facing change?
yes

before this PR:
<img width="867" alt="Screenshot 2023-06-20 at 21 38 23" src="https://github.com/apache/spark/assets/7322292/bee3c41d-8fa5-4981-9392-cde93a1e9f34">

after this PR:
<img width="878" alt="Screenshot 2023-06-20 at 21 39 42" src="https://github.com/apache/spark/assets/7322292/85e5c7cc-86b7-4919-8c8a-db8dba2c94a9">



### How was this patch tested?
existing UTs and manually check in ipython
