### PR TITLE
[SPARK-44110][BUILD] Propagate proxy settings to forked JVMs

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -342,6 +342,18 @@ object SparkBuild extends PomBuild {
       }
     },
 
+    // Copy system properties to forked JVMs so that tests know proxy settings
+    javaOptions ++= {
+      val q = "\""
+      sys.props.toList
+        .filter {
+          case (key, value) => key.startsWith("http.") || key.startsWith("https.")
+        }
+        .map {
+          case (key, value) => s"-D$key=$q$value$q"
+        }
+    },
+
     (Compile / doc / javacOptions) ++= {
       val versionParts = System.getProperty("java.version").split("[+.\\-]+", 3)
       var major = versionParts(0).toInt

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -342,18 +342,6 @@ object SparkBuild extends PomBuild {
       }
     },
 
-    // Copy system properties to forked JVMs so that tests know proxy settings
-    javaOptions ++= {
-      val q = "\""
-      sys.props.toList
-        .filter {
-          case (key, value) => key.startsWith("http.") || key.startsWith("https.")
-        }
-        .map {
-          case (key, value) => s"-D$key=$q$value$q"
-        }
-    },
-
     (Compile / doc / javacOptions) ++= {
       val versionParts = System.getProperty("java.version").split("[+.\\-]+", 3)
       var major = versionParts(0).toInt
@@ -1592,6 +1580,19 @@ object TestSettings {
       "SPARK_TESTING" -> "1",
       "JAVA_HOME" -> sys.env.get("JAVA_HOME").getOrElse(sys.props("java.home")),
       "SPARK_BEELINE_OPTS" -> "-DmyKey=yourValue"),
+
+    // Copy system properties to forked JVMs so that tests know proxy settings
+    (Test / javaOptions) ++= {
+      val q = "\""
+      sys.props.toList
+        .filter {
+          case (key, value) => key.startsWith("http.") || key.startsWith("https.")
+        }
+        .map {
+          case (key, value) => s"-D$key=$q$value$q"
+        }
+    },
+
     (Test / javaOptions) += s"-Djava.io.tmpdir=$testTempDir",
     (Test / javaOptions) += "-Dspark.test.home=" + sparkHome,
     (Test / javaOptions) += "-Dspark.testing=1",


### PR DESCRIPTION
### What changes were proposed in this pull request?
Propagate proxy settings to forked unit test JVMs.  System properties that start with `http.` or `https.` are copied into the `jvmOptions` of the forked processes, ensuring that required proxy settings are available during the tests.

### Why are the changes needed?
Running a subset of unit tests fail in enterprise environments that have additional constraints on network access that are handled by using a proxy.  Examples of impacted tests:

- HadoopVersionInfoSuite, test name: SPARK-32256: Hadoop VersionInfo should be preloaded. 
- HiveClientUserNameSuite(2.0), test name: 2.0: username of HiveClient - no UGI. 

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
A local CI build was modified to use Spark branches (3.3 and 3.4) that included this change to verify it addressed the test failures.  In addition, logging changes were introduced to verify that the system properties were absent when running the tests prior to the change.