### PR TITLE
[SPARK-44129][INFRA] Use "3.5.0" for "master" branch until creating `branch-3.5`

### DIFF
--- a/dev/merge_spark_pr.py
+++ b/dev/merge_spark_pr.py
@@ -240,7 +240,7 @@ def cherry_pick(pr_num, merge_hash, default_branch):
 def fix_version_from_branch(branch, versions):
     # Note: Assumes this is a sorted (newest->oldest) list of un-released versions
     if branch == "master":
-        return versions[0]
+        return "3.5.0" # TODO(SPARK-44130) Revert SPARK-44129 after creating branch-3.5
     else:
         branch_ver = branch.replace("branch-", "")
         return list(filter(lambda x: x.name.startswith(branch_ver), versions))[-1]


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use a hard-coded "3.5.0" temporarily for "master" branch because we have "4.0.0" in Jira system and we cannot bump `master` version until we create `branch-3.5`.

### Why are the changes needed?

To avoid setting 4.0.0 as 'Fixed Version' mistakenly.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual.