### PR TITLE
[SPARK-36680][SQL] Supports Dynamic Table Options for Spark SQL

### DIFF
--- a/common/utils/src/main/resources/error/error-classes.json
+++ b/common/utils/src/main/resources/error/error-classes.json
@@ -3443,14 +3443,14 @@
       "Window function <funcName> requires an OVER clause."
     ]
   },
-  "WITH_OPTIONS_EXPECTED_TABLE" : {
-    "message" : [
-      "`with_options` function requires a table argument, \"TABLE($t)\"."
-    ]
-  },
   "WITH_OPTIONS_EXPECTED_SIMPLE_TABLE" : {
     "message" : [
       "`with_options` function only handles a simple table argument, \"TABLE($t)\"."
+    ]
+  },
+  "WITH_OPTIONS_EXPECTED_TABLE" : {
+    "message" : [
+      "`with_options` function requires a table argument, \"TABLE($t)\"."
     ]
   },
   "WRITE_STREAM_NOT_ALLOWED" : {

--- a/common/utils/src/main/resources/error/error-classes.json
+++ b/common/utils/src/main/resources/error/error-classes.json
@@ -3443,6 +3443,16 @@
       "Window function <funcName> requires an OVER clause."
     ]
   },
+  "WITH_OPTIONS_EXPECTED_TABLE" : {
+    "message" : [
+      "`with_options` function requires a table argument, \"TABLE($t)\"."
+    ]
+  },
+  "WITH_OPTIONS_EXPECTED_SIMPLE_TABLE" : {
+    "message" : [
+      "`with_options` function only handles a simple table argument, \"TABLE($t)\"."
+    ]
+  },
   "WRITE_STREAM_NOT_ALLOWED" : {
     "message" : [
       "`writeStream` can be called only on streaming Dataset/DataFrame."

--- a/docs/sql-error-conditions.md
+++ b/docs/sql-error-conditions.md
@@ -2137,6 +2137,18 @@ SQLSTATE: none assigned
 
 Window function `<funcName>` requires an OVER clause.
 
+### WITH_OPTIONS_EXPECTED_SIMPLE_TABLE
+
+SQLSTATE: none assigned
+
+`with_options` function only handles a simple table argument, "TABLE($t)".
+
+### WITH_OPTIONS_EXPECTED_TABLE
+
+SQLSTATE: none assigned
+
+`with_options` function requires a table argument, "TABLE($t)".
+
 ### WRITE_STREAM_NOT_ALLOWED
 
 SQLSTATE: none assigned

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -301,6 +301,7 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
       ExtractGenerator ::
       ResolveGenerate ::
       ResolveFunctions ::
+      ResolveRelationsWithOptions ::
       ResolveTableSpec ::
       ResolveAliases ::
       ResolveSubquery ::
@@ -3765,6 +3766,12 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
 
     private def hasUnresolvedFieldName(a: AlterTableCommand): Boolean = {
       a.expressions.exists(_.exists(_.isInstanceOf[UnresolvedFieldName]))
+    }
+  }
+
+  object ResolveRelationsWithOptions extends Rule[LogicalPlan] {
+    def apply(plan: LogicalPlan): LogicalPlan = plan.resolveOperators {
+      case RelationWithOptions(child) => child
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.catalyst.FunctionIdentifier
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.catalyst.expressions.xml._
-import org.apache.spark.sql.catalyst.plans.logical.{FunctionBuilderBase, Generate, LogicalPlan, OneRowRelation, Range}
+import org.apache.spark.sql.catalyst.plans.logical.{FunctionBuilderBase, Generate, LogicalPlan, OneRowRelation, Range, RelationWithOptions}
 import org.apache.spark.sql.catalyst.trees.TreeNodeTag
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.types._
@@ -1066,6 +1066,7 @@ object TableFunctionRegistry {
 
   val logicalPlans: Map[String, (ExpressionInfo, TableFunctionBuilder)] = Map(
     logicalPlan[Range]("range"),
+    logicalPlan[RelationWithOptions]("with_options"),
     generatorBuilder("explode", ExplodeGeneratorBuilder),
     generatorBuilder("explode_outer", ExplodeOuterGeneratorBuilder),
     generator[Inline]("inline"),

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -1141,9 +1141,9 @@ case class Range(
 }
 
 @ExpressionDescription(
-  usage = "_FUNC_(identifier: String, options: Map) - " +
-    "Returns the data source relation with the given options.  " +
-    "The first argument must be a simple TABLE() parameter.",
+  usage = """_FUNC_(table: String, options: Map) -
+    Returns the data source relation with the given options.
+    table must be a simple TABLE() parameter.""",
   examples = """
     Examples:
       > SELECT * FROM _FUNC_(TABLE(cat.db.table), map('split-size','5'));
@@ -1171,7 +1171,7 @@ object RelationWithOptions {
     val relationOptions = ExprUtils.convertToMapData(options)
 
     if (!tableExpr.isInstanceOf[FunctionTableSubqueryArgumentExpression]) {
-      throw QueryCompilationErrors.withOptionsExpectedTableError(tableExpr.sql)
+      throw QueryCompilationErrors.withOptionsExpectedTableError()
     }
     val table = tableExpr.asInstanceOf[FunctionTableSubqueryArgumentExpression]
 
@@ -1180,7 +1180,7 @@ object RelationWithOptions {
       // Support only DataSourceV2Relation as its the only relation with options
       case t @ SubqueryAlias(_, r @ DataSourceV2Relation(_, _, _, _, options))
         => t.copy(child = r.copy(options = merge(options, relationOptions)))
-      case _ => throw QueryCompilationErrors.withOptionsExpectedSimpleTableError(table.toString)
+      case _ => throw QueryCompilationErrors.withOptionsExpectedSimpleTableError()
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -1186,8 +1186,8 @@ object RelationWithOptions {
 
   def merge(original: CaseInsensitiveStringMap, newMap: Map[String, String]):
     CaseInsensitiveStringMap = {
-    val map = new java.util.HashMap[String, String](newMap.asJava)
-    map.putAll(original)
+    val map = new java.util.HashMap[String, String](original)
+    map.putAll(newMap.asJava)
     new CaseInsensitiveStringMap(map)
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -1169,8 +1169,7 @@ object RelationWithOptions {
     val tableIdentifier = CatalystSqlParser.parseMultipartIdentifier(
       identifier.asInstanceOf[Literal].toString)
     val relationOptions = ExprUtils.convertToMapData(options)
-    UnresolvedRelation(tableIdentifier,
-      new CaseInsensitiveStringMap(relationOptions.asJava))
+    UnresolvedRelation(tableIdentifier, new CaseInsensitiveStringMap(relationOptions.asJava))
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -1974,6 +1974,20 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
     )
   }
 
+  def withOptionsExpectedSimpleTableError(actual: String): Throwable = {
+    new AnalysisException(
+      errorClass = "WITH_OPTIONS_EXPECTED_SIMPLE_TABLE",
+      messageParameters = Map.empty
+    )
+  }
+
+  def withOptionsExpectedTableError(actual: String): Throwable = {
+    new AnalysisException(
+      errorClass = "WITH_OPTIONS_EXPECTED_TABLE",
+      messageParameters = Map.empty
+    )
+  }
+
   def identifierTooManyNamePartsError(originalIdentifier: String): Throwable = {
     new AnalysisException(
       errorClass = "IDENTIFIER_TOO_MANY_NAME_PARTS",

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -1974,14 +1974,14 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
     )
   }
 
-  def withOptionsExpectedSimpleTableError(actual: String): Throwable = {
+  def withOptionsExpectedSimpleTableError(): Throwable = {
     new AnalysisException(
       errorClass = "WITH_OPTIONS_EXPECTED_SIMPLE_TABLE",
       messageParameters = Map.empty
     )
   }
 
-  def withOptionsExpectedTableError(actual: String): Throwable = {
+  def withOptionsExpectedTableError(): Throwable = {
     new AnalysisException(
       errorClass = "WITH_OPTIONS_EXPECTED_TABLE",
       messageParameters = Map.empty


### PR DESCRIPTION
  ### What changes were proposed in this pull request?
This pr adds a SQL TVF (table-value-function): 
`with_options('table', map('foo', 'bar'))`

Details:
1. Add RelationWithOptions function object
2. Add ResolveRelationsWithOptions rule to resolve that to a Relation, with the given options.

  ### Why are the changes needed?

Currently there is no way to dynamically configure individual DataSource relations in Spark SQL query.

This is a continuation of the effort in https://github.com/apache/spark/pull/34072, and based on the comment there https://github.com/apache/spark/pull/34072#issuecomment-968451305, to use a TVF instead of query hints.

 ### Does this PR introduce _any_ user-facing change?
No

 ### How was this patch tested?
Unit test in DataSourceV2SQLSuite