### PR TITLE
[SPARK-44129][INFRA] Use "3.5.0" for "master" branch until creating `branch-3.5`

### DIFF
--- a/dev/merge_spark_pr.py
+++ b/dev/merge_spark_pr.py
@@ -240,7 +240,8 @@ def cherry_pick(pr_num, merge_hash, default_branch):
 def fix_version_from_branch(branch, versions):
     # Note: Assumes this is a sorted (newest->oldest) list of un-released versions
     if branch == "master":
-        return versions[0]
+        # TODO(SPARK-44130) Revert SPARK-44129 after creating branch-3.5
+        return [v for v in versions if v.name == "3.5.0"][0]
     else:
         branch_ver = branch.replace("branch-", "")
         return list(filter(lambda x: x.name.startswith(branch_ver), versions))[-1]


### PR DESCRIPTION
### What changes were proposed in this pull request?

This adds a couple of changes to make the script working
See https://github.com/apache/spark/pull/41682

### Why are the changes needed?

See https://github.com/apache/spark/pull/41682

### Does this PR introduce _any_ user-facing change?

See https://github.com/apache/spark/pull/41682

### How was this patch tested?

See https://github.com/apache/spark/pull/41682