### PR TITLE
[SPARK-43710][PS][CONNECT] Support `functions.date_part` for Spark Connect

### DIFF
--- a/python/pyspark/pandas/indexes/timedelta.py
+++ b/python/pyspark/pandas/indexes/timedelta.py
@@ -150,9 +150,9 @@ class TimedeltaIndex(Index):
 
         @no_type_check
         def get_seconds(scol):
-            hour_scol = SF.date_part("HOUR", scol)
-            minute_scol = SF.date_part("MINUTE", scol)
-            second_scol = SF.date_part("SECOND", scol)
+            hour_scol = F.date_part("HOUR", scol)
+            minute_scol = F.date_part("MINUTE", scol)
+            second_scol = F.date_part("SECOND", scol)
             return (
                 F.when(
                     hour_scol < 0,


### PR DESCRIPTION
### What changes were proposed in this pull request?
switch to the [newly added `date_part` function](https://github.com/apache/spark/commit/8dc02863b926b9e0780b994f9ee6c5c1058d49a0)

### Why are the changes needed?
to support connect



### Does this PR introduce _any_ user-facing change?
yes


### How was this patch tested?
existing UT