### PR TITLE
[SPARK-44138][SQL] Prohibit non-deterministic expressions, subqueries and aggregates in MERGE conditions

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -2576,6 +2576,28 @@
       }
     }
   },
+  "UNSUPPORTED_MERGE_CONDITION" : {
+    "message" : [
+      "MERGE operation contains unsupported <condName> condition."
+    ],
+    "subClass" : {
+      "AGGREGATE" : {
+        "message" : [
+          "Aggregates are not allowed: <cond>."
+        ]
+      },
+      "NON_DETERMINISTIC" : {
+        "message" : [
+          "Non-deterministic expressions are not allowed: <cond>."
+        ]
+      },
+      "SUBQUERY" : {
+        "message" : [
+          "Subqueries are not allowed: <cond>."
+        ]
+      }
+    }
+  },
   "UNSUPPORTED_OVERWRITE" : {
     "message" : [
       "Can't overwrite the target that is also being read from."

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteMergeIntoTable.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteMergeIntoTable.scala
@@ -496,7 +496,7 @@ object RewriteMergeIntoTable extends RewriteRowLevelCommand with PredicateHelper
       throw QueryCompilationErrors.subqueryNotAllowedInMergeCondition(condName, cond)
     }
 
-    if (cond.find(_.isInstanceOf[AggregateExpression]).isDefined) {
+    if (cond.exists(_.isInstanceOf[AggregateExpression])) {
       throw QueryCompilationErrors.aggregationNotAllowedInMergeCondition(condName, cond)
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteMergeIntoTable.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteMergeIntoTable.scala
@@ -18,8 +18,9 @@
 package org.apache.spark.sql.catalyst.analysis
 
 import org.apache.spark.sql.AnalysisException
-import org.apache.spark.sql.catalyst.expressions.{Alias, And, Attribute, AttributeReference, Exists, Expression, IsNotNull, Literal, MetadataAttribute, MonotonicallyIncreasingID, OuterReference, PredicateHelper}
+import org.apache.spark.sql.catalyst.expressions.{Alias, And, Attribute, AttributeReference, Exists, Expression, IsNotNull, Literal, MetadataAttribute, MonotonicallyIncreasingID, OuterReference, PredicateHelper, SubqueryExpression}
 import org.apache.spark.sql.catalyst.expressions.Literal.{FalseLiteral, TrueLiteral}
+import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
 import org.apache.spark.sql.catalyst.plans.{FullOuter, Inner, JoinType, LeftAnti, LeftOuter, RightOuter}
 import org.apache.spark.sql.catalyst.plans.logical.{AppendData, DeleteAction, Filter, HintInfo, InsertAction, Join, JoinHint, LogicalPlan, MergeAction, MergeIntoTable, MergeRows, NO_BROADCAST_AND_REPLICATION, Project, ReplaceData, UpdateAction, WriteDelta}
 import org.apache.spark.sql.catalyst.plans.logical.MergeRows.{Discard, Instruction, Keep, ROW_ID, Split}
@@ -27,6 +28,7 @@ import org.apache.spark.sql.catalyst.util.RowDeltaUtils.OPERATION_COLUMN
 import org.apache.spark.sql.connector.catalog.SupportsRowLevelOperations
 import org.apache.spark.sql.connector.write.{RowLevelOperationTable, SupportsDelta}
 import org.apache.spark.sql.connector.write.RowLevelOperation.Command.MERGE
+import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.types.IntegerType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
@@ -49,6 +51,8 @@ object RewriteMergeIntoTable extends RewriteRowLevelCommand with PredicateHelper
 
       EliminateSubqueryAliases(aliasedTable) match {
         case r: DataSourceV2Relation =>
+          validateMergeIntoConditions(m)
+
           // NOT MATCHED conditions may only refer to columns in source so they can be pushed down
           val insertAction = notMatchedActions.head.asInstanceOf[InsertAction]
           val filteredSource = insertAction.condition match {
@@ -80,6 +84,8 @@ object RewriteMergeIntoTable extends RewriteRowLevelCommand with PredicateHelper
 
       EliminateSubqueryAliases(aliasedTable) match {
         case r: DataSourceV2Relation =>
+          validateMergeIntoConditions(m)
+
           // there are only NOT MATCHED actions, use a left anti join to remove any matching rows
           // and switch to using a regular append instead of a row-level MERGE operation
           // only unmatched source rows that match action conditions are appended to the table
@@ -116,6 +122,7 @@ object RewriteMergeIntoTable extends RewriteRowLevelCommand with PredicateHelper
 
       EliminateSubqueryAliases(aliasedTable) match {
         case r @ DataSourceV2Relation(tbl: SupportsRowLevelOperations, _, _, _, _) =>
+          validateMergeIntoConditions(m)
           val table = buildOperationTable(tbl, MERGE, CaseInsensitiveStringMap.empty())
           table.operation match {
             case _: SupportsDelta =>
@@ -466,6 +473,31 @@ object RewriteMergeIntoTable extends RewriteRowLevelCommand with PredicateHelper
 
       case other =>
         throw new AnalysisException(s"Unexpected action: $other")
+    }
+  }
+
+  private def validateMergeIntoConditions(merge: MergeIntoTable): Unit = {
+    checkMergeIntoCondition("SEARCH", merge.mergeCondition)
+    val actions = merge.matchedActions ++ merge.notMatchedActions ++ merge.notMatchedBySourceActions
+    actions.foreach {
+      case DeleteAction(Some(cond)) => checkMergeIntoCondition("DELETE", cond)
+      case UpdateAction(Some(cond), _) => checkMergeIntoCondition("UPDATE", cond)
+      case InsertAction(Some(cond), _) => checkMergeIntoCondition("INSERT", cond)
+      case _ => // OK
+    }
+  }
+
+  private def checkMergeIntoCondition(condName: String, cond: Expression): Unit = {
+    if (!cond.deterministic) {
+      throw QueryCompilationErrors.nonDeterministicMergeCondition(condName, cond)
+    }
+
+    if (SubqueryExpression.hasSubquery(cond)) {
+      throw QueryCompilationErrors.subqueryNotAllowedInMergeCondition(condName, cond)
+    }
+
+    if (cond.find(_.isInstanceOf[AggregateExpression]).isDefined) {
+      throw QueryCompilationErrors.aggregationNotAllowedInMergeCondition(condName, cond)
     }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -3186,6 +3186,30 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase {
       messageParameters = Map.empty)
   }
 
+  def nonDeterministicMergeCondition(condName: String, cond: Expression): Throwable = {
+    new AnalysisException(
+      errorClass = "UNSUPPORTED_MERGE_CONDITION.NON_DETERMINISTIC",
+      messageParameters = Map(
+        "condName" -> condName,
+        "cond" -> toSQLExpr(cond)))
+  }
+
+  def subqueryNotAllowedInMergeCondition(condName: String, cond: Expression): Throwable = {
+    new AnalysisException(
+      errorClass = "UNSUPPORTED_MERGE_CONDITION.SUBQUERY",
+      messageParameters = Map(
+        "condName" -> condName,
+        "cond" -> toSQLExpr(cond)))
+  }
+
+  def aggregationNotAllowedInMergeCondition(condName: String, cond: Expression): Throwable = {
+    new AnalysisException(
+      errorClass = "UNSUPPORTED_MERGE_CONDITION.AGGREGATE",
+      messageParameters = Map(
+        "condName" -> condName,
+        "cond" -> toSQLExpr(cond)))
+  }
+
   def failedToParseExistenceDefaultAsLiteral(fieldName: String, defaultValue: String): Throwable = {
     new AnalysisException(
       errorClass = "_LEGACY_ERROR_TEMP_1344",


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR adds descriptive errors for cases when MERGE statements that are converted into executable plans by Spark contain unsupported expressions such as non-deterministic functions, subqueries, and aggregates.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

These changes are needed as the current version of the row-level framework does not support these operations. Keep in mind the new validation only applies to MERGE statements that are rewritten by `RewriteMergeIntoTable`. Data sources that inject their own implementation are NOT affected.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

This PR comes with tests.