### PR TITLE
[SPARK-44143][SQL][TESTS] Use checkError() to check Exception in *DDL*Suite

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -189,10 +189,13 @@ class InMemoryCatalogedDDLSuite extends DDLSuite with SharedSparkSession {
       sql("CREATE TABLE s(a INT, b INT) USING parquet")
       val source = catalog.getTableMetadata(TableIdentifier("s"))
       assert(source.provider == Some("parquet"))
-      val e = intercept[AnalysisException] {
-        sql("CREATE TABLE t LIKE s USING org.apache.spark.sql.hive.orc")
-      }.getMessage
-      assert(e.contains("Hive built-in ORC data source must be used with Hive support enabled"))
+      checkError(
+        exception = intercept[AnalysisException] {
+          sql("CREATE TABLE t LIKE s USING org.apache.spark.sql.hive.orc")
+        },
+        errorClass = "_LEGACY_ERROR_TEMP_1138",
+        parameters = Map.empty
+      )
     }
   }
 
@@ -282,13 +285,6 @@ trait DDLSuiteBase extends SQLTestUtils {
       case escapedIdentifier(i) => i
       case plainIdent => plainIdent
     }
-  }
-
-  protected def assertUnsupported(query: String): Unit = {
-    val e = intercept[AnalysisException] {
-      sql(query)
-    }
-    assert(e.getMessage.toLowerCase(Locale.ROOT).contains("operation not allowed"))
   }
 
   protected def maybeWrapException[T](expectException: Boolean)(body: => T): Unit = {
@@ -431,9 +427,11 @@ abstract class DDLSuite extends QueryTest with DDLSuiteBase {
            |$partitionClause
          """.stripMargin
       if (userSpecifiedSchema.isEmpty && userSpecifiedPartitionCols.nonEmpty) {
-        val e = intercept[AnalysisException](sql(sqlCreateTable)).getMessage
-        assert(e.contains(
-          "not allowed to specify partition columns when the table schema is not defined"))
+        checkError(
+          exception = intercept[AnalysisException](sql(sqlCreateTable)),
+          errorClass = null,
+          parameters = Map.empty
+        )
       } else {
         sql(sqlCreateTable)
         val tableMetadata = spark.sessionState.catalog.getTableMetadata(TableIdentifier(tabName))
@@ -615,17 +613,21 @@ abstract class DDLSuite extends QueryTest with DDLSuiteBase {
             .option("path", dir1.getCanonicalPath)
             .saveAsTable("path_test")
 
-          val ex = intercept[AnalysisException] {
-            Seq((3L, "c")).toDF("v1", "v2")
-              .write
-              .mode(SaveMode.Append)
-              .format("json")
-              .option("path", dir2.getCanonicalPath)
-              .saveAsTable("path_test")
-          }.getMessage
-          assert(ex.contains(
-            s"The location of the existing table `$SESSION_CATALOG_NAME`.`default`.`path_test`"))
-
+          checkErrorMatchPVals(
+            exception = intercept[AnalysisException] {
+              Seq((3L, "c")).toDF("v1", "v2")
+                .write
+                .mode(SaveMode.Append)
+                .format("json")
+                .option("path", dir2.getCanonicalPath)
+                .saveAsTable("path_test")
+            },
+            errorClass = "_LEGACY_ERROR_TEMP_1160",
+            parameters = Map(
+              "identifier" -> s"`$SESSION_CATALOG_NAME`.`default`.`path_test`",
+              "existingTableLoc" -> ".*",
+              "tableDescLoc" -> ".*")
+          )
           checkAnswer(
             spark.table("path_test"), Row(1L, "a") :: Nil)
         }
@@ -792,14 +794,16 @@ abstract class DDLSuite extends QueryTest with DDLSuiteBase {
           Row("1997", "Ford") :: Nil)
 
         // Fails if creating a new view with the same name
-        intercept[TempTableAlreadyExistsException] {
-          sql(
-            s"""
-               |CREATE TEMPORARY VIEW testview
-               |USING org.apache.spark.sql.execution.datasources.csv.CSVFileFormat
-               |OPTIONS (PATH '${tmpFile.toURI}')
-             """.stripMargin)
-        }
+        checkError(
+          exception = intercept[TempTableAlreadyExistsException] {
+            sql(
+              s"""
+                 |CREATE TEMPORARY VIEW testview
+                 |USING org.apache.spark.sql.execution.datasources.csv.CSVFileFormat
+                 |OPTIONS (PATH '${tmpFile.toURI}')
+               """.stripMargin)},
+          errorClass = "TEMP_TABLE_OR_VIEW_ALREADY_EXISTS",
+          parameters = Map("relationName" -> "`testview`"))
       }
     }
   }
@@ -817,12 +821,16 @@ abstract class DDLSuite extends QueryTest with DDLSuiteBase {
           |)
         """.stripMargin)
 
-      val e = intercept[AnalysisException] {
-        sql("ALTER TABLE tab1 RENAME TO default.tab2")
-      }
-      assert(e.getMessage.contains(
-        s"RENAME TEMPORARY VIEW from '`tab1`' to '`default`.`tab2`': " +
-          "cannot specify database name 'default' in the destination table"))
+      checkError(
+        exception = intercept[AnalysisException] {
+          sql("ALTER TABLE tab1 RENAME TO default.tab2")
+        },
+        errorClass = "_LEGACY_ERROR_TEMP_1074",
+        parameters = Map(
+          "oldName" -> "`tab1`",
+          "newName" -> "`default`.`tab2`",
+          "db" -> "default")
+      )
 
       val catalog = spark.sessionState.catalog
       assert(catalog.listTables("default") == Seq(TableIdentifier("tab1")))
@@ -842,12 +850,15 @@ abstract class DDLSuite extends QueryTest with DDLSuiteBase {
           |)
         """.stripMargin)
 
-      val e = intercept[AnalysisException] {
-        sql("ALTER TABLE view1 RENAME TO default.tab2")
-      }
-      assert(e.getMessage.contains(
-        s"RENAME TEMPORARY VIEW from '`view1`' to '`default`.`tab2`': " +
-          "cannot specify database name 'default' in the destination table"))
+      checkError(
+        exception = intercept[AnalysisException] {
+          sql("ALTER TABLE view1 RENAME TO default.tab2")
+        },
+        errorClass = "_LEGACY_ERROR_TEMP_1074",
+        parameters = Map(
+          "oldName" -> "`view1`",
+          "newName" -> "`default`.`tab2`",
+          "db" -> "default"))
 
       val catalog = spark.sessionState.catalog
       assert(catalog.listTables("default") == Seq(TableIdentifier("view1")))
@@ -863,7 +874,11 @@ abstract class DDLSuite extends QueryTest with DDLSuiteBase {
       checkErrorTableNotFound(e, "`tab1`")
       sql("ALTER VIEW tab2 RENAME TO tab1")
       checkAnswer(spark.table("tab1"), spark.range(10).toDF())
-      intercept[AnalysisException] { spark.table("tab2") }
+      checkError(
+        exception = intercept[AnalysisException] { spark.table("tab2") },
+        errorClass = "TABLE_OR_VIEW_NOT_FOUND",
+        parameters = Map("relationName" -> "`tab2`")
+      )
     }
   }
 
@@ -943,10 +958,38 @@ abstract class DDLSuite extends QueryTest with DDLSuiteBase {
     val tableIdent = TableIdentifier("tab1", Some("dbx"))
     createDatabase(catalog, "dbx")
     createTable(catalog, tableIdent)
-    assertUnsupported("ALTER TABLE dbx.tab1 CLUSTERED BY (blood, lemon, grape) INTO 11 BUCKETS")
-    assertUnsupported("ALTER TABLE dbx.tab1 CLUSTERED BY (fuji) SORTED BY (grape) INTO 5 BUCKETS")
-    assertUnsupported("ALTER TABLE dbx.tab1 NOT CLUSTERED")
-    assertUnsupported("ALTER TABLE dbx.tab1 NOT SORTED")
+    val sql1 = "ALTER TABLE dbx.tab1 CLUSTERED BY (blood, lemon, grape) INTO 11 BUCKETS"
+    checkError(
+      exception = intercept[AnalysisException] {
+        sql(sql1)
+      },
+      errorClass = "_LEGACY_ERROR_TEMP_0035",
+      parameters = Map("message" -> "ALTER TABLE CLUSTERED BY"),
+      context = ExpectedContext(fragment = sql1, start = 0, stop = 70))
+    val sql2 = "ALTER TABLE dbx.tab1 CLUSTERED BY (fuji) SORTED BY (grape) INTO 5 BUCKETS"
+    checkError(
+      exception = intercept[AnalysisException] {
+        sql(sql2)
+      },
+      errorClass = "_LEGACY_ERROR_TEMP_0035",
+      parameters = Map("message" -> "ALTER TABLE CLUSTERED BY"),
+      context = ExpectedContext(fragment = sql2, start = 0, stop = 72))
+    val sql3 = "ALTER TABLE dbx.tab1 NOT CLUSTERED"
+    checkError(
+      exception = intercept[AnalysisException] {
+        sql(sql3)
+      },
+      errorClass = "_LEGACY_ERROR_TEMP_0035",
+      parameters = Map("message" -> "ALTER TABLE NOT CLUSTERED"),
+      context = ExpectedContext(fragment = sql3, start = 0, stop = 33))
+    val sql4 = "ALTER TABLE dbx.tab1 NOT SORTED"
+    checkError(
+      exception = intercept[AnalysisException] {
+        sql(sql4)
+      },
+      errorClass = "_LEGACY_ERROR_TEMP_0035",
+      parameters = Map("message" -> "ALTER TABLE NOT SORTED"),
+      context = ExpectedContext(fragment = sql4, start = 0, stop = 30))
   }
 
   test("alter table: skew is not supported") {
@@ -954,20 +997,68 @@ abstract class DDLSuite extends QueryTest with DDLSuiteBase {
     val tableIdent = TableIdentifier("tab1", Some("dbx"))
     createDatabase(catalog, "dbx")
     createTable(catalog, tableIdent)
-    assertUnsupported("ALTER TABLE dbx.tab1 SKEWED BY (dt, country) ON " +
-      "(('2008-08-08', 'us'), ('2009-09-09', 'uk'), ('2010-10-10', 'cn'))")
-    assertUnsupported("ALTER TABLE dbx.tab1 SKEWED BY (dt, country) ON " +
-      "(('2008-08-08', 'us'), ('2009-09-09', 'uk')) STORED AS DIRECTORIES")
-    assertUnsupported("ALTER TABLE dbx.tab1 NOT SKEWED")
-    assertUnsupported("ALTER TABLE dbx.tab1 NOT STORED AS DIRECTORIES")
+    val sql1 = "ALTER TABLE dbx.tab1 SKEWED BY (dt, country) ON " +
+      "(('2008-08-08', 'us'), ('2009-09-09', 'uk'), ('2010-10-10', 'cn'))"
+    checkError(
+      exception = intercept[AnalysisException] {
+        sql(sql1)
+      },
+      errorClass = "_LEGACY_ERROR_TEMP_0035",
+      parameters = Map("message" -> "ALTER TABLE SKEWED BY"),
+      context = ExpectedContext(fragment = sql1, start = 0, stop = 113)
+    )
+    val sql2 = "ALTER TABLE dbx.tab1 SKEWED BY (dt, country) ON " +
+      "(('2008-08-08', 'us'), ('2009-09-09', 'uk')) STORED AS DIRECTORIES"
+    checkError(
+      exception = intercept[AnalysisException] {
+        sql(sql2)
+      },
+      errorClass = "_LEGACY_ERROR_TEMP_0035",
+      parameters = Map("message" -> "ALTER TABLE SKEWED BY"),
+      context = ExpectedContext(fragment = sql2, start = 0, stop = 113)
+    )
+    val sql3 = "ALTER TABLE dbx.tab1 NOT SKEWED"
+    checkError(
+      exception = intercept[AnalysisException] {
+        sql(sql3)
+      },
+      errorClass = "_LEGACY_ERROR_TEMP_0035",
+      parameters = Map("message" -> "ALTER TABLE NOT SKEWED"),
+      context = ExpectedContext(fragment = sql3, start = 0, stop = 30)
+    )
+    val sql4 = "ALTER TABLE dbx.tab1 NOT STORED AS DIRECTORIES"
+    checkError(
+      exception = intercept[AnalysisException] {
+        sql(sql4)
+      },
+      errorClass = "_LEGACY_ERROR_TEMP_0035",
+      parameters = Map("message" -> "ALTER TABLE NOT STORED AS DIRECTORIES"),
+      context = ExpectedContext(fragment = sql4, start = 0, stop = 45)
+    )
   }
 
   test("alter table: add partition is not supported for views") {
-    assertUnsupported("ALTER VIEW dbx.tab1 ADD IF NOT EXISTS PARTITION (b='2')")
+    val sql1 = "ALTER VIEW dbx.tab1 ADD IF NOT EXISTS PARTITION (b='2')"
+    checkError(
+      exception = intercept[AnalysisException] {
+        sql(sql1)
+      },
+      errorClass = "_LEGACY_ERROR_TEMP_0035",
+      parameters = Map("message" -> "ALTER VIEW ... ADD PARTITION"),
+      context = ExpectedContext(fragment = sql1, start = 0, stop = 54)
+    )
   }
 
   test("alter table: drop partition is not supported for views") {
-    assertUnsupported("ALTER VIEW dbx.tab1 DROP IF EXISTS PARTITION (b='2')")
+    val sql1 = "ALTER VIEW dbx.tab1 DROP IF EXISTS PARTITION (b='2')"
+    checkError(
+      exception = intercept[AnalysisException] {
+        sql(sql1)
+      },
+      errorClass = "_LEGACY_ERROR_TEMP_0035",
+      parameters = Map("message" -> "ALTER VIEW ... DROP PARTITION"),
+      context = ExpectedContext(fragment = sql1, start = 0, stop = 51)
+    )
   }
 
   test("drop view - temporary view") {
@@ -1032,9 +1123,14 @@ abstract class DDLSuite extends QueryTest with DDLSuiteBase {
     sql("ALTER TABLE tab1 SET TBLPROPERTIES ('kor' = 'belle', 'kar' = 'bol')")
     assert(getProps == Map("andrew" -> "or14", "kor" -> "belle", "kar" -> "bol"))
     // table to alter does not exist
-    intercept[AnalysisException] {
-      sql("ALTER TABLE does_not_exist SET TBLPROPERTIES ('winner' = 'loser')")
-    }
+    checkError(
+      exception = intercept[AnalysisException] {
+        sql("ALTER TABLE does_not_exist SET TBLPROPERTIES ('winner' = 'loser')")
+      },
+      errorClass = "TABLE_OR_VIEW_NOT_FOUND",
+      parameters = Map("relationName" -> "`does_not_exist`"),
+      context = ExpectedContext(fragment = "does_not_exist", start = 12, stop = 25)
+    )
   }
 
   protected def testUnsetProperties(isDatasourceTable: Boolean): Unit = {
@@ -1061,14 +1157,23 @@ abstract class DDLSuite extends QueryTest with DDLSuiteBase {
     sql("ALTER TABLE tab1 UNSET TBLPROPERTIES ('p')")
     assert(getProps == Map("c" -> "lan", "x" -> "y"))
     // table to alter does not exist
-    intercept[AnalysisException] {
-      sql("ALTER TABLE does_not_exist UNSET TBLPROPERTIES ('c' = 'lan')")
-    }
+    val sql1 = "ALTER TABLE does_not_exist UNSET TBLPROPERTIES ('c' = 'lan')"
+    checkError(
+      exception = intercept[AnalysisException] {
+        sql(sql1)
+      },
+      errorClass = "_LEGACY_ERROR_TEMP_0035",
+      parameters = Map("message" -> "Values should not be specified for key(s): [c]"),
+      context = ExpectedContext(fragment = sql1, start = 0, stop = 59)
+    )
     // property to unset does not exist
-    val e = intercept[AnalysisException] {
-      sql("ALTER TABLE tab1 UNSET TBLPROPERTIES ('c', 'xyz')")
-    }
-    assert(e.getMessage.contains("xyz"))
+    checkError(
+      exception = intercept[AnalysisException] {
+        sql("ALTER TABLE tab1 UNSET TBLPROPERTIES ('c', 'xyz')")
+      },
+      errorClass = "UNSET_NONEXISTENT_PROPERTIES",
+      parameters = Map("properties" -> "`xyz`", "table" -> "`spark_catalog`.`dbx`.`tab1`")
+    )
     // property to unset does not exist, but "IF EXISTS" is specified
     sql("ALTER TABLE tab1 UNSET TBLPROPERTIES IF EXISTS ('c', 'xyz')")
     assert(getProps == Map("x" -> "y"))
@@ -1100,20 +1205,27 @@ abstract class DDLSuite extends QueryTest with DDLSuiteBase {
     Seq("true", "false").foreach { caseSensitive =>
       withSQLConf(SQLConf.CASE_SENSITIVE.key -> caseSensitive) {
         // partition to add already exists
-        var e = intercept[AnalysisException] {
-          sql("DROP TEMPORARY FUNCTION year")
-        }
-        assert(e.getMessage.contains("Cannot drop built-in function 'year'"))
-
-        e = intercept[AnalysisException] {
-          sql("DROP TEMPORARY FUNCTION YeAr")
-        }
-        assert(e.getMessage.contains("Cannot drop built-in function 'YeAr'"))
-
-        e = intercept[AnalysisException] {
-          sql("DROP TEMPORARY FUNCTION `YeAr`")
-        }
-        assert(e.getMessage.contains("Cannot drop built-in function 'YeAr'"))
+        checkError(
+          exception = intercept[AnalysisException] {
+            sql("DROP TEMPORARY FUNCTION year")
+          },
+          errorClass = "_LEGACY_ERROR_TEMP_1255",
+          parameters = Map("functionName" -> "year")
+        )
+        checkError(
+          exception = intercept[AnalysisException] {
+            sql("DROP TEMPORARY FUNCTION YeAr")
+          },
+          errorClass = "_LEGACY_ERROR_TEMP_1255",
+          parameters = Map("functionName" -> "YeAr")
+        )
+        checkError(
+          exception = intercept[AnalysisException] {
+            sql("DROP TEMPORARY FUNCTION `YeAr`")
+          },
+          errorClass = "_LEGACY_ERROR_TEMP_1255",
+          parameters = Map("functionName" -> "YeAr")
+        )
       }
     }
   }
@@ -1237,11 +1349,13 @@ abstract class DDLSuite extends QueryTest with DDLSuiteBase {
     withTable("tab1") {
       spark.range(10).write.saveAsTable("tab1")
       withView("view1") {
-        val e = intercept[AnalysisException] {
-          sql("CREATE TEMPORARY VIEW view1 (col1, col3) AS SELECT * FROM tab1")
-        }.getMessage
-        assert(e.contains("the SELECT clause (num: `1`) does not match")
-          && e.contains("CREATE VIEW (num: `2`)"))
+        checkError(
+          exception = intercept[AnalysisException] {
+            sql("CREATE TEMPORARY VIEW view1 (col1, col3) AS SELECT * FROM tab1")
+          },
+          errorClass = "_LEGACY_ERROR_TEMP_1277",
+          parameters = Map("analyzedPlanLength" -> "1", "userSpecifiedColumnsLength" -> "2")
+        )
       }
     }
   }
@@ -1286,17 +1400,37 @@ abstract class DDLSuite extends QueryTest with DDLSuiteBase {
     withTable("partitionedTable") {
       df.write.mode("overwrite").partitionBy("a", "b").saveAsTable("partitionedTable")
       // Misses some partition columns
-      intercept[AnalysisException] {
-        df.write.mode("append").partitionBy("a").saveAsTable("partitionedTable")
-      }
+      checkError(
+        exception = intercept[AnalysisException] {
+          df.write.mode("append").partitionBy("a").saveAsTable("partitionedTable")
+        },
+        errorClass = "_LEGACY_ERROR_TEMP_1163",
+        parameters = Map(
+          "tableName" -> "spark_catalog.default.partitionedtable",
+          "specifiedPartCols" -> "a",
+          "existingPartCols" -> "a, b")
+      )
       // Wrong order
-      intercept[AnalysisException] {
-        df.write.mode("append").partitionBy("b", "a").saveAsTable("partitionedTable")
-      }
+      checkError(
+        exception = intercept[AnalysisException] {
+          df.write.mode("append").partitionBy("b", "a").saveAsTable("partitionedTable")
+        },
+        errorClass = "_LEGACY_ERROR_TEMP_1163",
+        parameters = Map(
+          "tableName" -> "spark_catalog.default.partitionedtable",
+          "specifiedPartCols" -> "b, a",
+          "existingPartCols" -> "a, b")
+      )
       // Partition columns not specified
-      intercept[AnalysisException] {
-        df.write.mode("append").saveAsTable("partitionedTable")
-      }
+      checkError(
+        exception = intercept[AnalysisException] {
+          df.write.mode("append").saveAsTable("partitionedTable")
+        },
+        errorClass = "_LEGACY_ERROR_TEMP_1163",
+        parameters = Map(
+          "tableName" -> "spark_catalog.default.partitionedtable",
+          "specifiedPartCols" -> "", "existingPartCols" -> "a, b")
+      )
       assert(sql("select * from partitionedTable").collect().size == 1)
       // Inserts new data successfully when partition columns are correctly specified in
       // partitionBy(...).
@@ -1329,12 +1463,13 @@ abstract class DDLSuite extends QueryTest with DDLSuiteBase {
         val tabName = s"$db.showcolumn"
         withTable(tabName) {
           sql(s"CREATE TABLE $tabName(col1 int, col2 string) USING parquet ")
-          val message = intercept[AnalysisException] {
-            sql(s"SHOW COLUMNS IN $db.showcolumn FROM ${db.toUpperCase(Locale.ROOT)}")
-          }.getMessage
-          assert(message.contains(
-            s"SHOW COLUMNS with conflicting databases: " +
-              s"'${db.toUpperCase(Locale.ROOT)}' != '$db'"))
+          checkError(
+            exception = intercept[AnalysisException] {
+              sql(s"SHOW COLUMNS IN $db.showcolumn FROM ${db.toUpperCase(Locale.ROOT)}")
+            },
+            errorClass = "_LEGACY_ERROR_TEMP_1057",
+            parameters = Map("dbA" -> db.toUpperCase(Locale.ROOT), "dbB" -> db)
+          )
         }
       }
     }
@@ -1343,10 +1478,13 @@ abstract class DDLSuite extends QueryTest with DDLSuiteBase {
   test("show columns - invalid db name") {
     withTable("tbl") {
       sql("CREATE TABLE tbl(col1 int, col2 string) USING parquet ")
-      val message = intercept[AnalysisException] {
-        sql("SHOW COLUMNS IN tbl FROM a.b.c")
-      }.getMessage
-      assert(message.contains("requires a single-part namespace"))
+      checkError(
+        exception = intercept[AnalysisException] {
+          sql("SHOW COLUMNS IN tbl FROM a.b.c")
+        },
+        errorClass = "REQUIRES_SINGLE_PART_NAMESPACE",
+        parameters = Map("sessionCatalog" -> "spark_catalog", "namespace" -> "`a`.`b`.`c`")
+      )
     }
   }
 
@@ -1904,10 +2042,16 @@ abstract class DDLSuite extends QueryTest with DDLSuiteBase {
   test("alter datasource table add columns - text format not supported") {
     withTable("t1") {
       sql("CREATE TABLE t1 (c1 string) USING text")
-      val e = intercept[AnalysisException] {
-        sql("ALTER TABLE t1 ADD COLUMNS (c2 int)")
-      }.getMessage
-      assert(e.contains("ALTER ADD COLUMNS does not support datasource table with type"))
+      checkErrorMatchPVals(
+        exception = intercept[AnalysisException] {
+          sql("ALTER TABLE t1 ADD COLUMNS (c2 int)")
+        },
+        errorClass = "_LEGACY_ERROR_TEMP_1260",
+        parameters = Map(
+          "tableType" -> ("org\\.apache\\.spark\\.sql\\.execution\\." +
+            "datasources\\.v2\\.text\\.TextDataSourceV2.*"),
+          "table" -> ".*t1.*")
+      )
     }
   }
 
@@ -2006,10 +2150,14 @@ abstract class DDLSuite extends QueryTest with DDLSuiteBase {
   }
 
   test("set command rejects SparkConf entries") {
-    val ex = intercept[AnalysisException] {
-      sql(s"SET ${config.CPUS_PER_TASK.key} = 4")
-    }
-    assert(ex.getMessage.contains("Spark config"))
+    checkError(
+      exception = intercept[AnalysisException] {
+        sql(s"SET ${config.CPUS_PER_TASK.key} = 4")
+      },
+      errorClass = "CANNOT_MODIFY_CONFIG",
+      parameters = Map(
+        "key" -> "\"spark.task.cpus\"",
+        "docroot" -> "https://spark.apache.org/docs/latest"))
   }
 
   test("Refresh table before drop database cascade") {
@@ -2095,20 +2243,27 @@ abstract class DDLSuite extends QueryTest with DDLSuiteBase {
   test(s"Add a directory when ${SQLConf.LEGACY_ADD_SINGLE_FILE_IN_ADD_FILE.key} set to true") {
     withTempDir { testDir =>
       withSQLConf(SQLConf.LEGACY_ADD_SINGLE_FILE_IN_ADD_FILE.key -> "true") {
-        val msg = intercept[SparkException] {
-          spark.sql(s"ADD FILE $testDir")
-        }.getMessage
-        assert(msg.contains("is a directory and recursive is not turned on"))
+        checkError(
+          exception = intercept[SparkException] {
+            sql(s"ADD FILE $testDir")
+          },
+          errorClass = null,
+          parameters = Map.empty
+        )
       }
     }
   }
 
   test("REFRESH FUNCTION") {
-    val msg = intercept[AnalysisException] {
-      sql("REFRESH FUNCTION md5")
-    }.getMessage
-    assert(msg.contains(
-      "md5 is a built-in/temporary function. 'REFRESH FUNCTION' expects a persistent function"))
+    checkError(
+      exception = intercept[AnalysisException] {
+        sql("REFRESH FUNCTION md5")
+      },
+      errorClass = "_LEGACY_ERROR_TEMP_1017",
+      parameters = Map(
+        "name" -> "md5",
+        "cmd" -> "REFRESH FUNCTION", "hintStr" -> ""),
+      context = ExpectedContext(fragment = "md5", start = 17, stop = 19))
     checkError(
       exception = intercept[AnalysisException] {
         sql("REFRESH FUNCTION default.md5")
@@ -2124,19 +2279,32 @@ abstract class DDLSuite extends QueryTest with DDLSuiteBase {
 
     withUserDefinedFunction("func1" -> true) {
       sql("CREATE TEMPORARY FUNCTION func1 AS 'test.org.apache.spark.sql.MyDoubleAvg'")
-      val msg = intercept[AnalysisException] {
-        sql("REFRESH FUNCTION func1")
-      }.getMessage
-      assert(msg.contains("" +
-        "func1 is a built-in/temporary function. 'REFRESH FUNCTION' expects a persistent function"))
+      checkError(
+        exception = intercept[AnalysisException] {
+          sql("REFRESH FUNCTION func1")
+        },
+        errorClass = "_LEGACY_ERROR_TEMP_1017",
+        parameters = Map("name" -> "func1", "cmd" -> "REFRESH FUNCTION", "hintStr" -> ""),
+        context = ExpectedContext(
+          fragment = "func1",
+          start = 17,
+          stop = 21)
+      )
     }
 
     withUserDefinedFunction("func1" -> false) {
       val func = FunctionIdentifier("func1", Some("default"))
       assert(!spark.sessionState.catalog.isRegisteredFunction(func))
-      intercept[AnalysisException] {
-        sql("REFRESH FUNCTION func1")
-      }
+      checkError(
+        exception = intercept[AnalysisException] {
+          sql("REFRESH FUNCTION func1")
+        },
+        errorClass = "UNRESOLVED_ROUTINE",
+        parameters = Map(
+          "routineName" -> "`func1`",
+          "searchPath" -> "[`system`.`builtin`, `system`.`session`, `spark_catalog`.`default`]"),
+        context = ExpectedContext(fragment = "func1", start = 17, stop = 21)
+      )
       assert(!spark.sessionState.catalog.isRegisteredFunction(func))
 
       sql("CREATE FUNCTION func1 AS 'test.org.apache.spark.sql.MyDoubleAvg'")
@@ -2159,9 +2327,14 @@ abstract class DDLSuite extends QueryTest with DDLSuiteBase {
 
       spark.sessionState.catalog.externalCatalog.dropFunction("default", "func1")
       assert(spark.sessionState.catalog.isRegisteredFunction(func))
-      intercept[AnalysisException] {
-        sql("REFRESH FUNCTION func1")
-      }
+      checkError(
+        exception = intercept[AnalysisException] {
+          sql("REFRESH FUNCTION func1")
+        },
+        errorClass = "ROUTINE_NOT_FOUND",
+        parameters = Map("routineName" -> "`default`.`func1`")
+      )
+
       assert(!spark.sessionState.catalog.isRegisteredFunction(func))
 
       val function = CatalogFunction(func, "test.non.exists.udf", Seq.empty)
@@ -2186,11 +2359,14 @@ abstract class DDLSuite extends QueryTest with DDLSuiteBase {
       val rand = FunctionIdentifier("rand", Some("default"))
       sql("CREATE FUNCTION rand AS 'test.org.apache.spark.sql.MyDoubleAvg'")
       assert(!spark.sessionState.catalog.isRegisteredFunction(rand))
-      val msg = intercept[AnalysisException] {
-        sql("REFRESH FUNCTION rand")
-      }.getMessage
-      assert(msg.contains(
-        "rand is a built-in/temporary function. 'REFRESH FUNCTION' expects a persistent function"))
+      checkError(
+        exception = intercept[AnalysisException] {
+          sql("REFRESH FUNCTION rand")
+        },
+        errorClass = "_LEGACY_ERROR_TEMP_1017",
+        parameters = Map("name" -> "rand", "cmd" -> "REFRESH FUNCTION", "hintStr" -> ""),
+        context = ExpectedContext(fragment = "rand", start = 17, stop = 20)
+      )
       assert(!spark.sessionState.catalog.isRegisteredFunction(rand))
       sql("REFRESH FUNCTION default.rand")
       assert(spark.sessionState.catalog.isRegisteredFunction(rand))

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/DDLSourceLoadSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/DDLSourceLoadSuite.scala
@@ -26,10 +26,17 @@ import org.apache.spark.sql.types._
 class DDLSourceLoadSuite extends DataSourceTest with SharedSparkSession {
 
   test("data sources with the same name - internal data sources") {
-    val e = intercept[AnalysisException] {
-      spark.read.format("Fluet da Bomb").load()
-    }
-    assert(e.getMessage.contains("Multiple sources found for Fluet da Bomb"))
+    checkError(
+      exception = intercept[AnalysisException] {
+        spark.read.format("Fluet da Bomb").load()
+      },
+      errorClass = "_LEGACY_ERROR_TEMP_1141",
+      parameters = Map(
+        "provider" -> "Fluet da Bomb",
+        "sourceNames" -> ("org.apache.spark.sql.sources.FakeSourceOne, " +
+          "org.apache.spark.sql.sources.FakeSourceTwo")
+      )
+    )
   }
 
   test("data sources with the same name - internal data source/external data source") {
@@ -38,10 +45,17 @@ class DDLSourceLoadSuite extends DataSourceTest with SharedSparkSession {
   }
 
   test("data sources with the same name - external data sources") {
-    val e = intercept[AnalysisException] {
-      spark.read.format("Fake external source").load()
-    }
-    assert(e.getMessage.contains("Multiple sources found for Fake external source"))
+    checkError(
+      exception = intercept[AnalysisException] {
+        spark.read.format("Fake external source").load()
+      },
+      errorClass = "_LEGACY_ERROR_TEMP_1141",
+      parameters = Map(
+        "provider" -> "Fake external source",
+        "sourceNames" -> ("org.apache.fakesource.FakeExternalSourceOne, " +
+          "org.apache.fakesource.FakeExternalSourceTwo")
+      )
+    )
   }
 
   test("load data source from format alias") {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/Hive_2_1_DDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/Hive_2_1_DDLSuite.scala
@@ -100,13 +100,16 @@ class Hive_2_1_DDLSuite extends SparkFunSuite with TestHiveSingleton {
   }
 
   test("SPARK-21617: ALTER TABLE with incompatible schema on Hive-compatible table") {
-    val exception = intercept[AnalysisException] {
-      testAlterTable(
-        "t1",
-        "CREATE TABLE t1 (c1 string) USING parquet",
-        StructType(Array(StructField("c2", IntegerType))))
-    }
-    assert(exception.getMessage().contains("types incompatible with the existing columns"))
+    checkError(
+      exception = intercept[AnalysisException] {
+        testAlterTable(
+          "t1",
+          "CREATE TABLE t1 (c1 string) USING parquet",
+          StructType(Array(StructField("c2", IntegerType))))
+      },
+      errorClass = null,
+      parameters = Map.empty
+    )
   }
 
   private def testAlterTable(


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to use `checkError()` to check `Exception` in `*DDL*Suite`, include:
- sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite
- sql/core/src/test/scala/org/apache/spark/sql/sources/DDLSourceLoadSuite
- sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite
- sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/Hive_2_1_DDLSuite

### Why are the changes needed?
Migration on checkError() will make the tests independent from the text of error messages.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
- Manually test.
- Pass GA.