### PR TITLE
[SPARK-44139][SQL] Discard completely pushed down filters in group-based MERGE operations

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryBaseTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryBaseTable.scala
@@ -292,12 +292,31 @@ abstract class InMemoryBaseTable(
     new InMemoryScanBuilder(schema)
   }
 
+  private def canEvaluate(filter: Filter): Boolean = {
+    if (partitioning.length == 1 && partitioning.head.references.length == 1) {
+      filter match {
+        case In(attrName, _) if attrName == partitioning.head.references.head.toString => true
+        case _ => false
+      }
+    } else {
+      false
+    }
+  }
+
   class InMemoryScanBuilder(tableSchema: StructType) extends ScanBuilder
       with SupportsPushDownRequiredColumns with SupportsPushDownFilters {
     private var schema: StructType = tableSchema
+    private var postScanFilters: Array[Filter] = Array.empty
+    private var evaluableFilters: Array[Filter] = Array.empty
+    private var _pushedFilters: Array[Filter] = Array.empty
 
-    override def build: Scan =
-      InMemoryBatchScan(data.map(_.asInstanceOf[InputPartition]), schema, tableSchema)
+    override def build: Scan = {
+      val scan = InMemoryBatchScan(data.map(_.asInstanceOf[InputPartition]), schema, tableSchema)
+      if (evaluableFilters.nonEmpty) {
+        scan.filter(evaluableFilters)
+      }
+      scan
+    }
 
     override def pruneColumns(requiredSchema: StructType): Unit = {
       // The required schema could contain conflict-renamed metadata columns, so we need to match
@@ -310,11 +329,12 @@ abstract class InMemoryBaseTable(
       schema = StructType(prunedFields)
     }
 
-    private var _pushedFilters: Array[Filter] = Array.empty
-
     override def pushFilters(filters: Array[Filter]): Array[Filter] = {
+      val (evaluableFilters, postScanFilters) = filters.partition(canEvaluate)
+      this.evaluableFilters = evaluableFilters
+      this.postScanFilters = postScanFilters
       this._pushedFilters = filters
-      this._pushedFilters
+      postScanFilters
     }
 
     override def pushedFilters(): Array[Filter] = this._pushedFilters

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/GroupBasedRowLevelOperationScanPlanning.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/GroupBasedRowLevelOperationScanPlanning.scala
@@ -17,12 +17,14 @@
 
 package org.apache.spark.sql.execution.datasources.v2
 
-import org.apache.spark.sql.catalyst.expressions.{AttributeReference, AttributeSet, Expression, PredicateHelper, SubqueryExpression}
-import org.apache.spark.sql.catalyst.planning.GroupBasedRowLevelOperation
-import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, ReplaceData}
+import org.apache.spark.sql.catalyst.expressions.{And, AttributeReference, AttributeSet, Expression, ExpressionSet, PredicateHelper, SubqueryExpression}
+import org.apache.spark.sql.catalyst.expressions.Literal.TrueLiteral
+import org.apache.spark.sql.catalyst.planning.{GroupBasedRowLevelOperation, PhysicalOperation}
+import org.apache.spark.sql.catalyst.plans.logical.{Join, LogicalPlan, ReplaceData}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.connector.expressions.filter.{Predicate => V2Filter}
 import org.apache.spark.sql.connector.read.ScanBuilder
+import org.apache.spark.sql.connector.write.RowLevelOperation.Command.MERGE
 import org.apache.spark.sql.execution.datasources.DataSourceStrategy
 import org.apache.spark.sql.sources.Filter
 
@@ -40,10 +42,14 @@ object GroupBasedRowLevelOperationScanPlanning extends Rule[LogicalPlan] with Pr
     // push down the filter from the command condition instead of the filter in the rewrite plan,
     // which is negated for data sources that only support replacing groups of data (e.g. files)
     case GroupBasedRowLevelOperation(rd: ReplaceData, cond, _, relation: DataSourceV2Relation) =>
+      assert(cond.deterministic, "row-level operation conditions must be deterministic")
+
       val table = relation.table.asRowLevelOperationTable
       val scanBuilder = table.newScanBuilder(relation.options)
 
-      val (pushedFilters, remainingFilters) = pushFilters(cond, relation.output, scanBuilder)
+      val (pushedFilters, evaluatedFilters, postScanFilters) =
+        pushFilters(cond, relation.output, scanBuilder)
+
       val pushedFiltersStr = if (pushedFilters.isLeft) {
         pushedFilters.left.get.mkString(", ")
       } else {
@@ -56,29 +62,67 @@ object GroupBasedRowLevelOperationScanPlanning extends Rule[LogicalPlan] with Pr
         s"""
            |Pushing operators to ${relation.name}
            |Pushed filters: $pushedFiltersStr
-           |Filters that were not pushed: ${remainingFilters.mkString(", ")}
+           |Filters evaluated on data source side: ${evaluatedFilters.mkString(", ")}
+           |Filters evaluated on Spark side: ${postScanFilters.mkString(", ")}
            |Output: ${output.mkString(", ")}
          """.stripMargin)
 
-      // replace DataSourceV2Relation with DataSourceV2ScanRelation for the row operation table
-      // there may be multiple read relations for UPDATEs that are rewritten as UNION
-      rd transform {
+      rd transformDown {
+        // simplify the join condition in MERGE operations by discarding already evaluated filters
+        case j @ Join(
+            PhysicalOperation(_, _, r: DataSourceV2Relation), _, _, Some(cond), _)
+            if rd.operation.command == MERGE && evaluatedFilters.nonEmpty && r.table.eq(table) =>
+          j.copy(condition = Some(optimizeMergeJoinCondition(cond, evaluatedFilters)))
+
+        // replace DataSourceV2Relation with DataSourceV2ScanRelation for the row operation table
+        // there may be multiple read relations for UPDATEs that are rewritten as UNION
         case r: DataSourceV2Relation if r.table eq table =>
           DataSourceV2ScanRelation(r, scan, PushDownUtils.toOutputAttrs(scan.readSchema(), r))
       }
   }
 
+  // pushes down the operation condition and returns the following information:
+  // - pushed down filters
+  // - filter expressions that are fully evaluated on the data source side
+  //   (such filters can be discarded and don't have to be evaluated again on the Spark side)
+  // - post-scan filter expressions that must be evaluated on the Spark side
+  //   (such filters can overlap with pushed down filters, e.g. Parquet row group filtering)
   private def pushFilters(
       cond: Expression,
       tableAttrs: Seq[AttributeReference],
-      scanBuilder: ScanBuilder): (Either[Seq[Filter], Seq[V2Filter]], Seq[Expression]) = {
+      scanBuilder: ScanBuilder)
+  : (Either[Seq[Filter], Seq[V2Filter]], Seq[Expression], Seq[Expression]) = {
 
+    val (filtersWithSubquery, filtersWithoutSubquery) = findTableFilters(cond, tableAttrs)
+
+    val (pushedFilters, postScanFiltersWithoutSubquery) =
+      PushDownUtils.pushFilters(scanBuilder, filtersWithoutSubquery)
+
+    val postScanFilterSetWithoutSubquery = ExpressionSet(postScanFiltersWithoutSubquery)
+    val evaluatedFilters = filtersWithoutSubquery.filterNot { filter =>
+      postScanFilterSetWithoutSubquery.contains(filter)
+    }
+
+    val postScanFilters = postScanFiltersWithoutSubquery ++ filtersWithSubquery
+
+    (pushedFilters, evaluatedFilters, postScanFilters)
+  }
+
+  private def findTableFilters(
+      cond: Expression,
+      tableAttrs: Seq[AttributeReference]): (Seq[Expression], Seq[Expression]) = {
     val tableAttrSet = AttributeSet(tableAttrs)
     val filters = splitConjunctivePredicates(cond).filter(_.references.subsetOf(tableAttrSet))
     val normalizedFilters = DataSourceStrategy.normalizeExprs(filters, tableAttrs)
-    val (_, normalizedFiltersWithoutSubquery) =
-      normalizedFilters.partition(SubqueryExpression.hasSubquery)
+    normalizedFilters.partition(SubqueryExpression.hasSubquery)
+  }
 
-    PushDownUtils.pushFilters(scanBuilder, normalizedFiltersWithoutSubquery)
+  private def optimizeMergeJoinCondition(
+      cond: Expression,
+      evaluatedFilters: Seq[Expression]): Expression = {
+    val evaluatedFilterSet = ExpressionSet(evaluatedFilters)
+    val predicates = splitConjunctivePredicates(cond)
+    val remainingPredicates = predicates.filterNot(evaluatedFilterSet.contains)
+    remainingPredicates.reduceLeftOption(And).getOrElse(TrueLiteral)
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR adds logic to discard completely pushed down filters in group-based MERGE operations.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

These changes are needed to simplify join conditions used in group-based MERGE operations to avoid evaluating unnecessary expressions.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

This PR comes with tests.
