### PR TITLE
[SPARK-44147][DOCS] Add `spark.ui.allowFramingFrom` doc to `Security` page

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -290,6 +290,12 @@ The following options control the authentication of Web UIs:
 <table class="table table-striped">
 <thead><tr><th>Property Name</th><th>Default</th><th>Meaning</th><th>Since Version</th></tr></thead>
 <tr>
+  <td><code>spark.ui.allowFramingFrom</code></td>
+  <td><code>SAMEORIGIN</code></td>
+  <td>Allow framing for a specific named URI via <code>X-Frame-Options</code>. By default, allow only from the same origin.</td>
+  <td>1.6.0</td>
+</tr>
+<tr>
   <td><code>spark.ui.filters</code></td>
   <td>None</td>
   <td>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add a documentation for `spark.ui.allowFramingFrom` doc to `Security` page

### Why are the changes needed?

To improve `Security` page.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual generate the document and review.

![Screenshot 2023-06-22 at 10 48 59 AM](https://github.com/apache/spark/assets/9700541/5d2b4c3d-db41-40a8-a3ae-d3e00e5f4df8)
