### PR TITLE
[SPARK-44161][Connect] Handle Row input for UDFs

### DIFF
--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/expressions/UserDefinedFunction.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/expressions/UserDefinedFunction.scala
@@ -22,9 +22,11 @@ import scala.reflect.runtime.universe.TypeTag
 import com.google.protobuf.ByteString
 
 import org.apache.spark.connect.proto
-import org.apache.spark.sql.Column
+import org.apache.spark.sql.{Column, Row}
 import org.apache.spark.sql.catalyst.ScalaReflection
+import org.apache.spark.sql.catalyst.ScalaReflection.localTypeOf
 import org.apache.spark.sql.catalyst.encoders.AgnosticEncoder
+import org.apache.spark.sql.catalyst.encoders.AgnosticEncoders.UnboundRowEncoder
 import org.apache.spark.sql.connect.common.{DataTypeProtoConverter, UdfPacket}
 import org.apache.spark.util.Utils
 
@@ -142,7 +144,15 @@ object ScalarUserDefinedFunction {
 
     ScalarUserDefinedFunction(
       function = function,
-      inputEncoders = parameterTypes.map(tag => ScalaReflection.encoderFor(tag)),
+      // Input can be a row because the input data schema can be found from the plan.
+      inputEncoders = parameterTypes.map(tag =>
+        tag.tpe match {
+          case t if t <:< localTypeOf[Row] =>
+            UnboundRowEncoder
+          case _ =>
+            ScalaReflection.encoderFor(tag)
+        }),
+      // Output cannot be a row as there is no good way to get the return data type.
       outputEncoder = ScalaReflection.encoderFor(returnType))
   }
 

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/expressions/UserDefinedFunction.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/expressions/UserDefinedFunction.scala
@@ -22,11 +22,9 @@ import scala.reflect.runtime.universe.TypeTag
 import com.google.protobuf.ByteString
 
 import org.apache.spark.connect.proto
-import org.apache.spark.sql.{Column, Row}
+import org.apache.spark.sql.Column
 import org.apache.spark.sql.catalyst.ScalaReflection
-import org.apache.spark.sql.catalyst.ScalaReflection.localTypeOf
 import org.apache.spark.sql.catalyst.encoders.AgnosticEncoder
-import org.apache.spark.sql.catalyst.encoders.AgnosticEncoders.UnboundRowEncoder
 import org.apache.spark.sql.connect.common.{DataTypeProtoConverter, UdfPacket}
 import org.apache.spark.util.Utils
 
@@ -145,13 +143,8 @@ object ScalarUserDefinedFunction {
     ScalarUserDefinedFunction(
       function = function,
       // Input can be a row because the input data schema can be found from the plan.
-      inputEncoders = parameterTypes.map(tag =>
-        tag.tpe match {
-          case t if t <:< localTypeOf[Row] =>
-            UnboundRowEncoder
-          case _ =>
-            ScalaReflection.encoderFor(tag)
-        }),
+      inputEncoders =
+        parameterTypes.map(tag => ScalaReflection.encoderForWithRowEncoderSupport(tag)),
       // Output cannot be a row as there is no good way to get the return data type.
       outputEncoder = ScalaReflection.encoderFor(returnType))
   }

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/KeyValueGroupedDatasetE2ETestSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/KeyValueGroupedDatasetE2ETestSuite.scala
@@ -580,6 +580,51 @@ class KeyValueGroupedDatasetE2ETestSuite extends QueryTest with SQLHelper {
 
     checkDataset(values, ClickState("a", 5), ClickState("b", 3), ClickState("c", 1))
   }
+
+  test("RowEncoder in udf") {
+    val ds = Seq(("a", 10), ("a", 20), ("b", 1), ("b", 2), ("c", 1)).toDF("c1", "c2")
+
+    checkDatasetUnorderly(
+      ds.groupByKey(k => k.getAs[String](0)).agg(sum("c2").as[Long]),
+      ("a", 30L),
+      ("b", 3L),
+      ("c", 1L))
+  }
+
+  test("mapGroups with row encoder") {
+    val df = Seq(("a", 10), ("a", 20), ("b", 1), ("b", 2), ("c", 1)).toDF("c1", "c2")
+
+    checkDataset(
+      df.groupByKey(r => r.getAs[String]("c1"))
+        .mapGroups((_, it) =>
+          it.map(r => {
+            r.getAs[Int]("c2")
+          }).sum),
+      30,
+      3,
+      1)
+  }
+
+  test("coGroup with row encoder") {
+    val df1 = Seq(("a", 10), ("a", 20), ("b", 1), ("b", 2), ("c", 1)).toDF("c1", "c2")
+    val df2 = Seq(("x", 10), ("x", 20), ("y", 1), ("y", 2), ("a", 1)).toDF("c1", "c2")
+
+    val ds1: KeyValueGroupedDataset[String, Row] =
+      df1.groupByKey(r => r.getAs[String]("c1"))
+    val ds2: KeyValueGroupedDataset[String, Row] =
+      df2.groupByKey(r => r.getAs[String]("c1"))
+    checkDataset(
+      ds1.cogroup(ds2)((_, it, it2) => {
+        val sum1 = it.map(r => r.getAs[Int]("c2")).sum
+        val sum2 = it2.map(r => r.getAs[Int]("c2")).sum
+        Iterator(sum1 + sum2)
+      }),
+      31,
+      3,
+      1,
+      30,
+      3)
+  }
 }
 
 case class K1(a: Long)

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/UserDefinedFunctionE2ETestSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/UserDefinedFunctionE2ETestSuite.scala
@@ -26,13 +26,13 @@ import scala.collection.JavaConverters._
 import org.apache.spark.TaskContext
 import org.apache.spark.api.java.function._
 import org.apache.spark.sql.catalyst.encoders.AgnosticEncoders.{PrimitiveIntEncoder, PrimitiveLongEncoder}
-import org.apache.spark.sql.connect.client.util.RemoteSparkSession
+import org.apache.spark.sql.connect.client.util.QueryTest
 import org.apache.spark.sql.functions.{col, udf}
 
 /**
  * All tests in this class requires client UDF defined in this test class synced with the server.
  */
-class UserDefinedFunctionE2ETestSuite extends RemoteSparkSession {
+class UserDefinedFunctionE2ETestSuite extends QueryTest {
   test("Dataset typed filter") {
     val rows = spark.range(10).filter(n => n % 2 == 0).collectAsList()
     assert(rows == Arrays.asList[Long](0, 2, 4, 6, 8))
@@ -226,5 +226,27 @@ class UserDefinedFunctionE2ETestSuite extends RemoteSparkSession {
         .reduce(new ReduceFunction[Long] {
           override def call(v1: Long, v2: Long): Long = v1 + v2
         }) == 55)
+  }
+
+  test("Filter with row input encoder") {
+    val session: SparkSession = spark
+    import session.implicits._
+    val df = Seq(("a", 10), ("a", 20), ("b", 1), ("b", 2), ("c", 1)).toDF("c1", "c2")
+
+    checkDataset(df.filter(r => r.getInt(1) > 5), Row("a", 10), Row("a", 20))
+  }
+
+  test("mapPartitions with row input encoder") {
+    val session: SparkSession = spark
+    import session.implicits._
+    val df = Seq(("a", 10), ("a", 20), ("b", 1), ("b", 2), ("c", 1)).toDF("c1", "c2")
+
+    checkDataset(
+      df.mapPartitions(it => it.map(r => r.getAs[String]("c1"))),
+      "a",
+      "a",
+      "b",
+      "b",
+      "c")
   }
 }

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/streaming/StreamingQuerySuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/streaming/StreamingQuerySuite.scala
@@ -215,34 +215,29 @@ class StreamingQuerySuite extends RemoteSparkSession with SQLHelper {
     query.stop()
   }
 
-  // TODO[SPARK-43796]: Enable this test once ammonite client fixes the issue.
-  //  test("foreach Custom class") {
-  //    val session: SparkSession = spark
-  //    import session.implicits._
-  //
-  //    case class TestClass(value: Int) {
-  //      override def toString: String = value.toString
-  //    }
-  //
-  //    val writer = new TestForeachWriter[TestClass]
-  //    val df = spark.readStream
-  //      .format("rate")
-  //      .option("rowsPerSecond", "10")
-  //      .load()
-  //
-  //    val query = df
-  //      .selectExpr("CAST(value AS INT)")
-  //      .as[TestClass]
-  //      .writeStream
-  //      .foreach(writer)
-  //      .outputMode("update")
-  //      .start()
-  //
-  //    assert(query.isActive)
-  //    assert(query.exception.isEmpty)
-  //
-  //    query.stop()
-  //  }
+  test("foreach Custom class") {
+    val session: SparkSession = spark
+    import session.implicits._
+
+    val writer = new TestForeachWriter[TestClass]
+    val df = spark.readStream
+      .format("rate")
+      .option("rowsPerSecond", "10")
+      .load()
+
+    val query = df
+      .selectExpr("CAST(value AS INT)")
+      .as[TestClass]
+      .writeStream
+      .foreach(writer)
+      .outputMode("update")
+      .start()
+
+    assert(query.isActive)
+    assert(query.exception.isEmpty)
+
+    query.stop()
+  }
 
   test("streaming query manager") {
     assert(spark.streams.active.isEmpty)
@@ -292,4 +287,8 @@ class TestForeachWriter[T] extends ForeachWriter[T] {
     fileWriter.close()
     Utils.deleteRecursively(path)
   }
+}
+
+case class TestClass(value: Int) {
+  override def toString: String = value.toString
 }

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.connect.planner
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
+import scala.util.Try
 
 import com.google.common.collect.{Lists, Maps}
 import com.google.protobuf.{Any => ProtoAny, ByteString}
@@ -45,7 +46,6 @@ import org.apache.spark.sql.avro.{AvroDataToCatalyst, CatalystDataToAvro}
 import org.apache.spark.sql.catalyst.{expressions, AliasIdentifier, FunctionIdentifier}
 import org.apache.spark.sql.catalyst.analysis.{GlobalTempView, LocalTempView, MultiAlias, NameParameterizedQuery, PosParameterizedQuery, UnresolvedAlias, UnresolvedAttribute, UnresolvedDeserializer, UnresolvedExtractValue, UnresolvedFunction, UnresolvedRegex, UnresolvedRelation, UnresolvedStar}
 import org.apache.spark.sql.catalyst.encoders.{AgnosticEncoder, ExpressionEncoder, RowEncoder}
-import org.apache.spark.sql.catalyst.encoders.AgnosticEncoders.UnboundRowEncoder
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.parser.{CatalystSqlParser, ParseException, ParserUtils}
 import org.apache.spark.sql.catalyst.plans.{Cross, FullOuter, Inner, JoinType, LeftAnti, LeftOuter, LeftSemi, RightOuter, UsingJoin}
@@ -828,10 +828,9 @@ class SparkConnectPlanner(val sessionHolder: SessionHolder) extends Logging {
     def inputDeserializer(inputAttributes: Seq[Attribute] = Nil): Expression =
       UnresolvedDeserializer(inEnc.deserializer, inputAttributes)
 
-    def outEnc: ExpressionEncoder[_] = ExpressionEncoder(encoderFor(funcOutEnc, "output"))
+    def outEnc: ExpressionEncoder[_] = encoderFor(funcOutEnc, "output")
     def outputObjAttr: Attribute = generateObjAttr(outEnc)
-    def inEnc: ExpressionEncoder[_] = ExpressionEncoder(
-      encoderFor(funcInEnc, "input", inputAttrs))
+    def inEnc: ExpressionEncoder[_] = encoderFor(funcInEnc, "input", inputAttrs)
     def inputObjAttr: Attribute = generateObjAttr(inEnc)
   }
 
@@ -861,15 +860,16 @@ class SparkConnectPlanner(val sessionHolder: SessionHolder) extends Logging {
     def encoderFor(
         encoder: AgnosticEncoder[_],
         errorType: String,
-        inputAttrs: Option[Seq[Attribute]] = None): AgnosticEncoder[_] = {
-      if (encoder == UnboundRowEncoder) { // TODO e.g. product(row, row)
+        inputAttrs: Option[Seq[Attribute]] = None): ExpressionEncoder[_] = {
+      // First try to find the encoder with reflection, if failed
+      // fall back to a row encoder with input schema when the schema is provided.
+      Try(ExpressionEncoder(encoder)).getOrElse(
         inputAttrs
           .map(attrs =>
-            RowEncoder.encoderFor(
-              StructType(attrs.map(a => StructField(a.name, a.dataType, a.nullable)))))
+            ExpressionEncoder(RowEncoder.encoderFor(StructType(attrs.map(a =>
+              StructField(a.name, a.dataType, a.nullable))))))
           .getOrElse(
-            throw InvalidPlanInput(s"Row is not a supported $errorType type for this UDF."))
-      } else encoder
+            throw InvalidPlanInput(s"Row is not a supported $errorType type for this UDF.")))
     }
   }
 
@@ -1477,7 +1477,7 @@ class SparkConnectPlanner(val sessionHolder: SessionHolder) extends Logging {
       function = udfPacket.function,
       dataType = transformDataType(udf.getOutputType),
       children = fun.getArgumentsList.asScala.map(transformExpression).toSeq,
-      inputEncoders = udfPacket.inputEncoders.map(e => Option(ExpressionEncoder(e))),
+      inputEncoders = udfPacket.inputEncoders.map(e => Try(ExpressionEncoder(e)).toOption),
       outputEncoder = Option(ExpressionEncoder(udfPacket.outputEncoder)),
       udfName = Option(fun.getFunctionName),
       nullable = udf.getNullable,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
@@ -29,6 +29,7 @@ import org.apache.commons.lang3.reflect.ConstructorUtils
 
 import org.apache.spark.SPARK_DOC_ROOT
 import org.apache.spark.internal.Logging
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.{expressions => exprs}
 import org.apache.spark.sql.catalyst.DeserializerBuildHelper._
 import org.apache.spark.sql.catalyst.SerializerBuildHelper._
@@ -807,24 +808,37 @@ object ScalaReflection extends ScalaReflection {
   }
 
   /**
+   * Same as [[encoderFor]] but with extended support to return [[UnboundRowEncoder]] for [[Row]]
+   * type.
+   */
+  def encoderForWithRowEncoderSupport[E: TypeTag]: AgnosticEncoder[E] = {
+    encoderFor(typeTag[E].in(mirror).tpe, isRowEncoderSupported = true)
+      .asInstanceOf[AgnosticEncoder[E]]
+  }
+
+  /**
    * Create an [[AgnosticEncoder]] for a [[Type]].
    */
-  def encoderFor(tpe: `Type`): AgnosticEncoder[_] = cleanUpReflectionObjects {
+  def encoderFor(
+     tpe: `Type`,
+     isRowEncoderSupported: Boolean = false): AgnosticEncoder[_] = cleanUpReflectionObjects {
     val clsName = getClassNameFromType(tpe)
     val walkedTypePath = WalkedTypePath().recordRoot(clsName)
-    encoderFor(tpe, Set.empty, walkedTypePath)
+    encoderFor(tpe, Set.empty, walkedTypePath, isRowEncoderSupported)
   }
 
   private def encoderFor(
       tpe: `Type`,
       seenTypeSet: Set[`Type`],
-      path: WalkedTypePath): AgnosticEncoder[_] = {
+      path: WalkedTypePath,
+      isRowEncoderSupported: Boolean): AgnosticEncoder[_] = {
     def createIterableEncoder(t: `Type`, fallbackClass: Class[_]): AgnosticEncoder[_] = {
       val TypeRef(_, _, Seq(elementType)) = t
       val encoder = encoderFor(
         elementType,
         seenTypeSet,
-        path.recordArray(getClassNameFromType(elementType)))
+        path.recordArray(getClassNameFromType(elementType)),
+        isRowEncoderSupported)
       val companion = t.dealias.typeSymbol.companion.typeSignature
       val targetClass = companion.member(TermName("newBuilder")) match {
         case NoSymbol => fallbackClass
@@ -888,6 +902,7 @@ object ScalaReflection extends ScalaReflection {
       case t if isSubtype(t, localTypeOf[java.sql.Timestamp]) => STRICT_TIMESTAMP_ENCODER
       case t if isSubtype(t, localTypeOf[java.time.Instant]) => STRICT_INSTANT_ENCODER
       case t if isSubtype(t, localTypeOf[java.time.LocalDateTime]) => LocalDateTimeEncoder
+      case t if isSubtype(t, localTypeOf[Row]) => UnboundRowEncoder
 
       // UDT encoders
       case t if t.typeSymbol.annotations.exists(_.tree.tpe =:= typeOf[SQLUserDefinedType]) =>
@@ -907,7 +922,8 @@ object ScalaReflection extends ScalaReflection {
         val encoder = encoderFor(
           optType,
           seenTypeSet,
-          path.recordOption(getClassNameFromType(optType)))
+          path.recordOption(getClassNameFromType(optType)),
+          isRowEncoderSupported)
         OptionEncoder(encoder)
 
       case t if isSubtype(t, localTypeOf[Array[_]]) =>
@@ -915,7 +931,8 @@ object ScalaReflection extends ScalaReflection {
         val encoder = encoderFor(
           elementType,
           seenTypeSet,
-          path.recordArray(getClassNameFromType(elementType)))
+          path.recordArray(getClassNameFromType(elementType)),
+          isRowEncoderSupported)
         ArrayEncoder(encoder, encoder.nullable)
 
       case t if isSubtype(t, localTypeOf[scala.collection.Seq[_]]) =>
@@ -929,11 +946,13 @@ object ScalaReflection extends ScalaReflection {
         val keyEncoder = encoderFor(
           keyType,
           seenTypeSet,
-          path.recordKeyForMap(getClassNameFromType(keyType)))
+          path.recordKeyForMap(getClassNameFromType(keyType)),
+          isRowEncoderSupported)
         val valueEncoder = encoderFor(
           valueType,
           seenTypeSet,
-          path.recordValueForMap(getClassNameFromType(valueType)))
+          path.recordValueForMap(getClassNameFromType(valueType)),
+          isRowEncoderSupported)
         MapEncoder(ClassTag(getClassFromType(t)), keyEncoder, valueEncoder, valueEncoder.nullable)
 
       case t if definedByConstructorParams(t) =>
@@ -951,7 +970,8 @@ object ScalaReflection extends ScalaReflection {
             val encoder = encoderFor(
               fieldType,
               seenTypeSet + t,
-              path.recordField(getClassNameFromType(fieldType), fieldName))
+              path.recordField(getClassNameFromType(fieldType), fieldName),
+              isRowEncoderSupported)
             EncoderField(fieldName, encoder, encoder.nullable, Metadata.empty)
         }
         ProductEncoder(ClassTag(getClassFromType(t)), params)

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamWriter.scala
@@ -451,16 +451,14 @@ final class DataStreamWriter[T] private[sql](ds: Dataset[T]) {
   }
 
   private[sql] def foreachImplementation(writer: ForeachWriter[Any],
-      encoder: ExpressionEncoder[Any] = null): DataStreamWriter[T] = {
+      encoder: Option[ExpressionEncoder[Any]] = None): DataStreamWriter[T] = {
     this.source = SOURCE_NAME_FOREACH
     this.foreachWriter = if (writer != null) {
       ds.sparkSession.sparkContext.clean(writer)
     } else {
       throw new IllegalArgumentException("foreach writer cannot be null")
     }
-    if (encoder != null) {
-      this.foreachWriterEncoder = encoder
-    }
+    encoder.foreach(e => this.foreachWriterEncoder = e)
     this
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -68,6 +68,14 @@ class DatasetSuite extends QueryTest
 
   private implicit val ordering = Ordering.by((c: ClassData) => c.a -> c.b)
 
+  test("udf with row input encoder") {
+    val session: SparkSession = spark
+    import session.implicits._
+    val df = Seq((1, 2, 3)).toDF("a", "b", "c")
+    val f = functions.udf((row: Row) => row.schema.fieldNames)
+    checkDataset(df.select(f(struct(df.columns map col: _*))), Row(1, 2, 3))
+  }
+
   test("checkAnswer should compare map correctly") {
     val data = Seq((1, "2", Map(1 -> 2, 2 -> 1)))
     checkAnswer(

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -68,14 +68,6 @@ class DatasetSuite extends QueryTest
 
   private implicit val ordering = Ordering.by((c: ClassData) => c.a -> c.b)
 
-  test("udf with row input encoder") {
-    val session: SparkSession = spark
-    import session.implicits._
-    val df = Seq((1, 2, 3)).toDF("a", "b", "c")
-    val f = functions.udf((row: Row) => row.schema.fieldNames)
-    checkDataset(df.select(f(struct(df.columns map col: _*))), Row(1, 2, 3))
-  }
-
   test("checkAnswer should compare map correctly") {
     val data = Seq((1, "2", Map(1 -> 2, 2 -> 1)))
     checkAnswer(


### PR DESCRIPTION
### What changes were proposed in this pull request?
If the client passes Rows as inputs to UDFs, the Spark connect planner will fail to create the RowEncoder for the Row input. 

The Row encoder sent by the client contains no field or schema information. The real input schema should be obtained from the plan's output.

This PR ensures if the server planner failed to create the encoder for the UDF input using reflection, then it will fall back to use RowEncoders created from the plan.output schema.

This PR fixed [SPARK-43761](https://issues.apache.org/jira/browse/SPARK-43761) using the same logic.
This PR resolved [SPARK-43796](https://issues.apache.org/jira/browse/SPARK-43796). The error is just caused by the case class defined in the test.

### Why are the changes needed?
Fix the bug where the Row cannot be used as UDF inputs.


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
E2E tests.