### PR TITLE
[SPARK-44151][BUILD] Upgrade `commons-codec` to 1.16.0

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -36,7 +36,7 @@ cats-kernel_2.12/2.1.1//cats-kernel_2.12-2.1.1.jar
 chill-java/0.10.0//chill-java-0.10.0.jar
 chill_2.12/0.10.0//chill_2.12-0.10.0.jar
 commons-cli/1.5.0//commons-cli-1.5.0.jar
-commons-codec/1.15//commons-codec-1.15.jar
+commons-codec/1.16.0//commons-codec-1.16.0.jar
 commons-collections/3.2.2//commons-collections-3.2.2.jar
 commons-collections4/4.4//commons-collections4-4.4.jar
 commons-compiler/3.1.9//commons-compiler-3.1.9.jar

--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,7 @@
     <fasterxml.jackson.databind.version>2.15.2</fasterxml.jackson.databind.version>
     <snappy.version>1.1.10.1</snappy.version>
     <netlib.ludovic.dev.version>3.0.3</netlib.ludovic.dev.version>
-    <commons-codec.version>1.15</commons-codec.version>
+    <commons-codec.version>1.16.0</commons-codec.version>
     <commons-compress.version>1.23.0</commons-compress.version>
     <commons-io.version>2.13.0</commons-io.version>
     <!-- org.apache.commons/commons-lang/-->


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade commons-codec from 1.15 to 1.16.0.

### Why are the changes needed?
1.The new version brings some bug fixed, eg:
- Fix byte-skipping in Base16 decoding #135. Fixes CODEC-305. 
- BaseNCodecOutputStream.eof() should not throw IOException.
- Add support for Blake3 family of hashes. Fixes [CODEC-296](https://issues.apache.org/jira/browse/CODEC-296).

2.The full release notes:
https://commons.apache.org/proper/commons-codec/changes-report.html#a1.16.0

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA.