### PR TITLE
[SPARK-43255][SQL] Replace the error class _LEGACY_ERROR_TEMP_2020 by an internal error

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -4223,11 +4223,6 @@
       "class `<cls>` is not supported by `MapObjects` as resulting collection."
     ]
   },
-  "_LEGACY_ERROR_TEMP_2020" : {
-    "message" : [
-      "Couldn't find a valid constructor on <cls>."
-    ]
-  },
   "_LEGACY_ERROR_TEMP_2021" : {
     "message" : [
       "Couldn't find a primary constructor on <cls>."

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -457,7 +457,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase {
 
   def constructorNotFoundError(cls: String): Throwable = {
     SparkException.internalError(
-      s"Couldn't find a valid constructor on "$cls".")
+      s"""Couldn't find a valid constructor on "$cls".""")
   }
 
   def primaryConstructorNotFoundError(cls: Class[_]): SparkRuntimeException = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -455,10 +455,9 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase {
       s"""A method named "$name" is not declared in any enclosing class nor any supertype""")
   }
 
-  def constructorNotFoundError(cls: String): SparkRuntimeException = {
-    new SparkRuntimeException(
-      errorClass = "_LEGACY_ERROR_TEMP_2020",
-      messageParameters = Map("cls" -> cls))
+  def constructorNotFoundError(cls: String): Throwable = {
+    SparkException.internalError(
+      s"Couldn't find a valid constructor on "$cls".")
   }
 
   def primaryConstructorNotFoundError(cls: Class[_]): SparkRuntimeException = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Change the error class_LEGACY_ERROR_TEMP_2020 to internal error as it is not reproducable from user space(using SQL).

### Why are the changes needed?
Fix jira issue [SPARK-43255](https://issues.apache.org/jira/browse/SPARK-43255).  By oberserving functions where throw *'constructorNotFoundError'*,  I think this error class could be replaced with internal error.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Already exist tests.