### PR TITLE
[SPARK-43969][SQL][TESTS][FOLLOWUP] Update  `numeric.sql.out.java21`

### DIFF
--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/numeric.sql.out.java21
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/numeric.sql.out.java21
@@ -3832,12 +3832,11 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "INSERT_COLUMN_ARITY_MISMATCH",
+  "errorClass" : "INSERT_COLUMN_ARITY_MISMATCH.TOO_MANY_DATA_COLUMNS",
   "sqlState" : "21S01",
   "messageParameters" : {
-    "dataColumns" : "'id', 'id', 'val', 'val', '(val * val)'",
-    "reason" : "too many data columns",
-    "tableColumns" : "'id1', 'id2', 'result'",
+    "dataColumns" : "`id`, `id`, `val`, `val`, `(val * val)`",
+    "tableColumns" : "`id1`, `id2`, `result`",
     "tableName" : "`spark_catalog`.`default`.`num_result`"
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
https://github.com/apache/spark/pull/41458 updated `numeric.sql.out` but not update `numeric.sql.out.java21`, this pr updated `numeric.sql.out.java21` for Java 21.


### Why are the changes needed?
Fix golden file for Java 21.

https://github.com/apache/spark/actions/runs/5362442727/jobs/9729315685

```
[info] - postgreSQL/numeric.sql *** FAILED *** (1 minute, 4 seconds)
[info]   postgreSQL/numeric.sql
[info]   Expected "...OLUMN_ARITY_MISMATCH[",
[info]     "sqlState" : "21S01",
[info]     "messageParameters" : {
[info]       "dataColumns" : "'id', 'id', 'val', 'val', '(val * val)'",
[info]       "reason" : "too many data columns",
[info]       "tableColumns" : "'id1', 'id2', 'result']",
[info]       "tableName" :...", but got "...OLUMN_ARITY_MISMATCH[.TOO_MANY_DATA_COLUMNS",
[info]     "sqlState" : "21S01",
[info]     "messageParameters" : {
[info]       "dataColumns" : "`id`, `id`, `val`, `val`, `(val * val)`",
[info]       "tableColumns" : "`id1`, `id2`, `result`]",
[info]       "tableName" :..." Result did not match for query #474
[info]   INSERT INTO num_result SELECT t1.id, t2.id, t1.val, t2.val, t1.val * t2.val
[info]       FROM num_data t1, num_data t2 (SQLQueryTestSuite.scala:848)
[info]   org.scalatest.exceptions.TestFailedException:
[info]   at org.scalatest.Assertions.newAssertionFailedException(Assertions.scala:472)
[info]   at org.scalatest.Assertions.newAssertionFailedException$(Assertions.scala:471)
[info]   at org.scalatest.funsuite.AnyFunSuite.newAssertionFailedException(AnyFunSuite.scala:1564)
[info]   at org.scalatest.Assertions.assertResult(Assertions.scala:847)
[info]   at org.scalatest.Assertions.assertResult$(Assertions.scala:842)
[info]   at org.scalatest.funsuite.AnyFunSuite.assertResult(AnyFunSuite.scala:1564)
[info]   at org.apache.spark.sql.SQLQueryTestSuite.$anonfun$readGoldenFileAndCompareResults$3(SQLQueryTestSuite.scala:848)
```

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass GitHub Actions
- Manual checked using Java 21