### PR TITLE
[SPARK-44174][SQL][TESTS] Fix `QueryExecutionErrorsSuite` for Java 21

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
@@ -41,7 +41,6 @@ import org.apache.spark.sql.execution.datasources.orc.OrcTest
 import org.apache.spark.sql.execution.datasources.parquet.ParquetTest
 import org.apache.spark.sql.execution.datasources.v2.jdbc.JDBCTableCatalog
 import org.apache.spark.sql.execution.streaming.FileSystemBasedCheckpointFileManager
-import org.apache.spark.sql.expressions.SparkUserDefinedFunction
 import org.apache.spark.sql.functions.{lit, lower, struct, sum, udf}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.LegacyBehaviorPolicy.EXCEPTION
@@ -411,7 +410,7 @@ class QueryExecutionErrorsSuite
     }
     assert(e.getCause.isInstanceOf[SparkException])
     val functionNameRegex = if (Utils.isJavaVersionAtLeast21) {
-      "`luckyCharOfWord \\(QueryExecutionErrorsSuite\\$\\$Lambda/0x[0-9a-f]+\\)`"
+      "`luckyCharOfWord \\(QueryExecutionErrorsSuite\\$\\$Lambda/\\w+\\)`"
     } else {
       "`luckyCharOfWord \\(QueryExecutionErrorsSuite\\$\\$Lambda\\$\\d+/\\w+\\)`"
     }
@@ -436,7 +435,7 @@ class QueryExecutionErrorsSuite
     }
     assert(e.getCause.isInstanceOf[SparkException])
     val functionNameRegex = if (Utils.isJavaVersionAtLeast21) {
-      "`QueryExecutionErrorsSuite\\$\\$Lambda/0x[0-9a-f]+`"
+      "`QueryExecutionErrorsSuite\\$\\$Lambda/\\w+`"
     } else {
       "`QueryExecutionErrorsSuite\\$\\$Lambda\\$\\d+/\\w+`"
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr change to use new `functionNameRegex` to fix the following test case in `QueryExecutionErrorsSuite` for Java 21:

- `FAILED_EXECUTE_UDF: execute user defined function with registered UDF`
- `FAILED_EXECUTE_UDF: execute user defined function`


### Why are the changes needed?
After https://bugs.openjdk.org/browse/JDK-8292914

The format of the lambda-class name change from

`<declaring_class>$$Lambda$<counter>/#<hidden_class_reference>`

to

`<declaring_class>$$Lambda/#<hidden_class_reference>` 

So the check condition of test cases should be changed accordingly for Java 21




### Does this PR introduce _any_ user-facing change?
No, just for test


### How was this patch tested?
- Pass GitHub Actions
- Checked

```
java -version
openjdk version "21-ea" 2023-09-19
OpenJDK Runtime Environment Zulu21+57-CA (build 21-ea+22)
OpenJDK 64-Bit Server VM Zulu21+57-CA (build 21-ea+22, mixed mode, sharing)
```

```
build/sbt clean "sql/testOnly org.apache.spark.sql.errors.QueryExecutionErrorsSuite"  
```

Before

```
[info] - FAILED_EXECUTE_UDF: execute user defined function with registered UDF *** FAILED *** (78 milliseconds)
[info]   java.lang.IllegalArgumentException: For parameter 'functionName' value '`luckyCharOfWord (QueryExecutionErrorsSuite$$Lambda/0x00000008022254b8)`' does not match: `luckyCharOfWord \(QueryExecutionErrorsSuite\$\$Lambda\$\d+/\w+\)`
[info]   at org.apache.spark.SparkFunSuite.$anonfun$checkError$2(SparkFunSuite.scala:333)
[info]   at org.apache.spark.SparkFunSuite.$anonfun$checkError$2$adapted(SparkFunSuite.scala:328)
[info]   at scala.collection.Iterator.foreach(Iterator.scala:943)
[info]   at scala.collection.Iterator.foreach$(Iterator.scala:943)
[info]   at scala.collection.AbstractIterator.foreach(Iterator.scala:1431)
[info]   at scala.collection.IterableLike.foreach(IterableLike.scala:74)
[info]   at scala.collection.IterableLike.foreach$(IterableLike.scala:73)
[info]   at scala.collection.AbstractIterable.foreach(Iterable.scala:56)
...
[info] - FAILED_EXECUTE_UDF: execute user defined function *** FAILED *** (33 milliseconds)
[info]   java.lang.IllegalArgumentException: For parameter 'functionName' value '`QueryExecutionErrorsSuite$$Lambda/0x000000080225d710`' does not match: `QueryExecutionErrorsSuite\$\$Lambda\$\d+/\w+`
[info]   at org.apache.spark.SparkFunSuite.$anonfun$checkError$2(SparkFunSuite.scala:333)
[info]   at org.apache.spark.SparkFunSuite.$anonfun$checkError$2$adapted(SparkFunSuite.scala:328)
[info]   at scala.collection.Iterator.foreach(Iterator.scala:943)
[info]   at scala.collection.Iterator.foreach$(Iterator.scala:943)
[info]   at scala.collection.AbstractIterator.foreach(Iterator.scala:1431)
...
[info] Run completed in 9 seconds, 467 milliseconds.
[info] Total number of tests run: 39
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 37, failed 2, canceled 0, ignored 0, pending 0
[info] *** 2 TESTS FAILED ***
[error] Failed tests:
[error]   org.apache.spark.sql.errors.QueryExecutionErrorsSuite
[error] (sql / Test / testOnly) sbt.TestsFailedException: Tests unsuccessful

```


After

```
[info] Run completed in 9 seconds, 678 milliseconds.
[info] Total number of tests run: 39
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 39, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
```
