### PR TITLE
[SPARK-44179][CORE]Fix the number of executors is calculated incorrctly when the task fails and it is speculated that the task is still executing

### DIFF
--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
@@ -761,10 +761,6 @@ private[spark] class ExecutorAllocationManager(
           val map = stageAttemptToRunningSpeculativeTasks.getOrElseUpdate(stageAttempt,
             new mutable.HashMap[Int, Int])
           map(taskIndex) = map.getOrElse(taskIndex, 0) + 1
-          if (map(taskIndex) == 2) {
-            stageAttemptToTaskIndices.getOrElseUpdate(stageAttempt,
-              new mutable.HashSet[Int]) += taskIndex
-          }
           stageAttemptToPendingSpeculativeTasks
             .get(stageAttempt).foreach(_.remove(taskIndex))
         } else {

--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
@@ -818,9 +818,9 @@ private[spark] class ExecutorAllocationManager(
               // case, the task index is completed and we shouldn't remove it from
               // stageAttemptToTaskIndices. Otherwise, we will have a pending non-speculative task
               // for the task index (SPARK-30511)
-              val map = stageAttemptToRunningSpeculativeTasks.getOrElseUpdate(stageAttempt,
+              val runningSpeculativeTasksMap = stageAttemptToRunningSpeculativeTasks.getOrElseUpdate(stageAttempt,
                 new mutable.HashMap[Int, Int])
-              if (map.getOrElse(taskIndex, 0) == 0) {
+              if (runningSpeculativeTasksMap.getOrElse(taskIndex, 0) == 0) {
                 stageAttemptToTaskIndices.get(stageAttempt).foreach {
                   _.remove(taskIndex)
                 }

--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
@@ -818,7 +818,8 @@ private[spark] class ExecutorAllocationManager(
               // case, the task index is completed and we shouldn't remove it from
               // stageAttemptToTaskIndices. Otherwise, we will have a pending non-speculative task
               // for the task index (SPARK-30511)
-              val runningSpeculativeTasksMap = stageAttemptToRunningSpeculativeTasks.getOrElseUpdate(stageAttempt,
+              val runningSpeculativeTasksMap =
+              stageAttemptToRunningSpeculativeTasks.getOrElseUpdate(stageAttempt,
                 new mutable.HashMap[Int, Int])
               if (runningSpeculativeTasksMap.getOrElse(taskIndex, 0) == 0) {
                 stageAttemptToTaskIndices.get(stageAttempt).foreach {

--- a/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
@@ -1780,7 +1780,7 @@ class ExecutorAllocationManagerSuite extends SparkFunSuite {
     assert(numExecutorsTargetForDefaultProfileId(manager) === 1)
   }
 
-  test("SPARK-MI: Fix a bug where the number of executors is calculated incorrectly " +
+  test("SPARK-44179: Fix a bug where the number of executors is calculated incorrectly " +
     "when the task fails and it is speculated that the task is still executing") {
     val clock = new ManualClock()
     val manager = createManager(createConf(0, 10, 0), clock)
@@ -1798,8 +1798,6 @@ class ExecutorAllocationManagerSuite extends SparkFunSuite {
     val taskInfo1_2 = createTaskInfo(1, 1, "executor-1_2", true)
     post(SparkListenerTaskStart(1, 0, taskInfo0))
     post(SparkListenerTaskStart(1, 0, taskInfo1))
-    // Verify that we're capped at number of tasks including the speculative ones in the stage
-    // post(speculativeTaskSubmitEventFromTaskIndex(1, taskIndex = 0))
 
     assert(numExecutorsTargetForDefaultProfileId(manager) === 0)
     assert(numExecutorsToAddForDefaultProfile(manager) === 1)
@@ -1825,7 +1823,6 @@ class ExecutorAllocationManagerSuite extends SparkFunSuite {
     assert(numExecutorsTargetForDefaultProfileId(manager) === 4)
     assert(numExecutorsToAddForDefaultProfile(manager) === 1)
 
-
     val taskEndReason = ExceptionFailure(null, null, null, null, None)
     post(SparkListenerTaskEnd(1, 0, null, taskEndReason, taskInfo0, new ExecutorMetrics, null))
     post(SparkListenerTaskEnd(1, 0, null, taskEndReason, taskInfo1, new ExecutorMetrics, null))
@@ -1837,10 +1834,8 @@ class ExecutorAllocationManagerSuite extends SparkFunSuite {
     assert(numExecutorsToAddForDefaultProfile(manager) === 1)
     assert(addExecutorsToTargetForDefaultProfile(manager, updatesNeeded) === 0)
 
-
     post(SparkListenerTaskStart(1, 0, taskInfo0_2))
     post(SparkListenerTaskStart(1, 0, taskInfo1_2))
-    // Verify that running a task doesn't affect the target
 
     assert(numExecutorsTargetForDefaultProfileId(manager) === 2)
     assert(numExecutorsToAddForDefaultProfile(manager) === 1)


### PR DESCRIPTION

### What changes were proposed in this pull request?
The dynamic scheduler listener keeps track of the number of running speculative tasks. When a task fails and is not a speculative task, and its corresponding speculative task is still running, the stageAttemptToTaskIndices will not remove the task index.



### Why are the changes needed?
Assuming a stage has Task 1, with Task 1.0 and a speculative task Task 1.1 running concurrently, the dynamic scheduler calculates the number of executors as 2 (pendingTask: 0, pendingSpeculative: 0, running: 2).

At this point, Task 1.0 fails, and the dynamic scheduler recalculates the number of executors as 2 (pendingTask: 1, pendingSpeculative: 0, running: 1).

Due to the failure of Task 1.0, copyRunning(1) becomes 1. As a result, Task 1 is speculated again and a SparkListenerSpeculativeTaskSubmitted event is triggered. However, the dynamic scheduler's calculation for the number of executors becomes 3 (pendingTask: 1, pendingSpeculative: 1, running: 1), which is obviously not as expected.

Then, Task 1.2 starts, and it is marked as a speculative task. However, the dynamic scheduler still calculates the number of executors as 3 (pendingTask: 1, pendingSpeculative: 1, running: 1), which again is not as expected.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
add ut
