### PR TITLE
[SPARK-44183][PYTHON] Increase `PyArrow` minimum version to 4.0.0

### DIFF
--- a/python/docs/source/getting_started/install.rst
+++ b/python/docs/source/getting_started/install.rst
@@ -157,7 +157,7 @@ Package                    Minimum supported version Note
 ========================== ========================= ======================================================================================
 `py4j`                     0.10.9.7                  Required
 `pandas`                   1.0.5                     Required for pandas API on Spark and Spark Connect; Optional for Spark SQL
-`pyarrow`                  1.0.0                     Required for pandas API on Spark and Spark Connect; Optional for Spark SQL
+`pyarrow`                  4.0.0                     Required for pandas API on Spark and Spark Connect; Optional for Spark SQL
 `numpy`                    1.15                      Required for pandas API on Spark and MLLib DataFrame-based API; Optional for Spark SQL
 `grpc`                     1.48.1                    Required for Spark Connect
 `grpcio-status`            1.48.1                    Required for Spark Connect
@@ -168,10 +168,3 @@ Note that PySpark requires Java 8 or later with ``JAVA_HOME`` properly set.
 If using JDK 11, set ``-Dio.netty.tryReflectionSetAccessible=true`` for Arrow related features and refer
 to |downloading|_.
 
-Note for AArch64 (ARM64) users: PyArrow is required by PySpark SQL, but PyArrow support for AArch64
-is introduced in PyArrow 4.0.0. If PySpark installation fails on AArch64 due to PyArrow
-installation errors, you can install PyArrow >= 4.0.0 as below:
-
-.. code-block:: bash
-
-    pip install "pyarrow>=4.0.0" --prefer-binary

--- a/python/docs/source/user_guide/sql/arrow_pandas.rst
+++ b/python/docs/source/user_guide/sql/arrow_pandas.rst
@@ -392,6 +392,25 @@ For usage with pyspark.sql, the minimum supported versions of Pandas is 1.0.5 an
 Higher versions may be used, however, compatibility and data correctness can not be guaranteed and should
 be verified by the user.
 
+Compatibility Setting for PyArrow >= 0.15.0 and Spark 2.3.x, 2.4.x
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Since Arrow 0.15.0, a change in the binary IPC format requires an environment variable to be
+compatible with previous versions of Arrow <= 0.14.1. This is only necessary to do for PySpark
+users with versions 2.3.x and 2.4.x that have manually upgraded PyArrow to 0.15.0. The following
+can be added to ``conf/spark-env.sh`` to use the legacy Arrow IPC format:
+
+.. code-block:: bash
+
+    ARROW_PRE_0_15_IPC_FORMAT=1
+
+
+This will instruct PyArrow >= 0.15.0 to use the legacy IPC format with the older Arrow Java that
+is in Spark 2.3.x and 2.4.x. Not setting this environment variable will lead to a similar error as
+described in `SPARK-29367 <https://issues.apache.org/jira/browse/SPARK-29367>`_ when running
+``pandas_udf``\s or :meth:`DataFrame.toPandas` with Arrow enabled. More information about the Arrow IPC change can
+be read on the Arrow 0.15.0 release `blog <https://arrow.apache.org/blog/2019/10/06/0.15.0-release/#columnar-streaming-protocol-change-since-0140>`_.
+
 Setting Arrow ``self_destruct`` for memory savings
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/python/docs/source/user_guide/sql/arrow_pandas.rst
+++ b/python/docs/source/user_guide/sql/arrow_pandas.rst
@@ -388,28 +388,9 @@ working with timestamps in ``pandas_udf``\s to get the best performance, see
 Recommended Pandas and PyArrow Versions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-For usage with pyspark.sql, the minimum supported versions of Pandas is 1.0.5 and PyArrow is 1.0.0.
+For usage with pyspark.sql, the minimum supported versions of Pandas is 1.0.5 and PyArrow is 4.0.0.
 Higher versions may be used, however, compatibility and data correctness can not be guaranteed and should
 be verified by the user.
-
-Compatibility Setting for PyArrow >= 0.15.0 and Spark 2.3.x, 2.4.x
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Since Arrow 0.15.0, a change in the binary IPC format requires an environment variable to be
-compatible with previous versions of Arrow <= 0.14.1. This is only necessary to do for PySpark
-users with versions 2.3.x and 2.4.x that have manually upgraded PyArrow to 0.15.0. The following
-can be added to ``conf/spark-env.sh`` to use the legacy Arrow IPC format:
-
-.. code-block:: bash
-
-    ARROW_PRE_0_15_IPC_FORMAT=1
-
-
-This will instruct PyArrow >= 0.15.0 to use the legacy IPC format with the older Arrow Java that
-is in Spark 2.3.x and 2.4.x. Not setting this environment variable will lead to a similar error as
-described in `SPARK-29367 <https://issues.apache.org/jira/browse/SPARK-29367>`_ when running
-``pandas_udf``\s or :meth:`DataFrame.toPandas` with Arrow enabled. More information about the Arrow IPC change can
-be read on the Arrow 0.15.0 release `blog <https://arrow.apache.org/blog/2019/10/06/0.15.0-release/#columnar-streaming-protocol-change-since-0140>`_.
 
 Setting Arrow ``self_destruct`` for memory savings
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/python/pyspark/sql/pandas/utils.py
+++ b/python/pyspark/sql/pandas/utils.py
@@ -44,7 +44,7 @@ def require_minimum_pandas_version() -> None:
 def require_minimum_pyarrow_version() -> None:
     """Raise ImportError if minimum version of pyarrow is not installed"""
     # TODO(HyukjinKwon): Relocate and deduplicate the version specification.
-    minimum_pyarrow_version = "1.0.0"
+    minimum_pyarrow_version = "4.0.0"
 
     from distutils.version import LooseVersion
     import os

--- a/python/setup.py
+++ b/python/setup.py
@@ -131,7 +131,7 @@ if in_spark:
 # binary format protocol with the Java version, see ARROW_HOME/format/* for specifications.
 # Also don't forget to update python/docs/source/getting_started/install.rst.
 _minimum_pandas_version = "1.0.5"
-_minimum_pyarrow_version = "1.0.0"
+_minimum_pyarrow_version = "4.0.0"
 _minimum_grpc_version = "1.48.1"
 _minimum_googleapis_common_protos_version = "1.56.4"
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to increase `PyArrow` minimum version from `1.0.0` to `4.0.0` in Apache Spark 3.5.0 because
- PyArrow 4.0.0 starts to support `ARM64` officially.
- Most user environments are using PyArrow 9.0.0 already. If possible, we had better set the minimum to at least 9.0.0 later because Arrow 9.0 started to support Java 17+ via [ARROW-15179](https://issues.apache.org/jira/browse/ARROW-15179).

### Why are the changes needed?

PyArrow 1.0.0 was released 3 year ago and the latest version is PyArrow 12.0.1.

- https://pypi.org/project/pyarrow/12.0.1/ (Jun 13, 2023)
- https://pypi.org/project/pyarrow/9.0.0/ (Aug 3, 2022)
- https://pypi.org/project/pyarrow/8.0.0/ (May 6, 2022)
- https://pypi.org/project/pyarrow/4.0.0/ (Apr 26, 2021)
- https://pypi.org/project/pyarrow/1.0.0/ (Jul 24, 2020)

Most recent notebook-based community moved to Python 3.10 and PyArrow 9.0 already.

**Google Colab**

![Screenshot 2023-06-25 at 3 01 38 PM](https://github.com/apache/spark/assets/9700541/e4d3b8cb-2cd2-4bc9-9608-baf1c4101366)
 
**Kaggle**

![Screenshot 2023-06-25 at 3 07 43 PM](https://github.com/apache/spark/assets/9700541/1259c9ee-f11f-47be-9fcb-6b6fe9332cb2)


### Does this PR introduce _any_ user-facing change?

PyArrow 4.0 was also released over 2 years ago.
I believe most Spark 3.5 customers are not affected.

### How was this patch tested?

N/A.