### PR TITLE
[SPARK-44185][SQL] Fix inconsistent path qualifying between catalog and data operations

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -416,7 +416,7 @@ class SessionCatalog(
     }
   }
 
-  private def makeQualifiedTablePath(locationUri: URI, database: String): URI = {
+  def makeQualifiedTablePath(locationUri: URI, database: String): URI = {
     if (locationUri.isAbsolute) {
       locationUri
     } else if (new Path(locationUri).isAbsolute) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ddl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ddl.scala
@@ -59,6 +59,15 @@ case class CreateTable(
   override protected def withNewChildrenInternal(
       newChildren: IndexedSeq[LogicalPlan]): LogicalPlan =
     copy(query = if (query.isDefined) Some(newChildren.head) else None)
+
+  /**
+   * Identifies the underlying table's location is qualified or absent.
+   *
+   * @return true if the location is absolute or absent, false otherwise.
+   */
+  def locationQualifiedOrAbsent: Boolean = {
+    tableDesc.storage.locationUri.map(_.isAbsolute).getOrElse(true)
+  }
 }
 
 /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala
@@ -195,6 +195,7 @@ abstract class BaseSessionStateBuilder(
 
     override val postHocResolutionRules: Seq[Rule[LogicalPlan]] =
       DetectAmbiguousSelfJoin +:
+        QualifyLocationWithWarehouse(catalog) +:
         PreprocessTableCreation(catalog) +:
         PreprocessTableInsertion +:
         DataSourceAnalysis +:

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/TableLocationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/TableLocationSuite.scala
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources
+
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.sql.{AnalysisException, QueryTest}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SharedSparkSession
+
+class TableLocationSuite extends QueryTest with SharedSparkSession {
+
+  test("relative LOCATION in CTAS should be qualified with warehouse") {
+    withSQLConf(SQLConf.ALLOW_NON_EMPTY_LOCATION_IN_CTAS.key -> "false") {
+      withTable("ctas1", "ctas2") {
+        sql("CREATE TABLE ctas1 USING parquet AS SELECT 1 AS ID")
+        val m = intercept[AnalysisException] {
+          // 'ctas1' should be qualified with warehouse path for the checker as same as
+          // table creation in catalog. Otherwise, the data could be polluted accidentally.
+          sql("CREATE TABLE ctas2 USING parquet LOCATION 'ctas1' AS SELECT 1 AS ID")
+        }.getMessage
+        assert(m.contains("CREATE-TABLE-AS-SELECT cannot create table with location to a " +
+          "non-empty directory"))
+      }
+    }
+  }
+
+
+  test("relative LOCATION with Append SaveMode shall check the qualified path") {
+    withTable("ctas1", "ctas2") {
+      sql("CREATE TABLE ctas1 USING parquet AS SELECT 1L AS ID")
+      spark.range(10)
+        .write
+        .mode("append")
+        .option("path", "ctas1")
+        .format("parquet")
+        .saveAsTable("ctas2")
+      checkAnswer(spark.table("ctas1"), spark.table("ctas2"))
+    }
+  }
+
+  test("abc") {
+    withTable("ct2", "ct1") {
+      try {
+        sql("CREATE TABLE ct1 USING parquet SELECT 1 AS ID")
+        // TODO: INSERT OVERWRITE DIRECTORY shall be qualified with current working
+        //   directory(AS-IS) or with warehouse path?
+        sql("INSERT OVERWRITE DIRECTORY 'ct1' USING parquet " + "SELECT 1 AS ID1, 2 AS ID2")
+
+        // table 'ct2' should not use 'current working directory'/ct1 to infer schema and
+        // `warehouse path`/xx..x/ct1 to read data, which shall be consistent to each other.
+        sql("CREATE TABLE ct2 USING parquet LOCATION 'ct1'")
+        checkAnswer(spark.table("ct1"), spark.table("ct2"))
+      } finally {
+        val path = new Path("ct1")
+        val fs = path.getFileSystem(spark.sessionState.newHadoopConf())
+        val qualified = path.makeQualified(fs.getUri, fs.getWorkingDirectory)
+        fs.delete(qualified, true)
+      }
+    }
+  }
+
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/TableLocationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/TableLocationSuite.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.test.SharedSparkSession
 
 class TableLocationSuite extends QueryTest with SharedSparkSession {
 
-  test("relative LOCATION in CTAS should be qualified with warehouse") {
+  test("SPARK-44185: relative LOCATION in CTAS should be qualified with warehouse") {
     withSQLConf(SQLConf.ALLOW_NON_EMPTY_LOCATION_IN_CTAS.key -> "false") {
       withTable("ctas1", "ctas2") {
         sql("CREATE TABLE ctas1 USING parquet AS SELECT 1 AS ID")
@@ -41,7 +41,7 @@ class TableLocationSuite extends QueryTest with SharedSparkSession {
   }
 
 
-  test("relative LOCATION with Append SaveMode shall check the qualified path") {
+  test("SPARK-44185: relative LOCATION with Append SaveMode shall check the qualified path") {
     withTable("ctas1", "ctas2") {
       sql("CREATE TABLE ctas1 USING parquet AS SELECT 1L AS ID")
       spark.range(10)
@@ -54,11 +54,12 @@ class TableLocationSuite extends QueryTest with SharedSparkSession {
     }
   }
 
-  test("abc") {
+  test("SPARK-44185: relative LOCATION in CREATE TABLE shall lookup the path qualified with" +
+    " warehouse for consistency") {
     withTable("ct2", "ct1") {
       try {
         sql("CREATE TABLE ct1 USING parquet SELECT 1 AS ID")
-        // TODO: INSERT OVERWRITE DIRECTORY shall be qualified with current working
+        // TODO(SPARK-44185): INSERT OVERWRITE DIRECTORY shall be qualified with current working
         //   directory(AS-IS) or with warehouse path?
         sql("INSERT OVERWRITE DIRECTORY 'ct1' USING parquet " + "SELECT 1 AS ID1, 2 AS ID2")
 
@@ -74,5 +75,4 @@ class TableLocationSuite extends QueryTest with SharedSparkSession {
       }
     }
   }
-
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/TableLocationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/TableLocationSuite.scala
@@ -63,8 +63,9 @@ class TableLocationSuite extends QueryTest with SharedSparkSession {
         //   directory(AS-IS) or with warehouse path?
         sql("INSERT OVERWRITE DIRECTORY 'ct1' USING parquet " + "SELECT 1 AS ID1, 2 AS ID2")
 
-        // table 'ct2' should not use 'current working directory'/ct1 to infer schema and
-        // `warehouse path`/xx..x/ct1 to read data, which shall be consistent to each other.
+        // When schema is absent, ct2's infered from data files. Here table 'ct2' should not
+        // use 'current working directory'/ct1 to infer and `warehouse path`/xx..x/ct1 to read
+        // data, which shall be consistent to each other.
         sql("CREATE TABLE ct2 USING parquet LOCATION 'ct1'")
         checkAnswer(spark.table("ct1"), spark.table("ct2"))
       } finally {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionStateBuilder.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionStateBuilder.scala
@@ -98,6 +98,7 @@ class HiveSessionStateBuilder(
       DetectAmbiguousSelfJoin +:
         new DetermineTableStats(session) +:
         RelationConversions(catalog) +:
+        QualifyLocationWithWarehouse(catalog) +:
         PreprocessTableCreation(catalog) +:
         PreprocessTableInsertion +:
         DataSourceAnalysis +:

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/MetastoreDataSourcesSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/MetastoreDataSourcesSuite.scala
@@ -525,10 +525,21 @@ class MetastoreDataSourcesSuite extends QueryTest
           assert(table("createdJsonTable").schema === df.schema)
           checkAnswer(sql("SELECT * FROM createdJsonTable"), df)
 
-          val e = intercept[AnalysisException] {
-              sparkSession.catalog.createTable("createdJsonTable", jsonFilePath.toString)
+          Seq("true", "false").foreach { caseSensitive =>
+            withSQLConf(SQLConf.CASE_SENSITIVE.key -> caseSensitive) {
+              val e = intercept[AnalysisException] {
+                sparkSession.catalog.createTable("createdJsonTable", tempPath.toString)
+              }
+              val expectedTableName = s"`$SESSION_CATALOG_NAME`.`default`." + {
+                if (caseSensitive.toBoolean) {
+                  "`createdJsonTable`"
+                } else {
+                  "`createdjsontable`"
+                }
+              }
+              checkErrorTableAlreadyExists(e, expectedTableName)
             }
-          checkErrorTableAlreadyExists(e, s"`$SESSION_CATALOG_NAME`.`default`.`createdjsontable`")
+          }
         }
 
         // Data should not be deleted.

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/MetastoreDataSourcesSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/MetastoreDataSourcesSuite.scala
@@ -528,7 +528,7 @@ class MetastoreDataSourcesSuite extends QueryTest
           val e = intercept[AnalysisException] {
               sparkSession.catalog.createTable("createdJsonTable", jsonFilePath.toString)
             }
-          checkErrorTableAlreadyExists(e, s"`$SESSION_CATALOG_NAME`.`default`.`createdJsonTable`")
+          checkErrorTableAlreadyExists(e, s"`$SESSION_CATALOG_NAME`.`default`.`createdjsontable`")
         }
 
         // Data should not be deleted.

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveSerDeSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveSerDeSuite.scala
@@ -145,7 +145,7 @@ class HiveSerDeSuite extends HiveComparisonTest with PlanTest with BeforeAndAfte
       .add("id", "int")
       .add("name", "string", nullable = true, comment = "blabla"))
     assert(table.provider == Some(DDLUtils.HIVE_PROVIDER))
-    assert(table.storage.locationUri == Some(new URI("/tmp/file")))
+    assert(table.storage.locationUri == Some(new URI("file:///tmp/file")))
     assert(table.storage.properties == Map("my_prop" -> "1"))
     assert(table.comment == Some("BLABLA"))
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR adds a new analysis rule to qualify the table path before execution to fix inconsistent path qualifying between catalog and data operations

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

To fix bugs like

- CREATE TABLE statement with relative LOCATION w/o table schema will infer schema from files from the directory relative to the current working directory and store the directory relative to the warehouse path. 
- CTAS statement with relative LOCATION cannot assert empty root path as it checks the wrong path it will finally use.
- DataframeWriter does not qualify the path before checking

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

yes.
 For table statements with a LOCATION clause or 'path' option, when you specify a relative path, spark now uses warehouse path to qualify both the catalog and data operation. Before this patch, it used warehouse path for catalog mostly and CWD for data.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

new unit tests.