### PR TITLE
[SPARK-44187][INFRA][BUILD] Enable benchmark on github to support Java 21

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -27,7 +27,7 @@ on:
         required: true
         default: '*'
       jdk:
-        description: 'JDK version: 8, 11 or 17'
+        description: 'JDK version: 8, 11, 17 or 21'
         required: true
         default: '8'
       scala:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -27,7 +27,7 @@ on:
         required: true
         default: '*'
       jdk:
-        description: 'JDK version: 8, 11, 17 or 21'
+        description: 'JDK version: 8, 11, 17 or 21-ea'
         required: true
         default: '8'
       scala:


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to enable benchmark on github to support Java 21.

### Why are the changes needed?
To be ready for Java 21.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
- Pass GA.
- Manually test.
