### PR TITLE
[SPARK-43952][FOLLOWUP] Don't set JobGroup in Spark Connect after all

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectStreamHandler.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectStreamHandler.scala
@@ -88,7 +88,6 @@ class SparkConnectStreamHandler(responseObserver: StreamObserver[ExecutePlanResp
         }
       } finally {
         session.sparkContext.removeJobTag(executeHolder.jobTag)
-        session.sparkContext.clearJobGroup()
         sessionHolder.removeExecutePlanHolder(executeHolder.operationId)
       }
     }

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectStreamHandler.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectStreamHandler.scala
@@ -65,12 +65,6 @@ class SparkConnectStreamHandler(responseObserver: StreamObserver[ExecutePlanResp
       val executeHolder = sessionHolder.createExecutePlanHolder(v)
       session.sparkContext.addJobTag(executeHolder.jobTag)
       session.sparkContext.setInterruptOnCancel(true)
-      // Also set the tag as the JobGroup for all the jobs in the query.
-      // TODO: In the long term, it should be encouraged to use job tag only.
-      session.sparkContext.setJobGroup(
-        executeHolder.jobTag,
-        s"Spark Connect - ${StringUtils.abbreviate(debugString, 128)}",
-        interruptOnCancel = true)
 
       try {
         // Add debug information to the query execution so that the jobs are traceable.


### PR DESCRIPTION
### What changes were proposed in this pull request?

After further discussion, setting JobGroup in Spark Connect for the scope of the query is not necessary.
Use cases that want to identify Spark Connect queries (e.g. SparkListener events from https://github.com/apache/spark/pull/41443) should use their jobTag for that instead.

### Why are the changes needed?

Discussion around where Jobgroup should be used. Since there may be only one Jobgroup at a time, using it for Spark Connect queries is prone to being reset by another unrelated user. Better to use the new "jobTags".

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI