### PR TITLE
[SPARK-44145][SQL] Callback when ready for execution

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/QueryPlanningTracker.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/QueryPlanningTracker.scala
@@ -101,14 +101,14 @@ abstract class QueryPlanningTrackerCallback {
    * @param analyzedPlan The plan after analysis,
    *                     see @org.apache.spark.sql.catalyst.analysis.Analyzer
    */
-  private[sql] def analyzed(tracker: QueryPlanningTracker, analyzedPlan: LogicalPlan): Unit
+  def analyzed(tracker: QueryPlanningTracker, analyzedPlan: LogicalPlan): Unit
 
   /**
    * Called when query is ready for execution.
    * This is after analysis for eager commands and after planning for other queries.
    * @param tracker tracker that triggered the callback.
    */
-  private[sql] def readyForExecution(tracker: QueryPlanningTracker): Unit
+  def readyForExecution(tracker: QueryPlanningTracker): Unit
 }
 
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/QueryPlanningTracker.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/QueryPlanningTracker.scala
@@ -129,16 +129,15 @@ class QueryPlanningTracker(
 
   /**
    * Set when the query has been analysed and is ready for execution. This is after analysis for
-   * eager commands and after planning for other queries. see @link
-   * org.apache.spark.sql.execution.CommandExecutionMode. When called multiple times, ignores
-   * subsequent call.
+   * eager commands and after planning for other queries.
+   * see @link org.apache.spark.sql.execution.CommandExecutionMode
+   * When called multiple times, ignores subsequent call.
    */
   def setReadyForExecution(analyzedPlan: LogicalPlan): Unit = {
-    if (readyForExecution) {
-      return
+    if (!readyForExecution) {
+      readyForExecution = true
+      readyForExecutionCallback(this, analyzedPlan)
     }
-    readyForExecution = true
-    readyForExecutionCallback(this, analyzedPlan)
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/QueryPlanningTracker.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/QueryPlanningTracker.scala
@@ -92,18 +92,23 @@ object QueryPlanningTracker {
 
 /**
  * Callbacks after planning phase completion.
+ *
+ * @since 3.5.0
  */
-trait QueryPlanningTrackerCallback {
+abstract class QueryPlanningTrackerCallback {
   /**
    * Called when query has been analyzed.
-   * @param tracker tracker that triggered the callback
+   *
+   * @param tracker tracker that triggered the callback.
+   * @param analyzedPlan The plan after analysis,
+   *                     see @org.apache.spark.sql.catalyst.analysis.Analyzer
    */
-  def analyzed(tracker: QueryPlanningTracker, plan: LogicalPlan): Unit
+  def analyzed(tracker: QueryPlanningTracker, analyzedPlan: LogicalPlan): Unit
 
   /**
    * Called when query is ready for execution.
    * This is after analysis for eager commands and after planning for other queries.
-   * @param tracker tracker that triggered the callback
+   * @param tracker tracker that triggered the callback.
    */
   def readyForExecution(tracker: QueryPlanningTracker): Unit
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/QueryPlanningTracker.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/QueryPlanningTracker.scala
@@ -91,8 +91,8 @@ object QueryPlanningTracker {
 }
 
 /**
- * @param readyForExecutionCallback Called when the query has been analysed and is ready for
- *                                  execution see setReadyForExecution
+ * @param readyForExecutionCallback
+ *   Called when the query has been analysed and is ready for execution see setReadyForExecution
  */
 class QueryPlanningTracker(
     readyForExecutionCallback: (QueryPlanningTracker, LogicalPlan) => Unit = (_, _) => ()) {
@@ -128,14 +128,14 @@ class QueryPlanningTracker(
   }
 
   /**
-   * Set when the query has been analysed and is ready for execution.
-   * This is after analysis for eager commands and after planning
-   * for other queries.
-   * see @link org.apache.spark.sql.execution.CommandExecutionMode
+   * Set when the query has been analysed and is ready for execution. This is after analysis for
+   * eager commands and after planning for other queries. see @link
+   * org.apache.spark.sql.execution.CommandExecutionMode. When called multiple times, ignores
+   * subsequent call.
    */
   def setReadyForExecution(analyzedPlan: LogicalPlan): Unit = {
     if (readyForExecution) {
-      throw new IllegalStateException("Cannot setReadyForExecution more than once")
+      return
     }
     readyForExecution = true
     readyForExecutionCallback(this, analyzedPlan)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/QueryPlanningTracker.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/QueryPlanningTracker.scala
@@ -97,7 +97,7 @@ object QueryPlanningTracker {
  * @since 3.5.0
  */
 @DeveloperApi
-abstract class QueryPlanningTrackerCallback {
+private[sql] abstract class QueryPlanningTrackerCallback {
   /**
    * Called when query has been analyzed.
    *
@@ -105,14 +105,14 @@ abstract class QueryPlanningTrackerCallback {
    * @param analyzedPlan The plan after analysis,
    *                     see @org.apache.spark.sql.catalyst.analysis.Analyzer
    */
-  def analyzed(tracker: QueryPlanningTracker, analyzedPlan: LogicalPlan): Unit
+  private[sql] def analyzed(tracker: QueryPlanningTracker, analyzedPlan: LogicalPlan): Unit
 
   /**
    * Called when query is ready for execution.
    * This is after analysis for eager commands and after planning for other queries.
    * @param tracker tracker that triggered the callback.
    */
-  def readyForExecution(tracker: QueryPlanningTracker): Unit
+  private[sql] def readyForExecution(tracker: QueryPlanningTracker): Unit
 }
 
 /**
@@ -159,7 +159,7 @@ class QueryPlanningTracker(
    * @param analyzedPlan The plan after analysis,
    *                     see @org.apache.spark.sql.catalyst.analysis.Analyzer
    */
-  def setAnalyzed(analyzedPlan: LogicalPlan): Unit = {
+  private[sql] def setAnalyzed(analyzedPlan: LogicalPlan): Unit = {
     if (!analyzed) {
       analyzed = true
       trackerCallback.foreach(_.analyzed(this, analyzedPlan))
@@ -172,7 +172,7 @@ class QueryPlanningTracker(
    * see @link org.apache.spark.sql.execution.CommandExecutionMode
    * When called multiple times, ignores subsequent call.
    */
-  def setReadyForExecution(): Unit = {
+  private[sql] def setReadyForExecution(): Unit = {
     if (!readyForExecution) {
       readyForExecution = true
       trackerCallback.foreach(_.readyForExecution(this))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/QueryPlanningTracker.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/QueryPlanningTracker.scala
@@ -132,8 +132,6 @@ class QueryPlanningTracker(
 
   private var readyForExecution = false
 
-  private var analyzed = false
-
   /**
    * Measure the start and end time of a phase. Note that if this function is called multiple
    * times for the same phase, the recorded start time will be the start time of the first call,
@@ -155,15 +153,12 @@ class QueryPlanningTracker(
 
   /**
    * Set when the query has been analysed.
-   * When called multiple times, ignores subsequent call.
+   * Can be called multiple times upon plan change.
    * @param analyzedPlan The plan after analysis,
    *                     see @org.apache.spark.sql.catalyst.analysis.Analyzer
    */
   private[sql] def setAnalyzed(analyzedPlan: LogicalPlan): Unit = {
-    if (!analyzed) {
-      analyzed = true
-      trackerCallback.foreach(_.analyzed(this, analyzedPlan))
-    }
+    trackerCallback.foreach(_.analyzed(this, analyzedPlan))
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/QueryPlanningTracker.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/QueryPlanningTracker.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql.catalyst
 
 import scala.collection.JavaConverters._
 
-import org.apache.spark.annotation.{DeveloperApi}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.util.BoundedPriorityQueue
 
@@ -93,11 +92,8 @@ object QueryPlanningTracker {
 
 /**
  * Callbacks after planning phase completion.
- *
- * @since 3.5.0
  */
-@DeveloperApi
-private[sql] abstract class QueryPlanningTrackerCallback {
+abstract class QueryPlanningTrackerCallback {
   /**
    * Called when query has been analyzed.
    *

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/QueryPlanningTracker.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/QueryPlanningTracker.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.catalyst
 
 import scala.collection.JavaConverters._
 
+import org.apache.spark.annotation.{DeveloperApi}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.util.BoundedPriorityQueue
 
@@ -95,6 +96,7 @@ object QueryPlanningTracker {
  *
  * @since 3.5.0
  */
+@DeveloperApi
 abstract class QueryPlanningTrackerCallback {
   /**
    * Called when query has been analyzed.

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/QueryPlanningTrackerSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/QueryPlanningTrackerSuite.scala
@@ -17,7 +17,11 @@
 
 package org.apache.spark.sql.catalyst
 
+import org.mockito.Mockito.{times, verify}
+import org.scalatestplus.mockito.MockitoSugar.mock
+
 import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 
 class QueryPlanningTrackerSuite extends SparkFunSuite {
 
@@ -85,5 +89,20 @@ class QueryPlanningTrackerSuite extends SparkFunSuite {
 
     // k > total size
     assert(t.topRulesByTime(10).size == 4)
+  }
+
+  test("test ready for execution callback") {
+    val mockCallback = mock[AnalyzedCallback]
+    val mockPlan = mock[LogicalPlan]
+    val t = new QueryPlanningTracker(mockCallback.callback)
+    t.setReadyForExecution(mockPlan)
+    verify(mockCallback, times(1)).callback(t, mockPlan)
+    assertThrows[IllegalStateException] {
+      t.setReadyForExecution(mockPlan)
+    }
+  }
+
+  trait AnalyzedCallback {
+    def callback(tracker: QueryPlanningTracker, plan: LogicalPlan): Unit
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/QueryPlanningTrackerSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/QueryPlanningTrackerSuite.scala
@@ -93,12 +93,13 @@ class QueryPlanningTrackerSuite extends SparkFunSuite {
 
   test("test ready for execution callback") {
     val mockCallback = mock[QueryPlanningTrackerCallback]
-    val mockPlan = mock[LogicalPlan]
+    val mockPlan1 = mock[LogicalPlan]
+    val mockPlan2 = mock[LogicalPlan]
     val t = new QueryPlanningTracker(Some(mockCallback))
-    t.setAnalyzed(mockPlan)
-    verify(mockCallback, times(1)).analyzed(t, mockPlan)
-    t.setAnalyzed(mockPlan)
-    verify(mockCallback, times(1)).analyzed(t, mockPlan)
+    t.setAnalyzed(mockPlan1)
+    verify(mockCallback, times(1)).analyzed(t, mockPlan1)
+    t.setAnalyzed(mockPlan2)
+    verify(mockCallback, times(1)).analyzed(t, mockPlan2)
     t.setReadyForExecution()
     verify(mockCallback, times(1)).readyForExecution(t)
     t.setReadyForExecution()

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/QueryPlanningTrackerSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/QueryPlanningTrackerSuite.scala
@@ -92,17 +92,16 @@ class QueryPlanningTrackerSuite extends SparkFunSuite {
   }
 
   test("test ready for execution callback") {
-    val mockCallback = mock[AnalyzedCallback]
+    val mockCallback = mock[QueryPlanningTrackerCallback]
     val mockPlan = mock[LogicalPlan]
-    val t = new QueryPlanningTracker(mockCallback.callback)
-    t.setReadyForExecution(mockPlan)
-    verify(mockCallback, times(1)).callback(t, mockPlan)
-    assertThrows[IllegalStateException] {
-      t.setReadyForExecution(mockPlan)
-    }
-  }
-
-  trait AnalyzedCallback {
-    def callback(tracker: QueryPlanningTracker, plan: LogicalPlan): Unit
+    val t = new QueryPlanningTracker(Some(mockCallback))
+    t.setAnalyzed(mockPlan)
+    verify(mockCallback, times(1)).analyzed(t, mockPlan)
+    t.setAnalyzed(mockPlan)
+    verify(mockCallback, times(1)).analyzed(t, mockPlan)
+    t.setReadyForExecution()
+    verify(mockCallback, times(1)).readyForExecution(t)
+    t.setReadyForExecution()
+    verify(mockCallback, times(1)).readyForExecution(t)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -32,6 +32,7 @@ import org.apache.spark.sql.connector.catalog.{CatalogPlugin, CatalogV2Implicits
 import org.apache.spark.sql.connector.catalog.TableCapability._
 import org.apache.spark.sql.connector.expressions.{FieldReference, IdentityTransform, Transform}
 import org.apache.spark.sql.errors.QueryCompilationErrors
+import org.apache.spark.sql.execution.QueryExecution
 import org.apache.spark.sql.execution.command.DDLUtils
 import org.apache.spark.sql.execution.datasources.{CreateTable, DataSource, DataSourceUtils, LogicalRelation}
 import org.apache.spark.sql.execution.datasources.v2._
@@ -854,7 +855,7 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) {
    * user-registered callback functions.
    */
   private def runCommand(session: SparkSession)(command: LogicalPlan): Unit = {
-    val qe = session.sessionState.executePlan(command)
+    val qe = new QueryExecution(session, command, df.queryExecution.tracker)
     qe.assertCommandExecuted()
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriterV2.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriterV2.scala
@@ -26,6 +26,7 @@ import org.apache.spark.sql.catalyst.expressions.{Attribute, Bucket, Days, Hours
 import org.apache.spark.sql.catalyst.plans.logical.{AppendData, CreateTableAsSelect, LogicalPlan, OptionList, OverwriteByExpression, OverwritePartitionsDynamic, ReplaceTableAsSelect, UnresolvedTableSpec}
 import org.apache.spark.sql.connector.expressions.{LogicalExpressions, NamedReference, Transform}
 import org.apache.spark.sql.errors.QueryCompilationErrors
+import org.apache.spark.sql.execution.QueryExecution
 import org.apache.spark.sql.types.IntegerType
 
 /**
@@ -191,7 +192,7 @@ final class DataFrameWriterV2[T] private[sql](table: String, ds: Dataset[T])
    * callback functions.
    */
   private def runCommand(command: LogicalPlan): Unit = {
-    val qe = sparkSession.sessionState.executePlan(command)
+    val qe = new QueryExecution(sparkSession, command, df.queryExecution.tracker)
     qe.assertCommandExecuted()
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -623,16 +623,74 @@ class SparkSession private(
    *             For example, 1, "Steven", LocalDate.of(2023, 4, 2).
    *             A value can be also a `Column` of literal expression, in that case
    *             it is taken as is.
+   * @param tracker A tracker that can notify when query is ready for execution
+   *
+   * @since 3.5.0
+   */
+  @Experimental
+  def sql(
+      sqlText: String,
+      args: Array[_],
+      tracker: QueryPlanningTracker): DataFrame = withActive {
+    val plan = tracker.measurePhase(QueryPlanningTracker.PARSING) {
+      val parsedPlan = sessionState.sqlParser.parsePlan(sqlText)
+      if (args.nonEmpty) {
+        PosParameterizedQuery(parsedPlan, args.map(lit(_).expr))
+      } else {
+        parsedPlan
+      }
+    }
+    Dataset.ofRows(self, plan, tracker)
+  }
+
+  /**
+   * Executes a SQL query substituting positional parameters by the given arguments,
+   * returning the result as a `DataFrame`.
+   * This API eagerly runs DDL/DML commands, but not for SELECT queries.
+   *
+   * @param sqlText A SQL statement with positional parameters to execute.
+   * @param args An array of Java/Scala objects that can be converted to
+   *             SQL literal expressions. See
+   *             <a href="https://spark.apache.org/docs/latest/sql-ref-datatypes.html">
+   *             Supported Data Types</a> for supported value types in Scala/Java.
+   *             For example, 1, "Steven", LocalDate.of(2023, 4, 2).
+   *             A value can be also a `Column` of literal expression, in that case
+   *             it is taken as is.
    *
    * @since 3.5.0
    */
   @Experimental
   def sql(sqlText: String, args: Array[_]): DataFrame = withActive {
-    val tracker = new QueryPlanningTracker
+    sql(sqlText, args, new QueryPlanningTracker)
+  }
+
+  /**
+   * Executes a SQL query substituting named parameters by the given arguments,
+   * returning the result as a `DataFrame`.
+   * This API eagerly runs DDL/DML commands, but not for SELECT queries.
+   *
+   * @param sqlText A SQL statement with named parameters to execute.
+   * @param args A map of parameter names to Java/Scala objects that can be converted to
+   *             SQL literal expressions. See
+   *             <a href="https://spark.apache.org/docs/latest/sql-ref-datatypes.html">
+   *             Supported Data Types</a> for supported value types in Scala/Java.
+   *             For example, map keys: "rank", "name", "birthdate";
+   *             map values: 1, "Steven", LocalDate.of(2023, 4, 2).
+   *             Map value can be also a `Column` of literal expression, in that case
+   *             it is taken as is.
+   * @param tracker A tracker that can notify when query is ready for execution
+   *
+   * @since 3.4.0
+   */
+  @Experimental
+  def sql(
+      sqlText: String,
+      args: Map[String, Any],
+      tracker: QueryPlanningTracker): DataFrame = withActive {
     val plan = tracker.measurePhase(QueryPlanningTracker.PARSING) {
       val parsedPlan = sessionState.sqlParser.parsePlan(sqlText)
       if (args.nonEmpty) {
-        PosParameterizedQuery(parsedPlan, args.map(lit(_).expr))
+        NameParameterizedQuery(parsedPlan, args.mapValues(lit(_).expr).toMap)
       } else {
         parsedPlan
       }
@@ -659,16 +717,7 @@ class SparkSession private(
    */
   @Experimental
   def sql(sqlText: String, args: Map[String, Any]): DataFrame = withActive {
-    val tracker = new QueryPlanningTracker
-    val plan = tracker.measurePhase(QueryPlanningTracker.PARSING) {
-      val parsedPlan = sessionState.sqlParser.parsePlan(sqlText)
-      if (args.nonEmpty) {
-        NameParameterizedQuery(parsedPlan, args.mapValues(lit(_).expr).toMap)
-      } else {
-        parsedPlan
-      }
-    }
-    Dataset.ofRows(self, plan, tracker)
+    sql(sqlText, args, new QueryPlanningTracker)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -628,7 +628,7 @@ class SparkSession private(
    * @since 3.5.0
    */
   @Experimental
-  def sql(sqlText: String, args: Array[_], tracker: QueryPlanningTracker): DataFrame =
+  private[sql] def sql(sqlText: String, args: Array[_], tracker: QueryPlanningTracker): DataFrame =
     withActive {
       val plan = tracker.measurePhase(QueryPlanningTracker.PARSING) {
         val parsedPlan = sessionState.sqlParser.parsePlan(sqlText)
@@ -681,7 +681,10 @@ class SparkSession private(
    * @since 3.5.0
    */
   @Experimental
-  def sql(sqlText: String, args: Map[String, Any], tracker: QueryPlanningTracker): DataFrame =
+  private[sql] def sql(
+      sqlText: String,
+      args: Map[String, Any],
+      tracker: QueryPlanningTracker): DataFrame =
     withActive {
       val plan = tracker.measurePhase(QueryPlanningTracker.PARSING) {
         val parsedPlan = sessionState.sqlParser.parsePlan(sqlText)
@@ -735,7 +738,7 @@ class SparkSession private(
    * @since 3.5.0
    */
   @Experimental
-  def sql(
+  private[sql] def sql(
       sqlText: String,
       args: java.util.Map[String, Any],
       tracker: QueryPlanningTracker): DataFrame = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -624,10 +624,7 @@ class SparkSession private(
    *             A value can be also a `Column` of literal expression, in that case
    *             it is taken as is.
    * @param tracker A tracker that can notify when query is ready for execution
-   *
-   * @since 3.5.0
    */
-  @Experimental
   private[sql] def sql(sqlText: String, args: Array[_], tracker: QueryPlanningTracker): DataFrame =
     withActive {
       val plan = tracker.measurePhase(QueryPlanningTracker.PARSING) {
@@ -677,10 +674,7 @@ class SparkSession private(
    *             Map value can be also a `Column` of literal expression, in that case
    *             it is taken as is.
    * @param tracker A tracker that can notify when query is ready for execution
-   *
-   * @since 3.5.0
    */
-  @Experimental
   private[sql] def sql(
       sqlText: String,
       args: Map[String, Any],
@@ -733,55 +727,12 @@ class SparkSession private(
    *             map values: 1, "Steven", LocalDate.of(2023, 4, 2).
    *             Map value can be also a `Column` of literal expression, in that case
    *             it is taken as is.
-   * @param tracker A tracker that can notify when query is ready for execution
-   *
-   * @since 3.5.0
-   */
-  @Experimental
-  private[sql] def sql(
-      sqlText: String,
-      args: java.util.Map[String, Any],
-      tracker: QueryPlanningTracker): DataFrame = {
-    sql(sqlText, args.asScala.toMap, tracker)
-  }
-
-  /**
-   * Executes a SQL query substituting named parameters by the given arguments,
-   * returning the result as a `DataFrame`.
-   * This API eagerly runs DDL/DML commands, but not for SELECT queries.
-   *
-   * @param sqlText A SQL statement with named parameters to execute.
-   * @param args A map of parameter names to Java/Scala objects that can be converted to
-   *             SQL literal expressions. See
-   *             <a href="https://spark.apache.org/docs/latest/sql-ref-datatypes.html">
-   *             Supported Data Types</a> for supported value types in Scala/Java.
-   *             For example, map keys: "rank", "name", "birthdate";
-   *             map values: 1, "Steven", LocalDate.of(2023, 4, 2).
-   *             Map value can be also a `Column` of literal expression, in that case
-   *             it is taken as is.
    *
    * @since 3.4.0
    */
   @Experimental
   def sql(sqlText: String, args: java.util.Map[String, Any]): DataFrame = {
     sql(sqlText, args.asScala.toMap)
-  }
-
-  /**
-   * Executes a SQL query using Spark, returning the result as a `DataFrame`.
-   * This API eagerly runs DDL/DML commands, but not for SELECT queries.
-   *
-   * @param sqlText
-   *   A SQL statement with named parameters to execute. Map value can be also a `Column` of
-   *   literal expression, in that case it is taken as is.
-   * @param tracker
-   *   A tracker that can notify when query is ready for execution
-   *
-   * @since 3.5.0
-   */
-  @Experimental
-  def sql(sqlText: String, tracker: QueryPlanningTracker): DataFrame = {
-    sql(sqlText, Map.empty[String, Any], tracker)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -658,7 +658,7 @@ class SparkSession private(
    * @since 3.5.0
    */
   @Experimental
-  def sql(sqlText: String, args: Array[_]): DataFrame = withActive {
+  def sql(sqlText: String, args: Array[_]): DataFrame = {
     sql(sqlText, args, new QueryPlanningTracker)
   }
 
@@ -712,7 +712,7 @@ class SparkSession private(
    * @since 3.4.0
    */
   @Experimental
-  def sql(sqlText: String, args: Map[String, Any]): DataFrame = withActive {
+  def sql(sqlText: String, args: Map[String, Any]): DataFrame = {
     sql(sqlText, args, new QueryPlanningTracker)
   }
 
@@ -777,7 +777,7 @@ class SparkSession private(
    * @since 3.5.0
    */
   @Experimental
-  def sql(sqlText: String, tracker: QueryPlanningTracker): DataFrame = withActive {
+  def sql(sqlText: String, tracker: QueryPlanningTracker): DataFrame = {
     sql(sqlText, Map.empty[String, Any], tracker)
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add a callback in QueryPlanningTracker after either
- analysis is done for eager commands
- planning is done for other queries.

1.  Ideally, the callback would receive QueryExecution, but there's currently no dependency from [spark-catalyst] to [spark-sql]. 
- The tracker is needed for validation in the tests & to improve the usability of the callback. The callback owner does not need to maintain reference to the tracker. This is especially useful as Dataset.ofRows() & spark.sql create execution internally.
-  The analyzed plan is needed for use cases that need to access the plan after the analysis is completed. SPARK-43923 is one such use case.

3. Added new methods on SparkSession vs default param due to 
```
multiple overloaded alternatives define default arguments
```

### Why are the changes needed?
Commands are eagerly executed after analysis phase, while other queries are executed after planning. Users of Spark need to understand time spent prior to execution. Currently, they need to understand the difference between these 2 modes. Abstract the complexity in 1 callback.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Unit
