### PR TITLE
[SPARK-44199] CacheManager refreshes the fileIndex unnecessarily

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/catalog/Catalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalog/Catalog.scala
@@ -632,8 +632,9 @@ abstract class Catalog {
 
   /**
    * Invalidates and refreshes all the cached data (and the associated metadata) for any `Dataset`
-   * that contains the given data source path. Path matching is by prefix, i.e. "/" would invalidate
-   * everything that is cached.
+   * that contains the given data source path. Path matching is by checking for sub-directories,
+   * i.e. "/" would invalidate everything that is cached and "/test/parent" would invalidate
+   * everything that is a subdirectory of "/test/parent".
    *
    * @since 2.0.0
    */

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/CacheManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/CacheManager.scala
@@ -359,7 +359,8 @@ class CacheManager extends Logging with AdaptiveSparkPlanHelper {
   }
 
   /**
-   * Refresh the given [[FileIndex]] if any of its root paths starts with `qualifiedPath`.
+   * Refresh the given [[FileIndex]] if any of its root paths is a subdirectory
+   * of the `qualifiedPath`.
    * @return whether the [[FileIndex]] is refreshed.
    */
   private def refreshFileIndexIfNecessary(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/CacheManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/CacheManager.scala
@@ -382,7 +382,7 @@ class CacheManager extends Logging with AdaptiveSparkPlanHelper {
   def isSubDir(qualifiedPathParent: Path, qualifiedPathChild: Path): Boolean = {
     Iterator.iterate(qualifiedPathChild)(_.getParent)
       .takeWhile(_ != null)
-      .exists(_.toString.equals(qualifiedPathParent.toString))
+      .exists(_.equals(qualifiedPathParent))
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/CacheManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/CacheManager.scala
@@ -375,12 +375,16 @@ class CacheManager extends Logging with AdaptiveSparkPlanHelper {
 
   /**
    * Checks if the given child path is a sub-directory of the given parent path.
-   * @param qualifiedPathChild: Fully qualified child path
-   * @param qualifiedPathParent: Fully qualified parent path.
-   * @return True if the child path is a sub-directory of the given parent path. Otherwise, false.
+   * @param qualifiedPathChild:
+   *   Fully qualified child path
+   * @param qualifiedPathParent:
+   *   Fully qualified parent path.
+   * @return
+   *   True if the child path is a sub-directory of the given parent path. Otherwise, false.
    */
   def isSubDir(qualifiedPathParent: Path, qualifiedPathChild: Path): Boolean = {
-    Iterator.iterate(qualifiedPathChild)(_.getParent)
+    Iterator
+      .iterate(qualifiedPathChild)(_.getParent)
       .takeWhile(_ != null)
       .exists(_.equals(qualifiedPathParent))
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/CacheManagerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CacheManagerSuite.scala
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.test.SharedSparkSession
+
+class CacheManagerSuite extends SparkFunSuite with SharedSparkSession {
+
+  test("SPARK-44199: isSubDirectory tests") {
+    val cacheManager = spark.sharedState.cacheManager
+    val testCases = Map[(String, String), Boolean](
+      ("s3://bucket/a/b", "s3://bucket/a/b/c") -> true,
+      ("s3://bucket/a/b/c", "s3://bucket/a/b/c") -> true,
+      ("s3://bucket/a/b/c", "s3://bucket/a/b") -> false,
+      ("s3://bucket/a/z/c", "s3://bucket/a/b/c") -> false,
+      ("s3://bucket/a/b/c", "abfs://bucket/a/b/c") -> false,
+    )
+    testCases.foreach { test =>
+      val result = cacheManager.isSubDir(
+        new Path(test._1._1),
+        new Path(test._1._2)
+      )
+      assert(result == test._2)
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/CacheManagerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CacheManagerSuite.scala
@@ -31,13 +31,9 @@ class CacheManagerSuite extends SparkFunSuite with SharedSparkSession {
       ("s3://bucket/a/b/c", "s3://bucket/a/b/c") -> true,
       ("s3://bucket/a/b/c", "s3://bucket/a/b") -> false,
       ("s3://bucket/a/z/c", "s3://bucket/a/b/c") -> false,
-      ("s3://bucket/a/b/c", "abfs://bucket/a/b/c") -> false
-    )
+      ("s3://bucket/a/b/c", "abfs://bucket/a/b/c") -> false)
     testCases.foreach { test =>
-      val result = cacheManager.isSubDir(
-        new Path(test._1._1),
-        new Path(test._1._2)
-      )
+      val result = cacheManager.isSubDir(new Path(test._1._1), new Path(test._1._2))
       assert(result == test._2)
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/CacheManagerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CacheManagerSuite.scala
@@ -31,7 +31,7 @@ class CacheManagerSuite extends SparkFunSuite with SharedSparkSession {
       ("s3://bucket/a/b/c", "s3://bucket/a/b/c") -> true,
       ("s3://bucket/a/b/c", "s3://bucket/a/b") -> false,
       ("s3://bucket/a/z/c", "s3://bucket/a/b/c") -> false,
-      ("s3://bucket/a/b/c", "abfs://bucket/a/b/c") -> false,
+      ("s3://bucket/a/b/c", "abfs://bucket/a/b/c") -> false
     )
     testCases.foreach { test =>
       val result = cacheManager.isSubDir(

--- a/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
@@ -23,7 +23,6 @@ import java.time.{Duration, LocalDateTime, Period}
 import scala.collection.mutable.HashSet
 import scala.concurrent.duration._
 import org.apache.commons.io.FileUtils
-import org.apache.hadoop.fs.Path
 import org.apache.spark.CleanerListener
 import org.apache.spark.executor.DataReadMethod._
 import org.apache.spark.executor.DataReadMethod.DataReadMethod
@@ -33,7 +32,7 @@ import org.apache.spark.sql.catalyst.analysis.TempTableAlreadyExistsException
 import org.apache.spark.sql.catalyst.expressions.SubqueryExpression
 import org.apache.spark.sql.catalyst.plans.logical.{BROADCAST, Join, JoinStrategyHint, SHUFFLE_HASH}
 import org.apache.spark.sql.catalyst.util.DateTimeConstants
-import org.apache.spark.sql.execution.{CacheManager, ColumnarToRowExec, ExecSubqueryExpression, RDDScanExec, SparkPlan}
+import org.apache.spark.sql.execution.{ColumnarToRowExec, ExecSubqueryExpression, RDDScanExec, SparkPlan}
 import org.apache.spark.sql.execution.adaptive.{AQEPropagateEmptyRelation, AdaptiveSparkPlanHelper}
 import org.apache.spark.sql.execution.columnar._
 import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
@@ -1681,24 +1680,6 @@ class CachedTableSuite extends QueryTest with SQLTestUtils
         sql("CACHE TABLE cached_t as SELECT udf(id) FROM VALUES (1), (2) t(id)")
         checkAnswer(sql("SELECT * FROM cached_t"), Row(2) :: Row(3) :: Nil)
       }
-    }
-  }
-
-  test("SPARK-44199: isSubDirectory tests") {
-    val cacheManager = spark.sharedState.cacheManager
-    val testCases = Map[(String, String), Boolean](
-      ("s3://bucket/a/b", "s3://bucket/a/b/c") -> true,
-      ("s3://bucket/a/b/c", "s3://bucket/a/b/c") -> true,
-      ("s3://bucket/a/b/c", "s3://bucket/a/b") -> false,
-      ("s3://bucket/a/z/c", "s3://bucket/a/b/c") -> false,
-      ("s3://bucket/a/b/c", "abfs://bucket/a/b/c") -> false,
-    )
-    testCases.foreach { test =>
-      val result = cacheManager.isSubDir(
-        new Path(test._1._1),
-        new Path(test._1._2)
-      )
-      assert(result == test._2)
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
@@ -20,9 +20,12 @@ package org.apache.spark.sql
 import java.io.{File, FilenameFilter}
 import java.nio.file.{Files, Paths}
 import java.time.{Duration, LocalDateTime, Period}
+
 import scala.collection.mutable.HashSet
 import scala.concurrent.duration._
+
 import org.apache.commons.io.FileUtils
+
 import org.apache.spark.CleanerListener
 import org.apache.spark.executor.DataReadMethod._
 import org.apache.spark.executor.DataReadMethod.DataReadMethod
@@ -33,12 +36,12 @@ import org.apache.spark.sql.catalyst.expressions.SubqueryExpression
 import org.apache.spark.sql.catalyst.plans.logical.{BROADCAST, Join, JoinStrategyHint, SHUFFLE_HASH}
 import org.apache.spark.sql.catalyst.util.DateTimeConstants
 import org.apache.spark.sql.execution.{ColumnarToRowExec, ExecSubqueryExpression, RDDScanExec, SparkPlan}
-import org.apache.spark.sql.execution.adaptive.{AQEPropagateEmptyRelation, AdaptiveSparkPlanHelper}
+import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanHelper, AQEPropagateEmptyRelation}
 import org.apache.spark.sql.execution.columnar._
 import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.{SQLTestUtils, SharedSparkSession}
+import org.apache.spark.sql.test.{SharedSparkSession, SQLTestUtils}
 import org.apache.spark.sql.types.{StringType, StructField, StructType}
 import org.apache.spark.storage.{RDDBlockId, StorageLevel}
 import org.apache.spark.storage.StorageLevel.{MEMORY_AND_DISK_2, MEMORY_ONLY}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
The `CacheManager` refreshFileIndexIfNecessary logic checks if the fileIndex root paths starts with the input path. This is problematic if the input path and root path share the prefixes but the root path is not a subdirectory of the input path. In such cases, the CacheManager can unnecessarily refresh the fileIndex which can fail the query if it does not have access to the rootPath for that SparkSession.


### Why are the changes needed?
Fixes the bug where the queries on cached dataframe APIs can fail if the cached path shares prefix with the different path.


### Does this PR introduce _any_ user-facing change?
NO


### How was this patch tested?
Unit test
