### PR TITLE
[SPARK-44202][CORE] Add JobTag APIs to JavaSparkContext

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -863,6 +863,8 @@ class SparkContext(config: SparkConf) extends Logging {
    * being called on the job's executor threads. This is useful to help ensure that the tasks
    * are actually stopped in a timely manner, but is off by default due to HDFS-1208, where HDFS
    * may respond to Thread.interrupt() by marking nodes as dead.
+   *
+   * @since 3.5.0
    */
   def setInterruptOnCancel(interruptOnCancel: Boolean): Unit = {
     setLocalProperty(SparkContext.SPARK_JOB_INTERRUPT_ON_CANCEL, interruptOnCancel.toString)
@@ -872,6 +874,8 @@ class SparkContext(config: SparkConf) extends Logging {
    * Add a tag to be assigned to all the jobs started by this thread.
    *
    * @param tag The tag to be added. Cannot contain ',' (comma) character.
+   *
+   * @since 3.5.0
    */
   def addJobTag(tag: String): Unit = {
     SparkContext.throwIfInvalidTag(tag)
@@ -885,6 +889,8 @@ class SparkContext(config: SparkConf) extends Logging {
    * Noop if such a tag was not added earlier.
    *
    * @param tag The tag to be removed. Cannot contain ',' (comma) character.
+   *
+   * @since 3.5.0
    */
   def removeJobTag(tag: String): Unit = {
     SparkContext.throwIfInvalidTag(tag)
@@ -893,14 +899,22 @@ class SparkContext(config: SparkConf) extends Logging {
     setLocalProperty(SparkContext.SPARK_JOB_TAGS, newTags)
   }
 
-  /** Get the tags that are currently set to be assigned to all the jobs started by this thread. */
+  /**
+   * Get the tags that are currently set to be assigned to all the jobs started by this thread.
+   *
+   * @since 3.5.0
+   */
   def getJobTags(): Set[String] = {
     Option(getLocalProperty(SparkContext.SPARK_JOB_TAGS))
       .map(_.split(SparkContext.SPARK_JOB_TAGS_SEP).toSet)
       .getOrElse(Set())
   }
 
-  /** Clear the current thread's job tags. */
+  /**
+   * Clear the current thread's job tags.
+   *
+   * @since 3.5.0
+   */
   def clearJobTags(): Unit = {
     setLocalProperty(SparkContext.SPARK_JOB_TAGS, null)
   }
@@ -2551,6 +2565,8 @@ class SparkContext(config: SparkConf) extends Logging {
    * Cancel active jobs that have the specified tag. See `org.apache.spark.SparkContext.addJobTag`.
    *
    * @param tag The tag to be added. Cannot contain ',' (comma) character.
+   *
+   * @since 3.5.0
    */
   def cancelJobsWithTag(tag: String): Unit = {
     SparkContext.throwIfInvalidTag(tag)

--- a/core/src/main/scala/org/apache/spark/api/java/JavaSparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/api/java/JavaSparkContext.scala
@@ -713,10 +713,49 @@ class JavaSparkContext(val sc: SparkContext) extends Closeable {
   def clearJobGroup(): Unit = sc.clearJobGroup()
 
   /**
+   * Set the behavior of job cancellation from jobs started in this thread.
+   *
+   * @param interruptOnCancel If true, then job cancellation will result in `Thread.interrupt()`
+   * being called on the job's executor threads. This is useful to help ensure that the tasks
+   * are actually stopped in a timely manner, but is off by default due to HDFS-1208, where HDFS
+   * may respond to Thread.interrupt() by marking nodes as dead.
+   */
+  def setInterruptOnCancel(interruptOnCancel: Boolean): Unit =
+    sc.setInterruptOnCancel(interruptOnCancel)
+
+  /**
+   * Add a tag to be assigned to all the jobs started by this thread.
+   *
+   * @param tag The tag to be added. Cannot contain ',' (comma) character.
+   */
+  def addJobTag(tag: String): Unit = sc.addJobTag(tag)
+
+  /**
+   * Remove a tag previously added to be assigned to all the jobs started by this thread.
+   * Noop if such a tag was not added earlier.
+   *
+   * @param tag The tag to be removed. Cannot contain ',' (comma) character.
+   */
+  def removeJobTag(tag: String): Unit = sc.removeJobTag(tag)
+
+  /** Get the tags that are currently set to be assigned to all the jobs started by this thread. */
+  def getJobTags(): util.Set[String] = sc.getJobTags.asJava
+
+  /** Clear the current thread's job tags. */
+  def clearJobTags(): Unit = sc.clearJobTags()
+
+  /**
    * Cancel active jobs for the specified group. See
    * `org.apache.spark.api.java.JavaSparkContext.setJobGroup` for more information.
    */
   def cancelJobGroup(groupId: String): Unit = sc.cancelJobGroup(groupId)
+
+  /**
+   * Cancel active jobs that have the specified tag. See `org.apache.spark.SparkContext.addJobTag`.
+   *
+   * @param tag The tag to be added. Cannot contain ',' (comma) character.
+   */
+  def cancelJobsWithTag(tag: String): Unit = sc.cancelJobsWithTag(tag)
 
   /** Cancel all jobs that have been scheduled or are running. */
   def cancelAllJobs(): Unit = sc.cancelAllJobs()

--- a/core/src/main/scala/org/apache/spark/api/java/JavaSparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/api/java/JavaSparkContext.scala
@@ -719,6 +719,8 @@ class JavaSparkContext(val sc: SparkContext) extends Closeable {
    * being called on the job's executor threads. This is useful to help ensure that the tasks
    * are actually stopped in a timely manner, but is off by default due to HDFS-1208, where HDFS
    * may respond to Thread.interrupt() by marking nodes as dead.
+   *
+   * @since 3.5.0
    */
   def setInterruptOnCancel(interruptOnCancel: Boolean): Unit =
     sc.setInterruptOnCancel(interruptOnCancel)
@@ -727,6 +729,8 @@ class JavaSparkContext(val sc: SparkContext) extends Closeable {
    * Add a tag to be assigned to all the jobs started by this thread.
    *
    * @param tag The tag to be added. Cannot contain ',' (comma) character.
+   *
+   * @since 3.5.0
    */
   def addJobTag(tag: String): Unit = sc.addJobTag(tag)
 
@@ -735,13 +739,23 @@ class JavaSparkContext(val sc: SparkContext) extends Closeable {
    * Noop if such a tag was not added earlier.
    *
    * @param tag The tag to be removed. Cannot contain ',' (comma) character.
+   *
+   * @since 3.5.0
    */
   def removeJobTag(tag: String): Unit = sc.removeJobTag(tag)
 
-  /** Get the tags that are currently set to be assigned to all the jobs started by this thread. */
+  /**
+   * Get the tags that are currently set to be assigned to all the jobs started by this thread.
+   *
+   * @since 3.5.0
+   */
   def getJobTags(): util.Set[String] = sc.getJobTags.asJava
 
-  /** Clear the current thread's job tags. */
+  /**
+   * Clear the current thread's job tags.
+   *
+   * @since 3.5.0
+   */
   def clearJobTags(): Unit = sc.clearJobTags()
 
   /**
@@ -754,6 +768,8 @@ class JavaSparkContext(val sc: SparkContext) extends Closeable {
    * Cancel active jobs that have the specified tag. See `org.apache.spark.SparkContext.addJobTag`.
    *
    * @param tag The tag to be added. Cannot contain ',' (comma) character.
+   *
+   * @since 3.5.0
    */
   def cancelJobsWithTag(tag: String): Unit = sc.cancelJobsWithTag(tag)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to add:

- `SparkContext.setInterruptOnCancel(interruptOnCancel: Boolean): Unit`
- `SparkContext.addJobTag(tag: String): Unit`
- `SparkContext.removeJobTag(tag: String): Unit`
- `SparkContext.getJobTags(): Set[String]`
- `SparkContext.clearJobTags(): Unit`
- `SparkContext.cancelJobsWithTag(tag: String): Unit`

into Java API.

### Why are the changes needed?

For Java users. In addition, these will be used in Python implementation in SPARK-44194

### Does this PR introduce _any_ user-facing change?

Yes, it adds new API in Java.

### How was this patch tested?

It's an alias so no tests added. These will be at least called once via PySpark when I work on SPARK-44194 so I don't worry about it too much.