### PR TITLE
[SPARK-44192][BUILD][R] Support R 4.3.1

### DIFF
--- a/dev/appveyor-install-dependencies.ps1
+++ b/dev/appveyor-install-dependencies.ps1
@@ -129,7 +129,7 @@ $env:PATH = "$env:HADOOP_HOME\bin;" + $env:PATH
 Pop-Location
 
 # ========================== R
-$rVer = "4.3.0"
+$rVer = "4.3.1"
 $rToolsVer = "4.0.2"
 
 InstallR


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to support R 4.3.1 officially in Apache Spark 3.5.0 by upgrading AppVeyor to 4.3.1.



### Why are the changes needed?
R 4.3.1 is released on Jun 16, 2023.
- https://stat.ethz.ch/pipermail/r-announce/2023/000694.html



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass GitHub Actions
