### PR TITLE
[SPARK-44197][BUILD][FOLLOWUP] Update `IsolatedClientLoader` hadoop version

### DIFF
--- a/assembly/README
+++ b/assembly/README
@@ -9,4 +9,4 @@ This module is off by default. To activate it specify the profile in the command
 
 If you need to build an assembly for a different version of Hadoop the
 hadoop-version system property needs to be set as in this example:
-  -Dhadoop.version=3.3.5
+  -Dhadoop.version=3.3.6

--- a/resource-managers/kubernetes/integration-tests/README.md
+++ b/resource-managers/kubernetes/integration-tests/README.md
@@ -129,7 +129,7 @@ properties to Maven.  For example:
 
     mvn integration-test -am -pl :spark-kubernetes-integration-tests_2.12 \
                             -Pkubernetes -Pkubernetes-integration-tests \
-                            -Phadoop-3 -Dhadoop.version=3.3.5 \
+                            -Phadoop-3 -Dhadoop.version=3.3.6 \
                             -Dspark.kubernetes.test.sparkTgz=spark-3.0.0-SNAPSHOT-bin-example.tgz \
                             -Dspark.kubernetes.test.imageTag=sometag \
                             -Dspark.kubernetes.test.imageRepo=docker.io/somerepo \

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/IsolatedClientLoader.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/IsolatedClientLoader.scala
@@ -66,7 +66,7 @@ private[hive] object IsolatedClientLoader extends Logging {
           case e: RuntimeException if e.getMessage.contains("hadoop") =>
             // If the error message contains hadoop, it is probably because the hadoop
             // version cannot be resolved.
-            val fallbackVersion = "3.3.5"
+            val fallbackVersion = "3.3.6"
             logWarning(s"Failed to resolve Hadoop artifacts for the version $hadoopVersion. We " +
               s"will change the hadoop version from $hadoopVersion to $fallbackVersion and try " +
               "again. It is recommended to set jars used by Hive metastore client through " +


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to follow up SPARK-44197.

### Why are the changes needed?
When the Hadoop version that Spark relies on is upgraded from `3.3.5` to `3.3.6`, the corresponding versions in `IsolatedClientLoader` should also be upgraded synchronously.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA.