### PR TITLE
[SPARK-43828][CORE] Add config to control whether close idle connections

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
@@ -46,6 +46,8 @@ public class TransportConf {
   private final String SPARK_NETWORK_VERBOSE_METRICS;
   private final String SPARK_NETWORK_IO_ENABLETCPKEEPALIVE_KEY;
 
+  private final String SPARK_NETWORK_CLOSE_IDLE_CONNECTION_KEY;
+
   private final ConfigProvider conf;
 
   private final String module;
@@ -69,6 +71,7 @@ public class TransportConf {
     SPARK_NETWORK_IO_LAZYFD_KEY = getConfKey("io.lazyFD");
     SPARK_NETWORK_VERBOSE_METRICS = getConfKey("io.enableVerboseMetrics");
     SPARK_NETWORK_IO_ENABLETCPKEEPALIVE_KEY = getConfKey("io.enableTcpKeepAlive");
+    SPARK_NETWORK_CLOSE_IDLE_CONNECTION_KEY = getConfKey("io.closeIdleConnection");
   }
 
   public int getInt(String name, int defaultValue) {
@@ -401,5 +404,11 @@ public class TransportConf {
   public long mergedShuffleCleanerShutdownTimeout() {
     return JavaUtils.timeStringAsSec(
       conf.get("spark.shuffle.push.server.mergedShuffleCleaner.shutdown.timeout", "60s"));
+  }
+
+  /** Whether to close idle connections. Default true. */
+  public boolean closeIdleConnections() {
+    boolean defaultCloseIdleConnection = conf.getBoolean("spark.network.closeIdleConnection", true);
+    return conf.getBoolean(SPARK_NETWORK_CLOSE_IDLE_CONNECTION_KEY, defaultCloseIdleConnection);
   }
 }

--- a/common/network-common/src/test/java/org/apache/spark/network/client/TransportClientFactorySuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/client/TransportClientFactorySuite.java
@@ -206,7 +206,7 @@ public class TransportClientFactorySuite {
         throw new UnsupportedOperationException();
       }
     });
-    try (TransportContext context = new TransportContext(conf, new NoOpRpcHandler(), true);
+    try (TransportContext context = new TransportContext(conf, new NoOpRpcHandler(), conf.closeIdleConnections());
          TransportClientFactory factory = context.createClientFactory()) {
       TransportClient c1 = factory.createClient(TestUtils.getLocalHost(), server1.getPort());
       assertTrue(c1.isActive());

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockStoreClient.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockStoreClient.java
@@ -79,7 +79,7 @@ public class ExternalBlockStoreClient extends BlockStoreClient {
   public void init(String appId) {
     this.appId = appId;
     TransportContext context = new TransportContext(
-      transportConf, new NoOpRpcHandler(), true, true);
+      transportConf, new NoOpRpcHandler(), transportConf.closeIdleConnections(), true);
     List<TransportClientBootstrap> bootstraps = Lists.newArrayList();
     if (authEnabled) {
       bootstraps.add(new AuthClientBootstrap(transportConf, appId, secretKeyHolder));

--- a/common/network-yarn/src/main/java/org/apache/spark/network/yarn/YarnShuffleService.java
+++ b/common/network-yarn/src/main/java/org/apache/spark/network/yarn/YarnShuffleService.java
@@ -300,7 +300,7 @@ public class YarnShuffleService extends AuxiliaryService {
 
       int port = _conf.getInt(
         SPARK_SHUFFLE_SERVICE_PORT_KEY, DEFAULT_SPARK_SHUFFLE_SERVICE_PORT);
-      transportContext = new TransportContext(transportConf, blockHandler, true);
+      transportContext = new TransportContext(transportConf, blockHandler);
       shuffleServer = transportContext.createServer(port, bootstraps);
       // the port should normally be fixed, but for tests its useful to find an open port
       port = shuffleServer.getPort();

--- a/core/src/main/scala/org/apache/spark/deploy/ExternalShuffleService.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/ExternalShuffleService.scala
@@ -109,7 +109,8 @@ class ExternalShuffleService(sparkConf: SparkConf, securityManager: SecurityMana
       } else {
         Nil
       }
-    transportContext = new TransportContext(transportConf, blockHandler, true)
+    transportContext = new TransportContext(transportConf, blockHandler,
+      transportConf.closeIdleConnections())
     server = transportContext.createServer(port, bootstraps.asJava)
 
     shuffleServiceSource.registerMetricSet(server.getAllMetrics)

--- a/core/src/main/scala/org/apache/spark/rpc/netty/NettyRpcEnv.scala
+++ b/core/src/main/scala/org/apache/spark/rpc/netty/NettyRpcEnv.scala
@@ -392,7 +392,8 @@ private[netty] class NettyRpcEnv(
 
         val ioThreads = clone.getInt("spark.files.io.threads", 1)
         val downloadConf = SparkTransportConf.fromSparkConf(clone, module, ioThreads)
-        val downloadContext = new TransportContext(downloadConf, new NoOpRpcHandler(), true)
+        val downloadContext = new TransportContext(downloadConf, new NoOpRpcHandler(),
+          transportConf.closeIdleConnections())
         fileDownloadFactory = downloadContext.createClientFactory(createClientBootstraps())
       }
     }

--- a/core/src/test/scala/org/apache/spark/network/netty/SparkTransportConfSuite.scala
+++ b/core/src/test/scala/org/apache/spark/network/netty/SparkTransportConfSuite.scala
@@ -38,6 +38,22 @@ class SparkTransportConfSuite extends SparkFunSuite with MockitoSugar {
     assert(cliActual == expected.toString)
   }
 
+  test("SPARK-43828: close idle connection should return correct value when set") {
+    val numUsableCores = 4
+    val closeIdleConnection = false
+    val conf = new SparkConf()
+      .set(s"spark.$module.io.closeIdleConnections", false.toString)
+    val sparkTransportConf = SparkTransportConf.fromSparkConf(conf, module, numUsableCores, None)
+    assert(sparkTransportConf.closeIdleConnections() == closeIdleConnection)
+  }
+
+  test("SPARK-43828: close idle connection should return true as default") {
+    val numUsableCores = 4
+    val conf = new SparkConf()
+    val sparkTransportConf = SparkTransportConf.fromSparkConf(conf, module, numUsableCores, None)
+    assert(sparkTransportConf.closeIdleConnections())
+  }
+
   test("module value is get when role is not set") {
     val numUsableCores = 3
     val serExpected = "7"


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add config `spark.network.closeIdleConnection` and `spark.$module.io.closeIdleConnection` to control whether close idle connections

### Why are the changes needed?
Allow user to config whether close idle connections

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Added UT in `SparkTransportConfSuite`
