### PR TITLE
[SPARK-44230][SQL][TESTS] Make `sql` module passes in Java 21

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/arrow/ArrowConvertersSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/arrow/ArrowConvertersSuite.scala
@@ -27,6 +27,7 @@ import org.apache.arrow.memory.RootAllocator
 import org.apache.arrow.vector.{VectorLoader, VectorSchemaRoot}
 import org.apache.arrow.vector.ipc.JsonFileReader
 import org.apache.arrow.vector.util.{ByteArrayReadableSeekableByteChannel, Validator}
+import org.apache.commons.lang3.{JavaVersion, SystemUtils}
 
 import org.apache.spark.{SparkException, SparkUnsupportedOperationException, TaskContext}
 import org.apache.spark.sql.{DataFrame, Row}
@@ -52,6 +53,8 @@ class ArrowConvertersSuite extends SharedSparkSession {
   }
 
   test("collect to arrow record batch") {
+    // TODO(SPARK-44229) Renable 'o.a.s.sql.execution.arrow' tests in Java 21
+    assume(SystemUtils.isJavaVersionAtMost(JavaVersion.JAVA_17))
     val indexData = (1 to 6).toDF("i")
     val arrowBatches = indexData.toArrowBatchRdd.collect()
     assert(arrowBatches.nonEmpty)
@@ -66,6 +69,8 @@ class ArrowConvertersSuite extends SharedSparkSession {
   }
 
   test("short conversion") {
+    // TODO(SPARK-44229) Renable 'o.a.s.sql.execution.arrow' tests in Java 21
+    assume(SystemUtils.isJavaVersionAtMost(JavaVersion.JAVA_17))
     val json =
       s"""
          |{
@@ -115,6 +120,8 @@ class ArrowConvertersSuite extends SharedSparkSession {
   }
 
   test("int conversion") {
+    // TODO(SPARK-44229) Renable 'o.a.s.sql.execution.arrow' tests in Java 21
+    assume(SystemUtils.isJavaVersionAtMost(JavaVersion.JAVA_17))
     val json =
       s"""
          |{
@@ -164,6 +171,8 @@ class ArrowConvertersSuite extends SharedSparkSession {
   }
 
   test("long conversion") {
+    // TODO(SPARK-44229) Renable 'o.a.s.sql.execution.arrow' tests in Java 21
+    assume(SystemUtils.isJavaVersionAtMost(JavaVersion.JAVA_17))
     val json =
       s"""
          |{
@@ -213,6 +222,8 @@ class ArrowConvertersSuite extends SharedSparkSession {
   }
 
   test("float conversion") {
+    // TODO(SPARK-44229) Renable 'o.a.s.sql.execution.arrow' tests in Java 21
+    assume(SystemUtils.isJavaVersionAtMost(JavaVersion.JAVA_17))
     val json =
       s"""
          |{
@@ -260,6 +271,8 @@ class ArrowConvertersSuite extends SharedSparkSession {
   }
 
   test("double conversion") {
+    // TODO(SPARK-44229) Renable 'o.a.s.sql.execution.arrow' tests in Java 21
+    assume(SystemUtils.isJavaVersionAtMost(JavaVersion.JAVA_17))
     val json =
       s"""
          |{
@@ -307,6 +320,8 @@ class ArrowConvertersSuite extends SharedSparkSession {
   }
 
   test("decimal conversion") {
+    // TODO(SPARK-44229) Renable 'o.a.s.sql.execution.arrow' tests in Java 21
+    assume(SystemUtils.isJavaVersionAtMost(JavaVersion.JAVA_17))
     val json =
       s"""
          |{
@@ -371,6 +386,8 @@ class ArrowConvertersSuite extends SharedSparkSession {
   }
 
   test("index conversion") {
+    // TODO(SPARK-44229) Renable 'o.a.s.sql.execution.arrow' tests in Java 21
+    assume(SystemUtils.isJavaVersionAtMost(JavaVersion.JAVA_17))
     val data = List[Int](1, 2, 3, 4, 5, 6)
     val json =
       s"""
@@ -404,6 +421,8 @@ class ArrowConvertersSuite extends SharedSparkSession {
   }
 
   test("mixed numeric type conversion") {
+    // TODO(SPARK-44229) Renable 'o.a.s.sql.execution.arrow' tests in Java 21
+    assume(SystemUtils.isJavaVersionAtMost(JavaVersion.JAVA_17))
     val json =
       s"""
          |{
@@ -495,6 +514,8 @@ class ArrowConvertersSuite extends SharedSparkSession {
   }
 
   test("string type conversion") {
+    // TODO(SPARK-44229) Renable 'o.a.s.sql.execution.arrow' tests in Java 21
+    assume(SystemUtils.isJavaVersionAtMost(JavaVersion.JAVA_17))
     val json =
       s"""
          |{
@@ -557,6 +578,8 @@ class ArrowConvertersSuite extends SharedSparkSession {
   }
 
   test("boolean type conversion") {
+    // TODO(SPARK-44229) Renable 'o.a.s.sql.execution.arrow' tests in Java 21
+    assume(SystemUtils.isJavaVersionAtMost(JavaVersion.JAVA_17))
     val json =
       s"""
          |{
@@ -586,6 +609,8 @@ class ArrowConvertersSuite extends SharedSparkSession {
   }
 
   test("byte type conversion") {
+    // TODO(SPARK-44229) Renable 'o.a.s.sql.execution.arrow' tests in Java 21
+    assume(SystemUtils.isJavaVersionAtMost(JavaVersion.JAVA_17))
     val json =
       s"""
          |{
@@ -618,6 +643,8 @@ class ArrowConvertersSuite extends SharedSparkSession {
   }
 
   test("binary type conversion") {
+    // TODO(SPARK-44229) Renable 'o.a.s.sql.execution.arrow' tests in Java 21
+    assume(SystemUtils.isJavaVersionAtMost(JavaVersion.JAVA_17))
     val json =
       s"""
          |{
@@ -652,6 +679,8 @@ class ArrowConvertersSuite extends SharedSparkSession {
   }
 
   test("date type conversion") {
+    // TODO(SPARK-44229) Renable 'o.a.s.sql.execution.arrow' tests in Java 21
+    assume(SystemUtils.isJavaVersionAtMost(JavaVersion.JAVA_17))
     val json =
       s"""
          |{
@@ -689,6 +718,8 @@ class ArrowConvertersSuite extends SharedSparkSession {
   }
 
   test("timestamp type conversion") {
+    // TODO(SPARK-44229) Renable 'o.a.s.sql.execution.arrow' tests in Java 21
+    assume(SystemUtils.isJavaVersionAtMost(JavaVersion.JAVA_17))
     withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> "America/Los_Angeles") {
       val json =
         s"""
@@ -731,6 +762,8 @@ class ArrowConvertersSuite extends SharedSparkSession {
   }
 
   test("floating-point NaN") {
+    // TODO(SPARK-44229) Renable 'o.a.s.sql.execution.arrow' tests in Java 21
+    assume(SystemUtils.isJavaVersionAtMost(JavaVersion.JAVA_17))
     val json =
       s"""
          |{
@@ -778,6 +811,8 @@ class ArrowConvertersSuite extends SharedSparkSession {
   }
 
   test("array type conversion") {
+    // TODO(SPARK-44229) Renable 'o.a.s.sql.execution.arrow' tests in Java 21
+    assume(SystemUtils.isJavaVersionAtMost(JavaVersion.JAVA_17))
     val json =
       s"""
          |{
@@ -925,6 +960,8 @@ class ArrowConvertersSuite extends SharedSparkSession {
   }
 
   test("struct type conversion") {
+    // TODO(SPARK-44229) Renable 'o.a.s.sql.execution.arrow' tests in Java 21
+    assume(SystemUtils.isJavaVersionAtMost(JavaVersion.JAVA_17))
     val json =
       s"""
          |{
@@ -1074,6 +1111,8 @@ class ArrowConvertersSuite extends SharedSparkSession {
   }
 
   test("null type conversion") {
+    // TODO(SPARK-44229) Renable 'o.a.s.sql.execution.arrow' tests in Java 21
+    assume(SystemUtils.isJavaVersionAtMost(JavaVersion.JAVA_17))
     val json =
       s"""
          |{
@@ -1129,6 +1168,8 @@ class ArrowConvertersSuite extends SharedSparkSession {
   }
 
   test("partitioned DataFrame") {
+    // TODO(SPARK-44229) Renable 'o.a.s.sql.execution.arrow' tests in Java 21
+    assume(SystemUtils.isJavaVersionAtMost(JavaVersion.JAVA_17))
     val json1 =
       s"""
          |{
@@ -1225,6 +1266,8 @@ class ArrowConvertersSuite extends SharedSparkSession {
   }
 
   test("empty frame collect") {
+    // TODO(SPARK-44229) Renable 'o.a.s.sql.execution.arrow' tests in Java 21
+    assume(SystemUtils.isJavaVersionAtMost(JavaVersion.JAVA_17))
     val arrowBatches = spark.emptyDataFrame.toArrowBatchRdd.collect()
     assert(arrowBatches.isEmpty)
 
@@ -1234,6 +1277,8 @@ class ArrowConvertersSuite extends SharedSparkSession {
   }
 
   test("empty partition collect") {
+    // TODO(SPARK-44229) Renable 'o.a.s.sql.execution.arrow' tests in Java 21
+    assume(SystemUtils.isJavaVersionAtMost(JavaVersion.JAVA_17))
     val emptyPart = spark.sparkContext.parallelize(Seq(1), 2).toDF("i")
     val arrowBatches = emptyPart.toArrowBatchRdd.collect()
     assert(arrowBatches.length === 1)
@@ -1245,6 +1290,8 @@ class ArrowConvertersSuite extends SharedSparkSession {
   }
 
   test("max records in batch conf") {
+    // TODO(SPARK-44229) Renable 'o.a.s.sql.execution.arrow' tests in Java 21
+    assume(SystemUtils.isJavaVersionAtMost(JavaVersion.JAVA_17))
     val totalRecords = 10
     val maxRecordsPerBatch = 3
     spark.conf.set(SQLConf.ARROW_EXECUTION_MAX_RECORDS_PER_BATCH.key, maxRecordsPerBatch)
@@ -1277,6 +1324,8 @@ class ArrowConvertersSuite extends SharedSparkSession {
   }
 
   test("test Arrow Validator") {
+    // TODO(SPARK-44229) Renable 'o.a.s.sql.execution.arrow' tests in Java 21
+    assume(SystemUtils.isJavaVersionAtMost(JavaVersion.JAVA_17))
     val json =
       s"""
          |{
@@ -1374,6 +1423,8 @@ class ArrowConvertersSuite extends SharedSparkSession {
   }
 
   test("roundtrip arrow batches") {
+    // TODO(SPARK-44229) Renable 'o.a.s.sql.execution.arrow' tests in Java 21
+    assume(SystemUtils.isJavaVersionAtMost(JavaVersion.JAVA_17))
     val inputRows = (0 until 9).map { i =>
       InternalRow(i)
     } :+ InternalRow(null)
@@ -1398,6 +1449,8 @@ class ArrowConvertersSuite extends SharedSparkSession {
   }
 
   test("ArrowBatchStreamWriter roundtrip") {
+    // TODO(SPARK-44229) Renable 'o.a.s.sql.execution.arrow' tests in Java 21
+    assume(SystemUtils.isJavaVersionAtMost(JavaVersion.JAVA_17))
     val inputRows = (0 until 9).map(InternalRow(_)) :+ InternalRow(null)
 
     val schema = StructType(Seq(StructField("int", IntegerType, nullable = true)))
@@ -1431,6 +1484,8 @@ class ArrowConvertersSuite extends SharedSparkSession {
   }
 
   test("roundtrip arrow batches with complex schema") {
+    // TODO(SPARK-44229) Renable 'o.a.s.sql.execution.arrow' tests in Java 21
+    assume(SystemUtils.isJavaVersionAtMost(JavaVersion.JAVA_17))
     val rows = (0 until 9).map { i =>
       InternalRow(i, UTF8String.fromString(s"str-$i"), InternalRow(i))
     }
@@ -1462,6 +1517,8 @@ class ArrowConvertersSuite extends SharedSparkSession {
   }
 
   test("roundtrip empty arrow batches") {
+    // TODO(SPARK-44229) Renable 'o.a.s.sql.execution.arrow' tests in Java 21
+    assume(SystemUtils.isJavaVersionAtMost(JavaVersion.JAVA_17))
     val schema = StructType(Seq(StructField("int", IntegerType, nullable = true)))
     val ctx = TaskContext.empty()
     val batchIter =
@@ -1473,6 +1530,8 @@ class ArrowConvertersSuite extends SharedSparkSession {
   }
 
   test("two batches with different schema") {
+    // TODO(SPARK-44229) Renable 'o.a.s.sql.execution.arrow' tests in Java 21
+    assume(SystemUtils.isJavaVersionAtMost(JavaVersion.JAVA_17))
     val schema1 = StructType(Seq(StructField("field1", IntegerType, nullable = true)))
     val inputRows1 = Array(InternalRow(1)).map { row =>
       val proj = UnsafeProjection.create(schema1)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to make `sql` module passes in Java 21 except `ArrowConvertersSuite`. The following TODO JIRA is created for that.
- SPARK-44229 Reenable 'o.a.s.sql.execution.arrow' tests in Java 21

### Why are the changes needed?

To monitor Java 21 test coverage more easily by detecting newly broken tests.

According to our Java 21-EA job, this is the last failed suite in SQL module.

- https://github.com/apache/spark/actions/runs/5385615528

![Screenshot 2023-06-28 at 12 45 22 PM](https://github.com/apache/spark/assets/9700541/d9d76499-05b8-4fef-b473-4bd036f6782b)

- https://pipelines.actions.githubusercontent.com/serviceHosts/03398d36-4378-4d47-a936-fba0a5e8ccb9/_apis/pipelines/1/runs/254252/signedlogcontent/17?urlExpires=2023-06-28T19%3A44%3A11.3174335Z&urlSigningMethod=HMACV1&urlSignature=KzKGfUUjLn38DkKdzkA%2FhKpONmM%2BhJvx0RR7bHK4BGI%3D
```
Failed tests:
org.apache.spark.sql.execution.arrow.ArrowConvertersSuite
```

### Does this PR introduce _any_ user-facing change?

No, this is a test-only PR.

### How was this patch tested?

Pass the CIs and manually tests with Java 21.

```
$ java -version
openjdk version "21-ea" 2023-09-19
OpenJDK Runtime Environment (build 21-ea+28-2377)
OpenJDK 64-Bit Server VM (build 21-ea+28-2377, mixed mode, sharing)

$ build/sbt "sql/testOnly *.ArrowConvertersSuite"
...
[info] Run completed in 3 seconds, 451 milliseconds.
[info] Total number of tests run: 1
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 1, failed 0, canceled 29, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 53 s, completed Jun 28, 2023, 12:51:51 PM
```