### PR TITLE
[SPARK-44237][CORE] Simplify DirectByteBuffer constructor lookup logic

### DIFF
--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/Platform.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/Platform.java
@@ -68,14 +68,9 @@ public final class Platform {
     }
     try {
       Class<?> cls = Class.forName("java.nio.DirectByteBuffer");
-      Constructor<?> constructor;
-      try {
-        constructor = cls.getDeclaredConstructor(Long.TYPE, Integer.TYPE);
-      } catch (NoSuchMethodException e) {
-        // DirectByteBuffer(long,int) was removed in
-        // https://github.com/openjdk/jdk/commit/a56598f5a534cc9223367e7faa8433ea38661db9
-        constructor = cls.getDeclaredConstructor(Long.TYPE, Long.TYPE);
-      }
+      Constructor<?> constructor = (majorVersion < 21) ?
+        cls.getDeclaredConstructor(Long.TYPE, Integer.TYPE) :
+        cls.getDeclaredConstructor(Long.TYPE, Long.TYPE);
       Field cleanerField = cls.getDeclaredField("cleaner");
       try {
         constructor.setAccessible(true);


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to simplify `DirectByteBuffer` constructor lookup logic.

### Why are the changes needed?

`try-catch` statement is not needed because we know version number already.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.