### PR TITLE
[WIP][SPARK-44243][CORE] Add a parameter to determine the locality of local shuffle reader

### DIFF
--- a/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
+++ b/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
@@ -675,7 +675,7 @@ private[spark] class MapOutputTrackerMaster(
   private val minSizeForBroadcast = conf.get(SHUFFLE_MAPOUTPUT_MIN_SIZE_FOR_BROADCAST).toInt
 
   /** Whether to compute locality preferences for reduce tasks */
-  private val shuffleLocalityEnabled = conf.get(SHUFFLE_REDUCE_LOCALITY_ENABLE)
+  private[spark] val shuffleLocalityEnabled = conf.get(SHUFFLE_REDUCE_LOCALITY_ENABLE)
 
   // Number of map and reduce tasks above which we do not assign preferred locations based on map
   // output sizes. We limit the size of jobs for which assign preferred locations as computing the
@@ -1130,8 +1130,6 @@ private[spark] class MapOutputTrackerMaster(
       startMapIndex: Int,
       endMapIndex: Int): Seq[String] =
   {
-    if (!shuffleLocalityEnabled) return Nil
-
     val shuffleStatus = shuffleStatuses.get(dep.shuffleId).orNull
     if (shuffleStatus != null) {
       shuffleStatus.withMapStatuses { statuses =>

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1572,6 +1572,13 @@ package object config {
       .booleanConf
       .createWithDefault(true)
 
+  private[spark] val LOCAL_SHUFFLE_LOCALITY_ENABLE =
+    ConfigBuilder("spark.shuffle.localShuffleLocality.enabled")
+      .doc("Whether to compute locality preferences for local shuffle readers")
+      .version("3.5.0")
+      .booleanConf
+      .createWithDefault(true)
+
   private[spark] val SHUFFLE_MAPOUTPUT_MIN_SIZE_FOR_BROADCAST =
     ConfigBuilder("spark.shuffle.mapOutput.minSizeForBroadcast")
       .doc("The size at which we use Broadcast to send the map output statuses to the executors.")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ShuffledRowRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ShuffledRowRDD.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.execution
 import java.util.Arrays
 
 import org.apache.spark._
+import org.apache.spark.internal.config.LOCAL_SHUFFLE_LOCALITY_ENABLE
 import org.apache.spark.rdd.RDD
 import org.apache.spark.shuffle.sort.SortShuffleManager
 import org.apache.spark.sql.catalyst.InternalRow
@@ -175,12 +176,15 @@ class ShuffledRowRDD(
         }
 
       case PartialReducerPartitionSpec(_, startMapIndex, endMapIndex, _) =>
+        if (!tracker.shuffleLocalityEnabled) return Nil
         tracker.getMapLocation(dependency, startMapIndex, endMapIndex)
 
       case PartialMapperPartitionSpec(mapIndex, _, _) =>
+        if (!conf.get(LOCAL_SHUFFLE_LOCALITY_ENABLE)) return Nil
         tracker.getMapLocation(dependency, mapIndex, mapIndex + 1)
 
       case CoalescedMapperPartitionSpec(startMapIndex, endMapIndex, numReducers) =>
+        if (!conf.get(LOCAL_SHUFFLE_LOCALITY_ENABLE)) return Nil
         tracker.getMapLocation(dependency, startMapIndex, endMapIndex)
     }
   }


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Follow changes of https://github.com/apache/spark/pull/40339

Local shuffle reader can achieve better performance with preferred locations. If we disable SHUFFLE_REDUCE_LOCALITY_ENABLE in queries that include reduce shuffles and local shuffles, local shuffle readers can not get preferred locations.

Add new parameter LOCAL_SHUFFLE_LOCALITY_ENABLE to determine whether to get the preferred locations of the current partitionSpec.

### Why are the changes needed?

Improvement for spark local shuffle.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Exists UT