### PR TITLE
[SPARK-44245][PYTHON] pyspark.sql.dataframe sample() doctests should be illustrative-only

### DIFF
--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -1873,11 +1873,11 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         Examples
         --------
         >>> df = spark.range(10)
-        >>> df.sample(0.5, 3).count()
+        >>> df.sample(0.5, 3).count() # doctest: +SKIP
         7
-        >>> df.sample(fraction=0.5, seed=3).count()
+        >>> df.sample(fraction=0.5, seed=3).count() # doctest: +SKIP
         7
-        >>> df.sample(withReplacement=True, fraction=0.5, seed=3).count()
+        >>> df.sample(withReplacement=True, fraction=0.5, seed=3).count() # doctest: +SKIP
         1
         >>> df.sample(1.0).count()
         10


### PR DESCRIPTION
### What changes were proposed in this pull request?
Disable running example doctests in pyspark.sql.dataframe

### Why are the changes needed?
The doctest serves illustrative purpose and can be broken easily due to external factors.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Checked that doctest is ignoring those lines