### PR TITLE
[SPARK-44248][SS][SQL][Kafka] Add preferred location in kafka source v2

### DIFF
--- a/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaBatchPartitionReader.scala
+++ b/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaBatchPartitionReader.scala
@@ -34,7 +34,11 @@ private[kafka010] case class KafkaBatchInputPartition(
     executorKafkaParams: ju.Map[String, Object],
     pollTimeoutMs: Long,
     failOnDataLoss: Boolean,
-    includeHeaders: Boolean) extends InputPartition
+    includeHeaders: Boolean) extends InputPartition {
+  override def preferredLocations(): Array[String] = {
+    offsetRange.preferredLoc.map(Array(_)).getOrElse(Array())
+  }
+}
 
 private[kafka010] object KafkaBatchReaderFactory extends PartitionReaderFactory with Logging {
   override def createReader(partition: InputPartition): PartitionReader[InternalRow] = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
In KafkaBatchInputPartition, which is used for Kafka v2 source, preferredLocations() is now returned from the location already pre-calculated.


### Why are the changes needed?
DSv2 Kafka streaming source seems to miss setting the preferred location, which may destroy the purpose of cache for Kafka consumer (connection) & fetched data. For DSv1, we have set the preferred location in RDD. This information is not returned in DSv2.

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Some manual verification.
