### PR TITLE
[SPARK-44285] MSK IAM Support

### DIFF
--- a/connector/kafka-0-10-sql/pom.xml
+++ b/connector/kafka-0-10-sql/pom.xml
@@ -174,6 +174,7 @@
       <scope>test</scope>
     </dependency>
 
+    <!--introduces the aws-msk-library which can be used for connecting to kafka msk clients with iam-->
     <dependency>
       <groupId>software.amazon.msk</groupId>
       <artifactId>aws-msk-iam-auth</artifactId>

--- a/connector/kafka-0-10-sql/pom.xml
+++ b/connector/kafka-0-10-sql/pom.xml
@@ -174,6 +174,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>software.amazon.msk</groupId>
+      <artifactId>aws-msk-iam-auth</artifactId>
+      <version>1.1.7</version>
+    </dependency>
+
   </dependencies>
   <build>
     <outputDirectory>target/scala-${scala.binary.version}/classes</outputDirectory>

--- a/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaRelationSuite.scala
+++ b/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaRelationSuite.scala
@@ -666,10 +666,7 @@ class KafkaRelationSuiteV2 extends KafkaRelationSuiteBase {
   Seq("source and stream", "sink and streaming",
     "source and batch", "sink and batch").foreach { testType =>
     val options: Map[String, String] = Map(
-      "kafka.bootstrap.servers" ->
-        ("b-2-public.nihalmskiamtesting.5len6e.c6.kafka.us-west-2.amazonaws.com:9198," +
-        "b-3-public.nihalmskiamtesting.5len6e.c6.kafka.us-west-2.amazonaws.com:9198," +
-          "b-1-public.nihalmskiamtesting.5len6e.c6.kafka.us-west-2.amazonaws.com:9198"),
+      "kafka.bootstrap.servers" -> "localhost:8080",
       "subscribe" -> "msk-123",
       "startingOffsets" -> "earliest",
       "kafka.sasl.mechanism" -> "AWS_MSK_IAM",

--- a/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaRelationSuite.scala
+++ b/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaRelationSuite.scala
@@ -617,31 +617,6 @@ abstract class KafkaRelationSuiteBase extends QueryTest with SharedSparkSession 
     assert(df.rdd.collectPartitions().flatMap(_.map(_.getString(0))).toSet
       === (0 to 30).map(_.toString).toSet)
   }
-
-  test("test MSK IAM auth") {
-    val topic = newTopic()
-    testUtils.createTopic(topic, partitions = 3)
-    testUtils.sendMessages(topic, (0 to 9).map(_.toString).toArray, Some(0))
-    testUtils.sendMessages(topic, (10 to 19).map(_.toString).toArray, Some(1))
-    testUtils.sendMessages(topic, Array("20"), Some(2))
-
-    // Implicit offset values, should default to earliest and latest
-    spark.readStream
-      .format("kafka")
-      .option("kafka.bootstrap.servers", "kafka.privatelink." +
-        "oregon.private.staging.cloud.databricks.com:9090")
-      .option("subscribe", "nihal-msk-iam-test")
-      .option("startingOffsets", "earliest")
-      .option("kafka.sasl.mechanism", "AWS_MSK_IAM")
-      .option("kafka.sasl.jaas.config", "software.amazon.msk.auth.iam.IAMLoginModule required;")
-      .option("kafka.security.protocol", "SASL_SSL")
-      .option("kafka.sasl.client.callback.handler.class", "software." +
-        "amazon.msk.auth.iam.IAMClientCallbackHandler")
-      .load()
-      .writeStream
-      .format("console")
-      .start()
-  }
 }
 
 class KafkaRelationSuiteWithAdminV1 extends KafkaRelationSuiteV1 {

--- a/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaRelationSuite.scala
+++ b/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaRelationSuite.scala
@@ -663,7 +663,7 @@ class KafkaRelationSuiteV2 extends KafkaRelationSuiteBase {
     }.nonEmpty)
   }
 
-  Seq("source and stream", "sink and streaming",
+  Seq("source and stream", "sink and stream",
     "source and batch", "sink and batch").foreach { testType =>
     val options: Map[String, String] = Map(
       "kafka.bootstrap.servers" -> "localhost:8080",

--- a/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaRelationSuite.scala
+++ b/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaRelationSuite.scala
@@ -19,21 +19,17 @@ package org.apache.spark.sql.kafka010
 
 import java.nio.charset.StandardCharsets.UTF_8
 import java.util.Locale
-import java.util.concurrent.ExecutionException
 import java.util.concurrent.atomic.AtomicInteger
 
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.TopicPartition
 
-import org.apache.spark.{SparkConf, SparkException, TestUtils}
-import org.apache.spark.sql.{DataFrameReader, QueryTest, Row}
+import org.apache.spark.{SparkConf, TestUtils}
+import org.apache.spark.sql.{DataFrameReader, QueryTest}
 import org.apache.spark.sql.execution.datasources.LogicalRelation
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
-import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.streaming.StreamingQueryException
 import org.apache.spark.sql.test.SharedSparkSession
-import org.apache.spark.sql.types.{StringType, StructType}
 import org.apache.spark.util.Utils
 
 abstract class KafkaRelationSuiteBase extends QueryTest with SharedSparkSession with KafkaTest {
@@ -648,8 +644,6 @@ class KafkaRelationSuiteV1 extends KafkaRelationSuiteBase {
 }
 
 class KafkaRelationSuiteV2 extends KafkaRelationSuiteBase {
-  import scala.collection.JavaConverters._
-
   override protected def sparkConf: SparkConf =
     super
       .sparkConf
@@ -661,60 +655,5 @@ class KafkaRelationSuiteV2 extends KafkaRelationSuiteBase {
     assert(df.logicalPlan.collect {
       case _: DataSourceV2Relation => true
     }.nonEmpty)
-  }
-
-  Seq("source and stream", "sink and stream",
-    "source and batch", "sink and batch").foreach { testType =>
-    val options: Map[String, String] = Map(
-      "kafka.bootstrap.servers" -> "localhost:8080",
-      "subscribe" -> "msk-123",
-      "startingOffsets" -> "earliest",
-      "kafka.sasl.mechanism" -> "AWS_MSK_IAM",
-      "kafka.sasl.jaas.config" ->
-        "software.amazon.msk.auth.iam.IAMLoginModule required;",
-      "kafka.security.protocol" -> "SASL_SSL",
-      "kafka.sasl.client.callback.handler.class" ->
-        "software.amazon.msk.auth.iam.IAMClientCallbackHandler"
-    )
-
-    // if testType contains source/sink, then kafka is used as a source/sink option respectively
-    // if testType contains stream/batch, it is used either in readStream/read
-    test(s"test MSK IAM auth on kafka '$testType' side") {
-      var e : Throwable = null
-      if (testType.contains("stream")) {
-          if (testType.contains("source")) {
-            e = intercept[StreamingQueryException] {
-              spark.readStream.format("kafka").options(options).load()
-                .writeStream.format("console").start().processAllAvailable()
-            }
-            TestUtils.assertExceptionMsg(e, "Timed out")
-          } else {
-            e = intercept[StreamingQueryException] {
-              spark.readStream.format("rate").option("rowsPerSecond", 10).load()
-                .withColumn("value", col("value").cast(StringType)).writeStream
-                .format("kafka").options(options).option("checkpointLocation", "temp/testing")
-                .option("topic", "msk-123").start().processAllAvailable()
-            }
-            TestUtils.assertExceptionMsg(e, "Timeout")
-          }
-      } else {
-        if (testType.contains("source")) {
-          e = intercept[ExecutionException] {
-            spark.read.format("kafka").options(options).load()
-              .write.format("console").save()
-          }
-          TestUtils.assertExceptionMsg(e, "Timed out")
-        } else {
-          val schema = new StructType().add("value", "string")
-          e = intercept[SparkException] {
-            spark.createDataFrame(Seq(Row("test"), Row("test2")).asJava, schema)
-              .write.mode("append").format("kafka")
-              .options(options).option("checkpointLocation", "temp/testing/1")
-              .option("topic", "msk-123").save()
-          }
-          TestUtils.assertExceptionMsg(e, "Timeout")
-        }
-      }
-    }
   }
 }

--- a/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaRelationSuite.scala
+++ b/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaRelationSuite.scala
@@ -616,6 +616,31 @@ abstract class KafkaRelationSuiteBase extends QueryTest with SharedSparkSession 
     assert(df.rdd.collectPartitions().flatMap(_.map(_.getString(0))).toSet
       === (0 to 30).map(_.toString).toSet)
   }
+
+  test("test MSK IAM auth") {
+    val topic = newTopic()
+    testUtils.createTopic(topic, partitions = 3)
+    testUtils.sendMessages(topic, (0 to 9).map(_.toString).toArray, Some(0))
+    testUtils.sendMessages(topic, (10 to 19).map(_.toString).toArray, Some(1))
+    testUtils.sendMessages(topic, Array("20"), Some(2))
+
+    // Implicit offset values, should default to earliest and latest
+    spark.readStream
+      .format("kafka")
+      .option("kafka.bootstrap.servers", "kafka.privatelink." +
+        "oregon.private.staging.cloud.databricks.com:9090")
+      .option("subscribe", "nihal-msk-iam-test")
+      .option("startingOffsets", "earliest")
+      .option("kafka.sasl.mechanism", "AWS_MSK_IAM")
+      .option("kafka.sasl.jaas.config", "software.amazon.msk.auth.iam.IAMLoginModule required;")
+      .option("kafka.security.protocol", "SASL_SSL")
+      .option("kafka.sasl.client.callback.handler.class", "software." +
+        "amazon.msk.auth.iam.IAMClientCallbackHandler")
+      .load()
+      .writeStream
+      .format("console")
+      .start()
+  }
 }
 
 class KafkaRelationSuiteWithAdminV1 extends KafkaRelationSuiteV1 {

--- a/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaSourceProviderSuite.scala
+++ b/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaSourceProviderSuite.scala
@@ -20,6 +20,8 @@ package org.apache.spark.sql.kafka010
 import java.util.Locale
 import java.util.concurrent.ExecutionException
 
+import scala.collection.JavaConverters._
+
 import org.mockito.Mockito.{mock, when}
 
 import org.apache.spark.{SparkConf, SparkEnv, SparkException, SparkFunSuite, TestUtils}
@@ -32,8 +34,6 @@ import org.apache.spark.sql.types.{StringType, StructType}
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 class KafkaSourceProviderSuite extends SparkFunSuite with SharedSparkSession {
-  import scala.collection.JavaConverters._
-
   private val expected = "1111"
 
   protected var testUtils: KafkaTestUtils = _
@@ -65,8 +65,12 @@ class KafkaSourceProviderSuite extends SparkFunSuite with SharedSparkSession {
     })
   }
 
-  /* if testType contains source/sink, kafka is used as a source/sink option respectively
-  if testType contains stream/batch, it is used either in readStream/read or writeStream/write */
+  /*
+    the goal of this test is to verify the functionality of the aws msk IAM auth
+    how this test works:
+    if testType contains source/sink, kafka is used as a source/sink option respectively
+    if testType contains stream/batch, it is used either in readStream/read or writeStream/write
+  */
   Seq("source and stream", "sink and stream",
     "source and batch", "sink and batch").foreach { testType =>
     test(s"test MSK IAM auth on kafka '$testType' side") {

--- a/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaSourceProviderSuite.scala
+++ b/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaSourceProviderSuite.scala
@@ -74,7 +74,7 @@ class KafkaSourceProviderSuite extends SparkFunSuite with SharedSparkSession {
     while using IAM authentication which times out since it doesn't have IAM auth enabled.
     Thus, it is expected that a timeout error will be thrown.
   */
-  private var mskIAMTestKafkaOptions: Map[String, String] = Map(
+  private val mskIAMTestKafkaOptions: Map[String, String] = Map(
     "subscribe" -> "msk-123",
     "startingOffsets" -> "earliest",
     "kafka.sasl.mechanism" -> "AWS_MSK_IAM",

--- a/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaSourceProviderSuite.scala
+++ b/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaSourceProviderSuite.scala
@@ -89,7 +89,9 @@ class KafkaSourceProviderSuite extends SparkFunSuite with SharedSparkSession {
         "kafka.security.protocol" -> "SASL_SSL",
         "kafka.sasl.client.callback.handler.class" ->
           "software.amazon.msk.auth.iam.IAMClientCallbackHandler",
-        "retries" -> "0"
+        "retries" -> "0",
+        "kafka.request.timeout.ms" -> "3000",
+        "kafka.max.block.ms" -> "3000"
       )
 
       testUtils.createTopic(options("subscribe"))

--- a/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaSourceProviderSuite.scala
+++ b/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaSourceProviderSuite.scala
@@ -91,6 +91,7 @@ class KafkaSourceProviderSuite extends SparkFunSuite with SharedSparkSession {
           "software.amazon.msk.auth.iam.IAMClientCallbackHandler",
         "retries" -> "0",
         "kafka.request.timeout.ms" -> "3000",
+        "kafka.default.api.timeout.ms" -> "3000",
         "kafka.max.block.ms" -> "3000"
       )
 

--- a/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaSourceProviderSuite.scala
+++ b/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaSourceProviderSuite.scala
@@ -96,18 +96,28 @@ class KafkaSourceProviderSuite extends SparkFunSuite with SharedSparkSession {
   */
   test("test MSK IAM auth with streaming API and with kafka source") {
     val e = intercept[StreamingQueryException] {
-      spark.readStream.format("kafka").options(mskIAMTestKafkaOptions)
-        .option("kafka.bootstrap.servers", testUtils.brokerAddress).load()
-        .writeStream.format("console").start().processAllAvailable()
+      spark
+        .readStream.format("kafka")
+        .options(mskIAMTestKafkaOptions)
+        .option("kafka.bootstrap.servers", testUtils.brokerAddress)
+        .load()
+        .writeStream.format("console")
+        .start()
+        .processAllAvailable()
     }
     TestUtils.assertExceptionMsg(e, "Timed out waiting for a node assignment")
   }
 
   test("test MSK IAM auth with batch API and with kafka source") {
     val e = intercept[ExecutionException] {
-      spark.read.format("kafka").options(mskIAMTestKafkaOptions)
-      .option("kafka.bootstrap.servers", testUtils.brokerAddress).load()
-        .write.format("console").save()
+      spark
+        .read
+        .format("kafka")
+        .options(mskIAMTestKafkaOptions)
+        .option("kafka.bootstrap.servers", testUtils.brokerAddress)
+        .load()
+        .write.format("console")
+        .save()
     }
     TestUtils.assertExceptionMsg(e, "Timed out waiting for a node assignment")
   }
@@ -121,12 +131,20 @@ class KafkaSourceProviderSuite extends SparkFunSuite with SharedSparkSession {
     testUtils.createTopic(mskIAMTestKafkaOptions("subscribe"))
     withTempDir { checkpointDir =>
       val e = intercept[StreamingQueryException] {
-        spark.readStream.format("rate").option("rowsPerSecond", 10).load()
-          .withColumn("value", col("value").cast(StringType)).writeStream
-          .format("kafka").options(mskIAMTestKafkaOptions).option("kafka.bootstrap.servers",
-          testUtils.brokerAddress).option("checkpointLocation",
-          checkpointDir.getCanonicalPath()).option("topic", mskIAMTestKafkaOptions("subscribe"))
-          .start().processAllAvailable()
+        spark
+          .readStream
+          .format("rate")
+          .option("rowsPerSecond", 10)
+          .load()
+          .withColumn("value", col("value").cast(StringType))
+          .writeStream
+          .format("kafka")
+          .options(mskIAMTestKafkaOptions)
+          .option("kafka.bootstrap.servers", testUtils.brokerAddress)
+          .option("checkpointLocation", checkpointDir.getCanonicalPath())
+          .option("topic", mskIAMTestKafkaOptions("subscribe"))
+          .start()
+          .processAllAvailable()
       }
       TestUtils.assertExceptionMsg(e,
         s"TimeoutException: Topic ${mskIAMTestKafkaOptions("subscribe")} not present in metadata")
@@ -140,11 +158,16 @@ class KafkaSourceProviderSuite extends SparkFunSuite with SharedSparkSession {
     withTempDir { checkpointDir =>
       val schema = new StructType().add("value", "string")
       val e = intercept[SparkException] {
-        spark.createDataFrame(Seq(Row("test"), Row("test2")).asJava, schema)
-          .write.mode("append").format("kafka")
-          .options(mskIAMTestKafkaOptions).option("checkpointLocation",
-          checkpointDir.getCanonicalPath()).option("kafka.bootstrap.servers",
-          testUtils.brokerAddress).option("topic", mskIAMTestKafkaOptions("subscribe")).save()
+        spark
+          .createDataFrame(Seq(Row("test"), Row("test2")).asJava, schema)
+          .write
+          .mode("append")
+          .format("kafka")
+          .options(mskIAMTestKafkaOptions)
+          .option("checkpointLocation", checkpointDir.getCanonicalPath())
+          .option("kafka.bootstrap.servers", testUtils.brokerAddress)
+          .option("topic", mskIAMTestKafkaOptions("subscribe"))
+          .save()
       }
       TestUtils.assertExceptionMsg(e,
         s"TimeoutException: Topic ${mskIAMTestKafkaOptions("subscribe")} not present in metadata")

--- a/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaSourceProviderSuite.scala
+++ b/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaSourceProviderSuite.scala
@@ -70,6 +70,11 @@ class KafkaSourceProviderSuite extends SparkFunSuite with SharedSparkSession {
     how this test works:
     if testType contains source/sink, kafka is used as a source/sink option respectively
     if testType contains stream/batch, it is used either in readStream/read or writeStream/write
+
+    In each case, we test that the library paths are discoverable since
+    if the library was not to be found, another error message would be thrown.
+    Although this broker exists, it does not have IAM capabilities and thus
+    it is expected that a timeout error will be thrown.
   */
   Seq("source and stream", "sink and stream",
     "source and batch", "sink and batch").foreach { testType =>

--- a/docs/structured-streaming-kafka-integration.md
+++ b/docs/structured-streaming-kafka-integration.md
@@ -1171,3 +1171,14 @@ This can be done several ways. One possibility is to provide additional JVM para
         --driver-java-options "-Djava.security.auth.login.config=/path/to/custom_jaas.conf" \
         --conf spark.executor.extraJavaOptions=-Djava.security.auth.login.config=/path/to/custom_jaas.conf \
         ...
+
+### IAM authentication
+
+Managed Streaming for Kafka (MSK) is a fully managed service offered by Amazon Web Services (AWS) that simplifies the deployment, management, and scaling of Apache Kafka clusters. 
+One way to connect to MSK is by using IAM authentication. To facilitate this, Spark already ships with the [aws msk library](https://github.com/aws/aws-msk-iam-auth) by default so no additional dependencies are required.
+To use IAM authentication, you can set the kafka config as in the [library documentation](https://github.com/aws/aws-msk-iam-auth). For example:
+
+    --conf spark.kafka.clusters.${cluster}.kafka.security.protocol=SASL_SSL
+    --conf spark.kafka.clusters.${cluster}.kafka.sasl.mechanism=AWS_MSK_IAM
+    --conf spark.kafka.clusters.${cluster}.kafka.sasl.jaas.config=software.amazon.msk.auth.iam.IAMLoginModule required;
+    --conf spark.kafka.clusters.${cluster}.kafka.sasl.client.callback.handler.class=software.amazon.msk.auth.iam.IAMClientCallbackHandler

--- a/docs/structured-streaming-kafka-integration.md
+++ b/docs/structured-streaming-kafka-integration.md
@@ -1176,9 +1176,14 @@ This can be done several ways. One possibility is to provide additional JVM para
 
 Managed Streaming for Kafka (MSK) is a fully managed service offered by Amazon Web Services (AWS) that simplifies the deployment, management, and scaling of Apache Kafka clusters. 
 One way to connect to MSK is by using IAM authentication. To facilitate this, Spark already ships with the [aws msk library](https://github.com/aws/aws-msk-iam-auth) by default so no additional dependencies are required.
-To use IAM authentication, you can set the kafka config as in the [library documentation](https://github.com/aws/aws-msk-iam-auth). For example:
+To use IAM authentication, you can set the kafka config as in the [library documentation](https://github.com/aws/aws-msk-iam-auth). For example to run with an existing spark-session:
 
-    --conf spark.kafka.clusters.${cluster}.kafka.security.protocol=SASL_SSL
-    --conf spark.kafka.clusters.${cluster}.kafka.sasl.mechanism=AWS_MSK_IAM
-    --conf spark.kafka.clusters.${cluster}.kafka.sasl.jaas.config=software.amazon.msk.auth.iam.IAMLoginModule required;
-    --conf spark.kafka.clusters.${cluster}.kafka.sasl.client.callback.handler.class=software.amazon.msk.auth.iam.IAMClientCallbackHandler
+```
+val df = spark.readStream.format("kafka")
+  .option("kafka.bootstrap.servers", "your-msk-cluster:9094")
+  .option("kafka.security.protocol", "SASL_SSL")
+  .option("kafka.sasl.mechanism", "AWS_MSK_IAM")
+  .option("kafka.sasl.jaas.config", "software.amazon.msk.auth.iam.IAMLoginModule required;")
+  .option("subscribe", "your-topic")
+  .load()
+```

--- a/docs/structured-streaming-kafka-integration.md
+++ b/docs/structured-streaming-kafka-integration.md
@@ -1180,10 +1180,11 @@ To use IAM authentication, you can set the kafka config as in the [library docum
 
 ```
 val df = spark.readStream.format("kafka")
-  .option("kafka.bootstrap.servers", "your-msk-cluster:9094")
+  .option("kafka.bootstrap.servers", "<your-msk-cluster>")
   .option("kafka.security.protocol", "SASL_SSL")
   .option("kafka.sasl.mechanism", "AWS_MSK_IAM")
   .option("kafka.sasl.jaas.config", "software.amazon.msk.auth.iam.IAMLoginModule required;")
+  .option("kafka.sasl.client.callback.handler.class", "software.amazon.msk.auth.iam.IAMClientCallbackHandler")
   .option("subscribe", "your-topic")
   .load()
 ```


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
adding a dependency for [MSK IAM ](https://github.com/aws/aws-msk-iam-auth) into the repository. While Kafka can already be used to connect to MSK, this PR introduces IAM support. This should solve customer pain points as in https://github.com/aws/aws-msk-iam-auth/issues/115. 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
While Kafka can already be used to connect to MSK, this PR introduces IAM support. This should solve customer pain points as in https://github.com/aws/aws-msk-iam-auth/issues/115. 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, customers can now use the configs like 
```
--conf spark.kafka.clusters.${cluster}.kafka.security.protocol=SASL_SSL
    --conf spark.kafka.clusters.${cluster}.kafka.sasl.mechanism=AWS_MSK_IAM
    --conf spark.kafka.clusters.${cluster}.kafka.sasl.jaas.config=software.amazon.msk.auth.iam.IAMLoginModule required;
    --conf spark.kafka.clusters.${cluster}.kafka.sasl.client.callback.handler.class=software.amazon.msk.auth.iam.IAMClientCallbackHandler
```

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Testing is challenging since there's no easy to mock AWS locally for testing IAM. Instead we test that a specific error is thrown in various scenarios to validate that the library is discoverable. This has also been manually tested.

The stackPR for the timeout is as follows:

This is for source-side errors;
```
[info] - test MSK IAM auth on kafka 'source and stream' side *** FAILED *** (14 seconds, 971 milliseconds)
[info]   org.apache.spark.sql.streaming.StreamingQueryException: [STREAM_FAILED] Query [id = 536052c3-968d-49d4-8196-34606826a6e6, runId = 8f342aff-62bb-49ac-a8c7-d81dc4b34252] terminated with exception: org.apache.kafka.common.errors.TimeoutException: Timed out waiting for a node assignment. Call: describeTopics
[info]   at org.apache.spark.sql.execution.streaming.StreamExecution.org$apache$spark$sql$execution$streaming$StreamExecution$$runStream(StreamExecution.scala:327)
[info]   at org.apache.spark.sql.execution.streaming.StreamExecution$$anon$1.run(StreamExecution.scala:207)
[info]   Cause: java.util.concurrent.ExecutionException: org.apache.kafka.common.errors.TimeoutException: Timed out waiting for a node assignment. Call: describeTopics
[info]   at java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:357)
[info]   at java.util.concurrent.CompletableFuture.get(CompletableFuture.java:1908)
[info]   at org.apache.kafka.common.internals.KafkaFutureImpl.get(KafkaFutureImpl.java:165)
[info]   at org.apache.spark.sql.kafka010.ConsumerStrategy.retrieveAllPartitions(ConsumerStrategy.scala:66)
[info]   at org.apache.spark.sql.kafka010.ConsumerStrategy.retrieveAllPartitions$(ConsumerStrategy.scala:65)
[info]   at org.apache.spark.sql.kafka010.SubscribeStrategy.retrieveAllPartitions(ConsumerStrategy.scala:102)
[info]   at org.apache.spark.sql.kafka010.SubscribeStrategy.assignedTopicPartitions(ConsumerStrategy.scala:113)
[info]   at org.apache.spark.sql.kafka010.KafkaOffsetReaderAdmin.$anonfun$partitionsAssignedToAdmin$1(KafkaOffsetReaderAdmin.scala:499)
[info]   at org.apache.spark.sql.kafka010.KafkaOffsetReaderAdmin.withRetries(KafkaOffsetReaderAdmin.scala:518)
[info]   at org.apache.spark.sql.kafka010.KafkaOffsetReaderAdmin.partitionsAssignedToAdmin(KafkaOffsetReaderAdmin.scala:498)
[info]   at org.apache.spark.sql.kafka010.KafkaOffsetReaderAdmin.fetchEarliestOffsets(KafkaOffsetReaderAdmin.scala:288)
[info]   at org.apache.spark.sql.kafka010.KafkaMicroBatchStream.$anonfun$getOrCreateInitialPartitionOffsets$1(KafkaMicroBatchStream.scala:244)
[info]   at scala.Option.getOrElse(Option.scala:189)
[info]   at org.apache.spark.sql.kafka010.KafkaMicroBatchStream.getOrCreateInitialPartitionOffsets(KafkaMicroBatchStream.scala:241)
[info]   at org.apache.spark.sql.kafka010.KafkaMicroBatchStream.initialOffset(KafkaMicroBatchStream.scala:98)
[info]   at org.apache.spark.sql.execution.streaming.MicroBatchExecution.$anonfun$getStartOffset$2(MicroBatchExecution.scala:457)
[info]   at scala.Option.getOrElse(Option.scala:189)
[info]   at org.apache.spark.sql.execution.streaming.MicroBatchExecution.getStartOffset(MicroBatchExecution.scala:457)
[info]   at org.apache.spark.sql.execution.streaming.MicroBatchExecution.$anonfun$constructNextBatch$4(MicroBatchExecution.scala:491)
[info]   at org.apache.spark.sql.execution.streaming.ProgressReporter.reportTimeTaken(ProgressReporter.scala:405)
[info]   at org.apache.spark.sql.execution.streaming.ProgressReporter.reportTimeTaken$(ProgressReporter.scala:403)
[info]   at org.apache.spark.sql.execution.streaming.StreamExecution.reportTimeTaken(StreamExecution.scala:67)
[info]   at org.apache.spark.sql.execution.streaming.MicroBatchExecution.$anonfun$constructNextBatch$2(MicroBatchExecution.scala:490)
[info]   at scala.collection.TraversableLike.$anonfun$map$1(TraversableLike.scala:286)
[info]   at scala.collection.Iterator.foreach(Iterator.scala:943)
[info]   at scala.collection.Iterator.foreach$(Iterator.scala:943)
[info]   at scala.collection.AbstractIterator.foreach(Iterator.scala:1431)
[info]   at scala.collection.IterableLike.foreach(IterableLike.scala:74)
[info]   at scala.collection.IterableLike.foreach$(IterableLike.scala:73)
[info]   at scala.collection.AbstractIterable.foreach(Iterable.scala:56)
[info]   at scala.collection.TraversableLike.map(TraversableLike.scala:286)
[info]   at scala.collection.TraversableLike.map$(TraversableLike.scala:279)
[info]   at scala.collection.AbstractTraversable.map(Traversable.scala:108)
[info]   at org.apache.spark.sql.execution.streaming.MicroBatchExecution.$anonfun$constructNextBatch$1(MicroBatchExecution.scala:479)
[info]   at scala.runtime.java8.JFunction0$mcZ$sp.apply(JFunction0$mcZ$sp.java:23)
[info]   at org.apache.spark.sql.execution.streaming.MicroBatchExecution.withProgressLocked(MicroBatchExecution.scala:810)
[info]   at org.apache.spark.sql.execution.streaming.MicroBatchExecution.constructNextBatch(MicroBatchExecution.scala:475)
[info]   at org.apache.spark.sql.execution.streaming.MicroBatchExecution.$anonfun$runActivatedStream$2(MicroBatchExecution.scala:268)
[info]   at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
[info]   at org.apache.spark.sql.execution.streaming.ProgressReporter.reportTimeTaken(ProgressReporter.scala:405)
[info]   at org.apache.spark.sql.execution.streaming.ProgressReporter.reportTimeTaken$(ProgressReporter.scala:403)
[info]   at org.apache.spark.sql.execution.streaming.StreamExecution.reportTimeTaken(StreamExecution.scala:67)
[info]   at org.apache.spark.sql.execution.streaming.MicroBatchExecution.$anonfun$runActivatedStream$1(MicroBatchExecution.scala:249)
[info]   at org.apache.spark.sql.execution.streaming.ProcessingTimeExecutor.execute(TriggerExecutor.scala:67)
[info]   at org.apache.spark.sql.execution.streaming.MicroBatchExecution.runActivatedStream(MicroBatchExecution.scala:239)
[info]   at org.apache.spark.sql.execution.streaming.StreamExecution.$anonfun$runStream$1(StreamExecution.scala:306)
[info]   at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
[info]   at org.apache.spark.sql.SparkSession.withActive(SparkSession.scala:857)
[info]   at org.apache.spark.sql.execution.streaming.StreamExecution.org$apache$spark$sql$execution$streaming$StreamExecution$$runStream(StreamExecution.scala:284)
[info]   at org.apache.spark.sql.execution.streaming.StreamExecution$$anon$1.run(StreamExecution.scala:207)
[info]   Cause: org.apache.kafka.common.errors.TimeoutException: Timed out waiting for a node assignment. Call: describeTopics
```

This is for sink-side errors (the topic is present in the metadata but it is not found in the metadata):

```
[info] Driver stacktrace:
[info]   at org.apache.spark.sql.execution.streaming.StreamExecution.org$apache$spark$sql$execution$streaming$StreamExecution$$runStream(StreamExecution.scala:327)
[info]   at org.apache.spark.sql.execution.streaming.StreamExecution$$anon$1.run(StreamExecution.scala:207)
[info]   Cause: org.apache.spark.SparkException: Job aborted due to stage failure: Task 0 in stage 0.0 failed 1 times, most recent failure: Lost task 0.0 in stage 0.0 (TID 0) (ip-10-110-24-27.us-west-2.compute.internal executor driver): org.apache.kafka.common.errors.TimeoutException: Topic msk-123 not present in metadata after 3000 ms.
[info]
[info] Driver stacktrace:
[info]   at org.apache.spark.scheduler.DAGScheduler.failJobAndIndependentStages(DAGScheduler.scala:2844)
[info]   at org.apache.spark.scheduler.DAGScheduler.$anonfun$abortStage$2(DAGScheduler.scala:2780)
[info]   at org.apache.spark.scheduler.DAGScheduler.$anonfun$abortStage$2$adapted(DAGScheduler.scala:2779)
[info]   at scala.collection.mutable.ResizableArray.foreach(ResizableArray.scala:62)
[info]   at scala.collection.mutable.ResizableArray.foreach$(ResizableArray.scala:55)
[info]   at scala.collection.mutable.ArrayBuffer.foreach(ArrayBuffer.scala:49)
[info]   at org.apache.spark.scheduler.DAGScheduler.abortStage(DAGScheduler.scala:2779)
[info]   at org.apache.spark.scheduler.DAGScheduler.$anonfun$handleTaskSetFailed$1(DAGScheduler.scala:1242)
[info]   at org.apache.spark.scheduler.DAGScheduler.$anonfun$handleTaskSetFailed$1$adapted(DAGScheduler.scala:1242)
[info]   at scala.Option.foreach(Option.scala:407)
[info]   at org.apache.spark.scheduler.DAGScheduler.handleTaskSetFailed(DAGScheduler.scala:1242)
[info]   at org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.doOnReceive(DAGScheduler.scala:3048)
[info]   at org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.onReceive(DAGScheduler.scala:2982)
[info]   at org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.onReceive(DAGScheduler.scala:2971)
[info]   at org.apache.spark.util.EventLoop$$anon$1.run(EventLoop.scala:49)
[info]   at org.apache.spark.scheduler.DAGScheduler.runJob(DAGScheduler.scala:984)
[info]   at org.apache.spark.SparkContext.runJob(SparkContext.scala:2340)
[info]   at org.apache.spark.sql.execution.datasources.v2.V2TableWriteExec.writeWithV2(WriteToDataSourceV2Exec.scala:385)
[info]   at org.apache.spark.sql.execution.datasources.v2.V2TableWriteExec.writeWithV2$(WriteToDataSourceV2Exec.scala:359)
[info]   at org.apache.spark.sql.execution.datasources.v2.WriteToDataSourceV2Exec.writeWithV2(WriteToDataSourceV2Exec.scala:307)
[info]   at org.apache.spark.sql.execution.datasources.v2.WriteToDataSourceV2Exec.run(WriteToDataSourceV2Exec.scala:318)
[info]   at org.apache.spark.sql.execution.datasources.v2.V2CommandExec.result$lzycompute(V2CommandExec.scala:43)
[info]   at org.apache.spark.sql.execution.datasources.v2.V2CommandExec.result(V2CommandExec.scala:43)
[info]   at org.apache.spark.sql.execution.datasources.v2.V2CommandExec.executeCollect(V2CommandExec.scala:49)
[info]   at org.apache.spark.sql.Dataset.collectFromPlan(Dataset.scala:4384)
[info]   at org.apache.spark.sql.Dataset.$anonfun$collect$1(Dataset.scala:3625)
[info]   at org.apache.spark.sql.Dataset.$anonfun$withAction$2(Dataset.scala:4374)
[info]   at org.apache.spark.sql.execution.QueryExecution$.withInternalError(QueryExecution.scala:529)
[info]   at org.apache.spark.sql.Dataset.$anonfun$withAction$1(Dataset.scala:4372)
[info]   at org.apache.spark.sql.execution.SQLExecution$.$anonfun$withNewExecutionId$6(SQLExecution.scala:118)
[info]   at org.apache.spark.sql.execution.SQLExecution$.withSQLConfPropagated(SQLExecution.scala:195)
[info]   at org.apache.spark.sql.execution.SQLExecution$.$anonfun$withNewExecutionId$1(SQLExecution.scala:103)
[info]   at org.apache.spark.sql.SparkSession.withActive(SparkSession.scala:857)
[info]   at org.apache.spark.sql.execution.SQLExecution$.withNewExecutionId(SQLExecution.scala:65)
[info]   at org.apache.spark.sql.Dataset.withAction(Dataset.scala:4372)
[info]   at org.apache.spark.sql.Dataset.collect(Dataset.scala:3625)
[info]   at org.apache.spark.sql.execution.streaming.MicroBatchExecution.$anonfun$runBatch$17(MicroBatchExecution.scala:741)
[info]   at org.apache.spark.sql.execution.SQLExecution$.$anonfun$withNewExecutionId$6(SQLExecution.scala:118)
[info]   at org.apache.spark.sql.execution.SQLExecution$.withSQLConfPropagated(SQLExecution.scala:195)
[info]   at org.apache.spark.sql.execution.SQLExecution$.$anonfun$withNewExecutionId$1(SQLExecution.scala:103)
[info]   at org.apache.spark.sql.SparkSession.withActive(SparkSession.scala:857)
[info]   at org.apache.spark.sql.execution.SQLExecution$.withNewExecutionId(SQLExecution.scala:65)
[info]   at org.apache.spark.sql.execution.streaming.MicroBatchExecution.$anonfun$runBatch$16(MicroBatchExecution.scala:729)
[info]   at org.apache.spark.sql.execution.streaming.ProgressReporter.reportTimeTaken(ProgressReporter.scala:405)
[info]   at org.apache.spark.sql.execution.streaming.ProgressReporter.reportTimeTaken$(ProgressReporter.scala:403)
[info]   at org.apache.spark.sql.execution.streaming.StreamExecution.reportTimeTaken(StreamExecution.scala:67)
[info]   at org.apache.spark.sql.execution.streaming.MicroBatchExecution.runBatch(MicroBatchExecution.scala:729)
[info]   at org.apache.spark.sql.execution.streaming.MicroBatchExecution.$anonfun$runActivatedStream$2(MicroBatchExecution.scala:286)
[info]   at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
[info]   at org.apache.spark.sql.execution.streaming.ProgressReporter.reportTimeTaken(ProgressReporter.scala:405)
[info]   at org.apache.spark.sql.execution.streaming.ProgressReporter.reportTimeTaken$(ProgressReporter.scala:403)
[info]   at org.apache.spark.sql.execution.streaming.StreamExecution.reportTimeTaken(StreamExecution.scala:67)
[info]   at org.apache.spark.sql.execution.streaming.MicroBatchExecution.$anonfun$runActivatedStream$1(MicroBatchExecution.scala:249)
[info]   at org.apache.spark.sql.execution.streaming.ProcessingTimeExecutor.execute(TriggerExecutor.scala:67)
[info]   at org.apache.spark.sql.execution.streaming.MicroBatchExecution.runActivatedStream(MicroBatchExecution.scala:239)
[info]   at org.apache.spark.sql.execution.streaming.StreamExecution.$anonfun$runStream$1(StreamExecution.scala:306)
[info]   at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
[info]   at org.apache.spark.sql.SparkSession.withActive(SparkSession.scala:857)
[info]   at org.apache.spark.sql.execution.streaming.StreamExecution.org$apache$spark$sql$execution$streaming$StreamExecution$$runStream(StreamExecution.scala:284)
[info]   at org.apache.spark.sql.execution.streaming.StreamExecution$$anon$1.run(StreamExecution.scala:207)
[info]   Cause: org.apache.kafka.common.errors.TimeoutException: Topic msk-123 not present in metadata after 3000 ms.
```
