### PR TITLE
[SPARK-44150][PYTHON][FOLLOW-UP] Fix ArrowStreamPandasSerializer to set arguments properly

### DIFF
--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -230,11 +230,13 @@ class ArrowStreamPandasSerializer(ArrowStreamSerializer):
             mask = series.isnull()
         try:
             if arrow_cast:
-                return pa.Array.from_pandas(series, mask=mask, type=arrow_type).cast(
+                return pa.Array.from_pandas(series, mask=mask).cast(
                     target_type=arrow_type, safe=self._safecheck
                 )
             else:
-                return pa.Array.from_pandas(series, mask=mask, safe=self._safecheck)
+                return pa.Array.from_pandas(
+                    series, mask=mask, type=arrow_type, safe=self._safecheck
+                )
         except TypeError as e:
             error_msg = (
                 "Exception thrown when converting pandas.Series (%s) "


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up of #41503.

Fix `ArrowStreamPandasSerializer` to set `type` argument properly.

### Why are the changes needed?

To fix CI.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests.