### PR TITLE
[SPARK-44150][PYTHON][FOLLOW-UP] Fallback to cast only when ArrowInvalid is raised

### DIFF
--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -229,14 +229,17 @@ class ArrowStreamPandasSerializer(ArrowStreamSerializer):
         else:
             mask = series.isnull()
         try:
-            if arrow_cast:
-                return pa.Array.from_pandas(series, mask=mask).cast(
-                    target_type=arrow_type, safe=self._safecheck
-                )
-            else:
+            try:
                 return pa.Array.from_pandas(
                     series, mask=mask, type=arrow_type, safe=self._safecheck
                 )
+            except pa.lib.ArrowInvalid:
+                if arrow_cast:
+                    return pa.Array.from_pandas(series, mask=mask).cast(
+                        target_type=arrow_type, safe=self._safecheck
+                    )
+                else:
+                    raise
         except TypeError as e:
             error_msg = (
                 "Exception thrown when converting pandas.Series (%s) "


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up of https://github.com/apache/spark/pull/41503.

Fallback to `cast` only when `ArrowInvalid` is raised.

### Why are the changes needed?

The fix at https://github.com/apache/spark/pull/41795 was not enough.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests.