### PR TITLE
[SPARK-44150][PYTHON][CONNECT] Explicit Arrow casting for mismatched return type in Arrow Python UDF

### DIFF
--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -190,7 +190,7 @@ class ArrowStreamPandasSerializer(ArrowStreamSerializer):
         )
         return converter(s)
 
-    def _create_array(self, series, arrow_type, spark_type=None):
+    def _create_array(self, series, arrow_type, spark_type=None, arrow_cast=False):
         """
         Create an Arrow Array from the given pandas.Series and optional type.
 
@@ -233,28 +233,34 @@ class ArrowStreamPandasSerializer(ArrowStreamSerializer):
                 "with name '%s' to Arrow Array (%s)."
             )
             raise PySparkTypeError(error_msg % (series.dtype, series.name, arrow_type)) from e
-        except ValueError:
-            def force_cast(array: pa.Array):
-                try:
-                    return array.cast(target_type=arrow_type, safe=self._safecheck)
-                except Exception as e:
-                    error_msg = (
-                        "Exception thrown when converting pandas.Series (%s) "
-                        "with name '%s' to Arrow Array (%s)."
-                    )
-                    if self._safecheck:
-                        error_msg = error_msg + (
-                            " It can be caused by overflows or other "
-                            "unsafe conversions warned by Arrow. Arrow safe type check "
-                            "can be disabled by using SQL config "
-                            "`spark.sql.execution.pandas.convertToArrowArraySafely`."
-                        )
-                    raise PySparkValueError(
-                        error_msg % (series.dtype, series.name, arrow_type)
-                    ) from e
+        except ValueError as e:
 
-            array = pa.Array.from_pandas(series, mask=mask, safe=self._safecheck)
-            return force_cast(array)
+            def _raise_exception(e):
+                error_msg = (
+                    "Exception thrown when converting pandas.Series (%s) "
+                    "with name '%s' to Arrow Array (%s)."
+                )
+                if self._safecheck:
+                    error_msg = error_msg + (
+                        " It can be caused by overflows or other "
+                        "unsafe conversions warned by Arrow. Arrow safe type check "
+                        "can be disabled by using SQL config "
+                        "`spark.sql.execution.pandas.convertToArrowArraySafely`."
+                    )
+                raise PySparkValueError(error_msg % (series.dtype, series.name, arrow_type)) from e
+
+            if arrow_cast:
+
+                def force_cast(array: pa.Array):
+                    try:
+                        return array.cast(target_type=arrow_type, safe=self._safecheck)
+                    except Exception as ee:
+                        _raise_exception(ee)
+
+                array = pa.Array.from_pandas(series, mask=mask, safe=self._safecheck)
+                return force_cast(array)
+            else:
+                _raise_exception(e)
 
     def _create_batch(self, series):
         """
@@ -328,12 +334,14 @@ class ArrowStreamPandasUDFSerializer(ArrowStreamPandasSerializer):
         df_for_struct=False,
         struct_in_pandas="dict",
         ndarray_as_list=False,
+        arrow_cast=False,
     ):
         super(ArrowStreamPandasUDFSerializer, self).__init__(timezone, safecheck)
         self._assign_cols_by_name = assign_cols_by_name
         self._df_for_struct = df_for_struct
         self._struct_in_pandas = struct_in_pandas
         self._ndarray_as_list = ndarray_as_list
+        self._arrow_cast = arrow_cast
 
     def arrow_to_pandas(self, arrow_column):
         import pyarrow.types as types
@@ -395,7 +403,13 @@ class ArrowStreamPandasUDFSerializer(ArrowStreamPandasSerializer):
                 # Assign result columns by schema name if user labeled with strings
                 elif self._assign_cols_by_name and any(isinstance(name, str) for name in s.columns):
                     arrs_names = [
-                        (self._create_array(s[field.name], field.type), field.name) for field in t
+                        (
+                            self._create_array(
+                                s[field.name], field.type, arrow_cast=self._arrow_cast
+                            ),
+                            field.name,
+                        )
+                        for field in t
                     ]
                 # Assign result columns by  position
                 else:
@@ -403,7 +417,11 @@ class ArrowStreamPandasUDFSerializer(ArrowStreamPandasSerializer):
                         # the selected series has name '1', so we rename it to field.name
                         # as the name is used by _create_array to provide a meaningful error message
                         (
-                            self._create_array(s[s.columns[i]].rename(field.name), field.type),
+                            self._create_array(
+                                s[s.columns[i]].rename(field.name),
+                                field.type,
+                                arrow_cast=self._arrow_cast,
+                            ),
                             field.name,
                         )
                         for i, field in enumerate(t)
@@ -412,7 +430,7 @@ class ArrowStreamPandasUDFSerializer(ArrowStreamPandasSerializer):
                 struct_arrs, struct_names = zip(*arrs_names)
                 arrs.append(pa.StructArray.from_arrays(struct_arrs, struct_names))
             else:
-                arrs.append(self._create_array(s, t))
+                arrs.append(self._create_array(s, t, arrow_cast=self._arrow_cast))
 
         return pa.RecordBatch.from_arrays(arrs, ["_%d" % i for i in range(len(arrs))])
 

--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -260,7 +260,6 @@ class ArrowStreamPandasSerializer(ArrowStreamSerializer):
                 )
             raise PySparkValueError(error_msg % (series.dtype, series.name, arrow_type)) from e
 
-
     def _create_batch(self, series):
         """
         Create an Arrow record batch from the given pandas.Series or list of Series,

--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -229,7 +229,17 @@ class ArrowStreamPandasSerializer(ArrowStreamSerializer):
         else:
             mask = series.isnull()
         try:
-            return pa.Array.from_pandas(series, mask=mask, type=arrow_type, safe=self._safecheck)
+            try:
+                return pa.Array.from_pandas(
+                    series, mask=mask, type=arrow_type, safe=self._safecheck
+                )
+            except pa.lib.ArrowInvalid:
+                if arrow_cast:
+                    return pa.Array.from_pandas(series, mask=mask).cast(
+                        target_type=arrow_type, safe=self._safecheck
+                    )
+                else:
+                    raise
         except TypeError as e:
             error_msg = (
                 "Exception thrown when converting pandas.Series (%s) "
@@ -237,33 +247,19 @@ class ArrowStreamPandasSerializer(ArrowStreamSerializer):
             )
             raise PySparkTypeError(error_msg % (series.dtype, series.name, arrow_type)) from e
         except ValueError as e:
-
-            def _raise_exception(e):
-                error_msg = (
-                    "Exception thrown when converting pandas.Series (%s) "
-                    "with name '%s' to Arrow Array (%s)."
+            error_msg = (
+                "Exception thrown when converting pandas.Series (%s) "
+                "with name '%s' to Arrow Array (%s)."
+            )
+            if self._safecheck:
+                error_msg = error_msg + (
+                    " It can be caused by overflows or other "
+                    "unsafe conversions warned by Arrow. Arrow safe type check "
+                    "can be disabled by using SQL config "
+                    "`spark.sql.execution.pandas.convertToArrowArraySafely`."
                 )
-                if self._safecheck:
-                    error_msg = error_msg + (
-                        " It can be caused by overflows or other "
-                        "unsafe conversions warned by Arrow. Arrow safe type check "
-                        "can be disabled by using SQL config "
-                        "`spark.sql.execution.pandas.convertToArrowArraySafely`."
-                    )
-                raise PySparkValueError(error_msg % (series.dtype, series.name, arrow_type)) from e
+            raise PySparkValueError(error_msg % (series.dtype, series.name, arrow_type)) from e
 
-            if arrow_cast:
-
-                def force_cast(array: pa.Array):
-                    try:
-                        return array.cast(target_type=arrow_type, safe=self._safecheck)
-                    except Exception as ee:
-                        _raise_exception(ee)
-
-                array = pa.Array.from_pandas(series, mask=mask, safe=self._safecheck)
-                return force_cast(array)
-            else:
-                _raise_exception(e)
 
     def _create_batch(self, series):
         """

--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -233,31 +233,28 @@ class ArrowStreamPandasSerializer(ArrowStreamSerializer):
                 "with name '%s' to Arrow Array (%s)."
             )
             raise PySparkTypeError(error_msg % (series.dtype, series.name, arrow_type)) from e
-        except ValueError as e:
-            error_msg = (
-                "Exception thrown when converting pandas.Series (%s) "
-                "with name '%s' to Arrow Array (%s)."
-            )
-            if isinstance(e, pa.ArrowInvalid):
+        except ValueError:
+            def force_cast(array: pa.Array):
+                try:
+                    return array.cast(target_type=arrow_type, safe=self._safecheck)
+                except Exception as e:
+                    error_msg = (
+                        "Exception thrown when converting pandas.Series (%s) "
+                        "with name '%s' to Arrow Array (%s)."
+                    )
+                    if self._safecheck:
+                        error_msg = error_msg + (
+                            " It can be caused by overflows or other "
+                            "unsafe conversions warned by Arrow. Arrow safe type check "
+                            "can be disabled by using SQL config "
+                            "`spark.sql.execution.pandas.convertToArrowArraySafely`."
+                        )
+                    raise PySparkValueError(
+                        error_msg % (series.dtype, series.name, arrow_type)
+                    ) from e
 
-                def force_cast(array: pa.Array):
-                    try:
-                        return array.cast(target_type=arrow_type)
-                    except Exception as e:
-                        raise PySparkValueError(
-                            error_msg % (series.dtype, series.name, arrow_type)
-                        ) from e
-
-                array = pa.Array.from_pandas(series, mask=mask, safe=self._safecheck)
-                return force_cast(array)
-            if self._safecheck:
-                error_msg = error_msg + (
-                    " It can be caused by overflows or other "
-                    "unsafe conversions warned by Arrow. Arrow safe type check "
-                    "can be disabled by using SQL config "
-                    "`spark.sql.execution.pandas.convertToArrowArraySafely`."
-                )
-            raise PySparkValueError(error_msg % (series.dtype, series.name, arrow_type)) from e
+            array = pa.Array.from_pandas(series, mask=mask, safe=self._safecheck)
+            return force_cast(array)
 
     def _create_batch(self, series):
         """

--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -202,6 +202,9 @@ class ArrowStreamPandasSerializer(ArrowStreamSerializer):
             If None, pyarrow's inferred type will be used
         spark_type : DataType, optional
             If None, spark type converted from arrow_type will be used
+        arrow_cast: bool, optional
+            Whether to apply Arrow casting when the user-specified return type mismatches the
+            actual return values.
 
         Returns
         -------

--- a/python/pyspark/sql/tests/pandas/test_pandas_udf_scalar.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_udf_scalar.py
@@ -50,7 +50,7 @@ from pyspark.sql.types import (
     BinaryType,
     YearMonthIntervalType,
 )
-from pyspark.errors import AnalysisException, PythonException
+from pyspark.errors import AnalysisException
 from pyspark.testing.sqlutils import (
     ReusedSQLTestCase,
     test_compiled,
@@ -1445,26 +1445,6 @@ class ScalarPandasUDFTestsMixin:
                     )
         finally:
             shutil.rmtree(path)
-
-    def test_type_coercion_string_to_numeric(self):
-        # string to int
-        df = self.spark.createDataFrame(["1", "2"], schema="string")
-        self.assertEquals(
-            df.select(pandas_udf(lambda x: x, "int")("value").alias("res")).collect(),
-            [Row(res=1), Row(res=2)],
-        )
-        df = self.spark.createDataFrame(["1", "x"], schema="string")
-        with self.assertRaises(PythonException):
-            df.select(pandas_udf(lambda x: x, "int")("value").alias("res")).collect()
-
-        df = self.spark.createDataFrame(["1", "1.1"], schema="string")
-        with self.assertRaises(PythonException):
-            df.select(pandas_udf(lambda x: x, "int")("value").alias("res")).collect()
-
-        # string to double
-        df = self.spark.createDataFrame(["1.1", "2.2"], schema="string")
-        with self.assertRaises(PythonException):
-            df.select(pandas_udf(lambda x: x, "double")("value").alias("res")).collect()
 
 
 class ScalarPandasUDFTests(ScalarPandasUDFTestsMixin, ReusedSQLTestCase):

--- a/python/pyspark/sql/tests/pandas/test_pandas_udf_scalar.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_udf_scalar.py
@@ -50,7 +50,7 @@ from pyspark.sql.types import (
     BinaryType,
     YearMonthIntervalType,
 )
-from pyspark.errors import AnalysisException
+from pyspark.errors import AnalysisException, PythonException
 from pyspark.testing.sqlutils import (
     ReusedSQLTestCase,
     test_compiled,
@@ -1445,6 +1445,17 @@ class ScalarPandasUDFTestsMixin:
                     )
         finally:
             shutil.rmtree(path)
+
+    def test_type_coercion(self):
+        # string to int
+        df = self.spark.createDataFrame(["1", "2"], schema="string")
+        self.assertEquals(
+            df.select(pandas_udf(lambda x: x, "int")("value").alias("res")).collect(),
+            [Row(res=1), Row(res=2)],
+        )
+        df = self.spark.createDataFrame(["1", "x"], schema="string")
+        with self.assertRaises(PythonException):
+            df.select(pandas_udf(lambda x: x, "int")("value").alias("res")).collect()
 
 
 class ScalarPandasUDFTests(ScalarPandasUDFTestsMixin, ReusedSQLTestCase):

--- a/python/pyspark/sql/tests/pandas/test_pandas_udf_scalar.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_udf_scalar.py
@@ -1446,7 +1446,7 @@ class ScalarPandasUDFTestsMixin:
         finally:
             shutil.rmtree(path)
 
-    def test_type_coercion(self):
+    def test_type_coercion_string_to_numeric(self):
         # string to int
         df = self.spark.createDataFrame(["1", "2"], schema="string")
         self.assertEquals(
@@ -1456,6 +1456,15 @@ class ScalarPandasUDFTestsMixin:
         df = self.spark.createDataFrame(["1", "x"], schema="string")
         with self.assertRaises(PythonException):
             df.select(pandas_udf(lambda x: x, "int")("value").alias("res")).collect()
+
+        df = self.spark.createDataFrame(["1", "1.1"], schema="string")
+        with self.assertRaises(PythonException):
+            df.select(pandas_udf(lambda x: x, "int")("value").alias("res")).collect()
+
+        # string to double
+        df = self.spark.createDataFrame(["1.1", "2.2"], schema="string")
+        with self.assertRaises(PythonException):
+            df.select(pandas_udf(lambda x: x, "double")("value").alias("res")).collect()
 
 
 class ScalarPandasUDFTests(ScalarPandasUDFTestsMixin, ReusedSQLTestCase):

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -598,6 +598,8 @@ def read_udfs(pickleSer, infile, eval_type):
                 "row" if eval_type == PythonEvalType.SQL_ARROW_BATCHED_UDF else "dict"
             )
             ndarray_as_list = eval_type == PythonEvalType.SQL_ARROW_BATCHED_UDF
+            # Arrow-optimized Python UDF uses explicit Arrow cast for type coercion
+            arrow_cast = eval_type == PythonEvalType.SQL_ARROW_BATCHED_UDF
             ser = ArrowStreamPandasUDFSerializer(
                 timezone,
                 safecheck,
@@ -605,6 +607,7 @@ def read_udfs(pickleSer, infile, eval_type):
                 df_for_struct,
                 struct_in_pandas,
                 ndarray_as_list,
+                arrow_cast,
             )
     else:
         ser = BatchedSerializer(CPickleSerializer(), 100)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Explicit Arrow casting for the mismatched return type of Arrow Python UDF.

### Why are the changes needed?
A more standardized and coherent type coercion.

Please refer to https://github.com/apache/spark/pull/41706 for a comprehensive comparison between type coercion rules of Arrow and Pickle(used by the default Python UDF) separately.

See more at [[Design] Type-coercion in Arrow Python UDFs](https://docs.google.com/document/d/e/2PACX-1vTEGElOZfhl9NfgbBw4CTrlm-8F_xQCAKNOXouz-7mg5vYobS7lCGUsGkDZxPY0wV5YkgoZmkYlxccU/pub).


### Does this PR introduce _any_ user-facing change?
Yes.

FROM
```py
>>> df = spark.createDataFrame(['1', '2'], schema='string')
df.select(pandas_udf(lambda x: x, 'int')('value')).show()
>>> df.select(pandas_udf(lambda x: x, 'int')('value')).show()
...
org.apache.spark.api.python.PythonException: Traceback (most recent call last):
...
pyarrow.lib.ArrowInvalid: Could not convert '1' with type str: tried to convert to int32
```

TO
```py
>>> df = spark.createDataFrame(['1', '2'], schema='string')
>>> df.select(pandas_udf(lambda x: x, 'int')('value')).show()
+---------------+                                                               
|<lambda>(value)|
+---------------+
|              1|
|              2|
+---------------+
```
### How was this patch tested?
Unit tests.

SPARK-40307
