### PR TITLE
[SPARK-44256][BUILD] Upgrade rocksdbjni to 8.3.2

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -223,7 +223,7 @@ parquet-jackson/1.13.1//parquet-jackson-1.13.1.jar
 pickle/1.3//pickle-1.3.jar
 py4j/0.10.9.7//py4j-0.10.9.7.jar
 remotetea-oncrpc/1.1.2//remotetea-oncrpc-1.1.2.jar
-rocksdbjni/8.1.1.1//rocksdbjni-8.1.1.1.jar
+rocksdbjni/8.3.2//rocksdbjni-8.3.2.jar
 scala-collection-compat_2.12/2.7.0//scala-collection-compat_2.12-2.7.0.jar
 scala-compiler/2.12.18//scala-compiler-2.12.18.jar
 scala-library/2.12.18//scala-library-2.12.18.jar

--- a/pom.xml
+++ b/pom.xml
@@ -675,7 +675,7 @@
       <dependency>
         <groupId>org.rocksdb</groupId>
         <artifactId>rocksdbjni</artifactId>
-        <version>8.1.1.1</version>
+        <version>8.3.2</version>
       </dependency>
       <dependency>
         <groupId>${leveldbjni.group}</groupId>

--- a/sql/core/benchmarks/StateStoreBasicOperationsBenchmark-jdk11-results.txt
+++ b/sql/core/benchmarks/StateStoreBasicOperationsBenchmark-jdk11-results.txt
@@ -2,110 +2,110 @@
 put rows
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.19+7 on Linux 5.15.0-1037-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 11.0.19+7 on Linux 5.15.0-1040-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 putting 10000 rows (10000 rows to overwrite - rate 100):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                            8              8           1          1.3         751.0       1.0X
-RocksDB (trackTotalNumberOfRows: true)                              59             61           1          0.2        5930.2       0.1X
-RocksDB (trackTotalNumberOfRows: false)                             21             21           0          0.5        2057.7       0.4X
+In-memory                                                            9             11           2          1.1         872.7       1.0X
+RocksDB (trackTotalNumberOfRows: true)                              61             63           1          0.2        6148.5       0.1X
+RocksDB (trackTotalNumberOfRows: false)                             21             22           0          0.5        2108.9       0.4X
 
-OpenJDK 64-Bit Server VM 11.0.19+7 on Linux 5.15.0-1037-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 11.0.19+7 on Linux 5.15.0-1040-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 putting 10000 rows (5000 rows to overwrite - rate 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                          8              8           1          1.3         757.4       1.0X
-RocksDB (trackTotalNumberOfRows: true)                            50             51           1          0.2        4970.6       0.2X
-RocksDB (trackTotalNumberOfRows: false)                           20             22           0          0.5        2041.7       0.4X
+In-memory                                                          9             10           1          1.1         872.0       1.0X
+RocksDB (trackTotalNumberOfRows: true)                            51             53           1          0.2        5134.7       0.2X
+RocksDB (trackTotalNumberOfRows: false)                           21             22           0          0.5        2149.6       0.4X
 
-OpenJDK 64-Bit Server VM 11.0.19+7 on Linux 5.15.0-1037-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 11.0.19+7 on Linux 5.15.0-1040-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 putting 10000 rows (1000 rows to overwrite - rate 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                          7              8           1          1.4         728.3       1.0X
-RocksDB (trackTotalNumberOfRows: true)                            41             42           0          0.2        4060.1       0.2X
-RocksDB (trackTotalNumberOfRows: false)                           21             22           0          0.5        2053.6       0.4X
+In-memory                                                          8             10           1          1.2         833.6       1.0X
+RocksDB (trackTotalNumberOfRows: true)                            41             43           1          0.2        4128.6       0.2X
+RocksDB (trackTotalNumberOfRows: false)                           21             22           0          0.5        2114.3       0.4X
 
-OpenJDK 64-Bit Server VM 11.0.19+7 on Linux 5.15.0-1037-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 11.0.19+7 on Linux 5.15.0-1040-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 putting 10000 rows (0 rows to overwrite - rate 0):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                      7              8           0          1.4         722.5       1.0X
-RocksDB (trackTotalNumberOfRows: true)                        38             40           1          0.3        3815.7       0.2X
-RocksDB (trackTotalNumberOfRows: false)                       20             22           0          0.5        2048.5       0.4X
+In-memory                                                      8              9           1          1.2         812.9       1.0X
+RocksDB (trackTotalNumberOfRows: true)                        39             40           1          0.3        3855.8       0.2X
+RocksDB (trackTotalNumberOfRows: false)                       21             22           0          0.5        2111.9       0.4X
 
 
 ================================================================================================
 delete rows
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.19+7 on Linux 5.15.0-1037-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 11.0.19+7 on Linux 5.15.0-1040-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 trying to delete 10000 rows from 10000 rows(10000 rows are non-existing - rate 100):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                        1              1           0         16.8          59.5       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                          38             39           1          0.3        3801.1       0.0X
-RocksDB (trackTotalNumberOfRows: false)                                                         20             21           0          0.5        2038.7       0.0X
+In-memory                                                                                        1              1           0         15.7          63.6       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                          39             41           0          0.3        3935.3       0.0X
+RocksDB (trackTotalNumberOfRows: false)                                                         22             22           0          0.5        2158.8       0.0X
 
-OpenJDK 64-Bit Server VM 11.0.19+7 on Linux 5.15.0-1037-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 11.0.19+7 on Linux 5.15.0-1040-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 trying to delete 10000 rows from 10000 rows(5000 rows are non-existing - rate 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                      5              6           0          1.8         547.3       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                        49             50           1          0.2        4874.6       0.1X
-RocksDB (trackTotalNumberOfRows: false)                                                       20             21           0          0.5        2021.8       0.3X
+In-memory                                                                                      6              7           0          1.7         597.0       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                        51             53           0          0.2        5120.0       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                                       21             22           0          0.5        2068.2       0.3X
 
-OpenJDK 64-Bit Server VM 11.0.19+7 on Linux 5.15.0-1037-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 11.0.19+7 on Linux 5.15.0-1040-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 trying to delete 10000 rows from 10000 rows(1000 rows are non-existing - rate 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                      6              7           1          1.6         619.6       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                        57             58           1          0.2        5695.0       0.1X
-RocksDB (trackTotalNumberOfRows: false)                                                       20             21           0          0.5        2036.2       0.3X
+In-memory                                                                                      7              8           0          1.5         676.2       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                        60             62           1          0.2        6040.0       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                                       21             21           0          0.5        2067.2       0.3X
 
-OpenJDK 64-Bit Server VM 11.0.19+7 on Linux 5.15.0-1037-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 11.0.19+7 on Linux 5.15.0-1040-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 trying to delete 10000 rows from 10000 rows(0 rows are non-existing - rate 0):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                  6              7           0          1.6         629.0       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                    59             60           1          0.2        5910.3       0.1X
-RocksDB (trackTotalNumberOfRows: false)                                                   20             21           0          0.5        2028.0       0.3X
+In-memory                                                                                  7              8           0          1.5         684.0       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                    62             64           1          0.2        6208.6       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                                   20             21           0          0.5        2030.6       0.3X
 
 
 ================================================================================================
 evict rows
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.19+7 on Linux 5.15.0-1037-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 11.0.19+7 on Linux 5.15.0-1040-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 evicting 10000 rows (maxTimestampToEvictInMillis: 9999) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                            7              7           0          1.5         660.9       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                              57             59           1          0.2        5725.3       0.1X
-RocksDB (trackTotalNumberOfRows: false)                                             23             23           0          0.4        2257.0       0.3X
+In-memory                                                                            6              7           0          1.6         643.9       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                              65             66           1          0.2        6454.6       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                             24             25           0          0.4        2379.3       0.3X
 
-OpenJDK 64-Bit Server VM 11.0.19+7 on Linux 5.15.0-1037-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 11.0.19+7 on Linux 5.15.0-1040-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 evicting 5000 rows (maxTimestampToEvictInMillis: 4999) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                           6              6           0          1.8         554.4       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                             31             32           1          0.3        3122.3       0.2X
-RocksDB (trackTotalNumberOfRows: false)                                            14             14           0          0.7        1369.2       0.4X
+In-memory                                                                           6              6           0          1.8         568.7       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                             34             36           1          0.3        3383.3       0.2X
+RocksDB (trackTotalNumberOfRows: false)                                            14             14           0          0.7        1390.8       0.4X
 
-OpenJDK 64-Bit Server VM 11.0.19+7 on Linux 5.15.0-1037-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 11.0.19+7 on Linux 5.15.0-1040-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 evicting 1000 rows (maxTimestampToEvictInMillis: 999) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                          5              5           0          2.2         462.3       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                            11             11           0          0.9        1057.6       0.4X
-RocksDB (trackTotalNumberOfRows: false)                                            7              7           0          1.4         704.0       0.7X
+In-memory                                                                          5              5           0          2.1         474.6       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                            11             11           0          0.9        1082.8       0.4X
+RocksDB (trackTotalNumberOfRows: false)                                            7              7           0          1.4         693.5       0.7X
 
-OpenJDK 64-Bit Server VM 11.0.19+7 on Linux 5.15.0-1037-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 11.0.19+7 on Linux 5.15.0-1040-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 evicting 0 rows (maxTimestampToEvictInMillis: -1) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                      1              1           0         15.6          64.0       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                         5              5           0          1.9         525.6       0.1X
-RocksDB (trackTotalNumberOfRows: false)                                        5              5           0          1.9         514.3       0.1X
+In-memory                                                                      1              1           0         14.8          67.4       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                         5              5           0          2.0         501.7       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                        5              5           0          2.0         502.3       0.1X
 
 

--- a/sql/core/benchmarks/StateStoreBasicOperationsBenchmark-jdk17-results.txt
+++ b/sql/core/benchmarks/StateStoreBasicOperationsBenchmark-jdk17-results.txt
@@ -2,110 +2,110 @@
 put rows
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.7+7 on Linux 5.15.0-1037-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.7+7 on Linux 5.15.0-1040-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 putting 10000 rows (10000 rows to overwrite - rate 100):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                            9             10           1          1.2         864.7       1.0X
-RocksDB (trackTotalNumberOfRows: true)                              59             61           1          0.2        5924.5       0.1X
-RocksDB (trackTotalNumberOfRows: false)                             20             21           0          0.5        2031.8       0.4X
+In-memory                                                            9              9           1          1.2         852.9       1.0X
+RocksDB (trackTotalNumberOfRows: true)                              60             62           2          0.2        6009.7       0.1X
+RocksDB (trackTotalNumberOfRows: false)                             21             23           1          0.5        2139.2       0.4X
 
-OpenJDK 64-Bit Server VM 17.0.7+7 on Linux 5.15.0-1037-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.7+7 on Linux 5.15.0-1040-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 putting 10000 rows (5000 rows to overwrite - rate 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                          9             10           1          1.1         883.6       1.0X
-RocksDB (trackTotalNumberOfRows: true)                            49             50           1          0.2        4867.5       0.2X
-RocksDB (trackTotalNumberOfRows: false)                           20             22           0          0.5        2017.7       0.4X
+In-memory                                                          9             10           1          1.2         861.2       1.0X
+RocksDB (trackTotalNumberOfRows: true)                            50             52           1          0.2        5032.7       0.2X
+RocksDB (trackTotalNumberOfRows: false)                           21             23           0          0.5        2110.3       0.4X
 
-OpenJDK 64-Bit Server VM 17.0.7+7 on Linux 5.15.0-1037-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.7+7 on Linux 5.15.0-1040-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 putting 10000 rows (1000 rows to overwrite - rate 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                          8              9           1          1.2         825.4       1.0X
-RocksDB (trackTotalNumberOfRows: true)                            38             40           1          0.3        3848.6       0.2X
-RocksDB (trackTotalNumberOfRows: false)                           20             21           1          0.5        1989.0       0.4X
+In-memory                                                          8              9           1          1.2         822.2       1.0X
+RocksDB (trackTotalNumberOfRows: true)                            40             42           1          0.2        4043.3       0.2X
+RocksDB (trackTotalNumberOfRows: false)                           21             22           0          0.5        2070.5       0.4X
 
-OpenJDK 64-Bit Server VM 17.0.7+7 on Linux 5.15.0-1037-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.7+7 on Linux 5.15.0-1040-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 putting 10000 rows (0 rows to overwrite - rate 0):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                      8              9           1          1.2         817.1       1.0X
-RocksDB (trackTotalNumberOfRows: true)                        36             37           1          0.3        3563.6       0.2X
-RocksDB (trackTotalNumberOfRows: false)                       20             21           0          0.5        1985.2       0.4X
+In-memory                                                      8              9           1          1.2         802.6       1.0X
+RocksDB (trackTotalNumberOfRows: true)                        38             39           1          0.3        3773.1       0.2X
+RocksDB (trackTotalNumberOfRows: false)                       21             22           0          0.5        2050.8       0.4X
 
 
 ================================================================================================
 delete rows
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.7+7 on Linux 5.15.0-1037-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.7+7 on Linux 5.15.0-1040-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 trying to delete 10000 rows from 10000 rows(10000 rows are non-existing - rate 100):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                        1              1           0         16.8          59.4       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                          35             37           1          0.3        3548.2       0.0X
-RocksDB (trackTotalNumberOfRows: false)                                                         20             20           0          0.5        1951.4       0.0X
+In-memory                                                                                        1              1           0         17.3          57.9       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                          39             40           0          0.3        3903.8       0.0X
+RocksDB (trackTotalNumberOfRows: false)                                                         21             22           0          0.5        2145.7       0.0X
 
-OpenJDK 64-Bit Server VM 17.0.7+7 on Linux 5.15.0-1037-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.7+7 on Linux 5.15.0-1040-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 trying to delete 10000 rows from 10000 rows(5000 rows are non-existing - rate 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                      6              7           1          1.6         639.5       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                        47             48           1          0.2        4680.8       0.1X
-RocksDB (trackTotalNumberOfRows: false)                                                       19             20           0          0.5        1944.8       0.3X
+In-memory                                                                                      6              7           0          1.6         639.5       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                        50             51           1          0.2        4996.4       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                                       21             22           0          0.5        2136.3       0.3X
 
-OpenJDK 64-Bit Server VM 17.0.7+7 on Linux 5.15.0-1037-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.7+7 on Linux 5.15.0-1040-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 trying to delete 10000 rows from 10000 rows(1000 rows are non-existing - rate 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                      7              8           0          1.4         699.0       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                        56             57           1          0.2        5552.7       0.1X
-RocksDB (trackTotalNumberOfRows: false)                                                       19             20           0          0.5        1941.1       0.4X
+In-memory                                                                                      7              8           0          1.5         688.6       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                        58             59           1          0.2        5769.8       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                                       21             22           1          0.5        2111.7       0.3X
 
-OpenJDK 64-Bit Server VM 17.0.7+7 on Linux 5.15.0-1037-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.7+7 on Linux 5.15.0-1040-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 trying to delete 10000 rows from 10000 rows(0 rows are non-existing - rate 0):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                  7              8           0          1.4         708.8       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                    57             59           2          0.2        5734.3       0.1X
-RocksDB (trackTotalNumberOfRows: false)                                                   19             20           0          0.5        1934.9       0.4X
+In-memory                                                                                  7              8           0          1.4         706.4       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                    60             61           0          0.2        6012.9       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                                   21             22           0          0.5        2135.2       0.3X
 
 
 ================================================================================================
 evict rows
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.7+7 on Linux 5.15.0-1037-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.7+7 on Linux 5.15.0-1040-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 evicting 10000 rows (maxTimestampToEvictInMillis: 9999) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                            7              8           0          1.4         695.6       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                              59             60           1          0.2        5870.6       0.1X
-RocksDB (trackTotalNumberOfRows: false)                                             21             22           0          0.5        2096.3       0.3X
+In-memory                                                                            7              8           0          1.4         724.6       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                              61             62           1          0.2        6107.3       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                             23             24           0          0.4        2337.9       0.3X
 
-OpenJDK 64-Bit Server VM 17.0.7+7 on Linux 5.15.0-1037-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.7+7 on Linux 5.15.0-1040-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 evicting 5000 rows (maxTimestampToEvictInMillis: 4999) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                           6              7           0          1.5         646.1       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                             31             32           0          0.3        3146.2       0.2X
-RocksDB (trackTotalNumberOfRows: false)                                            13             13           0          0.8        1257.7       0.5X
+In-memory                                                                           7              7           0          1.5         657.7       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                             33             33           0          0.3        3266.8       0.2X
+RocksDB (trackTotalNumberOfRows: false)                                            14             14           1          0.7        1366.6       0.5X
 
-OpenJDK 64-Bit Server VM 17.0.7+7 on Linux 5.15.0-1037-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.7+7 on Linux 5.15.0-1040-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 evicting 1000 rows (maxTimestampToEvictInMillis: 999) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                          6              6           0          1.8         556.0       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                            10             10           0          1.0         971.6       0.6X
-RocksDB (trackTotalNumberOfRows: false)                                            6              6           0          1.7         588.4       0.9X
+In-memory                                                                          6              6           0          1.8         560.9       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                            10             11           0          1.0        1006.6       0.6X
+RocksDB (trackTotalNumberOfRows: false)                                            6              6           0          1.6         630.5       0.9X
 
-OpenJDK 64-Bit Server VM 17.0.7+7 on Linux 5.15.0-1037-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.7+7 on Linux 5.15.0-1040-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 evicting 0 rows (maxTimestampToEvictInMillis: -1) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                      1              1           0         14.9          67.2       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                         4              4           0          2.4         412.3       0.2X
-RocksDB (trackTotalNumberOfRows: false)                                        4              4           0          2.5         406.9       0.2X
+In-memory                                                                      1              1           0         15.3          65.5       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                         4              5           0          2.3         431.5       0.2X
+RocksDB (trackTotalNumberOfRows: false)                                        4              5           0          2.3         431.9       0.2X
 
 

--- a/sql/core/benchmarks/StateStoreBasicOperationsBenchmark-results.txt
+++ b/sql/core/benchmarks/StateStoreBasicOperationsBenchmark-results.txt
@@ -2,110 +2,110 @@
 put rows
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1037-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 1.8.0_372-b07 on Linux 5.15.0-1040-azure
+Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
 putting 10000 rows (10000 rows to overwrite - rate 100):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                            9             11           2          1.1         879.8       1.0X
-RocksDB (trackTotalNumberOfRows: true)                              56             60           4          0.2        5649.3       0.2X
-RocksDB (trackTotalNumberOfRows: false)                             19             21           2          0.5        1912.6       0.5X
+In-memory                                                            7              9           1          1.4         720.9       1.0X
+RocksDB (trackTotalNumberOfRows: true)                              79             92           6          0.1        7934.4       0.1X
+RocksDB (trackTotalNumberOfRows: false)                             23             27           3          0.4        2263.3       0.3X
 
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1037-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 1.8.0_372-b07 on Linux 5.15.0-1040-azure
+Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
 putting 10000 rows (5000 rows to overwrite - rate 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                          9             11           2          1.2         859.4       1.0X
-RocksDB (trackTotalNumberOfRows: true)                            48             51           3          0.2        4777.0       0.2X
-RocksDB (trackTotalNumberOfRows: false)                           20             22           1          0.5        2034.6       0.4X
+In-memory                                                          8             12           2          1.2         831.9       1.0X
+RocksDB (trackTotalNumberOfRows: true)                            65             77           5          0.2        6476.8       0.1X
+RocksDB (trackTotalNumberOfRows: false)                           22             28           2          0.4        2235.4       0.4X
 
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1037-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 1.8.0_372-b07 on Linux 5.15.0-1040-azure
+Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
 putting 10000 rows (1000 rows to overwrite - rate 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                          8             10           2          1.3         765.4       1.0X
-RocksDB (trackTotalNumberOfRows: true)                            38             41           2          0.3        3827.4       0.2X
-RocksDB (trackTotalNumberOfRows: false)                           20             21           1          0.5        1969.3       0.4X
+In-memory                                                          7             10           2          1.4         728.4       1.0X
+RocksDB (trackTotalNumberOfRows: true)                            47             57           4          0.2        4715.0       0.2X
+RocksDB (trackTotalNumberOfRows: false)                           22             27           2          0.5        2207.1       0.3X
 
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1037-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 1.8.0_372-b07 on Linux 5.15.0-1040-azure
+Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
 putting 10000 rows (0 rows to overwrite - rate 0):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                      7              9           1          1.3         744.1       1.0X
-RocksDB (trackTotalNumberOfRows: true)                        35             38           2          0.3        3544.0       0.2X
-RocksDB (trackTotalNumberOfRows: false)                       19             21           1          0.5        1938.0       0.4X
+In-memory                                                      8             10           1          1.3         750.4       1.0X
+RocksDB (trackTotalNumberOfRows: true)                        41             51           4          0.2        4116.2       0.2X
+RocksDB (trackTotalNumberOfRows: false)                       20             25           2          0.5        1962.6       0.4X
 
 
 ================================================================================================
 delete rows
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1037-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 1.8.0_372-b07 on Linux 5.15.0-1040-azure
+Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
 trying to delete 10000 rows from 10000 rows(10000 rows are non-existing - rate 100):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                        1              1           0         19.1          52.5       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                          36             38           2          0.3        3550.6       0.0X
-RocksDB (trackTotalNumberOfRows: false)                                                         19             20           1          0.5        1920.1       0.0X
+In-memory                                                                                        0              1           0         24.5          40.9       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                          42             50           4          0.2        4170.1       0.0X
+RocksDB (trackTotalNumberOfRows: false)                                                         19             24           2          0.5        1878.5       0.0X
 
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1037-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 1.8.0_372-b07 on Linux 5.15.0-1040-azure
+Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
 trying to delete 10000 rows from 10000 rows(5000 rows are non-existing - rate 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                      6              7           1          1.8         556.2       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                        47             50           3          0.2        4683.6       0.1X
-RocksDB (trackTotalNumberOfRows: false)                                                       20             21           1          0.5        1954.1       0.3X
+In-memory                                                                                      6              8           1          1.7         578.7       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                        57             68           5          0.2        5697.0       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                                       19             24           2          0.5        1861.9       0.3X
 
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1037-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 1.8.0_372-b07 on Linux 5.15.0-1040-azure
+Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
 trying to delete 10000 rows from 10000 rows(1000 rows are non-existing - rate 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                      7              9           1          1.5         660.5       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                        56             59           3          0.2        5577.0       0.1X
-RocksDB (trackTotalNumberOfRows: false)                                                       20             21           1          0.5        1973.1       0.3X
+In-memory                                                                                      6              9           2          1.6         635.0       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                        66             80           5          0.2        6605.7       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                                       19             24           2          0.5        1861.2       0.3X
 
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1037-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 1.8.0_372-b07 on Linux 5.15.0-1040-azure
+Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
 trying to delete 10000 rows from 10000 rows(0 rows are non-existing - rate 0):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                  7              8           1          1.5         670.0       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                    58             61           3          0.2        5800.5       0.1X
-RocksDB (trackTotalNumberOfRows: false)                                                   20             21           1          0.5        1980.6       0.3X
+In-memory                                                                                  7              9           1          1.5         651.4       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                    71             83           5          0.1        7108.8       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                                   18             24           2          0.6        1812.3       0.4X
 
 
 ================================================================================================
 evict rows
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1037-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 1.8.0_372-b07 on Linux 5.15.0-1040-azure
+Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
 evicting 10000 rows (maxTimestampToEvictInMillis: 9999) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                            7              8           1          1.5         661.3       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                              56             59           3          0.2        5648.5       0.1X
-RocksDB (trackTotalNumberOfRows: false)                                             20             21           1          0.5        1953.6       0.3X
+In-memory                                                                            6              9           1          1.6         619.6       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                              74             86           5          0.1        7380.0       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                             22             27           2          0.4        2245.3       0.3X
 
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1037-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 1.8.0_372-b07 on Linux 5.15.0-1040-azure
+Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
 evicting 5000 rows (maxTimestampToEvictInMillis: 4999) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                           6              7           1          1.8         570.4       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                             30             32           2          0.3        3018.1       0.2X
-RocksDB (trackTotalNumberOfRows: false)                                            11             12           1          0.9        1129.8       0.5X
+In-memory                                                                           6              8           1          1.7         579.2       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                             40             47           3          0.3        3985.4       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                            12             15           1          0.8        1214.1       0.5X
 
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1037-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 1.8.0_372-b07 on Linux 5.15.0-1040-azure
+Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
 evicting 1000 rows (maxTimestampToEvictInMillis: 999) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                          5              6           1          2.1         477.2       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                             9              9           1          1.1         882.8       0.5X
-RocksDB (trackTotalNumberOfRows: false)                                            5              5           0          2.0         512.0       0.9X
+In-memory                                                                          5              6           1          2.1         470.2       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                            11             13           1          0.9        1080.6       0.4X
+RocksDB (trackTotalNumberOfRows: false)                                            6              7           1          1.8         560.1       0.8X
 
-OpenJDK 64-Bit Server VM 1.8.0_362-b09 on Linux 5.15.0-1037-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 1.8.0_372-b07 on Linux 5.15.0-1040-azure
+Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
 evicting 0 rows (maxTimestampToEvictInMillis: -1) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                      1              1           0         14.8          67.3       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                         3              4           0          3.0         332.8       0.2X
-RocksDB (trackTotalNumberOfRows: false)                                        3              4           0          3.0         333.5       0.2X
+In-memory                                                                      1              1           0         18.4          54.3       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                         4              4           1          2.8         352.7       0.2X
+RocksDB (trackTotalNumberOfRows: false)                                        3              4           1          3.0         328.0       0.2X
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to upgrade rocksdbjni from 8.1.1.1 to 8.3.2.

### Why are the changes needed?
The release notes: https://github.com/facebook/rocksdb/releases/tag/v8.3.2
- Bug Fixes
Reduced cases of illegally using Env::Default() during static destruction by never destroying the internal PosixEnv itself (except for builds checking for memory leaks). (https://github.com/facebook/rocksdb/pull/11538)

- Performance Improvements
Fixed higher read QPS during DB::Open() reading files created prior to https://github.com/facebook/rocksdb/pull/11406, especially when reading many small file (size < 52 MB) during DB::Open() and partitioned filter or index is used.


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
- Pass GA.
- Manual test: `org.apache.spark.util.kvstore.RocksDBBenchmark`

**A.8.1.1.1**
```
                                        	count	mean	min	max	95th
dbClose                                 	4	0.472	0.413	0.527	0.527
dbCreation                              	4	263.388	42.032	922.916	922.916
naturalIndexCreateIterator              	1024	0.005	0.001	2.646	0.004
naturalIndexDescendingCreateIterator    	1024	0.002	0.002	0.055	0.002
naturalIndexDescendingIteration         	1024	0.003	0.003	0.021	0.004
naturalIndexIteration                   	1024	0.009	0.003	3.156	0.012
randomDeleteIndexed                     	1024	0.017	0.013	0.381	0.023
randomDeletesNoIndex                    	1024	0.010	0.009	0.032	0.011
randomUpdatesIndexed                    	1024	0.066	0.025	19.900	0.074
randomUpdatesNoIndex                    	1024	0.017	0.015	0.380	0.019
randomWritesIndexed                     	1024	0.097	0.024	52.970	0.093
randomWritesNoIndex                     	1024	0.019	0.015	1.101	0.021
refIndexCreateIterator                  	1024	0.002	0.002	0.044	0.002
refIndexDescendingCreateIterator        	1024	0.001	0.001	0.013	0.001
refIndexDescendingIteration             	1024	0.004	0.003	0.070	0.005
refIndexIteration                       	1024	0.005	0.003	0.230	0.005
sequentialDeleteIndexed                 	1024	0.016	0.013	0.104	0.022
sequentialDeleteNoIndex                 	1024	0.011	0.009	0.044	0.011
sequentialUpdatesIndexed                	1024	0.027	0.019	0.660	0.050
sequentialUpdatesNoIndex                	1024	0.025	0.016	0.523	0.033
sequentialWritesIndexed                 	1024	0.030	0.020	1.526	0.040
sequentialWritesNoIndex                 	1024	0.030	0.017	4.410	0.035
```
**B.8.3.2**
```
                                        	count	mean	min	max	95th
dbClose                                 	4	0.488	0.424	0.556	0.556
dbCreation                              	4	241.375	35.710	850.488	850.488
naturalIndexCreateIterator              	1024	0.004	0.001	1.555	0.006
naturalIndexDescendingCreateIterator    	1024	0.002	0.002	0.064	0.002
naturalIndexDescendingIteration         	1024	0.004	0.003	0.035	0.004
naturalIndexIteration                   	1024	0.011	0.003	4.464	0.012
randomDeleteIndexed                     	1024	0.018	0.013	0.505	0.024
randomDeletesNoIndex                    	1024	0.010	0.009	0.025	0.011
randomUpdatesIndexed                    	1024	0.065	0.024	20.210	0.077
randomUpdatesNoIndex                    	1024	0.019	0.015	0.449	0.027
randomWritesIndexed                     	1024	0.087	0.026	38.782	0.096
randomWritesNoIndex                     	1024	0.019	0.016	1.040	0.019
refIndexCreateIterator                  	1024	0.002	0.002	0.051	0.002
refIndexDescendingCreateIterator        	1024	0.001	0.001	0.013	0.001
refIndexDescendingIteration             	1024	0.004	0.003	0.064	0.004
refIndexIteration                       	1024	0.005	0.003	0.253	0.006
sequentialDeleteIndexed                 	1024	0.016	0.013	0.286	0.024
sequentialDeleteNoIndex                 	1024	0.010	0.009	0.071	0.012
sequentialUpdatesIndexed                	1024	0.026	0.020	0.711	0.042
sequentialUpdatesNoIndex                	1024	0.024	0.016	0.455	0.030
sequentialWritesIndexed                 	1024	0.025	0.020	1.359	0.033
sequentialWritesNoIndex                 	1024	0.028	0.017	4.354	0.030
```

    B.Checked core module UTs with rocksdb live ui
    ```
    export LIVE_UI_LOCAL_STORE_DIR=/${basedir}/spark-ui
    build/mvn clean install -pl core -am -Dtest.exclude.tags=org.apache.spark.tags.ExtendedLevelDBTest -fn
    [INFO] ------------------------------------------------------------------------
    [INFO] BUILD SUCCESS
    [INFO] ------------------------------------------------------------------------
    [INFO] Total time:  39:09 min
    [INFO] Finished at: 2023-06-30T09:48:44+08:00
    [INFO] ------------------------------------------------------------------------
    ```




