### PR TITLE
[SPARK-43851][SQL] Support LCA in grouping expressions

### DIFF
--- a/common/utils/src/main/resources/error/error-classes.json
+++ b/common/utils/src/main/resources/error/error-classes.json
@@ -2489,11 +2489,6 @@
           "Referencing lateral column alias <lca> in the aggregate query both with window expressions and with having clause. Please rewrite the aggregate query by removing the having clause or removing lateral alias reference in the SELECT list."
         ]
       },
-      "LATERAL_COLUMN_ALIAS_IN_GROUP_BY" : {
-        "message" : [
-          "Referencing a lateral column alias via GROUP BY alias/ALL is not supported yet."
-        ]
-      },
       "LATERAL_COLUMN_ALIAS_IN_WINDOW" : {
         "message" : [
           "Referencing a lateral column alias <lca> in window expression <windowExpr>."

--- a/docs/sql-error-conditions-unsupported-feature-error-class.md
+++ b/docs/sql-error-conditions-unsupported-feature-error-class.md
@@ -65,10 +65,6 @@ Referencing a lateral column alias `<lca>` in the aggregate function `<aggFunc>`
 
 Referencing lateral column alias `<lca>` in the aggregate query both with window expressions and with having clause. Please rewrite the aggregate query by removing the having clause or removing lateral alias reference in the SELECT list.
 
-## LATERAL_COLUMN_ALIAS_IN_GROUP_BY
-
-Referencing a lateral column alias via GROUP BY alias/ALL is not supported yet.
-
 ## LATERAL_COLUMN_ALIAS_IN_WINDOW
 
 Referencing a lateral column alias `<lca>` in window expression `<windowExpr>`.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveReferencesInAggregate.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveReferencesInAggregate.scala
@@ -107,10 +107,9 @@ object ResolveReferencesInAggregate extends SQLConfHelper
       groupExprs.map { g =>
         g.transformWithPruning(_.containsAnyPattern(UNRESOLVED_ATTRIBUTE,
           LATERAL_COLUMN_ALIAS_REFERENCE)) {
-          case u: UnresolvedAttribute =>
-            selectList.find(ne => conf.resolver(ne.name, u.name)).getOrElse(u)
-          case u: LateralColumnAliasReference =>
-            selectList.find(ne => conf.resolver(ne.name, u.name)).getOrElse(u)
+          case u @ (_: UnresolvedAttribute | _: LateralColumnAliasReference) =>
+            selectList.find(ne => conf.resolver(ne.name, u.asInstanceOf[NamedExpression].name))
+              .getOrElse(u)
         }
       }
     } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveReferencesInAggregate.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveReferencesInAggregate.scala
@@ -17,9 +17,8 @@
 
 package org.apache.spark.sql.catalyst.analysis
 
-import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.SQLConfHelper
-import org.apache.spark.sql.catalyst.expressions.{AliasHelper, Attribute, Expression, NamedExpression}
+import org.apache.spark.sql.catalyst.expressions.{AliasHelper, Attribute, Expression, LateralColumnAliasReference, NamedExpression}
 import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
 import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, AppendColumns, LogicalPlan}
 import org.apache.spark.sql.catalyst.trees.TreePattern.{LATERAL_COLUMN_ALIAS_REFERENCE, UNRESOLVED_ATTRIBUTE}
@@ -74,12 +73,6 @@ object ResolveReferencesInAggregate extends SQLConfHelper
         resolvedAggExprsWithOuter,
         resolveGroupByAlias(resolvedAggExprsWithOuter, resolvedGroupExprsNoOuter)
       ).map(resolveOuterRef)
-      // TODO: currently we don't support LCA in `groupingExpressions` yet.
-      if (resolved.exists(_.containsPattern(LATERAL_COLUMN_ALIAS_REFERENCE))) {
-        throw new AnalysisException(
-          errorClass = "UNSUPPORTED_FEATURE.LATERAL_COLUMN_ALIAS_IN_GROUP_BY",
-          messageParameters = Map.empty)
-      }
       resolved
     } else {
       // Do not resolve columns in grouping expressions to outer references here, as the aggregate
@@ -112,8 +105,11 @@ object ResolveReferencesInAggregate extends SQLConfHelper
     assert(selectList.forall(_.resolved))
     if (conf.groupByAliases) {
       groupExprs.map { g =>
-        g.transformWithPruning(_.containsPattern(UNRESOLVED_ATTRIBUTE)) {
+        g.transformWithPruning(_.containsAnyPattern(UNRESOLVED_ATTRIBUTE,
+          LATERAL_COLUMN_ALIAS_REFERENCE)) {
           case u: UnresolvedAttribute =>
+            selectList.find(ne => conf.resolver(ne.name, u.name)).getOrElse(u)
+          case u: LateralColumnAliasReference =>
             selectList.find(ne => conf.resolver(ne.name, u.name)).getOrElse(u)
         }
       }
@@ -133,8 +129,9 @@ object ResolveReferencesInAggregate extends SQLConfHelper
         // tell the user in checkAnalysis that we cannot resolve the all in group by.
         groupExprs
       } else {
-        // This is a valid GROUP BY ALL aggregate.
-        expandedGroupExprs.get
+        // This is a valid GROUP BY ALL aggregate, resolve group by alias again to transform the
+        // LCA reference
+        resolveGroupByAlias(selectList, expandedGroupExprs.get)
       }
     } else {
       groupExprs

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/column-resolution-aggregate.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/column-resolution-aggregate.sql.out
@@ -94,21 +94,27 @@ org.apache.spark.sql.AnalysisException
 -- !query
 SELECT k AS lca, lca + 1 AS col FROM v1 GROUP BY k, col
 -- !query analysis
-org.apache.spark.sql.AnalysisException
-{
-  "errorClass" : "UNSUPPORTED_FEATURE.LATERAL_COLUMN_ALIAS_IN_GROUP_BY",
-  "sqlState" : "0A000"
-}
+Project [lca#x, (lca#x + 1) AS col#x]
++- Project [k#x, k#x AS lca#x]
+   +- Aggregate [k#x, (k#x + 1)], [k#x]
+      +- SubqueryAlias v1
+         +- View (`v1`, [a#x,b#x,k#x])
+            +- Project [cast(a#x as int) AS a#x, cast(b#x as int) AS b#x, cast(k#x as int) AS k#x]
+               +- SubqueryAlias t
+                  +- LocalRelation [a#x, b#x, k#x]
 
 
 -- !query
 SELECT k AS lca, lca + 1 AS col FROM v1 GROUP BY all
 -- !query analysis
-org.apache.spark.sql.AnalysisException
-{
-  "errorClass" : "UNSUPPORTED_FEATURE.LATERAL_COLUMN_ALIAS_IN_GROUP_BY",
-  "sqlState" : "0A000"
-}
+Project [lca#x, (lca#x + 1) AS col#x]
++- Project [k#x, k#x AS lca#x]
+   +- Aggregate [k#x, (k#x + 1)], [k#x]
+      +- SubqueryAlias v1
+         +- View (`v1`, [a#x,b#x,k#x])
+            +- Project [cast(a#x as int) AS a#x, cast(b#x as int) AS b#x, cast(k#x as int) AS k#x]
+               +- SubqueryAlias t
+                  +- LocalRelation [a#x, b#x, k#x]
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/column-resolution-aggregate.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/column-resolution-aggregate.sql.out
@@ -91,25 +91,17 @@ org.apache.spark.sql.AnalysisException
 -- !query
 SELECT k AS lca, lca + 1 AS col FROM v1 GROUP BY k, col
 -- !query schema
-struct<>
+struct<lca:int,col:int>
 -- !query output
-org.apache.spark.sql.AnalysisException
-{
-  "errorClass" : "UNSUPPORTED_FEATURE.LATERAL_COLUMN_ALIAS_IN_GROUP_BY",
-  "sqlState" : "0A000"
-}
+1	2
 
 
 -- !query
 SELECT k AS lca, lca + 1 AS col FROM v1 GROUP BY all
 -- !query schema
-struct<>
+struct<lca:int,col:int>
 -- !query output
-org.apache.spark.sql.AnalysisException
-{
-  "errorClass" : "UNSUPPORTED_FEATURE.LATERAL_COLUMN_ALIAS_IN_GROUP_BY",
-  "sqlState" : "0A000"
-}
+1	2
 
 
 -- !query


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
This PR bring support lateral column alias reference in grouping expressions.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
add new feature for LCA 
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
No
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
exist test
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
