### PR TITLE
[SPARK-44242] Improve Max Heap not set check

### DIFF
--- a/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
@@ -314,9 +314,9 @@ class SparkSubmitCommandBuilder extends AbstractCommandBuilder {
     if (!isEmpty(javaOptions)) {
       for (String javaOption: CommandBuilderUtils.parseOptionString(javaOptions)) {
         if (javaOption.startsWith("-Xmx")) {
-            String msg = String.format("Not allowed to specify max heap(Xmx) memory settings through " +
-                    "java options (was %s). Use the corresponding --driver-memory or " +
-                    "spark.driver.memory configuration instead.", javaOptions);
+            String msg = String.format("Not allowed to specify max heap(Xmx) memory settings " +
+              "through java options (was %s). Use the corresponding --driver-memory or " +
+              "spark.driver.memory configuration instead.", javaOptions);
             throw new IllegalArgumentException(msg);
         }
       }

--- a/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
@@ -311,11 +311,15 @@ class SparkSubmitCommandBuilder extends AbstractCommandBuilder {
   }
 
   private void checkJavaOptions(String javaOptions) {
-    if (!isEmpty(javaOptions) && javaOptions.contains("Xmx")) {
-      String msg = String.format("Not allowed to specify max heap(Xmx) memory settings through " +
-        "java options (was %s). Use the corresponding --driver-memory or " +
-        "spark.driver.memory configuration instead.", javaOptions);
-      throw new IllegalArgumentException(msg);
+    if (!isEmpty(javaOptions)) {
+      for (String javaOption: CommandBuilderUtils.parseOptionString(javaOptions)) {
+        if (javaOption.startsWith("-Xmx")) {
+            String msg = String.format("Not allowed to specify max heap(Xmx) memory settings through " +
+                    "java options (was %s). Use the corresponding --driver-memory or " +
+                    "spark.driver.memory configuration instead.", javaOptions);
+            throw new IllegalArgumentException(msg);
+        }
+      }
     }
   }
 

--- a/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitCommandBuilderSuite.java
+++ b/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitCommandBuilderSuite.java
@@ -76,14 +76,14 @@ public class SparkSubmitCommandBuilderSuite extends BaseSuite {
   public void testCheckJavaOptionsThrowException() throws Exception {
     Map<String, String> env = new HashMap<>();
     List<String> sparkSubmitArgs = Arrays.asList(
-            parser.MASTER,
-            "local",
-            parser.DRIVER_CLASS_PATH,
-            "/driverCp",
-            parser.DRIVER_JAVA_OPTIONS,
-            "-Xmx64g -Dprop=Other -Dprop1=\"-Xmx -Xmx\" -Dprop2=\"-Xmx '-Xmx\" " +
-              "-Dprop3='-Xmx -Xmx' -Dprop4='-Xmx \"-Xmx'",
-            SparkLauncher.NO_RESOURCE);
+      parser.MASTER,
+      "local",
+      parser.DRIVER_CLASS_PATH,
+      "/driverCp",
+      parser.DRIVER_JAVA_OPTIONS,
+      "-Xmx64g -Dprop=Other -Dprop1=\"-Xmx -Xmx\" -Dprop2=\"-Xmx '-Xmx\" " +
+        "-Dprop3='-Xmx -Xmx' -Dprop4='-Xmx \"-Xmx'",
+      SparkLauncher.NO_RESOURCE);
     buildCommand(sparkSubmitArgs, env);
   }
 
@@ -91,14 +91,14 @@ public class SparkSubmitCommandBuilderSuite extends BaseSuite {
   public void testCheckJavaOptions() throws Exception {
     Map<String, String> env = new HashMap<>();
     List<String> sparkSubmitArgs = Arrays.asList(
-            parser.MASTER,
-            "local",
-            parser.DRIVER_CLASS_PATH,
-            "/driverCp",
-            parser.DRIVER_JAVA_OPTIONS,
-            "-Dprop=-Xmx -Dprop1=\"-Xmx -Xmx\" -Dprop2=\"-Xmx '-Xmx\" " +
-              "-Dprop3='-Xmx -Xmx' -Dprop4='-Xmx \"-Xmx'",
-            SparkLauncher.NO_RESOURCE);
+      parser.MASTER,
+      "local",
+      parser.DRIVER_CLASS_PATH,
+      "/driverCp",
+      parser.DRIVER_JAVA_OPTIONS,
+      "-Dprop=-Xmx -Dprop1=\"-Xmx -Xmx\" -Dprop2=\"-Xmx '-Xmx\" " +
+        "-Dprop3='-Xmx -Xmx' -Dprop4='-Xmx \"-Xmx'",
+      SparkLauncher.NO_RESOURCE);
     buildCommand(sparkSubmitArgs, env);
   }
 

--- a/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitCommandBuilderSuite.java
+++ b/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitCommandBuilderSuite.java
@@ -72,6 +72,34 @@ public class SparkSubmitCommandBuilderSuite extends BaseSuite {
       cmd.contains("org.apache.spark.deploy.SparkSubmit"));
   }
 
+  @Test(expected = IllegalArgumentException.class)
+  public void testCheckJavaOptionsThrowException() throws Exception {
+    Map<String, String> env = new HashMap<>();
+    List<String> sparkSubmitArgs = Arrays.asList(
+            parser.MASTER,
+            "local",
+            parser.DRIVER_CLASS_PATH,
+            "/driverCp",
+            parser.DRIVER_JAVA_OPTIONS,
+            "-Xmx64g -Dprop=Other -Dprop1=\"-Xmx -Xmx\" -Dprop2=\"-Xmx '-Xmx\" -Dprop3='-Xmx -Xmx' -Dprop4='-Xmx \"-Xmx'",
+            SparkLauncher.NO_RESOURCE);
+    buildCommand(sparkSubmitArgs, env);
+  }
+
+  @Test
+  public void testCheckJavaOptions() throws Exception {
+    Map<String, String> env = new HashMap<>();
+    List<String> sparkSubmitArgs = Arrays.asList(
+            parser.MASTER,
+            "local",
+            parser.DRIVER_CLASS_PATH,
+            "/driverCp",
+            parser.DRIVER_JAVA_OPTIONS,
+            "-Dprop=-Xmx -Dprop1=\"-Xmx -Xmx\" -Dprop2=\"-Xmx '-Xmx\" -Dprop3='-Xmx -Xmx' -Dprop4='-Xmx \"-Xmx'",
+            SparkLauncher.NO_RESOURCE);
+    buildCommand(sparkSubmitArgs, env);
+  }
+
   @Test
   public void testCliKillAndStatus() throws Exception {
     List<String> params = Arrays.asList("driver-20160531171222-0000");

--- a/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitCommandBuilderSuite.java
+++ b/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitCommandBuilderSuite.java
@@ -81,7 +81,8 @@ public class SparkSubmitCommandBuilderSuite extends BaseSuite {
             parser.DRIVER_CLASS_PATH,
             "/driverCp",
             parser.DRIVER_JAVA_OPTIONS,
-            "-Xmx64g -Dprop=Other -Dprop1=\"-Xmx -Xmx\" -Dprop2=\"-Xmx '-Xmx\" -Dprop3='-Xmx -Xmx' -Dprop4='-Xmx \"-Xmx'",
+            "-Xmx64g -Dprop=Other -Dprop1=\"-Xmx -Xmx\" -Dprop2=\"-Xmx '-Xmx\" " +
+              "-Dprop3='-Xmx -Xmx' -Dprop4='-Xmx \"-Xmx'",
             SparkLauncher.NO_RESOURCE);
     buildCommand(sparkSubmitArgs, env);
   }
@@ -95,7 +96,8 @@ public class SparkSubmitCommandBuilderSuite extends BaseSuite {
             parser.DRIVER_CLASS_PATH,
             "/driverCp",
             parser.DRIVER_JAVA_OPTIONS,
-            "-Dprop=-Xmx -Dprop1=\"-Xmx -Xmx\" -Dprop2=\"-Xmx '-Xmx\" -Dprop3='-Xmx -Xmx' -Dprop4='-Xmx \"-Xmx'",
+            "-Dprop=-Xmx -Dprop1=\"-Xmx -Xmx\" -Dprop2=\"-Xmx '-Xmx\" " +
+              "-Dprop3='-Xmx -Xmx' -Dprop4='-Xmx \"-Xmx'",
             SparkLauncher.NO_RESOURCE);
     buildCommand(sparkSubmitArgs, env);
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Currently if any Xmx string is available in the driver java options even if not related to Max Heap setting the job sumission failed
For Ex. this command failed
`./bin/spark-submit --class org.apache.spark.examples.SparkPi --conf "spark.driver.extraJavaOptions=-Dtest=Xmx"  examples/jars/spark-examples_2.12-3.4.1.jar 100`


### Why are the changes needed?
The command should any failed if the -Xmx argument is set not if it is part of another parameter or string


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Added a unitary test
