### PR TITLE
[SPARK-44263][CONNECT] Channel Builder support

### DIFF
--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/connect/client/ChannelBuilder.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/connect/client/ChannelBuilder.scala
@@ -24,7 +24,28 @@ import io.grpc.{ChannelCredentials, Grpc, ManagedChannel, ManagedChannelBuilder}
 import org.apache.spark.sql.connect.client.SparkConnectClient.MetadataHeaderClientInterceptor
 import org.apache.spark.sql.connect.common.config.ConnectCommon
 
+/**
+ * This class controls how the grpc channel is created.
+ *
+ * Implementations can override [[createChannelBuilder]] method to add custom behavior.
+ *
+ * The custom channel builder can be provided during [[org.apache.spark.sql.SparkSession]] creation as follows:
+ *
+ * {{{
+ *   SparkSession.builder().remote("...").channelBuilder(channelBuilder).create()
+ * }}}
+ */
 class ChannelBuilder() {
+  /**
+   * Implement this method to customize how the grpc channel is created
+   * @param host
+   *    Host part of the remote address
+   * @param port
+   *    Port part of the remote address
+   * @param credentials
+   *    Channel credentials
+   * @return ManagedChannelBuilder
+   */
   def createChannelBuilder(
       host: String,
       port: Int,

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/connect/client/ChannelBuilder.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/connect/client/ChannelBuilder.scala
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connect.client
+
+import scala.language.existentials
+
+import io.grpc.{ChannelCredentials, Grpc, ManagedChannel, ManagedChannelBuilder}
+
+import org.apache.spark.sql.connect.client.SparkConnectClient.MetadataHeaderClientInterceptor
+import org.apache.spark.sql.connect.common.config.ConnectCommon
+
+class ChannelBuilder() {
+  def createChannelBuilder(
+      host: String,
+      port: Int,
+      credentials: ChannelCredentials): ManagedChannelBuilder[_] = {
+    val builder = Grpc.newChannelBuilderForAddress(host, port, credentials)
+    builder.maxInboundMessageSize(ConnectCommon.CONNECT_GRPC_MAX_MESSAGE_SIZE)
+    builder
+  }
+
+  private[sql] def createChannelFromConf(
+      conf: SparkConnectClient.Configuration): ManagedChannel = {
+    val channel = createChannelBuilder(conf.host, conf.port, conf.credentials)
+    if (conf.metadata.nonEmpty) {
+      channel.intercept(new MetadataHeaderClientInterceptor(conf.metadata))
+    }
+
+    channel.build()
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
Extend SparkSession to allow custom channelbuilders.
This is already done in Python --- https://github.com/apache/spark/pull/40993
Now implementing this in Scala

### Why are the changes needed?
This can be used for different purposes, such as customized authentication mechanisms

### Does this PR introduce _any_ user-facing change?
Allows to have user-supplied channelbuilders. See tests for examples.


### How was this patch tested?
Unit tests