### PR TITLE
[MINOR][SQL][TESTS] Use SystemUtils.isJavaVersionAtMost for java version check

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/TimestampFormatterSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/TimestampFormatterSuite.scala
@@ -412,7 +412,7 @@ class TimestampFormatterSuite extends DatetimeFormatterSuite {
     assert(formatter.format(date(1970, 1, 3)) == "03")
     assert(formatter.format(date(1970, 4, 9)) == "99")
 
-    if (System.getProperty("java.version").split("\\D+")(0).toInt < 9) {
+    if (SystemUtils.isJavaVersionAtMost(JavaVersion.JAVA_1_8)) {
       // https://bugs.openjdk.java.net/browse/JDK-8079628
       intercept[SparkUpgradeException] {
         formatter.format(date(1970, 4, 10))


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to use Apache Common API for proper Java version checking instead of manual check via `System.getProperty("java.version")`.

### Why are the changes needed?

To have the consistent codebase. This is the only place left.

### Does this PR introduce _any_ user-facing change?

No, with/without this change virtually same.

### How was this patch tested?

Manually tested.