### PR TITLE
upgrade github action

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -321,7 +321,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           context: ./dev/infra/
           push: true
@@ -425,7 +425,7 @@ jobs:
         ./dev/run-tests --parallelism 1 --modules "$MODULES_TO_TEST"
     - name: Upload coverage to Codecov
       if: fromJSON(inputs.envs).PYSPARK_CODECOV == 'true'
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3
       with:
         files: ./python/coverage.xml
         flags: unittests

--- a/.github/workflows/build_infra_images_cache.yml
+++ b/.github/workflows/build_infra_images_cache.yml
@@ -51,7 +51,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           context: ./dev/infra/
           push: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -27,7 +27,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@c201d45ef4b0ccbd3bb0616f93bae13e73d0a080 # pin@v1.1.0
+    - uses: actions/stale@v8
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-pr-message: >


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade some github action to newest version, include:
- build-push-action from v3 to v4
- codecov-action from v2 to v3
- actions/stale from v1.1 to v8

### Why are the changes needed?
- build-push-action
Release Notes: 
https://github.com/docker/build-push-action/releases/tag/v4.1.1
https://github.com/docker/build-push-action/releases/tag/v4.1.0
https://github.com/docker/build-push-action/releases/tag/v4.0.0

- codecov-action
Release Notes: 
https://github.com/codecov/codecov-action/releases/tag/v3.1.4
https://github.com/codecov/codecov-action/releases/tag/v3.1.3
https://github.com/codecov/codecov-action/releases/tag/v3.1.2
https://github.com/codecov/codecov-action/releases/tag/v3.1.1
https://github.com/codecov/codecov-action/releases/tag/v3.1.0
https://github.com/codecov/codecov-action/releases/tag/v3.0.0

- actions/stale
Release Notes: 

https://github.com/actions/stale/releases/tag/v2.0.1

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA.