### PR TITLE
[SPARK-44278][CONNECT] Implement a GRPC server interceptor that cleans up thread local properties

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/LocalPropertiesCleanupInterceptor.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/LocalPropertiesCleanupInterceptor.scala
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connect.service
+
+import io.grpc.{Metadata, ServerCall, ServerCallHandler, ServerInterceptor}
+import io.grpc.ForwardingServerCallListener.SimpleForwardingServerCallListener
+
+import org.apache.spark.SparkContext
+
+/**
+ * Interceptor for cleaning up local properties in the SparkContext after gRPC server calls.
+ */
+class LocalPropertiesCleanupInterceptor extends ServerInterceptor {
+
+  override def interceptCall[ReqT, RespT](
+    serverCall: ServerCall[ReqT, RespT],
+    metadata: Metadata,
+    serverCallHandler: ServerCallHandler[ReqT, RespT]
+  ): ServerCall.Listener[ReqT] = {
+    new SimpleForwardingServerCallListener[ReqT](
+      serverCallHandler.startCall(serverCall, metadata)
+    ) {
+        override def onComplete(): Unit = {
+          cleanupLocalProperties()
+          super.onComplete()
+        }
+
+        override def onCancel(): Unit = {
+          cleanupLocalProperties()
+          super.onCancel()
+        }
+
+        private def cleanupLocalProperties(): Unit = {
+          SparkContext.getActive.foreach(_.getLocalProperties.clear())
+        }
+      }
+  }
+}

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/LocalPropertiesCleanupInterceptor.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/LocalPropertiesCleanupInterceptor.scala
@@ -28,26 +28,24 @@ import org.apache.spark.SparkContext
 class LocalPropertiesCleanupInterceptor extends ServerInterceptor {
 
   override def interceptCall[ReqT, RespT](
-    serverCall: ServerCall[ReqT, RespT],
-    metadata: Metadata,
-    serverCallHandler: ServerCallHandler[ReqT, RespT]
-  ): ServerCall.Listener[ReqT] = {
+      serverCall: ServerCall[ReqT, RespT],
+      metadata: Metadata,
+      serverCallHandler: ServerCallHandler[ReqT, RespT]): ServerCall.Listener[ReqT] = {
     new SimpleForwardingServerCallListener[ReqT](
-      serverCallHandler.startCall(serverCall, metadata)
-    ) {
-        override def onComplete(): Unit = {
-          cleanupLocalProperties()
-          super.onComplete()
-        }
-
-        override def onCancel(): Unit = {
-          cleanupLocalProperties()
-          super.onCancel()
-        }
-
-        private def cleanupLocalProperties(): Unit = {
-          SparkContext.getActive.foreach(_.getLocalProperties.clear())
-        }
+      serverCallHandler.startCall(serverCall, metadata)) {
+      override def onComplete(): Unit = {
+        cleanupLocalProperties()
+        super.onComplete()
       }
+
+      override def onCancel(): Unit = {
+        cleanupLocalProperties()
+        super.onCancel()
+      }
+
+      private def cleanupLocalProperties(): Unit = {
+        SparkContext.getActive.foreach(_.getLocalProperties.clear())
+      }
+    }
   }
 }

--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/service/InterceptorRegistrySuite.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/service/InterceptorRegistrySuite.scala
@@ -184,4 +184,14 @@ class InterceptorRegistrySuite extends SharedSparkSession {
       assert(interceptors.head.isInstanceOf[LoggingInterceptor])
     }
   }
+
+  test("LocalPropertiesCleanupInterceptor initializes when configured in spark conf") {
+    withSparkConf(
+      Connect.CONNECT_GRPC_INTERCEPTOR_CLASSES.key ->
+        "org.apache.spark.sql.connect.service.LocalPropertiesCleanupInterceptor") {
+      val interceptors = SparkConnectInterceptorRegistry.createConfiguredInterceptors()
+      assert(interceptors.size == 1)
+      assert(interceptors.head.isInstanceOf[LocalPropertiesCleanupInterceptor])
+    }
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This pr implements a GRPC server interceptor that cleans up thread local properties (e.g. SparkContext local properties) for Spark Connect service.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

To prevent the leakage of thread-local variables from one request to another request, ensure proper isolation between requests.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Existing tests
