### PR TITLE
[SPARK-44287][SQL] Use PartitionEvaluator API in RowToColumnarExec & ColumnarToRowExec SQL operators.

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ColumnarEvaluatorFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ColumnarEvaluatorFactory.scala
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution
+
+import scala.collection.JavaConverters._
+
+import org.apache.spark.{PartitionEvaluator, PartitionEvaluatorFactory, TaskContext}
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{Attribute, UnsafeProjection}
+import org.apache.spark.sql.execution.metric.SQLMetric
+import org.apache.spark.sql.execution.vectorized.{OffHeapColumnVector, OnHeapColumnVector, WritableColumnVector}
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.vectorized.ColumnarBatch
+
+class ColumnarToRowEvaluatorFactory(
+    childOutput: Seq[Attribute],
+    numOutputRows: SQLMetric,
+    numInputBatches: SQLMetric)
+    extends PartitionEvaluatorFactory[ColumnarBatch, InternalRow] {
+
+  override def createEvaluator(): PartitionEvaluator[ColumnarBatch, InternalRow] = {
+    new ColumnarToRowEvaluator
+  }
+
+  private class ColumnarToRowEvaluator extends PartitionEvaluator[ColumnarBatch, InternalRow] {
+    override def eval(
+        partitionIndex: Int,
+        inputs: Iterator[ColumnarBatch]*): Iterator[InternalRow] = {
+      assert(inputs.length == 1)
+      val toUnsafe = UnsafeProjection.create(childOutput, childOutput)
+      inputs.head.flatMap { input =>
+        numInputBatches += 1
+        numOutputRows += input.numRows()
+        input.rowIterator().asScala.map(toUnsafe)
+      }
+    }
+  }
+}
+
+class RowToColumnarEvaluatorFactory(
+    enableOffHeapColumnVector: Boolean,
+    numRows: Int,
+    schema: StructType,
+    numInputRows: SQLMetric,
+    numOutputBatches: SQLMetric)
+    extends PartitionEvaluatorFactory[InternalRow, ColumnarBatch] {
+
+  override def createEvaluator(): PartitionEvaluator[InternalRow, ColumnarBatch] = {
+    new RowToColumnarEvaluator
+  }
+
+  private class RowToColumnarEvaluator extends PartitionEvaluator[InternalRow, ColumnarBatch] {
+    override def eval(
+        partitionIndex: Int,
+        inputs: Iterator[InternalRow]*): Iterator[ColumnarBatch] = {
+      assert(inputs.length == 1)
+      val rowIterator = inputs.head
+
+      if (rowIterator.hasNext) {
+        new Iterator[ColumnarBatch] {
+          private val converters = new RowToColumnConverter(schema)
+          private val vectors: Seq[WritableColumnVector] = if (enableOffHeapColumnVector) {
+            OffHeapColumnVector.allocateColumns(numRows, schema)
+          } else {
+            OnHeapColumnVector.allocateColumns(numRows, schema)
+          }
+          private val cb: ColumnarBatch = new ColumnarBatch(vectors.toArray)
+
+          TaskContext.get().addTaskCompletionListener[Unit] { _ =>
+            cb.close()
+          }
+
+          override def hasNext: Boolean = {
+            rowIterator.hasNext
+          }
+
+          override def next(): ColumnarBatch = {
+            cb.setNumRows(0)
+            vectors.foreach(_.reset())
+            var rowCount = 0
+            while (rowCount < numRows && rowIterator.hasNext) {
+              val row = rowIterator.next()
+              converters.convert(row, vectors.toArray)
+              rowCount += 1
+            }
+            cb.setNumRows(rowCount)
+            numInputRows += rowCount
+            numOutputBatches += 1
+            cb
+          }
+        }
+      } else {
+        Iterator.empty
+      }
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionExtensionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionExtensionSuite.scala
@@ -279,36 +279,40 @@ class SparkSessionExtensionSuite extends SparkFunSuite with SQLHelper {
     }
     withSession(extensions) { session =>
       session.conf.set(SQLConf.ADAPTIVE_EXECUTION_ENABLED, enableAQE)
-      assert(session.sessionState.columnarRules.contains(
-        MyColumnarRule(PreRuleReplaceAddWithBrokenVersion(), MyPostRule())))
-      import session.sqlContext.implicits._
-      // perform a join to inject a broadcast exchange
-      val left = Seq((1, 50L), (2, 100L), (3, 150L)).toDF("l1", "l2")
-      val right = Seq((1, 50L), (2, 100L), (3, 150L)).toDF("r1", "r2")
-      val data = left.join(right, $"l1" === $"r1")
-        // repartitioning avoids having the add operation pushed up into the LocalTableScan
-        .repartition(1)
-      val df = data.selectExpr("l2 + r2")
-      // execute the plan so that the final adaptive plan is available when AQE is on
-      df.collect()
-      val found = collectPlanSteps(df.queryExecution.executedPlan).sum
-      // 1 MyBroadcastExchangeExec
-      // 1 MyShuffleExchangeExec
-      // 1 ColumnarToRowExec
-      // 2 ColumnarProjectExec
-      // 1 ReplacedRowToColumnarExec
-      // so 11121 is expected.
-      assert(found == 11121)
+      Seq(true, false).foreach { enableEvaluator =>
+        withSQLConf(SQLConf.USE_PARTITION_EVALUATOR.key -> enableEvaluator.toString) {
+          assert(session.sessionState.columnarRules.contains(
+            MyColumnarRule(PreRuleReplaceAddWithBrokenVersion(), MyPostRule())))
+          import session.sqlContext.implicits._
+          // perform a join to inject a broadcast exchange
+          val left = Seq((1, 50L), (2, 100L), (3, 150L)).toDF("l1", "l2")
+          val right = Seq((1, 50L), (2, 100L), (3, 150L)).toDF("r1", "r2")
+          val data = left.join(right, $"l1" === $"r1")
+            // repartitioning avoids having the add operation pushed up into the LocalTableScan
+            .repartition(1)
+          val df = data.selectExpr("l2 + r2")
+          // execute the plan so that the final adaptive plan is available when AQE is on
+          df.collect()
+          val found = collectPlanSteps(df.queryExecution.executedPlan).sum
+          // 1 MyBroadcastExchangeExec
+          // 1 MyShuffleExchangeExec
+          // 1 ColumnarToRowExec
+          // 2 ColumnarProjectExec
+          // 1 ReplacedRowToColumnarExec
+          // so 11121 is expected.
+          assert(found == 11121)
 
-      // Verify that we get back the expected, wrong, result
-      val result = df.collect()
-      assert(result(0).getLong(0) == 101L) // Check that broken columnar Add was used.
-      assert(result(1).getLong(0) == 201L)
-      assert(result(2).getLong(0) == 301L)
+          // Verify that we get back the expected, wrong, result
+          val result = df.collect()
+          assert(result(0).getLong(0) == 101L) // Check that broken columnar Add was used.
+          assert(result(1).getLong(0) == 201L)
+          assert(result(2).getLong(0) == 301L)
 
-      withTempPath { path =>
-        val e = intercept[Exception](df.write.parquet(path.getCanonicalPath))
-        assert(e.getMessage == "columnar write")
+          withTempPath { path =>
+            val e = intercept[Exception](df.write.parquet(path.getCanonicalPath))
+            assert(e.getMessage == "columnar write")
+          }
+        }
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkPlanSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkPlanSuite.scala
@@ -127,18 +127,22 @@ class SparkPlanSuite extends QueryTest with SharedSparkSession {
 
   test("SPARK-37779: ColumnarToRowExec should be canonicalizable after being (de)serialized") {
     withSQLConf(SQLConf.USE_V1_SOURCE_LIST.key -> "parquet") {
-      withTempPath { path =>
-        spark.range(1).write.parquet(path.getAbsolutePath)
-        val df = spark.read.parquet(path.getAbsolutePath)
-        val columnarToRowExec =
-          df.queryExecution.executedPlan.collectFirst { case p: ColumnarToRowExec => p }.get
-        try {
-          spark.range(1).foreach { _ =>
-            columnarToRowExec.canonicalized
-            ()
+      Seq(true, false).foreach { enable =>
+        withSQLConf(SQLConf.USE_PARTITION_EVALUATOR.key -> enable.toString) {
+          withTempPath { path =>
+            spark.range(1).write.parquet(path.getAbsolutePath)
+            val df = spark.read.parquet(path.getAbsolutePath)
+            val columnarToRowExec =
+              df.queryExecution.executedPlan.collectFirst { case p: ColumnarToRowExec => p }.get
+            try {
+              spark.range(1).foreach { _ =>
+                columnarToRowExec.canonicalized
+                ()
+              }
+            } catch {
+              case e: Throwable => fail("ColumnarToRowExec was not canonicalizable", e)
+            }
           }
-        } catch {
-          case e: Throwable => fail("ColumnarToRowExec was not canonicalizable", e)
         }
       }
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
SQL operators `RowToColumnarExec` & `ColumnarToRowExec`  are updated to use the `PartitionEvaluator` API to do execution.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To avoid the use of lambda during distributed execution.
Ref: SPARK-43061 for more details.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Updated 2 test cases, once all the SQL operators are migrated, the flag `spark.sql.execution.useTaskEvaluator` will be enabled by default to avoid running the tests with and without this TaskEvaluator
