### PR TITLE
[SPARK-44288][SS] Set the column family options before passing to DBOptions in RocksDB state store provider

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -92,9 +92,6 @@ class RocksDB(
 
   private val columnFamilyOptions = new ColumnFamilyOptions()
 
-  private val dbOptions =
-    new Options(new DBOptions(), columnFamilyOptions) // options to open the RocksDB
-
   // Set RocksDB options around MemTable memory usage. By default, we let RocksDB
   // use its internal default values for these settings.
   if (conf.writeBufferSizeMB > 0L) {
@@ -104,6 +101,9 @@ class RocksDB(
   if (conf.maxWriteBufferNumber > 0L) {
     columnFamilyOptions.setMaxWriteBufferNumber(conf.maxWriteBufferNumber)
   }
+
+  private val dbOptions =
+    new Options(new DBOptions(), columnFamilyOptions) // options to open the RocksDB
 
   dbOptions.setCreateIfMissing(true)
   dbOptions.setTableFormatConfig(tableFormatConfig)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Set the column family options before passing to DBOptions in RocksDB state store provider


### Why are the changes needed?
Address bug fix to ensure column family options around memory usage are passed correctly to dbOptions


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existing tests
