### PR TITLE
[MINOR] Eliminate maven build warnings: Using platform locale (en actually) to format date/time, i.e. build is platform dependent!

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2836,6 +2836,7 @@
                 <pattern>${maven.build.timestamp.format}</pattern>
                 <timeSource>current</timeSource>
                 <timeZone>America/Los_Angeles</timeZone>
+                <locale>en,US</locale>
               </configuration>
             </execution>
             <execution>
@@ -2849,6 +2850,7 @@
                 <pattern>${maven.build.timestamp.format}</pattern>
                 <timeSource>build</timeSource>
                 <timeZone>America/Los_Angeles</timeZone>
+                <locale>en,US</locale>
               </configuration>
             </execution>
           </executions>


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to eliminate maven build warnings: `Using platform locale (en actually) to format date/time, i.e. build is platform dependent!`

### Why are the changes needed?
Eliminate maven build warnings.


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
- Pass GA.
- Manually test:
  Before:
'''
[INFO] --- build-helper-maven-plugin:3.4.0:timestamp-property (module-timestamp-property) @ spark-catalyst_2.12 ---
[WARNING] Using platform locale (en_CN actually) to format date/time, i.e. build is platform dependent!
[INFO]
[INFO] --- build-helper-maven-plugin:3.4.0:timestamp-property (local-timestamp-property) @ spark-catalyst_2.12 ---
[WARNING] Using platform locale (en_CN actually) to format date/time, i.e. build is platform dependent!
'''

  After:
The above warning has been eliminated