### PR TITLE
[SPARK-44295][BUILD] Upgrade `scala-parser-combinators` to 2.3.0

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -227,7 +227,7 @@ rocksdbjni/8.3.2//rocksdbjni-8.3.2.jar
 scala-collection-compat_2.12/2.7.0//scala-collection-compat_2.12-2.7.0.jar
 scala-compiler/2.12.18//scala-compiler-2.12.18.jar
 scala-library/2.12.18//scala-library-2.12.18.jar
-scala-parser-combinators_2.12/2.2.0//scala-parser-combinators_2.12-2.2.0.jar
+scala-parser-combinators_2.12/2.3.0//scala-parser-combinators_2.12-2.3.0.jar
 scala-reflect/2.12.18//scala-reflect-2.12.18.jar
 scala-xml_2.12/2.1.0//scala-xml_2.12-2.1.0.jar
 shims/0.9.45//shims-0.9.45.jar

--- a/pom.xml
+++ b/pom.xml
@@ -1102,7 +1102,7 @@
       <dependency>
         <groupId>org.scala-lang.modules</groupId>
         <artifactId>scala-parser-combinators_${scala.binary.version}</artifactId>
-        <version>2.2.0</version>
+        <version>2.3.0</version>
       </dependency>
       <dependency>
         <groupId>jline</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to upgrade `scala-parser-combinators` from 2.2.0 to 2.3.0

### Why are the changes needed?
The new version [dropped support for Scala 2.11](https://github.com/scala/scala-parser-combinators/pull/504) and bring a bug fix:
- https://github.com/scala/scala-parser-combinators/pull/507

The full release notes as follows:
- https://github.com/scala/scala-parser-combinators/releases/tag/v2.3.0

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass Github Actions