### PR TITLE
[SPARK-34612][CORE] Make outputDeterministicLevel a public API

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -2064,10 +2064,9 @@ abstract class RDD[T: ClassTag](
    * candidate that is deterministic least. Please override [[getOutputDeterministicLevel]] to
    * provide custom logic of calculating output deterministic level.
    */
-  // TODO(SPARK-34612): make it public so users can set deterministic level to their custom RDDs.
   // TODO: this can be per-partition. e.g. UnionRDD can have different deterministic level for
   // different partitions.
-  private[spark] final def outputDeterministicLevel: DeterministicLevel.Value = {
+  final def outputDeterministicLevel: DeterministicLevel.Value = {
     if (isReliablyCheckpointed) {
       DeterministicLevel.DETERMINATE
     } else {
@@ -2176,6 +2175,6 @@ object RDD {
  * Note that, the output of an RDD usually relies on the parent RDDs. When the parent RDD's output
  * is INDETERMINATE, it's very likely the RDD's output is also INDETERMINATE.
  */
-private[spark] object DeterministicLevel extends Enumeration {
+object DeterministicLevel extends Enumeration {
   val DETERMINATE, UNORDERED, INDETERMINATE = Value
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Making `RDD.getOutputDeterministicLevel` a public API.

### Why are the changes needed?
The concept of RDDs having is already "exposed" in that developer API `RDD.getOutputDeterministicLevel` and in SPARK-34592 RDDs deterministic level are shown in the Web UI.

Having this be part of the public API is useful for user and library authors. For example consider some library that uses RDDs internally and want to call for example `zipWithIndex` on a RDD. Since `zipWithIndex` has a precondition that `outputDeterministicLevel == DeterministicLevel.DETERMINATE` it would be very good if such a library author could add asserts and/or only conditionally checkpoint the RDD only paying the overhead when it actually needed.

The ticket SPARK-34612 says that we should decide if we should expose outputDeterministicLevel. So if this PR is rejected we should consider closing the ticket with the decision that we should not expose it.


### Does this PR introduce _any_ user-facing change?
Yes, it makes  `RDD.getOutputDeterministicLevel` public.

### How was this patch tested?
Existing tests.
