### PR TITLE
[SPARK-44307][SQL] Add Bloom filter for left outer join even if the left side table is smaller than broadcast threshold.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InjectRuntimeFilter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InjectRuntimeFilter.scala
@@ -175,7 +175,7 @@ object InjectRuntimeFilter extends Rule[LogicalPlan] with PredicateHelper with J
       right: LogicalPlan,
       hint: JoinHint,
       joinType: JoinType): Boolean = {
-    // If any of the side can be broadcast, then it is not a shuffle join.
+    // If any of the child can be broadcast, then it is not a shuffle join.
     !(canLeftSideBeBroadcast(left, conf, hint, joinType) ||
       canRightSideBeBroadcast(right, conf, hint, joinType))
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InjectRuntimeFilter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InjectRuntimeFilter.scala
@@ -171,12 +171,12 @@ object InjectRuntimeFilter extends Rule[LogicalPlan] with PredicateHelper with J
   }
 
   private def isProbablyShuffleJoin(left: LogicalPlan,
-                                    right: LogicalPlan,
-                                    hint: JoinHint,
-                                    joinType: JoinType): Boolean = {
+      right: LogicalPlan,
+      hint: JoinHint,
+      joinType: JoinType): Boolean = {
     // If any of the side can be broadcast, then it is not a shuffle join.
-    !canLeftSideBeBroadcast(left, conf, hint, joinType) &&
-      !canRightSideBeBroadcast(right, conf, hint, joinType)
+    !(canLeftSideBeBroadcast(left, conf, hint, joinType) ||
+      canRightSideBeBroadcast(right, conf, hint, joinType))
   }
 
   private def probablyHasShuffle(plan: LogicalPlan): Boolean = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InjectRuntimeFilter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InjectRuntimeFilter.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.catalyst.optimizer
 
 import scala.annotation.tailrec
+
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate.BloomFilterAggregate
 import org.apache.spark.sql.catalyst.planning.ExtractEquiJoinKeys

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InjectRuntimeFilter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InjectRuntimeFilter.scala
@@ -299,6 +299,7 @@ object InjectRuntimeFilter extends Rule[LogicalPlan] with PredicateHelper with J
             // 2. The current join is a shuffle join or a broadcast join that
             //    has a shuffle below it
             // 3. There is no bloom filter on the left key yet
+            val hasShuffle = isProbablyShuffleJoin(left, right, hint, joinType)
             if (canPruneLeft(joinType) && (hasShuffle || probablyHasShuffle(left)) &&
               !hasBloomFilter(newLeft, l)) {
               extractBeneficialFilterCreatePlan(left, right, l, r).foreach {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InjectRuntimeFilter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InjectRuntimeFilter.scala
@@ -170,7 +170,8 @@ object InjectRuntimeFilter extends Rule[LogicalPlan] with PredicateHelper with J
       REGEXP_EXTRACT_FAMILY, REGEXP_REPLACE)
   }
 
-  private def isProbablyShuffleJoin(left: LogicalPlan,
+  private def isProbablyShuffleJoin(
+      left: LogicalPlan,
       right: LogicalPlan,
       hint: JoinHint,
       joinType: JoinType): Boolean = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
@@ -484,6 +484,20 @@ trait JoinSelectionHelper {
     hint.rightHint.exists(_.strategy.contains(NO_BROADCAST_AND_REPLICATION))
   }
 
+  def canLeftSideBeBroadcast(left: LogicalPlan, conf: SQLConf,
+                             hint: JoinHint, joinType: JoinType): Boolean = {
+    // Left side can not be broadcast for left outer join and left semi join.
+    canBuildBroadcastLeft(joinType) &&
+      (canBroadcastBySize(left, conf) || hintToBroadcastLeft(hint))
+  }
+
+  def canRightSideBeBroadcast(right: LogicalPlan, conf: SQLConf,
+                              hint: JoinHint, joinType: JoinType): Boolean = {
+    // Right side can not be broadcast for right outer join.
+    canBuildBroadcastRight(joinType) &&
+      (canBroadcastBySize(right, conf) || hintToBroadcastRight(hint))
+  }
+
   private def getBuildSide(
       canBuildLeft: Boolean,
       canBuildRight: Boolean,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
@@ -484,15 +484,21 @@ trait JoinSelectionHelper {
     hint.rightHint.exists(_.strategy.contains(NO_BROADCAST_AND_REPLICATION))
   }
 
-  def canLeftSideBeBroadcast(left: LogicalPlan, conf: SQLConf,
-                             hint: JoinHint, joinType: JoinType): Boolean = {
+  def canLeftSideBeBroadcast(
+      left: LogicalPlan,
+      conf: SQLConf,
+      hint: JoinHint,
+      joinType: JoinType): Boolean = {
     // Left side can not be broadcast for left outer join and left semi join.
     canBuildBroadcastLeft(joinType) &&
       (canBroadcastBySize(left, conf) || hintToBroadcastLeft(hint))
   }
 
-  def canRightSideBeBroadcast(right: LogicalPlan, conf: SQLConf,
-                              hint: JoinHint, joinType: JoinType): Boolean = {
+  def canRightSideBeBroadcast(
+      right: LogicalPlan,
+      conf: SQLConf,
+      hint: JoinHint,
+      joinType: JoinType): Boolean = {
     // Right side can not be broadcast for right outer join.
     canBuildBroadcastRight(joinType) &&
       (canBroadcastBySize(right, conf) || hintToBroadcastRight(hint))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
@@ -484,26 +484,6 @@ trait JoinSelectionHelper {
     hint.rightHint.exists(_.strategy.contains(NO_BROADCAST_AND_REPLICATION))
   }
 
-  def canLeftSideBeBroadcast(
-      left: LogicalPlan,
-      conf: SQLConf,
-      hint: JoinHint,
-      joinType: JoinType): Boolean = {
-    // Left side can not be broadcast for left outer join and left semi join.
-    canBuildBroadcastLeft(joinType) &&
-      (canBroadcastBySize(left, conf) || hintToBroadcastLeft(hint))
-  }
-
-  def canRightSideBeBroadcast(
-      right: LogicalPlan,
-      conf: SQLConf,
-      hint: JoinHint,
-      joinType: JoinType): Boolean = {
-    // Right side can not be broadcast for right outer join.
-    canBuildBroadcastRight(joinType) &&
-      (canBroadcastBySize(right, conf) || hintToBroadcastRight(hint))
-  }
-
   private def getBuildSide(
       canBuildLeft: Boolean,
       canBuildRight: Boolean,

--- a/sql/core/src/test/scala/org/apache/spark/sql/InjectRuntimeFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/InjectRuntimeFilterSuite.scala
@@ -605,7 +605,7 @@ class InjectRuntimeFilterSuite extends QueryTest with SQLTestUtils with SharedSp
     }
   }
 
-  test ("Runtime bloom filter join: should add bf for right outer join even if right side is" +
+  test("Runtime bloom filter join: should add bf for right outer join even if right side is" +
     " smaller than broadcast threshold") {
     withSQLConf(SQLConf.RUNTIME_BLOOM_FILTER_APPLICATION_SIDE_SCAN_SIZE_THRESHOLD.key -> "600",
       SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "300",
@@ -629,7 +629,7 @@ class InjectRuntimeFilterSuite extends QueryTest with SQLTestUtils with SharedSp
     }
   }
 
-  test ("Runtime bloom filter join: should add bf for left semi join even if left side is" +
+  test("Runtime bloom filter join: should add bf for left semi join even if left side is" +
     " smaller than broadcast threshold") {
     withSQLConf(SQLConf.RUNTIME_BLOOM_FILTER_APPLICATION_SIDE_SCAN_SIZE_THRESHOLD.key -> "600",
       SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "100",

--- a/sql/core/src/test/scala/org/apache/spark/sql/InjectRuntimeFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/InjectRuntimeFilterSuite.scala
@@ -583,73 +583,67 @@ class InjectRuntimeFilterSuite extends QueryTest with SQLTestUtils with SharedSp
 
   test("Runtime bloom filter join: should add bf for left outer join even if left side is" +
     " smaller than broadcast threshold") {
-    withSQLConf(SQLConf.RUNTIME_BLOOM_FILTER_APPLICATION_SIDE_SCAN_SIZE_THRESHOLD.key -> "600",
-      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "300",
-      SQLConf.RUNTIME_BLOOM_FILTER_CREATION_SIDE_THRESHOLD.key -> "4000",
-      SQLConf.CBO_ENABLED.key -> "true") {
+    // left side size : 1278 right side size 2941
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "2000",
+      SQLConf.RUNTIME_BLOOM_FILTER_APPLICATION_SIDE_SCAN_SIZE_THRESHOLD.key -> "1000") {
       assertRewroteWithBloomFilter(
-        "select * from bf2 left outer join bf1 on bf1.c1 = bf2.c2 where bf2.a2 = 62"
-      )
+        "select bf1.a1, bf1.b1, bf1.c1, bf1.d1, bf1.e1 from bf3 left outer join bf1 on bf1.c1 =" +
+          " bf3.c3 where bf3.b3 = 3")
     }
   }
 
   test("Runtime bloom filter join: should not add bf for left outer join if right side is" +
     " smaller than broadcast threshold") {
-    withSQLConf(SQLConf.RUNTIME_BLOOM_FILTER_APPLICATION_SIDE_SCAN_SIZE_THRESHOLD.key -> "600",
-      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "600",
-      SQLConf.RUNTIME_BLOOM_FILTER_CREATION_SIDE_THRESHOLD.key -> "4000",
-      SQLConf.CBO_ENABLED.key -> "true") {
+    // left side size : 1278 right side size 2941
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "3000",
+      SQLConf.RUNTIME_BLOOM_FILTER_APPLICATION_SIDE_SCAN_SIZE_THRESHOLD.key -> "1000") {
       assertDidNotRewriteWithBloomFilter(
-        "select * from bf2 left outer join bf1 on bf1.c1 = bf2.c2 where bf2.a2 = 62"
-      )
+        "select bf1.a1, bf1.b1, bf1.c1, bf1.d1, bf1.e1 from bf3 left outer join bf1 on bf1.c1 =" +
+          " bf3.c3 where bf3.b3 = 3")
     }
   }
 
   test("Runtime bloom filter join: should add bf for right outer join even if right side is" +
     " smaller than broadcast threshold") {
-    withSQLConf(SQLConf.RUNTIME_BLOOM_FILTER_APPLICATION_SIDE_SCAN_SIZE_THRESHOLD.key -> "600",
-      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "300",
-      SQLConf.RUNTIME_BLOOM_FILTER_CREATION_SIDE_THRESHOLD.key -> "4000",
-      SQLConf.CBO_ENABLED.key -> "true") {
+    // left side size : 2914 right side size 1278
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "2000",
+      SQLConf.RUNTIME_BLOOM_FILTER_APPLICATION_SIDE_SCAN_SIZE_THRESHOLD.key -> "1000") {
       assertRewroteWithBloomFilter(
-        "select * from bf1 right outer join bf2 on bf1.c1 = bf2.c2 where bf2.a2 = 62"
-      )
+        "select bf1.a1, bf1.b1, bf1.c1, bf1.d1, bf1.e1 from bf1 right outer join bf3 on bf1.c1 =" +
+          " bf3.c3 where bf3.b3 = 3")
     }
   }
 
   test("Runtime bloom filter join: should not add bf for right outer join if left side is" +
     " smaller than broadcast threshold") {
-    withSQLConf(SQLConf.RUNTIME_BLOOM_FILTER_APPLICATION_SIDE_SCAN_SIZE_THRESHOLD.key -> "600",
-      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "600",
-      SQLConf.RUNTIME_BLOOM_FILTER_CREATION_SIDE_THRESHOLD.key -> "4000",
-      SQLConf.CBO_ENABLED.key -> "true") {
+    // left side size : 2914 right side size 1278
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "3000",
+      SQLConf.RUNTIME_BLOOM_FILTER_APPLICATION_SIDE_SCAN_SIZE_THRESHOLD.key -> "1000") {
       assertDidNotRewriteWithBloomFilter(
-        "select * from bf1 right outer join bf2 on bf1.c1 = bf2.c2 where bf2.a2 = 62"
-      )
+        "select bf1.a1, bf1.b1, bf1.c1, bf1.d1, bf1.e1 from bf1 right outer join bf3 on bf1.c1 =" +
+          " bf3.c3 where bf3.b3 = 3")
     }
   }
 
   test("Runtime bloom filter join: should add bf for left semi join even if left side is" +
     " smaller than broadcast threshold") {
+    // left side size : 1260 right side size 1278
     withSQLConf(SQLConf.RUNTIME_BLOOM_FILTER_APPLICATION_SIDE_SCAN_SIZE_THRESHOLD.key -> "600",
-      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "100",
-      SQLConf.RUNTIME_BLOOM_FILTER_CREATION_SIDE_THRESHOLD.key -> "4000",
-      SQLConf.CBO_ENABLED.key -> "true") {
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "1270") {
       assertRewroteWithBloomFilter(
-          "select * from bf2 left semi join bf1 on bf1.c1 = bf2.c2 where bf2.a2 = 62"
-      )
+        "select bf1.a1 from bf1 left semi join bf2 on bf1.a1 =" +
+          " bf2.a2 where bf1.a1 = 62")
     }
   }
 
   test("Runtime bloom filter join: should not add bf for left semi join if right side is" +
     " smaller than broadcast threshold") {
+    // left side size : 1260 right side size 1278
     withSQLConf(SQLConf.RUNTIME_BLOOM_FILTER_APPLICATION_SIDE_SCAN_SIZE_THRESHOLD.key -> "600",
-      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "600",
-      SQLConf.RUNTIME_BLOOM_FILTER_CREATION_SIDE_THRESHOLD.key -> "4000",
-      SQLConf.CBO_ENABLED.key -> "true") {
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "1280") {
       assertDidNotRewriteWithBloomFilter(
-        "select * from bf2 left semi join bf1 on bf1.c1 = bf2.c2 where bf2.a2 = 62"
-      )
+        "select bf1.a1 from bf1 left semi join bf2 on bf1.a1 =" +
+          " bf2.a2 where bf1.a1 = 62")
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/InjectRuntimeFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/InjectRuntimeFilterSuite.scala
@@ -580,4 +580,76 @@ class InjectRuntimeFilterSuite extends QueryTest with SQLTestUtils with SharedSp
         "Missing or unexpected reused ReusedSubqueryExec in the plan")
     }
   }
+
+  test("Runtime bloom filter join: should add bf for left outer join even if left side is" +
+    " smaller than broadcast threshold") {
+    withSQLConf(SQLConf.RUNTIME_BLOOM_FILTER_APPLICATION_SIDE_SCAN_SIZE_THRESHOLD.key -> "600",
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "300",
+      SQLConf.RUNTIME_BLOOM_FILTER_CREATION_SIDE_THRESHOLD.key -> "4000",
+      SQLConf.CBO_ENABLED.key -> "true") {
+      assertRewroteWithBloomFilter(
+        "select * from bf2 left outer join bf1 on bf1.c1 = bf2.c2 where bf2.a2 = 62"
+      )
+    }
+  }
+
+  test("Runtime bloom filter join: should not add bf for left outer join if right side is" +
+    " smaller than broadcast threshold") {
+    withSQLConf(SQLConf.RUNTIME_BLOOM_FILTER_APPLICATION_SIDE_SCAN_SIZE_THRESHOLD.key -> "600",
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "600",
+      SQLConf.RUNTIME_BLOOM_FILTER_CREATION_SIDE_THRESHOLD.key -> "4000",
+      SQLConf.CBO_ENABLED.key -> "true") {
+      assertDidNotRewriteWithBloomFilter(
+        "select * from bf2 left outer join bf1 on bf1.c1 = bf2.c2 where bf2.a2 = 62"
+      )
+    }
+  }
+
+  test ("Runtime bloom filter join: should add bf for right outer join even if right side is" +
+    " smaller than broadcast threshold") {
+    withSQLConf(SQLConf.RUNTIME_BLOOM_FILTER_APPLICATION_SIDE_SCAN_SIZE_THRESHOLD.key -> "600",
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "300",
+      SQLConf.RUNTIME_BLOOM_FILTER_CREATION_SIDE_THRESHOLD.key -> "4000",
+      SQLConf.CBO_ENABLED.key -> "true") {
+      assertRewroteWithBloomFilter(
+        "select * from bf1 right outer join bf2 on bf1.c1 = bf2.c2 where bf2.a2 = 62"
+      )
+    }
+  }
+
+  test("Runtime bloom filter join: should not add bf for right outer join if left side is" +
+    " smaller than broadcast threshold") {
+    withSQLConf(SQLConf.RUNTIME_BLOOM_FILTER_APPLICATION_SIDE_SCAN_SIZE_THRESHOLD.key -> "600",
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "600",
+      SQLConf.RUNTIME_BLOOM_FILTER_CREATION_SIDE_THRESHOLD.key -> "4000",
+      SQLConf.CBO_ENABLED.key -> "true") {
+      assertDidNotRewriteWithBloomFilter(
+        "select * from bf1 right outer join bf2 on bf1.c1 = bf2.c2 where bf2.a2 = 62"
+      )
+    }
+  }
+
+  test ("Runtime bloom filter join: should add bf for left semi join even if left side is" +
+    " smaller than broadcast threshold") {
+    withSQLConf(SQLConf.RUNTIME_BLOOM_FILTER_APPLICATION_SIDE_SCAN_SIZE_THRESHOLD.key -> "600",
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "100",
+      SQLConf.RUNTIME_BLOOM_FILTER_CREATION_SIDE_THRESHOLD.key -> "4000",
+      SQLConf.CBO_ENABLED.key -> "true") {
+      assertRewroteWithBloomFilter(
+          "select * from bf2 left semi join bf1 on bf1.c1 = bf2.c2 where bf2.a2 = 62"
+      )
+    }
+  }
+
+  test("Runtime bloom filter join: should not add bf for left semi join if right side is" +
+    " smaller than broadcast threshold") {
+    withSQLConf(SQLConf.RUNTIME_BLOOM_FILTER_APPLICATION_SIDE_SCAN_SIZE_THRESHOLD.key -> "600",
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "600",
+      SQLConf.RUNTIME_BLOOM_FILTER_CREATION_SIDE_THRESHOLD.key -> "4000",
+      SQLConf.CBO_ENABLED.key -> "true") {
+      assertDidNotRewriteWithBloomFilter(
+        "select * from bf2 left semi join bf1 on bf1.c1 = bf2.c2 where bf2.a2 = 62"
+      )
+    }
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

 In the current code, to check if a join is a shuffle join or not, left and right sides are interchanged. This is not correct as for few joins the left and right side are considered to check if  a join is shuffle or not. This PR has moved the check to a place where left and right side are know. Then the value is used for verification at other places. 

The method checking if the join is a shuffle or not is not taking join type into consideration. Added a extra parameter in isProbablyShuffleJoin method and used it to determine if the join is a shuffle join or not.

### Why are the changes needed?

The left side of left outer join is not broadcasted even if its small enough to avoid incorrect result. One of the ways to optimize this is using bloom filter. This helps in reducing the size of right size. But bloom filter is not created if the filter creation side is small enough to be broadcasted. This is causing small left outer join relation are neither broadcasted nor able to use bloom filter. So we need to add a check in bloom filter to allow bloom filter for left outer, right outer and semi joins even if the size is small enough to be broadcasted. 

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Added unit test 