### PR TITLE
[SPARK-44310][CONNECT] The Connect Server startup log should display the hostname and port

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectServer.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectServer.scala
@@ -17,6 +17,10 @@
 
 package org.apache.spark.sql.connect.service
 
+import java.net.InetSocketAddress
+
+import scala.collection.convert.ImplicitConversions._
+
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
 
@@ -31,7 +35,11 @@ object SparkConnectServer extends Logging {
     try {
       try {
         SparkConnectService.start()
-        logInfo("Spark Connect server started.")
+        SparkConnectService.server.getListenSockets.foreach { sa =>
+          val isa = sa.asInstanceOf[InetSocketAddress]
+          logInfo(s"Spark Connect server started at: " +
+            s"${isa.getAddress.getHostAddress}:${isa.getPort}")
+        }
       } catch {
         case e: Exception =>
           logError("Error starting Spark Connect server", e)

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectServer.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectServer.scala
@@ -37,8 +37,9 @@ object SparkConnectServer extends Logging {
         SparkConnectService.start()
         SparkConnectService.server.getListenSockets.foreach { sa =>
           val isa = sa.asInstanceOf[InetSocketAddress]
-          logInfo(s"Spark Connect server started at: " +
-            s"${isa.getAddress.getHostAddress}:${isa.getPort}")
+          logInfo(
+            s"Spark Connect server started at: " +
+              s"${isa.getAddress.getHostAddress}:${isa.getPort}")
         }
       } catch {
         case e: Exception =>


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to make the Connect Server startup log to display the hostname and port.

### Why are the changes needed?
Displaying hostname and port in logs can make it easier for service providers to provide intuitive information to client users.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
- Pass GA.
- Manually Test.
