### PR TITLE
[SPARK-44303][SQL] Assign names to the error class _LEGACY_ERROR_TEMP_[2320-2324]

### DIFF
--- a/common/utils/src/main/resources/error/error-classes.json
+++ b/common/utils/src/main/resources/error/error-classes.json
@@ -729,6 +729,11 @@
     ],
     "sqlState" : "42K04"
   },
+  "FIELDS_ALREADY_EXISTS" : {
+    "message" : [
+      "Cannot <op> column, because <fieldNames> already exists in <struct>."
+    ]
+  },
   "FIELD_NOT_FOUND" : {
     "message" : [
       "No such struct field <fieldName> in <fields>."
@@ -1357,6 +1362,16 @@
       "Invalid observed metrics."
     ],
     "subClass" : {
+      "AGGREGATE_EXPRESSION_WITH_DISTINCT_UNSUPPORTED" : {
+        "message" : [
+          "Aggregate expression with distinct are not allowed in observed metrics, but found: <expr>."
+        ]
+      },
+      "AGGREGATE_EXPRESSION_WITH_FILTER_UNSUPPORTED" : {
+        "message" : [
+          "Aggregate expression with filter predicate are not allowed in observed metrics, but found: <expr>."
+        ]
+      },
       "MISSING_NAME" : {
         "message" : [
           "The observed metrics should be named: <operator>."
@@ -1365,6 +1380,11 @@
       "NESTED_AGGREGATES_UNSUPPORTED" : {
         "message" : [
           "Nested aggregates are not allowed in observed metrics, but found: <expr>."
+        ]
+      },
+      "NON_AGGREGATE_FUNC_ARG_IS_ATTRIBUTE" : {
+        "message" : [
+          "Attribute <expr> can only be used as an argument to an aggregate function."
         ]
       },
       "NON_AGGREGATE_FUNC_ARG_IS_NON_DETERMINISTIC" : {
@@ -2927,6 +2947,11 @@
       "1. use typed Scala UDF APIs(without return type parameter), e.g. `udf((x: Int) => x)`.",
       "2. use Java UDF APIs, e.g. `udf(new UDF1[String, Integer] { override def call(s: String): Integer = s.length() }, IntegerType)`, if input types are all non primitive.",
       "3. set \"spark.sql.legacy.allowUntypedScalaUDF\" to \"true\" and use this API with caution."
+    ]
+  },
+  "UPDATE_FIELD_WITH_STRUCT_UNSUPPORTED" : {
+    "message" : [
+      "Cannot update <table> field <fieldName> type: update a struct by updating its fields."
     ]
   },
   "VIEW_ALREADY_EXISTS" : {
@@ -5650,31 +5675,6 @@
   "_LEGACY_ERROR_TEMP_2277" : {
     "message" : [
       "Number of dynamic partitions created is <numWrittenParts>, which is more than <maxDynamicPartitions>. To solve this try to set <maxDynamicPartitionsKey> to at least <numWrittenParts>."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_2320" : {
-    "message" : [
-      "distinct aggregates are not allowed in observed metrics, but found: <sqlExpr>."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_2321" : {
-    "message" : [
-      "aggregates with filter predicate are not allowed in observed metrics, but found: <sqlExpr>."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_2322" : {
-    "message" : [
-      "attribute <sqlExpr> can only be used as an argument to an aggregate function."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_2323" : {
-    "message" : [
-      "Cannot <op> column, because <fieldNames> already exists in <struct>."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_2324" : {
-    "message" : [
-      "Cannot update <table> field <fieldName> type: update a struct by updating its fields."
     ]
   },
   "_LEGACY_ERROR_TEMP_2325" : {

--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectProtoSuite.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectProtoSuite.scala
@@ -991,8 +991,8 @@ class SparkConnectProtoSuite extends PlanTest with SparkConnectPlanTest {
         analyzePlan(
           transform(connectTestRelation.observe("my_metric", "id".protoAttr.cast("string"))))
       },
-      errorClass = "_LEGACY_ERROR_TEMP_2322",
-      parameters = Map("sqlExpr" -> "CAST(id AS STRING) AS id"))
+      errorClass = "INVALID_OBSERVED_METRICS.NON_AGGREGATE_FUNC_ARG_IS_ATTRIBUTE",
+      parameters = Map("expr" -> "\"id AS id\""))
 
     val connectPlan2 =
       connectTestRelation.observe(
@@ -1022,8 +1022,8 @@ class SparkConnectProtoSuite extends PlanTest with SparkConnectPlanTest {
           transform(
             connectTestRelation.observe(Observation("my_metric"), "id".protoAttr.cast("string"))))
       },
-      errorClass = "_LEGACY_ERROR_TEMP_2322",
-      parameters = Map("sqlExpr" -> "CAST(id AS STRING) AS id"))
+      errorClass = "INVALID_OBSERVED_METRICS.NON_AGGREGATE_FUNC_ARG_IS_ATTRIBUTE",
+      parameters = Map("expr" -> "\"id AS id\""))
   }
 
   test("Test RandomSplit") {

--- a/docs/sql-error-conditions-invalid-observed-metrics-error-class.md
+++ b/docs/sql-error-conditions-invalid-observed-metrics-error-class.md
@@ -23,6 +23,14 @@ Invalid observed metrics.
 
 This error class has the following derived error classes:
 
+## AGGREGATE_EXPRESSION_WITH_DISTINCT_UNSUPPORTED
+
+Aggregate expression with distinct are not allowed in observed metrics, but found: `<expr>`.
+
+## AGGREGATE_EXPRESSION_WITH_FILTER_UNSUPPORTED
+
+Aggregate expression with filter predicate are not allowed in observed metrics, but found: `<expr>`.
+
 ## MISSING_NAME
 
 The observed metrics should be named: `<operator>`.
@@ -30,6 +38,10 @@ The observed metrics should be named: `<operator>`.
 ## NESTED_AGGREGATES_UNSUPPORTED
 
 Nested aggregates are not allowed in observed metrics, but found: `<expr>`.
+
+## NON_AGGREGATE_FUNC_ARG_IS_ATTRIBUTE
+
+Attribute `<expr>` can only be used as an argument to an aggregate function.
 
 ## NON_AGGREGATE_FUNC_ARG_IS_NON_DETERMINISTIC
 

--- a/docs/sql-error-conditions.md
+++ b/docs/sql-error-conditions.md
@@ -497,6 +497,12 @@ Failed parsing struct: `<raw>`.
 
 Failed to rename `<sourcePath>` to `<targetPath>` as destination already exists.
 
+### FIELDS_ALREADY_EXISTS
+
+SQLSTATE: none assigned
+
+Cannot `<op>` column, because `<fieldNames>` already exists in <struct>.
+
 ### FIELD_NOT_FOUND
 
 [SQLSTATE: 42704](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
@@ -1903,6 +1909,12 @@ You're using untyped Scala UDF, which does not have the input type information. 
 2. use Java UDF APIs, e.g. `udf(new UDF1[String, Integer] { override def call(s: String): Integer = s.length() }, IntegerType)`, if input types are all non primitive.
 
 3. set "spark.sql.legacy.allowUntypedScalaUDF" to "true" and use this API with caution.
+
+### UPDATE_FIELD_WITH_STRUCT_UNSUPPORTED
+
+SQLSTATE: none assigned
+
+Cannot update `<table>` field `<fieldName>` type: update a struct by updating its fields.
 
 ### VIEW_ALREADY_EXISTS
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -510,11 +510,17 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
                     "INVALID_OBSERVED_METRICS.NESTED_AGGREGATES_UNSUPPORTED",
                     Map("expr" -> toSQLExpr(s)))
                 case a: AggregateExpression if a.isDistinct =>
-                  e.failAnalysis("_LEGACY_ERROR_TEMP_2320", Map("sqlExpr" -> s.sql))
+                  e.failAnalysis(
+                    "INVALID_OBSERVED_METRICS.AGGREGATE_EXPRESSION_WITH_DISTINCT_UNSUPPORTED",
+                    Map("expr" -> toSQLExpr(s)))
                 case a: AggregateExpression if a.filter.isDefined =>
-                  e.failAnalysis("_LEGACY_ERROR_TEMP_2321", Map("sqlExpr" -> s.sql))
+                  e.failAnalysis(
+                    "INVALID_OBSERVED_METRICS.AGGREGATE_EXPRESSION_WITH_FILTER_UNSUPPORTED",
+                    Map("expr" -> toSQLExpr(s)))
                 case _: Attribute if !seenAggregate =>
-                  e.failAnalysis("_LEGACY_ERROR_TEMP_2322", Map("sqlExpr" -> s.sql))
+                  e.failAnalysis(
+                    "INVALID_OBSERVED_METRICS.NON_AGGREGATE_FUNC_ARG_IS_ATTRIBUTE",
+                    Map("expr" -> toSQLExpr(s)))
                 case _: AggregateExpression =>
                   e.children.foreach(checkMetric (s, _, seenAggregate = true))
                 case _ =>
@@ -1394,11 +1400,11 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
       if (struct.findNestedField(
           fieldNames, includeCollections = true, alter.conf.resolver).isDefined) {
         alter.failAnalysis(
-          errorClass = "_LEGACY_ERROR_TEMP_2323",
+          errorClass = "FIELDS_ALREADY_EXISTS",
           messageParameters = Map(
             "op" -> op,
-            "fieldNames" -> fieldNames.quoted,
-            "struct" -> struct.treeString))
+            "fieldNames" -> toSQLId(fieldNames),
+            "struct" -> toSQLType(struct)))
       }
     }
 
@@ -1430,7 +1436,8 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
           val newDataType = a.dataType.get
           newDataType match {
             case _: StructType => alter.failAnalysis(
-              "_LEGACY_ERROR_TEMP_2324", Map("table" -> table.name, "fieldName" -> fieldName))
+              "UPDATE_FIELD_WITH_STRUCT_UNSUPPORTED",
+              Map("table" -> toSQLId(table.name), "fieldName" -> toSQLId(fieldName)))
             case _: MapType => alter.failAnalysis(
               "_LEGACY_ERROR_TEMP_2325", Map("table" -> table.name, "fieldName" -> fieldName))
             case _: ArrayType => alter.failAnalysis(


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to assign names to the error class _LEGACY_ERROR_TEMP_[2320-2324].


### Why are the changes needed?
Improve the error framework.


### Does this PR introduce _any_ user-facing change?
'No'.


### How was this patch tested?
Exists test cases updated and added new test cases.
