### PR TITLE
[SPARK-44154][SQL][FOLLOWUP] Add `INVALID_BITMAP_POSITION` error into doc

### DIFF
--- a/docs/sql-error-conditions.md
+++ b/docs/sql-error-conditions.md
@@ -738,6 +738,12 @@ The boundary `<boundary>` is invalid: `<invalidValue>`.
 
  For more details see [INVALID_BOUNDARY](sql-error-conditions-invalid-boundary.html)
 
+### INVALID_BITMAP_POSITION
+
+[SQLSTATE: 22003](sql-error-conditions-sqlstates.html#class-22-data-exception)
+
+The 0-indexed bitmap position `<bitPosition>` is out of bounds. The bitmap has `<bitmapNumBits>` bits (`<bitmapNumBytes>` bytes).
+
 ### INVALID_BUCKET_FILE
 
 SQLSTATE: none assigned


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a followup PR for https://github.com/apache/spark/pull/41623, because we add test for sync doc and `error-classes.json` after https://github.com/apache/spark/pull/41813 . We should add `INVALID_BITMAP_POSITION` (add on https://github.com/apache/spark/pull/41623) into doc.

### Why are the changes needed?

CI fails without this PR.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Existing test.

