### PR TITLE
[SPARK-44330][SQL] Use PartitionEvaluator API in BroadcastNestedLoopJoinExec & BroadcastHashJoinExec

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BroadcastHashJoinEvaluatorFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BroadcastHashJoinEvaluatorFactory.scala
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.joins
+
+import org.apache.spark.{PartitionEvaluator, PartitionEvaluatorFactory, TaskContext}
+import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{Attribute, BindReferences, Expression, UnsafeProjection, UnsafeRow}
+import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight, BuildSide}
+import org.apache.spark.sql.execution.metric.SQLMetric
+
+class BroadcastHashJoinEvaluatorFactory(
+    broadcastRelation: Broadcast[HashedRelation],
+    join: (Iterator[InternalRow], HashedRelation, SQLMetric) => Iterator[InternalRow],
+    buildSide: BuildSide,
+    leftOutput: Seq[Attribute],
+    rightOutput: Seq[Attribute],
+    streamedKeys: Seq[Expression],
+    isNullAwareAntiJoin: Boolean,
+    numOutputRows: SQLMetric)
+    extends PartitionEvaluatorFactory[InternalRow, InternalRow] {
+  override def createEvaluator(): PartitionEvaluator[InternalRow, InternalRow] =
+    new BroadcastHashJoinEvaluator
+
+  private class BroadcastHashJoinEvaluator extends PartitionEvaluator[InternalRow, InternalRow] {
+    override def eval(
+        partitionIndex: Int,
+        inputs: Iterator[InternalRow]*): Iterator[InternalRow] = {
+      assert(inputs.length == 1)
+      val streamedIter = inputs(0)
+      val hashed = broadcastRelation.value.asReadOnlyCopy()
+      TaskContext.get().taskMetrics().incPeakExecutionMemory(hashed.estimatedSize)
+
+      if (isNullAwareAntiJoin) {
+        if (hashed == EmptyHashedRelation) {
+          streamedIter
+        } else if (hashed == HashedRelationWithAllNullKeys) {
+          Iterator.empty
+        } else {
+          val streamedOutput = {
+            buildSide match {
+              case BuildLeft => rightOutput
+              case BuildRight => leftOutput
+            }
+          }
+          val streamedBoundKeys =
+            BindReferences.bindReferences(HashJoin.rewriteKeyExpr(streamedKeys), streamedOutput)
+          val keyGenerator = UnsafeProjection.create(streamedBoundKeys)
+          streamedIter
+            .filter { row =>
+              val lookupKey: UnsafeRow = keyGenerator(row)
+              if (lookupKey.anyNull()) {
+                false
+              } else {
+                // Anti Join: Drop the row on the streamed side if it is a match on the build
+                hashed.get(lookupKey) == null
+              }
+            }
+            .map { row =>
+              numOutputRows += 1
+              row
+            }
+        }
+      } else {
+        join(streamedIter, hashed, numOutputRows)
+      }
+    }
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BroadcastNestedLoopJoinEvaluatorFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BroadcastNestedLoopJoinEvaluatorFactory.scala
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.joins
+
+import org.apache.spark.{PartitionEvaluator, PartitionEvaluatorFactory}
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{Attribute, UnsafeProjection}
+import org.apache.spark.sql.catalyst.plans.{JoinType, LeftExistence}
+import org.apache.spark.sql.execution.metric.SQLMetric
+
+class BroadcastNestedLoopJoinEvaluatorFactory(
+    output: Seq[Attribute],
+    streamedOutput: Seq[Attribute],
+    broadcastOutput: Seq[Attribute],
+    joinType: JoinType,
+    numOutputRows: SQLMetric)
+    extends PartitionEvaluatorFactory[InternalRow, InternalRow] {
+  override def createEvaluator(): PartitionEvaluator[InternalRow, InternalRow] =
+    new BroadcastNestedLoopJoinEvaluator
+
+  private class BroadcastNestedLoopJoinEvaluator
+      extends PartitionEvaluator[InternalRow, InternalRow] {
+
+    private def genResultProjection: UnsafeProjection = joinType match {
+      case LeftExistence(_) =>
+        UnsafeProjection.create(output, output)
+      case _ =>
+        // Always put the stream side on left to simplify implementation
+        // both of left and right side could be null
+        UnsafeProjection.create(
+          output,
+          (streamedOutput ++ broadcastOutput).map(_.withNullability(true)))
+    }
+    override def eval(
+        partitionIndex: Int,
+        inputs: Iterator[InternalRow]*): Iterator[InternalRow] = {
+      assert(inputs.length == 1)
+      val iter = inputs(0)
+      val resultProj = genResultProjection
+      resultProj.initialize(partitionIndex)
+      iter.map { r =>
+        numOutputRows += 1
+        resultProj(r)
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
SQL operators `BroadcastNestedLoopJoinExec` & `BroadcastHashJoinExec` were updated to use the `PartitionEvaluator` API to do execution.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To avoid the use of lambda during distributed execution.
Ref: SPARK-43061 for more details.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Updated 1 test case, once all the SQL operators are migrated, the flag `spark.sql.execution.useTaskEvaluator` will be enabled by default to avoid running the tests with and without this TaskEvaluator
