### PR TITLE
[SPARK-44287][SQL] Reuse evaluator in ColumnarToRowExec#doExecute

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/Columnar.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/Columnar.scala
@@ -470,8 +470,8 @@ case class RowToColumnarExec(child: SparkPlan) extends RowToColumnarTransition {
     if (conf.usePartitionEvaluator) {
       child.execute().mapPartitionsWithEvaluator(evaluatorFactory)
     } else {
+      val evaluator = evaluatorFactory.createEvaluator()
       child.execute().mapPartitionsInternal { rowIterator =>
-        val evaluator = evaluatorFactory.createEvaluator()
         evaluator.eval(0, rowIterator)
       }
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/Columnar.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/Columnar.scala
@@ -96,8 +96,8 @@ case class ColumnarToRowExec(child: SparkPlan) extends ColumnarToRowTransition w
     if (conf.usePartitionEvaluator) {
       child.executeColumnar().mapPartitionsWithEvaluator(evaluatorFactory)
     } else {
+      val evaluator = evaluatorFactory.createEvaluator()
       child.executeColumnar().mapPartitionsInternal { batches =>
-        val evaluator = evaluatorFactory.createEvaluator()
         evaluator.eval(0, batches)
       }
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
In `ColumnarToRowExec#doExecute`, we can instantiate the evaluator and use it in `mapPartitionsInternal`.

### Why are the changes needed?
We don't need to instantiate the evaluator for every iteration.

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Existing test suite.