### PR TITLE
[SPARK-44323][SQL] Do not allow options inside tuples to set to null

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoder.scala
@@ -112,7 +112,7 @@ object ExpressionEncoder {
         case GetColumnByOrdinal(0, _) => input
       }
 
-      if (enc.objSerializer.nullable) {
+      if (enc.objSerializer.nullable && !enc.isOptionClass) {
         nullSafe(input, childDeserializer)
       } else {
         childDeserializer
@@ -294,6 +294,8 @@ case class ExpressionEncoder[T](
     StructField(s.name, s.dataType, s.nullable)
   })
 
+  def isOptionClass: Boolean = classOf[Option[_]].isAssignableFrom(clsTag.runtimeClass)
+
   /**
    * Returns true if the type `T` is serialized as a struct by `objSerializer`.
    */
@@ -307,7 +309,7 @@ case class ExpressionEncoder[T](
    * returns true if `T` is serialized as struct and is not `Option` type.
    */
   def isSerializedAsStructForTopLevel: Boolean = {
-    isSerializedAsStruct && !classOf[Option[_]].isAssignableFrom(clsTag.runtimeClass)
+    isSerializedAsStruct && !isOptionClass
   }
 
   // serializer expressions are used to encode an object to a row, while the object is usually an


### PR DESCRIPTION
### What changes were proposed in this pull request?
To correct a bug introduced in SPARK-37829 where a Scala Option can become null instead of None in typed operations (e.g. Dataset, Aggregator).

### Why are the changes needed?
When we use Option we expect to get back Some(...) or None, but never null.

### Does this PR introduce _any_ user-facing change?
Yes it restores the behavior where no nulls show up for Option[_]

### How was this patch tested?
Added a test for Aggregator where the output without this PR has a null where it shouldn't. 