### PR TITLE
[SPARK-43389][SQL] Added a null check for lineSep option

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
@@ -264,7 +264,6 @@ class CSVOptions(
     sep
   }
 
-
   val lineSeparatorInRead: Option[Array[Byte]] = lineSeparator.map { lineSep =>
     lineSep.getBytes(charset)
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
@@ -253,15 +253,17 @@ class CSVOptions(
   /**
    * A string between two consecutive JSON records.
    */
-  val lineSeparator: Option[String] = parameters.get(LINE_SEP).map { sep =>
-    require(sep.nonEmpty, "'lineSep' cannot be an empty string.")
-    // Intentionally allow it up to 2 for Window's CRLF although multiple
-    // characters have an issue with quotes. This is intentionally undocumented.
-    require(sep.length <= 2, "'lineSep' can contain only 1 character.")
-    if (sep.length == 2) logWarning("It is not recommended to set 'lineSep' " +
-      "with 2 characters due to the limitation of supporting multi-char 'lineSep' within quotes.")
-    sep
+  val lineSeparator: Option[String] = parameters.get(LINE_SEP) match {
+    case Some(sep) if sep != null =>
+      require(sep.nonEmpty, "'lineSep' cannot be an empty string.")
+      require(sep.length <= 2, "'lineSep' can contain only 1 character.")
+      if (sep.length == 2) logWarning("It is not recommended to set 'lineSep' " +
+        "with 2 characters due to the limitation of supporting multi-char 'lineSep' within quotes.")
+      Some(sep)
+    case _ =>
+      None
   }
+
 
   val lineSeparatorInRead: Option[Array[Byte]] = lineSeparator.map { lineSep =>
     lineSep.getBytes(charset)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
@@ -253,15 +253,15 @@ class CSVOptions(
   /**
    * A string between two consecutive JSON records.
    */
-  val lineSeparator: Option[String] = parameters.get(LINE_SEP) match {
-    case Some(sep) if sep != null =>
-      require(sep.nonEmpty, "'lineSep' cannot be an empty string.")
-      require(sep.length <= 2, "'lineSep' can contain only 1 character.")
-      if (sep.length == 2) logWarning("It is not recommended to set 'lineSep' " +
-        "with 2 characters due to the limitation of supporting multi-char 'lineSep' within quotes.")
-      Some(sep)
-    case _ =>
-      None
+  val lineSeparator: Option[String] = parameters.get(LINE_SEP).map { sep =>
+    require(sep != null, "'lineSep' cannot be a null value.")
+    require(sep.nonEmpty, "'lineSep' cannot be an empty string.")
+    // Intentionally allow it up to 2 for Window's CRLF although multiple
+    // characters have an issue with quotes. This is intentionally undocumented.
+    require(sep.length <= 2, "'lineSep' can contain only 1 character.")
+    if (sep.length == 2) logWarning("It is not recommended to set 'lineSep' " +
+      "with 2 characters due to the limitation of supporting multi-char 'lineSep' within quotes.")
+    sep
   }
 
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/text/TextOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/text/TextOptions.scala
@@ -44,10 +44,12 @@ class TextOptions(@transient private val parameters: CaseInsensitiveMap[String])
 
   val encoding: Option[String] = parameters.get(ENCODING)
 
-  val lineSeparator: Option[String] = parameters.get(LINE_SEP).map { lineSep =>
+  val lineSeparator: Option[String] = parameters.get(LINE_SEP) match {
+    case Some(lineSep) if lineSep != null =>
     require(lineSep.nonEmpty, s"'$LINE_SEP' cannot be an empty string.")
-
-    lineSep
+      Some(lineSep)
+    case _ =>
+      None
   }
 
   // Note that the option 'lineSep' uses a different default value in read and write.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/text/TextOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/text/TextOptions.scala
@@ -44,12 +44,11 @@ class TextOptions(@transient private val parameters: CaseInsensitiveMap[String])
 
   val encoding: Option[String] = parameters.get(ENCODING)
 
-  val lineSeparator: Option[String] = parameters.get(LINE_SEP) match {
-    case Some(lineSep) if lineSep != null =>
-      require(lineSep.nonEmpty, s"'$LINE_SEP' cannot be an empty string.")
-      Some(lineSep)
-    case _ =>
-      None
+  val lineSeparator: Option[String] = parameters.get(LINE_SEP).map { lineSep =>
+    require(lineSep != null, s"'$LINE_SEP' cannot be a null value.")
+    require(lineSep.nonEmpty, s"'$LINE_SEP' cannot be an empty string.")
+
+    lineSep
   }
 
   // Note that the option 'lineSep' uses a different default value in read and write.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/text/TextOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/text/TextOptions.scala
@@ -46,7 +46,7 @@ class TextOptions(@transient private val parameters: CaseInsensitiveMap[String])
 
   val lineSeparator: Option[String] = parameters.get(LINE_SEP) match {
     case Some(lineSep) if lineSep != null =>
-    require(lineSep.nonEmpty, s"'$LINE_SEP' cannot be an empty string.")
+      require(lineSep.nonEmpty, s"'$LINE_SEP' cannot be an empty string.")
       Some(lineSep)
     case _ =>
       None


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
- `spark.read.csv` throws `NullPointerException` when lineSep is set to None
- More details about the issue here: https://issues.apache.org/jira/browse/SPARK-43389

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
~~Users now should be able to explicitly set `lineSep` as `None` without getting an exception~~
After some discussion, it was decided to add a `require` check for `null` instead of letting it through. 

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Tested the changes with a python script that explicitly sets `lineSep` to `None`
```python
from pyspark.sql import SparkSession

# Create a SparkSession
spark = SparkSession.builder.appName("HelloWorld").getOrCreate()

# Read CSV into a DataFrame
df = spark.read.csv("/tmp/hello.csv", header=True, inferSchema=True, lineSep=None)

# Also tested the following case when options are passed before invoking .csv
#df = spark.read.option("lineSep", None).csv("/Users/gdhuper/Documents/tmp/hello.csv", header=True, inferSchema=True)

# Show the DataFrame
df.show()

# Stop the SparkSession
spark.stop()
```
