### PR TITLE
[SPARK-44345][CORE] Lower `unknown shuffle map output` log level to WARN if shuffle migration is enabled

### DIFF
--- a/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
+++ b/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
@@ -677,6 +677,9 @@ private[spark] class MapOutputTrackerMaster(
   /** Whether to compute locality preferences for reduce tasks */
   private val shuffleLocalityEnabled = conf.get(SHUFFLE_REDUCE_LOCALITY_ENABLE)
 
+  private val shuffleMigrationEnabled = conf.get(DECOMMISSION_ENABLED) &&
+    conf.get(STORAGE_DECOMMISSION_ENABLED) && conf.get(STORAGE_DECOMMISSION_SHUFFLE_BLOCKS_ENABLED)
+
   // Number of map and reduce tasks above which we do not assign preferred locations based on map
   // output sizes. We limit the size of jobs for which assign preferred locations as computing the
   // top locations by size becomes expensive.
@@ -805,6 +808,8 @@ private[spark] class MapOutputTrackerMaster(
     shuffleStatuses.get(shuffleId) match {
       case Some(shuffleStatus) =>
         shuffleStatus.updateMapOutput(mapId, bmAddress)
+      case None if shuffleMigrationEnabled =>
+        logWarning(s"Asked to update map output for unknown shuffle ${shuffleId}")
       case None =>
         logError(s"Asked to update map output for unknown shuffle ${shuffleId}")
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Only log unknown shuffle map output as error when shuffle migration disabled

### Why are the changes needed?
When decommission and shuffle migration is enabled, there're lots of error message like `Asked to update map output for unknown shuffle` .

As shuffle clean and unregister is done by `ContextCleaner` in an async way, when target block manager received the shuffle block from decommissioned block manager, then update shuffle location to map output tracker, but at that time, shuffle might have been unregistered. This should not consider as error.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Manually tested.
