### PR TITLE
[SPARK-43710][PS][FOLLOWUP] Fix `date_part` invocations

### DIFF
--- a/python/pyspark/pandas/indexes/timedelta.py
+++ b/python/pyspark/pandas/indexes/timedelta.py
@@ -25,7 +25,6 @@ from pyspark._globals import _NoValue
 from pyspark.pandas.indexes.base import Index
 from pyspark.pandas.missing.indexes import MissingPandasLikeTimedeltaIndex
 from pyspark.pandas.series import Series
-from pyspark.pandas.spark import functions as SF
 from pyspark.sql import functions as F
 
 
@@ -150,9 +149,9 @@ class TimedeltaIndex(Index):
 
         @no_type_check
         def get_seconds(scol):
-            hour_scol = F.date_part("HOUR", scol)
-            minute_scol = F.date_part("MINUTE", scol)
-            second_scol = F.date_part("SECOND", scol)
+            hour_scol = F.date_part(F.lit("HOUR"), scol)
+            minute_scol = F.date_part(F.lit("MINUTE"), scol)
+            second_scol = F.date_part(F.lit("SECOND"), scol)
             return (
                 F.when(
                     hour_scol < 0,
@@ -178,7 +177,7 @@ class TimedeltaIndex(Index):
 
         @no_type_check
         def get_microseconds(scol):
-            second_scol = SF.date_part("SECOND", scol)
+            second_scol = F.date_part(F.lit("SECOND"), scol)
             return (
                 (
                     F.when(


### PR DESCRIPTION
### What changes were proposed in this pull request?
fix https://github.com/apache/spark/commit/bc20e85b0e1da510cc091dbd03f210ef9fc56b25:
1, should use `F.lit("HOUR")` as the parameter;
2, should also change `def microseconds` since the old function was removed;



### Why are the changes needed?
to fix wrong usage


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
existing UT