### PR TITLE
[SPARK-44290][CONNECT][FOLLOW-UP] Skip flaky tests, and fix a typo in session UUID together

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/python/PythonWorkerFactory.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonWorkerFactory.scala
@@ -157,7 +157,7 @@ private[spark] class PythonWorkerFactory(pythonExec: String, envVars: Map[String
 
       // Create and start the worker
       val pb = new ProcessBuilder(Arrays.asList(pythonExec, "-m", workerModule))
-      val sessionId = envVars.getOrElse("SPARK_CONNECT_SESSION_UUID", "deafult")
+      val sessionId = envVars.getOrElse("SPARK_CONNECT_SESSION_UUID", "default")
       if (sessionId != "default") {
         pb.directory(new File(SparkFiles.getRootDirectory(), sessionId))
       }
@@ -214,7 +214,7 @@ private[spark] class PythonWorkerFactory(pythonExec: String, envVars: Map[String
         // Create and start the daemon
         val command = Arrays.asList(pythonExec, "-m", daemonModule)
         val pb = new ProcessBuilder(command)
-        val sessionId = envVars.getOrElse("SPARK_CONNECT_SESSION_UUID", "deafult")
+        val sessionId = envVars.getOrElse("SPARK_CONNECT_SESSION_UUID", "default")
         if (sessionId != "default") {
           pb.directory(new File(SparkFiles.getRootDirectory(), sessionId))
         }

--- a/python/pyspark/sql/tests/connect/client/test_artifact.py
+++ b/python/pyspark/sql/tests/connect/client/test_artifact.py
@@ -273,7 +273,7 @@ class ArtifactTests(ReusedConnectTestCase):
             spark_session.addArtifacts(f"{package_path}.zip", pyfile=True)
             self.assertEqual(spark_session.range(1).select(func("id")).first()[0], 5)
 
-    @unittest.skip("SPARK-44348: Reeanble Session-based artifact test cases")
+    @unittest.skip("SPARK-44348: Reenable Session-based artifact test cases")
     def test_add_zipped_package(self):
         self.check_add_zipped_package(self.spark)
 

--- a/python/pyspark/sql/tests/connect/client/test_artifact.py
+++ b/python/pyspark/sql/tests/connect/client/test_artifact.py
@@ -245,6 +245,7 @@ class ArtifactTests(ReusedConnectTestCase):
             spark_session.addArtifacts(pyfile_path, pyfile=True)
             self.assertEqual(spark_session.range(1).select(func("id")).first()[0], 10)
 
+    @unittest.skip("SPARK-44348: Reeanble Session-based artifact test cases")
     def test_add_pyfile(self):
         self.check_add_pyfile(self.spark)
 
@@ -272,6 +273,7 @@ class ArtifactTests(ReusedConnectTestCase):
             spark_session.addArtifacts(f"{package_path}.zip", pyfile=True)
             self.assertEqual(spark_session.range(1).select(func("id")).first()[0], 5)
 
+    @unittest.skip("SPARK-44348: Reeanble Session-based artifact test cases")
     def test_add_zipped_package(self):
         self.check_add_zipped_package(self.spark)
 
@@ -303,6 +305,7 @@ class ArtifactTests(ReusedConnectTestCase):
             spark_session.addArtifacts(f"{archive_path}.zip#my_files", archive=True)
             self.assertEqual(spark_session.range(1).select(func("id")).first()[0], "hello world!")
 
+    @unittest.skip("SPARK-44348: Reeanble Session-based artifact test cases")
     def test_add_archive(self):
         self.check_add_archive(self.spark)
 
@@ -328,6 +331,7 @@ class ArtifactTests(ReusedConnectTestCase):
             spark_session.addArtifacts(file_path, file=True)
             self.assertEqual(spark_session.range(1).select(func("id")).first()[0], "Hello world!!")
 
+    @unittest.skip("SPARK-44348: Reeanble Session-based artifact test cases")
     def test_add_file(self):
         self.check_add_file(self.spark)
 

--- a/python/pyspark/sql/tests/connect/client/test_artifact.py
+++ b/python/pyspark/sql/tests/connect/client/test_artifact.py
@@ -331,7 +331,7 @@ class ArtifactTests(ReusedConnectTestCase):
             spark_session.addArtifacts(file_path, file=True)
             self.assertEqual(spark_session.range(1).select(func("id")).first()[0], "Hello world!!")
 
-    @unittest.skip("SPARK-44348: Reeanble Session-based artifact test cases")
+    @unittest.skip("SPARK-44348: Reenable Session-based artifact test cases")
     def test_add_file(self):
         self.check_add_file(self.spark)
 

--- a/python/pyspark/sql/tests/connect/client/test_artifact.py
+++ b/python/pyspark/sql/tests/connect/client/test_artifact.py
@@ -305,7 +305,7 @@ class ArtifactTests(ReusedConnectTestCase):
             spark_session.addArtifacts(f"{archive_path}.zip#my_files", archive=True)
             self.assertEqual(spark_session.range(1).select(func("id")).first()[0], "hello world!")
 
-    @unittest.skip("SPARK-44348: Reeanble Session-based artifact test cases")
+    @unittest.skip("SPARK-44348: Reenable Session-based artifact test cases")
     def test_add_archive(self):
         self.check_add_archive(self.spark)
 

--- a/python/pyspark/sql/tests/connect/client/test_artifact.py
+++ b/python/pyspark/sql/tests/connect/client/test_artifact.py
@@ -245,7 +245,7 @@ class ArtifactTests(ReusedConnectTestCase):
             spark_session.addArtifacts(pyfile_path, pyfile=True)
             self.assertEqual(spark_session.range(1).select(func("id")).first()[0], 10)
 
-    @unittest.skip("SPARK-44348: Reeanble Session-based artifact test cases")
+    @unittest.skip("SPARK-44348: Reenable Session-based artifact test cases")
     def test_add_pyfile(self):
         self.check_add_pyfile(self.spark)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/41495 that skips a couple of flaky tests. In addition, this PR fixes a typo together.

### Why are the changes needed?

To keep the tests green. In order to reenable the tests, it needs other fixes together that might refactor the whole test cases which takes a while. I will followup and fix them in SPARK-44348

### Does this PR introduce _any_ user-facing change?

No, the feature is not released to end users yet.

### How was this patch tested?

Unittests skipped for now.
