### PR TITLE
[SPARK-44352][CONNECT] Put back sameType and friends in DataType.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/types/DataTypeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/types/DataTypeUtils.scala
@@ -16,7 +16,6 @@
  */
 package org.apache.spark.sql.catalyst.types
 
-import org.apache.spark.sql.SqlApiConf
 import org.apache.spark.sql.catalyst.analysis.Resolver
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Cast, Literal}
 import org.apache.spark.sql.internal.SQLConf.StoreAssignmentPolicy
@@ -29,30 +28,13 @@ object DataTypeUtils {
    * Check if `this` and `other` are the same data type when ignoring nullability
    * (`StructField.nullable`, `ArrayType.containsNull`, and `MapType.valueContainsNull`).
    */
-  def sameType(left: DataType, right: DataType): Boolean =
-    if (SqlApiConf.get.caseSensitiveAnalysis) {
-      equalsIgnoreNullability(left, right)
-    } else {
-      equalsIgnoreCaseAndNullability(left, right)
-    }
+  def sameType(left: DataType, right: DataType): Boolean = left.sameType(right)
 
   /**
    * Compares two types, ignoring nullability of ArrayType, MapType, StructType.
    */
   def equalsIgnoreNullability(left: DataType, right: DataType): Boolean = {
-    (left, right) match {
-      case (ArrayType(leftElementType, _), ArrayType(rightElementType, _)) =>
-        equalsIgnoreNullability(leftElementType, rightElementType)
-      case (MapType(leftKeyType, leftValueType, _), MapType(rightKeyType, rightValueType, _)) =>
-        equalsIgnoreNullability(leftKeyType, rightKeyType) &&
-          equalsIgnoreNullability(leftValueType, rightValueType)
-      case (StructType(leftFields), StructType(rightFields)) =>
-        leftFields.length == rightFields.length &&
-          leftFields.zip(rightFields).forall { case (l, r) =>
-            l.name == r.name && equalsIgnoreNullability(l.dataType, r.dataType)
-          }
-      case (l, r) => l == r
-    }
+    DataType.equalsIgnoreNullability(left, right)
   }
 
   /**
@@ -60,23 +42,7 @@ object DataTypeUtils {
    * sensitivity of field names in StructType.
    */
   def equalsIgnoreCaseAndNullability(from: DataType, to: DataType): Boolean = {
-    (from, to) match {
-      case (ArrayType(fromElement, _), ArrayType(toElement, _)) =>
-        equalsIgnoreCaseAndNullability(fromElement, toElement)
-
-      case (MapType(fromKey, fromValue, _), MapType(toKey, toValue, _)) =>
-        equalsIgnoreCaseAndNullability(fromKey, toKey) &&
-          equalsIgnoreCaseAndNullability(fromValue, toValue)
-
-      case (StructType(fromFields), StructType(toFields)) =>
-        fromFields.length == toFields.length &&
-          fromFields.zip(toFields).forall { case (l, r) =>
-            l.name.equalsIgnoreCase(r.name) &&
-              equalsIgnoreCaseAndNullability(l.dataType, r.dataType)
-          }
-
-      case (fromDataType, toDataType) => fromDataType == toDataType
-    }
+    DataType.equalsIgnoreCaseAndNullability(from, to)
   }
 
   private val SparkGeneratedName = """col\d+""".r

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructType.scala
@@ -679,7 +679,7 @@ object StructType extends AbstractDataType {
         // Found a missing field in `source`.
         newFields += field
       } else if (bothStructType(found.get.dataType, field.dataType) &&
-          !DataTypeUtils.sameType(found.get.dataType, field.dataType)) {
+          !found.get.dataType.sameType(field.dataType)) {
         // Found a field with same name, but different data type.
         findMissingFields(found.get.dataType.asInstanceOf[StructType],
           field.dataType.asInstanceOf[StructType], resolver).map { missingType =>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR moves back sameType and friends into DataType. Now that we have a conf system for SQL/API we can host them in there.

### Why are the changes needed?
We want to retain compatibility with the existing DataType APIs. Also we need to eliminate the use of catalyst specific code in the DataType hierarchy.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Existing tests.