### PR TITLE
[SPARK-44356][SQL] Resolve `WITH` on top of `INSERT INTO` via CTEDef

### DIFF
--- a/sql/core/src/test/resources/sql-tests/analyzer-results/postgreSQL/with.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/postgreSQL/with.sql.out
@@ -452,10 +452,14 @@ with test as (select 42) insert into test select * from test
 -- !query analysis
 InsertIntoHadoopFsRelationCommand file:[not included in comparison]/{warehouse_dir}/test, false, Parquet, [path=file:[not included in comparison]/{warehouse_dir}/test], Append, `spark_catalog`.`default`.`test`, org.apache.spark.sql.execution.datasources.InMemoryFileIndex(file:[not included in comparison]/{warehouse_dir}/test), [i]
 +- Project [cast(42#x as int) AS i#x]
-   +- Project [42#x]
-      +- SubqueryAlias test
-         +- Project [42 AS 42#x]
-            +- OneRowRelation
+   +- WithCTE
+      :- CTERelationDef xxxx, false
+      :  +- SubqueryAlias test
+      :     +- Project [42 AS 42#x]
+      :        +- OneRowRelation
+      +- Project [42#x]
+         +- SubqueryAlias test
+            +- CTERelationRef xxxx, true, [42#x]
 
 
 -- !query

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
@@ -2528,7 +2528,7 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
     }
   }
 
-  test("SPARK-XXXXX: CTE on top of INSERT INTO") {
+  test("SPARK-44356: CTE on top of INSERT INTO") {
     withTable("t") {
       sql("CREATE TABLE t(i int, part1 int, part2 int) using parquet")
       sql("WITH v1(c1) as (values (1)) INSERT INTO t select c1, 2, 3 from v1")

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
@@ -2528,6 +2528,14 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
     }
   }
 
+  test("SPARK-XXXXX: CTE on top of INSERT INTO") {
+    withTable("t") {
+      sql("CREATE TABLE t(i int, part1 int, part2 int) using parquet")
+      sql("WITH v1(c1) as (values (1)) INSERT INTO t select c1, 2, 3 from v1")
+      checkAnswer(spark.table("t"), Row(1, 2, 3))
+    }
+  }
+
   test("SELECT clause with star wildcard") {
     withTable("t1") {
       sql("CREATE TABLE t1(c1 int, c2 string) using parquet")


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to resolve `WITH` on top of `INSERT INTO` via the regular code path similar to non-commands. In this way, `InsertIntoStatement` is excluded from commands in the rule `CTESubstitution`, and `UnresolvedWith` is moved into `InsertIntoStatement` on top of its `query`.

### Why are the changes needed?
To improve code maintenance. Right now the CTE resolution code path is diverged: query with commands go into CTE inline code path where non-command queries go into CTEDef code path. 

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By running new test:
```
$ build/sbt "test:testOnly *InsertSuite"
```