### PR TITLE
[SPARK-38476][CORE] Use error class in org.apache.spark.storage

### DIFF
--- a/common/utils/src/main/resources/error/error-classes.json
+++ b/common/utils/src/main/resources/error/error-classes.json
@@ -1067,6 +1067,12 @@
     ],
     "sqlState" : "XX000"
   },
+  "INTERNAL_ERROR_STORAGE" : {
+    "message" : [
+      "<message>"
+    ],
+    "sqlState" : "XX000"
+  },
   "INTERVAL_ARITHMETIC_OVERFLOW" : {
     "message" : [
       "<message>.<alternative>"

--- a/core/src/main/scala/org/apache/spark/storage/BlockInfoManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockInfoManager.scala
@@ -29,7 +29,7 @@ import scala.reflect.ClassTag
 import com.google.common.collect.{ConcurrentHashMultiset, ImmutableMultiset}
 import com.google.common.util.concurrent.Striped
 
-import org.apache.spark.TaskContext
+import org.apache.spark.{SparkException, TaskContext}
 import org.apache.spark.errors.SparkCoreErrors
 import org.apache.spark.internal.Logging
 
@@ -543,8 +543,9 @@ private[storage] class BlockInfoManager(trackingCacheVisibility: Boolean = false
     logTrace(s"Task $taskAttemptId trying to remove block $blockId")
     blockInfo(blockId) { (info, condition) =>
       if (info.writerTask != taskAttemptId) {
-        throw new IllegalStateException(
-          s"Task $taskAttemptId called remove() on block $blockId without a write lock")
+        throw SparkException.internalError(
+          s"Task $taskAttemptId called remove() on block $blockId without a write lock",
+          category = "STORAGE")
       } else {
         invisibleRDDBlocks.synchronized {
           blockInfoWrappers.remove(blockId)

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -1171,8 +1171,8 @@ private[spark] class BlockManager(
         val buf = blockTransferService.fetchBlockSync(loc.host, loc.port, loc.executorId,
           blockId.toString, tempFileManager)
         if (blockSize > 0 && buf.size() == 0) {
-          throw new IllegalStateException("Empty buffer received for non empty block " +
-            s"when fetching remote block $blockId from $loc")
+          throw SparkException.internalError("Empty buffer received for non empty block " +
+            s"when fetching remote block $blockId from $loc", category = "STORAGE")
         }
         buf
       } catch {

--- a/core/src/main/scala/org/apache/spark/storage/DiskBlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/DiskBlockManager.scala
@@ -27,7 +27,7 @@ import scala.collection.mutable.HashMap
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 
-import org.apache.spark.SparkConf
+import org.apache.spark.{SparkConf, SparkException}
 import org.apache.spark.errors.SparkCoreErrors
 import org.apache.spark.executor.ExecutorExitCode
 import org.apache.spark.internal.{config, Logging}
@@ -139,15 +139,15 @@ private[spark] class DiskBlockManager(
       case mergedMetaBlockId: ShuffleMergedMetaBlockId =>
         getMergedShuffleFile(mergedMetaBlockId.name, dirs)
       case _ =>
-        throw new IllegalArgumentException(
-          s"Only merged block ID is supported, but got $blockId")
+        throw SparkException.internalError(
+          s"Only merged block ID is supported, but got $blockId", category = "STORAGE")
     }
   }
 
   private def getMergedShuffleFile(filename: String, dirs: Option[Array[String]]): File = {
     if (!dirs.exists(_.nonEmpty)) {
-      throw new IllegalArgumentException(
-        s"Cannot read $filename because merged shuffle dirs is empty")
+      throw SparkException.internalError(
+        s"Cannot read $filename because merged shuffle dirs is empty", category = "STORAGE")
     }
     new File(ExecutorDiskUtils.getFilePath(dirs.get, subDirsPerLocalDir, filename))
   }

--- a/core/src/main/scala/org/apache/spark/storage/DiskBlockObjectWriter.scala
+++ b/core/src/main/scala/org/apache/spark/storage/DiskBlockObjectWriter.scala
@@ -22,6 +22,7 @@ import java.nio.channels.{ClosedByInterruptException, FileChannel}
 import java.nio.file.Files
 import java.util.zip.Checksum
 
+import org.apache.spark.SparkException
 import org.apache.spark.errors.SparkCoreErrors
 import org.apache.spark.internal.Logging
 import org.apache.spark.io.MutableCheckedOutputStream
@@ -153,7 +154,8 @@ private[spark] class DiskBlockObjectWriter(
 
   def open(): DiskBlockObjectWriter = {
     if (hasBeenClosed) {
-      throw new IllegalStateException("Writer already closed. Cannot be reopened.")
+      throw SparkException.internalError(
+        "Writer already closed. Cannot be reopened.", category = "STORAGE")
     }
     if (!initialized) {
       initialize()

--- a/core/src/main/scala/org/apache/spark/storage/DiskStore.scala
+++ b/core/src/main/scala/org/apache/spark/storage/DiskStore.scala
@@ -29,7 +29,7 @@ import com.google.common.io.Closeables
 import io.netty.channel.DefaultFileRegion
 import org.apache.commons.io.FileUtils
 
-import org.apache.spark.{SecurityManager, SparkConf}
+import org.apache.spark.{SecurityManager, SparkConf, SparkException}
 import org.apache.spark.internal.{config, Logging}
 import org.apache.spark.network.buffer.ManagedBuffer
 import org.apache.spark.network.util.{AbstractFileRegion, JavaUtils}
@@ -67,8 +67,9 @@ private[spark] class DiskStore(
         diskManager.getFile(blockId).delete()
       } catch {
         case e: Exception =>
-          throw new IllegalStateException(
-            s"Block $blockId is already present in the disk store and could not delete it $e")
+          throw SparkException.internalError(
+            s"Block $blockId is already present in the disk store and could not delete it $e",
+            category = "STORAGE")
       }
     }
     logDebug(s"Attempting to put block $blockId")

--- a/core/src/main/scala/org/apache/spark/storage/FallbackStorage.scala
+++ b/core/src/main/scala/org/apache/spark/storage/FallbackStorage.scala
@@ -26,7 +26,7 @@ import scala.reflect.ClassTag
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
 
-import org.apache.spark.SparkConf
+import org.apache.spark.{SparkConf, SparkException}
 import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config.{STORAGE_DECOMMISSION_FALLBACK_STORAGE_CLEANUP, STORAGE_DECOMMISSION_FALLBACK_STORAGE_PATH}
@@ -170,7 +170,8 @@ private[spark] object FallbackStorage extends Logging {
       case batchId: ShuffleBlockBatchId =>
         (batchId.shuffleId, batchId.mapId, batchId.startReduceId, batchId.endReduceId)
       case _ =>
-        throw new IllegalArgumentException("unexpected shuffle block id format: " + blockId)
+        throw SparkException.internalError(
+          s"unexpected shuffle block id format: $blockId", category = "STORAGE")
     }
 
     val name = ShuffleIndexBlockId(shuffleId, mapId, NOOP_REDUCE_ID).name

--- a/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
+++ b/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
@@ -33,7 +33,7 @@ import io.netty.util.internal.OutOfDirectMemoryError
 import org.apache.commons.io.IOUtils
 import org.roaringbitmap.RoaringBitmap
 
-import org.apache.spark.{MapOutputTracker, TaskContext}
+import org.apache.spark.{MapOutputTracker, SparkException, TaskContext}
 import org.apache.spark.MapOutputTracker.SHUFFLE_PUSH_MAP_ID
 import org.apache.spark.errors.SparkCoreErrors
 import org.apache.spark.internal.Logging
@@ -1143,7 +1143,8 @@ final class ShuffleBlockFetcherIterator(
         logWarning(diagnosisResponse)
         diagnosisResponse
       case unexpected: BlockId =>
-        throw new IllegalArgumentException(s"Unexpected type of BlockId, $unexpected")
+        throw SparkException.internalError(
+          s"Unexpected type of BlockId, $unexpected", category = "STORAGE")
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/storage/BlockInfoManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockInfoManagerSuite.scala
@@ -309,7 +309,7 @@ class BlockInfoManagerSuite extends SparkFunSuite {
     withTaskId(0) {
       assert(blockInfoManager.lockNewBlockForWriting("block", newBlockInfo()))
       blockInfoManager.unlock("block")
-      intercept[IllegalStateException] {
+      intercept[SparkException] {
         blockInfoManager.removeBlock("block")
       }
     }
@@ -320,7 +320,7 @@ class BlockInfoManagerSuite extends SparkFunSuite {
       assert(blockInfoManager.lockNewBlockForWriting("block", newBlockInfo()))
       blockInfoManager.unlock("block")
       assert(blockInfoManager.lockForReading("block").isDefined)
-      intercept[IllegalStateException] {
+      intercept[SparkException] {
         blockInfoManager.removeBlock("block")
       }
     }

--- a/core/src/test/scala/org/apache/spark/storage/DiskBlockObjectWriterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/DiskBlockObjectWriterSuite.scala
@@ -18,7 +18,7 @@ package org.apache.spark.storage
 
 import java.io.File
 
-import org.apache.spark.{SparkConf, SparkFunSuite}
+import org.apache.spark.{SparkConf, SparkException, SparkFunSuite}
 import org.apache.spark.executor.ShuffleWriteMetrics
 import org.apache.spark.serializer.{JavaSerializer, SerializerManager}
 import org.apache.spark.util.Utils
@@ -96,7 +96,7 @@ class DiskBlockObjectWriterSuite extends SparkFunSuite {
 
     writer.open()
     writer.close()
-    intercept[IllegalStateException] {
+    intercept[SparkException] {
       writer.open()
     }
   }

--- a/core/src/test/scala/org/apache/spark/storage/PartiallySerializedBlockSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/PartiallySerializedBlockSuite.scala
@@ -26,7 +26,7 @@ import org.mockito.Mockito.atLeastOnce
 import org.mockito.invocation.InvocationOnMock
 import org.scalatest.{BeforeAndAfterEach, PrivateMethodTester}
 
-import org.apache.spark.{SparkConf, SparkFunSuite, TaskContext, TaskContextImpl}
+import org.apache.spark.{SparkConf, SparkException, SparkFunSuite, TaskContext, TaskContextImpl}
 import org.apache.spark.memory.MemoryMode
 import org.apache.spark.serializer.{JavaSerializer, SerializationStream, SerializerManager}
 import org.apache.spark.storage.memory.{MemoryStore, PartiallySerializedBlock, RedirectableOutputStream}
@@ -97,10 +97,10 @@ class PartiallySerializedBlockSuite
   test("valuesIterator() and finishWritingToStream() cannot be called after discard() is called") {
     val partiallySerializedBlock = partiallyUnroll((1 to 10).iterator, 2)
     partiallySerializedBlock.discard()
-    intercept[IllegalStateException] {
+    intercept[SparkException] {
       partiallySerializedBlock.finishWritingToStream(null)
     }
-    intercept[IllegalStateException] {
+    intercept[SparkException] {
       partiallySerializedBlock.valuesIterator
     }
   }
@@ -114,7 +114,7 @@ class PartiallySerializedBlockSuite
   test("cannot call valuesIterator() more than once") {
     val partiallySerializedBlock = partiallyUnroll((1 to 10).iterator, 2)
     partiallySerializedBlock.valuesIterator
-    intercept[IllegalStateException] {
+    intercept[SparkException] {
       partiallySerializedBlock.valuesIterator
     }
   }
@@ -122,7 +122,7 @@ class PartiallySerializedBlockSuite
   test("cannot call finishWritingToStream() more than once") {
     val partiallySerializedBlock = partiallyUnroll((1 to 10).iterator, 2)
     partiallySerializedBlock.finishWritingToStream(new ByteBufferOutputStream())
-    intercept[IllegalStateException] {
+    intercept[SparkException] {
       partiallySerializedBlock.finishWritingToStream(new ByteBufferOutputStream())
     }
   }
@@ -130,7 +130,7 @@ class PartiallySerializedBlockSuite
   test("cannot call finishWritingToStream() after valuesIterator()") {
     val partiallySerializedBlock = partiallyUnroll((1 to 10).iterator, 2)
     partiallySerializedBlock.valuesIterator
-    intercept[IllegalStateException] {
+    intercept[SparkException] {
       partiallySerializedBlock.finishWritingToStream(new ByteBufferOutputStream())
     }
   }
@@ -138,7 +138,7 @@ class PartiallySerializedBlockSuite
   test("cannot call valuesIterator() after finishWritingToStream()") {
     val partiallySerializedBlock = partiallyUnroll((1 to 10).iterator, 2)
     partiallySerializedBlock.finishWritingToStream(new ByteBufferOutputStream())
-    intercept[IllegalStateException] {
+    intercept[SparkException] {
       partiallySerializedBlock.valuesIterator
     }
   }

--- a/docs/sql-error-conditions.md
+++ b/docs/sql-error-conditions.md
@@ -742,6 +742,12 @@ For more details see [INSUFFICIENT_TABLE_PROPERTY](sql-error-conditions-insuffic
 
 `<message>`
 
+### INTERNAL_ERROR_STORAGE
+
+[SQLSTATE: XX000](sql-error-conditions-sqlstates.html#class-XX-internal-error)
+
+`<message>`
+
 ### INTERVAL_ARITHMETIC_OVERFLOW
 
 [SQLSTATE: 22015](sql-error-conditions-sqlstates.html#class-22-data-exception)


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to change exceptions created in package org.apache.spark.shuffle to use error class. This also adds an error class INTERNAL_ERROR_STORAGE and uses that for the internal errors in the package.


### Why are the changes needed?
This is to move exceptions created in package org.apache.spark.storage to error class.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Updated existing tests.