### PR TITLE
[SPARK-44360][SQL] Support schema pruning in delta-based MERGE operations

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -882,6 +882,10 @@ object ColumnPruning extends Rule[LogicalPlan] {
     case e @ Expand(_, _, child) if !child.outputSet.subsetOf(e.references) =>
       e.copy(child = prunedChild(child, e.references))
 
+    // prune unused columns from child of MergeRows for row-level operations
+    case e @ MergeRows(_, _, _, _, _, _, _, child) if !child.outputSet.subsetOf(e.references) =>
+      e.copy(child = prunedChild(child, e.references))
+
     // prune unrequired references
     case p @ Project(_, g: Generate) if p.references != g.outputSet =>
       val requiredAttrs = p.references -- g.producedAttributes ++ g.generator.references

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedMergeIntoTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedMergeIntoTableSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.connector
 
-class DeltaBasedMergeIntoTableSuite extends MergeIntoTableSuiteBase {
+class DeltaBasedMergeIntoTableSuite extends DeltaBasedMergeIntoTableSuiteBase {
 
   override protected lazy val extraTableProps: java.util.Map[String, String] = {
     val props = new java.util.HashMap[String, String]()

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedMergeIntoTableSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedMergeIntoTableSuiteBase.scala
@@ -1,0 +1,232 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.catalyst.types.DataTypeUtils
+import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
+import org.apache.spark.sql.types.StructType
+
+abstract class DeltaBasedMergeIntoTableSuiteBase extends MergeIntoTableSuiteBase {
+
+  import testImplicits._
+
+  test("merge into schema pruning with WHEN MATCHED clause (update)") {
+    withTempView("source") {
+      createAndInitTable("pk INT NOT NULL, salary INT, country STRING, dep STRING",
+        """{ "pk": 1, "salary": 100, "country": "uk", "dep": "hr" }
+          |{ "pk": 2, "salary": 200, "country": "us", "dep": "corrupted" }
+          |""".stripMargin)
+
+      val sourceRows = Seq(
+        (1, 100, "france", "software"),
+        (2, 200, "india", "finance"),
+        (3, 300, "china", "software"))
+      sourceRows.toDF("pk", "salary", "country", "dep").createOrReplaceTempView("source")
+
+      executeAndCheckScan(
+        s"""MERGE INTO $tableNameAsString t
+           |USING source s
+           |ON t.pk = s.pk
+           |WHEN MATCHED AND t.salary = 200 THEN
+           | UPDATE SET *
+           |""".stripMargin,
+        // `pk` is used in the SEARCH condition
+        // `salary` is used in the UPDATE condition
+        // `_partition` is used in the requested write distribution
+        expectedScanSchema = "pk INT, salary INT, _partition STRING")
+
+      checkAnswer(
+        sql(s"SELECT * FROM $tableNameAsString"),
+        Seq(
+          Row(1, 100, "uk", "hr"), // unchanged
+          Row(2, 200, "india", "finance"))) // update
+    }
+  }
+
+  test("merge into schema pruning with WHEN MATCHED clause (delete)") {
+    withTempView("source") {
+      createAndInitTable("pk INT NOT NULL, salary INT, country STRING, dep STRING",
+        """{ "pk": 1, "salary": 100, "country": "uk", "dep": "hr" }
+          |{ "pk": 2, "salary": 200, "country": "us", "dep": "corrupted" }
+          |""".stripMargin)
+
+      Seq(1, 2, 3).toDF("pk").createOrReplaceTempView("source")
+
+      executeAndCheckScan(
+        s"""MERGE INTO $tableNameAsString t
+           |USING source s
+           |ON t.pk = s.pk
+           |WHEN MATCHED AND t.salary = 200 THEN
+           | DELETE
+           |""".stripMargin,
+        // `pk` is used in the SEARCH condition
+        // `salary` is used in the DELETE condition
+        // `_partition` is used in the requested write distribution
+        expectedScanSchema = "pk INT, salary INT, _partition STRING")
+
+      checkAnswer(
+        sql(s"SELECT * FROM $tableNameAsString"),
+        Seq(Row(1, 100, "uk", "hr"))) // unchanged
+    }
+  }
+
+  test("merge into schema pruning with WHEN NOT MATCHED clause") {
+    withTempView("source") {
+      createAndInitTable("pk INT NOT NULL, salary INT, country STRING, dep STRING",
+        """{ "pk": 1, "salary": 100, "country": "uk", "dep": "hr" }
+          |{ "pk": 2, "salary": 200, "country": "us", "dep": "software" }
+          |""".stripMargin)
+
+      val sourceRows = Seq(
+        (1, 100, "france", "software"),
+        (2, 200, "india", "finance"),
+        (3, 300, "china", "software"))
+      sourceRows.toDF("pk", "salary", "country", "dep").createOrReplaceTempView("source")
+
+      executeAndCheckScan(
+        s"""MERGE INTO $tableNameAsString t
+           |USING source s
+           |ON t.pk = s.pk
+           |WHEN NOT MATCHED THEN
+           | INSERT *
+           |""".stripMargin,
+        // `pk` is used in the SEARCH condition
+        expectedScanSchema = "pk INT")
+
+      checkAnswer(
+        sql(s"SELECT * FROM $tableNameAsString"),
+        Seq(
+          Row(1, 100, "uk", "hr"), // unchanged
+          Row(2, 200, "us", "software"), // unchanged
+          Row(3, 300, "china", "software"))) // insert
+    }
+  }
+
+  test("merge into schema pruning with WHEN NOT MATCHED BY SOURCE clause (update)") {
+    withTempView("source") {
+      createAndInitTable("pk INT NOT NULL, salary INT, country STRING, dep STRING",
+        """{ "pk": 1, "salary": 100, "country": "uk", "dep": "hr" }
+          |{ "pk": 2, "salary": 200, "country": "us", "dep": "software" }
+          |""".stripMargin)
+
+      val sourceRows = Seq(
+        (2, 200, "india", "finance"),
+        (3, 300, "china", "software"))
+      sourceRows.toDF("pk", "salary", "country", "dep").createOrReplaceTempView("source")
+
+      executeAndCheckScan(
+        s"""MERGE INTO $tableNameAsString t
+           |USING source s
+           |ON t.pk = s.pk
+           |WHEN NOT MATCHED BY SOURCE AND salary = 100 THEN
+           | UPDATE SET country = 'invalid', dep = 'invalid'
+           |""".stripMargin,
+        // `pk` is used in the SEARCH condition
+        // `salary` is used in the UPDATE condition
+        // `_partition` is used in the requested write distribution
+        expectedScanSchema = "pk INT, salary INT, _partition STRING")
+
+      checkAnswer(
+        sql(s"SELECT * FROM $tableNameAsString"),
+        Seq(
+          Row(1, 100, "invalid", "invalid"), // update
+          Row(2, 200, "us", "software"))) // unchanged
+    }
+  }
+
+  test("merge into schema pruning with WHEN NOT MATCHED BY SOURCE clause (delete)") {
+    withTempView("source") {
+      createAndInitTable("pk INT NOT NULL, salary INT, country STRING, dep STRING",
+        """{ "pk": 1, "salary": 100, "country": "uk", "dep": "hr" }
+          |{ "pk": 2, "salary": 200, "country": "us", "dep": "software" }
+          |""".stripMargin)
+
+      val sourceRows = Seq(
+        (2, 200, "india", "finance"),
+        (3, 300, "china", "software"))
+      sourceRows.toDF("pk", "salary", "country", "dep").createOrReplaceTempView("source")
+
+      executeAndCheckScan(
+        s"""MERGE INTO $tableNameAsString t
+           |USING source s
+           |ON t.pk = s.pk
+           |WHEN NOT MATCHED BY SOURCE AND salary = 100 THEN
+           | DELETE
+           |""".stripMargin,
+        // `pk` is used in the SEARCH condition
+        // `salary` is used in the UPDATE condition
+        // `_partition` is used in the requested write distribution
+        expectedScanSchema = "pk INT, salary INT, _partition STRING")
+
+      checkAnswer(
+        sql(s"SELECT * FROM $tableNameAsString"),
+        Seq(Row(2, 200, "us", "software"))) // unchanged
+    }
+  }
+
+  test("merge into schema pruning with clauses") {
+    withTempView("source") {
+      createAndInitTable("pk INT NOT NULL, salary INT, country STRING, dep STRING",
+        """{ "pk": 1, "salary": 100, "country": "uk", "dep": "hr" }
+          |{ "pk": 2, "salary": 200, "country": "us", "dep": "software" }
+          |""".stripMargin)
+
+      val sourceRows = Seq(
+        (2, 200, "india", "finance"),
+        (3, 300, "china", "software"))
+      sourceRows.toDF("pk", "salary", "country", "dep").createOrReplaceTempView("source")
+
+      executeAndCheckScan(
+        s"""MERGE INTO $tableNameAsString t
+           |USING source s
+           |ON t.pk = s.pk
+           |WHEN MATCHED THEN
+           | UPDATE SET *
+           |WHEN NOT MATCHED THEN
+           | INSERT *
+           |WHEN NOT MATCHED BY SOURCE AND salary = 100 THEN
+           | DELETE
+           |""".stripMargin,
+        // `pk` is used in the SEARCH condition
+        // `salary` is used in the DELETE condition
+        // `_partition` is used in the requested write distribution
+        expectedScanSchema = "pk INT, salary INT, _partition STRING")
+
+      checkAnswer(
+        sql(s"SELECT * FROM $tableNameAsString"),
+        Seq(
+          Row(2, 200, "india", "finance"), // update
+          Row(3, 300, "china", "software"))) // insert
+    }
+  }
+
+  private def executeAndCheckScan(
+      query: String,
+      expectedScanSchema: String): Unit = {
+
+    val executedPlan = executeAndKeepPlan {
+      sql(query)
+    }
+
+    val scan = collect(executedPlan) {
+      case s: BatchScanExec => s
+    }.head
+    assert(DataTypeUtils.sameType(scan.schema, StructType.fromDDL(expectedScanSchema)))
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedMergeIntoTableUpdateAsDeleteAndInsertSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DeltaBasedMergeIntoTableUpdateAsDeleteAndInsertSuite.scala
@@ -17,7 +17,8 @@
 
 package org.apache.spark.sql.connector
 
-class DeltaBasedMergeIntoTableUpdateAsDeleteAndInsertSuite extends MergeIntoTableSuiteBase {
+class DeltaBasedMergeIntoTableUpdateAsDeleteAndInsertSuite
+  extends DeltaBasedMergeIntoTableSuiteBase {
 
   override protected lazy val extraTableProps: java.util.Map[String, String] = {
     val props = new java.util.HashMap[String, String]()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR adds support for schema pruning in delta-based MERGE operations. 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

These changes are needed to improve the performance of certain row-level operations by skipping columns that are not required to materialize changes.

Consider an example.

```
createAndInitTable("pk INT NOT NULL, salary INT, country STRING, dep STRING")

sql(
  s"""MERGE INTO table t
     |USING source s
     |ON t.pk = s.pk
     |WHEN MATCHED AND t.salary = 200 THEN
     | UPDATE SET *
     |""".stripMargin)
```

In order to compute the new state of updated records we only need `pk` and `salary` columns from the target table. Hence, we can skip reading `country` and `dep` as values for those columns are coming from the source relation.

This logic does not apply to group-based MERGE operations as those have to copy over records and need values for all columns of the target table.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

This PR comes with tests.
