### PR TITLE
[SPARK-44384][SQL][TESTS] Use checkError() to check Exception in *View*Suite, *Namespace*Suite, *DataSource*Suite

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/FileBasedDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/FileBasedDataSourceSuite.scala
@@ -26,7 +26,7 @@ import scala.collection.mutable
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{LocalFileSystem, Path}
 
-import org.apache.spark.SparkException
+import org.apache.spark.{SparkException, SparkFileNotFoundException, SparkRuntimeException}
 import org.apache.spark.scheduler.{SparkListener, SparkListenerTaskEnd}
 import org.apache.spark.sql.TestingUDT.{IntervalUDT, NullData, NullUDT}
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, GreaterThan, Literal}
@@ -129,11 +129,13 @@ class FileBasedDataSourceSuite extends QueryTest
   allFileBasedDataSources.foreach { format =>
     test(s"SPARK-23372 error while writing empty schema files using $format") {
       withTempPath { outputPath =>
-        val errMsg = intercept[AnalysisException] {
-          spark.emptyDataFrame.write.format(format).save(outputPath.toString)
-        }
-        assert(errMsg.getMessage.contains(
-          "Datasource does not support writing empty or nested empty schemas"))
+        checkError(
+          exception = intercept[AnalysisException] {
+            spark.emptyDataFrame.write.format(format).save(outputPath.toString)
+          },
+          errorClass = "_LEGACY_ERROR_TEMP_1142",
+          parameters = Map.empty
+        )
       }
 
       // Nested empty schema
@@ -144,11 +146,13 @@ class FileBasedDataSourceSuite extends QueryTest
           StructField("c", IntegerType)
         ))
         val df = spark.createDataFrame(sparkContext.emptyRDD[Row], schema)
-        val errMsg = intercept[AnalysisException] {
-          df.write.format(format).save(outputPath.toString)
-        }
-        assert(errMsg.getMessage.contains(
-          "Datasource does not support writing empty or nested empty schemas"))
+        checkError(
+          exception = intercept[AnalysisException] {
+            df.write.format(format).save(outputPath.toString)
+          },
+          errorClass = "_LEGACY_ERROR_TEMP_1142",
+          parameters = Map.empty
+        )
       }
     }
   }
@@ -242,10 +246,17 @@ class FileBasedDataSourceSuite extends QueryTest
           if (ignore.toBoolean) {
             testIgnoreMissingFiles(options)
           } else {
-            val exception = intercept[SparkException] {
-              testIgnoreMissingFiles(options)
+            val errorClass = sources match {
+              case "" => "_LEGACY_ERROR_TEMP_2062"
+              case _ => "_LEGACY_ERROR_TEMP_2055"
             }
-            assert(exception.getMessage().contains("does not exist"))
+            checkErrorMatchPVals(
+              exception = intercept[SparkException] {
+                testIgnoreMissingFiles(options)
+              }.getCause.asInstanceOf[SparkFileNotFoundException],
+              errorClass = errorClass,
+              parameters = Map("message" -> ".*does not exist")
+            )
           }
         }
       }
@@ -646,20 +657,20 @@ class FileBasedDataSourceSuite extends QueryTest
 
             // RuntimeException is triggered at executor side, which is then wrapped as
             // SparkException at driver side
-            val e1 = intercept[SparkException] {
-              sql(s"select b from $tableName").collect()
-            }
-            assert(
-              e1.getCause.isInstanceOf[RuntimeException] &&
-                e1.getCause.getMessage.contains(
-                  """Found duplicate field(s) "b": [b, B] in case-insensitive mode"""))
-            val e2 = intercept[SparkException] {
-              sql(s"select B from $tableName").collect()
-            }
-            assert(
-              e2.getCause.isInstanceOf[RuntimeException] &&
-                e2.getCause.getMessage.contains(
-                  """Found duplicate field(s) "b": [b, B] in case-insensitive mode"""))
+            checkError(
+              exception = intercept[SparkException] {
+                sql(s"select b from $tableName").collect()
+              }.getCause.asInstanceOf[SparkRuntimeException],
+              errorClass = "_LEGACY_ERROR_TEMP_2093",
+              parameters = Map("requiredFieldName" -> "b", "matchedOrcFields" -> "[b, B]")
+            )
+            checkError(
+              exception = intercept[SparkException] {
+                sql(s"select B from $tableName").collect()
+              }.getCause.asInstanceOf[SparkRuntimeException],
+              errorClass = "_LEGACY_ERROR_TEMP_2093",
+              parameters = Map("requiredFieldName" -> "b", "matchedOrcFields" -> "[b, B]")
+            )
           }
 
           withSQLConf(SQLConf.CASE_SENSITIVE.key -> "true") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/NestedDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/NestedDataSourceSuite.scala
@@ -55,17 +55,19 @@ trait NestedDataSourceSuiteBase extends QueryTest with SharedSparkSession {
             withTempPath { dir =>
               val path = dir.getCanonicalPath
               save(selectExpr, format, path)
-              val e = intercept[AnalysisException] {
-                spark
-                  .read
-                  .options(readOptions(caseInsensitiveSchema))
-                  .schema(caseInsensitiveSchema)
-                  .format(format)
-                  .load(path)
-                  .collect()
-              }
-              assert(e.getErrorClass == "COLUMN_ALREADY_EXISTS")
-              assert(e.getMessageParameters().get("columnName") == "`camelcase`")
+              checkError(
+                exception = intercept[AnalysisException] {
+                  spark
+                    .read
+                    .options(readOptions(caseInsensitiveSchema))
+                    .schema(caseInsensitiveSchema)
+                    .format(format)
+                    .load(path)
+                    .collect()
+                },
+                errorClass = "COLUMN_ALREADY_EXISTS",
+                parameters = Map("columnName" -> "`camelcase`")
+              )
             }
           }
         }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2DataFrameSuite.scala
@@ -182,12 +182,21 @@ class DataSourceV2DataFrameSuite
           Array.empty[Transform], Collections.emptyMap[String, String])
         val df = sql(s"select interval 1 millisecond as i")
         val v2Writer = df.writeTo("testcat.table_name")
-        val e1 = intercept[AnalysisException](v2Writer.append())
-        assert(e1.getMessage.contains(s"Cannot use interval type in the table schema."))
-        val e2 = intercept[AnalysisException](v2Writer.overwrite(df("i")))
-        assert(e2.getMessage.contains(s"Cannot use interval type in the table schema."))
-        val e3 = intercept[AnalysisException](v2Writer.overwritePartitions())
-        assert(e3.getMessage.contains(s"Cannot use interval type in the table schema."))
+        checkError(
+          exception = intercept[AnalysisException](v2Writer.append()),
+          errorClass = "_LEGACY_ERROR_TEMP_1183",
+          parameters = Map.empty
+        )
+        checkError(
+          exception = intercept[AnalysisException](v2Writer.overwrite(df("i"))),
+          errorClass = "_LEGACY_ERROR_TEMP_1183",
+          parameters = Map.empty
+        )
+        checkError(
+          exception = intercept[AnalysisException](v2Writer.overwritePartitions()),
+          errorClass = "_LEGACY_ERROR_TEMP_1183",
+          parameters = Map.empty
+        )
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -815,10 +815,14 @@ class DataSourceV2SQLSuiteV1Filter
         if (nullable) {
           insertNullValueAndCheck()
         } else {
-          val e = intercept[Exception] {
-            insertNullValueAndCheck()
-          }
-          assert(e.getMessage.contains("Null value appeared in non-nullable field"))
+          // TODO assign a error-classes name
+          checkError(
+            exception = intercept[SparkException] {
+              insertNullValueAndCheck()
+            },
+            errorClass = null,
+            parameters = Map.empty
+          )
         }
     }
   }
@@ -1109,9 +1113,17 @@ class DataSourceV2SQLSuiteV1Filter
       sql(s"INSERT INTO $t1(data, id) VALUES('c', 3)")
       verifyTable(t1, df)
       // Missing columns
-      assert(intercept[AnalysisException] {
-        sql(s"INSERT INTO $t1 VALUES(4)")
-      }.getMessage.contains("not enough data columns"))
+      checkError(
+        exception = intercept[AnalysisException] {
+          sql(s"INSERT INTO $t1 VALUES(4)")
+        },
+        errorClass = "INSERT_COLUMN_ARITY_MISMATCH.NOT_ENOUGH_DATA_COLUMNS",
+        parameters = Map(
+          "tableName" -> "`default`.`tbl`",
+          "tableColumns" -> "`id`, `data`",
+          "dataColumns" -> "`col1`"
+        )
+      )
       // Duplicate columns
       checkError(
         exception = intercept[AnalysisException] {
@@ -1136,9 +1148,17 @@ class DataSourceV2SQLSuiteV1Filter
       sql(s"INSERT OVERWRITE $t1(data, id) VALUES('c', 3)")
       verifyTable(t1, Seq((3L, "c")).toDF("id", "data"))
       // Missing columns
-      assert(intercept[AnalysisException] {
-        sql(s"INSERT OVERWRITE $t1 VALUES(4)")
-      }.getMessage.contains("not enough data columns"))
+      checkError(
+        exception = intercept[AnalysisException] {
+          sql(s"INSERT OVERWRITE $t1 VALUES(4)")
+        },
+        errorClass = "INSERT_COLUMN_ARITY_MISMATCH.NOT_ENOUGH_DATA_COLUMNS",
+        parameters = Map(
+          "tableName" -> "`default`.`tbl`",
+          "tableColumns" -> "`id`, `data`",
+          "dataColumns" -> "`col1`"
+        )
+      )
       // Duplicate columns
       checkError(
         exception = intercept[AnalysisException] {
@@ -1164,9 +1184,13 @@ class DataSourceV2SQLSuiteV1Filter
       sql(s"INSERT OVERWRITE $t1(data, data2, id) VALUES('c', 'e', 1)")
       verifyTable(t1, Seq((1L, "c", "e"), (2L, "b", "d")).toDF("id", "data", "data2"))
       // Missing columns
-      assert(intercept[AnalysisException] {
-        sql(s"INSERT OVERWRITE $t1 VALUES('a', 4)")
-      }.getMessage.contains("not enough data columns"))
+      checkError(
+        exception = intercept[AnalysisException] {
+          sql(s"INSERT OVERWRITE $t1 VALUES('a', 4)")
+        },
+        errorClass = "INSERT_COLUMN_ARITY_MISMATCH.NOT_ENOUGH_DATA_COLUMNS",
+        parameters = Map.empty
+      )
       // Duplicate columns
       checkError(
         exception = intercept[AnalysisException] {

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -1189,7 +1189,11 @@ class DataSourceV2SQLSuiteV1Filter
           sql(s"INSERT OVERWRITE $t1 VALUES('a', 4)")
         },
         errorClass = "INSERT_COLUMN_ARITY_MISMATCH.NOT_ENOUGH_DATA_COLUMNS",
-        parameters = Map.empty
+        parameters = Map(
+          "tableName" -> "`default`.`tbl`",
+          "tableColumns" -> "`id`, `data`, `data2`",
+          "dataColumns" -> "`col1`, `col2`"
+        )
       )
       // Duplicate columns
       checkError(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowNamespacesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowNamespacesSuite.scala
@@ -40,17 +40,29 @@ class ShowNamespacesSuite extends command.ShowNamespacesSuiteBase with CommandSu
 
   test("default v2 catalog doesn't support namespace") {
     withSQLConf(SQLConf.DEFAULT_CATALOG.key -> "testcat_no_namespace") {
-      val errMsg = intercept[AnalysisException] {
-        sql("SHOW NAMESPACES")
-      }.getMessage
-      assert(errMsg.contains("does not support namespaces"))
+      checkError(
+        exception = intercept[AnalysisException] {
+          sql("SHOW NAMESPACES")
+        },
+        errorClass = "_LEGACY_ERROR_TEMP_1184",
+        parameters = Map(
+          "plugin" -> "testcat_no_namespace",
+          "ability" -> "namespaces"
+        )
+      )
     }
   }
 
   test("v2 catalog doesn't support namespace") {
-    val errMsg = intercept[AnalysisException] {
-      sql("SHOW NAMESPACES in testcat_no_namespace")
-    }.getMessage
-    assert(errMsg.contains("does not support namespaces"))
+    checkError(
+      exception = intercept[AnalysisException] {
+        sql("SHOW NAMESPACES in testcat_no_namespace")
+      },
+      errorClass = "_LEGACY_ERROR_TEMP_1184",
+      parameters = Map(
+        "plugin" -> "testcat_no_namespace",
+        "ability" -> "namespaces"
+      )
+    )
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/ResolvedDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/ResolvedDataSourceSuite.scala
@@ -80,20 +80,24 @@ class ResolvedDataSourceSuite extends SharedSparkSession {
 
   test("avro: show deploy guide for loading the external avro module") {
     Seq("avro", "org.apache.spark.sql.avro").foreach { provider =>
-      val message = intercept[AnalysisException] {
-        getProvidingClass(provider)
-      }.getMessage
-      assert(message.contains(s"Failed to find data source: $provider"))
-      assert(message.contains("Please deploy the application as per the deployment section of"))
+      checkError(
+        exception = intercept[AnalysisException] {
+          getProvidingClass(provider)
+        },
+        errorClass = "_LEGACY_ERROR_TEMP_1139",
+        parameters = Map("provider" -> provider)
+      )
     }
   }
 
   test("kafka: show deploy guide for loading the external kafka module") {
-    val message = intercept[AnalysisException] {
-      getProvidingClass("kafka")
-    }.getMessage
-    assert(message.contains("Failed to find data source: kafka"))
-    assert(message.contains("Please deploy the application as per the deployment section of"))
+    checkError(
+      exception = intercept[AnalysisException] {
+        getProvidingClass("kafka")
+      },
+      errorClass = "_LEGACY_ERROR_TEMP_1140",
+      parameters = Map("provider" -> "kafka")
+    )
   }
 
   test("error message for unknown data sources") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/sources/StreamingDataSourceV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/sources/StreamingDataSourceV2Suite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.streaming.sources
 
 import java.util
 
+import org.apache.spark.SparkUnsupportedOperationException
 import org.apache.spark.sql.{DataFrame, SQLContext}
 import org.apache.spark.sql.connector.catalog.{SessionConfigSupport, SupportsRead, SupportsWrite, Table, TableCapability, TableProvider}
 import org.apache.spark.sql.connector.catalog.TableCapability._
@@ -300,7 +301,7 @@ class StreamingDataSourceV2Suite extends StreamTest {
     Trigger.ProcessingTime(1000),
     Trigger.Continuous(1000))
 
-  private def testPositiveCase(readFormat: String, writeFormat: String, trigger: Trigger): Unit = {
+  private def testCase(readFormat: String, writeFormat: String, trigger: Trigger): Unit = {
     testPositiveCaseWithQuery(readFormat, writeFormat, trigger)(_ => ())
   }
 
@@ -319,22 +320,12 @@ class StreamingDataSourceV2Suite extends StreamTest {
     query.stop()
   }
 
-  private def testNegativeCase(
-      readFormat: String,
-      writeFormat: String,
-      trigger: Trigger,
-      errorMsg: String) = {
-    val ex = intercept[UnsupportedOperationException] {
-      testPositiveCase(readFormat, writeFormat, trigger)
-    }
-    assert(ex.getMessage.contains(errorMsg))
-  }
-
   private def testPostCreationNegativeCase(
       readFormat: String,
       writeFormat: String,
       trigger: Trigger,
-      errorMsg: String) = {
+      errorClass: String,
+      parameters: Map[String, String]) = {
     val query = spark.readStream
       .format(readFormat)
       .load()
@@ -346,7 +337,11 @@ class StreamingDataSourceV2Suite extends StreamTest {
     eventually(timeout(streamingTimeout)) {
       assert(query.exception.isDefined)
       assert(query.exception.get.cause != null)
-      assert(query.exception.get.cause.getMessage.contains(errorMsg))
+      checkErrorMatchPVals(
+        exception = query.exception.get.cause.asInstanceOf[SparkUnsupportedOperationException],
+        errorClass = errorClass,
+        parameters = parameters
+      )
     }
   }
 
@@ -437,32 +432,59 @@ class StreamingDataSourceV2Suite extends StreamTest {
       trigger match {
         // Invalid - can't read at all
         case _ if !sourceTable.supportsAny(MICRO_BATCH_READ, CONTINUOUS_READ) =>
-          testNegativeCase(read, write, trigger,
-            s"Data source $read does not support streamed reading")
+          checkError(
+            exception = intercept[SparkUnsupportedOperationException] {
+              testCase(read, write, trigger)
+            },
+            errorClass = "_LEGACY_ERROR_TEMP_2049",
+            parameters = Map(
+              "className" -> "fake-read-neither-mode",
+              "operator" -> "reading"
+            )
+          )
 
         // Invalid - can't write
         case _ if !sinkTable.supports(STREAMING_WRITE) =>
-          testNegativeCase(read, write, trigger,
-            s"Data source $write does not support streamed writing")
+          checkError(
+            exception = intercept[SparkUnsupportedOperationException] {
+              testCase(read, write, trigger)
+            },
+            errorClass = "_LEGACY_ERROR_TEMP_2049",
+            parameters = Map(
+              "className" -> "fake-write-neither-mode",
+              "operator" -> "writing"
+            )
+          )
 
         case _: ContinuousTrigger =>
           if (sourceTable.supports(CONTINUOUS_READ)) {
             // Valid microbatch queries.
-            testPositiveCase(read, write, trigger)
+            testCase(read, write, trigger)
           } else {
             // Invalid - trigger is continuous but reader is not
-            testNegativeCase(
-              read, write, trigger, s"Data source $read does not support continuous processing")
+            checkError(
+              exception = intercept[SparkUnsupportedOperationException] {
+                testCase(read, write, trigger)
+              },
+              errorClass = "_LEGACY_ERROR_TEMP_2253",
+              parameters = Map("sourceName" -> "fake-read-microbatch-only")
+            )
           }
 
         case microBatchTrigger =>
           if (sourceTable.supports(MICRO_BATCH_READ)) {
             // Valid continuous queries.
-            testPositiveCase(read, write, trigger)
+            testCase(read, write, trigger)
           } else {
             // Invalid - trigger is microbatch but reader is not
             testPostCreationNegativeCase(read, write, trigger,
-              s"Data source $read does not support microbatch processing")
+              errorClass = "_LEGACY_ERROR_TEMP_2209",
+              parameters = Map(
+                "srcName" -> read,
+                "disabledSources" -> "",
+                "table" -> ".*"
+              )
+            )
           }
       }
     }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveSQLViewSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveSQLViewSuite.scala
@@ -209,17 +209,26 @@ class HiveSQLViewSuite extends SQLViewSuite with TestHiveSingleton {
            """.stripMargin
         )
 
-        val cause = intercept[AnalysisException] {
-          sql("SHOW CREATE TABLE v1")
-        }
-
-        assert(cause.getMessage.contains(" - partitioned view"))
-
-        val causeForSpark = intercept[AnalysisException] {
-          sql("SHOW CREATE TABLE v1 AS SERDE")
-        }
-
-        assert(causeForSpark.getMessage.contains(" - partitioned view"))
+        checkError(
+          exception = intercept[AnalysisException] {
+            sql("SHOW CREATE TABLE v1")
+          },
+          errorClass = "_LEGACY_ERROR_TEMP_1271",
+          parameters = Map(
+            "unsupportedFeatures" -> " - partitioned view",
+            "table" -> s"`$SESSION_CATALOG_NAME`.`default`.`v1`"
+          )
+        )
+        checkError(
+          exception = intercept[AnalysisException] {
+            sql("SHOW CREATE TABLE v1 AS SERDE")
+          },
+          errorClass = "_LEGACY_ERROR_TEMP_1275",
+          parameters = Map(
+            "table" -> s"`$SESSION_CATALOG_NAME`.`default`.`v1`",
+            "features" -> " - partitioned view"
+          )
+        )
       }
     }
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/AlterNamespaceSetLocationSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/AlterNamespaceSetLocationSuite.scala
@@ -32,10 +32,13 @@ class AlterNamespaceSetLocationSuite extends v1.AlterNamespaceSetLocationSuiteBa
     val ns = s"$catalog.$namespace"
     withNamespace(ns) {
       sql(s"CREATE NAMESPACE $ns")
-      val e = intercept[AnalysisException] {
-        sql(s"ALTER DATABASE $ns SET LOCATION 'loc'")
-      }
-      assert(e.getMessage.contains("does not support altering database location"))
+      checkError(
+        exception = intercept[AnalysisException] {
+          sql(s"ALTER DATABASE $ns SET LOCATION 'loc'")
+        },
+        errorClass = "_LEGACY_ERROR_TEMP_1219",
+        parameters = Map.empty
+      )
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to use `checkError()` to check `Exception` in `*View*Suite`, `*Namespace*Suite`, `*DataSource*Suite`, include:
- sql/core/src/test/scala/org/apache/spark/sql/FileBasedDataSourceSuite
- sql/core/src/test/scala/org/apache/spark/sql/NestedDataSourceSuite
- sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2DataFrameSuite
- sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2FunctionSuite
- sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite
- sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2Suite
- sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite
- sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowNamespacesSuite
- sql/core/src/test/scala/org/apache/spark/sql/sources/ResolvedDataSourceSuite
- sql/core/src/test/scala/org/apache/spark/sql/streaming/sources/StreamingDataSourceV2Suite
- sql/hive/src/test/scala/org/apache/spark/sql/hive/MetastoreDataSourcesSuite
- sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveSQLViewSuite
- sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/AlterNamespaceSetLocationSuite

### Why are the changes needed?
Migration on checkError() will make the tests independent from the text of error messages.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
- Manually test.
- Pass GA.