### PR TITLE
[SPARK-44387][CONNECT][TESTS] Configure a custom `RetryPolicy` when `Test encryption` initializing `SparkConnectClient`

### DIFF
--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/SparkConnectClientSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/SparkConnectClientSuite.scala
@@ -100,6 +100,7 @@ class SparkConnectClientSuite extends ConnectFunSuite with BeforeAndAfterEach {
     client = SparkConnectClient
       .builder()
       .connectionString(s"sc://localhost:${server.getPort}/;use_ssl=true")
+      .retryPolicy(GrpcRetryHandler.RetryPolicy(maxRetries = 0))
       .build()
 
     val request = AnalyzePlanRequest.newBuilder().setSessionId("abc123").build()


### PR DESCRIPTION
### What changes were proposed in this pull request?
After SPARK-44275, this make SparkConnectClient init with a RetryPolicy, this causes `Test encryption` in `SparkConnectClientSuite` to run longer.

Before

https://github.com/apache/spark/actions/runs/5482075870/jobs/9987058551

```
[info] - Test encryption (323 milliseconds)
```

After

https://github.com/apache/spark/actions/runs/5482264019/jobs/9987435847

```
[info] *** Test still running after 2 minutes, 44 seconds: suite name: SparkConnectClientSuite, test name: Test encryption. 
[info] *** Test still running after 7 minutes, 44 seconds: suite name: SparkConnectClientSuite, test name: Test encryption. 
[info] - Test encryption (10 minutes, 8 seconds)
```


`Test encryption` is an Exception testing and the exception is `io.netty.handler.ssl.NotSslRecordException(not an SSL/TLS record: 00001204000000000000037fffffff000400100000000600002000000004080000000000000f0001)` wrapped in `SparkException`, so there's no need retry to succeed. So this pr Configure a custom RetryPolicy with `maxRetries = 0` when `Test encryption` initializing `SparkConnectClient` to restore the execution time of `Test encryption` to normal.



 
### Why are the changes needed?
Make the execution time of `Test encryption` to normal.


### Does this PR introduce _any_ user-facing change?
No, just for test.


### How was this patch tested?
- Pass GitHub Actions
- manual test

run `build/sbt clean "connect-client-jvm/testOnly org.apache.spark.sql.connect.client.SparkConnectClientSuite" -Phive`

Before

```
[info] SparkConnectClientSuite:
...
[info] - Test connection string (7 milliseconds)
[info] *** Test still running after 4 minutes, 59 seconds: suite name: SparkConnectClientSuite, test name: Test encryption. 
[info] *** Test still running after 9 minutes, 59 seconds: suite name: SparkConnectClientSuite, test name: Test encryption. 
[info] - Test encryption (10 minutes, 8 seconds)
...
[info] Run completed in 10 minutes, 11 seconds.
[info] Total number of tests run: 34
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 34, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 758 s (12:38), completed 2023-7-12 21:29:47
```

After

```
[info] SparkConnectClientSuite:
...
[info] - Test encryption (170 milliseconds)
...
[info] Run completed in 3 seconds, 308 milliseconds.
[info] Total number of tests run: 34
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 34, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 149 s (02:29), completed 2023-7-12 21:33:13
```