### PR TITLE
[SPARK-44390][CORE][SQL] Rename `SparkSerDerseUtils` to `SparkSerDeUtils`

### DIFF
--- a/common/utils/src/main/scala/org/apache/spark/util/SparkSerDeUtils.scala
+++ b/common/utils/src/main/scala/org/apache/spark/util/SparkSerDeUtils.scala
@@ -18,7 +18,7 @@ package org.apache.spark.util
 
 import java.io.{ByteArrayOutputStream, ObjectOutputStream}
 
-object SparkSerDerseUtils {
+object SparkSerDeUtils {
   /** Serialize an object using Java serialization */
   def serialize[T](o: T): Array[Byte] = {
     val bos = new ByteArrayOutputStream()

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/expressions/UserDefinedFunction.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/expressions/UserDefinedFunction.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.Column
 import org.apache.spark.sql.catalyst.ScalaReflection
 import org.apache.spark.sql.catalyst.encoders.AgnosticEncoder
 import org.apache.spark.sql.connect.common.{DataTypeProtoConverter, UdfPacket}
-import org.apache.spark.util.SparkSerDerseUtils
+import org.apache.spark.util.SparkSerDeUtils
 
 /**
  * A user-defined function. To create one, use the `udf` functions in `functions`.
@@ -104,7 +104,7 @@ case class ScalarUserDefinedFunction(
   // SPARK-43198: Eagerly serialize to prevent the UDF from containing a reference to this class.
   private[this] val udf = {
     val udfPacketBytes =
-      SparkSerDerseUtils.serialize(UdfPacket(function, inputEncoders, outputEncoder))
+      SparkSerDeUtils.serialize(UdfPacket(function, inputEncoders, outputEncoder))
     val scalaUdfBuilder = proto.ScalarScalaUDF
       .newBuilder()
       .setPayload(ByteString.copyFrom(udfPacketBytes))

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/streaming/DataStreamWriter.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/streaming/DataStreamWriter.scala
@@ -35,7 +35,7 @@ import org.apache.spark.sql.execution.streaming.AvailableNowTrigger
 import org.apache.spark.sql.execution.streaming.ContinuousTrigger
 import org.apache.spark.sql.execution.streaming.OneTimeTrigger
 import org.apache.spark.sql.execution.streaming.ProcessingTimeTrigger
-import org.apache.spark.util.SparkSerDerseUtils
+import org.apache.spark.util.SparkSerDeUtils
 
 /**
  * Interface used to write a streaming `Dataset` to external storage systems (e.g. file systems,
@@ -214,7 +214,7 @@ final class DataStreamWriter[T] private[sql] (ds: Dataset[T]) extends Logging {
    * @since 3.5.0
    */
   def foreach(writer: ForeachWriter[T]): DataStreamWriter[T] = {
-    val serialized = SparkSerDerseUtils.serialize(ForeachWriterPacket(writer, ds.encoder))
+    val serialized = SparkSerDeUtils.serialize(ForeachWriterPacket(writer, ds.encoder))
     val scalaWriterBuilder = proto.ScalarScalaUDF
       .newBuilder()
       .setPayload(ByteString.copyFrom(serialized))

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -121,7 +121,7 @@ private[spark] object Utils extends Logging with SparkClassUtils {
 
   /** Serialize an object using Java serialization */
   def serialize[T](o: T): Array[Byte] = {
-    SparkSerDerseUtils.serialize(o)
+    SparkSerDeUtils.serialize(o)
   }
 
   /** Deserialize an object using Java serialization */


### PR DESCRIPTION
### What changes were proposed in this pull request?
The change to this pr is to rename `SparkSerDerseUtils` to `SparkSerDeUtils`.

### Why are the changes needed?
`SerDe` is a more commonly used naming convention in Spark, such as `o.a.s.api.python.SerDeUtil`, `o.a.s.ml.python.MLSerDe` and `o.a.s.sql.internal.HiveSerDe`, etc., so we should follow this habit.



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass Git Hub Actions
