### PR TITLE
[MINOR][CONNECT] Fix compilation warning related to `Top-level wildcard is not allowed and will error under -Xsource:3`

### DIFF
--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/connect/client/SparkResult.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/connect/client/SparkResult.scala
@@ -58,7 +58,7 @@ private[sql] class SparkResult[T](
   /**
    * Update RowEncoder and recursively update the fields of the ProductEncoder if found.
    */
-  private def createEncoder[_](
+  private def createEncoder(
       enc: AgnosticEncoder[_],
       dataType: DataType): AgnosticEncoder[_] = {
     enc match {

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/connect/client/SparkResult.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/connect/client/SparkResult.scala
@@ -58,9 +58,7 @@ private[sql] class SparkResult[T](
   /**
    * Update RowEncoder and recursively update the fields of the ProductEncoder if found.
    */
-  private def createEncoder(
-      enc: AgnosticEncoder[_],
-      dataType: DataType): AgnosticEncoder[_] = {
+  private def createEncoder(enc: AgnosticEncoder[_], dataType: DataType): AgnosticEncoder[_] = {
     enc match {
       case UnboundRowEncoder =>
         // Replace the row encoder with the encoder inferred from the schema.


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to fix the following compilation warning in `connect-jvm-client` module:

```
[warn] /spark/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/connect/client/SparkResult.scala:60:29: [deprecation @  | origin= | version=2.13.7] Top-level wildcard is not allowed and will error under -Xsource:3
[warn]   private def createEncoder[_](
```

### Why are the changes needed?
Fix compilation warning.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
- Pass GitHub Actions
- Manually checked,  there are no more related compilation warnings after this pr

