### PR TITLE
[SPARK-44397][PYTHON] Expose assertDataFrameEqual in pyspark.testing.utils

### DIFF
--- a/python/pyspark/testing/utils.py
+++ b/python/pyspark/testing/utils.py
@@ -55,6 +55,7 @@ except ImportError:
     # No NumPy, but that's okay, we'll skip those tests
     pass
 
+__all__ = ["assertDataFrameEqual"]
 
 SPARK_HOME = _find_spark_home()
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR adds the util function `assertDataFrameEqual` to the `__all__` list in `pyspark/testing/utils.py`.

### Why are the changes needed?
The change is needed to expose `assertDataFrameEqual`.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existing tests in `python/pyspark/sql/tests/test_utils.py` and `python/pyspark/sql/tests/connect/test_utils.py`