### PR TITLE
[MINOR][PYTHON] Fix PySpark error class get_error_message

### DIFF
--- a/python/pyspark/errors/utils.py
+++ b/python/pyspark/errors/utils.py
@@ -37,7 +37,7 @@ class ErrorClassesReader:
         # Verify message parameters.
         message_parameters_from_template = re.findall("<([a-zA-Z0-9_-]+)>", message_template)
         assert set(message_parameters_from_template) == set(message_parameters), (
-            f"Undifined error message parameter for error class: {error_class}. "
+            f"Undefined error message parameter for error class: {error_class}. "
             f"Parameters: {message_parameters}"
         )
         table = str.maketrans("<>", "{}")


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix message returned by PySpark ErrorClassesReader `get_error_message`

### Why are the changes needed?
The change corrects a typo in the error message returned for undefined error message parameters.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existing tests
