### PR TITLE
[SPARK-44264][ML][PYTHON] Refactoring TorchDistributor To Allow for Custom "run_training_on_file" Function Pointer

### DIFF
--- a/python/pyspark/ml/torch/distributor.py
+++ b/python/pyspark/ml/torch/distributor.py
@@ -545,7 +545,7 @@ class TorchDistributor(Distributor):
             Returns the result of the framework_wrapper
         """
         if not framework_wrapper:
-            raise RuntimeError("In the _get_output_from_framework_wrapper function, found a framework wrapper that is not set. framework_wrapper must always be a valid function pointer!")
+            raise RuntimeError("`framework_wrapper` is not set. ...")
         # The object to train is a file path, so framework_wrapper is some run_training_on_pytorch_file function.
         if type(train_object) is str:
             return framework_wrapper(input_params, train_object, *args, **kwargs)

--- a/python/pyspark/ml/torch/distributor.py
+++ b/python/pyspark/ml/torch/distributor.py
@@ -516,6 +516,30 @@ class TorchDistributor(Distributor):
             )
     @staticmethod  
     def _get_output_from_framework_wrapper(framework_wrapper: Optional[Callable], input_params: Dict, train_object: Union[Callable, str], run_pytorch_file_fn: Optional[Callable], *args, **kwargs) -> Optional[Any]:
+        """
+        This function is meant to get the output from framework wrapper function by passing in the correct arguments,
+        depending on the type of train_object.
+
+        Parameters
+        ----------
+        framework_wrapper: Optional[Callable]
+            Function pointer that will be invoked. Can either be the function that runs distributed training on
+            files if train_object is a string. Otherwise, it will be the function that runs distributed training
+            for functions if the train_object is a Callable
+        input_params: Dict
+            A dictionary that maps parameter to arguments for the command to be created.
+        train_object: Union[Callable, str]
+            Either a function to be used for distributed training, or a string representing the path of a 
+            file to be run in a distributed fashion.
+        run_pytorch_file_fn: Optional[Callable]
+            The function that will be used to run distributed training of a file; mainly used for the 
+            distributed training using a function.
+        *args: Any
+            Extra arguments to be used by framework wrapper.
+        **kwargs: Any
+            Extra keyword args to be used. Not currently supported but kept for future improvement.
+
+        """
         if not framework_wrapper:
             raise RuntimeError("In the _get_output_from_framework_wrapper function, found a framework wrapper that is none. I wonder why this is...")
         # The object to train is a file path, so framework_wrapper is some run_training_on_pytorch_file function.

--- a/python/pyspark/ml/torch/distributor.py
+++ b/python/pyspark/ml/torch/distributor.py
@@ -538,7 +538,11 @@ class TorchDistributor(Distributor):
             Extra arguments to be used by framework wrapper.
         **kwargs: Any
             Extra keyword args to be used. Not currently supported but kept for future improvement.
-
+        
+        Returns
+        -------
+        Optional[Any]
+            Returns the result of the framework_wrapper
         """
         if not framework_wrapper:
             raise RuntimeError("In the _get_output_from_framework_wrapper function, found a framework wrapper that is not set. framework_wrapper must always be a valid function pointer!")

--- a/python/pyspark/ml/torch/distributor.py
+++ b/python/pyspark/ml/torch/distributor.py
@@ -932,17 +932,20 @@ class TorchDistributor(Distributor):
             train_object is a Callable with an expected output. Returns None if train_object is
             a file.
         """
+        return self._run(train_object, TorchDistributor._run_training_on_pytorch_file, *args, **kwargs)
+
+    def _run(self, train_object: Union[Callable, str], run_training_on_pytorch_file_fn: Callable, *args: Any, **kwargs: Any) -> Optional[Any]:
         if isinstance(train_object, str):
-            framework_wrapper_fn = TorchDistributor._run_training_on_pytorch_file
+            framework_wrapper_fn = run_training_on_pytorch_file_fn
         else:
             framework_wrapper_fn = (
                 TorchDistributor._run_training_on_pytorch_function  # type: ignore
             )
         if self.local_mode:
-            output = self._run_local_training(framework_wrapper_fn, train_object, TorchDistributor._run_training_on_pytorch_file, *args, **kwargs)
+            output = self._run_local_training(framework_wrapper_fn, train_object, run_training_on_pytorch_file_fn, *args, **kwargs)
         else:
             output = self._run_distributed_training(
-                framework_wrapper_fn, train_object, TorchDistributor._run_training_on_pytorch_file, None, *args, **kwargs
+                framework_wrapper_fn, train_object, run_training_on_pytorch_file_fn, None, *args, **kwargs
             )
         return output
 

--- a/python/pyspark/ml/torch/distributor.py
+++ b/python/pyspark/ml/torch/distributor.py
@@ -541,7 +541,7 @@ class TorchDistributor(Distributor):
 
         """
         if not framework_wrapper:
-            raise RuntimeError("In the _get_output_from_framework_wrapper function, found a framework wrapper that is none. I wonder why this is...")
+            raise RuntimeError("In the _get_output_from_framework_wrapper function, found a framework wrapper that is not set. framework_wrapper must always be a valid function pointer!")
         # The object to train is a file path, so framework_wrapper is some run_training_on_pytorch_file function.
         if type(train_object) is str:
             return framework_wrapper(input_params, train_object, *args, **kwargs)

--- a/python/pyspark/ml/torch/distributor.py
+++ b/python/pyspark/ml/torch/distributor.py
@@ -998,6 +998,7 @@ class TorchDistributor(Distributor):
         return self._run_distributed_training(
             TorchDistributor._run_training_on_pytorch_function,
             train_function,
+            TorchDistributor._run_training_on_pytorch_file,
             spark_dataframe,
             *args,
             **kwargs,

--- a/python/pyspark/ml/torch/distributor.py
+++ b/python/pyspark/ml/torch/distributor.py
@@ -529,8 +529,9 @@ class TorchDistributor(Distributor):
         input_params: Dict
             A dictionary that maps parameter to arguments for the command to be created.
         train_object: Union[Callable, str]
-            Either a function to be used for distributed training, or a string representing the path of a 
-            file to be run in a distributed fashion.
+            This input comes from the user. If the user inputs a string, then this means it's a filepath.
+            Otherwise, if the input is a function, then this means that the user wants to run this 
+            function in a distributed manner. 
         run_pytorch_file_fn: Optional[Callable]
             The function that will be used to run distributed training of a file; mainly used for the 
             distributed training using a function.

--- a/python/pyspark/ml/torch/distributor.py
+++ b/python/pyspark/ml/torch/distributor.py
@@ -516,7 +516,7 @@ class TorchDistributor(Distributor):
                 f"The {last_n_msg} included below: {task_output}"
             )
     @staticmethod  
-    def _get_output_from_framework_wrapper(framework_wrapper: Optional[Callable], input_params: Dict, train_object: Union[Callable, str], run_training_on_pytorch_file: Optional[Callable], *args, **kwargs) -> Optional[Any]:
+    def _get_output_from_framework_wrapper(framework_wrapper: Optional[Callable], input_params: Dict, train_object: Union[Callable, str], run_pytorch_file_fn: Optional[Callable], *args, **kwargs) -> Optional[Any]:
         if not framework_wrapper:
             raise RuntimeError("In the _get_output_from_framework_wrapper function, found a framework wrapper that is none. I wonder why this is...")
         # The object to train is a file path, so framework_wrapper is some run_training_on_pytorch_file function.
@@ -524,9 +524,9 @@ class TorchDistributor(Distributor):
             return framework_wrapper(input_params, train_object, *args, **kwargs)
         else:
             # We are doing training with a function, will call run_training_on_pytorch_function
-            if not run_training_on_pytorch_file:
-                run_training_on_pytorch_file = TorchDistributor._run_training_on_pytorch_file
-            return framework_wrapper(input_params, train_object, run_training_on_pytorch_file, *args, **kwargs)
+            if not run_pytorch_file_fn:
+                run_pytorch_file_fn = TorchDistributor._run_training_on_pytorch_file
+            return framework_wrapper(input_params, train_object, run_pytorch_file_fn, *args, **kwargs)
 
         
 
@@ -534,7 +534,7 @@ class TorchDistributor(Distributor):
         self,
         framework_wrapper_fn: Callable,
         train_object: Union[Callable, str],
-        run_training_on_pytorch_file: Optional[Callable],
+        run_pytorch_file_fn: Optional[Callable],
         *args: Any,
         **kwargs: Any,
     ) -> Optional[Any]:
@@ -552,7 +552,7 @@ class TorchDistributor(Distributor):
                 os.environ[CUDA_VISIBLE_DEVICES] = ",".join(selected_gpus)
 
             self.logger.info(f"Started local training with {self.num_processes} processes")
-            output = TorchDistributor._get_output_from_framework_wrapper(framework_wrapper_fn, self.input_params, train_object, run_training_on_pytorch_file, *args, **kwargs)
+            output = TorchDistributor._get_output_from_framework_wrapper(framework_wrapper_fn, self.input_params, train_object, run_pytorch_file_fn, *args, **kwargs)
             self.logger.info(f"Finished local training with {self.num_processes} processes")
 
         finally:
@@ -568,7 +568,7 @@ class TorchDistributor(Distributor):
         self,
         framework_wrapper_fn: Optional[Callable],
         train_object: Union[Callable, str],
-        run_training_on_pytorch_file: Optional[Callable],
+        run_pytorch_file_fn: Optional[Callable],
         input_dataframe: Optional["DataFrame"],
         *args: Any,
         **kwargs: Any,
@@ -673,7 +673,7 @@ class TorchDistributor(Distributor):
             input_params["log_streaming_client"] = log_streaming_client
             try:
                 with TorchDistributor._setup_spark_partition_data(iterator, schema_json):
-                    output = TorchDistributor._get_output_from_framework_wrapper(framework_wrapper_fn, input_params,train_object, run_training_on_pytorch_file, *args, **kwargs)
+                    output = TorchDistributor._get_output_from_framework_wrapper(framework_wrapper_fn, input_params,train_object, run_pytorch_file_fn, *args, **kwargs)
             finally:
                 try:
                     LogStreamingClient._destroy()
@@ -703,7 +703,7 @@ class TorchDistributor(Distributor):
         self,
         framework_wrapper_fn: Callable,
         train_object: Union[Callable, str],
-        run_training_on_pytorch_file: Optional[Callable],
+        run_pytorch_file_fn: Optional[Callable],
         spark_dataframe: Optional["DataFrame"],
         *args: Any,
         **kwargs: Any,
@@ -720,7 +720,7 @@ class TorchDistributor(Distributor):
 
         try:
             spark_task_function = self._get_spark_task_function(
-                framework_wrapper_fn, train_object, run_training_on_pytorch_file, spark_dataframe, *args, **kwargs
+                framework_wrapper_fn, train_object, run_pytorch_file_fn, spark_dataframe, *args, **kwargs
             )
             self._check_encryption()
             self.logger.info(
@@ -822,17 +822,17 @@ class TorchDistributor(Distributor):
 
     @staticmethod
     def _run_training_on_pytorch_function(
-            input_params: Dict[str, Any], train_fn: Callable, run_training_on_pytorch_file: Optional[Callable], *args: Any, **kwargs: Any
+            input_params: Dict[str, Any], train_fn: Callable, run_pytorch_file_fn: Optional[Callable], *args: Any, **kwargs: Any
     ) -> Any:
 
-        if not run_training_on_pytorch_file:
-            run_training_on_pytorch_file = TorchDistributor._run_training_on_pytorch_file
+        if not run_pytorch_file_fn:
+            run_pytorch_file_fn = TorchDistributor._run_training_on_pytorch_file
 
         with TorchDistributor._setup_files(train_fn, *args, **kwargs) as (
             train_file_path,
             output_file_path,
         ):
-            run_training_on_pytorch_file(input_params, train_file_path)
+            run_pytorch_file_fn(input_params, train_file_path)
             if not os.path.exists(output_file_path):
                 raise RuntimeError(
                     "TorchDistributor failed during training."
@@ -934,18 +934,18 @@ class TorchDistributor(Distributor):
         """
         return self._run(train_object, TorchDistributor._run_training_on_pytorch_file, *args, **kwargs)
 
-    def _run(self, train_object: Union[Callable, str], run_training_on_pytorch_file_fn: Callable, *args: Any, **kwargs: Any) -> Optional[Any]:
+    def _run(self, train_object: Union[Callable, str], run_pytorch_file_fn: Callable, *args: Any, **kwargs: Any) -> Optional[Any]:
         if isinstance(train_object, str):
-            framework_wrapper_fn = run_training_on_pytorch_file_fn
+            framework_wrapper_fn = run_pytorch_file_fn
         else:
             framework_wrapper_fn = (
                 TorchDistributor._run_training_on_pytorch_function  # type: ignore
             )
         if self.local_mode:
-            output = self._run_local_training(framework_wrapper_fn, train_object, run_training_on_pytorch_file_fn, *args, **kwargs)
+            output = self._run_local_training(framework_wrapper_fn, train_object, run_pytorch_file_fn, *args, **kwargs)
         else:
             output = self._run_distributed_training(
-                framework_wrapper_fn, train_object, run_training_on_pytorch_file_fn, None, *args, **kwargs
+                framework_wrapper_fn, train_object, run_pytorch_file_fn, None, *args, **kwargs
             )
         return output
 

--- a/python/pyspark/ml/torch/distributor.py
+++ b/python/pyspark/ml/torch/distributor.py
@@ -41,7 +41,6 @@ from typing import (
 )
 
 from pyspark import cloudpickle
-from pyspark.pandas.missing import frame
 from pyspark.resource.information import ResourceInformation
 from pyspark.sql import DataFrame, SparkSession
 from pyspark.taskcontext import BarrierTaskContext

--- a/python/pyspark/ml/torch/tests/test_distributor.py
+++ b/python/pyspark/ml/torch/tests/test_distributor.py
@@ -463,7 +463,12 @@ class TorchDistributorDistributedUnitTestsMixin:
                 )
                 self.assertEqual(
                     expected,
-                    dist._run_distributed_training(dist._run_training_on_pytorch_file, "...", TorchDistributor._run_training_on_pytorch_file, None),
+                    dist._run_distributed_training(
+                        dist._run_training_on_pytorch_file,
+                        "...",
+                        TorchDistributor._run_training_on_pytorch_file,
+                        None,
+                    ),
                 )
 
     def test_get_num_tasks_distributed(self) -> None:
@@ -542,6 +547,8 @@ class TorchWrapperUnitTestsMixin:
 @unittest.skipIf(not have_torch, "torch is required")
 class TorchWrapperUnitTests(TorchWrapperUnitTestsMixin, unittest.TestCase):
     pass
+
+
 if __name__ == "__main__":
     from pyspark.ml.torch.tests.test_distributor import *  # noqa: F401,F403
 

--- a/python/pyspark/ml/torch/tests/test_distributor.py
+++ b/python/pyspark/ml/torch/tests/test_distributor.py
@@ -383,7 +383,7 @@ class TorchDistributorLocalUnitTestsMixin:
                 )
                 self.assertEqual(
                     expected,
-                    dist._run_local_training(dist._run_training_on_pytorch_file, "train.py"),
+                    dist._run_local_training(dist._run_training_on_pytorch_file, "train.py", None),
                 )
                 # cleanup
                 if cuda_env_var:
@@ -463,7 +463,7 @@ class TorchDistributorDistributedUnitTestsMixin:
                 )
                 self.assertEqual(
                     expected,
-                    dist._run_distributed_training(dist._run_training_on_pytorch_file, "...", None),
+                    dist._run_distributed_training(dist._run_training_on_pytorch_file, "...", TorchDistributor._run_training_on_pytorch_file, None),
                 )
 
     def test_get_num_tasks_distributed(self) -> None:
@@ -542,8 +542,6 @@ class TorchWrapperUnitTestsMixin:
 @unittest.skipIf(not have_torch, "torch is required")
 class TorchWrapperUnitTests(TorchWrapperUnitTestsMixin, unittest.TestCase):
     pass
-
-
 if __name__ == "__main__":
     from pyspark.ml.torch.tests.test_distributor import *  # noqa: F401,F403
 


### PR DESCRIPTION
### What Was Changed
We enable for a custom function pointer to be passed around the private functions that allow for distributed training of a function. 

### Why Do We Need This Change

By abstracting the "run_training_on_pytorch_file" function to something that can be passed in, it allows for much easier creation of distributors that run on top of torch.distributed. Specifically, it makes it easy to implement distributed training of picklable functions in DeepspeedTorchDistributor. As mentioned, if there are accelerators that come out in the future built on top of torch.distributed, it will be very easy to support them in Spark. One can simply do the following:
1. Inherit from TorchDistributor and define a _run_training_on_pytorch_file function or equivalent for your class
2.  When defining run(...), simply return _run() and pass in your custom _run_training_on_pytorch_file function in as the respective argument

### Any User-Facing Changes?
No.

### How Is This Tested?

The existing tests for TorchDistributor.