### PR TITLE
[SPARK-44348][TESTS][PYTHON][FOLLOW-UP] Reduces the memory used in local-cluster tests

### DIFF
--- a/python/pyspark/sql/tests/connect/client/test_artifact.py
+++ b/python/pyspark/sql/tests/connect/client/test_artifact.py
@@ -397,7 +397,7 @@ class LocalClusterArtifactTests(ReusedConnectTestCase, ArtifactTestsMixin):
 
     @classmethod
     def master(cls):
-        return "local-cluster[2,2,1024]"
+        return "local-cluster[2,2,512]"
 
 
 if __name__ == "__main__":

--- a/python/pyspark/sql/tests/connect/client/test_artifact.py
+++ b/python/pyspark/sql/tests/connect/client/test_artifact.py
@@ -391,6 +391,12 @@ class ArtifactTests(ReusedConnectTestCase, ArtifactTestsMixin):
 
 class LocalClusterArtifactTests(ReusedConnectTestCase, ArtifactTestsMixin):
     @classmethod
+    def conf(cls):
+        return (
+            super().conf().set("spark.driver.memory", "512M").set("spark.executor.memory", "512M")
+        )
+
+    @classmethod
     def root(cls):
         # In local cluster, we can mimic the production usage.
         return "."


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/41942 that reduces the memory used in tests.

### Why are the changes needed?

To reduce the memory used in GitHub Actions test. This is consistent with:

https://github.com/apache/spark/blob/master/python/pyspark/ml/tests/connect/test_parity_torch_distributor.py#L67C55-L67C58

See also https://github.com/apache/spark/pull/40874

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Manually ran the tests in my local to verify the change.