### PR TITLE
[SPARK-32268][SQL][FOLLOWUP] Filter creation side size threshold judgment should prun column in injectBloomFilter

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InjectRuntimeFilter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InjectRuntimeFilter.scala
@@ -73,7 +73,9 @@ object InjectRuntimeFilter extends Rule[LogicalPlan] with PredicateHelper with J
       filterCreationSideExp: Expression,
       filterCreationSidePlan: LogicalPlan): LogicalPlan = {
     // Skip if the filter creation side is too big
-    if (filterCreationSidePlan.stats.sizeInBytes > conf.runtimeFilterCreationSideThreshold) {
+    val sizeInBytes = Aggregate(Seq(filterCreationSideExp), Nil, filterCreationSidePlan)
+      .stats.sizeInBytes
+    if (sizeInBytes > conf.runtimeFilterCreationSideThreshold) {
       return filterApplicationSidePlan
     }
     val rowCount = filterCreationSidePlan.stats.rowCount

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q12.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q12.sf100/explain.txt
@@ -37,7 +37,7 @@ Input [3]: [ws_item_sk#1, ws_ext_sales_price#2, ws_sold_date_sk#3]
 
 (3) Filter [codegen id : 1]
 Input [3]: [ws_item_sk#1, ws_ext_sales_price#2, ws_sold_date_sk#3]
-Condition : isnotnull(ws_item_sk#1)
+Condition : (isnotnull(ws_item_sk#1) AND might_contain(Subquery scalar-subquery#5, [id=#6], xxhash64(ws_item_sk#1, 42)))
 
 (4) Exchange
 Input [3]: [ws_item_sk#1, ws_ext_sales_price#2, ws_sold_date_sk#3]
@@ -48,118 +48,164 @@ Input [3]: [ws_item_sk#1, ws_ext_sales_price#2, ws_sold_date_sk#3]
 Arguments: [ws_item_sk#1 ASC NULLS FIRST], false, 0
 
 (6) Scan parquet spark_catalog.default.item
-Output [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
+Output [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [In(i_category, [Books                                             ,Home                                              ,Sports                                            ]), IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_item_id:string,i_item_desc:string,i_current_price:decimal(7,2),i_class:string,i_category:string>
 
 (7) ColumnarToRow [codegen id : 3]
-Input [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
+Input [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
 
 (8) Filter [codegen id : 3]
-Input [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Condition : (i_category#10 IN (Sports                                            ,Books                                             ,Home                                              ) AND isnotnull(i_item_sk#5))
+Input [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Condition : (i_category#12 IN (Sports                                            ,Books                                             ,Home                                              ) AND isnotnull(i_item_sk#7))
 
 (9) Exchange
-Input [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Arguments: hashpartitioning(i_item_sk#5, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+Input [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Arguments: hashpartitioning(i_item_sk#7, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
 (10) Sort [codegen id : 4]
-Input [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Arguments: [i_item_sk#5 ASC NULLS FIRST], false, 0
+Input [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Arguments: [i_item_sk#7 ASC NULLS FIRST], false, 0
 
 (11) SortMergeJoin [codegen id : 6]
 Left keys [1]: [ws_item_sk#1]
-Right keys [1]: [i_item_sk#5]
+Right keys [1]: [i_item_sk#7]
 Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 6]
-Output [7]: [ws_ext_sales_price#2, ws_sold_date_sk#3, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Input [9]: [ws_item_sk#1, ws_ext_sales_price#2, ws_sold_date_sk#3, i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
+Output [7]: [ws_ext_sales_price#2, ws_sold_date_sk#3, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Input [9]: [ws_item_sk#1, ws_ext_sales_price#2, ws_sold_date_sk#3, i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
 
-(13) ReusedExchange [Reuses operator id: 28]
-Output [1]: [d_date_sk#11]
+(13) ReusedExchange [Reuses operator id: 35]
+Output [1]: [d_date_sk#13]
 
 (14) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ws_sold_date_sk#3]
-Right keys [1]: [d_date_sk#11]
+Right keys [1]: [d_date_sk#13]
 Join type: Inner
 Join condition: None
 
 (15) Project [codegen id : 6]
-Output [6]: [ws_ext_sales_price#2, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Input [8]: [ws_ext_sales_price#2, ws_sold_date_sk#3, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10, d_date_sk#11]
+Output [6]: [ws_ext_sales_price#2, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Input [8]: [ws_ext_sales_price#2, ws_sold_date_sk#3, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12, d_date_sk#13]
 
 (16) HashAggregate [codegen id : 6]
-Input [6]: [ws_ext_sales_price#2, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Keys [5]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8]
+Input [6]: [ws_ext_sales_price#2, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Keys [5]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10]
 Functions [1]: [partial_sum(UnscaledValue(ws_ext_sales_price#2))]
-Aggregate Attributes [1]: [sum#12]
-Results [6]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, sum#13]
+Aggregate Attributes [1]: [sum#14]
+Results [6]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, sum#15]
 
 (17) Exchange
-Input [6]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, sum#13]
-Arguments: hashpartitioning(i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+Input [6]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, sum#15]
+Arguments: hashpartitioning(i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (18) HashAggregate [codegen id : 7]
-Input [6]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, sum#13]
-Keys [5]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8]
+Input [6]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, sum#15]
+Keys [5]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10]
 Functions [1]: [sum(UnscaledValue(ws_ext_sales_price#2))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ws_ext_sales_price#2))#14]
-Results [7]: [i_item_desc#7, i_category#10, i_class#9, i_current_price#8, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#2))#14,17,2) AS itemrevenue#15, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#2))#14,17,2) AS _w0#16, i_item_id#6]
+Aggregate Attributes [1]: [sum(UnscaledValue(ws_ext_sales_price#2))#16]
+Results [7]: [i_item_desc#9, i_category#12, i_class#11, i_current_price#10, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#2))#16,17,2) AS itemrevenue#17, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#2))#16,17,2) AS _w0#18, i_item_id#8]
 
 (19) Exchange
-Input [7]: [i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, _w0#16, i_item_id#6]
-Arguments: hashpartitioning(i_class#9, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+Input [7]: [i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, _w0#18, i_item_id#8]
+Arguments: hashpartitioning(i_class#11, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
 (20) Sort [codegen id : 8]
-Input [7]: [i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, _w0#16, i_item_id#6]
-Arguments: [i_class#9 ASC NULLS FIRST], false, 0
+Input [7]: [i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, _w0#18, i_item_id#8]
+Arguments: [i_class#11 ASC NULLS FIRST], false, 0
 
 (21) Window
-Input [7]: [i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, _w0#16, i_item_id#6]
-Arguments: [sum(_w0#16) windowspecdefinition(i_class#9, specifiedwindowframe(RowFrame, unboundedpreceding$(), unboundedfollowing$())) AS _we0#17], [i_class#9]
+Input [7]: [i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, _w0#18, i_item_id#8]
+Arguments: [sum(_w0#18) windowspecdefinition(i_class#11, specifiedwindowframe(RowFrame, unboundedpreceding$(), unboundedfollowing$())) AS _we0#19], [i_class#11]
 
 (22) Project [codegen id : 9]
-Output [7]: [i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, ((_w0#16 * 100) / _we0#17) AS revenueratio#18, i_item_id#6]
-Input [8]: [i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, _w0#16, i_item_id#6, _we0#17]
+Output [7]: [i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, ((_w0#18 * 100) / _we0#19) AS revenueratio#20, i_item_id#8]
+Input [8]: [i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, _w0#18, i_item_id#8, _we0#19]
 
 (23) TakeOrderedAndProject
-Input [7]: [i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, revenueratio#18, i_item_id#6]
-Arguments: 100, [i_category#10 ASC NULLS FIRST, i_class#9 ASC NULLS FIRST, i_item_id#6 ASC NULLS FIRST, i_item_desc#7 ASC NULLS FIRST, revenueratio#18 ASC NULLS FIRST], [i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, revenueratio#18]
+Input [7]: [i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, revenueratio#20, i_item_id#8]
+Arguments: 100, [i_category#12 ASC NULLS FIRST, i_class#11 ASC NULLS FIRST, i_item_id#8 ASC NULLS FIRST, i_item_desc#9 ASC NULLS FIRST, revenueratio#20 ASC NULLS FIRST], [i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, revenueratio#20]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 1 Hosting Expression = ws_sold_date_sk#3 IN dynamicpruning#4
-BroadcastExchange (28)
-+- * Project (27)
-   +- * Filter (26)
-      +- * ColumnarToRow (25)
-         +- Scan parquet spark_catalog.default.date_dim (24)
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#5, [id=#6]
+ObjectHashAggregate (30)
++- Exchange (29)
+   +- ObjectHashAggregate (28)
+      +- * Project (27)
+         +- * Filter (26)
+            +- * ColumnarToRow (25)
+               +- Scan parquet spark_catalog.default.item (24)
 
 
-(24) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#11, d_date#19]
+(24) Scan parquet spark_catalog.default.item
+Output [2]: [i_item_sk#7, i_category#12]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/item]
+PushedFilters: [In(i_category, [Books                                             ,Home                                              ,Sports                                            ]), IsNotNull(i_item_sk)]
+ReadSchema: struct<i_item_sk:int,i_category:string>
+
+(25) ColumnarToRow [codegen id : 1]
+Input [2]: [i_item_sk#7, i_category#12]
+
+(26) Filter [codegen id : 1]
+Input [2]: [i_item_sk#7, i_category#12]
+Condition : (i_category#12 IN (Sports                                            ,Books                                             ,Home                                              ) AND isnotnull(i_item_sk#7))
+
+(27) Project [codegen id : 1]
+Output [1]: [i_item_sk#7]
+Input [2]: [i_item_sk#7, i_category#12]
+
+(28) ObjectHashAggregate
+Input [1]: [i_item_sk#7]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#7, 42), 61200, 979099, 0, 0)]
+Aggregate Attributes [1]: [buf#21]
+Results [1]: [buf#22]
+
+(29) Exchange
+Input [1]: [buf#22]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=5]
+
+(30) ObjectHashAggregate
+Input [1]: [buf#22]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#7, 42), 61200, 979099, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#7, 42), 61200, 979099, 0, 0)#23]
+Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#7, 42), 61200, 979099, 0, 0)#23 AS bloomFilter#24]
+
+Subquery:2 Hosting operator id = 1 Hosting Expression = ws_sold_date_sk#3 IN dynamicpruning#4
+BroadcastExchange (35)
++- * Project (34)
+   +- * Filter (33)
+      +- * ColumnarToRow (32)
+         +- Scan parquet spark_catalog.default.date_dim (31)
+
+
+(31) Scan parquet spark_catalog.default.date_dim
+Output [2]: [d_date_sk#13, d_date#25]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,1999-02-22), LessThanOrEqual(d_date,1999-03-24), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
-(25) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#11, d_date#19]
+(32) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#13, d_date#25]
 
-(26) Filter [codegen id : 1]
-Input [2]: [d_date_sk#11, d_date#19]
-Condition : (((isnotnull(d_date#19) AND (d_date#19 >= 1999-02-22)) AND (d_date#19 <= 1999-03-24)) AND isnotnull(d_date_sk#11))
+(33) Filter [codegen id : 1]
+Input [2]: [d_date_sk#13, d_date#25]
+Condition : (((isnotnull(d_date#25) AND (d_date#25 >= 1999-02-22)) AND (d_date#25 <= 1999-03-24)) AND isnotnull(d_date_sk#13))
 
-(27) Project [codegen id : 1]
-Output [1]: [d_date_sk#11]
-Input [2]: [d_date_sk#11, d_date#19]
+(34) Project [codegen id : 1]
+Output [1]: [d_date_sk#13]
+Input [2]: [d_date_sk#13, d_date#25]
 
-(28) BroadcastExchange
-Input [1]: [d_date_sk#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
+(35) BroadcastExchange
+Input [1]: [d_date_sk#13]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=6]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q12.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q12.sf100/simplified.txt
@@ -24,6 +24,16 @@ TakeOrderedAndProject [i_category,i_class,i_item_id,i_item_desc,revenueratio,i_c
                                               Exchange [ws_item_sk] #3
                                                 WholeStageCodegen (1)
                                                   Filter [ws_item_sk]
+                                                    Subquery #2
+                                                      ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(i_item_sk, 42), 61200, 979099, 0, 0),bloomFilter,buf]
+                                                        Exchange #5
+                                                          ObjectHashAggregate [i_item_sk] [buf,buf]
+                                                            WholeStageCodegen (1)
+                                                              Project [i_item_sk]
+                                                                Filter [i_category,i_item_sk]
+                                                                  ColumnarToRow
+                                                                    InputAdapter
+                                                                      Scan parquet spark_catalog.default.item [i_item_sk,i_category]
                                                     ColumnarToRow
                                                       InputAdapter
                                                         Scan parquet spark_catalog.default.web_sales [ws_item_sk,ws_ext_sales_price,ws_sold_date_sk]
@@ -39,7 +49,7 @@ TakeOrderedAndProject [i_category,i_class,i_item_id,i_item_desc,revenueratio,i_c
                                         WholeStageCodegen (4)
                                           Sort [i_item_sk]
                                             InputAdapter
-                                              Exchange [i_item_sk] #5
+                                              Exchange [i_item_sk] #6
                                                 WholeStageCodegen (3)
                                                   Filter [i_category,i_item_sk]
                                                     ColumnarToRow

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q18.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q18.sf100/explain.txt
@@ -63,249 +63,295 @@ Input [9]: [cs_bill_customer_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#3, cs_quantity
 
 (3) Filter [codegen id : 4]
 Input [9]: [cs_bill_customer_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9]
-Condition : ((isnotnull(cs_bill_cdemo_sk#2) AND isnotnull(cs_bill_customer_sk#1)) AND isnotnull(cs_item_sk#3))
+Condition : (((isnotnull(cs_bill_cdemo_sk#2) AND isnotnull(cs_bill_customer_sk#1)) AND isnotnull(cs_item_sk#3)) AND might_contain(Subquery scalar-subquery#11, [id=#12], xxhash64(cs_bill_customer_sk#1, 42)))
 
 (4) Scan parquet spark_catalog.default.customer_demographics
-Output [4]: [cd_demo_sk#11, cd_gender#12, cd_education_status#13, cd_dep_count#14]
+Output [4]: [cd_demo_sk#13, cd_gender#14, cd_education_status#15, cd_dep_count#16]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_demographics]
 PushedFilters: [IsNotNull(cd_gender), IsNotNull(cd_education_status), EqualTo(cd_gender,F), EqualTo(cd_education_status,Unknown             ), IsNotNull(cd_demo_sk)]
 ReadSchema: struct<cd_demo_sk:int,cd_gender:string,cd_education_status:string,cd_dep_count:int>
 
 (5) ColumnarToRow [codegen id : 1]
-Input [4]: [cd_demo_sk#11, cd_gender#12, cd_education_status#13, cd_dep_count#14]
+Input [4]: [cd_demo_sk#13, cd_gender#14, cd_education_status#15, cd_dep_count#16]
 
 (6) Filter [codegen id : 1]
-Input [4]: [cd_demo_sk#11, cd_gender#12, cd_education_status#13, cd_dep_count#14]
-Condition : ((((isnotnull(cd_gender#12) AND isnotnull(cd_education_status#13)) AND (cd_gender#12 = F)) AND (cd_education_status#13 = Unknown             )) AND isnotnull(cd_demo_sk#11))
+Input [4]: [cd_demo_sk#13, cd_gender#14, cd_education_status#15, cd_dep_count#16]
+Condition : ((((isnotnull(cd_gender#14) AND isnotnull(cd_education_status#15)) AND (cd_gender#14 = F)) AND (cd_education_status#15 = Unknown             )) AND isnotnull(cd_demo_sk#13))
 
 (7) Project [codegen id : 1]
-Output [2]: [cd_demo_sk#11, cd_dep_count#14]
-Input [4]: [cd_demo_sk#11, cd_gender#12, cd_education_status#13, cd_dep_count#14]
+Output [2]: [cd_demo_sk#13, cd_dep_count#16]
+Input [4]: [cd_demo_sk#13, cd_gender#14, cd_education_status#15, cd_dep_count#16]
 
 (8) BroadcastExchange
-Input [2]: [cd_demo_sk#11, cd_dep_count#14]
+Input [2]: [cd_demo_sk#13, cd_dep_count#16]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
 
 (9) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_bill_cdemo_sk#2]
-Right keys [1]: [cd_demo_sk#11]
+Right keys [1]: [cd_demo_sk#13]
 Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 4]
-Output [9]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9, cd_dep_count#14]
-Input [11]: [cs_bill_customer_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9, cd_demo_sk#11, cd_dep_count#14]
+Output [9]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9, cd_dep_count#16]
+Input [11]: [cs_bill_customer_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9, cd_demo_sk#13, cd_dep_count#16]
 
-(11) ReusedExchange [Reuses operator id: 54]
-Output [1]: [d_date_sk#15]
+(11) ReusedExchange [Reuses operator id: 61]
+Output [1]: [d_date_sk#17]
 
 (12) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_sold_date_sk#9]
-Right keys [1]: [d_date_sk#15]
+Right keys [1]: [d_date_sk#17]
 Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 4]
-Output [8]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14]
-Input [10]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9, cd_dep_count#14, d_date_sk#15]
+Output [8]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#16]
+Input [10]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9, cd_dep_count#16, d_date_sk#17]
 
 (14) Scan parquet spark_catalog.default.item
-Output [2]: [i_item_sk#16, i_item_id#17]
+Output [2]: [i_item_sk#18, i_item_id#19]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_item_id:string>
 
 (15) ColumnarToRow [codegen id : 3]
-Input [2]: [i_item_sk#16, i_item_id#17]
+Input [2]: [i_item_sk#18, i_item_id#19]
 
 (16) Filter [codegen id : 3]
-Input [2]: [i_item_sk#16, i_item_id#17]
-Condition : isnotnull(i_item_sk#16)
+Input [2]: [i_item_sk#18, i_item_id#19]
+Condition : isnotnull(i_item_sk#18)
 
 (17) BroadcastExchange
-Input [2]: [i_item_sk#16, i_item_id#17]
+Input [2]: [i_item_sk#18, i_item_id#19]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=2]
 
 (18) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_item_sk#3]
-Right keys [1]: [i_item_sk#16]
+Right keys [1]: [i_item_sk#18]
 Join type: Inner
 Join condition: None
 
 (19) Project [codegen id : 4]
-Output [8]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, i_item_id#17]
-Input [10]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, i_item_sk#16, i_item_id#17]
+Output [8]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#16, i_item_id#19]
+Input [10]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#16, i_item_sk#18, i_item_id#19]
 
 (20) Exchange
-Input [8]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, i_item_id#17]
+Input [8]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#16, i_item_id#19]
 Arguments: hashpartitioning(cs_bill_customer_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (21) Sort [codegen id : 5]
-Input [8]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, i_item_id#17]
+Input [8]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#16, i_item_id#19]
 Arguments: [cs_bill_customer_sk#1 ASC NULLS FIRST], false, 0
 
 (22) Scan parquet spark_catalog.default.customer
-Output [5]: [c_customer_sk#18, c_current_cdemo_sk#19, c_current_addr_sk#20, c_birth_month#21, c_birth_year#22]
+Output [5]: [c_customer_sk#20, c_current_cdemo_sk#21, c_current_addr_sk#22, c_birth_month#23, c_birth_year#24]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer]
 PushedFilters: [In(c_birth_month, [1,12,2,6,8,9]), IsNotNull(c_customer_sk), IsNotNull(c_current_cdemo_sk), IsNotNull(c_current_addr_sk)]
 ReadSchema: struct<c_customer_sk:int,c_current_cdemo_sk:int,c_current_addr_sk:int,c_birth_month:int,c_birth_year:int>
 
 (23) ColumnarToRow [codegen id : 7]
-Input [5]: [c_customer_sk#18, c_current_cdemo_sk#19, c_current_addr_sk#20, c_birth_month#21, c_birth_year#22]
+Input [5]: [c_customer_sk#20, c_current_cdemo_sk#21, c_current_addr_sk#22, c_birth_month#23, c_birth_year#24]
 
 (24) Filter [codegen id : 7]
-Input [5]: [c_customer_sk#18, c_current_cdemo_sk#19, c_current_addr_sk#20, c_birth_month#21, c_birth_year#22]
-Condition : (((c_birth_month#21 IN (1,6,8,9,12,2) AND isnotnull(c_customer_sk#18)) AND isnotnull(c_current_cdemo_sk#19)) AND isnotnull(c_current_addr_sk#20))
+Input [5]: [c_customer_sk#20, c_current_cdemo_sk#21, c_current_addr_sk#22, c_birth_month#23, c_birth_year#24]
+Condition : (((c_birth_month#23 IN (1,6,8,9,12,2) AND isnotnull(c_customer_sk#20)) AND isnotnull(c_current_cdemo_sk#21)) AND isnotnull(c_current_addr_sk#22))
 
 (25) Project [codegen id : 7]
-Output [4]: [c_customer_sk#18, c_current_cdemo_sk#19, c_current_addr_sk#20, c_birth_year#22]
-Input [5]: [c_customer_sk#18, c_current_cdemo_sk#19, c_current_addr_sk#20, c_birth_month#21, c_birth_year#22]
+Output [4]: [c_customer_sk#20, c_current_cdemo_sk#21, c_current_addr_sk#22, c_birth_year#24]
+Input [5]: [c_customer_sk#20, c_current_cdemo_sk#21, c_current_addr_sk#22, c_birth_month#23, c_birth_year#24]
 
 (26) Scan parquet spark_catalog.default.customer_address
-Output [4]: [ca_address_sk#23, ca_county#24, ca_state#25, ca_country#26]
+Output [4]: [ca_address_sk#25, ca_county#26, ca_state#27, ca_country#28]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [In(ca_state, [IN,MS,ND,NM,OK,VA]), IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_county:string,ca_state:string,ca_country:string>
 
 (27) ColumnarToRow [codegen id : 6]
-Input [4]: [ca_address_sk#23, ca_county#24, ca_state#25, ca_country#26]
+Input [4]: [ca_address_sk#25, ca_county#26, ca_state#27, ca_country#28]
 
 (28) Filter [codegen id : 6]
-Input [4]: [ca_address_sk#23, ca_county#24, ca_state#25, ca_country#26]
-Condition : (ca_state#25 IN (MS,IN,ND,OK,NM,VA) AND isnotnull(ca_address_sk#23))
+Input [4]: [ca_address_sk#25, ca_county#26, ca_state#27, ca_country#28]
+Condition : (ca_state#27 IN (MS,IN,ND,OK,NM,VA) AND isnotnull(ca_address_sk#25))
 
 (29) BroadcastExchange
-Input [4]: [ca_address_sk#23, ca_county#24, ca_state#25, ca_country#26]
+Input [4]: [ca_address_sk#25, ca_county#26, ca_state#27, ca_country#28]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=4]
 
 (30) BroadcastHashJoin [codegen id : 7]
-Left keys [1]: [c_current_addr_sk#20]
-Right keys [1]: [ca_address_sk#23]
+Left keys [1]: [c_current_addr_sk#22]
+Right keys [1]: [ca_address_sk#25]
 Join type: Inner
 Join condition: None
 
 (31) Project [codegen id : 7]
-Output [6]: [c_customer_sk#18, c_current_cdemo_sk#19, c_birth_year#22, ca_county#24, ca_state#25, ca_country#26]
-Input [8]: [c_customer_sk#18, c_current_cdemo_sk#19, c_current_addr_sk#20, c_birth_year#22, ca_address_sk#23, ca_county#24, ca_state#25, ca_country#26]
+Output [6]: [c_customer_sk#20, c_current_cdemo_sk#21, c_birth_year#24, ca_county#26, ca_state#27, ca_country#28]
+Input [8]: [c_customer_sk#20, c_current_cdemo_sk#21, c_current_addr_sk#22, c_birth_year#24, ca_address_sk#25, ca_county#26, ca_state#27, ca_country#28]
 
 (32) Exchange
-Input [6]: [c_customer_sk#18, c_current_cdemo_sk#19, c_birth_year#22, ca_county#24, ca_state#25, ca_country#26]
-Arguments: hashpartitioning(c_current_cdemo_sk#19, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+Input [6]: [c_customer_sk#20, c_current_cdemo_sk#21, c_birth_year#24, ca_county#26, ca_state#27, ca_country#28]
+Arguments: hashpartitioning(c_current_cdemo_sk#21, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
 (33) Sort [codegen id : 8]
-Input [6]: [c_customer_sk#18, c_current_cdemo_sk#19, c_birth_year#22, ca_county#24, ca_state#25, ca_country#26]
-Arguments: [c_current_cdemo_sk#19 ASC NULLS FIRST], false, 0
+Input [6]: [c_customer_sk#20, c_current_cdemo_sk#21, c_birth_year#24, ca_county#26, ca_state#27, ca_country#28]
+Arguments: [c_current_cdemo_sk#21 ASC NULLS FIRST], false, 0
 
 (34) Scan parquet spark_catalog.default.customer_demographics
-Output [1]: [cd_demo_sk#27]
+Output [1]: [cd_demo_sk#29]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_demographics]
 PushedFilters: [IsNotNull(cd_demo_sk)]
 ReadSchema: struct<cd_demo_sk:int>
 
 (35) ColumnarToRow [codegen id : 9]
-Input [1]: [cd_demo_sk#27]
+Input [1]: [cd_demo_sk#29]
 
 (36) Filter [codegen id : 9]
-Input [1]: [cd_demo_sk#27]
-Condition : isnotnull(cd_demo_sk#27)
+Input [1]: [cd_demo_sk#29]
+Condition : isnotnull(cd_demo_sk#29)
 
 (37) Exchange
-Input [1]: [cd_demo_sk#27]
-Arguments: hashpartitioning(cd_demo_sk#27, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+Input [1]: [cd_demo_sk#29]
+Arguments: hashpartitioning(cd_demo_sk#29, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
 (38) Sort [codegen id : 10]
-Input [1]: [cd_demo_sk#27]
-Arguments: [cd_demo_sk#27 ASC NULLS FIRST], false, 0
+Input [1]: [cd_demo_sk#29]
+Arguments: [cd_demo_sk#29 ASC NULLS FIRST], false, 0
 
 (39) SortMergeJoin [codegen id : 11]
-Left keys [1]: [c_current_cdemo_sk#19]
-Right keys [1]: [cd_demo_sk#27]
+Left keys [1]: [c_current_cdemo_sk#21]
+Right keys [1]: [cd_demo_sk#29]
 Join type: Inner
 Join condition: None
 
 (40) Project [codegen id : 11]
-Output [5]: [c_customer_sk#18, c_birth_year#22, ca_county#24, ca_state#25, ca_country#26]
-Input [7]: [c_customer_sk#18, c_current_cdemo_sk#19, c_birth_year#22, ca_county#24, ca_state#25, ca_country#26, cd_demo_sk#27]
+Output [5]: [c_customer_sk#20, c_birth_year#24, ca_county#26, ca_state#27, ca_country#28]
+Input [7]: [c_customer_sk#20, c_current_cdemo_sk#21, c_birth_year#24, ca_county#26, ca_state#27, ca_country#28, cd_demo_sk#29]
 
 (41) Exchange
-Input [5]: [c_customer_sk#18, c_birth_year#22, ca_county#24, ca_state#25, ca_country#26]
-Arguments: hashpartitioning(c_customer_sk#18, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+Input [5]: [c_customer_sk#20, c_birth_year#24, ca_county#26, ca_state#27, ca_country#28]
+Arguments: hashpartitioning(c_customer_sk#20, 5), ENSURE_REQUIREMENTS, [plan_id=7]
 
 (42) Sort [codegen id : 12]
-Input [5]: [c_customer_sk#18, c_birth_year#22, ca_county#24, ca_state#25, ca_country#26]
-Arguments: [c_customer_sk#18 ASC NULLS FIRST], false, 0
+Input [5]: [c_customer_sk#20, c_birth_year#24, ca_county#26, ca_state#27, ca_country#28]
+Arguments: [c_customer_sk#20 ASC NULLS FIRST], false, 0
 
 (43) SortMergeJoin [codegen id : 13]
 Left keys [1]: [cs_bill_customer_sk#1]
-Right keys [1]: [c_customer_sk#18]
+Right keys [1]: [c_customer_sk#20]
 Join type: Inner
 Join condition: None
 
 (44) Project [codegen id : 13]
-Output [11]: [cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, c_birth_year#22, i_item_id#17, ca_country#26, ca_state#25, ca_county#24]
-Input [13]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, i_item_id#17, c_customer_sk#18, c_birth_year#22, ca_county#24, ca_state#25, ca_country#26]
+Output [11]: [cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#16, c_birth_year#24, i_item_id#19, ca_country#28, ca_state#27, ca_county#26]
+Input [13]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#16, i_item_id#19, c_customer_sk#20, c_birth_year#24, ca_county#26, ca_state#27, ca_country#28]
 
 (45) Expand [codegen id : 13]
-Input [11]: [cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, c_birth_year#22, i_item_id#17, ca_country#26, ca_state#25, ca_county#24]
-Arguments: [[cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, c_birth_year#22, i_item_id#17, ca_country#26, ca_state#25, ca_county#24, 0], [cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, c_birth_year#22, i_item_id#17, ca_country#26, ca_state#25, null, 1], [cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, c_birth_year#22, i_item_id#17, ca_country#26, null, null, 3], [cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, c_birth_year#22, i_item_id#17, null, null, null, 7], [cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, c_birth_year#22, null, null, null, null, 15]], [cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, c_birth_year#22, i_item_id#28, ca_country#29, ca_state#30, ca_county#31, spark_grouping_id#32]
+Input [11]: [cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#16, c_birth_year#24, i_item_id#19, ca_country#28, ca_state#27, ca_county#26]
+Arguments: [[cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#16, c_birth_year#24, i_item_id#19, ca_country#28, ca_state#27, ca_county#26, 0], [cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#16, c_birth_year#24, i_item_id#19, ca_country#28, ca_state#27, null, 1], [cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#16, c_birth_year#24, i_item_id#19, ca_country#28, null, null, 3], [cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#16, c_birth_year#24, i_item_id#19, null, null, null, 7], [cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#16, c_birth_year#24, null, null, null, null, 15]], [cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#16, c_birth_year#24, i_item_id#30, ca_country#31, ca_state#32, ca_county#33, spark_grouping_id#34]
 
 (46) HashAggregate [codegen id : 13]
-Input [12]: [cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, c_birth_year#22, i_item_id#28, ca_country#29, ca_state#30, ca_county#31, spark_grouping_id#32]
-Keys [5]: [i_item_id#28, ca_country#29, ca_state#30, ca_county#31, spark_grouping_id#32]
-Functions [7]: [partial_avg(cast(cs_quantity#4 as decimal(12,2))), partial_avg(cast(cs_list_price#5 as decimal(12,2))), partial_avg(cast(cs_coupon_amt#7 as decimal(12,2))), partial_avg(cast(cs_sales_price#6 as decimal(12,2))), partial_avg(cast(cs_net_profit#8 as decimal(12,2))), partial_avg(cast(c_birth_year#22 as decimal(12,2))), partial_avg(cast(cd_dep_count#14 as decimal(12,2)))]
-Aggregate Attributes [14]: [sum#33, count#34, sum#35, count#36, sum#37, count#38, sum#39, count#40, sum#41, count#42, sum#43, count#44, sum#45, count#46]
-Results [19]: [i_item_id#28, ca_country#29, ca_state#30, ca_county#31, spark_grouping_id#32, sum#47, count#48, sum#49, count#50, sum#51, count#52, sum#53, count#54, sum#55, count#56, sum#57, count#58, sum#59, count#60]
+Input [12]: [cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#16, c_birth_year#24, i_item_id#30, ca_country#31, ca_state#32, ca_county#33, spark_grouping_id#34]
+Keys [5]: [i_item_id#30, ca_country#31, ca_state#32, ca_county#33, spark_grouping_id#34]
+Functions [7]: [partial_avg(cast(cs_quantity#4 as decimal(12,2))), partial_avg(cast(cs_list_price#5 as decimal(12,2))), partial_avg(cast(cs_coupon_amt#7 as decimal(12,2))), partial_avg(cast(cs_sales_price#6 as decimal(12,2))), partial_avg(cast(cs_net_profit#8 as decimal(12,2))), partial_avg(cast(c_birth_year#24 as decimal(12,2))), partial_avg(cast(cd_dep_count#16 as decimal(12,2)))]
+Aggregate Attributes [14]: [sum#35, count#36, sum#37, count#38, sum#39, count#40, sum#41, count#42, sum#43, count#44, sum#45, count#46, sum#47, count#48]
+Results [19]: [i_item_id#30, ca_country#31, ca_state#32, ca_county#33, spark_grouping_id#34, sum#49, count#50, sum#51, count#52, sum#53, count#54, sum#55, count#56, sum#57, count#58, sum#59, count#60, sum#61, count#62]
 
 (47) Exchange
-Input [19]: [i_item_id#28, ca_country#29, ca_state#30, ca_county#31, spark_grouping_id#32, sum#47, count#48, sum#49, count#50, sum#51, count#52, sum#53, count#54, sum#55, count#56, sum#57, count#58, sum#59, count#60]
-Arguments: hashpartitioning(i_item_id#28, ca_country#29, ca_state#30, ca_county#31, spark_grouping_id#32, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+Input [19]: [i_item_id#30, ca_country#31, ca_state#32, ca_county#33, spark_grouping_id#34, sum#49, count#50, sum#51, count#52, sum#53, count#54, sum#55, count#56, sum#57, count#58, sum#59, count#60, sum#61, count#62]
+Arguments: hashpartitioning(i_item_id#30, ca_country#31, ca_state#32, ca_county#33, spark_grouping_id#34, 5), ENSURE_REQUIREMENTS, [plan_id=8]
 
 (48) HashAggregate [codegen id : 14]
-Input [19]: [i_item_id#28, ca_country#29, ca_state#30, ca_county#31, spark_grouping_id#32, sum#47, count#48, sum#49, count#50, sum#51, count#52, sum#53, count#54, sum#55, count#56, sum#57, count#58, sum#59, count#60]
-Keys [5]: [i_item_id#28, ca_country#29, ca_state#30, ca_county#31, spark_grouping_id#32]
-Functions [7]: [avg(cast(cs_quantity#4 as decimal(12,2))), avg(cast(cs_list_price#5 as decimal(12,2))), avg(cast(cs_coupon_amt#7 as decimal(12,2))), avg(cast(cs_sales_price#6 as decimal(12,2))), avg(cast(cs_net_profit#8 as decimal(12,2))), avg(cast(c_birth_year#22 as decimal(12,2))), avg(cast(cd_dep_count#14 as decimal(12,2)))]
-Aggregate Attributes [7]: [avg(cast(cs_quantity#4 as decimal(12,2)))#61, avg(cast(cs_list_price#5 as decimal(12,2)))#62, avg(cast(cs_coupon_amt#7 as decimal(12,2)))#63, avg(cast(cs_sales_price#6 as decimal(12,2)))#64, avg(cast(cs_net_profit#8 as decimal(12,2)))#65, avg(cast(c_birth_year#22 as decimal(12,2)))#66, avg(cast(cd_dep_count#14 as decimal(12,2)))#67]
-Results [11]: [i_item_id#28, ca_country#29, ca_state#30, ca_county#31, avg(cast(cs_quantity#4 as decimal(12,2)))#61 AS agg1#68, avg(cast(cs_list_price#5 as decimal(12,2)))#62 AS agg2#69, avg(cast(cs_coupon_amt#7 as decimal(12,2)))#63 AS agg3#70, avg(cast(cs_sales_price#6 as decimal(12,2)))#64 AS agg4#71, avg(cast(cs_net_profit#8 as decimal(12,2)))#65 AS agg5#72, avg(cast(c_birth_year#22 as decimal(12,2)))#66 AS agg6#73, avg(cast(cd_dep_count#14 as decimal(12,2)))#67 AS agg7#74]
+Input [19]: [i_item_id#30, ca_country#31, ca_state#32, ca_county#33, spark_grouping_id#34, sum#49, count#50, sum#51, count#52, sum#53, count#54, sum#55, count#56, sum#57, count#58, sum#59, count#60, sum#61, count#62]
+Keys [5]: [i_item_id#30, ca_country#31, ca_state#32, ca_county#33, spark_grouping_id#34]
+Functions [7]: [avg(cast(cs_quantity#4 as decimal(12,2))), avg(cast(cs_list_price#5 as decimal(12,2))), avg(cast(cs_coupon_amt#7 as decimal(12,2))), avg(cast(cs_sales_price#6 as decimal(12,2))), avg(cast(cs_net_profit#8 as decimal(12,2))), avg(cast(c_birth_year#24 as decimal(12,2))), avg(cast(cd_dep_count#16 as decimal(12,2)))]
+Aggregate Attributes [7]: [avg(cast(cs_quantity#4 as decimal(12,2)))#63, avg(cast(cs_list_price#5 as decimal(12,2)))#64, avg(cast(cs_coupon_amt#7 as decimal(12,2)))#65, avg(cast(cs_sales_price#6 as decimal(12,2)))#66, avg(cast(cs_net_profit#8 as decimal(12,2)))#67, avg(cast(c_birth_year#24 as decimal(12,2)))#68, avg(cast(cd_dep_count#16 as decimal(12,2)))#69]
+Results [11]: [i_item_id#30, ca_country#31, ca_state#32, ca_county#33, avg(cast(cs_quantity#4 as decimal(12,2)))#63 AS agg1#70, avg(cast(cs_list_price#5 as decimal(12,2)))#64 AS agg2#71, avg(cast(cs_coupon_amt#7 as decimal(12,2)))#65 AS agg3#72, avg(cast(cs_sales_price#6 as decimal(12,2)))#66 AS agg4#73, avg(cast(cs_net_profit#8 as decimal(12,2)))#67 AS agg5#74, avg(cast(c_birth_year#24 as decimal(12,2)))#68 AS agg6#75, avg(cast(cd_dep_count#16 as decimal(12,2)))#69 AS agg7#76]
 
 (49) TakeOrderedAndProject
-Input [11]: [i_item_id#28, ca_country#29, ca_state#30, ca_county#31, agg1#68, agg2#69, agg3#70, agg4#71, agg5#72, agg6#73, agg7#74]
-Arguments: 100, [ca_country#29 ASC NULLS FIRST, ca_state#30 ASC NULLS FIRST, ca_county#31 ASC NULLS FIRST, i_item_id#28 ASC NULLS FIRST], [i_item_id#28, ca_country#29, ca_state#30, ca_county#31, agg1#68, agg2#69, agg3#70, agg4#71, agg5#72, agg6#73, agg7#74]
+Input [11]: [i_item_id#30, ca_country#31, ca_state#32, ca_county#33, agg1#70, agg2#71, agg3#72, agg4#73, agg5#74, agg6#75, agg7#76]
+Arguments: 100, [ca_country#31 ASC NULLS FIRST, ca_state#32 ASC NULLS FIRST, ca_county#33 ASC NULLS FIRST, i_item_id#30 ASC NULLS FIRST], [i_item_id#30, ca_country#31, ca_state#32, ca_county#33, agg1#70, agg2#71, agg3#72, agg4#73, agg5#74, agg6#75, agg7#76]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 1 Hosting Expression = cs_sold_date_sk#9 IN dynamicpruning#10
-BroadcastExchange (54)
-+- * Project (53)
-   +- * Filter (52)
-      +- * ColumnarToRow (51)
-         +- Scan parquet spark_catalog.default.date_dim (50)
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#11, [id=#12]
+ObjectHashAggregate (56)
++- Exchange (55)
+   +- ObjectHashAggregate (54)
+      +- * Project (53)
+         +- * Filter (52)
+            +- * ColumnarToRow (51)
+               +- Scan parquet spark_catalog.default.customer (50)
 
 
-(50) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#15, d_year#75]
+(50) Scan parquet spark_catalog.default.customer
+Output [4]: [c_customer_sk#20, c_current_cdemo_sk#21, c_current_addr_sk#22, c_birth_month#23]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer]
+PushedFilters: [In(c_birth_month, [1,12,2,6,8,9]), IsNotNull(c_customer_sk), IsNotNull(c_current_cdemo_sk), IsNotNull(c_current_addr_sk)]
+ReadSchema: struct<c_customer_sk:int,c_current_cdemo_sk:int,c_current_addr_sk:int,c_birth_month:int>
+
+(51) ColumnarToRow [codegen id : 1]
+Input [4]: [c_customer_sk#20, c_current_cdemo_sk#21, c_current_addr_sk#22, c_birth_month#23]
+
+(52) Filter [codegen id : 1]
+Input [4]: [c_customer_sk#20, c_current_cdemo_sk#21, c_current_addr_sk#22, c_birth_month#23]
+Condition : (((c_birth_month#23 IN (1,6,8,9,12,2) AND isnotnull(c_customer_sk#20)) AND isnotnull(c_current_cdemo_sk#21)) AND isnotnull(c_current_addr_sk#22))
+
+(53) Project [codegen id : 1]
+Output [1]: [c_customer_sk#20]
+Input [4]: [c_customer_sk#20, c_current_cdemo_sk#21, c_current_addr_sk#22, c_birth_month#23]
+
+(54) ObjectHashAggregate
+Input [1]: [c_customer_sk#20]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(c_customer_sk#20, 42), 965029, 9899191, 0, 0)]
+Aggregate Attributes [1]: [buf#77]
+Results [1]: [buf#78]
+
+(55) Exchange
+Input [1]: [buf#78]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=9]
+
+(56) ObjectHashAggregate
+Input [1]: [buf#78]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(c_customer_sk#20, 42), 965029, 9899191, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(c_customer_sk#20, 42), 965029, 9899191, 0, 0)#79]
+Results [1]: [bloom_filter_agg(xxhash64(c_customer_sk#20, 42), 965029, 9899191, 0, 0)#79 AS bloomFilter#80]
+
+Subquery:2 Hosting operator id = 1 Hosting Expression = cs_sold_date_sk#9 IN dynamicpruning#10
+BroadcastExchange (61)
++- * Project (60)
+   +- * Filter (59)
+      +- * ColumnarToRow (58)
+         +- Scan parquet spark_catalog.default.date_dim (57)
+
+
+(57) Scan parquet spark_catalog.default.date_dim
+Output [2]: [d_date_sk#17, d_year#81]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,1998), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(51) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#15, d_year#75]
+(58) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#17, d_year#81]
 
-(52) Filter [codegen id : 1]
-Input [2]: [d_date_sk#15, d_year#75]
-Condition : ((isnotnull(d_year#75) AND (d_year#75 = 1998)) AND isnotnull(d_date_sk#15))
+(59) Filter [codegen id : 1]
+Input [2]: [d_date_sk#17, d_year#81]
+Condition : ((isnotnull(d_year#81) AND (d_year#81 = 1998)) AND isnotnull(d_date_sk#17))
 
-(53) Project [codegen id : 1]
-Output [1]: [d_date_sk#15]
-Input [2]: [d_date_sk#15, d_year#75]
+(60) Project [codegen id : 1]
+Output [1]: [d_date_sk#17]
+Input [2]: [d_date_sk#17, d_year#81]
 
-(54) BroadcastExchange
-Input [1]: [d_date_sk#15]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=9]
+(61) BroadcastExchange
+Input [1]: [d_date_sk#17]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=10]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q18.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q18.sf100/simplified.txt
@@ -21,6 +21,16 @@ TakeOrderedAndProject [ca_country,ca_state,ca_county,i_item_id,agg1,agg2,agg3,ag
                                         Project [cs_bill_customer_sk,cs_item_sk,cs_quantity,cs_list_price,cs_sales_price,cs_coupon_amt,cs_net_profit,cs_sold_date_sk,cd_dep_count]
                                           BroadcastHashJoin [cs_bill_cdemo_sk,cd_demo_sk]
                                             Filter [cs_bill_cdemo_sk,cs_bill_customer_sk,cs_item_sk]
+                                              Subquery #2
+                                                ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(c_customer_sk, 42), 965029, 9899191, 0, 0),bloomFilter,buf]
+                                                  Exchange #4
+                                                    ObjectHashAggregate [c_customer_sk] [buf,buf]
+                                                      WholeStageCodegen (1)
+                                                        Project [c_customer_sk]
+                                                          Filter [c_birth_month,c_customer_sk,c_current_cdemo_sk,c_current_addr_sk]
+                                                            ColumnarToRow
+                                                              InputAdapter
+                                                                Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_cdemo_sk,c_current_addr_sk,c_birth_month]
                                               ColumnarToRow
                                                 InputAdapter
                                                   Scan parquet spark_catalog.default.catalog_sales [cs_bill_customer_sk,cs_bill_cdemo_sk,cs_item_sk,cs_quantity,cs_list_price,cs_sales_price,cs_coupon_amt,cs_net_profit,cs_sold_date_sk]
@@ -33,7 +43,7 @@ TakeOrderedAndProject [ca_country,ca_state,ca_county,i_item_id,agg1,agg2,agg3,ag
                                                                 InputAdapter
                                                                   Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year]
                                             InputAdapter
-                                              BroadcastExchange #4
+                                              BroadcastExchange #5
                                                 WholeStageCodegen (1)
                                                   Project [cd_demo_sk,cd_dep_count]
                                                     Filter [cd_gender,cd_education_status,cd_demo_sk]
@@ -43,7 +53,7 @@ TakeOrderedAndProject [ca_country,ca_state,ca_county,i_item_id,agg1,agg2,agg3,ag
                                         InputAdapter
                                           ReusedExchange [d_date_sk] #3
                                     InputAdapter
-                                      BroadcastExchange #5
+                                      BroadcastExchange #6
                                         WholeStageCodegen (3)
                                           Filter [i_item_sk]
                                             ColumnarToRow
@@ -53,7 +63,7 @@ TakeOrderedAndProject [ca_country,ca_state,ca_county,i_item_id,agg1,agg2,agg3,ag
                       WholeStageCodegen (12)
                         Sort [c_customer_sk]
                           InputAdapter
-                            Exchange [c_customer_sk] #6
+                            Exchange [c_customer_sk] #7
                               WholeStageCodegen (11)
                                 Project [c_customer_sk,c_birth_year,ca_county,ca_state,ca_country]
                                   SortMergeJoin [c_current_cdemo_sk,cd_demo_sk]
@@ -61,7 +71,7 @@ TakeOrderedAndProject [ca_country,ca_state,ca_county,i_item_id,agg1,agg2,agg3,ag
                                       WholeStageCodegen (8)
                                         Sort [c_current_cdemo_sk]
                                           InputAdapter
-                                            Exchange [c_current_cdemo_sk] #7
+                                            Exchange [c_current_cdemo_sk] #8
                                               WholeStageCodegen (7)
                                                 Project [c_customer_sk,c_current_cdemo_sk,c_birth_year,ca_county,ca_state,ca_country]
                                                   BroadcastHashJoin [c_current_addr_sk,ca_address_sk]
@@ -71,7 +81,7 @@ TakeOrderedAndProject [ca_country,ca_state,ca_county,i_item_id,agg1,agg2,agg3,ag
                                                           InputAdapter
                                                             Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_cdemo_sk,c_current_addr_sk,c_birth_month,c_birth_year]
                                                     InputAdapter
-                                                      BroadcastExchange #8
+                                                      BroadcastExchange #9
                                                         WholeStageCodegen (6)
                                                           Filter [ca_state,ca_address_sk]
                                                             ColumnarToRow
@@ -81,7 +91,7 @@ TakeOrderedAndProject [ca_country,ca_state,ca_county,i_item_id,agg1,agg2,agg3,ag
                                       WholeStageCodegen (10)
                                         Sort [cd_demo_sk]
                                           InputAdapter
-                                            Exchange [cd_demo_sk] #9
+                                            Exchange [cd_demo_sk] #10
                                               WholeStageCodegen (9)
                                                 Filter [cd_demo_sk]
                                                   ColumnarToRow

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q20.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q20.sf100/explain.txt
@@ -37,7 +37,7 @@ Input [3]: [cs_item_sk#1, cs_ext_sales_price#2, cs_sold_date_sk#3]
 
 (3) Filter [codegen id : 1]
 Input [3]: [cs_item_sk#1, cs_ext_sales_price#2, cs_sold_date_sk#3]
-Condition : isnotnull(cs_item_sk#1)
+Condition : (isnotnull(cs_item_sk#1) AND might_contain(Subquery scalar-subquery#5, [id=#6], xxhash64(cs_item_sk#1, 42)))
 
 (4) Exchange
 Input [3]: [cs_item_sk#1, cs_ext_sales_price#2, cs_sold_date_sk#3]
@@ -48,118 +48,164 @@ Input [3]: [cs_item_sk#1, cs_ext_sales_price#2, cs_sold_date_sk#3]
 Arguments: [cs_item_sk#1 ASC NULLS FIRST], false, 0
 
 (6) Scan parquet spark_catalog.default.item
-Output [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
+Output [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [In(i_category, [Books                                             ,Home                                              ,Sports                                            ]), IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_item_id:string,i_item_desc:string,i_current_price:decimal(7,2),i_class:string,i_category:string>
 
 (7) ColumnarToRow [codegen id : 3]
-Input [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
+Input [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
 
 (8) Filter [codegen id : 3]
-Input [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Condition : (i_category#10 IN (Sports                                            ,Books                                             ,Home                                              ) AND isnotnull(i_item_sk#5))
+Input [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Condition : (i_category#12 IN (Sports                                            ,Books                                             ,Home                                              ) AND isnotnull(i_item_sk#7))
 
 (9) Exchange
-Input [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Arguments: hashpartitioning(i_item_sk#5, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+Input [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Arguments: hashpartitioning(i_item_sk#7, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
 (10) Sort [codegen id : 4]
-Input [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Arguments: [i_item_sk#5 ASC NULLS FIRST], false, 0
+Input [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Arguments: [i_item_sk#7 ASC NULLS FIRST], false, 0
 
 (11) SortMergeJoin [codegen id : 6]
 Left keys [1]: [cs_item_sk#1]
-Right keys [1]: [i_item_sk#5]
+Right keys [1]: [i_item_sk#7]
 Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 6]
-Output [7]: [cs_ext_sales_price#2, cs_sold_date_sk#3, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Input [9]: [cs_item_sk#1, cs_ext_sales_price#2, cs_sold_date_sk#3, i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
+Output [7]: [cs_ext_sales_price#2, cs_sold_date_sk#3, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Input [9]: [cs_item_sk#1, cs_ext_sales_price#2, cs_sold_date_sk#3, i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
 
-(13) ReusedExchange [Reuses operator id: 28]
-Output [1]: [d_date_sk#11]
+(13) ReusedExchange [Reuses operator id: 35]
+Output [1]: [d_date_sk#13]
 
 (14) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [cs_sold_date_sk#3]
-Right keys [1]: [d_date_sk#11]
+Right keys [1]: [d_date_sk#13]
 Join type: Inner
 Join condition: None
 
 (15) Project [codegen id : 6]
-Output [6]: [cs_ext_sales_price#2, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Input [8]: [cs_ext_sales_price#2, cs_sold_date_sk#3, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10, d_date_sk#11]
+Output [6]: [cs_ext_sales_price#2, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Input [8]: [cs_ext_sales_price#2, cs_sold_date_sk#3, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12, d_date_sk#13]
 
 (16) HashAggregate [codegen id : 6]
-Input [6]: [cs_ext_sales_price#2, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Keys [5]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8]
+Input [6]: [cs_ext_sales_price#2, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Keys [5]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10]
 Functions [1]: [partial_sum(UnscaledValue(cs_ext_sales_price#2))]
-Aggregate Attributes [1]: [sum#12]
-Results [6]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, sum#13]
+Aggregate Attributes [1]: [sum#14]
+Results [6]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, sum#15]
 
 (17) Exchange
-Input [6]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, sum#13]
-Arguments: hashpartitioning(i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+Input [6]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, sum#15]
+Arguments: hashpartitioning(i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (18) HashAggregate [codegen id : 7]
-Input [6]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, sum#13]
-Keys [5]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8]
+Input [6]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, sum#15]
+Keys [5]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10]
 Functions [1]: [sum(UnscaledValue(cs_ext_sales_price#2))]
-Aggregate Attributes [1]: [sum(UnscaledValue(cs_ext_sales_price#2))#14]
-Results [7]: [i_item_desc#7, i_category#10, i_class#9, i_current_price#8, MakeDecimal(sum(UnscaledValue(cs_ext_sales_price#2))#14,17,2) AS itemrevenue#15, MakeDecimal(sum(UnscaledValue(cs_ext_sales_price#2))#14,17,2) AS _w0#16, i_item_id#6]
+Aggregate Attributes [1]: [sum(UnscaledValue(cs_ext_sales_price#2))#16]
+Results [7]: [i_item_desc#9, i_category#12, i_class#11, i_current_price#10, MakeDecimal(sum(UnscaledValue(cs_ext_sales_price#2))#16,17,2) AS itemrevenue#17, MakeDecimal(sum(UnscaledValue(cs_ext_sales_price#2))#16,17,2) AS _w0#18, i_item_id#8]
 
 (19) Exchange
-Input [7]: [i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, _w0#16, i_item_id#6]
-Arguments: hashpartitioning(i_class#9, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+Input [7]: [i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, _w0#18, i_item_id#8]
+Arguments: hashpartitioning(i_class#11, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
 (20) Sort [codegen id : 8]
-Input [7]: [i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, _w0#16, i_item_id#6]
-Arguments: [i_class#9 ASC NULLS FIRST], false, 0
+Input [7]: [i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, _w0#18, i_item_id#8]
+Arguments: [i_class#11 ASC NULLS FIRST], false, 0
 
 (21) Window
-Input [7]: [i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, _w0#16, i_item_id#6]
-Arguments: [sum(_w0#16) windowspecdefinition(i_class#9, specifiedwindowframe(RowFrame, unboundedpreceding$(), unboundedfollowing$())) AS _we0#17], [i_class#9]
+Input [7]: [i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, _w0#18, i_item_id#8]
+Arguments: [sum(_w0#18) windowspecdefinition(i_class#11, specifiedwindowframe(RowFrame, unboundedpreceding$(), unboundedfollowing$())) AS _we0#19], [i_class#11]
 
 (22) Project [codegen id : 9]
-Output [7]: [i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, ((_w0#16 * 100) / _we0#17) AS revenueratio#18, i_item_id#6]
-Input [8]: [i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, _w0#16, i_item_id#6, _we0#17]
+Output [7]: [i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, ((_w0#18 * 100) / _we0#19) AS revenueratio#20, i_item_id#8]
+Input [8]: [i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, _w0#18, i_item_id#8, _we0#19]
 
 (23) TakeOrderedAndProject
-Input [7]: [i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, revenueratio#18, i_item_id#6]
-Arguments: 100, [i_category#10 ASC NULLS FIRST, i_class#9 ASC NULLS FIRST, i_item_id#6 ASC NULLS FIRST, i_item_desc#7 ASC NULLS FIRST, revenueratio#18 ASC NULLS FIRST], [i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, revenueratio#18]
+Input [7]: [i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, revenueratio#20, i_item_id#8]
+Arguments: 100, [i_category#12 ASC NULLS FIRST, i_class#11 ASC NULLS FIRST, i_item_id#8 ASC NULLS FIRST, i_item_desc#9 ASC NULLS FIRST, revenueratio#20 ASC NULLS FIRST], [i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, revenueratio#20]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 1 Hosting Expression = cs_sold_date_sk#3 IN dynamicpruning#4
-BroadcastExchange (28)
-+- * Project (27)
-   +- * Filter (26)
-      +- * ColumnarToRow (25)
-         +- Scan parquet spark_catalog.default.date_dim (24)
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#5, [id=#6]
+ObjectHashAggregate (30)
++- Exchange (29)
+   +- ObjectHashAggregate (28)
+      +- * Project (27)
+         +- * Filter (26)
+            +- * ColumnarToRow (25)
+               +- Scan parquet spark_catalog.default.item (24)
 
 
-(24) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#11, d_date#19]
+(24) Scan parquet spark_catalog.default.item
+Output [2]: [i_item_sk#7, i_category#12]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/item]
+PushedFilters: [In(i_category, [Books                                             ,Home                                              ,Sports                                            ]), IsNotNull(i_item_sk)]
+ReadSchema: struct<i_item_sk:int,i_category:string>
+
+(25) ColumnarToRow [codegen id : 1]
+Input [2]: [i_item_sk#7, i_category#12]
+
+(26) Filter [codegen id : 1]
+Input [2]: [i_item_sk#7, i_category#12]
+Condition : (i_category#12 IN (Sports                                            ,Books                                             ,Home                                              ) AND isnotnull(i_item_sk#7))
+
+(27) Project [codegen id : 1]
+Output [1]: [i_item_sk#7]
+Input [2]: [i_item_sk#7, i_category#12]
+
+(28) ObjectHashAggregate
+Input [1]: [i_item_sk#7]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#7, 42), 61200, 979099, 0, 0)]
+Aggregate Attributes [1]: [buf#21]
+Results [1]: [buf#22]
+
+(29) Exchange
+Input [1]: [buf#22]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=5]
+
+(30) ObjectHashAggregate
+Input [1]: [buf#22]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#7, 42), 61200, 979099, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#7, 42), 61200, 979099, 0, 0)#23]
+Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#7, 42), 61200, 979099, 0, 0)#23 AS bloomFilter#24]
+
+Subquery:2 Hosting operator id = 1 Hosting Expression = cs_sold_date_sk#3 IN dynamicpruning#4
+BroadcastExchange (35)
++- * Project (34)
+   +- * Filter (33)
+      +- * ColumnarToRow (32)
+         +- Scan parquet spark_catalog.default.date_dim (31)
+
+
+(31) Scan parquet spark_catalog.default.date_dim
+Output [2]: [d_date_sk#13, d_date#25]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,1999-02-22), LessThanOrEqual(d_date,1999-03-24), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
-(25) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#11, d_date#19]
+(32) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#13, d_date#25]
 
-(26) Filter [codegen id : 1]
-Input [2]: [d_date_sk#11, d_date#19]
-Condition : (((isnotnull(d_date#19) AND (d_date#19 >= 1999-02-22)) AND (d_date#19 <= 1999-03-24)) AND isnotnull(d_date_sk#11))
+(33) Filter [codegen id : 1]
+Input [2]: [d_date_sk#13, d_date#25]
+Condition : (((isnotnull(d_date#25) AND (d_date#25 >= 1999-02-22)) AND (d_date#25 <= 1999-03-24)) AND isnotnull(d_date_sk#13))
 
-(27) Project [codegen id : 1]
-Output [1]: [d_date_sk#11]
-Input [2]: [d_date_sk#11, d_date#19]
+(34) Project [codegen id : 1]
+Output [1]: [d_date_sk#13]
+Input [2]: [d_date_sk#13, d_date#25]
 
-(28) BroadcastExchange
-Input [1]: [d_date_sk#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
+(35) BroadcastExchange
+Input [1]: [d_date_sk#13]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=6]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q20.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q20.sf100/simplified.txt
@@ -24,6 +24,16 @@ TakeOrderedAndProject [i_category,i_class,i_item_id,i_item_desc,revenueratio,i_c
                                               Exchange [cs_item_sk] #3
                                                 WholeStageCodegen (1)
                                                   Filter [cs_item_sk]
+                                                    Subquery #2
+                                                      ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(i_item_sk, 42), 61200, 979099, 0, 0),bloomFilter,buf]
+                                                        Exchange #5
+                                                          ObjectHashAggregate [i_item_sk] [buf,buf]
+                                                            WholeStageCodegen (1)
+                                                              Project [i_item_sk]
+                                                                Filter [i_category,i_item_sk]
+                                                                  ColumnarToRow
+                                                                    InputAdapter
+                                                                      Scan parquet spark_catalog.default.item [i_item_sk,i_category]
                                                     ColumnarToRow
                                                       InputAdapter
                                                         Scan parquet spark_catalog.default.catalog_sales [cs_item_sk,cs_ext_sales_price,cs_sold_date_sk]
@@ -39,7 +49,7 @@ TakeOrderedAndProject [i_category,i_class,i_item_id,i_item_desc,revenueratio,i_c
                                         WholeStageCodegen (4)
                                           Sort [i_item_sk]
                                             InputAdapter
-                                              Exchange [i_item_sk] #5
+                                              Exchange [i_item_sk] #6
                                                 WholeStageCodegen (3)
                                                   Filter [i_category,i_item_sk]
                                                     ColumnarToRow

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q49.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q49.sf100/explain.txt
@@ -100,24 +100,24 @@ Input [6]: [ws_item_sk#1, ws_order_number#2, ws_quantity#3, ws_net_paid#4, ws_ne
 
 (3) Filter [codegen id : 2]
 Input [6]: [ws_item_sk#1, ws_order_number#2, ws_quantity#3, ws_net_paid#4, ws_net_profit#5, ws_sold_date_sk#6]
-Condition : (((((((isnotnull(ws_net_profit#5) AND isnotnull(ws_net_paid#4)) AND isnotnull(ws_quantity#3)) AND (ws_net_profit#5 > 1.00)) AND (ws_net_paid#4 > 0.00)) AND (ws_quantity#3 > 0)) AND isnotnull(ws_order_number#2)) AND isnotnull(ws_item_sk#1))
+Condition : ((((((((isnotnull(ws_net_profit#5) AND isnotnull(ws_net_paid#4)) AND isnotnull(ws_quantity#3)) AND (ws_net_profit#5 > 1.00)) AND (ws_net_paid#4 > 0.00)) AND (ws_quantity#3 > 0)) AND isnotnull(ws_order_number#2)) AND isnotnull(ws_item_sk#1)) AND might_contain(Subquery scalar-subquery#8, [id=#9], xxhash64(ws_item_sk#1, 42)))
 
 (4) Project [codegen id : 2]
 Output [5]: [ws_item_sk#1, ws_order_number#2, ws_quantity#3, ws_net_paid#4, ws_sold_date_sk#6]
 Input [6]: [ws_item_sk#1, ws_order_number#2, ws_quantity#3, ws_net_paid#4, ws_net_profit#5, ws_sold_date_sk#6]
 
-(5) ReusedExchange [Reuses operator id: 91]
-Output [1]: [d_date_sk#8]
+(5) ReusedExchange [Reuses operator id: 98]
+Output [1]: [d_date_sk#10]
 
 (6) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ws_sold_date_sk#6]
-Right keys [1]: [d_date_sk#8]
+Right keys [1]: [d_date_sk#10]
 Join type: Inner
 Join condition: None
 
 (7) Project [codegen id : 2]
 Output [4]: [ws_item_sk#1, ws_order_number#2, ws_quantity#3, ws_net_paid#4]
-Input [6]: [ws_item_sk#1, ws_order_number#2, ws_quantity#3, ws_net_paid#4, ws_sold_date_sk#6, d_date_sk#8]
+Input [6]: [ws_item_sk#1, ws_order_number#2, ws_quantity#3, ws_net_paid#4, ws_sold_date_sk#6, d_date_sk#10]
 
 (8) Exchange
 Input [4]: [ws_item_sk#1, ws_order_number#2, ws_quantity#3, ws_net_paid#4]
@@ -128,389 +128,527 @@ Input [4]: [ws_item_sk#1, ws_order_number#2, ws_quantity#3, ws_net_paid#4]
 Arguments: [ws_order_number#2 ASC NULLS FIRST, ws_item_sk#1 ASC NULLS FIRST], false, 0
 
 (10) Scan parquet spark_catalog.default.web_returns
-Output [5]: [wr_item_sk#9, wr_order_number#10, wr_return_quantity#11, wr_return_amt#12, wr_returned_date_sk#13]
+Output [5]: [wr_item_sk#11, wr_order_number#12, wr_return_quantity#13, wr_return_amt#14, wr_returned_date_sk#15]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/web_returns]
 PushedFilters: [IsNotNull(wr_return_amt), GreaterThan(wr_return_amt,10000.00), IsNotNull(wr_order_number), IsNotNull(wr_item_sk)]
 ReadSchema: struct<wr_item_sk:int,wr_order_number:int,wr_return_quantity:int,wr_return_amt:decimal(7,2)>
 
 (11) ColumnarToRow [codegen id : 4]
-Input [5]: [wr_item_sk#9, wr_order_number#10, wr_return_quantity#11, wr_return_amt#12, wr_returned_date_sk#13]
+Input [5]: [wr_item_sk#11, wr_order_number#12, wr_return_quantity#13, wr_return_amt#14, wr_returned_date_sk#15]
 
 (12) Filter [codegen id : 4]
-Input [5]: [wr_item_sk#9, wr_order_number#10, wr_return_quantity#11, wr_return_amt#12, wr_returned_date_sk#13]
-Condition : (((isnotnull(wr_return_amt#12) AND (wr_return_amt#12 > 10000.00)) AND isnotnull(wr_order_number#10)) AND isnotnull(wr_item_sk#9))
+Input [5]: [wr_item_sk#11, wr_order_number#12, wr_return_quantity#13, wr_return_amt#14, wr_returned_date_sk#15]
+Condition : (((isnotnull(wr_return_amt#14) AND (wr_return_amt#14 > 10000.00)) AND isnotnull(wr_order_number#12)) AND isnotnull(wr_item_sk#11))
 
 (13) Project [codegen id : 4]
-Output [4]: [wr_item_sk#9, wr_order_number#10, wr_return_quantity#11, wr_return_amt#12]
-Input [5]: [wr_item_sk#9, wr_order_number#10, wr_return_quantity#11, wr_return_amt#12, wr_returned_date_sk#13]
+Output [4]: [wr_item_sk#11, wr_order_number#12, wr_return_quantity#13, wr_return_amt#14]
+Input [5]: [wr_item_sk#11, wr_order_number#12, wr_return_quantity#13, wr_return_amt#14, wr_returned_date_sk#15]
 
 (14) Exchange
-Input [4]: [wr_item_sk#9, wr_order_number#10, wr_return_quantity#11, wr_return_amt#12]
-Arguments: hashpartitioning(wr_order_number#10, wr_item_sk#9, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+Input [4]: [wr_item_sk#11, wr_order_number#12, wr_return_quantity#13, wr_return_amt#14]
+Arguments: hashpartitioning(wr_order_number#12, wr_item_sk#11, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
 (15) Sort [codegen id : 5]
-Input [4]: [wr_item_sk#9, wr_order_number#10, wr_return_quantity#11, wr_return_amt#12]
-Arguments: [wr_order_number#10 ASC NULLS FIRST, wr_item_sk#9 ASC NULLS FIRST], false, 0
+Input [4]: [wr_item_sk#11, wr_order_number#12, wr_return_quantity#13, wr_return_amt#14]
+Arguments: [wr_order_number#12 ASC NULLS FIRST, wr_item_sk#11 ASC NULLS FIRST], false, 0
 
 (16) SortMergeJoin [codegen id : 6]
 Left keys [2]: [ws_order_number#2, ws_item_sk#1]
-Right keys [2]: [wr_order_number#10, wr_item_sk#9]
+Right keys [2]: [wr_order_number#12, wr_item_sk#11]
 Join type: Inner
 Join condition: None
 
 (17) Project [codegen id : 6]
-Output [5]: [ws_item_sk#1, ws_quantity#3, ws_net_paid#4, wr_return_quantity#11, wr_return_amt#12]
-Input [8]: [ws_item_sk#1, ws_order_number#2, ws_quantity#3, ws_net_paid#4, wr_item_sk#9, wr_order_number#10, wr_return_quantity#11, wr_return_amt#12]
+Output [5]: [ws_item_sk#1, ws_quantity#3, ws_net_paid#4, wr_return_quantity#13, wr_return_amt#14]
+Input [8]: [ws_item_sk#1, ws_order_number#2, ws_quantity#3, ws_net_paid#4, wr_item_sk#11, wr_order_number#12, wr_return_quantity#13, wr_return_amt#14]
 
 (18) HashAggregate [codegen id : 6]
-Input [5]: [ws_item_sk#1, ws_quantity#3, ws_net_paid#4, wr_return_quantity#11, wr_return_amt#12]
+Input [5]: [ws_item_sk#1, ws_quantity#3, ws_net_paid#4, wr_return_quantity#13, wr_return_amt#14]
 Keys [1]: [ws_item_sk#1]
-Functions [4]: [partial_sum(coalesce(wr_return_quantity#11, 0)), partial_sum(coalesce(ws_quantity#3, 0)), partial_sum(coalesce(cast(wr_return_amt#12 as decimal(12,2)), 0.00)), partial_sum(coalesce(cast(ws_net_paid#4 as decimal(12,2)), 0.00))]
-Aggregate Attributes [6]: [sum#14, sum#15, sum#16, isEmpty#17, sum#18, isEmpty#19]
-Results [7]: [ws_item_sk#1, sum#20, sum#21, sum#22, isEmpty#23, sum#24, isEmpty#25]
+Functions [4]: [partial_sum(coalesce(wr_return_quantity#13, 0)), partial_sum(coalesce(ws_quantity#3, 0)), partial_sum(coalesce(cast(wr_return_amt#14 as decimal(12,2)), 0.00)), partial_sum(coalesce(cast(ws_net_paid#4 as decimal(12,2)), 0.00))]
+Aggregate Attributes [6]: [sum#16, sum#17, sum#18, isEmpty#19, sum#20, isEmpty#21]
+Results [7]: [ws_item_sk#1, sum#22, sum#23, sum#24, isEmpty#25, sum#26, isEmpty#27]
 
 (19) Exchange
-Input [7]: [ws_item_sk#1, sum#20, sum#21, sum#22, isEmpty#23, sum#24, isEmpty#25]
+Input [7]: [ws_item_sk#1, sum#22, sum#23, sum#24, isEmpty#25, sum#26, isEmpty#27]
 Arguments: hashpartitioning(ws_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (20) HashAggregate [codegen id : 7]
-Input [7]: [ws_item_sk#1, sum#20, sum#21, sum#22, isEmpty#23, sum#24, isEmpty#25]
+Input [7]: [ws_item_sk#1, sum#22, sum#23, sum#24, isEmpty#25, sum#26, isEmpty#27]
 Keys [1]: [ws_item_sk#1]
-Functions [4]: [sum(coalesce(wr_return_quantity#11, 0)), sum(coalesce(ws_quantity#3, 0)), sum(coalesce(cast(wr_return_amt#12 as decimal(12,2)), 0.00)), sum(coalesce(cast(ws_net_paid#4 as decimal(12,2)), 0.00))]
-Aggregate Attributes [4]: [sum(coalesce(wr_return_quantity#11, 0))#26, sum(coalesce(ws_quantity#3, 0))#27, sum(coalesce(cast(wr_return_amt#12 as decimal(12,2)), 0.00))#28, sum(coalesce(cast(ws_net_paid#4 as decimal(12,2)), 0.00))#29]
-Results [3]: [ws_item_sk#1 AS item#30, (cast(sum(coalesce(wr_return_quantity#11, 0))#26 as decimal(15,4)) / cast(sum(coalesce(ws_quantity#3, 0))#27 as decimal(15,4))) AS return_ratio#31, (cast(sum(coalesce(cast(wr_return_amt#12 as decimal(12,2)), 0.00))#28 as decimal(15,4)) / cast(sum(coalesce(cast(ws_net_paid#4 as decimal(12,2)), 0.00))#29 as decimal(15,4))) AS currency_ratio#32]
+Functions [4]: [sum(coalesce(wr_return_quantity#13, 0)), sum(coalesce(ws_quantity#3, 0)), sum(coalesce(cast(wr_return_amt#14 as decimal(12,2)), 0.00)), sum(coalesce(cast(ws_net_paid#4 as decimal(12,2)), 0.00))]
+Aggregate Attributes [4]: [sum(coalesce(wr_return_quantity#13, 0))#28, sum(coalesce(ws_quantity#3, 0))#29, sum(coalesce(cast(wr_return_amt#14 as decimal(12,2)), 0.00))#30, sum(coalesce(cast(ws_net_paid#4 as decimal(12,2)), 0.00))#31]
+Results [3]: [ws_item_sk#1 AS item#32, (cast(sum(coalesce(wr_return_quantity#13, 0))#28 as decimal(15,4)) / cast(sum(coalesce(ws_quantity#3, 0))#29 as decimal(15,4))) AS return_ratio#33, (cast(sum(coalesce(cast(wr_return_amt#14 as decimal(12,2)), 0.00))#30 as decimal(15,4)) / cast(sum(coalesce(cast(ws_net_paid#4 as decimal(12,2)), 0.00))#31 as decimal(15,4))) AS currency_ratio#34]
 
 (21) Exchange
-Input [3]: [item#30, return_ratio#31, currency_ratio#32]
+Input [3]: [item#32, return_ratio#33, currency_ratio#34]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=4]
 
 (22) Sort [codegen id : 8]
-Input [3]: [item#30, return_ratio#31, currency_ratio#32]
-Arguments: [return_ratio#31 ASC NULLS FIRST], false, 0
+Input [3]: [item#32, return_ratio#33, currency_ratio#34]
+Arguments: [return_ratio#33 ASC NULLS FIRST], false, 0
 
 (23) Window
-Input [3]: [item#30, return_ratio#31, currency_ratio#32]
-Arguments: [rank(return_ratio#31) windowspecdefinition(return_ratio#31 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS return_rank#33], [return_ratio#31 ASC NULLS FIRST]
+Input [3]: [item#32, return_ratio#33, currency_ratio#34]
+Arguments: [rank(return_ratio#33) windowspecdefinition(return_ratio#33 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS return_rank#35], [return_ratio#33 ASC NULLS FIRST]
 
 (24) Sort [codegen id : 9]
-Input [4]: [item#30, return_ratio#31, currency_ratio#32, return_rank#33]
-Arguments: [currency_ratio#32 ASC NULLS FIRST], false, 0
+Input [4]: [item#32, return_ratio#33, currency_ratio#34, return_rank#35]
+Arguments: [currency_ratio#34 ASC NULLS FIRST], false, 0
 
 (25) Window
-Input [4]: [item#30, return_ratio#31, currency_ratio#32, return_rank#33]
-Arguments: [rank(currency_ratio#32) windowspecdefinition(currency_ratio#32 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS currency_rank#34], [currency_ratio#32 ASC NULLS FIRST]
+Input [4]: [item#32, return_ratio#33, currency_ratio#34, return_rank#35]
+Arguments: [rank(currency_ratio#34) windowspecdefinition(currency_ratio#34 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS currency_rank#36], [currency_ratio#34 ASC NULLS FIRST]
 
 (26) Filter [codegen id : 10]
-Input [5]: [item#30, return_ratio#31, currency_ratio#32, return_rank#33, currency_rank#34]
-Condition : ((return_rank#33 <= 10) OR (currency_rank#34 <= 10))
+Input [5]: [item#32, return_ratio#33, currency_ratio#34, return_rank#35, currency_rank#36]
+Condition : ((return_rank#35 <= 10) OR (currency_rank#36 <= 10))
 
 (27) Project [codegen id : 10]
-Output [5]: [web AS channel#35, item#30, return_ratio#31, return_rank#33, currency_rank#34]
-Input [5]: [item#30, return_ratio#31, currency_ratio#32, return_rank#33, currency_rank#34]
+Output [5]: [web AS channel#37, item#32, return_ratio#33, return_rank#35, currency_rank#36]
+Input [5]: [item#32, return_ratio#33, currency_ratio#34, return_rank#35, currency_rank#36]
 
 (28) Scan parquet spark_catalog.default.catalog_sales
-Output [6]: [cs_item_sk#36, cs_order_number#37, cs_quantity#38, cs_net_paid#39, cs_net_profit#40, cs_sold_date_sk#41]
+Output [6]: [cs_item_sk#38, cs_order_number#39, cs_quantity#40, cs_net_paid#41, cs_net_profit#42, cs_sold_date_sk#43]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#41), dynamicpruningexpression(cs_sold_date_sk#41 IN dynamicpruning#7)]
+PartitionFilters: [isnotnull(cs_sold_date_sk#43), dynamicpruningexpression(cs_sold_date_sk#43 IN dynamicpruning#7)]
 PushedFilters: [IsNotNull(cs_net_profit), IsNotNull(cs_net_paid), IsNotNull(cs_quantity), GreaterThan(cs_net_profit,1.00), GreaterThan(cs_net_paid,0.00), GreaterThan(cs_quantity,0), IsNotNull(cs_order_number), IsNotNull(cs_item_sk)]
 ReadSchema: struct<cs_item_sk:int,cs_order_number:int,cs_quantity:int,cs_net_paid:decimal(7,2),cs_net_profit:decimal(7,2)>
 
 (29) ColumnarToRow [codegen id : 12]
-Input [6]: [cs_item_sk#36, cs_order_number#37, cs_quantity#38, cs_net_paid#39, cs_net_profit#40, cs_sold_date_sk#41]
+Input [6]: [cs_item_sk#38, cs_order_number#39, cs_quantity#40, cs_net_paid#41, cs_net_profit#42, cs_sold_date_sk#43]
 
 (30) Filter [codegen id : 12]
-Input [6]: [cs_item_sk#36, cs_order_number#37, cs_quantity#38, cs_net_paid#39, cs_net_profit#40, cs_sold_date_sk#41]
-Condition : (((((((isnotnull(cs_net_profit#40) AND isnotnull(cs_net_paid#39)) AND isnotnull(cs_quantity#38)) AND (cs_net_profit#40 > 1.00)) AND (cs_net_paid#39 > 0.00)) AND (cs_quantity#38 > 0)) AND isnotnull(cs_order_number#37)) AND isnotnull(cs_item_sk#36))
+Input [6]: [cs_item_sk#38, cs_order_number#39, cs_quantity#40, cs_net_paid#41, cs_net_profit#42, cs_sold_date_sk#43]
+Condition : ((((((((isnotnull(cs_net_profit#42) AND isnotnull(cs_net_paid#41)) AND isnotnull(cs_quantity#40)) AND (cs_net_profit#42 > 1.00)) AND (cs_net_paid#41 > 0.00)) AND (cs_quantity#40 > 0)) AND isnotnull(cs_order_number#39)) AND isnotnull(cs_item_sk#38)) AND might_contain(Subquery scalar-subquery#44, [id=#45], xxhash64(cs_item_sk#38, 42)))
 
 (31) Project [codegen id : 12]
-Output [5]: [cs_item_sk#36, cs_order_number#37, cs_quantity#38, cs_net_paid#39, cs_sold_date_sk#41]
-Input [6]: [cs_item_sk#36, cs_order_number#37, cs_quantity#38, cs_net_paid#39, cs_net_profit#40, cs_sold_date_sk#41]
+Output [5]: [cs_item_sk#38, cs_order_number#39, cs_quantity#40, cs_net_paid#41, cs_sold_date_sk#43]
+Input [6]: [cs_item_sk#38, cs_order_number#39, cs_quantity#40, cs_net_paid#41, cs_net_profit#42, cs_sold_date_sk#43]
 
-(32) ReusedExchange [Reuses operator id: 91]
-Output [1]: [d_date_sk#42]
+(32) ReusedExchange [Reuses operator id: 98]
+Output [1]: [d_date_sk#46]
 
 (33) BroadcastHashJoin [codegen id : 12]
-Left keys [1]: [cs_sold_date_sk#41]
-Right keys [1]: [d_date_sk#42]
+Left keys [1]: [cs_sold_date_sk#43]
+Right keys [1]: [d_date_sk#46]
 Join type: Inner
 Join condition: None
 
 (34) Project [codegen id : 12]
-Output [4]: [cs_item_sk#36, cs_order_number#37, cs_quantity#38, cs_net_paid#39]
-Input [6]: [cs_item_sk#36, cs_order_number#37, cs_quantity#38, cs_net_paid#39, cs_sold_date_sk#41, d_date_sk#42]
+Output [4]: [cs_item_sk#38, cs_order_number#39, cs_quantity#40, cs_net_paid#41]
+Input [6]: [cs_item_sk#38, cs_order_number#39, cs_quantity#40, cs_net_paid#41, cs_sold_date_sk#43, d_date_sk#46]
 
 (35) Exchange
-Input [4]: [cs_item_sk#36, cs_order_number#37, cs_quantity#38, cs_net_paid#39]
-Arguments: hashpartitioning(cs_order_number#37, cs_item_sk#36, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+Input [4]: [cs_item_sk#38, cs_order_number#39, cs_quantity#40, cs_net_paid#41]
+Arguments: hashpartitioning(cs_order_number#39, cs_item_sk#38, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
 (36) Sort [codegen id : 13]
-Input [4]: [cs_item_sk#36, cs_order_number#37, cs_quantity#38, cs_net_paid#39]
-Arguments: [cs_order_number#37 ASC NULLS FIRST, cs_item_sk#36 ASC NULLS FIRST], false, 0
+Input [4]: [cs_item_sk#38, cs_order_number#39, cs_quantity#40, cs_net_paid#41]
+Arguments: [cs_order_number#39 ASC NULLS FIRST, cs_item_sk#38 ASC NULLS FIRST], false, 0
 
 (37) Scan parquet spark_catalog.default.catalog_returns
-Output [5]: [cr_item_sk#43, cr_order_number#44, cr_return_quantity#45, cr_return_amount#46, cr_returned_date_sk#47]
+Output [5]: [cr_item_sk#47, cr_order_number#48, cr_return_quantity#49, cr_return_amount#50, cr_returned_date_sk#51]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/catalog_returns]
 PushedFilters: [IsNotNull(cr_return_amount), GreaterThan(cr_return_amount,10000.00), IsNotNull(cr_order_number), IsNotNull(cr_item_sk)]
 ReadSchema: struct<cr_item_sk:int,cr_order_number:int,cr_return_quantity:int,cr_return_amount:decimal(7,2)>
 
 (38) ColumnarToRow [codegen id : 14]
-Input [5]: [cr_item_sk#43, cr_order_number#44, cr_return_quantity#45, cr_return_amount#46, cr_returned_date_sk#47]
+Input [5]: [cr_item_sk#47, cr_order_number#48, cr_return_quantity#49, cr_return_amount#50, cr_returned_date_sk#51]
 
 (39) Filter [codegen id : 14]
-Input [5]: [cr_item_sk#43, cr_order_number#44, cr_return_quantity#45, cr_return_amount#46, cr_returned_date_sk#47]
-Condition : (((isnotnull(cr_return_amount#46) AND (cr_return_amount#46 > 10000.00)) AND isnotnull(cr_order_number#44)) AND isnotnull(cr_item_sk#43))
+Input [5]: [cr_item_sk#47, cr_order_number#48, cr_return_quantity#49, cr_return_amount#50, cr_returned_date_sk#51]
+Condition : (((isnotnull(cr_return_amount#50) AND (cr_return_amount#50 > 10000.00)) AND isnotnull(cr_order_number#48)) AND isnotnull(cr_item_sk#47))
 
 (40) Project [codegen id : 14]
-Output [4]: [cr_item_sk#43, cr_order_number#44, cr_return_quantity#45, cr_return_amount#46]
-Input [5]: [cr_item_sk#43, cr_order_number#44, cr_return_quantity#45, cr_return_amount#46, cr_returned_date_sk#47]
+Output [4]: [cr_item_sk#47, cr_order_number#48, cr_return_quantity#49, cr_return_amount#50]
+Input [5]: [cr_item_sk#47, cr_order_number#48, cr_return_quantity#49, cr_return_amount#50, cr_returned_date_sk#51]
 
 (41) Exchange
-Input [4]: [cr_item_sk#43, cr_order_number#44, cr_return_quantity#45, cr_return_amount#46]
-Arguments: hashpartitioning(cr_order_number#44, cr_item_sk#43, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+Input [4]: [cr_item_sk#47, cr_order_number#48, cr_return_quantity#49, cr_return_amount#50]
+Arguments: hashpartitioning(cr_order_number#48, cr_item_sk#47, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
 (42) Sort [codegen id : 15]
-Input [4]: [cr_item_sk#43, cr_order_number#44, cr_return_quantity#45, cr_return_amount#46]
-Arguments: [cr_order_number#44 ASC NULLS FIRST, cr_item_sk#43 ASC NULLS FIRST], false, 0
+Input [4]: [cr_item_sk#47, cr_order_number#48, cr_return_quantity#49, cr_return_amount#50]
+Arguments: [cr_order_number#48 ASC NULLS FIRST, cr_item_sk#47 ASC NULLS FIRST], false, 0
 
 (43) SortMergeJoin [codegen id : 16]
-Left keys [2]: [cs_order_number#37, cs_item_sk#36]
-Right keys [2]: [cr_order_number#44, cr_item_sk#43]
+Left keys [2]: [cs_order_number#39, cs_item_sk#38]
+Right keys [2]: [cr_order_number#48, cr_item_sk#47]
 Join type: Inner
 Join condition: None
 
 (44) Project [codegen id : 16]
-Output [5]: [cs_item_sk#36, cs_quantity#38, cs_net_paid#39, cr_return_quantity#45, cr_return_amount#46]
-Input [8]: [cs_item_sk#36, cs_order_number#37, cs_quantity#38, cs_net_paid#39, cr_item_sk#43, cr_order_number#44, cr_return_quantity#45, cr_return_amount#46]
+Output [5]: [cs_item_sk#38, cs_quantity#40, cs_net_paid#41, cr_return_quantity#49, cr_return_amount#50]
+Input [8]: [cs_item_sk#38, cs_order_number#39, cs_quantity#40, cs_net_paid#41, cr_item_sk#47, cr_order_number#48, cr_return_quantity#49, cr_return_amount#50]
 
 (45) HashAggregate [codegen id : 16]
-Input [5]: [cs_item_sk#36, cs_quantity#38, cs_net_paid#39, cr_return_quantity#45, cr_return_amount#46]
-Keys [1]: [cs_item_sk#36]
-Functions [4]: [partial_sum(coalesce(cr_return_quantity#45, 0)), partial_sum(coalesce(cs_quantity#38, 0)), partial_sum(coalesce(cast(cr_return_amount#46 as decimal(12,2)), 0.00)), partial_sum(coalesce(cast(cs_net_paid#39 as decimal(12,2)), 0.00))]
-Aggregate Attributes [6]: [sum#48, sum#49, sum#50, isEmpty#51, sum#52, isEmpty#53]
-Results [7]: [cs_item_sk#36, sum#54, sum#55, sum#56, isEmpty#57, sum#58, isEmpty#59]
+Input [5]: [cs_item_sk#38, cs_quantity#40, cs_net_paid#41, cr_return_quantity#49, cr_return_amount#50]
+Keys [1]: [cs_item_sk#38]
+Functions [4]: [partial_sum(coalesce(cr_return_quantity#49, 0)), partial_sum(coalesce(cs_quantity#40, 0)), partial_sum(coalesce(cast(cr_return_amount#50 as decimal(12,2)), 0.00)), partial_sum(coalesce(cast(cs_net_paid#41 as decimal(12,2)), 0.00))]
+Aggregate Attributes [6]: [sum#52, sum#53, sum#54, isEmpty#55, sum#56, isEmpty#57]
+Results [7]: [cs_item_sk#38, sum#58, sum#59, sum#60, isEmpty#61, sum#62, isEmpty#63]
 
 (46) Exchange
-Input [7]: [cs_item_sk#36, sum#54, sum#55, sum#56, isEmpty#57, sum#58, isEmpty#59]
-Arguments: hashpartitioning(cs_item_sk#36, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+Input [7]: [cs_item_sk#38, sum#58, sum#59, sum#60, isEmpty#61, sum#62, isEmpty#63]
+Arguments: hashpartitioning(cs_item_sk#38, 5), ENSURE_REQUIREMENTS, [plan_id=7]
 
 (47) HashAggregate [codegen id : 17]
-Input [7]: [cs_item_sk#36, sum#54, sum#55, sum#56, isEmpty#57, sum#58, isEmpty#59]
-Keys [1]: [cs_item_sk#36]
-Functions [4]: [sum(coalesce(cr_return_quantity#45, 0)), sum(coalesce(cs_quantity#38, 0)), sum(coalesce(cast(cr_return_amount#46 as decimal(12,2)), 0.00)), sum(coalesce(cast(cs_net_paid#39 as decimal(12,2)), 0.00))]
-Aggregate Attributes [4]: [sum(coalesce(cr_return_quantity#45, 0))#60, sum(coalesce(cs_quantity#38, 0))#61, sum(coalesce(cast(cr_return_amount#46 as decimal(12,2)), 0.00))#62, sum(coalesce(cast(cs_net_paid#39 as decimal(12,2)), 0.00))#63]
-Results [3]: [cs_item_sk#36 AS item#64, (cast(sum(coalesce(cr_return_quantity#45, 0))#60 as decimal(15,4)) / cast(sum(coalesce(cs_quantity#38, 0))#61 as decimal(15,4))) AS return_ratio#65, (cast(sum(coalesce(cast(cr_return_amount#46 as decimal(12,2)), 0.00))#62 as decimal(15,4)) / cast(sum(coalesce(cast(cs_net_paid#39 as decimal(12,2)), 0.00))#63 as decimal(15,4))) AS currency_ratio#66]
+Input [7]: [cs_item_sk#38, sum#58, sum#59, sum#60, isEmpty#61, sum#62, isEmpty#63]
+Keys [1]: [cs_item_sk#38]
+Functions [4]: [sum(coalesce(cr_return_quantity#49, 0)), sum(coalesce(cs_quantity#40, 0)), sum(coalesce(cast(cr_return_amount#50 as decimal(12,2)), 0.00)), sum(coalesce(cast(cs_net_paid#41 as decimal(12,2)), 0.00))]
+Aggregate Attributes [4]: [sum(coalesce(cr_return_quantity#49, 0))#64, sum(coalesce(cs_quantity#40, 0))#65, sum(coalesce(cast(cr_return_amount#50 as decimal(12,2)), 0.00))#66, sum(coalesce(cast(cs_net_paid#41 as decimal(12,2)), 0.00))#67]
+Results [3]: [cs_item_sk#38 AS item#68, (cast(sum(coalesce(cr_return_quantity#49, 0))#64 as decimal(15,4)) / cast(sum(coalesce(cs_quantity#40, 0))#65 as decimal(15,4))) AS return_ratio#69, (cast(sum(coalesce(cast(cr_return_amount#50 as decimal(12,2)), 0.00))#66 as decimal(15,4)) / cast(sum(coalesce(cast(cs_net_paid#41 as decimal(12,2)), 0.00))#67 as decimal(15,4))) AS currency_ratio#70]
 
 (48) Exchange
-Input [3]: [item#64, return_ratio#65, currency_ratio#66]
+Input [3]: [item#68, return_ratio#69, currency_ratio#70]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=8]
 
 (49) Sort [codegen id : 18]
-Input [3]: [item#64, return_ratio#65, currency_ratio#66]
-Arguments: [return_ratio#65 ASC NULLS FIRST], false, 0
+Input [3]: [item#68, return_ratio#69, currency_ratio#70]
+Arguments: [return_ratio#69 ASC NULLS FIRST], false, 0
 
 (50) Window
-Input [3]: [item#64, return_ratio#65, currency_ratio#66]
-Arguments: [rank(return_ratio#65) windowspecdefinition(return_ratio#65 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS return_rank#67], [return_ratio#65 ASC NULLS FIRST]
+Input [3]: [item#68, return_ratio#69, currency_ratio#70]
+Arguments: [rank(return_ratio#69) windowspecdefinition(return_ratio#69 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS return_rank#71], [return_ratio#69 ASC NULLS FIRST]
 
 (51) Sort [codegen id : 19]
-Input [4]: [item#64, return_ratio#65, currency_ratio#66, return_rank#67]
-Arguments: [currency_ratio#66 ASC NULLS FIRST], false, 0
+Input [4]: [item#68, return_ratio#69, currency_ratio#70, return_rank#71]
+Arguments: [currency_ratio#70 ASC NULLS FIRST], false, 0
 
 (52) Window
-Input [4]: [item#64, return_ratio#65, currency_ratio#66, return_rank#67]
-Arguments: [rank(currency_ratio#66) windowspecdefinition(currency_ratio#66 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS currency_rank#68], [currency_ratio#66 ASC NULLS FIRST]
+Input [4]: [item#68, return_ratio#69, currency_ratio#70, return_rank#71]
+Arguments: [rank(currency_ratio#70) windowspecdefinition(currency_ratio#70 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS currency_rank#72], [currency_ratio#70 ASC NULLS FIRST]
 
 (53) Filter [codegen id : 20]
-Input [5]: [item#64, return_ratio#65, currency_ratio#66, return_rank#67, currency_rank#68]
-Condition : ((return_rank#67 <= 10) OR (currency_rank#68 <= 10))
+Input [5]: [item#68, return_ratio#69, currency_ratio#70, return_rank#71, currency_rank#72]
+Condition : ((return_rank#71 <= 10) OR (currency_rank#72 <= 10))
 
 (54) Project [codegen id : 20]
-Output [5]: [catalog AS channel#69, item#64, return_ratio#65, return_rank#67, currency_rank#68]
-Input [5]: [item#64, return_ratio#65, currency_ratio#66, return_rank#67, currency_rank#68]
+Output [5]: [catalog AS channel#73, item#68, return_ratio#69, return_rank#71, currency_rank#72]
+Input [5]: [item#68, return_ratio#69, currency_ratio#70, return_rank#71, currency_rank#72]
 
 (55) Scan parquet spark_catalog.default.store_sales
-Output [6]: [ss_item_sk#70, ss_ticket_number#71, ss_quantity#72, ss_net_paid#73, ss_net_profit#74, ss_sold_date_sk#75]
+Output [6]: [ss_item_sk#74, ss_ticket_number#75, ss_quantity#76, ss_net_paid#77, ss_net_profit#78, ss_sold_date_sk#79]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#75), dynamicpruningexpression(ss_sold_date_sk#75 IN dynamicpruning#7)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#79), dynamicpruningexpression(ss_sold_date_sk#79 IN dynamicpruning#7)]
 PushedFilters: [IsNotNull(ss_net_profit), IsNotNull(ss_net_paid), IsNotNull(ss_quantity), GreaterThan(ss_net_profit,1.00), GreaterThan(ss_net_paid,0.00), GreaterThan(ss_quantity,0), IsNotNull(ss_ticket_number), IsNotNull(ss_item_sk)]
 ReadSchema: struct<ss_item_sk:int,ss_ticket_number:int,ss_quantity:int,ss_net_paid:decimal(7,2),ss_net_profit:decimal(7,2)>
 
 (56) ColumnarToRow [codegen id : 22]
-Input [6]: [ss_item_sk#70, ss_ticket_number#71, ss_quantity#72, ss_net_paid#73, ss_net_profit#74, ss_sold_date_sk#75]
+Input [6]: [ss_item_sk#74, ss_ticket_number#75, ss_quantity#76, ss_net_paid#77, ss_net_profit#78, ss_sold_date_sk#79]
 
 (57) Filter [codegen id : 22]
-Input [6]: [ss_item_sk#70, ss_ticket_number#71, ss_quantity#72, ss_net_paid#73, ss_net_profit#74, ss_sold_date_sk#75]
-Condition : (((((((isnotnull(ss_net_profit#74) AND isnotnull(ss_net_paid#73)) AND isnotnull(ss_quantity#72)) AND (ss_net_profit#74 > 1.00)) AND (ss_net_paid#73 > 0.00)) AND (ss_quantity#72 > 0)) AND isnotnull(ss_ticket_number#71)) AND isnotnull(ss_item_sk#70))
+Input [6]: [ss_item_sk#74, ss_ticket_number#75, ss_quantity#76, ss_net_paid#77, ss_net_profit#78, ss_sold_date_sk#79]
+Condition : ((((((((isnotnull(ss_net_profit#78) AND isnotnull(ss_net_paid#77)) AND isnotnull(ss_quantity#76)) AND (ss_net_profit#78 > 1.00)) AND (ss_net_paid#77 > 0.00)) AND (ss_quantity#76 > 0)) AND isnotnull(ss_ticket_number#75)) AND isnotnull(ss_item_sk#74)) AND might_contain(Subquery scalar-subquery#80, [id=#81], xxhash64(ss_item_sk#74, 42)))
 
 (58) Project [codegen id : 22]
-Output [5]: [ss_item_sk#70, ss_ticket_number#71, ss_quantity#72, ss_net_paid#73, ss_sold_date_sk#75]
-Input [6]: [ss_item_sk#70, ss_ticket_number#71, ss_quantity#72, ss_net_paid#73, ss_net_profit#74, ss_sold_date_sk#75]
+Output [5]: [ss_item_sk#74, ss_ticket_number#75, ss_quantity#76, ss_net_paid#77, ss_sold_date_sk#79]
+Input [6]: [ss_item_sk#74, ss_ticket_number#75, ss_quantity#76, ss_net_paid#77, ss_net_profit#78, ss_sold_date_sk#79]
 
-(59) ReusedExchange [Reuses operator id: 91]
-Output [1]: [d_date_sk#76]
+(59) ReusedExchange [Reuses operator id: 98]
+Output [1]: [d_date_sk#82]
 
 (60) BroadcastHashJoin [codegen id : 22]
-Left keys [1]: [ss_sold_date_sk#75]
-Right keys [1]: [d_date_sk#76]
+Left keys [1]: [ss_sold_date_sk#79]
+Right keys [1]: [d_date_sk#82]
 Join type: Inner
 Join condition: None
 
 (61) Project [codegen id : 22]
-Output [4]: [ss_item_sk#70, ss_ticket_number#71, ss_quantity#72, ss_net_paid#73]
-Input [6]: [ss_item_sk#70, ss_ticket_number#71, ss_quantity#72, ss_net_paid#73, ss_sold_date_sk#75, d_date_sk#76]
+Output [4]: [ss_item_sk#74, ss_ticket_number#75, ss_quantity#76, ss_net_paid#77]
+Input [6]: [ss_item_sk#74, ss_ticket_number#75, ss_quantity#76, ss_net_paid#77, ss_sold_date_sk#79, d_date_sk#82]
 
 (62) Exchange
-Input [4]: [ss_item_sk#70, ss_ticket_number#71, ss_quantity#72, ss_net_paid#73]
-Arguments: hashpartitioning(ss_ticket_number#71, ss_item_sk#70, 5), ENSURE_REQUIREMENTS, [plan_id=9]
+Input [4]: [ss_item_sk#74, ss_ticket_number#75, ss_quantity#76, ss_net_paid#77]
+Arguments: hashpartitioning(ss_ticket_number#75, ss_item_sk#74, 5), ENSURE_REQUIREMENTS, [plan_id=9]
 
 (63) Sort [codegen id : 23]
-Input [4]: [ss_item_sk#70, ss_ticket_number#71, ss_quantity#72, ss_net_paid#73]
-Arguments: [ss_ticket_number#71 ASC NULLS FIRST, ss_item_sk#70 ASC NULLS FIRST], false, 0
+Input [4]: [ss_item_sk#74, ss_ticket_number#75, ss_quantity#76, ss_net_paid#77]
+Arguments: [ss_ticket_number#75 ASC NULLS FIRST, ss_item_sk#74 ASC NULLS FIRST], false, 0
 
 (64) Scan parquet spark_catalog.default.store_returns
-Output [5]: [sr_item_sk#77, sr_ticket_number#78, sr_return_quantity#79, sr_return_amt#80, sr_returned_date_sk#81]
+Output [5]: [sr_item_sk#83, sr_ticket_number#84, sr_return_quantity#85, sr_return_amt#86, sr_returned_date_sk#87]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store_returns]
 PushedFilters: [IsNotNull(sr_return_amt), GreaterThan(sr_return_amt,10000.00), IsNotNull(sr_ticket_number), IsNotNull(sr_item_sk)]
 ReadSchema: struct<sr_item_sk:int,sr_ticket_number:int,sr_return_quantity:int,sr_return_amt:decimal(7,2)>
 
 (65) ColumnarToRow [codegen id : 24]
-Input [5]: [sr_item_sk#77, sr_ticket_number#78, sr_return_quantity#79, sr_return_amt#80, sr_returned_date_sk#81]
+Input [5]: [sr_item_sk#83, sr_ticket_number#84, sr_return_quantity#85, sr_return_amt#86, sr_returned_date_sk#87]
 
 (66) Filter [codegen id : 24]
-Input [5]: [sr_item_sk#77, sr_ticket_number#78, sr_return_quantity#79, sr_return_amt#80, sr_returned_date_sk#81]
-Condition : (((isnotnull(sr_return_amt#80) AND (sr_return_amt#80 > 10000.00)) AND isnotnull(sr_ticket_number#78)) AND isnotnull(sr_item_sk#77))
+Input [5]: [sr_item_sk#83, sr_ticket_number#84, sr_return_quantity#85, sr_return_amt#86, sr_returned_date_sk#87]
+Condition : (((isnotnull(sr_return_amt#86) AND (sr_return_amt#86 > 10000.00)) AND isnotnull(sr_ticket_number#84)) AND isnotnull(sr_item_sk#83))
 
 (67) Project [codegen id : 24]
-Output [4]: [sr_item_sk#77, sr_ticket_number#78, sr_return_quantity#79, sr_return_amt#80]
-Input [5]: [sr_item_sk#77, sr_ticket_number#78, sr_return_quantity#79, sr_return_amt#80, sr_returned_date_sk#81]
+Output [4]: [sr_item_sk#83, sr_ticket_number#84, sr_return_quantity#85, sr_return_amt#86]
+Input [5]: [sr_item_sk#83, sr_ticket_number#84, sr_return_quantity#85, sr_return_amt#86, sr_returned_date_sk#87]
 
 (68) Exchange
-Input [4]: [sr_item_sk#77, sr_ticket_number#78, sr_return_quantity#79, sr_return_amt#80]
-Arguments: hashpartitioning(sr_ticket_number#78, sr_item_sk#77, 5), ENSURE_REQUIREMENTS, [plan_id=10]
+Input [4]: [sr_item_sk#83, sr_ticket_number#84, sr_return_quantity#85, sr_return_amt#86]
+Arguments: hashpartitioning(sr_ticket_number#84, sr_item_sk#83, 5), ENSURE_REQUIREMENTS, [plan_id=10]
 
 (69) Sort [codegen id : 25]
-Input [4]: [sr_item_sk#77, sr_ticket_number#78, sr_return_quantity#79, sr_return_amt#80]
-Arguments: [sr_ticket_number#78 ASC NULLS FIRST, sr_item_sk#77 ASC NULLS FIRST], false, 0
+Input [4]: [sr_item_sk#83, sr_ticket_number#84, sr_return_quantity#85, sr_return_amt#86]
+Arguments: [sr_ticket_number#84 ASC NULLS FIRST, sr_item_sk#83 ASC NULLS FIRST], false, 0
 
 (70) SortMergeJoin [codegen id : 26]
-Left keys [2]: [ss_ticket_number#71, ss_item_sk#70]
-Right keys [2]: [sr_ticket_number#78, sr_item_sk#77]
+Left keys [2]: [ss_ticket_number#75, ss_item_sk#74]
+Right keys [2]: [sr_ticket_number#84, sr_item_sk#83]
 Join type: Inner
 Join condition: None
 
 (71) Project [codegen id : 26]
-Output [5]: [ss_item_sk#70, ss_quantity#72, ss_net_paid#73, sr_return_quantity#79, sr_return_amt#80]
-Input [8]: [ss_item_sk#70, ss_ticket_number#71, ss_quantity#72, ss_net_paid#73, sr_item_sk#77, sr_ticket_number#78, sr_return_quantity#79, sr_return_amt#80]
+Output [5]: [ss_item_sk#74, ss_quantity#76, ss_net_paid#77, sr_return_quantity#85, sr_return_amt#86]
+Input [8]: [ss_item_sk#74, ss_ticket_number#75, ss_quantity#76, ss_net_paid#77, sr_item_sk#83, sr_ticket_number#84, sr_return_quantity#85, sr_return_amt#86]
 
 (72) HashAggregate [codegen id : 26]
-Input [5]: [ss_item_sk#70, ss_quantity#72, ss_net_paid#73, sr_return_quantity#79, sr_return_amt#80]
-Keys [1]: [ss_item_sk#70]
-Functions [4]: [partial_sum(coalesce(sr_return_quantity#79, 0)), partial_sum(coalesce(ss_quantity#72, 0)), partial_sum(coalesce(cast(sr_return_amt#80 as decimal(12,2)), 0.00)), partial_sum(coalesce(cast(ss_net_paid#73 as decimal(12,2)), 0.00))]
-Aggregate Attributes [6]: [sum#82, sum#83, sum#84, isEmpty#85, sum#86, isEmpty#87]
-Results [7]: [ss_item_sk#70, sum#88, sum#89, sum#90, isEmpty#91, sum#92, isEmpty#93]
+Input [5]: [ss_item_sk#74, ss_quantity#76, ss_net_paid#77, sr_return_quantity#85, sr_return_amt#86]
+Keys [1]: [ss_item_sk#74]
+Functions [4]: [partial_sum(coalesce(sr_return_quantity#85, 0)), partial_sum(coalesce(ss_quantity#76, 0)), partial_sum(coalesce(cast(sr_return_amt#86 as decimal(12,2)), 0.00)), partial_sum(coalesce(cast(ss_net_paid#77 as decimal(12,2)), 0.00))]
+Aggregate Attributes [6]: [sum#88, sum#89, sum#90, isEmpty#91, sum#92, isEmpty#93]
+Results [7]: [ss_item_sk#74, sum#94, sum#95, sum#96, isEmpty#97, sum#98, isEmpty#99]
 
 (73) Exchange
-Input [7]: [ss_item_sk#70, sum#88, sum#89, sum#90, isEmpty#91, sum#92, isEmpty#93]
-Arguments: hashpartitioning(ss_item_sk#70, 5), ENSURE_REQUIREMENTS, [plan_id=11]
+Input [7]: [ss_item_sk#74, sum#94, sum#95, sum#96, isEmpty#97, sum#98, isEmpty#99]
+Arguments: hashpartitioning(ss_item_sk#74, 5), ENSURE_REQUIREMENTS, [plan_id=11]
 
 (74) HashAggregate [codegen id : 27]
-Input [7]: [ss_item_sk#70, sum#88, sum#89, sum#90, isEmpty#91, sum#92, isEmpty#93]
-Keys [1]: [ss_item_sk#70]
-Functions [4]: [sum(coalesce(sr_return_quantity#79, 0)), sum(coalesce(ss_quantity#72, 0)), sum(coalesce(cast(sr_return_amt#80 as decimal(12,2)), 0.00)), sum(coalesce(cast(ss_net_paid#73 as decimal(12,2)), 0.00))]
-Aggregate Attributes [4]: [sum(coalesce(sr_return_quantity#79, 0))#94, sum(coalesce(ss_quantity#72, 0))#95, sum(coalesce(cast(sr_return_amt#80 as decimal(12,2)), 0.00))#96, sum(coalesce(cast(ss_net_paid#73 as decimal(12,2)), 0.00))#97]
-Results [3]: [ss_item_sk#70 AS item#98, (cast(sum(coalesce(sr_return_quantity#79, 0))#94 as decimal(15,4)) / cast(sum(coalesce(ss_quantity#72, 0))#95 as decimal(15,4))) AS return_ratio#99, (cast(sum(coalesce(cast(sr_return_amt#80 as decimal(12,2)), 0.00))#96 as decimal(15,4)) / cast(sum(coalesce(cast(ss_net_paid#73 as decimal(12,2)), 0.00))#97 as decimal(15,4))) AS currency_ratio#100]
+Input [7]: [ss_item_sk#74, sum#94, sum#95, sum#96, isEmpty#97, sum#98, isEmpty#99]
+Keys [1]: [ss_item_sk#74]
+Functions [4]: [sum(coalesce(sr_return_quantity#85, 0)), sum(coalesce(ss_quantity#76, 0)), sum(coalesce(cast(sr_return_amt#86 as decimal(12,2)), 0.00)), sum(coalesce(cast(ss_net_paid#77 as decimal(12,2)), 0.00))]
+Aggregate Attributes [4]: [sum(coalesce(sr_return_quantity#85, 0))#100, sum(coalesce(ss_quantity#76, 0))#101, sum(coalesce(cast(sr_return_amt#86 as decimal(12,2)), 0.00))#102, sum(coalesce(cast(ss_net_paid#77 as decimal(12,2)), 0.00))#103]
+Results [3]: [ss_item_sk#74 AS item#104, (cast(sum(coalesce(sr_return_quantity#85, 0))#100 as decimal(15,4)) / cast(sum(coalesce(ss_quantity#76, 0))#101 as decimal(15,4))) AS return_ratio#105, (cast(sum(coalesce(cast(sr_return_amt#86 as decimal(12,2)), 0.00))#102 as decimal(15,4)) / cast(sum(coalesce(cast(ss_net_paid#77 as decimal(12,2)), 0.00))#103 as decimal(15,4))) AS currency_ratio#106]
 
 (75) Exchange
-Input [3]: [item#98, return_ratio#99, currency_ratio#100]
+Input [3]: [item#104, return_ratio#105, currency_ratio#106]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=12]
 
 (76) Sort [codegen id : 28]
-Input [3]: [item#98, return_ratio#99, currency_ratio#100]
-Arguments: [return_ratio#99 ASC NULLS FIRST], false, 0
+Input [3]: [item#104, return_ratio#105, currency_ratio#106]
+Arguments: [return_ratio#105 ASC NULLS FIRST], false, 0
 
 (77) Window
-Input [3]: [item#98, return_ratio#99, currency_ratio#100]
-Arguments: [rank(return_ratio#99) windowspecdefinition(return_ratio#99 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS return_rank#101], [return_ratio#99 ASC NULLS FIRST]
+Input [3]: [item#104, return_ratio#105, currency_ratio#106]
+Arguments: [rank(return_ratio#105) windowspecdefinition(return_ratio#105 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS return_rank#107], [return_ratio#105 ASC NULLS FIRST]
 
 (78) Sort [codegen id : 29]
-Input [4]: [item#98, return_ratio#99, currency_ratio#100, return_rank#101]
-Arguments: [currency_ratio#100 ASC NULLS FIRST], false, 0
+Input [4]: [item#104, return_ratio#105, currency_ratio#106, return_rank#107]
+Arguments: [currency_ratio#106 ASC NULLS FIRST], false, 0
 
 (79) Window
-Input [4]: [item#98, return_ratio#99, currency_ratio#100, return_rank#101]
-Arguments: [rank(currency_ratio#100) windowspecdefinition(currency_ratio#100 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS currency_rank#102], [currency_ratio#100 ASC NULLS FIRST]
+Input [4]: [item#104, return_ratio#105, currency_ratio#106, return_rank#107]
+Arguments: [rank(currency_ratio#106) windowspecdefinition(currency_ratio#106 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS currency_rank#108], [currency_ratio#106 ASC NULLS FIRST]
 
 (80) Filter [codegen id : 30]
-Input [5]: [item#98, return_ratio#99, currency_ratio#100, return_rank#101, currency_rank#102]
-Condition : ((return_rank#101 <= 10) OR (currency_rank#102 <= 10))
+Input [5]: [item#104, return_ratio#105, currency_ratio#106, return_rank#107, currency_rank#108]
+Condition : ((return_rank#107 <= 10) OR (currency_rank#108 <= 10))
 
 (81) Project [codegen id : 30]
-Output [5]: [store AS channel#103, item#98, return_ratio#99, return_rank#101, currency_rank#102]
-Input [5]: [item#98, return_ratio#99, currency_ratio#100, return_rank#101, currency_rank#102]
+Output [5]: [store AS channel#109, item#104, return_ratio#105, return_rank#107, currency_rank#108]
+Input [5]: [item#104, return_ratio#105, currency_ratio#106, return_rank#107, currency_rank#108]
 
 (82) Union
 
 (83) HashAggregate [codegen id : 31]
-Input [5]: [channel#35, item#30, return_ratio#31, return_rank#33, currency_rank#34]
-Keys [5]: [channel#35, item#30, return_ratio#31, return_rank#33, currency_rank#34]
+Input [5]: [channel#37, item#32, return_ratio#33, return_rank#35, currency_rank#36]
+Keys [5]: [channel#37, item#32, return_ratio#33, return_rank#35, currency_rank#36]
 Functions: []
 Aggregate Attributes: []
-Results [5]: [channel#35, item#30, return_ratio#31, return_rank#33, currency_rank#34]
+Results [5]: [channel#37, item#32, return_ratio#33, return_rank#35, currency_rank#36]
 
 (84) Exchange
-Input [5]: [channel#35, item#30, return_ratio#31, return_rank#33, currency_rank#34]
-Arguments: hashpartitioning(channel#35, item#30, return_ratio#31, return_rank#33, currency_rank#34, 5), ENSURE_REQUIREMENTS, [plan_id=13]
+Input [5]: [channel#37, item#32, return_ratio#33, return_rank#35, currency_rank#36]
+Arguments: hashpartitioning(channel#37, item#32, return_ratio#33, return_rank#35, currency_rank#36, 5), ENSURE_REQUIREMENTS, [plan_id=13]
 
 (85) HashAggregate [codegen id : 32]
-Input [5]: [channel#35, item#30, return_ratio#31, return_rank#33, currency_rank#34]
-Keys [5]: [channel#35, item#30, return_ratio#31, return_rank#33, currency_rank#34]
+Input [5]: [channel#37, item#32, return_ratio#33, return_rank#35, currency_rank#36]
+Keys [5]: [channel#37, item#32, return_ratio#33, return_rank#35, currency_rank#36]
 Functions: []
 Aggregate Attributes: []
-Results [5]: [channel#35, item#30, return_ratio#31, return_rank#33, currency_rank#34]
+Results [5]: [channel#37, item#32, return_ratio#33, return_rank#35, currency_rank#36]
 
 (86) TakeOrderedAndProject
-Input [5]: [channel#35, item#30, return_ratio#31, return_rank#33, currency_rank#34]
-Arguments: 100, [channel#35 ASC NULLS FIRST, return_rank#33 ASC NULLS FIRST, currency_rank#34 ASC NULLS FIRST], [channel#35, item#30, return_ratio#31, return_rank#33, currency_rank#34]
+Input [5]: [channel#37, item#32, return_ratio#33, return_rank#35, currency_rank#36]
+Arguments: 100, [channel#37 ASC NULLS FIRST, return_rank#35 ASC NULLS FIRST, currency_rank#36 ASC NULLS FIRST], [channel#37, item#32, return_ratio#33, return_rank#35, currency_rank#36]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 1 Hosting Expression = ws_sold_date_sk#6 IN dynamicpruning#7
-BroadcastExchange (91)
-+- * Project (90)
-   +- * Filter (89)
-      +- * ColumnarToRow (88)
-         +- Scan parquet spark_catalog.default.date_dim (87)
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#8, [id=#9]
+ObjectHashAggregate (93)
++- Exchange (92)
+   +- ObjectHashAggregate (91)
+      +- * Project (90)
+         +- * Filter (89)
+            +- * ColumnarToRow (88)
+               +- Scan parquet spark_catalog.default.web_returns (87)
 
 
-(87) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#8, d_year#104, d_moy#105]
+(87) Scan parquet spark_catalog.default.web_returns
+Output [4]: [wr_item_sk#11, wr_order_number#12, wr_return_amt#14, wr_returned_date_sk#15]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/web_returns]
+PushedFilters: [IsNotNull(wr_return_amt), GreaterThan(wr_return_amt,10000.00), IsNotNull(wr_order_number), IsNotNull(wr_item_sk)]
+ReadSchema: struct<wr_item_sk:int,wr_order_number:int,wr_return_amt:decimal(7,2)>
+
+(88) ColumnarToRow [codegen id : 1]
+Input [4]: [wr_item_sk#11, wr_order_number#12, wr_return_amt#14, wr_returned_date_sk#15]
+
+(89) Filter [codegen id : 1]
+Input [4]: [wr_item_sk#11, wr_order_number#12, wr_return_amt#14, wr_returned_date_sk#15]
+Condition : (((isnotnull(wr_return_amt#14) AND (wr_return_amt#14 > 10000.00)) AND isnotnull(wr_order_number#12)) AND isnotnull(wr_item_sk#11))
+
+(90) Project [codegen id : 1]
+Output [1]: [wr_item_sk#11]
+Input [4]: [wr_item_sk#11, wr_order_number#12, wr_return_amt#14, wr_returned_date_sk#15]
+
+(91) ObjectHashAggregate
+Input [1]: [wr_item_sk#11]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(wr_item_sk#11, 42), 4449121, 32471646, 0, 0)]
+Aggregate Attributes [1]: [buf#110]
+Results [1]: [buf#111]
+
+(92) Exchange
+Input [1]: [buf#111]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=14]
+
+(93) ObjectHashAggregate
+Input [1]: [buf#111]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(wr_item_sk#11, 42), 4449121, 32471646, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(wr_item_sk#11, 42), 4449121, 32471646, 0, 0)#112]
+Results [1]: [bloom_filter_agg(xxhash64(wr_item_sk#11, 42), 4449121, 32471646, 0, 0)#112 AS bloomFilter#113]
+
+Subquery:2 Hosting operator id = 1 Hosting Expression = ws_sold_date_sk#6 IN dynamicpruning#7
+BroadcastExchange (98)
++- * Project (97)
+   +- * Filter (96)
+      +- * ColumnarToRow (95)
+         +- Scan parquet spark_catalog.default.date_dim (94)
+
+
+(94) Scan parquet spark_catalog.default.date_dim
+Output [3]: [d_date_sk#10, d_year#114, d_moy#115]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), EqualTo(d_year,2001), EqualTo(d_moy,12), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
 
-(88) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#8, d_year#104, d_moy#105]
+(95) ColumnarToRow [codegen id : 1]
+Input [3]: [d_date_sk#10, d_year#114, d_moy#115]
 
-(89) Filter [codegen id : 1]
-Input [3]: [d_date_sk#8, d_year#104, d_moy#105]
-Condition : ((((isnotnull(d_year#104) AND isnotnull(d_moy#105)) AND (d_year#104 = 2001)) AND (d_moy#105 = 12)) AND isnotnull(d_date_sk#8))
+(96) Filter [codegen id : 1]
+Input [3]: [d_date_sk#10, d_year#114, d_moy#115]
+Condition : ((((isnotnull(d_year#114) AND isnotnull(d_moy#115)) AND (d_year#114 = 2001)) AND (d_moy#115 = 12)) AND isnotnull(d_date_sk#10))
 
-(90) Project [codegen id : 1]
-Output [1]: [d_date_sk#8]
-Input [3]: [d_date_sk#8, d_year#104, d_moy#105]
+(97) Project [codegen id : 1]
+Output [1]: [d_date_sk#10]
+Input [3]: [d_date_sk#10, d_year#114, d_moy#115]
 
-(91) BroadcastExchange
-Input [1]: [d_date_sk#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=14]
+(98) BroadcastExchange
+Input [1]: [d_date_sk#10]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=15]
 
-Subquery:2 Hosting operator id = 28 Hosting Expression = cs_sold_date_sk#41 IN dynamicpruning#7
+Subquery:3 Hosting operator id = 30 Hosting Expression = Subquery scalar-subquery#44, [id=#45]
+ObjectHashAggregate (105)
++- Exchange (104)
+   +- ObjectHashAggregate (103)
+      +- * Project (102)
+         +- * Filter (101)
+            +- * ColumnarToRow (100)
+               +- Scan parquet spark_catalog.default.catalog_returns (99)
 
-Subquery:3 Hosting operator id = 55 Hosting Expression = ss_sold_date_sk#75 IN dynamicpruning#7
+
+(99) Scan parquet spark_catalog.default.catalog_returns
+Output [4]: [cr_item_sk#47, cr_order_number#48, cr_return_amount#50, cr_returned_date_sk#51]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/catalog_returns]
+PushedFilters: [IsNotNull(cr_return_amount), GreaterThan(cr_return_amount,10000.00), IsNotNull(cr_order_number), IsNotNull(cr_item_sk)]
+ReadSchema: struct<cr_item_sk:int,cr_order_number:int,cr_return_amount:decimal(7,2)>
+
+(100) ColumnarToRow [codegen id : 1]
+Input [4]: [cr_item_sk#47, cr_order_number#48, cr_return_amount#50, cr_returned_date_sk#51]
+
+(101) Filter [codegen id : 1]
+Input [4]: [cr_item_sk#47, cr_order_number#48, cr_return_amount#50, cr_returned_date_sk#51]
+Condition : (((isnotnull(cr_return_amount#50) AND (cr_return_amount#50 > 10000.00)) AND isnotnull(cr_order_number#48)) AND isnotnull(cr_item_sk#47))
+
+(102) Project [codegen id : 1]
+Output [1]: [cr_item_sk#47]
+Input [4]: [cr_item_sk#47, cr_order_number#48, cr_return_amount#50, cr_returned_date_sk#51]
+
+(103) ObjectHashAggregate
+Input [1]: [cr_item_sk#47]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(cr_item_sk#47, 42), 9210895, 67108864, 0, 0)]
+Aggregate Attributes [1]: [buf#116]
+Results [1]: [buf#117]
+
+(104) Exchange
+Input [1]: [buf#117]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=16]
+
+(105) ObjectHashAggregate
+Input [1]: [buf#117]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(cr_item_sk#47, 42), 9210895, 67108864, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(cr_item_sk#47, 42), 9210895, 67108864, 0, 0)#118]
+Results [1]: [bloom_filter_agg(xxhash64(cr_item_sk#47, 42), 9210895, 67108864, 0, 0)#118 AS bloomFilter#119]
+
+Subquery:4 Hosting operator id = 28 Hosting Expression = cs_sold_date_sk#43 IN dynamicpruning#7
+
+Subquery:5 Hosting operator id = 57 Hosting Expression = Subquery scalar-subquery#80, [id=#81]
+ObjectHashAggregate (112)
++- Exchange (111)
+   +- ObjectHashAggregate (110)
+      +- * Project (109)
+         +- * Filter (108)
+            +- * ColumnarToRow (107)
+               +- Scan parquet spark_catalog.default.store_returns (106)
+
+
+(106) Scan parquet spark_catalog.default.store_returns
+Output [4]: [sr_item_sk#83, sr_ticket_number#84, sr_return_amt#86, sr_returned_date_sk#87]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/store_returns]
+PushedFilters: [IsNotNull(sr_return_amt), GreaterThan(sr_return_amt,10000.00), IsNotNull(sr_ticket_number), IsNotNull(sr_item_sk)]
+ReadSchema: struct<sr_item_sk:int,sr_ticket_number:int,sr_return_amt:decimal(7,2)>
+
+(107) ColumnarToRow [codegen id : 1]
+Input [4]: [sr_item_sk#83, sr_ticket_number#84, sr_return_amt#86, sr_returned_date_sk#87]
+
+(108) Filter [codegen id : 1]
+Input [4]: [sr_item_sk#83, sr_ticket_number#84, sr_return_amt#86, sr_returned_date_sk#87]
+Condition : (((isnotnull(sr_return_amt#86) AND (sr_return_amt#86 > 10000.00)) AND isnotnull(sr_ticket_number#84)) AND isnotnull(sr_item_sk#83))
+
+(109) Project [codegen id : 1]
+Output [1]: [sr_item_sk#83]
+Input [4]: [sr_item_sk#83, sr_ticket_number#84, sr_return_amt#86, sr_returned_date_sk#87]
+
+(110) ObjectHashAggregate
+Input [1]: [sr_item_sk#83]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(sr_item_sk#83, 42), 13141919, 67108864, 0, 0)]
+Aggregate Attributes [1]: [buf#120]
+Results [1]: [buf#121]
+
+(111) Exchange
+Input [1]: [buf#121]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=17]
+
+(112) ObjectHashAggregate
+Input [1]: [buf#121]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(sr_item_sk#83, 42), 13141919, 67108864, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(sr_item_sk#83, 42), 13141919, 67108864, 0, 0)#122]
+Results [1]: [bloom_filter_agg(xxhash64(sr_item_sk#83, 42), 13141919, 67108864, 0, 0)#122 AS bloomFilter#123]
+
+Subquery:6 Hosting operator id = 55 Hosting Expression = ss_sold_date_sk#79 IN dynamicpruning#7
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q49.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q49.sf100/simplified.txt
@@ -38,6 +38,16 @@ TakeOrderedAndProject [channel,return_rank,currency_rank,item,return_ratio]
                                                                           BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
                                                                             Project [ws_item_sk,ws_order_number,ws_quantity,ws_net_paid,ws_sold_date_sk]
                                                                               Filter [ws_net_profit,ws_net_paid,ws_quantity,ws_order_number,ws_item_sk]
+                                                                                Subquery #2
+                                                                                  ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(wr_item_sk, 42), 4449121, 32471646, 0, 0),bloomFilter,buf]
+                                                                                    Exchange #6
+                                                                                      ObjectHashAggregate [wr_item_sk] [buf,buf]
+                                                                                        WholeStageCodegen (1)
+                                                                                          Project [wr_item_sk]
+                                                                                            Filter [wr_return_amt,wr_order_number,wr_item_sk]
+                                                                                              ColumnarToRow
+                                                                                                InputAdapter
+                                                                                                  Scan parquet spark_catalog.default.web_returns [wr_item_sk,wr_order_number,wr_return_amt,wr_returned_date_sk]
                                                                                 ColumnarToRow
                                                                                   InputAdapter
                                                                                     Scan parquet spark_catalog.default.web_sales [ws_item_sk,ws_order_number,ws_quantity,ws_net_paid,ws_net_profit,ws_sold_date_sk]
@@ -55,7 +65,7 @@ TakeOrderedAndProject [channel,return_rank,currency_rank,item,return_ratio]
                                                               WholeStageCodegen (5)
                                                                 Sort [wr_order_number,wr_item_sk]
                                                                   InputAdapter
-                                                                    Exchange [wr_order_number,wr_item_sk] #6
+                                                                    Exchange [wr_order_number,wr_item_sk] #7
                                                                       WholeStageCodegen (4)
                                                                         Project [wr_item_sk,wr_order_number,wr_return_quantity,wr_return_amt]
                                                                           Filter [wr_return_amt,wr_order_number,wr_item_sk]
@@ -74,11 +84,11 @@ TakeOrderedAndProject [channel,return_rank,currency_rank,item,return_ratio]
                                     WholeStageCodegen (18)
                                       Sort [return_ratio]
                                         InputAdapter
-                                          Exchange #7
+                                          Exchange #8
                                             WholeStageCodegen (17)
                                               HashAggregate [cs_item_sk,sum,sum,sum,isEmpty,sum,isEmpty] [sum(coalesce(cr_return_quantity, 0)),sum(coalesce(cs_quantity, 0)),sum(coalesce(cast(cr_return_amount as decimal(12,2)), 0.00)),sum(coalesce(cast(cs_net_paid as decimal(12,2)), 0.00)),item,return_ratio,currency_ratio,sum,sum,sum,isEmpty,sum,isEmpty]
                                                 InputAdapter
-                                                  Exchange [cs_item_sk] #8
+                                                  Exchange [cs_item_sk] #9
                                                     WholeStageCodegen (16)
                                                       HashAggregate [cs_item_sk,cr_return_quantity,cs_quantity,cr_return_amount,cs_net_paid] [sum,sum,sum,isEmpty,sum,isEmpty,sum,sum,sum,isEmpty,sum,isEmpty]
                                                         Project [cs_item_sk,cs_quantity,cs_net_paid,cr_return_quantity,cr_return_amount]
@@ -87,12 +97,22 @@ TakeOrderedAndProject [channel,return_rank,currency_rank,item,return_ratio]
                                                               WholeStageCodegen (13)
                                                                 Sort [cs_order_number,cs_item_sk]
                                                                   InputAdapter
-                                                                    Exchange [cs_order_number,cs_item_sk] #9
+                                                                    Exchange [cs_order_number,cs_item_sk] #10
                                                                       WholeStageCodegen (12)
                                                                         Project [cs_item_sk,cs_order_number,cs_quantity,cs_net_paid]
                                                                           BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
                                                                             Project [cs_item_sk,cs_order_number,cs_quantity,cs_net_paid,cs_sold_date_sk]
                                                                               Filter [cs_net_profit,cs_net_paid,cs_quantity,cs_order_number,cs_item_sk]
+                                                                                Subquery #3
+                                                                                  ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(cr_item_sk, 42), 9210895, 67108864, 0, 0),bloomFilter,buf]
+                                                                                    Exchange #11
+                                                                                      ObjectHashAggregate [cr_item_sk] [buf,buf]
+                                                                                        WholeStageCodegen (1)
+                                                                                          Project [cr_item_sk]
+                                                                                            Filter [cr_return_amount,cr_order_number,cr_item_sk]
+                                                                                              ColumnarToRow
+                                                                                                InputAdapter
+                                                                                                  Scan parquet spark_catalog.default.catalog_returns [cr_item_sk,cr_order_number,cr_return_amount,cr_returned_date_sk]
                                                                                 ColumnarToRow
                                                                                   InputAdapter
                                                                                     Scan parquet spark_catalog.default.catalog_sales [cs_item_sk,cs_order_number,cs_quantity,cs_net_paid,cs_net_profit,cs_sold_date_sk]
@@ -103,7 +123,7 @@ TakeOrderedAndProject [channel,return_rank,currency_rank,item,return_ratio]
                                                               WholeStageCodegen (15)
                                                                 Sort [cr_order_number,cr_item_sk]
                                                                   InputAdapter
-                                                                    Exchange [cr_order_number,cr_item_sk] #10
+                                                                    Exchange [cr_order_number,cr_item_sk] #12
                                                                       WholeStageCodegen (14)
                                                                         Project [cr_item_sk,cr_order_number,cr_return_quantity,cr_return_amount]
                                                                           Filter [cr_return_amount,cr_order_number,cr_item_sk]
@@ -122,11 +142,11 @@ TakeOrderedAndProject [channel,return_rank,currency_rank,item,return_ratio]
                                     WholeStageCodegen (28)
                                       Sort [return_ratio]
                                         InputAdapter
-                                          Exchange #11
+                                          Exchange #13
                                             WholeStageCodegen (27)
                                               HashAggregate [ss_item_sk,sum,sum,sum,isEmpty,sum,isEmpty] [sum(coalesce(sr_return_quantity, 0)),sum(coalesce(ss_quantity, 0)),sum(coalesce(cast(sr_return_amt as decimal(12,2)), 0.00)),sum(coalesce(cast(ss_net_paid as decimal(12,2)), 0.00)),item,return_ratio,currency_ratio,sum,sum,sum,isEmpty,sum,isEmpty]
                                                 InputAdapter
-                                                  Exchange [ss_item_sk] #12
+                                                  Exchange [ss_item_sk] #14
                                                     WholeStageCodegen (26)
                                                       HashAggregate [ss_item_sk,sr_return_quantity,ss_quantity,sr_return_amt,ss_net_paid] [sum,sum,sum,isEmpty,sum,isEmpty,sum,sum,sum,isEmpty,sum,isEmpty]
                                                         Project [ss_item_sk,ss_quantity,ss_net_paid,sr_return_quantity,sr_return_amt]
@@ -135,12 +155,22 @@ TakeOrderedAndProject [channel,return_rank,currency_rank,item,return_ratio]
                                                               WholeStageCodegen (23)
                                                                 Sort [ss_ticket_number,ss_item_sk]
                                                                   InputAdapter
-                                                                    Exchange [ss_ticket_number,ss_item_sk] #13
+                                                                    Exchange [ss_ticket_number,ss_item_sk] #15
                                                                       WholeStageCodegen (22)
                                                                         Project [ss_item_sk,ss_ticket_number,ss_quantity,ss_net_paid]
                                                                           BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                                                             Project [ss_item_sk,ss_ticket_number,ss_quantity,ss_net_paid,ss_sold_date_sk]
                                                                               Filter [ss_net_profit,ss_net_paid,ss_quantity,ss_ticket_number,ss_item_sk]
+                                                                                Subquery #4
+                                                                                  ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(sr_item_sk, 42), 13141919, 67108864, 0, 0),bloomFilter,buf]
+                                                                                    Exchange #16
+                                                                                      ObjectHashAggregate [sr_item_sk] [buf,buf]
+                                                                                        WholeStageCodegen (1)
+                                                                                          Project [sr_item_sk]
+                                                                                            Filter [sr_return_amt,sr_ticket_number,sr_item_sk]
+                                                                                              ColumnarToRow
+                                                                                                InputAdapter
+                                                                                                  Scan parquet spark_catalog.default.store_returns [sr_item_sk,sr_ticket_number,sr_return_amt,sr_returned_date_sk]
                                                                                 ColumnarToRow
                                                                                   InputAdapter
                                                                                     Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_ticket_number,ss_quantity,ss_net_paid,ss_net_profit,ss_sold_date_sk]
@@ -151,7 +181,7 @@ TakeOrderedAndProject [channel,return_rank,currency_rank,item,return_ratio]
                                                               WholeStageCodegen (25)
                                                                 Sort [sr_ticket_number,sr_item_sk]
                                                                   InputAdapter
-                                                                    Exchange [sr_ticket_number,sr_item_sk] #14
+                                                                    Exchange [sr_ticket_number,sr_item_sk] #17
                                                                       WholeStageCodegen (24)
                                                                         Project [sr_item_sk,sr_ticket_number,sr_return_quantity,sr_return_amt]
                                                                           Filter [sr_return_amt,sr_ticket_number,sr_item_sk]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q98.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q98.sf100/explain.txt
@@ -39,7 +39,7 @@ Input [3]: [ss_item_sk#1, ss_ext_sales_price#2, ss_sold_date_sk#3]
 
 (3) Filter [codegen id : 1]
 Input [3]: [ss_item_sk#1, ss_ext_sales_price#2, ss_sold_date_sk#3]
-Condition : isnotnull(ss_item_sk#1)
+Condition : (isnotnull(ss_item_sk#1) AND might_contain(Subquery scalar-subquery#5, [id=#6], xxhash64(ss_item_sk#1, 42)))
 
 (4) Exchange
 Input [3]: [ss_item_sk#1, ss_ext_sales_price#2, ss_sold_date_sk#3]
@@ -50,126 +50,172 @@ Input [3]: [ss_item_sk#1, ss_ext_sales_price#2, ss_sold_date_sk#3]
 Arguments: [ss_item_sk#1 ASC NULLS FIRST], false, 0
 
 (6) Scan parquet spark_catalog.default.item
-Output [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
+Output [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [In(i_category, [Books                                             ,Home                                              ,Sports                                            ]), IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_item_id:string,i_item_desc:string,i_current_price:decimal(7,2),i_class:string,i_category:string>
 
 (7) ColumnarToRow [codegen id : 3]
-Input [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
+Input [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
 
 (8) Filter [codegen id : 3]
-Input [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Condition : (i_category#10 IN (Sports                                            ,Books                                             ,Home                                              ) AND isnotnull(i_item_sk#5))
+Input [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Condition : (i_category#12 IN (Sports                                            ,Books                                             ,Home                                              ) AND isnotnull(i_item_sk#7))
 
 (9) Exchange
-Input [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Arguments: hashpartitioning(i_item_sk#5, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+Input [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Arguments: hashpartitioning(i_item_sk#7, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
 (10) Sort [codegen id : 4]
-Input [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Arguments: [i_item_sk#5 ASC NULLS FIRST], false, 0
+Input [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Arguments: [i_item_sk#7 ASC NULLS FIRST], false, 0
 
 (11) SortMergeJoin [codegen id : 6]
 Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [i_item_sk#5]
+Right keys [1]: [i_item_sk#7]
 Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 6]
-Output [7]: [ss_ext_sales_price#2, ss_sold_date_sk#3, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Input [9]: [ss_item_sk#1, ss_ext_sales_price#2, ss_sold_date_sk#3, i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
+Output [7]: [ss_ext_sales_price#2, ss_sold_date_sk#3, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Input [9]: [ss_item_sk#1, ss_ext_sales_price#2, ss_sold_date_sk#3, i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
 
-(13) ReusedExchange [Reuses operator id: 30]
-Output [1]: [d_date_sk#11]
+(13) ReusedExchange [Reuses operator id: 37]
+Output [1]: [d_date_sk#13]
 
 (14) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_sold_date_sk#3]
-Right keys [1]: [d_date_sk#11]
+Right keys [1]: [d_date_sk#13]
 Join type: Inner
 Join condition: None
 
 (15) Project [codegen id : 6]
-Output [6]: [ss_ext_sales_price#2, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Input [8]: [ss_ext_sales_price#2, ss_sold_date_sk#3, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10, d_date_sk#11]
+Output [6]: [ss_ext_sales_price#2, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Input [8]: [ss_ext_sales_price#2, ss_sold_date_sk#3, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12, d_date_sk#13]
 
 (16) HashAggregate [codegen id : 6]
-Input [6]: [ss_ext_sales_price#2, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Keys [5]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8]
+Input [6]: [ss_ext_sales_price#2, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Keys [5]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10]
 Functions [1]: [partial_sum(UnscaledValue(ss_ext_sales_price#2))]
-Aggregate Attributes [1]: [sum#12]
-Results [6]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, sum#13]
+Aggregate Attributes [1]: [sum#14]
+Results [6]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, sum#15]
 
 (17) Exchange
-Input [6]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, sum#13]
-Arguments: hashpartitioning(i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+Input [6]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, sum#15]
+Arguments: hashpartitioning(i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (18) HashAggregate [codegen id : 7]
-Input [6]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, sum#13]
-Keys [5]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8]
+Input [6]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, sum#15]
+Keys [5]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10]
 Functions [1]: [sum(UnscaledValue(ss_ext_sales_price#2))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ss_ext_sales_price#2))#14]
-Results [7]: [i_item_desc#7, i_category#10, i_class#9, i_current_price#8, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#2))#14,17,2) AS itemrevenue#15, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#2))#14,17,2) AS _w0#16, i_item_id#6]
+Aggregate Attributes [1]: [sum(UnscaledValue(ss_ext_sales_price#2))#16]
+Results [7]: [i_item_desc#9, i_category#12, i_class#11, i_current_price#10, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#2))#16,17,2) AS itemrevenue#17, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#2))#16,17,2) AS _w0#18, i_item_id#8]
 
 (19) Exchange
-Input [7]: [i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, _w0#16, i_item_id#6]
-Arguments: hashpartitioning(i_class#9, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+Input [7]: [i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, _w0#18, i_item_id#8]
+Arguments: hashpartitioning(i_class#11, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
 (20) Sort [codegen id : 8]
-Input [7]: [i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, _w0#16, i_item_id#6]
-Arguments: [i_class#9 ASC NULLS FIRST], false, 0
+Input [7]: [i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, _w0#18, i_item_id#8]
+Arguments: [i_class#11 ASC NULLS FIRST], false, 0
 
 (21) Window
-Input [7]: [i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, _w0#16, i_item_id#6]
-Arguments: [sum(_w0#16) windowspecdefinition(i_class#9, specifiedwindowframe(RowFrame, unboundedpreceding$(), unboundedfollowing$())) AS _we0#17], [i_class#9]
+Input [7]: [i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, _w0#18, i_item_id#8]
+Arguments: [sum(_w0#18) windowspecdefinition(i_class#11, specifiedwindowframe(RowFrame, unboundedpreceding$(), unboundedfollowing$())) AS _we0#19], [i_class#11]
 
 (22) Project [codegen id : 9]
-Output [7]: [i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, ((_w0#16 * 100) / _we0#17) AS revenueratio#18, i_item_id#6]
-Input [8]: [i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, _w0#16, i_item_id#6, _we0#17]
+Output [7]: [i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, ((_w0#18 * 100) / _we0#19) AS revenueratio#20, i_item_id#8]
+Input [8]: [i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, _w0#18, i_item_id#8, _we0#19]
 
 (23) Exchange
-Input [7]: [i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, revenueratio#18, i_item_id#6]
-Arguments: rangepartitioning(i_category#10 ASC NULLS FIRST, i_class#9 ASC NULLS FIRST, i_item_id#6 ASC NULLS FIRST, i_item_desc#7 ASC NULLS FIRST, revenueratio#18 ASC NULLS FIRST, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+Input [7]: [i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, revenueratio#20, i_item_id#8]
+Arguments: rangepartitioning(i_category#12 ASC NULLS FIRST, i_class#11 ASC NULLS FIRST, i_item_id#8 ASC NULLS FIRST, i_item_desc#9 ASC NULLS FIRST, revenueratio#20 ASC NULLS FIRST, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
 (24) Sort [codegen id : 10]
-Input [7]: [i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, revenueratio#18, i_item_id#6]
-Arguments: [i_category#10 ASC NULLS FIRST, i_class#9 ASC NULLS FIRST, i_item_id#6 ASC NULLS FIRST, i_item_desc#7 ASC NULLS FIRST, revenueratio#18 ASC NULLS FIRST], true, 0
+Input [7]: [i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, revenueratio#20, i_item_id#8]
+Arguments: [i_category#12 ASC NULLS FIRST, i_class#11 ASC NULLS FIRST, i_item_id#8 ASC NULLS FIRST, i_item_desc#9 ASC NULLS FIRST, revenueratio#20 ASC NULLS FIRST], true, 0
 
 (25) Project [codegen id : 10]
-Output [6]: [i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, revenueratio#18]
-Input [7]: [i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, revenueratio#18, i_item_id#6]
+Output [6]: [i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, revenueratio#20]
+Input [7]: [i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, revenueratio#20, i_item_id#8]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#3 IN dynamicpruning#4
-BroadcastExchange (30)
-+- * Project (29)
-   +- * Filter (28)
-      +- * ColumnarToRow (27)
-         +- Scan parquet spark_catalog.default.date_dim (26)
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#5, [id=#6]
+ObjectHashAggregate (32)
++- Exchange (31)
+   +- ObjectHashAggregate (30)
+      +- * Project (29)
+         +- * Filter (28)
+            +- * ColumnarToRow (27)
+               +- Scan parquet spark_catalog.default.item (26)
 
 
-(26) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#11, d_date#19]
+(26) Scan parquet spark_catalog.default.item
+Output [2]: [i_item_sk#7, i_category#12]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/item]
+PushedFilters: [In(i_category, [Books                                             ,Home                                              ,Sports                                            ]), IsNotNull(i_item_sk)]
+ReadSchema: struct<i_item_sk:int,i_category:string>
+
+(27) ColumnarToRow [codegen id : 1]
+Input [2]: [i_item_sk#7, i_category#12]
+
+(28) Filter [codegen id : 1]
+Input [2]: [i_item_sk#7, i_category#12]
+Condition : (i_category#12 IN (Sports                                            ,Books                                             ,Home                                              ) AND isnotnull(i_item_sk#7))
+
+(29) Project [codegen id : 1]
+Output [1]: [i_item_sk#7]
+Input [2]: [i_item_sk#7, i_category#12]
+
+(30) ObjectHashAggregate
+Input [1]: [i_item_sk#7]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#7, 42), 61200, 979099, 0, 0)]
+Aggregate Attributes [1]: [buf#21]
+Results [1]: [buf#22]
+
+(31) Exchange
+Input [1]: [buf#22]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=6]
+
+(32) ObjectHashAggregate
+Input [1]: [buf#22]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#7, 42), 61200, 979099, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#7, 42), 61200, 979099, 0, 0)#23]
+Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#7, 42), 61200, 979099, 0, 0)#23 AS bloomFilter#24]
+
+Subquery:2 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#3 IN dynamicpruning#4
+BroadcastExchange (37)
++- * Project (36)
+   +- * Filter (35)
+      +- * ColumnarToRow (34)
+         +- Scan parquet spark_catalog.default.date_dim (33)
+
+
+(33) Scan parquet spark_catalog.default.date_dim
+Output [2]: [d_date_sk#13, d_date#25]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,1999-02-22), LessThanOrEqual(d_date,1999-03-24), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
-(27) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#11, d_date#19]
+(34) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#13, d_date#25]
 
-(28) Filter [codegen id : 1]
-Input [2]: [d_date_sk#11, d_date#19]
-Condition : (((isnotnull(d_date#19) AND (d_date#19 >= 1999-02-22)) AND (d_date#19 <= 1999-03-24)) AND isnotnull(d_date_sk#11))
+(35) Filter [codegen id : 1]
+Input [2]: [d_date_sk#13, d_date#25]
+Condition : (((isnotnull(d_date#25) AND (d_date#25 >= 1999-02-22)) AND (d_date#25 <= 1999-03-24)) AND isnotnull(d_date_sk#13))
 
-(29) Project [codegen id : 1]
-Output [1]: [d_date_sk#11]
-Input [2]: [d_date_sk#11, d_date#19]
+(36) Project [codegen id : 1]
+Output [1]: [d_date_sk#13]
+Input [2]: [d_date_sk#13, d_date#25]
 
-(30) BroadcastExchange
-Input [1]: [d_date_sk#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=6]
+(37) BroadcastExchange
+Input [1]: [d_date_sk#13]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=7]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q98.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q98.sf100/simplified.txt
@@ -28,6 +28,16 @@ WholeStageCodegen (10)
                                                       Exchange [ss_item_sk] #4
                                                         WholeStageCodegen (1)
                                                           Filter [ss_item_sk]
+                                                            Subquery #2
+                                                              ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(i_item_sk, 42), 61200, 979099, 0, 0),bloomFilter,buf]
+                                                                Exchange #6
+                                                                  ObjectHashAggregate [i_item_sk] [buf,buf]
+                                                                    WholeStageCodegen (1)
+                                                                      Project [i_item_sk]
+                                                                        Filter [i_category,i_item_sk]
+                                                                          ColumnarToRow
+                                                                            InputAdapter
+                                                                              Scan parquet spark_catalog.default.item [i_item_sk,i_category]
                                                             ColumnarToRow
                                                               InputAdapter
                                                                 Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_ext_sales_price,ss_sold_date_sk]
@@ -43,7 +53,7 @@ WholeStageCodegen (10)
                                                 WholeStageCodegen (4)
                                                   Sort [i_item_sk]
                                                     InputAdapter
-                                                      Exchange [i_item_sk] #6
+                                                      Exchange [i_item_sk] #7
                                                         WholeStageCodegen (3)
                                                           Filter [i_category,i_item_sk]
                                                             ColumnarToRow

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q12.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q12.sf100/explain.txt
@@ -37,7 +37,7 @@ Input [3]: [ws_item_sk#1, ws_ext_sales_price#2, ws_sold_date_sk#3]
 
 (3) Filter [codegen id : 1]
 Input [3]: [ws_item_sk#1, ws_ext_sales_price#2, ws_sold_date_sk#3]
-Condition : isnotnull(ws_item_sk#1)
+Condition : (isnotnull(ws_item_sk#1) AND might_contain(Subquery scalar-subquery#5, [id=#6], xxhash64(ws_item_sk#1, 42)))
 
 (4) Exchange
 Input [3]: [ws_item_sk#1, ws_ext_sales_price#2, ws_sold_date_sk#3]
@@ -48,118 +48,164 @@ Input [3]: [ws_item_sk#1, ws_ext_sales_price#2, ws_sold_date_sk#3]
 Arguments: [ws_item_sk#1 ASC NULLS FIRST], false, 0
 
 (6) Scan parquet spark_catalog.default.item
-Output [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
+Output [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [In(i_category, [Books                                             ,Home                                              ,Sports                                            ]), IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_item_id:string,i_item_desc:string,i_current_price:decimal(7,2),i_class:string,i_category:string>
 
 (7) ColumnarToRow [codegen id : 3]
-Input [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
+Input [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
 
 (8) Filter [codegen id : 3]
-Input [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Condition : (i_category#10 IN (Sports                                            ,Books                                             ,Home                                              ) AND isnotnull(i_item_sk#5))
+Input [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Condition : (i_category#12 IN (Sports                                            ,Books                                             ,Home                                              ) AND isnotnull(i_item_sk#7))
 
 (9) Exchange
-Input [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Arguments: hashpartitioning(i_item_sk#5, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+Input [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Arguments: hashpartitioning(i_item_sk#7, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
 (10) Sort [codegen id : 4]
-Input [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Arguments: [i_item_sk#5 ASC NULLS FIRST], false, 0
+Input [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Arguments: [i_item_sk#7 ASC NULLS FIRST], false, 0
 
 (11) SortMergeJoin [codegen id : 6]
 Left keys [1]: [ws_item_sk#1]
-Right keys [1]: [i_item_sk#5]
+Right keys [1]: [i_item_sk#7]
 Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 6]
-Output [7]: [ws_ext_sales_price#2, ws_sold_date_sk#3, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Input [9]: [ws_item_sk#1, ws_ext_sales_price#2, ws_sold_date_sk#3, i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
+Output [7]: [ws_ext_sales_price#2, ws_sold_date_sk#3, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Input [9]: [ws_item_sk#1, ws_ext_sales_price#2, ws_sold_date_sk#3, i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
 
-(13) ReusedExchange [Reuses operator id: 28]
-Output [1]: [d_date_sk#11]
+(13) ReusedExchange [Reuses operator id: 35]
+Output [1]: [d_date_sk#13]
 
 (14) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ws_sold_date_sk#3]
-Right keys [1]: [d_date_sk#11]
+Right keys [1]: [d_date_sk#13]
 Join type: Inner
 Join condition: None
 
 (15) Project [codegen id : 6]
-Output [6]: [ws_ext_sales_price#2, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Input [8]: [ws_ext_sales_price#2, ws_sold_date_sk#3, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10, d_date_sk#11]
+Output [6]: [ws_ext_sales_price#2, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Input [8]: [ws_ext_sales_price#2, ws_sold_date_sk#3, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12, d_date_sk#13]
 
 (16) HashAggregate [codegen id : 6]
-Input [6]: [ws_ext_sales_price#2, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Keys [5]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8]
+Input [6]: [ws_ext_sales_price#2, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Keys [5]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10]
 Functions [1]: [partial_sum(UnscaledValue(ws_ext_sales_price#2))]
-Aggregate Attributes [1]: [sum#12]
-Results [6]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, sum#13]
+Aggregate Attributes [1]: [sum#14]
+Results [6]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, sum#15]
 
 (17) Exchange
-Input [6]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, sum#13]
-Arguments: hashpartitioning(i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+Input [6]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, sum#15]
+Arguments: hashpartitioning(i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (18) HashAggregate [codegen id : 7]
-Input [6]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, sum#13]
-Keys [5]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8]
+Input [6]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, sum#15]
+Keys [5]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10]
 Functions [1]: [sum(UnscaledValue(ws_ext_sales_price#2))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ws_ext_sales_price#2))#14]
-Results [7]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#2))#14,17,2) AS itemrevenue#15, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#2))#14,17,2) AS _w0#16]
+Aggregate Attributes [1]: [sum(UnscaledValue(ws_ext_sales_price#2))#16]
+Results [7]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#2))#16,17,2) AS itemrevenue#17, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#2))#16,17,2) AS _w0#18]
 
 (19) Exchange
-Input [7]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, _w0#16]
-Arguments: hashpartitioning(i_class#9, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+Input [7]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, _w0#18]
+Arguments: hashpartitioning(i_class#11, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
 (20) Sort [codegen id : 8]
-Input [7]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, _w0#16]
-Arguments: [i_class#9 ASC NULLS FIRST], false, 0
+Input [7]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, _w0#18]
+Arguments: [i_class#11 ASC NULLS FIRST], false, 0
 
 (21) Window
-Input [7]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, _w0#16]
-Arguments: [sum(_w0#16) windowspecdefinition(i_class#9, specifiedwindowframe(RowFrame, unboundedpreceding$(), unboundedfollowing$())) AS _we0#17], [i_class#9]
+Input [7]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, _w0#18]
+Arguments: [sum(_w0#18) windowspecdefinition(i_class#11, specifiedwindowframe(RowFrame, unboundedpreceding$(), unboundedfollowing$())) AS _we0#19], [i_class#11]
 
 (22) Project [codegen id : 9]
-Output [7]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, ((_w0#16 * 100) / _we0#17) AS revenueratio#18]
-Input [8]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, _w0#16, _we0#17]
+Output [7]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, ((_w0#18 * 100) / _we0#19) AS revenueratio#20]
+Input [8]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, _w0#18, _we0#19]
 
 (23) TakeOrderedAndProject
-Input [7]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, revenueratio#18]
-Arguments: 100, [i_category#10 ASC NULLS FIRST, i_class#9 ASC NULLS FIRST, i_item_id#6 ASC NULLS FIRST, i_item_desc#7 ASC NULLS FIRST, revenueratio#18 ASC NULLS FIRST], [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, revenueratio#18]
+Input [7]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, revenueratio#20]
+Arguments: 100, [i_category#12 ASC NULLS FIRST, i_class#11 ASC NULLS FIRST, i_item_id#8 ASC NULLS FIRST, i_item_desc#9 ASC NULLS FIRST, revenueratio#20 ASC NULLS FIRST], [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, revenueratio#20]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 1 Hosting Expression = ws_sold_date_sk#3 IN dynamicpruning#4
-BroadcastExchange (28)
-+- * Project (27)
-   +- * Filter (26)
-      +- * ColumnarToRow (25)
-         +- Scan parquet spark_catalog.default.date_dim (24)
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#5, [id=#6]
+ObjectHashAggregate (30)
++- Exchange (29)
+   +- ObjectHashAggregate (28)
+      +- * Project (27)
+         +- * Filter (26)
+            +- * ColumnarToRow (25)
+               +- Scan parquet spark_catalog.default.item (24)
 
 
-(24) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#11, d_date#19]
+(24) Scan parquet spark_catalog.default.item
+Output [2]: [i_item_sk#7, i_category#12]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/item]
+PushedFilters: [In(i_category, [Books                                             ,Home                                              ,Sports                                            ]), IsNotNull(i_item_sk)]
+ReadSchema: struct<i_item_sk:int,i_category:string>
+
+(25) ColumnarToRow [codegen id : 1]
+Input [2]: [i_item_sk#7, i_category#12]
+
+(26) Filter [codegen id : 1]
+Input [2]: [i_item_sk#7, i_category#12]
+Condition : (i_category#12 IN (Sports                                            ,Books                                             ,Home                                              ) AND isnotnull(i_item_sk#7))
+
+(27) Project [codegen id : 1]
+Output [1]: [i_item_sk#7]
+Input [2]: [i_item_sk#7, i_category#12]
+
+(28) ObjectHashAggregate
+Input [1]: [i_item_sk#7]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#7, 42), 61200, 979099, 0, 0)]
+Aggregate Attributes [1]: [buf#21]
+Results [1]: [buf#22]
+
+(29) Exchange
+Input [1]: [buf#22]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=5]
+
+(30) ObjectHashAggregate
+Input [1]: [buf#22]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#7, 42), 61200, 979099, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#7, 42), 61200, 979099, 0, 0)#23]
+Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#7, 42), 61200, 979099, 0, 0)#23 AS bloomFilter#24]
+
+Subquery:2 Hosting operator id = 1 Hosting Expression = ws_sold_date_sk#3 IN dynamicpruning#4
+BroadcastExchange (35)
++- * Project (34)
+   +- * Filter (33)
+      +- * ColumnarToRow (32)
+         +- Scan parquet spark_catalog.default.date_dim (31)
+
+
+(31) Scan parquet spark_catalog.default.date_dim
+Output [2]: [d_date_sk#13, d_date#25]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,1999-02-22), LessThanOrEqual(d_date,1999-03-24), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
-(25) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#11, d_date#19]
+(32) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#13, d_date#25]
 
-(26) Filter [codegen id : 1]
-Input [2]: [d_date_sk#11, d_date#19]
-Condition : (((isnotnull(d_date#19) AND (d_date#19 >= 1999-02-22)) AND (d_date#19 <= 1999-03-24)) AND isnotnull(d_date_sk#11))
+(33) Filter [codegen id : 1]
+Input [2]: [d_date_sk#13, d_date#25]
+Condition : (((isnotnull(d_date#25) AND (d_date#25 >= 1999-02-22)) AND (d_date#25 <= 1999-03-24)) AND isnotnull(d_date_sk#13))
 
-(27) Project [codegen id : 1]
-Output [1]: [d_date_sk#11]
-Input [2]: [d_date_sk#11, d_date#19]
+(34) Project [codegen id : 1]
+Output [1]: [d_date_sk#13]
+Input [2]: [d_date_sk#13, d_date#25]
 
-(28) BroadcastExchange
-Input [1]: [d_date_sk#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
+(35) BroadcastExchange
+Input [1]: [d_date_sk#13]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=6]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q12.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q12.sf100/simplified.txt
@@ -24,6 +24,16 @@ TakeOrderedAndProject [i_category,i_class,i_item_id,i_item_desc,revenueratio,i_c
                                               Exchange [ws_item_sk] #3
                                                 WholeStageCodegen (1)
                                                   Filter [ws_item_sk]
+                                                    Subquery #2
+                                                      ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(i_item_sk, 42), 61200, 979099, 0, 0),bloomFilter,buf]
+                                                        Exchange #5
+                                                          ObjectHashAggregate [i_item_sk] [buf,buf]
+                                                            WholeStageCodegen (1)
+                                                              Project [i_item_sk]
+                                                                Filter [i_category,i_item_sk]
+                                                                  ColumnarToRow
+                                                                    InputAdapter
+                                                                      Scan parquet spark_catalog.default.item [i_item_sk,i_category]
                                                     ColumnarToRow
                                                       InputAdapter
                                                         Scan parquet spark_catalog.default.web_sales [ws_item_sk,ws_ext_sales_price,ws_sold_date_sk]
@@ -39,7 +49,7 @@ TakeOrderedAndProject [i_category,i_class,i_item_id,i_item_desc,revenueratio,i_c
                                         WholeStageCodegen (4)
                                           Sort [i_item_sk]
                                             InputAdapter
-                                              Exchange [i_item_sk] #5
+                                              Exchange [i_item_sk] #6
                                                 WholeStageCodegen (3)
                                                   Filter [i_category,i_item_sk]
                                                     ColumnarToRow

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q18a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q18a.sf100/explain.txt
@@ -170,747 +170,793 @@ Input [9]: [cs_bill_customer_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#3, cs_quantity
 
 (3) Filter [codegen id : 4]
 Input [9]: [cs_bill_customer_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9]
-Condition : ((isnotnull(cs_bill_cdemo_sk#2) AND isnotnull(cs_bill_customer_sk#1)) AND isnotnull(cs_item_sk#3))
+Condition : (((isnotnull(cs_bill_cdemo_sk#2) AND isnotnull(cs_bill_customer_sk#1)) AND isnotnull(cs_item_sk#3)) AND might_contain(Subquery scalar-subquery#11, [id=#12], xxhash64(cs_bill_customer_sk#1, 42)))
 
 (4) Scan parquet spark_catalog.default.customer_demographics
-Output [4]: [cd_demo_sk#11, cd_gender#12, cd_education_status#13, cd_dep_count#14]
+Output [4]: [cd_demo_sk#13, cd_gender#14, cd_education_status#15, cd_dep_count#16]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_demographics]
 PushedFilters: [IsNotNull(cd_gender), IsNotNull(cd_education_status), EqualTo(cd_gender,M), EqualTo(cd_education_status,College             ), IsNotNull(cd_demo_sk)]
 ReadSchema: struct<cd_demo_sk:int,cd_gender:string,cd_education_status:string,cd_dep_count:int>
 
 (5) ColumnarToRow [codegen id : 1]
-Input [4]: [cd_demo_sk#11, cd_gender#12, cd_education_status#13, cd_dep_count#14]
+Input [4]: [cd_demo_sk#13, cd_gender#14, cd_education_status#15, cd_dep_count#16]
 
 (6) Filter [codegen id : 1]
-Input [4]: [cd_demo_sk#11, cd_gender#12, cd_education_status#13, cd_dep_count#14]
-Condition : ((((isnotnull(cd_gender#12) AND isnotnull(cd_education_status#13)) AND (cd_gender#12 = M)) AND (cd_education_status#13 = College             )) AND isnotnull(cd_demo_sk#11))
+Input [4]: [cd_demo_sk#13, cd_gender#14, cd_education_status#15, cd_dep_count#16]
+Condition : ((((isnotnull(cd_gender#14) AND isnotnull(cd_education_status#15)) AND (cd_gender#14 = M)) AND (cd_education_status#15 = College             )) AND isnotnull(cd_demo_sk#13))
 
 (7) Project [codegen id : 1]
-Output [2]: [cd_demo_sk#11, cd_dep_count#14]
-Input [4]: [cd_demo_sk#11, cd_gender#12, cd_education_status#13, cd_dep_count#14]
+Output [2]: [cd_demo_sk#13, cd_dep_count#16]
+Input [4]: [cd_demo_sk#13, cd_gender#14, cd_education_status#15, cd_dep_count#16]
 
 (8) BroadcastExchange
-Input [2]: [cd_demo_sk#11, cd_dep_count#14]
+Input [2]: [cd_demo_sk#13, cd_dep_count#16]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
 
 (9) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_bill_cdemo_sk#2]
-Right keys [1]: [cd_demo_sk#11]
+Right keys [1]: [cd_demo_sk#13]
 Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 4]
-Output [9]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9, cd_dep_count#14]
-Input [11]: [cs_bill_customer_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9, cd_demo_sk#11, cd_dep_count#14]
+Output [9]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9, cd_dep_count#16]
+Input [11]: [cs_bill_customer_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9, cd_demo_sk#13, cd_dep_count#16]
 
-(11) ReusedExchange [Reuses operator id: 161]
-Output [1]: [d_date_sk#15]
+(11) ReusedExchange [Reuses operator id: 168]
+Output [1]: [d_date_sk#17]
 
 (12) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_sold_date_sk#9]
-Right keys [1]: [d_date_sk#15]
+Right keys [1]: [d_date_sk#17]
 Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 4]
-Output [8]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14]
-Input [10]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9, cd_dep_count#14, d_date_sk#15]
+Output [8]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#16]
+Input [10]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9, cd_dep_count#16, d_date_sk#17]
 
 (14) Scan parquet spark_catalog.default.item
-Output [2]: [i_item_sk#16, i_item_id#17]
+Output [2]: [i_item_sk#18, i_item_id#19]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_item_id:string>
 
 (15) ColumnarToRow [codegen id : 3]
-Input [2]: [i_item_sk#16, i_item_id#17]
+Input [2]: [i_item_sk#18, i_item_id#19]
 
 (16) Filter [codegen id : 3]
-Input [2]: [i_item_sk#16, i_item_id#17]
-Condition : isnotnull(i_item_sk#16)
+Input [2]: [i_item_sk#18, i_item_id#19]
+Condition : isnotnull(i_item_sk#18)
 
 (17) BroadcastExchange
-Input [2]: [i_item_sk#16, i_item_id#17]
+Input [2]: [i_item_sk#18, i_item_id#19]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=2]
 
 (18) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_item_sk#3]
-Right keys [1]: [i_item_sk#16]
+Right keys [1]: [i_item_sk#18]
 Join type: Inner
 Join condition: None
 
 (19) Project [codegen id : 4]
-Output [8]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, i_item_id#17]
-Input [10]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, i_item_sk#16, i_item_id#17]
+Output [8]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#16, i_item_id#19]
+Input [10]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#16, i_item_sk#18, i_item_id#19]
 
 (20) Exchange
-Input [8]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, i_item_id#17]
+Input [8]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#16, i_item_id#19]
 Arguments: hashpartitioning(cs_bill_customer_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (21) Sort [codegen id : 5]
-Input [8]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, i_item_id#17]
+Input [8]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#16, i_item_id#19]
 Arguments: [cs_bill_customer_sk#1 ASC NULLS FIRST], false, 0
 
 (22) Scan parquet spark_catalog.default.customer
-Output [5]: [c_customer_sk#18, c_current_cdemo_sk#19, c_current_addr_sk#20, c_birth_month#21, c_birth_year#22]
+Output [5]: [c_customer_sk#20, c_current_cdemo_sk#21, c_current_addr_sk#22, c_birth_month#23, c_birth_year#24]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer]
 PushedFilters: [In(c_birth_month, [1,10,12,4,5,9]), IsNotNull(c_customer_sk), IsNotNull(c_current_cdemo_sk), IsNotNull(c_current_addr_sk)]
 ReadSchema: struct<c_customer_sk:int,c_current_cdemo_sk:int,c_current_addr_sk:int,c_birth_month:int,c_birth_year:int>
 
 (23) ColumnarToRow [codegen id : 7]
-Input [5]: [c_customer_sk#18, c_current_cdemo_sk#19, c_current_addr_sk#20, c_birth_month#21, c_birth_year#22]
+Input [5]: [c_customer_sk#20, c_current_cdemo_sk#21, c_current_addr_sk#22, c_birth_month#23, c_birth_year#24]
 
 (24) Filter [codegen id : 7]
-Input [5]: [c_customer_sk#18, c_current_cdemo_sk#19, c_current_addr_sk#20, c_birth_month#21, c_birth_year#22]
-Condition : (((c_birth_month#21 IN (9,5,12,4,1,10) AND isnotnull(c_customer_sk#18)) AND isnotnull(c_current_cdemo_sk#19)) AND isnotnull(c_current_addr_sk#20))
+Input [5]: [c_customer_sk#20, c_current_cdemo_sk#21, c_current_addr_sk#22, c_birth_month#23, c_birth_year#24]
+Condition : (((c_birth_month#23 IN (9,5,12,4,1,10) AND isnotnull(c_customer_sk#20)) AND isnotnull(c_current_cdemo_sk#21)) AND isnotnull(c_current_addr_sk#22))
 
 (25) Project [codegen id : 7]
-Output [4]: [c_customer_sk#18, c_current_cdemo_sk#19, c_current_addr_sk#20, c_birth_year#22]
-Input [5]: [c_customer_sk#18, c_current_cdemo_sk#19, c_current_addr_sk#20, c_birth_month#21, c_birth_year#22]
+Output [4]: [c_customer_sk#20, c_current_cdemo_sk#21, c_current_addr_sk#22, c_birth_year#24]
+Input [5]: [c_customer_sk#20, c_current_cdemo_sk#21, c_current_addr_sk#22, c_birth_month#23, c_birth_year#24]
 
 (26) Scan parquet spark_catalog.default.customer_address
-Output [4]: [ca_address_sk#23, ca_county#24, ca_state#25, ca_country#26]
+Output [4]: [ca_address_sk#25, ca_county#26, ca_state#27, ca_country#28]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [In(ca_state, [AL,MS,NC,ND,OK,TN,WI]), IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_county:string,ca_state:string,ca_country:string>
 
 (27) ColumnarToRow [codegen id : 6]
-Input [4]: [ca_address_sk#23, ca_county#24, ca_state#25, ca_country#26]
+Input [4]: [ca_address_sk#25, ca_county#26, ca_state#27, ca_country#28]
 
 (28) Filter [codegen id : 6]
-Input [4]: [ca_address_sk#23, ca_county#24, ca_state#25, ca_country#26]
-Condition : (ca_state#25 IN (ND,WI,AL,NC,OK,MS,TN) AND isnotnull(ca_address_sk#23))
+Input [4]: [ca_address_sk#25, ca_county#26, ca_state#27, ca_country#28]
+Condition : (ca_state#27 IN (ND,WI,AL,NC,OK,MS,TN) AND isnotnull(ca_address_sk#25))
 
 (29) BroadcastExchange
-Input [4]: [ca_address_sk#23, ca_county#24, ca_state#25, ca_country#26]
+Input [4]: [ca_address_sk#25, ca_county#26, ca_state#27, ca_country#28]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=4]
 
 (30) BroadcastHashJoin [codegen id : 7]
-Left keys [1]: [c_current_addr_sk#20]
-Right keys [1]: [ca_address_sk#23]
+Left keys [1]: [c_current_addr_sk#22]
+Right keys [1]: [ca_address_sk#25]
 Join type: Inner
 Join condition: None
 
 (31) Project [codegen id : 7]
-Output [6]: [c_customer_sk#18, c_current_cdemo_sk#19, c_birth_year#22, ca_county#24, ca_state#25, ca_country#26]
-Input [8]: [c_customer_sk#18, c_current_cdemo_sk#19, c_current_addr_sk#20, c_birth_year#22, ca_address_sk#23, ca_county#24, ca_state#25, ca_country#26]
+Output [6]: [c_customer_sk#20, c_current_cdemo_sk#21, c_birth_year#24, ca_county#26, ca_state#27, ca_country#28]
+Input [8]: [c_customer_sk#20, c_current_cdemo_sk#21, c_current_addr_sk#22, c_birth_year#24, ca_address_sk#25, ca_county#26, ca_state#27, ca_country#28]
 
 (32) Exchange
-Input [6]: [c_customer_sk#18, c_current_cdemo_sk#19, c_birth_year#22, ca_county#24, ca_state#25, ca_country#26]
-Arguments: hashpartitioning(c_current_cdemo_sk#19, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+Input [6]: [c_customer_sk#20, c_current_cdemo_sk#21, c_birth_year#24, ca_county#26, ca_state#27, ca_country#28]
+Arguments: hashpartitioning(c_current_cdemo_sk#21, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
 (33) Sort [codegen id : 8]
-Input [6]: [c_customer_sk#18, c_current_cdemo_sk#19, c_birth_year#22, ca_county#24, ca_state#25, ca_country#26]
-Arguments: [c_current_cdemo_sk#19 ASC NULLS FIRST], false, 0
+Input [6]: [c_customer_sk#20, c_current_cdemo_sk#21, c_birth_year#24, ca_county#26, ca_state#27, ca_country#28]
+Arguments: [c_current_cdemo_sk#21 ASC NULLS FIRST], false, 0
 
 (34) Scan parquet spark_catalog.default.customer_demographics
-Output [1]: [cd_demo_sk#27]
+Output [1]: [cd_demo_sk#29]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_demographics]
 PushedFilters: [IsNotNull(cd_demo_sk)]
 ReadSchema: struct<cd_demo_sk:int>
 
 (35) ColumnarToRow [codegen id : 9]
-Input [1]: [cd_demo_sk#27]
+Input [1]: [cd_demo_sk#29]
 
 (36) Filter [codegen id : 9]
-Input [1]: [cd_demo_sk#27]
-Condition : isnotnull(cd_demo_sk#27)
+Input [1]: [cd_demo_sk#29]
+Condition : isnotnull(cd_demo_sk#29)
 
 (37) Exchange
-Input [1]: [cd_demo_sk#27]
-Arguments: hashpartitioning(cd_demo_sk#27, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+Input [1]: [cd_demo_sk#29]
+Arguments: hashpartitioning(cd_demo_sk#29, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
 (38) Sort [codegen id : 10]
-Input [1]: [cd_demo_sk#27]
-Arguments: [cd_demo_sk#27 ASC NULLS FIRST], false, 0
+Input [1]: [cd_demo_sk#29]
+Arguments: [cd_demo_sk#29 ASC NULLS FIRST], false, 0
 
 (39) SortMergeJoin [codegen id : 11]
-Left keys [1]: [c_current_cdemo_sk#19]
-Right keys [1]: [cd_demo_sk#27]
+Left keys [1]: [c_current_cdemo_sk#21]
+Right keys [1]: [cd_demo_sk#29]
 Join type: Inner
 Join condition: None
 
 (40) Project [codegen id : 11]
-Output [5]: [c_customer_sk#18, c_birth_year#22, ca_county#24, ca_state#25, ca_country#26]
-Input [7]: [c_customer_sk#18, c_current_cdemo_sk#19, c_birth_year#22, ca_county#24, ca_state#25, ca_country#26, cd_demo_sk#27]
+Output [5]: [c_customer_sk#20, c_birth_year#24, ca_county#26, ca_state#27, ca_country#28]
+Input [7]: [c_customer_sk#20, c_current_cdemo_sk#21, c_birth_year#24, ca_county#26, ca_state#27, ca_country#28, cd_demo_sk#29]
 
 (41) Exchange
-Input [5]: [c_customer_sk#18, c_birth_year#22, ca_county#24, ca_state#25, ca_country#26]
-Arguments: hashpartitioning(c_customer_sk#18, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+Input [5]: [c_customer_sk#20, c_birth_year#24, ca_county#26, ca_state#27, ca_country#28]
+Arguments: hashpartitioning(c_customer_sk#20, 5), ENSURE_REQUIREMENTS, [plan_id=7]
 
 (42) Sort [codegen id : 12]
-Input [5]: [c_customer_sk#18, c_birth_year#22, ca_county#24, ca_state#25, ca_country#26]
-Arguments: [c_customer_sk#18 ASC NULLS FIRST], false, 0
+Input [5]: [c_customer_sk#20, c_birth_year#24, ca_county#26, ca_state#27, ca_country#28]
+Arguments: [c_customer_sk#20 ASC NULLS FIRST], false, 0
 
 (43) SortMergeJoin [codegen id : 13]
 Left keys [1]: [cs_bill_customer_sk#1]
-Right keys [1]: [c_customer_sk#18]
+Right keys [1]: [c_customer_sk#20]
 Join type: Inner
 Join condition: None
 
 (44) Project [codegen id : 13]
-Output [11]: [i_item_id#17, ca_country#26, ca_state#25, ca_county#24, cast(cs_quantity#4 as decimal(12,2)) AS agg1#28, cast(cs_list_price#5 as decimal(12,2)) AS agg2#29, cast(cs_coupon_amt#7 as decimal(12,2)) AS agg3#30, cast(cs_sales_price#6 as decimal(12,2)) AS agg4#31, cast(cs_net_profit#8 as decimal(12,2)) AS agg5#32, cast(c_birth_year#22 as decimal(12,2)) AS agg6#33, cast(cd_dep_count#14 as decimal(12,2)) AS agg7#34]
-Input [13]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, i_item_id#17, c_customer_sk#18, c_birth_year#22, ca_county#24, ca_state#25, ca_country#26]
+Output [11]: [i_item_id#19, ca_country#28, ca_state#27, ca_county#26, cast(cs_quantity#4 as decimal(12,2)) AS agg1#30, cast(cs_list_price#5 as decimal(12,2)) AS agg2#31, cast(cs_coupon_amt#7 as decimal(12,2)) AS agg3#32, cast(cs_sales_price#6 as decimal(12,2)) AS agg4#33, cast(cs_net_profit#8 as decimal(12,2)) AS agg5#34, cast(c_birth_year#24 as decimal(12,2)) AS agg6#35, cast(cd_dep_count#16 as decimal(12,2)) AS agg7#36]
+Input [13]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#16, i_item_id#19, c_customer_sk#20, c_birth_year#24, ca_county#26, ca_state#27, ca_country#28]
 
 (45) HashAggregate [codegen id : 13]
-Input [11]: [i_item_id#17, ca_country#26, ca_state#25, ca_county#24, agg1#28, agg2#29, agg3#30, agg4#31, agg5#32, agg6#33, agg7#34]
-Keys [4]: [i_item_id#17, ca_country#26, ca_state#25, ca_county#24]
-Functions [7]: [partial_avg(agg1#28), partial_avg(agg2#29), partial_avg(agg3#30), partial_avg(agg4#31), partial_avg(agg5#32), partial_avg(agg6#33), partial_avg(agg7#34)]
-Aggregate Attributes [14]: [sum#35, count#36, sum#37, count#38, sum#39, count#40, sum#41, count#42, sum#43, count#44, sum#45, count#46, sum#47, count#48]
-Results [18]: [i_item_id#17, ca_country#26, ca_state#25, ca_county#24, sum#49, count#50, sum#51, count#52, sum#53, count#54, sum#55, count#56, sum#57, count#58, sum#59, count#60, sum#61, count#62]
+Input [11]: [i_item_id#19, ca_country#28, ca_state#27, ca_county#26, agg1#30, agg2#31, agg3#32, agg4#33, agg5#34, agg6#35, agg7#36]
+Keys [4]: [i_item_id#19, ca_country#28, ca_state#27, ca_county#26]
+Functions [7]: [partial_avg(agg1#30), partial_avg(agg2#31), partial_avg(agg3#32), partial_avg(agg4#33), partial_avg(agg5#34), partial_avg(agg6#35), partial_avg(agg7#36)]
+Aggregate Attributes [14]: [sum#37, count#38, sum#39, count#40, sum#41, count#42, sum#43, count#44, sum#45, count#46, sum#47, count#48, sum#49, count#50]
+Results [18]: [i_item_id#19, ca_country#28, ca_state#27, ca_county#26, sum#51, count#52, sum#53, count#54, sum#55, count#56, sum#57, count#58, sum#59, count#60, sum#61, count#62, sum#63, count#64]
 
 (46) Exchange
-Input [18]: [i_item_id#17, ca_country#26, ca_state#25, ca_county#24, sum#49, count#50, sum#51, count#52, sum#53, count#54, sum#55, count#56, sum#57, count#58, sum#59, count#60, sum#61, count#62]
-Arguments: hashpartitioning(i_item_id#17, ca_country#26, ca_state#25, ca_county#24, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+Input [18]: [i_item_id#19, ca_country#28, ca_state#27, ca_county#26, sum#51, count#52, sum#53, count#54, sum#55, count#56, sum#57, count#58, sum#59, count#60, sum#61, count#62, sum#63, count#64]
+Arguments: hashpartitioning(i_item_id#19, ca_country#28, ca_state#27, ca_county#26, 5), ENSURE_REQUIREMENTS, [plan_id=8]
 
 (47) HashAggregate [codegen id : 14]
-Input [18]: [i_item_id#17, ca_country#26, ca_state#25, ca_county#24, sum#49, count#50, sum#51, count#52, sum#53, count#54, sum#55, count#56, sum#57, count#58, sum#59, count#60, sum#61, count#62]
-Keys [4]: [i_item_id#17, ca_country#26, ca_state#25, ca_county#24]
-Functions [7]: [avg(agg1#28), avg(agg2#29), avg(agg3#30), avg(agg4#31), avg(agg5#32), avg(agg6#33), avg(agg7#34)]
-Aggregate Attributes [7]: [avg(agg1#28)#63, avg(agg2#29)#64, avg(agg3#30)#65, avg(agg4#31)#66, avg(agg5#32)#67, avg(agg6#33)#68, avg(agg7#34)#69]
-Results [11]: [i_item_id#17, ca_country#26, ca_state#25, ca_county#24, avg(agg1#28)#63 AS agg1#70, avg(agg2#29)#64 AS agg2#71, avg(agg3#30)#65 AS agg3#72, avg(agg4#31)#66 AS agg4#73, avg(agg5#32)#67 AS agg5#74, avg(agg6#33)#68 AS agg6#75, avg(agg7#34)#69 AS agg7#76]
+Input [18]: [i_item_id#19, ca_country#28, ca_state#27, ca_county#26, sum#51, count#52, sum#53, count#54, sum#55, count#56, sum#57, count#58, sum#59, count#60, sum#61, count#62, sum#63, count#64]
+Keys [4]: [i_item_id#19, ca_country#28, ca_state#27, ca_county#26]
+Functions [7]: [avg(agg1#30), avg(agg2#31), avg(agg3#32), avg(agg4#33), avg(agg5#34), avg(agg6#35), avg(agg7#36)]
+Aggregate Attributes [7]: [avg(agg1#30)#65, avg(agg2#31)#66, avg(agg3#32)#67, avg(agg4#33)#68, avg(agg5#34)#69, avg(agg6#35)#70, avg(agg7#36)#71]
+Results [11]: [i_item_id#19, ca_country#28, ca_state#27, ca_county#26, avg(agg1#30)#65 AS agg1#72, avg(agg2#31)#66 AS agg2#73, avg(agg3#32)#67 AS agg3#74, avg(agg4#33)#68 AS agg4#75, avg(agg5#34)#69 AS agg5#76, avg(agg6#35)#70 AS agg6#77, avg(agg7#36)#71 AS agg7#78]
 
 (48) ReusedExchange [Reuses operator id: 20]
-Output [8]: [cs_bill_customer_sk#77, cs_quantity#78, cs_list_price#79, cs_sales_price#80, cs_coupon_amt#81, cs_net_profit#82, cd_dep_count#83, i_item_id#84]
+Output [8]: [cs_bill_customer_sk#79, cs_quantity#80, cs_list_price#81, cs_sales_price#82, cs_coupon_amt#83, cs_net_profit#84, cd_dep_count#85, i_item_id#86]
 
 (49) Sort [codegen id : 19]
-Input [8]: [cs_bill_customer_sk#77, cs_quantity#78, cs_list_price#79, cs_sales_price#80, cs_coupon_amt#81, cs_net_profit#82, cd_dep_count#83, i_item_id#84]
-Arguments: [cs_bill_customer_sk#77 ASC NULLS FIRST], false, 0
+Input [8]: [cs_bill_customer_sk#79, cs_quantity#80, cs_list_price#81, cs_sales_price#82, cs_coupon_amt#83, cs_net_profit#84, cd_dep_count#85, i_item_id#86]
+Arguments: [cs_bill_customer_sk#79 ASC NULLS FIRST], false, 0
 
 (50) Scan parquet spark_catalog.default.customer
-Output [5]: [c_customer_sk#85, c_current_cdemo_sk#86, c_current_addr_sk#87, c_birth_month#88, c_birth_year#89]
+Output [5]: [c_customer_sk#87, c_current_cdemo_sk#88, c_current_addr_sk#89, c_birth_month#90, c_birth_year#91]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer]
 PushedFilters: [In(c_birth_month, [1,10,12,4,5,9]), IsNotNull(c_customer_sk), IsNotNull(c_current_cdemo_sk), IsNotNull(c_current_addr_sk)]
 ReadSchema: struct<c_customer_sk:int,c_current_cdemo_sk:int,c_current_addr_sk:int,c_birth_month:int,c_birth_year:int>
 
 (51) ColumnarToRow [codegen id : 21]
-Input [5]: [c_customer_sk#85, c_current_cdemo_sk#86, c_current_addr_sk#87, c_birth_month#88, c_birth_year#89]
+Input [5]: [c_customer_sk#87, c_current_cdemo_sk#88, c_current_addr_sk#89, c_birth_month#90, c_birth_year#91]
 
 (52) Filter [codegen id : 21]
-Input [5]: [c_customer_sk#85, c_current_cdemo_sk#86, c_current_addr_sk#87, c_birth_month#88, c_birth_year#89]
-Condition : (((c_birth_month#88 IN (9,5,12,4,1,10) AND isnotnull(c_customer_sk#85)) AND isnotnull(c_current_cdemo_sk#86)) AND isnotnull(c_current_addr_sk#87))
+Input [5]: [c_customer_sk#87, c_current_cdemo_sk#88, c_current_addr_sk#89, c_birth_month#90, c_birth_year#91]
+Condition : (((c_birth_month#90 IN (9,5,12,4,1,10) AND isnotnull(c_customer_sk#87)) AND isnotnull(c_current_cdemo_sk#88)) AND isnotnull(c_current_addr_sk#89))
 
 (53) Project [codegen id : 21]
-Output [4]: [c_customer_sk#85, c_current_cdemo_sk#86, c_current_addr_sk#87, c_birth_year#89]
-Input [5]: [c_customer_sk#85, c_current_cdemo_sk#86, c_current_addr_sk#87, c_birth_month#88, c_birth_year#89]
+Output [4]: [c_customer_sk#87, c_current_cdemo_sk#88, c_current_addr_sk#89, c_birth_year#91]
+Input [5]: [c_customer_sk#87, c_current_cdemo_sk#88, c_current_addr_sk#89, c_birth_month#90, c_birth_year#91]
 
 (54) Scan parquet spark_catalog.default.customer_address
-Output [3]: [ca_address_sk#90, ca_state#91, ca_country#92]
+Output [3]: [ca_address_sk#92, ca_state#93, ca_country#94]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [In(ca_state, [AL,MS,NC,ND,OK,TN,WI]), IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_state:string,ca_country:string>
 
 (55) ColumnarToRow [codegen id : 20]
-Input [3]: [ca_address_sk#90, ca_state#91, ca_country#92]
+Input [3]: [ca_address_sk#92, ca_state#93, ca_country#94]
 
 (56) Filter [codegen id : 20]
-Input [3]: [ca_address_sk#90, ca_state#91, ca_country#92]
-Condition : (ca_state#91 IN (ND,WI,AL,NC,OK,MS,TN) AND isnotnull(ca_address_sk#90))
+Input [3]: [ca_address_sk#92, ca_state#93, ca_country#94]
+Condition : (ca_state#93 IN (ND,WI,AL,NC,OK,MS,TN) AND isnotnull(ca_address_sk#92))
 
 (57) BroadcastExchange
-Input [3]: [ca_address_sk#90, ca_state#91, ca_country#92]
+Input [3]: [ca_address_sk#92, ca_state#93, ca_country#94]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=9]
 
 (58) BroadcastHashJoin [codegen id : 21]
-Left keys [1]: [c_current_addr_sk#87]
-Right keys [1]: [ca_address_sk#90]
+Left keys [1]: [c_current_addr_sk#89]
+Right keys [1]: [ca_address_sk#92]
 Join type: Inner
 Join condition: None
 
 (59) Project [codegen id : 21]
-Output [5]: [c_customer_sk#85, c_current_cdemo_sk#86, c_birth_year#89, ca_state#91, ca_country#92]
-Input [7]: [c_customer_sk#85, c_current_cdemo_sk#86, c_current_addr_sk#87, c_birth_year#89, ca_address_sk#90, ca_state#91, ca_country#92]
+Output [5]: [c_customer_sk#87, c_current_cdemo_sk#88, c_birth_year#91, ca_state#93, ca_country#94]
+Input [7]: [c_customer_sk#87, c_current_cdemo_sk#88, c_current_addr_sk#89, c_birth_year#91, ca_address_sk#92, ca_state#93, ca_country#94]
 
 (60) Exchange
-Input [5]: [c_customer_sk#85, c_current_cdemo_sk#86, c_birth_year#89, ca_state#91, ca_country#92]
-Arguments: hashpartitioning(c_current_cdemo_sk#86, 5), ENSURE_REQUIREMENTS, [plan_id=10]
+Input [5]: [c_customer_sk#87, c_current_cdemo_sk#88, c_birth_year#91, ca_state#93, ca_country#94]
+Arguments: hashpartitioning(c_current_cdemo_sk#88, 5), ENSURE_REQUIREMENTS, [plan_id=10]
 
 (61) Sort [codegen id : 22]
-Input [5]: [c_customer_sk#85, c_current_cdemo_sk#86, c_birth_year#89, ca_state#91, ca_country#92]
-Arguments: [c_current_cdemo_sk#86 ASC NULLS FIRST], false, 0
+Input [5]: [c_customer_sk#87, c_current_cdemo_sk#88, c_birth_year#91, ca_state#93, ca_country#94]
+Arguments: [c_current_cdemo_sk#88 ASC NULLS FIRST], false, 0
 
 (62) ReusedExchange [Reuses operator id: 37]
-Output [1]: [cd_demo_sk#93]
+Output [1]: [cd_demo_sk#95]
 
 (63) Sort [codegen id : 24]
-Input [1]: [cd_demo_sk#93]
-Arguments: [cd_demo_sk#93 ASC NULLS FIRST], false, 0
+Input [1]: [cd_demo_sk#95]
+Arguments: [cd_demo_sk#95 ASC NULLS FIRST], false, 0
 
 (64) SortMergeJoin [codegen id : 25]
-Left keys [1]: [c_current_cdemo_sk#86]
-Right keys [1]: [cd_demo_sk#93]
+Left keys [1]: [c_current_cdemo_sk#88]
+Right keys [1]: [cd_demo_sk#95]
 Join type: Inner
 Join condition: None
 
 (65) Project [codegen id : 25]
-Output [4]: [c_customer_sk#85, c_birth_year#89, ca_state#91, ca_country#92]
-Input [6]: [c_customer_sk#85, c_current_cdemo_sk#86, c_birth_year#89, ca_state#91, ca_country#92, cd_demo_sk#93]
+Output [4]: [c_customer_sk#87, c_birth_year#91, ca_state#93, ca_country#94]
+Input [6]: [c_customer_sk#87, c_current_cdemo_sk#88, c_birth_year#91, ca_state#93, ca_country#94, cd_demo_sk#95]
 
 (66) Exchange
-Input [4]: [c_customer_sk#85, c_birth_year#89, ca_state#91, ca_country#92]
-Arguments: hashpartitioning(c_customer_sk#85, 5), ENSURE_REQUIREMENTS, [plan_id=11]
+Input [4]: [c_customer_sk#87, c_birth_year#91, ca_state#93, ca_country#94]
+Arguments: hashpartitioning(c_customer_sk#87, 5), ENSURE_REQUIREMENTS, [plan_id=11]
 
 (67) Sort [codegen id : 26]
-Input [4]: [c_customer_sk#85, c_birth_year#89, ca_state#91, ca_country#92]
-Arguments: [c_customer_sk#85 ASC NULLS FIRST], false, 0
+Input [4]: [c_customer_sk#87, c_birth_year#91, ca_state#93, ca_country#94]
+Arguments: [c_customer_sk#87 ASC NULLS FIRST], false, 0
 
 (68) SortMergeJoin [codegen id : 27]
-Left keys [1]: [cs_bill_customer_sk#77]
-Right keys [1]: [c_customer_sk#85]
+Left keys [1]: [cs_bill_customer_sk#79]
+Right keys [1]: [c_customer_sk#87]
 Join type: Inner
 Join condition: None
 
 (69) Project [codegen id : 27]
-Output [10]: [i_item_id#84, ca_country#92, ca_state#91, cast(cs_quantity#78 as decimal(12,2)) AS agg1#94, cast(cs_list_price#79 as decimal(12,2)) AS agg2#95, cast(cs_coupon_amt#81 as decimal(12,2)) AS agg3#96, cast(cs_sales_price#80 as decimal(12,2)) AS agg4#97, cast(cs_net_profit#82 as decimal(12,2)) AS agg5#98, cast(c_birth_year#89 as decimal(12,2)) AS agg6#99, cast(cd_dep_count#83 as decimal(12,2)) AS agg7#100]
-Input [12]: [cs_bill_customer_sk#77, cs_quantity#78, cs_list_price#79, cs_sales_price#80, cs_coupon_amt#81, cs_net_profit#82, cd_dep_count#83, i_item_id#84, c_customer_sk#85, c_birth_year#89, ca_state#91, ca_country#92]
+Output [10]: [i_item_id#86, ca_country#94, ca_state#93, cast(cs_quantity#80 as decimal(12,2)) AS agg1#96, cast(cs_list_price#81 as decimal(12,2)) AS agg2#97, cast(cs_coupon_amt#83 as decimal(12,2)) AS agg3#98, cast(cs_sales_price#82 as decimal(12,2)) AS agg4#99, cast(cs_net_profit#84 as decimal(12,2)) AS agg5#100, cast(c_birth_year#91 as decimal(12,2)) AS agg6#101, cast(cd_dep_count#85 as decimal(12,2)) AS agg7#102]
+Input [12]: [cs_bill_customer_sk#79, cs_quantity#80, cs_list_price#81, cs_sales_price#82, cs_coupon_amt#83, cs_net_profit#84, cd_dep_count#85, i_item_id#86, c_customer_sk#87, c_birth_year#91, ca_state#93, ca_country#94]
 
 (70) HashAggregate [codegen id : 27]
-Input [10]: [i_item_id#84, ca_country#92, ca_state#91, agg1#94, agg2#95, agg3#96, agg4#97, agg5#98, agg6#99, agg7#100]
-Keys [3]: [i_item_id#84, ca_country#92, ca_state#91]
-Functions [7]: [partial_avg(agg1#94), partial_avg(agg2#95), partial_avg(agg3#96), partial_avg(agg4#97), partial_avg(agg5#98), partial_avg(agg6#99), partial_avg(agg7#100)]
-Aggregate Attributes [14]: [sum#101, count#102, sum#103, count#104, sum#105, count#106, sum#107, count#108, sum#109, count#110, sum#111, count#112, sum#113, count#114]
-Results [17]: [i_item_id#84, ca_country#92, ca_state#91, sum#115, count#116, sum#117, count#118, sum#119, count#120, sum#121, count#122, sum#123, count#124, sum#125, count#126, sum#127, count#128]
+Input [10]: [i_item_id#86, ca_country#94, ca_state#93, agg1#96, agg2#97, agg3#98, agg4#99, agg5#100, agg6#101, agg7#102]
+Keys [3]: [i_item_id#86, ca_country#94, ca_state#93]
+Functions [7]: [partial_avg(agg1#96), partial_avg(agg2#97), partial_avg(agg3#98), partial_avg(agg4#99), partial_avg(agg5#100), partial_avg(agg6#101), partial_avg(agg7#102)]
+Aggregate Attributes [14]: [sum#103, count#104, sum#105, count#106, sum#107, count#108, sum#109, count#110, sum#111, count#112, sum#113, count#114, sum#115, count#116]
+Results [17]: [i_item_id#86, ca_country#94, ca_state#93, sum#117, count#118, sum#119, count#120, sum#121, count#122, sum#123, count#124, sum#125, count#126, sum#127, count#128, sum#129, count#130]
 
 (71) Exchange
-Input [17]: [i_item_id#84, ca_country#92, ca_state#91, sum#115, count#116, sum#117, count#118, sum#119, count#120, sum#121, count#122, sum#123, count#124, sum#125, count#126, sum#127, count#128]
-Arguments: hashpartitioning(i_item_id#84, ca_country#92, ca_state#91, 5), ENSURE_REQUIREMENTS, [plan_id=12]
+Input [17]: [i_item_id#86, ca_country#94, ca_state#93, sum#117, count#118, sum#119, count#120, sum#121, count#122, sum#123, count#124, sum#125, count#126, sum#127, count#128, sum#129, count#130]
+Arguments: hashpartitioning(i_item_id#86, ca_country#94, ca_state#93, 5), ENSURE_REQUIREMENTS, [plan_id=12]
 
 (72) HashAggregate [codegen id : 28]
-Input [17]: [i_item_id#84, ca_country#92, ca_state#91, sum#115, count#116, sum#117, count#118, sum#119, count#120, sum#121, count#122, sum#123, count#124, sum#125, count#126, sum#127, count#128]
-Keys [3]: [i_item_id#84, ca_country#92, ca_state#91]
-Functions [7]: [avg(agg1#94), avg(agg2#95), avg(agg3#96), avg(agg4#97), avg(agg5#98), avg(agg6#99), avg(agg7#100)]
-Aggregate Attributes [7]: [avg(agg1#94)#129, avg(agg2#95)#130, avg(agg3#96)#131, avg(agg4#97)#132, avg(agg5#98)#133, avg(agg6#99)#134, avg(agg7#100)#135]
-Results [11]: [i_item_id#84, ca_country#92, ca_state#91, null AS county#136, avg(agg1#94)#129 AS agg1#137, avg(agg2#95)#130 AS agg2#138, avg(agg3#96)#131 AS agg3#139, avg(agg4#97)#132 AS agg4#140, avg(agg5#98)#133 AS agg5#141, avg(agg6#99)#134 AS agg6#142, avg(agg7#100)#135 AS agg7#143]
+Input [17]: [i_item_id#86, ca_country#94, ca_state#93, sum#117, count#118, sum#119, count#120, sum#121, count#122, sum#123, count#124, sum#125, count#126, sum#127, count#128, sum#129, count#130]
+Keys [3]: [i_item_id#86, ca_country#94, ca_state#93]
+Functions [7]: [avg(agg1#96), avg(agg2#97), avg(agg3#98), avg(agg4#99), avg(agg5#100), avg(agg6#101), avg(agg7#102)]
+Aggregate Attributes [7]: [avg(agg1#96)#131, avg(agg2#97)#132, avg(agg3#98)#133, avg(agg4#99)#134, avg(agg5#100)#135, avg(agg6#101)#136, avg(agg7#102)#137]
+Results [11]: [i_item_id#86, ca_country#94, ca_state#93, null AS county#138, avg(agg1#96)#131 AS agg1#139, avg(agg2#97)#132 AS agg2#140, avg(agg3#98)#133 AS agg3#141, avg(agg4#99)#134 AS agg4#142, avg(agg5#100)#135 AS agg5#143, avg(agg6#101)#136 AS agg6#144, avg(agg7#102)#137 AS agg7#145]
 
 (73) ReusedExchange [Reuses operator id: 20]
-Output [8]: [cs_bill_customer_sk#144, cs_quantity#145, cs_list_price#146, cs_sales_price#147, cs_coupon_amt#148, cs_net_profit#149, cd_dep_count#150, i_item_id#151]
+Output [8]: [cs_bill_customer_sk#146, cs_quantity#147, cs_list_price#148, cs_sales_price#149, cs_coupon_amt#150, cs_net_profit#151, cd_dep_count#152, i_item_id#153]
 
 (74) Sort [codegen id : 33]
-Input [8]: [cs_bill_customer_sk#144, cs_quantity#145, cs_list_price#146, cs_sales_price#147, cs_coupon_amt#148, cs_net_profit#149, cd_dep_count#150, i_item_id#151]
-Arguments: [cs_bill_customer_sk#144 ASC NULLS FIRST], false, 0
+Input [8]: [cs_bill_customer_sk#146, cs_quantity#147, cs_list_price#148, cs_sales_price#149, cs_coupon_amt#150, cs_net_profit#151, cd_dep_count#152, i_item_id#153]
+Arguments: [cs_bill_customer_sk#146 ASC NULLS FIRST], false, 0
 
 (75) Scan parquet spark_catalog.default.customer
-Output [5]: [c_customer_sk#152, c_current_cdemo_sk#153, c_current_addr_sk#154, c_birth_month#155, c_birth_year#156]
+Output [5]: [c_customer_sk#154, c_current_cdemo_sk#155, c_current_addr_sk#156, c_birth_month#157, c_birth_year#158]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer]
 PushedFilters: [In(c_birth_month, [1,10,12,4,5,9]), IsNotNull(c_customer_sk), IsNotNull(c_current_cdemo_sk), IsNotNull(c_current_addr_sk)]
 ReadSchema: struct<c_customer_sk:int,c_current_cdemo_sk:int,c_current_addr_sk:int,c_birth_month:int,c_birth_year:int>
 
 (76) ColumnarToRow [codegen id : 35]
-Input [5]: [c_customer_sk#152, c_current_cdemo_sk#153, c_current_addr_sk#154, c_birth_month#155, c_birth_year#156]
+Input [5]: [c_customer_sk#154, c_current_cdemo_sk#155, c_current_addr_sk#156, c_birth_month#157, c_birth_year#158]
 
 (77) Filter [codegen id : 35]
-Input [5]: [c_customer_sk#152, c_current_cdemo_sk#153, c_current_addr_sk#154, c_birth_month#155, c_birth_year#156]
-Condition : (((c_birth_month#155 IN (9,5,12,4,1,10) AND isnotnull(c_customer_sk#152)) AND isnotnull(c_current_cdemo_sk#153)) AND isnotnull(c_current_addr_sk#154))
+Input [5]: [c_customer_sk#154, c_current_cdemo_sk#155, c_current_addr_sk#156, c_birth_month#157, c_birth_year#158]
+Condition : (((c_birth_month#157 IN (9,5,12,4,1,10) AND isnotnull(c_customer_sk#154)) AND isnotnull(c_current_cdemo_sk#155)) AND isnotnull(c_current_addr_sk#156))
 
 (78) Project [codegen id : 35]
-Output [4]: [c_customer_sk#152, c_current_cdemo_sk#153, c_current_addr_sk#154, c_birth_year#156]
-Input [5]: [c_customer_sk#152, c_current_cdemo_sk#153, c_current_addr_sk#154, c_birth_month#155, c_birth_year#156]
+Output [4]: [c_customer_sk#154, c_current_cdemo_sk#155, c_current_addr_sk#156, c_birth_year#158]
+Input [5]: [c_customer_sk#154, c_current_cdemo_sk#155, c_current_addr_sk#156, c_birth_month#157, c_birth_year#158]
 
 (79) Scan parquet spark_catalog.default.customer_address
-Output [3]: [ca_address_sk#157, ca_state#158, ca_country#159]
+Output [3]: [ca_address_sk#159, ca_state#160, ca_country#161]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [In(ca_state, [AL,MS,NC,ND,OK,TN,WI]), IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_state:string,ca_country:string>
 
 (80) ColumnarToRow [codegen id : 34]
-Input [3]: [ca_address_sk#157, ca_state#158, ca_country#159]
+Input [3]: [ca_address_sk#159, ca_state#160, ca_country#161]
 
 (81) Filter [codegen id : 34]
-Input [3]: [ca_address_sk#157, ca_state#158, ca_country#159]
-Condition : (ca_state#158 IN (ND,WI,AL,NC,OK,MS,TN) AND isnotnull(ca_address_sk#157))
+Input [3]: [ca_address_sk#159, ca_state#160, ca_country#161]
+Condition : (ca_state#160 IN (ND,WI,AL,NC,OK,MS,TN) AND isnotnull(ca_address_sk#159))
 
 (82) Project [codegen id : 34]
-Output [2]: [ca_address_sk#157, ca_country#159]
-Input [3]: [ca_address_sk#157, ca_state#158, ca_country#159]
+Output [2]: [ca_address_sk#159, ca_country#161]
+Input [3]: [ca_address_sk#159, ca_state#160, ca_country#161]
 
 (83) BroadcastExchange
-Input [2]: [ca_address_sk#157, ca_country#159]
+Input [2]: [ca_address_sk#159, ca_country#161]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=13]
 
 (84) BroadcastHashJoin [codegen id : 35]
-Left keys [1]: [c_current_addr_sk#154]
-Right keys [1]: [ca_address_sk#157]
+Left keys [1]: [c_current_addr_sk#156]
+Right keys [1]: [ca_address_sk#159]
 Join type: Inner
 Join condition: None
 
 (85) Project [codegen id : 35]
-Output [4]: [c_customer_sk#152, c_current_cdemo_sk#153, c_birth_year#156, ca_country#159]
-Input [6]: [c_customer_sk#152, c_current_cdemo_sk#153, c_current_addr_sk#154, c_birth_year#156, ca_address_sk#157, ca_country#159]
+Output [4]: [c_customer_sk#154, c_current_cdemo_sk#155, c_birth_year#158, ca_country#161]
+Input [6]: [c_customer_sk#154, c_current_cdemo_sk#155, c_current_addr_sk#156, c_birth_year#158, ca_address_sk#159, ca_country#161]
 
 (86) Exchange
-Input [4]: [c_customer_sk#152, c_current_cdemo_sk#153, c_birth_year#156, ca_country#159]
-Arguments: hashpartitioning(c_current_cdemo_sk#153, 5), ENSURE_REQUIREMENTS, [plan_id=14]
+Input [4]: [c_customer_sk#154, c_current_cdemo_sk#155, c_birth_year#158, ca_country#161]
+Arguments: hashpartitioning(c_current_cdemo_sk#155, 5), ENSURE_REQUIREMENTS, [plan_id=14]
 
 (87) Sort [codegen id : 36]
-Input [4]: [c_customer_sk#152, c_current_cdemo_sk#153, c_birth_year#156, ca_country#159]
-Arguments: [c_current_cdemo_sk#153 ASC NULLS FIRST], false, 0
+Input [4]: [c_customer_sk#154, c_current_cdemo_sk#155, c_birth_year#158, ca_country#161]
+Arguments: [c_current_cdemo_sk#155 ASC NULLS FIRST], false, 0
 
 (88) ReusedExchange [Reuses operator id: 37]
-Output [1]: [cd_demo_sk#160]
+Output [1]: [cd_demo_sk#162]
 
 (89) Sort [codegen id : 38]
-Input [1]: [cd_demo_sk#160]
-Arguments: [cd_demo_sk#160 ASC NULLS FIRST], false, 0
+Input [1]: [cd_demo_sk#162]
+Arguments: [cd_demo_sk#162 ASC NULLS FIRST], false, 0
 
 (90) SortMergeJoin [codegen id : 39]
-Left keys [1]: [c_current_cdemo_sk#153]
-Right keys [1]: [cd_demo_sk#160]
+Left keys [1]: [c_current_cdemo_sk#155]
+Right keys [1]: [cd_demo_sk#162]
 Join type: Inner
 Join condition: None
 
 (91) Project [codegen id : 39]
-Output [3]: [c_customer_sk#152, c_birth_year#156, ca_country#159]
-Input [5]: [c_customer_sk#152, c_current_cdemo_sk#153, c_birth_year#156, ca_country#159, cd_demo_sk#160]
+Output [3]: [c_customer_sk#154, c_birth_year#158, ca_country#161]
+Input [5]: [c_customer_sk#154, c_current_cdemo_sk#155, c_birth_year#158, ca_country#161, cd_demo_sk#162]
 
 (92) Exchange
-Input [3]: [c_customer_sk#152, c_birth_year#156, ca_country#159]
-Arguments: hashpartitioning(c_customer_sk#152, 5), ENSURE_REQUIREMENTS, [plan_id=15]
+Input [3]: [c_customer_sk#154, c_birth_year#158, ca_country#161]
+Arguments: hashpartitioning(c_customer_sk#154, 5), ENSURE_REQUIREMENTS, [plan_id=15]
 
 (93) Sort [codegen id : 40]
-Input [3]: [c_customer_sk#152, c_birth_year#156, ca_country#159]
-Arguments: [c_customer_sk#152 ASC NULLS FIRST], false, 0
+Input [3]: [c_customer_sk#154, c_birth_year#158, ca_country#161]
+Arguments: [c_customer_sk#154 ASC NULLS FIRST], false, 0
 
 (94) SortMergeJoin [codegen id : 41]
-Left keys [1]: [cs_bill_customer_sk#144]
-Right keys [1]: [c_customer_sk#152]
+Left keys [1]: [cs_bill_customer_sk#146]
+Right keys [1]: [c_customer_sk#154]
 Join type: Inner
 Join condition: None
 
 (95) Project [codegen id : 41]
-Output [9]: [i_item_id#151, ca_country#159, cast(cs_quantity#145 as decimal(12,2)) AS agg1#161, cast(cs_list_price#146 as decimal(12,2)) AS agg2#162, cast(cs_coupon_amt#148 as decimal(12,2)) AS agg3#163, cast(cs_sales_price#147 as decimal(12,2)) AS agg4#164, cast(cs_net_profit#149 as decimal(12,2)) AS agg5#165, cast(c_birth_year#156 as decimal(12,2)) AS agg6#166, cast(cd_dep_count#150 as decimal(12,2)) AS agg7#167]
-Input [11]: [cs_bill_customer_sk#144, cs_quantity#145, cs_list_price#146, cs_sales_price#147, cs_coupon_amt#148, cs_net_profit#149, cd_dep_count#150, i_item_id#151, c_customer_sk#152, c_birth_year#156, ca_country#159]
+Output [9]: [i_item_id#153, ca_country#161, cast(cs_quantity#147 as decimal(12,2)) AS agg1#163, cast(cs_list_price#148 as decimal(12,2)) AS agg2#164, cast(cs_coupon_amt#150 as decimal(12,2)) AS agg3#165, cast(cs_sales_price#149 as decimal(12,2)) AS agg4#166, cast(cs_net_profit#151 as decimal(12,2)) AS agg5#167, cast(c_birth_year#158 as decimal(12,2)) AS agg6#168, cast(cd_dep_count#152 as decimal(12,2)) AS agg7#169]
+Input [11]: [cs_bill_customer_sk#146, cs_quantity#147, cs_list_price#148, cs_sales_price#149, cs_coupon_amt#150, cs_net_profit#151, cd_dep_count#152, i_item_id#153, c_customer_sk#154, c_birth_year#158, ca_country#161]
 
 (96) HashAggregate [codegen id : 41]
-Input [9]: [i_item_id#151, ca_country#159, agg1#161, agg2#162, agg3#163, agg4#164, agg5#165, agg6#166, agg7#167]
-Keys [2]: [i_item_id#151, ca_country#159]
-Functions [7]: [partial_avg(agg1#161), partial_avg(agg2#162), partial_avg(agg3#163), partial_avg(agg4#164), partial_avg(agg5#165), partial_avg(agg6#166), partial_avg(agg7#167)]
-Aggregate Attributes [14]: [sum#168, count#169, sum#170, count#171, sum#172, count#173, sum#174, count#175, sum#176, count#177, sum#178, count#179, sum#180, count#181]
-Results [16]: [i_item_id#151, ca_country#159, sum#182, count#183, sum#184, count#185, sum#186, count#187, sum#188, count#189, sum#190, count#191, sum#192, count#193, sum#194, count#195]
+Input [9]: [i_item_id#153, ca_country#161, agg1#163, agg2#164, agg3#165, agg4#166, agg5#167, agg6#168, agg7#169]
+Keys [2]: [i_item_id#153, ca_country#161]
+Functions [7]: [partial_avg(agg1#163), partial_avg(agg2#164), partial_avg(agg3#165), partial_avg(agg4#166), partial_avg(agg5#167), partial_avg(agg6#168), partial_avg(agg7#169)]
+Aggregate Attributes [14]: [sum#170, count#171, sum#172, count#173, sum#174, count#175, sum#176, count#177, sum#178, count#179, sum#180, count#181, sum#182, count#183]
+Results [16]: [i_item_id#153, ca_country#161, sum#184, count#185, sum#186, count#187, sum#188, count#189, sum#190, count#191, sum#192, count#193, sum#194, count#195, sum#196, count#197]
 
 (97) Exchange
-Input [16]: [i_item_id#151, ca_country#159, sum#182, count#183, sum#184, count#185, sum#186, count#187, sum#188, count#189, sum#190, count#191, sum#192, count#193, sum#194, count#195]
-Arguments: hashpartitioning(i_item_id#151, ca_country#159, 5), ENSURE_REQUIREMENTS, [plan_id=16]
+Input [16]: [i_item_id#153, ca_country#161, sum#184, count#185, sum#186, count#187, sum#188, count#189, sum#190, count#191, sum#192, count#193, sum#194, count#195, sum#196, count#197]
+Arguments: hashpartitioning(i_item_id#153, ca_country#161, 5), ENSURE_REQUIREMENTS, [plan_id=16]
 
 (98) HashAggregate [codegen id : 42]
-Input [16]: [i_item_id#151, ca_country#159, sum#182, count#183, sum#184, count#185, sum#186, count#187, sum#188, count#189, sum#190, count#191, sum#192, count#193, sum#194, count#195]
-Keys [2]: [i_item_id#151, ca_country#159]
-Functions [7]: [avg(agg1#161), avg(agg2#162), avg(agg3#163), avg(agg4#164), avg(agg5#165), avg(agg6#166), avg(agg7#167)]
-Aggregate Attributes [7]: [avg(agg1#161)#196, avg(agg2#162)#197, avg(agg3#163)#198, avg(agg4#164)#199, avg(agg5#165)#200, avg(agg6#166)#201, avg(agg7#167)#202]
-Results [11]: [i_item_id#151, ca_country#159, null AS ca_state#203, null AS county#204, avg(agg1#161)#196 AS agg1#205, avg(agg2#162)#197 AS agg2#206, avg(agg3#163)#198 AS agg3#207, avg(agg4#164)#199 AS agg4#208, avg(agg5#165)#200 AS agg5#209, avg(agg6#166)#201 AS agg6#210, avg(agg7#167)#202 AS agg7#211]
+Input [16]: [i_item_id#153, ca_country#161, sum#184, count#185, sum#186, count#187, sum#188, count#189, sum#190, count#191, sum#192, count#193, sum#194, count#195, sum#196, count#197]
+Keys [2]: [i_item_id#153, ca_country#161]
+Functions [7]: [avg(agg1#163), avg(agg2#164), avg(agg3#165), avg(agg4#166), avg(agg5#167), avg(agg6#168), avg(agg7#169)]
+Aggregate Attributes [7]: [avg(agg1#163)#198, avg(agg2#164)#199, avg(agg3#165)#200, avg(agg4#166)#201, avg(agg5#167)#202, avg(agg6#168)#203, avg(agg7#169)#204]
+Results [11]: [i_item_id#153, ca_country#161, null AS ca_state#205, null AS county#206, avg(agg1#163)#198 AS agg1#207, avg(agg2#164)#199 AS agg2#208, avg(agg3#165)#200 AS agg3#209, avg(agg4#166)#201 AS agg4#210, avg(agg5#167)#202 AS agg5#211, avg(agg6#168)#203 AS agg6#212, avg(agg7#169)#204 AS agg7#213]
 
 (99) Scan parquet spark_catalog.default.catalog_sales
-Output [9]: [cs_bill_customer_sk#212, cs_bill_cdemo_sk#213, cs_item_sk#214, cs_quantity#215, cs_list_price#216, cs_sales_price#217, cs_coupon_amt#218, cs_net_profit#219, cs_sold_date_sk#220]
+Output [9]: [cs_bill_customer_sk#214, cs_bill_cdemo_sk#215, cs_item_sk#216, cs_quantity#217, cs_list_price#218, cs_sales_price#219, cs_coupon_amt#220, cs_net_profit#221, cs_sold_date_sk#222]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#220), dynamicpruningexpression(cs_sold_date_sk#220 IN dynamicpruning#10)]
+PartitionFilters: [isnotnull(cs_sold_date_sk#222), dynamicpruningexpression(cs_sold_date_sk#222 IN dynamicpruning#10)]
 PushedFilters: [IsNotNull(cs_bill_cdemo_sk), IsNotNull(cs_bill_customer_sk), IsNotNull(cs_item_sk)]
 ReadSchema: struct<cs_bill_customer_sk:int,cs_bill_cdemo_sk:int,cs_item_sk:int,cs_quantity:int,cs_list_price:decimal(7,2),cs_sales_price:decimal(7,2),cs_coupon_amt:decimal(7,2),cs_net_profit:decimal(7,2)>
 
 (100) ColumnarToRow [codegen id : 49]
-Input [9]: [cs_bill_customer_sk#212, cs_bill_cdemo_sk#213, cs_item_sk#214, cs_quantity#215, cs_list_price#216, cs_sales_price#217, cs_coupon_amt#218, cs_net_profit#219, cs_sold_date_sk#220]
+Input [9]: [cs_bill_customer_sk#214, cs_bill_cdemo_sk#215, cs_item_sk#216, cs_quantity#217, cs_list_price#218, cs_sales_price#219, cs_coupon_amt#220, cs_net_profit#221, cs_sold_date_sk#222]
 
 (101) Filter [codegen id : 49]
-Input [9]: [cs_bill_customer_sk#212, cs_bill_cdemo_sk#213, cs_item_sk#214, cs_quantity#215, cs_list_price#216, cs_sales_price#217, cs_coupon_amt#218, cs_net_profit#219, cs_sold_date_sk#220]
-Condition : ((isnotnull(cs_bill_cdemo_sk#213) AND isnotnull(cs_bill_customer_sk#212)) AND isnotnull(cs_item_sk#214))
+Input [9]: [cs_bill_customer_sk#214, cs_bill_cdemo_sk#215, cs_item_sk#216, cs_quantity#217, cs_list_price#218, cs_sales_price#219, cs_coupon_amt#220, cs_net_profit#221, cs_sold_date_sk#222]
+Condition : ((isnotnull(cs_bill_cdemo_sk#215) AND isnotnull(cs_bill_customer_sk#214)) AND isnotnull(cs_item_sk#216))
 
 (102) ReusedExchange [Reuses operator id: 8]
-Output [2]: [cd_demo_sk#221, cd_dep_count#222]
+Output [2]: [cd_demo_sk#223, cd_dep_count#224]
 
 (103) BroadcastHashJoin [codegen id : 49]
-Left keys [1]: [cs_bill_cdemo_sk#213]
-Right keys [1]: [cd_demo_sk#221]
+Left keys [1]: [cs_bill_cdemo_sk#215]
+Right keys [1]: [cd_demo_sk#223]
 Join type: Inner
 Join condition: None
 
 (104) Project [codegen id : 49]
-Output [9]: [cs_bill_customer_sk#212, cs_item_sk#214, cs_quantity#215, cs_list_price#216, cs_sales_price#217, cs_coupon_amt#218, cs_net_profit#219, cs_sold_date_sk#220, cd_dep_count#222]
-Input [11]: [cs_bill_customer_sk#212, cs_bill_cdemo_sk#213, cs_item_sk#214, cs_quantity#215, cs_list_price#216, cs_sales_price#217, cs_coupon_amt#218, cs_net_profit#219, cs_sold_date_sk#220, cd_demo_sk#221, cd_dep_count#222]
+Output [9]: [cs_bill_customer_sk#214, cs_item_sk#216, cs_quantity#217, cs_list_price#218, cs_sales_price#219, cs_coupon_amt#220, cs_net_profit#221, cs_sold_date_sk#222, cd_dep_count#224]
+Input [11]: [cs_bill_customer_sk#214, cs_bill_cdemo_sk#215, cs_item_sk#216, cs_quantity#217, cs_list_price#218, cs_sales_price#219, cs_coupon_amt#220, cs_net_profit#221, cs_sold_date_sk#222, cd_demo_sk#223, cd_dep_count#224]
 
-(105) ReusedExchange [Reuses operator id: 161]
-Output [1]: [d_date_sk#223]
+(105) ReusedExchange [Reuses operator id: 168]
+Output [1]: [d_date_sk#225]
 
 (106) BroadcastHashJoin [codegen id : 49]
-Left keys [1]: [cs_sold_date_sk#220]
-Right keys [1]: [d_date_sk#223]
+Left keys [1]: [cs_sold_date_sk#222]
+Right keys [1]: [d_date_sk#225]
 Join type: Inner
 Join condition: None
 
 (107) Project [codegen id : 49]
-Output [8]: [cs_bill_customer_sk#212, cs_item_sk#214, cs_quantity#215, cs_list_price#216, cs_sales_price#217, cs_coupon_amt#218, cs_net_profit#219, cd_dep_count#222]
-Input [10]: [cs_bill_customer_sk#212, cs_item_sk#214, cs_quantity#215, cs_list_price#216, cs_sales_price#217, cs_coupon_amt#218, cs_net_profit#219, cs_sold_date_sk#220, cd_dep_count#222, d_date_sk#223]
+Output [8]: [cs_bill_customer_sk#214, cs_item_sk#216, cs_quantity#217, cs_list_price#218, cs_sales_price#219, cs_coupon_amt#220, cs_net_profit#221, cd_dep_count#224]
+Input [10]: [cs_bill_customer_sk#214, cs_item_sk#216, cs_quantity#217, cs_list_price#218, cs_sales_price#219, cs_coupon_amt#220, cs_net_profit#221, cs_sold_date_sk#222, cd_dep_count#224, d_date_sk#225]
 
 (108) Scan parquet spark_catalog.default.customer
-Output [5]: [c_customer_sk#224, c_current_cdemo_sk#225, c_current_addr_sk#226, c_birth_month#227, c_birth_year#228]
+Output [5]: [c_customer_sk#226, c_current_cdemo_sk#227, c_current_addr_sk#228, c_birth_month#229, c_birth_year#230]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer]
 PushedFilters: [In(c_birth_month, [1,10,12,4,5,9]), IsNotNull(c_customer_sk), IsNotNull(c_current_cdemo_sk), IsNotNull(c_current_addr_sk)]
 ReadSchema: struct<c_customer_sk:int,c_current_cdemo_sk:int,c_current_addr_sk:int,c_birth_month:int,c_birth_year:int>
 
 (109) ColumnarToRow [codegen id : 46]
-Input [5]: [c_customer_sk#224, c_current_cdemo_sk#225, c_current_addr_sk#226, c_birth_month#227, c_birth_year#228]
+Input [5]: [c_customer_sk#226, c_current_cdemo_sk#227, c_current_addr_sk#228, c_birth_month#229, c_birth_year#230]
 
 (110) Filter [codegen id : 46]
-Input [5]: [c_customer_sk#224, c_current_cdemo_sk#225, c_current_addr_sk#226, c_birth_month#227, c_birth_year#228]
-Condition : (((c_birth_month#227 IN (9,5,12,4,1,10) AND isnotnull(c_customer_sk#224)) AND isnotnull(c_current_cdemo_sk#225)) AND isnotnull(c_current_addr_sk#226))
+Input [5]: [c_customer_sk#226, c_current_cdemo_sk#227, c_current_addr_sk#228, c_birth_month#229, c_birth_year#230]
+Condition : (((c_birth_month#229 IN (9,5,12,4,1,10) AND isnotnull(c_customer_sk#226)) AND isnotnull(c_current_cdemo_sk#227)) AND isnotnull(c_current_addr_sk#228))
 
 (111) Project [codegen id : 46]
-Output [4]: [c_customer_sk#224, c_current_cdemo_sk#225, c_current_addr_sk#226, c_birth_year#228]
-Input [5]: [c_customer_sk#224, c_current_cdemo_sk#225, c_current_addr_sk#226, c_birth_month#227, c_birth_year#228]
+Output [4]: [c_customer_sk#226, c_current_cdemo_sk#227, c_current_addr_sk#228, c_birth_year#230]
+Input [5]: [c_customer_sk#226, c_current_cdemo_sk#227, c_current_addr_sk#228, c_birth_month#229, c_birth_year#230]
 
 (112) Scan parquet spark_catalog.default.customer_address
-Output [2]: [ca_address_sk#229, ca_state#230]
+Output [2]: [ca_address_sk#231, ca_state#232]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [In(ca_state, [AL,MS,NC,ND,OK,TN,WI]), IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_state:string>
 
 (113) ColumnarToRow [codegen id : 45]
-Input [2]: [ca_address_sk#229, ca_state#230]
+Input [2]: [ca_address_sk#231, ca_state#232]
 
 (114) Filter [codegen id : 45]
-Input [2]: [ca_address_sk#229, ca_state#230]
-Condition : (ca_state#230 IN (ND,WI,AL,NC,OK,MS,TN) AND isnotnull(ca_address_sk#229))
+Input [2]: [ca_address_sk#231, ca_state#232]
+Condition : (ca_state#232 IN (ND,WI,AL,NC,OK,MS,TN) AND isnotnull(ca_address_sk#231))
 
 (115) Project [codegen id : 45]
-Output [1]: [ca_address_sk#229]
-Input [2]: [ca_address_sk#229, ca_state#230]
+Output [1]: [ca_address_sk#231]
+Input [2]: [ca_address_sk#231, ca_state#232]
 
 (116) BroadcastExchange
-Input [1]: [ca_address_sk#229]
+Input [1]: [ca_address_sk#231]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=17]
 
 (117) BroadcastHashJoin [codegen id : 46]
-Left keys [1]: [c_current_addr_sk#226]
-Right keys [1]: [ca_address_sk#229]
+Left keys [1]: [c_current_addr_sk#228]
+Right keys [1]: [ca_address_sk#231]
 Join type: Inner
 Join condition: None
 
 (118) Project [codegen id : 46]
-Output [3]: [c_customer_sk#224, c_current_cdemo_sk#225, c_birth_year#228]
-Input [5]: [c_customer_sk#224, c_current_cdemo_sk#225, c_current_addr_sk#226, c_birth_year#228, ca_address_sk#229]
+Output [3]: [c_customer_sk#226, c_current_cdemo_sk#227, c_birth_year#230]
+Input [5]: [c_customer_sk#226, c_current_cdemo_sk#227, c_current_addr_sk#228, c_birth_year#230, ca_address_sk#231]
 
 (119) BroadcastExchange
-Input [3]: [c_customer_sk#224, c_current_cdemo_sk#225, c_birth_year#228]
+Input [3]: [c_customer_sk#226, c_current_cdemo_sk#227, c_birth_year#230]
 Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, true] as bigint)),false), [plan_id=18]
 
 (120) Scan parquet spark_catalog.default.customer_demographics
-Output [1]: [cd_demo_sk#231]
+Output [1]: [cd_demo_sk#233]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_demographics]
 PushedFilters: [IsNotNull(cd_demo_sk)]
 ReadSchema: struct<cd_demo_sk:int>
 
 (121) ColumnarToRow
-Input [1]: [cd_demo_sk#231]
+Input [1]: [cd_demo_sk#233]
 
 (122) Filter
-Input [1]: [cd_demo_sk#231]
-Condition : isnotnull(cd_demo_sk#231)
+Input [1]: [cd_demo_sk#233]
+Condition : isnotnull(cd_demo_sk#233)
 
 (123) BroadcastHashJoin [codegen id : 47]
-Left keys [1]: [c_current_cdemo_sk#225]
-Right keys [1]: [cd_demo_sk#231]
+Left keys [1]: [c_current_cdemo_sk#227]
+Right keys [1]: [cd_demo_sk#233]
 Join type: Inner
 Join condition: None
 
 (124) Project [codegen id : 47]
-Output [2]: [c_customer_sk#224, c_birth_year#228]
-Input [4]: [c_customer_sk#224, c_current_cdemo_sk#225, c_birth_year#228, cd_demo_sk#231]
+Output [2]: [c_customer_sk#226, c_birth_year#230]
+Input [4]: [c_customer_sk#226, c_current_cdemo_sk#227, c_birth_year#230, cd_demo_sk#233]
 
 (125) BroadcastExchange
-Input [2]: [c_customer_sk#224, c_birth_year#228]
+Input [2]: [c_customer_sk#226, c_birth_year#230]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=19]
 
 (126) BroadcastHashJoin [codegen id : 49]
-Left keys [1]: [cs_bill_customer_sk#212]
-Right keys [1]: [c_customer_sk#224]
+Left keys [1]: [cs_bill_customer_sk#214]
+Right keys [1]: [c_customer_sk#226]
 Join type: Inner
 Join condition: None
 
 (127) Project [codegen id : 49]
-Output [8]: [cs_item_sk#214, cs_quantity#215, cs_list_price#216, cs_sales_price#217, cs_coupon_amt#218, cs_net_profit#219, cd_dep_count#222, c_birth_year#228]
-Input [10]: [cs_bill_customer_sk#212, cs_item_sk#214, cs_quantity#215, cs_list_price#216, cs_sales_price#217, cs_coupon_amt#218, cs_net_profit#219, cd_dep_count#222, c_customer_sk#224, c_birth_year#228]
+Output [8]: [cs_item_sk#216, cs_quantity#217, cs_list_price#218, cs_sales_price#219, cs_coupon_amt#220, cs_net_profit#221, cd_dep_count#224, c_birth_year#230]
+Input [10]: [cs_bill_customer_sk#214, cs_item_sk#216, cs_quantity#217, cs_list_price#218, cs_sales_price#219, cs_coupon_amt#220, cs_net_profit#221, cd_dep_count#224, c_customer_sk#226, c_birth_year#230]
 
 (128) ReusedExchange [Reuses operator id: 17]
-Output [2]: [i_item_sk#232, i_item_id#233]
+Output [2]: [i_item_sk#234, i_item_id#235]
 
 (129) BroadcastHashJoin [codegen id : 49]
-Left keys [1]: [cs_item_sk#214]
-Right keys [1]: [i_item_sk#232]
+Left keys [1]: [cs_item_sk#216]
+Right keys [1]: [i_item_sk#234]
 Join type: Inner
 Join condition: None
 
 (130) Project [codegen id : 49]
-Output [8]: [i_item_id#233, cast(cs_quantity#215 as decimal(12,2)) AS agg1#234, cast(cs_list_price#216 as decimal(12,2)) AS agg2#235, cast(cs_coupon_amt#218 as decimal(12,2)) AS agg3#236, cast(cs_sales_price#217 as decimal(12,2)) AS agg4#237, cast(cs_net_profit#219 as decimal(12,2)) AS agg5#238, cast(c_birth_year#228 as decimal(12,2)) AS agg6#239, cast(cd_dep_count#222 as decimal(12,2)) AS agg7#240]
-Input [10]: [cs_item_sk#214, cs_quantity#215, cs_list_price#216, cs_sales_price#217, cs_coupon_amt#218, cs_net_profit#219, cd_dep_count#222, c_birth_year#228, i_item_sk#232, i_item_id#233]
+Output [8]: [i_item_id#235, cast(cs_quantity#217 as decimal(12,2)) AS agg1#236, cast(cs_list_price#218 as decimal(12,2)) AS agg2#237, cast(cs_coupon_amt#220 as decimal(12,2)) AS agg3#238, cast(cs_sales_price#219 as decimal(12,2)) AS agg4#239, cast(cs_net_profit#221 as decimal(12,2)) AS agg5#240, cast(c_birth_year#230 as decimal(12,2)) AS agg6#241, cast(cd_dep_count#224 as decimal(12,2)) AS agg7#242]
+Input [10]: [cs_item_sk#216, cs_quantity#217, cs_list_price#218, cs_sales_price#219, cs_coupon_amt#220, cs_net_profit#221, cd_dep_count#224, c_birth_year#230, i_item_sk#234, i_item_id#235]
 
 (131) HashAggregate [codegen id : 49]
-Input [8]: [i_item_id#233, agg1#234, agg2#235, agg3#236, agg4#237, agg5#238, agg6#239, agg7#240]
-Keys [1]: [i_item_id#233]
-Functions [7]: [partial_avg(agg1#234), partial_avg(agg2#235), partial_avg(agg3#236), partial_avg(agg4#237), partial_avg(agg5#238), partial_avg(agg6#239), partial_avg(agg7#240)]
-Aggregate Attributes [14]: [sum#241, count#242, sum#243, count#244, sum#245, count#246, sum#247, count#248, sum#249, count#250, sum#251, count#252, sum#253, count#254]
-Results [15]: [i_item_id#233, sum#255, count#256, sum#257, count#258, sum#259, count#260, sum#261, count#262, sum#263, count#264, sum#265, count#266, sum#267, count#268]
+Input [8]: [i_item_id#235, agg1#236, agg2#237, agg3#238, agg4#239, agg5#240, agg6#241, agg7#242]
+Keys [1]: [i_item_id#235]
+Functions [7]: [partial_avg(agg1#236), partial_avg(agg2#237), partial_avg(agg3#238), partial_avg(agg4#239), partial_avg(agg5#240), partial_avg(agg6#241), partial_avg(agg7#242)]
+Aggregate Attributes [14]: [sum#243, count#244, sum#245, count#246, sum#247, count#248, sum#249, count#250, sum#251, count#252, sum#253, count#254, sum#255, count#256]
+Results [15]: [i_item_id#235, sum#257, count#258, sum#259, count#260, sum#261, count#262, sum#263, count#264, sum#265, count#266, sum#267, count#268, sum#269, count#270]
 
 (132) Exchange
-Input [15]: [i_item_id#233, sum#255, count#256, sum#257, count#258, sum#259, count#260, sum#261, count#262, sum#263, count#264, sum#265, count#266, sum#267, count#268]
-Arguments: hashpartitioning(i_item_id#233, 5), ENSURE_REQUIREMENTS, [plan_id=20]
+Input [15]: [i_item_id#235, sum#257, count#258, sum#259, count#260, sum#261, count#262, sum#263, count#264, sum#265, count#266, sum#267, count#268, sum#269, count#270]
+Arguments: hashpartitioning(i_item_id#235, 5), ENSURE_REQUIREMENTS, [plan_id=20]
 
 (133) HashAggregate [codegen id : 50]
-Input [15]: [i_item_id#233, sum#255, count#256, sum#257, count#258, sum#259, count#260, sum#261, count#262, sum#263, count#264, sum#265, count#266, sum#267, count#268]
-Keys [1]: [i_item_id#233]
-Functions [7]: [avg(agg1#234), avg(agg2#235), avg(agg3#236), avg(agg4#237), avg(agg5#238), avg(agg6#239), avg(agg7#240)]
-Aggregate Attributes [7]: [avg(agg1#234)#269, avg(agg2#235)#270, avg(agg3#236)#271, avg(agg4#237)#272, avg(agg5#238)#273, avg(agg6#239)#274, avg(agg7#240)#275]
-Results [11]: [i_item_id#233, null AS ca_country#276, null AS ca_state#277, null AS county#278, avg(agg1#234)#269 AS agg1#279, avg(agg2#235)#270 AS agg2#280, avg(agg3#236)#271 AS agg3#281, avg(agg4#237)#272 AS agg4#282, avg(agg5#238)#273 AS agg5#283, avg(agg6#239)#274 AS agg6#284, avg(agg7#240)#275 AS agg7#285]
+Input [15]: [i_item_id#235, sum#257, count#258, sum#259, count#260, sum#261, count#262, sum#263, count#264, sum#265, count#266, sum#267, count#268, sum#269, count#270]
+Keys [1]: [i_item_id#235]
+Functions [7]: [avg(agg1#236), avg(agg2#237), avg(agg3#238), avg(agg4#239), avg(agg5#240), avg(agg6#241), avg(agg7#242)]
+Aggregate Attributes [7]: [avg(agg1#236)#271, avg(agg2#237)#272, avg(agg3#238)#273, avg(agg4#239)#274, avg(agg5#240)#275, avg(agg6#241)#276, avg(agg7#242)#277]
+Results [11]: [i_item_id#235, null AS ca_country#278, null AS ca_state#279, null AS county#280, avg(agg1#236)#271 AS agg1#281, avg(agg2#237)#272 AS agg2#282, avg(agg3#238)#273 AS agg3#283, avg(agg4#239)#274 AS agg4#284, avg(agg5#240)#275 AS agg5#285, avg(agg6#241)#276 AS agg6#286, avg(agg7#242)#277 AS agg7#287]
 
 (134) Scan parquet spark_catalog.default.catalog_sales
-Output [9]: [cs_bill_customer_sk#286, cs_bill_cdemo_sk#287, cs_item_sk#288, cs_quantity#289, cs_list_price#290, cs_sales_price#291, cs_coupon_amt#292, cs_net_profit#293, cs_sold_date_sk#294]
+Output [9]: [cs_bill_customer_sk#288, cs_bill_cdemo_sk#289, cs_item_sk#290, cs_quantity#291, cs_list_price#292, cs_sales_price#293, cs_coupon_amt#294, cs_net_profit#295, cs_sold_date_sk#296]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#294), dynamicpruningexpression(cs_sold_date_sk#294 IN dynamicpruning#10)]
+PartitionFilters: [isnotnull(cs_sold_date_sk#296), dynamicpruningexpression(cs_sold_date_sk#296 IN dynamicpruning#10)]
 PushedFilters: [IsNotNull(cs_bill_cdemo_sk), IsNotNull(cs_bill_customer_sk), IsNotNull(cs_item_sk)]
 ReadSchema: struct<cs_bill_customer_sk:int,cs_bill_cdemo_sk:int,cs_item_sk:int,cs_quantity:int,cs_list_price:decimal(7,2),cs_sales_price:decimal(7,2),cs_coupon_amt:decimal(7,2),cs_net_profit:decimal(7,2)>
 
 (135) ColumnarToRow [codegen id : 57]
-Input [9]: [cs_bill_customer_sk#286, cs_bill_cdemo_sk#287, cs_item_sk#288, cs_quantity#289, cs_list_price#290, cs_sales_price#291, cs_coupon_amt#292, cs_net_profit#293, cs_sold_date_sk#294]
+Input [9]: [cs_bill_customer_sk#288, cs_bill_cdemo_sk#289, cs_item_sk#290, cs_quantity#291, cs_list_price#292, cs_sales_price#293, cs_coupon_amt#294, cs_net_profit#295, cs_sold_date_sk#296]
 
 (136) Filter [codegen id : 57]
-Input [9]: [cs_bill_customer_sk#286, cs_bill_cdemo_sk#287, cs_item_sk#288, cs_quantity#289, cs_list_price#290, cs_sales_price#291, cs_coupon_amt#292, cs_net_profit#293, cs_sold_date_sk#294]
-Condition : ((isnotnull(cs_bill_cdemo_sk#287) AND isnotnull(cs_bill_customer_sk#286)) AND isnotnull(cs_item_sk#288))
+Input [9]: [cs_bill_customer_sk#288, cs_bill_cdemo_sk#289, cs_item_sk#290, cs_quantity#291, cs_list_price#292, cs_sales_price#293, cs_coupon_amt#294, cs_net_profit#295, cs_sold_date_sk#296]
+Condition : ((isnotnull(cs_bill_cdemo_sk#289) AND isnotnull(cs_bill_customer_sk#288)) AND isnotnull(cs_item_sk#290))
 
 (137) ReusedExchange [Reuses operator id: 8]
-Output [2]: [cd_demo_sk#295, cd_dep_count#296]
+Output [2]: [cd_demo_sk#297, cd_dep_count#298]
 
 (138) BroadcastHashJoin [codegen id : 57]
-Left keys [1]: [cs_bill_cdemo_sk#287]
-Right keys [1]: [cd_demo_sk#295]
+Left keys [1]: [cs_bill_cdemo_sk#289]
+Right keys [1]: [cd_demo_sk#297]
 Join type: Inner
 Join condition: None
 
 (139) Project [codegen id : 57]
-Output [9]: [cs_bill_customer_sk#286, cs_item_sk#288, cs_quantity#289, cs_list_price#290, cs_sales_price#291, cs_coupon_amt#292, cs_net_profit#293, cs_sold_date_sk#294, cd_dep_count#296]
-Input [11]: [cs_bill_customer_sk#286, cs_bill_cdemo_sk#287, cs_item_sk#288, cs_quantity#289, cs_list_price#290, cs_sales_price#291, cs_coupon_amt#292, cs_net_profit#293, cs_sold_date_sk#294, cd_demo_sk#295, cd_dep_count#296]
+Output [9]: [cs_bill_customer_sk#288, cs_item_sk#290, cs_quantity#291, cs_list_price#292, cs_sales_price#293, cs_coupon_amt#294, cs_net_profit#295, cs_sold_date_sk#296, cd_dep_count#298]
+Input [11]: [cs_bill_customer_sk#288, cs_bill_cdemo_sk#289, cs_item_sk#290, cs_quantity#291, cs_list_price#292, cs_sales_price#293, cs_coupon_amt#294, cs_net_profit#295, cs_sold_date_sk#296, cd_demo_sk#297, cd_dep_count#298]
 
-(140) ReusedExchange [Reuses operator id: 161]
-Output [1]: [d_date_sk#297]
+(140) ReusedExchange [Reuses operator id: 168]
+Output [1]: [d_date_sk#299]
 
 (141) BroadcastHashJoin [codegen id : 57]
-Left keys [1]: [cs_sold_date_sk#294]
-Right keys [1]: [d_date_sk#297]
+Left keys [1]: [cs_sold_date_sk#296]
+Right keys [1]: [d_date_sk#299]
 Join type: Inner
 Join condition: None
 
 (142) Project [codegen id : 57]
-Output [8]: [cs_bill_customer_sk#286, cs_item_sk#288, cs_quantity#289, cs_list_price#290, cs_sales_price#291, cs_coupon_amt#292, cs_net_profit#293, cd_dep_count#296]
-Input [10]: [cs_bill_customer_sk#286, cs_item_sk#288, cs_quantity#289, cs_list_price#290, cs_sales_price#291, cs_coupon_amt#292, cs_net_profit#293, cs_sold_date_sk#294, cd_dep_count#296, d_date_sk#297]
+Output [8]: [cs_bill_customer_sk#288, cs_item_sk#290, cs_quantity#291, cs_list_price#292, cs_sales_price#293, cs_coupon_amt#294, cs_net_profit#295, cd_dep_count#298]
+Input [10]: [cs_bill_customer_sk#288, cs_item_sk#290, cs_quantity#291, cs_list_price#292, cs_sales_price#293, cs_coupon_amt#294, cs_net_profit#295, cs_sold_date_sk#296, cd_dep_count#298, d_date_sk#299]
 
 (143) Scan parquet spark_catalog.default.item
-Output [1]: [i_item_sk#298]
+Output [1]: [i_item_sk#300]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int>
 
 (144) ColumnarToRow [codegen id : 53]
-Input [1]: [i_item_sk#298]
+Input [1]: [i_item_sk#300]
 
 (145) Filter [codegen id : 53]
-Input [1]: [i_item_sk#298]
-Condition : isnotnull(i_item_sk#298)
+Input [1]: [i_item_sk#300]
+Condition : isnotnull(i_item_sk#300)
 
 (146) BroadcastExchange
-Input [1]: [i_item_sk#298]
+Input [1]: [i_item_sk#300]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=21]
 
 (147) BroadcastHashJoin [codegen id : 57]
-Left keys [1]: [cs_item_sk#288]
-Right keys [1]: [i_item_sk#298]
+Left keys [1]: [cs_item_sk#290]
+Right keys [1]: [i_item_sk#300]
 Join type: Inner
 Join condition: None
 
 (148) Project [codegen id : 57]
-Output [7]: [cs_bill_customer_sk#286, cs_quantity#289, cs_list_price#290, cs_sales_price#291, cs_coupon_amt#292, cs_net_profit#293, cd_dep_count#296]
-Input [9]: [cs_bill_customer_sk#286, cs_item_sk#288, cs_quantity#289, cs_list_price#290, cs_sales_price#291, cs_coupon_amt#292, cs_net_profit#293, cd_dep_count#296, i_item_sk#298]
+Output [7]: [cs_bill_customer_sk#288, cs_quantity#291, cs_list_price#292, cs_sales_price#293, cs_coupon_amt#294, cs_net_profit#295, cd_dep_count#298]
+Input [9]: [cs_bill_customer_sk#288, cs_item_sk#290, cs_quantity#291, cs_list_price#292, cs_sales_price#293, cs_coupon_amt#294, cs_net_profit#295, cd_dep_count#298, i_item_sk#300]
 
 (149) ReusedExchange [Reuses operator id: 125]
-Output [2]: [c_customer_sk#299, c_birth_year#300]
+Output [2]: [c_customer_sk#301, c_birth_year#302]
 
 (150) BroadcastHashJoin [codegen id : 57]
-Left keys [1]: [cs_bill_customer_sk#286]
-Right keys [1]: [c_customer_sk#299]
+Left keys [1]: [cs_bill_customer_sk#288]
+Right keys [1]: [c_customer_sk#301]
 Join type: Inner
 Join condition: None
 
 (151) Project [codegen id : 57]
-Output [7]: [cast(cs_quantity#289 as decimal(12,2)) AS agg1#301, cast(cs_list_price#290 as decimal(12,2)) AS agg2#302, cast(cs_coupon_amt#292 as decimal(12,2)) AS agg3#303, cast(cs_sales_price#291 as decimal(12,2)) AS agg4#304, cast(cs_net_profit#293 as decimal(12,2)) AS agg5#305, cast(c_birth_year#300 as decimal(12,2)) AS agg6#306, cast(cd_dep_count#296 as decimal(12,2)) AS agg7#307]
-Input [9]: [cs_bill_customer_sk#286, cs_quantity#289, cs_list_price#290, cs_sales_price#291, cs_coupon_amt#292, cs_net_profit#293, cd_dep_count#296, c_customer_sk#299, c_birth_year#300]
+Output [7]: [cast(cs_quantity#291 as decimal(12,2)) AS agg1#303, cast(cs_list_price#292 as decimal(12,2)) AS agg2#304, cast(cs_coupon_amt#294 as decimal(12,2)) AS agg3#305, cast(cs_sales_price#293 as decimal(12,2)) AS agg4#306, cast(cs_net_profit#295 as decimal(12,2)) AS agg5#307, cast(c_birth_year#302 as decimal(12,2)) AS agg6#308, cast(cd_dep_count#298 as decimal(12,2)) AS agg7#309]
+Input [9]: [cs_bill_customer_sk#288, cs_quantity#291, cs_list_price#292, cs_sales_price#293, cs_coupon_amt#294, cs_net_profit#295, cd_dep_count#298, c_customer_sk#301, c_birth_year#302]
 
 (152) HashAggregate [codegen id : 57]
-Input [7]: [agg1#301, agg2#302, agg3#303, agg4#304, agg5#305, agg6#306, agg7#307]
+Input [7]: [agg1#303, agg2#304, agg3#305, agg4#306, agg5#307, agg6#308, agg7#309]
 Keys: []
-Functions [7]: [partial_avg(agg1#301), partial_avg(agg2#302), partial_avg(agg3#303), partial_avg(agg4#304), partial_avg(agg5#305), partial_avg(agg6#306), partial_avg(agg7#307)]
-Aggregate Attributes [14]: [sum#308, count#309, sum#310, count#311, sum#312, count#313, sum#314, count#315, sum#316, count#317, sum#318, count#319, sum#320, count#321]
-Results [14]: [sum#322, count#323, sum#324, count#325, sum#326, count#327, sum#328, count#329, sum#330, count#331, sum#332, count#333, sum#334, count#335]
+Functions [7]: [partial_avg(agg1#303), partial_avg(agg2#304), partial_avg(agg3#305), partial_avg(agg4#306), partial_avg(agg5#307), partial_avg(agg6#308), partial_avg(agg7#309)]
+Aggregate Attributes [14]: [sum#310, count#311, sum#312, count#313, sum#314, count#315, sum#316, count#317, sum#318, count#319, sum#320, count#321, sum#322, count#323]
+Results [14]: [sum#324, count#325, sum#326, count#327, sum#328, count#329, sum#330, count#331, sum#332, count#333, sum#334, count#335, sum#336, count#337]
 
 (153) Exchange
-Input [14]: [sum#322, count#323, sum#324, count#325, sum#326, count#327, sum#328, count#329, sum#330, count#331, sum#332, count#333, sum#334, count#335]
+Input [14]: [sum#324, count#325, sum#326, count#327, sum#328, count#329, sum#330, count#331, sum#332, count#333, sum#334, count#335, sum#336, count#337]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=22]
 
 (154) HashAggregate [codegen id : 58]
-Input [14]: [sum#322, count#323, sum#324, count#325, sum#326, count#327, sum#328, count#329, sum#330, count#331, sum#332, count#333, sum#334, count#335]
+Input [14]: [sum#324, count#325, sum#326, count#327, sum#328, count#329, sum#330, count#331, sum#332, count#333, sum#334, count#335, sum#336, count#337]
 Keys: []
-Functions [7]: [avg(agg1#301), avg(agg2#302), avg(agg3#303), avg(agg4#304), avg(agg5#305), avg(agg6#306), avg(agg7#307)]
-Aggregate Attributes [7]: [avg(agg1#301)#336, avg(agg2#302)#337, avg(agg3#303)#338, avg(agg4#304)#339, avg(agg5#305)#340, avg(agg6#306)#341, avg(agg7#307)#342]
-Results [11]: [null AS i_item_id#343, null AS ca_country#344, null AS ca_state#345, null AS county#346, avg(agg1#301)#336 AS agg1#347, avg(agg2#302)#337 AS agg2#348, avg(agg3#303)#338 AS agg3#349, avg(agg4#304)#339 AS agg4#350, avg(agg5#305)#340 AS agg5#351, avg(agg6#306)#341 AS agg6#352, avg(agg7#307)#342 AS agg7#353]
+Functions [7]: [avg(agg1#303), avg(agg2#304), avg(agg3#305), avg(agg4#306), avg(agg5#307), avg(agg6#308), avg(agg7#309)]
+Aggregate Attributes [7]: [avg(agg1#303)#338, avg(agg2#304)#339, avg(agg3#305)#340, avg(agg4#306)#341, avg(agg5#307)#342, avg(agg6#308)#343, avg(agg7#309)#344]
+Results [11]: [null AS i_item_id#345, null AS ca_country#346, null AS ca_state#347, null AS county#348, avg(agg1#303)#338 AS agg1#349, avg(agg2#304)#339 AS agg2#350, avg(agg3#305)#340 AS agg3#351, avg(agg4#306)#341 AS agg4#352, avg(agg5#307)#342 AS agg5#353, avg(agg6#308)#343 AS agg6#354, avg(agg7#309)#344 AS agg7#355]
 
 (155) Union
 
 (156) TakeOrderedAndProject
-Input [11]: [i_item_id#17, ca_country#26, ca_state#25, ca_county#24, agg1#70, agg2#71, agg3#72, agg4#73, agg5#74, agg6#75, agg7#76]
-Arguments: 100, [ca_country#26 ASC NULLS FIRST, ca_state#25 ASC NULLS FIRST, ca_county#24 ASC NULLS FIRST, i_item_id#17 ASC NULLS FIRST], [i_item_id#17, ca_country#26, ca_state#25, ca_county#24, agg1#70, agg2#71, agg3#72, agg4#73, agg5#74, agg6#75, agg7#76]
+Input [11]: [i_item_id#19, ca_country#28, ca_state#27, ca_county#26, agg1#72, agg2#73, agg3#74, agg4#75, agg5#76, agg6#77, agg7#78]
+Arguments: 100, [ca_country#28 ASC NULLS FIRST, ca_state#27 ASC NULLS FIRST, ca_county#26 ASC NULLS FIRST, i_item_id#19 ASC NULLS FIRST], [i_item_id#19, ca_country#28, ca_state#27, ca_county#26, agg1#72, agg2#73, agg3#74, agg4#75, agg5#76, agg6#77, agg7#78]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 1 Hosting Expression = cs_sold_date_sk#9 IN dynamicpruning#10
-BroadcastExchange (161)
-+- * Project (160)
-   +- * Filter (159)
-      +- * ColumnarToRow (158)
-         +- Scan parquet spark_catalog.default.date_dim (157)
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#11, [id=#12]
+ObjectHashAggregate (163)
++- Exchange (162)
+   +- ObjectHashAggregate (161)
+      +- * Project (160)
+         +- * Filter (159)
+            +- * ColumnarToRow (158)
+               +- Scan parquet spark_catalog.default.customer (157)
 
 
-(157) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#15, d_year#354]
+(157) Scan parquet spark_catalog.default.customer
+Output [4]: [c_customer_sk#20, c_current_cdemo_sk#21, c_current_addr_sk#22, c_birth_month#23]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer]
+PushedFilters: [In(c_birth_month, [1,10,12,4,5,9]), IsNotNull(c_customer_sk), IsNotNull(c_current_cdemo_sk), IsNotNull(c_current_addr_sk)]
+ReadSchema: struct<c_customer_sk:int,c_current_cdemo_sk:int,c_current_addr_sk:int,c_birth_month:int>
+
+(158) ColumnarToRow [codegen id : 1]
+Input [4]: [c_customer_sk#20, c_current_cdemo_sk#21, c_current_addr_sk#22, c_birth_month#23]
+
+(159) Filter [codegen id : 1]
+Input [4]: [c_customer_sk#20, c_current_cdemo_sk#21, c_current_addr_sk#22, c_birth_month#23]
+Condition : (((c_birth_month#23 IN (9,5,12,4,1,10) AND isnotnull(c_customer_sk#20)) AND isnotnull(c_current_cdemo_sk#21)) AND isnotnull(c_current_addr_sk#22))
+
+(160) Project [codegen id : 1]
+Output [1]: [c_customer_sk#20]
+Input [4]: [c_customer_sk#20, c_current_cdemo_sk#21, c_current_addr_sk#22, c_birth_month#23]
+
+(161) ObjectHashAggregate
+Input [1]: [c_customer_sk#20]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(c_customer_sk#20, 42), 965029, 9899191, 0, 0)]
+Aggregate Attributes [1]: [buf#356]
+Results [1]: [buf#357]
+
+(162) Exchange
+Input [1]: [buf#357]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=23]
+
+(163) ObjectHashAggregate
+Input [1]: [buf#357]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(c_customer_sk#20, 42), 965029, 9899191, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(c_customer_sk#20, 42), 965029, 9899191, 0, 0)#358]
+Results [1]: [bloom_filter_agg(xxhash64(c_customer_sk#20, 42), 965029, 9899191, 0, 0)#358 AS bloomFilter#359]
+
+Subquery:2 Hosting operator id = 1 Hosting Expression = cs_sold_date_sk#9 IN dynamicpruning#10
+BroadcastExchange (168)
++- * Project (167)
+   +- * Filter (166)
+      +- * ColumnarToRow (165)
+         +- Scan parquet spark_catalog.default.date_dim (164)
+
+
+(164) Scan parquet spark_catalog.default.date_dim
+Output [2]: [d_date_sk#17, d_year#360]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2001), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(158) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#15, d_year#354]
+(165) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#17, d_year#360]
 
-(159) Filter [codegen id : 1]
-Input [2]: [d_date_sk#15, d_year#354]
-Condition : ((isnotnull(d_year#354) AND (d_year#354 = 2001)) AND isnotnull(d_date_sk#15))
+(166) Filter [codegen id : 1]
+Input [2]: [d_date_sk#17, d_year#360]
+Condition : ((isnotnull(d_year#360) AND (d_year#360 = 2001)) AND isnotnull(d_date_sk#17))
 
-(160) Project [codegen id : 1]
-Output [1]: [d_date_sk#15]
-Input [2]: [d_date_sk#15, d_year#354]
+(167) Project [codegen id : 1]
+Output [1]: [d_date_sk#17]
+Input [2]: [d_date_sk#17, d_year#360]
 
-(161) BroadcastExchange
-Input [1]: [d_date_sk#15]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=23]
+(168) BroadcastExchange
+Input [1]: [d_date_sk#17]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=24]
 
-Subquery:2 Hosting operator id = 99 Hosting Expression = cs_sold_date_sk#220 IN dynamicpruning#10
+Subquery:3 Hosting operator id = 99 Hosting Expression = cs_sold_date_sk#222 IN dynamicpruning#10
 
-Subquery:3 Hosting operator id = 134 Hosting Expression = cs_sold_date_sk#294 IN dynamicpruning#10
+Subquery:4 Hosting operator id = 134 Hosting Expression = cs_sold_date_sk#296 IN dynamicpruning#10
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q18a.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q18a.sf100/simplified.txt
@@ -21,6 +21,16 @@ TakeOrderedAndProject [ca_country,ca_state,ca_county,i_item_id,agg1,agg2,agg3,ag
                                         Project [cs_bill_customer_sk,cs_item_sk,cs_quantity,cs_list_price,cs_sales_price,cs_coupon_amt,cs_net_profit,cs_sold_date_sk,cd_dep_count]
                                           BroadcastHashJoin [cs_bill_cdemo_sk,cd_demo_sk]
                                             Filter [cs_bill_cdemo_sk,cs_bill_customer_sk,cs_item_sk]
+                                              Subquery #2
+                                                ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(c_customer_sk, 42), 965029, 9899191, 0, 0),bloomFilter,buf]
+                                                  Exchange #4
+                                                    ObjectHashAggregate [c_customer_sk] [buf,buf]
+                                                      WholeStageCodegen (1)
+                                                        Project [c_customer_sk]
+                                                          Filter [c_birth_month,c_customer_sk,c_current_cdemo_sk,c_current_addr_sk]
+                                                            ColumnarToRow
+                                                              InputAdapter
+                                                                Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_cdemo_sk,c_current_addr_sk,c_birth_month]
                                               ColumnarToRow
                                                 InputAdapter
                                                   Scan parquet spark_catalog.default.catalog_sales [cs_bill_customer_sk,cs_bill_cdemo_sk,cs_item_sk,cs_quantity,cs_list_price,cs_sales_price,cs_coupon_amt,cs_net_profit,cs_sold_date_sk]
@@ -33,7 +43,7 @@ TakeOrderedAndProject [ca_country,ca_state,ca_county,i_item_id,agg1,agg2,agg3,ag
                                                                 InputAdapter
                                                                   Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year]
                                             InputAdapter
-                                              BroadcastExchange #4
+                                              BroadcastExchange #5
                                                 WholeStageCodegen (1)
                                                   Project [cd_demo_sk,cd_dep_count]
                                                     Filter [cd_gender,cd_education_status,cd_demo_sk]
@@ -43,7 +53,7 @@ TakeOrderedAndProject [ca_country,ca_state,ca_county,i_item_id,agg1,agg2,agg3,ag
                                         InputAdapter
                                           ReusedExchange [d_date_sk] #3
                                     InputAdapter
-                                      BroadcastExchange #5
+                                      BroadcastExchange #6
                                         WholeStageCodegen (3)
                                           Filter [i_item_sk]
                                             ColumnarToRow
@@ -53,7 +63,7 @@ TakeOrderedAndProject [ca_country,ca_state,ca_county,i_item_id,agg1,agg2,agg3,ag
                       WholeStageCodegen (12)
                         Sort [c_customer_sk]
                           InputAdapter
-                            Exchange [c_customer_sk] #6
+                            Exchange [c_customer_sk] #7
                               WholeStageCodegen (11)
                                 Project [c_customer_sk,c_birth_year,ca_county,ca_state,ca_country]
                                   SortMergeJoin [c_current_cdemo_sk,cd_demo_sk]
@@ -61,7 +71,7 @@ TakeOrderedAndProject [ca_country,ca_state,ca_county,i_item_id,agg1,agg2,agg3,ag
                                       WholeStageCodegen (8)
                                         Sort [c_current_cdemo_sk]
                                           InputAdapter
-                                            Exchange [c_current_cdemo_sk] #7
+                                            Exchange [c_current_cdemo_sk] #8
                                               WholeStageCodegen (7)
                                                 Project [c_customer_sk,c_current_cdemo_sk,c_birth_year,ca_county,ca_state,ca_country]
                                                   BroadcastHashJoin [c_current_addr_sk,ca_address_sk]
@@ -71,7 +81,7 @@ TakeOrderedAndProject [ca_country,ca_state,ca_county,i_item_id,agg1,agg2,agg3,ag
                                                           InputAdapter
                                                             Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_cdemo_sk,c_current_addr_sk,c_birth_month,c_birth_year]
                                                     InputAdapter
-                                                      BroadcastExchange #8
+                                                      BroadcastExchange #9
                                                         WholeStageCodegen (6)
                                                           Filter [ca_state,ca_address_sk]
                                                             ColumnarToRow
@@ -81,7 +91,7 @@ TakeOrderedAndProject [ca_country,ca_state,ca_county,i_item_id,agg1,agg2,agg3,ag
                                       WholeStageCodegen (10)
                                         Sort [cd_demo_sk]
                                           InputAdapter
-                                            Exchange [cd_demo_sk] #9
+                                            Exchange [cd_demo_sk] #10
                                               WholeStageCodegen (9)
                                                 Filter [cd_demo_sk]
                                                   ColumnarToRow
@@ -90,7 +100,7 @@ TakeOrderedAndProject [ca_country,ca_state,ca_county,i_item_id,agg1,agg2,agg3,ag
     WholeStageCodegen (28)
       HashAggregate [i_item_id,ca_country,ca_state,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count] [avg(agg1),avg(agg2),avg(agg3),avg(agg4),avg(agg5),avg(agg6),avg(agg7),county,agg1,agg2,agg3,agg4,agg5,agg6,agg7,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count]
         InputAdapter
-          Exchange [i_item_id,ca_country,ca_state] #10
+          Exchange [i_item_id,ca_country,ca_state] #11
             WholeStageCodegen (27)
               HashAggregate [i_item_id,ca_country,ca_state,agg1,agg2,agg3,agg4,agg5,agg6,agg7] [sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count]
                 Project [i_item_id,ca_country,ca_state,cs_quantity,cs_list_price,cs_coupon_amt,cs_sales_price,cs_net_profit,c_birth_year,cd_dep_count]
@@ -104,7 +114,7 @@ TakeOrderedAndProject [ca_country,ca_state,ca_county,i_item_id,agg1,agg2,agg3,ag
                       WholeStageCodegen (26)
                         Sort [c_customer_sk]
                           InputAdapter
-                            Exchange [c_customer_sk] #11
+                            Exchange [c_customer_sk] #12
                               WholeStageCodegen (25)
                                 Project [c_customer_sk,c_birth_year,ca_state,ca_country]
                                   SortMergeJoin [c_current_cdemo_sk,cd_demo_sk]
@@ -112,7 +122,7 @@ TakeOrderedAndProject [ca_country,ca_state,ca_county,i_item_id,agg1,agg2,agg3,ag
                                       WholeStageCodegen (22)
                                         Sort [c_current_cdemo_sk]
                                           InputAdapter
-                                            Exchange [c_current_cdemo_sk] #12
+                                            Exchange [c_current_cdemo_sk] #13
                                               WholeStageCodegen (21)
                                                 Project [c_customer_sk,c_current_cdemo_sk,c_birth_year,ca_state,ca_country]
                                                   BroadcastHashJoin [c_current_addr_sk,ca_address_sk]
@@ -122,7 +132,7 @@ TakeOrderedAndProject [ca_country,ca_state,ca_county,i_item_id,agg1,agg2,agg3,ag
                                                           InputAdapter
                                                             Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_cdemo_sk,c_current_addr_sk,c_birth_month,c_birth_year]
                                                     InputAdapter
-                                                      BroadcastExchange #13
+                                                      BroadcastExchange #14
                                                         WholeStageCodegen (20)
                                                           Filter [ca_state,ca_address_sk]
                                                             ColumnarToRow
@@ -132,11 +142,11 @@ TakeOrderedAndProject [ca_country,ca_state,ca_county,i_item_id,agg1,agg2,agg3,ag
                                       WholeStageCodegen (24)
                                         Sort [cd_demo_sk]
                                           InputAdapter
-                                            ReusedExchange [cd_demo_sk] #9
+                                            ReusedExchange [cd_demo_sk] #10
     WholeStageCodegen (42)
       HashAggregate [i_item_id,ca_country,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count] [avg(agg1),avg(agg2),avg(agg3),avg(agg4),avg(agg5),avg(agg6),avg(agg7),ca_state,county,agg1,agg2,agg3,agg4,agg5,agg6,agg7,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count]
         InputAdapter
-          Exchange [i_item_id,ca_country] #14
+          Exchange [i_item_id,ca_country] #15
             WholeStageCodegen (41)
               HashAggregate [i_item_id,ca_country,agg1,agg2,agg3,agg4,agg5,agg6,agg7] [sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count]
                 Project [i_item_id,ca_country,cs_quantity,cs_list_price,cs_coupon_amt,cs_sales_price,cs_net_profit,c_birth_year,cd_dep_count]
@@ -150,7 +160,7 @@ TakeOrderedAndProject [ca_country,ca_state,ca_county,i_item_id,agg1,agg2,agg3,ag
                       WholeStageCodegen (40)
                         Sort [c_customer_sk]
                           InputAdapter
-                            Exchange [c_customer_sk] #15
+                            Exchange [c_customer_sk] #16
                               WholeStageCodegen (39)
                                 Project [c_customer_sk,c_birth_year,ca_country]
                                   SortMergeJoin [c_current_cdemo_sk,cd_demo_sk]
@@ -158,7 +168,7 @@ TakeOrderedAndProject [ca_country,ca_state,ca_county,i_item_id,agg1,agg2,agg3,ag
                                       WholeStageCodegen (36)
                                         Sort [c_current_cdemo_sk]
                                           InputAdapter
-                                            Exchange [c_current_cdemo_sk] #16
+                                            Exchange [c_current_cdemo_sk] #17
                                               WholeStageCodegen (35)
                                                 Project [c_customer_sk,c_current_cdemo_sk,c_birth_year,ca_country]
                                                   BroadcastHashJoin [c_current_addr_sk,ca_address_sk]
@@ -168,7 +178,7 @@ TakeOrderedAndProject [ca_country,ca_state,ca_county,i_item_id,agg1,agg2,agg3,ag
                                                           InputAdapter
                                                             Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_cdemo_sk,c_current_addr_sk,c_birth_month,c_birth_year]
                                                     InputAdapter
-                                                      BroadcastExchange #17
+                                                      BroadcastExchange #18
                                                         WholeStageCodegen (34)
                                                           Project [ca_address_sk,ca_country]
                                                             Filter [ca_state,ca_address_sk]
@@ -179,11 +189,11 @@ TakeOrderedAndProject [ca_country,ca_state,ca_county,i_item_id,agg1,agg2,agg3,ag
                                       WholeStageCodegen (38)
                                         Sort [cd_demo_sk]
                                           InputAdapter
-                                            ReusedExchange [cd_demo_sk] #9
+                                            ReusedExchange [cd_demo_sk] #10
     WholeStageCodegen (50)
       HashAggregate [i_item_id,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count] [avg(agg1),avg(agg2),avg(agg3),avg(agg4),avg(agg5),avg(agg6),avg(agg7),ca_country,ca_state,county,agg1,agg2,agg3,agg4,agg5,agg6,agg7,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count]
         InputAdapter
-          Exchange [i_item_id] #18
+          Exchange [i_item_id] #19
             WholeStageCodegen (49)
               HashAggregate [i_item_id,agg1,agg2,agg3,agg4,agg5,agg6,agg7] [sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count]
                 Project [i_item_id,cs_quantity,cs_list_price,cs_coupon_amt,cs_sales_price,cs_net_profit,c_birth_year,cd_dep_count]
@@ -200,16 +210,16 @@ TakeOrderedAndProject [ca_country,ca_state,ca_county,i_item_id,agg1,agg2,agg3,ag
                                       Scan parquet spark_catalog.default.catalog_sales [cs_bill_customer_sk,cs_bill_cdemo_sk,cs_item_sk,cs_quantity,cs_list_price,cs_sales_price,cs_coupon_amt,cs_net_profit,cs_sold_date_sk]
                                         ReusedSubquery [d_date_sk] #1
                                 InputAdapter
-                                  ReusedExchange [cd_demo_sk,cd_dep_count] #4
+                                  ReusedExchange [cd_demo_sk,cd_dep_count] #5
                             InputAdapter
                               ReusedExchange [d_date_sk] #3
                         InputAdapter
-                          BroadcastExchange #19
+                          BroadcastExchange #20
                             WholeStageCodegen (47)
                               Project [c_customer_sk,c_birth_year]
                                 BroadcastHashJoin [c_current_cdemo_sk,cd_demo_sk]
                                   InputAdapter
-                                    BroadcastExchange #20
+                                    BroadcastExchange #21
                                       WholeStageCodegen (46)
                                         Project [c_customer_sk,c_current_cdemo_sk,c_birth_year]
                                           BroadcastHashJoin [c_current_addr_sk,ca_address_sk]
@@ -219,7 +229,7 @@ TakeOrderedAndProject [ca_country,ca_state,ca_county,i_item_id,agg1,agg2,agg3,ag
                                                   InputAdapter
                                                     Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_cdemo_sk,c_current_addr_sk,c_birth_month,c_birth_year]
                                             InputAdapter
-                                              BroadcastExchange #21
+                                              BroadcastExchange #22
                                                 WholeStageCodegen (45)
                                                   Project [ca_address_sk]
                                                     Filter [ca_state,ca_address_sk]
@@ -231,11 +241,11 @@ TakeOrderedAndProject [ca_country,ca_state,ca_county,i_item_id,agg1,agg2,agg3,ag
                                       InputAdapter
                                         Scan parquet spark_catalog.default.customer_demographics [cd_demo_sk]
                     InputAdapter
-                      ReusedExchange [i_item_sk,i_item_id] #5
+                      ReusedExchange [i_item_sk,i_item_id] #6
     WholeStageCodegen (58)
       HashAggregate [sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count] [avg(agg1),avg(agg2),avg(agg3),avg(agg4),avg(agg5),avg(agg6),avg(agg7),i_item_id,ca_country,ca_state,county,agg1,agg2,agg3,agg4,agg5,agg6,agg7,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count]
         InputAdapter
-          Exchange #22
+          Exchange #23
             WholeStageCodegen (57)
               HashAggregate [agg1,agg2,agg3,agg4,agg5,agg6,agg7] [sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count]
                 Project [cs_quantity,cs_list_price,cs_coupon_amt,cs_sales_price,cs_net_profit,c_birth_year,cd_dep_count]
@@ -252,15 +262,15 @@ TakeOrderedAndProject [ca_country,ca_state,ca_county,i_item_id,agg1,agg2,agg3,ag
                                       Scan parquet spark_catalog.default.catalog_sales [cs_bill_customer_sk,cs_bill_cdemo_sk,cs_item_sk,cs_quantity,cs_list_price,cs_sales_price,cs_coupon_amt,cs_net_profit,cs_sold_date_sk]
                                         ReusedSubquery [d_date_sk] #1
                                 InputAdapter
-                                  ReusedExchange [cd_demo_sk,cd_dep_count] #4
+                                  ReusedExchange [cd_demo_sk,cd_dep_count] #5
                             InputAdapter
                               ReusedExchange [d_date_sk] #3
                         InputAdapter
-                          BroadcastExchange #23
+                          BroadcastExchange #24
                             WholeStageCodegen (53)
                               Filter [i_item_sk]
                                 ColumnarToRow
                                   InputAdapter
                                     Scan parquet spark_catalog.default.item [i_item_sk]
                     InputAdapter
-                      ReusedExchange [c_customer_sk,c_birth_year] #19
+                      ReusedExchange [c_customer_sk,c_birth_year] #20

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q20.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q20.sf100/explain.txt
@@ -37,7 +37,7 @@ Input [3]: [cs_item_sk#1, cs_ext_sales_price#2, cs_sold_date_sk#3]
 
 (3) Filter [codegen id : 1]
 Input [3]: [cs_item_sk#1, cs_ext_sales_price#2, cs_sold_date_sk#3]
-Condition : isnotnull(cs_item_sk#1)
+Condition : (isnotnull(cs_item_sk#1) AND might_contain(Subquery scalar-subquery#5, [id=#6], xxhash64(cs_item_sk#1, 42)))
 
 (4) Exchange
 Input [3]: [cs_item_sk#1, cs_ext_sales_price#2, cs_sold_date_sk#3]
@@ -48,118 +48,164 @@ Input [3]: [cs_item_sk#1, cs_ext_sales_price#2, cs_sold_date_sk#3]
 Arguments: [cs_item_sk#1 ASC NULLS FIRST], false, 0
 
 (6) Scan parquet spark_catalog.default.item
-Output [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
+Output [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [In(i_category, [Books                                             ,Home                                              ,Sports                                            ]), IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_item_id:string,i_item_desc:string,i_current_price:decimal(7,2),i_class:string,i_category:string>
 
 (7) ColumnarToRow [codegen id : 3]
-Input [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
+Input [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
 
 (8) Filter [codegen id : 3]
-Input [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Condition : (i_category#10 IN (Sports                                            ,Books                                             ,Home                                              ) AND isnotnull(i_item_sk#5))
+Input [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Condition : (i_category#12 IN (Sports                                            ,Books                                             ,Home                                              ) AND isnotnull(i_item_sk#7))
 
 (9) Exchange
-Input [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Arguments: hashpartitioning(i_item_sk#5, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+Input [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Arguments: hashpartitioning(i_item_sk#7, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
 (10) Sort [codegen id : 4]
-Input [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Arguments: [i_item_sk#5 ASC NULLS FIRST], false, 0
+Input [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Arguments: [i_item_sk#7 ASC NULLS FIRST], false, 0
 
 (11) SortMergeJoin [codegen id : 6]
 Left keys [1]: [cs_item_sk#1]
-Right keys [1]: [i_item_sk#5]
+Right keys [1]: [i_item_sk#7]
 Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 6]
-Output [7]: [cs_ext_sales_price#2, cs_sold_date_sk#3, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Input [9]: [cs_item_sk#1, cs_ext_sales_price#2, cs_sold_date_sk#3, i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
+Output [7]: [cs_ext_sales_price#2, cs_sold_date_sk#3, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Input [9]: [cs_item_sk#1, cs_ext_sales_price#2, cs_sold_date_sk#3, i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
 
-(13) ReusedExchange [Reuses operator id: 28]
-Output [1]: [d_date_sk#11]
+(13) ReusedExchange [Reuses operator id: 35]
+Output [1]: [d_date_sk#13]
 
 (14) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [cs_sold_date_sk#3]
-Right keys [1]: [d_date_sk#11]
+Right keys [1]: [d_date_sk#13]
 Join type: Inner
 Join condition: None
 
 (15) Project [codegen id : 6]
-Output [6]: [cs_ext_sales_price#2, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Input [8]: [cs_ext_sales_price#2, cs_sold_date_sk#3, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10, d_date_sk#11]
+Output [6]: [cs_ext_sales_price#2, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Input [8]: [cs_ext_sales_price#2, cs_sold_date_sk#3, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12, d_date_sk#13]
 
 (16) HashAggregate [codegen id : 6]
-Input [6]: [cs_ext_sales_price#2, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Keys [5]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8]
+Input [6]: [cs_ext_sales_price#2, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Keys [5]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10]
 Functions [1]: [partial_sum(UnscaledValue(cs_ext_sales_price#2))]
-Aggregate Attributes [1]: [sum#12]
-Results [6]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, sum#13]
+Aggregate Attributes [1]: [sum#14]
+Results [6]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, sum#15]
 
 (17) Exchange
-Input [6]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, sum#13]
-Arguments: hashpartitioning(i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+Input [6]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, sum#15]
+Arguments: hashpartitioning(i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (18) HashAggregate [codegen id : 7]
-Input [6]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, sum#13]
-Keys [5]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8]
+Input [6]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, sum#15]
+Keys [5]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10]
 Functions [1]: [sum(UnscaledValue(cs_ext_sales_price#2))]
-Aggregate Attributes [1]: [sum(UnscaledValue(cs_ext_sales_price#2))#14]
-Results [7]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, MakeDecimal(sum(UnscaledValue(cs_ext_sales_price#2))#14,17,2) AS itemrevenue#15, MakeDecimal(sum(UnscaledValue(cs_ext_sales_price#2))#14,17,2) AS _w0#16]
+Aggregate Attributes [1]: [sum(UnscaledValue(cs_ext_sales_price#2))#16]
+Results [7]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, MakeDecimal(sum(UnscaledValue(cs_ext_sales_price#2))#16,17,2) AS itemrevenue#17, MakeDecimal(sum(UnscaledValue(cs_ext_sales_price#2))#16,17,2) AS _w0#18]
 
 (19) Exchange
-Input [7]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, _w0#16]
-Arguments: hashpartitioning(i_class#9, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+Input [7]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, _w0#18]
+Arguments: hashpartitioning(i_class#11, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
 (20) Sort [codegen id : 8]
-Input [7]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, _w0#16]
-Arguments: [i_class#9 ASC NULLS FIRST], false, 0
+Input [7]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, _w0#18]
+Arguments: [i_class#11 ASC NULLS FIRST], false, 0
 
 (21) Window
-Input [7]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, _w0#16]
-Arguments: [sum(_w0#16) windowspecdefinition(i_class#9, specifiedwindowframe(RowFrame, unboundedpreceding$(), unboundedfollowing$())) AS _we0#17], [i_class#9]
+Input [7]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, _w0#18]
+Arguments: [sum(_w0#18) windowspecdefinition(i_class#11, specifiedwindowframe(RowFrame, unboundedpreceding$(), unboundedfollowing$())) AS _we0#19], [i_class#11]
 
 (22) Project [codegen id : 9]
-Output [7]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, ((_w0#16 * 100) / _we0#17) AS revenueratio#18]
-Input [8]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, _w0#16, _we0#17]
+Output [7]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, ((_w0#18 * 100) / _we0#19) AS revenueratio#20]
+Input [8]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, _w0#18, _we0#19]
 
 (23) TakeOrderedAndProject
-Input [7]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, revenueratio#18]
-Arguments: 100, [i_category#10 ASC NULLS FIRST, i_class#9 ASC NULLS FIRST, i_item_id#6 ASC NULLS FIRST, i_item_desc#7 ASC NULLS FIRST, revenueratio#18 ASC NULLS FIRST], [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, revenueratio#18]
+Input [7]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, revenueratio#20]
+Arguments: 100, [i_category#12 ASC NULLS FIRST, i_class#11 ASC NULLS FIRST, i_item_id#8 ASC NULLS FIRST, i_item_desc#9 ASC NULLS FIRST, revenueratio#20 ASC NULLS FIRST], [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, revenueratio#20]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 1 Hosting Expression = cs_sold_date_sk#3 IN dynamicpruning#4
-BroadcastExchange (28)
-+- * Project (27)
-   +- * Filter (26)
-      +- * ColumnarToRow (25)
-         +- Scan parquet spark_catalog.default.date_dim (24)
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#5, [id=#6]
+ObjectHashAggregate (30)
++- Exchange (29)
+   +- ObjectHashAggregate (28)
+      +- * Project (27)
+         +- * Filter (26)
+            +- * ColumnarToRow (25)
+               +- Scan parquet spark_catalog.default.item (24)
 
 
-(24) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#11, d_date#19]
+(24) Scan parquet spark_catalog.default.item
+Output [2]: [i_item_sk#7, i_category#12]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/item]
+PushedFilters: [In(i_category, [Books                                             ,Home                                              ,Sports                                            ]), IsNotNull(i_item_sk)]
+ReadSchema: struct<i_item_sk:int,i_category:string>
+
+(25) ColumnarToRow [codegen id : 1]
+Input [2]: [i_item_sk#7, i_category#12]
+
+(26) Filter [codegen id : 1]
+Input [2]: [i_item_sk#7, i_category#12]
+Condition : (i_category#12 IN (Sports                                            ,Books                                             ,Home                                              ) AND isnotnull(i_item_sk#7))
+
+(27) Project [codegen id : 1]
+Output [1]: [i_item_sk#7]
+Input [2]: [i_item_sk#7, i_category#12]
+
+(28) ObjectHashAggregate
+Input [1]: [i_item_sk#7]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#7, 42), 61200, 979099, 0, 0)]
+Aggregate Attributes [1]: [buf#21]
+Results [1]: [buf#22]
+
+(29) Exchange
+Input [1]: [buf#22]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=5]
+
+(30) ObjectHashAggregate
+Input [1]: [buf#22]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#7, 42), 61200, 979099, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#7, 42), 61200, 979099, 0, 0)#23]
+Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#7, 42), 61200, 979099, 0, 0)#23 AS bloomFilter#24]
+
+Subquery:2 Hosting operator id = 1 Hosting Expression = cs_sold_date_sk#3 IN dynamicpruning#4
+BroadcastExchange (35)
++- * Project (34)
+   +- * Filter (33)
+      +- * ColumnarToRow (32)
+         +- Scan parquet spark_catalog.default.date_dim (31)
+
+
+(31) Scan parquet spark_catalog.default.date_dim
+Output [2]: [d_date_sk#13, d_date#25]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,1999-02-22), LessThanOrEqual(d_date,1999-03-24), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
-(25) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#11, d_date#19]
+(32) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#13, d_date#25]
 
-(26) Filter [codegen id : 1]
-Input [2]: [d_date_sk#11, d_date#19]
-Condition : (((isnotnull(d_date#19) AND (d_date#19 >= 1999-02-22)) AND (d_date#19 <= 1999-03-24)) AND isnotnull(d_date_sk#11))
+(33) Filter [codegen id : 1]
+Input [2]: [d_date_sk#13, d_date#25]
+Condition : (((isnotnull(d_date#25) AND (d_date#25 >= 1999-02-22)) AND (d_date#25 <= 1999-03-24)) AND isnotnull(d_date_sk#13))
 
-(27) Project [codegen id : 1]
-Output [1]: [d_date_sk#11]
-Input [2]: [d_date_sk#11, d_date#19]
+(34) Project [codegen id : 1]
+Output [1]: [d_date_sk#13]
+Input [2]: [d_date_sk#13, d_date#25]
 
-(28) BroadcastExchange
-Input [1]: [d_date_sk#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
+(35) BroadcastExchange
+Input [1]: [d_date_sk#13]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=6]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q20.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q20.sf100/simplified.txt
@@ -24,6 +24,16 @@ TakeOrderedAndProject [i_category,i_class,i_item_id,i_item_desc,revenueratio,i_c
                                               Exchange [cs_item_sk] #3
                                                 WholeStageCodegen (1)
                                                   Filter [cs_item_sk]
+                                                    Subquery #2
+                                                      ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(i_item_sk, 42), 61200, 979099, 0, 0),bloomFilter,buf]
+                                                        Exchange #5
+                                                          ObjectHashAggregate [i_item_sk] [buf,buf]
+                                                            WholeStageCodegen (1)
+                                                              Project [i_item_sk]
+                                                                Filter [i_category,i_item_sk]
+                                                                  ColumnarToRow
+                                                                    InputAdapter
+                                                                      Scan parquet spark_catalog.default.item [i_item_sk,i_category]
                                                     ColumnarToRow
                                                       InputAdapter
                                                         Scan parquet spark_catalog.default.catalog_sales [cs_item_sk,cs_ext_sales_price,cs_sold_date_sk]
@@ -39,7 +49,7 @@ TakeOrderedAndProject [i_category,i_class,i_item_id,i_item_desc,revenueratio,i_c
                                         WholeStageCodegen (4)
                                           Sort [i_item_sk]
                                             InputAdapter
-                                              Exchange [i_item_sk] #5
+                                              Exchange [i_item_sk] #6
                                                 WholeStageCodegen (3)
                                                   Filter [i_category,i_item_sk]
                                                     ColumnarToRow

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q49.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q49.sf100/explain.txt
@@ -100,24 +100,24 @@ Input [6]: [ws_item_sk#1, ws_order_number#2, ws_quantity#3, ws_net_paid#4, ws_ne
 
 (3) Filter [codegen id : 2]
 Input [6]: [ws_item_sk#1, ws_order_number#2, ws_quantity#3, ws_net_paid#4, ws_net_profit#5, ws_sold_date_sk#6]
-Condition : (((((((isnotnull(ws_net_profit#5) AND isnotnull(ws_net_paid#4)) AND isnotnull(ws_quantity#3)) AND (ws_net_profit#5 > 1.00)) AND (ws_net_paid#4 > 0.00)) AND (ws_quantity#3 > 0)) AND isnotnull(ws_order_number#2)) AND isnotnull(ws_item_sk#1))
+Condition : ((((((((isnotnull(ws_net_profit#5) AND isnotnull(ws_net_paid#4)) AND isnotnull(ws_quantity#3)) AND (ws_net_profit#5 > 1.00)) AND (ws_net_paid#4 > 0.00)) AND (ws_quantity#3 > 0)) AND isnotnull(ws_order_number#2)) AND isnotnull(ws_item_sk#1)) AND might_contain(Subquery scalar-subquery#8, [id=#9], xxhash64(ws_item_sk#1, 42)))
 
 (4) Project [codegen id : 2]
 Output [5]: [ws_item_sk#1, ws_order_number#2, ws_quantity#3, ws_net_paid#4, ws_sold_date_sk#6]
 Input [6]: [ws_item_sk#1, ws_order_number#2, ws_quantity#3, ws_net_paid#4, ws_net_profit#5, ws_sold_date_sk#6]
 
-(5) ReusedExchange [Reuses operator id: 91]
-Output [1]: [d_date_sk#8]
+(5) ReusedExchange [Reuses operator id: 98]
+Output [1]: [d_date_sk#10]
 
 (6) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ws_sold_date_sk#6]
-Right keys [1]: [d_date_sk#8]
+Right keys [1]: [d_date_sk#10]
 Join type: Inner
 Join condition: None
 
 (7) Project [codegen id : 2]
 Output [4]: [ws_item_sk#1, ws_order_number#2, ws_quantity#3, ws_net_paid#4]
-Input [6]: [ws_item_sk#1, ws_order_number#2, ws_quantity#3, ws_net_paid#4, ws_sold_date_sk#6, d_date_sk#8]
+Input [6]: [ws_item_sk#1, ws_order_number#2, ws_quantity#3, ws_net_paid#4, ws_sold_date_sk#6, d_date_sk#10]
 
 (8) Exchange
 Input [4]: [ws_item_sk#1, ws_order_number#2, ws_quantity#3, ws_net_paid#4]
@@ -128,389 +128,527 @@ Input [4]: [ws_item_sk#1, ws_order_number#2, ws_quantity#3, ws_net_paid#4]
 Arguments: [ws_order_number#2 ASC NULLS FIRST, ws_item_sk#1 ASC NULLS FIRST], false, 0
 
 (10) Scan parquet spark_catalog.default.web_returns
-Output [5]: [wr_item_sk#9, wr_order_number#10, wr_return_quantity#11, wr_return_amt#12, wr_returned_date_sk#13]
+Output [5]: [wr_item_sk#11, wr_order_number#12, wr_return_quantity#13, wr_return_amt#14, wr_returned_date_sk#15]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/web_returns]
 PushedFilters: [IsNotNull(wr_return_amt), GreaterThan(wr_return_amt,10000.00), IsNotNull(wr_order_number), IsNotNull(wr_item_sk)]
 ReadSchema: struct<wr_item_sk:int,wr_order_number:int,wr_return_quantity:int,wr_return_amt:decimal(7,2)>
 
 (11) ColumnarToRow [codegen id : 4]
-Input [5]: [wr_item_sk#9, wr_order_number#10, wr_return_quantity#11, wr_return_amt#12, wr_returned_date_sk#13]
+Input [5]: [wr_item_sk#11, wr_order_number#12, wr_return_quantity#13, wr_return_amt#14, wr_returned_date_sk#15]
 
 (12) Filter [codegen id : 4]
-Input [5]: [wr_item_sk#9, wr_order_number#10, wr_return_quantity#11, wr_return_amt#12, wr_returned_date_sk#13]
-Condition : (((isnotnull(wr_return_amt#12) AND (wr_return_amt#12 > 10000.00)) AND isnotnull(wr_order_number#10)) AND isnotnull(wr_item_sk#9))
+Input [5]: [wr_item_sk#11, wr_order_number#12, wr_return_quantity#13, wr_return_amt#14, wr_returned_date_sk#15]
+Condition : (((isnotnull(wr_return_amt#14) AND (wr_return_amt#14 > 10000.00)) AND isnotnull(wr_order_number#12)) AND isnotnull(wr_item_sk#11))
 
 (13) Project [codegen id : 4]
-Output [4]: [wr_item_sk#9, wr_order_number#10, wr_return_quantity#11, wr_return_amt#12]
-Input [5]: [wr_item_sk#9, wr_order_number#10, wr_return_quantity#11, wr_return_amt#12, wr_returned_date_sk#13]
+Output [4]: [wr_item_sk#11, wr_order_number#12, wr_return_quantity#13, wr_return_amt#14]
+Input [5]: [wr_item_sk#11, wr_order_number#12, wr_return_quantity#13, wr_return_amt#14, wr_returned_date_sk#15]
 
 (14) Exchange
-Input [4]: [wr_item_sk#9, wr_order_number#10, wr_return_quantity#11, wr_return_amt#12]
-Arguments: hashpartitioning(wr_order_number#10, wr_item_sk#9, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+Input [4]: [wr_item_sk#11, wr_order_number#12, wr_return_quantity#13, wr_return_amt#14]
+Arguments: hashpartitioning(wr_order_number#12, wr_item_sk#11, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
 (15) Sort [codegen id : 5]
-Input [4]: [wr_item_sk#9, wr_order_number#10, wr_return_quantity#11, wr_return_amt#12]
-Arguments: [wr_order_number#10 ASC NULLS FIRST, wr_item_sk#9 ASC NULLS FIRST], false, 0
+Input [4]: [wr_item_sk#11, wr_order_number#12, wr_return_quantity#13, wr_return_amt#14]
+Arguments: [wr_order_number#12 ASC NULLS FIRST, wr_item_sk#11 ASC NULLS FIRST], false, 0
 
 (16) SortMergeJoin [codegen id : 6]
 Left keys [2]: [ws_order_number#2, ws_item_sk#1]
-Right keys [2]: [wr_order_number#10, wr_item_sk#9]
+Right keys [2]: [wr_order_number#12, wr_item_sk#11]
 Join type: Inner
 Join condition: None
 
 (17) Project [codegen id : 6]
-Output [5]: [ws_item_sk#1, ws_quantity#3, ws_net_paid#4, wr_return_quantity#11, wr_return_amt#12]
-Input [8]: [ws_item_sk#1, ws_order_number#2, ws_quantity#3, ws_net_paid#4, wr_item_sk#9, wr_order_number#10, wr_return_quantity#11, wr_return_amt#12]
+Output [5]: [ws_item_sk#1, ws_quantity#3, ws_net_paid#4, wr_return_quantity#13, wr_return_amt#14]
+Input [8]: [ws_item_sk#1, ws_order_number#2, ws_quantity#3, ws_net_paid#4, wr_item_sk#11, wr_order_number#12, wr_return_quantity#13, wr_return_amt#14]
 
 (18) HashAggregate [codegen id : 6]
-Input [5]: [ws_item_sk#1, ws_quantity#3, ws_net_paid#4, wr_return_quantity#11, wr_return_amt#12]
+Input [5]: [ws_item_sk#1, ws_quantity#3, ws_net_paid#4, wr_return_quantity#13, wr_return_amt#14]
 Keys [1]: [ws_item_sk#1]
-Functions [4]: [partial_sum(coalesce(wr_return_quantity#11, 0)), partial_sum(coalesce(ws_quantity#3, 0)), partial_sum(coalesce(cast(wr_return_amt#12 as decimal(12,2)), 0.00)), partial_sum(coalesce(cast(ws_net_paid#4 as decimal(12,2)), 0.00))]
-Aggregate Attributes [6]: [sum#14, sum#15, sum#16, isEmpty#17, sum#18, isEmpty#19]
-Results [7]: [ws_item_sk#1, sum#20, sum#21, sum#22, isEmpty#23, sum#24, isEmpty#25]
+Functions [4]: [partial_sum(coalesce(wr_return_quantity#13, 0)), partial_sum(coalesce(ws_quantity#3, 0)), partial_sum(coalesce(cast(wr_return_amt#14 as decimal(12,2)), 0.00)), partial_sum(coalesce(cast(ws_net_paid#4 as decimal(12,2)), 0.00))]
+Aggregate Attributes [6]: [sum#16, sum#17, sum#18, isEmpty#19, sum#20, isEmpty#21]
+Results [7]: [ws_item_sk#1, sum#22, sum#23, sum#24, isEmpty#25, sum#26, isEmpty#27]
 
 (19) Exchange
-Input [7]: [ws_item_sk#1, sum#20, sum#21, sum#22, isEmpty#23, sum#24, isEmpty#25]
+Input [7]: [ws_item_sk#1, sum#22, sum#23, sum#24, isEmpty#25, sum#26, isEmpty#27]
 Arguments: hashpartitioning(ws_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (20) HashAggregate [codegen id : 7]
-Input [7]: [ws_item_sk#1, sum#20, sum#21, sum#22, isEmpty#23, sum#24, isEmpty#25]
+Input [7]: [ws_item_sk#1, sum#22, sum#23, sum#24, isEmpty#25, sum#26, isEmpty#27]
 Keys [1]: [ws_item_sk#1]
-Functions [4]: [sum(coalesce(wr_return_quantity#11, 0)), sum(coalesce(ws_quantity#3, 0)), sum(coalesce(cast(wr_return_amt#12 as decimal(12,2)), 0.00)), sum(coalesce(cast(ws_net_paid#4 as decimal(12,2)), 0.00))]
-Aggregate Attributes [4]: [sum(coalesce(wr_return_quantity#11, 0))#26, sum(coalesce(ws_quantity#3, 0))#27, sum(coalesce(cast(wr_return_amt#12 as decimal(12,2)), 0.00))#28, sum(coalesce(cast(ws_net_paid#4 as decimal(12,2)), 0.00))#29]
-Results [3]: [ws_item_sk#1 AS item#30, (cast(sum(coalesce(wr_return_quantity#11, 0))#26 as decimal(15,4)) / cast(sum(coalesce(ws_quantity#3, 0))#27 as decimal(15,4))) AS return_ratio#31, (cast(sum(coalesce(cast(wr_return_amt#12 as decimal(12,2)), 0.00))#28 as decimal(15,4)) / cast(sum(coalesce(cast(ws_net_paid#4 as decimal(12,2)), 0.00))#29 as decimal(15,4))) AS currency_ratio#32]
+Functions [4]: [sum(coalesce(wr_return_quantity#13, 0)), sum(coalesce(ws_quantity#3, 0)), sum(coalesce(cast(wr_return_amt#14 as decimal(12,2)), 0.00)), sum(coalesce(cast(ws_net_paid#4 as decimal(12,2)), 0.00))]
+Aggregate Attributes [4]: [sum(coalesce(wr_return_quantity#13, 0))#28, sum(coalesce(ws_quantity#3, 0))#29, sum(coalesce(cast(wr_return_amt#14 as decimal(12,2)), 0.00))#30, sum(coalesce(cast(ws_net_paid#4 as decimal(12,2)), 0.00))#31]
+Results [3]: [ws_item_sk#1 AS item#32, (cast(sum(coalesce(wr_return_quantity#13, 0))#28 as decimal(15,4)) / cast(sum(coalesce(ws_quantity#3, 0))#29 as decimal(15,4))) AS return_ratio#33, (cast(sum(coalesce(cast(wr_return_amt#14 as decimal(12,2)), 0.00))#30 as decimal(15,4)) / cast(sum(coalesce(cast(ws_net_paid#4 as decimal(12,2)), 0.00))#31 as decimal(15,4))) AS currency_ratio#34]
 
 (21) Exchange
-Input [3]: [item#30, return_ratio#31, currency_ratio#32]
+Input [3]: [item#32, return_ratio#33, currency_ratio#34]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=4]
 
 (22) Sort [codegen id : 8]
-Input [3]: [item#30, return_ratio#31, currency_ratio#32]
-Arguments: [return_ratio#31 ASC NULLS FIRST], false, 0
+Input [3]: [item#32, return_ratio#33, currency_ratio#34]
+Arguments: [return_ratio#33 ASC NULLS FIRST], false, 0
 
 (23) Window
-Input [3]: [item#30, return_ratio#31, currency_ratio#32]
-Arguments: [rank(return_ratio#31) windowspecdefinition(return_ratio#31 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS return_rank#33], [return_ratio#31 ASC NULLS FIRST]
+Input [3]: [item#32, return_ratio#33, currency_ratio#34]
+Arguments: [rank(return_ratio#33) windowspecdefinition(return_ratio#33 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS return_rank#35], [return_ratio#33 ASC NULLS FIRST]
 
 (24) Sort [codegen id : 9]
-Input [4]: [item#30, return_ratio#31, currency_ratio#32, return_rank#33]
-Arguments: [currency_ratio#32 ASC NULLS FIRST], false, 0
+Input [4]: [item#32, return_ratio#33, currency_ratio#34, return_rank#35]
+Arguments: [currency_ratio#34 ASC NULLS FIRST], false, 0
 
 (25) Window
-Input [4]: [item#30, return_ratio#31, currency_ratio#32, return_rank#33]
-Arguments: [rank(currency_ratio#32) windowspecdefinition(currency_ratio#32 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS currency_rank#34], [currency_ratio#32 ASC NULLS FIRST]
+Input [4]: [item#32, return_ratio#33, currency_ratio#34, return_rank#35]
+Arguments: [rank(currency_ratio#34) windowspecdefinition(currency_ratio#34 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS currency_rank#36], [currency_ratio#34 ASC NULLS FIRST]
 
 (26) Filter [codegen id : 10]
-Input [5]: [item#30, return_ratio#31, currency_ratio#32, return_rank#33, currency_rank#34]
-Condition : ((return_rank#33 <= 10) OR (currency_rank#34 <= 10))
+Input [5]: [item#32, return_ratio#33, currency_ratio#34, return_rank#35, currency_rank#36]
+Condition : ((return_rank#35 <= 10) OR (currency_rank#36 <= 10))
 
 (27) Project [codegen id : 10]
-Output [5]: [web AS channel#35, item#30, return_ratio#31, return_rank#33, currency_rank#34]
-Input [5]: [item#30, return_ratio#31, currency_ratio#32, return_rank#33, currency_rank#34]
+Output [5]: [web AS channel#37, item#32, return_ratio#33, return_rank#35, currency_rank#36]
+Input [5]: [item#32, return_ratio#33, currency_ratio#34, return_rank#35, currency_rank#36]
 
 (28) Scan parquet spark_catalog.default.catalog_sales
-Output [6]: [cs_item_sk#36, cs_order_number#37, cs_quantity#38, cs_net_paid#39, cs_net_profit#40, cs_sold_date_sk#41]
+Output [6]: [cs_item_sk#38, cs_order_number#39, cs_quantity#40, cs_net_paid#41, cs_net_profit#42, cs_sold_date_sk#43]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#41), dynamicpruningexpression(cs_sold_date_sk#41 IN dynamicpruning#7)]
+PartitionFilters: [isnotnull(cs_sold_date_sk#43), dynamicpruningexpression(cs_sold_date_sk#43 IN dynamicpruning#7)]
 PushedFilters: [IsNotNull(cs_net_profit), IsNotNull(cs_net_paid), IsNotNull(cs_quantity), GreaterThan(cs_net_profit,1.00), GreaterThan(cs_net_paid,0.00), GreaterThan(cs_quantity,0), IsNotNull(cs_order_number), IsNotNull(cs_item_sk)]
 ReadSchema: struct<cs_item_sk:int,cs_order_number:int,cs_quantity:int,cs_net_paid:decimal(7,2),cs_net_profit:decimal(7,2)>
 
 (29) ColumnarToRow [codegen id : 12]
-Input [6]: [cs_item_sk#36, cs_order_number#37, cs_quantity#38, cs_net_paid#39, cs_net_profit#40, cs_sold_date_sk#41]
+Input [6]: [cs_item_sk#38, cs_order_number#39, cs_quantity#40, cs_net_paid#41, cs_net_profit#42, cs_sold_date_sk#43]
 
 (30) Filter [codegen id : 12]
-Input [6]: [cs_item_sk#36, cs_order_number#37, cs_quantity#38, cs_net_paid#39, cs_net_profit#40, cs_sold_date_sk#41]
-Condition : (((((((isnotnull(cs_net_profit#40) AND isnotnull(cs_net_paid#39)) AND isnotnull(cs_quantity#38)) AND (cs_net_profit#40 > 1.00)) AND (cs_net_paid#39 > 0.00)) AND (cs_quantity#38 > 0)) AND isnotnull(cs_order_number#37)) AND isnotnull(cs_item_sk#36))
+Input [6]: [cs_item_sk#38, cs_order_number#39, cs_quantity#40, cs_net_paid#41, cs_net_profit#42, cs_sold_date_sk#43]
+Condition : ((((((((isnotnull(cs_net_profit#42) AND isnotnull(cs_net_paid#41)) AND isnotnull(cs_quantity#40)) AND (cs_net_profit#42 > 1.00)) AND (cs_net_paid#41 > 0.00)) AND (cs_quantity#40 > 0)) AND isnotnull(cs_order_number#39)) AND isnotnull(cs_item_sk#38)) AND might_contain(Subquery scalar-subquery#44, [id=#45], xxhash64(cs_item_sk#38, 42)))
 
 (31) Project [codegen id : 12]
-Output [5]: [cs_item_sk#36, cs_order_number#37, cs_quantity#38, cs_net_paid#39, cs_sold_date_sk#41]
-Input [6]: [cs_item_sk#36, cs_order_number#37, cs_quantity#38, cs_net_paid#39, cs_net_profit#40, cs_sold_date_sk#41]
+Output [5]: [cs_item_sk#38, cs_order_number#39, cs_quantity#40, cs_net_paid#41, cs_sold_date_sk#43]
+Input [6]: [cs_item_sk#38, cs_order_number#39, cs_quantity#40, cs_net_paid#41, cs_net_profit#42, cs_sold_date_sk#43]
 
-(32) ReusedExchange [Reuses operator id: 91]
-Output [1]: [d_date_sk#42]
+(32) ReusedExchange [Reuses operator id: 98]
+Output [1]: [d_date_sk#46]
 
 (33) BroadcastHashJoin [codegen id : 12]
-Left keys [1]: [cs_sold_date_sk#41]
-Right keys [1]: [d_date_sk#42]
+Left keys [1]: [cs_sold_date_sk#43]
+Right keys [1]: [d_date_sk#46]
 Join type: Inner
 Join condition: None
 
 (34) Project [codegen id : 12]
-Output [4]: [cs_item_sk#36, cs_order_number#37, cs_quantity#38, cs_net_paid#39]
-Input [6]: [cs_item_sk#36, cs_order_number#37, cs_quantity#38, cs_net_paid#39, cs_sold_date_sk#41, d_date_sk#42]
+Output [4]: [cs_item_sk#38, cs_order_number#39, cs_quantity#40, cs_net_paid#41]
+Input [6]: [cs_item_sk#38, cs_order_number#39, cs_quantity#40, cs_net_paid#41, cs_sold_date_sk#43, d_date_sk#46]
 
 (35) Exchange
-Input [4]: [cs_item_sk#36, cs_order_number#37, cs_quantity#38, cs_net_paid#39]
-Arguments: hashpartitioning(cs_order_number#37, cs_item_sk#36, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+Input [4]: [cs_item_sk#38, cs_order_number#39, cs_quantity#40, cs_net_paid#41]
+Arguments: hashpartitioning(cs_order_number#39, cs_item_sk#38, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
 (36) Sort [codegen id : 13]
-Input [4]: [cs_item_sk#36, cs_order_number#37, cs_quantity#38, cs_net_paid#39]
-Arguments: [cs_order_number#37 ASC NULLS FIRST, cs_item_sk#36 ASC NULLS FIRST], false, 0
+Input [4]: [cs_item_sk#38, cs_order_number#39, cs_quantity#40, cs_net_paid#41]
+Arguments: [cs_order_number#39 ASC NULLS FIRST, cs_item_sk#38 ASC NULLS FIRST], false, 0
 
 (37) Scan parquet spark_catalog.default.catalog_returns
-Output [5]: [cr_item_sk#43, cr_order_number#44, cr_return_quantity#45, cr_return_amount#46, cr_returned_date_sk#47]
+Output [5]: [cr_item_sk#47, cr_order_number#48, cr_return_quantity#49, cr_return_amount#50, cr_returned_date_sk#51]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/catalog_returns]
 PushedFilters: [IsNotNull(cr_return_amount), GreaterThan(cr_return_amount,10000.00), IsNotNull(cr_order_number), IsNotNull(cr_item_sk)]
 ReadSchema: struct<cr_item_sk:int,cr_order_number:int,cr_return_quantity:int,cr_return_amount:decimal(7,2)>
 
 (38) ColumnarToRow [codegen id : 14]
-Input [5]: [cr_item_sk#43, cr_order_number#44, cr_return_quantity#45, cr_return_amount#46, cr_returned_date_sk#47]
+Input [5]: [cr_item_sk#47, cr_order_number#48, cr_return_quantity#49, cr_return_amount#50, cr_returned_date_sk#51]
 
 (39) Filter [codegen id : 14]
-Input [5]: [cr_item_sk#43, cr_order_number#44, cr_return_quantity#45, cr_return_amount#46, cr_returned_date_sk#47]
-Condition : (((isnotnull(cr_return_amount#46) AND (cr_return_amount#46 > 10000.00)) AND isnotnull(cr_order_number#44)) AND isnotnull(cr_item_sk#43))
+Input [5]: [cr_item_sk#47, cr_order_number#48, cr_return_quantity#49, cr_return_amount#50, cr_returned_date_sk#51]
+Condition : (((isnotnull(cr_return_amount#50) AND (cr_return_amount#50 > 10000.00)) AND isnotnull(cr_order_number#48)) AND isnotnull(cr_item_sk#47))
 
 (40) Project [codegen id : 14]
-Output [4]: [cr_item_sk#43, cr_order_number#44, cr_return_quantity#45, cr_return_amount#46]
-Input [5]: [cr_item_sk#43, cr_order_number#44, cr_return_quantity#45, cr_return_amount#46, cr_returned_date_sk#47]
+Output [4]: [cr_item_sk#47, cr_order_number#48, cr_return_quantity#49, cr_return_amount#50]
+Input [5]: [cr_item_sk#47, cr_order_number#48, cr_return_quantity#49, cr_return_amount#50, cr_returned_date_sk#51]
 
 (41) Exchange
-Input [4]: [cr_item_sk#43, cr_order_number#44, cr_return_quantity#45, cr_return_amount#46]
-Arguments: hashpartitioning(cr_order_number#44, cr_item_sk#43, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+Input [4]: [cr_item_sk#47, cr_order_number#48, cr_return_quantity#49, cr_return_amount#50]
+Arguments: hashpartitioning(cr_order_number#48, cr_item_sk#47, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
 (42) Sort [codegen id : 15]
-Input [4]: [cr_item_sk#43, cr_order_number#44, cr_return_quantity#45, cr_return_amount#46]
-Arguments: [cr_order_number#44 ASC NULLS FIRST, cr_item_sk#43 ASC NULLS FIRST], false, 0
+Input [4]: [cr_item_sk#47, cr_order_number#48, cr_return_quantity#49, cr_return_amount#50]
+Arguments: [cr_order_number#48 ASC NULLS FIRST, cr_item_sk#47 ASC NULLS FIRST], false, 0
 
 (43) SortMergeJoin [codegen id : 16]
-Left keys [2]: [cs_order_number#37, cs_item_sk#36]
-Right keys [2]: [cr_order_number#44, cr_item_sk#43]
+Left keys [2]: [cs_order_number#39, cs_item_sk#38]
+Right keys [2]: [cr_order_number#48, cr_item_sk#47]
 Join type: Inner
 Join condition: None
 
 (44) Project [codegen id : 16]
-Output [5]: [cs_item_sk#36, cs_quantity#38, cs_net_paid#39, cr_return_quantity#45, cr_return_amount#46]
-Input [8]: [cs_item_sk#36, cs_order_number#37, cs_quantity#38, cs_net_paid#39, cr_item_sk#43, cr_order_number#44, cr_return_quantity#45, cr_return_amount#46]
+Output [5]: [cs_item_sk#38, cs_quantity#40, cs_net_paid#41, cr_return_quantity#49, cr_return_amount#50]
+Input [8]: [cs_item_sk#38, cs_order_number#39, cs_quantity#40, cs_net_paid#41, cr_item_sk#47, cr_order_number#48, cr_return_quantity#49, cr_return_amount#50]
 
 (45) HashAggregate [codegen id : 16]
-Input [5]: [cs_item_sk#36, cs_quantity#38, cs_net_paid#39, cr_return_quantity#45, cr_return_amount#46]
-Keys [1]: [cs_item_sk#36]
-Functions [4]: [partial_sum(coalesce(cr_return_quantity#45, 0)), partial_sum(coalesce(cs_quantity#38, 0)), partial_sum(coalesce(cast(cr_return_amount#46 as decimal(12,2)), 0.00)), partial_sum(coalesce(cast(cs_net_paid#39 as decimal(12,2)), 0.00))]
-Aggregate Attributes [6]: [sum#48, sum#49, sum#50, isEmpty#51, sum#52, isEmpty#53]
-Results [7]: [cs_item_sk#36, sum#54, sum#55, sum#56, isEmpty#57, sum#58, isEmpty#59]
+Input [5]: [cs_item_sk#38, cs_quantity#40, cs_net_paid#41, cr_return_quantity#49, cr_return_amount#50]
+Keys [1]: [cs_item_sk#38]
+Functions [4]: [partial_sum(coalesce(cr_return_quantity#49, 0)), partial_sum(coalesce(cs_quantity#40, 0)), partial_sum(coalesce(cast(cr_return_amount#50 as decimal(12,2)), 0.00)), partial_sum(coalesce(cast(cs_net_paid#41 as decimal(12,2)), 0.00))]
+Aggregate Attributes [6]: [sum#52, sum#53, sum#54, isEmpty#55, sum#56, isEmpty#57]
+Results [7]: [cs_item_sk#38, sum#58, sum#59, sum#60, isEmpty#61, sum#62, isEmpty#63]
 
 (46) Exchange
-Input [7]: [cs_item_sk#36, sum#54, sum#55, sum#56, isEmpty#57, sum#58, isEmpty#59]
-Arguments: hashpartitioning(cs_item_sk#36, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+Input [7]: [cs_item_sk#38, sum#58, sum#59, sum#60, isEmpty#61, sum#62, isEmpty#63]
+Arguments: hashpartitioning(cs_item_sk#38, 5), ENSURE_REQUIREMENTS, [plan_id=7]
 
 (47) HashAggregate [codegen id : 17]
-Input [7]: [cs_item_sk#36, sum#54, sum#55, sum#56, isEmpty#57, sum#58, isEmpty#59]
-Keys [1]: [cs_item_sk#36]
-Functions [4]: [sum(coalesce(cr_return_quantity#45, 0)), sum(coalesce(cs_quantity#38, 0)), sum(coalesce(cast(cr_return_amount#46 as decimal(12,2)), 0.00)), sum(coalesce(cast(cs_net_paid#39 as decimal(12,2)), 0.00))]
-Aggregate Attributes [4]: [sum(coalesce(cr_return_quantity#45, 0))#60, sum(coalesce(cs_quantity#38, 0))#61, sum(coalesce(cast(cr_return_amount#46 as decimal(12,2)), 0.00))#62, sum(coalesce(cast(cs_net_paid#39 as decimal(12,2)), 0.00))#63]
-Results [3]: [cs_item_sk#36 AS item#64, (cast(sum(coalesce(cr_return_quantity#45, 0))#60 as decimal(15,4)) / cast(sum(coalesce(cs_quantity#38, 0))#61 as decimal(15,4))) AS return_ratio#65, (cast(sum(coalesce(cast(cr_return_amount#46 as decimal(12,2)), 0.00))#62 as decimal(15,4)) / cast(sum(coalesce(cast(cs_net_paid#39 as decimal(12,2)), 0.00))#63 as decimal(15,4))) AS currency_ratio#66]
+Input [7]: [cs_item_sk#38, sum#58, sum#59, sum#60, isEmpty#61, sum#62, isEmpty#63]
+Keys [1]: [cs_item_sk#38]
+Functions [4]: [sum(coalesce(cr_return_quantity#49, 0)), sum(coalesce(cs_quantity#40, 0)), sum(coalesce(cast(cr_return_amount#50 as decimal(12,2)), 0.00)), sum(coalesce(cast(cs_net_paid#41 as decimal(12,2)), 0.00))]
+Aggregate Attributes [4]: [sum(coalesce(cr_return_quantity#49, 0))#64, sum(coalesce(cs_quantity#40, 0))#65, sum(coalesce(cast(cr_return_amount#50 as decimal(12,2)), 0.00))#66, sum(coalesce(cast(cs_net_paid#41 as decimal(12,2)), 0.00))#67]
+Results [3]: [cs_item_sk#38 AS item#68, (cast(sum(coalesce(cr_return_quantity#49, 0))#64 as decimal(15,4)) / cast(sum(coalesce(cs_quantity#40, 0))#65 as decimal(15,4))) AS return_ratio#69, (cast(sum(coalesce(cast(cr_return_amount#50 as decimal(12,2)), 0.00))#66 as decimal(15,4)) / cast(sum(coalesce(cast(cs_net_paid#41 as decimal(12,2)), 0.00))#67 as decimal(15,4))) AS currency_ratio#70]
 
 (48) Exchange
-Input [3]: [item#64, return_ratio#65, currency_ratio#66]
+Input [3]: [item#68, return_ratio#69, currency_ratio#70]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=8]
 
 (49) Sort [codegen id : 18]
-Input [3]: [item#64, return_ratio#65, currency_ratio#66]
-Arguments: [return_ratio#65 ASC NULLS FIRST], false, 0
+Input [3]: [item#68, return_ratio#69, currency_ratio#70]
+Arguments: [return_ratio#69 ASC NULLS FIRST], false, 0
 
 (50) Window
-Input [3]: [item#64, return_ratio#65, currency_ratio#66]
-Arguments: [rank(return_ratio#65) windowspecdefinition(return_ratio#65 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS return_rank#67], [return_ratio#65 ASC NULLS FIRST]
+Input [3]: [item#68, return_ratio#69, currency_ratio#70]
+Arguments: [rank(return_ratio#69) windowspecdefinition(return_ratio#69 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS return_rank#71], [return_ratio#69 ASC NULLS FIRST]
 
 (51) Sort [codegen id : 19]
-Input [4]: [item#64, return_ratio#65, currency_ratio#66, return_rank#67]
-Arguments: [currency_ratio#66 ASC NULLS FIRST], false, 0
+Input [4]: [item#68, return_ratio#69, currency_ratio#70, return_rank#71]
+Arguments: [currency_ratio#70 ASC NULLS FIRST], false, 0
 
 (52) Window
-Input [4]: [item#64, return_ratio#65, currency_ratio#66, return_rank#67]
-Arguments: [rank(currency_ratio#66) windowspecdefinition(currency_ratio#66 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS currency_rank#68], [currency_ratio#66 ASC NULLS FIRST]
+Input [4]: [item#68, return_ratio#69, currency_ratio#70, return_rank#71]
+Arguments: [rank(currency_ratio#70) windowspecdefinition(currency_ratio#70 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS currency_rank#72], [currency_ratio#70 ASC NULLS FIRST]
 
 (53) Filter [codegen id : 20]
-Input [5]: [item#64, return_ratio#65, currency_ratio#66, return_rank#67, currency_rank#68]
-Condition : ((return_rank#67 <= 10) OR (currency_rank#68 <= 10))
+Input [5]: [item#68, return_ratio#69, currency_ratio#70, return_rank#71, currency_rank#72]
+Condition : ((return_rank#71 <= 10) OR (currency_rank#72 <= 10))
 
 (54) Project [codegen id : 20]
-Output [5]: [catalog AS channel#69, item#64, return_ratio#65, return_rank#67, currency_rank#68]
-Input [5]: [item#64, return_ratio#65, currency_ratio#66, return_rank#67, currency_rank#68]
+Output [5]: [catalog AS channel#73, item#68, return_ratio#69, return_rank#71, currency_rank#72]
+Input [5]: [item#68, return_ratio#69, currency_ratio#70, return_rank#71, currency_rank#72]
 
 (55) Scan parquet spark_catalog.default.store_sales
-Output [6]: [ss_item_sk#70, ss_ticket_number#71, ss_quantity#72, ss_net_paid#73, ss_net_profit#74, ss_sold_date_sk#75]
+Output [6]: [ss_item_sk#74, ss_ticket_number#75, ss_quantity#76, ss_net_paid#77, ss_net_profit#78, ss_sold_date_sk#79]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#75), dynamicpruningexpression(ss_sold_date_sk#75 IN dynamicpruning#7)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#79), dynamicpruningexpression(ss_sold_date_sk#79 IN dynamicpruning#7)]
 PushedFilters: [IsNotNull(ss_net_profit), IsNotNull(ss_net_paid), IsNotNull(ss_quantity), GreaterThan(ss_net_profit,1.00), GreaterThan(ss_net_paid,0.00), GreaterThan(ss_quantity,0), IsNotNull(ss_ticket_number), IsNotNull(ss_item_sk)]
 ReadSchema: struct<ss_item_sk:int,ss_ticket_number:int,ss_quantity:int,ss_net_paid:decimal(7,2),ss_net_profit:decimal(7,2)>
 
 (56) ColumnarToRow [codegen id : 22]
-Input [6]: [ss_item_sk#70, ss_ticket_number#71, ss_quantity#72, ss_net_paid#73, ss_net_profit#74, ss_sold_date_sk#75]
+Input [6]: [ss_item_sk#74, ss_ticket_number#75, ss_quantity#76, ss_net_paid#77, ss_net_profit#78, ss_sold_date_sk#79]
 
 (57) Filter [codegen id : 22]
-Input [6]: [ss_item_sk#70, ss_ticket_number#71, ss_quantity#72, ss_net_paid#73, ss_net_profit#74, ss_sold_date_sk#75]
-Condition : (((((((isnotnull(ss_net_profit#74) AND isnotnull(ss_net_paid#73)) AND isnotnull(ss_quantity#72)) AND (ss_net_profit#74 > 1.00)) AND (ss_net_paid#73 > 0.00)) AND (ss_quantity#72 > 0)) AND isnotnull(ss_ticket_number#71)) AND isnotnull(ss_item_sk#70))
+Input [6]: [ss_item_sk#74, ss_ticket_number#75, ss_quantity#76, ss_net_paid#77, ss_net_profit#78, ss_sold_date_sk#79]
+Condition : ((((((((isnotnull(ss_net_profit#78) AND isnotnull(ss_net_paid#77)) AND isnotnull(ss_quantity#76)) AND (ss_net_profit#78 > 1.00)) AND (ss_net_paid#77 > 0.00)) AND (ss_quantity#76 > 0)) AND isnotnull(ss_ticket_number#75)) AND isnotnull(ss_item_sk#74)) AND might_contain(Subquery scalar-subquery#80, [id=#81], xxhash64(ss_item_sk#74, 42)))
 
 (58) Project [codegen id : 22]
-Output [5]: [ss_item_sk#70, ss_ticket_number#71, ss_quantity#72, ss_net_paid#73, ss_sold_date_sk#75]
-Input [6]: [ss_item_sk#70, ss_ticket_number#71, ss_quantity#72, ss_net_paid#73, ss_net_profit#74, ss_sold_date_sk#75]
+Output [5]: [ss_item_sk#74, ss_ticket_number#75, ss_quantity#76, ss_net_paid#77, ss_sold_date_sk#79]
+Input [6]: [ss_item_sk#74, ss_ticket_number#75, ss_quantity#76, ss_net_paid#77, ss_net_profit#78, ss_sold_date_sk#79]
 
-(59) ReusedExchange [Reuses operator id: 91]
-Output [1]: [d_date_sk#76]
+(59) ReusedExchange [Reuses operator id: 98]
+Output [1]: [d_date_sk#82]
 
 (60) BroadcastHashJoin [codegen id : 22]
-Left keys [1]: [ss_sold_date_sk#75]
-Right keys [1]: [d_date_sk#76]
+Left keys [1]: [ss_sold_date_sk#79]
+Right keys [1]: [d_date_sk#82]
 Join type: Inner
 Join condition: None
 
 (61) Project [codegen id : 22]
-Output [4]: [ss_item_sk#70, ss_ticket_number#71, ss_quantity#72, ss_net_paid#73]
-Input [6]: [ss_item_sk#70, ss_ticket_number#71, ss_quantity#72, ss_net_paid#73, ss_sold_date_sk#75, d_date_sk#76]
+Output [4]: [ss_item_sk#74, ss_ticket_number#75, ss_quantity#76, ss_net_paid#77]
+Input [6]: [ss_item_sk#74, ss_ticket_number#75, ss_quantity#76, ss_net_paid#77, ss_sold_date_sk#79, d_date_sk#82]
 
 (62) Exchange
-Input [4]: [ss_item_sk#70, ss_ticket_number#71, ss_quantity#72, ss_net_paid#73]
-Arguments: hashpartitioning(ss_ticket_number#71, ss_item_sk#70, 5), ENSURE_REQUIREMENTS, [plan_id=9]
+Input [4]: [ss_item_sk#74, ss_ticket_number#75, ss_quantity#76, ss_net_paid#77]
+Arguments: hashpartitioning(ss_ticket_number#75, ss_item_sk#74, 5), ENSURE_REQUIREMENTS, [plan_id=9]
 
 (63) Sort [codegen id : 23]
-Input [4]: [ss_item_sk#70, ss_ticket_number#71, ss_quantity#72, ss_net_paid#73]
-Arguments: [ss_ticket_number#71 ASC NULLS FIRST, ss_item_sk#70 ASC NULLS FIRST], false, 0
+Input [4]: [ss_item_sk#74, ss_ticket_number#75, ss_quantity#76, ss_net_paid#77]
+Arguments: [ss_ticket_number#75 ASC NULLS FIRST, ss_item_sk#74 ASC NULLS FIRST], false, 0
 
 (64) Scan parquet spark_catalog.default.store_returns
-Output [5]: [sr_item_sk#77, sr_ticket_number#78, sr_return_quantity#79, sr_return_amt#80, sr_returned_date_sk#81]
+Output [5]: [sr_item_sk#83, sr_ticket_number#84, sr_return_quantity#85, sr_return_amt#86, sr_returned_date_sk#87]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store_returns]
 PushedFilters: [IsNotNull(sr_return_amt), GreaterThan(sr_return_amt,10000.00), IsNotNull(sr_ticket_number), IsNotNull(sr_item_sk)]
 ReadSchema: struct<sr_item_sk:int,sr_ticket_number:int,sr_return_quantity:int,sr_return_amt:decimal(7,2)>
 
 (65) ColumnarToRow [codegen id : 24]
-Input [5]: [sr_item_sk#77, sr_ticket_number#78, sr_return_quantity#79, sr_return_amt#80, sr_returned_date_sk#81]
+Input [5]: [sr_item_sk#83, sr_ticket_number#84, sr_return_quantity#85, sr_return_amt#86, sr_returned_date_sk#87]
 
 (66) Filter [codegen id : 24]
-Input [5]: [sr_item_sk#77, sr_ticket_number#78, sr_return_quantity#79, sr_return_amt#80, sr_returned_date_sk#81]
-Condition : (((isnotnull(sr_return_amt#80) AND (sr_return_amt#80 > 10000.00)) AND isnotnull(sr_ticket_number#78)) AND isnotnull(sr_item_sk#77))
+Input [5]: [sr_item_sk#83, sr_ticket_number#84, sr_return_quantity#85, sr_return_amt#86, sr_returned_date_sk#87]
+Condition : (((isnotnull(sr_return_amt#86) AND (sr_return_amt#86 > 10000.00)) AND isnotnull(sr_ticket_number#84)) AND isnotnull(sr_item_sk#83))
 
 (67) Project [codegen id : 24]
-Output [4]: [sr_item_sk#77, sr_ticket_number#78, sr_return_quantity#79, sr_return_amt#80]
-Input [5]: [sr_item_sk#77, sr_ticket_number#78, sr_return_quantity#79, sr_return_amt#80, sr_returned_date_sk#81]
+Output [4]: [sr_item_sk#83, sr_ticket_number#84, sr_return_quantity#85, sr_return_amt#86]
+Input [5]: [sr_item_sk#83, sr_ticket_number#84, sr_return_quantity#85, sr_return_amt#86, sr_returned_date_sk#87]
 
 (68) Exchange
-Input [4]: [sr_item_sk#77, sr_ticket_number#78, sr_return_quantity#79, sr_return_amt#80]
-Arguments: hashpartitioning(sr_ticket_number#78, sr_item_sk#77, 5), ENSURE_REQUIREMENTS, [plan_id=10]
+Input [4]: [sr_item_sk#83, sr_ticket_number#84, sr_return_quantity#85, sr_return_amt#86]
+Arguments: hashpartitioning(sr_ticket_number#84, sr_item_sk#83, 5), ENSURE_REQUIREMENTS, [plan_id=10]
 
 (69) Sort [codegen id : 25]
-Input [4]: [sr_item_sk#77, sr_ticket_number#78, sr_return_quantity#79, sr_return_amt#80]
-Arguments: [sr_ticket_number#78 ASC NULLS FIRST, sr_item_sk#77 ASC NULLS FIRST], false, 0
+Input [4]: [sr_item_sk#83, sr_ticket_number#84, sr_return_quantity#85, sr_return_amt#86]
+Arguments: [sr_ticket_number#84 ASC NULLS FIRST, sr_item_sk#83 ASC NULLS FIRST], false, 0
 
 (70) SortMergeJoin [codegen id : 26]
-Left keys [2]: [ss_ticket_number#71, ss_item_sk#70]
-Right keys [2]: [sr_ticket_number#78, sr_item_sk#77]
+Left keys [2]: [ss_ticket_number#75, ss_item_sk#74]
+Right keys [2]: [sr_ticket_number#84, sr_item_sk#83]
 Join type: Inner
 Join condition: None
 
 (71) Project [codegen id : 26]
-Output [5]: [ss_item_sk#70, ss_quantity#72, ss_net_paid#73, sr_return_quantity#79, sr_return_amt#80]
-Input [8]: [ss_item_sk#70, ss_ticket_number#71, ss_quantity#72, ss_net_paid#73, sr_item_sk#77, sr_ticket_number#78, sr_return_quantity#79, sr_return_amt#80]
+Output [5]: [ss_item_sk#74, ss_quantity#76, ss_net_paid#77, sr_return_quantity#85, sr_return_amt#86]
+Input [8]: [ss_item_sk#74, ss_ticket_number#75, ss_quantity#76, ss_net_paid#77, sr_item_sk#83, sr_ticket_number#84, sr_return_quantity#85, sr_return_amt#86]
 
 (72) HashAggregate [codegen id : 26]
-Input [5]: [ss_item_sk#70, ss_quantity#72, ss_net_paid#73, sr_return_quantity#79, sr_return_amt#80]
-Keys [1]: [ss_item_sk#70]
-Functions [4]: [partial_sum(coalesce(sr_return_quantity#79, 0)), partial_sum(coalesce(ss_quantity#72, 0)), partial_sum(coalesce(cast(sr_return_amt#80 as decimal(12,2)), 0.00)), partial_sum(coalesce(cast(ss_net_paid#73 as decimal(12,2)), 0.00))]
-Aggregate Attributes [6]: [sum#82, sum#83, sum#84, isEmpty#85, sum#86, isEmpty#87]
-Results [7]: [ss_item_sk#70, sum#88, sum#89, sum#90, isEmpty#91, sum#92, isEmpty#93]
+Input [5]: [ss_item_sk#74, ss_quantity#76, ss_net_paid#77, sr_return_quantity#85, sr_return_amt#86]
+Keys [1]: [ss_item_sk#74]
+Functions [4]: [partial_sum(coalesce(sr_return_quantity#85, 0)), partial_sum(coalesce(ss_quantity#76, 0)), partial_sum(coalesce(cast(sr_return_amt#86 as decimal(12,2)), 0.00)), partial_sum(coalesce(cast(ss_net_paid#77 as decimal(12,2)), 0.00))]
+Aggregate Attributes [6]: [sum#88, sum#89, sum#90, isEmpty#91, sum#92, isEmpty#93]
+Results [7]: [ss_item_sk#74, sum#94, sum#95, sum#96, isEmpty#97, sum#98, isEmpty#99]
 
 (73) Exchange
-Input [7]: [ss_item_sk#70, sum#88, sum#89, sum#90, isEmpty#91, sum#92, isEmpty#93]
-Arguments: hashpartitioning(ss_item_sk#70, 5), ENSURE_REQUIREMENTS, [plan_id=11]
+Input [7]: [ss_item_sk#74, sum#94, sum#95, sum#96, isEmpty#97, sum#98, isEmpty#99]
+Arguments: hashpartitioning(ss_item_sk#74, 5), ENSURE_REQUIREMENTS, [plan_id=11]
 
 (74) HashAggregate [codegen id : 27]
-Input [7]: [ss_item_sk#70, sum#88, sum#89, sum#90, isEmpty#91, sum#92, isEmpty#93]
-Keys [1]: [ss_item_sk#70]
-Functions [4]: [sum(coalesce(sr_return_quantity#79, 0)), sum(coalesce(ss_quantity#72, 0)), sum(coalesce(cast(sr_return_amt#80 as decimal(12,2)), 0.00)), sum(coalesce(cast(ss_net_paid#73 as decimal(12,2)), 0.00))]
-Aggregate Attributes [4]: [sum(coalesce(sr_return_quantity#79, 0))#94, sum(coalesce(ss_quantity#72, 0))#95, sum(coalesce(cast(sr_return_amt#80 as decimal(12,2)), 0.00))#96, sum(coalesce(cast(ss_net_paid#73 as decimal(12,2)), 0.00))#97]
-Results [3]: [ss_item_sk#70 AS item#98, (cast(sum(coalesce(sr_return_quantity#79, 0))#94 as decimal(15,4)) / cast(sum(coalesce(ss_quantity#72, 0))#95 as decimal(15,4))) AS return_ratio#99, (cast(sum(coalesce(cast(sr_return_amt#80 as decimal(12,2)), 0.00))#96 as decimal(15,4)) / cast(sum(coalesce(cast(ss_net_paid#73 as decimal(12,2)), 0.00))#97 as decimal(15,4))) AS currency_ratio#100]
+Input [7]: [ss_item_sk#74, sum#94, sum#95, sum#96, isEmpty#97, sum#98, isEmpty#99]
+Keys [1]: [ss_item_sk#74]
+Functions [4]: [sum(coalesce(sr_return_quantity#85, 0)), sum(coalesce(ss_quantity#76, 0)), sum(coalesce(cast(sr_return_amt#86 as decimal(12,2)), 0.00)), sum(coalesce(cast(ss_net_paid#77 as decimal(12,2)), 0.00))]
+Aggregate Attributes [4]: [sum(coalesce(sr_return_quantity#85, 0))#100, sum(coalesce(ss_quantity#76, 0))#101, sum(coalesce(cast(sr_return_amt#86 as decimal(12,2)), 0.00))#102, sum(coalesce(cast(ss_net_paid#77 as decimal(12,2)), 0.00))#103]
+Results [3]: [ss_item_sk#74 AS item#104, (cast(sum(coalesce(sr_return_quantity#85, 0))#100 as decimal(15,4)) / cast(sum(coalesce(ss_quantity#76, 0))#101 as decimal(15,4))) AS return_ratio#105, (cast(sum(coalesce(cast(sr_return_amt#86 as decimal(12,2)), 0.00))#102 as decimal(15,4)) / cast(sum(coalesce(cast(ss_net_paid#77 as decimal(12,2)), 0.00))#103 as decimal(15,4))) AS currency_ratio#106]
 
 (75) Exchange
-Input [3]: [item#98, return_ratio#99, currency_ratio#100]
+Input [3]: [item#104, return_ratio#105, currency_ratio#106]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=12]
 
 (76) Sort [codegen id : 28]
-Input [3]: [item#98, return_ratio#99, currency_ratio#100]
-Arguments: [return_ratio#99 ASC NULLS FIRST], false, 0
+Input [3]: [item#104, return_ratio#105, currency_ratio#106]
+Arguments: [return_ratio#105 ASC NULLS FIRST], false, 0
 
 (77) Window
-Input [3]: [item#98, return_ratio#99, currency_ratio#100]
-Arguments: [rank(return_ratio#99) windowspecdefinition(return_ratio#99 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS return_rank#101], [return_ratio#99 ASC NULLS FIRST]
+Input [3]: [item#104, return_ratio#105, currency_ratio#106]
+Arguments: [rank(return_ratio#105) windowspecdefinition(return_ratio#105 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS return_rank#107], [return_ratio#105 ASC NULLS FIRST]
 
 (78) Sort [codegen id : 29]
-Input [4]: [item#98, return_ratio#99, currency_ratio#100, return_rank#101]
-Arguments: [currency_ratio#100 ASC NULLS FIRST], false, 0
+Input [4]: [item#104, return_ratio#105, currency_ratio#106, return_rank#107]
+Arguments: [currency_ratio#106 ASC NULLS FIRST], false, 0
 
 (79) Window
-Input [4]: [item#98, return_ratio#99, currency_ratio#100, return_rank#101]
-Arguments: [rank(currency_ratio#100) windowspecdefinition(currency_ratio#100 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS currency_rank#102], [currency_ratio#100 ASC NULLS FIRST]
+Input [4]: [item#104, return_ratio#105, currency_ratio#106, return_rank#107]
+Arguments: [rank(currency_ratio#106) windowspecdefinition(currency_ratio#106 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS currency_rank#108], [currency_ratio#106 ASC NULLS FIRST]
 
 (80) Filter [codegen id : 30]
-Input [5]: [item#98, return_ratio#99, currency_ratio#100, return_rank#101, currency_rank#102]
-Condition : ((return_rank#101 <= 10) OR (currency_rank#102 <= 10))
+Input [5]: [item#104, return_ratio#105, currency_ratio#106, return_rank#107, currency_rank#108]
+Condition : ((return_rank#107 <= 10) OR (currency_rank#108 <= 10))
 
 (81) Project [codegen id : 30]
-Output [5]: [store AS channel#103, item#98, return_ratio#99, return_rank#101, currency_rank#102]
-Input [5]: [item#98, return_ratio#99, currency_ratio#100, return_rank#101, currency_rank#102]
+Output [5]: [store AS channel#109, item#104, return_ratio#105, return_rank#107, currency_rank#108]
+Input [5]: [item#104, return_ratio#105, currency_ratio#106, return_rank#107, currency_rank#108]
 
 (82) Union
 
 (83) HashAggregate [codegen id : 31]
-Input [5]: [channel#35, item#30, return_ratio#31, return_rank#33, currency_rank#34]
-Keys [5]: [channel#35, item#30, return_ratio#31, return_rank#33, currency_rank#34]
+Input [5]: [channel#37, item#32, return_ratio#33, return_rank#35, currency_rank#36]
+Keys [5]: [channel#37, item#32, return_ratio#33, return_rank#35, currency_rank#36]
 Functions: []
 Aggregate Attributes: []
-Results [5]: [channel#35, item#30, return_ratio#31, return_rank#33, currency_rank#34]
+Results [5]: [channel#37, item#32, return_ratio#33, return_rank#35, currency_rank#36]
 
 (84) Exchange
-Input [5]: [channel#35, item#30, return_ratio#31, return_rank#33, currency_rank#34]
-Arguments: hashpartitioning(channel#35, item#30, return_ratio#31, return_rank#33, currency_rank#34, 5), ENSURE_REQUIREMENTS, [plan_id=13]
+Input [5]: [channel#37, item#32, return_ratio#33, return_rank#35, currency_rank#36]
+Arguments: hashpartitioning(channel#37, item#32, return_ratio#33, return_rank#35, currency_rank#36, 5), ENSURE_REQUIREMENTS, [plan_id=13]
 
 (85) HashAggregate [codegen id : 32]
-Input [5]: [channel#35, item#30, return_ratio#31, return_rank#33, currency_rank#34]
-Keys [5]: [channel#35, item#30, return_ratio#31, return_rank#33, currency_rank#34]
+Input [5]: [channel#37, item#32, return_ratio#33, return_rank#35, currency_rank#36]
+Keys [5]: [channel#37, item#32, return_ratio#33, return_rank#35, currency_rank#36]
 Functions: []
 Aggregate Attributes: []
-Results [5]: [channel#35, item#30, return_ratio#31, return_rank#33, currency_rank#34]
+Results [5]: [channel#37, item#32, return_ratio#33, return_rank#35, currency_rank#36]
 
 (86) TakeOrderedAndProject
-Input [5]: [channel#35, item#30, return_ratio#31, return_rank#33, currency_rank#34]
-Arguments: 100, [channel#35 ASC NULLS FIRST, return_rank#33 ASC NULLS FIRST, currency_rank#34 ASC NULLS FIRST, item#30 ASC NULLS FIRST], [channel#35, item#30, return_ratio#31, return_rank#33, currency_rank#34]
+Input [5]: [channel#37, item#32, return_ratio#33, return_rank#35, currency_rank#36]
+Arguments: 100, [channel#37 ASC NULLS FIRST, return_rank#35 ASC NULLS FIRST, currency_rank#36 ASC NULLS FIRST, item#32 ASC NULLS FIRST], [channel#37, item#32, return_ratio#33, return_rank#35, currency_rank#36]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 1 Hosting Expression = ws_sold_date_sk#6 IN dynamicpruning#7
-BroadcastExchange (91)
-+- * Project (90)
-   +- * Filter (89)
-      +- * ColumnarToRow (88)
-         +- Scan parquet spark_catalog.default.date_dim (87)
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#8, [id=#9]
+ObjectHashAggregate (93)
++- Exchange (92)
+   +- ObjectHashAggregate (91)
+      +- * Project (90)
+         +- * Filter (89)
+            +- * ColumnarToRow (88)
+               +- Scan parquet spark_catalog.default.web_returns (87)
 
 
-(87) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#8, d_year#104, d_moy#105]
+(87) Scan parquet spark_catalog.default.web_returns
+Output [4]: [wr_item_sk#11, wr_order_number#12, wr_return_amt#14, wr_returned_date_sk#15]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/web_returns]
+PushedFilters: [IsNotNull(wr_return_amt), GreaterThan(wr_return_amt,10000.00), IsNotNull(wr_order_number), IsNotNull(wr_item_sk)]
+ReadSchema: struct<wr_item_sk:int,wr_order_number:int,wr_return_amt:decimal(7,2)>
+
+(88) ColumnarToRow [codegen id : 1]
+Input [4]: [wr_item_sk#11, wr_order_number#12, wr_return_amt#14, wr_returned_date_sk#15]
+
+(89) Filter [codegen id : 1]
+Input [4]: [wr_item_sk#11, wr_order_number#12, wr_return_amt#14, wr_returned_date_sk#15]
+Condition : (((isnotnull(wr_return_amt#14) AND (wr_return_amt#14 > 10000.00)) AND isnotnull(wr_order_number#12)) AND isnotnull(wr_item_sk#11))
+
+(90) Project [codegen id : 1]
+Output [1]: [wr_item_sk#11]
+Input [4]: [wr_item_sk#11, wr_order_number#12, wr_return_amt#14, wr_returned_date_sk#15]
+
+(91) ObjectHashAggregate
+Input [1]: [wr_item_sk#11]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(wr_item_sk#11, 42), 4449121, 32471646, 0, 0)]
+Aggregate Attributes [1]: [buf#110]
+Results [1]: [buf#111]
+
+(92) Exchange
+Input [1]: [buf#111]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=14]
+
+(93) ObjectHashAggregate
+Input [1]: [buf#111]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(wr_item_sk#11, 42), 4449121, 32471646, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(wr_item_sk#11, 42), 4449121, 32471646, 0, 0)#112]
+Results [1]: [bloom_filter_agg(xxhash64(wr_item_sk#11, 42), 4449121, 32471646, 0, 0)#112 AS bloomFilter#113]
+
+Subquery:2 Hosting operator id = 1 Hosting Expression = ws_sold_date_sk#6 IN dynamicpruning#7
+BroadcastExchange (98)
++- * Project (97)
+   +- * Filter (96)
+      +- * ColumnarToRow (95)
+         +- Scan parquet spark_catalog.default.date_dim (94)
+
+
+(94) Scan parquet spark_catalog.default.date_dim
+Output [3]: [d_date_sk#10, d_year#114, d_moy#115]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), EqualTo(d_year,2001), EqualTo(d_moy,12), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
 
-(88) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#8, d_year#104, d_moy#105]
+(95) ColumnarToRow [codegen id : 1]
+Input [3]: [d_date_sk#10, d_year#114, d_moy#115]
 
-(89) Filter [codegen id : 1]
-Input [3]: [d_date_sk#8, d_year#104, d_moy#105]
-Condition : ((((isnotnull(d_year#104) AND isnotnull(d_moy#105)) AND (d_year#104 = 2001)) AND (d_moy#105 = 12)) AND isnotnull(d_date_sk#8))
+(96) Filter [codegen id : 1]
+Input [3]: [d_date_sk#10, d_year#114, d_moy#115]
+Condition : ((((isnotnull(d_year#114) AND isnotnull(d_moy#115)) AND (d_year#114 = 2001)) AND (d_moy#115 = 12)) AND isnotnull(d_date_sk#10))
 
-(90) Project [codegen id : 1]
-Output [1]: [d_date_sk#8]
-Input [3]: [d_date_sk#8, d_year#104, d_moy#105]
+(97) Project [codegen id : 1]
+Output [1]: [d_date_sk#10]
+Input [3]: [d_date_sk#10, d_year#114, d_moy#115]
 
-(91) BroadcastExchange
-Input [1]: [d_date_sk#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=14]
+(98) BroadcastExchange
+Input [1]: [d_date_sk#10]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=15]
 
-Subquery:2 Hosting operator id = 28 Hosting Expression = cs_sold_date_sk#41 IN dynamicpruning#7
+Subquery:3 Hosting operator id = 30 Hosting Expression = Subquery scalar-subquery#44, [id=#45]
+ObjectHashAggregate (105)
++- Exchange (104)
+   +- ObjectHashAggregate (103)
+      +- * Project (102)
+         +- * Filter (101)
+            +- * ColumnarToRow (100)
+               +- Scan parquet spark_catalog.default.catalog_returns (99)
 
-Subquery:3 Hosting operator id = 55 Hosting Expression = ss_sold_date_sk#75 IN dynamicpruning#7
+
+(99) Scan parquet spark_catalog.default.catalog_returns
+Output [4]: [cr_item_sk#47, cr_order_number#48, cr_return_amount#50, cr_returned_date_sk#51]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/catalog_returns]
+PushedFilters: [IsNotNull(cr_return_amount), GreaterThan(cr_return_amount,10000.00), IsNotNull(cr_order_number), IsNotNull(cr_item_sk)]
+ReadSchema: struct<cr_item_sk:int,cr_order_number:int,cr_return_amount:decimal(7,2)>
+
+(100) ColumnarToRow [codegen id : 1]
+Input [4]: [cr_item_sk#47, cr_order_number#48, cr_return_amount#50, cr_returned_date_sk#51]
+
+(101) Filter [codegen id : 1]
+Input [4]: [cr_item_sk#47, cr_order_number#48, cr_return_amount#50, cr_returned_date_sk#51]
+Condition : (((isnotnull(cr_return_amount#50) AND (cr_return_amount#50 > 10000.00)) AND isnotnull(cr_order_number#48)) AND isnotnull(cr_item_sk#47))
+
+(102) Project [codegen id : 1]
+Output [1]: [cr_item_sk#47]
+Input [4]: [cr_item_sk#47, cr_order_number#48, cr_return_amount#50, cr_returned_date_sk#51]
+
+(103) ObjectHashAggregate
+Input [1]: [cr_item_sk#47]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(cr_item_sk#47, 42), 9210895, 67108864, 0, 0)]
+Aggregate Attributes [1]: [buf#116]
+Results [1]: [buf#117]
+
+(104) Exchange
+Input [1]: [buf#117]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=16]
+
+(105) ObjectHashAggregate
+Input [1]: [buf#117]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(cr_item_sk#47, 42), 9210895, 67108864, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(cr_item_sk#47, 42), 9210895, 67108864, 0, 0)#118]
+Results [1]: [bloom_filter_agg(xxhash64(cr_item_sk#47, 42), 9210895, 67108864, 0, 0)#118 AS bloomFilter#119]
+
+Subquery:4 Hosting operator id = 28 Hosting Expression = cs_sold_date_sk#43 IN dynamicpruning#7
+
+Subquery:5 Hosting operator id = 57 Hosting Expression = Subquery scalar-subquery#80, [id=#81]
+ObjectHashAggregate (112)
++- Exchange (111)
+   +- ObjectHashAggregate (110)
+      +- * Project (109)
+         +- * Filter (108)
+            +- * ColumnarToRow (107)
+               +- Scan parquet spark_catalog.default.store_returns (106)
+
+
+(106) Scan parquet spark_catalog.default.store_returns
+Output [4]: [sr_item_sk#83, sr_ticket_number#84, sr_return_amt#86, sr_returned_date_sk#87]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/store_returns]
+PushedFilters: [IsNotNull(sr_return_amt), GreaterThan(sr_return_amt,10000.00), IsNotNull(sr_ticket_number), IsNotNull(sr_item_sk)]
+ReadSchema: struct<sr_item_sk:int,sr_ticket_number:int,sr_return_amt:decimal(7,2)>
+
+(107) ColumnarToRow [codegen id : 1]
+Input [4]: [sr_item_sk#83, sr_ticket_number#84, sr_return_amt#86, sr_returned_date_sk#87]
+
+(108) Filter [codegen id : 1]
+Input [4]: [sr_item_sk#83, sr_ticket_number#84, sr_return_amt#86, sr_returned_date_sk#87]
+Condition : (((isnotnull(sr_return_amt#86) AND (sr_return_amt#86 > 10000.00)) AND isnotnull(sr_ticket_number#84)) AND isnotnull(sr_item_sk#83))
+
+(109) Project [codegen id : 1]
+Output [1]: [sr_item_sk#83]
+Input [4]: [sr_item_sk#83, sr_ticket_number#84, sr_return_amt#86, sr_returned_date_sk#87]
+
+(110) ObjectHashAggregate
+Input [1]: [sr_item_sk#83]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(sr_item_sk#83, 42), 13141919, 67108864, 0, 0)]
+Aggregate Attributes [1]: [buf#120]
+Results [1]: [buf#121]
+
+(111) Exchange
+Input [1]: [buf#121]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=17]
+
+(112) ObjectHashAggregate
+Input [1]: [buf#121]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(sr_item_sk#83, 42), 13141919, 67108864, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(sr_item_sk#83, 42), 13141919, 67108864, 0, 0)#122]
+Results [1]: [bloom_filter_agg(xxhash64(sr_item_sk#83, 42), 13141919, 67108864, 0, 0)#122 AS bloomFilter#123]
+
+Subquery:6 Hosting operator id = 55 Hosting Expression = ss_sold_date_sk#79 IN dynamicpruning#7
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q49.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q49.sf100/simplified.txt
@@ -38,6 +38,16 @@ TakeOrderedAndProject [channel,return_rank,currency_rank,item,return_ratio]
                                                                           BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
                                                                             Project [ws_item_sk,ws_order_number,ws_quantity,ws_net_paid,ws_sold_date_sk]
                                                                               Filter [ws_net_profit,ws_net_paid,ws_quantity,ws_order_number,ws_item_sk]
+                                                                                Subquery #2
+                                                                                  ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(wr_item_sk, 42), 4449121, 32471646, 0, 0),bloomFilter,buf]
+                                                                                    Exchange #6
+                                                                                      ObjectHashAggregate [wr_item_sk] [buf,buf]
+                                                                                        WholeStageCodegen (1)
+                                                                                          Project [wr_item_sk]
+                                                                                            Filter [wr_return_amt,wr_order_number,wr_item_sk]
+                                                                                              ColumnarToRow
+                                                                                                InputAdapter
+                                                                                                  Scan parquet spark_catalog.default.web_returns [wr_item_sk,wr_order_number,wr_return_amt,wr_returned_date_sk]
                                                                                 ColumnarToRow
                                                                                   InputAdapter
                                                                                     Scan parquet spark_catalog.default.web_sales [ws_item_sk,ws_order_number,ws_quantity,ws_net_paid,ws_net_profit,ws_sold_date_sk]
@@ -55,7 +65,7 @@ TakeOrderedAndProject [channel,return_rank,currency_rank,item,return_ratio]
                                                               WholeStageCodegen (5)
                                                                 Sort [wr_order_number,wr_item_sk]
                                                                   InputAdapter
-                                                                    Exchange [wr_order_number,wr_item_sk] #6
+                                                                    Exchange [wr_order_number,wr_item_sk] #7
                                                                       WholeStageCodegen (4)
                                                                         Project [wr_item_sk,wr_order_number,wr_return_quantity,wr_return_amt]
                                                                           Filter [wr_return_amt,wr_order_number,wr_item_sk]
@@ -74,11 +84,11 @@ TakeOrderedAndProject [channel,return_rank,currency_rank,item,return_ratio]
                                     WholeStageCodegen (18)
                                       Sort [return_ratio]
                                         InputAdapter
-                                          Exchange #7
+                                          Exchange #8
                                             WholeStageCodegen (17)
                                               HashAggregate [cs_item_sk,sum,sum,sum,isEmpty,sum,isEmpty] [sum(coalesce(cr_return_quantity, 0)),sum(coalesce(cs_quantity, 0)),sum(coalesce(cast(cr_return_amount as decimal(12,2)), 0.00)),sum(coalesce(cast(cs_net_paid as decimal(12,2)), 0.00)),item,return_ratio,currency_ratio,sum,sum,sum,isEmpty,sum,isEmpty]
                                                 InputAdapter
-                                                  Exchange [cs_item_sk] #8
+                                                  Exchange [cs_item_sk] #9
                                                     WholeStageCodegen (16)
                                                       HashAggregate [cs_item_sk,cr_return_quantity,cs_quantity,cr_return_amount,cs_net_paid] [sum,sum,sum,isEmpty,sum,isEmpty,sum,sum,sum,isEmpty,sum,isEmpty]
                                                         Project [cs_item_sk,cs_quantity,cs_net_paid,cr_return_quantity,cr_return_amount]
@@ -87,12 +97,22 @@ TakeOrderedAndProject [channel,return_rank,currency_rank,item,return_ratio]
                                                               WholeStageCodegen (13)
                                                                 Sort [cs_order_number,cs_item_sk]
                                                                   InputAdapter
-                                                                    Exchange [cs_order_number,cs_item_sk] #9
+                                                                    Exchange [cs_order_number,cs_item_sk] #10
                                                                       WholeStageCodegen (12)
                                                                         Project [cs_item_sk,cs_order_number,cs_quantity,cs_net_paid]
                                                                           BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
                                                                             Project [cs_item_sk,cs_order_number,cs_quantity,cs_net_paid,cs_sold_date_sk]
                                                                               Filter [cs_net_profit,cs_net_paid,cs_quantity,cs_order_number,cs_item_sk]
+                                                                                Subquery #3
+                                                                                  ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(cr_item_sk, 42), 9210895, 67108864, 0, 0),bloomFilter,buf]
+                                                                                    Exchange #11
+                                                                                      ObjectHashAggregate [cr_item_sk] [buf,buf]
+                                                                                        WholeStageCodegen (1)
+                                                                                          Project [cr_item_sk]
+                                                                                            Filter [cr_return_amount,cr_order_number,cr_item_sk]
+                                                                                              ColumnarToRow
+                                                                                                InputAdapter
+                                                                                                  Scan parquet spark_catalog.default.catalog_returns [cr_item_sk,cr_order_number,cr_return_amount,cr_returned_date_sk]
                                                                                 ColumnarToRow
                                                                                   InputAdapter
                                                                                     Scan parquet spark_catalog.default.catalog_sales [cs_item_sk,cs_order_number,cs_quantity,cs_net_paid,cs_net_profit,cs_sold_date_sk]
@@ -103,7 +123,7 @@ TakeOrderedAndProject [channel,return_rank,currency_rank,item,return_ratio]
                                                               WholeStageCodegen (15)
                                                                 Sort [cr_order_number,cr_item_sk]
                                                                   InputAdapter
-                                                                    Exchange [cr_order_number,cr_item_sk] #10
+                                                                    Exchange [cr_order_number,cr_item_sk] #12
                                                                       WholeStageCodegen (14)
                                                                         Project [cr_item_sk,cr_order_number,cr_return_quantity,cr_return_amount]
                                                                           Filter [cr_return_amount,cr_order_number,cr_item_sk]
@@ -122,11 +142,11 @@ TakeOrderedAndProject [channel,return_rank,currency_rank,item,return_ratio]
                                     WholeStageCodegen (28)
                                       Sort [return_ratio]
                                         InputAdapter
-                                          Exchange #11
+                                          Exchange #13
                                             WholeStageCodegen (27)
                                               HashAggregate [ss_item_sk,sum,sum,sum,isEmpty,sum,isEmpty] [sum(coalesce(sr_return_quantity, 0)),sum(coalesce(ss_quantity, 0)),sum(coalesce(cast(sr_return_amt as decimal(12,2)), 0.00)),sum(coalesce(cast(ss_net_paid as decimal(12,2)), 0.00)),item,return_ratio,currency_ratio,sum,sum,sum,isEmpty,sum,isEmpty]
                                                 InputAdapter
-                                                  Exchange [ss_item_sk] #12
+                                                  Exchange [ss_item_sk] #14
                                                     WholeStageCodegen (26)
                                                       HashAggregate [ss_item_sk,sr_return_quantity,ss_quantity,sr_return_amt,ss_net_paid] [sum,sum,sum,isEmpty,sum,isEmpty,sum,sum,sum,isEmpty,sum,isEmpty]
                                                         Project [ss_item_sk,ss_quantity,ss_net_paid,sr_return_quantity,sr_return_amt]
@@ -135,12 +155,22 @@ TakeOrderedAndProject [channel,return_rank,currency_rank,item,return_ratio]
                                                               WholeStageCodegen (23)
                                                                 Sort [ss_ticket_number,ss_item_sk]
                                                                   InputAdapter
-                                                                    Exchange [ss_ticket_number,ss_item_sk] #13
+                                                                    Exchange [ss_ticket_number,ss_item_sk] #15
                                                                       WholeStageCodegen (22)
                                                                         Project [ss_item_sk,ss_ticket_number,ss_quantity,ss_net_paid]
                                                                           BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                                                             Project [ss_item_sk,ss_ticket_number,ss_quantity,ss_net_paid,ss_sold_date_sk]
                                                                               Filter [ss_net_profit,ss_net_paid,ss_quantity,ss_ticket_number,ss_item_sk]
+                                                                                Subquery #4
+                                                                                  ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(sr_item_sk, 42), 13141919, 67108864, 0, 0),bloomFilter,buf]
+                                                                                    Exchange #16
+                                                                                      ObjectHashAggregate [sr_item_sk] [buf,buf]
+                                                                                        WholeStageCodegen (1)
+                                                                                          Project [sr_item_sk]
+                                                                                            Filter [sr_return_amt,sr_ticket_number,sr_item_sk]
+                                                                                              ColumnarToRow
+                                                                                                InputAdapter
+                                                                                                  Scan parquet spark_catalog.default.store_returns [sr_item_sk,sr_ticket_number,sr_return_amt,sr_returned_date_sk]
                                                                                 ColumnarToRow
                                                                                   InputAdapter
                                                                                     Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_ticket_number,ss_quantity,ss_net_paid,ss_net_profit,ss_sold_date_sk]
@@ -151,7 +181,7 @@ TakeOrderedAndProject [channel,return_rank,currency_rank,item,return_ratio]
                                                               WholeStageCodegen (25)
                                                                 Sort [sr_ticket_number,sr_item_sk]
                                                                   InputAdapter
-                                                                    Exchange [sr_ticket_number,sr_item_sk] #14
+                                                                    Exchange [sr_ticket_number,sr_item_sk] #17
                                                                       WholeStageCodegen (24)
                                                                         Project [sr_item_sk,sr_ticket_number,sr_return_quantity,sr_return_amt]
                                                                           Filter [sr_return_amt,sr_ticket_number,sr_item_sk]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q98.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q98.sf100/explain.txt
@@ -38,7 +38,7 @@ Input [3]: [ss_item_sk#1, ss_ext_sales_price#2, ss_sold_date_sk#3]
 
 (3) Filter [codegen id : 1]
 Input [3]: [ss_item_sk#1, ss_ext_sales_price#2, ss_sold_date_sk#3]
-Condition : isnotnull(ss_item_sk#1)
+Condition : (isnotnull(ss_item_sk#1) AND might_contain(Subquery scalar-subquery#5, [id=#6], xxhash64(ss_item_sk#1, 42)))
 
 (4) Exchange
 Input [3]: [ss_item_sk#1, ss_ext_sales_price#2, ss_sold_date_sk#3]
@@ -49,122 +49,168 @@ Input [3]: [ss_item_sk#1, ss_ext_sales_price#2, ss_sold_date_sk#3]
 Arguments: [ss_item_sk#1 ASC NULLS FIRST], false, 0
 
 (6) Scan parquet spark_catalog.default.item
-Output [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
+Output [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [In(i_category, [Books                                             ,Home                                              ,Sports                                            ]), IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_item_id:string,i_item_desc:string,i_current_price:decimal(7,2),i_class:string,i_category:string>
 
 (7) ColumnarToRow [codegen id : 3]
-Input [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
+Input [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
 
 (8) Filter [codegen id : 3]
-Input [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Condition : (i_category#10 IN (Sports                                            ,Books                                             ,Home                                              ) AND isnotnull(i_item_sk#5))
+Input [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Condition : (i_category#12 IN (Sports                                            ,Books                                             ,Home                                              ) AND isnotnull(i_item_sk#7))
 
 (9) Exchange
-Input [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Arguments: hashpartitioning(i_item_sk#5, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+Input [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Arguments: hashpartitioning(i_item_sk#7, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
 (10) Sort [codegen id : 4]
-Input [6]: [i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Arguments: [i_item_sk#5 ASC NULLS FIRST], false, 0
+Input [6]: [i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Arguments: [i_item_sk#7 ASC NULLS FIRST], false, 0
 
 (11) SortMergeJoin [codegen id : 6]
 Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [i_item_sk#5]
+Right keys [1]: [i_item_sk#7]
 Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 6]
-Output [7]: [ss_ext_sales_price#2, ss_sold_date_sk#3, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Input [9]: [ss_item_sk#1, ss_ext_sales_price#2, ss_sold_date_sk#3, i_item_sk#5, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
+Output [7]: [ss_ext_sales_price#2, ss_sold_date_sk#3, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Input [9]: [ss_item_sk#1, ss_ext_sales_price#2, ss_sold_date_sk#3, i_item_sk#7, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
 
-(13) ReusedExchange [Reuses operator id: 29]
-Output [1]: [d_date_sk#11]
+(13) ReusedExchange [Reuses operator id: 36]
+Output [1]: [d_date_sk#13]
 
 (14) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_sold_date_sk#3]
-Right keys [1]: [d_date_sk#11]
+Right keys [1]: [d_date_sk#13]
 Join type: Inner
 Join condition: None
 
 (15) Project [codegen id : 6]
-Output [6]: [ss_ext_sales_price#2, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Input [8]: [ss_ext_sales_price#2, ss_sold_date_sk#3, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10, d_date_sk#11]
+Output [6]: [ss_ext_sales_price#2, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Input [8]: [ss_ext_sales_price#2, ss_sold_date_sk#3, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12, d_date_sk#13]
 
 (16) HashAggregate [codegen id : 6]
-Input [6]: [ss_ext_sales_price#2, i_item_id#6, i_item_desc#7, i_current_price#8, i_class#9, i_category#10]
-Keys [5]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8]
+Input [6]: [ss_ext_sales_price#2, i_item_id#8, i_item_desc#9, i_current_price#10, i_class#11, i_category#12]
+Keys [5]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10]
 Functions [1]: [partial_sum(UnscaledValue(ss_ext_sales_price#2))]
-Aggregate Attributes [1]: [sum#12]
-Results [6]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, sum#13]
+Aggregate Attributes [1]: [sum#14]
+Results [6]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, sum#15]
 
 (17) Exchange
-Input [6]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, sum#13]
-Arguments: hashpartitioning(i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+Input [6]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, sum#15]
+Arguments: hashpartitioning(i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (18) HashAggregate [codegen id : 7]
-Input [6]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, sum#13]
-Keys [5]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8]
+Input [6]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, sum#15]
+Keys [5]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10]
 Functions [1]: [sum(UnscaledValue(ss_ext_sales_price#2))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ss_ext_sales_price#2))#14]
-Results [7]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#2))#14,17,2) AS itemrevenue#15, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#2))#14,17,2) AS _w0#16]
+Aggregate Attributes [1]: [sum(UnscaledValue(ss_ext_sales_price#2))#16]
+Results [7]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#2))#16,17,2) AS itemrevenue#17, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#2))#16,17,2) AS _w0#18]
 
 (19) Exchange
-Input [7]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, _w0#16]
-Arguments: hashpartitioning(i_class#9, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+Input [7]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, _w0#18]
+Arguments: hashpartitioning(i_class#11, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
 (20) Sort [codegen id : 8]
-Input [7]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, _w0#16]
-Arguments: [i_class#9 ASC NULLS FIRST], false, 0
+Input [7]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, _w0#18]
+Arguments: [i_class#11 ASC NULLS FIRST], false, 0
 
 (21) Window
-Input [7]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, _w0#16]
-Arguments: [sum(_w0#16) windowspecdefinition(i_class#9, specifiedwindowframe(RowFrame, unboundedpreceding$(), unboundedfollowing$())) AS _we0#17], [i_class#9]
+Input [7]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, _w0#18]
+Arguments: [sum(_w0#18) windowspecdefinition(i_class#11, specifiedwindowframe(RowFrame, unboundedpreceding$(), unboundedfollowing$())) AS _we0#19], [i_class#11]
 
 (22) Project [codegen id : 9]
-Output [7]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, ((_w0#16 * 100) / _we0#17) AS revenueratio#18]
-Input [8]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, _w0#16, _we0#17]
+Output [7]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, ((_w0#18 * 100) / _we0#19) AS revenueratio#20]
+Input [8]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, _w0#18, _we0#19]
 
 (23) Exchange
-Input [7]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, revenueratio#18]
-Arguments: rangepartitioning(i_category#10 ASC NULLS FIRST, i_class#9 ASC NULLS FIRST, i_item_id#6 ASC NULLS FIRST, i_item_desc#7 ASC NULLS FIRST, revenueratio#18 ASC NULLS FIRST, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+Input [7]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, revenueratio#20]
+Arguments: rangepartitioning(i_category#12 ASC NULLS FIRST, i_class#11 ASC NULLS FIRST, i_item_id#8 ASC NULLS FIRST, i_item_desc#9 ASC NULLS FIRST, revenueratio#20 ASC NULLS FIRST, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
 (24) Sort [codegen id : 10]
-Input [7]: [i_item_id#6, i_item_desc#7, i_category#10, i_class#9, i_current_price#8, itemrevenue#15, revenueratio#18]
-Arguments: [i_category#10 ASC NULLS FIRST, i_class#9 ASC NULLS FIRST, i_item_id#6 ASC NULLS FIRST, i_item_desc#7 ASC NULLS FIRST, revenueratio#18 ASC NULLS FIRST], true, 0
+Input [7]: [i_item_id#8, i_item_desc#9, i_category#12, i_class#11, i_current_price#10, itemrevenue#17, revenueratio#20]
+Arguments: [i_category#12 ASC NULLS FIRST, i_class#11 ASC NULLS FIRST, i_item_id#8 ASC NULLS FIRST, i_item_desc#9 ASC NULLS FIRST, revenueratio#20 ASC NULLS FIRST], true, 0
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#3 IN dynamicpruning#4
-BroadcastExchange (29)
-+- * Project (28)
-   +- * Filter (27)
-      +- * ColumnarToRow (26)
-         +- Scan parquet spark_catalog.default.date_dim (25)
+Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#5, [id=#6]
+ObjectHashAggregate (31)
++- Exchange (30)
+   +- ObjectHashAggregate (29)
+      +- * Project (28)
+         +- * Filter (27)
+            +- * ColumnarToRow (26)
+               +- Scan parquet spark_catalog.default.item (25)
 
 
-(25) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#11, d_date#19]
+(25) Scan parquet spark_catalog.default.item
+Output [2]: [i_item_sk#7, i_category#12]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/item]
+PushedFilters: [In(i_category, [Books                                             ,Home                                              ,Sports                                            ]), IsNotNull(i_item_sk)]
+ReadSchema: struct<i_item_sk:int,i_category:string>
+
+(26) ColumnarToRow [codegen id : 1]
+Input [2]: [i_item_sk#7, i_category#12]
+
+(27) Filter [codegen id : 1]
+Input [2]: [i_item_sk#7, i_category#12]
+Condition : (i_category#12 IN (Sports                                            ,Books                                             ,Home                                              ) AND isnotnull(i_item_sk#7))
+
+(28) Project [codegen id : 1]
+Output [1]: [i_item_sk#7]
+Input [2]: [i_item_sk#7, i_category#12]
+
+(29) ObjectHashAggregate
+Input [1]: [i_item_sk#7]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#7, 42), 61200, 979099, 0, 0)]
+Aggregate Attributes [1]: [buf#21]
+Results [1]: [buf#22]
+
+(30) Exchange
+Input [1]: [buf#22]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=6]
+
+(31) ObjectHashAggregate
+Input [1]: [buf#22]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#7, 42), 61200, 979099, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#7, 42), 61200, 979099, 0, 0)#23]
+Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#7, 42), 61200, 979099, 0, 0)#23 AS bloomFilter#24]
+
+Subquery:2 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#3 IN dynamicpruning#4
+BroadcastExchange (36)
++- * Project (35)
+   +- * Filter (34)
+      +- * ColumnarToRow (33)
+         +- Scan parquet spark_catalog.default.date_dim (32)
+
+
+(32) Scan parquet spark_catalog.default.date_dim
+Output [2]: [d_date_sk#13, d_date#25]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,1999-02-22), LessThanOrEqual(d_date,1999-03-24), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
-(26) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#11, d_date#19]
+(33) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#13, d_date#25]
 
-(27) Filter [codegen id : 1]
-Input [2]: [d_date_sk#11, d_date#19]
-Condition : (((isnotnull(d_date#19) AND (d_date#19 >= 1999-02-22)) AND (d_date#19 <= 1999-03-24)) AND isnotnull(d_date_sk#11))
+(34) Filter [codegen id : 1]
+Input [2]: [d_date_sk#13, d_date#25]
+Condition : (((isnotnull(d_date#25) AND (d_date#25 >= 1999-02-22)) AND (d_date#25 <= 1999-03-24)) AND isnotnull(d_date_sk#13))
 
-(28) Project [codegen id : 1]
-Output [1]: [d_date_sk#11]
-Input [2]: [d_date_sk#11, d_date#19]
+(35) Project [codegen id : 1]
+Output [1]: [d_date_sk#13]
+Input [2]: [d_date_sk#13, d_date#25]
 
-(29) BroadcastExchange
-Input [1]: [d_date_sk#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=6]
+(36) BroadcastExchange
+Input [1]: [d_date_sk#13]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=7]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q98.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q98.sf100/simplified.txt
@@ -27,6 +27,16 @@ WholeStageCodegen (10)
                                                     Exchange [ss_item_sk] #4
                                                       WholeStageCodegen (1)
                                                         Filter [ss_item_sk]
+                                                          Subquery #2
+                                                            ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(i_item_sk, 42), 61200, 979099, 0, 0),bloomFilter,buf]
+                                                              Exchange #6
+                                                                ObjectHashAggregate [i_item_sk] [buf,buf]
+                                                                  WholeStageCodegen (1)
+                                                                    Project [i_item_sk]
+                                                                      Filter [i_category,i_item_sk]
+                                                                        ColumnarToRow
+                                                                          InputAdapter
+                                                                            Scan parquet spark_catalog.default.item [i_item_sk,i_category]
                                                           ColumnarToRow
                                                             InputAdapter
                                                               Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_ext_sales_price,ss_sold_date_sk]
@@ -42,7 +52,7 @@ WholeStageCodegen (10)
                                               WholeStageCodegen (4)
                                                 Sort [i_item_sk]
                                                   InputAdapter
-                                                    Exchange [i_item_sk] #6
+                                                    Exchange [i_item_sk] #7
                                                       WholeStageCodegen (3)
                                                         Filter [i_category,i_item_sk]
                                                           ColumnarToRow


### PR DESCRIPTION
### What changes were proposed in this pull request?
In `injectBloomFilter`, filter creation side size threshold judgment prun column.

### Why are the changes needed?
Regarding whether to trigger `injectBloomFilter`, it should be consistent with `injectInSubqueryFilter` and not affected by columns other than `filterCreationSideExp`.

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Existing tests.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
