### PR TITLE
[SPARK-41811][PYTHON][CONNECT] Implement SparkSession.sql's string formatter

### DIFF
--- a/python/pyspark/pandas/sql_formatter.py
+++ b/python/pyspark/pandas/sql_formatter.py
@@ -264,10 +264,9 @@ class PandasSQLStringFormatter(string.Formatter):
             val._to_spark().createOrReplaceTempView(df_name)
             return df_name
         elif isinstance(val, str):
-            # This is matched to behavior from JVM implementation.
-            # See `sql` definition from `sql/catalyst/src/main/scala/org/apache/spark/
-            # sql/catalyst/expressions/literals.scala`
-            return "'" + val.replace("\\", "\\\\").replace("'", "\\'") + "'"
+            from pyspark.sql.utils import get_lit_sql_str
+
+            return get_lit_sql_str(val)
         else:
             return val
 

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -489,13 +489,31 @@ class SparkSession:
 
     createDataFrame.__doc__ = PySparkSession.createDataFrame.__doc__
 
-    def sql(self, sqlQuery: str, args: Optional[Union[Dict[str, Any], List]] = None) -> "DataFrame":
-        cmd = SQL(sqlQuery, args)
-        data, properties = self.client.execute_command(cmd.command(self._client))
-        if "sql_command_result" in properties:
-            return DataFrame.withPlan(CachedRelation(properties["sql_command_result"]), self)
-        else:
-            return DataFrame.withPlan(SQL(sqlQuery, args), self)
+    def sql(
+        self,
+        sqlQuery: str,
+        args: Optional[Union[Dict[str, Any], List]] = None,
+        **kwargs: Any,
+    ) -> "DataFrame":
+
+        if len(kwargs) > 0:
+            from pyspark.sql.connect.sql_formatter import SQLStringFormatter
+
+            formatter = SQLStringFormatter(self)
+            sqlQuery = formatter.format(sqlQuery, **kwargs)
+
+        try:
+            cmd = SQL(sqlQuery, args)
+            data, properties = self.client.execute_command(cmd.command(self._client))
+            if "sql_command_result" in properties:
+                return DataFrame.withPlan(CachedRelation(properties["sql_command_result"]), self)
+            else:
+                return DataFrame.withPlan(SQL(sqlQuery, args), self)
+        finally:
+            if len(kwargs) > 0:
+                # TODO: should drop temp views after SPARK-44406 get resolved
+                # formatter.clear()
+                pass
 
     sql.__doc__ = PySparkSession.sql.__doc__
 
@@ -807,9 +825,6 @@ def _test() -> None:
     del pyspark.sql.connect.session.SparkSession.Builder.master.__doc__
     # RDD API is not supported in Spark Connect.
     del pyspark.sql.connect.session.SparkSession.createDataFrame.__doc__
-
-    # TODO(SPARK-41811): Implement SparkSession.sql's string formatter
-    del pyspark.sql.connect.session.SparkSession.sql.__doc__
 
     (failure_count, test_count) = doctest.testmod(
         pyspark.sql.connect.session,

--- a/python/pyspark/sql/utils.py
+++ b/python/pyspark/sql/utils.py
@@ -294,3 +294,11 @@ def get_window_class() -> Type["Window"]:
         return ConnectWindow  # type: ignore[return-value]
     else:
         return PySparkWindow
+
+
+def get_lit_sql_str(val: str) -> str:
+    # Equivalent to `lit(val)._jc.expr().sql()` for string typed val
+    # This is matched to behavior from JVM implementation.
+    # See `sql` definition from `sql/catalyst/src/main/scala/org/apache/spark/
+    # sql/catalyst/expressions/literals.scala`
+    return "'" + val.replace("\\", "\\\\").replace("'", "\\'") + "'"


### PR DESCRIPTION
### What changes were proposed in this pull request?
Implement SparkSession.sql's string formatter


### Why are the changes needed?
for parity




### Does this PR introduce _any_ user-facing change?
yes


before:
```
In [1]: spark.createDataFrame([("Alice", 6), ("Bob", 7), ("John", 10)], ['name', 'age']).createOrReplaceTempView("person")

In [2]: spark.sql("""SELECT * FROM person WHERE age < {age}""", age = 9).show()
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[2], line 1
----> 1 spark.sql("""SELECT * FROM person WHERE age < {age}""", age = 9).show()

TypeError: sql() got an unexpected keyword argument 'age'
```


after:
```
In [1]: spark.createDataFrame([("Alice", 6), ("Bob", 7), ("John", 10)], ['name', 'age']).createOrReplaceTempView("person")

In [2]: spark.sql("""SELECT * FROM person WHERE age < {age}""", age = 9).show()
+-----+---+
| name|age|
+-----+---+
|Alice|  6|
|  Bob|  7|
+-----+---+
```



### How was this patch tested?
enabled doc test
