### PR TITLE
[SPARK-44203][SQL][HIVE] Return nextRenewalDate instead of None for obtainDelegationTokens method

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
@@ -340,6 +340,26 @@ private[spark] class SparkHadoopUtil extends Logging {
     ugi.getAuthenticationMethod() == UserGroupInformation.AuthenticationMethod.PROXY
   }
 
+
+  def getIssueDate(kind: String, identifier: AbstractDelegationTokenIdentifier): Long = {
+    val now = System.currentTimeMillis()
+    val issueDate = identifier.getIssueDate
+    if (issueDate > now) {
+      logWarning(s"Token $kind has set up issue date later than current time. (provided: " +
+        s"$issueDate / current timestamp: $now) Please make sure clocks are in sync between " +
+        "machines. If the issue is not a clock mismatch, consult token implementor to check " +
+        "whether issue date is valid.")
+      issueDate
+    } else if (issueDate > 0L) {
+      issueDate
+    } else {
+      logWarning(s"Token $kind has not set up issue date properly. (provided: $issueDate) " +
+        s"Using current timestamp ($now) as issue date instead. Consult token implementor to fix " +
+        "the behavior.")
+      now
+    }
+  }
+
 }
 
 private[spark] object SparkHadoopUtil extends Logging {

--- a/sql/hive/src/main/resources/META-INF/services/org.apache.hadoop.security.token.TokenIdentifier
+++ b/sql/hive/src/main/resources/META-INF/services/org.apache.hadoop.security.token.TokenIdentifier
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.apache.hadoop.hive.thrift.DelegationTokenIdentifier


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Return nextRenewalDate instead of None for obtainDelegationTokens method

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Regarding hive token, there are some configuration parameters as follows

metastore.cluster.delegation.key.update-interval / hive.cluster.delegation.key.update-interval
metastore.cluster.delegation.token.gc-interval / hive.cluster.delegation.token.gc-interval
metastore.cluster.delegation.token.max-lifetime / hive.cluster.delegation.token.max-lifetime
metastore.cluster.delegation.token.renew-interval / hive.cluster.delegation.token.renew-interval
metastore.cluster.delegation.token.store.class / hive.cluster.delegation.token.store.class

Return nextRenewalDate instead of None for obtainDelegationTokens method

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
NO

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
manual test

```
23/07/13 14:17:04 DEBUG HiveDelegationTokenProvider: Get Token from hive metastore: Kind: HIVE_DELEGATION_TOKEN, Service: , Ident: 00 13 6f 63 64 70 2d 64 70 31 38 34 40 4f 43 44 50 2e 43 4f 4d 04 6f 63 64 70 13 6f 63 64 70 2d 64 70 31 38 34 40 4f 43 44 50 2e 43 4f 4d 8a 01 89 4d e5 5c 71 8a 01 89 71 f1 e0 71 8e 01 2a 3c
23/07/13 14:17:04 DEBUG HiveDelegationTokenProvider: Got Delegation token is HIVE_DELEGATION_TOKEN owner=xxx@xxxx, renewer=xxx, realUser=xxx@xxxx, issueDate=1689229024369, maxDate=1689833824369, sequenceNumber=298, masterKeyId=60
23/07/13 14:17:04 DEBUG TSaslTransport: writing data length: 188
23/07/13 14:17:04 DEBUG TSaslTransport: CLIENT: reading data length: 46
23/07/13 14:17:04 INFO HiveDelegationTokenProvider: Renewal interval is 86400179 for token HIVE_DELEGATION_TOKEN
23/07/13 14:17:04 DEBUG HiveDelegationTokenProvider: Renewal date is 1689315424548 for token HIVE_DELEGATION_TOKEN
```

