### PR TITLE
[SPARK-44391][SQL][3.4] Check the number of argument types in `InvokeLike`

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -468,6 +468,11 @@
           "The <exprName> must be between <valueRange> (current value = <currentValue>)."
         ]
       },
+      "WRONG_NUM_ARG_TYPES" : {
+        "message" : [
+          "The expression requires <expectedNum> argument types but the actual number is <actualNum>."
+        ]
+      },
       "WRONG_NUM_ENDPOINTS" : {
         "message" : [
           "The number of endpoints must be >= 2 to construct intervals but the actual number is <actualNumber>."

--- a/docs/sql-error-conditions-datatype-mismatch-error-class.md
+++ b/docs/sql-error-conditions-datatype-mismatch-error-class.md
@@ -231,6 +231,10 @@ The input of `<functionName>` can't be `<dataType>` type data.
 
 The `<exprName>` must be between `<valueRange>` (current value = `<currentValue>`).
 
+## WRONG_NUM_ARG_TYPES
+
+The expression requires `<expectedNum>` argument types but the actual number is `<actualNum>`.
+
 ## WRONG_NUM_ENDPOINTS
 
 The number of endpoints must be >= 2 to construct intervals but the actual number is `<actualNumber>`.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -288,8 +288,9 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
                 "srcType" -> c.child.dataType.catalogString,
                 "targetType" -> c.dataType.catalogString))
           case e: RuntimeReplaceable if !e.replacement.resolved =>
-            throw new IllegalStateException("Illegal RuntimeReplaceable: " + e +
-              "\nReplacement is unresolved: " + e.replacement)
+            throw SparkException.internalError(
+              s"Cannot resolve the runtime replaceable expression ${toSQLExpr(e)}. " +
+              s"The replacement is unresolved: ${toSQLExpr(e.replacement)}.")
 
           case g: Grouping =>
             g.failAnalysis(errorClass = "_LEGACY_ERROR_TEMP_2445", messageParameters = Map.empty)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/urlExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/urlExpressions.scala
@@ -57,7 +57,7 @@ case class UrlEncode(child: Expression)
       StringType,
       "encode",
       Seq(child, Literal("UTF-8")),
-      Seq(StringType))
+      Seq(StringType, StringType))
 
   override protected def withNewChildInternal(newChild: Expression): Expression = {
     copy(child = newChild)
@@ -94,7 +94,7 @@ case class UrlDecode(child: Expression)
       StringType,
       "decode",
       Seq(child, Literal("UTF-8")),
-      Seq(StringType))
+      Seq(StringType, StringType))
 
   override protected def withNewChildInternal(newChild: Expression): Expression = {
     copy(child = newChild)


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to check the number of argument types in the `InvokeLike` expressions. If the input types are provided, the number of types should be exactly the same as the number of argument expressions.

This is a backport of https://github.com/apache/spark/pull/41954.

### Why are the changes needed?
1. This PR checks the contract described in the comment explicitly:
https://github.com/apache/spark/blob/d9248e83bbb3af49333608bebe7149b1aaeca738/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala#L247 

that can prevent the errors of expression implementations, and improve code maintainability.

2. Also it fixes the issue in the `UrlEncode` and `UrlDecode`.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By running the related tests:
```
$ build/sbt "test:testOnly *UrlFunctionsSuite"
$ build/sbt "test:testOnly *DataSourceV2FunctionSuite"
```

Authored-by: Max Gekk <max.gekk@gmail.com>
(cherry picked from commit 3e82ac6ea3d9f87c8ac09e481235beefaa1bf758)