### PR TITLE
[SPARK-44406][CONNECT] Make `SparkSession.sql` work properly with dropped temp view

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -2385,15 +2385,13 @@ class SparkConnectPlanner(val sessionHolder: SessionHolder) extends Logging {
               .newBuilder()
               .setData(ByteString.copyFrom(bytes))))
     } else {
+      val relationId = s"${sessionId}_${sessionHolder.nextSQLId.getAndIncrement()}"
+      sessionHolder.cacheDataFrameById(relationId, df)
       result.setRelation(
         proto.Relation
           .newBuilder()
-          .setSql(
-            proto.SQL
-              .newBuilder()
-              .setQuery(getSqlCommand.getSql)
-              .putAllArgs(getSqlCommand.getArgsMap)
-              .addAllPosArgs(getSqlCommand.getPosArgsList)))
+          .setCachedRemoteRelation(
+            proto.CachedRemoteRelation.newBuilder().setRelationId(relationId).build()))
     }
     // Exactly one SQL Command Result Batch
     responseObserver.onNext(

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SessionHolder.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SessionHolder.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.connect.service
 import java.nio.file.Path
 import java.util.UUID
 import java.util.concurrent.{ConcurrentHashMap, ConcurrentMap}
+import java.util.concurrent.atomic.AtomicLong
 
 import scala.collection.JavaConverters._
 import scala.util.control.NonFatal
@@ -39,6 +40,9 @@ import org.apache.spark.util.Utils
  */
 case class SessionHolder(userId: String, sessionId: String, session: SparkSession)
     extends Logging {
+
+  // Counter to ensure SQL commands are unique
+  private[connect] val nextSQLId = new AtomicLong(0)
 
   val executePlanOperations: ConcurrentMap[String, ExecutePlanHolder] =
     new ConcurrentHashMap[String, ExecutePlanHolder]()

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -1233,6 +1233,15 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
         df2 = self.spark.sql("SELECT * FROM range(10) WHERE id > ?", args=[7])
         self.assert_eq(df.toPandas(), df2.toPandas())
 
+    def test_sql_with_temp_view(self):
+        df = self.connect.range(0, 10)
+        df.createOrReplaceTempView("t1")
+
+        df2 = self.connect.sql("select * from t1")
+        self.connect.catalog.dropTempView("t1")
+
+        self.assert_eq(df2.count(), 10)
+
     def test_head(self):
         # SPARK-41002: test `head` API in Python Client
         df = self.connect.read.table(self.tbl_name)


### PR DESCRIPTION
### What changes were proposed in this pull request?

`SparkSession.sql` in Connect actually only return a unresolved plan, however it may reference temp view, it should hold the analyzed plan in the server side in this case, since the temp view maybe dropped somewhere.

### Why are the changes needed?

it is a common pattern:

1. create temp views;
2. reference temp views in `SparkSession.sql` and get a result dataframe;
3. drop temp views;
4. return the dataframe;


for example:
1, in sql_formatter: https://github.com/apache/spark/blob/9aa42a970c4bd8e54603b1795a0f449bd556b11b/python/pyspark/sql/sql_formatter.py#L67-L85
2, in mllib:
https://github.com/apache/spark/blob/d679dabdd1b5ad04b8c7deb1c06ce886a154a928/mllib/src/main/scala/org/apache/spark/ml/feature/SQLTransformer.scala#L70-L75




### Does this PR introduce _any_ user-facing change?
yes

before:
```
In [1]: df = spark.range(0, 10)

In [2]: df.createOrReplaceTempView("t1")

In [3]: df2 = spark.sql("select * from t1")

In [4]: spark.catalog.dropTempView("t1")
Out[4]: True

In [5]: df2.show()
23/07/13 18:33:08 ERROR SparkConnectService: Error during: execute. UserId: ruifeng.zheng. SessionId: 3ce414b0-c99e-450d-ba11-c0f5fcb2daf3.
org.apache.spark.sql.AnalysisException: [TABLE_OR_VIEW_NOT_FOUND] The table or view `t1` cannot be found. Verify the spelling and correctness of the schema and catalog.
If you did not qualify the name with a schema, verify the current_schema() output, or qualify the name with the correct schema and catalog.
To tolerate the error on drop use DROP VIEW IF EXISTS or DROP TABLE IF EXISTS.; line 1 pos 14;
'Project [*]
+- 'UnresolvedRelation [t1], [], false
```

after:
```
In [1]: df = spark.range(0, 10)

In [2]: df.createOrReplaceTempView("t1")

In [3]: df2 = spark.sql("select * from t1")

In [4]: spark.catalog.dropTempView("t1")
Out[4]: True

In [5]: df2.show()
+---+
| id|
+---+
|  0|
|  1|
|  2|
|  3|
|  4|
|  5|
|  6|
|  7|
|  8|
|  9|
+---+
```


### How was this patch tested?
added ut