### PR TITLE
[MINOR][SS][DOCS] Fix typos in the Scaladoc and make the semantic of getCurrentWatermarkMs explicit

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/RatePerMicroBatchProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/RatePerMicroBatchProvider.scala
@@ -34,11 +34,11 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap
  *  with 0L.
  *
  *  This source supports the following options:
- *  - `rowsPerMicroBatch` (e.g. 100): How many rows should be generated per micro-batch.
+ *  - `rowsPerBatch` (e.g. 100): How many rows should be generated per micro-batch.
  *  - `numPartitions` (e.g. 10, default: Spark's default parallelism): The partition number for the
  *    generated rows.
  *  - `startTimestamp` (e.g. 1000, default: 0): starting value of generated time
- *  - `advanceMillisPerMicroBatch` (e.g. 1000, default: 1000): the amount of time being advanced in
+ *  - `advanceMillisPerBatch` (e.g. 1000, default: 1000): the amount of time being advanced in
  *    generated time on each micro-batch.
  *
  *  Unlike `rate` data source, this data source provides a consistent set of input rows per

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/GroupState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/GroupState.scala
@@ -315,6 +315,11 @@ trait GroupState[S] extends LogicalGroupState[S] {
    *
    * @note In a streaming query, this can be called only when watermark is set before calling
    *       `[map/flatMap]GroupsWithState`. In a batch query, this method always returns -1.
+   * @note The watermark gets propagated in the end of each query. As a result, this method will
+   *       return 0 (1970-01-01T00:00:00) for the first micro-batch. If you use this value
+   *       as a part of the timestamp set in the `setTimeoutTimestamp`, it may lead to the
+   *       state expiring immediately in the next micro-batch, once the watermark gets the
+   *       real value from your data.
    */
   @throws[UnsupportedOperationException](
     "if watermark has not been set before in [map|flatMap]GroupsWithState")


### PR DESCRIPTION
### What changes were proposed in this pull request?
Improve the code comments:
1. Rate micro-batch data source Scaladoc parameters aren't consistent with the options really supported by this data source.
2. The `getCurrentWatermarkMs` has a special semantic for the 1st micro-batch when the watermark is not set yet. IMO, it should return `Option[Long]`, hence `None` instead of `0` for the first micro-batch, but since it's a breaking change, I preferred to add a note on that instead.

### Why are the changes needed?
1. Avoid confusion while using the classes and methods.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
The tests weren't added because the change is only at the Scaladoc level. I affirm that the contribution is my original work and that I license the work to the project under the project's open source license.