### PR TITLE
[SPARK-44414][SQL] Fixed matching check for CharType/VarcharType

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -62,10 +62,11 @@ trait V2WriteCommand extends UnaryCommand with KeepAnalyzedQuery {
     table.skipSchemaResolution || (query.output.size == table.output.size &&
       query.output.zip(table.output).forall {
         case (inAttr, outAttr) =>
+          val inType = CharVarcharUtils.getRawType(inAttr.metadata).getOrElse(inAttr.dataType)
           val outType = CharVarcharUtils.getRawType(outAttr.metadata).getOrElse(outAttr.dataType)
           // names and types must match, nullability must be compatible
           inAttr.name == outAttr.name &&
-            DataType.equalsIgnoreCompatibleNullability(inAttr.dataType, outType) &&
+            DataType.equalsIgnoreCompatibleNullability(inType, outType) &&
             (outAttr.nullable || !inAttr.nullable)
       })
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/V2WriteAnalysisSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/V2WriteAnalysisSuite.scala
@@ -744,6 +744,46 @@ abstract class V2WriteAnalysisSuiteBase extends AnalysisTest {
     }
   }
 
+  test ("SPARK-44414: Fixed matching check for CharType/VarcharType") {
+    // check varchar type
+    val json1 = "{\"__CHAR_VARCHAR_TYPE_STRING\":\"varchar(80)\"}"
+    val metadata1 = new MetadataBuilder().withMetadata(Metadata.fromJson(json1)).build()
+
+    val query1 = TestRelation(StructType(Seq(
+      StructField("x", StringType, metadata = metadata1),
+      StructField("y", StringType, metadata = metadata1))))
+
+    val table1 = TestRelation(StructType(Seq(
+      StructField("x", StringType, metadata = metadata1),
+      StructField("y", StringType, metadata = metadata1))))
+
+    val parsedPlanByName1 = byName(table1, query1)
+    val parsedPlanByPosition1 = byPosition(table1, query1)
+    checkAnalysis(parsedPlanByName1, parsedPlanByName1)
+    assertResolved(parsedPlanByName1)
+    checkAnalysis(parsedPlanByPosition1, parsedPlanByPosition1)
+    assertResolved(parsedPlanByPosition1)
+
+    // check char type
+    val json2 = "{\"__CHAR_VARCHAR_TYPE_STRING\":\"char(80)\"}"
+    val metadata2 = new MetadataBuilder().withMetadata(Metadata.fromJson(json2)).build()
+
+    val query2 = TestRelation(StructType(Seq(
+      StructField("x", StringType, metadata = metadata2),
+      StructField("y", StringType, metadata = metadata2))))
+
+    val table2 = TestRelation(StructType(Seq(
+      StructField("x", StringType, metadata = metadata2),
+      StructField("y", StringType, metadata = metadata2))))
+
+    val parsedPlanByName2 = byName(table2, query2)
+    val parsedPlanByPosition2 = byPosition(table2, query2)
+    checkAnalysis(parsedPlanByName2, parsedPlanByName2)
+    assertResolved(parsedPlanByName2)
+    checkAnalysis(parsedPlanByPosition2, parsedPlanByPosition2)
+    assertResolved(parsedPlanByPosition2)
+  }
+
   test("SPARK-42997: extra fields in nested struct (byName)") {
     checkExtraFieldsInNestedStruct(byNameResolution = true)
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/V2WriteAnalysisSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/V2WriteAnalysisSuite.scala
@@ -745,43 +745,26 @@ abstract class V2WriteAnalysisSuiteBase extends AnalysisTest {
   }
 
   test ("SPARK-44414: Fixed matching check for CharType/VarcharType") {
-    // check varchar type
-    val json1 = "{\"__CHAR_VARCHAR_TYPE_STRING\":\"varchar(80)\"}"
-    val metadata1 = new MetadataBuilder().withMetadata(Metadata.fromJson(json1)).build()
 
-    val query1 = TestRelation(StructType(Seq(
-      StructField("x", StringType, metadata = metadata1),
-      StructField("y", StringType, metadata = metadata1))))
+    Seq("{\"__CHAR_VARCHAR_TYPE_STRING\":\"varchar(80)\"}",
+      "{\"__CHAR_VARCHAR_TYPE_STRING\":\"char(80)\"}").foreach(json => {
+      val metadata = new MetadataBuilder().withMetadata(Metadata.fromJson(json)).build()
 
-    val table1 = TestRelation(StructType(Seq(
-      StructField("x", StringType, metadata = metadata1),
-      StructField("y", StringType, metadata = metadata1))))
+      val query = TestRelation(StructType(Seq(
+        StructField("x", StringType, metadata = metadata),
+        StructField("y", StringType, metadata = metadata))))
 
-    val parsedPlanByName1 = byName(table1, query1)
-    val parsedPlanByPosition1 = byPosition(table1, query1)
-    checkAnalysis(parsedPlanByName1, parsedPlanByName1)
-    assertResolved(parsedPlanByName1)
-    checkAnalysis(parsedPlanByPosition1, parsedPlanByPosition1)
-    assertResolved(parsedPlanByPosition1)
+      val table = TestRelation(StructType(Seq(
+        StructField("x", StringType, metadata = metadata),
+        StructField("y", StringType, metadata = metadata))))
 
-    // check char type
-    val json2 = "{\"__CHAR_VARCHAR_TYPE_STRING\":\"char(80)\"}"
-    val metadata2 = new MetadataBuilder().withMetadata(Metadata.fromJson(json2)).build()
-
-    val query2 = TestRelation(StructType(Seq(
-      StructField("x", StringType, metadata = metadata2),
-      StructField("y", StringType, metadata = metadata2))))
-
-    val table2 = TestRelation(StructType(Seq(
-      StructField("x", StringType, metadata = metadata2),
-      StructField("y", StringType, metadata = metadata2))))
-
-    val parsedPlanByName2 = byName(table2, query2)
-    val parsedPlanByPosition2 = byPosition(table2, query2)
-    checkAnalysis(parsedPlanByName2, parsedPlanByName2)
-    assertResolved(parsedPlanByName2)
-    checkAnalysis(parsedPlanByPosition2, parsedPlanByPosition2)
-    assertResolved(parsedPlanByPosition2)
+      val parsedPlanByName = byName(table, query)
+      val parsedPlanByPosition = byPosition(table, query)
+      checkAnalysis(parsedPlanByName, parsedPlanByName)
+      assertResolved(parsedPlanByName)
+      checkAnalysis(parsedPlanByPosition, parsedPlanByPosition)
+      assertResolved(parsedPlanByPosition)
+    })
   }
 
   test("SPARK-42997: extra fields in nested struct (byName)") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
The input/output Attribute is preferred for validation using the `__CHAR_VARCHAR_TYPE_STRING` type specified in its Metadata.
If not specified, use the Attribute datatype again.


### Why are the changes needed?
If the input/output Attribute specifies a `__CHAR_VARCHAR_TYPE_STRING` tag in its Metadata, then the type specified by `__CHAR_VARCHAR_TYPE_STRING` should be used for validation.
Otherwise, use the Attribute DataType for verification  to avoid the following exception：
```
org.apache.spark.sql.AnalysisException: unresolved operator 'AppendData TestRelation [x#8, y#9], true;
'AppendData TestRelation [x#8, y#9], true
+- TestRelation [x#6, y#7] 
```

How to reproduce？
```
val analyzer = getAnalyzer
// check varchar type
val json1 = "{\"__CHAR_VARCHAR_TYPE_STRING\":\"varchar(80)\"}"
val metadata1 = new MetadataBuilder().withMetadata(Metadata.fromJson(json1)).build()

val query1 = TestRelation(StructType(Seq(
StructField("x", StringType, metadata = metadata1),
StructField("y", StringType, metadata = metadata1))).toAttributes)

val table1 = TestRelation(StructType(Seq(
StructField("x", StringType, metadata = metadata1),
StructField("y", StringType, metadata = metadata1))).toAttributes)

val parsedPlanByName1 = byName(table1, query1)
analyzer.executeAndCheck(parsedPlanByName1, new QueryPlanningTracker()) 
```


### Does this PR introduce _any_ user-facing change?
Yes. The above code works fine.


### How was this patch tested?
new UT