### PR TITLE
[SPARK-44415][BUILD] Upgrade snappy-java to 1.1.10.2

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -234,7 +234,7 @@ shims/0.9.45//shims-0.9.45.jar
 slf4j-api/2.0.7//slf4j-api-2.0.7.jar
 snakeyaml-engine/2.6//snakeyaml-engine-2.6.jar
 snakeyaml/2.0//snakeyaml-2.0.jar
-snappy-java/1.1.10.1//snappy-java-1.1.10.1.jar
+snappy-java/1.1.10.2//snappy-java-1.1.10.2.jar
 spire-macros_2.12/0.17.0//spire-macros_2.12-0.17.0.jar
 spire-platform_2.12/0.17.0//spire-platform_2.12-0.17.0.jar
 spire-util_2.12/0.17.0//spire-util_2.12-0.17.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -182,7 +182,7 @@
     <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
     <fasterxml.jackson.version>2.15.2</fasterxml.jackson.version>
     <fasterxml.jackson.databind.version>2.15.2</fasterxml.jackson.databind.version>
-    <snappy.version>1.1.10.1</snappy.version>
+    <snappy.version>1.1.10.2</snappy.version>
     <netlib.ludovic.dev.version>3.0.3</netlib.ludovic.dev.version>
     <commons-codec.version>1.16.0</commons-codec.version>
     <commons-compress.version>1.23.0</commons-compress.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR upgrades snappy-java to 1.1.10.2. snappy-java 1.1.10.2 includes the following changes:

https://github.com/xerial/snappy-java/releases/tag/v1.1.10.2

### Why are the changes needed?

It seem the 1.1.10.1's libsnappy.so fails to uncompress on s390x.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests.
