### PR TITLE
[SPARK-44419][SQL] Support to extract partial filters of datasource v2 table and push them down

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryBaseTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryBaseTable.scala
@@ -311,7 +311,8 @@ abstract class InMemoryBaseTable(
     private var _pushedFilters: Array[Filter] = Array.empty
 
     override def build: Scan = {
-      val scan = InMemoryBatchScan(data.map(_.asInstanceOf[InputPartition]), schema, tableSchema)
+      val scan = new AdvancedBatchScanWithFilter(data.map(_.asInstanceOf[InputPartition]),
+        schema, tableSchema, _pushedFilters)
       if (evaluableFilters.nonEmpty) {
         scan.filter(evaluableFilters)
       }
@@ -465,6 +466,17 @@ abstract class InMemoryBaseTable(
         }
       }
     }
+  }
+
+  class AdvancedBatchScanWithFilter(data: Array[InputPartition],
+                                readSchema: StructType,
+                                tableSchema: StructType,
+                                filters: Array[Filter])
+    extends InMemoryBatchScan(data: Array[InputPartition],
+      readSchema: StructType,
+      tableSchema: StructType) {
+
+    def pushedFilters(): Array[Filter] = filters
   }
 
   abstract class InMemoryWriterBuilder() extends SupportsTruncate with SupportsDynamicOverwrite

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -3296,7 +3296,7 @@ class DataSourceV2SQLSuiteV1Filter
     }
   }
 
-  test("Support to extract partial filters of datasource v2 table and push them down") {
+  test("SPARK-44419: Support to extract partial filters of datasource v2 table and push them down") {
     val t1 = s"${catalogAndNamespace}table"
     withUserDefinedFunction("udfStrLen" -> true) {
       withTable(t1) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -40,12 +40,13 @@ import org.apache.spark.sql.errors.QueryErrorsBase
 import org.apache.spark.sql.execution.FilterExec
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.execution.columnar.InMemoryRelation
+import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2ScanRelation
 import org.apache.spark.sql.execution.streaming.MemoryStream
 import org.apache.spark.sql.internal.{SQLConf, StaticSQLConf}
 import org.apache.spark.sql.internal.SQLConf.{PARTITION_OVERWRITE_MODE, PartitionOverwriteMode, V2_SESSION_CATALOG_IMPLEMENTATION}
 import org.apache.spark.sql.internal.connector.SimpleTableProvider
-import org.apache.spark.sql.sources.SimpleScanSource
+import org.apache.spark.sql.sources.{EqualTo, IsNotNull, Not, Or, SimpleScanSource}
 import org.apache.spark.sql.types.{LongType, StringType, StructType}
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.unsafe.types.UTF8String
@@ -3291,6 +3292,189 @@ class DataSourceV2SQLSuiteV1Filter
           && expressionsAfter(0).toString.trim.startsWith("isnotnull(id")
           && expressionsAfter(1).toString.trim.startsWith("(id")
           && expressionsAfter(2).toString.trim.startsWith("(udfStrLen(data"))
+      }
+    }
+  }
+
+  test("Support to extract partial filters of datasource v2 table and push them down") {
+    val t1 = s"${catalogAndNamespace}table"
+    withUserDefinedFunction("udfStrLen" -> true) {
+      withTable(t1) {
+        spark.udf.register("udfStrLen", (str: String) => str.length)
+        sql(s"CREATE TABLE $t1 (id bigint, data string, date int) USING $v2Format")
+        sql(s"""
+               |INSERT INTO $t1 VALUES (1, 'a', 20221110), (2, 'b', 20221110), (3, 'c', 20221110),
+               |(4, 'a', 20221111), (5, 'a', 20221111), (6, 'aa', 20221111), (7, 'bb', 20221111),
+               |(8, 'a', 20221112), (9, 'a', 20221112), (10, 'b', 20221112)
+               |""".stripMargin)
+
+        val df = spark.sql(
+          s"""
+             |SELECT id, data FROM $t1
+             |where (date = 20221110 or (udfStrLen(data) = 1 and date = 20221111))
+             |""".stripMargin
+        )
+        df.queryExecution.executedPlan.collect {
+          case d: BatchScanExec =>
+            assert(
+              d.scan.asInstanceOf[InMemoryTable#AdvancedBatchScanWithFilter]
+                .pushedFilters() === Array(Or(EqualTo("date", 20221110), EqualTo("date", 20221111)))
+            )
+          case _ =>
+        }
+        assert(df.count() == 5)
+
+        val df1 = spark.sql(
+          s"""
+             |SELECT id, data, date FROM $t1
+             |where (date = 20221110 or (udfStrLen(date) = 8 and data = 'a'))
+             |""".stripMargin
+        )
+        df1.queryExecution.executedPlan.collect {
+          case d: BatchScanExec =>
+            assert(
+              d.scan.asInstanceOf[InMemoryTable#AdvancedBatchScanWithFilter]
+                .pushedFilters() === Array(Or(EqualTo("date", 20221110), EqualTo("data", "a")))
+            )
+          case _ =>
+        }
+        assert(df1.count() == 7)
+
+        val df2 = spark.sql(
+          s"""
+             |SELECT id, data, date FROM $t1
+             |where (date = 20221110 or (udfStrLen(date) = 8 and date = 20221111))
+             |""".stripMargin
+        )
+        df2.queryExecution.executedPlan.collect {
+          case d: BatchScanExec =>
+            assert(
+              d.scan.asInstanceOf[InMemoryTable#AdvancedBatchScanWithFilter]
+                .pushedFilters() === Array(Or(EqualTo("date", 20221110), EqualTo("date", 20221111)))
+            )
+          case _ =>
+        }
+        assert(df2.count() == 7)
+
+        val df3 = spark.sql(
+          s"""
+             |SELECT id, data, date FROM $t1
+             |where (date = 20221110 or (udfStrLen(date) = 8 and udfStrLen(data) = 1))
+             |""".stripMargin
+        )
+        df3.queryExecution.executedPlan.collect {
+          case d: BatchScanExec =>
+            assert(
+              d.scan.asInstanceOf[InMemoryTable#AdvancedBatchScanWithFilter]
+                .pushedFilters() === Array()
+            )
+          case _ =>
+        }
+        assert(df3.count() == 8)
+
+        val df4 = spark.sql(
+          s"""
+             |SELECT id, data, date FROM $t1
+             |where (date = 20221110 or udfStrLen(date) = 8) and data = 'a'
+             |""".stripMargin
+        )
+        df4.queryExecution.executedPlan.collect {
+          case d: BatchScanExec =>
+            assert(
+              d.scan.asInstanceOf[InMemoryTable#AdvancedBatchScanWithFilter]
+                .pushedFilters() === Array(IsNotNull("data"), EqualTo("data", "a"))
+            )
+          case _ =>
+        }
+        assert(df4.count() == 5)
+
+        // expression: !((date = 20221110 or udfStrLen(date) = 8) and data = 'a')
+        // will be parse to
+        // Not(date = 20221110)
+        // and
+        // (Not(udfStrLen(cast(date as string)) = 8) or Not(data = 'a'))
+        val df5 = spark.sql(
+          s"""
+             |SELECT id, data, date FROM $t1
+             |where !((date = 20221110 or udfStrLen(date) = 8) and data = 'a')
+             |and ((data = 'b' or udfStrLen(date) = 9) or (data = 'c' and udfStrLen(date) = 10))
+             |""".stripMargin
+        )
+        df5.queryExecution.executedPlan.collect {
+          case d: BatchScanExec =>
+            assert(
+              d.scan.asInstanceOf[InMemoryTable#AdvancedBatchScanWithFilter]
+                .pushedFilters() === Array(
+                Or(Not(EqualTo("date", 20221110)), Not(EqualTo("data", "a"))))
+            )
+          case _ =>
+        }
+        assert(df5.count() == 2)
+
+        // expression: !(date = 20221110 or udfStrLen(date) = 8 and data = 'a')
+        // will be parse to
+        // Not(date = 20221110)
+        // and
+        // (Not(udfStrLen(cast(date as string)) = 8) or Not(data = 'a'))
+        val df6 = spark.sql(
+          s"""
+             |SELECT id, data, date FROM $t1
+             |where !(date = 20221110 or udfStrLen(date) = 8 and data = 'a')
+             |and ((data = 'b' or udfStrLen(date) = 9) and (data = 'c' or udfStrLen(date) = 10))
+             |""".stripMargin
+        )
+        df6.queryExecution.executedPlan.collect {
+          case d: BatchScanExec =>
+            assert(
+              d.scan.asInstanceOf[InMemoryTable#AdvancedBatchScanWithFilter]
+                .pushedFilters() === Array(IsNotNull("date"), Not(EqualTo("date", 20221110)))
+            )
+          case _ =>
+        }
+        assert(df6.count() == 0)
+
+        // expression: date = 20221110 or udfStrLen(date) = 8 and data = 'a'
+        // will be parse to
+        // (
+        // (date = 20221110)
+        // or
+        // (udfStrLen(cast(date as string)) = 8 and data = 'a'))
+        val df7 = spark.sql(
+          s"""
+             |SELECT id, data, date FROM $t1
+             |where date = 20221110 or udfStrLen(date) = 8 and data = 'a'
+             |""".stripMargin
+        )
+        df7.queryExecution.executedPlan.collect {
+          case d: BatchScanExec =>
+            assert(
+              d.scan.asInstanceOf[InMemoryTable#AdvancedBatchScanWithFilter]
+                .pushedFilters() === Array(Or(EqualTo("date", 20221110), EqualTo("data", "a")))
+            )
+          case _ =>
+        }
+        assert(df7.count() == 7)
+
+        // expression: !(date = 20221110 or udfStrLen(date) = 8 and data = 'a')
+        // will be parse to
+        // Not(date = 20221110)
+        // and
+        // (Not(udfStrLen(cast(date as string)) = 8) or Not(data = 'a'))
+        val df8 = spark.sql(
+          s"""
+             |SELECT id, data, date FROM $t1
+             |where !(date = 20221110 or udfStrLen(date) = 8 and data = 'a')
+             |""".stripMargin
+        )
+        df8.queryExecution.executedPlan.collect {
+          case d: BatchScanExec =>
+            assert(
+              d.scan.asInstanceOf[InMemoryTable#AdvancedBatchScanWithFilter]
+                .pushedFilters() === Array(IsNotNull("date"), Not(EqualTo("date", 20221110)))
+            )
+          case _ =>
+        }
+        assert(df8.count() == 3)
       }
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
For this query
```
explain select * from iceberg_xxx.tmp.xxx_tst_pat 
where date = 20221011 or (date = 20221012 and char_length(col2)=8)
```

Before Optimization，no predicates were pushed down.
![image](https://github.com/apache/spark/assets/94670132/8d6f4df3-e977-4535-b4f4-758726f9795a)

After Optimization, `(date = 20221011 OR date = 20221012)` was pushed down.
![image](https://github.com/apache/spark/assets/94670132/54d938b9-668c-4dc6-ab83-a078d27d3934)


### Why are the changes needed?
Performance optimization.
Avoid full table scanning.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
New UT.
