### PR TITLE
[SPARK-44426][SQL] Optimize adaptive skew join for ExistenceJoin

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeSkewedJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeSkewedJoin.scala
@@ -84,7 +84,7 @@ case class OptimizeSkewedJoin(ensureRequirements: EnsureRequirements)
 
   private def canSplitLeftSide(joinType: JoinType) = {
     joinType == Inner || joinType == Cross || joinType == LeftSemi ||
-      joinType == LeftAnti || joinType == LeftOuter
+      joinType == LeftAnti || joinType == LeftOuter || joinType.isInstanceOf[ExistenceJoin]
   }
 
   private def canSplitRightSide(joinType: JoinType) = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Supports automatic processing of data skews of the ExistenceJoin type, and only for left-table skews.


### Why are the changes needed?
Automatic processing of data skews of the ExistenceJoin type is not currently supported and if data skew occurs, the application executes very slowly.
![image](https://github.com/apache/spark/assets/94670132/ff200720-ae50-42dd-8f47-270aae21393a)



### Does this PR introduce _any_ user-facing change?
Yes. It will automatically handle data skew in the left table.

### How was this patch tested?
New UT.