### PR TITLE
[SPARK-44429][SQL][TESTS] Make `MsSqlServerIntegrationSuite` robust in ANSI mode

### DIFF
--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MsSqlServerIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MsSqlServerIntegrationSuite.scala
@@ -372,7 +372,7 @@ class MsSqlServerIntegrationSuite extends DockerJDBCIntegrationSuite {
     val df = spark.read.jdbc(jdbcUrl, "bits", new Properties)
     val rows = df.collect()
     assert(rows.length == 1)
-    val filtered = df.where(col("c") === 0).collect()
+    val filtered = df.where(!col("c")).collect()
     assert(filtered.length == 0)
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR changes the filter condition from `col("c") === 0` to `!col("c")` in `MsSqlServerIntegrationSuite` to avoid `AnalysisException` when ANSI is enabled by default. The root cause is that `AnsiTypeCoercion` does not contain [`BooleanEquality`](https://github.com/apache/spark/blob/618b52097c07105d734aaf9b2a22b372920b3f31/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala#L842).

### Why are the changes needed?

Make `MsSqlServerIntegrationSuite` robust in ANSI mode. This test has nothing to do with whether ANSI is enabled or not.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

N/A.