### PR TITLE
[SPARK-44430][SQL] Add cause to `AnalysisException` when option is invalid

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveTableSpec.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveTableSpec.scala
@@ -71,8 +71,8 @@ object ResolveTableSpec extends Rule[LogicalPlan] {
                 Literal(result, dt).toString
             }
           } catch {
-            case _: SparkThrowable | _: java.lang.RuntimeException =>
-              throw QueryCompilationErrors.optionMustBeConstant(key)
+            case e @ (_: SparkThrowable | _: java.lang.RuntimeException) =>
+              throw QueryCompilationErrors.optionMustBeConstant(key, Some(e))
           }
           (key, newValue)
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds cause to `AnalysisException` when option is invalid.

### Why are the changes needed?

Makes it easy to locate the incorrect options.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit test.