### PR TITLE
[SPARK-44438][SS] Shutdown scheduled executor used for maintenance task if an error is reported

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
@@ -579,10 +579,12 @@ object StateStore extends Logging {
     loadedProviders.contains(storeProviderId)
   }
 
+  /** Check if maintenance thread is running and scheduled future is not done */
   def isMaintenanceRunning: Boolean = loadedProviders.synchronized {
     maintenanceTask != null && maintenanceTask.isRunning
   }
 
+  /** Stop maintenance thread and reset the maintenance task */
   def stopMaintenanceTask(): Unit = loadedProviders.synchronized {
     if (maintenanceTask != null) {
       maintenanceTask.stop()

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
@@ -1314,7 +1314,7 @@ abstract class StateStoreSuiteBase[ProviderClass <: StateStoreProvider]
     )
     // Make maintenance interval small so that maintenance task is called right after scheduling.
     sqlConf.setConf(SQLConf.STREAMING_MAINTENANCE_INTERVAL, 100L)
-    // Use the `FakeStateStoreProviderWithMaintenance` to run the test
+    // Use the `FakeStateStoreProviderWithMaintenanceError` to run the test
     sqlConf.setConf(SQLConf.STATE_STORE_PROVIDER_CLASS,
       classOf[FakeStateStoreProviderWithMaintenanceError].getName)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Shutdown scheduled executor used for maintenance task if an error is reported

### Why are the changes needed?
Without this change, we basically would never clean up the maintenance task threads and the pointer is lost too, so we have no way to shutdown this scheduled executor which could eventually lead to thread exhaustion. The change here fixes this issue.



### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Added unit tests

```
[info] - SPARK-44438: maintenance task should be shutdown on error (759 milliseconds)
13:59:57.755 WARN org.apache.spark.sql.execution.streaming.state.StateStoreSuite:

===== POSSIBLE THREAD LEAK IN SUITE o.a.s.sql.execution.streaming.state.StateStoreSuite, threads: rpc-boss-3-1 (daemon=true), shuffle-boss-6-1 (daemon=true) =====
[info] Run completed in 2 seconds, 255 milliseconds.
[info] Total number of tests run: 1
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 1, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
```
