### PR TITLE
[SPARK-44441][BUILD] Upgrade `bcprov-jdk15on` and `bcpkix-jdk15on` to 1.70

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -214,7 +214,7 @@
     <maven-antrun.version>3.1.0</maven-antrun.version>
     <commons-crypto.version>1.1.0</commons-crypto.version>
     <commons-cli.version>1.5.0</commons-cli.version>
-    <bouncycastle.version>1.60</bouncycastle.version>
+    <bouncycastle.version>1.70</bouncycastle.version>
     <tink.version>1.9.0</tink.version>
     <!--
       Please don't upgrade the version to 4.1.94.Final,


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to upgrade `bcprov-jdk15on` and `bcpkix-jdk15on`  from 1.60 to 1.70

### Why are the changes needed?
The new version fixed [CVE-2020-15522](https://github.com/bcgit/bc-java/wiki/CVE-2020-15522).

The release notes as follows:
- https://www.bouncycastle.org/releasenotes.html#r1rv70


### Does this PR introduce _any_ user-facing change?
No, just upgrade test dependency


### How was this patch tested?
Pass Git Hub Actions