### PR TITLE
[SPARK-43418][CONNECT][FOLLOWUP] Remove the deprecation warning in `SparkSession.Builder.build`

### DIFF
--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -718,7 +718,6 @@ object SparkSession extends Logging {
      *
      * This will always return a newly created session.
      */
-    @deprecated(message = "Please use create() instead.", since = "3.5.0")
     def build(): SparkSession = create()
 
     /**


### PR DESCRIPTION
### What changes were proposed in this pull request?
Remove the deprecation warning in `SparkSession.Builder.build`


### Why are the changes needed?
this method was added in 3.4, now it is an alias for newly added method `create`.
This warning is not necessary.

### Does this PR introduce _any_ user-facing change?
yes, remove a warning


### How was this patch tested?
existing CI