### PR TITLE
[SPARK-44361][SQL] Use PartitionEvaluator API in MapInBatchExec

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/RDDBarrier.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDDBarrier.scala
@@ -19,8 +19,8 @@ package org.apache.spark.rdd
 
 import scala.reflect.ClassTag
 
-import org.apache.spark.TaskContext
-import org.apache.spark.annotation.{Experimental, Since}
+import org.apache.spark.{PartitionEvaluatorFactory, TaskContext}
+import org.apache.spark.annotation.{DeveloperApi, Experimental, Since}
 
 /**
  * :: Experimental ::
@@ -76,5 +76,16 @@ class RDDBarrier[T: ClassTag] private[spark] (rdd: RDD[T]) {
     )
   }
 
+  /**
+   * Return a new RDD by applying an evaluator to each partition of the wrapped RDD. The given
+   * evaluator factory will be serialized and sent to executors, and each task will create an
+   * evaluator with the factory, and use the evaluator to transform the data of the input partition.
+   */
+  @DeveloperApi
+  @Since("3.5.0")
+  def mapPartitionsWithEvaluator[U: ClassTag](
+         evaluatorFactory: PartitionEvaluatorFactory[T, U]): RDD[U] = rdd.withScope {
+    new MapPartitionsWithEvaluatorRDD(rdd, evaluatorFactory)
+  }
   // TODO: [SPARK-25247] add extra conf to RDDBarrier, e.g., timeout.
 }

--- a/core/src/main/scala/org/apache/spark/rdd/RDDBarrier.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDDBarrier.scala
@@ -79,12 +79,13 @@ class RDDBarrier[T: ClassTag] private[spark] (rdd: RDD[T]) {
   /**
    * Return a new RDD by applying an evaluator to each partition of the wrapped RDD. The given
    * evaluator factory will be serialized and sent to executors, and each task will create an
-   * evaluator with the factory, and use the evaluator to transform the data of the input partition.
+   * evaluator with the factory, and use the evaluator to transform the data of the input
+   * partition.
    */
   @DeveloperApi
   @Since("3.5.0")
   def mapPartitionsWithEvaluator[U: ClassTag](
-         evaluatorFactory: PartitionEvaluatorFactory[T, U]): RDD[U] = rdd.withScope {
+      evaluatorFactory: PartitionEvaluatorFactory[T, U]): RDD[U] = rdd.withScope {
     new MapPartitionsWithEvaluatorRDD(rdd, evaluatorFactory)
   }
   // TODO: [SPARK-25247] add extra conf to RDDBarrier, e.g., timeout.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/MapInBatchEvaluatorFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/MapInBatchEvaluatorFactory.scala
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.python
+
+import scala.collection.JavaConverters._
+
+import org.apache.spark.{ContextAwareIterator, TaskContext}
+import org.apache.spark.{PartitionEvaluator, PartitionEvaluatorFactory}
+import org.apache.spark.api.python.{ChainedPythonFunctions}
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.execution.metric.SQLMetric
+import org.apache.spark.sql.types.{StructField, StructType}
+import org.apache.spark.sql.vectorized.{ArrowColumnVector, ColumnarBatch}
+
+class MapInBatchEvaluatorFactory(
+                                  output: Seq[Attribute],
+                                  chainedFunc: Seq[ChainedPythonFunctions],
+                                  outputTypes: StructType,
+                                  batchSize: Int,
+                                  pythonEvalType: Int,
+                                  sessionLocalTimeZone: String,
+                                  largeVarTypes: Boolean,
+                                  pythonRunnerConf: Map[String, String],
+                                  pythonMetrics: Map[String, SQLMetric],
+                                  jobArtifactUUID: Option[String]
+                                )
+  extends PartitionEvaluatorFactory[InternalRow, InternalRow] {
+  override def createEvaluator(): PartitionEvaluator[InternalRow, InternalRow] =
+    new MapInBatchEvaluator
+
+  private class MapInBatchEvaluator extends PartitionEvaluator[InternalRow, InternalRow] {
+    override def eval(
+           partitionIndex: Int, inputs: Iterator[InternalRow]*): Iterator[InternalRow] = {
+      assert(inputs.length == 1)
+      val inputIter = inputs.head
+      // Single function with one struct.
+      val argOffsets = Array(Array(0))
+      val context = TaskContext.get()
+      val contextAwareIterator = new ContextAwareIterator(context, inputIter)
+
+      // Here we wrap it via another row so that Python sides understand it
+      // as a DataFrame.
+      val wrappedIter = contextAwareIterator.map(InternalRow(_))
+
+      // DO NOT use iter.grouped(). See BatchIterator.
+      val batchIter =
+        if (batchSize > 0) new BatchIterator(wrappedIter, batchSize) else Iterator(wrappedIter)
+
+      val columnarBatchIter = new ArrowPythonRunner(
+        chainedFunc,
+        pythonEvalType,
+        argOffsets,
+        StructType(Array(StructField("struct", outputTypes))),
+        sessionLocalTimeZone,
+        largeVarTypes,
+        pythonRunnerConf,
+        pythonMetrics,
+        jobArtifactUUID).compute(batchIter, context.partitionId(), context)
+
+      val unsafeProj = UnsafeProjection.create(output, output)
+
+      columnarBatchIter.flatMap { batch =>
+        // Scalar Iterator UDF returns a StructType column in ColumnarBatch, select
+        // the children here
+        val structVector = batch.column(0).asInstanceOf[ArrowColumnVector]
+        val outputVectors = output.indices.map(structVector.getChild)
+        val flattenedBatch = new ColumnarBatch(outputVectors.toArray)
+        flattenedBatch.setNumRows(batch.numRows())
+        flattenedBatch.rowIterator.asScala
+      }.map(unsafeProj)
+    }
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/MapInBatchExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/MapInBatchExec.scala
@@ -17,18 +17,14 @@
 
 package org.apache.spark.sql.execution.python
 
-import scala.collection.JavaConverters._
-
-import org.apache.spark.{ContextAwareIterator, JobArtifactSet, TaskContext}
+import org.apache.spark.JobArtifactSet
 import org.apache.spark.api.python.ChainedPythonFunctions
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.physical._
 import org.apache.spark.sql.execution.UnaryExecNode
-import org.apache.spark.sql.types.{StructField, StructType}
 import org.apache.spark.sql.util.ArrowUtils
-import org.apache.spark.sql.vectorized.{ArrowColumnVector, ColumnarBatch}
 
 /**
  * A relation produced by applying a function that takes an iterator of batches
@@ -56,53 +52,37 @@ trait MapInBatchExec extends UnaryExecNode with PythonSQLMetrics {
   override def outputPartitioning: Partitioning = child.outputPartitioning
 
   override protected def doExecute(): RDD[InternalRow] = {
-    def mapper(inputIter: Iterator[InternalRow]): Iterator[InternalRow] = {
-      // Single function with one struct.
-      val argOffsets = Array(Array(0))
-      val chainedFunc = Seq(ChainedPythonFunctions(Seq(pythonFunction)))
-      val sessionLocalTimeZone = conf.sessionLocalTimeZone
-      val pythonRunnerConf = ArrowUtils.getPythonRunnerConfMap(conf)
-      val outputTypes = child.schema
-
-      val context = TaskContext.get()
-      val contextAwareIterator = new ContextAwareIterator(context, inputIter)
-
-      // Here we wrap it via another row so that Python sides understand it
-      // as a DataFrame.
-      val wrappedIter = contextAwareIterator.map(InternalRow(_))
-
-      // DO NOT use iter.grouped(). See BatchIterator.
-      val batchIter =
-        if (batchSize > 0) new BatchIterator(wrappedIter, batchSize) else Iterator(wrappedIter)
-
-      val columnarBatchIter = new ArrowPythonRunner(
-        chainedFunc,
-        pythonEvalType,
-        argOffsets,
-        StructType(Array(StructField("struct", outputTypes))),
-        sessionLocalTimeZone,
-        largeVarTypes,
-        pythonRunnerConf,
-        pythonMetrics,
-        jobArtifactUUID).compute(batchIter, context.partitionId(), context)
-
-      val unsafeProj = UnsafeProjection.create(output, output)
-
-      columnarBatchIter.flatMap { batch =>
-        // Scalar Iterator UDF returns a StructType column in ColumnarBatch, select
-        // the children here
-        val structVector = batch.column(0).asInstanceOf[ArrowColumnVector]
-        val outputVectors = output.indices.map(structVector.getChild)
-        val flattenedBatch = new ColumnarBatch(outputVectors.toArray)
-        flattenedBatch.setNumRows(batch.numRows())
-        flattenedBatch.rowIterator.asScala
-      }.map(unsafeProj)
-    }
+    val pythonRunnerConf = ArrowUtils.getPythonRunnerConfMap(conf)
+    val pythonFunction = func.asInstanceOf[PythonUDF].func
+    val chainedFunc = Seq(ChainedPythonFunctions(Seq(pythonFunction)))
+    val evaluatorFactory = new MapInBatchEvaluatorFactory(
+      output,
+      chainedFunc,
+      child.schema,
+      conf.arrowMaxRecordsPerBatch,
+      pythonEvalType,
+      conf.sessionLocalTimeZone,
+      conf.arrowUseLargeVarTypes,
+      pythonRunnerConf,
+      pythonMetrics,
+      jobArtifactUUID)
 
     if (isBarrier) {
-      child.execute().barrier().mapPartitions(mapper)
+      if (conf.usePartitionEvaluator) {
+        child.execute().barrier().mapPartitionsWithEvaluator(evaluatorFactory)
+      } else {
+        child.execute().barrier().mapPartitions { iter =>
+          evaluatorFactory.createEvaluator().eval(0, iter)
+        }
+      }
     } else {
-      child.execute().mapPartitionsInternal(mapper)
+      if (conf.usePartitionEvaluator) {
+        child.execute().mapPartitionsWithEvaluator(evaluatorFactory)
+      } else {
+        child.execute().mapPartitionsInternal { iter =>
+          evaluatorFactory.createEvaluator().eval(0, iter)
+        }
+      }
     }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/MapInBatchExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/MapInBatchExec.scala
@@ -68,18 +68,20 @@ trait MapInBatchExec extends UnaryExecNode with PythonSQLMetrics {
       jobArtifactUUID)
 
     if (isBarrier) {
+      val rddBarrier = child.execute().barrier()
       if (conf.usePartitionEvaluator) {
-        child.execute().barrier().mapPartitionsWithEvaluator(evaluatorFactory)
+        rddBarrier.mapPartitionsWithEvaluator(evaluatorFactory)
       } else {
-        child.execute().barrier().mapPartitions { iter =>
+        rddBarrier.mapPartitions { iter =>
           evaluatorFactory.createEvaluator().eval(0, iter)
         }
       }
     } else {
+      val inputRdd = child.execute()
       if (conf.usePartitionEvaluator) {
-        child.execute().mapPartitionsWithEvaluator(evaluatorFactory)
+        inputRdd.mapPartitionsWithEvaluator(evaluatorFactory)
       } else {
-        child.execute().mapPartitionsInternal { iter =>
+        inputRdd.mapPartitionsInternal { iter =>
           evaluatorFactory.createEvaluator().eval(0, iter)
         }
       }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
SQL operator `MapInBatchExec` is updated to use the `PartitionEvaluator` API to do execution.
Added a new method `mapPartitionsWithEvaluator` in `RDDBarrier`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To avoid the use of lambda during distributed execution.
Ref: SPARK-43061 for more details.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Existing test cases. Once all SQL operators are refactored, will enable `spark.sql.execution.usePartitionEvaluator` by default, so all tests cover this code path.