### PR TITLE
[SPARK-44413][PYTHON] Clarify error for unsupported arg data type in assertDataFrameEqual

### DIFF
--- a/python/pyspark/errors/error_classes.py
+++ b/python/pyspark/errors/error_classes.py
@@ -258,14 +258,14 @@ ERROR_CLASSES_JSON = """
       "Argument `<arg_name>` should not be a <data_type>."
     ]
   },
-  "INVALID_TYPE_DF_EQUALITY_ARG" : {
-    "message" : [
-      "Expected type <expected_type> for `<arg_name>` but got type <actual_type>."
-    ]
-  },
   "INVALID_TYPENAME_CALL" : {
     "message" : [
       "StructField does not have typeName. Use typeName on its type explicitly instead."
+    ]
+  },
+  "INVALID_TYPE_DF_EQUALITY_ARG" : {
+    "message" : [
+      "Expected type <expected_type> for `<arg_name>` but got type <actual_type>."
     ]
   },
   "INVALID_UDF_EVAL_TYPE" : {

--- a/python/pyspark/errors/error_classes.py
+++ b/python/pyspark/errors/error_classes.py
@@ -258,6 +258,11 @@ ERROR_CLASSES_JSON = """
       "Argument `<arg_name>` should not be a <data_type>."
     ]
   },
+  "INVALID_TYPE_DF_EQUALITY_ARG" : {
+    "message" : [
+      "Expected type <expected_type> for `<arg_name>` but got type <actual_type>."
+    ]
+  },
   "INVALID_TYPENAME_CALL" : {
     "message" : [
       "StructField does not have typeName. Use typeName on its type explicitly instead."

--- a/python/pyspark/sql/tests/test_utils.py
+++ b/python/pyspark/sql/tests/test_utils.py
@@ -39,6 +39,7 @@ from pyspark.sql.types import (
     IntegerType,
     BooleanType,
 )
+from pyspark.sql.dataframe import DataFrame
 
 import difflib
 
@@ -648,8 +649,12 @@ class UtilsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="UNSUPPORTED_DATA_TYPE",
-            message_parameters={"data_type": pd.DataFrame},
+            error_class="INVALID_TYPE_DF_EQUALITY_ARG",
+            message_parameters={
+                "expected_type": DataFrame,
+                "arg_name": "df",
+                "actual_type": pd.DataFrame,
+            },
         )
 
         with self.assertRaises(PySparkAssertionError) as pe:
@@ -657,8 +662,12 @@ class UtilsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="UNSUPPORTED_DATA_TYPE",
-            message_parameters={"data_type": pd.DataFrame},
+            error_class="INVALID_TYPE_DF_EQUALITY_ARG",
+            message_parameters={
+                "expected_type": DataFrame,
+                "arg_name": "df",
+                "actual_type": pd.DataFrame,
+            },
         )
 
     def test_assert_error_non_pyspark_df(self):
@@ -670,8 +679,12 @@ class UtilsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="UNSUPPORTED_DATA_TYPE",
-            message_parameters={"data_type": type(dict1)},
+            error_class="INVALID_TYPE_DF_EQUALITY_ARG",
+            message_parameters={
+                "expected_type": DataFrame,
+                "arg_name": "df",
+                "actual_type": type(dict1),
+            },
         )
 
         with self.assertRaises(PySparkAssertionError) as pe:
@@ -679,8 +692,12 @@ class UtilsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="UNSUPPORTED_DATA_TYPE",
-            message_parameters={"data_type": type(dict1)},
+            error_class="INVALID_TYPE_DF_EQUALITY_ARG",
+            message_parameters={
+                "expected_type": DataFrame,
+                "arg_name": "df",
+                "actual_type": type(dict1),
+            },
         )
 
     def test_row_order_ignored(self):

--- a/python/pyspark/testing/utils.py
+++ b/python/pyspark/testing/utils.py
@@ -35,7 +35,7 @@ from itertools import zip_longest
 from pyspark import SparkContext, SparkConf
 from pyspark.errors import PySparkAssertionError, PySparkException
 from pyspark.find_spark_home import _find_spark_home
-from pyspark.sql.dataframe import DataFrame as DataFrame
+from pyspark.sql.dataframe import DataFrame
 from pyspark.sql import Row
 from pyspark.sql.types import StructType, AtomicType, StructField
 
@@ -322,7 +322,7 @@ def assertDataFrameEqual(
 ):
     r"""
     A util function to assert equality between `actual` (DataFrame) and `expected`
-    (either DataFrame or list of Rows), with optional parameter `checkRowOrder`.
+    (DataFrame or list of Rows), with optional parameters `checkRowOrder`, `rtol`, and `atol`.
 
     .. versionadded:: 3.5.0
 
@@ -390,8 +390,12 @@ def assertDataFrameEqual(
 
         if not isinstance(actual, DataFrame) and not isinstance(actual, ConnectDataFrame):
             raise PySparkAssertionError(
-                error_class="UNSUPPORTED_DATA_TYPE",
-                message_parameters={"data_type": type(actual)},
+                error_class="INVALID_TYPE_DF_EQUALITY_ARG",
+                message_parameters={
+                    "expected_type": DataFrame,
+                    "arg_name": "df",
+                    "actual_type": type(actual),
+                },
             )
         elif (
             not isinstance(expected, DataFrame)
@@ -399,19 +403,31 @@ def assertDataFrameEqual(
             and not isinstance(expected, List)
         ):
             raise PySparkAssertionError(
-                error_class="UNSUPPORTED_DATA_TYPE",
-                message_parameters={"data_type": type(expected)},
+                error_class="INVALID_TYPE_DF_EQUALITY_ARG",
+                message_parameters={
+                    "expected_type": Union[DataFrame, List[Row]],
+                    "arg_name": "expected",
+                    "actual_type": type(expected),
+                },
             )
     except Exception:
         if not isinstance(actual, DataFrame):
             raise PySparkAssertionError(
-                error_class="UNSUPPORTED_DATA_TYPE",
-                message_parameters={"data_type": type(actual)},
+                error_class="INVALID_TYPE_DF_EQUALITY_ARG",
+                message_parameters={
+                    "expected_type": DataFrame,
+                    "arg_name": "df",
+                    "actual_type": type(actual),
+                },
             )
         elif not isinstance(expected, DataFrame) and not isinstance(expected, List):
             raise PySparkAssertionError(
-                error_class="UNSUPPORTED_DATA_TYPE",
-                message_parameters={"data_type": type(expected)},
+                error_class="INVALID_TYPE_DF_EQUALITY_ARG",
+                message_parameters={
+                    "expected_type": Union[DataFrame, List[Row]],
+                    "arg_name": "expected",
+                    "actual_type": type(expected),
+                },
             )
 
     # special cases: empty datasets, datasets with 0 columns


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR adds an error class, `INVALID_TYPE_DF_EQUALITY_ARG`, to clarify the error message for unsupported argument data types when calling `assertDataFrameEqual`.

### Why are the changes needed?
The fix helps clarify why an error is thrown and what is wrong when a user passes unsupported arg types into the `assertDataFrameEqual` util function.

### Does this PR introduce any user-facing change?
Yes, the PR modifies error message seen by users.

### How was this patch tested?
Modified tests in `/python/pyspark/sql/tests/test_utils.py` and `python/pyspark/sql/tests/connect/test_utils.py`