### PR TITLE
[SPARK-44451][BUILD] Make built document downloadable

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -687,8 +687,10 @@ jobs:
         cd docs
         bundle exec jekyll build
     - name: Tar documentation
+      if: github.repository != 'apache/spark'
       run: tar cjf site.tar.bz2 docs/_site
     - name: Upload documentation
+      if: github.repository != 'apache/spark'
       uses: actions/upload-artifact@v3
       with:
         name: site

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -686,14 +686,14 @@ jobs:
         fi
         cd docs
         bundle exec jekyll build
-        cd ..
     - name: Tar documentation
       run: tar cjf site.tar.bz2 docs/_site
     - name: Upload documentation
       uses: actions/upload-artifact@v3
       with:
         name: site
-        path: "site.tar.bz2"
+        path: site.tar.bz2
+        retention-days: 1
 
   java-11-17:
     needs: precondition

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -685,12 +685,12 @@ jobs:
           if [ `./dev/is-changed.py -m sparkr` = false ]; then export SKIP_RDOC=1; fi
         fi
     - name: Tar documentation
-      run: cd $HOME && tar cjf docs.tar.bz2 docs
+      run: cd $HOME && tar cjf site.tar.bz2 docs/_site
     - name: Upload documentation
       uses: actions/upload-artifact@v3
       with:
-        name: docs
-        path: "docs.tar.bz2"
+        name: site
+        path: "site.tar.bz2"
 
   java-11-17:
     needs: precondition

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -684,8 +684,11 @@ jobs:
           if [ `./dev/is-changed.py -m $pyspark_modules` = false ]; then export SKIP_PYTHONDOC=1; fi
           if [ `./dev/is-changed.py -m sparkr` = false ]; then export SKIP_RDOC=1; fi
         fi
+        cd docs
+        bundle exec jekyll build
+        cd ..
     - name: Tar documentation
-      run: cd $HOME && tar cjf site.tar.bz2 docs/_site
+      run: tar cjf site.tar.bz2 docs/_site
     - name: Upload documentation
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -684,8 +684,13 @@ jobs:
           if [ `./dev/is-changed.py -m $pyspark_modules` = false ]; then export SKIP_PYTHONDOC=1; fi
           if [ `./dev/is-changed.py -m sparkr` = false ]; then export SKIP_RDOC=1; fi
         fi
-        cd docs
-        bundle exec jekyll build
+    - name: Tar documentation
+      run: cd $HOME && tar cjf docs.tar.bz2 docs
+    - name: Upload documentation
+      uses: actions/upload-artifact@v3
+      with:
+        name: docs
+        path: "docs.tar.bz2"
 
   java-11-17:
     needs: precondition

--- a/dev/merge_spark_pr.py
+++ b/dev/merge_spark_pr.py
@@ -44,7 +44,7 @@ except ImportError:
 
 # Location of your Spark git development area
 SPARK_HOME = os.environ.get("SPARK_HOME", os.getcwd())
-# Remote name which points to the Github site
+# Remote name which points to the Gihub site
 PR_REMOTE_NAME = os.environ.get("PR_REMOTE_NAME", "apache-github")
 # Remote name which points to Apache git
 PUSH_REMOTE_NAME = os.environ.get("PUSH_REMOTE_NAME", "apache")

--- a/dev/merge_spark_pr.py
+++ b/dev/merge_spark_pr.py
@@ -44,7 +44,7 @@ except ImportError:
 
 # Location of your Spark git development area
 SPARK_HOME = os.environ.get("SPARK_HOME", os.getcwd())
-# Remote name which points to the Gihub site
+# Remote name which points to the Github site
 PR_REMOTE_NAME = os.environ.get("PR_REMOTE_NAME", "apache-github")
 # Remote name which points to Apache git
 PUSH_REMOTE_NAME = os.environ.get("PUSH_REMOTE_NAME", "apache")


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make built document downloadable

new steps:
![image](https://github.com/apache/spark/assets/7322292/49818e9e-4c2d-4722-aa04-57aa5d0e388d)

built-docs:
![image](https://github.com/apache/spark/assets/7322292/77c29749-7ebe-4390-8c58-b69146f3e210)

(actually 55M to download)


<img width="884" alt="image" src="https://github.com/apache/spark/assets/7322292/c871a0f5-a14c-48cb-b75a-44608ddabe12">



### Why are the changes needed?
1, to make it much easier for reviewers to verify the document PRs;
~~2, to make it much easier for maintainers to check the built document in branches;~~


### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
CI and manually check the downloaded docs