### PR TITLE
[SPARK-44362][SQL] Use PartitionEvaluator API in AggregateInPandasExec and AttachDistributedSequenceExec

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/AggregateInPandasEvaluatorFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/AggregateInPandasEvaluatorFactory.scala
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.python
+
+import java.io.File
+
+import scala.collection.mutable.ArrayBuffer
+
+import org.apache.spark.{PartitionEvaluator, PartitionEvaluatorFactory, SparkEnv, TaskContext}
+import org.apache.spark.api.python.{ChainedPythonFunctions, PythonEvalType}
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
+import org.apache.spark.sql.execution.GroupedIterator
+import org.apache.spark.sql.execution.aggregate.UpdatingSessionsIterator
+import org.apache.spark.sql.execution.metric.SQLMetric
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.util.Utils
+
+class AggregateInPandasEvaluatorFactory(
+    childOutput: Seq[Attribute],
+    aggExpressions: Seq[AggregateExpression],
+    resultExpressions: Seq[NamedExpression],
+    windowExecBufferInMemoryThreshold: Int,
+    windowExecBufferSpillThreshold: Int,
+    sessionWindowOption: Option[NamedExpression],
+    groupingWithoutSessionExpressions: Seq[NamedExpression],
+    allInputs: ArrayBuffer[Expression],
+    groupingExpressions: Seq[NamedExpression],
+    pyFuncs: Seq[ChainedPythonFunctions],
+    argOffsets: Array[Array[Int]],
+    aggInputSchema: StructType,
+    sessionLocalTimeZone: String,
+    largeVarTypes: Boolean,
+    pythonRunnerConf: Map[String, String],
+    pythonMetrics: Map[String, SQLMetric],
+    jobArtifactUUID: Option[String])
+    extends PartitionEvaluatorFactory[InternalRow, InternalRow] {
+  override def createEvaluator(): PartitionEvaluator[InternalRow, InternalRow] =
+    new AggregateInPandasEvaluator
+
+  private class AggregateInPandasEvaluator extends PartitionEvaluator[InternalRow, InternalRow] {
+
+    private def mayAppendUpdatingSessionIterator(
+        iter: Iterator[InternalRow]): Iterator[InternalRow] = {
+      val newIter = sessionWindowOption match {
+        case Some(sessionExpression) =>
+          new UpdatingSessionsIterator(
+            iter,
+            groupingWithoutSessionExpressions,
+            sessionExpression,
+            childOutput,
+            windowExecBufferInMemoryThreshold,
+            windowExecBufferSpillThreshold)
+
+        case None => iter
+      }
+      newIter
+    }
+
+    override def eval(
+        partitionIndex: Int,
+        inputs: Iterator[InternalRow]*): Iterator[InternalRow] = {
+      assert(inputs.length == 1)
+      val iter = inputs.head
+      // Map grouped rows to ArrowPythonRunner results, Only execute if partition is not empty
+      if (iter.isEmpty) iter else {
+        // If we have session window expression in aggregation, we wrap iterator with
+        // UpdatingSessionIterator to calculate sessions for input rows and update
+        // rows' session column, so that further aggregations can aggregate input rows
+        // for the same session.
+        val newIter: Iterator[InternalRow] = mayAppendUpdatingSessionIterator(iter)
+        val prunedProj = UnsafeProjection.create(allInputs.toSeq, childOutput)
+
+        val groupedItr = if (groupingExpressions.isEmpty) {
+          // Use an empty unsafe row as a place holder for the grouping key
+          Iterator((new UnsafeRow(), newIter))
+        } else {
+          GroupedIterator(newIter, groupingExpressions, childOutput)
+        }
+        val grouped = groupedItr.map { case (key, rows) =>
+          (key, rows.map(prunedProj))
+        }
+
+        val context = TaskContext.get()
+
+        // The queue used to buffer input rows so we can drain it to
+        // combine input with output from Python.
+        val queue = HybridRowQueue(
+          context.taskMemoryManager(),
+          new File(Utils.getLocalDir(SparkEnv.get.conf)),
+          groupingExpressions.length)
+        context.addTaskCompletionListener[Unit] { _ =>
+          queue.close()
+        }
+
+        // Add rows to queue to join later with the result.
+        val projectedRowIter = grouped.map { case (groupingKey, rows) =>
+          queue.add(groupingKey.asInstanceOf[UnsafeRow])
+          rows
+        }
+
+        val columnarBatchIter = new ArrowPythonRunner(
+          pyFuncs,
+          PythonEvalType.SQL_GROUPED_AGG_PANDAS_UDF,
+          argOffsets,
+          aggInputSchema,
+          sessionLocalTimeZone,
+          largeVarTypes,
+          pythonRunnerConf,
+          pythonMetrics,
+          jobArtifactUUID).compute(projectedRowIter, context.partitionId(), context)
+
+        val joinedAttributes =
+          groupingExpressions.map(_.toAttribute) ++ aggExpressions.map(_.resultAttribute)
+        val joined = new JoinedRow
+        val resultProj = UnsafeProjection.create(resultExpressions, joinedAttributes)
+
+        columnarBatchIter.map(_.rowIterator.next()).map { aggOutputRow =>
+          val leftRow = queue.remove()
+          val joinedRow = joined(leftRow, aggOutputRow)
+          resultProj(joinedRow)
+        }
+      }
+    }
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/AggregateInPandasExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/AggregateInPandasExec.scala
@@ -17,22 +17,18 @@
 
 package org.apache.spark.sql.execution.python
 
-import java.io.File
-
 import scala.collection.mutable.ArrayBuffer
 
-import org.apache.spark.{JobArtifactSet, SparkEnv, TaskContext}
-import org.apache.spark.api.python.{ChainedPythonFunctions, PythonEvalType}
+import org.apache.spark.JobArtifactSet
+import org.apache.spark.api.python.{ChainedPythonFunctions}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
 import org.apache.spark.sql.catalyst.plans.physical.{AllTuples, ClusteredDistribution, Distribution, Partitioning}
-import org.apache.spark.sql.execution.{GroupedIterator, SparkPlan, UnaryExecNode}
-import org.apache.spark.sql.execution.aggregate.UpdatingSessionsIterator
+import org.apache.spark.sql.execution.{SparkPlan, UnaryExecNode}
 import org.apache.spark.sql.types.{DataType, StructField, StructType}
 import org.apache.spark.sql.util.ArrowUtils
-import org.apache.spark.util.Utils
 
 /**
  * Physical node for aggregation with group aggregate Pandas UDF.
@@ -100,8 +96,6 @@ case class AggregateInPandasExec(
   override protected def doExecute(): RDD[InternalRow] = {
     val inputRDD = child.execute()
 
-    val sessionLocalTimeZone = conf.sessionLocalTimeZone
-    val largeVarTypes = conf.arrowUseLargeVarTypes
     val pythonRunnerConf = ArrowUtils.getPythonRunnerConfMap(conf)
 
     val (pyFuncs, inputs) = udfExpressions.map(collectFunctions).unzip
@@ -130,82 +124,34 @@ case class AggregateInPandasExec(
 
     val jobArtifactUUID = JobArtifactSet.getCurrentJobArtifactState.map(_.uuid)
 
-    // Map grouped rows to ArrowPythonRunner results, Only execute if partition is not empty
-    inputRDD.mapPartitionsInternal { iter => if (iter.isEmpty) iter else {
-      // If we have session window expression in aggregation, we wrap iterator with
-      // UpdatingSessionIterator to calculate sessions for input rows and update
-      // rows' session column, so that further aggregations can aggregate input rows
-      // for the same session.
-      val newIter: Iterator[InternalRow] = mayAppendUpdatingSessionIterator(iter)
-      val prunedProj = UnsafeProjection.create(allInputs.toSeq, child.output)
+    val evaluatorFactory = new AggregateInPandasEvaluatorFactory(
+      child.output,
+      aggExpressions,
+      resultExpressions,
+      conf.windowExecBufferInMemoryThreshold,
+      conf.windowExecBufferSpillThreshold,
+      sessionWindowOption,
+      groupingWithoutSessionExpressions,
+      allInputs,
+      groupingExpressions,
+      pyFuncs,
+      argOffsets,
+      aggInputSchema,
+      conf.sessionLocalTimeZone,
+      conf.arrowUseLargeVarTypes,
+      pythonRunnerConf,
+      pythonMetrics,
+      jobArtifactUUID)
 
-      val groupedItr = if (groupingExpressions.isEmpty) {
-        // Use an empty unsafe row as a place holder for the grouping key
-        Iterator((new UnsafeRow(), newIter))
-      } else {
-        GroupedIterator(newIter, groupingExpressions, child.output)
+    if (conf.usePartitionEvaluator) {
+      inputRDD.mapPartitionsWithEvaluator(evaluatorFactory)
+    } else {
+      inputRDD.mapPartitionsWithIndexInternal { (index, iter) =>
+        evaluatorFactory.createEvaluator().eval(index, iter)
       }
-      val grouped = groupedItr.map { case (key, rows) =>
-        (key, rows.map(prunedProj))
-      }
-
-      val context = TaskContext.get()
-
-      // The queue used to buffer input rows so we can drain it to
-      // combine input with output from Python.
-      val queue = HybridRowQueue(context.taskMemoryManager(),
-        new File(Utils.getLocalDir(SparkEnv.get.conf)), groupingExpressions.length)
-      context.addTaskCompletionListener[Unit] { _ =>
-        queue.close()
-      }
-
-      // Add rows to queue to join later with the result.
-      val projectedRowIter = grouped.map { case (groupingKey, rows) =>
-        queue.add(groupingKey.asInstanceOf[UnsafeRow])
-        rows
-      }
-
-      val columnarBatchIter = new ArrowPythonRunner(
-        pyFuncs,
-        PythonEvalType.SQL_GROUPED_AGG_PANDAS_UDF,
-        argOffsets,
-        aggInputSchema,
-        sessionLocalTimeZone,
-        largeVarTypes,
-        pythonRunnerConf,
-        pythonMetrics,
-        jobArtifactUUID).compute(projectedRowIter, context.partitionId(), context)
-
-      val joinedAttributes =
-        groupingExpressions.map(_.toAttribute) ++ aggExpressions.map(_.resultAttribute)
-      val joined = new JoinedRow
-      val resultProj = UnsafeProjection.create(resultExpressions, joinedAttributes)
-
-      columnarBatchIter.map(_.rowIterator.next()).map { aggOutputRow =>
-        val leftRow = queue.remove()
-        val joinedRow = joined(leftRow, aggOutputRow)
-        resultProj(joinedRow)
-      }
-    }}
+    }
   }
 
   override protected def withNewChildInternal(newChild: SparkPlan): SparkPlan =
     copy(child = newChild)
-
-
-  private def mayAppendUpdatingSessionIterator(
-      iter: Iterator[InternalRow]): Iterator[InternalRow] = {
-    val newIter = sessionWindowOption match {
-      case Some(sessionExpression) =>
-        val inMemoryThreshold = conf.windowExecBufferInMemoryThreshold
-        val spillThreshold = conf.windowExecBufferSpillThreshold
-
-        new UpdatingSessionsIterator(iter, groupingWithoutSessionExpressions, sessionExpression,
-          child.output, inMemoryThreshold, spillThreshold)
-
-      case None => iter
-    }
-
-    newIter
-  }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/AttachDistributedSequenceEvaluatorFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/AttachDistributedSequenceEvaluatorFactory.scala
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.python
+
+import org.apache.spark.{PartitionEvaluator, PartitionEvaluatorFactory}
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions._
+
+class AttachDistributedSequenceEvaluatorFactory(output: Seq[Attribute])
+    extends PartitionEvaluatorFactory[(InternalRow, Long), InternalRow] {
+  override def createEvaluator(): PartitionEvaluator[(InternalRow, Long), InternalRow] =
+    new AttachDistributedSequenceEvaluator
+
+  private class AttachDistributedSequenceEvaluator
+      extends PartitionEvaluator[(InternalRow, Long), InternalRow] {
+    override def eval(
+        partitionIndex: Int,
+        inputs: Iterator[(InternalRow, Long)]*): Iterator[InternalRow] = {
+      assert(inputs.length == 1)
+      val iter = inputs(0)
+      val unsafeProj = UnsafeProjection.create(output, output)
+      val joinedRow = new JoinedRow
+      val unsafeRowWriter =
+        new org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter(1)
+
+      iter
+        .map { case (row, id) =>
+          // Writes to an UnsafeRow directly
+          unsafeRowWriter.reset()
+          unsafeRowWriter.write(0, id)
+          joinedRow(unsafeRowWriter.getRow, row)
+        }
+        .map(unsafeProj)
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
SQL operators  `AggregateInPandasExec` and  `AttachDistributedSequenceExec` are updated to use the `PartitionEvaluator` API to do execution.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To avoid the use of lambda during distributed execution.
Ref: SPARK-43061 for more details.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Existing test cases. Once all SQL operators are refactored, will enable `spark.sql.execution.usePartitionEvaluator` by default, so all tests cover this code path
