### PR TITLE
[SPARK-44453][PYTHON] Use difflib to display errors in assertDataFrameEqual

### DIFF
--- a/python/pyspark/sql/tests/test_utils.py
+++ b/python/pyspark/sql/tests/test_utils.py
@@ -151,19 +151,14 @@ class UtilsTestsMixin:
         expected_error_message = "Results do not match: "
         percent_diff = (1 / 2) * 100
         expected_error_message += "( %.5f %% )" % percent_diff
-        diff_msg = (
-            "[actual]"
-            + "\n"
-            + str(df1.collect()[1])
-            + "\n\n"
-            + "[expected]"
-            + "\n"
-            + str(df2.collect()[1])
-            + "\n\n"
-            + "********************"
-            + "\n\n"
+
+        generated_diff = difflib.ndiff(
+            str(df1.collect()[1]).splitlines(), str(df2.collect()[1]).splitlines()
         )
-        expected_error_message += "\n" + diff_msg
+        diff_msg = "\n" + "\n".join(generated_diff) + "\n"
+        diff_msg += "********************" + "\n"
+
+        expected_error_message += "\n" + "--- actual\n+++ expected\n" + diff_msg
 
         with self.assertRaises(PySparkAssertionError) as pe:
             assertDataFrameEqual(df1, df2)
@@ -294,19 +289,14 @@ class UtilsTestsMixin:
         expected_error_message = "Results do not match: "
         percent_diff = (1 / 2) * 100
         expected_error_message += "( %.5f %% )" % percent_diff
-        diff_msg = (
-            "[actual]"
-            + "\n"
-            + str(df1.collect()[1])
-            + "\n\n"
-            + "[expected]"
-            + "\n"
-            + str(df2.collect()[1])
-            + "\n\n"
-            + "********************"
-            + "\n\n"
+
+        generated_diff = difflib.ndiff(
+            str(df1.collect()[1]).splitlines(), str(df2.collect()[1]).splitlines()
         )
-        expected_error_message += "\n" + diff_msg
+        diff_msg = "\n" + "\n".join(generated_diff) + "\n"
+        diff_msg += "********************" + "\n"
+
+        expected_error_message += "\n" + "--- actual\n+++ expected\n" + diff_msg
 
         with self.assertRaises(PySparkAssertionError) as pe:
             assertDataFrameEqual(df1, df2)
@@ -598,19 +588,14 @@ class UtilsTestsMixin:
         expected_error_message = "Results do not match: "
         percent_diff = (1 / 2) * 100
         expected_error_message += "( %.5f %% )" % percent_diff
-        diff_msg = (
-            "[actual]"
-            + "\n"
-            + str(df1.collect()[1])
-            + "\n\n"
-            + "[expected]"
-            + "\n"
-            + str(df2.collect()[1])
-            + "\n\n"
-            + "********************"
-            + "\n\n"
+
+        generated_diff = difflib.ndiff(
+            str(df1.collect()[1]).splitlines(), str(df2.collect()[1]).splitlines()
         )
-        expected_error_message += "\n" + diff_msg
+        diff_msg = "\n" + "\n".join(generated_diff) + "\n"
+        diff_msg += "********************" + "\n"
+
+        expected_error_message += "\n" + "--- actual\n+++ expected\n" + diff_msg
 
         with self.assertRaises(PySparkAssertionError) as pe:
             assertDataFrameEqual(df1, df2)
@@ -722,31 +707,19 @@ class UtilsTestsMixin:
         expected_error_message = "Results do not match: "
         percent_diff = (2 / 2) * 100
         expected_error_message += "( %.5f %% )" % percent_diff
-        diff_msg = (
-            "[actual]"
-            + "\n"
-            + str(df1.collect()[0])
-            + "\n\n"
-            + "[expected]"
-            + "\n"
-            + str(df2.collect()[0])
-            + "\n\n"
-            + "********************"
-            + "\n\n"
+
+        generated_diff = difflib.ndiff(
+            str(df1.collect()[0]).splitlines(), str(df2.collect()[0]).splitlines()
         )
-        diff_msg += (
-            "[actual]"
-            + "\n"
-            + str(df1.collect()[1])
-            + "\n\n"
-            + "[expected]"
-            + "\n"
-            + str(df2.collect()[1])
-            + "\n\n"
-            + "********************"
-            + "\n\n"
+        diff_msg = "\n" + "\n".join(generated_diff) + "\n"
+        diff_msg += "********************" + "\n"
+        generated_diff = difflib.ndiff(
+            str(df1.collect()[1]).splitlines(), str(df2.collect()[1]).splitlines()
         )
-        expected_error_message += "\n" + diff_msg
+        diff_msg += "\n" + "\n".join(generated_diff) + "\n"
+        diff_msg += "********************" + "\n"
+
+        expected_error_message += "\n" + "--- actual\n+++ expected\n" + diff_msg
 
         with self.assertRaises(PySparkAssertionError) as pe:
             assertDataFrameEqual(df1, df2, checkRowOrder=True)
@@ -829,31 +802,19 @@ class UtilsTestsMixin:
         expected_error_message = "Results do not match: "
         percent_diff = (2 / 3) * 100
         expected_error_message += "( %.5f %% )" % percent_diff
-        diff_msg = (
-            "[actual]"
-            + "\n"
-            + str(df1.collect()[0])
-            + "\n\n"
-            + "[expected]"
-            + "\n"
-            + str(df2.collect()[0])
-            + "\n\n"
-            + "********************"
-            + "\n\n"
+
+        generated_diff = difflib.ndiff(
+            str(df1.collect()[0]).splitlines(), str(df2.collect()[0]).splitlines()
         )
-        diff_msg += (
-            "[actual]"
-            + "\n"
-            + str(df1.collect()[2])
-            + "\n\n"
-            + "[expected]"
-            + "\n"
-            + str(df2.collect()[2])
-            + "\n\n"
-            + "********************"
-            + "\n\n"
+        diff_msg = "\n" + "\n".join(generated_diff) + "\n"
+        diff_msg += "********************" + "\n"
+        generated_diff = difflib.ndiff(
+            str(df1.collect()[2]).splitlines(), str(df2.collect()[2]).splitlines()
         )
-        expected_error_message += "\n" + diff_msg
+        diff_msg += "\n" + "\n".join(generated_diff) + "\n"
+        diff_msg += "********************" + "\n"
+
+        expected_error_message += "\n" + "--- actual\n+++ expected\n" + diff_msg
 
         with self.assertRaises(PySparkAssertionError) as pe:
             assertDataFrameEqual(df1, df2)
@@ -1173,31 +1134,19 @@ class UtilsTestsMixin:
         expected_error_message = "Results do not match: "
         percent_diff = (2 / 2) * 100
         expected_error_message += "( %.5f %% )" % percent_diff
-        diff_msg = (
-            "[actual]"
-            + "\n"
-            + str(df1.collect()[0])
-            + "\n\n"
-            + "[expected]"
-            + "\n"
-            + str(list_of_rows[0])
-            + "\n\n"
-            + "********************"
-            + "\n\n"
+
+        generated_diff = difflib.ndiff(
+            str(df1.collect()[0]).splitlines(), str(list_of_rows[0]).splitlines()
         )
-        diff_msg += (
-            "[actual]"
-            + "\n"
-            + str(df1.collect()[1])
-            + "\n\n"
-            + "[expected]"
-            + "\n"
-            + str(list_of_rows[1])
-            + "\n\n"
-            + "********************"
-            + "\n\n"
+        diff_msg = "\n" + "\n".join(generated_diff) + "\n"
+        diff_msg += "********************" + "\n"
+        generated_diff = difflib.ndiff(
+            str(df1.collect()[1]).splitlines(), str(list_of_rows[1]).splitlines()
         )
-        expected_error_message += "\n" + diff_msg
+        diff_msg += "\n" + "\n".join(generated_diff) + "\n"
+        diff_msg += "********************" + "\n"
+
+        expected_error_message += "\n" + "--- actual\n+++ expected\n" + diff_msg
 
         with self.assertRaises(PySparkAssertionError) as pe:
             assertDataFrameEqual(df1, list_of_rows)

--- a/python/pyspark/testing/utils.py
+++ b/python/pyspark/testing/utils.py
@@ -346,6 +346,9 @@ def assertDataFrameEqual(
 
     Notes
     -----
+    When assertDataFrameEqual fails, the error message uses the Python `difflib` library to display
+    a diff log of each row that differs in `actual` and `expected`.
+
     For checkRowOrder, note that PySpark DataFrame ordering is non-deterministic, unless
     explicitly sorted.
 
@@ -353,9 +356,6 @@ def assertDataFrameEqual(
     Two float values a and b are approximately equal if the following equation is True:
 
     ``absolute(a - b) <= (atol + rtol * absolute(b))``.
-
-    When assertDataFrameEqual fails, the error message uses the Python `difflib` library to display
-    a diff log of each row that differs in `actual` and `expected`.
 
     Examples
     --------
@@ -375,16 +375,15 @@ def assertDataFrameEqual(
     PySparkAssertionError: [DIFFERENT_ROWS] Results do not match: ( 66.66667 % )
     --- actual
     +++ expected
-
     - Row(id='1', amount=1000.0)
     ?                       ^
     + Row(id='1', amount=1001.0)
     ?                       ^
-
     - Row(id='3', amount=2000.0)
     ?                       ^
     + Row(id='3', amount=2003.0)
     ?                       ^
+
     """
     if actual is None and expected is None:
         return True


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR uses the built-in Python library, difflib, to display errors in the testing util `assertDataFrameEqual`


### Why are the changes needed?
The change makes the error message output more user-friendly, as well as consistent with `assertSchemaEqual`


### Does this PR introduce _any_ user-facing change?
Yes, the PR changes the test util output for the user-facing util function `assertDataFrameEqual`.


### How was this patch tested?
Existing tests in `python/pyspark/sql/tests/test_utils.py` and `python/pyspark/sql/tests/connect/test_utils.py`

Example output:
<img width="891" alt="Screenshot 2023-07-16 at 8 20 31 PM" src="https://github.com/apache/spark/assets/68875504/2d7a9d02-bb9e-4c21-b330-5ec01b2e9ec8">

<img width="868" alt="Screenshot 2023-07-16 at 8 20 41 PM" src="https://github.com/apache/spark/assets/68875504/eba9f3e8-e147-491c-934b-34e8351df012">

