### PR TITLE
[MINOR][DOCS] Fix a typo in dev/merge_spark_pr.py

### DIFF
--- a/dev/merge_spark_pr.py
+++ b/dev/merge_spark_pr.py
@@ -44,7 +44,7 @@ except ImportError:
 
 # Location of your Spark git development area
 SPARK_HOME = os.environ.get("SPARK_HOME", os.getcwd())
-# Remote name which points to the Gihub site
+# Remote name which points to the Github site
 PR_REMOTE_NAME = os.environ.get("PR_REMOTE_NAME", "apache-github")
 # Remote name which points to Apache git
 PUSH_REMOTE_NAME = os.environ.get("PUSH_REMOTE_NAME", "apache")


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix a typo in `dev/merge_spark_pr.py`, I don't find similar typos in `dev/`

### Why are the changes needed?
just fix a typo

### Does this PR introduce _any_ user-facing change?
no, dev-only


### How was this patch tested?
CI