### PR TITLE
[SPARK-44455][SQL] Quote identifiers with backticks in SHOW CREATE TABLE result

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -456,7 +456,7 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
       if (asSerde) {
         throw QueryCompilationErrors.showCreateTableAsSerdeNotSupportedForV2TablesError()
       }
-      ShowCreateTableExec(output, rt.table, rt.name) :: Nil
+      ShowCreateTableExec(output, rt) :: Nil
 
     case TruncateTable(r: ResolvedTable) =>
       TruncateTableExec(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -456,7 +456,7 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
       if (asSerde) {
         throw QueryCompilationErrors.showCreateTableAsSerdeNotSupportedForV2TablesError()
       }
-      ShowCreateTableExec(output, rt.table) :: Nil
+      ShowCreateTableExec(output, rt.table, rt.name) :: Nil
 
     case TruncateTable(r: ResolvedTable) =>
       TruncateTableExec(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowCreateTableExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowCreateTableExec.scala
@@ -21,6 +21,7 @@ import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
 
 import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.analysis.ResolvedTable
 import org.apache.spark.sql.catalyst.catalog.BucketSpec
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.util.{escapeSingleQuotedString, CharVarcharUtils}
@@ -34,15 +35,16 @@ import org.apache.spark.unsafe.types.UTF8String
  */
 case class ShowCreateTableExec(
     output: Seq[Attribute],
-    table: Table,
-    quotedName: String) extends V2CommandExec with LeafExecNode {
+    resolvedTable: ResolvedTable) extends V2CommandExec with LeafExecNode {
   override protected def run(): Seq[InternalRow] = {
     val builder = new StringBuilder
     showCreateTable(table, builder, quotedName)
     Seq(InternalRow(UTF8String.fromString(builder.toString)))
   }
 
-  private def showCreateTable(table: Table, builder: StringBuilder, quotedName: String): Unit = {
+  private def showCreateTable(resolvedTable: ResolvedTable, builder: StringBuilder): Unit = {
+    val table = resolvedTable.table
+    val quotedName = resolvedTable.name
     builder ++= s"CREATE TABLE ${quotedName} "
 
     showTableDataColumns(table, builder)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowCreateTableExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowCreateTableExec.scala
@@ -34,15 +34,16 @@ import org.apache.spark.unsafe.types.UTF8String
  */
 case class ShowCreateTableExec(
     output: Seq[Attribute],
-    table: Table) extends V2CommandExec with LeafExecNode {
+    table: Table,
+    quotedName: String) extends V2CommandExec with LeafExecNode {
   override protected def run(): Seq[InternalRow] = {
     val builder = new StringBuilder
-    showCreateTable(table, builder)
+    showCreateTable(table, builder, quotedName)
     Seq(InternalRow(UTF8String.fromString(builder.toString)))
   }
 
   private def showCreateTable(table: Table, builder: StringBuilder): Unit = {
-    builder ++= s"CREATE TABLE ${table.name()} "
+    builder ++= s"CREATE TABLE ${quotedName} "
 
     showTableDataColumns(table, builder)
     showTableUsing(table, builder)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowCreateTableExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowCreateTableExec.scala
@@ -42,7 +42,7 @@ case class ShowCreateTableExec(
     Seq(InternalRow(UTF8String.fromString(builder.toString)))
   }
 
-  private def showCreateTable(table: Table, builder: StringBuilder): Unit = {
+  private def showCreateTable(table: Table, builder: StringBuilder, quotedName: String): Unit = {
     builder ++= s"CREATE TABLE ${quotedName} "
 
     showTableDataColumns(table, builder)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowCreateTableExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowCreateTableExec.scala
@@ -38,7 +38,7 @@ case class ShowCreateTableExec(
     resolvedTable: ResolvedTable) extends V2CommandExec with LeafExecNode {
   override protected def run(): Seq[InternalRow] = {
     val builder = new StringBuilder
-    showCreateTable(table, builder, quotedName)
+    showCreateTable(resolvedTable, builder)
     Seq(InternalRow(UTF8String.fromString(builder.toString)))
   }
 

--- a/sql/core/src/test/resources/sql-tests/results/charvarchar.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/charvarchar.sql.out
@@ -49,7 +49,7 @@ show create table char_tbl
 -- !query schema
 struct<createtab_stmt:string>
 -- !query output
-CREATE TABLE default.char_tbl (
+CREATE TABLE spark_catalog.default.char_tbl (
   c CHAR(5),
   v VARCHAR(6))
 USING parquet
@@ -68,7 +68,7 @@ show create table char_tbl2
 -- !query schema
 struct<createtab_stmt:string>
 -- !query output
-CREATE TABLE default.char_tbl2 (
+CREATE TABLE spark_catalog.default.char_tbl2 (
   c CHAR(5),
   v VARCHAR(6))
 USING parquet
@@ -161,7 +161,7 @@ show create table char_tbl3
 -- !query schema
 struct<createtab_stmt:string>
 -- !query output
-CREATE TABLE default.char_tbl3 (
+CREATE TABLE spark_catalog.default.char_tbl3 (
   c CHAR(5),
   v VARCHAR(6))
 USING parquet

--- a/sql/core/src/test/resources/sql-tests/results/show-create-table.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/show-create-table.sql.out
@@ -12,7 +12,7 @@ SHOW CREATE TABLE tbl
 -- !query schema
 struct<createtab_stmt:string>
 -- !query output
-CREATE TABLE default.tbl (
+CREATE TABLE spark_catalog.default.tbl (
   a INT,
   b STRING,
   c INT)
@@ -41,7 +41,7 @@ SHOW CREATE TABLE tbl
 -- !query schema
 struct<createtab_stmt:string>
 -- !query output
-CREATE TABLE default.tbl (
+CREATE TABLE spark_catalog.default.tbl (
   a INT,
   b STRING,
   c INT)
@@ -73,7 +73,7 @@ SHOW CREATE TABLE tbl
 -- !query schema
 struct<createtab_stmt:string>
 -- !query output
-CREATE TABLE default.tbl (
+CREATE TABLE spark_catalog.default.tbl (
   a INT,
   b STRING,
   c INT)
@@ -103,7 +103,7 @@ SHOW CREATE TABLE tbl
 -- !query schema
 struct<createtab_stmt:string>
 -- !query output
-CREATE TABLE default.tbl (
+CREATE TABLE spark_catalog.default.tbl (
   a INT,
   b STRING,
   c INT)
@@ -133,7 +133,7 @@ SHOW CREATE TABLE tbl
 -- !query schema
 struct<createtab_stmt:string>
 -- !query output
-CREATE TABLE default.tbl (
+CREATE TABLE spark_catalog.default.tbl (
   b STRING,
   c INT,
   a INT)
@@ -163,7 +163,7 @@ SHOW CREATE TABLE tbl
 -- !query schema
 struct<createtab_stmt:string>
 -- !query output
-CREATE TABLE default.tbl (
+CREATE TABLE spark_catalog.default.tbl (
   a INT,
   b STRING,
   c INT)
@@ -195,7 +195,7 @@ SHOW CREATE TABLE tbl
 -- !query schema
 struct<createtab_stmt:string>
 -- !query output
-CREATE TABLE default.tbl (
+CREATE TABLE spark_catalog.default.tbl (
   a INT DEFAULT 42,
   b STRING DEFAULT 'abc, def',
   c INT DEFAULT 42)
@@ -225,7 +225,7 @@ SHOW CREATE TABLE tbl
 -- !query schema
 struct<createtab_stmt:string>
 -- !query output
-CREATE TABLE default.tbl (
+CREATE TABLE spark_catalog.default.tbl (
   a INT,
   b STRING,
   c INT)
@@ -255,7 +255,7 @@ SHOW CREATE TABLE tbl
 -- !query schema
 struct<createtab_stmt:string>
 -- !query output
-CREATE TABLE default.tbl (
+CREATE TABLE spark_catalog.default.tbl (
   a INT,
   b STRING,
   c INT)
@@ -286,7 +286,7 @@ SHOW CREATE TABLE tbl
 -- !query schema
 struct<createtab_stmt:string>
 -- !query output
-CREATE TABLE default.tbl (
+CREATE TABLE spark_catalog.default.tbl (
   a FLOAT,
   b DECIMAL(10,0),
   c DECIMAL(10,0),

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowCreateTableSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowCreateTableSuiteBase.scala
@@ -194,7 +194,8 @@ trait ShowCreateTableSuiteBase extends QueryTest with DDLCommandTestUtils {
         """.stripMargin)
       val showDDL = getShowCreateDDL(t)
       assert(
-        showDDL(0) == s"CREATE TABLE test_catalog.`a_schema-with+special^chars`.`a_table-with+special^chars` ("
+        showDDL(0) == s"CREATE TABLE test_catalog.`a_schema-with+special^chars`." +
+        s"`a_table-with+special^chars` ("
       )
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowCreateTableSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowCreateTableSuiteBase.scala
@@ -183,6 +183,22 @@ trait ShowCreateTableSuiteBase extends QueryTest with DDLCommandTestUtils {
     }
   }
 
+  test("should quote identifiers with special characters") {
+    withNamespaceAndTable("`a_schema-with+special^chars`", "`a_table-with+special^chars`") { t =>
+      sql(s"""
+           |CREATE TABLE $t (
+           |  a bigint NOT NULL,
+           |  b bigint
+           |)
+           |USING ${classOf[SimpleInsertSource].getName}
+        """.stripMargin)
+      val showDDL = getShowCreateDDL(t)
+      assert(
+        showDDL(0) == s"CREATE TABLE test_catalog.`a_schema-with+special^chars`.`a_table-with+special^chars` ("
+      )
+    }
+  }
+
   def getShowCreateDDL(table: String, serde: Boolean = false): Array[String] = {
     val result = if (serde) {
       sql(s"SHOW CREATE TABLE $table AS SERDE")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowCreateTableSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowCreateTableSuiteBase.scala
@@ -183,23 +183,6 @@ trait ShowCreateTableSuiteBase extends QueryTest with DDLCommandTestUtils {
     }
   }
 
-  test("should quote identifiers with special characters") {
-    withNamespaceAndTable("`a_schema-with+special^chars`", "`a_table-with+special^chars`") { t =>
-      sql(s"""
-           |CREATE TABLE $t (
-           |  a bigint NOT NULL,
-           |  b bigint
-           |)
-           |USING ${classOf[SimpleInsertSource].getName}
-        """.stripMargin)
-      val showDDL = getShowCreateDDL(t)
-      assert(
-        showDDL(0) == s"CREATE TABLE test_catalog.`a_schema-with+special^chars`." +
-        s"`a_table-with+special^chars` ("
-      )
-    }
-  }
-
   def getShowCreateDDL(table: String, serde: Boolean = false): Array[String] = {
     val result = if (serde) {
       sql(s"SHOW CREATE TABLE $table AS SERDE")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowCreateTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowCreateTableSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.execution.command.v1
 
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.execution.command
+import org.apache.spark.sql.execution.command.DDLCommandTestUtils.V1_COMMAND_VERSION
 
 /**
  * This base suite contains unified tests for the `SHOW CREATE TABLE` command that checks V1
@@ -193,4 +194,8 @@ trait ShowCreateTableSuiteBase extends command.ShowCreateTableSuiteBase
  */
 class ShowCreateTableSuite extends ShowCreateTableSuiteBase with CommandSuiteBase {
   override def commandVersion: String = super[ShowCreateTableSuiteBase].commandVersion
+  override def fullName: String = commandVersion match {
+    case V1_COMMAND_VERSION => s"$ns.$table"
+    case _ => s"$catalog.$ns.$table"
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowCreateTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowCreateTableSuite.scala
@@ -32,7 +32,10 @@ import org.apache.spark.sql.execution.command.DDLCommandTestUtils.V1_COMMAND_VER
  */
 trait ShowCreateTableSuiteBase extends command.ShowCreateTableSuiteBase
     with command.TestsV1AndV2Commands {
-  override def fullName: String = s"$ns.$table"
+  override def fullName: String = commandVersion match {
+    case V1_COMMAND_VERSION => s"$ns.$table"
+    case _ => s"$catalog.$ns.$table"
+  }
 
   test("show create table[simple]") {
     // todo After SPARK-37517 unify the testcase both v1 and v2
@@ -194,8 +197,4 @@ trait ShowCreateTableSuiteBase extends command.ShowCreateTableSuiteBase
  */
 class ShowCreateTableSuite extends ShowCreateTableSuiteBase with CommandSuiteBase {
   override def commandVersion: String = super[ShowCreateTableSuiteBase].commandVersion
-  override def fullName: String = commandVersion match {
-    case V1_COMMAND_VERSION => s"$ns.$table"
-    case _ => s"$catalog.$ns.$table"
-  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowCreateTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowCreateTableSuite.scala
@@ -144,4 +144,20 @@ class ShowCreateTableSuite extends command.ShowCreateTableSuiteBase with Command
       ))
     }
   }
+
+  test("should quote identifiers with special characters") {
+    withNamespaceAndTable("`a_schema-with+special^chars`", "`a_table-with+special^chars`") { t =>
+      sql(s"""
+           |CREATE TABLE $t (
+           |  a bigint NOT NULL,
+           |  b bigint
+           |) $defaultUsing
+        """.stripMargin)
+      val showDDL = getShowCreateDDL(t)
+      assert(
+        showDDL(0) == s"CREATE TABLE test_catalog.`a_schema-with+special^chars`." +
+        s"`a_table-with+special^chars` ("
+      )
+    }
+  }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/ShowCreateTableSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/ShowCreateTableSuite.scala
@@ -30,6 +30,7 @@ import org.apache.spark.sql.internal.HiveSerDe
  */
 class ShowCreateTableSuite extends v1.ShowCreateTableSuiteBase with CommandSuiteBase {
   override def commandVersion: String = super[ShowCreateTableSuiteBase].commandVersion
+  def nsTable: String = s"$ns.$table"
 
   override def getShowCreateDDL(table: String, serde: Boolean = false): Array[String] = {
     super.getShowCreateDDL(table, serde).filter(!_.startsWith("'transient_lastDdlTime'"))
@@ -48,7 +49,7 @@ class ShowCreateTableSuite extends v1.ShowCreateTableSuiteBase with CommandSuite
            |)
          """.stripMargin
       )
-      val expected = s"CREATE TABLE $fullName ( c1 INT COMMENT 'bla', c2 STRING)" +
+      val expected = s"CREATE TABLE $nsTable ( c1 INT COMMENT 'bla', c2 STRING)" +
         " ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe'" +
         " WITH SERDEPROPERTIES ( 'serialization.format' = '1')" +
         " STORED AS INPUTFORMAT 'org.apache.hadoop.mapred.TextInputFormat'" +
@@ -73,7 +74,7 @@ class ShowCreateTableSuite extends v1.ShowCreateTableSuiteBase with CommandSuite
              |)
            """.stripMargin
         )
-        val expected = s"CREATE EXTERNAL TABLE $fullName ( c1 INT COMMENT 'bla', c2 STRING)" +
+        val expected = s"CREATE EXTERNAL TABLE $nsTable ( c1 INT COMMENT 'bla', c2 STRING)" +
           s" ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe'" +
           s" WITH SERDEPROPERTIES ( 'serialization.format' = '1')" +
           s" STORED AS INPUTFORMAT 'org.apache.hadoop.mapred.TextInputFormat'" +
@@ -100,7 +101,7 @@ class ShowCreateTableSuite extends v1.ShowCreateTableSuiteBase with CommandSuite
            |)
          """.stripMargin
       )
-      val expected = s"CREATE TABLE $fullName ( c1 INT COMMENT 'bla', c2 STRING)" +
+      val expected = s"CREATE TABLE $nsTable ( c1 INT COMMENT 'bla', c2 STRING)" +
         " COMMENT 'bla' PARTITIONED BY (p1 BIGINT COMMENT 'bla', p2 STRING)" +
         " ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe'" +
         " WITH SERDEPROPERTIES ( 'serialization.format' = '1')" +
@@ -124,7 +125,7 @@ class ShowCreateTableSuite extends v1.ShowCreateTableSuiteBase with CommandSuite
            |NULL DEFINED AS 'NaN'
          """.stripMargin
       )
-      val expected = s"CREATE TABLE $fullName ( c1 INT COMMENT 'bla', c2 STRING)" +
+      val expected = s"CREATE TABLE $nsTable ( c1 INT COMMENT 'bla', c2 STRING)" +
         " ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe'" +
         " WITH SERDEPROPERTIES (" +
         " 'colelction.delim' = '@'," +
@@ -148,7 +149,7 @@ class ShowCreateTableSuite extends v1.ShowCreateTableSuiteBase with CommandSuite
            |STORED AS PARQUET
          """.stripMargin
       )
-      val expected = s"CREATE TABLE $fullName ( c1 INT COMMENT 'bla', c2 STRING)" +
+      val expected = s"CREATE TABLE $nsTable ( c1 INT COMMENT 'bla', c2 STRING)" +
         " ROW FORMAT SERDE 'org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe'" +
         " WITH SERDEPROPERTIES ( 'serialization.format' = '1')" +
         " STORED AS INPUTFORMAT 'org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat'" +
@@ -175,7 +176,7 @@ class ShowCreateTableSuite extends v1.ShowCreateTableSuiteBase with CommandSuite
            |  OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat'
          """.stripMargin
       )
-      val expected = s"CREATE TABLE $fullName ( c1 INT COMMENT 'bla', c2 STRING)" +
+      val expected = s"CREATE TABLE $nsTable ( c1 INT COMMENT 'bla', c2 STRING)" +
         " ROW FORMAT SERDE 'org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe'" +
         " WITH SERDEPROPERTIES (" +
         " 'field.delim' = ','," +
@@ -197,7 +198,7 @@ class ShowCreateTableSuite extends v1.ShowCreateTableSuiteBase with CommandSuite
            |INTO 2 BUCKETS
          """.stripMargin
       )
-      val expected = s"CREATE TABLE $fullName ( a INT, b STRING)" +
+      val expected = s"CREATE TABLE $nsTable ( a INT, b STRING)" +
         " CLUSTERED BY (a) SORTED BY (b ASC) INTO 2 BUCKETS" +
         " ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe'" +
         " WITH SERDEPROPERTIES ( 'serialization.format' = '1')" +


### PR DESCRIPTION

### What changes were proposed in this pull request?

This PR adds backticks to any identifiers with special characters for `SHOW CREATE TABLE`.

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?

Without proper backticks to quote the identifiers, if users copy paste the results from running `SHOW CREATE TABLE`,  they will hit analysis exception.

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?

Yes. The identifiers from the result of `SHOW CREATE TABLE` will be quoted if necessary (having special characters).

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?

Added UT.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
