### PR TITLE
[SPARK-42944][SS][PYTHON] Streaming ForeachBatch in Python

### DIFF
--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/streaming/StreamingQuerySuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/streaming/StreamingQuerySuite.scala
@@ -341,7 +341,7 @@ class StreamingQuerySuite extends QueryTest with SQLHelper with Logging {
         .start()
 
       eventually(timeout(30.seconds)) { // Wait for first progress.
-        assert(q.lastProgress != null)
+        assert(q.lastProgress != null, "Failed to make progress")
         assert(q.lastProgress.numInputRows > 0)
       }
 

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -2709,6 +2709,9 @@ class SparkConnectPlanner(val sessionHolder: SessionHolder) extends Logging {
             writeOp.getForeachBatch.getScalaFunction.getPayload.toByteArray,
             Utils.getContextOrSparkClassLoader)
           StreamingForeachBatchHelper.scalaForeachBatchWrapper(scalaFn, sessionHolder)
+
+        case StreamingForeachFunction.FunctionCase.FUNCTION_NOT_SET =>
+          throw InvalidPlanInput("Unexpected") // Unreachable
       }
 
       writer.foreachBatch(foreachBatchFn)

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/StreamingForeachBatchHelper.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/StreamingForeachBatchHelper.scala
@@ -18,6 +18,9 @@ package org.apache.spark.sql.connect.planner
 
 import java.util.UUID
 
+import org.apache.spark.api.python.PythonRDD
+import org.apache.spark.api.python.SimplePythonFunction
+import org.apache.spark.api.python.StreamingPythonRunner
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.connect.service.SessionHolder
@@ -29,23 +32,25 @@ object StreamingForeachBatchHelper extends Logging {
 
   type ForeachBatchFnType = (DataFrame, Long) => Unit
 
+  private case class FnArgsWithId(dfId: String, df: DataFrame, batchId: Long)
+
   /**
    * Return a new ForeachBatch function that wraps `fn`. It sets up DataFrame cache so that the
    * user function can access it. The cache is cleared once ForeachBatch returns.
    */
-  def dataFrameCachingWrapper(
-      fn: ForeachBatchFnType,
+  private def dataFrameCachingWrapper(
+      fn: FnArgsWithId => Unit,
       sessionHolder: SessionHolder): ForeachBatchFnType = { (df: DataFrame, batchId: Long) =>
     {
       val dfId = UUID.randomUUID().toString
       log.info(s"Caching DataFrame with id $dfId") // TODO: Add query id to the log.
 
-      // TODO: Sanity check there is no other active DataFrame for this query. Need to include
-      //       query id available in the cache for this check.
+      // TODO: Sanity check there is no other active DataFrame for this query. The query id
+      //       needs to be saved in the cache for this check.
 
       sessionHolder.cacheDataFrameById(dfId, df)
       try {
-        fn(df, batchId)
+        fn(FnArgsWithId(dfId, df, batchId))
       } finally {
         log.info(s"Removing DataFrame with id $dfId from the cache")
         sessionHolder.removeCachedDataFrame(dfId)
@@ -64,6 +69,41 @@ object StreamingForeachBatchHelper extends Logging {
       fn: ForeachBatchFnType,
       sessionHolder: SessionHolder): ForeachBatchFnType = {
     // TODO: Set up Spark Connect session. Do we actually need this for the first version?
-    dataFrameCachingWrapper(fn, sessionHolder)
+    dataFrameCachingWrapper(
+      (args: FnArgsWithId) => {
+        assert(sessionHolder.session == args.df.sparkSession) // XXX
+        fn(args.df, args.batchId) // dfId is not used, see hack comment above.
+      },
+      sessionHolder)
+  }
+
+  def pythonForeachBatchWrapper(
+    pythonFn: SimplePythonFunction,
+    sessionHolder: SessionHolder): ForeachBatchFnType = {
+
+    val runner = StreamingPythonRunner(pythonFn)
+    val (dataOut, dataIn) = runner.init(sessionHolder.sessionId)
+    // Need to register this runner shutdown as part of query shutdown.
+
+    val foreachBatchRunnerFn: FnArgsWithId => Unit = (args: FnArgsWithId) => {
+
+      // TODO: Set userId
+      // TODO: Auth credentials
+      // TODO: The current protocol is very basic. Improve this for SafeSpark.
+      PythonRDD.writeUTF(args.dfId, dataOut)
+      dataOut.writeLong(args.batchId)
+      dataOut.flush()
+
+      val ret = dataIn.readInt()
+      log.info(s"Python foreach batch for dfId ${args.dfId} completed (ret: $ret)")
+
+      // TODO: Decide on when to close the python process. Should be part of query shutdown.
+      //     : We could register a query listener.
+      //     : Need the caller to call back with queryId once it is registered.
+      //     : Do this as a follow up PR
+      // TODO: What does daemon process mean in this context? Do we need it?
+    }
+
+    dataFrameCachingWrapper(foreachBatchRunnerFn, sessionHolder)
   }
 }

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/StreamingForeachBatchHelper.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/StreamingForeachBatchHelper.scala
@@ -78,9 +78,9 @@ object StreamingForeachBatchHelper extends Logging {
   }
 
   /**
-   * Starts up Python worker and initializes it with Python function.
-   * Returns a foreachBatch function that sets up the session and Dataframe cache and
-   * and interacts with the Python worker to execute user's function.
+   * Starts up Python worker and initializes it with Python function. Returns a foreachBatch
+   * function that sets up the session and Dataframe cache and and interacts with the Python
+   * worker to execute user's function.
    */
   def pythonForeachBatchWrapper(
       pythonFn: SimplePythonFunction,

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/StreamingForeachBatchHelper.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/StreamingForeachBatchHelper.scala
@@ -89,7 +89,6 @@ object StreamingForeachBatchHelper extends Logging {
 
     val foreachBatchRunnerFn: FnArgsWithId => Unit = (args: FnArgsWithId) => {
 
-      // TODO: Set userId
       // TODO: Auth credentials
       // TODO: The current protocol is very basic. Improve this, especially for SafeSpark.
 
@@ -105,8 +104,6 @@ object StreamingForeachBatchHelper extends Logging {
       val ret = dataIn.readInt()
       log.info(s"Python foreach batch for dfId ${args.dfId} completed (ret: $ret)")
 
-      // When to terminate the runner: See comment below.
-      // TODO: What does daemon process mean in this context? Do we need it?
     }
 
     dataFrameCachingWrapper(foreachBatchRunnerFn, sessionHolder)

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/StreamingForeachBatchHelper.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/StreamingForeachBatchHelper.scala
@@ -72,7 +72,6 @@ object StreamingForeachBatchHelper extends Logging {
     // TODO: Set up Spark Connect session. Do we actually need this for the first version?
     dataFrameCachingWrapper(
       (args: FnArgsWithId) => {
-        assert(sessionHolder.session == args.df.sparkSession) // XXX
         fn(args.df, args.batchId) // dfId is not used, see hack comment above.
       },
       sessionHolder)

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/StreamingForeachBatchHelper.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/StreamingForeachBatchHelper.scala
@@ -83,13 +83,12 @@ object StreamingForeachBatchHelper extends Logging {
 
     val runner = StreamingPythonRunner(pythonFn)
     val (dataOut, dataIn) = runner.init(sessionHolder.sessionId)
-    // Need to register this runner shutdown as part of query shutdown.
 
     val foreachBatchRunnerFn: FnArgsWithId => Unit = (args: FnArgsWithId) => {
 
       // TODO: Set userId
       // TODO: Auth credentials
-      // TODO: The current protocol is very basic. Improve this for SafeSpark.
+      // TODO: The current protocol is very basic. Improve this, especially for SafeSpark.
       PythonRDD.writeUTF(args.dfId, dataOut)
       dataOut.writeLong(args.batchId)
       dataOut.flush()

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/StreamingForeachBatchHelper.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/StreamingForeachBatchHelper.scala
@@ -57,8 +57,8 @@ object StreamingForeachBatchHelper extends Logging {
    * Handles setting up Scala remote session and other Spark Connect environment and then runs the
    * provided foreachBatch function `fn`.
    *
-   * HACK ALERT: This version does not atually set up Spark connect. Directly passes the
-   * DataFrame, so the user code actually runs with legacy DataFrame.
+   * HACK ALERT: This version does not actually set up Spark Connect session. Directly passes the
+   * DataFrame, so the user code actually runs with legacy DataFrame and session..
    */
   def scalaForeachBatchWrapper(
       fn: ForeachBatchFnType,

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/StreamingForeachBatchHelper.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/StreamingForeachBatchHelper.scala
@@ -79,8 +79,8 @@ object StreamingForeachBatchHelper extends Logging {
   }
 
   def pythonForeachBatchWrapper(
-    pythonFn: SimplePythonFunction,
-    sessionHolder: SessionHolder): ForeachBatchFnType = {
+      pythonFn: SimplePythonFunction,
+      sessionHolder: SessionHolder): ForeachBatchFnType = {
 
     val port = SparkConnectService.localPort
     val connectUrl = s"sc://localhost:$port/;user_id=${sessionHolder.userId}"

--- a/core/src/main/scala/org/apache/spark/api/python/PythonRunner.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRunner.scala
@@ -799,6 +799,7 @@ private[spark] object SpecialLengths {
   val END_OF_STREAM = -4
   val NULL = -5
   val START_ARROW_STREAM = -6
+  val END_OF_MICRO_BATCH = -7
 }
 
 private[spark] object BarrierTaskContextMessageProtocol {

--- a/core/src/main/scala/org/apache/spark/api/python/PythonWorkerFactory.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonWorkerFactory.scala
@@ -106,59 +106,13 @@ private[spark] class PythonWorkerFactory(pythonExec: String, envVars: Map[String
       }
       createThroughDaemon()
     } else {
-      createSimpleWorker()
+      createSimpleWorker(workerModule)
     }
   }
 
+  /** Creates a Python worker with `pyspark.streaming_worker` module. */
   def createStreamingWorker(): (Socket, Option[Int]) = {
-    var serverSocket: ServerSocket = null
-    try {
-      serverSocket = new ServerSocket(0, 1, InetAddress.getLoopbackAddress())
-
-      val streamingWorkerModule = "pyspark.streaming_worker"
-
-      // Create and start the worker
-      val pb = new ProcessBuilder(Arrays.asList(pythonExec, "-m", streamingWorkerModule))
-      val workerEnv = pb.environment()
-      workerEnv.putAll(envVars.asJava)
-      workerEnv.put("PYTHONPATH", pythonPath)
-      // This is equivalent to setting the -u flag; we use it because ipython doesn't support -u:
-      workerEnv.put("PYTHONUNBUFFERED", "YES")
-      workerEnv.put("PYTHON_WORKER_FACTORY_PORT", serverSocket.getLocalPort.toString)
-      workerEnv.put("PYTHON_WORKER_FACTORY_SECRET", authHelper.secret)
-      if (Utils.preferIPv6) {
-        workerEnv.put("SPARK_PREFER_IPV6", "True")
-      }
-      val worker = pb.start()
-
-      // Redirect worker stdout and stderr
-      redirectStreamsToStderr(worker.getInputStream, worker.getErrorStream)
-
-      // Wait for it to connect to our socket, and validate the auth secret.
-      serverSocket.setSoTimeout(10000)
-
-      try {
-        val socket = serverSocket.accept()
-        authHelper.authClient(socket)
-        // TODO: When we drop JDK 8, we can just use worker.pid()
-        val pid = new DataInputStream(socket.getInputStream).readInt()
-        if (pid < 0) {
-          throw new IllegalStateException("Python failed to launch worker with code " + pid)
-        }
-        self.synchronized {
-          simpleWorkers.put(socket, worker)
-        }
-        return (socket, Some(pid))
-      } catch {
-        case e: Exception =>
-          throw new SparkException("Python worker failed to connect back.", e)
-      }
-    } finally {
-      if (serverSocket != null) {
-        serverSocket.close()
-      }
-    }
-    null
+    createSimpleWorker("pyspark.streaming_worker")
   }
 
   /**
@@ -201,7 +155,7 @@ private[spark] class PythonWorkerFactory(pythonExec: String, envVars: Map[String
   /**
    * Launch a worker by executing worker.py (by default) directly and telling it to connect to us.
    */
-  private def createSimpleWorker(): (Socket, Option[Int]) = {
+  private def createSimpleWorker(workerModule: String): (Socket, Option[Int]) = {
     var serverSocket: ServerSocket = null
     try {
       serverSocket = new ServerSocket(0, 1, InetAddress.getLoopbackAddress())

--- a/core/src/main/scala/org/apache/spark/api/python/StreamingPythonRunner.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/StreamingPythonRunner.scala
@@ -44,6 +44,10 @@ private[spark] class StreamingPythonRunner(func: PythonFunction, connectUrl: Str
   private val pythonExec: String = func.pythonExec
   protected val pythonVer: String = func.pythonVer
 
+  /**
+   * Initializes the Python worker for streaming functions. Sets up Spark Connect session
+   * to be used with the functions.
+   */
   def init(sessionId: String): (DataOutputStream, DataInputStream) = {
     log.info(s"Initializing Python runner (session: $sessionId ,pythonExec: $pythonExec")
 
@@ -57,7 +61,6 @@ private[spark] class StreamingPythonRunner(func: PythonFunction, connectUrl: Str
     conf.set(PYTHON_USE_DAEMON, false)
     envVars.put("SPARK_CONNECT_LOCAL_URL", connectUrl)
 
-    // TODO: cache and reuse the pythonWorkerFactory
     val pythonWorkerFactory = new PythonWorkerFactory(pythonExec, envVars.asScala.toMap)
     val (worker: Socket, _) = pythonWorkerFactory.createStreamingWorker()
 
@@ -82,5 +85,4 @@ private[spark] class StreamingPythonRunner(func: PythonFunction, connectUrl: Str
 
     (dataOut, dataIn)
   }
-
 }

--- a/core/src/main/scala/org/apache/spark/api/python/StreamingPythonRunner.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/StreamingPythonRunner.scala
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.api.python
+
+import java.io.{BufferedInputStream, BufferedOutputStream, DataInputStream, DataOutputStream}
+import java.net.Socket
+
+import scala.collection.JavaConverters._
+
+import org.apache.spark.SparkEnv
+import org.apache.spark.internal.config.BUFFER_SIZE
+import org.apache.spark.internal.config.Python.{PYTHON_AUTH_SOCKET_TIMEOUT, PYTHON_USE_DAEMON}
+
+
+private[spark] object StreamingPythonRunner {
+  def apply(func: PythonFunction): StreamingPythonRunner = {
+    new StreamingPythonRunner(func)
+  }
+}
+
+private[spark] class StreamingPythonRunner(func: PythonFunction) {
+  private val conf = SparkEnv.get.conf
+  protected val bufferSize: Int = conf.get(BUFFER_SIZE)
+  protected val authSocketTimeout = conf.get(PYTHON_AUTH_SOCKET_TIMEOUT)
+
+  private val envVars: java.util.Map[String, String] = func.envVars
+  private val pythonExec: String = func.pythonExec
+  protected val pythonVer: String = func.pythonVer
+
+  def init(sessionId: String): (DataOutputStream, DataInputStream) = {
+    // scalastyle:off println
+    println(s"##### init python runner for sessionId=$sessionId")
+    println(s"##### init python runner pythonExec=$pythonExec")
+    // scalastyle:on println
+
+    val startTime = System.currentTimeMillis
+    val env = SparkEnv.get
+
+    val localdir = env.blockManager.diskBlockManager.localDirs.map(f => f.getPath()).mkString(",")
+    envVars.put("SPARK_LOCAL_DIRS", localdir)
+
+    envVars.put("SPARK_AUTH_SOCKET_TIMEOUT", authSocketTimeout.toString)
+    envVars.put("SPARK_BUFFER_SIZE", bufferSize.toString)
+
+    // For now, not use daemon : XXX What does it mean?
+    conf.set(PYTHON_USE_DAEMON, false)
+
+    // TODO: cache and reuse the pythonWorkerFactory
+    val pythonWorkerFactory = new PythonWorkerFactory(pythonExec, envVars.asScala.toMap)
+    val (worker: Socket, pid: Option[Int]) = pythonWorkerFactory.createStreamingWorker()
+
+    val stream = new BufferedOutputStream(worker.getOutputStream, bufferSize)
+    val dataOut = new DataOutputStream(stream)
+
+    // TODO: verify python version
+
+    // send sessionID
+    PythonRDD.writeUTF(sessionId, dataOut)
+    // scalastyle:off println
+    println(s"##### sent sessionId to python")
+    // scalastyle:on println
+
+    // send the user function to python process
+    val command = func.command
+    dataOut.writeInt(command.length)
+    dataOut.write(command.toArray)
+    dataOut.flush()
+
+    // scalastyle:off println
+    println(s"##### sent func to python")
+    // scalastyle:on println
+
+    val dataIn = new DataInputStream(new BufferedInputStream(worker.getInputStream, bufferSize))
+    // scalastyle:off println
+    println(s"##### init dataIn")
+    // scalastyle:on println
+
+    val resFromPython = dataIn.readInt()
+    // scalastyle:off println
+    println(s"##### resFromPython = $resFromPython")
+    // scalastyle:on println
+
+    (dataOut, dataIn)
+  }
+
+}

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -58,6 +58,7 @@ from pyspark.sql.connect.plan import (
     LogicalPlan,
     CachedLocalRelation,
     CachedRelation,
+    CachedRemoteRelation,
 )
 from pyspark.sql.connect.readwriter import DataFrameReader
 from pyspark.sql.connect.streaming import DataStreamReader, StreamingQueryManager
@@ -653,6 +654,14 @@ class SparkSession:
         self._client.copy_from_local_to_fs(local_path, dest_path)
 
     copyFromLocalToFs.__doc__ = PySparkSession.copyFromLocalToFs.__doc__
+
+    def _createRemoteDataFrame(self, remote_id: str) -> "DataFrame":
+        """
+        In internal API to reference a runtime DataFrame on the server side.
+        This is used in ForeachBatch() runner, where the remote DataFrame refers to the
+        output of a micro batch.
+        """
+        return DataFrame.withPlan(CachedRemoteRelation(remote_id), self)
 
     @staticmethod
     def _start_connect_server(master: str, opts: Dict[str, Any]) -> None:

--- a/python/pyspark/sql/connect/streaming/readwriter.py
+++ b/python/pyspark/sql/connect/streaming/readwriter.py
@@ -495,18 +495,11 @@ class DataStreamWriter:
 
     foreach.__doc__ = PySparkDataStreamWriter.foreach.__doc__
 
-    # TODO (SPARK-42944): Implement and uncomment the doc
     def foreachBatch(self, func: Callable[["DataFrame", int], None]) -> "DataStreamWriter":
-        from pyspark.sql.connect.udf import UserDefinedFunction
-
-        udf_obj = UserDefinedFunction(
-            func,
-            returnType=StringType(),
-            evalType=PythonEvalType.SQL_BATCHED_UDF,
+        self._write_proto.foreach_batch.python_function.command = (
+            CloudPickleSerializer().dumps(func)
         )
-        udf_proto = udf_obj._build_common_inline_user_defined_function().to_plan_udf(self._session.client)
-        self._write_proto.for_each_batch.CopyFrom(udf_proto)
-
+        self._write_proto.foreach_batch.python_function.python_ver = "%d.%d" % sys.version_info[:2]
         return self
 
     foreachBatch.__doc__ = PySparkDataStreamWriter.foreachBatch.__doc__

--- a/python/pyspark/sql/connect/streaming/readwriter.py
+++ b/python/pyspark/sql/connect/streaming/readwriter.py
@@ -584,18 +584,6 @@ class DataStreamWriter:
     toTable.__doc__ = PySparkDataStreamWriter.toTable.__doc__
 
 
-# XXX Temporary:
-# Foreach batch steps:
-#   - Investigate how UDF starts the external process.
-#   - Connect over local unix socket.
-#   - pass the credentials, note down any todos w.r.t. credentials.
-#   - trigger execution from the driver
-#   - Cache the Dataframe and remove it once the execution is done.
-#   - Ensure there is only one.
-#   - Handle the errors.
-#   - Handle missing python process.
-#   - Write tests.
-
 def _test() -> None:
     import sys
     import doctest

--- a/python/pyspark/sql/connect/streaming/readwriter.py
+++ b/python/pyspark/sql/connect/streaming/readwriter.py
@@ -496,8 +496,8 @@ class DataStreamWriter:
     foreach.__doc__ = PySparkDataStreamWriter.foreach.__doc__
 
     def foreachBatch(self, func: Callable[["DataFrame", int], None]) -> "DataStreamWriter":
-        self._write_proto.foreach_batch.python_function.command = (
-            CloudPickleSerializer().dumps(func)
+        self._write_proto.foreach_batch.python_function.command = CloudPickleSerializer().dumps(
+            func
         )
         self._write_proto.foreach_batch.python_function.python_ver = "%d.%d" % sys.version_info[:2]
         return self

--- a/python/pyspark/sql/connect/streaming/readwriter.py
+++ b/python/pyspark/sql/connect/streaming/readwriter.py
@@ -31,8 +31,8 @@ from pyspark.sql.streaming.readwriter import (
     DataStreamReader as PySparkDataStreamReader,
     DataStreamWriter as PySparkDataStreamWriter,
 )
-from pyspark.sql.types import Row, StructType, StringType
-from pyspark.errors import PySparkTypeError, PySparkValueError, PySparkNotImplementedError
+from pyspark.sql.types import Row, StructType
+from pyspark.errors import PySparkTypeError, PySparkValueError
 
 if TYPE_CHECKING:
     from pyspark.sql.connect.session import SparkSession

--- a/python/pyspark/sql/tests/connect/streaming/test_parity_streaming_foreachBatch.py
+++ b/python/pyspark/sql/tests/connect/streaming/test_parity_streaming_foreachBatch.py
@@ -15,13 +15,21 @@
 # limitations under the License.
 #
 
+import unittest
+
 from pyspark.sql.tests.streaming.test_streaming_foreachBatch import StreamingTestsForeachBatchMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase
 
 
 class StreamingForeachBatchParityTests(StreamingTestsForeachBatchMixin, ReusedConnectTestCase):
-    def test_temp_verify_remote_session(self):
-        self.assertTrue(hasattr(self.spark, '_client'), "Why is this not using remote session?")
+
+    @unittest.skip("SPARK-XXX: Error handling needs improvement in connect foreachBatch")
+    def test_streaming_foreachBatch_propagates_python_errors(self):
+        super().test_streaming_foreachBatch_propagates_python_errors
+
+    @unittest.skip("This seems specific to py4j and pinned threads. The intention is unclear")
+    def test_streaming_foreachBatch_graceful_stop(self):
+        super().test_streaming_foreachBatch_graceful_stop()
 
 
 if __name__ == "__main__":

--- a/python/pyspark/sql/tests/connect/streaming/test_parity_streaming_foreachBatch.py
+++ b/python/pyspark/sql/tests/connect/streaming/test_parity_streaming_foreachBatch.py
@@ -33,7 +33,7 @@ class StreamingForeachBatchParityTests(StreamingTestsForeachBatchMixin, ReusedCo
 
 if __name__ == "__main__":
     import unittest
-    from pyspark.sql.tests.connect.streaming.test_parity_streaming_foreachBatch import *
+    from pyspark.sql.tests.connect.streaming.test_parity_streaming_foreachBatch import *  # noqa: F401
 
     try:
         import xmlrunner  # type: ignore[import]

--- a/python/pyspark/sql/tests/connect/streaming/test_parity_streaming_foreachBatch.py
+++ b/python/pyspark/sql/tests/connect/streaming/test_parity_streaming_foreachBatch.py
@@ -1,0 +1,36 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from pyspark.sql.tests.streaming.test_streaming_foreachBatch import StreamingTestsForeachBatchMixin
+from pyspark.testing.connectutils import ReusedConnectTestCase
+
+
+class StreamingForeachBatchParityTests(StreamingTestsForeachBatchMixin, ReusedConnectTestCase):
+    pass
+
+
+if __name__ == "__main__":
+    import unittest
+    from pyspark.sql.tests.connect.streaming.test_parity_streaming_foreachBatch import StreamingForeachBatchParityTests  # noqa: F401
+
+    try:
+        import xmlrunner  # type: ignore[import]
+
+        testRunner = xmlrunner.XMLTestRunner(output="target/test-reports", verbosity=2)
+    except ImportError:
+        testRunner = None
+    unittest.main(testRunner=testRunner, verbosity=2)

--- a/python/pyspark/sql/tests/connect/streaming/test_parity_streaming_foreachBatch.py
+++ b/python/pyspark/sql/tests/connect/streaming/test_parity_streaming_foreachBatch.py
@@ -23,7 +23,7 @@ from pyspark.testing.connectutils import ReusedConnectTestCase
 
 class StreamingForeachBatchParityTests(StreamingTestsForeachBatchMixin, ReusedConnectTestCase):
 
-    @unittest.skip("SPARK-XXX: Error handling needs improvement in connect foreachBatch")
+    @unittest.skip("SPARK-44463: Error handling needs improvement in connect foreachBatch")
     def test_streaming_foreachBatch_propagates_python_errors(self):
         super().test_streaming_foreachBatch_propagates_python_errors
 

--- a/python/pyspark/sql/tests/connect/streaming/test_parity_streaming_foreachBatch.py
+++ b/python/pyspark/sql/tests/connect/streaming/test_parity_streaming_foreachBatch.py
@@ -25,7 +25,9 @@ class StreamingForeachBatchParityTests(StreamingTestsForeachBatchMixin, ReusedCo
 
 if __name__ == "__main__":
     import unittest
-    from pyspark.sql.tests.connect.streaming.test_parity_streaming_foreachBatch import StreamingForeachBatchParityTests  # noqa: F401
+    from pyspark.sql.tests.connect.streaming.test_parity_streaming_foreachBatch import (
+        StreamingForeachBatchParityTests,
+    )  # noqa: F401
 
     try:
         import xmlrunner  # type: ignore[import]

--- a/python/pyspark/sql/tests/connect/streaming/test_parity_streaming_foreachBatch.py
+++ b/python/pyspark/sql/tests/connect/streaming/test_parity_streaming_foreachBatch.py
@@ -33,7 +33,7 @@ class StreamingForeachBatchParityTests(StreamingTestsForeachBatchMixin, ReusedCo
 
 if __name__ == "__main__":
     import unittest
-    from pyspark.sql.tests.connect.streaming.test_parity_streaming_foreachBatch import *  # noqa: F401
+    from pyspark.sql.tests.connect.streaming.test_parity_streaming_foreachBatch import *  # noqa: F401,E501
 
     try:
         import xmlrunner  # type: ignore[import]

--- a/python/pyspark/sql/tests/connect/streaming/test_parity_streaming_foreachBatch.py
+++ b/python/pyspark/sql/tests/connect/streaming/test_parity_streaming_foreachBatch.py
@@ -20,14 +20,13 @@ from pyspark.testing.connectutils import ReusedConnectTestCase
 
 
 class StreamingForeachBatchParityTests(StreamingTestsForeachBatchMixin, ReusedConnectTestCase):
-    pass
+    def test_temp_verify_remote_session(self):
+        self.assertTrue(hasattr(self.spark, '_client'), "Why is this not using remote session?")
 
 
 if __name__ == "__main__":
     import unittest
-    from pyspark.sql.tests.connect.streaming.test_parity_streaming_foreachBatch import (
-        StreamingForeachBatchParityTests,
-    )  # noqa: F401
+    from pyspark.sql.tests.connect.streaming.test_parity_streaming_foreachBatch import *
 
     try:
         import xmlrunner  # type: ignore[import]

--- a/python/pyspark/sql/tests/connect/streaming/test_parity_streaming_foreachBatch.py
+++ b/python/pyspark/sql/tests/connect/streaming/test_parity_streaming_foreachBatch.py
@@ -22,7 +22,6 @@ from pyspark.testing.connectutils import ReusedConnectTestCase
 
 
 class StreamingForeachBatchParityTests(StreamingTestsForeachBatchMixin, ReusedConnectTestCase):
-
     @unittest.skip("SPARK-44463: Error handling needs improvement in connect foreachBatch")
     def test_streaming_foreachBatch_propagates_python_errors(self):
         super().test_streaming_foreachBatch_propagates_python_errors

--- a/python/pyspark/sql/tests/streaming/test_streaming_foreachBatch.py
+++ b/python/pyspark/sql/tests/streaming/test_streaming_foreachBatch.py
@@ -20,40 +20,41 @@ import time
 from pyspark.testing.sqlutils import ReusedSQLTestCase
 
 
-class StreamingTestsForeachBatch(ReusedSQLTestCase):
+class StreamingTestsForeachBatchMixin(ReusedSQLTestCase):
     def test_streaming_foreachBatch(self):
         q = None
-        collected = dict()
 
         def collectBatch(batch_df, batch_id):
-            collected[batch_id] = batch_df.collect()
+            batch_df.createOrReplaceGlobalTempView("test_view")
 
         try:
             df = self.spark.readStream.format("text").load("python/test_support/sql/streaming")
             q = df.writeStream.foreachBatch(collectBatch).start()
             q.processAllAvailable()
-            self.assertTrue(0 in collected)
-            self.assertTrue(len(collected[0]), 2)
+            collected = self.spark.sql("select * from global_temp.test_view").collect()
+            self.assertTrue(len(collected), 2)
         finally:
             if q:
                 q.stop()
 
     def test_streaming_foreachBatch_tempview(self):
         q = None
-        collected = dict()
 
         def collectBatch(batch_df, batch_id):
             batch_df.createOrReplaceTempView("updates")
             # it should use the spark session within given DataFrame, as microbatch execution will
             # clone the session which is no longer same with the session used to start the
             # streaming query
-            collected[batch_id] = batch_df.sparkSession.sql("SELECT * FROM updates").collect()
+            self.assertTrue(
+                len(batch_df.sparkSession.sql("SELECT * FROM updates").collect()), 2)
+            # Write to a global view verify on the repl/client side.
+            batch_df.createOrReplaceGlobalTempView("temp_view")
 
         try:
             df = self.spark.readStream.format("text").load("python/test_support/sql/streaming")
             q = df.writeStream.foreachBatch(collectBatch).start()
             q.processAllAvailable()
-            self.assertTrue(0 in collected)
+            collected = self.spark.sql("SELECT * FROM global_temp.temp_view").collect()
             self.assertTrue(len(collected[0]), 2)
         finally:
             if q:
@@ -89,9 +90,13 @@ class StreamingTestsForeachBatch(ReusedSQLTestCase):
         self.assertIsNone(q.exception(), "No exception has to be propagated.")
 
 
+class StreamingTestsForeachBatch(StreamingTestsForeachBatchMixin, ReusedSQLTestCase):
+    pass
+
+
 if __name__ == "__main__":
     import unittest
-    from pyspark.sql.tests.streaming.test_streaming_foreachBatch import *  # noqa: F401
+    from pyspark.sql.tests.streaming.test_streaming_foreachBatch import StreamingTestsForeachBatch  # noqa: F401
 
     try:
         import xmlrunner

--- a/python/pyspark/sql/tests/streaming/test_streaming_foreachBatch.py
+++ b/python/pyspark/sql/tests/streaming/test_streaming_foreachBatch.py
@@ -20,7 +20,7 @@ import time
 from pyspark.testing.sqlutils import ReusedSQLTestCase
 
 
-class StreamingTestsForeachBatchMixin(ReusedSQLTestCase):
+class StreamingTestsForeachBatchMixin:
     def test_streaming_foreachBatch(self):
         q = None
 
@@ -95,9 +95,7 @@ class StreamingTestsForeachBatch(StreamingTestsForeachBatchMixin, ReusedSQLTestC
 
 if __name__ == "__main__":
     import unittest
-    from pyspark.sql.tests.streaming.test_streaming_foreachBatch import (
-        StreamingTestsForeachBatch,
-    )  # noqa: F401
+    from pyspark.sql.tests.streaming.test_streaming_foreachBatch import *  # noqa: F401
 
     try:
         import xmlrunner

--- a/python/pyspark/sql/tests/streaming/test_streaming_foreachBatch.py
+++ b/python/pyspark/sql/tests/streaming/test_streaming_foreachBatch.py
@@ -45,7 +45,7 @@ class StreamingTestsForeachBatchMixin:
             # it should use the spark session within given DataFrame, as microbatch execution will
             # clone the session which is no longer same with the session used to start the
             # streaming query
-            self.assertTrue(len(batch_df.sparkSession.sql("SELECT * FROM updates").collect()), 2)
+            assert len(batch_df.sparkSession.sql("SELECT * FROM updates").collect()) == 2
             # Write to a global view verify on the repl/client side.
             batch_df.createOrReplaceGlobalTempView("temp_view")
 

--- a/python/pyspark/sql/tests/streaming/test_streaming_foreachBatch.py
+++ b/python/pyspark/sql/tests/streaming/test_streaming_foreachBatch.py
@@ -45,8 +45,7 @@ class StreamingTestsForeachBatchMixin(ReusedSQLTestCase):
             # it should use the spark session within given DataFrame, as microbatch execution will
             # clone the session which is no longer same with the session used to start the
             # streaming query
-            self.assertTrue(
-                len(batch_df.sparkSession.sql("SELECT * FROM updates").collect()), 2)
+            self.assertTrue(len(batch_df.sparkSession.sql("SELECT * FROM updates").collect()), 2)
             # Write to a global view verify on the repl/client side.
             batch_df.createOrReplaceGlobalTempView("temp_view")
 
@@ -96,7 +95,9 @@ class StreamingTestsForeachBatch(StreamingTestsForeachBatchMixin, ReusedSQLTestC
 
 if __name__ == "__main__":
     import unittest
-    from pyspark.sql.tests.streaming.test_streaming_foreachBatch import StreamingTestsForeachBatch  # noqa: F401
+    from pyspark.sql.tests.streaming.test_streaming_foreachBatch import (
+        StreamingTestsForeachBatch,
+    )  # noqa: F401
 
     try:
         import xmlrunner

--- a/python/pyspark/streaming_worker.py
+++ b/python/pyspark/streaming_worker.py
@@ -61,7 +61,7 @@ def main(infile, outfile):
     # TODO: Enable Process Isolation
 
     func = worker.read_command(pickleSer, infile)
-    write_int(0, outfile) # Indicate successful initialization
+    write_int(0, outfile)  # Indicate successful initialization
 
     outfile.flush()
 

--- a/python/pyspark/streaming_worker.py
+++ b/python/pyspark/streaming_worker.py
@@ -1,0 +1,114 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Worker that receives input from Piped RDD.
+"""
+import os
+import sys
+import time
+from inspect import currentframe, getframeinfo, getfullargspec
+import importlib
+import json
+
+# 'resource' is a Unix specific module.
+has_resource_module = True
+try:
+    import resource
+except ImportError:
+    has_resource_module = False
+import traceback
+import warnings
+import faulthandler
+
+from pyspark.accumulators import _accumulatorRegistry
+from pyspark.broadcast import Broadcast, _broadcastRegistry
+from pyspark.java_gateway import local_connect_and_auth
+from pyspark.taskcontext import BarrierTaskContext, TaskContext
+from pyspark.files import SparkFiles
+from pyspark.resource import ResourceInformation
+from pyspark.rdd import PythonEvalType
+from pyspark.serializers import (
+    write_with_length,
+    write_int,
+    read_long,
+    read_bool,
+    write_long,
+    read_int,
+    SpecialLengths,
+    UTF8Deserializer,
+    CPickleSerializer,
+    BatchedSerializer,
+)
+from pyspark.sql.pandas.serializers import (
+    ArrowStreamPandasUDFSerializer,
+    CogroupUDFSerializer,
+    ArrowStreamUDFSerializer,
+    ApplyInPandasWithStateSerializer,
+)
+from pyspark.sql.pandas.types import to_arrow_type
+from pyspark.sql.types import StructType
+from pyspark.util import fail_on_stopiteration, try_simplify_traceback
+from pyspark import shuffle
+from pyspark import worker
+from pyspark.sql import SparkSession
+
+pickleSer = CPickleSerializer()
+utf8_deserializer = UTF8Deserializer()
+
+def main(infile, outfile):
+    sessionId = utf8_deserializer.loads(infile)
+    print("##### sessionId in python process is", sessionId)
+    sparkConnectSession = SparkSession.builder.remote("sc://localhost:15002").getOrCreate()
+    sparkConnectSession._client._session_id = sessionId
+
+    # XXX Need to pass in user id. Any other credentials?
+
+    func, _ = worker.read_command(pickleSer, infile)
+    print("##### func test test in python process is", func)
+
+    write_int(9999, outfile)
+    print("##### write data 9999 to server", func)
+
+    outfile.flush()
+
+    def process(dfRefId, batchId):
+        print('##### start processing dfRefId', dfRefId)
+        batchDf = sparkConnectSession.createRefDataFrame(dfRefId) # Use new id.
+        func(batchDf, batchId)
+
+    while True:
+        dfRefId = utf8_deserializer.loads(infile)
+        print("##### dfRefId received from python process is", dfRefId)
+        batchId = read_long(infile)
+        print("##### batchId received from python process is", batchId)
+        process(dfRefId, int(batchId)) # Handle errors.
+        write_int(SpecialLengths.END_OF_MICRO_BATCH, outfile)
+        outfile.flush()
+
+
+if __name__ == "__main__":
+    print("##### start streaming worker.py")
+
+    # Read information about how to connect back to the JVM from the environment.
+    java_port = int(os.environ["PYTHON_WORKER_FACTORY_PORT"])
+    auth_secret = os.environ["PYTHON_WORKER_FACTORY_SECRET"]
+    (sock_file, _) = local_connect_and_auth(java_port, auth_secret)
+    # TODO: Remove the following two lines and use `Process.pid()` when we drop JDK 8.
+    write_int(os.getpid(), sock_file)
+    sock_file.flush()
+    main(sock_file, sock_file)

--- a/python/pyspark/streaming_worker.py
+++ b/python/pyspark/streaming_worker.py
@@ -34,7 +34,7 @@ pickleSer = CPickleSerializer()
 utf8_deserializer = UTF8Deserializer()
 
 
-def main(infile, outfile) -> None:
+def main(infile, outfile):  # type: ignore[no-untyped-def]
     log_name = "Streaming ForeachBatch worker"
     connect_url = os.environ["SPARK_CONNECT_LOCAL_URL"]
     sessionId = utf8_deserializer.loads(infile)
@@ -42,7 +42,7 @@ def main(infile, outfile) -> None:
     print(f"{log_name} is starting with url {connect_url} and sessionId {sessionId}.")
 
     sparkConnectSession = SparkSession.builder.remote(connect_url).getOrCreate()
-    sparkConnectSession._client._session_id = sessionId
+    sparkConnectSession._client._session_id = sessionId  # type: ignore[attr-defined]
 
     # TODO(SPARK-44460): Pass credentials.
     # TODO(SPARK-44461): Enable Process Isolation
@@ -52,9 +52,9 @@ def main(infile, outfile) -> None:
 
     outfile.flush()
 
-    def process(dfId, batchId) -> None:
+    def process(dfId, batchId):  # type: ignore[no-untyped-def]
         print(f"{log_name} Started batch {batchId} with DF id {dfId}")
-        batchDf = sparkConnectSession._createRemoteDataFrame(dfId)
+        batchDf = sparkConnectSession._createRemoteDataFrame(dfId)  # type: ignore[attr-defined]
         func(batchDf, batchId)
         print(f"{log_name} Completed batch {batchId} with DF id {dfId}")
 

--- a/python/pyspark/streaming_worker.py
+++ b/python/pyspark/streaming_worker.py
@@ -16,27 +16,14 @@
 #
 
 """
-Worker that receives input from Piped RDD.
+A worker for streaming foreachBatch and query listener in Spark Connect.
 """
 import os
-import sys
-import time
-from inspect import currentframe, getframeinfo, getfullargspec
-import importlib
-import json
-
-# 'resource' is a Unix specific module.
-has_resource_module = True
-try:
-    import resource
-except ImportError:
-    has_resource_module = False
 
 from pyspark.java_gateway import local_connect_and_auth
 from pyspark.serializers import (
     write_int,
     read_long,
-    SpecialLengths,
     UTF8Deserializer,
     CPickleSerializer,
 )
@@ -47,7 +34,7 @@ pickleSer = CPickleSerializer()
 utf8_deserializer = UTF8Deserializer()
 
 
-def main(infile, outfile):
+def main(infile, outfile) -> None:
     log_name = "Streaming ForeachBatch worker"
     connect_url = os.environ["SPARK_CONNECT_LOCAL_URL"]
     sessionId = utf8_deserializer.loads(infile)
@@ -65,7 +52,7 @@ def main(infile, outfile):
 
     outfile.flush()
 
-    def process(dfId, batchId):
+    def process(dfId, batchId) -> None:
         print(f"{log_name} Started batch {batchId} with DF id {dfId}")
         batchDf = sparkConnectSession._createRemoteDataFrame(dfId)
         func(batchDf, batchId)

--- a/python/pyspark/streaming_worker.py
+++ b/python/pyspark/streaming_worker.py
@@ -74,7 +74,7 @@ def main(infile, outfile):
     while True:
         dfRefId = utf8_deserializer.loads(infile)
         batchId = read_long(infile)
-        process(dfRefId, int(batchId))  # TODO:     Propagate error better to the user.
+        process(dfRefId, int(batchId))  # TODO(SPARK-44463): Propagate error to the user.
         write_int(0, outfile)
         outfile.flush()
 

--- a/python/pyspark/streaming_worker.py
+++ b/python/pyspark/streaming_worker.py
@@ -49,7 +49,7 @@ utf8_deserializer = UTF8Deserializer()
 
 def main(infile, outfile):
     log_name = "Streaming ForeachBatch worker"
-    connect_url = os.environ["SPARK_CONNECT_LOCAL_URLX"]
+    connect_url = os.environ["SPARK_CONNECT_LOCAL_URL"]
     sessionId = utf8_deserializer.loads(infile)
 
     print(f"{log_name} is starting with url {connect_url} and sessionId {sessionId}.")

--- a/python/pyspark/streaming_worker.py
+++ b/python/pyspark/streaming_worker.py
@@ -42,7 +42,7 @@ def main(infile, outfile):  # type: ignore[no-untyped-def]
     print(f"{log_name} is starting with url {connect_url} and sessionId {sessionId}.")
 
     sparkConnectSession = SparkSession.builder.remote(connect_url).getOrCreate()
-    sparkConnectSession._client._session_id = sessionId  # type: ignore[attr-defined]
+    sparkConnectSession._client._session_id = sessionId
 
     # TODO(SPARK-44460): Pass credentials.
     # TODO(SPARK-44461): Enable Process Isolation
@@ -54,7 +54,7 @@ def main(infile, outfile):  # type: ignore[no-untyped-def]
 
     def process(dfId, batchId):  # type: ignore[no-untyped-def]
         print(f"{log_name} Started batch {batchId} with DF id {dfId}")
-        batchDf = sparkConnectSession._createRemoteDataFrame(dfId)  # type: ignore[attr-defined]
+        batchDf = sparkConnectSession._createRemoteDataFrame(dfId)
         func(batchDf, batchId)
         print(f"{log_name} Completed batch {batchId} with DF id {dfId}")
 

--- a/python/pyspark/streaming_worker.py
+++ b/python/pyspark/streaming_worker.py
@@ -57,8 +57,8 @@ def main(infile, outfile):
     sparkConnectSession = SparkSession.builder.remote(connect_url).getOrCreate()
     sparkConnectSession._client._session_id = sessionId
 
-    # TODO: Pass credentials.
-    # TODO: Enable Process Isolation
+    # TODO(SPARK-44460): Pass credentials.
+    # TODO(SPARK-44461): Enable Process Isolation
 
     func = worker.read_command(pickleSer, infile)
     write_int(0, outfile)  # Indicate successful initialization


### PR DESCRIPTION
Adds `foreachBatch()` in Python. This adds a new runner `StreamingPythonRunner`.
Note that this PR focuses on core functionality and includes TODO for followup improvements (will update with jira tickets where missing).

Included more inline comments to help with the review. 

### What changes were proposed in this pull request?
Adds support for foreachBatch() in Spark connect. 

### Why are the changes needed?
  - Manual tests
  - Unit tests:
     - The tests are updated to use a global temp view, rather than shared variable since connect version of the function runs on the server side.



### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
