### PR TITLE
[SPARK-44305][SQL] Dynamically choose whether to broadcast hadoop conf

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormat.scala
@@ -95,6 +95,14 @@ trait FileFormat {
   }
 
   /**
+   * Returns whether Hadoop configuration needs to be broadcasted.
+   */
+  def isBroadcastHadoopConf(
+      options: Map[String, String]): Boolean = {
+    true
+  }
+
+  /**
    * Returns a function that can be used to read a single file in as an Iterator of InternalRow.
    *
    * @param dataSchema The global data schema. It can be either specified by the user, or

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormat.scala
@@ -97,7 +97,7 @@ trait FileFormat {
   /**
    * Returns whether Hadoop configuration needs to be broadcasted.
    */
-  def isBroadcastHadoopConf(
+  def shouldBroadcastHadoopConf(
       options: Map[String, String]): Boolean = {
     true
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
@@ -170,7 +170,7 @@ class OrcFileFormat
       } else {
         val conf = SparkHadoopUtil.newConfiguration(sparkConf)
         OrcConf.IS_SCHEMA_EVOLUTION_CASE_SENSITIVE.setBoolean(conf, isCaseSensitive)
-        new SerializableConfiguration(conf).value
+        conf
       }
 
       val filePath = file.toPath

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
@@ -108,7 +108,7 @@ class ParquetFileFormat
     true
   }
 
-  override def isBroadcastHadoopConf(options: Map[String, String]): Boolean = {
+  override def shouldBroadcastHadoopConf(options: Map[String, String]): Boolean = {
     options.isEmpty
   }
 
@@ -195,7 +195,7 @@ class ParquetFileFormat
       SQLConf.LEGACY_PARQUET_NANOS_AS_LONG.key,
       legacyParquetNanosAsLong)
 
-    val broadcastedHadoopConf = if (isBroadcastHadoopConf(options)) {
+    val broadcastedHadoopConf = if (shouldBroadcastHadoopConf(options)) {
       Option.empty
     } else {
       Option(sparkSession.sparkContext.broadcast(new SerializableConfiguration(hadoopConf)))
@@ -257,7 +257,7 @@ class ParquetFileFormat
         conf.setBoolean(
           SQLConf.LEGACY_PARQUET_NANOS_AS_LONG.key,
           legacyParquetNanosAsLong)
-        new SerializableConfiguration(conf).value
+        conf
       }
 
       val fileFooter = if (enableVectorizedReader) {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/orc/OrcFileFormat.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/orc/OrcFileFormat.scala
@@ -128,6 +128,10 @@ class OrcFileFormat extends FileFormat with DataSourceRegister with Serializable
     true
   }
 
+  override def shouldBroadcastHadoopConf(options: Map[String, String]): Boolean = {
+    options.isEmpty
+  }
+
   override def buildReader(
       sparkSession: SparkSession,
       dataSchema: StructType,
@@ -146,7 +150,7 @@ class OrcFileFormat extends FileFormat with DataSourceRegister with Serializable
       }
     }
 
-    val broadcastedHadoopConf = if (options.isEmpty) {
+    val broadcastedHadoopConf = if (shouldBroadcastHadoopConf(options)) {
       Option.empty
     } else {
       Option(sparkSession.sparkContext.broadcast(new SerializableConfiguration(hadoopConf)))
@@ -166,7 +170,7 @@ class OrcFileFormat extends FileFormat with DataSourceRegister with Serializable
             conf.setBoolean(ConfVars.HIVEOPTINDEXFILTER.varname, true)
           }
         }
-        new SerializableConfiguration(conf).value
+        conf
       }
 
       val filePath = file.toPath


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
The ability introduced by [SPARK-14912](https://issues.apache.org/jira/browse/SPARK-14912), we can broadcast the parameters of the data source to the read and write operations, but if the user does not specify a specific parameter, the propagation operation will also be performed, which affects the performance has a greater impact, so we need to avoid broadcasting the full Hadoop parameters when the user does not specify a specific parameter
-->
In the buildReaderWithPartitionValues method of ParquetFileFormat and OrcFileFormat, it will determine whether to broadcast hadoopconf according to whether there are hadoop parameters specified by the customer. If there are no parameters specified by the user, the broadcast operation of hadoopconf will not be performed to improve the performance of the driver.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
The ability introduced by [SPARK-14912](https://issues.apache.org/jira/browse/SPARK-14912), we can broadcast the parameters of the data source to the read and write operations, but if the user does not specify a specific parameter, the propagation operation will also be performed, which affects the performance has a greater impact, so we need to avoid broadcasting the full Hadoop parameters when the user does not specify a specific parameter

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
NO

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
QPS improvement, detailed test data will be added later