### PR TITLE
[SPARK-44264][ML][PYTHON] Incorporating FunctionPickler Into TorchDistributor

### DIFF
--- a/python/pyspark/ml/torch/distributor.py
+++ b/python/pyspark/ml/torch/distributor.py
@@ -751,8 +751,9 @@ class TorchDistributor(Distributor):
             train_fn, "", save_dir, *args, **kwargs
         )
         output_file_path = os.path.join(save_dir, TorchDistributor._PICKLED_OUTPUT_FILE)
+        script_path = os.path.join(save_dir, TorchDistributor._TRAIN_FILE)
         train_file_path = FunctionPickler.create_fn_run_script(
-            pickle_file_path, output_file_path, TorchDistributor._TRAIN_FILE
+            pickle_file_path, output_file_path, script_path
         )
         try:
             yield (train_file_path, output_file_path)


### PR DESCRIPTION
### What changes were proposed in this pull request?
For the pickling process when running distributed training on functions, I migrated the TorchDistributor to leverage the FunctionPickler class instead of internal functions. This separates the responsibility better and uses code already written and tested. 

FunctionPickler PR is [here](https://github.com/apache/spark/pull/41946).


### Why are the changes needed?
Separates the responsibility, making TorchDistributor class deal with more focused responsibility.


### Does this PR introduce _any_ user-facing change?
No, this is all internal. 


### How was this patch tested?
Existing TorchDistributor tests.
