### PR TITLE
[SPARK-44465][BUILD] Upgrade zstd-jni to 1.5.5-5

### DIFF
--- a/core/benchmarks/ZStandardBenchmark-jdk11-results.txt
+++ b/core/benchmarks/ZStandardBenchmark-jdk11-results.txt
@@ -2,26 +2,26 @@
 Benchmark ZStandardCompressionCodec
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.19+7 on Linux 5.15.0-1038-azure
+OpenJDK 64-Bit Server VM 11.0.19+7 on Linux 5.15.0-1041-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Benchmark ZStandardCompressionCodec:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------
-Compression 10000 times at level 1 without buffer pool            531            598          80          0.0       53076.5       1.0X
-Compression 10000 times at level 2 without buffer pool            594            594           0          0.0       59383.7       0.9X
-Compression 10000 times at level 3 without buffer pool            792            806          18          0.0       79199.0       0.7X
-Compression 10000 times at level 1 with buffer pool               333            334           1          0.0       33294.3       1.6X
-Compression 10000 times at level 2 with buffer pool               397            399           2          0.0       39743.5       1.3X
-Compression 10000 times at level 3 with buffer pool               588            588           0          0.0       58806.3       0.9X
+Compression 10000 times at level 1 without buffer pool            544            550           8          0.0       54399.6       1.0X
+Compression 10000 times at level 2 without buffer pool            835            837           2          0.0       83483.4       0.7X
+Compression 10000 times at level 3 without buffer pool           1012           1018           8          0.0      101204.0       0.5X
+Compression 10000 times at level 1 with buffer pool               377            379           1          0.0       37655.3       1.4X
+Compression 10000 times at level 2 with buffer pool               442            443           1          0.0       44175.8       1.2X
+Compression 10000 times at level 3 with buffer pool               622            628           5          0.0       62236.7       0.9X
 
-OpenJDK 64-Bit Server VM 11.0.19+7 on Linux 5.15.0-1038-azure
+OpenJDK 64-Bit Server VM 11.0.19+7 on Linux 5.15.0-1041-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Benchmark ZStandardCompressionCodec:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------
-Decompression 10000 times from level 1 without buffer pool            721            722           2          0.0       72112.3       1.0X
-Decompression 10000 times from level 2 without buffer pool            718            719           1          0.0       71807.7       1.0X
-Decompression 10000 times from level 3 without buffer pool            721            722           0          0.0       72103.6       1.0X
-Decompression 10000 times from level 1 with buffer pool               529            530           2          0.0       52856.1       1.4X
-Decompression 10000 times from level 2 with buffer pool               529            529           0          0.0       52850.4       1.4X
-Decompression 10000 times from level 3 with buffer pool               529            529           0          0.0       52878.5       1.4X
+Decompression 10000 times from level 1 without buffer pool            720            735          16          0.0       72013.1       1.0X
+Decompression 10000 times from level 2 without buffer pool            721            743          31          0.0       72115.0       1.0X
+Decompression 10000 times from level 3 without buffer pool            718            728           9          0.0       71837.2       1.0X
+Decompression 10000 times from level 1 with buffer pool               527            528           1          0.0       52734.3       1.4X
+Decompression 10000 times from level 2 with buffer pool               529            530           2          0.0       52879.0       1.4X
+Decompression 10000 times from level 3 with buffer pool               529            530           2          0.0       52867.5       1.4X
 
 

--- a/core/benchmarks/ZStandardBenchmark-jdk17-results.txt
+++ b/core/benchmarks/ZStandardBenchmark-jdk17-results.txt
@@ -2,26 +2,26 @@
 Benchmark ZStandardCompressionCodec
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.7+7 on Linux 5.15.0-1039-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.7+7 on Linux 5.15.0-1041-azure
+Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
 Benchmark ZStandardCompressionCodec:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------
-Compression 10000 times at level 1 without buffer pool           2281           2288          10          0.0      228093.0       1.0X
-Compression 10000 times at level 2 without buffer pool           2213           2282          98          0.0      221314.5       1.0X
-Compression 10000 times at level 3 without buffer pool           2377           2379           3          0.0      237678.5       1.0X
-Compression 10000 times at level 1 with buffer pool              2053           2058           6          0.0      205331.4       1.1X
-Compression 10000 times at level 2 with buffer pool              2115           2123          11          0.0      211512.9       1.1X
-Compression 10000 times at level 3 with buffer pool              2288           2291           3          0.0      228832.4       1.0X
+Compression 10000 times at level 1 without buffer pool           2961           2961           0          0.0      296098.7       1.0X
+Compression 10000 times at level 2 without buffer pool           3071           3091          28          0.0      307071.4       1.0X
+Compression 10000 times at level 3 without buffer pool           3371           3431          86          0.0      337077.6       0.9X
+Compression 10000 times at level 1 with buffer pool              2719           2729          14          0.0      271869.6       1.1X
+Compression 10000 times at level 2 with buffer pool              2812           2824          18          0.0      281208.3       1.1X
+Compression 10000 times at level 3 with buffer pool              3095           3103          11          0.0      309545.6       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.7+7 on Linux 5.15.0-1039-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.7+7 on Linux 5.15.0-1041-azure
+Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
 Benchmark ZStandardCompressionCodec:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------
-Decompression 10000 times from level 1 without buffer pool           2101           2105           6          0.0      210130.8       1.0X
-Decompression 10000 times from level 2 without buffer pool           2104           2105           2          0.0      210381.8       1.0X
-Decompression 10000 times from level 3 without buffer pool           2105           2106           2          0.0      210502.2       1.0X
-Decompression 10000 times from level 1 with buffer pool              1945           1946           1          0.0      194513.0       1.1X
-Decompression 10000 times from level 2 with buffer pool              1947           1947           0          0.0      194670.9       1.1X
-Decompression 10000 times from level 3 with buffer pool              1947           1947           0          0.0      194663.1       1.1X
+Decompression 10000 times from level 1 without buffer pool           2888           2904          22          0.0      288829.8       1.0X
+Decompression 10000 times from level 2 without buffer pool           2887           2891           6          0.0      288689.6       1.0X
+Decompression 10000 times from level 3 without buffer pool           2989           2993           6          0.0      298852.0       1.0X
+Decompression 10000 times from level 1 with buffer pool              2671           2687          23          0.0      267052.5       1.1X
+Decompression 10000 times from level 2 with buffer pool              2616           2618           4          0.0      261552.7       1.1X
+Decompression 10000 times from level 3 with buffer pool              2609           2633          34          0.0      260941.0       1.1X
 
 

--- a/core/benchmarks/ZStandardBenchmark-results.txt
+++ b/core/benchmarks/ZStandardBenchmark-results.txt
@@ -2,26 +2,26 @@
 Benchmark ZStandardCompressionCodec
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_372-b07 on Linux 5.15.0-1038-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_372-b07 on Linux 5.15.0-1041-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Benchmark ZStandardCompressionCodec:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------
-Compression 10000 times at level 1 without buffer pool            462            596         154          0.0       46182.3       1.0X
-Compression 10000 times at level 2 without buffer pool            532            544          11          0.0       53213.2       0.9X
-Compression 10000 times at level 3 without buffer pool            777            785          10          0.0       77733.9       0.6X
-Compression 10000 times at level 1 with buffer pool               252            256           5          0.0       25152.3       1.8X
-Compression 10000 times at level 2 with buffer pool               331            343           7          0.0       33129.1       1.4X
-Compression 10000 times at level 3 with buffer pool               563            579          13          0.0       56340.4       0.8X
+Compression 10000 times at level 1 without buffer pool            293            327          85          0.0       29283.2       1.0X
+Compression 10000 times at level 2 without buffer pool            322            324           2          0.0       32184.8       0.9X
+Compression 10000 times at level 3 without buffer pool            453            456           2          0.0       45285.1       0.6X
+Compression 10000 times at level 1 with buffer pool               171            173           1          0.1       17065.2       1.7X
+Compression 10000 times at level 2 with buffer pool               208            209           1          0.0       20786.5       1.4X
+Compression 10000 times at level 3 with buffer pool               334            335           2          0.0       33350.3       0.9X
 
-OpenJDK 64-Bit Server VM 1.8.0_372-b07 on Linux 5.15.0-1038-azure
-Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_372-b07 on Linux 5.15.0-1041-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Benchmark ZStandardCompressionCodec:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------
-Decompression 10000 times from level 1 without buffer pool            722            744          22          0.0       72246.4       1.0X
-Decompression 10000 times from level 2 without buffer pool            726            745          19          0.0       72557.0       1.0X
-Decompression 10000 times from level 3 without buffer pool            743            751          10          0.0       74300.3       1.0X
-Decompression 10000 times from level 1 with buffer pool               521            530           6          0.0       52097.1       1.4X
-Decompression 10000 times from level 2 with buffer pool               521            529           6          0.0       52119.5       1.4X
-Decompression 10000 times from level 3 with buffer pool               532            540           7          0.0       53232.3       1.4X
+Decompression 10000 times from level 1 without buffer pool            554            558           3          0.0       55412.8       1.0X
+Decompression 10000 times from level 2 without buffer pool            555            557           3          0.0       55466.7       1.0X
+Decompression 10000 times from level 3 without buffer pool            554            557           3          0.0       55440.9       1.0X
+Decompression 10000 times from level 1 with buffer pool               438            439           1          0.0       43763.4       1.3X
+Decompression 10000 times from level 2 with buffer pool               438            439           1          0.0       43783.1       1.3X
+Decompression 10000 times from level 3 with buffer pool               438            439           2          0.0       43781.5       1.3X
 
 

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -252,4 +252,4 @@ xz/1.9//xz-1.9.jar
 zjsonpatch/0.3.0//zjsonpatch-0.3.0.jar
 zookeeper-jute/3.6.3//zookeeper-jute-3.6.3.jar
 zookeeper/3.6.3//zookeeper-3.6.3.jar
-zstd-jni/1.5.5-4//zstd-jni-1.5.5-4.jar
+zstd-jni/1.5.5-5//zstd-jni-1.5.5-5.jar

--- a/pom.xml
+++ b/pom.xml
@@ -797,7 +797,7 @@
       <dependency>
         <groupId>com.github.luben</groupId>
         <artifactId>zstd-jni</artifactId>
-        <version>1.5.5-4</version>
+        <version>1.5.5-5</version>
       </dependency>
       <dependency>
         <groupId>com.clearspring.analytics</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?
 This pr aims upgrade `zstd-jni` from 1.5.5-4 to 1.5.5-5.

### Why are the changes needed?
New version includes some improvment:
[Support setting advanced compression parameters](https://github.com/luben/zstd-jni/commit/449d162cafbe564bdca0536f5cbd1e3964622c42)


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA.