### PR TITLE
[SPARK-44466][SQL] Exclude configs starting with `SPARK_DRIVER_PREFIX` and `SPARK_EXECUTOR_PREFIX` from modifiedConfigs

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -1103,9 +1103,7 @@ object SparkSession extends Logging {
         loadExtensions(extensions)
         applyExtensions(sparkContext, extensions)
 
-        // Some config might supplemented. For example: spark.driver.extraJavaOptions.
-        val supplementedOptions = options.map { case (k, v) => k -> sparkContext.conf.get(k, v) }
-        session = new SparkSession(sparkContext, None, None, extensions, supplementedOptions.toMap)
+        session = new SparkSession(sparkContext, None, None, extensions, options.toMap)
         setDefaultSession(session)
         setActiveSession(session)
         registerContextListener(sparkContext)

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -1103,7 +1103,9 @@ object SparkSession extends Logging {
         loadExtensions(extensions)
         applyExtensions(sparkContext, extensions)
 
-        session = new SparkSession(sparkContext, None, None, extensions, options.toMap)
+        // Some config might supplemented. For example: spark.driver.extraJavaOptions.
+        val supplementedOptions = options.map { case (k, _) => k -> sparkContext.conf.get(k) }
+        session = new SparkSession(sparkContext, None, None, extensions, supplementedOptions.toMap)
         setDefaultSession(session)
         setActiveSession(session)
         registerContextListener(sparkContext)

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -1104,7 +1104,7 @@ object SparkSession extends Logging {
         applyExtensions(sparkContext, extensions)
 
         // Some config might supplemented. For example: spark.driver.extraJavaOptions.
-        val supplementedOptions = options.map { case (k, _) => k -> sparkContext.conf.get(k) }
+        val supplementedOptions = options.map { case (k, v) => k -> sparkContext.conf.get(k, v) }
         session = new SparkSession(sparkContext, None, None, extensions, supplementedOptions.toMap)
         setDefaultSession(session)
         setActiveSession(session)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala
@@ -21,6 +21,7 @@ import java.util.concurrent.{ConcurrentHashMap, ExecutorService, Future => JFutu
 import java.util.concurrent.atomic.AtomicLong
 
 import org.apache.spark.{ErrorMessageFormat, SparkContext, SparkThrowable, SparkThrowableHelper}
+import org.apache.spark.internal.config.{SPARK_DRIVER_PREFIX, SPARK_EXECUTOR_PREFIX}
 import org.apache.spark.internal.config.Tests.IS_TESTING
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.execution.ui.{SparkListenerSQLExecutionEnd, SparkListenerSQLExecutionStart}
@@ -97,7 +98,11 @@ object SQLExecution {
 
       val globalConfigs = sparkSession.sharedState.conf.getAll.toMap
       val modifiedConfigs = sparkSession.sessionState.conf.getAllConfs
-        .filterNot(kv => globalConfigs.get(kv._1).contains(kv._2))
+        .filterNot { case (key, value) =>
+          key.startsWith(SPARK_DRIVER_PREFIX) ||
+            key.startsWith(SPARK_EXECUTOR_PREFIX) ||
+            globalConfigs.get(key).contains(value)
+        }
       val redactedConfigs = sparkSession.sessionState.conf.redactOptions(modifiedConfigs)
 
       withSQLConfPropagated(sparkSession) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLExecutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLExecutionSuite.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.sql.execution
 
-
-
 import java.util.Locale
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicInteger

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLExecutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLExecutionSuite.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.execution
 
+
+
 import java.util.Locale
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicInteger
@@ -26,6 +28,7 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
 
 import org.apache.spark.{SparkConf, SparkContext, SparkFunSuite}
+import org.apache.spark.launcher.SparkLauncher
 import org.apache.spark.scheduler.{SparkListener, SparkListenerEvent, SparkListenerJobStart}
 import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionStart
@@ -167,6 +170,7 @@ class SQLExecutionSuite extends SparkFunSuite {
       .master("local[*]")
       .appName("test")
       .config("k1", "v1")
+      .config(SparkLauncher.DRIVER_EXTRA_JAVA_OPTIONS, "-Dkey=value")
       .getOrCreate()
 
     try {
@@ -182,6 +186,7 @@ class SQLExecutionSuite extends SparkFunSuite {
               assert(start.modifiedConfigs("k2") == "v2")
               assert(start.modifiedConfigs.contains("redaction.password"))
               assert(start.modifiedConfigs("redaction.password") == REDACTION_REPLACEMENT_TEXT)
+              assert(!start.modifiedConfigs.contains(SparkLauncher.DRIVER_EXTRA_JAVA_OPTIONS))
               index.incrementAndGet()
             }
           case _ =>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR excludes configs starting with `SPARK_DRIVER_PREFIX` and `SPARK_EXECUTOR_PREFIX` from modifiedConfigs.

### Why are the changes needed?

To make `SQL / DataFrame Properties` excluding these properties because some configs [might supplemented](https://github.com/apache/spark/blob/caa3df48d94ff2e7c824a87acf51ab4978e18098/core/src/main/scala/org/apache/spark/SparkContext.scala#L422-L423):
<img width="1640" alt="image" src="https://github.com/apache/spark/assets/5399861/9c1ad853-5883-4c66-8a32-573604ebb7ea">

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit test.