### PR TITLE
[SPARK-44348][CONNECT][FOLLOW-UP] Avoid double slashes in the URI

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -442,7 +442,7 @@ private[spark] object Utils extends Logging with SparkClassUtils {
     // `file` and `localhost` are not used. Just to prevent URI from parsing `fileName` as
     // scheme or host. The prefix "/" is required because URI doesn't accept a relative path.
     // We should remove it after we get the raw path.
-    encodeRelativeUnixPathToURIRawPath(fileName).substring(1)
+    encodeRelativeUnixPathToURIRawPath(fileName)
   }
 
   /**
@@ -453,7 +453,7 @@ private[spark] object Utils extends Logging with SparkClassUtils {
     // `file` and `localhost` are not used. Just to prevent URI from parsing `fileName` as
     // scheme or host. The prefix "/" is required because URI doesn't accept a relative path.
     // We should remove it after we get the raw path.
-    new URI("file", null, "localhost", -1, "/" + path, null, null).getRawPath
+    new URI("file", null, "localhost", -1, "/" + path, null, null).getRawPath.substring(1)
   }
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/41942 that does `substring(1)` to remove the leading slash so it makes it relative parts from URI. Otherwise, it can end up with having double slashes in the middle.

### Why are the changes needed?

To avoid having unnecessary double slashes  ... and save one byte :-)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manually tested. It's really trivial.