### PR TITLE
[SPARK-43035][Connect] Add error class in Spark Connect server's ErrorInfo

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectServer.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectServer.scala
@@ -17,12 +17,13 @@
 
 package org.apache.spark.sql.connect.service
 
+import java.net.InetSocketAddress
+
+import scala.collection.convert.ImplicitConversions._
+
 import org.apache.spark.SparkThrowable
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
-
-import java.net.InetSocketAddress
-import scala.collection.convert.ImplicitConversions._
 
 /**
  * The Spark Connect server
@@ -43,15 +44,7 @@ object SparkConnectServer extends Logging {
         }
       } catch {
         case e: Exception =>
-          e.getCause match {
-            case sparkThrowable: SparkThrowable if (sparkThrowable.getErrorClass != null) =>
-              logError(
-                "Error starting Spark Connect server with error class "
-                  + sparkThrowable.getErrorClass,
-                e)
-            case _ =>
-              logError("Error starting Spark Connect server", e)
-          }
+          handleStartServerError(e)
           System.exit(-1)
       }
       SparkConnectService.server.awaitTermination()
@@ -59,4 +52,17 @@ object SparkConnectServer extends Logging {
       session.stop()
     }
   }
+
+  def handleStartServerError(e: Exception): Unit = {
+    e.getCause match {
+      case sparkThrowable: SparkThrowable if (sparkThrowable.getErrorClass != null) =>
+        logError(
+          "Error starting Spark Connect server with error class: "
+            + sparkThrowable.getErrorClass,
+          e)
+      case _ =>
+        logError("Error starting Spark Connect server", e)
+    }
+  }
+
 }

--- a/connector/connect/server/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/connector/connect/server/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectServerSuite.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectServerSuite.scala
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connect.service
+
+import org.apache.logging.log4j.Level
+import org.apache.logging.log4j.core.Logger
+import org.mockito.Mockito.{spy, verify, when}
+import org.scalatestplus.mockito.MockitoSugar
+
+import org.apache.spark.{SparkException, SparkFunSuite}
+import org.apache.spark.sql.test.SharedSparkSession
+
+class SparkConnectServerSuite extends SparkFunSuite with MockitoSugar with SharedSparkSession {
+
+  test("SparkConnectServerSuite: Error handling") {
+    // Mock the logger
+    val mockLogger = mock[Logger]
+    val sparkServer = spy(SparkConnectServer)
+    when(mockLogger.getLevel()).thenReturn(Level.INFO)
+
+    // Exception with SparkThrowable
+    val exceptionWithSparkThrowable = new SparkException(
+      message = "INTERNAL_ERROR message",
+      cause = null,
+      errorClass = Some("INTERNAL_ERROR"),
+      messageParameters = Map("INTERNAL_ERROR" -> "message"))
+
+    // Exception without SparkThrowable
+    val exceptionWithoutSparkThrowable = new Exception("Exception message")
+
+    // Verify log messages for exception with SparkThrowable
+    when(sparkServer.handleStartServerError(exceptionWithSparkThrowable))
+      .thenAnswer(_ =>
+        mockLogger.error(
+          "Error starting Spark Connect server with error class: " +
+            exceptionWithSparkThrowable.getErrorClass(),
+          exceptionWithSparkThrowable))
+
+    // Verify log messages for exception without SparkThrowable
+    when(sparkServer.handleStartServerError(exceptionWithoutSparkThrowable))
+      .thenAnswer(_ =>
+        mockLogger.error("Error starting Spark Connect server", exceptionWithoutSparkThrowable))
+
+    // Call the methods to trigger the logging
+    sparkServer.handleStartServerError(exceptionWithSparkThrowable)
+    sparkServer.handleStartServerError(exceptionWithoutSparkThrowable)
+
+    // Verify that the appropriate logError messages were called
+    verify(mockLogger)
+      .error(
+        "Error starting Spark Connect server with error class: INTERNAL_ERROR",
+        exceptionWithSparkThrowable)
+    verify(mockLogger)
+      .error("Error starting Spark Connect server", exceptionWithoutSparkThrowable)
+  }
+
+}

--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectServerSuite.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectServerSuite.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.sql.connect.service
 
-import org.apache.logging.log4j.Level
 import org.apache.logging.log4j.core.Logger
 import org.mockito.Mockito.{spy, verify, when}
 import org.scalatestplus.mockito.MockitoSugar
@@ -30,8 +29,8 @@ class SparkConnectServerSuite extends SparkFunSuite with MockitoSugar with Share
   test("SparkConnectServerSuite: Error handling") {
     // Mock the logger
     val mockLogger = mock[Logger]
-    val sparkServer = spy(SparkConnectServer)
-    when(mockLogger.getLevel()).thenReturn(Level.INFO)
+    // Mock the SparkConnectServer
+    val mockSparkServer = spy(SparkConnectServer)
 
     // Exception with SparkThrowable
     val exceptionWithSparkThrowable = new SparkException(
@@ -44,7 +43,7 @@ class SparkConnectServerSuite extends SparkFunSuite with MockitoSugar with Share
     val exceptionWithoutSparkThrowable = new Exception("Exception message")
 
     // Verify log messages for exception with SparkThrowable
-    when(sparkServer.handleStartServerError(exceptionWithSparkThrowable))
+    when(mockSparkServer.handleStartServerError(exceptionWithSparkThrowable))
       .thenAnswer(_ =>
         mockLogger.error(
           "Error starting Spark Connect server with error class: " +
@@ -52,13 +51,13 @@ class SparkConnectServerSuite extends SparkFunSuite with MockitoSugar with Share
           exceptionWithSparkThrowable))
 
     // Verify log messages for exception without SparkThrowable
-    when(sparkServer.handleStartServerError(exceptionWithoutSparkThrowable))
+    when(mockSparkServer.handleStartServerError(exceptionWithoutSparkThrowable))
       .thenAnswer(_ =>
         mockLogger.error("Error starting Spark Connect server", exceptionWithoutSparkThrowable))
 
     // Call the methods to trigger the logging
-    sparkServer.handleStartServerError(exceptionWithSparkThrowable)
-    sparkServer.handleStartServerError(exceptionWithoutSparkThrowable)
+    mockSparkServer.handleStartServerError(exceptionWithSparkThrowable)
+    mockSparkServer.handleStartServerError(exceptionWithoutSparkThrowable)
 
     // Verify that the appropriate logError messages were called
     verify(mockLogger)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
This PR adds error handling in case error is of type SparkThrowable 
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
The changes are needed so that user can have a bit more idea about the error
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
User will be able to see specific error in case of SparkThrowable Exceptions
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
