### PR TITLE
[SPARK-43923][CONNECT][FOLLOW-UP][TESTS] Skip "Test observe response" at SparkConnectServiceSuite

### DIFF
--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectServiceSuite.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectServiceSuite.scala
@@ -564,7 +564,8 @@ class SparkConnectServiceSuite extends SharedSparkSession with MockitoSugar with
     }
   }
 
-  test("Test observe response") {
+  // TODO(SPARK-44474): Reenable Test observe response at SparkConnectServiceSuite
+  ignore("Test observe response") {
     // TODO(SPARK-44121) Renable Arrow-based connect tests in Java 21
     assume(SystemUtils.isJavaVersionAtMost(JavaVersion.JAVA_17))
     withTable("test") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR skips "Test observe response" at SparkConnectServiceSuite for now.

### Why are the changes needed?

To unblock other PRs.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Skipped unittests