### PR TITLE
[SPARK-43755][CONNECT][MINOR] Open `AdaptiveSparkPlanHelper.allChildren` instead of using copy in `MetricGenerator` 

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/utils/MetricGenerator.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/utils/MetricGenerator.scala
@@ -22,7 +22,7 @@ import scala.collection.JavaConverters._
 import org.apache.spark.connect.proto.ExecutePlanResponse
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.execution.SparkPlan
-import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanExec, AdaptiveSparkPlanHelper, QueryStageExec}
+import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 
 /**
  * Helper object for generating responses with metrics from queries.

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/utils/MetricGenerator.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/utils/MetricGenerator.scala
@@ -47,12 +47,6 @@ private[connect] object MetricGenerator extends AdaptiveSparkPlanHelper {
     allChildren(p).flatMap(c => transformPlan(c, p.id))
   }
 
-  private def allChildren(p: SparkPlan): Seq[SparkPlan] = p match {
-    case a: AdaptiveSparkPlanExec => Seq(a.executedPlan)
-    case s: QueryStageExec => Seq(s.plan)
-    case _ => p.children
-  }
-
   private def transformPlan(
       p: SparkPlan,
       parentId: Int): Seq[ExecutePlanResponse.Metrics.MetricObject] = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanHelper.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanHelper.scala
@@ -122,7 +122,7 @@ trait AdaptiveSparkPlanHelper {
     subqueries ++ subqueries.flatMap(subqueriesAll)
   }
 
-  private def allChildren(p: SparkPlan): Seq[SparkPlan] = p match {
+  protected def allChildren(p: SparkPlan): Seq[SparkPlan] = p match {
     case a: AdaptiveSparkPlanExec => Seq(a.executedPlan)
     case s: QueryStageExec => Seq(s.plan)
     case _ => p.children


### PR DESCRIPTION
### What changes were proposed in this pull request?

Minor refactor - make `AdaptiveSparkPlanHelper.allChildren` protected in place of private, so that we don't have to copy it over, risking that the two versions will get out of sync.

### Why are the changes needed?

Minor refactor.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI