### PR TITLE
[SPARK-44476][CORE][CONNECT] Fix population of artifacts for a JobArtifactState with no associated artifacts 

### DIFF
--- a/core/src/main/scala/org/apache/spark/JobArtifactSet.scala
+++ b/core/src/main/scala/org/apache/spark/JobArtifactSet.scala
@@ -110,13 +110,13 @@ private[spark] object JobArtifactSet {
     new JobArtifactSet(
       state = maybeState,
       jars = maybeState
-        .map(s => sc.addedJars.getOrElse(s.uuid, sc.allAddedJars))
+        .map(s => sc.addedJars.getOrElse(s.uuid, Map.empty[String, Long]))
         .getOrElse(sc.allAddedJars).toMap,
       files = maybeState
-        .map(s => sc.addedFiles.getOrElse(s.uuid, sc.allAddedFiles))
+        .map(s => sc.addedFiles.getOrElse(s.uuid, Map.empty[String, Long]))
         .getOrElse(sc.allAddedFiles).toMap,
       archives = maybeState
-        .map(s => sc.addedArchives.getOrElse(s.uuid, sc.allAddedArchives))
+        .map(s => sc.addedArchives.getOrElse(s.uuid, Map.empty[String, Long]))
         .getOrElse(sc.allAddedArchives).toMap)
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
When a `JobArtifactSet` is created form a specific `JobArtifactState`, an empty collection of files/jars/archives is returned if there have previously been no associated artifacts of that specific type rather than all files/jars/archives.  

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Consider each artifact type - files/jars/archives. For each artifact type, the following bug exists:

1. Initialise a `JobArtifactState` with no artifacts added to it.
2. Create a  `JobArtifactSet` from the `JobArtifactState`.
3. Add an artifact with the same active `JobArtifactState`.
4. Create another `JobArtifactSet`

In the current behaviour, the set created in step 2 contains all existing artifacts of that type (through `sc.allAddedFiles` for example) while step 4 would only contain the single artifact added in step 3.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No. (Bug-fix addresses the previously incorrect user behaviour)

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New unit test in `JobArtifactSetSuite`.