### PR TITLE
[SPARK-44361][SQL][FOLLOW-UP] Remove unused variables and fix import statements

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/MapInBatchEvaluatorFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/MapInBatchEvaluatorFactory.scala
@@ -19,9 +19,8 @@ package org.apache.spark.sql.execution.python
 
 import scala.collection.JavaConverters._
 
-import org.apache.spark.{ContextAwareIterator, TaskContext}
-import org.apache.spark.{PartitionEvaluator, PartitionEvaluatorFactory}
-import org.apache.spark.api.python.{ChainedPythonFunctions}
+import org.apache.spark.{ContextAwareIterator, PartitionEvaluator, PartitionEvaluatorFactory, TaskContext}
+import org.apache.spark.api.python.ChainedPythonFunctions
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.execution.metric.SQLMetric
@@ -85,8 +84,7 @@ class MapInBatchEvaluatorFactory(
           val flattenedBatch = new ColumnarBatch(outputVectors.toArray)
           flattenedBatch.setNumRows(batch.numRows())
           flattenedBatch.rowIterator.asScala
-        }
-        .map(unsafeProj)
+        }.map(unsafeProj)
     }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/MapInBatchEvaluatorFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/MapInBatchEvaluatorFactory.scala
@@ -75,16 +75,15 @@ class MapInBatchEvaluatorFactory(
 
       val unsafeProj = UnsafeProjection.create(output, output)
 
-      columnarBatchIter
-        .flatMap { batch =>
-          // Scalar Iterator UDF returns a StructType column in ColumnarBatch, select
-          // the children here
-          val structVector = batch.column(0).asInstanceOf[ArrowColumnVector]
-          val outputVectors = output.indices.map(structVector.getChild)
-          val flattenedBatch = new ColumnarBatch(outputVectors.toArray)
-          flattenedBatch.setNumRows(batch.numRows())
-          flattenedBatch.rowIterator.asScala
-        }.map(unsafeProj)
+      columnarBatchIter.flatMap { batch =>
+        // Scalar Iterator UDF returns a StructType column in ColumnarBatch, select
+        // the children here
+        val structVector = batch.column(0).asInstanceOf[ArrowColumnVector]
+        val outputVectors = output.indices.map(structVector.getChild)
+        val flattenedBatch = new ColumnarBatch(outputVectors.toArray)
+        flattenedBatch.setNumRows(batch.numRows())
+        flattenedBatch.rowIterator.asScala
+      }.map(unsafeProj)
     }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/MapInBatchExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/MapInBatchExec.scala
@@ -39,13 +39,7 @@ trait MapInBatchExec extends UnaryExecNode with PythonSQLMetrics {
 
   protected val isBarrier: Boolean
 
-  private val pythonFunction = func.asInstanceOf[PythonUDF].func
-
   override def producedAttributes: AttributeSet = AttributeSet(output)
-
-  private val batchSize = conf.arrowMaxRecordsPerBatch
-
-  private val largeVarTypes = conf.arrowUseLargeVarTypes
 
   private[this] val jobArtifactUUID = JobArtifactSet.getCurrentJobArtifactState.map(_.uuid)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/42024 that removes unused variables and fix import statements (which should be the part of the whole refactoring).

### Why are the changes needed?

To properly cleanup.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests should covoer
