### PR TITLE
[MINOR][INFRA] Update the labeler for CORE and CONNECT

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -76,7 +76,7 @@ CORE:
   - "common/kvstore/**/*"
   - "common/network-common/**/*"
   - "common/network-shuffle/**/*"
-  - "python/pyspark/**/*.py"
+  - "python/pyspark/*.py"
   - "python/pyspark/tests/**/*.py"
 SPARK SUBMIT:
   - "bin/spark-submit*"
@@ -155,6 +155,7 @@ CONNECT:
   - "connector/connect/**/*"
   - "**/sql/sparkconnect/**/*"
   - "python/pyspark/sql/**/connect/**/*"
+  - "python/pyspark/ml/**/connect/**/*"
 PROTOBUF:
   - "connector/protobuf/**/*"
   - "python/pyspark/sql/protobuf/**/*"


### PR DESCRIPTION
### What changes were proposed in this pull request?
Update the labeler for CORE and CONNECT


### Why are the changes needed?
1, existing `CORE` label actually match almost all python files under `pyspark`;
2, add ML on Connect to `CONNECT` label;



### Does this PR introduce _any_ user-facing change?
no, dev-only


### How was this patch tested?
manually check
