### PR TITLE
[SPARK-43839][SQL][FOLLOWUP] Convert _LEGACY_ERROR_TEMP_1337 to UNSUPPORTED_FEATURE.TIME_TRAVEL

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2SessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2SessionCatalog.scala
@@ -88,19 +88,11 @@ class V2SessionCatalog(catalog: SessionCatalog)
   }
 
   private def failTimeTravel(ident: Identifier, t: Table): Table = {
-    t match {
-      case V1Table(catalogTable) =>
-        if (catalogTable.tableType == CatalogTableType.VIEW) {
-          throw QueryCompilationErrors.timeTravelUnsupportedError(
-            toSQLId(catalogTable.identifier.nameParts))
-        } else {
-          throw QueryCompilationErrors.timeTravelUnsupportedError(
-            toSQLId(catalogTable.identifier.nameParts))
-        }
-
-      case _ => throw QueryCompilationErrors.timeTravelUnsupportedError(
-        toSQLId(ident.asTableIdentifier.nameParts))
+    val nameParts = t match {
+      case V1Table(catalogTable) => catalogTable.identifier.nameParts
+      case _ => ident.asTableIdentifier.nameParts
     }
+    throw QueryCompilationErrors.timeTravelUnsupportedError(toSQLId(nameParts))
   }
 
   override def invalidateTable(ident: Identifier): Unit = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
- The pr is following up https://github.com/apache/spark/pull/41349.
- The pr aims to simplify code logic after merge `_LEGACY_ERROR_TEMP_1337` to `UNSUPPORTED_FEATURE.TIME_TRAVEL`.

### Why are the changes needed?
Simplify code logic.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA.