### PR TITLE
[SPARK-44292][SQL][FOLLOWUP] Make TYPE_CHECK_FAILURE_WITH_HINT use correct name

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -279,7 +279,7 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
                 e.setTagValue(DATA_TYPE_MISMATCH_ERROR, true)
                 val extraHint = extraHintForAnsiTypeCoercionExpression(operator)
                 e.failAnalysis(
-                  errorClass = "TYPE_CHECK_FAILURE_WITH_HINT",
+                  errorClass = "DATATYPE_MISMATCH.TYPE_CHECK_FAILURE_WITH_HINT",
                   messageParameters = Map(
                     "expr" -> toSQLExpr(e),
                     "msg" -> message,


### PR DESCRIPTION
### What changes were proposed in this pull request?
https://github.com/apache/spark/pull/41850 uses `TYPE_CHECK_FAILURE_WITH_HINT`, it should be `DATATYPE_MISMATCH.TYPE_CHECK_FAILURE_WITH_HINT`. 

The first commit come from https://github.com/apache/spark/pull/34747.

### Why are the changes needed?
Fix a bug.


### Does this PR introduce _any_ user-facing change?
'No'.


### How was this patch tested?
N/A
