### PR TITLE
[SPARK-44483] [SQL] When using Spark to read the hive table, the number of file partitions cannot be set using Spark's configuration settings

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1,4 +1,4 @@
-/*
+ /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -1765,7 +1765,7 @@ object SQLConf {
     .doc("Suggested (non guaranteed) minimum number of split hive table files. " +
       "If not set, the default value is `spark.default.palelism`. This configuration is" +
       "Only valid when using file based sources such as Parquet, JSON, and ORC.")
-    .version("3.5.0")
+    .version("3.4.1")
     .intConf
     .checkValue(v => v > 0, "The min partition number must be a positive integer.")
     .createOptional

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4565,6 +4565,8 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
 
   def filesMinPartitionNum: Option[Int] = getConf(FILES_MIN_PARTITION_NUM)
 
+  def hiveMinPartitionNum: Option[Int] = getConf(HIVE_MIN_PARTITION_NUM)
+
   def filesMaxPartitionNum: Option[Int] = getConf(FILES_MAX_PARTITION_NUM)
 
   def ignoreCorruptFiles: Boolean = getConf(IGNORE_CORRUPT_FILES)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1761,6 +1761,15 @@ object SQLConf {
     .checkValue(v => v > 0, "The min partition number must be a positive integer.")
     .createOptional
 
+  val HIVE_MIN_PARTITION_NUM = buildConf("spark.sql.hive.file.minPartitionNum")
+    .doc("Suggested (non guaranteed) minimum number of split hive table files. " +
+      "If not set, the default value is `spark.default.palelism`. This configuration is" +
+      "Only valid when using file based sources such as Parquet, JSON, and ORC.")
+    .version("3.5.0")
+    .intConf
+    .checkValue(v => v > 0, "The min partition number must be a positive integer.")
+    .createOptional
+
   val FILES_MAX_PARTITION_NUM = buildConf("spark.sql.files.maxPartitionNum")
     .doc("The suggested (not guaranteed) maximum number of split file partitions. If it is set, " +
       "Spark will rescale each partition to make the number of partitions is close to this " +

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1,4 +1,4 @@
- /*
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
@@ -79,8 +79,9 @@ class HadoopTableReader(
   private val _minSplitsPerRDD = if (sparkSession.sparkContext.isLocal) {
     0 // will splitted based on block by default.
   } else {
-    math.max(hadoopConf.getInt("mapreduce.job.maps", 1),
-      sparkSession.sparkContext.defaultMinPartitions)
+    val defaultMinPartitions = sparkSession.sparkContext.defaultMinPartitions
+    val value = sparkSession.conf.get(SQLConf.HIVE_MIN_PARTITION_NUM, defaultMinPartitions)
+    math.max(hadoopConf.getInt("mapreduce.job.maps", 1), value)
   }
 
   SparkHadoopUtil.get.appendS3AndSparkHadoopHiveConfigurations(

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
@@ -79,8 +79,8 @@ class HadoopTableReader(
   private val _minSplitsPerRDD = if (sparkSession.sparkContext.isLocal) {
     0 // will splitted based on block by default.
   } else {
-    val defaultMinPartitions = sparkSession.sparkContext.defaultMinPartitions
-    val value = sparkSession.conf.get(SQLConf.HIVE_MIN_PARTITION_NUM, defaultMinPartitions)
+    val value = sparkSession.sessionState.conf.hiveMinPartitionNum
+      .getOrElse(sparkSession.sparkContext.defaultMinPartitions)
     math.max(hadoopConf.getInt("mapreduce.job.maps", 1), value)
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Increase the parallelism of sparksql settings when reading the hive table

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
The current user is unable to set the parallelism for reading the hive table in the session

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Can add a configuration for users to read the hive table and set parallelism

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
exist test. Tested in cluster
