### PR TITLE
[SPARK-44494][INFRA] Use `minikube` v1.30.1 for `k8s-integration-tests`

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1010,6 +1010,7 @@ jobs:
         run: |
           # See more in "Installation" https://minikube.sigs.k8s.io/docs/start/
           # curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
+          # TODO(SPARK-44495): Resume to use the latest minikube for k8s-integration-tests.
           curl -LO https://storage.googleapis.com/minikube/releases/v1.30.1/minikube-linux-amd64
           sudo install minikube-linux-amd64 /usr/local/bin/minikube
           # Github Action limit cpu:2, memory: 6947MB, limit to 2U6G for better resource statistic

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1009,7 +1009,8 @@ jobs:
       - name: start minikube
         run: |
           # See more in "Installation" https://minikube.sigs.k8s.io/docs/start/
-          curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
+          # curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
+          curl -LO https://storage.googleapis.com/minikube/releases/v1.30.1/minikube-linux-amd64
           sudo install minikube-linux-amd64 /usr/local/bin/minikube
           # Github Action limit cpu:2, memory: 6947MB, limit to 2U6G for better resource statistic
           minikube start --cpus 2 --memory 6144

--- a/R/pkg/DESCRIPTION
+++ b/R/pkg/DESCRIPTION
@@ -57,7 +57,7 @@ Collate:
     'types.R'
     'utils.R'
     'window.R'
-RoxygenNote: 7.2.3
+RoxygenNote: 7.1.2
 VignetteBuilder: knitr
 NeedsCompilation: no
 Encoding: UTF-8

--- a/R/pkg/DESCRIPTION
+++ b/R/pkg/DESCRIPTION
@@ -57,7 +57,7 @@ Collate:
     'types.R'
     'utils.R'
     'window.R'
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.3
 VignetteBuilder: knitr
 NeedsCompilation: no
 Encoding: UTF-8


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr change to use `minikube` v1.30.1 for `k8s-integration-tests` on GitHub Action, this is a temporary solution.
This PR also leaves a TODO:

- SPARK-44495: Resume to use the latest minikube for `k8s-integration-tests` on GitHub Action


### Why are the changes needed?
Restore `k8s-integration-tests` GA testing


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- `k8s-integration-tests` test pass on GitHub Action