### PR TITLE
[SPARK-44497][WEBUI] Show task partition id in Task table

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/stagepage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/stagepage.js
@@ -846,14 +846,8 @@ $(document).ready(function () {
             }
           },
           "columns": [
-            {
-              data: function (row, type) {
-                return type !== 'display' ? (isNaN(row.index) ? 0 : row.index ) : row.index;
-              },
-              name: "Index"
-            },
+            {data: "partitionId", name: "Index"},
             {data : "taskId", name: "ID"},
-            {data : "partitionId", name: "Partition ID"},
             {data : "attempt", name: "Attempt"},
             {data : "status", name: "Status"},
             {data : "taskLocality", name: "Locality Level"},

--- a/core/src/main/resources/org/apache/spark/ui/static/stagepage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/stagepage.js
@@ -853,6 +853,7 @@ $(document).ready(function () {
               name: "Index"
             },
             {data : "taskId", name: "ID"},
+            {data : "partitionId", name: "Partition ID"},
             {data : "attempt", name: "Attempt"},
             {data : "status", name: "Status"},
             {data : "taskLocality", name: "Locality Level"},

--- a/core/src/main/resources/org/apache/spark/ui/static/stagespage-template.html
+++ b/core/src/main/resources/org/apache/spark/ui/static/stagespage-template.html
@@ -105,7 +105,6 @@ limitations under the License.
                 <tr>
                     <th>Index</th>
                     <th>Task ID</th>
-                    <th>Partition ID</th>
                     <th>Attempt</th>
                     <th>Status</th>
                     <th>Locality level</th>

--- a/core/src/main/resources/org/apache/spark/ui/static/stagespage-template.html
+++ b/core/src/main/resources/org/apache/spark/ui/static/stagespage-template.html
@@ -54,7 +54,7 @@ limitations under the License.
     <div class="container-fluid d-none" id="toggle-aggregatedMetrics">
         <table id="summary-executor-table" class="table table-striped compact table-dataTable cell-border">
             <thead>
-	        <tr>
+            <tr>
                 <th>Executor ID</th>
                 <th>Logs</th>
                 <th>Address</th>
@@ -105,6 +105,7 @@ limitations under the License.
                 <tr>
                     <th>Index</th>
                     <th>Task ID</th>
+                    <th>Partition ID</th>
                     <th>Attempt</th>
                     <th>Status</th>
                     <th>Locality level</th>

--- a/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
@@ -442,7 +442,6 @@ private[spark] object ApiHelper {
 
   val HEADER_ID = "ID"
   val HEADER_TASK_INDEX = "Index"
-  val HEADER_PARTITION_ID = "Partition ID"
   val HEADER_ATTEMPT = "Attempt"
   val HEADER_STATUS = "Status"
   val HEADER_LOCALITY = "Locality Level"
@@ -470,8 +469,7 @@ private[spark] object ApiHelper {
 
   private[ui] val COLUMN_TO_INDEX = Map(
     HEADER_ID -> null.asInstanceOf[String],
-    HEADER_TASK_INDEX -> TaskIndexNames.TASK_INDEX,
-    HEADER_PARTITION_ID -> TaskIndexNames.TASK_PARTITION_ID,
+    HEADER_TASK_INDEX -> TaskIndexNames.TASK_PARTITION_ID,
     HEADER_ATTEMPT -> TaskIndexNames.ATTEMPT,
     HEADER_STATUS -> TaskIndexNames.STATUS,
     HEADER_LOCALITY -> TaskIndexNames.LOCALITY,

--- a/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
@@ -442,6 +442,7 @@ private[spark] object ApiHelper {
 
   val HEADER_ID = "ID"
   val HEADER_TASK_INDEX = "Index"
+  val HEADER_PARTITION_ID = "Partition ID"
   val HEADER_ATTEMPT = "Attempt"
   val HEADER_STATUS = "Status"
   val HEADER_LOCALITY = "Locality Level"
@@ -470,6 +471,7 @@ private[spark] object ApiHelper {
   private[ui] val COLUMN_TO_INDEX = Map(
     HEADER_ID -> null.asInstanceOf[String],
     HEADER_TASK_INDEX -> TaskIndexNames.TASK_INDEX,
+    HEADER_PARTITION_ID -> TaskIndexNames.TASK_PARTITION_ID,
     HEADER_ATTEMPT -> TaskIndexNames.ATTEMPT,
     HEADER_STATUS -> TaskIndexNames.STATUS,
     HEADER_LOCALITY -> TaskIndexNames.LOCALITY,


### PR DESCRIPTION
### What changes were proposed in this pull request?


### Why are the changes needed?
In [SPARK-37831](https://issues.apache.org/jira/browse/SPARK-37831), the partition id is added in taskinfo, and the task partition id cannot be directly seen in the UI.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
local test

