### PR TITLE
[SPARK-44485][SQL] Optimize TreeNode.generateTreeString

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/StringUtils.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/StringUtils.scala
@@ -29,7 +29,7 @@ import org.apache.spark.unsafe.array.ByteArrayUtils
  * the string.
  */
 class StringConcat(val maxLength: Int = ByteArrayUtils.MAX_ROUNDED_ARRAY_LENGTH) {
-  protected val strings = new ArrayBuffer[String]
+  protected val strings = new java.util.LinkedList[String]
   protected var length: Int = 0
 
   def atLimit: Boolean = length >= maxLength
@@ -45,7 +45,7 @@ class StringConcat(val maxLength: Int = ByteArrayUtils.MAX_ROUNDED_ARRAY_LENGTH)
       if (!atLimit) {
         val available = maxLength - length
         val stringToAppend = if (available >= sLen) s else s.substring(0, available)
-        strings.append(stringToAppend)
+        strings.addLast(stringToAppend)
       }
 
       // Keeps the total length of appended strings. Note that we need to cap the length at
@@ -62,7 +62,7 @@ class StringConcat(val maxLength: Int = ByteArrayUtils.MAX_ROUNDED_ARRAY_LENGTH)
   override def toString: String = {
     val finalLength = if (atLimit) maxLength else length
     val result = new java.lang.StringBuilder(finalLength)
-    strings.foreach(result.append)
+    strings.forEach(s => result.append(s))
     result.toString
   }
 }

--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/StringUtils.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/StringUtils.scala
@@ -27,7 +27,7 @@ import org.apache.spark.unsafe.array.ByteArrayUtils
  * the string.
  */
 class StringConcat(val maxLength: Int = ByteArrayUtils.MAX_ROUNDED_ARRAY_LENGTH) {
-  protected val strings = new java.util.LinkedList[String]
+  protected val strings = new java.util.ArrayList[String]
   protected var length: Int = 0
 
   def atLimit: Boolean = length >= maxLength
@@ -43,7 +43,7 @@ class StringConcat(val maxLength: Int = ByteArrayUtils.MAX_ROUNDED_ARRAY_LENGTH)
       if (!atLimit) {
         val available = maxLength - length
         val stringToAppend = if (available >= sLen) s else s.substring(0, available)
-        strings.addLast(stringToAppend)
+        strings.add(stringToAppend)
       }
 
       // Keeps the total length of appended strings. Note that we need to cap the length at

--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/StringUtils.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/StringUtils.scala
@@ -18,8 +18,6 @@ package org.apache.spark.sql.catalyst.util
 
 import java.util.concurrent.atomic.AtomicBoolean
 
-import scala.collection.mutable.ArrayBuffer
-
 import org.apache.spark.internal.Logging
 import org.apache.spark.unsafe.array.ByteArrayUtils
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -1007,7 +1007,7 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]]
       maxFields: Int,
       printNodeId: Boolean,
       indent: Int = 0): Unit = {
-    (0 until indent).foreach(_ => append(" "))
+    (0 until indent).foreach(_ => append("   "))
     if (depth > 0) {
       val iter = lastChildren.iterator
       (0 until lastChildren.size - 1).foreach { i =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -936,7 +936,7 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]]
       addSuffix: Boolean,
       maxFields: Int,
       printOperatorId: Boolean): Unit = {
-    generateTreeString(0, new java.util.LinkedList(), append, verbose, "", addSuffix, maxFields,
+    generateTreeString(0, new java.util.ArrayList(), append, verbose, "", addSuffix, maxFields,
       printOperatorId, 0)
   }
 
@@ -999,7 +999,7 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]]
    */
   def generateTreeString(
       depth: Int,
-      lastChildren: java.util.LinkedList[Boolean],
+      lastChildren: java.util.ArrayList[Boolean],
       append: String => Unit,
       verbose: Boolean,
       prefix: String = "",
@@ -1014,7 +1014,7 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]]
         val isLast = iter.next
         append(if (isLast) "   " else ":  ")
       }
-      append(if (lastChildren.getLast) "+- " else ":- ")
+      append(if (lastChildren.get(lastChildren.size() - 1)) "+- " else ":- ")
     }
 
     val str = if (verbose) {
@@ -1031,36 +1031,36 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]]
     append("\n")
 
     if (innerChildren.nonEmpty) {
-      lastChildren.addLast(children.isEmpty)
-      lastChildren.addLast(false)
+      lastChildren.add(children.isEmpty)
+      lastChildren.add(false)
       innerChildren.init.foreach(_.generateTreeString(
         depth + 2, lastChildren, append, verbose,
         addSuffix = addSuffix, maxFields = maxFields, printNodeId = printNodeId, indent = indent))
-      lastChildren.removeLast()
-      lastChildren.removeLast()
+      lastChildren.remove(lastChildren.size() - 1)
+      lastChildren.remove(lastChildren.size() - 1)
 
-      lastChildren.addLast(children.isEmpty)
-      lastChildren.addLast(true)
+      lastChildren.add(children.isEmpty)
+      lastChildren.add(true)
       innerChildren.last.generateTreeString(
         depth + 2, lastChildren, append, verbose,
         addSuffix = addSuffix, maxFields = maxFields, printNodeId = printNodeId, indent = indent)
-      lastChildren.removeLast()
-      lastChildren.removeLast()
+      lastChildren.remove(lastChildren.size() - 1)
+      lastChildren.remove(lastChildren.size() - 1)
     }
 
     if (children.nonEmpty) {
-      lastChildren.addLast(false)
+      lastChildren.add(false)
       children.init.foreach(_.generateTreeString(
         depth + 1, lastChildren, append, verbose, prefix, addSuffix,
         maxFields, printNodeId = printNodeId, indent = indent)
       )
-      lastChildren.removeLast()
+      lastChildren.remove(lastChildren.size() - 1)
 
-      lastChildren.addLast(true)
+      lastChildren.add(true)
       children.last.generateTreeString(
         depth + 1, lastChildren, append, verbose, prefix,
         addSuffix, maxFields, printNodeId = printNodeId, indent = indent)
-      lastChildren.removeLast()
+      lastChildren.remove(lastChildren.size() - 1)
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -23,7 +23,6 @@ import scala.collection.{mutable, Map}
 import scala.collection.JavaConverters._
 import scala.reflect.ClassTag
 
-import java.util
 import org.apache.commons.lang3.ClassUtils
 import org.json4s.JsonAST._
 import org.json4s.JsonDSL._
@@ -937,7 +936,7 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]]
       addSuffix: Boolean,
       maxFields: Int,
       printOperatorId: Boolean): Unit = {
-    generateTreeString(0, new util.LinkedList(), append, verbose, "", addSuffix, maxFields,
+    generateTreeString(0, new java.util.LinkedList(), append, verbose, "", addSuffix, maxFields,
       printOperatorId, 0)
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/StringUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/StringUtils.scala
@@ -145,7 +145,7 @@ object StringUtils extends Logging {
           s"... ${length - maxLength} more characters"
         }
         val result = new java.lang.StringBuilder(maxLength + truncateMsg.length)
-        strings.foreach(result.append)
+        strings.forEach(s => result.append(s))
         result.append(truncateMsg)
         result.toString
       } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/WholeStageCodegenExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/WholeStageCodegenExec.scala
@@ -534,7 +534,7 @@ case class InputAdapter(child: SparkPlan) extends UnaryExecNode with InputRDDCod
 
   override def generateTreeString(
       depth: Int,
-      lastChildren: java.util.LinkedList[Boolean],
+      lastChildren: java.util.ArrayList[Boolean],
       append: String => Unit,
       verbose: Boolean,
       prefix: String = "",
@@ -800,7 +800,7 @@ case class WholeStageCodegenExec(child: SparkPlan)(val codegenStageId: Int)
 
   override def generateTreeString(
       depth: Int,
-      lastChildren: java.util.LinkedList[Boolean],
+      lastChildren: java.util.ArrayList[Boolean],
       append: String => Unit,
       verbose: Boolean,
       prefix: String = "",

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/WholeStageCodegenExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/WholeStageCodegenExec.scala
@@ -534,7 +534,7 @@ case class InputAdapter(child: SparkPlan) extends UnaryExecNode with InputRDDCod
 
   override def generateTreeString(
       depth: Int,
-      lastChildren: Seq[Boolean],
+      lastChildren: java.util.LinkedList[Boolean],
       append: String => Unit,
       verbose: Boolean,
       prefix: String = "",
@@ -800,7 +800,7 @@ case class WholeStageCodegenExec(child: SparkPlan)(val codegenStageId: Int)
 
   override def generateTreeString(
       depth: Int,
-      lastChildren: Seq[Boolean],
+      lastChildren: java.util.LinkedList[Boolean],
       append: String => Unit,
       verbose: Boolean,
       prefix: String = "",

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
@@ -472,7 +472,7 @@ case class AdaptiveSparkPlanExec(
     append(s"+- == $header ==\n")
     plan.generateTreeString(
       0,
-      Nil,
+      new java.util.LinkedList(),
       append,
       verbose,
       prefix = "",

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
@@ -408,7 +408,7 @@ case class AdaptiveSparkPlanExec(
 
   override def generateTreeString(
       depth: Int,
-      lastChildren: Seq[Boolean],
+      lastChildren: java.util.LinkedList[Boolean],
       append: String => Unit,
       verbose: Boolean,
       prefix: String = "",
@@ -427,9 +427,10 @@ case class AdaptiveSparkPlanExec(
       printNodeId,
       indent)
     if (currentPhysicalPlan.fastEquals(initialPlan)) {
+      lastChildren.addLast(true)
       currentPhysicalPlan.generateTreeString(
         depth + 1,
-        lastChildren :+ true,
+        lastChildren,
         append,
         verbose,
         prefix = "",
@@ -437,6 +438,7 @@ case class AdaptiveSparkPlanExec(
         maxFields,
         printNodeId,
         indent)
+      lastChildren.removeLast()
     } else {
       generateTreeStringWithHeader(
         if (isFinalPlan) "Final Plan" else "Current Plan",

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
@@ -408,7 +408,7 @@ case class AdaptiveSparkPlanExec(
 
   override def generateTreeString(
       depth: Int,
-      lastChildren: java.util.LinkedList[Boolean],
+      lastChildren: java.util.ArrayList[Boolean],
       append: String => Unit,
       verbose: Boolean,
       prefix: String = "",
@@ -427,7 +427,7 @@ case class AdaptiveSparkPlanExec(
       printNodeId,
       indent)
     if (currentPhysicalPlan.fastEquals(initialPlan)) {
-      lastChildren.addLast(true)
+      lastChildren.add(true)
       currentPhysicalPlan.generateTreeString(
         depth + 1,
         lastChildren,
@@ -438,7 +438,7 @@ case class AdaptiveSparkPlanExec(
         maxFields,
         printNodeId,
         indent)
-      lastChildren.removeLast()
+      lastChildren.remove(lastChildren.size() - 1)
     } else {
       generateTreeStringWithHeader(
         if (isFinalPlan) "Final Plan" else "Current Plan",
@@ -472,7 +472,7 @@ case class AdaptiveSparkPlanExec(
     append(s"+- == $header ==\n")
     plan.generateTreeString(
       0,
-      new java.util.LinkedList(),
+      new java.util.ArrayList(),
       append,
       verbose,
       prefix = "",

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStageExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStageExec.scala
@@ -118,7 +118,6 @@ abstract class QueryStageExec extends LeafExecNode {
       maxFields: Int,
       printNodeId: Boolean,
       indent: Int = 0): Unit = {
-    lastChildren.add(true)
     super.generateTreeString(depth,
       lastChildren,
       append,
@@ -128,6 +127,7 @@ abstract class QueryStageExec extends LeafExecNode {
       maxFields,
       printNodeId,
       indent)
+    lastChildren.add(true)
     plan.generateTreeString(
       depth + 1, lastChildren, append, verbose, "", false, maxFields, printNodeId, indent)
     lastChildren.remove(lastChildren.size() - 1)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStageExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStageExec.scala
@@ -110,7 +110,7 @@ abstract class QueryStageExec extends LeafExecNode {
 
   override def generateTreeString(
       depth: Int,
-      lastChildren: Seq[Boolean],
+      lastChildren: java.util.LinkedList[Boolean],
       append: String => Unit,
       verbose: Boolean,
       prefix: String = "",
@@ -118,6 +118,7 @@ abstract class QueryStageExec extends LeafExecNode {
       maxFields: Int,
       printNodeId: Boolean,
       indent: Int = 0): Unit = {
+    lastChildren.addLast(true)
     super.generateTreeString(depth,
       lastChildren,
       append,
@@ -128,7 +129,8 @@ abstract class QueryStageExec extends LeafExecNode {
       printNodeId,
       indent)
     plan.generateTreeString(
-      depth + 1, lastChildren :+ true, append, verbose, "", false, maxFields, printNodeId, indent)
+      depth + 1, lastChildren, append, verbose, "", false, maxFields, printNodeId, indent)
+    lastChildren.removeLast()
   }
 
   override protected[sql] def cleanupResources(): Unit = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStageExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStageExec.scala
@@ -110,7 +110,7 @@ abstract class QueryStageExec extends LeafExecNode {
 
   override def generateTreeString(
       depth: Int,
-      lastChildren: java.util.LinkedList[Boolean],
+      lastChildren: java.util.ArrayList[Boolean],
       append: String => Unit,
       verbose: Boolean,
       prefix: String = "",
@@ -118,7 +118,7 @@ abstract class QueryStageExec extends LeafExecNode {
       maxFields: Int,
       printNodeId: Boolean,
       indent: Int = 0): Unit = {
-    lastChildren.addLast(true)
+    lastChildren.add(true)
     super.generateTreeString(depth,
       lastChildren,
       append,
@@ -130,7 +130,7 @@ abstract class QueryStageExec extends LeafExecNode {
       indent)
     plan.generateTreeString(
       depth + 1, lastChildren, append, verbose, "", false, maxFields, printNodeId, indent)
-    lastChildren.removeLast()
+    lastChildren.remove(lastChildren.size() - 1)
   }
 
   override protected[sql] def cleanupResources(): Unit = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -783,7 +783,7 @@ abstract class BaseSubqueryExec extends SparkPlan {
 
   override def generateTreeString(
       depth: Int,
-      lastChildren: java.util.LinkedList[Boolean],
+      lastChildren: java.util.ArrayList[Boolean],
       append: String => Unit,
       verbose: Boolean,
       prefix: String = "",

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -783,7 +783,7 @@ abstract class BaseSubqueryExec extends SparkPlan {
 
   override def generateTreeString(
       depth: Int,
-      lastChildren: Seq[Boolean],
+      lastChildren: java.util.LinkedList[Boolean],
       append: String => Unit,
       verbose: Boolean,
       prefix: String = "",


### PR DESCRIPTION
### What changes were proposed in this pull request?

Optimize several critical code path in `TreeNode.generateTreeString`

### Why are the changes needed?

In `TreeNode.generateTreeString`, we observed inefficiency in scala collection operations and virtual function call in our internal workload.

This inefficiency become significant in large plan (we hit a example of more than 1000 nodes). So it’s worth optimizing the super hot code path. By rewriting into native Java code(not so sweet as scala syntax sugar though), we should be able to get rid of most of the overhead.

- `ArrayBuffer.append`
<img width="440" alt="itable1" src="https://github.com/apache/spark/assets/22358241/3e1d2e5e-1eeb-46ef-ab7a-20f4cb75f602">

- `Seq.last`
<img width="302" alt="itable2" src="https://github.com/apache/spark/assets/22358241/23f29695-8a01-4c8e-b75a-148a92278c2b">

- `SeqLike.$colon$plus`
<img width="281" alt="itable3" src="https://github.com/apache/spark/assets/22358241/f0526746-62d0-4556-99be-04a24ab805d2">

- `StringOps.$times`
<img width="334" alt="itable4" src="https://github.com/apache/spark/assets/22358241/3a46f18e-7027-421e-aa5a-130d02e1c19c">



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existing UTs
