### PR TITLE
[SPARK-44504][SS] Unload provider thereby forcing DB instance close and releasing resources on maintenance task error

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -462,6 +462,8 @@ class RocksDB(
   /** Release all resources */
   def close(): Unit = {
     try {
+      // Acquire DB instance lock and release at the end to allow for synchronized access
+      acquire()
       closeDB()
 
       readOptions.close()
@@ -476,6 +478,8 @@ class RocksDB(
     } catch {
       case e: Exception =>
         logWarning("Error closing RocksDB", e)
+    } finally {
+      release()
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
@@ -611,6 +611,9 @@ object StateStore extends Logging {
           onError = { loadedProviders.synchronized {
               logInfo("Stopping maintenance task since an error was encountered.")
               stopMaintenanceTask()
+              // SPARK-44504 - Unload explicitly to force closing underlying DB instance
+              // and releasing allocated resources, especially for RocksDBStateStoreProvider.
+              loadedProviders.keySet.foreach { key => unload(key) }
               loadedProviders.clear()
             }
           }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Unload provider thereby forcing DB instance close and releasing resources on maintenance task error

### Why are the changes needed?
If we don't do the close, the DB instance and corresponding resources (memory, file descriptors etc) are always left open and the pointer to these objects is lost since loadedProviders is cleared.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Existing unit tests

```
), ForkJoinPool.commonPool-worker-5 (daemon=true), ForkJoinPool.commonPool-worker-17 (daemon=true), shuffle-boss-6-1 (daemon=true), ForkJoinPool.commonPool-worker-3 (daemon=true), ForkJoinPool.commonPool-worker-31 (daemon=true), ForkJoinPool.commonPool-worker-23 (daemon=true), state-store-maintenance-task (daemon=true), ForkJoinPool.commonPool-worker-9 (daemon=true) =====
[info] Run completed in 2 minutes, 49 seconds.
[info] Total number of tests run: 32
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 32, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
```