### PR TITLE
[SPARK-44505][SQL] Provide override for columnar support in Scan for DSv2

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/Scan.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/Scan.java
@@ -129,12 +129,12 @@ public interface Scan {
   /**
    * This enum defines how the columnar support for the partitions of the data source
    * should be determined. The default value is `PARTITION_DEFINED` which indicates that each
-   * partition can deterine if it should be columnar or not. SUPPORTED and UNSUPPORTED provide
+   * partition can determine if it should be columnar or not. SUPPORTED and UNSUPPORTED provide
    * default shortcuts to indicate support for columnar data or not.
    *
    * @since 3.5.0
    */
-  enum ColumnarSupportType {
+  enum ColumnarSupportMode {
     PARTITION_DEFINED,
     SUPPORTED,
     UNSUPPORTED
@@ -146,5 +146,5 @@ public interface Scan {
    *
    * @since 3.5.0
    */
-  default ColumnarSupportType supportsColumnar() { return ColumnarSupportType.PARTITION_DEFINED; }
+  default ColumnarSupportMode columnarSupportMode() { return ColumnarSupportMode.PARTITION_DEFINED; }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/Scan.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/Scan.java
@@ -146,5 +146,5 @@ public interface Scan {
    *
    * @since 3.5.0
    */
-  default ColumnarSupportType columnarSupported() { return ColumnarSupportType.PARTITION_DEFINED; }
+  default ColumnarSupportType supportsColumnar() { return ColumnarSupportType.PARTITION_DEFINED; }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/Scan.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/Scan.java
@@ -125,4 +125,26 @@ public interface Scan {
   default CustomTaskMetric[] reportDriverMetrics() {
     return new CustomTaskMetric[]{};
   }
+
+  /**
+   * This enum defines how the columnar support for the partitions of the data source
+   * should be determined. The default value is `PARTITION_DEFINED` which indicates that each
+   * partition can deterine if it should be columnar or not. SUPPORTED and UNSUPPORTED provide
+   * default shortcuts to indicate support for columnar data or not.
+   *
+   * @since 3.5.0
+   */
+  enum ColumnarSupportType {
+    PARTITION_DEFINED,
+    SUPPORTED,
+    UNSUPPORTED
+  }
+
+  /**
+   * Subclasses can implement this method to indicate if the support for columnar data should
+   * be determined by each partition or is set as a default for the whole scan.
+   *
+   * @since 3.5.0
+   */
+  default ColumnarSupportType columnarSupported() { return ColumnarSupportType.PARTITION_DEFINED; }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/Scan.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/Scan.java
@@ -146,5 +146,7 @@ public interface Scan {
    *
    * @since 3.5.0
    */
-  default ColumnarSupportMode columnarSupportMode() { return ColumnarSupportMode.PARTITION_DEFINED; }
+  default ColumnarSupportMode columnarSupportMode() {
+    return ColumnarSupportMode.PARTITION_DEFINED;
+  }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2ScanExecBase.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2ScanExecBase.scala
@@ -21,7 +21,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Expression, RowOrdering, SortOrder}
 import org.apache.spark.sql.catalyst.plans.physical
-import org.apache.spark.sql.catalyst.plans.physical.{KeyGroupedPartitioning, SinglePartition}
+import org.apache.spark.sql.catalyst.plans.physical.KeyGroupedPartitioning
 import org.apache.spark.sql.catalyst.util.{truncatedString, InternalRowComparableWrapper}
 import org.apache.spark.sql.connector.read.{HasPartitionKey, InputPartition, PartitionReaderFactory, Scan}
 import org.apache.spark.sql.execution.{ExplainUtils, LeafExecNode, SQLExecution}
@@ -91,9 +91,9 @@ trait DataSourceV2ScanExecBase extends LeafExecNode {
   }
 
   override def outputPartitioning: physical.Partitioning = {
-    if (partitions.length == 1) {
-      SinglePartition
-    } else {
+//    if (partitions.length == 1) {
+//      SinglePartition
+//    } else {
       keyGroupedPartitioning match {
         case Some(exprs) if KeyGroupedPartitioning.supportsExpressions(exprs) =>
           groupedPartitions.map { partitionValues =>
@@ -102,7 +102,7 @@ trait DataSourceV2ScanExecBase extends LeafExecNode {
         case _ =>
           super.outputPartitioning
       }
-    }
+    // }
   }
 
   @transient lazy val groupedPartitions: Option[Seq[(InternalRow, Seq[InputPartition])]] =

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2ScanExecBase.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2ScanExecBase.scala
@@ -170,7 +170,7 @@ trait DataSourceV2ScanExecBase extends LeafExecNode {
   }
 
   override def supportsColumnar: Boolean = {
-    scan.columnarSupported() match {
+    scan.supportsColumnar() match {
       case Scan.ColumnarSupportType.PARTITION_DEFINED =>
         require(
           inputPartitions.forall(readerFactory.supportColumnarReads) ||

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2ScanExecBase.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2ScanExecBase.scala
@@ -170,15 +170,15 @@ trait DataSourceV2ScanExecBase extends LeafExecNode {
   }
 
   override def supportsColumnar: Boolean = {
-    scan.supportsColumnar() match {
-      case Scan.ColumnarSupportType.PARTITION_DEFINED =>
+    scan.columnarSupportMode() match {
+      case Scan.ColumnarSupportMode.PARTITION_DEFINED =>
         require(
           inputPartitions.forall(readerFactory.supportColumnarReads) ||
             !inputPartitions.exists(readerFactory.supportColumnarReads),
           "Cannot mix row-based and columnar input partitions.")
         inputPartitions.exists(readerFactory.supportColumnarReads)
-      case Scan.ColumnarSupportType.SUPPORTED => true
-      case Scan.ColumnarSupportType.UNSUPPORTED => false
+      case Scan.ColumnarSupportMode.SUPPORTED => true
+      case Scan.ColumnarSupportMode.UNSUPPORTED => false
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2Suite.scala
@@ -396,8 +396,6 @@ class DataSourceV2Suite extends QueryTest with SharedSparkSession with AdaptiveS
     var ex = intercept[IllegalArgumentException](df.explain())
     assert(ex.getMessage == "planInputPartitions must not be called")
 
-    spark.sparkContext.setLogLevel("WARN")
-    spark.conf.set("spark.sql.planChangeLog.level", "WARN")
     Seq("SUPPORTED", "UNSUPPORTED").foreach { o =>
       val dfScan = spark.read.format(classOf[ScanDefinedColumnarSupport].getName)
         .option("columnar", o).load()

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2Suite.scala
@@ -28,8 +28,8 @@ import org.apache.spark.sql.connector.catalog.{PartitionInternalRow, SupportsRea
 import org.apache.spark.sql.connector.catalog.TableCapability._
 import org.apache.spark.sql.connector.expressions.{Expression, FieldReference, Literal, NamedReference, NullOrdering, SortDirection, SortOrder, Transform}
 import org.apache.spark.sql.connector.expressions.filter.Predicate
-import org.apache.spark.sql.connector.read.Scan.ColumnarSupportMode
 import org.apache.spark.sql.connector.read._
+import org.apache.spark.sql.connector.read.Scan.ColumnarSupportMode
 import org.apache.spark.sql.connector.read.partitioning.{KeyGroupedPartitioning, Partitioning, UnknownPartitioning}
 import org.apache.spark.sql.execution.SortExec
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
@@ -396,11 +396,13 @@ class DataSourceV2Suite extends QueryTest with SharedSparkSession with AdaptiveS
     var ex = intercept[IllegalArgumentException](df.explain())
     assert(ex.getMessage == "planInputPartitions must not be called")
 
-    Seq("SUPPORTED", "UNSUPPORTED").foreach {o =>
+    spark.sparkContext.setLogLevel("WARN")
+    spark.conf.set("spark.sql.planChangeLog.level", "WARN")
+    Seq("SUPPORTED", "UNSUPPORTED").foreach { o =>
       val dfScan = spark.read.format(classOf[ScanDefinedColumnarSupport].getName)
         .option("columnar", o).load()
       dfScan.explain()
-      // Will fail during regular execution.
+      //  Will fail during regular execution.
       ex = intercept[IllegalArgumentException](dfScan.count())
       assert(ex.getMessage == "planInputPartitions must not be called")
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2Suite.scala
@@ -711,7 +711,7 @@ class ScanDefinedColumnarSupport extends TestingV2Source {
       throw new IllegalArgumentException("Should not happen")
     }
 
-    override def columnarSupported()
+    override def supportsColumnar()
         : Scan.ColumnarSupportType = st
 
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
@@ -128,7 +128,10 @@ class KeyGroupedPartitioningSuite extends DistributionAndOrderingSuiteBase {
     val distribution = physical.ClusteredDistribution(
       Seq(TransformExpression(BucketFunction, Seq(attr("ts")), Some(32))))
 
-    checkQueryPlan(df, distribution, physical.SinglePartition)
+    // Has exactly one partition.
+    val partitionValues = Seq(31).map(v => InternalRow.fromSeq(Seq(v)))
+    checkQueryPlan(df, distribution,
+      physical.KeyGroupedPartitioning(distribution.clustering, 1, partitionValues))
   }
 
   test("non-clustered distribution: no V2 catalog") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/AlignAssignmentsSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/AlignAssignmentsSuiteBase.scala
@@ -147,7 +147,7 @@ abstract class AlignAssignmentsSuiteBase extends AnalysisTest {
   private val v2Catalog = {
     val newCatalog = mock(classOf[TableCatalog])
     when(newCatalog.loadTable(any())).thenAnswer((invocation: InvocationOnMock) => {
-      val ident = invocation.getArgument[Identifier](0)
+      val ident = invocation.getArguments()(0).asInstanceOf[Identifier]
       ident.name match {
         case "primitive_table" => primitiveTable
         case "primitive_table_src" => primitiveTableSource
@@ -172,7 +172,7 @@ abstract class AlignAssignmentsSuiteBase extends AnalysisTest {
   private val catalogManager = {
     val manager = mock(classOf[CatalogManager])
     when(manager.catalog(any())).thenAnswer((invocation: InvocationOnMock) => {
-      invocation.getArgument[String](0) match {
+      invocation.getArguments()(0).asInstanceOf[String] match {
         case "testcat" => v2Catalog
         case CatalogManager.SESSION_CATALOG_NAME => v2SessionCatalog
         case name => throw new CatalogNotFoundException(s"No such catalog: $name")


### PR DESCRIPTION
### What changes were proposed in this pull request?
Previously, when a new DSv2 data source is implemented during planning, it will always call `BatchScanExec:supportsColumnar` which will in turn iterate over all input partitions to check if they support columnar or not. 

When the `planInputPartitions` method is expensive this can be problematic. This patch adds an option to the Scan interface that allows specifying a default value. For backward compatibility the default value provided by the Scan interface is partition defined, but a Scan can change it accordingly.

To fully support the changes of this PR, the following additional changes had to be done:

* `DataSourceV2ScanExecBase::outputPartitioning` removed the case for single partitions.
* `lazyval DataSourceV2ScanExecBase::groupedPartitions` added a special check for empty key group partitioning so that the simple case does not trigger a materialization of the input partitions during planning. 

Additionally:
* Fixes similar issues as https://github.com/apache/spark/pull/40004

### Why are the changes needed?
Avoid costly operations during explain operations.

### Does this PR introduce _any_ user-facing change?
Np

### How was this patch tested?
Added new UT.