### PR TITLE
[SPARK-44506][BUILD] Upgrade mima-core & sbt-mima-plugin to 1.1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -289,7 +289,7 @@
     <connect.guava.version>32.0.1-jre</connect.guava.version>
     <guava.failureaccess.version>1.0.1</guava.failureaccess.version>
     <io.grpc.version>1.56.0</io.grpc.version>
-    <mima.version>1.1.2</mima.version>
+    <mima.version>1.1.3</mima.version>
     <tomcat.annotations.api.version>6.0.53</tomcat.annotations.api.version>
 
     <CodeCacheSize>128m</CodeCacheSize>

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -31,7 +31,7 @@ addSbtPlugin("com.github.sbt" % "sbt-eclipse" % "6.0.0")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 
-addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.2")
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.3")
 
 addSbtPlugin("com.github.sbt" % "sbt-unidoc" % "0.5.0")
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade `mima-core` & `sbt-mima-plugin` from 1.1.2 to 1.1.3.

### Why are the changes needed?
- Release note:
https://github.com/lightbend/mima/releases/tag/1.1.3

- This version adapts to scala-2.12.18 & scala-2.13.11, which is also used by Spark currently
Update scala-library, scala-reflect to 2.12.18 by @scala-steward in https://github.com/lightbend/mima/pull/764
Update scala-library, scala-reflect to 2.13.11 by @scala-steward in https://github.com/lightbend/mima/pull/765

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA.