### PR TITLE
[SPARK-44507][SQL][CONNECT] Scala client does not depend on AnalysisException

### DIFF
--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2197,7 +2197,7 @@ class Dataset[T] private[sql] (
    * @group untypedrel
    * @since 3.4.0
    */
-  @throws[AnalysisException]
+  @throws[SparkException]
   def withColumnsRenamed(colsMap: Map[String, String]): DataFrame = {
     withColumnsRenamed(colsMap.asJava)
   }
@@ -2258,13 +2258,13 @@ class Dataset[T] private[sql] (
    * created it, i.e. it will be automatically dropped when the session terminates. It's not tied
    * to any databases, i.e. we can't use `db1.view1` to reference a local temporary view.
    *
-   * @throws AnalysisException
+   * @throws SparkException
    *   if the view name is invalid or already exists
    *
    * @group basic
    * @since 3.4.0
    */
-  @throws[AnalysisException]
+  @throws[SparkException]
   def createTempView(viewName: String): Unit = {
     buildAndExecuteTempView(viewName, replace = false, global = false)
   }
@@ -2289,13 +2289,13 @@ class Dataset[T] private[sql] (
    * to a system preserved database `global_temp`, and we must use the qualified name to refer a
    * global temp view, e.g. `SELECT * FROM global_temp.view1`.
    *
-   * @throws AnalysisException
+   * @throws SparkException
    *   if the view name is invalid or already exists
    *
    * @group basic
    * @since 3.4.0
    */
-  @throws[AnalysisException]
+  @throws[SparkException]
   def createGlobalTempView(viewName: String): Unit = {
     buildAndExecuteTempView(viewName, replace = false, global = true)
   }

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2191,7 +2191,7 @@ class Dataset[T] private[sql] (
    *
    * `colsMap` is a map of existing column name and new column name.
    *
-   * @throws AnalysisException
+   * @throws SparkException
    *   if there are duplicate names in resulting projection
    *
    * @group untypedrel

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/catalog/Catalog.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/catalog/Catalog.scala
@@ -19,7 +19,8 @@ package org.apache.spark.sql.catalog
 
 import scala.collection.JavaConverters._
 
-import org.apache.spark.sql.{AnalysisException, DataFrame, Dataset}
+import org.apache.spark.SparkException
+import org.apache.spark.sql.{DataFrame, Dataset}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.storage.StorageLevel
 
@@ -73,7 +74,7 @@ abstract class Catalog {
    *
    * @since 3.5.0
    */
-  @throws[AnalysisException]("database does not exist")
+  @throws[SparkException]("database does not exist")
   def listTables(dbName: String): Dataset[Table]
 
   /**
@@ -82,7 +83,7 @@ abstract class Catalog {
    *
    * @since 3.5.0
    */
-  @throws[AnalysisException]("database does not exist")
+  @throws[SparkException]("database does not exist")
   def listTables(dbName: String, pattern: String): Dataset[Table]
 
   /**
@@ -99,7 +100,7 @@ abstract class Catalog {
    *
    * @since 3.5.0
    */
-  @throws[AnalysisException]("database does not exist")
+  @throws[SparkException]("database does not exist")
   def listFunctions(dbName: String): Dataset[Function]
 
   /**
@@ -109,7 +110,7 @@ abstract class Catalog {
    *
    * @since 3.5.0
    */
-  @throws[AnalysisException]("database does not exist")
+  @throws[SparkException]("database does not exist")
   def listFunctions(dbName: String, pattern: String): Dataset[Function]
 
   /**
@@ -121,7 +122,7 @@ abstract class Catalog {
    *   database (namespace).
    * @since 3.5.0
    */
-  @throws[AnalysisException]("table does not exist")
+  @throws[SparkException]("table does not exist")
   def listColumns(tableName: String): Dataset[Column]
 
   /**
@@ -137,21 +138,21 @@ abstract class Catalog {
    *   is an unqualified name that designates a table/view.
    * @since 3.5.0
    */
-  @throws[AnalysisException]("database or table does not exist")
+  @throws[SparkException]("database or table does not exist")
   def listColumns(dbName: String, tableName: String): Dataset[Column]
 
   /**
    * Get the database (namespace) with the specified name (can be qualified with catalog). This
-   * throws an AnalysisException when the database (namespace) cannot be found.
+   * throws an SparkException when the database (namespace) cannot be found.
    *
    * @since 3.5.0
    */
-  @throws[AnalysisException]("database does not exist")
+  @throws[SparkException]("database does not exist")
   def getDatabase(dbName: String): Database
 
   /**
    * Get the table or view with the specified name. This table can be a temporary view or a
-   * table/view. This throws an AnalysisException when no Table can be found.
+   * table/view. This throws an SparkException when no Table can be found.
    *
    * @param tableName
    *   is either a qualified or unqualified name that designates a table/view. It follows the same
@@ -159,24 +160,24 @@ abstract class Catalog {
    *   database (namespace).
    * @since 3.5.0
    */
-  @throws[AnalysisException]("table does not exist")
+  @throws[SparkException]("table does not exist")
   def getTable(tableName: String): Table
 
   /**
    * Get the table or view with the specified name in the specified database under the Hive
-   * Metastore. This throws an AnalysisException when no Table can be found.
+   * Metastore. This throws an SparkException when no Table can be found.
    *
    * To get table/view in other catalogs, please use `getTable(tableName)` with qualified
    * table/view name instead.
    *
    * @since 3.5.0
    */
-  @throws[AnalysisException]("database or table does not exist")
+  @throws[SparkException]("database or table does not exist")
   def getTable(dbName: String, tableName: String): Table
 
   /**
    * Get the function with the specified name. This function can be a temporary function or a
-   * function. This throws an AnalysisException when the function cannot be found.
+   * function. This throws an SparkException when the function cannot be found.
    *
    * @param functionName
    *   is either a qualified or unqualified name that designates a function. It follows the same
@@ -184,12 +185,12 @@ abstract class Catalog {
    *   current database (namespace).
    * @since 3.5.0
    */
-  @throws[AnalysisException]("function does not exist")
+  @throws[SparkException]("function does not exist")
   def getFunction(functionName: String): Function
 
   /**
    * Get the function with the specified name in the specified database under the Hive Metastore.
-   * This throws an AnalysisException when the function cannot be found.
+   * This throws an SparkException when the function cannot be found.
    *
    * To get functions in other catalogs, please use `getFunction(functionName)` with qualified
    * function name instead.
@@ -200,7 +201,7 @@ abstract class Catalog {
    *   is an unqualified name that designates a function in the specified database
    * @since 3.5.0
    */
-  @throws[AnalysisException]("database or function does not exist")
+  @throws[SparkException]("database or function does not exist")
   def getFunction(dbName: String, functionName: String): Function
 
   /**

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
@@ -17,7 +17,8 @@
 
 package org.apache.spark.sql.internal
 
-import org.apache.spark.sql.{AnalysisException, DataFrame, Dataset, SparkSession}
+import org.apache.spark.SparkException
+import org.apache.spark.sql.{DataFrame, Dataset, SparkSession}
 import org.apache.spark.sql.catalog.{Catalog, CatalogMetadata, Column, Database, Function, Table}
 import org.apache.spark.sql.catalyst.ScalaReflection
 import org.apache.spark.sql.catalyst.encoders.AgnosticEncoder
@@ -45,7 +46,7 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
    *
    * @since 3.5.0
    */
-  @throws[AnalysisException]("database does not exist")
+  @throws[SparkException]("database does not exist")
   override def setCurrentDatabase(dbName: String): Unit = {
     // we assume `dbName` will not include the catalog name. e.g. if you call
     // `setCurrentDatabase("catalog.db")`, it will search for a database 'catalog.db' in the current
@@ -94,7 +95,7 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
    *
    * @since 3.5.0
    */
-  @throws[AnalysisException]("database does not exist")
+  @throws[SparkException]("database does not exist")
   override def listTables(dbName: String): Dataset[Table] = {
     sparkSession.newDataset(CatalogImpl.tableEncoder) { builder =>
       builder.getCatalogBuilder.getListTablesBuilder.setDbName(dbName)
@@ -107,7 +108,7 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
    *
    * @since 3.5.0
    */
-  @throws[AnalysisException]("database does not exist")
+  @throws[SparkException]("database does not exist")
   def listTables(dbName: String, pattern: String): Dataset[Table] = {
     sparkSession.newDataset(CatalogImpl.tableEncoder) { builder =>
       builder.getCatalogBuilder.getListTablesBuilder.setDbName(dbName).setPattern(pattern)
@@ -130,7 +131,7 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
    *
    * @since 3.5.0
    */
-  @throws[AnalysisException]("database does not exist")
+  @throws[SparkException]("database does not exist")
   override def listFunctions(dbName: String): Dataset[Function] = {
     sparkSession.newDataset(CatalogImpl.functionEncoder) { builder =>
       builder.getCatalogBuilder.getListFunctionsBuilder.setDbName(dbName)
@@ -144,7 +145,7 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
    *
    * @since 3.5.0
    */
-  @throws[AnalysisException]("database does not exist")
+  @throws[SparkException]("database does not exist")
   def listFunctions(dbName: String, pattern: String): Dataset[Function] = {
     sparkSession.newDataset(CatalogImpl.functionEncoder) { builder =>
       builder.getCatalogBuilder.getListFunctionsBuilder.setDbName(dbName).setPattern(pattern)
@@ -160,7 +161,7 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
    *   database (namespace).
    * @since 3.5.0
    */
-  @throws[AnalysisException]("database or table does not exist")
+  @throws[SparkException]("database or table does not exist")
   override def listColumns(tableName: String): Dataset[Column] = {
     sparkSession.newDataset(CatalogImpl.columnEncoder) { builder =>
       builder.getCatalogBuilder.getListColumnsBuilder.setTableName(tableName)
@@ -180,7 +181,7 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
    *   is an unqualified name that designates a table/view.
    * @since 3.5.0
    */
-  @throws[AnalysisException]("database does not exist")
+  @throws[SparkException]("database does not exist")
   override def listColumns(dbName: String, tableName: String): Dataset[Column] = {
     sparkSession.newDataset(CatalogImpl.columnEncoder) { builder =>
       builder.getCatalogBuilder.getListColumnsBuilder
@@ -191,7 +192,7 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
 
   /**
    * Get the database (namespace) with the specified name (can be qualified with catalog). This
-   * throws an AnalysisException when the database (namespace) cannot be found.
+   * throws an SparkException when the database (namespace) cannot be found.
    *
    * @since 3.5.0
    */
@@ -205,7 +206,7 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
 
   /**
    * Get the table or view with the specified name. This table can be a temporary view or a
-   * table/view. This throws an AnalysisException when no Table can be found.
+   * table/view. This throws an SparkException when no Table can be found.
    *
    * @param tableName
    *   is either a qualified or unqualified name that designates a table/view. It follows the same
@@ -223,7 +224,7 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
 
   /**
    * Get the table or view with the specified name in the specified database under the Hive
-   * Metastore. This throws an AnalysisException when no Table can be found.
+   * Metastore. This throws an SparkException when no Table can be found.
    *
    * To get table/view in other catalogs, please use `getTable(tableName)` with qualified
    * table/view name instead.
@@ -242,7 +243,7 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
 
   /**
    * Get the function with the specified name. This function can be a temporary function or a
-   * function. This throws an AnalysisException when the function cannot be found.
+   * function. This throws an SparkException when the function cannot be found.
    *
    * @param functionName
    *   is either a qualified or unqualified name that designates a function. It follows the same
@@ -260,7 +261,7 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
 
   /**
    * Get the function with the specified name in the specified database under the Hive Metastore.
-   * This throws an AnalysisException when the function cannot be found.
+   * This throws an SparkException when the function cannot be found.
    *
    * To get functions in other catalogs, please use `getFunction(functionName)` with qualified
    * function name instead.

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/CheckConnectJvmClientCompatibility.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/CheckConnectJvmClientCompatibility.scala
@@ -314,6 +314,9 @@ object CheckConnectJvmClientCompatibility {
       // Catalyst Refactoring
       ProblemFilters.exclude[Problem]("org.apache.spark.sql.catalyst.util.SparkCollectionUtils"),
       ProblemFilters.exclude[Problem]("org.apache.spark.sql.catalyst.util.SparkCollectionUtils$"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.catalog.Catalog"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.Dataset"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.internal.CatalogImpl"),
 
       // New public APIs added in the client
       // ScalarUserDefinedFunction


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Replace AnalysisException to SparkException in Scala client.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Scala client do not need to depend on Spark thus it cannot depend on `AnalysisException` which needs `LogicalPlan`.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. This PR changes the Scala client API so that AnalysisException won't be thrown (SparkException will be the replacement).

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
UT