### PR TITLE
[MINOR][CONNECT] Remove redundant type cast in `ArtifactManager`

### DIFF
--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/connect/client/ArtifactManager.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/connect/client/ArtifactManager.scala
@@ -219,7 +219,7 @@ class ArtifactManager(
       .setUserContext(userContext)
       .setSessionId(sessionId)
     artifacts.foreach { artifact =>
-      val in = new CheckedInputStream(artifact.storage.asInstanceOf[LocalData].stream, new CRC32)
+      val in = new CheckedInputStream(artifact.storage.stream, new CRC32)
       try {
         val data = proto.AddArtifactsRequest.ArtifactChunk
           .newBuilder()
@@ -274,7 +274,7 @@ class ArtifactManager(
       .setUserContext(userContext)
       .setSessionId(sessionId)
 
-    val in = new CheckedInputStream(artifact.storage.asInstanceOf[LocalData].stream, new CRC32)
+    val in = new CheckedInputStream(artifact.storage.stream, new CRC32)
     try {
       // First RPC contains the `BeginChunkedArtifact` payload (`begin_chunk`).
       // Subsequent RPCs contains the `ArtifactChunk` payload (`chunk`).


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr just remove redundant type cast in `ArtifactManager`

### Why are the changes needed?
remove redundant type cast.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Pass GitHub Actions