### PR TITLE
[SPARK-44380][PYTHON][FOLLOWUP] Set __doc__ for analyze static method when Arrow is enabled

### DIFF
--- a/python/pyspark/sql/tests/test_udtf.py
+++ b/python/pyspark/sql/tests/test_udtf.py
@@ -749,6 +749,11 @@ class BaseUDTFTestsMixin:
                 """Initialize the UDTF"""
                 ...
 
+            @staticmethod
+            def analyze(x: AnalyzeArgument) -> AnalyzeResult:
+                """Analyze the argument."""
+                ...
+
             def eval(self, x: int):
                 """Evaluate the input row."""
                 yield x + 1,
@@ -757,9 +762,10 @@ class BaseUDTFTestsMixin:
                 """Terminate the UDTF."""
                 ...
 
-        cls = udtf(TestUDTF, returnType="y: int").func
+        cls = udtf(TestUDTF).func
         self.assertIn("A UDTF for test", cls.__doc__)
         self.assertIn("Initialize the UDTF", cls.__init__.__doc__)
+        self.assertIn("Analyze the argument", cls.analyze.__doc__)
         self.assertIn("Evaluate the input row", cls.eval.__doc__)
         self.assertIn("Terminate the UDTF", cls.terminate.__doc__)
 

--- a/python/pyspark/sql/udtf.py
+++ b/python/pyspark/sql/udtf.py
@@ -178,6 +178,9 @@ def _vectorize_udtf(cls: Type) -> Type:
     if hasattr(cls, "terminate"):
         getattr(vectorized_udtf, "terminate").__doc__ = getattr(cls, "terminate").__doc__
 
+    if hasattr(vectorized_udtf, "analyze"):
+        getattr(vectorized_udtf, "analyze").__doc__ = getattr(cls, "analyze").__doc__
+
     return vectorized_udtf
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up of apache/spark#41948.

Set `__doc__` for `analyze` static method when Arrow is enabled.

### Why are the changes needed?

When Arrow is enabled, `analyze` static method doesn't have `__doc__` that should be the same as the original contents.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Updated the related tests.