### PR TITLE
[SPARK-44517][SQL] Respect ignorenulls and child's nullability in first

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/First.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/First.scala
@@ -60,7 +60,13 @@ case class First(child: Expression, ignoreNulls: Boolean)
     this(child, FirstLast.validateIgnoreNullExpr(ignoreNullsExpr, "first"))
   }
 
-  override def nullable: Boolean = true
+  override def nullable: Boolean = {
+    if (ignoreNulls) {
+      false
+    } else {
+      child.nullable
+    }
+  }
 
   // Return data type.
   override def dataType: DataType = child.dataType


### PR DESCRIPTION
### What changes were proposed in this pull request?

this PR changed the nullable of first() operator by respecting the ignoreNulls and child's nullability


### Why are the changes needed?

copied from JIRA

I found the following problem when using Spark recently:

 

```scala
import spark.implicits._

val s = Seq((1.2, "s", 2.2)).toDF("v1", "v2", "v3")

val schema = StructType(Seq(StructField("v1", DoubleType, nullable = false),StructField("v2", StringType, nullable = true),StructField("v3", DoubleType, nullable = false)))

val df = spark.createDataFrame(s.rdd, schema)val inputDF = 

val inputDF = df.dropDuplicates("v3")

spark.sql("CREATE TABLE local.db.table (\n v1 DOUBLE NOT NULL,\n v2 STRING, v3 DOUBLE NOT NULL)")

inputDF.write.mode("overwrite").format("iceberg").save("local.db.table") 
```

 

when I use the above code to write to iceberg (i guess Delta Lake will have the same problem) , I got very confusing exception

Exception in thread "main" java.lang.IllegalArgumentException: Cannot write incompatible dataset to table with schema:

```
table 

{  1: v1: required double  2: v2: optional string  3: v3: required double}

Provided schema:

table {  1: v1: optional double  2: v2: optional string  3: v3: required double} 

```

basically it complains that we have v1 as the nullable column in our `inputDF` which is not allowed as we created table with v1 as not nullable. The confusion comes from that,  if we check the schema with printSchema() of inputDF, v1 is not nullable

```
root 
|-- v1: double (nullable = false) 
|-- v2: string (nullable = true) 
|-- v3: double (nullable = false)
```

Clearly, something changed the v1's nullability unexpectedly!

 

After some debugging I found that the key is that `dropDuplicates("v3")`. In optimization phase, we have `ReplaceDeduplicateWithAggregate` to replace the Deduplicate with aggregate on v3 and run first() over all other columns. However, first() operator has hard coded nullable as always "true" which is the source of the changed nullability of v1



this is a very confusing behavior of Spark, and probably no one really noticed as we do not care too much without the new table formats like delta lake and iceberg which can make nullability check correctly. Nowadays, when users adopt them more and more, this is surfaced up


### Does this PR introduce _any_ user-facing change?

NO

### How was this patch tested?

unit test and integration test