### PR TITLE
[SPARK-44521][CONNECT][TESTS] Use `Utils.createTempDir` to make the dirs generated by `SparkConnectServiceSuite` is cleaned up after testing

### DIFF
--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectServiceSuite.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectServiceSuite.scala
@@ -252,7 +252,7 @@ class SparkConnectServiceSuite extends SharedSparkSession with MockitoSugar with
             .newBuilder()
             .setInput(
               proto.Relation.newBuilder().setSql(proto.SQL.newBuilder().setQuery("select 1")))
-            .setPath("my/test/path")
+            .setPath(Utils.createTempDir().getAbsolutePath)
             .setMode(proto.WriteOperation.SaveMode.SAVE_MODE_OVERWRITE)),
       proto.Command
         .newBuilder()
@@ -300,7 +300,7 @@ class SparkConnectServiceSuite extends SharedSparkSession with MockitoSugar with
             .setAvailableNow(true)
             .setQueryName("test")
             .setFormat("memory")
-            .putOptions("checkpointLocation", s"${UUID.randomUUID}")
+            .putOptions("checkpointLocation", Utils.createTempDir().getAbsolutePath)
             .setPath("test-path")
             .build()),
       proto.Command


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr change to use `Utils.createTempDir` to make the dirs generated by `SparkConnectServiceSuite` is cleaned up after testing.


### Why are the changes needed?
There are residual directories after run  `SparkConnectServiceSuite` like follows:

```
connector/connect/server/282ce745-440f-44ac-9f43-4fad70d89a44/
connector/connect/server/my/ 
```

The test cases should ensure that they are cleaned up after testing.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass GitHub Actions
- Manual checked:

```
build/sbt "connect/testOnly org.apache.spark.sql.connect.planner.SparkConnectServiceSuite"
git status 
```

Before

```
connector/connect/server/7e7f16c4-4792-4ddc-b7b0-08d3b1d1b8fe/
connector/connect/server/my/
```
After

No diff