### PR TITLE
[SPARK-44264][PYTHON] Added Deepspeed Folder to setup.py

### DIFF
--- a/python/pyspark/ml/deepspeed/__init__.py
+++ b/python/pyspark/ml/deepspeed/__init__.py
@@ -1,0 +1,16 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/python/setup.py
+++ b/python/setup.py
@@ -241,6 +241,7 @@ try:
             "pyspark.ml.linalg",
             "pyspark.ml.param",
             "pyspark.ml.torch",
+            "pyspark.ml.deepspeed",
             "pyspark.sql",
             "pyspark.sql.avro",
             "pyspark.sql.connect",


### PR DESCRIPTION
### What changes were proposed in this pull request?
Added pyspark.ml.deepspeed to the setup.py


### Why are the changes needed?
It allows the deepspeed distributor to be pip installed when you pip install pyspark.


### Does this PR introduce _any_ user-facing change?
No

