### PR TITLE
[SPARK-44513][BUILD][3.4] Upgrade snappy-java to 1.1.10.3

### DIFF
--- a/dev/deps/spark-deps-hadoop-2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2-hive-2.3
@@ -248,7 +248,7 @@ scala-xml_2.12/2.1.0//scala-xml_2.12-2.1.0.jar
 shims/0.9.38//shims-0.9.38.jar
 slf4j-api/2.0.6//slf4j-api-2.0.6.jar
 snakeyaml/1.33//snakeyaml-1.33.jar
-snappy-java/1.1.10.2//snappy-java-1.1.10.2.jar
+snappy-java/1.1.10.3//snappy-java-1.1.10.3.jar
 spire-macros_2.12/0.17.0//spire-macros_2.12-0.17.0.jar
 spire-platform_2.12/0.17.0//spire-platform_2.12-0.17.0.jar
 spire-util_2.12/0.17.0//spire-util_2.12-0.17.0.jar

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -235,7 +235,7 @@ scala-xml_2.12/2.1.0//scala-xml_2.12-2.1.0.jar
 shims/0.9.38//shims-0.9.38.jar
 slf4j-api/2.0.6//slf4j-api-2.0.6.jar
 snakeyaml/1.33//snakeyaml-1.33.jar
-snappy-java/1.1.10.2//snappy-java-1.1.10.2.jar
+snappy-java/1.1.10.3//snappy-java-1.1.10.3.jar
 spire-macros_2.12/0.17.0//spire-macros_2.12-0.17.0.jar
 spire-platform_2.12/0.17.0//spire-platform_2.12-0.17.0.jar
 spire-util_2.12/0.17.0//spire-util_2.12-0.17.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,7 @@
     <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
     <fasterxml.jackson.version>2.14.2</fasterxml.jackson.version>
     <fasterxml.jackson.databind.version>2.14.2</fasterxml.jackson.databind.version>
-    <snappy.version>1.1.10.2</snappy.version>
+    <snappy.version>1.1.10.3</snappy.version>
     <netlib.ludovic.dev.version>3.0.3</netlib.ludovic.dev.version>
     <commons-codec.version>1.15</commons-codec.version>
     <commons-compress.version>1.22</commons-compress.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
- The pr is for branch-3.4.
- The pr aims to upgrade snappy-java from  1.1.10.2 to 1.1.10.3.

### Why are the changes needed?
1.The newest version include a bug fixed:
- Fix the GLIBC_2.32 not found issue of libsnappyjava.so in certain Linux distributions on s390x by @kun-lu20 in https://github.com/xerial/snappy-java/pull/481

2.Release notes:
https://github.com/xerial/snappy-java/releases/tag/v1.1.10.3

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA.