### PR TITLE
[SPARK-43964][PYTHON][TESTS][FOLLOWUP] Skip a test using pandas when pandas is not available

### DIFF
--- a/python/pyspark/sql/tests/test_udtf.py
+++ b/python/pyspark/sql/tests/test_udtf.py
@@ -487,6 +487,7 @@ class BaseUDTFTestsMixin:
 
         self.assertEqual(TestUDTF(lit(1)).collect(), [Row(x={1: "1"})])
 
+    @unittest.skipIf(not have_pandas, pandas_requirement_message)
     def test_udtf_with_pandas_input_type(self):
         import pandas as pd
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up of apache/spark#41867.

Skips a test using pandas when pandas is not available.

### Why are the changes needed?

There is a test using pandas, but there is a case where pandas is not available.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manually.