### PR TITLE
[SPARK-44541][SQL] Remove useless function `hasRangeExprAgainstEventTimeCol` from `UnsupportedOperationChecker`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationChecker.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationChecker.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.catalyst.analysis
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.AnalysisException
-import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, BinaryComparison, CurrentDate, CurrentTimestampLike, Expression, GreaterThan, GreaterThanOrEqual, GroupingSets, LessThan, LessThanOrEqual, LocalTimestamp, MonotonicallyIncreasingID, SessionWindow, WindowExpression}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, CurrentDate, CurrentTimestampLike, Expression, GroupingSets, LocalTimestamp, MonotonicallyIncreasingID, SessionWindow, WindowExpression}
 import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical._
@@ -54,26 +54,6 @@ object UnsupportedOperationChecker extends Logging {
   private def hasEventTimeCol(exp: Expression): Boolean = exp.exists {
     case a: AttributeReference => a.metadata.contains(EventTimeWatermark.delayKey)
     case _ => false
-  }
-
-  /**
-   * Checks if the expression contains a range comparison, in which
-   * either side of the comparison is an event-time column. This is used for checking
-   * stream-stream time interval join.
-   * @param e the expression to be checked
-   * @return true if there is a time-interval join.
-   */
-  private def hasRangeExprAgainstEventTimeCol(e: Expression): Boolean = {
-    def hasEventTimeColBinaryComp(neq: Expression): Boolean = {
-      val exp = neq.asInstanceOf[BinaryComparison]
-      hasEventTimeCol(exp.left) || hasEventTimeCol(exp.right)
-    }
-
-    e.exists {
-      case neq @ (_: LessThanOrEqual | _: LessThan | _: GreaterThanOrEqual | _: GreaterThan) =>
-        hasEventTimeColBinaryComp(neq)
-      case _ => false
-    }
   }
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to remove useless funciton `hasRangeExprAgainstEventTimeCol` from `UnsupportedOperationChecker`.
The function `hasRangeExprAgainstEventTimeCol` was introduced by SPARK-40940 and no longer be used after SPARK-42376


### Why are the changes needed?
Code cleanup.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions
