### PR TITLE
[SPARK-44503][SQL][FOLLOWUP] Simplify the test case for PARTITION BY and ORDER BY clause after TABLE arguments for TVF calls

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
@@ -1493,52 +1493,32 @@ class PlanParserSuite extends AnalysisTest {
   }
 
   test("SPARK-44503: Support PARTITION BY and ORDER BY clause for TVF TABLE arguments") {
+    val message = "Specifying the PARTITION BY clause for TABLE arguments is not implemented yet"
+    val startIndex = 29
+
+    def check(sqlSuffix: String): Unit = {
+      val sql = s"select * from my_tvf(arg1 => $sqlSuffix)"
+      checkError(
+        exception = parseException(sql),
+        errorClass = "_LEGACY_ERROR_TEMP_0035",
+        parameters = Map("message" -> message),
+        context = ExpectedContext(
+          fragment = sqlSuffix,
+          start = startIndex,
+          stop = sql.length - 2))
+    }
+
     Seq("partition", "distribute").foreach { partition =>
+      val sqlSuffix = s"table(v1) $partition by col1"
+      check(sqlSuffix)
+
       Seq("order", "sort").foreach { order =>
-        val sql1suffix = s"table(v1) $partition by col1"
-        val sql1 = s"select * from my_tvf(arg1 => $sql1suffix)"
-        val startIndex = 29
-        val message =
-          "Specifying the PARTITION BY clause for TABLE arguments is not implemented yet"
-        checkError(
-          exception = parseException(sql1),
-          errorClass = "_LEGACY_ERROR_TEMP_0035",
-          parameters = Map("message" -> message),
-          context = ExpectedContext(
-            fragment = sql1suffix,
-            start = startIndex,
-            stop = sql1.length - 2))
-        val sql2suffix = s"table(v1) $partition by col1 $order by col2 asc"
-        val sql2 = s"select * from my_tvf(arg1 => $sql2suffix)"
-        checkError(
-          exception = parseException(sql2),
-          errorClass = "_LEGACY_ERROR_TEMP_0035",
-          parameters = Map("message" -> message),
-          context = ExpectedContext(
-            fragment = sql2suffix,
-            start = startIndex,
-            stop = sql2.length - 2))
-        val sql3suffix = s"table(v1) $partition by col1, col2 $order by col2 asc, col3 desc"
-        val sql3 = s"select * from my_tvf(arg1 => $sql3suffix)"
-        checkError(
-          exception = parseException(sql3),
-          errorClass = "_LEGACY_ERROR_TEMP_0035",
-          parameters = Map("message" -> message),
-          context = ExpectedContext(
-            fragment = sql3suffix,
-            start = startIndex,
-            stop = sql3.length - 2))
-        val sql4Suffix = s"table(select col1, col2, col3 from v2) $partition by col1, col2 " +
+        Seq(
+          s"table(v1) $partition by col1 $order by col2 asc",
+          s"table(v1) $partition by col1, col2 $order by col2 asc, col3 desc",
+          s"table(select col1, col2, col3 from v2) $partition by col1, col2 " +
             s"$order by col2 asc, col3 desc"
-        val sql4 = s"select * from my_tvf(arg1 => $sql4Suffix)"
-        checkError(
-          exception = parseException(sql4),
-          errorClass = "_LEGACY_ERROR_TEMP_0035",
-          parameters = Map("message" -> message),
-          context = ExpectedContext(
-            fragment = sql4Suffix,
-            start = startIndex,
-            stop = sql4.length - 2))
+        ).foreach(check)
       }
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
https://github.com/apache/spark/pull/42100 added SQL grammar for PARTITION BY and ORDER BY clause after TABLE arguments for TVF calls.

Because I reviewed it later, so I commit this PR.


### Why are the changes needed?
Simplify the test case for PARTITION BY and ORDER BY clause after TABLE arguments for TVF calls


### Does this PR introduce _any_ user-facing change?
'No'.
New feature.


### How was this patch tested?
N/A.
