### PR TITLE
[SPARK-44509][CONNECT][FOLLOW-UP] Add inheritable support in new job cancellation API

### DIFF
--- a/python/pyspark/sql/tests/connect/test_session.py
+++ b/python/pyspark/sql/tests/connect/test_session.py
@@ -19,6 +19,7 @@ import time
 import unittest
 from typing import Optional
 
+from pyspark import InheritableThread, inheritable_thread_target
 from pyspark.sql.connect.client import ChannelBuilder
 from pyspark.sql.connect.session import SparkSession as RemoteSparkSession
 from pyspark.testing.connectutils import should_test_connect
@@ -179,3 +180,38 @@ class ArrowParityTests(ReusedConnectTestCase):
             self.assertFalse(
                 is_job_cancelled[i], "Thread {i}: Job in group B did not succeeded.".format(i=i)
             )
+
+    def test_inheritable_tags(self):
+        self.check_inheritable_tags(
+            create_thread=lambda target, session: InheritableThread(target, session=session)
+        )
+        self.check_inheritable_tags(
+            create_thread=lambda target, session: threading.Thread(
+                target=inheritable_thread_target(target, session=session)
+            )
+        )
+
+    def check_inheritable_tags(self, create_thread):
+        spark = self.spark
+        spark.addTag("a")
+        first = set()
+        second = set()
+
+        def get_inner_local_prop():
+            spark.addTag("c")
+            second.update(spark.getTags())
+
+        def get_outer_local_prop():
+            spark.addTag("b")
+            first.update(spark.getTags())
+            t2 = create_thread(target=get_inner_local_prop, session=spark)
+            t2.start()
+            t2.join()
+
+        t1 = create_thread(target=get_outer_local_prop, session=spark)
+        t1.start()
+        t1.join()
+
+        self.assertEqual(spark.getTags(), {"a"})
+        self.assertEqual(first, {"a", "b"})
+        self.assertEqual(second, {"a", "b", "c"})

--- a/python/pyspark/sql/tests/connect/test_session.py
+++ b/python/pyspark/sql/tests/connect/test_session.py
@@ -187,8 +187,17 @@ class ArrowParityTests(ReusedConnectTestCase):
         )
         self.check_inheritable_tags(
             create_thread=lambda target, session: threading.Thread(
-                target=inheritable_thread_target(target, session=session)
+                target=inheritable_thread_target(session)(target)
             )
+        )
+
+        # Test decorator usage
+        @inheritable_thread_target(self.spark)
+        def func(target):
+            return target()
+
+        self.check_inheritable_tags(
+            create_thread=lambda target, session: threading.Thread(target=func, args=(target,))
         )
 
     def check_inheritable_tags(self, create_thread):

--- a/python/pyspark/util.py
+++ b/python/pyspark/util.py
@@ -332,7 +332,7 @@ def inheritable_thread_target(f: Callable, session: Optional["SparkSession"] = N
 
     # Spark Connect
     if is_remote():
-        assert session is not None, "Spark Connect must be provided."
+        assert session is not None, "Spark Connect session must be provided."
         if not hasattr(session.client.thread_local, "tags"):
             session.client.thread_local.tags = set()
         tags = set(session.client.thread_local.tags)
@@ -340,7 +340,7 @@ def inheritable_thread_target(f: Callable, session: Optional["SparkSession"] = N
         @functools.wraps(f)
         def wrapped(*args: Any, **kwargs: Any) -> Any:
             # Set tags in child thread.
-            session.client.thread_local.tags = tags
+            session.client.thread_local.tags = tags  # type: ignore[union-attr]
             return f(*args, **kwargs)
 
         return wrapped
@@ -406,7 +406,7 @@ class InheritableThread(threading.Thread):
             def copy_local_properties(*a: Any, **k: Any) -> Any:
                 # Set tags in child thread.
                 assert hasattr(self, "_tags")
-                session.client.thread_local.tags = self._tags
+                session.client.thread_local.tags = self._tags  # type: ignore[union-attr, has-type]
                 return target(*a, **k)
 
             super(InheritableThread, self).__init__(

--- a/python/pyspark/util.py
+++ b/python/pyspark/util.py
@@ -329,7 +329,7 @@ def inheritable_thread_target(f: Optional[Union[Callable, "SparkSession"]] = Non
 
     If you're using Spark Connect, you should explicitly provide Spark session as follows:
 
-    >>> @inheritable_thread_target(session)
+    >>> @inheritable_thread_target(session)  # doctest: +SKIP
     ... def target_func():
     ...     pass  # your codes.
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a kind of a followup of https://github.com/apache/spark/pull/42120. This addresses my own comment at https://github.com/apache/spark/pull/42120#discussion_r1272933655 by adding the support of `InheritableThread` with Spark Connect.

### Why are the changes needed?

In order to allow the thread local hierarchy supported in Scala side. 

### Does this PR introduce _any_ user-facing change?

The main PR is not released out yet so it doesn't have user-facing change.

### How was this patch tested?

Unittests were added.