### PR TITLE
[DOCS] Update concat and concat_ws documentation to point out unexpected behavior

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
@@ -53,13 +53,17 @@ import org.apache.spark.unsafe.types.{ByteArray, UTF8String}
  */
 // scalastyle:off line.size.limit
 @ExpressionDescription(
-  usage = "_FUNC_(sep[, str | array(str)]+) - Returns the concatenation of the strings separated by `sep`.",
+  usage = "_FUNC_(sep[, str | array(str)]+) - Returns the concatenation of the strings separated by `sep`, skipping null values.",
   examples = """
     Examples:
       > SELECT _FUNC_(' ', 'Spark', 'SQL');
         Spark SQL
       > SELECT _FUNC_('s');
 
+      > SELECT _FUNC_('/', 'foo', null, 'bar');
+        foo/bar
+      > SELECT _FUNC_(null, 'Spark', 'SQL');
+        NULL
   """,
   since = "1.5.0",
   group = "string_funcs")

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -3821,6 +3821,8 @@ object functions {
   /**
    * Concatenates multiple input string columns together into a single string column,
    * using the given separator.
+   * 
+   * @note Input strings which are null are skipped.
    *
    * @group string_funcs
    * @since 1.5.0
@@ -6018,6 +6020,8 @@ object functions {
   /**
    * Concatenates multiple input columns together into a single column.
    * The function works with strings, binary and compatible array columns.
+   *
+   * @note Returns null if any of the input columns are null.
    *
    * @group collection_funcs
    * @since 1.5.0

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -3821,7 +3821,7 @@ object functions {
   /**
    * Concatenates multiple input string columns together into a single string column,
    * using the given separator.
-   * 
+   *
    * @note Input strings which are null are skipped.
    *
    * @group string_funcs


### PR DESCRIPTION
Add documentation covering unexpected behavior of concat and concat_ws with respect to null values.

### What changes were proposed in this pull request?
Adds additional documentation to `concat` and `concat_ws`.

### Why are the changes needed?
The behavior of `concat` and `concat_ws` were unexpected w.r.t. null values and the documentation did not help make their behavior clear.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?

