### PR TITLE
[SPARK-43968][PYTHON] Improve error messages for Python UDTFs with wrong number of outputs

### DIFF
--- a/python/pyspark/errors/error_classes.py
+++ b/python/pyspark/errors/error_classes.py
@@ -283,6 +283,11 @@ ERROR_CLASSES_JSON = """
       "The eval type for the UDTF '<name>' is invalid. It must be one of <eval_type>."
     ]
   },
+  "INVALID_UDTF_HANDLER_TYPE" : {
+    "message" : [
+      "The UDTF is invalid. The function handler must be a class, but got '<type>'. Please provide a class as the function handler."
+    ]
+  },
   "INVALID_UDTF_NO_EVAL" : {
     "message" : [
       "The UDTF '<name>' is invalid. It does not implement the required 'eval' method. Please implement the 'eval' method in '<name>' and try again."

--- a/python/pyspark/sql/connect/udtf.py
+++ b/python/pyspark/sql/connect/udtf.py
@@ -124,6 +124,8 @@ class UserDefinedTableFunction:
         evalType: int = PythonEvalType.SQL_TABLE_UDF,
         deterministic: bool = True,
     ) -> None:
+        _validate_udtf_handler(func, returnType)
+
         self.func = func
         self.returnType: Optional[DataType] = (
             None
@@ -135,8 +137,6 @@ class UserDefinedTableFunction:
         self._name = name or func.__name__
         self.evalType = evalType
         self.deterministic = deterministic
-
-        _validate_udtf_handler(func, returnType)
 
     def _build_common_inline_user_defined_table_function(
         self, *cols: "ColumnOrName"

--- a/python/pyspark/sql/tests/connect/test_parity_udtf.py
+++ b/python/pyspark/sql/tests/connect/test_parity_udtf.py
@@ -56,56 +56,6 @@ class UDTFParityTests(BaseUDTFTestsMixin, ReusedConnectTestCase):
         ):
             TestUDTF(lit(1)).collect()
 
-    def test_udtf_with_wrong_num_output(self):
-        err_msg = (
-            "java.lang.IllegalStateException: Input row doesn't have expected number of "
-            + "values required by the schema."
-        )
-
-        @udtf(returnType="a: int, b: int")
-        class TestUDTF:
-            def eval(self, a: int):
-                yield a,
-
-        with self.assertRaisesRegex(SparkConnectGrpcException, err_msg):
-            TestUDTF(lit(1)).collect()
-
-        @udtf(returnType="a: int")
-        class TestUDTF:
-            def eval(self, a: int):
-                yield a, a + 1
-
-        with self.assertRaisesRegex(SparkConnectGrpcException, err_msg):
-            TestUDTF(lit(1)).collect()
-
-    def test_udtf_terminate_with_wrong_num_output(self):
-        err_msg = (
-            "java.lang.IllegalStateException: Input row doesn't have expected number of "
-            "values required by the schema."
-        )
-
-        @udtf(returnType="a: int, b: int")
-        class TestUDTF:
-            def eval(self, a: int):
-                yield a, a + 1
-
-            def terminate(self):
-                yield 1, 2, 3
-
-        with self.assertRaisesRegex(SparkConnectGrpcException, err_msg):
-            TestUDTF(lit(1)).show()
-
-        @udtf(returnType="a: int, b: int")
-        class TestUDTF:
-            def eval(self, a: int):
-                yield a, a + 1
-
-            def terminate(self):
-                yield 1,
-
-        with self.assertRaisesRegex(SparkConnectGrpcException, err_msg):
-            TestUDTF(lit(1)).show()
-
     @unittest.skip("Spark Connect does not support broadcast but the test depends on it.")
     def test_udtf_with_analyze_using_broadcast(self):
         super().test_udtf_with_analyze_using_broadcast()

--- a/python/pyspark/sql/tests/test_udtf.py
+++ b/python/pyspark/sql/tests/test_udtf.py
@@ -291,6 +291,7 @@ class BaseUDTFTestsMixin:
             "result does not match the specified schema."
         )
 
+        # Output less columns than specified return schema
         @udtf(returnType="a: int, b: int")
         class TestUDTF:
             def eval(self, a: int):
@@ -299,6 +300,7 @@ class BaseUDTFTestsMixin:
         with self.assertRaisesRegex(PythonException, err_msg):
             TestUDTF(lit(1)).collect()
 
+        # Output more columns than specified return schema
         @udtf(returnType="a: int")
         class TestUDTF:
             def eval(self, a: int):
@@ -306,6 +308,24 @@ class BaseUDTFTestsMixin:
 
         with self.assertRaisesRegex(PythonException, err_msg):
             TestUDTF(lit(1)).collect()
+
+        # Empty output schema with non-empty output
+        @udtf(returnType=StructType())
+        class TestUDTF:
+            def eval(self):
+                yield 1,
+
+        with self.assertRaisesRegex(PythonException, err_msg):
+            TestUDTF().collect()
+
+        # Non-empty output schema with empty output
+        @udtf(returnType="a: int")
+        class TestUDTF:
+            def eval(self):
+                yield tuple()
+
+        with self.assertRaisesRegex(PythonException, err_msg):
+            TestUDTF().collect()
 
     def test_udtf_init(self):
         @udtf(returnType="a: int, b: int, c: string")

--- a/python/pyspark/sql/tests/test_udtf.py
+++ b/python/pyspark/sql/tests/test_udtf.py
@@ -21,8 +21,6 @@ import unittest
 
 from typing import Iterator
 
-from py4j.protocol import Py4JJavaError
-
 from pyspark.errors import (
     PySparkAttributeError,
     PythonException,
@@ -269,7 +267,7 @@ class BaseUDTFTestsMixin:
                 yield a,
 
         with self.assertRaisesRegex(
-            PythonException, "__init__\(\) missing 1 required positional argument: 'a'"
+            PythonException, r"__init__\(\) missing 1 required positional argument: 'a'"
         ):
             TestUDTF(lit(1)).show()
 
@@ -283,13 +281,13 @@ class BaseUDTFTestsMixin:
                 ...
 
         with self.assertRaisesRegex(
-            PythonException, "terminate\(\) missing 1 required positional argument: 'a'"
+            PythonException, r"terminate\(\) missing 1 required positional argument: 'a'"
         ):
             TestUDTF(lit(1)).show()
 
     def test_udtf_with_wrong_num_output(self):
         err_msg = (
-            "\[UDTF_RETURN_SCHEMA_MISMATCH\] The number of columns in the "
+            r"\[UDTF_RETURN_SCHEMA_MISMATCH\] The number of columns in the "
             "result does not match the specified schema."
         )
 
@@ -375,7 +373,7 @@ class BaseUDTFTestsMixin:
 
     def test_udtf_terminate_with_wrong_num_output(self):
         err_msg = (
-            "\[UDTF_RETURN_SCHEMA_MISMATCH\] The number of columns in the result "
+            r"\[UDTF_RETURN_SCHEMA_MISMATCH\] The number of columns in the result "
             "does not match the specified schema."
         )
 
@@ -576,6 +574,7 @@ class BaseUDTFTestsMixin:
 
     def test_udtf_with_no_handler_class(self):
         with self.assertRaises(PySparkTypeError) as e:
+
             @udtf(returnType="a: int")
             def test_udtf(a: int):
                 yield a,
@@ -587,7 +586,7 @@ class BaseUDTFTestsMixin:
         )
 
         with self.assertRaises(PySparkTypeError) as e:
-            func = udtf(1, returnType="a: int")
+            udtf(1, returnType="a: int")
 
         self.check_error(
             exception=e.exception,

--- a/python/pyspark/sql/tests/test_udtf.py
+++ b/python/pyspark/sql/tests/test_udtf.py
@@ -309,22 +309,22 @@ class BaseUDTFTestsMixin:
         with self.assertRaisesRegex(PythonException, err_msg):
             TestUDTF(lit(1)).collect()
 
-        # Empty output schema with non-empty output
+    def test_udtf_with_empty_output_schema_and_non_empty_output(self):
         @udtf(returnType=StructType())
         class TestUDTF:
             def eval(self):
                 yield 1,
 
-        with self.assertRaisesRegex(PythonException, err_msg):
+        with self.assertRaisesRegex(PythonException, "UDTF_RETURN_SCHEMA_MISMATCH"):
             TestUDTF().collect()
 
-        # Non-empty output schema with empty output
+    def test_udtf_with_non_empty_output_schema_and_empty_output(self):
         @udtf(returnType="a: int")
         class TestUDTF:
             def eval(self):
                 yield tuple()
 
-        with self.assertRaisesRegex(PythonException, err_msg):
+        with self.assertRaisesRegex(PythonException, "UDTF_RETURN_SCHEMA_MISMATCH"):
             TestUDTF().collect()
 
     def test_udtf_init(self):

--- a/python/pyspark/sql/udtf.py
+++ b/python/pyspark/sql/udtf.py
@@ -186,13 +186,10 @@ def _vectorize_udtf(cls: Type) -> Type:
 
 def _validate_udtf_handler(cls: Any, returnType: Optional[Union[StructType, str]]) -> None:
     """Validate the handler class of a UDTF."""
-    # TODO(SPARK-43968): add more compile time checks for UDTFs
 
     if not isinstance(cls, type):
         raise PySparkTypeError(
-            f"Invalid user defined table function: the function handler "
-            f"must be a class, but got {type(cls).__name__}. Please provide "
-            "a class as the handler."
+            error_class="INVALID_UDTF_HANDLER_TYPE", message_parameters={"type": type(cls).__name__}
         )
 
     if not hasattr(cls, "eval"):
@@ -237,6 +234,8 @@ class UserDefinedTableFunction:
         evalType: int = PythonEvalType.SQL_TABLE_UDF,
         deterministic: bool = True,
     ):
+        _validate_udtf_handler(func, returnType)
+
         self.func = func
         self._returnType = returnType
         self._returnType_placeholder: Optional[StructType] = None
@@ -245,8 +244,6 @@ class UserDefinedTableFunction:
         self._name = name or func.__name__
         self.evalType = evalType
         self.deterministic = deterministic
-
-        _validate_udtf_handler(func, returnType)
 
     @property
     def returnType(self) -> Optional[StructType]:

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -604,16 +604,14 @@ def read_udtf(pickleSer, infile, eval_type):
                         },
                     )
 
-                # Check when the dataframe has both rows and columns.
-                if not result.empty or len(result.columns) != 0:
-                    if len(result.columns) != len(return_type):
-                        raise PySparkRuntimeError(
-                            error_class="UDTF_RETURN_SCHEMA_MISMATCH",
-                            message_parameters={
-                                "expected": str(len(return_type)),
-                                "actual": str(len(result.columns)),
-                            },
-                        )
+                if len(result.columns) != len(return_type):
+                    raise PySparkRuntimeError(
+                        error_class="UDTF_RETURN_SCHEMA_MISMATCH",
+                        message_parameters={
+                            "expected": str(len(return_type)),
+                            "actual": str(len(result.columns)),
+                        },
+                    )
 
                 # Verify the type and the schema of the result.
                 verify_pandas_result(
@@ -656,7 +654,7 @@ def read_udtf(pickleSer, infile, eval_type):
 
             def verify_and_convert_result(result):
                 # TODO(SPARK-44005): support returning non-tuple values
-                if result and hasattr(result, "__len__"):
+                if result is not None and hasattr(result, "__len__"):
                     if len(result) != len(return_type):
                         raise PySparkRuntimeError(
                             error_class="UDTF_RETURN_SCHEMA_MISMATCH",


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR improves the error messages for Python UDTFs when the number of outputs mismatches the number of outputs specified in the return type of the UDTFs.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To make Python UDTFs more user-friendly.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. This PR improves the error messages.
Before this change, the error thrown by Spark will be a java IllegalStateException:
```
java.lang.IllegalStateException: Input row doesn't have expected number of values required by the schema
```
After this PR, it will throw a clearer error message with an error class:
```
[UDTF_RETURN_SCHEMA_MISMATCH] The number of columns in the result does not match the specified schema
```

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Existing tests and new unit tests.