### PR TITLE
[SPARK-44557][INFRA] Clean up untracked/ignored files before running pip packaging test in GitHub Actions

### DIFF
--- a/dev/run-pip-tests
+++ b/dev/run-pip-tests
@@ -25,6 +25,12 @@ shopt -s nullglob
 FWDIR="$(cd "$(dirname "$0")"/..; pwd)"
 cd "$FWDIR"
 
+du -hs *
+
+echo "============================="
+
+du -hs /*
+
 echo "Constructing virtual env for testing"
 VIRTUALENV_BASE=$(mktemp -d)
 

--- a/dev/run-pip-tests
+++ b/dev/run-pip-tests
@@ -31,9 +31,6 @@ cd "$FWDIR"
 if [[ -z "${GITHUB_ACTION}" ]]; then
   git clean -d -f -x -e assembly
 fi
-
-du -sch .[!.]* * |sort -h
-
 echo "Constructing virtual env for testing"
 VIRTUALENV_BASE=$(mktemp -d)
 

--- a/dev/run-pip-tests
+++ b/dev/run-pip-tests
@@ -26,10 +26,12 @@ FWDIR="$(cd "$(dirname "$0")"/..; pwd)"
 cd "$FWDIR"
 
 du -hs *
+du -hs tools/*
+du -hs tools/*/*
 
 echo "============================="
 
-sudo du -hs /*
+du -hs /*
 
 echo "Constructing virtual env for testing"
 VIRTUALENV_BASE=$(mktemp -d)

--- a/dev/run-pip-tests
+++ b/dev/run-pip-tests
@@ -29,7 +29,7 @@ du -hs *
 
 echo "============================="
 
-du -hs /*
+sudo du -hs /*
 
 echo "Constructing virtual env for testing"
 VIRTUALENV_BASE=$(mktemp -d)

--- a/dev/run-pip-tests
+++ b/dev/run-pip-tests
@@ -28,7 +28,7 @@ cd "$FWDIR"
 # Clean ignored/untracked files that do not need
 # for pip packaging test. Machines in GitHub Action do not have
 # enough space, see also SPARK-44557.
-if [[ -z "${GITHUB_ACTION}" ]]; then
+if [[ -z "${GITHUB_ACTIONS}" ]]; then
   git clean -d -f -x -e assembly
 fi
 echo "Constructing virtual env for testing"

--- a/dev/run-pip-tests
+++ b/dev/run-pip-tests
@@ -25,6 +25,7 @@ shopt -s nullglob
 FWDIR="$(cd "$(dirname "$0")"/..; pwd)"
 cd "$FWDIR"
 
+du -hs /__t/*
 du -hs /__w/*
 du -hs /usr/*
 du -hs /root/*

--- a/dev/run-pip-tests
+++ b/dev/run-pip-tests
@@ -25,7 +25,7 @@ shopt -s nullglob
 FWDIR="$(cd "$(dirname "$0")"/..; pwd)"
 cd "$FWDIR"
 
-du -hs /usr/local/*
+du -sch .[!.]* * |sort -h
 
 echo "Constructing virtual env for testing"
 VIRTUALENV_BASE=$(mktemp -d)

--- a/dev/run-pip-tests
+++ b/dev/run-pip-tests
@@ -25,6 +25,13 @@ shopt -s nullglob
 FWDIR="$(cd "$(dirname "$0")"/..; pwd)"
 cd "$FWDIR"
 
+# Clean ignored/untracked files that do not need
+# for pip packaging test. Machines in GitHub Action do not have
+# enough space, see also SPARK-44557.
+if [[ -z "${GITHUB_ACTION}" ]]; then
+  git clean -d -f -x -e assembly
+fi
+
 du -sch .[!.]* * |sort -h
 
 echo "Constructing virtual env for testing"

--- a/dev/run-pip-tests
+++ b/dev/run-pip-tests
@@ -25,13 +25,9 @@ shopt -s nullglob
 FWDIR="$(cd "$(dirname "$0")"/..; pwd)"
 cd "$FWDIR"
 
-du -hs *
-du -hs tools/*
-du -hs tools/*/*
-
-echo "============================="
-
-du -hs /*
+du -hs /__w/*
+du -hs /usr/*
+du -hs /root/*
 
 echo "Constructing virtual env for testing"
 VIRTUALENV_BASE=$(mktemp -d)

--- a/dev/run-pip-tests
+++ b/dev/run-pip-tests
@@ -28,9 +28,8 @@ cd "$FWDIR"
 # Clean ignored/untracked files that do not need
 # for pip packaging test. Machines in GitHub Action do not have
 # enough space, see also SPARK-44557.
-if [[ -z "${GITHUB_ACTIONS}" ]]; then
-  git clean -d -f -x -e assembly
-fi
+git clean -d -f -x -e assembly
+
 echo "Constructing virtual env for testing"
 VIRTUALENV_BASE=$(mktemp -d)
 

--- a/dev/run-pip-tests
+++ b/dev/run-pip-tests
@@ -28,7 +28,9 @@ cd "$FWDIR"
 # Clean ignored/untracked files that do not need
 # for pip packaging test. Machines in GitHub Action do not have
 # enough space, see also SPARK-44557.
-git clean -d -f -x -e assembly
+if [[ ! -z "${GITHUB_ACTIONS}" ]]; then
+  git clean -d -f -x -e assembly
+fi
 
 echo "Constructing virtual env for testing"
 VIRTUALENV_BASE=$(mktemp -d)

--- a/dev/run-pip-tests
+++ b/dev/run-pip-tests
@@ -25,10 +25,7 @@ shopt -s nullglob
 FWDIR="$(cd "$(dirname "$0")"/..; pwd)"
 cd "$FWDIR"
 
-du -hs /__t/*
-du -hs /__w/*
-du -hs /usr/*
-du -hs /root/*
+du -hs /usr/local/*
 
 echo "Constructing virtual env for testing"
 VIRTUALENV_BASE=$(mktemp -d)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to remove untracked/ignored files before running pip packaging test in GitHub Actions.

### Why are the changes needed?

In order to fix the flakiness in the test such as:

```
...
creating dist
Creating tar archive
error: [Errno 28] No space left on device
Cleaning up temporary directory - /tmp/tmp.CvSzgB7Kyy
```

See also https://github.com/apache/spark/actions/runs/5665869112/job/15351515539.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

GitHub Actions build in this PR.