### PR TITLE
[SPARK-44552][SQL] Remove `private object ParseState` definition from `IntervalUtils`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
@@ -739,21 +739,6 @@ object IntervalUtils extends SparkIntervalUtils {
     fromDoubles(interval.months / num, interval.days / num, interval.microseconds / num)
   }
 
-  private object ParseState extends Enumeration {
-    type ParseState = Value
-
-    val PREFIX,
-        TRIM_BEFORE_SIGN,
-        SIGN,
-        TRIM_BEFORE_VALUE,
-        VALUE,
-        VALUE_FRACTIONAL_PART,
-        TRIM_BEFORE_UNIT,
-        UNIT_BEGIN,
-        UNIT_SUFFIX,
-        UNIT_END = Value
-  }
-
   /**
    * A safe version of `stringToInterval`. It returns null for invalid input string.
    */


### PR DESCRIPTION
### What changes were proposed in this pull request?
SPARK-44326(https://github.com/apache/spark/pull/41885) moved the relevant code from `IntervalUtils` to `SparkIntervalUtils` (including `private object ParseState` definition), 

https://github.com/apache/spark/blob/6ca45c52b7416e7b3520dc902cb24f060c7c72dd/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/SparkIntervalUtils.scala#L247-L260

but did not delete the definition of `private object ParseState` in `IntervalUtils`. So this pr cleans up it.

### Why are the changes needed?
Code cleanup.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass Github Actions