### PR TITLE
[SPARK-44556][SQL] Reuse `OrcTail` when enable vectorizedReader

### DIFF
--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/orc/OrcColumnarBatchReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/orc/OrcColumnarBatchReader.java
@@ -50,7 +50,6 @@ public class OrcColumnarBatchReader extends RecordReader<Void, ColumnarBatch> {
 
   // The capacity of vectorized batch.
   private int capacity;
-  private OrcTail orcTail;
 
   // Vectorized ORC Row Batch wrap.
   private VectorizedRowBatchWrap wrap;
@@ -79,12 +78,7 @@ public class OrcColumnarBatchReader extends RecordReader<Void, ColumnarBatch> {
   private org.apache.spark.sql.vectorized.ColumnVector[] orcVectorWrappers;
 
   public OrcColumnarBatchReader(int capacity) {
-    this(capacity, null);
-  }
-
-  public OrcColumnarBatchReader(int capacity, OrcTail orcTail) {
     this.capacity = capacity;
-    this.orcTail = orcTail;
   }
 
 
@@ -127,6 +121,13 @@ public class OrcColumnarBatchReader extends RecordReader<Void, ColumnarBatch> {
   @Override
   public void initialize(
       InputSplit inputSplit, TaskAttemptContext taskAttemptContext) throws IOException {
+    initialize(inputSplit, taskAttemptContext, null);
+  }
+
+  public void initialize(
+      InputSplit inputSplit,
+      TaskAttemptContext taskAttemptContext,
+      OrcTail orcTail) throws IOException {
     FileSplit fileSplit = (FileSplit)inputSplit;
     Configuration conf = taskAttemptContext.getConfiguration();
     Reader reader = OrcFile.createReader(

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/orc/OrcColumnarBatchReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/orc/OrcColumnarBatchReader.java
@@ -78,6 +78,10 @@ public class OrcColumnarBatchReader extends RecordReader<Void, ColumnarBatch> {
   // The wrapped ORC column vectors.
   private org.apache.spark.sql.vectorized.ColumnVector[] orcVectorWrappers;
 
+  public OrcColumnarBatchReader(int capacity) {
+    this(capacity, null);
+  }
+
   public OrcColumnarBatchReader(int capacity, OrcTail orcTail) {
     this.capacity = capacity;
     this.orcTail = orcTail;

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
@@ -196,7 +196,7 @@ class OrcFileFormat
         val taskAttemptContext = new TaskAttemptContextImpl(taskConf, attemptId)
 
         if (enableVectorizedReader) {
-          val batchReader = new OrcColumnarBatchReader(capacity)
+          val batchReader = new OrcColumnarBatchReader(capacity, readerOptions.getOrcTail)
           // SPARK-23399 Register a task completion listener first to call `close()` in all cases.
           // There is a possibility that `initialize` and `initBatch` hit some errors (like OOM)
           // after opening a file.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
@@ -196,7 +196,7 @@ class OrcFileFormat
         val taskAttemptContext = new TaskAttemptContextImpl(taskConf, attemptId)
 
         if (enableVectorizedReader) {
-          val batchReader = new OrcColumnarBatchReader(capacity, readerOptions.getOrcTail)
+          val batchReader = new OrcColumnarBatchReader(capacity)
           // SPARK-23399 Register a task completion listener first to call `close()` in all cases.
           // There is a possibility that `initialize` and `initBatch` hit some errors (like OOM)
           // after opening a file.
@@ -205,7 +205,7 @@ class OrcFileFormat
           val requestedDataColIds = requestedColIds ++ Array.fill(partitionSchema.length)(-1)
           val requestedPartitionColIds =
             Array.fill(requiredSchema.length)(-1) ++ Range(0, partitionSchema.length)
-          batchReader.initialize(fileSplit, taskAttemptContext)
+          batchReader.initialize(fileSplit, taskAttemptContext, readerOptions.getOrcTail)
           batchReader.initBatch(
             TypeDescription.fromString(resultSchemaString),
             resultSchema.fields,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcPartitionReaderFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcPartitionReaderFactory.scala
@@ -167,13 +167,8 @@ case class OrcPartitionReaderFactory(
 
   private def createORCReader(filePath: Path, conf: Configuration): Reader = {
     OrcConf.IS_SCHEMA_EVOLUTION_CASE_SENSITIVE.setBoolean(conf, isCaseSensitive)
-
     val fs = filePath.getFileSystem(conf)
     val readerOptions = OrcFile.readerOptions(conf).filesystem(fs)
-    val reader = OrcFile.createReader(filePath, readerOptions)
-
-    pushDownPredicates(reader.getSchema, conf)
-
     createORCReaderWithOptions(filePath, conf, readerOptions)
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcPartitionReaderFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcPartitionReaderFactory.scala
@@ -150,8 +150,8 @@ case class OrcPartitionReaderFactory(
       val attemptId = new TaskAttemptID(new TaskID(new JobID(), TaskType.MAP, 0), 0)
       val taskAttemptContext = new TaskAttemptContextImpl(taskConf, attemptId)
 
-      val batchReader = new OrcColumnarBatchReader(capacity, readerOptions.getOrcTail)
-      batchReader.initialize(fileSplit, taskAttemptContext)
+      val batchReader = new OrcColumnarBatchReader(capacity)
+      batchReader.initialize(fileSplit, taskAttemptContext, readerOptions.getOrcTail)
       val requestedPartitionColIds =
         Array.fill(readDataSchema.length)(-1) ++ Range(0, partitionSchema.length)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Reuse `OrcTail`

### Why are the changes needed?

Avoid constructing `OrcTail` repeatedly when reading the same ORC file.

The ORC reader updates the `OrcTail` to the `ReaderOptions`.

org.apache.orc.impl.ReaderImpl#ReaderImpl
```java
      OrcTail orcTail = options.getOrcTail();
      if (orcTail == null) {
        tail = extractFileTail(getFileSystem(), path, options.getMaxLength());
        options.orcTail(tail);
      } else {
        checkOrcVersion(path, orcTail.getPostScript());
        tail = orcTail;
      }
```
https://github.com/apache/orc/blob/3b448e004bd22e0cb8f71e18077f142a6535bc45/java/core/src/java/org/apache/orc/impl/ReaderImpl.java#L567-L574

In addition, it can reduce one reading.


org.apache.orc.impl.ReaderImpl#extractFileTail
```java
    file = fs.open(path);
```


https://github.com/apache/orc/blob/3b448e004bd22e0cb8f71e18077f142a6535bc45/java/core/src/java/org/apache/orc/impl/ReaderImpl.java#L775-L781




### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
exist UT