### PR TITLE
[SPARK-44544][INFRA][FOLLOWUP] Force run `run_python_packaging_tests`

### DIFF
--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -559,6 +559,10 @@ def main():
 
         changed_modules = test_modules
         if len(changed_modules) == 0:
+            # If SKIP_PACKAGING is explicitly set (no matter true or false),
+            # let run_python_packaging_tests to determine whether it should be run.
+            if not os.environ.get("SKIP_PYTHON") and os.environ.get("SKIP_PACKAGING") is not None:
+                run_python_packaging_tests()
             print("[info] There are no modules to test, exiting without testing.")
             return
 

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -559,10 +559,6 @@ def main():
 
         changed_modules = test_modules
         if len(changed_modules) == 0:
-            # If SKIP_PACKAGING is explicitly set (no matter true or false),
-            # let run_python_packaging_tests to determine whether it should be run.
-            if not os.environ.get("SKIP_PYTHON") and os.environ.get("SKIP_PACKAGING") is not None:
-                run_python_packaging_tests()
             print("[info] There are no modules to test, exiting without testing.")
             return
 

--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -1040,7 +1040,14 @@ pyspark_pandas_slow_connect = Module(
 pyspark_errors = Module(
     name="pyspark-errors",
     dependencies=[],
-    source_file_regexes=["python/pyspark/errors"],
+    source_file_regexes=[
+        # [SPARK-44544] Force the execution of pyspark_errors when there is any changes
+        # in PySpark, since the Python Packaging Tests is only enabled within this module.
+        # This module is the smallest Python test modules, it only contains 1 test file
+        # and normally take < 2 seconds, so the additional cost is small.
+        "python/",
+        "python/pyspark/errors",
+    ],
     python_test_goals=[
         # unittests
         "pyspark.errors.tests.test_errors",

--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -1041,10 +1041,10 @@ pyspark_errors = Module(
     name="pyspark-errors",
     dependencies=[],
     source_file_regexes=[
-        # SPARK-44544: Force the execution of pyspark_errors when there is any changes
+        # SPARK-44544: Force the execution of pyspark_errors when there are any changes
         # in PySpark, since the Python Packaging Tests is only enabled within this module.
-        # This module is the smallest Python test modules, it only contains 1 test file
-        # and normally take < 2 seconds, so the additional cost is small.
+        # This module is the smallest Python test module, it contains only 1 test file
+        # and normally takes < 2 seconds, so the additional cost is small.
         "python/",
         "python/pyspark/errors",
     ],

--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -1041,7 +1041,7 @@ pyspark_errors = Module(
     name="pyspark-errors",
     dependencies=[],
     source_file_regexes=[
-        # [SPARK-44544] Force the execution of pyspark_errors when there is any changes
+        # SPARK-44544: Force the execution of pyspark_errors when there is any changes
         # in PySpark, since the Python Packaging Tests is only enabled within this module.
         # This module is the smallest Python test modules, it only contains 1 test file
         # and normally take < 2 seconds, so the additional cost is small.

--- a/dev/sparktestsupport/utils.py
+++ b/dev/sparktestsupport/utils.py
@@ -38,7 +38,7 @@ def determine_modules_for_files(filenames):
     and `README.md` is always ignored too.
 
     >>> sorted(x.name for x in determine_modules_for_files(["python/pyspark/a.py", "sql/core/foo"]))
-    ['pyspark-core', 'sql']
+    ['pyspark-core', 'pyspark-errors', 'sql']
     >>> [x.name for x in determine_modules_for_files(["file_not_matched_by_any_subproject"])]
     ['root']
     >>> [x.name for x in determine_modules_for_files(["appveyor.yml", "sql/README.md"])]


### PR DESCRIPTION
### What changes were proposed in this pull request?
run `run_python_packaging_tests` when there are any changes in PySpark


### Why are the changes needed?
https://github.com/apache/spark/pull/42146 make CI run `run_python_packaging_tests` only within `pyspark-errors` (see https://github.com/apache/spark/actions/runs/5666118302/job/15359190468 and https://github.com/apache/spark/actions/runs/5668071930/job/15358091003)

![image](https://github.com/apache/spark/assets/7322292/aef5cd4c-87ee-4b52-add3-e19ca131cdf1)



but I ignored that `pyspark-errors` maybe skipped (because no related source changes), so the `run_python_packaging_tests` maybe also skipped  unexpectedly (see https://github.com/apache/spark/actions/runs/5666523657/job/15353485731)

![image](https://github.com/apache/spark/assets/7322292/c2517d39-efcf-4a95-8562-1507dad35794)

this PR is to run `run_python_packaging_tests` even if `pyspark-errors` is skipped

### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
updated CI