### PR TITLE
[SPARK-44558][CONNECT][PYTHON] Export Spark Log Level

### DIFF
--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -17,7 +17,7 @@
 __all__ = [
     "ChannelBuilder",
     "SparkConnectClient",
-    "spark_connect_log_level",
+    "getLogLevel",
 ]
 
 from pyspark.sql.connect.utils import check_dependencies
@@ -115,17 +115,17 @@ def _configure_logging() -> logging.Logger:
 logger = _configure_logging()
 
 
-def spark_connect_log_level() -> Optional[int]:
+def getLogLevel() -> Optional[int]:
     """
     This returns this log level as integer, or none (if no logging is enabled).
 
     Spark Connect logging can be configured with environment variable 'SPARK_CONNECT_LOG_LEVEL'
+
     .. versionadded:: 3.5.0
     """
 
-    if logger.disabled:
-        return None
-    return logger.level
+    if not logger.disabled:
+        return logger.level
 
 
 class ChannelBuilder:

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -17,6 +17,7 @@
 __all__ = [
     "ChannelBuilder",
     "SparkConnectClient",
+    "spark_connect_log_level",
 ]
 
 from pyspark.sql.connect.utils import check_dependencies
@@ -104,7 +105,7 @@ def _configure_logging() -> logging.Logger:
 
     # Check the environment variables for log levels:
     if "SPARK_CONNECT_LOG_LEVEL" in os.environ:
-        logger.setLevel(os.getenv("SPARK_CONNECT_LOG_LEVEL", "error").upper())
+        logger.setLevel(os.environ["SPARK_CONNECT_LOG_LEVEL"].upper())
     else:
         logger.disabled = True
     return logger
@@ -112,6 +113,19 @@ def _configure_logging() -> logging.Logger:
 
 # Instantiate the logger based on the environment configuration.
 logger = _configure_logging()
+
+
+def spark_connect_log_level() -> Optional[int]:
+    """
+    This returns this log level as integer, or none (if no logging is enabled).
+
+    Spark Connect logging can be configured with environment variable 'SPARK_CONNECT_LOG_LEVEL'
+    .. versionadded:: 3.5.0
+    """
+
+    if logger.disabled:
+        return None
+    return logger.level
 
 
 class ChannelBuilder:

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -126,6 +126,7 @@ def getLogLevel() -> Optional[int]:
 
     if not logger.disabled:
         return logger.level
+    return None
 
 
 class ChannelBuilder:


### PR DESCRIPTION
### What changes were proposed in this pull request?

Export Spark Connect Log Level in pyspark. 

### Why are the changes needed?

This is convenient for software dependent on spark-connect so it can be possible to enable debug logging just in one place.

### Does this PR introduce _any_ user-facing change?

New api is suggested.

### How was this patch tested?

Checked it works from shell