### PR TITLE
[SPARK-44479][PYTHON][3.5] Fix ArrowStreamPandasUDFSerializer to accept no-column pandas DataFrame

### DIFF
--- a/python/pyspark/sql/connect/types.py
+++ b/python/pyspark/sql/connect/types.py
@@ -170,6 +170,7 @@ def pyspark_types_to_proto_types(data_type: DataType) -> pb2.DataType:
         ret.year_month_interval.start_field = data_type.startField
         ret.year_month_interval.end_field = data_type.endField
     elif isinstance(data_type, StructType):
+        struct = pb2.DataType.Struct()
         for field in data_type.fields:
             struct_field = pb2.DataType.StructField()
             struct_field.name = field.name
@@ -177,7 +178,8 @@ def pyspark_types_to_proto_types(data_type: DataType) -> pb2.DataType:
             struct_field.nullable = field.nullable
             if field.metadata is not None and len(field.metadata) > 0:
                 struct_field.metadata = json.dumps(field.metadata)
-            ret.struct.fields.append(struct_field)
+            struct.fields.append(struct_field)
+        ret.struct.CopyFrom(struct)
     elif isinstance(data_type, MapType):
         ret.map.key_type.CopyFrom(pyspark_types_to_proto_types(data_type.keyType))
         ret.map.value_type.CopyFrom(pyspark_types_to_proto_types(data_type.valueType))

--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -388,7 +388,7 @@ class ArrowStreamPandasUDFSerializer(ArrowStreamPandasSerializer):
         if len(df.columns) == 0:
             return pa.array([{}] * len(df), arrow_struct_type)
         # Assign result columns by schema name if user labeled with strings
-        elif self._assign_cols_by_name and any(isinstance(name, str) for name in df.columns):
+        if self._assign_cols_by_name and any(isinstance(name, str) for name in df.columns):
             struct_arrs = [
                 self._create_array(df[field.name], field.type, arrow_cast=self._arrow_cast)
                 for field in arrow_struct_type

--- a/python/pyspark/sql/tests/test_udtf.py
+++ b/python/pyspark/sql/tests/test_udtf.py
@@ -471,7 +471,7 @@ class BaseUDTFTestsMixin:
             def eval(self):
                 yield tuple()
 
-        self.assertEqual(TestUDTF().collect(), [Row()])
+        assertDataFrameEqual(TestUDTF(), [Row()])
 
     @unittest.skipIf(not have_pandas, pandas_requirement_message)
     def test_udtf_with_pandas_input_type(self):

--- a/python/pyspark/sql/tests/test_udtf.py
+++ b/python/pyspark/sql/tests/test_udtf.py
@@ -29,9 +29,8 @@ from pyspark.errors import (
 )
 from pyspark.rdd import PythonEvalType
 from pyspark.sql.functions import lit, udf, udtf
-from pyspark.sql.types import Row
+from pyspark.sql.types import IntegerType, MapType, Row, StringType, StructType
 from pyspark.testing import assertDataFrameEqual
-from pyspark.sql.types import MapType, StringType, IntegerType
 from pyspark.testing.sqlutils import (
     have_pandas,
     have_pyarrow,
@@ -465,6 +464,14 @@ class BaseUDTFTestsMixin:
                 yield {x: str(x)},
 
         self.assertEqual(TestUDTF(lit(1)).collect(), [Row(x={1: "1"})])
+
+    def test_udtf_with_empty_output_types(self):
+        @udtf(returnType=StructType())
+        class TestUDTF:
+            def eval(self):
+                yield tuple()
+
+        self.assertEqual(TestUDTF().collect(), [Row()])
 
     @unittest.skipIf(not have_pandas, pandas_requirement_message)
     def test_udtf_with_pandas_input_type(self):


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fixes `ArrowStreamPandasUDFSerializer` to accept no-column pandas DataFrame.

```py
>>> def _scalar_f(id):
...   return pd.DataFrame(index=id)
...
>>> scalar_f = pandas_udf(_scalar_f, returnType=StructType())
>>> df = spark.range(3).withColumn("f", scalar_f(col("id")))
>>> df.printSchema()
root
 |-- id: long (nullable = false)
 |-- f: struct (nullable = true)

>>> df.show()
+---+---+
| id|  f|
+---+---+
|  0| {}|
|  1| {}|
|  2| {}|
+---+---+
```

### Why are the changes needed?

The above query fails with the following error:

```py
>>> df.show()
org.apache.spark.api.python.PythonException: Traceback (most recent call last):
...
ValueError: not enough values to unpack (expected 2, got 0)
```

### Does this PR introduce _any_ user-facing change?

Yes, Pandas UDF will accept no-column pandas DataFrame.

### How was this patch tested?

Added related tests.