### PR TITLE
[MINOR][TESTS] Clearing residual files after SparkSubmitSuite

### DIFF
--- a/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
@@ -510,8 +510,19 @@ class SparkSubmitSuite
         "my.great.lib.MyLib", "my.great.dep.MyLib")
 
       val appArgs = new SparkSubmitArguments(clArgs)
-      val (_, _, sparkConf, _) = submit.prepareSubmitEnvironment(appArgs)
-      sparkConf.get("spark.jars").contains("mylib") shouldBe true
+      try {
+        val (_, _, sparkConf, _) = submit.prepareSubmitEnvironment(appArgs)
+        sparkConf.get("spark.jars").contains("mylib") shouldBe true
+      } finally {
+        val mainJarPath = Paths.get("my.great.dep_mylib-0.1.jar")
+        val depJarPath = Paths.get("my.great.lib_mylib-0.1.jar")
+        if (Files.exists(mainJarPath)) {
+          Files.delete(mainJarPath)
+        }
+        if (Files.exists(depJarPath)) {
+          Files.delete(depJarPath)
+        }
+      }
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to clear residual files after SparkSubmitSuite ("SPARK-35084: include jars of the --packages in k8s client mode & driver runs inside a POD")

### Why are the changes needed?
Clear residual files after UT.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Manually Test.
./build/sbt "core/testOnly *SparkSubmitSuite -- -z \"SPARK-35084: include jars of the --packages in k8s client mode & driver runs inside a POD\""
