### PR TITLE
[SPARK-44583][DOC] `spark.*.io.connectionCreationTimeout` parameter documentation

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
@@ -106,7 +106,7 @@ public class TransportConf {
     return defaultTimeoutMs < 0 ? 0 : (int) defaultTimeoutMs;
   }
 
-  /** Connect creation timeout in milliseconds. Default 30 secs. */
+  /** Connect creation timeout in milliseconds. Default 120 secs. */
   public int connectionCreationTimeoutMs() {
     long connectionTimeoutS = TimeUnit.MILLISECONDS.toSeconds(connectionTimeoutMs());
     long defaultTimeoutMs = JavaUtils.timeStringAsSec(

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1042,6 +1042,14 @@ Apart from these, the following properties are also available, and may be useful
   <td>1.2.0</td>
 </tr>
 <tr>
+  <td><code>spark.shuffle.io.connectionCreationTimeout</code></td>
+  <td>value of <code>spark.network.timeout</code></td>
+  <td>
+    Timeout for establishing a connection between the shuffle servers and clients.
+  </td>
+  <td>3.2.0</td>
+</tr>
+<tr>
   <td><code>spark.shuffle.service.enabled</code></td>
   <td>false</td>
   <td>
@@ -1216,6 +1224,14 @@ Apart from these, the following properties are also available, and may be useful
     for at least `connectionTimeout`.
   </td>
   <td>1.6.0</td>
+</tr>
+<tr>
+  <td><code>spark.files.io.connectionCreationTimeout</code></td>
+  <td>value of <code>spark.network.timeout</code></td>
+  <td>
+    Timeout for establishing a connection for fetching files in Spark RPC environments.
+  </td>
+  <td>3.2.0</td>
 </tr>
 <tr>
   <td><code>spark.shuffle.checksum.enabled</code></td>
@@ -2441,6 +2457,14 @@ Apart from these, the following properties are also available, and may be useful
     `connectionTimeout`.
   </td>
   <td>1.2.0</td>
+</tr>
+<tr>
+  <td><code>spark.rpc.io.connectionCreationTimeout</code></td>
+  <td>value of <code>spark.network.timeout</code></td>
+  <td>
+    Timeout for establishing a connection between RPC peers.
+  </td>
+  <td>3.2.0</td>
 </tr>
 </table>
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1043,7 +1043,7 @@ Apart from these, the following properties are also available, and may be useful
 </tr>
 <tr>
   <td><code>spark.shuffle.io.connectionCreationTimeout</code></td>
-  <td>value of <code>spark.network.timeout</code></td>
+  <td>value of <code>spark.shuffle.io.connectionTimeout</code></td>
   <td>
     Timeout for establishing a connection between the shuffle servers and clients.
   </td>
@@ -1227,7 +1227,7 @@ Apart from these, the following properties are also available, and may be useful
 </tr>
 <tr>
   <td><code>spark.files.io.connectionCreationTimeout</code></td>
-  <td>value of <code>spark.network.timeout</code></td>
+  <td>value of <code>spark.files.io.connectionTimeout</code></td>
   <td>
     Timeout for establishing a connection for fetching files in Spark RPC environments.
   </td>
@@ -2460,7 +2460,7 @@ Apart from these, the following properties are also available, and may be useful
 </tr>
 <tr>
   <td><code>spark.rpc.io.connectionCreationTimeout</code></td>
-  <td>value of <code>spark.network.timeout</code></td>
+  <td>value of <code>spark.rpc.io.connectionTimeout</code></td>
   <td>
     Timeout for establishing a connection between RPC peers.
   </td>


### PR DESCRIPTION
### What changes were proposed in this pull request?


### Why are the changes needed?
`spark.*.io.connectionCreationTimeout` The parameter description is missing, and the default time of the comment is wrong.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
