### PR TITLE
[SPARK-44584][CONNECT] Set client_type information for AddArtifactsRequest and ArtifactStatusesRequest in Scala Client

### DIFF
--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/connect/client/ArtifactManager.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/connect/client/ArtifactManager.scala
@@ -42,8 +42,8 @@ import org.apache.spark.util.{SparkFileUtils, SparkThreadUtils}
 /**
  * The Artifact Manager is responsible for handling and transferring artifacts from the local
  * client to the server (local/remote).
- * @param userContext
- *   The user context the artifact manager operates in.
+ * @param clientConfig
+ *   The configuration of the client that the artifact manager operates in.
  * @param sessionId
  *   An unique identifier of the session which the artifact manager belongs to.
  * @param bstub
@@ -52,7 +52,7 @@ import org.apache.spark.util.{SparkFileUtils, SparkThreadUtils}
  *   An async stub to the server.
  */
 class ArtifactManager(
-    userContext: proto.UserContext,
+    clientConfig: SparkConnectClient.Configuration,
     sessionId: String,
     bstub: CustomSparkConnectBlockingStub,
     stub: CustomSparkConnectStub) {
@@ -114,7 +114,8 @@ class ArtifactManager(
     val artifactName = CACHE_PREFIX + "/" + hash
     val request = proto.ArtifactStatusesRequest
       .newBuilder()
-      .setUserContext(userContext)
+      .setUserContext(clientConfig.userContext)
+      .setClientType(clientConfig.userAgent)
       .setSessionId(sessionId)
       .addAllNames(Arrays.asList(artifactName))
       .build()
@@ -216,7 +217,8 @@ class ArtifactManager(
       stream: StreamObserver[proto.AddArtifactsRequest]): Unit = {
     val builder = proto.AddArtifactsRequest
       .newBuilder()
-      .setUserContext(userContext)
+      .setUserContext(clientConfig.userContext)
+      .setClientType(clientConfig.userAgent)
       .setSessionId(sessionId)
     artifacts.foreach { artifact =>
       val in = new CheckedInputStream(artifact.storage.stream, new CRC32)
@@ -271,7 +273,8 @@ class ArtifactManager(
       stream: StreamObserver[proto.AddArtifactsRequest]): Unit = {
     val builder = proto.AddArtifactsRequest
       .newBuilder()
-      .setUserContext(userContext)
+      .setUserContext(clientConfig.userContext)
+      .setClientType(clientConfig.userAgent)
       .setSessionId(sessionId)
 
     val in = new CheckedInputStream(artifact.storage.stream, new CRC32)

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/connect/client/SparkConnectClient.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/connect/client/SparkConnectClient.scala
@@ -59,7 +59,7 @@ private[sql] class SparkConnectClient(
   private[sql] val sessionId: String = UUID.randomUUID.toString
 
   private[client] val artifactManager: ArtifactManager = {
-    new ArtifactManager(userContext, sessionId, bstub, stub)
+    new ArtifactManager(configuration, sessionId, bstub, stub)
   }
 
   /**

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/ArtifactSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/ArtifactSuite.scala
@@ -28,8 +28,8 @@ import io.grpc.inprocess.{InProcessChannelBuilder, InProcessServerBuilder}
 import org.apache.commons.codec.digest.DigestUtils.sha256Hex
 import org.scalatest.BeforeAndAfterEach
 
-import org.apache.spark.connect.proto
 import org.apache.spark.connect.proto.AddArtifactsRequest
+import org.apache.spark.sql.connect.client.SparkConnectClient.Configuration
 import org.apache.spark.sql.connect.client.util.ConnectFunSuite
 
 class ArtifactSuite extends ConnectFunSuite with BeforeAndAfterEach {
@@ -57,7 +57,7 @@ class ArtifactSuite extends ConnectFunSuite with BeforeAndAfterEach {
     retryPolicy = GrpcRetryHandler.RetryPolicy()
     bstub = new CustomSparkConnectBlockingStub(channel, retryPolicy)
     stub = new CustomSparkConnectStub(channel, retryPolicy)
-    artifactManager = new ArtifactManager(proto.UserContext.newBuilder().build(), "", bstub, stub)
+    artifactManager = new ArtifactManager(Configuration(), "", bstub, stub)
   }
 
   override def beforeEach(): Unit = {

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/SparkConnectClientSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/SparkConnectClientSuite.scala
@@ -331,7 +331,10 @@ class DummySparkConnectService() extends SparkConnectServiceGrpc.SparkConnectSer
 
   override def addArtifacts(responseObserver: StreamObserver[AddArtifactsResponse])
       : StreamObserver[AddArtifactsRequest] = new StreamObserver[AddArtifactsRequest] {
-    override def onNext(v: AddArtifactsRequest): Unit = inputArtifactRequests.append(v)
+    override def onNext(v: AddArtifactsRequest): Unit = {
+      assert(v.hasClientType)
+      inputArtifactRequests.append(v)
+    }
 
     override def onError(throwable: Throwable): Unit = responseObserver.onError(throwable)
 
@@ -344,6 +347,7 @@ class DummySparkConnectService() extends SparkConnectServiceGrpc.SparkConnectSer
   override def artifactStatus(
       request: ArtifactStatusesRequest,
       responseObserver: StreamObserver[ArtifactStatusesResponse]): Unit = {
+    assert(request.hasClientType)
     val builder = proto.ArtifactStatusesResponse.newBuilder()
     request.getNamesList().iterator().asScala.foreach { name =>
       val status = proto.ArtifactStatusesResponse.ArtifactStatus.newBuilder()

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/SparkConnectClientSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/SparkConnectClientSuite.scala
@@ -331,10 +331,7 @@ class DummySparkConnectService() extends SparkConnectServiceGrpc.SparkConnectSer
 
   override def addArtifacts(responseObserver: StreamObserver[AddArtifactsResponse])
       : StreamObserver[AddArtifactsRequest] = new StreamObserver[AddArtifactsRequest] {
-    override def onNext(v: AddArtifactsRequest): Unit = {
-      assert(v.hasClientType)
-      inputArtifactRequests.append(v)
-    }
+    override def onNext(v: AddArtifactsRequest): Unit = inputArtifactRequests.append(v)
 
     override def onError(throwable: Throwable): Unit = responseObserver.onError(throwable)
 
@@ -347,7 +344,6 @@ class DummySparkConnectService() extends SparkConnectServiceGrpc.SparkConnectSer
   override def artifactStatus(
       request: ArtifactStatusesRequest,
       responseObserver: StreamObserver[ArtifactStatusesResponse]): Unit = {
-    assert(request.hasClientType)
     val builder = proto.ArtifactStatusesResponse.newBuilder()
     request.getNamesList().iterator().asScala.foreach { name =>
       val status = proto.ArtifactStatusesResponse.ArtifactStatus.newBuilder()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->


### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Added `client_type` information to the `AddArtifactsRequest` and `ArtifactStatusesRequest` by having `ArtifactManager` take in the `SparkConnectClient.Configuration` param instead of just `userContext` (the configuration provides both the `userContext` and the `userAgent` (i.e the client type))

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
The client_type information is missing for the `AddArtifactsRequest` and `ArtifactStatusesRequest` compared to the other requests (e.g `analyze`, `execute` etc).

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

N/A