### PR TITLE
[SPARK-44596] Fix pandas-on-Spark type checks for assertDataFrameEqual

### DIFF
--- a/python/pyspark/errors/error_classes.py
+++ b/python/pyspark/errors/error_classes.py
@@ -269,12 +269,6 @@ ERROR_CLASSES_JSON = """
       "NumPy array input should be of <dimensions> dimensions."
     ]
   },
-  "INVALID_PANDAS_ON_SPARK_COMPARISON" : {
-    "message" : [
-      "Expected two pandas-on-Spark DataFrames",
-      "but got actual: <actual_type> and expected: <expected_type>"
-    ]
-  },
   "INVALID_PANDAS_UDF" : {
     "message" : [
       "Invalid function: <detail>"

--- a/python/pyspark/sql/tests/test_utils.py
+++ b/python/pyspark/sql/tests/test_utils.py
@@ -651,6 +651,7 @@ class UtilsTestsMixin:
 
     def test_assert_error_pandas_pyspark_df(self):
         import pyspark.pandas as ps
+        import pandas as pd
 
         df1 = ps.DataFrame(data=[10, 20, 30], columns=["Numbers"])
         df2 = self.spark.createDataFrame([(10,), (11,), (13,)], ["Numbers"])
@@ -660,10 +661,16 @@ class UtilsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="INVALID_PANDAS_ON_SPARK_COMPARISON",
+            error_class="INVALID_TYPE_DF_EQUALITY_ARG",
             message_parameters={
-                "actual_type": type(df1),
-                "expected_type": type(df2),
+                "expected_type": f"{ps.DataFrame.__name__}, "
+                f"{pd.DataFrame.__name__}, "
+                f"{ps.Series.__name__}, "
+                f"{pd.Series.__name__}, "
+                f"{ps.Index.__name__}"
+                f"{pd.Index.__name__}, ",
+                "arg_name": "expected",
+                "actual_type": type(df2),
             },
         )
 
@@ -672,10 +679,16 @@ class UtilsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="INVALID_PANDAS_ON_SPARK_COMPARISON",
+            error_class="INVALID_TYPE_DF_EQUALITY_ARG",
             message_parameters={
-                "actual_type": type(df1),
-                "expected_type": type(df2),
+                "expected_type": f"{ps.DataFrame.__name__}, "
+                f"{pd.DataFrame.__name__}, "
+                f"{ps.Series.__name__}, "
+                f"{pd.Series.__name__}, "
+                f"{ps.Index.__name__}"
+                f"{pd.Index.__name__}, ",
+                "arg_name": "expected",
+                "actual_type": type(df2),
             },
         )
 

--- a/python/pyspark/testing/pandasutils.py
+++ b/python/pyspark/testing/pandasutils.py
@@ -326,7 +326,7 @@ def _assert_pandas_almost_equal(
 
 def assertPandasOnSparkEqual(
     actual: Union[DataFrame, Series, Index],
-    expected: Union[DataFrame, pd.DataFrame, Series, Index],
+    expected: Union[DataFrame, pd.DataFrame, Series, pd.Series, Index, pd.Index],
     checkExact: bool = True,
     almost: bool = False,
     checkRowOrder: bool = False,
@@ -392,14 +392,16 @@ def assertPandasOnSparkEqual(
                 "actual_type": type(actual),
             },
         )
-    elif not isinstance(expected, (DataFrame, pd.DataFrame, Series, Index)):
+    elif not isinstance(expected, (DataFrame, pd.DataFrame, Series, pd.Series, Index, pd.Index)):
         raise PySparkAssertionError(
             error_class="INVALID_TYPE_DF_EQUALITY_ARG",
             message_parameters={
                 "expected_type": f"{DataFrame.__name__}, "
                 f"{pd.DataFrame.__name__}, "
                 f"{Series.__name__}, "
-                f"{Index.__name__}",
+                f"{pd.Series.__name__}, "
+                f"{Index.__name__}"
+                f"{pd.Index.__name__}, ",
                 "arg_name": "expected",
                 "actual_type": type(expected),
             },

--- a/python/pyspark/testing/utils.py
+++ b/python/pyspark/testing/utils.py
@@ -413,14 +413,6 @@ def assertDataFrameEqual(
 
         if isinstance(actual, ps.DataFrame) or isinstance(expected, ps.DataFrame):
             # handle pandas DataFrames
-            if not (isinstance(actual, ps.DataFrame) and isinstance(expected, ps.DataFrame)):
-                raise PySparkAssertionError(
-                    error_class="INVALID_PANDAS_ON_SPARK_COMPARISON",
-                    message_parameters={
-                        "actual_type": type(actual),
-                        "expected_type": type(expected),
-                    },
-                )
             # assert approximate equality for float data
             return assertPandasOnSparkEqual(
                 actual, expected, checkExact=False, checkRowOrder=checkRowOrder
@@ -446,14 +438,6 @@ def assertDataFrameEqual(
     except Exception:
         if isinstance(actual, ps.DataFrame) or isinstance(expected, ps.DataFrame):
             # handle pandas DataFrames
-            if not (isinstance(actual, ps.DataFrame) and isinstance(expected, ps.DataFrame)):
-                raise PySparkAssertionError(
-                    error_class="INVALID_PANDAS_ON_SPARK_COMPARISON",
-                    message_parameters={
-                        "actual_type": type(actual),
-                        "expected_type": type(expected),
-                    },
-                )
             # assert approximate equality for float data
             return assertPandasOnSparkEqual(
                 actual, expected, checkExact=False, checkRowOrder=checkRowOrder


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR fixes the type checks for pandas-on-Spark DataFrame comparison in `assertDataFrameEqual`


### Why are the changes needed?
Previously, the type checks restricted the `expected` argument to be a pandas-on-Spark DataFrame, when it should allow pandas or pandas-on-Spark


### Does this PR introduce _any_ user-facing change?
Modifies the user-facing API, `assertDataFrameEqual`

### How was this patch tested?
Existing tests in `python/pyspark/sql/tests/test_utils.py` and `python/pyspark/sql/tests/connect/test_utils.py`
