### PR TITLE
[SPARK-44593][INFRA] Make `breaking-changes-buf` cancelable

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -527,7 +527,7 @@ jobs:
 
   breaking-changes-buf:
     needs: [precondition]
-    if: always() && fromJson(needs.precondition.outputs.required).breaking-changes-buf == 'true'
+    if: (!cancelled()) && fromJson(needs.precondition.outputs.required).breaking-changes-buf == 'true'
     # Change 'branch-3.5' to 'branch-4.0' in master branch after cutting branch-4.0 branch.
     name: Breaking change detection with Buf (branch-3.5)
     runs-on: ubuntu-22.04


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make `breaking-changes-buf` cancelable, refering to https://docs.github.com/en/actions/learn-github-actions/expressions#always

> Warning: Avoid using always for any task that could suffer from a critical failure, for example: getting sources, otherwise the workflow may hang until it times out. If you want to run a job or step regardless of its success or failure, use the recommended alternative: if: ${{ !cancelled() }}


### Why are the changes needed?
release the runner ASAP, when we click the `Cancel Workflow` button

see cenceled run: https://github.com/zhengruifeng/spark/actions/runs/5697578362

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
manually check