### PR TITLE
[SPARK-44595][CONNECT] Make the user session cache number and cache time be configurable in spark connect service

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
@@ -124,9 +124,7 @@ object Connect {
 
   val CONNECT_USER_SESSION_CACHE_SIZE =
     ConfigBuilder("spark.connect.userSession.cacheSize")
-      .doc("""
-          |Sets the cache size of user session.
-          |""".stripMargin)
+      .doc("Sets the cache size of user session.")
       .version("4.0.0")
       .intConf
       .createWithDefault(100)

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
@@ -121,4 +121,22 @@ object Connect {
       .version("3.5.0")
       .booleanConf
       .createWithDefault(false)
+
+  val CONNECT_USER_SESSION_CACHE_SIZE =
+    ConfigBuilder("spark.connect.userSession.cacheSize")
+      .doc("""
+          |Sets the cache size of user session.
+          |""".stripMargin)
+      .version("4.0.0")
+      .intConf
+      .createWithDefault(100)
+
+  val CONNECT_USER_SESSION_CACHE_TIMEOUT =
+    ConfigBuilder("spark.connect.userSession.cacheTimeout")
+      .doc("""
+          |Sets the cache timeout of user session.
+          |""".stripMargin)
+      .version("4.0.0")
+      .intConf
+      .createWithDefault(3600)
 }

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
@@ -131,9 +131,7 @@ object Connect {
 
   val CONNECT_USER_SESSION_CACHE_TIMEOUT =
     ConfigBuilder("spark.connect.userSession.cacheTimeout")
-      .doc("""
-          |Sets the cache timeout of user session.
-          |""".stripMargin)
+      .doc("Sets the cache timeout of user session.")
       .version("4.0.0")
       .intConf
       .createWithDefault(3600)

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
@@ -34,7 +34,7 @@ import org.apache.spark.connect.proto
 import org.apache.spark.connect.proto.{AddArtifactsRequest, AddArtifactsResponse}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.connect.config.Connect.{CONNECT_GRPC_BINDING_ADDRESS, CONNECT_GRPC_BINDING_PORT, CONNECT_GRPC_MAX_INBOUND_MESSAGE_SIZE}
+import org.apache.spark.sql.connect.config.Connect.{CONNECT_GRPC_BINDING_ADDRESS, CONNECT_GRPC_BINDING_PORT, CONNECT_GRPC_MAX_INBOUND_MESSAGE_SIZE, CONNECT_USER_SESSION_CACHE_SIZE, CONNECT_USER_SESSION_CACHE_TIMEOUT}
 import org.apache.spark.sql.connect.utils.ErrorUtils
 
 /**
@@ -171,9 +171,9 @@ class SparkConnectService(debug: Boolean)
  */
 object SparkConnectService extends Logging {
 
-  private val CACHE_SIZE = 100
+  private val CACHE_SIZE = SparkEnv.get.conf.get(CONNECT_USER_SESSION_CACHE_SIZE)
 
-  private val CACHE_TIMEOUT_SECONDS = 3600
+  private val CACHE_TIMEOUT_SECONDS = SparkEnv.get.conf.get(CONNECT_USER_SESSION_CACHE_TIMEOUT)
 
   // Type alias for the SessionCacheKey. Right now this is a String but allows us to switch to a
   // different or complex type easily.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -3217,6 +3217,22 @@ Expression types in proto.</td>
 Command types in proto.</td>
   <td>3.4.0</td>
 </tr>
+<tr>
+  <td><code>spark.connect.userSession.cacheSize</code></td>
+  <td>
+    100
+  </td>
+  <td>Sets the cache size of user session.</td>
+  <td>4.0.0</td>
+</tr>
+<tr>
+  <td><code>spark.connect.userSession.cacheTimeout</code></td>
+  <td>
+    3600
+  </td>
+  <td>Sets the cache timeout of user session.</td>
+  <td>4.0.0</td>
+</tr>
 </table>
 
 ### Security


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Added configs for user session cache size and cache timeout in connect service.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Now, the cache size of user session is 100, the cache timeout is 3600. Make them modifiable to meet diverse scenarios.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

no
### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Existing can test it.