### PR TITLE
[SPARK-43744][CONNECT][FOLLOW-UP]Throw error from the constructor

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/artifact/SparkConnectArtifactManager.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/artifact/SparkConnectArtifactManager.scala
@@ -31,7 +31,7 @@ import org.apache.hadoop.fs.{LocalFileSystem, Path => FSPath}
 
 import org.apache.spark.{JobArtifactSet, JobArtifactState, SparkContext, SparkEnv}
 import org.apache.spark.internal.Logging
-import org.apache.spark.internal.config.CONNECT_SCALA_UDF_STUB_CLASSES
+import org.apache.spark.internal.config.CONNECT_SCALA_UDF_STUB_PREFIXES
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.connect.artifact.util.ArtifactUtils
 import org.apache.spark.sql.connect.config.Connect.CONNECT_COPY_FROM_LOCAL_TO_FS_ALLOW_DEST_LOCAL
@@ -162,9 +162,9 @@ class SparkConnectArtifactManager(sessionHolder: SessionHolder) extends Logging 
    */
   def classloader: ClassLoader = {
     val urls = getSparkConnectAddedJars :+ classDir.toUri.toURL
-    val loader = if (SparkEnv.get.conf.get(CONNECT_SCALA_UDF_STUB_CLASSES).nonEmpty) {
+    val loader = if (SparkEnv.get.conf.get(CONNECT_SCALA_UDF_STUB_PREFIXES).nonEmpty) {
       val stubClassLoader =
-        StubClassLoader(null, SparkEnv.get.conf.get(CONNECT_SCALA_UDF_STUB_CLASSES))
+        StubClassLoader(null, SparkEnv.get.conf.get(CONNECT_SCALA_UDF_STUB_PREFIXES))
       new ChildFirstURLClassLoader(
         urls.toArray,
         stubClassLoader,

--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/artifact/StubClassLoaderSuite.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/artifact/StubClassLoaderSuite.scala
@@ -55,6 +55,21 @@ class StubClassLoaderSuite extends SparkFunSuite {
     }
   }
 
+  test("call stub class default constructor") {
+    val cl = new RecordedStubClassLoader(getClass().getClassLoader(), _ => true)
+    // scalastyle:off classforname
+    val cls = Class.forName("my.name.HelloWorld", false, cl)
+    // scalastyle:on classforname
+    assert(cl.lastStubbed === "my.name.HelloWorld")
+    val error = intercept[java.lang.reflect.InvocationTargetException] {
+      cls.getDeclaredConstructor().newInstance()
+    }
+    assert(
+      error.getCause != null && error.getCause.getMessage.contains(
+        "Fail to initiate the class my.name.HelloWorld because it is stubbed"),
+      error)
+  }
+
   test("stub missing class") {
     val sysClassLoader = getClass.getClassLoader()
     val stubClassLoader = new RecordedStubClassLoader(null, _ => true)

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -2556,8 +2556,8 @@ package object config {
       .booleanConf
       .createWithDefault(false)
 
-  private[spark] val CONNECT_SCALA_UDF_STUB_CLASSES =
-    ConfigBuilder("spark.connect.scalaUdf.stubClasses")
+  private[spark] val CONNECT_SCALA_UDF_STUB_PREFIXES =
+    ConfigBuilder("spark.connect.scalaUdf.stubPrefixes")
       .internal()
       .doc("""
           |Comma-separated list of binary names of classes/packages that should be stubbed during

--- a/core/src/main/scala/org/apache/spark/util/StubClassLoader.scala
+++ b/core/src/main/scala/org/apache/spark/util/StubClassLoader.scala
@@ -70,8 +70,22 @@ object StubClassLoader {
       "()V",
       false)
 
-    ctorWriter.visitInsn(Opcodes.RETURN)
-    ctorWriter.visitMaxs(1, 1)
+    val internalException: String = "java/lang/ClassNotFoundException"
+    ctorWriter.visitTypeInsn(Opcodes.NEW, internalException)
+    ctorWriter.visitInsn(Opcodes.DUP)
+    ctorWriter.visitLdcInsn(
+      s"Fail to initiate the class $binaryName because it is stubbed. " +
+        "Please install the artifact of the missing class by calling session.addArtifact.")
+    // Invoke throwable constructor
+    ctorWriter.visitMethodInsn(
+      Opcodes.INVOKESPECIAL,
+      internalException,
+      "<init>",
+      "(Ljava/lang/String;)V",
+      false)
+
+    ctorWriter.visitInsn(Opcodes.ATHROW)
+    ctorWriter.visitMaxs(3, 3)
     ctorWriter.visitEnd()
     classWriter.visitEnd()
     classWriter.toByteArray


### PR DESCRIPTION
### What changes were proposed in this pull request?
Made the stub constructor to throw ClassNotFoundException if called.
A tiny improvement to not recreate class loaders in executor if stubbing is not enabled.

### Why are the changes needed?
Enhancement to https://github.com/apache/spark/pull/42069
Should be merged to 3.5.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Unit tests.