### PR TITLE
[MINOR][TESTS] Rename ArrowParityTests to JobCancellationTests

### DIFF
--- a/python/pyspark/sql/tests/connect/test_session.py
+++ b/python/pyspark/sql/tests/connect/test_session.py
@@ -78,7 +78,7 @@ class SparkSessionTestCase(unittest.TestCase):
         session.stop()
 
 
-class ArrowParityTests(ReusedConnectTestCase):
+class JobCancellationTests(ReusedConnectTestCase):
     def test_tags(self):
         self.spark.clearTags()
         self.spark.addTag("a")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/42120 that fixes the test class name from `ArrowParityTests` to `JobCancellationTests`. 


### Why are the changes needed?

The test class name doesn't make sense. It tests job cancellation.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Existing unittests should be good enough.