### PR TITLE
[SPARK-44603] Add pyspark.testing to setup.py

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -264,6 +264,7 @@ try:
             "pyspark.pandas.usage_logging",
             "pyspark.python.pyspark",
             "pyspark.python.lib",
+            "pyspark.testing",
             "pyspark.data",
             "pyspark.licenses",
             "pyspark.resource",


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR adds the pyspark.testing package to the Python setup.py file.

### Why are the changes needed?
The change ensures that the PySpark test utils are available when users pip install PySpark.


### Does this PR introduce _any_ user-facing change?
Yes, the PR allows users to use the PySpark test utils.


### How was this patch tested?
Existing tests.
