### PR TITLE
[SPARK-44424][CONNECT][PYTHON] Python client for reattaching to existing execute in Spark Connect

### DIFF
--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -1184,14 +1184,14 @@ class SparkConnectClient(object):
                     req, self._stub, self._retry_policy
                 )
                 for b in generator:
-                    yield handle_response(b)
+                    yield from handle_response(b)
             else:
                 for attempt in Retrying(
                     can_retry=SparkConnectClient.retry_exception, **self._retry_policy
                 ):
                     with attempt:
                         for b in self._stub.ExecutePlan(req, metadata=self._builder.metadata()):
-                            yield handle_response(b)
+                            yield from handle_response(b)
         except Exception as error:
             self._handle_error(error)
 

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -643,11 +643,11 @@ class SparkConnectClient(object):
         self._use_reattachable_execute = use_reattachable_execute
         # Configure logging for the SparkConnect client.
 
-    def disable_reattachable_execute(self):
+    def disable_reattachable_execute(self) -> "SparkConnectClient":
         self._use_reattachable_execute = False
         return self
 
-    def enable_reattachable_execute(self):
+    def enable_reattachable_execute(self) -> "SparkConnectClient":
         self._use_reattachable_execute = True
         return self
 

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -1102,7 +1102,7 @@ class SparkConnectClient(object):
             if self._use_reattachable_execute:
                 # Don't use retryHandler - own retry handling is inside.
                 generator = ExecutePlanResponseReattachableIterator(
-                    req, self._stub, self._retry_policy
+                    req, self._stub, self._retry_policy, self._builder.metadata()
                 )
                 for b in generator:
                     handle_response(b)
@@ -1189,7 +1189,7 @@ class SparkConnectClient(object):
             if self._use_reattachable_execute:
                 # Don't use retryHandler - own retry handling is inside.
                 generator = ExecutePlanResponseReattachableIterator(
-                    req, self._stub, self._retry_policy
+                    req, self._stub, self._retry_policy, self._builder.metadata()
                 )
                 for b in generator:
                     yield from handle_response(b)

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -602,7 +602,7 @@ class SparkConnectClient(object):
                 * ``initial_backoff``
                     Backoff to wait before the first retry. Default: 50(ms)
                 * ``max_backoff``
-                    Max backoff controls the maximum amount of time to wait before retrying
+                    Maximum backoff controls the maximum amount of time to wait before retrying
                     a failed request. Default: 60000(ms).
         use_reattachable_execute: bool
             Enable reattachable execution.
@@ -1131,7 +1131,15 @@ class SparkConnectClient(object):
 
         def handle_response(
             b: pb2.ExecutePlanResponse,
-        ) -> Union["pa.RecordBatch", StructType, PlanMetrics, PlanObservedMetrics, Dict[str, Any]]:
+        ) -> Iterator[
+            Union[
+                "pa.RecordBatch",
+                StructType,
+                PlanMetrics,
+                PlanObservedMetrics,
+                Dict[str, Any],
+            ]
+        ]:
             if b.session_id != self._session_id:
                 raise SparkConnectException(
                     "Received incorrect session identifier for request: "
@@ -1549,6 +1557,9 @@ class AttemptManager:
         else:
             self._retry_state.set_done()
             return None
+
+    def is_first_try(self) -> bool:
+        return self._retry_state._count == 0
 
 
 class Retrying:

--- a/python/pyspark/sql/connect/client/reattach.py
+++ b/python/pyspark/sql/connect/client/reattach.py
@@ -88,8 +88,8 @@ class ExecutePlanResponseReattachableIterator(Generator):
         # Initial iterator comes from ExecutePlan request.
         # Note: This is not retried, because no error would ever be thrown here, and GRPC will only
         # throw error on first self._has_next().
-        self._iterator: Iterator[pb2.ExecutePlanResponse] = self._stub.ExecutePlan(
-            self._initial_request, metadata=metadata
+        self._iterator: Iterator[pb2.ExecutePlanResponse] = iter(
+            self._stub.ExecutePlan(self._initial_request, metadata=metadata)
         )
 
         # Current item from this iterator.

--- a/python/pyspark/sql/connect/client/reattach.py
+++ b/python/pyspark/sql/connect/client/reattach.py
@@ -1,0 +1,166 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from pyspark.sql.connect.utils import check_dependencies
+
+check_dependencies(__name__)
+
+import uuid
+from collections.abc import Generator
+from typing import Optional, Dict, Any
+
+import pyspark.sql.connect.proto as pb2
+import pyspark.sql.connect.proto.base_pb2_grpc as grpc_lib
+from pyspark.sql.connect.client import SparkConnectClient
+from pyspark.sql.connect.client.core import Retrying
+
+
+class ExecutePlanResponseReattachableIterator(Generator):
+    def __init__(
+        self,
+        request: pb2.ExecutePlanRequest,
+        stub: grpc_lib.SparkConnectServiceStub,
+        retry_policy: Dict[str, Any],
+    ):
+        self._request = request
+        self._retry_policy = retry_policy
+        self._operation_id = str(uuid.uuid4())
+        self._stub = stub
+        request.reattach_options.reattachable = True  # type: ignore[attr-defined]
+        self._initial_request = request
+        self._response_complete = False
+        self._iterator = self._stub.ExecutePlan(self._initial_request)
+
+        self._last_response_id: Optional[str] = None
+        self._current: Optional[pb2.ExecutePlanResponse] = None
+
+    def send(self, value: Any) -> pb2.ExecutePlanResponse:
+        # will trigger reattach in case the stream completed without responseComplete
+        self._has_next()
+
+        # Get next response, possibly triggering reattach in case of stream error.
+        first_try = True
+        ret: Optional[pb2.ExecutePlanResponse] = None
+        for attempt in Retrying(can_retry=SparkConnectClient.retry_exception, **self._retry_policy):
+            with attempt:
+                if first_try:
+                    # on first try, we use the initial iterator.
+                    first_try = False
+                else:
+                    # Error retry reattach: After an error, attempt to
+                    self._iterator = self._stub.ReattachExecute(
+                        self._create_reattach_execute_request()
+                    )
+                ret = self._current
+
+        if ret is None:
+            raise StopIteration()
+
+        assert ret is not None
+        self._last_response_id = ret.response_id
+        if ret.response_complete:
+            self._response_complete = True
+            self._release_execute(None)  # release all
+        else:
+            self._release_execute(self._last_response_id)
+        self._current = None
+        return ret
+
+    def _has_next(self) -> bool:
+        if self._response_complete:
+            # After response complete response
+            return False
+        else:
+            for attempt in Retrying(
+                can_retry=SparkConnectClient.retry_exception, **self._retry_policy
+            ):
+                with attempt:
+                    if self._current is None:
+                        try:
+                            self._current = next(self._iterator)
+                        except StopIteration:
+                            pass
+                    has_next = self._current is not None
+
+                    # Graceful reattach:
+                    # If iterator ended, but there was no ResponseComplete, it means that
+                    # there is more, and we need to reattach. While ResponseComplete didn't
+                    # arrive, we keep reattaching.
+                    if not has_next and not self._response_complete:
+                        while not has_next:
+                            self._iterator = self._stub.ReattachExecute(
+                                self._create_reattach_execute_request()
+                            )
+                            # shouldn't change
+                            assert not self._response_complete
+                            try:
+                                self._current = next(self._iterator)
+                            except StopIteration:
+                                pass
+                            has_next = self._current is not None
+                    return has_next
+            return False
+
+    def _release_execute(self, until_response_id: Optional[str]) -> None:
+        request = self._create_release_execute_request(until_response_id)
+        for attempt in Retrying(can_retry=SparkConnectClient.retry_exception, **self._retry_policy):
+            with attempt:
+                self._stub.ReleaseExecute(request)
+
+    def _create_reattach_execute_request(self) -> pb2.ReattachExecuteRequest:
+        release = pb2.ReattachExecuteRequest(
+            session_id=self._initial_request.session_id,
+            user_context=self._initial_request.user_context,
+            operation_id=self._initial_request.operation_id,
+        )
+
+        if self._initial_request.client_type:
+            release.client_type = self._initial_request.client_type
+
+        return release
+
+    def _create_release_execute_request(
+        self, until_response_id: Optional[str]
+    ) -> pb2.ReattachExecuteRequest:
+        release = pb2.ReattachExecuteRequest(
+            session_id=self._initial_request.session_id,
+            user_context=self._initial_request.user_context,
+            operation_id=self._initial_request.operation_id,
+        )
+
+        if self._initial_request.client_type:
+            release.client_type = self._initial_request.client_type
+
+        if not until_response_id:
+            release.release_type = (  # type: ignore[attr-defined]
+                pb2.ReleaseExecuteRequest.ReleaseType.RELEASE_UNTIL_RESPONSE
+            )
+        else:
+            release.release_type = (  # type: ignore[attr-defined]
+                pb2.ReleaseExecuteRequest.ReleaseType.RELEASE_ALL
+            )
+            release.until_response_id = until_response_id  # type: ignore[attr-defined]
+
+        return release
+
+    def throw(self, type: Any = None, value: Any = None, traceback: Any = None) -> Any:
+        super().throw(type, value, traceback)
+
+    def close(self) -> None:
+        return super().close()
+
+    def __del__(self) -> None:
+        return self.close()

--- a/python/pyspark/sql/connect/client/reattach.py
+++ b/python/pyspark/sql/connect/client/reattach.py
@@ -64,7 +64,11 @@ class ExecutePlanResponseReattachableIterator(Generator):
             self._operation_id = str(uuid.uuid4())
 
         self._stub = stub
-        request.reattach_options.reattachable = True  # type: ignore[attr-defined]
+        request.request_options.append(
+            pb2.ExecutePlanRequest.RequestOption(
+                reattach_options=pb2.ReattachOptions(reattachable=True)
+            )
+        )
         self._initial_request = request
 
         # ResponseId of the last response returned by next()
@@ -84,8 +88,6 @@ class ExecutePlanResponseReattachableIterator(Generator):
         self._current: Optional[pb2.ExecutePlanResponse] = None
 
     def send(self, value: Any) -> pb2.ExecutePlanResponse:
-        from pyspark.sql.connect.client.core import SparkConnectClient
-
         # will trigger reattach in case the stream completed without response_complete
         if not self._has_next():
             raise StopIteration()

--- a/python/pyspark/sql/connect/client/reattach.py
+++ b/python/pyspark/sql/connect/client/reattach.py
@@ -209,14 +209,9 @@ class ExecutePlanResponseReattachableIterator(Generator):
             release.client_type = self._initial_request.client_type
 
         if not until_response_id:
-            release.release_type = (  # type: ignore[attr-defined]
-                pb2.ReleaseExecuteRequest.ReleaseType.RELEASE_UNTIL_RESPONSE  # type: ignore[attr-defined]
-            )
+            release.release_all.CopyFrom(pb2.ReleaseExecuteRequest.ReleaseAll())
         else:
-            release.release_type = (  # type: ignore[attr-defined]
-                pb2.ReleaseExecuteRequest.ReleaseType.RELEASE_ALL  # type: ignore[attr-defined]
-            )
-            release.until_response_id = until_response_id  # type: ignore[attr-defined]
+            release.release_util.response_id = until_response_id  # type: ignore[attr-defined]
 
         return release
 

--- a/python/pyspark/sql/connect/client/reattach.py
+++ b/python/pyspark/sql/connect/client/reattach.py
@@ -42,8 +42,13 @@ class ExecutePlanResponseReattachableIterator(Generator):
     ExecutePlanResponse on the iterator to return a new iterator from server that continues after
     that.
 
-    Since in reattachable execute the server does buffer some responses in case the client needs to
-    backtrack
+    In reattachable execute the server does buffer some responses in case the client needs to
+    backtrack. To let server release this buffer sooner, this iterator asynchronously sends
+    ReleaseExecute RPCs that instruct the server to release responses that it already processed.
+
+    Note: If the initial ExecutePlan did not even reach the server and execution didn't start,
+    the ReattachExecute can still fail with INVALID_HANDLE.OPERATION_NOT_FOUND, failing the whole
+    operation.
     """
 
     def __init__(
@@ -80,6 +85,8 @@ class ExecutePlanResponseReattachableIterator(Generator):
         self._result_complete = False
 
         # Initial iterator comes from ExecutePlan request.
+        # Note: This is not retried, because no error would ever be thrown here, and GRPC will only
+        # throw error on first self._has_next().
         self._iterator: Iterator[pb2.ExecutePlanResponse] = self._stub.ExecutePlan(
             self._initial_request
         )

--- a/python/pyspark/sql/connect/client/reattach.py
+++ b/python/pyspark/sql/connect/client/reattach.py
@@ -127,8 +127,8 @@ class ExecutePlanResponseReattachableIterator(Generator):
                     # on first try, we use the existing iterator.
                     if not attempt.is_first_try():
                         # on retry, the iterator is borked, so we need a new one
-                        self._iterator = self._stub.ReattachExecute(
-                            self._create_reattach_execute_request()
+                        self._iterator = iter(
+                            self._stub.ReattachExecute(self._create_reattach_execute_request())
                         )
 
                     if self._current is None:
@@ -146,8 +146,8 @@ class ExecutePlanResponseReattachableIterator(Generator):
                     first_loop = True
                     if not self._result_complete and not has_next:
                         while not has_next or first_loop:
-                            self._iterator = self._stub.ReattachExecute(
-                                self._create_reattach_execute_request()
+                            self._iterator = iter(
+                                self._stub.ReattachExecute(self._create_reattach_execute_request())
                             )
                             # shouldn't change
                             assert not self._result_complete

--- a/python/pyspark/sql/connect/client/reattach.py
+++ b/python/pyspark/sql/connect/client/reattach.py
@@ -20,7 +20,7 @@ check_dependencies(__name__)
 
 import uuid
 from collections.abc import Generator
-from typing import Optional, Dict, Any, Iterator
+from typing import Optional, Dict, Any, Iterator, Iterable, Tuple
 import threading
 
 import pyspark.sql.connect.proto as pb2
@@ -56,6 +56,7 @@ class ExecutePlanResponseReattachableIterator(Generator):
         request: pb2.ExecutePlanRequest,
         stub: grpc_lib.SparkConnectServiceStub,
         retry_policy: Dict[str, Any],
+        metadata: Iterable[Tuple[str, str]],
     ):
         self._request = request
         self._retry_policy = retry_policy
@@ -88,7 +89,7 @@ class ExecutePlanResponseReattachableIterator(Generator):
         # Note: This is not retried, because no error would ever be thrown here, and GRPC will only
         # throw error on first self._has_next().
         self._iterator: Iterator[pb2.ExecutePlanResponse] = self._stub.ExecutePlan(
-            self._initial_request
+            self._initial_request, metadata=metadata
         )
 
         # Current item from this iterator.

--- a/python/pyspark/sql/connect/client/reattach.py
+++ b/python/pyspark/sql/connect/client/reattach.py
@@ -25,7 +25,6 @@ import threading
 
 import pyspark.sql.connect.proto as pb2
 import pyspark.sql.connect.proto.base_pb2_grpc as grpc_lib
-from pyspark.sql.connect.client.core import Retrying
 
 
 class ExecutePlanResponseReattachableIterator(Generator):
@@ -105,6 +104,7 @@ class ExecutePlanResponseReattachableIterator(Generator):
 
     def _has_next(self) -> bool:
         from pyspark.sql.connect.client.core import SparkConnectClient
+        from pyspark.sql.connect.client.core import Retrying
 
         if self._result_complete:
             # After response complete response
@@ -165,13 +165,14 @@ class ExecutePlanResponseReattachableIterator(Generator):
         This will send an asynchronous RPC which will not block this iterator, the iterator can
         continue to be consumed.
 
-        Release with untilResponseId informs the server that the iterator has been consumed until and
-        including response with that responseId, and these responses can be freed.
+        Release with untilResponseId informs the server that the iterator has been consumed until
+        and including response with that responseId, and these responses can be freed.
 
         Release with None means that the responses have been completely consumed and informs the
         server that the completed execution can be completely freed.
         """
         from pyspark.sql.connect.client.core import SparkConnectClient
+        from pyspark.sql.connect.client.core import Retrying
 
         request = self._create_release_execute_request(until_response_id)
 

--- a/python/pyspark/sql/connect/client/reattach.py
+++ b/python/pyspark/sql/connect/client/reattach.py
@@ -20,15 +20,33 @@ check_dependencies(__name__)
 
 import uuid
 from collections.abc import Generator
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, Iterator
+import threading
 
 import pyspark.sql.connect.proto as pb2
 import pyspark.sql.connect.proto.base_pb2_grpc as grpc_lib
-from pyspark.sql.connect.client.core import SparkConnectClient
 from pyspark.sql.connect.client.core import Retrying
 
 
 class ExecutePlanResponseReattachableIterator(Generator):
+    """
+    Retryable iterator of ExecutePlanResponses to an ExecutePlan call.
+
+    It can handle situations when:
+      - the ExecutePlanResponse stream was broken by retryable network error (governed by
+        retryPolicy)
+      - the ExecutePlanResponse was gracefully ended by the server without a ResultComplete
+        message; this tells the client that there is more, and it should reattach to continue.
+
+    Initial iterator is the result of an ExecutePlan on the request, but it can be reattached with
+    ReattachExecute request. ReattachExecute request is provided the responseId of last returned
+    ExecutePlanResponse on the iterator to return a new iterator from server that continues after
+    that.
+
+    Since in reattachable execute the server does buffer some responses in case the client needs to
+    backtrack
+    """
+
     def __init__(
         self,
         request: pb2.ExecutePlanRequest,
@@ -37,70 +55,90 @@ class ExecutePlanResponseReattachableIterator(Generator):
     ):
         self._request = request
         self._retry_policy = retry_policy
-        self._operation_id = str(uuid.uuid4())
+        if request.operation_id:
+            self._operation_id = request.operation_id
+        else:
+            # Add operation id, if not present.
+            # with operationId set by the client, the client can use it to try to reattach on error
+            # even before getting the first response. If the operation in fact didn't even reach the
+            # server, that will end with INVALID_HANDLE.OPERATION_NOT_FOUND error.
+            self._operation_id = str(uuid.uuid4())
+
         self._stub = stub
         request.reattach_options.reattachable = True  # type: ignore[attr-defined]
         self._initial_request = request
-        self._response_complete = False
-        self._iterator = self._stub.ExecutePlan(self._initial_request)
 
-        self._last_response_id: Optional[str] = None
+        # ResponseId of the last response returned by next()
+        self._last_returned_response_id: Optional[str] = None
+
+        # True after ResponseComplete message was seen in the stream.
+        # Server will always send this message at the end of the stream, if the underlying iterator
+        # finishes without producing one, another iterator needs to be reattached.
+        self._response_complete = False
+
+        # Initial iterator comes from ExecutePlan request.
+        self._iterator: Iterator[pb2.ExecutePlanResponse] = self._stub.ExecutePlan(
+            self._initial_request
+        )
+
+        # Current item from this iterator.
         self._current: Optional[pb2.ExecutePlanResponse] = None
 
     def send(self, value: Any) -> pb2.ExecutePlanResponse:
-        # will trigger reattach in case the stream completed without responseComplete
-        self._has_next()
+        from pyspark.sql.connect.client.core import SparkConnectClient
 
-        # Get next response, possibly triggering reattach in case of stream error.
-        first_try = True
-        ret: Optional[pb2.ExecutePlanResponse] = None
-        for attempt in Retrying(can_retry=SparkConnectClient.retry_exception, **self._retry_policy):
-            with attempt:
-                if first_try:
-                    # on first try, we use the initial iterator.
-                    first_try = False
-                else:
-                    # Error retry reattach: After an error, attempt to
-                    self._iterator = self._stub.ReattachExecute(
-                        self._create_reattach_execute_request()
-                    )
-                ret = self._current
-
-        if ret is None:
+        # will trigger reattach in case the stream completed without response_complete
+        if not self._has_next():
             raise StopIteration()
 
+        ret = self._current
         assert ret is not None
-        self._last_response_id = ret.response_id
+
+        self._last_returned_response_id = ret.response_id
         if ret.response_complete:
             self._response_complete = True
             self._release_execute(None)  # release all
         else:
-            self._release_execute(self._last_response_id)
+            self._release_execute(self._last_returned_response_id)
         self._current = None
         return ret
 
     def _has_next(self) -> bool:
+        from pyspark.sql.connect.client.core import SparkConnectClient
+
         if self._response_complete:
             # After response complete response
             return False
         else:
+            first_try = True
             for attempt in Retrying(
                 can_retry=SparkConnectClient.retry_exception, **self._retry_policy
             ):
                 with attempt:
+                    if first_try:
+                        # on first try, we use the existing iterator.
+                        first_try = False
+                    else:
+                        # on retry, the iterator is borked, so we need a new one
+                        self._iterator = self._stub.ReattachExecute(
+                            self._create_reattach_execute_request()
+                        )
+
                     if self._current is None:
                         try:
                             self._current = next(self._iterator)
                         except StopIteration:
                             pass
+
                     has_next = self._current is not None
 
                     # Graceful reattach:
                     # If iterator ended, but there was no ResponseComplete, it means that
                     # there is more, and we need to reattach. While ResponseComplete didn't
                     # arrive, we keep reattaching.
+                    first_loop = True
                     if not has_next and not self._response_complete:
-                        while not has_next:
+                        while not has_next or first_loop:
                             self._iterator = self._stub.ReattachExecute(
                                 self._create_reattach_execute_request()
                             )
@@ -111,14 +149,40 @@ class ExecutePlanResponseReattachableIterator(Generator):
                             except StopIteration:
                                 pass
                             has_next = self._current is not None
+                            if first_loop:
+                                # It's possible that the new iterator will be empty, so we need
+                                # to loop to get another. Eventually, there will be a non empty
+                                # iterator, because there's always a ResultComplete at the end
+                                # of the stream.
+                                first_loop = False
                     return has_next
             return False
 
     def _release_execute(self, until_response_id: Optional[str]) -> None:
+        """
+        Inform the server to release the execution.
+
+        This will send an asynchronous RPC which will not block this iterator, the iterator can
+        continue to be consumed.
+
+        Release with untilResponseId informs the server that the iterator has been consumed until and
+        including response with that responseId, and these responses can be freed.
+
+        Release with None means that the responses have been completely consumed and informs the
+        server that the completed execution can be completely freed.
+        """
+        from pyspark.sql.connect.client.core import SparkConnectClient
+
         request = self._create_release_execute_request(until_response_id)
-        for attempt in Retrying(can_retry=SparkConnectClient.retry_exception, **self._retry_policy):
-            with attempt:
-                self._stub.ReleaseExecute(request)
+
+        def target():
+            for attempt in Retrying(
+                can_retry=SparkConnectClient.retry_exception, **self._retry_policy
+            ):
+                with attempt:
+                    self._stub.ReleaseExecute(request)
+
+        threading.Thread(target=target).start()
 
     def _create_reattach_execute_request(self) -> pb2.ReattachExecuteRequest:
         release = pb2.ReattachExecuteRequest(
@@ -146,11 +210,11 @@ class ExecutePlanResponseReattachableIterator(Generator):
 
         if not until_response_id:
             release.release_type = (  # type: ignore[attr-defined]
-                pb2.ReleaseExecuteRequest.ReleaseType.RELEASE_UNTIL_RESPONSE
+                pb2.ReleaseExecuteRequest.ReleaseType.RELEASE_UNTIL_RESPONSE  # type: ignore[attr-defined]
             )
         else:
             release.release_type = (  # type: ignore[attr-defined]
-                pb2.ReleaseExecuteRequest.ReleaseType.RELEASE_ALL
+                pb2.ReleaseExecuteRequest.ReleaseType.RELEASE_ALL  # type: ignore[attr-defined]
             )
             release.until_response_id = until_response_id  # type: ignore[attr-defined]
 

--- a/python/pyspark/sql/connect/client/reattach.py
+++ b/python/pyspark/sql/connect/client/reattach.py
@@ -24,7 +24,7 @@ from typing import Optional, Dict, Any
 
 import pyspark.sql.connect.proto as pb2
 import pyspark.sql.connect.proto.base_pb2_grpc as grpc_lib
-from pyspark.sql.connect.client import SparkConnectClient
+from pyspark.sql.connect.client.core import SparkConnectClient
 from pyspark.sql.connect.client.core import Retrying
 
 

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -233,7 +233,7 @@ class SparkSession:
             the $USER environment. Defining the user ID as part of the connection string
             takes precedence.
         """
-        self._client = SparkConnectClient(connection=connection, userId=userId)
+        self._client = SparkConnectClient(connection=connection, user_id=userId)
         self._session_id = self._client._session_id
 
     def table(self, tableName: str) -> DataFrame:

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -1788,6 +1788,8 @@ class SparkSession(SparkConversionMixin):
 
         Notes
         -----
+        This API is unstable, and a developer API. It returns non-API instance
+        :class:`SparkConnectClient`.
         This is an API dedicated to Spark Connect client only. With regular Spark Session, it throws
         an exception.
         """

--- a/python/pyspark/sql/tests/connect/client/test_client.py
+++ b/python/pyspark/sql/tests/connect/client/test_client.py
@@ -30,7 +30,7 @@ if should_test_connect:
 @unittest.skipIf(not should_test_connect, connect_requirement_message)
 class SparkConnectClientTestCase(unittest.TestCase):
     def test_user_agent_passthrough(self):
-        client = SparkConnectClient("sc://foo/;user_agent=bar")
+        client = SparkConnectClient("sc://foo/;user_agent=bar", use_reattachable_execute=False)
         mock = MockService(client._session_id)
         client._stub = mock
 
@@ -41,7 +41,7 @@ class SparkConnectClientTestCase(unittest.TestCase):
         self.assertRegex(mock.req.client_type, r"^bar spark/[^ ]+ os/[^ ]+ python/[^ ]+$")
 
     def test_user_agent_default(self):
-        client = SparkConnectClient("sc://foo/")
+        client = SparkConnectClient("sc://foo/", use_reattachable_execute=False)
         mock = MockService(client._session_id)
         client._stub = mock
 
@@ -54,11 +54,11 @@ class SparkConnectClientTestCase(unittest.TestCase):
         )
 
     def test_properties(self):
-        client = SparkConnectClient("sc://foo/;token=bar")
+        client = SparkConnectClient("sc://foo/;token=bar", use_reattachable_execute=False)
         self.assertEqual(client.token, "bar")
         self.assertEqual(client.host, "foo")
 
-        client = SparkConnectClient("sc://foo/")
+        client = SparkConnectClient("sc://foo/", use_reattachable_execute=False)
         self.assertIsNone(client.token)
 
     def test_channel_builder(self):
@@ -67,12 +67,14 @@ class SparkConnectClientTestCase(unittest.TestCase):
             def userId(self) -> Optional[str]:
                 return "abc"
 
-        client = SparkConnectClient(CustomChannelBuilder("sc://foo/"))
+        client = SparkConnectClient(
+            CustomChannelBuilder("sc://foo/"), use_reattachable_execute=False
+        )
 
         self.assertEqual(client._user_id, "abc")
 
     def test_interrupt_all(self):
-        client = SparkConnectClient("sc://foo/;token=bar")
+        client = SparkConnectClient("sc://foo/;token=bar", use_reattachable_execute=False)
         mock = MockService(client._session_id)
         client._stub = mock
 
@@ -80,7 +82,7 @@ class SparkConnectClientTestCase(unittest.TestCase):
         self.assertIsNotNone(mock.req, "Interrupt API was not called when expected")
 
     def test_is_closed(self):
-        client = SparkConnectClient("sc://foo/;token=bar")
+        client = SparkConnectClient("sc://foo/;token=bar", use_reattachable_execute=False)
 
         self.assertFalse(client.is_closed)
         client.close()

--- a/python/pyspark/testing/connectutils.py
+++ b/python/pyspark/testing/connectutils.py
@@ -170,6 +170,7 @@ class ReusedConnectTestCase(unittest.TestCase, SQLTestUtils, PySparkErrorTestUti
         # Disable JVM stack trace in Spark Connect tests to prevent the
         # HTTP header size from exceeding the maximum allowed size.
         conf.set("spark.sql.pyspark.jvmStacktrace.enabled", "false")
+        conf.set("spark.connect.execute.reattachable.senderMaxStreamDuration", "1s")
         return conf
 
     @classmethod

--- a/python/pyspark/testing/connectutils.py
+++ b/python/pyspark/testing/connectutils.py
@@ -170,7 +170,10 @@ class ReusedConnectTestCase(unittest.TestCase, SQLTestUtils, PySparkErrorTestUti
         # Disable JVM stack trace in Spark Connect tests to prevent the
         # HTTP header size from exceeding the maximum allowed size.
         conf.set("spark.sql.pyspark.jvmStacktrace.enabled", "false")
+        # Make the server terminate reattachable streams every 1 second and 123 bytes,
+        # to make the tests exercise reattach.
         conf.set("spark.connect.execute.reattachable.senderMaxStreamDuration", "1s")
+        conf.set("spark.connect.execute.reattachable.senderMaxStreamSize", "123")
         return conf
 
     @classmethod


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to implement the Python client side for https://github.com/apache/spark/pull/42228.

Basically this PR applies the same changes of `ExecutePlanResponseReattachableIterator`, and `SparkConnectClient` to PySpark as  the symmetry.

### Why are the changes needed?

To enable the same feature in https://github.com/apache/spark/pull/42228

### Does this PR introduce _any_ user-facing change?

Yes, see https://github.com/apache/spark/pull/42228.

### How was this patch tested?

Existing unittests because it enables the feature by default. Also, manual E2E tests.