### PR TITLE
[SPARK-44607][SQL] Remove unused function `containsNestedColumn` from `Filter`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/sources/filters.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/sources/filters.scala
@@ -65,13 +65,6 @@ sealed abstract class Filter {
   }
 
   /**
-   * If any of the references of this filter contains nested column
-   */
-  private[sql] def containsNestedColumn: Boolean = {
-    this.v2references.exists(_.length > 1)
-  }
-
-  /**
    * Converts V1 filter to V2 filter
    */
   private[sql] def toV2: Predicate


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims remove `private[sql] `function `containsNestedColumn` from `org.apache.spark.sql.sources.Filter`. 
This function was introduced by https://github.com/apache/spark/pull/27728 to avoid nested predicate pushdown for Orc.
After https://github.com/apache/spark/pull/28761, Orc also support nested column predicate pushdown, so this function become unused.

### Why are the changes needed?
Remove unused `private[sql] ` function `containsNestedColumn`.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions