### PR TITLE
[SPARK-44608][SQL] Remove unused definitions from `DataTypeExpression`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataTypeExpression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataTypeExpression.scala
@@ -33,12 +33,6 @@ case object BooleanTypeExpression extends DataTypeExpression(BooleanType)
 case object StringTypeExpression extends DataTypeExpression(StringType)
 case object TimestampTypeExpression extends DataTypeExpression(TimestampType)
 case object DateTypeExpression extends DataTypeExpression(DateType)
-case object ByteTypeExpression extends DataTypeExpression(ByteType)
-case object ShortTypeExpression extends DataTypeExpression(ShortType)
-case object IntegerTypeExpression extends DataTypeExpression(IntegerType)
-case object LongTypeExpression extends DataTypeExpression(LongType)
-case object DoubleTypeExpression extends DataTypeExpression(DoubleType)
-case object FloatTypeExpression extends DataTypeExpression(FloatType)
 
 object NumericTypeExpression {
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?
https://github.com/apache/spark/pull/41559 have defined some `DataTypeExpression` but did not use, such as `ByteTypeExpression`,  `ShortTypeExpression`, etc. This pr cleans them up and we can define them when we really need.


### Why are the changes needed?
Code cleanup


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions
