### PR TITLE
[SPARK-44618][INFRA] Free up disk space for non-container jobs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -408,6 +408,8 @@ jobs:
         key: pyspark-coursier-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
         restore-keys: |
           pyspark-coursier-
+    - name: Free up disk space
+      run: ./dev/free_disk_space
     - name: Install Java ${{ matrix.java }}
       uses: actions/setup-java@v3
       with:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -240,6 +240,8 @@ jobs:
         key: ${{ matrix.java }}-${{ matrix.hadoop }}-coursier-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
         restore-keys: |
           ${{ matrix.java }}-${{ matrix.hadoop }}-coursier-
+    - name: Free up disk space
+      run: ./dev/free_disk_space
     - name: Install Java ${{ matrix.java }}
       uses: actions/setup-java@v3
       with:
@@ -408,8 +410,6 @@ jobs:
         key: pyspark-coursier-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
         restore-keys: |
           pyspark-coursier-
-    - name: Free up disk space
-      run: ./dev/free_disk_space
     - name: Install Java ${{ matrix.java }}
       uses: actions/setup-java@v3
       with:

--- a/dev/free_disk_space
+++ b/dev/free_disk_space
@@ -26,10 +26,12 @@ dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n 100
 df -h
 echo "Removing large packages"
 sudo rm -rf /usr/share/dotnet/
+sudo rm -rf /usr/local/lib/android
 sudo apt-get remove --purge -y '^aspnet.*'
 sudo apt-get remove --purge -y '^dotnet-.*'
 sudo apt-get remove --purge -y '^llvm-.*'
 sudo apt-get remove --purge -y 'php.*'
+sudo apt-get remove --purge -y '^mongodb-.*'
 sudo apt-get remove --purge -y snapd google-chrome-stable microsoft-edge-stable firefox
 sudo apt-get remove --purge -y azure-cli google-cloud-sdk mono-devel powershell
 sudo apt-get autoremove --purge -y

--- a/dev/free_disk_space
+++ b/dev/free_disk_space
@@ -26,7 +26,13 @@ dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n 100
 df -h
 echo "Removing large packages"
 sudo rm -rf /usr/share/dotnet/
+sudo rm -rf /usr/local/graalvm/
+sudo rm -rf /usr/local/.ghcup/
+sudo rm -rf /usr/local/share/powershell
+sudo rm -rf /usr/local/share/chromium
 sudo rm -rf /usr/local/lib/android
+sudo rm -rf /usr/local/lib/node_modules
+
 sudo apt-get remove --purge -y '^aspnet.*'
 sudo apt-get remove --purge -y '^dotnet-.*'
 sudo apt-get remove --purge -y '^llvm-.*'

--- a/dev/free_disk_space
+++ b/dev/free_disk_space
@@ -21,22 +21,22 @@
 # large directories.
 # Referring to https://github.com/apache/flink/blob/master/tools/azure-pipelines/free_disk_space.sh
 echo "=============================================================================="
-echo "Freeing up disk space on CI system"
+echo "Free up disk space on CI system"
 echo "=============================================================================="
 
 echo "Listing 100 largest packages"
 dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n 100
 df -h
 echo "Removing large packages"
-apt-get remove -y '^ghc-8.*'
-apt-get remove -y '^dotnet-.*'
-apt-get remove -y '^llvm-.*'
-apt-get remove -y 'php.*'
-apt-get remove -y azure-cli google-cloud-sdk hhvm google-chrome-stable firefox powershell mono-devel
-apt-get autoremove -y
-apt-get clean
+sudo apt-get remove -y '^ghc-8.*'
+sudo apt-get remove -y '^dotnet-.*'
+sudo apt-get remove -y '^llvm-.*'
+sudo apt-get remove -y 'php.*'
+sudo apt-get remove -y azure-cli google-cloud-sdk hhvm google-chrome-stable firefox powershell mono-devel
+sudo apt-get autoremove -y
+sudo apt-get clean
 df -h
 echo "Removing large directories"
 # deleting 15GB
-rm -rf /usr/share/dotnet/
+sudo rm -rf /usr/share/dotnet/
 df -h

--- a/dev/free_disk_space
+++ b/dev/free_disk_space
@@ -17,8 +17,6 @@
 # limitations under the License.
 #
 
-# This script frees up 28 GB of disk space by deleting unneeded packages and
-# large directories.
 echo "=============================================================================="
 echo "Free up disk space on CI system"
 echo "=============================================================================="
@@ -31,12 +29,9 @@ sudo rm -rf /usr/share/dotnet/
 sudo apt-get remove --purge -y '^aspnet.*'
 sudo apt-get remove --purge -y '^dotnet-.*'
 sudo apt-get remove --purge -y '^llvm-.*'
-sudo apt-get remove --purge -y 'libllvm.*'
 sudo apt-get remove --purge -y 'php.*'
 sudo apt-get remove --purge -y snapd google-chrome-stable microsoft-edge-stable firefox
 sudo apt-get remove --purge -y azure-cli google-cloud-sdk mono-devel powershell
 sudo apt-get autoremove --purge -y
 sudo apt-get clean
-sudo apt-get update
-dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n 100
 df -h

--- a/dev/free_disk_space
+++ b/dev/free_disk_space
@@ -28,7 +28,7 @@ dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n 100
 df -h
 echo "Removing large packages"
 sudo rm -rf /usr/share/dotnet/
-sudo apt-get remove -y aspnetcore
+sudo apt-get remove -y '^aspnet.*'
 sudo apt-get remove -y '^dotnet-.*'
 sudo apt-get remove -y '^llvm-.*'
 sudo apt-get remove -y 'php.*'

--- a/dev/free_disk_space
+++ b/dev/free_disk_space
@@ -19,7 +19,6 @@
 
 # This script frees up 28 GB of disk space by deleting unneeded packages and
 # large directories.
-# Referring to https://github.com/apache/flink/blob/master/tools/azure-pipelines/free_disk_space.sh
 echo "=============================================================================="
 echo "Free up disk space on CI system"
 echo "=============================================================================="
@@ -28,15 +27,11 @@ echo "Listing 100 largest packages"
 dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n 100
 df -h
 echo "Removing large packages"
-sudo apt-get remove -y '^ghc-8.*'
+sudo rm -rf /usr/share/dotnet/
 sudo apt-get remove -y '^dotnet-.*'
 sudo apt-get remove -y '^llvm-.*'
 sudo apt-get remove -y 'php.*'
-sudo apt-get remove -y azure-cli google-cloud-sdk hhvm google-chrome-stable firefox powershell mono-devel
+sudo apt-get remove -y azure-cli google-cloud-sdk google-chrome-stable firefox powershell mono-devel
 sudo apt-get autoremove -y
 sudo apt-get clean
-df -h
-echo "Removing large directories"
-# deleting 15GB
-sudo rm -rf /usr/share/dotnet/
 df -h

--- a/dev/free_disk_space
+++ b/dev/free_disk_space
@@ -28,11 +28,12 @@ dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n 100
 df -h
 echo "Removing large packages"
 sudo rm -rf /usr/share/dotnet/
+sudo apt-get remove -y aspnetcore
 sudo apt-get remove -y '^dotnet-.*'
 sudo apt-get remove -y '^llvm-.*'
 sudo apt-get remove -y 'php.*'
 sudo apt-get remove -y azure-cli google-cloud-sdk google-chrome-stable firefox powershell mono-devel snapd
-sudo apt-get autoremove -y
+sudo apt-get autoremove --purge -y
 sudo apt-get clean
 dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n 100
 df -h

--- a/dev/free_disk_space
+++ b/dev/free_disk_space
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This script frees up 28 GB of disk space by deleting unneeded packages and
+# large directories.
+# Referring to https://github.com/apache/flink/blob/master/tools/azure-pipelines/free_disk_space.sh
+echo "=============================================================================="
+echo "Freeing up disk space on CI system"
+echo "=============================================================================="
+
+echo "Listing 100 largest packages"
+dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n 100
+df -h
+echo "Removing large packages"
+apt-get remove -y '^ghc-8.*'
+apt-get remove -y '^dotnet-.*'
+apt-get remove -y '^llvm-.*'
+apt-get remove -y 'php.*'
+apt-get remove -y azure-cli google-cloud-sdk hhvm google-chrome-stable firefox powershell mono-devel
+apt-get autoremove -y
+apt-get clean
+df -h
+echo "Removing large directories"
+# deleting 15GB
+rm -rf /usr/share/dotnet/
+df -h

--- a/dev/free_disk_space
+++ b/dev/free_disk_space
@@ -28,12 +28,15 @@ dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n 100
 df -h
 echo "Removing large packages"
 sudo rm -rf /usr/share/dotnet/
-sudo apt-get remove -y '^aspnet.*'
-sudo apt-get remove -y '^dotnet-.*'
-sudo apt-get remove -y '^llvm-.*'
-sudo apt-get remove -y 'php.*'
-sudo apt-get remove -y azure-cli google-cloud-sdk google-chrome-stable firefox powershell mono-devel snapd
+sudo apt-get remove --purge -y '^aspnet.*'
+sudo apt-get remove --purge -y '^dotnet-.*'
+sudo apt-get remove --purge -y '^llvm-.*'
+sudo apt-get remove --purge -y 'libllvm.*'
+sudo apt-get remove --purge -y 'php.*'
+sudo apt-get remove --purge -y snapd google-chrome-stable microsoft-edge-stable firefox
+sudo apt-get remove --purge -y azure-cli google-cloud-sdk mono-devel powershell
 sudo apt-get autoremove --purge -y
 sudo apt-get clean
+sudo apt-get update
 dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n 100
 df -h

--- a/dev/free_disk_space
+++ b/dev/free_disk_space
@@ -31,7 +31,8 @@ sudo rm -rf /usr/share/dotnet/
 sudo apt-get remove -y '^dotnet-.*'
 sudo apt-get remove -y '^llvm-.*'
 sudo apt-get remove -y 'php.*'
-sudo apt-get remove -y azure-cli google-cloud-sdk google-chrome-stable firefox powershell mono-devel
+sudo apt-get remove -y azure-cli google-cloud-sdk google-chrome-stable firefox powershell mono-devel snapd
 sudo apt-get autoremove -y
 sudo apt-get clean
+dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n 100
 df -h

--- a/dev/free_disk_space
+++ b/dev/free_disk_space
@@ -17,9 +17,9 @@
 # limitations under the License.
 #
 
-echo "=============================================================================="
+echo "=================================="
 echo "Free up disk space on CI system"
-echo "=============================================================================="
+echo "=================================="
 
 echo "Listing 100 largest packages"
 dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n 100
@@ -33,7 +33,7 @@ sudo apt-get remove --purge -y '^llvm-.*'
 sudo apt-get remove --purge -y 'php.*'
 sudo apt-get remove --purge -y '^mongodb-.*'
 sudo apt-get remove --purge -y snapd google-chrome-stable microsoft-edge-stable firefox
-sudo apt-get remove --purge -y azure-cli google-cloud-sdk mono-devel powershell
+sudo apt-get remove --purge -y azure-cli google-cloud-sdk mono-devel powershell libgl1-mesa-dri
 sudo apt-get autoremove --purge -y
 sudo apt-get clean
 df -h


### PR DESCRIPTION
### What changes were proposed in this pull request?
uninstall unneeded packages, referring to https://github.com/apache/flink/blob/master/tools/azure-pipelines/free_disk_space.sh


### Why are the changes needed?
increase the available disk space

before:
![image](https://github.com/apache/spark/assets/7322292/ba7c6489-41d8-472f-8f73-a7b36422e029)

after:
![image](https://github.com/apache/spark/assets/7322292/687d2f1f-8f45-41a8-9fe8-36dcc09e30c7)

Unfortunately, this won't work for container jobs (`pyspark`, `sparkr`, `lint`), since those packages were not installed at all


### Does this PR introduce _any_ user-facing change?
no, test-only


### How was this patch tested?
updated CI