### PR TITLE
[SPARK-38475][CORE] Use error class in org.apache.spark.serializer

### DIFF
--- a/common/utils/src/main/resources/error/error-classes.json
+++ b/common/utils/src/main/resources/error/error-classes.json
@@ -826,6 +826,11 @@
       "Not found an encoder of the type <typeName> to Spark SQL internal representation. Consider to change the input type to one of supported at '<docroot>/sql-ref-datatypes.html'."
     ]
   },
+  "ERROR_READING_AVRO_UNKNOWN_FINGERPRINT" : {
+    "message" : [
+      "Error reading avro data -- encountered an unknown fingerprint: <fingerprint>, not sure what schema to use. This could happen if you registered additional schemas after starting your spark context."
+    ]
+  },
   "EVENT_TIME_IS_NOT_ON_TIMESTAMP_TYPE" : {
     "message" : [
       "The event time <eventName> has the invalid type <eventType>, but expected \"TIMESTAMP\"."
@@ -858,6 +863,11 @@
       "Failed parsing struct: <raw>."
     ],
     "sqlState" : "22018"
+  },
+  "FAILED_REGISTER_CLASS_WITH_KRYO" : {
+    "message" : [
+      "Failed to register classes with Kryo"
+    ]
   },
   "FAILED_RENAME_PATH" : {
     "message" : [
@@ -1516,6 +1526,12 @@
     ],
     "sqlState" : "22032"
   },
+  "INVALID_KRYO_SERIALIZER_BUFFER_SIZE" : {
+    "message" : [
+      "<bufferSizeConfKey> must be less than 2048 MiB, got: <bufferSizeConfValue> MiB."
+    ],
+    "sqlState" : "F0000"
+  },
   "INVALID_LAMBDA_FUNCTION_CALL" : {
     "message" : [
       "Invalid lambda function call."
@@ -1956,6 +1972,11 @@
   "JOIN_CONDITION_IS_NOT_BOOLEAN_TYPE" : {
     "message" : [
       "The join condition <joinCondition> has the invalid type <conditionType>, expected \"BOOLEAN\"."
+    ]
+  },
+  "KRYO_BUFFER_OVERFLOW" : {
+    "message" : [
+      "Kryo serialization failed: <exceptionMsg>. To avoid this, increase <bufferSizeConfKey> value."
     ]
   },
   "LOAD_DATA_PATH_NOT_EXISTS" : {

--- a/common/utils/src/main/resources/error/error-classes.json
+++ b/common/utils/src/main/resources/error/error-classes.json
@@ -866,7 +866,7 @@
   },
   "FAILED_REGISTER_CLASS_WITH_KRYO" : {
     "message" : [
-      "Failed to register classes with Kryo"
+      "Failed to register classes with Kryo."
     ]
   },
   "FAILED_RENAME_PATH" : {
@@ -1528,7 +1528,7 @@
   },
   "INVALID_KRYO_SERIALIZER_BUFFER_SIZE" : {
     "message" : [
-      "<bufferSizeConfKey> must be less than 2048 MiB, got: <bufferSizeConfValue> MiB."
+      "The value of the config \"<bufferSizeConfKey>\" must be less than 2048 MiB, but got <bufferSizeConfValue> MiB."
     ],
     "sqlState" : "F0000"
   },
@@ -1976,7 +1976,7 @@
   },
   "KRYO_BUFFER_OVERFLOW" : {
     "message" : [
-      "Kryo serialization failed: <exceptionMsg>. To avoid this, increase <bufferSizeConfKey> value."
+      "Kryo serialization failed: <exceptionMsg>. To avoid this, increase \"<bufferSizeConfKey>\" value."
     ]
   },
   "LOAD_DATA_PATH_NOT_EXISTS" : {

--- a/common/utils/src/main/scala/org/apache/spark/SparkException.scala
+++ b/common/utils/src/main/scala/org/apache/spark/SparkException.scala
@@ -51,6 +51,13 @@ class SparkException(
       messageParameters = messageParameters,
       context)
 
+  def this(errorClass: String, messageParameters: Map[String, String]) =
+    this(
+      message = SparkThrowableHelper.getMessage(errorClass, messageParameters),
+      cause = null,
+      errorClass = Some(errorClass),
+      messageParameters = messageParameters)
+
   def this(errorClass: String, messageParameters: Map[String, String], cause: Throwable) =
     this(
       message = SparkThrowableHelper.getMessage(errorClass, messageParameters),

--- a/common/utils/src/main/scala/org/apache/spark/SparkException.scala
+++ b/common/utils/src/main/scala/org/apache/spark/SparkException.scala
@@ -51,13 +51,6 @@ class SparkException(
       messageParameters = messageParameters,
       context)
 
-  def this(errorClass: String, messageParameters: Map[String, String]) =
-    this(
-      message = SparkThrowableHelper.getMessage(errorClass, messageParameters),
-      cause = null,
-      errorClass = Some(errorClass),
-      messageParameters = messageParameters)
-
   def this(errorClass: String, messageParameters: Map[String, String], cause: Throwable) =
     this(
       message = SparkThrowableHelper.getMessage(errorClass, messageParameters),

--- a/core/src/main/scala/org/apache/spark/serializer/GenericAvroSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/serializer/GenericAvroSerializer.scala
@@ -141,7 +141,8 @@ private[serializer] class GenericAvroSerializer[D <: GenericContainer]
             case None =>
               throw new SparkException(
                 errorClass = "ERROR_READING_AVRO_UNKNOWN_FINGERPRINT",
-                messageParameters = Map("fingerprint" -> fingerprint.toString))
+                messageParameters = Map("fingerprint" -> fingerprint.toString),
+                cause = null)
           }
         })
       } else {

--- a/core/src/main/scala/org/apache/spark/serializer/GenericAvroSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/serializer/GenericAvroSerializer.scala
@@ -140,9 +140,8 @@ private[serializer] class GenericAvroSerializer[D <: GenericContainer]
             case Some(s) => new Schema.Parser().setValidateDefaults(false).parse(s)
             case None =>
               throw new SparkException(
-                "Error reading attempting to read avro data -- encountered an unknown " +
-                  s"fingerprint: $fingerprint, not sure what schema to use.  This could happen " +
-                  "if you registered additional schemas after starting your spark context.")
+                errorClass = "ERROR_READING_AVRO_UNKNOWN_FINGERPRINT",
+                messageParameters = Map("fingerprint" -> fingerprint.toString))
           }
         })
       } else {

--- a/docs/sql-error-conditions.md
+++ b/docs/sql-error-conditions.md
@@ -484,6 +484,12 @@ SQLSTATE: none assigned
 
 Not found an encoder of the type `<typeName>` to Spark SQL internal representation. Consider to change the input type to one of supported at '`<docroot>`/sql-ref-datatypes.html'.
 
+### ERROR_READING_AVRO_UNKNOWN_FINGERPRINT
+
+SQLSTATE: none assigned
+
+Error reading avro data -- encountered an unknown fingerprint: `<fingerprint>`, not sure what schema to use. This could happen if you registered additional schemas after starting your spark context.
+
 ### EVENT_TIME_IS_NOT_ON_TIMESTAMP_TYPE
 
 SQLSTATE: none assigned
@@ -519,6 +525,12 @@ Failed preparing of the function `<funcName>` for call. Please, double check fun
 [SQLSTATE: 22018](sql-error-conditions-sqlstates.html#class-22-data-exception)
 
 Failed parsing struct: `<raw>`.
+
+### FAILED_REGISTER_CLASS_WITH_KRYO
+
+SQLSTATE: none assigned
+
+Failed to register classes with Kryo
 
 ### FAILED_RENAME_PATH
 
@@ -964,6 +976,12 @@ Cannot convert JSON root field to target Spark type.
 
 Input schema `<jsonSchema>` can only contain STRING as a key type for a MAP.
 
+### INVALID_KRYO_SERIALIZER_BUFFER_SIZE
+
+SQLSTATE: F0000
+
+`<bufferSizeConfKey>` must be less than 2048 MiB, got: `<bufferSizeConfValue>` MiB.
+
 ### [INVALID_LAMBDA_FUNCTION_CALL](sql-error-conditions-invalid-lambda-function-call-error-class.html)
 
 SQLSTATE: none assigned
@@ -1154,6 +1172,12 @@ For more details see [INVALID_WRITE_DISTRIBUTION](sql-error-conditions-invalid-w
 SQLSTATE: none assigned
 
 The join condition `<joinCondition>` has the invalid type `<conditionType>`, expected "BOOLEAN".
+
+### KRYO_BUFFER_OVERFLOW
+
+SQLSTATE: none assigned
+
+Kryo serialization failed: `<exceptionMsg>`. To avoid this, increase `<bufferSizeConfKey>` value.
 
 ### LOAD_DATA_PATH_NOT_EXISTS
 

--- a/docs/sql-error-conditions.md
+++ b/docs/sql-error-conditions.md
@@ -530,7 +530,7 @@ Failed parsing struct: `<raw>`.
 
 SQLSTATE: none assigned
 
-Failed to register classes with Kryo
+Failed to register classes with Kryo.
 
 ### FAILED_RENAME_PATH
 
@@ -980,7 +980,7 @@ Input schema `<jsonSchema>` can only contain STRING as a key type for a MAP.
 
 SQLSTATE: F0000
 
-`<bufferSizeConfKey>` must be less than 2048 MiB, got: `<bufferSizeConfValue>` MiB.
+The value of the config "`<bufferSizeConfKey>`" must be less than 2048 MiB, but got `<bufferSizeConfValue>` MiB.
 
 ### [INVALID_LAMBDA_FUNCTION_CALL](sql-error-conditions-invalid-lambda-function-call-error-class.html)
 
@@ -1177,7 +1177,7 @@ The join condition `<joinCondition>` has the invalid type `<conditionType>`, exp
 
 SQLSTATE: none assigned
 
-Kryo serialization failed: `<exceptionMsg>`. To avoid this, increase `<bufferSizeConfKey>` value.
+Kryo serialization failed: `<exceptionMsg>`. To avoid this, increase "`<bufferSizeConfKey>`" value.
 
 ### LOAD_DATA_PATH_NOT_EXISTS
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to change exceptions created in package org.apache.spark.serializer to use error class.


### Why are the changes needed?
This is to move exceptions created in package org.apache.spark.serializer to error class.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Existing tests.
