### PR TITLE
[SPARK-44591][CONNECT][WEBUI] Use jobTags in SparkListenerSQLExecutionStart to link SQL Execution IDs for Spark UI Connect page

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/ui/SparkConnectServerListener.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/ui/SparkConnectServerListener.scala
@@ -26,7 +26,7 @@ import org.apache.spark.internal.config.Status.LIVE_ENTITY_UPDATE_PERIOD
 import org.apache.spark.scheduler._
 import org.apache.spark.sql.connect.config.Connect.{CONNECT_UI_SESSION_LIMIT, CONNECT_UI_STATEMENT_LIMIT}
 import org.apache.spark.sql.connect.service._
-import org.apache.spark.sql.execution.SQLExecution
+import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionStart
 import org.apache.spark.status.{ElementTrackingStore, KVUtils, LiveEntity}
 
 private[connect] class SparkConnectServerListener(
@@ -80,12 +80,9 @@ private[connect] class SparkConnectServerListener(
     }
     val executeJobTag = executeJobTagOpt.get
     val exec = executionList.get(executeJobTag)
-    val executionIdOpt: Option[String] = Option(jobStart.properties)
-      .flatMap { p => Option(p.getProperty(SQLExecution.EXECUTION_ID_KEY)) }
     if (exec.nonEmpty) {
       exec.foreach { exec =>
         exec.jobId += jobStart.jobId.toString
-        executionIdOpt.foreach { execId => exec.sqlExecId += execId }
         updateLiveStore(exec)
       }
     } else {
@@ -105,8 +102,8 @@ private[connect] class SparkConnectServerListener(
           exec.userId,
           exec.operationId,
           exec.sparkSessionTags)
+        liveExec.sqlExecId = exec.sqlExecId
         liveExec.jobId += jobStart.jobId.toString
-        executionIdOpt.foreach { execId => exec.sqlExecId += execId }
         updateStoreWithTriggerEnabled(liveExec)
         executionList.remove(liveExec.jobTag)
       }
@@ -115,6 +112,7 @@ private[connect] class SparkConnectServerListener(
 
   override def onOtherEvent(event: SparkListenerEvent): Unit = {
     event match {
+      case e: SparkListenerSQLExecutionStart => onSQLExecutionStart(e)
       case e: SparkListenerConnectOperationStarted => onOperationStarted(e)
       case e: SparkListenerConnectOperationAnalyzed => onOperationAnalyzed(e)
       case e: SparkListenerConnectOperationReadyForExecution => onOperationReadyForExecution(e)
@@ -125,6 +123,45 @@ private[connect] class SparkConnectServerListener(
       case e: SparkListenerConnectSessionStarted => onSessionStarted(e)
       case e: SparkListenerConnectSessionClosed => onSessionClosed(e)
       case _ => // Ignore
+    }
+  }
+
+  def onSQLExecutionStart(e: SparkListenerSQLExecutionStart): Unit = {
+    val executeJobTagOpt = e.jobTags.find {
+      case ExecuteJobTag(_) => true
+      case _ => false
+    }
+    if (executeJobTagOpt.isEmpty) {
+      return
+    }
+    val executeJobTag = executeJobTagOpt.get
+    val exec = executionList.get(executeJobTag)
+    if (exec.nonEmpty) {
+      exec.foreach { exec =>
+        exec.sqlExecId += e.executionId.toString
+        updateLiveStore(exec)
+      }
+    } else {
+      // This block guards against potential event re-ordering where a SQLExecutionStart
+      // event is processed after a ConnectOperationClosed event, in which case the Execution
+      // has already been evicted from the executionList.
+      val storeExecInfo =
+        KVUtils.viewToSeq(kvstore.view(classOf[ExecutionInfo]), Int.MaxValue)(exec =>
+          exec.jobTag == executeJobTag)
+      storeExecInfo.foreach { exec =>
+        val liveExec = getOrCreateExecution(
+          exec.jobTag,
+          exec.statement,
+          exec.sessionId,
+          exec.startTimestamp,
+          exec.userId,
+          exec.operationId,
+          exec.sparkSessionTags)
+        liveExec.jobId = exec.jobId
+        liveExec.sqlExecId += e.executionId.toString
+        updateStoreWithTriggerEnabled(liveExec)
+        executionList.remove(liveExec.jobTag)
+      }
     }
   }
 
@@ -326,7 +363,7 @@ private[connect] class LiveExecutionData(
   var closeTimestamp: Long = 0L
   var detail: String = ""
   var state: ExecutionState.Value = ExecutionState.STARTED
-  val jobId: ArrayBuffer[String] = ArrayBuffer[String]()
+  var jobId: ArrayBuffer[String] = ArrayBuffer[String]()
   var sqlExecId: mutable.Set[String] = mutable.Set[String]()
 
   override protected def doUpdate(): Any = {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Use jobTags in SparkListenerSQLExecutionStart to get the corresponding SQL Execution for Spark Connect request rather than SparkListenerJobStart.props.getProperty(SQLExecution.EXECUTION_ID_KEY), which won't work when the SQL Execution does not trigger a job.

### Why are the changes needed?
This change handles cases where a SQL Execution doesn't trigger a job and we can't retrieve the SQL Execution ID from SparkListenerJobStart

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
Update unit test + local manual testing
