### PR TITLE
[SPARK-44611][CONNECT] Do not exclude scala-xml

### DIFF
--- a/connector/connect/client/jvm/pom.xml
+++ b/connector/connect/client/jvm/pom.xml
@@ -94,12 +94,6 @@
       <artifactId>ammonite_${scala.version}</artifactId>
       <version>${ammonite.version}</version>
       <scope>provided</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.scala-lang.modules</groupId>
-          <artifactId>scala-xml_${scala.binary.version}</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR removes the scala-xml exclusion for ammonite.

### Why are the changes needed?
Ammonite does not work well without scala-xml.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Manually