### PR TITLE
[SPARK-44421][SPARK-44423][CONNECT][FOLLOW-UP][3.5] Extends Logging to allow SparkConnectService to use logging

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
@@ -251,7 +251,7 @@ class SparkConnectService(debug: Boolean) extends AsyncService with BindableServ
  * Used to start the overall SparkConnect service and provides global state to manage the
  * different SparkSession from different users connecting to the cluster.
  */
-object SparkConnectService {
+object SparkConnectService extends Logging {
 
   private val CACHE_SIZE = 100
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to resolve the conflict in branch-3.5. It has a partial conflict with https://github.com/apache/spark/pull/42073 about `extend Logging`.

### Why are the changes needed?

To recover the branch-3.5.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual.