### PR TITLE
[SPARK-40178][SQL][COONECT] Support coalesce hints with ease for PySpark and R

### DIFF
--- a/R/pkg/R/DataFrame.R
+++ b/R/pkg/R/DataFrame.R
@@ -4146,7 +4146,7 @@ setMethod("hint",
           function(x, name, ...) {
             parameters <- list(...)
             if (!all(sapply(parameters, function(y) {
-              if (is.character(y) || is.numeric(y) || is(class(y), "characterOrColumn") {
+              if (is.character(y) || is.numeric(y) || is(class(y), "characterOrColumn")) {
                 TRUE
               } else if (is.list(y)) {
                 all(sapply(y, function(z) { is.character(z) || is.numeric(z) }))

--- a/R/pkg/R/DataFrame.R
+++ b/R/pkg/R/DataFrame.R
@@ -4146,7 +4146,7 @@ setMethod("hint",
           function(x, name, ...) {
             parameters <- list(...)
             if (!all(sapply(parameters, function(y) {
-              if (is.character(y) || is.numeric(y)) {
+              if (is.character(y) || is.numeric(y) || is(class(y), "characterOrColumn") {
                 TRUE
               } else if (is.list(y)) {
                 all(sapply(y, function(z) { is.character(z) || is.numeric(z) }))

--- a/R/pkg/R/DataFrame.R
+++ b/R/pkg/R/DataFrame.R
@@ -4156,7 +4156,14 @@ setMethod("hint",
             }))) {
               stop("sql hint should be character, numeric, or list with character or numeric.")
             }
-            jdf <- callJMethod(x@sdf, "hint", name, parameters)
+            jparams <- lapply(parameters, function(c) {
+              if (is.character(c) || is.numeric(c) || is.list(c)) {
+                c
+              } else {
+                c@jc
+              }
+            })
+            jdf <- callJMethod(x@sdf, "hint", name, jparams)
             dataFrame(jdf)
           })
 

--- a/R/pkg/tests/fulltests/test_sparkSQL.R
+++ b/R/pkg/tests/fulltests/test_sparkSQL.R
@@ -2807,7 +2807,8 @@ test_that("test hint", {
   execution_plan_hint <- capture.output(
     explain(hint(df, "hint1", 1.23456, "aaaaaaaaaa", hintList), TRUE)
   )
-  expect_true(any(grepl("1.23456, aaaaaaaaaa", execution_plan_hint)))
+  # aaaaaaaaaa would be parsed as an UnresolvedAttribute
+  expect_true(any(grepl("1.23456, 'aaaaaaaaaa", execution_plan_hint)))
 })
 
 test_that("toJSON() on DataFrame", {

--- a/R/pkg/tests/fulltests/test_sparkSQL.R
+++ b/R/pkg/tests/fulltests/test_sparkSQL.R
@@ -2809,9 +2809,11 @@ test_that("test hint", {
   )
   expect_true(any(grepl("1.23456, aaaaaaaaaa", execution_plan_hint)))
 
+  a <- column("id")
   rebalance_plan_hint <- capture.output(
-      explain(hint(df, "rebalance", 1, column("a")), FALSE)
+      explain(hint(df, "rebalance", as.integer(2), a), TRUE)
   )
+  expect_true(any(grepl("RebalancePartitions", rebalance_plan_hint)))
 })
 
 test_that("toJSON() on DataFrame", {

--- a/R/pkg/tests/fulltests/test_sparkSQL.R
+++ b/R/pkg/tests/fulltests/test_sparkSQL.R
@@ -2807,8 +2807,11 @@ test_that("test hint", {
   execution_plan_hint <- capture.output(
     explain(hint(df, "hint1", 1.23456, "aaaaaaaaaa", hintList), TRUE)
   )
-  # aaaaaaaaaa would be parsed as an UnresolvedAttribute
-  expect_true(any(grepl("1.23456, 'aaaaaaaaaa", execution_plan_hint)))
+  expect_true(any(grepl("1.23456, aaaaaaaaaa", execution_plan_hint)))
+
+  rebalance_plan_hint <- capture.output(
+      explain(hint(df, "rebalance", 1, column("a")), FALSE)
+  )
 })
 
 test_that("toJSON() on DataFrame", {

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -992,21 +992,7 @@ class SparkConnectPlanner(val sessionHolder: SessionHolder) extends Logging {
 
   private def transformHint(rel: proto.Hint): LogicalPlan = {
 
-    def extractValue(expr: Expression): Any = {
-      expr match {
-        case Literal(s, StringType) if s != null =>
-          UnresolvedAttribute.quotedString(s.toString)
-        case literal: Literal => literal.value
-        case UnresolvedFunction(Seq("array"), arguments, _, _, _) =>
-          arguments.map(extractValue).toArray
-        case other =>
-          throw InvalidPlanInput(
-            s"Expression should be a Literal or CreateMap or CreateArray, " +
-              s"but got ${other.getClass} $other")
-      }
-    }
-
-    val params = rel.getParametersList.asScala.toSeq.map(transformExpression).map(extractValue)
+    val params = rel.getParametersList.asScala.toSeq.map(transformExpression)
     UnresolvedHint(rel.getName, params, transformRelation(rel.getInput))
   }
 

--- a/python/pyspark/sql/connect/plan.py
+++ b/python/pyspark/sql/connect/plan.py
@@ -578,7 +578,7 @@ class Hint(LogicalPlan):
         self._name = name
 
         for param in parameters:
-            assert isinstance(param, (list, str, float, int))
+            assert isinstance(param, (list, str, float, int, Column))
             if isinstance(param, list):
                 assert all(isinstance(p, (str, float, int)) for p in param)
 

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -1171,7 +1171,7 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         for p in parameters:
             if not isinstance(p, allowed_types):
                 raise PySparkTypeError(
-                    error_class="INVALID_ITEM_FOR_CONTAINER",
+                    error_class="DISALLOWED_TYPE_FOR_CONTAINER",
                     message_parameters={
                         "arg_name": "parameters",
                         "allowed_types": allowed_types_repr,
@@ -1181,7 +1181,7 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
             if isinstance(p, list):
                 if not all(isinstance(e, allowed_primitive_types) for e in p):
                     raise PySparkTypeError(
-                        error_class="INVALID_ITEM_FOR_CONTAINER",
+                        error_class="DISALLOWED_TYPE_FOR_CONTAINER",
                         message_parameters={
                             "arg_name": "parameters",
                             "allowed_types": allowed_types_repr,

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -1899,7 +1899,7 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
             error_class="INVALID_ITEM_FOR_CONTAINER",
             message_parameters={
                 "arg_name": "parameters",
-                "allowed_types": "str, list, float, int",
+                "allowed_types": "str, float, int, Column, list[str], list[float], list[int]",
                 "item_type": "dict",
             },
         )

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -645,6 +645,35 @@ class DataFrameTestsMixin:
             df1.join(df2.hint("broadcast"), "id").explain(True)
             self.assertEqual(1, buf.getvalue().count("BroadcastHashJoin"))
 
+    def test_partitioning_hint_with_columns(self):
+        with self.sql_conf({"spark.sql.adaptive.coalescePartitions.enabled": False}):
+            df = self.spark.createDataFrame(
+                zip(['A', 'B'] * 2 ** 9, range(2 ** 10)),
+                StructType([StructField('a', StringType()), StructField('n', IntegerType())])
+            )
+            # COALESCE
+            coalesce = df.hint("coalesce", 2)
+            self.assertEqual(coalesce.rdd.getNumPartitions(), 2)
+            # REPARTITION_BY_RANGE
+            range_partitioned = df.hint("REPARTITION_BY_RANGE", 2, "a")
+            self.assertEqual(range_partitioned.rdd.getNumPartitions(), 2)
+            # REPARTITION
+            repartitioned1 = df.hint("REPARTITION", "a")
+            self.assertEqual(repartitioned1.rdd.getNumPartitions(),
+                             int(self.spark.conf.get("spark.sql.shuffle.partitions")))
+            repartitioned2 = df.hint("REPARTITION", 2)
+            self.assertEqual(repartitioned2.rdd.getNumPartitions(), 2)
+            repartitioned3 = df.hint("REPARTITION",  2, "a")
+            self.assertEqual(repartitioned3.rdd.getNumPartitions(), 2)
+            # REBALANCE
+            rebalanced1 = df.hint("REBALANCE", "a")  # just check this doesn't error
+            self.assertEqual(rebalanced1.rdd.getNumPartitions(),
+                             int(self.spark.conf.get("spark.sql.shuffle.partitions")))
+            rebalanced2 = df.hint("REBALANCE", 2)
+            self.assertEqual(rebalanced2.rdd.getNumPartitions(), 2)
+            rebalanced3 = df.hint("REBALANCE", 2, "a")
+            self.assertEqual(rebalanced3.rdd.getNumPartitions(), 2)
+
     # add tests for SPARK-23647 (test more types for hint)
     def test_extended_hint_types(self):
         df = self.spark.range(10e10).toDF("id")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala
@@ -521,8 +521,9 @@ package object dsl {
         EliminateSubqueryAliases(analyzed)
       }
 
-      def hint(name: String, parameters: Any*): LogicalPlan =
+      def hint(name: String, parameters: Expression*): LogicalPlan = {
         UnresolvedHint(name, parameters, logicalPlan)
+      }
 
       def sample(
           lowerBound: Double,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/hints.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/hints.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.catalyst.plans.logical
 
-import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
 import org.apache.spark.sql.catalyst.trees.TreePattern.{TreePattern, UNRESOLVED_HINT}
 
 /**
@@ -27,7 +27,7 @@ import org.apache.spark.sql.catalyst.trees.TreePattern.{TreePattern, UNRESOLVED_
  * @param parameters the parameters of the hint
  * @param child the [[LogicalPlan]] on which this hint applies
  */
-case class UnresolvedHint(name: String, parameters: Seq[Any], child: LogicalPlan)
+case class UnresolvedHint(name: String, parameters: Seq[Expression], child: LogicalPlan)
   extends UnaryNode {
 
   // we need it to be resolved so that the analyzer can continue to analyze the rest of the query

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/DSLHintSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/DSLHintSuite.scala
@@ -43,9 +43,5 @@ class DSLHintSuite extends AnalysisTest {
       UnresolvedHint("hint1", Seq(1, $"a"), r1)
     )
 
-    comparePlans(
-      r1.hint("hint1", Seq(1, 2, 3), Seq($"a", $"b", $"c")),
-      UnresolvedHint("hint1", Seq(Seq(1, 2, 3), Seq($"a", $"b", $"c")), r1)
-    )
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/DSLHintSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/DSLHintSuite.scala
@@ -42,6 +42,5 @@ class DSLHintSuite extends AnalysisTest {
       r1.hint("hint1", 1, $"a"),
       UnresolvedHint("hint1", Seq(1, $"a"), r1)
     )
-
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveHintsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveHintsSuite.scala
@@ -352,11 +352,11 @@ class ResolveHintsSuite extends AnalysisTest {
     withSQLConf(SQLConf.SHUFFLE_PARTITIONS.key -> "3") {
       Seq(
         Nil -> 3,
-        Seq(1) -> 1,
+        Seq(Literal(1)) -> 1,
         Seq(UnresolvedAttribute("a")) -> 3,
-        Seq(1, UnresolvedAttribute("a")) -> 1).foreach { case (param, initialNumPartitions) =>
+        Seq(Literal(1), UnresolvedAttribute("a")) -> 1).foreach { case (param, numberPartitions) =>
         assert(UnresolvedHint("REBALANCE", param, testRelation).analyze
-          .asInstanceOf[RebalancePartitions].partitioning.numPartitions == initialNumPartitions)
+          .asInstanceOf[RebalancePartitions].partitioning.numPartitions == numberPartitions)
       }
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -1402,10 +1402,20 @@ class Dataset[T] private[sql](
    *   df1.join(df2.hint("broadcast"))
    * }}}
    *
+   * the following code specifies that this dataset could be rebalanced with given number of
+   * partitions:
+   *
+   * {{{
+   *    df1.hint("rebalance", 10)
+   * }}}
+   *
+   * @param name the name of the hint
+   * @param parameters the parameters of the hint, all the parameters should be a `Column` or
+   *                   `Expression` or `Symbol` or could be converted into a `Literal`
+   *
    * @group basic
    * @since 2.2.0
    */
-  @deprecated("use hint with Column input instead", "4.0.0")
   @scala.annotation.varargs
   def hint(name: String, parameters: Any*): Dataset[T] = withTypedPlan {
     val exprs = parameters.map {
@@ -1415,12 +1425,6 @@ class Dataset[T] private[sql](
       case literal => Literal(literal)
     }.toSeq
     UnresolvedHint(name, exprs, logicalPlan)
-  }
-
-  @scala.annotation.varargs
-  def hint(name: String, head: Column, tail: Column*): Dataset[T] = withTypedPlan {
-    val parameters = head +: tail
-    UnresolvedHint(name, parameters.map(_.expr), logicalPlan)
   }
 
   /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameHintSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameHintSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql
 
 import org.apache.spark.sql.catalyst.analysis.AnalysisTest
 import org.apache.spark.sql.catalyst.dsl.plans._
+import org.apache.spark.sql.catalyst.expressions.Literal
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.test.SharedSparkSession
 
@@ -43,36 +44,31 @@ class DataFrameHintSuite extends AnalysisTest with SharedSparkSession {
 
     check(
       df.hint("hint1", 1, "a"),
-      UnresolvedHint("hint1", Seq(1, $"a".expr), df.logicalPlan)
+      UnresolvedHint("hint1", Seq(Literal(1), $"a".expr), df.logicalPlan)
     )
 
     check(
       df.hint("hint1", 1, $"a"),
-      UnresolvedHint("hint1", Seq(1, $"a"),
+      UnresolvedHint("hint1", Seq(Literal(1), $"a".expr),
         df.logicalPlan
       )
     )
 
-    check(
-      df.hint("hint1", Seq(1, 2, 3), Seq($"a", $"b", $"c")),
-      UnresolvedHint("hint1", Seq(Seq(1, 2, 3), Seq($"a", $"b", $"c")),
-        df.logicalPlan
-      )
-    )
+    assertThrows(df.hint("hint1", Seq(1, 2, 3), Seq($"a", $"b", $"c")))
   }
 
   test("coalesce, repartition and rebalance hint") {
     check(
       df.hint("COALESCE", 10),
-      UnresolvedHint("COALESCE", Seq(10), df.logicalPlan))
+      UnresolvedHint("COALESCE", Seq(Literal(10)), df.logicalPlan))
 
     check(
       df.hint("REPARTITION", 100),
-      UnresolvedHint("REPARTITION", Seq(100), df.logicalPlan))
+      UnresolvedHint("REPARTITION", Seq(Literal(100)), df.logicalPlan))
 
     check(
       df.hint("REPARTITION", 10, $"id".expr),
-      UnresolvedHint("REPARTITION", Seq(10, $"id".expr), df.logicalPlan))
+      UnresolvedHint("REPARTITION", Seq(Literal(10), $"id".expr), df.logicalPlan))
 
     check(
       df.hint("REPARTITION_BY_RANGE", $"id".expr),
@@ -80,21 +76,21 @@ class DataFrameHintSuite extends AnalysisTest with SharedSparkSession {
 
     check(
       df.hint("REPARTITION_BY_RANGE", 10, $"id".expr),
-      UnresolvedHint("REPARTITION_BY_RANGE", Seq(10, $"id".expr), df.logicalPlan))
+      UnresolvedHint("REPARTITION_BY_RANGE", Seq(Literal(10), $"id".expr), df.logicalPlan))
 
     // simple column name should be accepted
     check(
       df.hint("REBALANCE", 10, "id"),
-      UnresolvedHint("REBALANCE", Seq(10, $"id".expr), df.logicalPlan))
+      UnresolvedHint("REBALANCE", Seq(Literal(10), $"id".expr), df.logicalPlan))
 
     check(
       df.hint("REBALANCE", 10, $"id".expr),
-      UnresolvedHint("REBALANCE", Seq(10, $"id".expr), df.logicalPlan))
+      UnresolvedHint("REBALANCE", Seq(Literal(10), $"id".expr), df.logicalPlan))
   }
 
   test("SPARK-40178: hint with string parameters should be supported") {
     checkAnalysisWithoutViewWrapper(
       df.hint("REBALANCE", 10, "id").logicalPlan,
-      UnresolvedHint("REBALANCE", Seq(10, $"id".expr), df.logicalPlan).analyze)
+      UnresolvedHint("REBALANCE", Seq(Literal(10), $"id".expr), df.logicalPlan).analyze)
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Refactor `UnresolvedHint` to accept Expressions only as parameters
2. ResolveHints now parses StringLiteral as UnresolvedAttribute, which would allow users to specify string in parameters directly
3. `hint` method in Dataset now treats all its parameters as `Column`s or `Literal`s, all other values would be rejected. The method signature is kept for better compatibility and ease of use. It also matches how hint method is handled in the Connect module.
4. Connect: PySpark Connect now accepts `Column` as hint's parameters.
5. PySpark: allows `Column` as hint's parameters and tighten the input parameters type check: for list input, only list of primitive values is now allowed
6. SparkR: allows `Column` as hint's parameters and corresponding test.

### Why are the changes needed?
This is a rework of #37616. Before this commit, there's no way for users to directly specify hint info that include column info in PySpark's hint method. In other ways, `rebalance` hint that requires column refs is not possible before this PR.

### Does this PR introduce _any_ user-facing change?
Yes. PySpark and Spark for R uses may specify rebalance and repartition hint with ease.

### How was this patch tested?
Added UTs.