### PR TITLE
[SPARK-41532][CONNECT][FOLLOWUP] Make the scala client using the same error class as python client.

### DIFF
--- a/common/utils/src/main/resources/error/error-classes.json
+++ b/common/utils/src/main/resources/error/error-classes.json
@@ -409,6 +409,11 @@
         "message" : [
           "Error instantiating Spark Connect plugin: <msg>"
         ]
+      },
+      "SESSION_NOT_SAME" : {
+        "message" : [
+          "Both Datasets must belong to the same SparkSession."
+        ]
       }
     }
   },

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -1750,7 +1750,10 @@ class Dataset[T] private[sql] (
 
   private def checkSameSparkSession(other: Dataset[_]): Unit = {
     if (this.sparkSession.sessionId != other.sparkSession.sessionId) {
-      throw new SparkException("Both Datasets must belong to the same SparkSession")
+      throw new SparkException(
+        errorClass = "CONNECT.SESSION_NOT_SAME",
+        messageParameters = Map.empty,
+        cause = null)
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
The python connect client define the error class in `error_classes.py`.
`SESSION_NOT_SAME` is an error class used to check the `SparkSession` of one dataset is the same the other dataset. Please refer [`error_classes.py` ](https://github.com/apache/spark/blob/546e39c5dabc1111243ab81b6238dc893d9993e0/python/pyspark/errors/error_classes.py#L678C1-L678C1)
But the scala connect client not the the same error class.


### Why are the changes needed?
This PR make the scala client using the same error class as python client.


### Does this PR introduce _any_ user-facing change?
'No'.
Just update the inner implementation. 


### How was this patch tested?
Exists test cases.
