### PR TITLE
[SPARK-44421][FOLLOWUP] Fix doc test in SparkThrowableSuite

### DIFF
--- a/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
@@ -149,7 +149,7 @@ class SparkThrowableSuite extends SparkFunSuite {
     checkIfUnique(messageFormats)
   }
 
-  ignore("Error classes match with document") {
+  test("Error classes match with document") {
     val errors = errorReader.errorInfoMap
 
     // the black list of error class name which should not add quote

--- a/docs/sql-error-conditions-invalid-cursor-error-class.md
+++ b/docs/sql-error-conditions-invalid-cursor-error-class.md
@@ -1,0 +1,44 @@
+---
+layout: global
+title: INVALID_CURSOR error class
+displayTitle: INVALID_CURSOR error class
+license: |
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+---
+
+[SQLSTATE: HY109](sql-error-conditions-sqlstates.html#class-HY-cli-specific-condition)
+
+The cursor is invalid.
+
+This error class has the following derived error classes:
+
+## DISCONNECTED
+
+The cursor has been disconnected by the server.
+
+## NOT_REATTACHABLE
+
+The cursor is not reattachable.
+
+## POSITION_NOT_AVAILABLE
+
+The cursor position id `<responseId>` is no longer available at index `<index>`.
+
+## POSITION_NOT_FOUND
+
+The cursor position id `<responseId>` is not found.
+
+


### PR DESCRIPTION
### What changes were proposed in this pull request?

Forgot to `git add` the file after regenerating docs.

### Why are the changes needed?

Fix docs and reenable test.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manually testing SparkThrowableSuite works in both master and branch-3.5.
