### PR TITLE
[SPARK-44623][BUILD] Upgrade `commons-lang3` to 3.13.0

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -45,7 +45,7 @@ commons-crypto/1.1.0//commons-crypto-1.1.0.jar
 commons-dbcp/1.4//commons-dbcp-1.4.jar
 commons-io/2.13.0//commons-io-2.13.0.jar
 commons-lang/2.6//commons-lang-2.6.jar
-commons-lang3/3.12.0//commons-lang3-3.12.0.jar
+commons-lang3/3.13.0//commons-lang3-3.13.0.jar
 commons-logging/1.1.3//commons-logging-1.1.3.jar
 commons-math3/3.6.1//commons-math3-3.6.1.jar
 commons-pool/1.5.4//commons-pool-1.5.4.jar

--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
     <!-- org.apache.commons/commons-lang/-->
     <commons-lang2.version>2.6</commons-lang2.version>
     <!-- org.apache.commons/commons-lang3/-->
-    <commons-lang3.version>3.12.0</commons-lang3.version>
+    <commons-lang3.version>3.13.0</commons-lang3.version>
     <!-- org.apache.commons/commons-pool2/-->
     <commons-pool2.version>2.11.1</commons-pool2.version>
     <datanucleus-core.version>4.1.17</datanucleus-core.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade commons-lang3 to 3.13.0.

### Why are the changes needed?

`commons-lang3` added Java 21 support at 3.13.0.
- https://commons.apache.org/proper/commons-lang/changes-report.html#a3.13.0

- https://github.com/apache/commons-lang/blob/9d85b0a11e5dbadd5da20865c3dd3f8ef4668c7d/src/main/java/org/apache/commons/lang3/JavaVersion.java#L167-L172

```java
    /**
     * Java 21.
     *
     * @since 3.13.0
     */
    JAVA_21(21, "21"),
```
### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.