### PR TITLE
[SPARK-44624][CONNECT] Retry ExecutePlan in case initial request didn't reach server overkill

### DIFF
--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/connect/client/ExecutePlanResponseReattachableIterator.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/connect/client/ExecutePlanResponseReattachableIterator.scala
@@ -86,8 +86,12 @@ class ExecutePlanResponseReattachableIterator(
   private var responseComplete: Boolean = false
 
   // Initial iterator comes from ExecutePlan request.
-  private var iterator: java.util.Iterator[proto.ExecutePlanResponse] =
+  private var iterator: java.util.Iterator[proto.ExecutePlanResponse] = retry {
+    // From empirical observation even if one would expect an immediate error from the GRPC call,
+    // one is only thrown from the first iterator.next() or iterator.hasNext() call.
+    // However, in case this is a GRPC quirk that cannot be relied upon, retry also here.
     rawBlockingStub.executePlan(initialRequest)
+  }
 
   override def next(): proto.ExecutePlanResponse = synchronized {
     // hasNext will trigger reattach in case the stream completed without responseComplete

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/connect/client/GrpcRetryHandler.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/connect/client/GrpcRetryHandler.scala
@@ -166,7 +166,8 @@ private[client] object GrpcRetryHandler extends Logging {
     try {
       return fn
     } catch {
-      case NonFatal(e) if retryPolicy.canRetry(e) && currentRetryNum < retryPolicy.maxRetries =>
+      case NonFatal(e) if (retryPolicy.canRetry(e) || e.isInstanceOf[RetryException]) &&
+        currentRetryNum < retryPolicy.maxRetries =>
         logWarning(
           s"Non fatal error during RPC execution: $e, " +
             s"retrying (currentRetryNum=$currentRetryNum)")
@@ -211,4 +212,9 @@ private[client] object GrpcRetryHandler extends Logging {
       maxBackoff: FiniteDuration = FiniteDuration(1, "min"),
       backoffMultiplier: Double = 4.0,
       canRetry: Throwable => Boolean = retryException) {}
+
+  /**
+   * An exception that is always retryable, and can be thrown upstream when inside retry.
+   */
+  class RetryException extends Throwable
 }

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/connect/client/GrpcRetryHandler.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/connect/client/GrpcRetryHandler.scala
@@ -166,8 +166,9 @@ private[client] object GrpcRetryHandler extends Logging {
     try {
       return fn
     } catch {
-      case NonFatal(e) if (retryPolicy.canRetry(e) || e.isInstanceOf[RetryException]) &&
-        currentRetryNum < retryPolicy.maxRetries =>
+      case NonFatal(e)
+          if (retryPolicy.canRetry(e) || e.isInstanceOf[RetryException]) &&
+            currentRetryNum < retryPolicy.maxRetries =>
         logWarning(
           s"Non fatal error during RPC execution: $e, " +
             s"retrying (currentRetryNum=$currentRetryNum)")


### PR DESCRIPTION
### What changes were proposed in this pull request?

If the ExecutePlan never reached the server, a ReattachExecute will fail with INVALID_HANDLE.OPERATION_NOT_FOUND. In that case, we could try to send ExecutePlan again.

Note: This is an "overkill" version of the change.
Even though we empirically observed that error is throws only from first next() or hasNext() of the response StreamObserver, wrap the initial call in retries as well to not depend on it in case it's just an quirk of GRPC that's not fully dependable.

### Why are the changes needed?

This solves an edge case of reattachable execution where the initial execution never reached the server.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Testing these failures is difficult, will require some special testing setup