### PR TITLE
[SPARK-44626][SS][CONNECT] Followup on streaming query termination when client session is timed out for Spark Connect

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
@@ -279,10 +279,7 @@ object SparkConnectService extends Logging {
     cacheBuilder(CACHE_SIZE, CACHE_TIMEOUT_SECONDS).build[SessionCacheKey, SessionHolder]()
 
   private[connect] val streamingSessionManager =
-    new SparkConnectStreamingQueryCache(sessionKeepAliveFn = { case (userId, sessionId) =>
-      // Use getIfPresent() rather than get() to prevent accidental loading.
-      userSessionMapping.getIfPresent((userId, sessionId))
-    })
+    new SparkConnectStreamingQueryCache()
 
   private class RemoveSessionListener extends RemovalListener[SessionCacheKey, SessionHolder] {
     override def onRemoval(

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectStreamingQueryCache.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectStreamingQueryCache.scala
@@ -163,8 +163,6 @@ private[connect] class SparkConnectStreamingQueryCache(
    * Periodic maintenance task to do the following:
    *   - Update status of query if it is inactive. Sets an expiery time for such queries
    *   - Drop expired queries from the cache.
-   *   - Poll sessions associated with the cached queries in order keep them alive in connect
-   *     service' mapping (by invoking `sessionKeepAliveFn`).
    */
   private def periodicMaintenance(): Unit = {
 

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectStreamingQueryCache.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectStreamingQueryCache.scala
@@ -40,8 +40,8 @@ import org.apache.spark.util.SystemClock
  *   - Check the status of the queries, and drops those that expired (1 hour after being stopped).
  *
  * This class helps with supporting following semantics for streaming query sessions:
- *   - If the session mapping on connect server side is expired, stop all the running queries
- *     that are associated with that session.
+ *   - If the session mapping on connect server side is expired, stop all the running queries that
+ *     are associated with that session.
  *   - Once a query is stopped, the reference and mappings are maintained for 1 hour and will be
  *     accessible from the client. This allows time for client to fetch status. If the client
  *     continues to access the query, it stays in the cache until 1 hour of inactivity.
@@ -105,8 +105,8 @@ private[connect] class SparkConnectStreamingQueryCache(
 
   /**
    * Terminate all the running queries attached to the given sessionHolder and remove them from
-   * the queryCache. This is used when session is expired and we need to cleanup resources of
-   * that session.
+   * the queryCache. This is used when session is expired and we need to cleanup resources of that
+   * session.
    */
   def cleanupRunningQueries(sessionHolder: SessionHolder): Unit = {
     for ((k, v) <- queryCache) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Removed keep alive feature in `SparkConnectStreamingQueryCache` so that the session mapping of running queries can expire after a client session times out. This is needed for a change to terminate the query when client session is timed out.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This is a followup of https://issues.apache.org/jira/browse/SPARK-44432. Without removing the keep alive feature, the session mapping for running queries cannot expire correctly since it would be accessed periodically

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Did manual testing and verified the change is working as expected. Adding unit test is kind of hard since the session mapping logic cannot be easily mocked. We want to get this checked in with Spark 3.5 asap and this is already verified with a manual testing.

Create a streaming query on client side and then disconnect:
```
@ val q = spark.readStream.format("rate").load().writeStream.format("console").start()

@ exit
```

Validate on server side that the running query is stopped after a while:
```
23/08/01 13:26:34 INFO SparkConnectStreamingQueryCache: Stopping the query with id 787cdaed-0e6a-4496-a4a3-78b77789193b since the session has timed out
23/08/01 13:26:34 INFO DAGScheduler: Asked to cancel job group c615e5a7-78ff-462b-b24c-bba55259f8f5
23/08/01 13:26:34 INFO MicroBatchExecution: Async log purge executor pool for query [id = 787cdaed-0e6a-4496-a4a3-78b77789193b, runId = c615e5a7-78ff-462b-b24c-bba55259f8f5] has been shutdown
23/08/01 13:26:34 INFO MicroBatchExecution: Deleting checkpoint file:/private/var/folders/b0/f9jmmrrx5js7xsswxyf58nwr0000gp/T/temporary-05b9e890-ec53-45df-a3ca-65c4c01a143d.
23/08/01 13:26:34 INFO DAGScheduler: Asked to cancel job group c615e5a7-78ff-462b-b24c-bba55259f8f5
23/08/01 13:26:34 INFO MicroBatchExecution: Query [id = 787cdaed-0e6a-4496-a4a3-78b77789193b, runId = c615e5a7-78ff-462b-b24c-bba55259f8f5] was stopped
```