### PR TITLE
[SPARK-44630][CORE][3.4] Revert "[SPARK-43043][CORE] Improve the performance of MapOutputTracker.updateMapOutput"

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/collection/OpenHashMap.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/OpenHashMap.scala
@@ -75,24 +75,6 @@ class OpenHashMap[K : ClassTag, @specialized(Long, Int, Double) V: ClassTag](
     }
   }
 
-  /** Get the value for a given key, return None if the key doesn't exist */
-  def get(k: K): Option[V] = {
-    if (k == null) {
-      if (haveNullValue) {
-        Some(nullValue)
-      } else {
-        None
-      }
-    } else {
-      val pos = _keySet.getPos(k)
-      if (pos < 0) {
-        None
-      } else {
-        Some(_values(pos))
-      }
-    }
-  }
-
   /** Set the value for a key */
   def update(k: K, v: V): Unit = {
     if (k == null) {

--- a/core/src/test/scala/org/apache/spark/util/collection/OpenHashMapSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/collection/OpenHashMapSuite.scala
@@ -231,22 +231,4 @@ class OpenHashMapSuite extends SparkFunSuite with Matchers {
     assert(map2("b") === 0.0)
     assert(map2("c") === null)
   }
-
-  test("get") {
-    val map = new OpenHashMap[String, String]()
-
-    // Get with normal/null keys.
-    map("1") = "1"
-    assert(map.get("1") === Some("1"))
-    assert(map.get("2") === None)
-    assert(map.get(null) === None)
-    map(null) = "hello"
-    assert(map.get(null) === Some("hello"))
-
-    // Get with null values.
-    map("1") = null
-    assert(map.get("1") === Some(null))
-    map(null) = null
-    assert(map.get(null) === Some(null))
-  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This reverts commit f68ece9e6074cecdaf74ad9b39eae3c7dc2cfaf1 from `branch-3.4` only.

### Why are the changes needed?

SPARK-43043 (#40690) was an improvement PR but it introduced a regression when it landed at Apache Spark 3.4.1.
```scala
  test("getMapOutputLocation should not throw NPE") {
    val tracker = newTrackerMaster()
    try {
      tracker.registerShuffle(0, 1, 1)
      tracker.registerMapOutput(0, 0, MapStatus(BlockManagerId("exec-1", "hostA", 1000),
        Array(2L), 0))
      tracker.removeOutputsOnHost("hostA")
      assert(tracker.getMapOutputLocation(0, 0) == None)
    } finally {
      tracker.stop()
    }
  }
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.