### PR TITLE
[SPARK-44618][INFRA][FOLLOWUPS] Make `free_disk_space` uninstall two unused packages completely

### DIFF
--- a/dev/free_disk_space
+++ b/dev/free_disk_space
@@ -25,13 +25,9 @@ echo "Listing 100 largest packages"
 dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n 100
 df -h
 
-du -sh /opt/*
-du -sh /opt/*/*
-
 echo "Removing large packages"
 sudo rm -rf /usr/share/dotnet/
 sudo rm -rf /usr/share/php/
-sudo rm -rf /usr/local/share/man/man1/
 sudo rm -rf /usr/local/graalvm/
 sudo rm -rf /usr/local/.ghcup/
 sudo rm -rf /usr/local/share/powershell
@@ -49,4 +45,5 @@ sudo apt-get remove --purge -y snapd google-chrome-stable microsoft-edge-stable 
 sudo apt-get remove --purge -y azure-cli google-cloud-sdk mono-devel powershell libgl1-mesa-dri
 sudo apt-get autoremove --purge -y
 sudo apt-get clean
+
 df -h

--- a/dev/free_disk_space
+++ b/dev/free_disk_space
@@ -24,14 +24,21 @@ echo "=================================="
 echo "Listing 100 largest packages"
 dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n 100
 df -h
+
+du -sh /opt/*
+du -sh /opt/*/*
+
 echo "Removing large packages"
 sudo rm -rf /usr/share/dotnet/
+sudo rm -rf /usr/share/php/
+sudo rm -rf /usr/local/share/man/man1/
 sudo rm -rf /usr/local/graalvm/
 sudo rm -rf /usr/local/.ghcup/
 sudo rm -rf /usr/local/share/powershell
 sudo rm -rf /usr/local/share/chromium
 sudo rm -rf /usr/local/lib/android
 sudo rm -rf /usr/local/lib/node_modules
+sudo rm -rf /opt/az
 
 sudo apt-get remove --purge -y '^aspnet.*'
 sudo apt-get remove --purge -y '^dotnet-.*'


### PR DESCRIPTION
### What changes were proposed in this pull request?

Make `free_disk_space` uninstall two unused packages completely


### Why are the changes needed?

```
dpkg: warning: while removing php8.1-fpm, directory '/usr/share/php' not empty so not removed
...
dpkg: warning: while removing powershell, directory '/usr/local/share/man/man1' not empty so not removed
Purging configuration files for azure-cli (2.50.0-1~jammy) ...
dpkg: warning: while removing azure-cli, directory '/opt/az' not empty so not removed
```

we can not remove '/usr/local/share/man/man1' for `powershell`:

1. this path contains docs for other packages;
2. after removing it, `powershell` requires to remove '/usr/local/share`

so let `powershell` alone

### Does this PR introduce _any_ user-facing change?
no, infra-only


### How was this patch tested?
updated CI and manually check