### PR TITLE
[SPARK-44635][CORE] Handle shuffle fetch failures in decommissions

### DIFF
--- a/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
+++ b/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
@@ -39,7 +39,7 @@ import org.apache.spark.internal.config._
 import org.apache.spark.io.CompressionCodec
 import org.apache.spark.rpc.{RpcCallContext, RpcEndpoint, RpcEndpointRef, RpcEnv}
 import org.apache.spark.scheduler.{MapStatus, MergeStatus, ShuffleOutputStatus}
-import org.apache.spark.shuffle.{MetadataFetchFailedException, MetadataUpdateFailedException}
+import org.apache.spark.shuffle.MetadataFetchFailedException
 import org.apache.spark.storage.{BlockId, BlockManagerId, ShuffleBlockId, ShuffleMergedBlockId}
 import org.apache.spark.util._
 import org.apache.spark.util.collection.OpenHashMap
@@ -1301,7 +1301,7 @@ private[spark] class MapOutputTrackerWorker(conf: SparkConf) extends MapOutputTr
       currentLocationOpt = getMapOutputLocation(shuffleId, mapId)
     }
     if (currentLocationOpt.isEmpty) {
-      throw new MetadataUpdateFailedException(shuffleId, mapId,
+      throw new MetadataFetchFailedException(shuffleId, -1,
         message = s"Failed to get map output location for shuffleId $shuffleId, mapId $mapId")
     }
     currentLocationOpt.get

--- a/core/src/main/scala/org/apache/spark/TestUtils.scala
+++ b/core/src/main/scala/org/apache/spark/TestUtils.scala
@@ -492,6 +492,7 @@ private[spark] object TestUtils {
     file.getPath
   }
 
+  /** Sets all configs specified in `confPairs`, calls `f`, and then restores them. */
   def withConf[T](confPairs: (String, String)*)(f: => T): T = {
     val conf = SparkEnv.get.conf
     val (keys, values) = confPairs.unzip

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -528,6 +528,15 @@ package object config {
       .bytesConf(ByteUnit.BYTE)
       .createOptional
 
+  private[spark] val STORAGE_DECOMMISSION_SHUFFLE_REFRESH =
+    ConfigBuilder("spark.storage.decommission.shuffleBlocks.refreshLocationsEnabled")
+      .doc("If true, executors will try to refresh the cached locations for the shuffle blocks" +
+        "when fetch failures happens (and decommission shuffle block migration is enabled), " +
+        "and retry fetching when the location changes.")
+      .version("3.5.0")
+      .booleanConf
+      .createWithDefault(false)
+
   private[spark] val STORAGE_REPLICATION_TOPOLOGY_FILE =
     ConfigBuilder("spark.storage.replication.topologyFile")
       .version("2.1.0")

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -533,7 +533,7 @@ package object config {
       .doc("If true, executors will try to refresh the cached locations for the shuffle blocks" +
         "when fetch failures happens (and decommission shuffle block migration is enabled), " +
         "and retry fetching when the location changes.")
-      .version("3.5.0")
+      .version("4.0.0")
       .booleanConf
       .createWithDefault(false)
 

--- a/core/src/main/scala/org/apache/spark/shuffle/FetchFailedException.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/FetchFailedException.scala
@@ -70,12 +70,3 @@ private[spark] class MetadataFetchFailedException(
     reduceId: Int,
     message: String)
   extends FetchFailedException(null, shuffleId, -1L, -1, reduceId, message)
-
-/**
- * Failed to update shuffle metadata (in cases like decommission).
- */
-private[spark] class MetadataUpdateFailedException(
-    shuffleId: Int,
-    mapId: Long,
-    message: String)
-  extends FetchFailedException(null, shuffleId, mapId, -1, -1, message)

--- a/core/src/main/scala/org/apache/spark/shuffle/FetchFailedException.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/FetchFailedException.scala
@@ -70,3 +70,12 @@ private[spark] class MetadataFetchFailedException(
     reduceId: Int,
     message: String)
   extends FetchFailedException(null, shuffleId, -1L, -1, reduceId, message)
+
+/**
+ * Failed to update shuffle metadata (in cases like decommission).
+ */
+private[spark] class MetadataUpdateFailedException(
+    shuffleId: Int,
+    mapId: Long,
+    message: String)
+  extends FetchFailedException(null, shuffleId, mapId, -1, -1, message)

--- a/core/src/main/scala/org/apache/spark/storage/BlockId.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockId.scala
@@ -217,6 +217,14 @@ object BlockId {
   val TEMP_SHUFFLE = "temp_shuffle_([-A-Fa-f0-9]+)".r
   val TEST = "test_(.*)".r
 
+  def getShuffleIdAndMapId(blockId: BlockId): (Int, Long) = blockId match {
+    case ShuffleBlockId(shuffleId, mapId, _) => (shuffleId, mapId)
+    case ShuffleBlockBatchId(shuffleId, mapId, _, _) => (shuffleId, mapId)
+    case ShuffleDataBlockId(shuffleId, mapId, _) => (shuffleId, mapId)
+    case ShuffleIndexBlockId(shuffleId, mapId, _) => (shuffleId, mapId)
+    case _ => throw new SparkException(s"Unexpected shuffle BlockId $blockId")
+  }
+
   def apply(name: String): BlockId = name match {
     case RDD(rddId, splitIndex) =>
       RDDBlockId(rddId.toInt, splitIndex.toInt)

--- a/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
+++ b/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
@@ -1622,7 +1622,8 @@ object ShuffleBlockFetcherIterator {
     extends FetchResult
 
   /**
-   * Result of a fetch request that should be deferred for some reasons, e.g., Netty OOM, decommission
+   * Result of a fetch request that should be deferred for some reasons, e.g., Netty OOM,
+   * shuffle block migration due to decommission
    */
   private[storage]
   case class DeferFetchRequestResult(

--- a/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
+++ b/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
@@ -1203,7 +1203,7 @@ final class ShuffleBlockFetcherIterator(
     // Skip when the address is the local BM Id (this may happen when shuffle migration is enabled)
     if (deferredFetchRequests.nonEmpty) {
       for ((remoteAddress, defReqQueue) <- deferredFetchRequests
-           if remoteAddress != blockManager.blockManagerId) {
+        if remoteAddress != blockManager.blockManagerId) {
         while (isRemoteBlockFetchable(defReqQueue) &&
             !isRemoteAddressMaxedOut(remoteAddress, defReqQueue.front)) {
           val request = defReqQueue.dequeue()
@@ -1622,7 +1622,7 @@ object ShuffleBlockFetcherIterator {
     extends FetchResult
 
   /**
-   * Result of a fetch request that should be deferred for some reasons, e.g., Netty OOM
+   * Result of a fetch request that should be deferred for some reasons, e.g., Netty OOM, decommission
    */
   private[storage]
   case class DeferFetchRequestResult(


### PR DESCRIPTION
### What changes were proposed in this pull request?
This change tries to handle shuffle fetch failures due to decommissions.

When encountering a fetch failure for a block, `ShuffleBlockFetcherIterator` will check the updated map output location (`BlockManagerId`) for it, and see if the location changes. When it does, the fetch failure will be ignored and the updated location and the block id will be recorded. At the end of the fetch request (when all blocks in the request are processed), multiple requests will be assembled and enqueued, to retry the fetches from the updated locations for the corresponding blocks.


### Why are the changes needed?
This is to improve stability when decommission is enabled.


### Does this PR introduce _any_ user-facing change?
This change comes with a feature flag `spark.storage.decommission.shuffleBlocks.refreshLocationsEnabled`.


### How was this patch tested?
Added a new unit test.
