### PR TITLE
[SPARK-44609][K8S] Remove executor pod from PodsAllocator if it was removed from scheduler backend

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
@@ -190,6 +190,13 @@ class ExecutorPodsAllocator(
       newlyCreatedExecutors.filterKeys(schedulerKnownExecs.contains(_)).mapValues(_._1)
     newlyCreatedExecutors --= schedulerKnownNewlyCreatedExecs.keySet
 
+    // If executor was created and removed in a short period, then it is possible that the creation
+    // was not captured by any snapshots. In this case, we should remove the executor from
+    // schedulerKnownNewlyCreatedExecs list, otherwise it will get stuck in the list and new
+    // executor will not be requested.
+    schedulerKnownNewlyCreatedExecs --=
+      schedulerKnownNewlyCreatedExecs.filterKeys(!schedulerKnownExecs.contains(_)).keySet
+
     // For all executors we've created against the API but have not seen in a snapshot
     // yet - check the current time. If the current time has exceeded some threshold,
     // assume that the pod was either never created (the API server never properly


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Remove executor pod from `schedulerKnownNewlyCreatedExecs` in `ExecutorPodsAllocator` if schedulerBackend no longer knows about that executor.


### Why are the changes needed?
If executor was created and removed in a short period, then it is possible that the creation was not captured by any snapshots. In this case, we should remove the executor from schedulerKnownNewlyCreatedExecs list, otherwise it will get stuck in the list and new executor will never be requested.

(This can often happen if watch connection is closed for some reason and driver has to fallback on `ExecutorPodsPollingSnapshotSource`)

Please check [jira issue](https://issues.apache.org/jira/browse/SPARK-44609) to get more details

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Unit tests `test("SPARK-44609: Do not track an executor if it was removed from scheduler backend.")`
- Tested locally by disabling informers and manually killing executor pods and seeing the new ones coming up within the `spark.kubernetes.executor.apiPollingInterval` 30s
