### PR TITLE
[SPARK-44636][CONNECT] Leave no dangling iterators

### DIFF
--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -252,10 +252,12 @@ class SparkSession private[sql] (
           .setSql(sqlText)
           .addAllPosArgs(args.map(toLiteralProto).toIterable.asJava)))
     val plan = proto.Plan.newBuilder().setCommand(cmd)
-    val responseIter = client.execute(plan.build())
+    val responseSeq = client.execute(plan.build()).asScala.toSeq
 
-    // Note: .toSeq makes the stream be consumed and closed.
-    val response = responseIter.asScala.toSeq
+    // sequence is a lazy stream, force materialize it to make sure it is consumed.
+    responseSeq.foreach(_ => ())
+
+    val response = responseSeq
       .find(_.hasSqlCommandResult)
       .getOrElse(throw new RuntimeException("SQLCommandResult must be present"))
 
@@ -309,10 +311,12 @@ class SparkSession private[sql] (
             .setSql(sqlText)
             .putAllArgs(args.asScala.mapValues(toLiteralProto).toMap.asJava)))
       val plan = proto.Plan.newBuilder().setCommand(cmd)
-      val responseIter = client.execute(plan.build())
+      val responseSeq = client.execute(plan.build()).asScala.toSeq
 
-      // Note: .toSeq makes the stream be consumed and closed.
-      val response = responseIter.asScala.toSeq
+      // sequence is a lazy stream, force materialize it to make sure it is consumed.
+      responseSeq.foreach(_ => ())
+
+      val response = responseSeq
         .find(_.hasSqlCommandResult)
         .getOrElse(throw new RuntimeException("SQLCommandResult must be present"))
 
@@ -549,14 +553,15 @@ class SparkSession private[sql] (
 
   private[sql] def execute(command: proto.Command): Seq[ExecutePlanResponse] = {
     val plan = proto.Plan.newBuilder().setCommand(command).build()
-    client.execute(plan).asScala.toSeq
+    val seq = client.execute(plan).asScala.toSeq
+    // sequence is a lazy stream, force materialize it to make sure it is consumed.
+    seq.foreach(_ => ())
+    seq
   }
 
   private[sql] def registerUdf(udf: proto.CommonInlineUserDefinedFunction): Unit = {
     val command = proto.Command.newBuilder().setRegisterFunction(udf).build()
-    val plan = proto.Plan.newBuilder().setCommand(command).build()
-
-    client.execute(plan).asScala.foreach(_ => ())
+    execute(command)
   }
 
   @DeveloperApi

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/connect/client/SparkConnectClient.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/connect/client/SparkConnectClient.scala
@@ -72,6 +72,12 @@ private[sql] class SparkConnectClient(
     bstub.analyzePlan(request)
   }
 
+  /**
+   * Execute the plan and return response iterator.
+   *
+   * It returns an open iterator. The caller needs to ensure that this iterator is fully consumed, otherwise
+   * resources held by a re-attachable query may be left dangling until server timeout.
+   */
   def execute(plan: proto.Plan): java.util.Iterator[proto.ExecutePlanResponse] = {
     artifactManager.uploadAllClassFileArtifacts()
     val request = proto.ExecutePlanRequest

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/connect/client/SparkConnectClient.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/connect/client/SparkConnectClient.scala
@@ -75,8 +75,8 @@ private[sql] class SparkConnectClient(
   /**
    * Execute the plan and return response iterator.
    *
-   * It returns an open iterator. The caller needs to ensure that this iterator is fully consumed, otherwise
-   * resources held by a re-attachable query may be left dangling until server timeout.
+   * It returns an open iterator. The caller needs to ensure that this iterator is fully consumed,
+   * otherwise resources held by a re-attachable query may be left dangling until server timeout.
    */
   def execute(plan: proto.Plan): java.util.Iterator[proto.ExecutePlanResponse] = {
     artifactManager.uploadAllClassFileArtifacts()


### PR DESCRIPTION
### What changes were proposed in this pull request?
Minorly refactored execute functions to not leave dangling iterators

(Note: we also should do that with SparkResult, however in almost all cases there should be no problem with iterators not consumed).

### Why are the changes needed?

Needed for ongoing work regarding session reattachment.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
This is intended to be tested after session reattachment is complete (cc @juliuszsompolski).