### PR TITLE
[SPARK-44643][SQL][PYTHON] Fix Row.__repr__ for the case the field is empty Row

### DIFF
--- a/python/pyspark/sql/tests/test_types.py
+++ b/python/pyspark/sql/tests/test_types.py
@@ -1323,6 +1323,11 @@ class DataTypeTests(unittest.TestCase):
         # test __repr__ with unicode values
         self.assertEqual(repr(Row("数", "量")), "<Row('数', '量')>")
 
+    # SPARK-44643: test __repr__ with empty Row
+    def test_row_repr_with_empty_row(self):
+        self.assertEqual(repr(Row(a=Row())), "Row(a=<Row()>)")
+        self.assertEqual(repr(Row(Row())), "<Row(<Row()>)>")
+
     def test_empty_row(self):
         row = Row()
         self.assertEqual(len(row), 0)

--- a/python/pyspark/sql/tests/test_types.py
+++ b/python/pyspark/sql/tests/test_types.py
@@ -1328,6 +1328,10 @@ class DataTypeTests(unittest.TestCase):
         self.assertEqual(repr(Row(a=Row())), "Row(a=<Row()>)")
         self.assertEqual(repr(Row(Row())), "<Row(<Row()>)>")
 
+        EmptyRow = Row()
+        self.assertEqual(repr(Row(a=EmptyRow())), "Row(a=Row())")
+        self.assertEqual(repr(Row(EmptyRow())), "<Row(Row())>")
+
     def test_empty_row(self):
         row = Row()
         self.assertEqual(len(row), 0)

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -2402,7 +2402,7 @@ class Row(tuple):
                 "%s=%r" % (k, v) for k, v in zip(self.__fields__, tuple(self))
             )
         else:
-            return "<Row(%s)>" % ", ".join("%r" % field for field in self)
+            return "<Row(%s)>" % ", ".join(repr(field) for field in self)
 
 
 class DateConverter:


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix `Row.__repr__` for the case the field is empty `Row`.

```py
>>> repr(Row(Row()))
'<Row(<Row()>)>'
```

### Why are the changes needed?

`Row.__repr__` is broken when it contains an empty `Row`:

```py
>>> repr(Row(Row()))
Traceback (most recent call last):
...
TypeError: not enough arguments for format string
```

### Does this PR introduce _any_ user-facing change?

`Row` that contains an empty `Row` will be shown in the REPL.

### How was this patch tested?

Added the related test.