### PR TITLE
[SPARK-44645][PYTHON][DOCS] Update assertDataFrameEqual docs error example output

### DIFF
--- a/python/pyspark/testing/utils.py
+++ b/python/pyspark/testing/utils.py
@@ -434,12 +434,12 @@ def assertDataFrameEqual(
     PySparkAssertionError: [DIFFERENT_ROWS] Results do not match: ( 66.66667 % )
     *** actual ***
     ! Row(id='1', amount=1000.0)
-      Row(id='2', amount=3000.0)
+    Row(id='2', amount=3000.0)
     ! Row(id='3', amount=2000.0)
 
     *** expected ***
     ! Row(id='1', amount=1001.0)
-      Row(id='2', amount=3000.0)
+    Row(id='2', amount=3000.0)
     ! Row(id='3', amount=2003.0)
     """
     if actual is None and expected is None:

--- a/python/pyspark/testing/utils.py
+++ b/python/pyspark/testing/utils.py
@@ -432,17 +432,15 @@ def assertDataFrameEqual(
     Traceback (most recent call last):
     ...
     PySparkAssertionError: [DIFFERENT_ROWS] Results do not match: ( 66.66667 % )
-    --- actual
-    +++ expected
-    - Row(id='1', amount=1000.0)
-    ?                       ^
-    + Row(id='1', amount=1001.0)
-    ?                       ^
-    - Row(id='3', amount=2000.0)
-    ?                       ^
-    + Row(id='3', amount=2003.0)
-    ?                       ^
+    *** actual ***
+    ! Row(id='1', amount=1000.0)
+      Row(id='2', amount=3000.0)
+    ! Row(id='3', amount=2000.0)
 
+    *** expected ***
+    ! Row(id='1', amount=1001.0)
+      Row(id='2', amount=3000.0)
+    ! Row(id='3', amount=2003.0)
     """
     if actual is None and expected is None:
         return True


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR updates the error example output for the `assertDataFrameEqual` docs, given the new error message formatting.


### Why are the changes needed?
The change is needed to display the accurate `assertDataFrameEqual` error message.

### Does this PR introduce _any_ user-facing change?
Yes, the PR affects the user view for the PySpark docs page.


### How was this patch tested?
Existing tests
