### PR TITLE
[SPARK-44424][PYTHON][CONNECT][FOLLOW-UP] Import Connect related libraries after checking dependencies

### DIFF
--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -20,7 +20,6 @@ __all__ = [
     "getLogLevel",
 ]
 
-from pyspark.sql.connect.client.reattach import ExecutePlanResponseReattachableIterator
 from pyspark.sql.connect.utils import check_dependencies
 
 check_dependencies(__name__)
@@ -66,6 +65,7 @@ from google.rpc import error_details_pb2
 from pyspark.version import __version__
 from pyspark.resource.information import ResourceInformation
 from pyspark.sql.connect.client.artifact import ArtifactManager
+from pyspark.sql.connect.client.reattach import ExecutePlanResponseReattachableIterator
 from pyspark.sql.connect.conversion import storage_level_to_proto, proto_to_storage_level
 import pyspark.sql.connect.proto as pb2
 import pyspark.sql.connect.proto.base_pb2_grpc as grpc_lib


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/42235 that fixes the Connect related import after the dependency checking.

### Why are the changes needed?

In order to show the end users a nice error message for optional dependencies instead of just saying that they were not found.

### Does this PR introduce _any_ user-facing change?

No, the PR has not been released out yet.

### How was this patch tested?

Manually.