### PR TITLE
[SPARK-44661][CORE][TESTS] `getMapOutputLocation` should not throw NPE

### DIFF
--- a/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
@@ -1093,7 +1093,7 @@ class MapOutputTrackerSuite extends SparkFunSuite with LocalSparkContext {
     assert(shuffleStatus.getMapStatus(0).isEmpty)
   }
 
-  test("SPARK-44658: getMapOutputLocation should not throw NPE") {
+  test("SPARK-44661: getMapOutputLocation should not throw NPE") {
     val rpcEnv = createRpcEnv("test")
     val tracker = newTrackerMaster()
     try {

--- a/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
@@ -1092,4 +1092,21 @@ class MapOutputTrackerSuite extends SparkFunSuite with LocalSparkContext {
     shuffleStatus.removeMapOutput(mapIndex = 1, bmID)
     assert(shuffleStatus.getMapStatus(0).isEmpty)
   }
+
+  test("SPARK-44658: getMapOutputLocation should not throw NPE") {
+    val rpcEnv = createRpcEnv("test")
+    val tracker = newTrackerMaster()
+    try {
+      tracker.trackerEndpoint = rpcEnv.setupEndpoint(MapOutputTracker.ENDPOINT_NAME,
+        new MapOutputTrackerMasterEndpoint(rpcEnv, tracker, conf))
+      tracker.registerShuffle(0, 1, 1)
+      tracker.registerMapOutput(0, 0, MapStatus(BlockManagerId("exec-1", "hostA", 1000),
+        Array(2L), 0))
+      tracker.removeOutputsOnHost("hostA")
+      assert(tracker.getMapOutputLocation(0, 0) == None)
+    } finally {
+      tracker.stop()
+      rpcEnv.shutdown()
+    }
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add a test coverage for Apache Spark 4.0/3.5/3.4.
This PR depends on SPARK-44658 (#42323) but is created separately because this aims to land `branch-3.4` too.

### Why are the changes needed?

To prevent a future regression.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.