### PR TITLE
[SPARK-44666][INFRA] Uninstall CodeQL/Go/Node in non-container jobs

### DIFF
--- a/dev/free_disk_space
+++ b/dev/free_disk_space
@@ -34,7 +34,11 @@ sudo rm -rf /usr/local/share/powershell
 sudo rm -rf /usr/local/share/chromium
 sudo rm -rf /usr/local/lib/android
 sudo rm -rf /usr/local/lib/node_modules
+
 sudo rm -rf /opt/az
+sudo rm -rf /opt/hostedtoolcache/CodeQL
+sudo rm -rf /opt/hostedtoolcache/go
+sudo rm -rf /opt/hostedtoolcache/node
 
 sudo apt-get remove --purge -y '^aspnet.*'
 sudo apt-get remove --purge -y '^dotnet-.*'


### PR DESCRIPTION
### What changes were proposed in this pull request?
Uninstall CodeQL/Go/Node in non-container jobs


### Why are the changes needed?
it can save 10G disk space

before this PR:
![image](https://github.com/apache/spark/assets/7322292/dcd45849-4849-4e95-ae76-f5b7c80b19d3)

after this PR:
![image](https://github.com/apache/spark/assets/7322292/042bda6d-43d6-42ea-9f53-abd57766ba99)



### Does this PR introduce _any_ user-facing change?
no, infra-only


### How was this patch tested?
updated CI