### PR TITLE
[SPARK-44669][SQL][HIVE] Parquet/ORC files written using Hive Serde should has file extension

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
@@ -209,6 +209,24 @@ private[spark] object HiveUtils extends Logging {
       .booleanConf
       .createWithDefault(true)
 
+  val HIVE_PARQUET_FILE_EXTENSION_ENABLED =
+    buildConf("spark.sql.hive.fileExtensionParquet.enabled")
+      .doc("When true, append file extension for Parquet files written using Hive Serde, " +
+        "as same as Data Source file format does. The file extension is composed of " +
+        "`.<compression-algorithm>.parquet`, e.g. `.zstd.parquet`.")
+      .version("4.0.0")
+      .booleanConf
+      .createWithDefault(false)
+
+  val HIVE_ORC_FILE_EXTENSION_ENABLED =
+    buildConf("spark.sql.hive.fileExtensionOrc.enabled")
+      .doc("When true, append file extension for ORC files written using Hive Serde, " +
+        "as same as Data Source file format does. The file extension is composed of " +
+        "`.<compression-algorithm>.orc`, e.g. `.zstd.orc`")
+      .version("4.0.0")
+      .booleanConf
+      .createWithDefault(false)
+
   /**
    * The version of the hive client that will be used to communicate with the metastore.  Note that
    * this does not necessarily need to be the same version of Hive that is used internally by


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Add file extensions for Parquet/ORC files written using Hive Serde, to keep behavior consistent with Spark DataSource implementation.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Currently, Parquet/ORC files written using DataSource has extension like `.snappy.orc`, but written using Hive Serde does not.

```
bin/spark-sql \
  --conf spark.sql.hive.convertMetastoreOrc=false \
  --conf spark.sql.hive.convertMetastoreParquet=false

CREATE DATABASE test;
USE test;

CREATE TABLE hive_parquet (id INT, name STRING) STORED AS parquet;
CREATE TABLE ds_parquet   (id INT, name STRING) USING parquet;
CREATE TABLE hive_orc     (id INT, name STRING) STORED AS orc;
CREATE TABLE ds_orc       (id INT, name STRING) USING orc;

INSERT OVERWRITE hive_parquet VALUES(1, 'one');
INSERT OVERWRITE ds_parquet   VALUES(1, 'one');
INSERT OVERWRITE hive_orc     VALUES(1, 'one');
INSERT OVERWRITE ds_orc       VALUES(1, 'one');
```

```
➜  test.db tree
.
├── ds_orc
│   ├── _SUCCESS
│   └── part-00000-583d43f5-e57b-40e3-b2fd-a140ccb90a8e-c000.snappy.orc
├── ds_parquet
│   ├── _SUCCESS
│   └── part-00000-740e0249-c090-4240-90ed-b4e170dd8899-c000.snappy.parquet
├── hive_orc
│   └── part-00000-5a481e57-caf3-471c-9cf3-0ec26e94e7a3-c000
└── hive_parquet
    └── part-00000-27470d2e-4a74-41a5-bcc0-3b5bc872a233-c000

5 directories, 6 files
```

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

After behavior:
```
bin/spark-sql \
  --conf spark.sql.hive.convertMetastoreOrc=false \
  --conf spark.sql.hive.convertMetastoreParquet=false \
  --conf spark.sql.hive.fileExtensionOrc.enabled=true \
  --conf spark.sql.hive.fileExtensionParquet.enabled=true

CREATE DATABASE spark_44669;
USE spark_44669;

CREATE TABLE hive_parquet (id INT, name STRING) STORED AS parquet;
CREATE TABLE ds_parquet   (id INT, name STRING) USING parquet;
CREATE TABLE hive_orc     (id INT, name STRING) STORED AS orc;
CREATE TABLE ds_orc       (id INT, name STRING) USING orc;

INSERT OVERWRITE hive_parquet VALUES(1, 'one');
INSERT OVERWRITE ds_parquet   VALUES(1, 'one');
INSERT OVERWRITE hive_orc     VALUES(1, 'one');
INSERT OVERWRITE ds_orc       VALUES(1, 'one');
```

```
➜  spark_44669.db tree
.
├── ds_orc
│   ├── _SUCCESS
│   └── part-00000-3d48ba2e-61df-4259-9e20-202d5530965b-c000.snappy.orc
├── ds_parquet
│   ├── _SUCCESS
│   └── part-00000-86b05b4b-d49a-40ec-898d-bfa7fb527e81-c000.snappy.parquet
├── hive_orc
│   └── part-00000-a80fc08f-8785-434f-9ba1-92ede7b58886-c000.snappy.orc
└── hive_parquet
    └── part-00000-68b20c75-17ed-45cf-a5ea-043a8e10e432-c000.snappy.parquet

5 directories, 6 files
```