### PR TITLE
[SPARK-44671][PYTHON][CONNECT] Retry ExecutePlan in case initial request didn't reach server in Python client

### DIFF
--- a/python/pyspark/errors/exceptions/connect.py
+++ b/python/pyspark/errors/exceptions/connect.py
@@ -188,3 +188,10 @@ class SparkUpgradeException(SparkConnectGrpcException, BaseSparkUpgradeException
     """
     Exception thrown because of Spark upgrade from Spark Connect.
     """
+
+
+class SparkConnectRetryException(SparkConnectException):
+    """
+    An exception that can be thrown upstream when inside retry and which will be retryable
+    regardless of policy.
+    """

--- a/python/pyspark/errors/exceptions/connect.py
+++ b/python/pyspark/errors/exceptions/connect.py
@@ -188,10 +188,3 @@ class SparkUpgradeException(SparkConnectGrpcException, BaseSparkUpgradeException
     """
     Exception thrown because of Spark upgrade from Spark Connect.
     """
-
-
-class SparkConnectRetryException(SparkConnectException):
-    """
-    An exception that can be thrown upstream when inside retry and which will be retryable
-    regardless of policy.
-    """

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -65,7 +65,10 @@ from google.rpc import error_details_pb2
 from pyspark.version import __version__
 from pyspark.resource.information import ResourceInformation
 from pyspark.sql.connect.client.artifact import ArtifactManager
-from pyspark.sql.connect.client.reattach import ExecutePlanResponseReattachableIterator
+from pyspark.sql.connect.client.reattach import (
+    ExecutePlanResponseReattachableIterator,
+    RetryException,
+)
 from pyspark.sql.connect.conversion import storage_level_to_proto, proto_to_storage_level
 import pyspark.sql.connect.proto as pb2
 import pyspark.sql.connect.proto.base_pb2_grpc as grpc_lib
@@ -74,7 +77,6 @@ from pyspark.errors.exceptions.connect import (
     convert_exception,
     SparkConnectException,
     SparkConnectGrpcException,
-    SparkConnectRetryException,
 )
 from pyspark.sql.connect.expressions import (
     PythonUDF,
@@ -1550,7 +1552,7 @@ class AttemptManager:
     ) -> Optional[bool]:
         if isinstance(exc_val, BaseException):
             # Swallow the exception.
-            if self._can_retry(exc_val) or isinstance(exc_val, SparkConnectRetryException):
+            if self._can_retry(exc_val) or isinstance(exc_val, RetryException):
                 self._retry_state.set_exception(exc_val)
                 return True
             # Bubble up the exception.

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -74,6 +74,7 @@ from pyspark.errors.exceptions.connect import (
     convert_exception,
     SparkConnectException,
     SparkConnectGrpcException,
+    SparkConnectRetryException,
 )
 from pyspark.sql.connect.expressions import (
     PythonUDF,
@@ -1549,7 +1550,7 @@ class AttemptManager:
     ) -> Optional[bool]:
         if isinstance(exc_val, BaseException):
             # Swallow the exception.
-            if self._can_retry(exc_val):
+            if self._can_retry(exc_val) or isinstance(exc_val, SparkConnectRetryException):
                 self._retry_state.set_exception(exc_val)
                 return True
             # Bubble up the exception.

--- a/python/pyspark/sql/connect/client/reattach.py
+++ b/python/pyspark/sql/connect/client/reattach.py
@@ -28,7 +28,6 @@ import os
 import grpc
 from grpc_status import rpc_status
 
-from pyspark.errors.exceptions.connect import SparkConnectRetryException
 import pyspark.sql.connect.proto as pb2
 import pyspark.sql.connect.proto.base_pb2_grpc as grpc_lib
 
@@ -251,7 +250,7 @@ class ExecutePlanResponseReattachableIterator(Generator):
                 self._iterator = iter(
                     self._stub.ExecutePlan(self._initial_request, metadata=self._metadata)
                 )
-                raise SparkConnectRetryException("Retrying ...")
+                raise RetryException()
             else:
                 raise e
 
@@ -298,3 +297,10 @@ class ExecutePlanResponseReattachableIterator(Generator):
 
     def __del__(self) -> None:
         return self.close()
+
+
+class RetryException(Exception):
+    """
+    An exception that can be thrown upstream when inside retry and which will be retryable
+    regardless of policy.
+    """

--- a/python/pyspark/sql/connect/client/reattach.py
+++ b/python/pyspark/sql/connect/client/reattach.py
@@ -252,6 +252,8 @@ class ExecutePlanResponseReattachableIterator(Generator):
                     self._stub.ExecutePlan(self._initial_request, metadata=self._metadata)
                 )
                 raise SparkConnectRetryException("Retrying ...")
+            else:
+                raise e
 
     def _create_reattach_execute_request(self) -> pb2.ReattachExecuteRequest:
         reattach = pb2.ReattachExecuteRequest(


### PR DESCRIPTION
### What changes were proposed in this pull request?

The fix for the symmetry to https://github.com/apache/spark/pull/42282.

### Why are the changes needed?

See also https://github.com/apache/spark/pull/42282

### Does this PR introduce _any_ user-facing change?

See also https://github.com/apache/spark/pull/42282

### How was this patch tested?

See also https://github.com/apache/spark/pull/42282