### PR TITLE
[SPARK-44672][INFRA] Fix git ignore rules related to Antlr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,6 +117,6 @@ spark-warehouse/
 node_modules
 
 # For Antlr
-sql/catalyst/gen/
-sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseLexer.tokens
-sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/gen/
+sql/api/gen/
+sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseLexer.tokens
+sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/gen/


### PR DESCRIPTION
### What changes were proposed in this pull request?
https://github.com/apache/spark/pull/41928 moved antlr4 related files and directories from the `sql/catalyst` module to the `sql/api` module. This pr fix the corresponding git ignore rules to avoid unexpected diffs when executing `git status`.

### Why are the changes needed?
Avoid unexpected diffs when executing `git status`.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Manual check `git status`

**Before**

```
sql/api/gen/
sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/gen/
```

**After**
no diff.
