### PR TITLE
[SPARK-44675][INFRA] Increase ReservedCodeCacheSize for release build

### DIFF
--- a/dev/create-release/release-build.sh
+++ b/dev/create-release/release-build.sh
@@ -220,7 +220,7 @@ git clean -d -f -x
 rm -f .gitignore
 cd ..
 
-export MAVEN_OPTS="-Xss128m -Xmx12g"
+export MAVEN_OPTS="-Xss128m -Xmx12g -XX:ReservedCodeCacheSize=1g"
 
 if [[ "$1" == "package" ]]; then
   # Source and binary tarballs


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR increases `ReservedCodeCacheSize` to 1g for release build.

The current warning and cache size:
```
OpenJDK 64-Bit Server VM warning: CodeCache is full. Compiler has been disabled.
OpenJDK 64-Bit Server VM warning: Try increasing the code cache size using -XX:ReservedCodeCacheSize=
```
```
$ ps -ef
UID        PID  PPID  C STIME TTY          TIME CMD
spark-rm     1     0  0 07:47 pts/0    00:00:00 bash /opt/spark-rm/do-release.sh
spark-rm    13     1  0 07:47 ?        00:00:02 gpg-agent --homedir /home/spark-rm/.gnupg --use-standard-socket --daemon
spark-rm    15     1  0 07:47 pts/0    00:00:00 bash /opt/spark-rm/release-build.sh package
spark-rm  6491     0  0 09:56 pts/1    00:00:00 /bin/sh
spark-rm  7809    15  0 10:07 pts/0    00:00:00 bash ./dev/make-distribution.sh --name hadoop3 --mvn /opt/spark-rm/output/spark-3.3.3-bin-hadoop3/
spark-rm  7977  7809 99 10:07 pts/0    00:01:16 /usr/bin/java -Xss128m -Xmx12g -classpath /opt/spark-rm/output/spark-3.3.3-bin-hadoop3/build/apach
spark-rm  8205  6491  0 10:08 pts/1    00:00:00 ps -ef
$ jinfo -flag ReservedCodeCacheSize   7977
-XX:ReservedCodeCacheSize=251658240
```

### Why are the changes needed?

Reduce build time.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual test.