### PR TITLE
[SPARK-44503][SQL] Project any PARTITION BY expressions not already returned from Python UDTF TABLE arguments

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/FunctionTableSubqueryArgumentExpression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/FunctionTableSubqueryArgumentExpression.scala
@@ -143,10 +143,13 @@ case class FunctionTableSubqueryArgumentExpression(
    * the Python UDTF evaluator so it knows which expressions to compare on adjacent rows to know
    * when the partition has changed.
    */
-  lazy val partitioningExpressionIndexes: Seq[Int] = partitionByExpressions.map { e =>
-    subqueryOutputs.get(e).getOrElse {
-      lazy val extraIndexes = extraProjectedPartitioningExpressions.map(_.child).zipWithIndex.toMap
-      extraIndexes.get(e).get + plan.output.length
+  lazy val partitioningExpressionIndexes: Seq[Int] = {
+    val extraPartitionByExpressionsToIndexes: Map[Expression, Int] =
+      extraProjectedPartitioningExpressions.map(_.child).zipWithIndex.toMap
+    partitionByExpressions.map { e =>
+      subqueryOutputs.get(e).getOrElse {
+        extraPartitionByExpressionsToIndexes.get(e).get + plan.output.length
+      }
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/FunctionTableSubqueryArgumentExpression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/FunctionTableSubqueryArgumentExpression.scala
@@ -140,8 +140,8 @@ case class FunctionTableSubqueryArgumentExpression(
   /**
    * These are the indexes of the PARTITION BY expressions within the concatenation of the child's
    * output attributes and the [[extraProjectedPartitioningExpressions]]. We send these indexes to
-   * the Python UDTF evalator so it knows which expressions to compare on adjacent rows to know when
-   * the partition has changed.
+   * the Python UDTF evaluator so it knows which expressions to compare on adjacent rows to know
+   * when the partition has changed.
    */
   lazy val partitioningExpressionIndexes: Seq[Int] = partitionByExpressions.map { e =>
     subqueryOutputs.get(e).getOrElse {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/FunctionTableSubqueryArgumentExpression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/FunctionTableSubqueryArgumentExpression.scala
@@ -113,11 +113,12 @@ case class FunctionTableSubqueryArgumentExpression(
       subquery = Project(
         projectList = subquery.output ++ extraProjectedPartitioningExpressions,
         child = subquery)
+      val partitioningAttributes = partitioningExpressionIndexes.map(i => subquery.output(i))
       subquery = Sort(
-        order = partitionByExpressions.map(e => SortOrder(e, Ascending)) ++ orderByExpressions,
+        order = partitioningAttributes.map(e => SortOrder(e, Ascending)) ++ orderByExpressions,
         global = false,
         child = RepartitionByExpression(
-          partitionExpressions = partitioningExpressionIndexes.map(i => subquery.output(i)),
+          partitionExpressions = partitioningAttributes,
           optNumPartitions = None,
           child = subquery))
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds a projection when any Python UDTF TABLE argument contains PARTITION BY expressions that are not simple attributes that are already present in the output of the relation.

For example:

```
CREATE TABLE t(d DATE, y INT) USING PARQUET;
INSERT INTO t VALUES ...
SELECT * FROM UDTF(TABLE(t) PARTITION BY EXTRACT(YEAR FROM d) ORDER BY y ASC);
```

This will generate a plan like:

```
+- Sort (y ASC)
  +- RepartitionByExpressions (partition_by_0)
    +- Project (t.d, t.y, EXTRACT(YEAR FROM t.d) AS partition_by_0)
      +- LogicalRelation "t"
```

### Why are the changes needed?

We project the PARTITION BY expressions so that their resulting values appear in attributes that the Python UDTF interpreter can simply inspect in order to know when the partition boundaries have changed.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

This PR adds unit test coverage.