### PR TITLE
[SPARK-44709][CONNECT] Run ExecuteGrpcResponseSender in reattachable execute in new thread to fix flow control

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
@@ -93,7 +93,7 @@ object Connect {
         "Set to 0 for unlimited.")
       .version("3.5.0")
       .timeConf(TimeUnit.MILLISECONDS)
-      .createWithDefaultString("20s")
+      .createWithDefaultString("2m")
 
   val CONNECT_EXECUTE_REATTACHABLE_SENDER_MAX_STREAM_SIZE =
     ConfigBuilder("spark.connect.execute.reattachable.senderMaxStreamSize")

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
@@ -82,7 +82,7 @@ object Connect {
         "Set to 0 for unlimited.")
       .version("3.5.0")
       .timeConf(TimeUnit.MILLISECONDS)
-      .createWithDefaultString("5m")
+      .createWithDefaultString("20s")
 
   val CONNECT_EXECUTE_REATTACHABLE_SENDER_MAX_STREAM_SIZE =
     ConfigBuilder("spark.connect.execute.reattachable.senderMaxStreamSize")

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
@@ -74,6 +74,17 @@ object Connect {
       .intConf
       .createWithDefault(1024)
 
+  val CONNECT_EXECUTE_REATTACHABLE_ENABLED =
+    ConfigBuilder("spark.connect.execute.reattachable.enabled")
+      .internal()
+      .doc("Enables reattachable execution on the server. If disabled and a client requests it, " +
+        "non-reattachable execution will follow and should run until query completion. This will " +
+        "work, unless there is a GRPC stream error, in which case the client will discover that " +
+        "execution is not reattachable when trying to reattach fails.")
+      .version("3.5.0")
+      .booleanConf
+      .createWithDefault(true)
+
   val CONNECT_EXECUTE_REATTACHABLE_SENDER_MAX_STREAM_DURATION =
     ConfigBuilder("spark.connect.execute.reattachable.senderMaxStreamDuration")
       .internal()

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/CachedStreamResponse.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/CachedStreamResponse.scala
@@ -22,6 +22,8 @@ import com.google.protobuf.MessageLite
 private[execution] case class CachedStreamResponse[T <: MessageLite](
     // the actual cached response
     response: T,
+    // the id of the response, an UUID.
+    responseId: String,
     // index of the response in the response stream.
     // responses produced in the stream are numbered consecutively starting from 1.
     streamIndex: Long) {

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/ExecuteResponseObserver.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/ExecuteResponseObserver.scala
@@ -21,7 +21,7 @@ import java.util.UUID
 
 import scala.collection.mutable
 
-import com.google.protobuf.MessageLite
+import com.google.protobuf.Message
 import io.grpc.stub.StreamObserver
 
 import org.apache.spark.{SparkEnv, SparkSQLException}
@@ -47,7 +47,7 @@ import org.apache.spark.sql.connect.service.ExecuteHolder
  * @see
  *   attachConsumer
  */
-private[connect] class ExecuteResponseObserver[T <: MessageLite](val executeHolder: ExecuteHolder)
+private[connect] class ExecuteResponseObserver[T <: Message](val executeHolder: ExecuteHolder)
     extends StreamObserver[T]
     with Logging {
 

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/ExecuteResponseObserver.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/ExecuteResponseObserver.scala
@@ -27,7 +27,7 @@ import io.grpc.stub.StreamObserver
 import org.apache.spark.{SparkEnv, SparkSQLException}
 import org.apache.spark.connect.proto
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.connect.config.Connect.CONNECT_EXECUTE_REATTACHABLE_SENDER_MAX_STREAM_SIZE
+import org.apache.spark.sql.connect.config.Connect.CONNECT_EXECUTE_REATTACHABLE_OBSERVER_RETRY_BUFFER_SIZE
 import org.apache.spark.sql.connect.service.ExecuteHolder
 
 /**
@@ -85,12 +85,18 @@ private[connect] class ExecuteResponseObserver[T <: Message](val executeHolder: 
    */
   private var responseSender: Option[ExecuteGrpcResponseSender[T]] = None
 
+  // Statistics about cached responses.
+  private var cachedSizeUntilHighestConsumed = CachedSize()
+  private var cachedSizeUntilLastProduced = CachedSize()
+  private var autoRemovedSize = CachedSize()
+  private var totalSize = CachedSize()
+
   /**
    * Total size of response to be held buffered after giving out with getResponse. 0 for none, any
    * value greater than 0 will buffer the response from getResponse.
    */
   private val retryBufferSize = if (executeHolder.reattachable) {
-    SparkEnv.get.conf.get(CONNECT_EXECUTE_REATTACHABLE_SENDER_MAX_STREAM_SIZE).toLong
+    SparkEnv.get.conf.get(CONNECT_EXECUTE_REATTACHABLE_OBSERVER_RETRY_BUFFER_SIZE).toLong
   } else {
     0
   }
@@ -101,11 +107,19 @@ private[connect] class ExecuteResponseObserver[T <: Message](val executeHolder: 
     }
     lastProducedIndex += 1
     val processedResponse = setCommonResponseFields(r)
-    responses +=
-      ((lastProducedIndex, CachedStreamResponse[T](processedResponse, lastProducedIndex)))
-    responseIndexToId += ((lastProducedIndex, getResponseId(processedResponse)))
-    responseIdToIndex += ((getResponseId(processedResponse), lastProducedIndex))
-    logDebug(s"Saved response with index=$lastProducedIndex")
+    val responseId = getResponseId(processedResponse)
+    val response = CachedStreamResponse[T](processedResponse, responseId, lastProducedIndex)
+
+    responses += ((lastProducedIndex, response))
+    responseIndexToId += ((lastProducedIndex, responseId))
+    responseIdToIndex += ((responseId, lastProducedIndex))
+
+    cachedSizeUntilLastProduced.add(response)
+    totalSize.add(response)
+
+    logDebug(
+      s"Execution opId=${executeHolder.operationId} produced response " +
+        s"responseId=${responseId} idx=$lastProducedIndex")
     notifyAll()
   }
 
@@ -115,7 +129,9 @@ private[connect] class ExecuteResponseObserver[T <: Message](val executeHolder: 
     }
     error = Some(t)
     finalProducedIndex = Some(lastProducedIndex) // no responses to be send after error.
-    logDebug(s"Error. Last stream index is $lastProducedIndex.")
+    logDebug(
+      s"Execution opId=${executeHolder.operationId} produced error. " +
+        s"Last stream index is $lastProducedIndex.")
     notifyAll()
   }
 
@@ -124,7 +140,9 @@ private[connect] class ExecuteResponseObserver[T <: Message](val executeHolder: 
       throw new IllegalStateException("Stream onCompleted can't be called after stream completed")
     }
     finalProducedIndex = Some(lastProducedIndex)
-    logDebug(s"Completed. Last stream index is $lastProducedIndex.")
+    logDebug(
+      s"Execution opId=${executeHolder.operationId} completed stream. " +
+        s"Last stream index is $lastProducedIndex.")
     notifyAll()
   }
 
@@ -150,9 +168,18 @@ private[connect] class ExecuteResponseObserver[T <: Message](val executeHolder: 
     assert(index <= highestConsumedIndex + 1)
     val ret = responses.get(index)
     if (ret.isDefined) {
-      if (index > highestConsumedIndex) highestConsumedIndex = index
+      if (index > highestConsumedIndex) {
+        highestConsumedIndex = index
+        cachedSizeUntilHighestConsumed.add(ret.get)
+      }
       // When the response is consumed, figure what previous responses can be uncached.
-      removeCachedResponses(index)
+      // (We keep at least one response before the one we send to consumer now)
+      removeCachedResponses(index - 1)
+      logDebug(
+        s"CONSUME opId=${executeHolder.operationId} responseId=${ret.get.responseId} " +
+          s"idx=$index. size=${ret.get.serializedByteSize} " +
+          s"cachedUntilConsumed=$cachedSizeUntilHighestConsumed " +
+          s"cachedUntilProduced=$cachedSizeUntilLastProduced")
     } else if (index <= highestConsumedIndex) {
       // If index is <= highestConsumedIndex and not available, it was already removed from cache.
       // This may happen if ReattachExecute is too late and the cached response was evicted.
@@ -191,6 +218,25 @@ private[connect] class ExecuteResponseObserver[T <: Message](val executeHolder: 
   def removeResponsesUntilId(responseId: String): Unit = synchronized {
     val index = getResponseIndexById(responseId)
     removeResponsesUntilIndex(index)
+    logDebug(
+      s"RELEASE opId=${executeHolder.operationId} until " +
+        s"responseId=$responseId " +
+        s"idx=$index. " +
+        s"cachedUntilConsumed=$cachedSizeUntilHighestConsumed " +
+        s"cachedUntilProduced=$cachedSizeUntilLastProduced")
+  }
+
+  /** Remove all cached responses */
+  def removeAll(): Unit = synchronized {
+    removeResponsesUntilIndex(lastProducedIndex)
+    logInfo(
+      s"Release all for opId=${executeHolder.operationId}. Execution stats: " +
+        s"total=${totalSize} " +
+        s"autoRemoved=${autoRemovedSize} " +
+        s"cachedUntilConsumed=$cachedSizeUntilHighestConsumed " +
+        s"cachedUntilProduced=$cachedSizeUntilLastProduced " +
+        s"maxCachedUntilConsumed=${cachedSizeUntilHighestConsumed.max} " +
+        s"maxCachedUntilProduced=${cachedSizeUntilLastProduced.max}")
   }
 
   /** Returns if the stream is finished. */
@@ -218,16 +264,31 @@ private[connect] class ExecuteResponseObserver[T <: Message](val executeHolder: 
       totalResponsesSize += responses.get(i).get.serializedByteSize
       i -= 1
     }
-    removeResponsesUntilIndex(i)
+    if (responses.get(i).isDefined) {
+      logDebug(
+        s"AUTORELEASE opId=${executeHolder.operationId} until idx=$i. " +
+          s"cachedUntilConsumed=$cachedSizeUntilHighestConsumed " +
+          s"cachedUntilProduced=$cachedSizeUntilLastProduced")
+      removeResponsesUntilIndex(i, true)
+    } else {
+      logDebug(
+        s"NO AUTORELEASE opId=${executeHolder.operationId}. " +
+          s"cachedUntilConsumed=$cachedSizeUntilHighestConsumed " +
+          s"cachedUntilProduced=$cachedSizeUntilLastProduced")
+    }
   }
 
   /**
    * Remove cached responses until given index. Iterating backwards, once an index is encountered
    * that has been removed, all earlier indexes would also be removed.
    */
-  private def removeResponsesUntilIndex(index: Long) = {
+  private def removeResponsesUntilIndex(index: Long, autoRemoved: Boolean = false) = {
     var i = index
     while (i >= 1 && responses.get(i).isDefined) {
+      val r = responses.get(i).get
+      cachedSizeUntilHighestConsumed.remove(r)
+      cachedSizeUntilLastProduced.remove(r)
+      if (autoRemoved) autoRemovedSize.add(r)
       responses.remove(i)
       i -= 1
     }
@@ -257,5 +318,27 @@ private[connect] class ExecuteResponseObserver[T <: Message](val executeHolder: 
       case executePlanResponse: proto.ExecutePlanResponse =>
         executePlanResponse.getResponseId
     }
+  }
+
+  /**
+   * Helper for counting statistics about cached responses.
+   */
+  private case class CachedSize(var bytes: Long = 0L, var num: Long = 0L) {
+    var maxBytes: Long = 0L
+    var maxNum: Long = 0L
+
+    def add(t: CachedStreamResponse[T]): Unit = {
+      bytes += t.serializedByteSize
+      if (bytes > maxBytes) maxBytes = bytes
+      num += 1
+      if (num > maxNum) maxNum = num
+    }
+
+    def remove(t: CachedStreamResponse[T]): Unit = {
+      bytes -= t.serializedByteSize
+      num -= 1
+    }
+
+    def max: CachedSize = CachedSize(maxBytes, maxNum)
   }
 }

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/ExecuteResponseObserver.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/ExecuteResponseObserver.scala
@@ -149,11 +149,8 @@ private[connect] class ExecuteResponseObserver[T <: Message](val executeHolder: 
   /** Attach a new consumer (ExecuteResponseGRPCSender). */
   def attachConsumer(newSender: ExecuteGrpcResponseSender[T]): Unit = synchronized {
     // detach the current sender before attaching new one
-    // this.synchronized() needs to be held while detaching a sender, and the detached sender
-    // needs to be notified with notifyAll() afterwards.
     responseSender.foreach(_.detach())
     responseSender = Some(newSender)
-    notifyAll() // consumer
   }
 
   /**

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/ExecuteThreadRunner.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/ExecuteThreadRunner.scala
@@ -222,7 +222,8 @@ private[connect] class ExecuteThreadRunner(executeHolder: ExecuteHolder) extends
       .build()
   }
 
-  private class ExecutionThread extends Thread {
+  private class ExecutionThread
+      extends Thread(s"SparkConnectExecuteThread_opId=${executeHolder.operationId}") {
     override def run(): Unit = {
       execute()
     }

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/ExecuteHolder.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/ExecuteHolder.scala
@@ -162,6 +162,7 @@ private[connect] class ExecuteHolder(
   def close(): Unit = {
     runner.interrupt()
     runner.join()
+    responseObserver.removeAll()
     eventsManager.postClosed()
     sessionHolder.removeExecuteHolder(operationId)
   }

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/ExecuteHolder.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/ExecuteHolder.scala
@@ -20,11 +20,13 @@ package org.apache.spark.sql.connect.service
 import java.util.UUID
 
 import scala.collection.JavaConverters._
+import scala.collection.mutable
 
-import org.apache.spark.SparkSQLException
+import org.apache.spark.{SparkEnv, SparkSQLException}
 import org.apache.spark.connect.proto
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.connect.common.ProtoUtils
+import org.apache.spark.sql.connect.config.Connect.CONNECT_EXECUTE_REATTACHABLE_ENABLED
 import org.apache.spark.sql.connect.execution.{ExecuteGrpcResponseSender, ExecuteResponseObserver, ExecuteThreadRunner}
 import org.apache.spark.util.SystemClock
 
@@ -35,6 +37,8 @@ private[connect] class ExecuteHolder(
     val request: proto.ExecutePlanRequest,
     val sessionHolder: SessionHolder)
     extends Logging {
+
+  val session = sessionHolder.session
 
   val operationId = if (request.hasOperationId) {
     try {
@@ -73,8 +77,11 @@ private[connect] class ExecuteHolder(
    * If execution is reattachable, it's life cycle is not limited to a single ExecutePlanRequest,
    * but can be reattached with ReattachExecute, and released with ReleaseExecute
    */
-  val reattachable: Boolean = request.getRequestOptionsList.asScala.exists { option =>
-    option.hasReattachOptions && option.getReattachOptions.getReattachable == true
+  val reattachable: Boolean = {
+    SparkEnv.get.conf.get(CONNECT_EXECUTE_REATTACHABLE_ENABLED) &&
+    request.getRequestOptionsList.asScala.exists { option =>
+      option.hasReattachOptions && option.getReattachOptions.getReattachable == true
+    }
   }
 
   /**
@@ -83,7 +90,12 @@ private[connect] class ExecuteHolder(
    */
   var attached: Boolean = true
 
-  val session = sessionHolder.session
+  /**
+   * Threads that execute the ExecuteGrpcResponseSender and send the GRPC responses.
+   *
+   * TODO(SPARK-44625): Joining and cleaning up these threads during cleanup.
+   */
+  val grpcSenderThreads: mutable.ArrayBuffer[Thread] = new mutable.ArrayBuffer[Thread]()
 
   val responseObserver: ExecuteResponseObserver[proto.ExecutePlanResponse] =
     new ExecuteResponseObserver[proto.ExecutePlanResponse](this)

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectExecutePlanHandler.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectExecutePlanHandler.scala
@@ -31,20 +31,10 @@ class SparkConnectExecutePlanHandler(responseObserver: StreamObserver[proto.Exec
       .getOrCreateIsolatedSession(v.getUserContext.getUserId, v.getSessionId)
     val executeHolder = sessionHolder.createExecuteHolder(v)
 
-    try {
-      executeHolder.eventsManager.postStarted()
-      executeHolder.start()
-      val responseSender =
-        new ExecuteGrpcResponseSender[proto.ExecutePlanResponse](executeHolder, responseObserver)
-      executeHolder.attachAndRunGrpcResponseSender(responseSender)
-    } finally {
-      if (!executeHolder.reattachable) {
-        // Non reattachable executions release here immediately.
-        executeHolder.close()
-      } else {
-        // Reattachable executions close release with ReleaseExecute RPC.
-        // TODO We mark in the ExecuteHolder that RPC detached.
-      }
-    }
+    executeHolder.eventsManager.postStarted()
+    executeHolder.start()
+    val responseSender =
+      new ExecuteGrpcResponseSender[proto.ExecutePlanResponse](executeHolder, responseObserver)
+    executeHolder.attachAndRunGrpcResponseSender(responseSender)
   }
 }

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectReattachExecuteHandler.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectReattachExecuteHandler.scala
@@ -44,20 +44,14 @@ class SparkConnectReattachExecuteHandler(
         messageParameters = Map.empty)
     }
 
-    try {
-      val responseSender =
-        new ExecuteGrpcResponseSender[proto.ExecutePlanResponse](executeHolder, responseObserver)
-      if (v.hasLastResponseId) {
-        // start from response after lastResponseId
-        executeHolder.attachAndRunGrpcResponseSender(responseSender, v.getLastResponseId)
-      } else {
-        // start from the start of the stream.
-        executeHolder.attachAndRunGrpcResponseSender(responseSender)
-      }
-    } finally {
-      // Reattachable executions do not free the execution here, but client needs to call
-      // ReleaseExecute RPC.
-      // TODO We mark in the ExecuteHolder that RPC detached.
+    val responseSender =
+      new ExecuteGrpcResponseSender[proto.ExecutePlanResponse](executeHolder, responseObserver)
+    if (v.hasLastResponseId) {
+      // start from response after lastResponseId
+      executeHolder.attachAndRunGrpcResponseSender(responseSender, v.getLastResponseId)
+    } else {
+      // start from the start of the stream.
+      executeHolder.attachAndRunGrpcResponseSender(responseSender)
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

If executePlan / reattachExecute handling is done directly on the GRPC thread, flow control OnReady events are getting queued until after the handler returns, so OnReadyHandler never gets notified until after the handler exits.
The correct way to use it is for the handler to delegate work to another thread and exit. See https://github.com/grpc/grpc-java/issues/7361

Tidied up and added a lot of logging and statistics to ExecuteGrpcResponseSender and ExecuteResponseObserver to be able to observe this behaviour.

Followup work in https://issues.apache.org/jira/browse/SPARK-44625 is needed for cleanup of abandoned executions that will also make sure that these threads are joined.

### Why are the changes needed?

ExecuteGrpcResponseSender gets stuck waiting on grpcCallObserverReadySignal because events from OnReadyHandler do not arrive.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Added extensive debugging to ExecuteGrpcResponseSender and ExecuteResponseObserver and tested and observer the behaviour of all the threads.