### PR TITLE
[SPARK-44688][INFRA] Add a file existence check before executing `free_disk_space` and `free_disk_space_container`

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -241,6 +241,7 @@ jobs:
         restore-keys: |
           ${{ matrix.java }}-${{ matrix.hadoop }}-coursier-
     - name: Free up disk space
+      if: hashFiles('./dev/free_disk_space')
       run: ./dev/free_disk_space
     - name: Install Java ${{ matrix.java }}
       uses: actions/setup-java@v3
@@ -419,7 +420,9 @@ jobs:
           # uninstall libraries dedicated for ML testing
           python3.9 -m pip uninstall -y torch torchvision torcheval torchtnt tensorboard mlflow
         fi
-        ./dev/free_disk_space_container
+        if [ -f ./dev/free_disk_space_container ]; then
+          ./dev/free_disk_space_container
+        fi
     - name: Install Java ${{ matrix.java }}
       uses: actions/setup-java@v3
       with:
@@ -519,6 +522,7 @@ jobs:
         restore-keys: |
           sparkr-coursier-
     - name: Free up disk space
+      if: hashFiles('./dev/free_disk_space_container')
       run: ./dev/free_disk_space_container
     - name: Install Java ${{ inputs.java }}
       uses: actions/setup-java@v3
@@ -629,6 +633,7 @@ jobs:
         restore-keys: |
           docs-maven-
     - name: Free up disk space
+      if: hashFiles('./dev/free_disk_space_container')
       run: ./dev/free_disk_space_container
     - name: Install Java 8
       uses: actions/setup-java@v3

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -241,8 +241,10 @@ jobs:
         restore-keys: |
           ${{ matrix.java }}-${{ matrix.hadoop }}-coursier-
     - name: Free up disk space
-      if: hashFiles('./dev/free_disk_space')
-      run: ./dev/free_disk_space
+      run: |
+        if [ -f ./dev/free_disk_space ]; then
+          ./dev/free_disk_space
+        fi
     - name: Install Java ${{ matrix.java }}
       uses: actions/setup-java@v3
       with:
@@ -522,8 +524,10 @@ jobs:
         restore-keys: |
           sparkr-coursier-
     - name: Free up disk space
-      if: hashFiles('./dev/free_disk_space_container')
-      run: ./dev/free_disk_space_container
+      run: |
+        if [ -f ./dev/free_disk_space_container ]; then
+          ./dev/free_disk_space_container
+        fi
     - name: Install Java ${{ inputs.java }}
       uses: actions/setup-java@v3
       with:
@@ -633,8 +637,10 @@ jobs:
         restore-keys: |
           docs-maven-
     - name: Free up disk space
-      if: hashFiles('./dev/free_disk_space_container')
-      run: ./dev/free_disk_space_container
+      run: |
+        if [ -f ./dev/free_disk_space_container ]; then
+          ./dev/free_disk_space_container
+        fi
     - name: Install Java 8
       uses: actions/setup-java@v3
       with:


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr add a file existence check before executing `dev/free_disk_space` and `dev/free_disk_space_container`

### Why are the changes needed?
We added `free_disk_space` and `free_disk_space_container` to clean up the disk, but because the daily tests of other branches and the master branch share the yml file, we should check if the file exists before execution, otherwise it will affect the daily tests of other branches.

- branch-3.5: https://github.com/apache/spark/actions/runs/5761479443
- branch-3.4: https://github.com/apache/spark/actions/runs/5760423900
- branch-3.3: https://github.com/apache/spark/actions/runs/5759384052

<img width="1073" alt="image" src="https://github.com/apache/spark/assets/1475305/6e46b34b-645a-4da5-b9c3-8a89bfacabcb">


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass GitHub Action