### PR TITLE
[SPARK-44693][BUILD] Rename the `object Catalyst` in SparkBuild to `object SqlApi`

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -451,7 +451,7 @@ object SparkBuild extends PomBuild {
   enable(Unidoc.settings)(spark)
 
   /* Sql-api ANTLR generation settings */
-  enable(Catalyst.settings)(sqlApi)
+  enable(SqlApi.settings)(sqlApi)
 
   /* Spark SQL Core console settings */
   enable(SQL.settings)(sql)
@@ -1171,7 +1171,7 @@ object OldDeps {
   )
 }
 
-object Catalyst {
+object SqlApi {
   import com.simplytyped.Antlr4Plugin
   import com.simplytyped.Antlr4Plugin.autoImport._
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR renames the Setting object used by the `SqlApi` module in `SparkBuild/scala` from `object Catalyst` to `object SqlApi`.


### Why are the changes needed?
The `SqlApi` module should use a more appropriate Setting object name.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass GitHub Actions