### PR TITLE
[SPARK-44680][SQL] Improve the error for parameters in `DEFAULT`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -3158,7 +3158,7 @@ class AstBuilder extends DataTypeAstBuilder with SQLConfHelper with Logging {
     // Make sure it can be converted to Catalyst expressions.
     val expr = expression(exprCtx)
     if (expr.containsPattern(PARAMETER)) {
-      QueryParsingErrors.parameterMarkerNotAllowed(place, expr.origin)
+      throw QueryParsingErrors.parameterMarkerNotAllowed(place, expr.origin)
     }
     // Extract the raw expression text so that we can save the user provided text. We don't
     // use `Expression.sql` to avoid storing incorrect text caused by bugs in any expression's

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -40,6 +40,7 @@ import org.apache.spark.sql.catalyst.parser.SqlBaseParser._
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.trees.CurrentOrigin
+import org.apache.spark.sql.catalyst.trees.TreePattern.PARAMETER
 import org.apache.spark.sql.catalyst.types.DataTypeUtils
 import org.apache.spark.sql.catalyst.util.{CharVarcharUtils, DateTimeUtils, GeneratedColumn, IntervalUtils, ResolveDefaultColumns}
 import org.apache.spark.sql.catalyst.util.DateTimeUtils.{convertSpecialDate, convertSpecialTimestamp, convertSpecialTimestampNTZ, getZoneId, stringToDate, stringToTimestamp, stringToTimestampWithoutTimeZone}
@@ -3153,9 +3154,12 @@ class AstBuilder extends DataTypeAstBuilder with SQLConfHelper with Logging {
     ctx.asScala.headOption.map(visitLocationSpec)
   }
 
-  private def verifyAndGetExpression(exprCtx: ExpressionContext): String = {
+  private def verifyAndGetExpression(exprCtx: ExpressionContext, place: String): String = {
     // Make sure it can be converted to Catalyst expressions.
-    expression(exprCtx)
+    val expr = expression(exprCtx)
+    if (expr.containsPattern(PARAMETER)) {
+      QueryParsingErrors.parameterMarkerNotAllowed(place, expr.origin)
+    }
     // Extract the raw expression text so that we can save the user provided text. We don't
     // use `Expression.sql` to avoid storing incorrect text caused by bugs in any expression's
     // `sql` method. Note: `exprCtx.getText` returns a string without spaces, so we need to
@@ -3170,7 +3174,7 @@ class AstBuilder extends DataTypeAstBuilder with SQLConfHelper with Logging {
    */
   override def visitDefaultExpression(ctx: DefaultExpressionContext): String =
     withOrigin(ctx) {
-      verifyAndGetExpression(ctx.expression())
+      verifyAndGetExpression(ctx.expression(), "DEFAULT")
     }
 
   /**
@@ -3178,7 +3182,7 @@ class AstBuilder extends DataTypeAstBuilder with SQLConfHelper with Logging {
    */
   override def visitGenerationExpression(ctx: GenerationExpressionContext): String =
     withOrigin(ctx) {
-      verifyAndGetExpression(ctx.expression())
+      verifyAndGetExpression(ctx.expression(), "GENERATED")
     }
 
   /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/ParametersSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ParametersSuite.scala
@@ -495,10 +495,11 @@ class ParametersSuite extends QueryTest with SharedSparkSession {
           "CREATE TABLE t11(c1 int default :parm) USING parquet",
           args = Map("parm" -> 5))
       },
-      errorClass = "INVALID_DEFAULT_VALUE.UNRESOLVED_EXPRESSION",
-      parameters = Map(
-        "statement" -> "CREATE TABLE",
-        "colName" -> "`c1`",
-        "defaultValue" -> ":parm"))
+      errorClass = "UNSUPPORTED_FEATURE.PARAMETER_MARKER_IN_UNEXPECTED_STATEMENT",
+      parameters = Map("statement" -> "DEFAULT"),
+      context = ExpectedContext(
+        fragment = "default :parm",
+        start = 24,
+        stop = 36))
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/ParametersSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ParametersSuite.scala
@@ -487,4 +487,18 @@ class ParametersSuite extends QueryTest with SharedSparkSession {
         start = 7,
         stop = 13))
   }
+
+  test("SPARK-44680: parameters in DEFAULT") {
+    checkError(
+      exception = intercept[AnalysisException] {
+        spark.sql(
+          "CREATE TABLE t11(c1 int default :parm) USING parquet",
+          args = Map("parm" -> 5))
+      },
+      errorClass = "INVALID_DEFAULT_VALUE.UNRESOLVED_EXPRESSION",
+      parameters = Map(
+        "statement" -> "CREATE TABLE",
+        "colName" -> "`c1`",
+        "defaultValue" -> ":parm"))
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to check that `DEFAULT` clause contains a parameter. If so, raise appropriate error about the feature is not supported. Currently, table creation with `DEFAULT` containing any parameters finishes successfully even parameters are not supported in such case:
```sql
scala>  spark.sql("CREATE TABLE t12(c1 int default :parm)", args = Map("parm" -> 5)).show()
++
||
++
++
scala>  spark.sql("describe t12");
org.apache.spark.sql.AnalysisException: [INVALID_DEFAULT_VALUE.UNRESOLVED_EXPRESSION] Failed to execute EXISTS_DEFAULT command because the destination table column `c1` has a DEFAULT value :parm, which fails to resolve as a valid expression.
```

### Why are the changes needed?
This improves user experience with Spark SQL by saying about the root cause of the issue.

### Does this PR introduce _any_ user-facing change?
Yes. After the change, the table creation completes w/ the error:
```sql
scala> spark.sql("CREATE TABLE t12(c1 int default :parm)", args = Map("parm" -> 5)).show()
org.apache.spark.sql.catalyst.parser.ParseException:
[UNSUPPORTED_FEATURE.PARAMETER_MARKER_IN_UNEXPECTED_STATEMENT] The feature is not supported: Parameter markers are not allowed in DEFAULT.(line 1, pos 32)

== SQL ==
CREATE TABLE t12(c1 int default :parm)
--------------------------------^^^
```

### How was this patch tested?
By running new test:
```
$ build/sbt "test:testOnly *ParametersSuite"
```