### PR TITLE
[SPARK-44697][CORE] Clean up the deprecated usage of `o.a.commons.lang3.RandomUtils`

### DIFF
--- a/core/src/test/java/org/apache/spark/io/GenericFileInputStreamSuite.java
+++ b/core/src/test/java/org/apache/spark/io/GenericFileInputStreamSuite.java
@@ -17,7 +17,6 @@
 package org.apache.spark.io;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.RandomUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -25,6 +24,7 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.concurrent.ThreadLocalRandom;
 
 import static org.junit.Assert.assertEquals;
 
@@ -33,7 +33,8 @@ import static org.junit.Assert.assertEquals;
  */
 public abstract class GenericFileInputStreamSuite {
 
-  private byte[] randomBytes;
+  // Create a byte array of size 2 MB with random bytes
+  private byte[] randomBytes = new byte[2 * 1024 * 1024];
 
   protected File inputFile;
 
@@ -41,8 +42,7 @@ public abstract class GenericFileInputStreamSuite {
 
   @Before
   public void setUp() throws IOException {
-    // Create a byte array of size 2 MB with random bytes
-    randomBytes =  RandomUtils.nextBytes(2 * 1024 * 1024);
+    ThreadLocalRandom.current().nextBytes(randomBytes);
     inputFile = File.createTempFile("temp-file", ".tmp");
     FileUtils.writeByteArrayToFile(inputFile, randomBytes);
   }

--- a/core/src/test/scala/org/apache/spark/deploy/master/PersistenceEngineSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/master/PersistenceEngineSuite.scala
@@ -19,8 +19,8 @@
 package org.apache.spark.deploy.master
 
 import java.net.ServerSocket
+import java.util.concurrent.ThreadLocalRandom
 
-import org.apache.commons.lang3.RandomUtils
 import org.apache.curator.test.TestingServer
 
 import org.apache.spark.{SecurityManager, SparkConf, SparkFunSuite}
@@ -117,7 +117,7 @@ class PersistenceEngineSuite extends SparkFunSuite {
   }
 
   private def findFreePort(conf: SparkConf): Int = {
-    val candidatePort = RandomUtils.nextInt(1024, 65536)
+    val candidatePort = ThreadLocalRandom.current().nextInt(1024, 65536)
     Utils.startServiceOnPort(candidatePort, (trialPort: Int) => {
       val socket = new ServerSocket(trialPort)
       socket.close()

--- a/core/src/test/scala/org/apache/spark/metrics/InputOutputMetricsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/metrics/InputOutputMetricsSuite.scala
@@ -18,10 +18,10 @@
 package org.apache.spark.metrics
 
 import java.io.{File, PrintWriter}
+import java.util.concurrent.ThreadLocalRandom
 
 import scala.collection.mutable.ArrayBuffer
 
-import org.apache.commons.lang3.RandomUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.hadoop.io.{LongWritable, Text}
@@ -54,7 +54,7 @@ class InputOutputMetricsSuite extends SparkFunSuite with SharedSparkContext
     Utils.tryWithResource(new PrintWriter(tmpFile)) { pw =>
       for (x <- 1 to numRecords) {
         // scalastyle:off println
-        pw.println(RandomUtils.nextInt(0, numBuckets))
+        pw.println(ThreadLocalRandom.current().nextInt(0, numBuckets))
         // scalastyle:on println
       }
     }

--- a/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
@@ -20,6 +20,7 @@ package org.apache.spark.storage
 import java.io.{File, InputStream, IOException}
 import java.nio.ByteBuffer
 import java.nio.file.Files
+import java.util.concurrent.ThreadLocalRandom
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
@@ -31,7 +32,6 @@ import scala.reflect.ClassTag
 import scala.reflect.classTag
 
 import com.esotericsoftware.kryo.KryoException
-import org.apache.commons.lang3.RandomUtils
 import org.mockito.{ArgumentCaptor, ArgumentMatchers => mc}
 import org.mockito.Mockito.{doAnswer, mock, never, spy, times, verify, when}
 import org.scalatest.PrivateMethodTester
@@ -1887,7 +1887,7 @@ class BlockManagerSuite extends SparkFunSuite with Matchers with PrivateMethodTe
         (transCtx.createServer(port, Seq.empty[TransportServerBootstrap].asJava), port)
       }
 
-      val candidatePort = RandomUtils.nextInt(1024, 65536)
+      val candidatePort = ThreadLocalRandom.current().nextInt(1024, 65536)
       val (server, shufflePort) = Utils.startServiceOnPort(candidatePort,
         newShuffleServer, conf, "ShuffleServer")
 
@@ -2274,7 +2274,7 @@ class BlockManagerSuite extends SparkFunSuite with Matchers with PrivateMethodTe
         (transCtx.createServer(port, Seq.empty[TransportServerBootstrap].asJava), port)
       }
 
-      val candidatePort = RandomUtils.nextInt(1024, 65536)
+      val candidatePort = ThreadLocalRandom.current().nextInt(1024, 65536)
       val (server, shufflePort) = Utils.startServiceOnPort(candidatePort,
         newShuffleServer, conf, "ShuffleServer")
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
In `commons-lang3` 3.13.0, `RandomUtils` has been marked as `@Deprecated`, the Java doc of `commons-lang3` suggests to instead use the api of `commons-rng`. 

https://github.com/apache/commons-lang/blob/bcc10b359318397a4d12dbaef22b101725bc6323/src/main/java/org/apache/commons/lang3/RandomUtils.java#L33

```
 * @deprecated Use Apache Commons RNG's optimized <a href="https://commons.apache.org/proper/commons-rng/commons-rng-client-api/apidocs/org/apache/commons/rng/UniformRandomProvider.html">UniformRandomProvider</a>

```

However, as Spark only uses `RandomUtils` in test code, so this pr attempts to replace `RandomUtils` with `ThreadLocalRandom` to avoid introducing additional third-party dependencies.

### Why are the changes needed?
Clean up the use of Deprecated api.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions