### PR TITLE
[SPARK-44699][CORE] Add log when finished write events to file in EventLogFileWriter.closeWriter

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/EventLogFileWriters.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/EventLogFileWriters.scala
@@ -124,7 +124,10 @@ abstract class EventLogFileWriter(
   }
 
   protected def closeWriter(): Unit = {
-    writer.foreach(_.close())
+    writer.foreach(w => {
+      logInfo(s"Finished logging events to $logPath")
+      w.close()
+    })
   }
 
   protected def renameFile(src: Path, dest: Path, overwrite: Boolean): Unit = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add log when finished write events to file in EventLogFileWriter.closeWriter.


### Why are the changes needed?
Sometimes we want to know when to finish logging the events to eventLog file, we need add a log to make it clearer.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Manual test, the change just relate to log.
