### PR TITLE
[SPARK-44698][SQL] Create table like other table should also copy tab…

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -130,6 +130,7 @@ case class CreateTableLikeCommand(
         partitionColumnNames = sourceTableDesc.partitionColumnNames,
         bucketSpec = sourceTableDesc.bucketSpec,
         properties = properties,
+        stats = sourceTableDesc.stats,
         tracksPartitionsInCatalog = sourceTableDesc.tracksPartitionsInCatalog)
 
     catalog.createTable(newTableDesc, ifNotExists)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -2236,6 +2236,19 @@ abstract class DDLSuite extends QueryTest with DDLSuiteBase {
     }
   }
 
+  test("SPARK-44698 Create table like should also copy table stats") {
+    val catalog = spark.sessionState.catalog
+    withTable("s", "t1") {
+      sql("CREATE TABLE s(a INT, b INT)")
+      sql("INSERT INTO s VALUES(1, 2)")
+      val source = catalog.getTableMetadata(TableIdentifier("s"))
+
+      sql("CREATE TABLE t1 LIKE s")
+      val table1 = catalog.getTableMetadata(TableIdentifier("t1"))
+      assert(table1.stats.size == source.stats.size)
+    }
+  }
+
   test(s"Add a directory when ${SQLConf.LEGACY_ADD_SINGLE_FILE_IN_ADD_FILE.key} set to false") {
     // SPARK-43093: Don't use `withTempDir` to clean up temp dir, it will cause test cases in
     // shared session that need to execute `Executor.updateDependencies` test fail.


### PR DESCRIPTION
…le stats.

### What changes were proposed in this pull request?

Jira:
[SPARK-44698](https://issues.apache.org/jira/browse/SPARK-44698)

Create table like other table should also copy table stats, now the stats is missing from the source table to the target table, for example:
For example:
describe table extended tbl;

col0                    int
col1                    int
col2                    int
col3                    int

Detailed Table Information
Catalog                 spark_catalog
Database                default
Table                   tbl
Owner                   zhuqi
Created Time            Mon Aug 07 14:02:30 CST 2023
Last Access             UNKNOWN
Created By              Spark 4.0.0-SNAPSHOT
Type                    MANAGED
Provider                hive
Table Properties        [transient_lastDdlTime=1691388473]
Statistics              30 bytes
Location                [file:/Users/zhuqi/spark/spark/spark-warehouse/tbl](file:///Users/zhuqi/spark/spark/spark-warehouse/tbl)
Serde Library           org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
InputFormat             org.apache.hadoop.mapred.TextInputFormat
OutputFormat            org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
Storage Properties      [serialization.format=1]
Partition Provider      Catalog
Time taken: 0.032 seconds, Fetched 23 row(s)

create table tbl2 like tbl;
23/08/07 14:14:07 WARN HiveMetaStore: Location: [file:/Users/zhuqi/spark/spark/spark-warehouse/tbl2](file:///Users/zhuqi/spark/spark/spark-warehouse/tbl2) specified for non-external table:tbl2
Time taken: 0.098 seconds
spark-sql (default)> describe table extended tbl2;
col0                    int
col1                    int
col2                    int
col3                    int

Detailed Table Information
Catalog                 spark_catalog
Database                default
Table                   tbl2
Owner                   zhuqi
Created Time            Mon Aug 07 14:14:07 CST 2023
Last Access             UNKNOWN
Created By              Spark 4.0.0-SNAPSHOT
Type                    MANAGED
Provider                hive
Table Properties        [transient_lastDdlTime=1691388847]
Location                [file:/Users/zhuqi/spark/spark/spark-warehouse/tbl2](file:///Users/zhuqi/spark/spark/spark-warehouse/tbl2)
Serde Library           org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
InputFormat             org.apache.hadoop.mapred.TextInputFormat
OutputFormat            org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
Storage Properties      [serialization.format=1]
Partition Provider      Catalog
Time taken: 0.03 seconds, Fetched 22 row(s)

The table stats are missing.



### Why are the changes needed?

1. Add the stats to copy.
2. Add the corresponding unit test to test.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
I create a unit test in code to confirm it.
