### PR TITLE
[SPARK-44701][PYTHON][TESTS] Skip `ClassificationTestsOnConnect` when `torch` is not installed

### DIFF
--- a/python/pyspark/ml/tests/connect/test_connect_classification.py
+++ b/python/pyspark/ml/tests/connect/test_connect_classification.py
@@ -20,7 +20,14 @@ import unittest
 from pyspark.sql import SparkSession
 from pyspark.ml.tests.connect.test_legacy_mode_classification import ClassificationTestsMixin
 
+have_torch = True
+try:
+    import torch  # noqa: F401
+except ImportError:
+    have_torch = False
 
+
+@unittest.skipIf(not have_torch, "torch is required")
 class ClassificationTestsOnConnect(ClassificationTestsMixin, unittest.TestCase):
     def setUp(self) -> None:
         self.spark = (


### PR DESCRIPTION
### What changes were proposed in this pull request?
Skip `ClassificationTestsOnConnect` when `torch` is not installed


### Why are the changes needed?
we moved torch on connect tests to `pyspark_ml_connect`, so module `pyspark_connect` won't have `torch`

to fix https://github.com/apache/spark/actions/runs/5776211318/job/15655104006 in 3.5 daily GA:

```
Starting test(python3.9): pyspark.ml.tests.connect.test_connect_classification (temp output: /__w/spark/spark/python/target/fbb6a495-df65-4334-8c04-4befc9ee81df/python3.9__pyspark.ml.tests.connect.test_connect_classification__jp1htw6f.log)
Traceback (most recent call last):
  File "/usr/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/__w/spark/spark/python/pyspark/ml/tests/connect/test_connect_classification.py", line 21, in <module>
    from pyspark.ml.tests.connect.test_legacy_mode_classification import ClassificationTestsMixin
  File "/__w/spark/spark/python/pyspark/ml/tests/connect/test_legacy_mode_classification.py", line 22, in <module>
    from pyspark.ml.connect.classification import (
  File "/__w/spark/spark/python/pyspark/ml/connect/classification.py", line 46, in <module>
    import torch
ModuleNotFoundError: No module named 'torch'
```


### Does this PR introduce _any_ user-facing change?
no, test-only


### How was this patch tested?
CI
