### PR TITLE
[SPARK-44700][SQL] Rule OptimizeCsvJsonExprs should not be applied to expression like from_json(regexp_replace)

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/OptimizeCsvJsonExprs.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/OptimizeCsvJsonExprs.scala
@@ -102,8 +102,12 @@ object OptimizeCsvJsonExprs extends Rule[LogicalPlan] {
       // this case similarly.
       child
 
-    case g @ GetStructField(j @ JsonToStructs(schema: StructType, _, _, _), ordinal, _)
-        if schema.length > 1 && j.options.isEmpty =>
+    case g @ GetStructField(j @ JsonToStructs(schema: StructType, _, child, _), ordinal, _)
+        if schema.length > 1 && j.options.isEmpty && child.exists {
+          case _: RegExpReplace => false
+          case _: RegExpExtract => false
+          case _ => true
+        } =>
         // Options here should be empty because the optimization should not be enabled
         // for some options. For example, when the parse mode is failfast it should not
         // optimize, and should force to parse the whole input JSON with failing fast for


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Rule OptimizeCsvJsonExprs should not be applied to expression like from_json(regexp_replace)
 


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
 It causes performance regression.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
yes,
sql like this:
```
select tmp.* 
 from
 (select
        device_id, ads_id, 
        from_json(regexp_replace(device_personas, '(?<=(\\\\\\{|,))"device_', '"user_device_'), ${device_schema}) as tmp
        from input )

${device_schema} includes more than 100 fields.
```
before this pr: 
it takes 42 minutes.
<img width="597" alt="image" src="https://github.com/apache/spark/assets/9074114/865314de-a048-4c19-9dfe-552fb3cc2ddc">

After this pr:
it takes 6 minutes.
<img width="642" alt="image" src="https://github.com/apache/spark/assets/9074114/a374e828-2582-4fbb-8f32-c8e640b8c2e7">

If Rule: OptimizeJsonExprs not been applied, 
in physical plan : ProjectExec 
function: InterpretedUnsafeProjection.createProjection or GenerateUnsafeProjection.generate will  eliminate common expression,so that regexp_replace will been computed  just one time.

If Rule: OptimizeJsonExprs been applied,  regexp_replace will been computed as many times as numbers of ${device_schema}  fields . 

BTW, it hard to find root cause, in this examples, it took me 2 days to find out the root cause. 





### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
NO, it just a rule optimization for OptimizeJsonExprs