### PR TITLE
[SPARK-44703][CORE] Log eventLog rewrite duration when compact old event log files

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/EventLogFileCompactor.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/EventLogFileCompactor.scala
@@ -149,6 +149,7 @@ class EventLogFileCompactor(
     val logWriter = new CompactedEventLogFileWriter(lastIndexEventLogPath, "dummy", None,
       lastIndexEventLogPath.getParent.toUri, sparkConf, hadoopConf)
 
+    val startTime = System.nanoTime()
     logWriter.start()
     eventLogFiles.foreach { file =>
       EventFilter.applyFilterToFile(fs, filters, file.getPath,
@@ -158,6 +159,8 @@ class EventLogFileCompactor(
       )
     }
     logWriter.stop()
+    val duration = System.nanoTime() - startTime
+    logInfo(s"Finished rewriting eventLog files to ${logWriter.logPath} took $duration ms.")
 
     logWriter.logPath
   }

--- a/core/src/main/scala/org/apache/spark/deploy/history/EventLogFileCompactor.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/EventLogFileCompactor.scala
@@ -149,7 +149,7 @@ class EventLogFileCompactor(
     val logWriter = new CompactedEventLogFileWriter(lastIndexEventLogPath, "dummy", None,
       lastIndexEventLogPath.getParent.toUri, sparkConf, hadoopConf)
 
-    val startTime = System.nanoTime()
+    val startTime = System.currentTimeMillis()
     logWriter.start()
     eventLogFiles.foreach { file =>
       EventFilter.applyFilterToFile(fs, filters, file.getPath,
@@ -159,7 +159,7 @@ class EventLogFileCompactor(
       )
     }
     logWriter.stop()
-    val duration = System.nanoTime() - startTime
+    val duration = System.currentTimeMillis() - startTime
     logInfo(s"Finished rewriting eventLog files to ${logWriter.logPath} took $duration ms.")
 
     logWriter.logPath


### PR DESCRIPTION
### What changes were proposed in this pull request?
Log eventLog rewrite duration when compact old event log files.


### Why are the changes needed?
When enable `spark.eventLog.rolling.enabled` and the number of eventLog files exceeds the value of `spark.history.fs.eventLog.rolling.maxFilesToRetain`, HistoryServer will compact the old event log files into one compact file.

Currently there is no log the rewrite duration in rewrite method, this metric is useful for understand the compact duration, so we need add logs in the method.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Manual test.
