### PR TITLE
[SPARK-44696][SQL] Support different timestamp precise for `from_json` function

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonParser.scala
@@ -286,7 +286,14 @@ class JacksonParser(
           }
 
         case VALUE_NUMBER_INT =>
-          parser.getLongValue * 1000000L
+          // consider negative number, which started with '-'
+          if (parser.getTextLength < 13) {
+            parser.getLongValue * 1000000L
+          } else if (parser.getTextLength < 16) {
+            parser.getLongValue * 1000L
+          } else {
+            parser.getLongValue * 1L
+          }
       }
 
     case TimestampNTZType =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
@@ -293,6 +293,33 @@ class JsonFunctionsSuite extends QueryTest with SharedSparkSession {
       Row(Row(java.sql.Date.valueOf("2015-08-26"))))
   }
 
+  test("from_json with timestamp in second") {
+    val df = Seq("""{"timestamp": 1691241070}""").toDS()
+    val schema = new StructType().add("timestamp", TimestampType)
+
+    checkAnswer(
+      df.select(from_json($"value", schema)),
+      Row(Row(java.sql.Timestamp.valueOf("2023-08-05 06:11:10.0"))))
+  }
+
+  test("from_json with timestamp in millisecond") {
+    val df = Seq("""{"timestamp": 1691241070000}""").toDS()
+    val schema = new StructType().add("timestamp", TimestampType)
+
+    checkAnswer(
+      df.select(from_json($"value", schema)),
+      Row(Row(java.sql.Timestamp.valueOf("2023-08-05 06:11:10.0"))))
+  }
+
+  test("from_json with timestamp in microsecond") {
+    val df = Seq("""{"timestamp": 1691241070000000}""").toDS()
+    val schema = new StructType().add("timestamp", TimestampType)
+
+    checkAnswer(
+      df.select(from_json($"value", schema)),
+      Row(Row(java.sql.Timestamp.valueOf("2023-08-05 06:11:10.0"))))
+  }
+
   test("from_json with option (allowUnquotedControlChars)") {
     val df = Seq("{\"str\": \"a\u0001b\"}").toDS()
     val schema = new StructType().add("str", StringType)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Add more cases to support  long value of different length to convert to timestamp in `from_json` function.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Currently, `from_json` function will treat all input timestamp as second precise.
However, if the input is millisecond or microsecond, this function will return wrong result and throw no exception, which will lead to misunderstanding.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Pass GitHub Actions. And the fellowing lines are test cases:
query & result before
```
spark-sql> SELECT from_json('{"a":1, "b":1691241070}', 'a INT, b TIMESTAMP');
{"a":1,"b":2023-08-05 21:11:10}
spark-sql> SELECT from_json('{"a":1, "b":1691241070000}', 'a INT, b TIMESTAMP');
{"a":1,"b":+55563-04-19 18:06:40}
spark-sql> SELECT from_json('{"a":1, "b":1691241070000000}', 'a INT, b TIMESTAMP');
{"a":1,"b":-183707-06-27 20:24:24.251328}

spark-sql> SELECT from_json('{"a":1, "b":-1691241070}', 'a INT, b TIMESTAMP');
{"a":1,"b":1916-05-29 18:48:50}
spark-sql> SELECT from_json('{"a":1, "b":-1691241070000}', 'a INT, b TIMESTAMP');
{"a":1,"b":-51624-09-14 21:59:03}
spark-sql> SELECT from_json('{"a":1, "b":-1691241070000000}', 'a INT, b TIMESTAMP');
{"a":1,"b":+187646-07-06 19:41:18.748672}
```

query & result after
```
spark-sql> SELECT from_json('{"a":1, "b":1691241070}', 'a INT, b TIMESTAMP');
{"a":1,"b":2023-08-05 21:11:10}
spark-sql> SELECT from_json('{"a":1, "b":1691241070000}', 'a INT, b TIMESTAMP');
{"a":1,"b":2023-08-05 21:11:10}
spark-sql> SELECT from_json('{"a":1, "b":1691241070000000}', 'a INT, b TIMESTAMP');
{"a":1,"b":2023-08-05 21:11:10}

spark-sql> SELECT from_json('{"a":1, "b":-1691241070}', 'a INT, b TIMESTAMP');
{"a":1,"b":1916-05-29 18:48:50}
spark-sql> SELECT from_json('{"a":1, "b":-1691241070000}', 'a INT, b TIMESTAMP');
{"a":1,"b":1916-05-29 18:48:50}
spark-sql> SELECT from_json('{"a":1, "b":-1691241070000000}', 'a INT, b TIMESTAMP');
{"a":1,"b":1916-05-29 18:48:50}
```



