### PR TITLE
[WIP][SPARK-40909][SQL] Reuse the broadcast exchange for bloom filter

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/runtimefilter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/runtimefilter.scala
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.expressions
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, ExprCode}
+import org.apache.spark.sql.catalyst.plans.logical.{HintInfo, LogicalPlan}
+import org.apache.spark.sql.catalyst.trees.TreePattern.{RUNTIME_FILTER_EXPRESSION, RUNTIME_FILTER_SUBQUERY, TreePattern}
+import org.apache.spark.sql.catalyst.trees.UnaryLike
+import org.apache.spark.sql.types.DataType
+
+/**
+ * The RuntimeFilterSubquery expression is only used in runtime filter. It is inserted in cases
+ * when broadcast exchange can be reused.
+ *
+ * @param filterApplicationSideExp the filtering key of the application side.
+ * @param buildPlan the bloom filter plan of build side.
+ * @param joinKeys the join keys corresponding to the build side of the join
+ * @param broadcastKeyIndex the index of the filtering key collected from the broadcast
+ */
+case class RuntimeFilterSubquery(
+    filterApplicationSideExp: Expression,
+    buildPlan: LogicalPlan,
+    joinKeys: Seq[Expression],
+    broadcastKeyIndex: Int,
+    exprId: ExprId = NamedExpression.newExprId,
+    hint: Option[HintInfo] = None)
+  extends SubqueryExpression(buildPlan, Seq(filterApplicationSideExp), exprId, Seq.empty, hint)
+    with Unevaluable
+    with UnaryLike[Expression] {
+
+  override def child: Expression = filterApplicationSideExp
+
+  override def dataType: DataType = {
+    assert(buildPlan.schema.fields.nonEmpty,
+      "Runtime filter subquery should have only one column")
+    buildPlan.schema.fields.head.dataType
+  }
+
+  override def plan: LogicalPlan = buildPlan
+
+  override def nullable: Boolean = false
+
+  override def withNewPlan(plan: LogicalPlan): RuntimeFilterSubquery =
+    copy(buildPlan = plan)
+
+  override def withNewHint(hint: Option[HintInfo]): SubqueryExpression = copy(hint = hint)
+
+  override lazy val resolved: Boolean = {
+    filterApplicationSideExp.resolved &&
+      buildPlan.resolved &&
+      joinKeys.nonEmpty &&
+      joinKeys.forall(_.resolved) &&
+      broadcastKeyIndex >= 0 &&
+      broadcastKeyIndex < joinKeys.size &&
+      filterApplicationSideExp.dataType == joinKeys(broadcastKeyIndex).dataType
+  }
+
+  final override def nodePatternsInternal: Seq[TreePattern] = Seq(RUNTIME_FILTER_SUBQUERY)
+
+  override def toString: String = s"runtimefilter#${exprId.id} $conditionString"
+
+  override lazy val canonicalized: RuntimeFilterSubquery = {
+    copy(
+      filterApplicationSideExp = filterApplicationSideExp.canonicalized,
+      buildPlan = buildPlan.canonicalized,
+      joinKeys = joinKeys.map(_.canonicalized),
+      exprId = ExprId(0))
+  }
+
+  override protected def withNewChildInternal(newChild: Expression): RuntimeFilterSubquery =
+    copy(filterApplicationSideExp = newChild)
+}
+
+/**
+ * Marker for a planned runtime filter expression.
+ * The expression is created during planning, and it defers to its child for evaluation.
+ *
+ * @param child underlying aggregate for runtime filter.
+ */
+case class RuntimeFilterExpression(child: Expression)
+  extends UnaryExpression {
+  override def dataType: DataType = child.dataType
+  override def eval(input: InternalRow): Any = child.eval(input)
+  final override val nodePatterns: Seq[TreePattern] = Seq(RUNTIME_FILTER_EXPRESSION)
+
+  override protected def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
+    child.genCode(ctx)
+  }
+
+  override protected def withNewChildInternal(newChild: Expression): RuntimeFilterExpression =
+    copy(child = newChild)
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InjectRuntimeFilter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InjectRuntimeFilter.scala
@@ -48,14 +48,18 @@ object InjectRuntimeFilter extends Rule[LogicalPlan] with PredicateHelper with J
       filterApplicationSideExp: Expression,
       filterApplicationSidePlan: LogicalPlan,
       filterCreationSideExp: Expression,
-      filterCreationSidePlan: LogicalPlan): LogicalPlan = {
+      filterCreationSidePlan: LogicalPlan,
+      hint: JoinHint): LogicalPlan = {
     require(conf.runtimeFilterBloomFilterEnabled || conf.runtimeFilterSemiJoinReductionEnabled)
     if (conf.runtimeFilterBloomFilterEnabled) {
+      val canReuseExchange = conf.exchangeReuseEnabled &&
+        (canBroadcastBySize(filterCreationSidePlan, conf) || hintToBroadcastRight(hint))
       injectBloomFilter(
         filterApplicationSideExp,
         filterApplicationSidePlan,
         filterCreationSideExp,
-        filterCreationSidePlan
+        filterCreationSidePlan,
+        canReuseExchange
       )
     } else {
       injectInSubqueryFilter(
@@ -71,7 +75,8 @@ object InjectRuntimeFilter extends Rule[LogicalPlan] with PredicateHelper with J
       filterApplicationSideExp: Expression,
       filterApplicationSidePlan: LogicalPlan,
       filterCreationSideExp: Expression,
-      filterCreationSidePlan: LogicalPlan): LogicalPlan = {
+      filterCreationSidePlan: LogicalPlan,
+      canReuseExchange: Boolean): LogicalPlan = {
     // Skip if the filter creation side is too big
     if (filterCreationSidePlan.stats.sizeInBytes > conf.runtimeFilterCreationSideThreshold) {
       return filterApplicationSidePlan
@@ -87,7 +92,12 @@ object InjectRuntimeFilter extends Rule[LogicalPlan] with PredicateHelper with J
     val alias = Alias(bloomFilterAgg.toAggregateExpression(), "bloomFilter")()
     val aggregate =
       ConstantFolding(ColumnPruning(Aggregate(Nil, Seq(alias), filterCreationSidePlan)))
-    val bloomFilterSubquery = ScalarSubquery(aggregate, Nil)
+    val bloomFilterSubquery = if (canReuseExchange) {
+      // Try to reuse the results of broadcast exchange.
+      RuntimeFilterSubquery(filterApplicationSideExp, aggregate, Seq(filterCreationSideExp), 0)
+    } else {
+      ScalarSubquery(aggregate, Nil)
+    }
     val filter = BloomFilterMightContain(bloomFilterSubquery,
       new XxHash64(Seq(filterApplicationSideExp)))
     Filter(filter, filterApplicationSidePlan)
@@ -329,14 +339,14 @@ object InjectRuntimeFilter extends Rule[LogicalPlan] with PredicateHelper with J
             if (canPruneLeft(joinType)) {
               extractBeneficialFilterCreatePlan(left, right, l, r, hint).foreach {
                 filterCreationSidePlan =>
-                  newLeft = injectFilter(l, newLeft, r, filterCreationSidePlan)
+                  newLeft = injectFilter(l, newLeft, r, filterCreationSidePlan, hint)
               }
             }
             // Did we actually inject on the left? If not, try on the right
             if (newLeft.fastEquals(oldLeft) && canPruneRight(joinType)) {
               extractBeneficialFilterCreatePlan(right, left, r, l, hint).foreach {
                 filterCreationSidePlan =>
-                  newRight = injectFilter(r, newRight, l, filterCreationSidePlan)
+                  newRight = injectFilter(r, newRight, l, filterCreationSidePlan, hint)
               }
             }
             if (!newLeft.fastEquals(oldLeft) || !newRight.fastEquals(oldRight)) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InjectRuntimeFilter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InjectRuntimeFilter.scala
@@ -94,7 +94,7 @@ object InjectRuntimeFilter extends Rule[LogicalPlan] with PredicateHelper with J
       ConstantFolding(ColumnPruning(Aggregate(Nil, Seq(alias), filterCreationSidePlan)))
     val bloomFilterSubquery = if (canReuseExchange) {
       // Try to reuse the results of broadcast exchange.
-      RuntimeFilterSubquery(filterApplicationSideExp, aggregate, Seq(filterCreationSideExp), 0)
+      RuntimeFilterSubquery(filterApplicationSideExp, aggregate, filterCreationSideExp)
     } else {
       ScalarSubquery(aggregate, Nil)
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
@@ -81,12 +81,15 @@ object TreePattern extends Enumeration  {
   val REGEXP_EXTRACT_FAMILY: Value = Value
   val REGEXP_REPLACE: Value = Value
   val RUNTIME_REPLACEABLE: Value = Value
+  val RUNTIME_FILTER_EXPRESSION: Value = Value
+  val RUNTIME_FILTER_SUBQUERY: Value = Value
   val SCALAR_SUBQUERY: Value = Value
   val SCALAR_SUBQUERY_REFERENCE: Value = Value
   val SCALA_UDF: Value = Value
   val SESSION_WINDOW: Value = Value
   val SORT: Value = Value
   val SUBQUERY_ALIAS: Value = Value
+  val SUBQUERY_WRAPPER: Value = Value
   val SUM: Value = Value
   val TIME_WINDOW: Value = Value
   val TIME_ZONE_AWARE_EXPRESSION: Value = Value

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/PlanRuntimeFilterFilters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/PlanRuntimeFilterFilters.scala
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.expressions.{BindReferences, RuntimeFilterExpression, RuntimeFilterSubquery}
+import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight}
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.catalyst.trees.TreePattern.RUNTIME_FILTER_SUBQUERY
+import org.apache.spark.sql.execution.aggregate.ObjectHashAggregateExec
+import org.apache.spark.sql.execution.exchange.{BroadcastExchangeExec, BroadcastExchangeExecProxy, ShuffleExchangeExec}
+import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, HashedRelationBroadcastMode, HashJoin}
+
+/**
+ * This planner rule aims at rewriting runtime filter in order to reuse the
+ * results of broadcast. For joins that are not planned as broadcast hash joins we keep
+ * the fallback mechanism with subquery duplicate.
+ */
+case class PlanRuntimeFilterFilters(sparkSession: SparkSession) extends Rule[SparkPlan] {
+  override def apply(plan: SparkPlan): SparkPlan = {
+    if (!conf.runtimeFilterBloomFilterEnabled) {
+      return plan
+    }
+
+    plan.transformAllExpressionsWithPruning(_.containsPattern(RUNTIME_FILTER_SUBQUERY)) {
+      case RuntimeFilterSubquery(
+      _, buildPlan, buildKeys, broadcastKeyIndex, exprId, _) =>
+        val sparkPlan = QueryExecution.createSparkPlan(
+          sparkSession, sparkSession.sessionState.planner, buildPlan)
+        val filterCreationSidePlan = getFilterCreationSidePlan(sparkPlan)
+
+        // Using `sparkPlan` is a little hacky as it is based on the assumption that this rule is
+        // the first to be applied (apart from `InsertAdaptiveSparkPlan`).
+        val canReuseExchange = conf.exchangeReuseEnabled && buildKeys.nonEmpty &&
+          plan.exists {
+            case BroadcastHashJoinExec(_, _, _, BuildLeft, _, left, _, _) =>
+              left.sameResult(filterCreationSidePlan)
+            case BroadcastHashJoinExec(_, _, _, BuildRight, _, _, right, _) =>
+              right.sameResult(filterCreationSidePlan)
+            case _ => false
+          }
+
+        val executedPlan = QueryExecution.prepareExecutedPlan(sparkSession, sparkPlan)
+
+        val bloomFilterSubquery = if (canReuseExchange) {
+          val executedFilterCreationSidePlan = getFilterCreationSidePlan(executedPlan)
+          val packedKeys = BindReferences.bindReferences(
+            HashJoin.rewriteKeyExpr(buildKeys), executedFilterCreationSidePlan.output)
+          val mode = HashedRelationBroadcastMode(packedKeys)
+          // plan a broadcast exchange of the build side of the join
+          val exchange = BroadcastExchangeExec(mode, executedFilterCreationSidePlan)
+          val name = s"runtimefilter#${exprId.id}"
+          val broadcastValues = SubqueryBroadcastExec(name, broadcastKeyIndex, buildKeys, exchange)
+          val broadcastProxy =
+            BroadcastExchangeExecProxy(broadcastValues, executedFilterCreationSidePlan.output)
+
+          val newExecutedPlan = executedPlan transformUp {
+            case hashAggregateExec: ObjectHashAggregateExec
+              if hashAggregateExec.child.eq(executedFilterCreationSidePlan) =>
+              hashAggregateExec.copy(child = broadcastProxy)
+          }
+
+          ScalarSubquery(
+            SubqueryExec.createForScalarSubquery(
+              s"scalar-subquery#${exprId.id}",
+              newExecutedPlan), exprId)
+        } else {
+          ScalarSubquery(
+            SubqueryExec.createForScalarSubquery(
+              s"scalar-subquery#${exprId.id}",
+              executedPlan), exprId)
+        }
+
+        RuntimeFilterExpression(bloomFilterSubquery)
+    }
+  }
+
+  private def getFilterCreationSidePlan(plan: SparkPlan): SparkPlan = {
+    assert(plan.isInstanceOf[ObjectHashAggregateExec])
+    plan.asInstanceOf[ObjectHashAggregateExec].child match {
+      case objectHashAggregate: ObjectHashAggregateExec =>
+        objectHashAggregate.child
+      case shuffleExchange: ShuffleExchangeExec =>
+        shuffleExchange.child.asInstanceOf[ObjectHashAggregateExec].child
+      case other => other
+    }
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
@@ -443,6 +443,7 @@ object QueryExecution {
     Seq(
       CoalesceBucketsInJoin,
       PlanDynamicPruningFilters(sparkSession),
+      PlanRuntimeFilterFilters(sparkSession),
       PlanSubqueries(sparkSession),
       RemoveRedundantProjects,
       EnsureRequirements(),

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
@@ -137,6 +137,7 @@ case class AdaptiveSparkPlanExec(
   // optimizations should be stage-independent.
   @transient private val queryStageOptimizerRules: Seq[Rule[SparkPlan]] = Seq(
     PlanAdaptiveDynamicPruningFilters(this),
+    PlanAdaptiveRuntimeFilterFilters(this),
     ReuseAdaptiveSubquery(context.subqueryCache),
     OptimizeSkewInRebalancePartitions,
     CoalesceShufflePartitions(context.session),

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/PlanAdaptiveRuntimeFilterFilters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/PlanAdaptiveRuntimeFilterFilters.scala
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.adaptive
+
+import org.apache.spark.sql.catalyst.expressions.{BindReferences, RuntimeFilterExpression}
+import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight}
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.catalyst.trees.TreePattern.{RUNTIME_FILTER_EXPRESSION, SUBQUERY_WRAPPER}
+import org.apache.spark.sql.execution.{QueryExecution, ScalarSubquery, SparkPlan, SubqueryAdaptiveBroadcastExec, SubqueryBroadcastExec, SubqueryExec, SubqueryWrapper}
+import org.apache.spark.sql.execution.aggregate.ObjectHashAggregateExec
+import org.apache.spark.sql.execution.exchange.{BroadcastExchangeExec, BroadcastExchangeExecProxy, ShuffleExchangeExec}
+import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, HashedRelationBroadcastMode, HashJoin}
+
+/**
+ * A rule to insert runtime filter in order to reuse the results of broadcast.
+ */
+case class PlanAdaptiveRuntimeFilterFilters(
+    rootPlan: AdaptiveSparkPlanExec) extends Rule[SparkPlan] with AdaptiveSparkPlanHelper {
+
+  def apply(plan: SparkPlan): SparkPlan = {
+    if (!conf.runtimeFilterBloomFilterEnabled) {
+      return plan
+    }
+
+    plan.transformAllExpressionsWithPruning(
+      _.containsAllPatterns(RUNTIME_FILTER_EXPRESSION, SUBQUERY_WRAPPER)) {
+      case RuntimeFilterExpression(SubqueryWrapper(
+      SubqueryAdaptiveBroadcastExec(name, index, true, _, buildKeys,
+      adaptivePlan: AdaptiveSparkPlanExec), exprId)) =>
+        val filterCreationSidePlan = getFilterCreationSidePlan(adaptivePlan.executedPlan)
+        val executedFilterCreationSidePlan =
+          QueryExecution.prepareExecutedPlan(adaptivePlan.session, filterCreationSidePlan)
+        val packedKeys = BindReferences.bindReferences(
+          HashJoin.rewriteKeyExpr(buildKeys), executedFilterCreationSidePlan.output)
+        val mode = HashedRelationBroadcastMode(packedKeys)
+        // plan a broadcast exchange of the build side of the join
+        val exchange = BroadcastExchangeExec(mode, executedFilterCreationSidePlan)
+
+        val canReuseExchange = conf.exchangeReuseEnabled && buildKeys.nonEmpty &&
+          find(rootPlan) {
+            case BroadcastHashJoinExec(_, _, _, BuildLeft, _, left, _, _) =>
+              if (left.isInstanceOf[BroadcastQueryStageExec]) {
+                left.asInstanceOf[BroadcastQueryStageExec].plan.sameResult(exchange)
+              } else {
+                left.sameResult(exchange)
+              }
+            case BroadcastHashJoinExec(_, _, _, BuildRight, _, _, right, _) =>
+              if (right.isInstanceOf[BroadcastQueryStageExec]) {
+                right.asInstanceOf[BroadcastQueryStageExec].plan.sameResult(exchange)
+              } else {
+                right.sameResult(exchange)
+              }
+            case _ => false
+          }.isDefined
+
+        val bloomFilterSubquery = if (canReuseExchange) {
+          exchange.setLogicalLink(filterCreationSidePlan.logicalLink.get)
+
+          val broadcastValues = SubqueryBroadcastExec(name, index, buildKeys, exchange)
+          val broadcastProxy =
+            BroadcastExchangeExecProxy(broadcastValues, executedFilterCreationSidePlan.output)
+
+          val newExecutedPlan = adaptivePlan.executedPlan transformUp {
+            case hashAggregateExec: ObjectHashAggregateExec
+              if hashAggregateExec.child.eq(filterCreationSidePlan) =>
+              hashAggregateExec.copy(child = broadcastProxy)
+          }
+          val newAdaptivePlan = adaptivePlan.copy(inputPlan = newExecutedPlan)
+
+          ScalarSubquery(
+            SubqueryExec.createForScalarSubquery(
+              s"scalar-subquery#${exprId.id}",
+              newAdaptivePlan), exprId)
+        } else {
+          ScalarSubquery(
+            SubqueryExec.createForScalarSubquery(
+              s"scalar-subquery#${exprId.id}",
+              adaptivePlan), exprId)
+        }
+
+        RuntimeFilterExpression(bloomFilterSubquery)
+    }
+  }
+
+  private def getFilterCreationSidePlan(plan: SparkPlan): SparkPlan = {
+    plan match {
+      case objectHashAggregate: ObjectHashAggregateExec =>
+        getFilterCreationSidePlan(objectHashAggregate.child)
+      case shuffleExchange: ShuffleExchangeExec =>
+        getFilterCreationSidePlan(shuffleExchange.child)
+      case queryStageExec: ShuffleQueryStageExec =>
+        getFilterCreationSidePlan(queryStageExec.plan)
+      case other => other
+    }
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/PlanAdaptiveSubqueries.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/PlanAdaptiveSubqueries.scala
@@ -53,10 +53,10 @@ case class PlanAdaptiveSubqueries(
           buildPlan, buildKeys, subqueryMap(exprId.id))
         DynamicPruningExpression(InSubqueryExec(value, subquery, exprId))
       case expressions.RuntimeFilterSubquery(_, buildPlan,
-          buildKeys, broadcastKeyIndex, exprId, _) =>
+          buildKey, exprId, _) =>
         val name = s"runtimefilter#${exprId.id}"
         val subquery = SubqueryAdaptiveBroadcastExec(
-          name, broadcastKeyIndex, true, buildPlan, buildKeys, subqueryMap(exprId.id))
+          name, 0, true, buildPlan, Seq(buildKey), subqueryMap(exprId.id))
         RuntimeFilterExpression(SubqueryWrapper(subquery, exprId))
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/Exchange.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/Exchange.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.execution.exchange
 import org.apache.spark.broadcast
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeMap, Expression, SortOrder}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeMap, AttributeSet, Expression, SortOrder}
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
 import org.apache.spark.sql.catalyst.trees.TreePattern._
 import org.apache.spark.sql.execution._
@@ -98,6 +98,8 @@ case class ReusedExchangeExec(override val output: Seq[Attribute], child: Exchan
  */
 case class BroadcastExchangeExecProxy(
     child: SparkPlan, output: Seq[Attribute]) extends UnaryExecNode {
+
+  override def producedAttributes: AttributeSet = AttributeSet(output)
 
   def doExecute(): RDD[InternalRow] = {
     val broadcastedValues = child.executeCollect()

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q10.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q10.sf100/explain.txt
@@ -1,13 +1,13 @@
 == Physical Plan ==
-TakeOrderedAndProject (48)
-+- * HashAggregate (47)
-   +- Exchange (46)
-      +- * HashAggregate (45)
-         +- * Project (44)
-            +- * BroadcastHashJoin Inner BuildLeft (43)
-               :- BroadcastExchange (39)
-               :  +- * Project (38)
-               :     +- * BroadcastHashJoin Inner BuildRight (37)
+TakeOrderedAndProject (44)
++- * HashAggregate (43)
+   +- Exchange (42)
+      +- * HashAggregate (41)
+         +- * Project (40)
+            +- * BroadcastHashJoin Inner BuildLeft (39)
+               :- BroadcastExchange (35)
+               :  +- * Project (34)
+               :     +- * BroadcastHashJoin Inner BuildRight (33)
                :        :- * Project (31)
                :        :  +- * SortMergeJoin LeftSemi (30)
                :        :     :- * SortMergeJoin LeftSemi (21)
@@ -39,14 +39,10 @@ TakeOrderedAndProject (48)
                :        :                 :  +- * ColumnarToRow (23)
                :        :                 :     +- Scan parquet spark_catalog.default.store_sales (22)
                :        :                 +- ReusedExchange (25)
-               :        +- BroadcastExchange (36)
-               :           +- * Project (35)
-               :              +- * Filter (34)
-               :                 +- * ColumnarToRow (33)
-               :                    +- Scan parquet spark_catalog.default.customer_address (32)
-               +- * Filter (42)
-                  +- * ColumnarToRow (41)
-                     +- Scan parquet spark_catalog.default.customer_demographics (40)
+               :        +- ReusedExchange (32)
+               +- * Filter (38)
+                  +- * ColumnarToRow (37)
+                     +- Scan parquet spark_catalog.default.customer_demographics (36)
 
 
 (1) Scan parquet spark_catalog.default.customer
@@ -61,7 +57,7 @@ Input [3]: [c_customer_sk#1, c_current_cdemo_sk#2, c_current_addr_sk#3]
 
 (3) Filter [codegen id : 1]
 Input [3]: [c_customer_sk#1, c_current_cdemo_sk#2, c_current_addr_sk#3]
-Condition : (((isnotnull(c_customer_sk#1) AND isnotnull(c_current_addr_sk#3)) AND isnotnull(c_current_cdemo_sk#2)) AND might_contain(Subquery scalar-subquery#4, [id=#5], xxhash64(c_current_addr_sk#3, 42)))
+Condition : (((isnotnull(c_customer_sk#1) AND isnotnull(c_current_addr_sk#3)) AND isnotnull(c_current_cdemo_sk#2)) AND might_contain(runtimefilterexpression(Subquery scalar-subquery#4, [id=#5]), xxhash64(c_current_addr_sk#3, 42)))
 
 (4) Exchange
 Input [3]: [c_customer_sk#1, c_current_cdemo_sk#2, c_current_addr_sk#3]
@@ -86,7 +82,7 @@ Input [2]: [ws_bill_customer_sk#6, ws_sold_date_sk#7]
 Input [2]: [ws_bill_customer_sk#6, ws_sold_date_sk#7]
 Condition : isnotnull(ws_bill_customer_sk#6)
 
-(9) ReusedExchange [Reuses operator id: 60]
+(9) ReusedExchange [Reuses operator id: 59]
 Output [1]: [d_date_sk#9]
 
 (10) BroadcastHashJoin [codegen id : 4]
@@ -114,7 +110,7 @@ Input [2]: [cs_ship_customer_sk#11, cs_sold_date_sk#12]
 Input [2]: [cs_ship_customer_sk#11, cs_sold_date_sk#12]
 Condition : isnotnull(cs_ship_customer_sk#11)
 
-(15) ReusedExchange [Reuses operator id: 60]
+(15) ReusedExchange [Reuses operator id: 59]
 Output [1]: [d_date_sk#13]
 
 (16) BroadcastHashJoin [codegen id : 6]
@@ -158,7 +154,7 @@ Input [2]: [ss_customer_sk#15, ss_sold_date_sk#16]
 Input [2]: [ss_customer_sk#15, ss_sold_date_sk#16]
 Condition : isnotnull(ss_customer_sk#15)
 
-(25) ReusedExchange [Reuses operator id: 60]
+(25) ReusedExchange [Reuses operator id: 59]
 Output [1]: [d_date_sk#17]
 
 (26) BroadcastHashJoin [codegen id : 10]
@@ -189,163 +185,153 @@ Join condition: None
 Output [2]: [c_current_cdemo_sk#2, c_current_addr_sk#3]
 Input [3]: [c_customer_sk#1, c_current_cdemo_sk#2, c_current_addr_sk#3]
 
-(32) Scan parquet spark_catalog.default.customer_address
-Output [2]: [ca_address_sk#19, ca_county#20]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer_address]
-PushedFilters: [In(ca_county, [Dona Ana County,Douglas County,Gaines County,Richland County,Walker County]), IsNotNull(ca_address_sk)]
-ReadSchema: struct<ca_address_sk:int,ca_county:string>
-
-(33) ColumnarToRow [codegen id : 12]
-Input [2]: [ca_address_sk#19, ca_county#20]
-
-(34) Filter [codegen id : 12]
-Input [2]: [ca_address_sk#19, ca_county#20]
-Condition : (ca_county#20 IN (Walker County,Richland County,Gaines County,Douglas County,Dona Ana County) AND isnotnull(ca_address_sk#19))
-
-(35) Project [codegen id : 12]
+(32) ReusedExchange [Reuses operator id: 49]
 Output [1]: [ca_address_sk#19]
-Input [2]: [ca_address_sk#19, ca_county#20]
 
-(36) BroadcastExchange
-Input [1]: [ca_address_sk#19]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=4]
-
-(37) BroadcastHashJoin [codegen id : 13]
+(33) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [c_current_addr_sk#3]
 Right keys [1]: [ca_address_sk#19]
 Join type: Inner
 Join condition: None
 
-(38) Project [codegen id : 13]
+(34) Project [codegen id : 13]
 Output [1]: [c_current_cdemo_sk#2]
 Input [3]: [c_current_cdemo_sk#2, c_current_addr_sk#3, ca_address_sk#19]
 
-(39) BroadcastExchange
+(35) BroadcastExchange
 Input [1]: [c_current_cdemo_sk#2]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=4]
 
-(40) Scan parquet spark_catalog.default.customer_demographics
-Output [9]: [cd_demo_sk#21, cd_gender#22, cd_marital_status#23, cd_education_status#24, cd_purchase_estimate#25, cd_credit_rating#26, cd_dep_count#27, cd_dep_employed_count#28, cd_dep_college_count#29]
+(36) Scan parquet spark_catalog.default.customer_demographics
+Output [9]: [cd_demo_sk#20, cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_demographics]
 PushedFilters: [IsNotNull(cd_demo_sk)]
 ReadSchema: struct<cd_demo_sk:int,cd_gender:string,cd_marital_status:string,cd_education_status:string,cd_purchase_estimate:int,cd_credit_rating:string,cd_dep_count:int,cd_dep_employed_count:int,cd_dep_college_count:int>
 
-(41) ColumnarToRow
-Input [9]: [cd_demo_sk#21, cd_gender#22, cd_marital_status#23, cd_education_status#24, cd_purchase_estimate#25, cd_credit_rating#26, cd_dep_count#27, cd_dep_employed_count#28, cd_dep_college_count#29]
+(37) ColumnarToRow
+Input [9]: [cd_demo_sk#20, cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
 
-(42) Filter
-Input [9]: [cd_demo_sk#21, cd_gender#22, cd_marital_status#23, cd_education_status#24, cd_purchase_estimate#25, cd_credit_rating#26, cd_dep_count#27, cd_dep_employed_count#28, cd_dep_college_count#29]
-Condition : isnotnull(cd_demo_sk#21)
+(38) Filter
+Input [9]: [cd_demo_sk#20, cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
+Condition : isnotnull(cd_demo_sk#20)
 
-(43) BroadcastHashJoin [codegen id : 14]
+(39) BroadcastHashJoin [codegen id : 14]
 Left keys [1]: [c_current_cdemo_sk#2]
-Right keys [1]: [cd_demo_sk#21]
+Right keys [1]: [cd_demo_sk#20]
 Join type: Inner
 Join condition: None
 
-(44) Project [codegen id : 14]
-Output [8]: [cd_gender#22, cd_marital_status#23, cd_education_status#24, cd_purchase_estimate#25, cd_credit_rating#26, cd_dep_count#27, cd_dep_employed_count#28, cd_dep_college_count#29]
-Input [10]: [c_current_cdemo_sk#2, cd_demo_sk#21, cd_gender#22, cd_marital_status#23, cd_education_status#24, cd_purchase_estimate#25, cd_credit_rating#26, cd_dep_count#27, cd_dep_employed_count#28, cd_dep_college_count#29]
+(40) Project [codegen id : 14]
+Output [8]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
+Input [10]: [c_current_cdemo_sk#2, cd_demo_sk#20, cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
 
-(45) HashAggregate [codegen id : 14]
-Input [8]: [cd_gender#22, cd_marital_status#23, cd_education_status#24, cd_purchase_estimate#25, cd_credit_rating#26, cd_dep_count#27, cd_dep_employed_count#28, cd_dep_college_count#29]
-Keys [8]: [cd_gender#22, cd_marital_status#23, cd_education_status#24, cd_purchase_estimate#25, cd_credit_rating#26, cd_dep_count#27, cd_dep_employed_count#28, cd_dep_college_count#29]
+(41) HashAggregate [codegen id : 14]
+Input [8]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
+Keys [8]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
 Functions [1]: [partial_count(1)]
-Aggregate Attributes [1]: [count#30]
-Results [9]: [cd_gender#22, cd_marital_status#23, cd_education_status#24, cd_purchase_estimate#25, cd_credit_rating#26, cd_dep_count#27, cd_dep_employed_count#28, cd_dep_college_count#29, count#31]
+Aggregate Attributes [1]: [count#29]
+Results [9]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28, count#30]
 
-(46) Exchange
-Input [9]: [cd_gender#22, cd_marital_status#23, cd_education_status#24, cd_purchase_estimate#25, cd_credit_rating#26, cd_dep_count#27, cd_dep_employed_count#28, cd_dep_college_count#29, count#31]
-Arguments: hashpartitioning(cd_gender#22, cd_marital_status#23, cd_education_status#24, cd_purchase_estimate#25, cd_credit_rating#26, cd_dep_count#27, cd_dep_employed_count#28, cd_dep_college_count#29, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+(42) Exchange
+Input [9]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28, count#30]
+Arguments: hashpartitioning(cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
-(47) HashAggregate [codegen id : 15]
-Input [9]: [cd_gender#22, cd_marital_status#23, cd_education_status#24, cd_purchase_estimate#25, cd_credit_rating#26, cd_dep_count#27, cd_dep_employed_count#28, cd_dep_college_count#29, count#31]
-Keys [8]: [cd_gender#22, cd_marital_status#23, cd_education_status#24, cd_purchase_estimate#25, cd_credit_rating#26, cd_dep_count#27, cd_dep_employed_count#28, cd_dep_college_count#29]
+(43) HashAggregate [codegen id : 15]
+Input [9]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28, count#30]
+Keys [8]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
 Functions [1]: [count(1)]
-Aggregate Attributes [1]: [count(1)#32]
-Results [14]: [cd_gender#22, cd_marital_status#23, cd_education_status#24, count(1)#32 AS cnt1#33, cd_purchase_estimate#25, count(1)#32 AS cnt2#34, cd_credit_rating#26, count(1)#32 AS cnt3#35, cd_dep_count#27, count(1)#32 AS cnt4#36, cd_dep_employed_count#28, count(1)#32 AS cnt5#37, cd_dep_college_count#29, count(1)#32 AS cnt6#38]
+Aggregate Attributes [1]: [count(1)#31]
+Results [14]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, count(1)#31 AS cnt1#32, cd_purchase_estimate#24, count(1)#31 AS cnt2#33, cd_credit_rating#25, count(1)#31 AS cnt3#34, cd_dep_count#26, count(1)#31 AS cnt4#35, cd_dep_employed_count#27, count(1)#31 AS cnt5#36, cd_dep_college_count#28, count(1)#31 AS cnt6#37]
 
-(48) TakeOrderedAndProject
-Input [14]: [cd_gender#22, cd_marital_status#23, cd_education_status#24, cnt1#33, cd_purchase_estimate#25, cnt2#34, cd_credit_rating#26, cnt3#35, cd_dep_count#27, cnt4#36, cd_dep_employed_count#28, cnt5#37, cd_dep_college_count#29, cnt6#38]
-Arguments: 100, [cd_gender#22 ASC NULLS FIRST, cd_marital_status#23 ASC NULLS FIRST, cd_education_status#24 ASC NULLS FIRST, cd_purchase_estimate#25 ASC NULLS FIRST, cd_credit_rating#26 ASC NULLS FIRST, cd_dep_count#27 ASC NULLS FIRST, cd_dep_employed_count#28 ASC NULLS FIRST, cd_dep_college_count#29 ASC NULLS FIRST], [cd_gender#22, cd_marital_status#23, cd_education_status#24, cnt1#33, cd_purchase_estimate#25, cnt2#34, cd_credit_rating#26, cnt3#35, cd_dep_count#27, cnt4#36, cd_dep_employed_count#28, cnt5#37, cd_dep_college_count#29, cnt6#38]
+(44) TakeOrderedAndProject
+Input [14]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cnt1#32, cd_purchase_estimate#24, cnt2#33, cd_credit_rating#25, cnt3#34, cd_dep_count#26, cnt4#35, cd_dep_employed_count#27, cnt5#36, cd_dep_college_count#28, cnt6#37]
+Arguments: 100, [cd_gender#21 ASC NULLS FIRST, cd_marital_status#22 ASC NULLS FIRST, cd_education_status#23 ASC NULLS FIRST, cd_purchase_estimate#24 ASC NULLS FIRST, cd_credit_rating#25 ASC NULLS FIRST, cd_dep_count#26 ASC NULLS FIRST, cd_dep_employed_count#27 ASC NULLS FIRST, cd_dep_college_count#28 ASC NULLS FIRST], [cd_gender#21, cd_marital_status#22, cd_education_status#23, cnt1#32, cd_purchase_estimate#24, cnt2#33, cd_credit_rating#25, cnt3#34, cd_dep_count#26, cnt4#35, cd_dep_employed_count#27, cnt5#36, cd_dep_college_count#28, cnt6#37]
 
 ===== Subqueries =====
 
 Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#4, [id=#5]
-ObjectHashAggregate (55)
-+- Exchange (54)
-   +- ObjectHashAggregate (53)
-      +- * Project (52)
-         +- * Filter (51)
-            +- * ColumnarToRow (50)
-               +- Scan parquet spark_catalog.default.customer_address (49)
+ObjectHashAggregate (54)
++- Exchange (53)
+   +- ObjectHashAggregate (52)
+      +- BroadcastExchangeExecProxy (51)
 
 
-(49) Scan parquet spark_catalog.default.customer_address
-Output [2]: [ca_address_sk#19, ca_county#20]
+(45) Scan parquet spark_catalog.default.customer_address
+Output [2]: [ca_address_sk#19, ca_county#38]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [In(ca_county, [Dona Ana County,Douglas County,Gaines County,Richland County,Walker County]), IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_county:string>
 
-(50) ColumnarToRow [codegen id : 1]
-Input [2]: [ca_address_sk#19, ca_county#20]
+(46) ColumnarToRow [codegen id : 1]
+Input [2]: [ca_address_sk#19, ca_county#38]
 
-(51) Filter [codegen id : 1]
-Input [2]: [ca_address_sk#19, ca_county#20]
-Condition : (ca_county#20 IN (Walker County,Richland County,Gaines County,Douglas County,Dona Ana County) AND isnotnull(ca_address_sk#19))
+(47) Filter [codegen id : 1]
+Input [2]: [ca_address_sk#19, ca_county#38]
+Condition : (ca_county#38 IN (Walker County,Richland County,Gaines County,Douglas County,Dona Ana County) AND isnotnull(ca_address_sk#19))
 
-(52) Project [codegen id : 1]
+(48) Project [codegen id : 1]
 Output [1]: [ca_address_sk#19]
-Input [2]: [ca_address_sk#19, ca_county#20]
+Input [2]: [ca_address_sk#19, ca_county#38]
 
-(53) ObjectHashAggregate
+(49) BroadcastExchange
+Input [1]: [ca_address_sk#19]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=6]
+
+(50) SubqueryBroadcast
+Input [1]: [ca_address_sk#19]
+Arguments: runtimefilter#4, 0, [ca_address_sk#19], [id=#39]
+
+(51) BroadcastExchangeExecProxy
+Input [1]: [ca_address_sk#40]
+Arguments: [ca_address_sk#19]
+
+(52) ObjectHashAggregate
 Input [1]: [ca_address_sk#19]
 Keys: []
 Functions [1]: [partial_bloom_filter_agg(xxhash64(ca_address_sk#19, 42), 2555, 57765, 0, 0)]
-Aggregate Attributes [1]: [buf#39]
-Results [1]: [buf#40]
+Aggregate Attributes [1]: [buf#41]
+Results [1]: [buf#42]
 
-(54) Exchange
-Input [1]: [buf#40]
+(53) Exchange
+Input [1]: [buf#42]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=7]
 
-(55) ObjectHashAggregate
-Input [1]: [buf#40]
+(54) ObjectHashAggregate
+Input [1]: [buf#42]
 Keys: []
 Functions [1]: [bloom_filter_agg(xxhash64(ca_address_sk#19, 42), 2555, 57765, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(ca_address_sk#19, 42), 2555, 57765, 0, 0)#41]
-Results [1]: [bloom_filter_agg(xxhash64(ca_address_sk#19, 42), 2555, 57765, 0, 0)#41 AS bloomFilter#42]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(ca_address_sk#19, 42), 2555, 57765, 0, 0)#43]
+Results [1]: [bloom_filter_agg(xxhash64(ca_address_sk#19, 42), 2555, 57765, 0, 0)#43 AS bloomFilter#44]
 
 Subquery:2 Hosting operator id = 6 Hosting Expression = ws_sold_date_sk#7 IN dynamicpruning#8
-BroadcastExchange (60)
-+- * Project (59)
-   +- * Filter (58)
-      +- * ColumnarToRow (57)
-         +- Scan parquet spark_catalog.default.date_dim (56)
+BroadcastExchange (59)
++- * Project (58)
+   +- * Filter (57)
+      +- * ColumnarToRow (56)
+         +- Scan parquet spark_catalog.default.date_dim (55)
 
 
-(56) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#9, d_year#43, d_moy#44]
+(55) Scan parquet spark_catalog.default.date_dim
+Output [3]: [d_date_sk#9, d_year#45, d_moy#46]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), EqualTo(d_year,2002), GreaterThanOrEqual(d_moy,4), LessThanOrEqual(d_moy,7), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
 
-(57) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#9, d_year#43, d_moy#44]
+(56) ColumnarToRow [codegen id : 1]
+Input [3]: [d_date_sk#9, d_year#45, d_moy#46]
 
-(58) Filter [codegen id : 1]
-Input [3]: [d_date_sk#9, d_year#43, d_moy#44]
-Condition : (((((isnotnull(d_year#43) AND isnotnull(d_moy#44)) AND (d_year#43 = 2002)) AND (d_moy#44 >= 4)) AND (d_moy#44 <= 7)) AND isnotnull(d_date_sk#9))
+(57) Filter [codegen id : 1]
+Input [3]: [d_date_sk#9, d_year#45, d_moy#46]
+Condition : (((((isnotnull(d_year#45) AND isnotnull(d_moy#46)) AND (d_year#45 = 2002)) AND (d_moy#46 >= 4)) AND (d_moy#46 <= 7)) AND isnotnull(d_date_sk#9))
 
-(59) Project [codegen id : 1]
+(58) Project [codegen id : 1]
 Output [1]: [d_date_sk#9]
-Input [3]: [d_date_sk#9, d_year#43, d_moy#44]
+Input [3]: [d_date_sk#9, d_year#45, d_moy#46]
 
-(60) BroadcastExchange
+(59) BroadcastExchange
 Input [1]: [d_date_sk#9]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=8]
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q10.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q10.sf100/simplified.txt
@@ -28,12 +28,15 @@ TakeOrderedAndProject [cd_gender,cd_marital_status,cd_education_status,cd_purcha
                                                       ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(ca_address_sk, 42), 2555, 57765, 0, 0),bloomFilter,buf]
                                                         Exchange #4
                                                           ObjectHashAggregate [ca_address_sk] [buf,buf]
-                                                            WholeStageCodegen (1)
-                                                              Project [ca_address_sk]
-                                                                Filter [ca_county,ca_address_sk]
-                                                                  ColumnarToRow
-                                                                    InputAdapter
-                                                                      Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_county]
+                                                            BroadcastExchangeExecProxy [ca_address_sk]
+                                                              SubqueryBroadcast [ca_address_sk] #2
+                                                                BroadcastExchange #5
+                                                                  WholeStageCodegen (1)
+                                                                    Project [ca_address_sk]
+                                                                      Filter [ca_county,ca_address_sk]
+                                                                        ColumnarToRow
+                                                                          InputAdapter
+                                                                            Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_county]
                                                     ColumnarToRow
                                                       InputAdapter
                                                         Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_cdemo_sk,c_current_addr_sk]
@@ -41,7 +44,7 @@ TakeOrderedAndProject [cd_gender,cd_marital_status,cd_education_status,cd_purcha
                                         WholeStageCodegen (7)
                                           Sort [customer_sk]
                                             InputAdapter
-                                              Exchange [customer_sk] #5
+                                              Exchange [customer_sk] #6
                                                 Union
                                                   WholeStageCodegen (4)
                                                     Project [ws_bill_customer_sk]
@@ -50,8 +53,8 @@ TakeOrderedAndProject [cd_gender,cd_marital_status,cd_education_status,cd_purcha
                                                           ColumnarToRow
                                                             InputAdapter
                                                               Scan parquet spark_catalog.default.web_sales [ws_bill_customer_sk,ws_sold_date_sk]
-                                                                SubqueryBroadcast [d_date_sk] #2
-                                                                  BroadcastExchange #6
+                                                                SubqueryBroadcast [d_date_sk] #3
+                                                                  BroadcastExchange #7
                                                                     WholeStageCodegen (1)
                                                                       Project [d_date_sk]
                                                                         Filter [d_year,d_moy,d_date_sk]
@@ -59,7 +62,7 @@ TakeOrderedAndProject [cd_gender,cd_marital_status,cd_education_status,cd_purcha
                                                                             InputAdapter
                                                                               Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_moy]
                                                         InputAdapter
-                                                          ReusedExchange [d_date_sk] #6
+                                                          ReusedExchange [d_date_sk] #7
                                                   WholeStageCodegen (6)
                                                     Project [cs_ship_customer_sk]
                                                       BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
@@ -67,14 +70,14 @@ TakeOrderedAndProject [cd_gender,cd_marital_status,cd_education_status,cd_purcha
                                                           ColumnarToRow
                                                             InputAdapter
                                                               Scan parquet spark_catalog.default.catalog_sales [cs_ship_customer_sk,cs_sold_date_sk]
-                                                                ReusedSubquery [d_date_sk] #2
+                                                                ReusedSubquery [d_date_sk] #3
                                                         InputAdapter
-                                                          ReusedExchange [d_date_sk] #6
+                                                          ReusedExchange [d_date_sk] #7
                                 InputAdapter
                                   WholeStageCodegen (11)
                                     Sort [customer_sk]
                                       InputAdapter
-                                        Exchange [customer_sk] #7
+                                        Exchange [customer_sk] #8
                                           WholeStageCodegen (10)
                                             Project [ss_customer_sk]
                                               BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
@@ -82,17 +85,11 @@ TakeOrderedAndProject [cd_gender,cd_marital_status,cd_education_status,cd_purcha
                                                   ColumnarToRow
                                                     InputAdapter
                                                       Scan parquet spark_catalog.default.store_sales [ss_customer_sk,ss_sold_date_sk]
-                                                        ReusedSubquery [d_date_sk] #2
+                                                        ReusedSubquery [d_date_sk] #3
                                                 InputAdapter
-                                                  ReusedExchange [d_date_sk] #6
+                                                  ReusedExchange [d_date_sk] #7
                             InputAdapter
-                              BroadcastExchange #8
-                                WholeStageCodegen (12)
-                                  Project [ca_address_sk]
-                                    Filter [ca_county,ca_address_sk]
-                                      ColumnarToRow
-                                        InputAdapter
-                                          Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_county]
+                              ReusedExchange [ca_address_sk] #5
                   Filter [cd_demo_sk]
                     ColumnarToRow
                       InputAdapter

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q59.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q59.sf100/explain.txt
@@ -1,9 +1,9 @@
 == Physical Plan ==
-TakeOrderedAndProject (54)
-+- * Project (53)
-   +- * BroadcastHashJoin Inner BuildRight (52)
-      :- * Project (25)
-      :  +- * BroadcastHashJoin Inner BuildRight (24)
+TakeOrderedAndProject (46)
++- * Project (45)
+   +- * BroadcastHashJoin Inner BuildRight (44)
+      :- * Project (21)
+      :  +- * BroadcastHashJoin Inner BuildRight (20)
       :     :- * Project (18)
       :     :  +- * BroadcastHashJoin Inner BuildRight (17)
       :     :     :- * HashAggregate (12)
@@ -22,37 +22,29 @@ TakeOrderedAndProject (54)
       :     :        +- * Filter (15)
       :     :           +- * ColumnarToRow (14)
       :     :              +- Scan parquet spark_catalog.default.store (13)
-      :     +- BroadcastExchange (23)
-      :        +- * Project (22)
-      :           +- * Filter (21)
-      :              +- * ColumnarToRow (20)
-      :                 +- Scan parquet spark_catalog.default.date_dim (19)
-      +- BroadcastExchange (51)
-         +- * Project (50)
-            +- * BroadcastHashJoin Inner BuildRight (49)
-               :- * Project (43)
-               :  +- * BroadcastHashJoin Inner BuildRight (42)
-               :     :- * HashAggregate (37)
-               :     :  +- Exchange (36)
-               :     :     +- * HashAggregate (35)
-               :     :        +- * Project (34)
-               :     :           +- * BroadcastHashJoin Inner BuildRight (33)
-               :     :              :- * Filter (28)
-               :     :              :  +- * ColumnarToRow (27)
-               :     :              :     +- Scan parquet spark_catalog.default.store_sales (26)
-               :     :              +- BroadcastExchange (32)
-               :     :                 +- * Filter (31)
-               :     :                    +- * ColumnarToRow (30)
-               :     :                       +- Scan parquet spark_catalog.default.date_dim (29)
-               :     +- BroadcastExchange (41)
-               :        +- * Filter (40)
-               :           +- * ColumnarToRow (39)
-               :              +- Scan parquet spark_catalog.default.store (38)
-               +- BroadcastExchange (48)
-                  +- * Project (47)
-                     +- * Filter (46)
-                        +- * ColumnarToRow (45)
-                           +- Scan parquet spark_catalog.default.date_dim (44)
+      :     +- ReusedExchange (19)
+      +- BroadcastExchange (43)
+         +- * Project (42)
+            +- * BroadcastHashJoin Inner BuildRight (41)
+               :- * Project (39)
+               :  +- * BroadcastHashJoin Inner BuildRight (38)
+               :     :- * HashAggregate (33)
+               :     :  +- Exchange (32)
+               :     :     +- * HashAggregate (31)
+               :     :        +- * Project (30)
+               :     :           +- * BroadcastHashJoin Inner BuildRight (29)
+               :     :              :- * Filter (24)
+               :     :              :  +- * ColumnarToRow (23)
+               :     :              :     +- Scan parquet spark_catalog.default.store_sales (22)
+               :     :              +- BroadcastExchange (28)
+               :     :                 +- * Filter (27)
+               :     :                    +- * ColumnarToRow (26)
+               :     :                       +- Scan parquet spark_catalog.default.date_dim (25)
+               :     +- BroadcastExchange (37)
+               :        +- * Filter (36)
+               :           +- * ColumnarToRow (35)
+               :              +- Scan parquet spark_catalog.default.store (34)
+               +- ReusedExchange (40)
 
 
 (1) Scan parquet spark_catalog.default.store_sales
@@ -82,7 +74,7 @@ Input [3]: [d_date_sk#4, d_week_seq#5, d_day_name#6]
 
 (6) Filter [codegen id : 1]
 Input [3]: [d_date_sk#4, d_week_seq#5, d_day_name#6]
-Condition : ((isnotnull(d_date_sk#4) AND isnotnull(d_week_seq#5)) AND might_contain(Subquery scalar-subquery#7, [id=#8], xxhash64(d_week_seq#5, 42)))
+Condition : ((isnotnull(d_date_sk#4) AND isnotnull(d_week_seq#5)) AND might_contain(runtimefilterexpression(Subquery scalar-subquery#7, [id=#8]), xxhash64(d_week_seq#5, 42)))
 
 (7) BroadcastExchange
 Input [3]: [d_date_sk#4, d_week_seq#5, d_day_name#6]
@@ -144,269 +136,249 @@ Join condition: None
 Output [10]: [d_week_seq#5, sun_sales#30, mon_sales#31, tue_sales#32, wed_sales#33, thu_sales#34, fri_sales#35, sat_sales#36, s_store_id#38, s_store_name#39]
 Input [12]: [d_week_seq#5, ss_store_sk#1, sun_sales#30, mon_sales#31, tue_sales#32, wed_sales#33, thu_sales#34, fri_sales#35, sat_sales#36, s_store_sk#37, s_store_id#38, s_store_name#39]
 
-(19) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_month_seq#40, d_week_seq#41]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/date_dim]
-PushedFilters: [IsNotNull(d_month_seq), GreaterThanOrEqual(d_month_seq,1185), LessThanOrEqual(d_month_seq,1196), IsNotNull(d_week_seq)]
-ReadSchema: struct<d_month_seq:int,d_week_seq:int>
+(19) ReusedExchange [Reuses operator id: 51]
+Output [1]: [d_week_seq#40]
 
-(20) ColumnarToRow [codegen id : 4]
-Input [2]: [d_month_seq#40, d_week_seq#41]
-
-(21) Filter [codegen id : 4]
-Input [2]: [d_month_seq#40, d_week_seq#41]
-Condition : (((isnotnull(d_month_seq#40) AND (d_month_seq#40 >= 1185)) AND (d_month_seq#40 <= 1196)) AND isnotnull(d_week_seq#41))
-
-(22) Project [codegen id : 4]
-Output [1]: [d_week_seq#41]
-Input [2]: [d_month_seq#40, d_week_seq#41]
-
-(23) BroadcastExchange
-Input [1]: [d_week_seq#41]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=4]
-
-(24) BroadcastHashJoin [codegen id : 10]
+(20) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [d_week_seq#5]
-Right keys [1]: [d_week_seq#41]
+Right keys [1]: [d_week_seq#40]
 Join type: Inner
 Join condition: None
 
-(25) Project [codegen id : 10]
-Output [10]: [s_store_name#39 AS s_store_name1#42, d_week_seq#5 AS d_week_seq1#43, s_store_id#38 AS s_store_id1#44, sun_sales#30 AS sun_sales1#45, mon_sales#31 AS mon_sales1#46, tue_sales#32 AS tue_sales1#47, wed_sales#33 AS wed_sales1#48, thu_sales#34 AS thu_sales1#49, fri_sales#35 AS fri_sales1#50, sat_sales#36 AS sat_sales1#51]
-Input [11]: [d_week_seq#5, sun_sales#30, mon_sales#31, tue_sales#32, wed_sales#33, thu_sales#34, fri_sales#35, sat_sales#36, s_store_id#38, s_store_name#39, d_week_seq#41]
+(21) Project [codegen id : 10]
+Output [10]: [s_store_name#39 AS s_store_name1#41, d_week_seq#5 AS d_week_seq1#42, s_store_id#38 AS s_store_id1#43, sun_sales#30 AS sun_sales1#44, mon_sales#31 AS mon_sales1#45, tue_sales#32 AS tue_sales1#46, wed_sales#33 AS wed_sales1#47, thu_sales#34 AS thu_sales1#48, fri_sales#35 AS fri_sales1#49, sat_sales#36 AS sat_sales1#50]
+Input [11]: [d_week_seq#5, sun_sales#30, mon_sales#31, tue_sales#32, wed_sales#33, thu_sales#34, fri_sales#35, sat_sales#36, s_store_id#38, s_store_name#39, d_week_seq#40]
 
-(26) Scan parquet spark_catalog.default.store_sales
-Output [3]: [ss_store_sk#52, ss_sales_price#53, ss_sold_date_sk#54]
+(22) Scan parquet spark_catalog.default.store_sales
+Output [3]: [ss_store_sk#51, ss_sales_price#52, ss_sold_date_sk#53]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#54)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#53)]
 PushedFilters: [IsNotNull(ss_store_sk)]
 ReadSchema: struct<ss_store_sk:int,ss_sales_price:decimal(7,2)>
 
-(27) ColumnarToRow [codegen id : 6]
-Input [3]: [ss_store_sk#52, ss_sales_price#53, ss_sold_date_sk#54]
+(23) ColumnarToRow [codegen id : 6]
+Input [3]: [ss_store_sk#51, ss_sales_price#52, ss_sold_date_sk#53]
 
-(28) Filter [codegen id : 6]
-Input [3]: [ss_store_sk#52, ss_sales_price#53, ss_sold_date_sk#54]
-Condition : isnotnull(ss_store_sk#52)
+(24) Filter [codegen id : 6]
+Input [3]: [ss_store_sk#51, ss_sales_price#52, ss_sold_date_sk#53]
+Condition : isnotnull(ss_store_sk#51)
 
-(29) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#55, d_week_seq#56, d_day_name#57]
+(25) Scan parquet spark_catalog.default.date_dim
+Output [3]: [d_date_sk#54, d_week_seq#55, d_day_name#56]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date_sk), IsNotNull(d_week_seq)]
 ReadSchema: struct<d_date_sk:int,d_week_seq:int,d_day_name:string>
 
-(30) ColumnarToRow [codegen id : 5]
-Input [3]: [d_date_sk#55, d_week_seq#56, d_day_name#57]
+(26) ColumnarToRow [codegen id : 5]
+Input [3]: [d_date_sk#54, d_week_seq#55, d_day_name#56]
 
-(31) Filter [codegen id : 5]
-Input [3]: [d_date_sk#55, d_week_seq#56, d_day_name#57]
-Condition : ((isnotnull(d_date_sk#55) AND isnotnull(d_week_seq#56)) AND might_contain(Subquery scalar-subquery#58, [id=#59], xxhash64(d_week_seq#56, 42)))
+(27) Filter [codegen id : 5]
+Input [3]: [d_date_sk#54, d_week_seq#55, d_day_name#56]
+Condition : ((isnotnull(d_date_sk#54) AND isnotnull(d_week_seq#55)) AND might_contain(runtimefilterexpression(Subquery scalar-subquery#57, [id=#58]), xxhash64(d_week_seq#55, 42)))
 
-(32) BroadcastExchange
-Input [3]: [d_date_sk#55, d_week_seq#56, d_day_name#57]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=5]
+(28) BroadcastExchange
+Input [3]: [d_date_sk#54, d_week_seq#55, d_day_name#56]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=4]
 
-(33) BroadcastHashJoin [codegen id : 6]
-Left keys [1]: [ss_sold_date_sk#54]
-Right keys [1]: [d_date_sk#55]
+(29) BroadcastHashJoin [codegen id : 6]
+Left keys [1]: [ss_sold_date_sk#53]
+Right keys [1]: [d_date_sk#54]
 Join type: Inner
 Join condition: None
 
-(34) Project [codegen id : 6]
-Output [4]: [ss_store_sk#52, ss_sales_price#53, d_week_seq#56, d_day_name#57]
-Input [6]: [ss_store_sk#52, ss_sales_price#53, ss_sold_date_sk#54, d_date_sk#55, d_week_seq#56, d_day_name#57]
+(30) Project [codegen id : 6]
+Output [4]: [ss_store_sk#51, ss_sales_price#52, d_week_seq#55, d_day_name#56]
+Input [6]: [ss_store_sk#51, ss_sales_price#52, ss_sold_date_sk#53, d_date_sk#54, d_week_seq#55, d_day_name#56]
 
-(35) HashAggregate [codegen id : 6]
-Input [4]: [ss_store_sk#52, ss_sales_price#53, d_week_seq#56, d_day_name#57]
-Keys [2]: [d_week_seq#56, ss_store_sk#52]
-Functions [6]: [partial_sum(UnscaledValue(CASE WHEN (d_day_name#57 = Sunday   ) THEN ss_sales_price#53 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#57 = Monday   ) THEN ss_sales_price#53 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#57 = Wednesday) THEN ss_sales_price#53 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#57 = Thursday ) THEN ss_sales_price#53 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#57 = Friday   ) THEN ss_sales_price#53 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#57 = Saturday ) THEN ss_sales_price#53 END))]
-Aggregate Attributes [6]: [sum#60, sum#61, sum#62, sum#63, sum#64, sum#65]
-Results [8]: [d_week_seq#56, ss_store_sk#52, sum#66, sum#67, sum#68, sum#69, sum#70, sum#71]
+(31) HashAggregate [codegen id : 6]
+Input [4]: [ss_store_sk#51, ss_sales_price#52, d_week_seq#55, d_day_name#56]
+Keys [2]: [d_week_seq#55, ss_store_sk#51]
+Functions [6]: [partial_sum(UnscaledValue(CASE WHEN (d_day_name#56 = Sunday   ) THEN ss_sales_price#52 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#56 = Monday   ) THEN ss_sales_price#52 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#56 = Wednesday) THEN ss_sales_price#52 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#56 = Thursday ) THEN ss_sales_price#52 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#56 = Friday   ) THEN ss_sales_price#52 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#56 = Saturday ) THEN ss_sales_price#52 END))]
+Aggregate Attributes [6]: [sum#59, sum#60, sum#61, sum#62, sum#63, sum#64]
+Results [8]: [d_week_seq#55, ss_store_sk#51, sum#65, sum#66, sum#67, sum#68, sum#69, sum#70]
 
-(36) Exchange
-Input [8]: [d_week_seq#56, ss_store_sk#52, sum#66, sum#67, sum#68, sum#69, sum#70, sum#71]
-Arguments: hashpartitioning(d_week_seq#56, ss_store_sk#52, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+(32) Exchange
+Input [8]: [d_week_seq#55, ss_store_sk#51, sum#65, sum#66, sum#67, sum#68, sum#69, sum#70]
+Arguments: hashpartitioning(d_week_seq#55, ss_store_sk#51, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
-(37) HashAggregate [codegen id : 9]
-Input [8]: [d_week_seq#56, ss_store_sk#52, sum#66, sum#67, sum#68, sum#69, sum#70, sum#71]
-Keys [2]: [d_week_seq#56, ss_store_sk#52]
-Functions [6]: [sum(UnscaledValue(CASE WHEN (d_day_name#57 = Sunday   ) THEN ss_sales_price#53 END)), sum(UnscaledValue(CASE WHEN (d_day_name#57 = Monday   ) THEN ss_sales_price#53 END)), sum(UnscaledValue(CASE WHEN (d_day_name#57 = Wednesday) THEN ss_sales_price#53 END)), sum(UnscaledValue(CASE WHEN (d_day_name#57 = Thursday ) THEN ss_sales_price#53 END)), sum(UnscaledValue(CASE WHEN (d_day_name#57 = Friday   ) THEN ss_sales_price#53 END)), sum(UnscaledValue(CASE WHEN (d_day_name#57 = Saturday ) THEN ss_sales_price#53 END))]
-Aggregate Attributes [6]: [sum(UnscaledValue(CASE WHEN (d_day_name#57 = Sunday   ) THEN ss_sales_price#53 END))#23, sum(UnscaledValue(CASE WHEN (d_day_name#57 = Monday   ) THEN ss_sales_price#53 END))#24, sum(UnscaledValue(CASE WHEN (d_day_name#57 = Wednesday) THEN ss_sales_price#53 END))#26, sum(UnscaledValue(CASE WHEN (d_day_name#57 = Thursday ) THEN ss_sales_price#53 END))#27, sum(UnscaledValue(CASE WHEN (d_day_name#57 = Friday   ) THEN ss_sales_price#53 END))#28, sum(UnscaledValue(CASE WHEN (d_day_name#57 = Saturday ) THEN ss_sales_price#53 END))#29]
-Results [8]: [d_week_seq#56, ss_store_sk#52, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#57 = Sunday   ) THEN ss_sales_price#53 END))#23,17,2) AS sun_sales#72, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#57 = Monday   ) THEN ss_sales_price#53 END))#24,17,2) AS mon_sales#73, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#57 = Wednesday) THEN ss_sales_price#53 END))#26,17,2) AS wed_sales#74, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#57 = Thursday ) THEN ss_sales_price#53 END))#27,17,2) AS thu_sales#75, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#57 = Friday   ) THEN ss_sales_price#53 END))#28,17,2) AS fri_sales#76, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#57 = Saturday ) THEN ss_sales_price#53 END))#29,17,2) AS sat_sales#77]
+(33) HashAggregate [codegen id : 9]
+Input [8]: [d_week_seq#55, ss_store_sk#51, sum#65, sum#66, sum#67, sum#68, sum#69, sum#70]
+Keys [2]: [d_week_seq#55, ss_store_sk#51]
+Functions [6]: [sum(UnscaledValue(CASE WHEN (d_day_name#56 = Sunday   ) THEN ss_sales_price#52 END)), sum(UnscaledValue(CASE WHEN (d_day_name#56 = Monday   ) THEN ss_sales_price#52 END)), sum(UnscaledValue(CASE WHEN (d_day_name#56 = Wednesday) THEN ss_sales_price#52 END)), sum(UnscaledValue(CASE WHEN (d_day_name#56 = Thursday ) THEN ss_sales_price#52 END)), sum(UnscaledValue(CASE WHEN (d_day_name#56 = Friday   ) THEN ss_sales_price#52 END)), sum(UnscaledValue(CASE WHEN (d_day_name#56 = Saturday ) THEN ss_sales_price#52 END))]
+Aggregate Attributes [6]: [sum(UnscaledValue(CASE WHEN (d_day_name#56 = Sunday   ) THEN ss_sales_price#52 END))#23, sum(UnscaledValue(CASE WHEN (d_day_name#56 = Monday   ) THEN ss_sales_price#52 END))#24, sum(UnscaledValue(CASE WHEN (d_day_name#56 = Wednesday) THEN ss_sales_price#52 END))#26, sum(UnscaledValue(CASE WHEN (d_day_name#56 = Thursday ) THEN ss_sales_price#52 END))#27, sum(UnscaledValue(CASE WHEN (d_day_name#56 = Friday   ) THEN ss_sales_price#52 END))#28, sum(UnscaledValue(CASE WHEN (d_day_name#56 = Saturday ) THEN ss_sales_price#52 END))#29]
+Results [8]: [d_week_seq#55, ss_store_sk#51, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#56 = Sunday   ) THEN ss_sales_price#52 END))#23,17,2) AS sun_sales#71, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#56 = Monday   ) THEN ss_sales_price#52 END))#24,17,2) AS mon_sales#72, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#56 = Wednesday) THEN ss_sales_price#52 END))#26,17,2) AS wed_sales#73, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#56 = Thursday ) THEN ss_sales_price#52 END))#27,17,2) AS thu_sales#74, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#56 = Friday   ) THEN ss_sales_price#52 END))#28,17,2) AS fri_sales#75, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#56 = Saturday ) THEN ss_sales_price#52 END))#29,17,2) AS sat_sales#76]
 
-(38) Scan parquet spark_catalog.default.store
-Output [2]: [s_store_sk#78, s_store_id#79]
+(34) Scan parquet spark_catalog.default.store
+Output [2]: [s_store_sk#77, s_store_id#78]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_store_sk), IsNotNull(s_store_id)]
 ReadSchema: struct<s_store_sk:int,s_store_id:string>
 
-(39) ColumnarToRow [codegen id : 7]
-Input [2]: [s_store_sk#78, s_store_id#79]
+(35) ColumnarToRow [codegen id : 7]
+Input [2]: [s_store_sk#77, s_store_id#78]
 
-(40) Filter [codegen id : 7]
-Input [2]: [s_store_sk#78, s_store_id#79]
-Condition : (isnotnull(s_store_sk#78) AND isnotnull(s_store_id#79))
+(36) Filter [codegen id : 7]
+Input [2]: [s_store_sk#77, s_store_id#78]
+Condition : (isnotnull(s_store_sk#77) AND isnotnull(s_store_id#78))
 
-(41) BroadcastExchange
-Input [2]: [s_store_sk#78, s_store_id#79]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=7]
+(37) BroadcastExchange
+Input [2]: [s_store_sk#77, s_store_id#78]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=6]
 
-(42) BroadcastHashJoin [codegen id : 9]
-Left keys [1]: [ss_store_sk#52]
-Right keys [1]: [s_store_sk#78]
+(38) BroadcastHashJoin [codegen id : 9]
+Left keys [1]: [ss_store_sk#51]
+Right keys [1]: [s_store_sk#77]
 Join type: Inner
 Join condition: None
 
-(43) Project [codegen id : 9]
-Output [8]: [d_week_seq#56, sun_sales#72, mon_sales#73, wed_sales#74, thu_sales#75, fri_sales#76, sat_sales#77, s_store_id#79]
-Input [10]: [d_week_seq#56, ss_store_sk#52, sun_sales#72, mon_sales#73, wed_sales#74, thu_sales#75, fri_sales#76, sat_sales#77, s_store_sk#78, s_store_id#79]
+(39) Project [codegen id : 9]
+Output [8]: [d_week_seq#55, sun_sales#71, mon_sales#72, wed_sales#73, thu_sales#74, fri_sales#75, sat_sales#76, s_store_id#78]
+Input [10]: [d_week_seq#55, ss_store_sk#51, sun_sales#71, mon_sales#72, wed_sales#73, thu_sales#74, fri_sales#75, sat_sales#76, s_store_sk#77, s_store_id#78]
 
-(44) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_month_seq#80, d_week_seq#81]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/date_dim]
-PushedFilters: [IsNotNull(d_month_seq), GreaterThanOrEqual(d_month_seq,1197), LessThanOrEqual(d_month_seq,1208), IsNotNull(d_week_seq)]
-ReadSchema: struct<d_month_seq:int,d_week_seq:int>
+(40) ReusedExchange [Reuses operator id: 61]
+Output [1]: [d_week_seq#79]
 
-(45) ColumnarToRow [codegen id : 8]
-Input [2]: [d_month_seq#80, d_week_seq#81]
-
-(46) Filter [codegen id : 8]
-Input [2]: [d_month_seq#80, d_week_seq#81]
-Condition : (((isnotnull(d_month_seq#80) AND (d_month_seq#80 >= 1197)) AND (d_month_seq#80 <= 1208)) AND isnotnull(d_week_seq#81))
-
-(47) Project [codegen id : 8]
-Output [1]: [d_week_seq#81]
-Input [2]: [d_month_seq#80, d_week_seq#81]
-
-(48) BroadcastExchange
-Input [1]: [d_week_seq#81]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=8]
-
-(49) BroadcastHashJoin [codegen id : 9]
-Left keys [1]: [d_week_seq#56]
-Right keys [1]: [d_week_seq#81]
+(41) BroadcastHashJoin [codegen id : 9]
+Left keys [1]: [d_week_seq#55]
+Right keys [1]: [d_week_seq#79]
 Join type: Inner
 Join condition: None
 
-(50) Project [codegen id : 9]
-Output [8]: [d_week_seq#56 AS d_week_seq2#82, s_store_id#79 AS s_store_id2#83, sun_sales#72 AS sun_sales2#84, mon_sales#73 AS mon_sales2#85, wed_sales#74 AS wed_sales2#86, thu_sales#75 AS thu_sales2#87, fri_sales#76 AS fri_sales2#88, sat_sales#77 AS sat_sales2#89]
-Input [9]: [d_week_seq#56, sun_sales#72, mon_sales#73, wed_sales#74, thu_sales#75, fri_sales#76, sat_sales#77, s_store_id#79, d_week_seq#81]
+(42) Project [codegen id : 9]
+Output [8]: [d_week_seq#55 AS d_week_seq2#80, s_store_id#78 AS s_store_id2#81, sun_sales#71 AS sun_sales2#82, mon_sales#72 AS mon_sales2#83, wed_sales#73 AS wed_sales2#84, thu_sales#74 AS thu_sales2#85, fri_sales#75 AS fri_sales2#86, sat_sales#76 AS sat_sales2#87]
+Input [9]: [d_week_seq#55, sun_sales#71, mon_sales#72, wed_sales#73, thu_sales#74, fri_sales#75, sat_sales#76, s_store_id#78, d_week_seq#79]
 
-(51) BroadcastExchange
-Input [8]: [d_week_seq2#82, s_store_id2#83, sun_sales2#84, mon_sales2#85, wed_sales2#86, thu_sales2#87, fri_sales2#88, sat_sales2#89]
-Arguments: HashedRelationBroadcastMode(List(input[1, string, true], (input[0, int, true] - 52)),false), [plan_id=9]
+(43) BroadcastExchange
+Input [8]: [d_week_seq2#80, s_store_id2#81, sun_sales2#82, mon_sales2#83, wed_sales2#84, thu_sales2#85, fri_sales2#86, sat_sales2#87]
+Arguments: HashedRelationBroadcastMode(List(input[1, string, true], (input[0, int, true] - 52)),false), [plan_id=7]
 
-(52) BroadcastHashJoin [codegen id : 10]
-Left keys [2]: [s_store_id1#44, d_week_seq1#43]
-Right keys [2]: [s_store_id2#83, (d_week_seq2#82 - 52)]
+(44) BroadcastHashJoin [codegen id : 10]
+Left keys [2]: [s_store_id1#43, d_week_seq1#42]
+Right keys [2]: [s_store_id2#81, (d_week_seq2#80 - 52)]
 Join type: Inner
 Join condition: None
 
-(53) Project [codegen id : 10]
-Output [10]: [s_store_name1#42, s_store_id1#44, d_week_seq1#43, (sun_sales1#45 / sun_sales2#84) AS (sun_sales1 / sun_sales2)#90, (mon_sales1#46 / mon_sales2#85) AS (mon_sales1 / mon_sales2)#91, (tue_sales1#47 / tue_sales1#47) AS (tue_sales1 / tue_sales1)#92, (wed_sales1#48 / wed_sales2#86) AS (wed_sales1 / wed_sales2)#93, (thu_sales1#49 / thu_sales2#87) AS (thu_sales1 / thu_sales2)#94, (fri_sales1#50 / fri_sales2#88) AS (fri_sales1 / fri_sales2)#95, (sat_sales1#51 / sat_sales2#89) AS (sat_sales1 / sat_sales2)#96]
-Input [18]: [s_store_name1#42, d_week_seq1#43, s_store_id1#44, sun_sales1#45, mon_sales1#46, tue_sales1#47, wed_sales1#48, thu_sales1#49, fri_sales1#50, sat_sales1#51, d_week_seq2#82, s_store_id2#83, sun_sales2#84, mon_sales2#85, wed_sales2#86, thu_sales2#87, fri_sales2#88, sat_sales2#89]
+(45) Project [codegen id : 10]
+Output [10]: [s_store_name1#41, s_store_id1#43, d_week_seq1#42, (sun_sales1#44 / sun_sales2#82) AS (sun_sales1 / sun_sales2)#88, (mon_sales1#45 / mon_sales2#83) AS (mon_sales1 / mon_sales2)#89, (tue_sales1#46 / tue_sales1#46) AS (tue_sales1 / tue_sales1)#90, (wed_sales1#47 / wed_sales2#84) AS (wed_sales1 / wed_sales2)#91, (thu_sales1#48 / thu_sales2#85) AS (thu_sales1 / thu_sales2)#92, (fri_sales1#49 / fri_sales2#86) AS (fri_sales1 / fri_sales2)#93, (sat_sales1#50 / sat_sales2#87) AS (sat_sales1 / sat_sales2)#94]
+Input [18]: [s_store_name1#41, d_week_seq1#42, s_store_id1#43, sun_sales1#44, mon_sales1#45, tue_sales1#46, wed_sales1#47, thu_sales1#48, fri_sales1#49, sat_sales1#50, d_week_seq2#80, s_store_id2#81, sun_sales2#82, mon_sales2#83, wed_sales2#84, thu_sales2#85, fri_sales2#86, sat_sales2#87]
 
-(54) TakeOrderedAndProject
-Input [10]: [s_store_name1#42, s_store_id1#44, d_week_seq1#43, (sun_sales1 / sun_sales2)#90, (mon_sales1 / mon_sales2)#91, (tue_sales1 / tue_sales1)#92, (wed_sales1 / wed_sales2)#93, (thu_sales1 / thu_sales2)#94, (fri_sales1 / fri_sales2)#95, (sat_sales1 / sat_sales2)#96]
-Arguments: 100, [s_store_name1#42 ASC NULLS FIRST, s_store_id1#44 ASC NULLS FIRST, d_week_seq1#43 ASC NULLS FIRST], [s_store_name1#42, s_store_id1#44, d_week_seq1#43, (sun_sales1 / sun_sales2)#90, (mon_sales1 / mon_sales2)#91, (tue_sales1 / tue_sales1)#92, (wed_sales1 / wed_sales2)#93, (thu_sales1 / thu_sales2)#94, (fri_sales1 / fri_sales2)#95, (sat_sales1 / sat_sales2)#96]
+(46) TakeOrderedAndProject
+Input [10]: [s_store_name1#41, s_store_id1#43, d_week_seq1#42, (sun_sales1 / sun_sales2)#88, (mon_sales1 / mon_sales2)#89, (tue_sales1 / tue_sales1)#90, (wed_sales1 / wed_sales2)#91, (thu_sales1 / thu_sales2)#92, (fri_sales1 / fri_sales2)#93, (sat_sales1 / sat_sales2)#94]
+Arguments: 100, [s_store_name1#41 ASC NULLS FIRST, s_store_id1#43 ASC NULLS FIRST, d_week_seq1#42 ASC NULLS FIRST], [s_store_name1#41, s_store_id1#43, d_week_seq1#42, (sun_sales1 / sun_sales2)#88, (mon_sales1 / mon_sales2)#89, (tue_sales1 / tue_sales1)#90, (wed_sales1 / wed_sales2)#91, (thu_sales1 / thu_sales2)#92, (fri_sales1 / fri_sales2)#93, (sat_sales1 / sat_sales2)#94]
 
 ===== Subqueries =====
 
 Subquery:1 Hosting operator id = 6 Hosting Expression = Subquery scalar-subquery#7, [id=#8]
-ObjectHashAggregate (61)
-+- Exchange (60)
-   +- ObjectHashAggregate (59)
-      +- * Project (58)
-         +- * Filter (57)
-            +- * ColumnarToRow (56)
-               +- Scan parquet spark_catalog.default.date_dim (55)
+ObjectHashAggregate (56)
++- Exchange (55)
+   +- ObjectHashAggregate (54)
+      +- BroadcastExchangeExecProxy (53)
 
 
-(55) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_month_seq#40, d_week_seq#41]
+(47) Scan parquet spark_catalog.default.date_dim
+Output [2]: [d_month_seq#95, d_week_seq#40]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_month_seq), GreaterThanOrEqual(d_month_seq,1185), LessThanOrEqual(d_month_seq,1196), IsNotNull(d_week_seq)]
 ReadSchema: struct<d_month_seq:int,d_week_seq:int>
 
-(56) ColumnarToRow [codegen id : 1]
-Input [2]: [d_month_seq#40, d_week_seq#41]
+(48) ColumnarToRow [codegen id : 1]
+Input [2]: [d_month_seq#95, d_week_seq#40]
 
-(57) Filter [codegen id : 1]
-Input [2]: [d_month_seq#40, d_week_seq#41]
-Condition : (((isnotnull(d_month_seq#40) AND (d_month_seq#40 >= 1185)) AND (d_month_seq#40 <= 1196)) AND isnotnull(d_week_seq#41))
+(49) Filter [codegen id : 1]
+Input [2]: [d_month_seq#95, d_week_seq#40]
+Condition : (((isnotnull(d_month_seq#95) AND (d_month_seq#95 >= 1185)) AND (d_month_seq#95 <= 1196)) AND isnotnull(d_week_seq#40))
 
-(58) Project [codegen id : 1]
-Output [1]: [d_week_seq#41]
-Input [2]: [d_month_seq#40, d_week_seq#41]
+(50) Project [codegen id : 1]
+Output [1]: [d_week_seq#40]
+Input [2]: [d_month_seq#95, d_week_seq#40]
 
-(59) ObjectHashAggregate
-Input [1]: [d_week_seq#41]
+(51) BroadcastExchange
+Input [1]: [d_week_seq#40]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=8]
+
+(52) SubqueryBroadcast
+Input [1]: [d_week_seq#40]
+Arguments: runtimefilter#7, 0, [d_week_seq#40], [id=#96]
+
+(53) BroadcastExchangeExecProxy
+Input [1]: [d_week_seq#97]
+Arguments: [d_week_seq#40]
+
+(54) ObjectHashAggregate
+Input [1]: [d_week_seq#40]
 Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(d_week_seq#41, 42), 335, 8990, 0, 0)]
-Aggregate Attributes [1]: [buf#97]
-Results [1]: [buf#98]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(d_week_seq#40, 42), 335, 8990, 0, 0)]
+Aggregate Attributes [1]: [buf#98]
+Results [1]: [buf#99]
 
-(60) Exchange
-Input [1]: [buf#98]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=10]
+(55) Exchange
+Input [1]: [buf#99]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=9]
 
-(61) ObjectHashAggregate
-Input [1]: [buf#98]
+(56) ObjectHashAggregate
+Input [1]: [buf#99]
 Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(d_week_seq#41, 42), 335, 8990, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(d_week_seq#41, 42), 335, 8990, 0, 0)#99]
-Results [1]: [bloom_filter_agg(xxhash64(d_week_seq#41, 42), 335, 8990, 0, 0)#99 AS bloomFilter#100]
+Functions [1]: [bloom_filter_agg(xxhash64(d_week_seq#40, 42), 335, 8990, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(d_week_seq#40, 42), 335, 8990, 0, 0)#100]
+Results [1]: [bloom_filter_agg(xxhash64(d_week_seq#40, 42), 335, 8990, 0, 0)#100 AS bloomFilter#101]
 
-Subquery:2 Hosting operator id = 31 Hosting Expression = Subquery scalar-subquery#58, [id=#59]
-ObjectHashAggregate (68)
-+- Exchange (67)
-   +- ObjectHashAggregate (66)
-      +- * Project (65)
-         +- * Filter (64)
-            +- * ColumnarToRow (63)
-               +- Scan parquet spark_catalog.default.date_dim (62)
+Subquery:2 Hosting operator id = 27 Hosting Expression = Subquery scalar-subquery#57, [id=#58]
+ObjectHashAggregate (66)
++- Exchange (65)
+   +- ObjectHashAggregate (64)
+      +- BroadcastExchangeExecProxy (63)
 
 
-(62) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_month_seq#80, d_week_seq#81]
+(57) Scan parquet spark_catalog.default.date_dim
+Output [2]: [d_month_seq#102, d_week_seq#79]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_month_seq), GreaterThanOrEqual(d_month_seq,1197), LessThanOrEqual(d_month_seq,1208), IsNotNull(d_week_seq)]
 ReadSchema: struct<d_month_seq:int,d_week_seq:int>
 
-(63) ColumnarToRow [codegen id : 1]
-Input [2]: [d_month_seq#80, d_week_seq#81]
+(58) ColumnarToRow [codegen id : 1]
+Input [2]: [d_month_seq#102, d_week_seq#79]
 
-(64) Filter [codegen id : 1]
-Input [2]: [d_month_seq#80, d_week_seq#81]
-Condition : (((isnotnull(d_month_seq#80) AND (d_month_seq#80 >= 1197)) AND (d_month_seq#80 <= 1208)) AND isnotnull(d_week_seq#81))
+(59) Filter [codegen id : 1]
+Input [2]: [d_month_seq#102, d_week_seq#79]
+Condition : (((isnotnull(d_month_seq#102) AND (d_month_seq#102 >= 1197)) AND (d_month_seq#102 <= 1208)) AND isnotnull(d_week_seq#79))
 
-(65) Project [codegen id : 1]
-Output [1]: [d_week_seq#81]
-Input [2]: [d_month_seq#80, d_week_seq#81]
+(60) Project [codegen id : 1]
+Output [1]: [d_week_seq#79]
+Input [2]: [d_month_seq#102, d_week_seq#79]
 
-(66) ObjectHashAggregate
-Input [1]: [d_week_seq#81]
+(61) BroadcastExchange
+Input [1]: [d_week_seq#79]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=10]
+
+(62) SubqueryBroadcast
+Input [1]: [d_week_seq#79]
+Arguments: runtimefilter#57, 0, [d_week_seq#79], [id=#103]
+
+(63) BroadcastExchangeExecProxy
+Input [1]: [d_week_seq#104]
+Arguments: [d_week_seq#79]
+
+(64) ObjectHashAggregate
+Input [1]: [d_week_seq#79]
 Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(d_week_seq#81, 42), 335, 8990, 0, 0)]
-Aggregate Attributes [1]: [buf#101]
-Results [1]: [buf#102]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(d_week_seq#79, 42), 335, 8990, 0, 0)]
+Aggregate Attributes [1]: [buf#105]
+Results [1]: [buf#106]
 
-(67) Exchange
-Input [1]: [buf#102]
+(65) Exchange
+Input [1]: [buf#106]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=11]
 
-(68) ObjectHashAggregate
-Input [1]: [buf#102]
+(66) ObjectHashAggregate
+Input [1]: [buf#106]
 Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(d_week_seq#81, 42), 335, 8990, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(d_week_seq#81, 42), 335, 8990, 0, 0)#103]
-Results [1]: [bloom_filter_agg(xxhash64(d_week_seq#81, 42), 335, 8990, 0, 0)#103 AS bloomFilter#104]
+Functions [1]: [bloom_filter_agg(xxhash64(d_week_seq#79, 42), 335, 8990, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(d_week_seq#79, 42), 335, 8990, 0, 0)#107]
+Results [1]: [bloom_filter_agg(xxhash64(d_week_seq#79, 42), 335, 8990, 0, 0)#107 AS bloomFilter#108]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q59.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q59.sf100/simplified.txt
@@ -25,30 +25,27 @@ TakeOrderedAndProject [s_store_name1,s_store_id1,d_week_seq1,(sun_sales1 / sun_s
                                         ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(d_week_seq, 42), 335, 8990, 0, 0),bloomFilter,buf]
                                           Exchange #3
                                             ObjectHashAggregate [d_week_seq] [buf,buf]
-                                              WholeStageCodegen (1)
-                                                Project [d_week_seq]
-                                                  Filter [d_month_seq,d_week_seq]
-                                                    ColumnarToRow
-                                                      InputAdapter
-                                                        Scan parquet spark_catalog.default.date_dim [d_month_seq,d_week_seq]
+                                              BroadcastExchangeExecProxy [d_week_seq]
+                                                SubqueryBroadcast [d_week_seq] #2
+                                                  BroadcastExchange #4
+                                                    WholeStageCodegen (1)
+                                                      Project [d_week_seq]
+                                                        Filter [d_month_seq,d_week_seq]
+                                                          ColumnarToRow
+                                                            InputAdapter
+                                                              Scan parquet spark_catalog.default.date_dim [d_month_seq,d_week_seq]
                                       ColumnarToRow
                                         InputAdapter
                                           Scan parquet spark_catalog.default.date_dim [d_date_sk,d_week_seq,d_day_name]
                 InputAdapter
-                  BroadcastExchange #4
+                  BroadcastExchange #5
                     WholeStageCodegen (3)
                       Filter [s_store_sk,s_store_id]
                         ColumnarToRow
                           InputAdapter
                             Scan parquet spark_catalog.default.store [s_store_sk,s_store_id,s_store_name]
             InputAdapter
-              BroadcastExchange #5
-                WholeStageCodegen (4)
-                  Project [d_week_seq]
-                    Filter [d_month_seq,d_week_seq]
-                      ColumnarToRow
-                        InputAdapter
-                          Scan parquet spark_catalog.default.date_dim [d_month_seq,d_week_seq]
+              ReusedExchange [d_week_seq] #4
         InputAdapter
           BroadcastExchange #6
             WholeStageCodegen (9)
@@ -71,31 +68,28 @@ TakeOrderedAndProject [s_store_name1,s_store_id1,d_week_seq1,(sun_sales1 / sun_s
                                       BroadcastExchange #8
                                         WholeStageCodegen (5)
                                           Filter [d_date_sk,d_week_seq]
-                                            Subquery #2
+                                            Subquery #3
                                               ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(d_week_seq, 42), 335, 8990, 0, 0),bloomFilter,buf]
                                                 Exchange #9
                                                   ObjectHashAggregate [d_week_seq] [buf,buf]
-                                                    WholeStageCodegen (1)
-                                                      Project [d_week_seq]
-                                                        Filter [d_month_seq,d_week_seq]
-                                                          ColumnarToRow
-                                                            InputAdapter
-                                                              Scan parquet spark_catalog.default.date_dim [d_month_seq,d_week_seq]
+                                                    BroadcastExchangeExecProxy [d_week_seq]
+                                                      SubqueryBroadcast [d_week_seq] #4
+                                                        BroadcastExchange #10
+                                                          WholeStageCodegen (1)
+                                                            Project [d_week_seq]
+                                                              Filter [d_month_seq,d_week_seq]
+                                                                ColumnarToRow
+                                                                  InputAdapter
+                                                                    Scan parquet spark_catalog.default.date_dim [d_month_seq,d_week_seq]
                                             ColumnarToRow
                                               InputAdapter
                                                 Scan parquet spark_catalog.default.date_dim [d_date_sk,d_week_seq,d_day_name]
                       InputAdapter
-                        BroadcastExchange #10
+                        BroadcastExchange #11
                           WholeStageCodegen (7)
                             Filter [s_store_sk,s_store_id]
                               ColumnarToRow
                                 InputAdapter
                                   Scan parquet spark_catalog.default.store [s_store_sk,s_store_id]
                   InputAdapter
-                    BroadcastExchange #11
-                      WholeStageCodegen (8)
-                        Project [d_week_seq]
-                          Filter [d_month_seq,d_week_seq]
-                            ColumnarToRow
-                              InputAdapter
-                                Scan parquet spark_catalog.default.date_dim [d_month_seq,d_week_seq]
+                    ReusedExchange [d_week_seq] #10

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q10.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q10.sf100/explain.txt
@@ -1,14 +1,14 @@
 == Physical Plan ==
-TakeOrderedAndProject (51)
-+- * HashAggregate (50)
-   +- Exchange (49)
-      +- * HashAggregate (48)
-         +- * Project (47)
-            +- * SortMergeJoin Inner (46)
-               :- * Sort (40)
-               :  +- Exchange (39)
-               :     +- * Project (38)
-               :        +- * BroadcastHashJoin Inner BuildRight (37)
+TakeOrderedAndProject (47)
++- * HashAggregate (46)
+   +- Exchange (45)
+      +- * HashAggregate (44)
+         +- * Project (43)
+            +- * SortMergeJoin Inner (42)
+               :- * Sort (36)
+               :  +- Exchange (35)
+               :     +- * Project (34)
+               :        +- * BroadcastHashJoin Inner BuildRight (33)
                :           :- * Project (31)
                :           :  +- * Filter (30)
                :           :     +- * SortMergeJoin ExistenceJoin(exists#1) (29)
@@ -40,16 +40,12 @@ TakeOrderedAndProject (51)
                :           :                    :- * ColumnarToRow (23)
                :           :                    :  +- Scan parquet spark_catalog.default.catalog_sales (22)
                :           :                    +- ReusedExchange (24)
-               :           +- BroadcastExchange (36)
-               :              +- * Project (35)
-               :                 +- * Filter (34)
-               :                    +- * ColumnarToRow (33)
-               :                       +- Scan parquet spark_catalog.default.customer_address (32)
-               +- * Sort (45)
-                  +- Exchange (44)
-                     +- * Filter (43)
-                        +- * ColumnarToRow (42)
-                           +- Scan parquet spark_catalog.default.customer_demographics (41)
+               :           +- ReusedExchange (32)
+               +- * Sort (41)
+                  +- Exchange (40)
+                     +- * Filter (39)
+                        +- * ColumnarToRow (38)
+                           +- Scan parquet spark_catalog.default.customer_demographics (37)
 
 
 (1) Scan parquet spark_catalog.default.customer
@@ -64,7 +60,7 @@ Input [3]: [c_customer_sk#3, c_current_cdemo_sk#4, c_current_addr_sk#5]
 
 (3) Filter [codegen id : 1]
 Input [3]: [c_customer_sk#3, c_current_cdemo_sk#4, c_current_addr_sk#5]
-Condition : ((isnotnull(c_current_addr_sk#5) AND isnotnull(c_current_cdemo_sk#4)) AND might_contain(Subquery scalar-subquery#6, [id=#7], xxhash64(c_current_addr_sk#5, 42)))
+Condition : ((isnotnull(c_current_addr_sk#5) AND isnotnull(c_current_cdemo_sk#4)) AND might_contain(runtimefilterexpression(Subquery scalar-subquery#6, [id=#7]), xxhash64(c_current_addr_sk#5, 42)))
 
 (4) Exchange
 Input [3]: [c_customer_sk#3, c_current_cdemo_sk#4, c_current_addr_sk#5]
@@ -84,7 +80,7 @@ ReadSchema: struct<ss_customer_sk:int>
 (7) ColumnarToRow [codegen id : 4]
 Input [2]: [ss_customer_sk#8, ss_sold_date_sk#9]
 
-(8) ReusedExchange [Reuses operator id: 63]
+(8) ReusedExchange [Reuses operator id: 62]
 Output [1]: [d_date_sk#11]
 
 (9) BroadcastHashJoin [codegen id : 4]
@@ -121,7 +117,7 @@ ReadSchema: struct<ws_bill_customer_sk:int>
 (15) ColumnarToRow [codegen id : 8]
 Input [2]: [ws_bill_customer_sk#12, ws_sold_date_sk#13]
 
-(16) ReusedExchange [Reuses operator id: 63]
+(16) ReusedExchange [Reuses operator id: 62]
 Output [1]: [d_date_sk#14]
 
 (17) BroadcastHashJoin [codegen id : 8]
@@ -158,7 +154,7 @@ ReadSchema: struct<cs_ship_customer_sk:int>
 (23) ColumnarToRow [codegen id : 12]
 Input [2]: [cs_ship_customer_sk#15, cs_sold_date_sk#16]
 
-(24) ReusedExchange [Reuses operator id: 63]
+(24) ReusedExchange [Reuses operator id: 62]
 Output [1]: [d_date_sk#17]
 
 (25) BroadcastHashJoin [codegen id : 12]
@@ -193,175 +189,165 @@ Condition : (exists#2 OR exists#1)
 Output [2]: [c_current_cdemo_sk#4, c_current_addr_sk#5]
 Input [5]: [c_customer_sk#3, c_current_cdemo_sk#4, c_current_addr_sk#5, exists#2, exists#1]
 
-(32) Scan parquet spark_catalog.default.customer_address
-Output [2]: [ca_address_sk#18, ca_county#19]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer_address]
-PushedFilters: [In(ca_county, [Dona Ana County,Jefferson County,La Porte County,Rush County,Toole County]), IsNotNull(ca_address_sk)]
-ReadSchema: struct<ca_address_sk:int,ca_county:string>
-
-(33) ColumnarToRow [codegen id : 14]
-Input [2]: [ca_address_sk#18, ca_county#19]
-
-(34) Filter [codegen id : 14]
-Input [2]: [ca_address_sk#18, ca_county#19]
-Condition : (ca_county#19 IN (Rush County,Toole County,Jefferson County,Dona Ana County,La Porte County) AND isnotnull(ca_address_sk#18))
-
-(35) Project [codegen id : 14]
+(32) ReusedExchange [Reuses operator id: 52]
 Output [1]: [ca_address_sk#18]
-Input [2]: [ca_address_sk#18, ca_county#19]
 
-(36) BroadcastExchange
-Input [1]: [ca_address_sk#18]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
-
-(37) BroadcastHashJoin [codegen id : 15]
+(33) BroadcastHashJoin [codegen id : 15]
 Left keys [1]: [c_current_addr_sk#5]
 Right keys [1]: [ca_address_sk#18]
 Join type: Inner
 Join condition: None
 
-(38) Project [codegen id : 15]
+(34) Project [codegen id : 15]
 Output [1]: [c_current_cdemo_sk#4]
 Input [3]: [c_current_cdemo_sk#4, c_current_addr_sk#5, ca_address_sk#18]
 
-(39) Exchange
+(35) Exchange
 Input [1]: [c_current_cdemo_sk#4]
-Arguments: hashpartitioning(c_current_cdemo_sk#4, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+Arguments: hashpartitioning(c_current_cdemo_sk#4, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
-(40) Sort [codegen id : 16]
+(36) Sort [codegen id : 16]
 Input [1]: [c_current_cdemo_sk#4]
 Arguments: [c_current_cdemo_sk#4 ASC NULLS FIRST], false, 0
 
-(41) Scan parquet spark_catalog.default.customer_demographics
-Output [9]: [cd_demo_sk#20, cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
+(37) Scan parquet spark_catalog.default.customer_demographics
+Output [9]: [cd_demo_sk#19, cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_demographics]
 PushedFilters: [IsNotNull(cd_demo_sk)]
 ReadSchema: struct<cd_demo_sk:int,cd_gender:string,cd_marital_status:string,cd_education_status:string,cd_purchase_estimate:int,cd_credit_rating:string,cd_dep_count:int,cd_dep_employed_count:int,cd_dep_college_count:int>
 
-(42) ColumnarToRow [codegen id : 17]
-Input [9]: [cd_demo_sk#20, cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
+(38) ColumnarToRow [codegen id : 17]
+Input [9]: [cd_demo_sk#19, cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
 
-(43) Filter [codegen id : 17]
-Input [9]: [cd_demo_sk#20, cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
-Condition : isnotnull(cd_demo_sk#20)
+(39) Filter [codegen id : 17]
+Input [9]: [cd_demo_sk#19, cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
+Condition : isnotnull(cd_demo_sk#19)
 
-(44) Exchange
-Input [9]: [cd_demo_sk#20, cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
-Arguments: hashpartitioning(cd_demo_sk#20, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+(40) Exchange
+Input [9]: [cd_demo_sk#19, cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
+Arguments: hashpartitioning(cd_demo_sk#19, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
-(45) Sort [codegen id : 18]
-Input [9]: [cd_demo_sk#20, cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
-Arguments: [cd_demo_sk#20 ASC NULLS FIRST], false, 0
+(41) Sort [codegen id : 18]
+Input [9]: [cd_demo_sk#19, cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
+Arguments: [cd_demo_sk#19 ASC NULLS FIRST], false, 0
 
-(46) SortMergeJoin [codegen id : 19]
+(42) SortMergeJoin [codegen id : 19]
 Left keys [1]: [c_current_cdemo_sk#4]
-Right keys [1]: [cd_demo_sk#20]
+Right keys [1]: [cd_demo_sk#19]
 Join type: Inner
 Join condition: None
 
-(47) Project [codegen id : 19]
-Output [8]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
-Input [10]: [c_current_cdemo_sk#4, cd_demo_sk#20, cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
+(43) Project [codegen id : 19]
+Output [8]: [cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
+Input [10]: [c_current_cdemo_sk#4, cd_demo_sk#19, cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
 
-(48) HashAggregate [codegen id : 19]
-Input [8]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
-Keys [8]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
+(44) HashAggregate [codegen id : 19]
+Input [8]: [cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
+Keys [8]: [cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
 Functions [1]: [partial_count(1)]
-Aggregate Attributes [1]: [count#29]
-Results [9]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28, count#30]
+Aggregate Attributes [1]: [count#28]
+Results [9]: [cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27, count#29]
 
-(49) Exchange
-Input [9]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28, count#30]
-Arguments: hashpartitioning(cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+(45) Exchange
+Input [9]: [cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27, count#29]
+Arguments: hashpartitioning(cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27, 5), ENSURE_REQUIREMENTS, [plan_id=7]
 
-(50) HashAggregate [codegen id : 20]
-Input [9]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28, count#30]
-Keys [8]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
+(46) HashAggregate [codegen id : 20]
+Input [9]: [cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27, count#29]
+Keys [8]: [cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
 Functions [1]: [count(1)]
-Aggregate Attributes [1]: [count(1)#31]
-Results [14]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, count(1)#31 AS cnt1#32, cd_purchase_estimate#24, count(1)#31 AS cnt2#33, cd_credit_rating#25, count(1)#31 AS cnt3#34, cd_dep_count#26, count(1)#31 AS cnt4#35, cd_dep_employed_count#27, count(1)#31 AS cnt5#36, cd_dep_college_count#28, count(1)#31 AS cnt6#37]
+Aggregate Attributes [1]: [count(1)#30]
+Results [14]: [cd_gender#20, cd_marital_status#21, cd_education_status#22, count(1)#30 AS cnt1#31, cd_purchase_estimate#23, count(1)#30 AS cnt2#32, cd_credit_rating#24, count(1)#30 AS cnt3#33, cd_dep_count#25, count(1)#30 AS cnt4#34, cd_dep_employed_count#26, count(1)#30 AS cnt5#35, cd_dep_college_count#27, count(1)#30 AS cnt6#36]
 
-(51) TakeOrderedAndProject
-Input [14]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cnt1#32, cd_purchase_estimate#24, cnt2#33, cd_credit_rating#25, cnt3#34, cd_dep_count#26, cnt4#35, cd_dep_employed_count#27, cnt5#36, cd_dep_college_count#28, cnt6#37]
-Arguments: 100, [cd_gender#21 ASC NULLS FIRST, cd_marital_status#22 ASC NULLS FIRST, cd_education_status#23 ASC NULLS FIRST, cd_purchase_estimate#24 ASC NULLS FIRST, cd_credit_rating#25 ASC NULLS FIRST, cd_dep_count#26 ASC NULLS FIRST, cd_dep_employed_count#27 ASC NULLS FIRST, cd_dep_college_count#28 ASC NULLS FIRST], [cd_gender#21, cd_marital_status#22, cd_education_status#23, cnt1#32, cd_purchase_estimate#24, cnt2#33, cd_credit_rating#25, cnt3#34, cd_dep_count#26, cnt4#35, cd_dep_employed_count#27, cnt5#36, cd_dep_college_count#28, cnt6#37]
+(47) TakeOrderedAndProject
+Input [14]: [cd_gender#20, cd_marital_status#21, cd_education_status#22, cnt1#31, cd_purchase_estimate#23, cnt2#32, cd_credit_rating#24, cnt3#33, cd_dep_count#25, cnt4#34, cd_dep_employed_count#26, cnt5#35, cd_dep_college_count#27, cnt6#36]
+Arguments: 100, [cd_gender#20 ASC NULLS FIRST, cd_marital_status#21 ASC NULLS FIRST, cd_education_status#22 ASC NULLS FIRST, cd_purchase_estimate#23 ASC NULLS FIRST, cd_credit_rating#24 ASC NULLS FIRST, cd_dep_count#25 ASC NULLS FIRST, cd_dep_employed_count#26 ASC NULLS FIRST, cd_dep_college_count#27 ASC NULLS FIRST], [cd_gender#20, cd_marital_status#21, cd_education_status#22, cnt1#31, cd_purchase_estimate#23, cnt2#32, cd_credit_rating#24, cnt3#33, cd_dep_count#25, cnt4#34, cd_dep_employed_count#26, cnt5#35, cd_dep_college_count#27, cnt6#36]
 
 ===== Subqueries =====
 
 Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#6, [id=#7]
-ObjectHashAggregate (58)
-+- Exchange (57)
-   +- ObjectHashAggregate (56)
-      +- * Project (55)
-         +- * Filter (54)
-            +- * ColumnarToRow (53)
-               +- Scan parquet spark_catalog.default.customer_address (52)
+ObjectHashAggregate (57)
++- Exchange (56)
+   +- ObjectHashAggregate (55)
+      +- BroadcastExchangeExecProxy (54)
 
 
-(52) Scan parquet spark_catalog.default.customer_address
-Output [2]: [ca_address_sk#18, ca_county#19]
+(48) Scan parquet spark_catalog.default.customer_address
+Output [2]: [ca_address_sk#18, ca_county#37]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [In(ca_county, [Dona Ana County,Jefferson County,La Porte County,Rush County,Toole County]), IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_county:string>
 
-(53) ColumnarToRow [codegen id : 1]
-Input [2]: [ca_address_sk#18, ca_county#19]
+(49) ColumnarToRow [codegen id : 1]
+Input [2]: [ca_address_sk#18, ca_county#37]
 
-(54) Filter [codegen id : 1]
-Input [2]: [ca_address_sk#18, ca_county#19]
-Condition : (ca_county#19 IN (Rush County,Toole County,Jefferson County,Dona Ana County,La Porte County) AND isnotnull(ca_address_sk#18))
+(50) Filter [codegen id : 1]
+Input [2]: [ca_address_sk#18, ca_county#37]
+Condition : (ca_county#37 IN (Rush County,Toole County,Jefferson County,Dona Ana County,La Porte County) AND isnotnull(ca_address_sk#18))
 
-(55) Project [codegen id : 1]
+(51) Project [codegen id : 1]
 Output [1]: [ca_address_sk#18]
-Input [2]: [ca_address_sk#18, ca_county#19]
+Input [2]: [ca_address_sk#18, ca_county#37]
 
-(56) ObjectHashAggregate
+(52) BroadcastExchange
+Input [1]: [ca_address_sk#18]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=8]
+
+(53) SubqueryBroadcast
+Input [1]: [ca_address_sk#18]
+Arguments: runtimefilter#6, 0, [ca_address_sk#18], [id=#38]
+
+(54) BroadcastExchangeExecProxy
+Input [1]: [ca_address_sk#39]
+Arguments: [ca_address_sk#18]
+
+(55) ObjectHashAggregate
 Input [1]: [ca_address_sk#18]
 Keys: []
 Functions [1]: [partial_bloom_filter_agg(xxhash64(ca_address_sk#18, 42), 2555, 57765, 0, 0)]
-Aggregate Attributes [1]: [buf#38]
-Results [1]: [buf#39]
+Aggregate Attributes [1]: [buf#40]
+Results [1]: [buf#41]
 
-(57) Exchange
-Input [1]: [buf#39]
+(56) Exchange
+Input [1]: [buf#41]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=9]
 
-(58) ObjectHashAggregate
-Input [1]: [buf#39]
+(57) ObjectHashAggregate
+Input [1]: [buf#41]
 Keys: []
 Functions [1]: [bloom_filter_agg(xxhash64(ca_address_sk#18, 42), 2555, 57765, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(ca_address_sk#18, 42), 2555, 57765, 0, 0)#40]
-Results [1]: [bloom_filter_agg(xxhash64(ca_address_sk#18, 42), 2555, 57765, 0, 0)#40 AS bloomFilter#41]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(ca_address_sk#18, 42), 2555, 57765, 0, 0)#42]
+Results [1]: [bloom_filter_agg(xxhash64(ca_address_sk#18, 42), 2555, 57765, 0, 0)#42 AS bloomFilter#43]
 
 Subquery:2 Hosting operator id = 6 Hosting Expression = ss_sold_date_sk#9 IN dynamicpruning#10
-BroadcastExchange (63)
-+- * Project (62)
-   +- * Filter (61)
-      +- * ColumnarToRow (60)
-         +- Scan parquet spark_catalog.default.date_dim (59)
+BroadcastExchange (62)
++- * Project (61)
+   +- * Filter (60)
+      +- * ColumnarToRow (59)
+         +- Scan parquet spark_catalog.default.date_dim (58)
 
 
-(59) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#11, d_year#42, d_moy#43]
+(58) Scan parquet spark_catalog.default.date_dim
+Output [3]: [d_date_sk#11, d_year#44, d_moy#45]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), EqualTo(d_year,2002), GreaterThanOrEqual(d_moy,1), LessThanOrEqual(d_moy,4), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
 
-(60) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#11, d_year#42, d_moy#43]
+(59) ColumnarToRow [codegen id : 1]
+Input [3]: [d_date_sk#11, d_year#44, d_moy#45]
 
-(61) Filter [codegen id : 1]
-Input [3]: [d_date_sk#11, d_year#42, d_moy#43]
-Condition : (((((isnotnull(d_year#42) AND isnotnull(d_moy#43)) AND (d_year#42 = 2002)) AND (d_moy#43 >= 1)) AND (d_moy#43 <= 4)) AND isnotnull(d_date_sk#11))
+(60) Filter [codegen id : 1]
+Input [3]: [d_date_sk#11, d_year#44, d_moy#45]
+Condition : (((((isnotnull(d_year#44) AND isnotnull(d_moy#45)) AND (d_year#44 = 2002)) AND (d_moy#45 >= 1)) AND (d_moy#45 <= 4)) AND isnotnull(d_date_sk#11))
 
-(62) Project [codegen id : 1]
+(61) Project [codegen id : 1]
 Output [1]: [d_date_sk#11]
-Input [3]: [d_date_sk#11, d_year#42, d_moy#43]
+Input [3]: [d_date_sk#11, d_year#44, d_moy#45]
 
-(63) BroadcastExchange
+(62) BroadcastExchange
 Input [1]: [d_date_sk#11]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=10]
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q10.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q10.sf100/simplified.txt
@@ -35,12 +35,15 @@ TakeOrderedAndProject [cd_gender,cd_marital_status,cd_education_status,cd_purcha
                                                                     ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(ca_address_sk, 42), 2555, 57765, 0, 0),bloomFilter,buf]
                                                                       Exchange #4
                                                                         ObjectHashAggregate [ca_address_sk] [buf,buf]
-                                                                          WholeStageCodegen (1)
-                                                                            Project [ca_address_sk]
-                                                                              Filter [ca_county,ca_address_sk]
-                                                                                ColumnarToRow
-                                                                                  InputAdapter
-                                                                                    Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_county]
+                                                                          BroadcastExchangeExecProxy [ca_address_sk]
+                                                                            SubqueryBroadcast [ca_address_sk] #2
+                                                                              BroadcastExchange #5
+                                                                                WholeStageCodegen (1)
+                                                                                  Project [ca_address_sk]
+                                                                                    Filter [ca_county,ca_address_sk]
+                                                                                      ColumnarToRow
+                                                                                        InputAdapter
+                                                                                          Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_county]
                                                                   ColumnarToRow
                                                                     InputAdapter
                                                                       Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_cdemo_sk,c_current_addr_sk]
@@ -48,15 +51,15 @@ TakeOrderedAndProject [cd_gender,cd_marital_status,cd_education_status,cd_purcha
                                                       WholeStageCodegen (5)
                                                         Sort [ss_customer_sk]
                                                           InputAdapter
-                                                            Exchange [ss_customer_sk] #5
+                                                            Exchange [ss_customer_sk] #6
                                                               WholeStageCodegen (4)
                                                                 Project [ss_customer_sk]
                                                                   BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                                                     ColumnarToRow
                                                                       InputAdapter
                                                                         Scan parquet spark_catalog.default.store_sales [ss_customer_sk,ss_sold_date_sk]
-                                                                          SubqueryBroadcast [d_date_sk] #2
-                                                                            BroadcastExchange #6
+                                                                          SubqueryBroadcast [d_date_sk] #3
+                                                                            BroadcastExchange #7
                                                                               WholeStageCodegen (1)
                                                                                 Project [d_date_sk]
                                                                                   Filter [d_year,d_moy,d_date_sk]
@@ -64,43 +67,37 @@ TakeOrderedAndProject [cd_gender,cd_marital_status,cd_education_status,cd_purcha
                                                                                       InputAdapter
                                                                                         Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_moy]
                                                                     InputAdapter
-                                                                      ReusedExchange [d_date_sk] #6
+                                                                      ReusedExchange [d_date_sk] #7
                                               InputAdapter
                                                 WholeStageCodegen (9)
                                                   Sort [ws_bill_customer_sk]
                                                     InputAdapter
-                                                      Exchange [ws_bill_customer_sk] #7
+                                                      Exchange [ws_bill_customer_sk] #8
                                                         WholeStageCodegen (8)
                                                           Project [ws_bill_customer_sk]
                                                             BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
                                                               ColumnarToRow
                                                                 InputAdapter
                                                                   Scan parquet spark_catalog.default.web_sales [ws_bill_customer_sk,ws_sold_date_sk]
-                                                                    ReusedSubquery [d_date_sk] #2
+                                                                    ReusedSubquery [d_date_sk] #3
                                                               InputAdapter
-                                                                ReusedExchange [d_date_sk] #6
+                                                                ReusedExchange [d_date_sk] #7
                                         InputAdapter
                                           WholeStageCodegen (13)
                                             Sort [cs_ship_customer_sk]
                                               InputAdapter
-                                                Exchange [cs_ship_customer_sk] #8
+                                                Exchange [cs_ship_customer_sk] #9
                                                   WholeStageCodegen (12)
                                                     Project [cs_ship_customer_sk]
                                                       BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
                                                         ColumnarToRow
                                                           InputAdapter
                                                             Scan parquet spark_catalog.default.catalog_sales [cs_ship_customer_sk,cs_sold_date_sk]
-                                                              ReusedSubquery [d_date_sk] #2
+                                                              ReusedSubquery [d_date_sk] #3
                                                         InputAdapter
-                                                          ReusedExchange [d_date_sk] #6
+                                                          ReusedExchange [d_date_sk] #7
                                   InputAdapter
-                                    BroadcastExchange #9
-                                      WholeStageCodegen (14)
-                                        Project [ca_address_sk]
-                                          Filter [ca_county,ca_address_sk]
-                                            ColumnarToRow
-                                              InputAdapter
-                                                Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_county]
+                                    ReusedExchange [ca_address_sk] #5
                   InputAdapter
                     WholeStageCodegen (18)
                       Sort [cd_demo_sk]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q16.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q16.sf100/explain.txt
@@ -1,15 +1,15 @@
 == Physical Plan ==
-* HashAggregate (45)
-+- Exchange (44)
-   +- * HashAggregate (43)
-      +- * HashAggregate (42)
-         +- * HashAggregate (41)
-            +- * Project (40)
-               +- * BroadcastHashJoin Inner BuildRight (39)
-                  :- * Project (33)
-                  :  +- * BroadcastHashJoin Inner BuildRight (32)
-                  :     :- * Project (26)
-                  :     :  +- * BroadcastHashJoin Inner BuildRight (25)
+* HashAggregate (33)
++- Exchange (32)
+   +- * HashAggregate (31)
+      +- * HashAggregate (30)
+         +- * HashAggregate (29)
+            +- * Project (28)
+               +- * BroadcastHashJoin Inner BuildRight (27)
+                  :- * Project (25)
+                  :  +- * BroadcastHashJoin Inner BuildRight (24)
+                  :     :- * Project (22)
+                  :     :  +- * BroadcastHashJoin Inner BuildRight (21)
                   :     :     :- * SortMergeJoin LeftAnti (19)
                   :     :     :  :- * Project (13)
                   :     :     :  :  +- * SortMergeJoin LeftSemi (12)
@@ -29,21 +29,9 @@
                   :     :     :        +- * Project (16)
                   :     :     :           +- * ColumnarToRow (15)
                   :     :     :              +- Scan parquet spark_catalog.default.catalog_returns (14)
-                  :     :     +- BroadcastExchange (24)
-                  :     :        +- * Project (23)
-                  :     :           +- * Filter (22)
-                  :     :              +- * ColumnarToRow (21)
-                  :     :                 +- Scan parquet spark_catalog.default.customer_address (20)
-                  :     +- BroadcastExchange (31)
-                  :        +- * Project (30)
-                  :           +- * Filter (29)
-                  :              +- * ColumnarToRow (28)
-                  :                 +- Scan parquet spark_catalog.default.call_center (27)
-                  +- BroadcastExchange (38)
-                     +- * Project (37)
-                        +- * Filter (36)
-                           +- * ColumnarToRow (35)
-                              +- Scan parquet spark_catalog.default.date_dim (34)
+                  :     :     +- ReusedExchange (20)
+                  :     +- ReusedExchange (23)
+                  +- ReusedExchange (26)
 
 
 (1) Scan parquet spark_catalog.default.catalog_sales
@@ -58,7 +46,7 @@ Input [8]: [cs_ship_date_sk#1, cs_ship_addr_sk#2, cs_call_center_sk#3, cs_wareho
 
 (3) Filter [codegen id : 1]
 Input [8]: [cs_ship_date_sk#1, cs_ship_addr_sk#2, cs_call_center_sk#3, cs_warehouse_sk#4, cs_order_number#5, cs_ext_ship_cost#6, cs_net_profit#7, cs_sold_date_sk#8]
-Condition : (((((isnotnull(cs_ship_date_sk#1) AND isnotnull(cs_ship_addr_sk#2)) AND isnotnull(cs_call_center_sk#3)) AND might_contain(Subquery scalar-subquery#9, [id=#10], xxhash64(cs_ship_addr_sk#2, 42))) AND might_contain(Subquery scalar-subquery#11, [id=#12], xxhash64(cs_call_center_sk#3, 42))) AND might_contain(Subquery scalar-subquery#13, [id=#14], xxhash64(cs_ship_date_sk#1, 42)))
+Condition : (((((isnotnull(cs_ship_date_sk#1) AND isnotnull(cs_ship_addr_sk#2)) AND isnotnull(cs_call_center_sk#3)) AND might_contain(runtimefilterexpression(Subquery scalar-subquery#9, [id=#10]), xxhash64(cs_ship_addr_sk#2, 42))) AND might_contain(runtimefilterexpression(Subquery scalar-subquery#11, [id=#12]), xxhash64(cs_call_center_sk#3, 42))) AND might_contain(runtimefilterexpression(Subquery scalar-subquery#13, [id=#14]), xxhash64(cs_ship_date_sk#1, 42)))
 
 (4) Project [codegen id : 1]
 Output [7]: [cs_ship_date_sk#1, cs_ship_addr_sk#2, cs_call_center_sk#3, cs_warehouse_sk#4, cs_order_number#5, cs_ext_ship_cost#6, cs_net_profit#7]
@@ -130,176 +118,128 @@ Right keys [1]: [cr_order_number#18]
 Join type: LeftAnti
 Join condition: None
 
-(20) Scan parquet spark_catalog.default.customer_address
-Output [2]: [ca_address_sk#20, ca_state#21]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer_address]
-PushedFilters: [IsNotNull(ca_state), EqualTo(ca_state,GA), IsNotNull(ca_address_sk)]
-ReadSchema: struct<ca_address_sk:int,ca_state:string>
-
-(21) ColumnarToRow [codegen id : 8]
-Input [2]: [ca_address_sk#20, ca_state#21]
-
-(22) Filter [codegen id : 8]
-Input [2]: [ca_address_sk#20, ca_state#21]
-Condition : ((isnotnull(ca_state#21) AND (ca_state#21 = GA)) AND isnotnull(ca_address_sk#20))
-
-(23) Project [codegen id : 8]
+(20) ReusedExchange [Reuses operator id: 38]
 Output [1]: [ca_address_sk#20]
-Input [2]: [ca_address_sk#20, ca_state#21]
 
-(24) BroadcastExchange
-Input [1]: [ca_address_sk#20]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=4]
-
-(25) BroadcastHashJoin [codegen id : 11]
+(21) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [cs_ship_addr_sk#2]
 Right keys [1]: [ca_address_sk#20]
 Join type: Inner
 Join condition: None
 
-(26) Project [codegen id : 11]
+(22) Project [codegen id : 11]
 Output [5]: [cs_ship_date_sk#1, cs_call_center_sk#3, cs_order_number#5, cs_ext_ship_cost#6, cs_net_profit#7]
 Input [7]: [cs_ship_date_sk#1, cs_ship_addr_sk#2, cs_call_center_sk#3, cs_order_number#5, cs_ext_ship_cost#6, cs_net_profit#7, ca_address_sk#20]
 
-(27) Scan parquet spark_catalog.default.call_center
-Output [2]: [cc_call_center_sk#22, cc_county#23]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/call_center]
-PushedFilters: [IsNotNull(cc_county), EqualTo(cc_county,Williamson County), IsNotNull(cc_call_center_sk)]
-ReadSchema: struct<cc_call_center_sk:int,cc_county:string>
+(23) ReusedExchange [Reuses operator id: 48]
+Output [1]: [cc_call_center_sk#21]
 
-(28) ColumnarToRow [codegen id : 9]
-Input [2]: [cc_call_center_sk#22, cc_county#23]
-
-(29) Filter [codegen id : 9]
-Input [2]: [cc_call_center_sk#22, cc_county#23]
-Condition : ((isnotnull(cc_county#23) AND (cc_county#23 = Williamson County)) AND isnotnull(cc_call_center_sk#22))
-
-(30) Project [codegen id : 9]
-Output [1]: [cc_call_center_sk#22]
-Input [2]: [cc_call_center_sk#22, cc_county#23]
-
-(31) BroadcastExchange
-Input [1]: [cc_call_center_sk#22]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
-
-(32) BroadcastHashJoin [codegen id : 11]
+(24) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [cs_call_center_sk#3]
-Right keys [1]: [cc_call_center_sk#22]
+Right keys [1]: [cc_call_center_sk#21]
 Join type: Inner
 Join condition: None
 
-(33) Project [codegen id : 11]
+(25) Project [codegen id : 11]
 Output [4]: [cs_ship_date_sk#1, cs_order_number#5, cs_ext_ship_cost#6, cs_net_profit#7]
-Input [6]: [cs_ship_date_sk#1, cs_call_center_sk#3, cs_order_number#5, cs_ext_ship_cost#6, cs_net_profit#7, cc_call_center_sk#22]
+Input [6]: [cs_ship_date_sk#1, cs_call_center_sk#3, cs_order_number#5, cs_ext_ship_cost#6, cs_net_profit#7, cc_call_center_sk#21]
 
-(34) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#24, d_date#25]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/date_dim]
-PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,2002-02-01), LessThanOrEqual(d_date,2002-04-02), IsNotNull(d_date_sk)]
-ReadSchema: struct<d_date_sk:int,d_date:date>
+(26) ReusedExchange [Reuses operator id: 58]
+Output [1]: [d_date_sk#22]
 
-(35) ColumnarToRow [codegen id : 10]
-Input [2]: [d_date_sk#24, d_date#25]
-
-(36) Filter [codegen id : 10]
-Input [2]: [d_date_sk#24, d_date#25]
-Condition : (((isnotnull(d_date#25) AND (d_date#25 >= 2002-02-01)) AND (d_date#25 <= 2002-04-02)) AND isnotnull(d_date_sk#24))
-
-(37) Project [codegen id : 10]
-Output [1]: [d_date_sk#24]
-Input [2]: [d_date_sk#24, d_date#25]
-
-(38) BroadcastExchange
-Input [1]: [d_date_sk#24]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=6]
-
-(39) BroadcastHashJoin [codegen id : 11]
+(27) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [cs_ship_date_sk#1]
-Right keys [1]: [d_date_sk#24]
+Right keys [1]: [d_date_sk#22]
 Join type: Inner
 Join condition: None
 
-(40) Project [codegen id : 11]
+(28) Project [codegen id : 11]
 Output [3]: [cs_order_number#5, cs_ext_ship_cost#6, cs_net_profit#7]
-Input [5]: [cs_ship_date_sk#1, cs_order_number#5, cs_ext_ship_cost#6, cs_net_profit#7, d_date_sk#24]
+Input [5]: [cs_ship_date_sk#1, cs_order_number#5, cs_ext_ship_cost#6, cs_net_profit#7, d_date_sk#22]
 
-(41) HashAggregate [codegen id : 11]
+(29) HashAggregate [codegen id : 11]
 Input [3]: [cs_order_number#5, cs_ext_ship_cost#6, cs_net_profit#7]
 Keys [1]: [cs_order_number#5]
 Functions [2]: [partial_sum(UnscaledValue(cs_ext_ship_cost#6)), partial_sum(UnscaledValue(cs_net_profit#7))]
-Aggregate Attributes [2]: [sum(UnscaledValue(cs_ext_ship_cost#6))#26, sum(UnscaledValue(cs_net_profit#7))#27]
-Results [3]: [cs_order_number#5, sum#28, sum#29]
+Aggregate Attributes [2]: [sum(UnscaledValue(cs_ext_ship_cost#6))#23, sum(UnscaledValue(cs_net_profit#7))#24]
+Results [3]: [cs_order_number#5, sum#25, sum#26]
 
-(42) HashAggregate [codegen id : 11]
-Input [3]: [cs_order_number#5, sum#28, sum#29]
+(30) HashAggregate [codegen id : 11]
+Input [3]: [cs_order_number#5, sum#25, sum#26]
 Keys [1]: [cs_order_number#5]
 Functions [2]: [merge_sum(UnscaledValue(cs_ext_ship_cost#6)), merge_sum(UnscaledValue(cs_net_profit#7))]
-Aggregate Attributes [2]: [sum(UnscaledValue(cs_ext_ship_cost#6))#26, sum(UnscaledValue(cs_net_profit#7))#27]
-Results [3]: [cs_order_number#5, sum#28, sum#29]
+Aggregate Attributes [2]: [sum(UnscaledValue(cs_ext_ship_cost#6))#23, sum(UnscaledValue(cs_net_profit#7))#24]
+Results [3]: [cs_order_number#5, sum#25, sum#26]
 
-(43) HashAggregate [codegen id : 11]
-Input [3]: [cs_order_number#5, sum#28, sum#29]
+(31) HashAggregate [codegen id : 11]
+Input [3]: [cs_order_number#5, sum#25, sum#26]
 Keys: []
 Functions [3]: [merge_sum(UnscaledValue(cs_ext_ship_cost#6)), merge_sum(UnscaledValue(cs_net_profit#7)), partial_count(distinct cs_order_number#5)]
-Aggregate Attributes [3]: [sum(UnscaledValue(cs_ext_ship_cost#6))#26, sum(UnscaledValue(cs_net_profit#7))#27, count(cs_order_number#5)#30]
-Results [3]: [sum#28, sum#29, count#31]
+Aggregate Attributes [3]: [sum(UnscaledValue(cs_ext_ship_cost#6))#23, sum(UnscaledValue(cs_net_profit#7))#24, count(cs_order_number#5)#27]
+Results [3]: [sum#25, sum#26, count#28]
 
-(44) Exchange
-Input [3]: [sum#28, sum#29, count#31]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=7]
+(32) Exchange
+Input [3]: [sum#25, sum#26, count#28]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=4]
 
-(45) HashAggregate [codegen id : 12]
-Input [3]: [sum#28, sum#29, count#31]
+(33) HashAggregate [codegen id : 12]
+Input [3]: [sum#25, sum#26, count#28]
 Keys: []
 Functions [3]: [sum(UnscaledValue(cs_ext_ship_cost#6)), sum(UnscaledValue(cs_net_profit#7)), count(distinct cs_order_number#5)]
-Aggregate Attributes [3]: [sum(UnscaledValue(cs_ext_ship_cost#6))#26, sum(UnscaledValue(cs_net_profit#7))#27, count(cs_order_number#5)#30]
-Results [3]: [count(cs_order_number#5)#30 AS order count #32, MakeDecimal(sum(UnscaledValue(cs_ext_ship_cost#6))#26,17,2) AS total shipping cost #33, MakeDecimal(sum(UnscaledValue(cs_net_profit#7))#27,17,2) AS total net profit #34]
+Aggregate Attributes [3]: [sum(UnscaledValue(cs_ext_ship_cost#6))#23, sum(UnscaledValue(cs_net_profit#7))#24, count(cs_order_number#5)#27]
+Results [3]: [count(cs_order_number#5)#27 AS order count #29, MakeDecimal(sum(UnscaledValue(cs_ext_ship_cost#6))#23,17,2) AS total shipping cost #30, MakeDecimal(sum(UnscaledValue(cs_net_profit#7))#24,17,2) AS total net profit #31]
 
 ===== Subqueries =====
 
 Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#9, [id=#10]
-ObjectHashAggregate (52)
-+- Exchange (51)
-   +- ObjectHashAggregate (50)
-      +- * Project (49)
-         +- * Filter (48)
-            +- * ColumnarToRow (47)
-               +- Scan parquet spark_catalog.default.customer_address (46)
+ObjectHashAggregate (43)
++- Exchange (42)
+   +- ObjectHashAggregate (41)
+      +- BroadcastExchangeExecProxy (40)
 
 
-(46) Scan parquet spark_catalog.default.customer_address
-Output [2]: [ca_address_sk#20, ca_state#21]
+(34) Scan parquet spark_catalog.default.customer_address
+Output [2]: [ca_address_sk#20, ca_state#32]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [IsNotNull(ca_state), EqualTo(ca_state,GA), IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_state:string>
 
-(47) ColumnarToRow [codegen id : 1]
-Input [2]: [ca_address_sk#20, ca_state#21]
+(35) ColumnarToRow [codegen id : 1]
+Input [2]: [ca_address_sk#20, ca_state#32]
 
-(48) Filter [codegen id : 1]
-Input [2]: [ca_address_sk#20, ca_state#21]
-Condition : ((isnotnull(ca_state#21) AND (ca_state#21 = GA)) AND isnotnull(ca_address_sk#20))
+(36) Filter [codegen id : 1]
+Input [2]: [ca_address_sk#20, ca_state#32]
+Condition : ((isnotnull(ca_state#32) AND (ca_state#32 = GA)) AND isnotnull(ca_address_sk#20))
 
-(49) Project [codegen id : 1]
+(37) Project [codegen id : 1]
 Output [1]: [ca_address_sk#20]
-Input [2]: [ca_address_sk#20, ca_state#21]
+Input [2]: [ca_address_sk#20, ca_state#32]
 
-(50) ObjectHashAggregate
+(38) BroadcastExchange
+Input [1]: [ca_address_sk#20]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
+
+(39) SubqueryBroadcast
+Input [1]: [ca_address_sk#20]
+Arguments: runtimefilter#9, 0, [ca_address_sk#20], [id=#33]
+
+(40) BroadcastExchangeExecProxy
+Input [1]: [ca_address_sk#34]
+Arguments: [ca_address_sk#20]
+
+(41) ObjectHashAggregate
 Input [1]: [ca_address_sk#20]
 Keys: []
 Functions [1]: [partial_bloom_filter_agg(xxhash64(ca_address_sk#20, 42), 17961, 333176, 0, 0)]
 Aggregate Attributes [1]: [buf#35]
 Results [1]: [buf#36]
 
-(51) Exchange
+(42) Exchange
 Input [1]: [buf#36]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=8]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=6]
 
-(52) ObjectHashAggregate
+(43) ObjectHashAggregate
 Input [1]: [buf#36]
 Keys: []
 Functions [1]: [bloom_filter_agg(xxhash64(ca_address_sk#20, 42), 17961, 333176, 0, 0)]
@@ -307,95 +247,113 @@ Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(ca_address_sk#20, 42), 1796
 Results [1]: [bloom_filter_agg(xxhash64(ca_address_sk#20, 42), 17961, 333176, 0, 0)#37 AS bloomFilter#38]
 
 Subquery:2 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#11, [id=#12]
-ObjectHashAggregate (59)
-+- Exchange (58)
-   +- ObjectHashAggregate (57)
-      +- * Project (56)
-         +- * Filter (55)
-            +- * ColumnarToRow (54)
-               +- Scan parquet spark_catalog.default.call_center (53)
+ObjectHashAggregate (53)
++- Exchange (52)
+   +- ObjectHashAggregate (51)
+      +- BroadcastExchangeExecProxy (50)
 
 
-(53) Scan parquet spark_catalog.default.call_center
-Output [2]: [cc_call_center_sk#22, cc_county#23]
+(44) Scan parquet spark_catalog.default.call_center
+Output [2]: [cc_call_center_sk#21, cc_county#39]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/call_center]
 PushedFilters: [IsNotNull(cc_county), EqualTo(cc_county,Williamson County), IsNotNull(cc_call_center_sk)]
 ReadSchema: struct<cc_call_center_sk:int,cc_county:string>
 
-(54) ColumnarToRow [codegen id : 1]
-Input [2]: [cc_call_center_sk#22, cc_county#23]
+(45) ColumnarToRow [codegen id : 1]
+Input [2]: [cc_call_center_sk#21, cc_county#39]
 
-(55) Filter [codegen id : 1]
-Input [2]: [cc_call_center_sk#22, cc_county#23]
-Condition : ((isnotnull(cc_county#23) AND (cc_county#23 = Williamson County)) AND isnotnull(cc_call_center_sk#22))
+(46) Filter [codegen id : 1]
+Input [2]: [cc_call_center_sk#21, cc_county#39]
+Condition : ((isnotnull(cc_county#39) AND (cc_county#39 = Williamson County)) AND isnotnull(cc_call_center_sk#21))
 
-(56) Project [codegen id : 1]
-Output [1]: [cc_call_center_sk#22]
-Input [2]: [cc_call_center_sk#22, cc_county#23]
+(47) Project [codegen id : 1]
+Output [1]: [cc_call_center_sk#21]
+Input [2]: [cc_call_center_sk#21, cc_county#39]
 
-(57) ObjectHashAggregate
-Input [1]: [cc_call_center_sk#22]
+(48) BroadcastExchange
+Input [1]: [cc_call_center_sk#21]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=7]
+
+(49) SubqueryBroadcast
+Input [1]: [cc_call_center_sk#21]
+Arguments: runtimefilter#11, 0, [cc_call_center_sk#21], [id=#40]
+
+(50) BroadcastExchangeExecProxy
+Input [1]: [cc_call_center_sk#41]
+Arguments: [cc_call_center_sk#21]
+
+(51) ObjectHashAggregate
+Input [1]: [cc_call_center_sk#21]
 Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(cc_call_center_sk#22, 42), 4, 144, 0, 0)]
-Aggregate Attributes [1]: [buf#39]
-Results [1]: [buf#40]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(cc_call_center_sk#21, 42), 4, 144, 0, 0)]
+Aggregate Attributes [1]: [buf#42]
+Results [1]: [buf#43]
 
-(58) Exchange
-Input [1]: [buf#40]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=9]
+(52) Exchange
+Input [1]: [buf#43]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=8]
 
-(59) ObjectHashAggregate
-Input [1]: [buf#40]
+(53) ObjectHashAggregate
+Input [1]: [buf#43]
 Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(cc_call_center_sk#22, 42), 4, 144, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(cc_call_center_sk#22, 42), 4, 144, 0, 0)#41]
-Results [1]: [bloom_filter_agg(xxhash64(cc_call_center_sk#22, 42), 4, 144, 0, 0)#41 AS bloomFilter#42]
+Functions [1]: [bloom_filter_agg(xxhash64(cc_call_center_sk#21, 42), 4, 144, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(cc_call_center_sk#21, 42), 4, 144, 0, 0)#44]
+Results [1]: [bloom_filter_agg(xxhash64(cc_call_center_sk#21, 42), 4, 144, 0, 0)#44 AS bloomFilter#45]
 
 Subquery:3 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#13, [id=#14]
-ObjectHashAggregate (66)
-+- Exchange (65)
-   +- ObjectHashAggregate (64)
-      +- * Project (63)
-         +- * Filter (62)
-            +- * ColumnarToRow (61)
-               +- Scan parquet spark_catalog.default.date_dim (60)
+ObjectHashAggregate (63)
++- Exchange (62)
+   +- ObjectHashAggregate (61)
+      +- BroadcastExchangeExecProxy (60)
 
 
-(60) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#24, d_date#25]
+(54) Scan parquet spark_catalog.default.date_dim
+Output [2]: [d_date_sk#22, d_date#46]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,2002-02-01), LessThanOrEqual(d_date,2002-04-02), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
-(61) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#24, d_date#25]
+(55) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#22, d_date#46]
 
-(62) Filter [codegen id : 1]
-Input [2]: [d_date_sk#24, d_date#25]
-Condition : (((isnotnull(d_date#25) AND (d_date#25 >= 2002-02-01)) AND (d_date#25 <= 2002-04-02)) AND isnotnull(d_date_sk#24))
+(56) Filter [codegen id : 1]
+Input [2]: [d_date_sk#22, d_date#46]
+Condition : (((isnotnull(d_date#46) AND (d_date#46 >= 2002-02-01)) AND (d_date#46 <= 2002-04-02)) AND isnotnull(d_date_sk#22))
 
-(63) Project [codegen id : 1]
-Output [1]: [d_date_sk#24]
-Input [2]: [d_date_sk#24, d_date#25]
+(57) Project [codegen id : 1]
+Output [1]: [d_date_sk#22]
+Input [2]: [d_date_sk#22, d_date#46]
 
-(64) ObjectHashAggregate
-Input [1]: [d_date_sk#24]
+(58) BroadcastExchange
+Input [1]: [d_date_sk#22]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=9]
+
+(59) SubqueryBroadcast
+Input [1]: [d_date_sk#22]
+Arguments: runtimefilter#13, 0, [d_date_sk#22], [id=#47]
+
+(60) BroadcastExchangeExecProxy
+Input [1]: [d_date_sk#48]
+Arguments: [d_date_sk#22]
+
+(61) ObjectHashAggregate
+Input [1]: [d_date_sk#22]
 Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(d_date_sk#24, 42), 73049, 1141755, 0, 0)]
-Aggregate Attributes [1]: [buf#43]
-Results [1]: [buf#44]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(d_date_sk#22, 42), 73049, 1141755, 0, 0)]
+Aggregate Attributes [1]: [buf#49]
+Results [1]: [buf#50]
 
-(65) Exchange
-Input [1]: [buf#44]
+(62) Exchange
+Input [1]: [buf#50]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=10]
 
-(66) ObjectHashAggregate
-Input [1]: [buf#44]
+(63) ObjectHashAggregate
+Input [1]: [buf#50]
 Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(d_date_sk#24, 42), 73049, 1141755, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(d_date_sk#24, 42), 73049, 1141755, 0, 0)#45]
-Results [1]: [bloom_filter_agg(xxhash64(d_date_sk#24, 42), 73049, 1141755, 0, 0)#45 AS bloomFilter#46]
+Functions [1]: [bloom_filter_agg(xxhash64(d_date_sk#22, 42), 73049, 1141755, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(d_date_sk#22, 42), 73049, 1141755, 0, 0)#51]
+Results [1]: [bloom_filter_agg(xxhash64(d_date_sk#22, 42), 73049, 1141755, 0, 0)#51 AS bloomFilter#52]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q16.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q16.sf100/simplified.txt
@@ -29,32 +29,41 @@ WholeStageCodegen (12)
                                                         ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(ca_address_sk, 42), 17961, 333176, 0, 0),bloomFilter,buf]
                                                           Exchange #3
                                                             ObjectHashAggregate [ca_address_sk] [buf,buf]
-                                                              WholeStageCodegen (1)
-                                                                Project [ca_address_sk]
-                                                                  Filter [ca_state,ca_address_sk]
-                                                                    ColumnarToRow
-                                                                      InputAdapter
-                                                                        Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state]
-                                                      Subquery #2
-                                                        ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(cc_call_center_sk, 42), 4, 144, 0, 0),bloomFilter,buf]
-                                                          Exchange #4
-                                                            ObjectHashAggregate [cc_call_center_sk] [buf,buf]
-                                                              WholeStageCodegen (1)
-                                                                Project [cc_call_center_sk]
-                                                                  Filter [cc_county,cc_call_center_sk]
-                                                                    ColumnarToRow
-                                                                      InputAdapter
-                                                                        Scan parquet spark_catalog.default.call_center [cc_call_center_sk,cc_county]
+                                                              BroadcastExchangeExecProxy [ca_address_sk]
+                                                                SubqueryBroadcast [ca_address_sk] #2
+                                                                  BroadcastExchange #4
+                                                                    WholeStageCodegen (1)
+                                                                      Project [ca_address_sk]
+                                                                        Filter [ca_state,ca_address_sk]
+                                                                          ColumnarToRow
+                                                                            InputAdapter
+                                                                              Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state]
                                                       Subquery #3
-                                                        ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(d_date_sk, 42), 73049, 1141755, 0, 0),bloomFilter,buf]
+                                                        ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(cc_call_center_sk, 42), 4, 144, 0, 0),bloomFilter,buf]
                                                           Exchange #5
+                                                            ObjectHashAggregate [cc_call_center_sk] [buf,buf]
+                                                              BroadcastExchangeExecProxy [cc_call_center_sk]
+                                                                SubqueryBroadcast [cc_call_center_sk] #4
+                                                                  BroadcastExchange #6
+                                                                    WholeStageCodegen (1)
+                                                                      Project [cc_call_center_sk]
+                                                                        Filter [cc_county,cc_call_center_sk]
+                                                                          ColumnarToRow
+                                                                            InputAdapter
+                                                                              Scan parquet spark_catalog.default.call_center [cc_call_center_sk,cc_county]
+                                                      Subquery #5
+                                                        ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(d_date_sk, 42), 73049, 1141755, 0, 0),bloomFilter,buf]
+                                                          Exchange #7
                                                             ObjectHashAggregate [d_date_sk] [buf,buf]
-                                                              WholeStageCodegen (1)
-                                                                Project [d_date_sk]
-                                                                  Filter [d_date,d_date_sk]
-                                                                    ColumnarToRow
-                                                                      InputAdapter
-                                                                        Scan parquet spark_catalog.default.date_dim [d_date_sk,d_date]
+                                                              BroadcastExchangeExecProxy [d_date_sk]
+                                                                SubqueryBroadcast [d_date_sk] #6
+                                                                  BroadcastExchange #8
+                                                                    WholeStageCodegen (1)
+                                                                      Project [d_date_sk]
+                                                                        Filter [d_date,d_date_sk]
+                                                                          ColumnarToRow
+                                                                            InputAdapter
+                                                                              Scan parquet spark_catalog.default.date_dim [d_date_sk,d_date]
                                                       ColumnarToRow
                                                         InputAdapter
                                                           Scan parquet spark_catalog.default.catalog_sales [cs_ship_date_sk,cs_ship_addr_sk,cs_call_center_sk,cs_warehouse_sk,cs_order_number,cs_ext_ship_cost,cs_net_profit,cs_sold_date_sk]
@@ -62,7 +71,7 @@ WholeStageCodegen (12)
                                         WholeStageCodegen (4)
                                           Sort [cs_order_number]
                                             InputAdapter
-                                              Exchange [cs_order_number] #6
+                                              Exchange [cs_order_number] #9
                                                 WholeStageCodegen (3)
                                                   Project [cs_warehouse_sk,cs_order_number]
                                                     ColumnarToRow
@@ -72,33 +81,15 @@ WholeStageCodegen (12)
                                 WholeStageCodegen (7)
                                   Sort [cr_order_number]
                                     InputAdapter
-                                      Exchange [cr_order_number] #7
+                                      Exchange [cr_order_number] #10
                                         WholeStageCodegen (6)
                                           Project [cr_order_number]
                                             ColumnarToRow
                                               InputAdapter
                                                 Scan parquet spark_catalog.default.catalog_returns [cr_order_number,cr_returned_date_sk]
                             InputAdapter
-                              BroadcastExchange #8
-                                WholeStageCodegen (8)
-                                  Project [ca_address_sk]
-                                    Filter [ca_state,ca_address_sk]
-                                      ColumnarToRow
-                                        InputAdapter
-                                          Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state]
+                              ReusedExchange [ca_address_sk] #4
                         InputAdapter
-                          BroadcastExchange #9
-                            WholeStageCodegen (9)
-                              Project [cc_call_center_sk]
-                                Filter [cc_county,cc_call_center_sk]
-                                  ColumnarToRow
-                                    InputAdapter
-                                      Scan parquet spark_catalog.default.call_center [cc_call_center_sk,cc_county]
+                          ReusedExchange [cc_call_center_sk] #6
                     InputAdapter
-                      BroadcastExchange #10
-                        WholeStageCodegen (10)
-                          Project [d_date_sk]
-                            Filter [d_date,d_date_sk]
-                              ColumnarToRow
-                                InputAdapter
-                                  Scan parquet spark_catalog.default.date_dim [d_date_sk,d_date]
+                      ReusedExchange [d_date_sk] #8

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q2.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q2.sf100/explain.txt
@@ -1,10 +1,10 @@
 == Physical Plan ==
-* Sort (51)
-+- Exchange (50)
-   +- * Project (49)
-      +- * BroadcastHashJoin Inner BuildRight (48)
-         :- * Project (23)
-         :  +- * BroadcastHashJoin Inner BuildRight (22)
+* Sort (43)
++- Exchange (42)
+   +- * Project (41)
+      +- * BroadcastHashJoin Inner BuildRight (40)
+         :- * Project (19)
+         :  +- * BroadcastHashJoin Inner BuildRight (18)
          :     :- * HashAggregate (16)
          :     :  +- Exchange (15)
          :     :     +- * HashAggregate (14)
@@ -21,35 +21,27 @@
          :     :                 +- * Filter (10)
          :     :                    +- * ColumnarToRow (9)
          :     :                       +- Scan parquet spark_catalog.default.date_dim (8)
-         :     +- BroadcastExchange (21)
-         :        +- * Project (20)
-         :           +- * Filter (19)
-         :              +- * ColumnarToRow (18)
-         :                 +- Scan parquet spark_catalog.default.date_dim (17)
-         +- BroadcastExchange (47)
-            +- * Project (46)
-               +- * BroadcastHashJoin Inner BuildRight (45)
-                  :- * HashAggregate (39)
-                  :  +- Exchange (38)
-                  :     +- * HashAggregate (37)
-                  :        +- * Project (36)
-                  :           +- * BroadcastHashJoin Inner BuildRight (35)
-                  :              :- Union (30)
-                  :              :  :- * Project (26)
-                  :              :  :  +- * ColumnarToRow (25)
-                  :              :  :     +- Scan parquet spark_catalog.default.web_sales (24)
-                  :              :  +- * Project (29)
-                  :              :     +- * ColumnarToRow (28)
-                  :              :        +- Scan parquet spark_catalog.default.catalog_sales (27)
-                  :              +- BroadcastExchange (34)
-                  :                 +- * Filter (33)
-                  :                    +- * ColumnarToRow (32)
-                  :                       +- Scan parquet spark_catalog.default.date_dim (31)
-                  +- BroadcastExchange (44)
-                     +- * Project (43)
-                        +- * Filter (42)
-                           +- * ColumnarToRow (41)
-                              +- Scan parquet spark_catalog.default.date_dim (40)
+         :     +- ReusedExchange (17)
+         +- BroadcastExchange (39)
+            +- * Project (38)
+               +- * BroadcastHashJoin Inner BuildRight (37)
+                  :- * HashAggregate (35)
+                  :  +- Exchange (34)
+                  :     +- * HashAggregate (33)
+                  :        +- * Project (32)
+                  :           +- * BroadcastHashJoin Inner BuildRight (31)
+                  :              :- Union (26)
+                  :              :  :- * Project (22)
+                  :              :  :  +- * ColumnarToRow (21)
+                  :              :  :     +- Scan parquet spark_catalog.default.web_sales (20)
+                  :              :  +- * Project (25)
+                  :              :     +- * ColumnarToRow (24)
+                  :              :        +- Scan parquet spark_catalog.default.catalog_sales (23)
+                  :              +- BroadcastExchange (30)
+                  :                 +- * Filter (29)
+                  :                    +- * ColumnarToRow (28)
+                  :                       +- Scan parquet spark_catalog.default.date_dim (27)
+                  +- ReusedExchange (36)
 
 
 (1) Scan parquet spark_catalog.default.web_sales
@@ -94,7 +86,7 @@ Input [3]: [d_date_sk#9, d_week_seq#10, d_day_name#11]
 
 (10) Filter [codegen id : 3]
 Input [3]: [d_date_sk#9, d_week_seq#10, d_day_name#11]
-Condition : ((isnotnull(d_date_sk#9) AND isnotnull(d_week_seq#10)) AND might_contain(Subquery scalar-subquery#12, [id=#13], xxhash64(d_week_seq#10, 42)))
+Condition : ((isnotnull(d_date_sk#9) AND isnotnull(d_week_seq#10)) AND might_contain(runtimefilterexpression(Subquery scalar-subquery#12, [id=#13]), xxhash64(d_week_seq#10, 42)))
 
 (11) BroadcastExchange
 Input [3]: [d_date_sk#9, d_week_seq#10, d_day_name#11]
@@ -128,260 +120,240 @@ Functions [7]: [sum(UnscaledValue(CASE WHEN (d_day_name#11 = Sunday   ) THEN sal
 Aggregate Attributes [7]: [sum(UnscaledValue(CASE WHEN (d_day_name#11 = Sunday   ) THEN sales_price#4 END))#28, sum(UnscaledValue(CASE WHEN (d_day_name#11 = Monday   ) THEN sales_price#4 END))#29, sum(UnscaledValue(CASE WHEN (d_day_name#11 = Tuesday  ) THEN sales_price#4 END))#30, sum(UnscaledValue(CASE WHEN (d_day_name#11 = Wednesday) THEN sales_price#4 END))#31, sum(UnscaledValue(CASE WHEN (d_day_name#11 = Thursday ) THEN sales_price#4 END))#32, sum(UnscaledValue(CASE WHEN (d_day_name#11 = Friday   ) THEN sales_price#4 END))#33, sum(UnscaledValue(CASE WHEN (d_day_name#11 = Saturday ) THEN sales_price#4 END))#34]
 Results [8]: [d_week_seq#10, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#11 = Sunday   ) THEN sales_price#4 END))#28,17,2) AS sun_sales#35, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#11 = Monday   ) THEN sales_price#4 END))#29,17,2) AS mon_sales#36, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#11 = Tuesday  ) THEN sales_price#4 END))#30,17,2) AS tue_sales#37, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#11 = Wednesday) THEN sales_price#4 END))#31,17,2) AS wed_sales#38, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#11 = Thursday ) THEN sales_price#4 END))#32,17,2) AS thu_sales#39, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#11 = Friday   ) THEN sales_price#4 END))#33,17,2) AS fri_sales#40, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#11 = Saturday ) THEN sales_price#4 END))#34,17,2) AS sat_sales#41]
 
-(17) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_week_seq#42, d_year#43]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/date_dim]
-PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2001), IsNotNull(d_week_seq)]
-ReadSchema: struct<d_week_seq:int,d_year:int>
-
-(18) ColumnarToRow [codegen id : 5]
-Input [2]: [d_week_seq#42, d_year#43]
-
-(19) Filter [codegen id : 5]
-Input [2]: [d_week_seq#42, d_year#43]
-Condition : ((isnotnull(d_year#43) AND (d_year#43 = 2001)) AND isnotnull(d_week_seq#42))
-
-(20) Project [codegen id : 5]
+(17) ReusedExchange [Reuses operator id: 48]
 Output [1]: [d_week_seq#42]
-Input [2]: [d_week_seq#42, d_year#43]
 
-(21) BroadcastExchange
-Input [1]: [d_week_seq#42]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=3]
-
-(22) BroadcastHashJoin [codegen id : 12]
+(18) BroadcastHashJoin [codegen id : 12]
 Left keys [1]: [d_week_seq#10]
 Right keys [1]: [d_week_seq#42]
 Join type: Inner
 Join condition: None
 
-(23) Project [codegen id : 12]
-Output [8]: [d_week_seq#10 AS d_week_seq1#44, sun_sales#35 AS sun_sales1#45, mon_sales#36 AS mon_sales1#46, tue_sales#37 AS tue_sales1#47, wed_sales#38 AS wed_sales1#48, thu_sales#39 AS thu_sales1#49, fri_sales#40 AS fri_sales1#50, sat_sales#41 AS sat_sales1#51]
+(19) Project [codegen id : 12]
+Output [8]: [d_week_seq#10 AS d_week_seq1#43, sun_sales#35 AS sun_sales1#44, mon_sales#36 AS mon_sales1#45, tue_sales#37 AS tue_sales1#46, wed_sales#38 AS wed_sales1#47, thu_sales#39 AS thu_sales1#48, fri_sales#40 AS fri_sales1#49, sat_sales#41 AS sat_sales1#50]
 Input [9]: [d_week_seq#10, sun_sales#35, mon_sales#36, tue_sales#37, wed_sales#38, thu_sales#39, fri_sales#40, sat_sales#41, d_week_seq#42]
 
-(24) Scan parquet spark_catalog.default.web_sales
-Output [2]: [ws_ext_sales_price#52, ws_sold_date_sk#53]
+(20) Scan parquet spark_catalog.default.web_sales
+Output [2]: [ws_ext_sales_price#51, ws_sold_date_sk#52]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#53)]
+PartitionFilters: [isnotnull(ws_sold_date_sk#52)]
 ReadSchema: struct<ws_ext_sales_price:decimal(7,2)>
 
-(25) ColumnarToRow [codegen id : 6]
-Input [2]: [ws_ext_sales_price#52, ws_sold_date_sk#53]
+(21) ColumnarToRow [codegen id : 6]
+Input [2]: [ws_ext_sales_price#51, ws_sold_date_sk#52]
 
-(26) Project [codegen id : 6]
-Output [2]: [ws_sold_date_sk#53 AS sold_date_sk#54, ws_ext_sales_price#52 AS sales_price#55]
-Input [2]: [ws_ext_sales_price#52, ws_sold_date_sk#53]
+(22) Project [codegen id : 6]
+Output [2]: [ws_sold_date_sk#52 AS sold_date_sk#53, ws_ext_sales_price#51 AS sales_price#54]
+Input [2]: [ws_ext_sales_price#51, ws_sold_date_sk#52]
 
-(27) Scan parquet spark_catalog.default.catalog_sales
-Output [2]: [cs_ext_sales_price#56, cs_sold_date_sk#57]
+(23) Scan parquet spark_catalog.default.catalog_sales
+Output [2]: [cs_ext_sales_price#55, cs_sold_date_sk#56]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#57)]
+PartitionFilters: [isnotnull(cs_sold_date_sk#56)]
 ReadSchema: struct<cs_ext_sales_price:decimal(7,2)>
 
-(28) ColumnarToRow [codegen id : 7]
-Input [2]: [cs_ext_sales_price#56, cs_sold_date_sk#57]
+(24) ColumnarToRow [codegen id : 7]
+Input [2]: [cs_ext_sales_price#55, cs_sold_date_sk#56]
 
-(29) Project [codegen id : 7]
-Output [2]: [cs_sold_date_sk#57 AS sold_date_sk#58, cs_ext_sales_price#56 AS sales_price#59]
-Input [2]: [cs_ext_sales_price#56, cs_sold_date_sk#57]
+(25) Project [codegen id : 7]
+Output [2]: [cs_sold_date_sk#56 AS sold_date_sk#57, cs_ext_sales_price#55 AS sales_price#58]
+Input [2]: [cs_ext_sales_price#55, cs_sold_date_sk#56]
 
-(30) Union
+(26) Union
 
-(31) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#60, d_week_seq#61, d_day_name#62]
+(27) Scan parquet spark_catalog.default.date_dim
+Output [3]: [d_date_sk#59, d_week_seq#60, d_day_name#61]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date_sk), IsNotNull(d_week_seq)]
 ReadSchema: struct<d_date_sk:int,d_week_seq:int,d_day_name:string>
 
-(32) ColumnarToRow [codegen id : 8]
-Input [3]: [d_date_sk#60, d_week_seq#61, d_day_name#62]
+(28) ColumnarToRow [codegen id : 8]
+Input [3]: [d_date_sk#59, d_week_seq#60, d_day_name#61]
 
-(33) Filter [codegen id : 8]
-Input [3]: [d_date_sk#60, d_week_seq#61, d_day_name#62]
-Condition : ((isnotnull(d_date_sk#60) AND isnotnull(d_week_seq#61)) AND might_contain(Subquery scalar-subquery#63, [id=#64], xxhash64(d_week_seq#61, 42)))
+(29) Filter [codegen id : 8]
+Input [3]: [d_date_sk#59, d_week_seq#60, d_day_name#61]
+Condition : ((isnotnull(d_date_sk#59) AND isnotnull(d_week_seq#60)) AND might_contain(runtimefilterexpression(Subquery scalar-subquery#62, [id=#63]), xxhash64(d_week_seq#60, 42)))
 
-(34) BroadcastExchange
-Input [3]: [d_date_sk#60, d_week_seq#61, d_day_name#62]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=4]
+(30) BroadcastExchange
+Input [3]: [d_date_sk#59, d_week_seq#60, d_day_name#61]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=3]
 
-(35) BroadcastHashJoin [codegen id : 9]
-Left keys [1]: [sold_date_sk#54]
-Right keys [1]: [d_date_sk#60]
+(31) BroadcastHashJoin [codegen id : 9]
+Left keys [1]: [sold_date_sk#53]
+Right keys [1]: [d_date_sk#59]
 Join type: Inner
 Join condition: None
 
-(36) Project [codegen id : 9]
-Output [3]: [sales_price#55, d_week_seq#61, d_day_name#62]
-Input [5]: [sold_date_sk#54, sales_price#55, d_date_sk#60, d_week_seq#61, d_day_name#62]
+(32) Project [codegen id : 9]
+Output [3]: [sales_price#54, d_week_seq#60, d_day_name#61]
+Input [5]: [sold_date_sk#53, sales_price#54, d_date_sk#59, d_week_seq#60, d_day_name#61]
 
-(37) HashAggregate [codegen id : 9]
-Input [3]: [sales_price#55, d_week_seq#61, d_day_name#62]
-Keys [1]: [d_week_seq#61]
-Functions [7]: [partial_sum(UnscaledValue(CASE WHEN (d_day_name#62 = Sunday   ) THEN sales_price#55 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#62 = Monday   ) THEN sales_price#55 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#62 = Tuesday  ) THEN sales_price#55 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#62 = Wednesday) THEN sales_price#55 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#62 = Thursday ) THEN sales_price#55 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#62 = Friday   ) THEN sales_price#55 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#62 = Saturday ) THEN sales_price#55 END))]
-Aggregate Attributes [7]: [sum#65, sum#66, sum#67, sum#68, sum#69, sum#70, sum#71]
-Results [8]: [d_week_seq#61, sum#72, sum#73, sum#74, sum#75, sum#76, sum#77, sum#78]
+(33) HashAggregate [codegen id : 9]
+Input [3]: [sales_price#54, d_week_seq#60, d_day_name#61]
+Keys [1]: [d_week_seq#60]
+Functions [7]: [partial_sum(UnscaledValue(CASE WHEN (d_day_name#61 = Sunday   ) THEN sales_price#54 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#61 = Monday   ) THEN sales_price#54 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#61 = Tuesday  ) THEN sales_price#54 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#61 = Wednesday) THEN sales_price#54 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#61 = Thursday ) THEN sales_price#54 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#61 = Friday   ) THEN sales_price#54 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#61 = Saturday ) THEN sales_price#54 END))]
+Aggregate Attributes [7]: [sum#64, sum#65, sum#66, sum#67, sum#68, sum#69, sum#70]
+Results [8]: [d_week_seq#60, sum#71, sum#72, sum#73, sum#74, sum#75, sum#76, sum#77]
 
-(38) Exchange
-Input [8]: [d_week_seq#61, sum#72, sum#73, sum#74, sum#75, sum#76, sum#77, sum#78]
-Arguments: hashpartitioning(d_week_seq#61, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+(34) Exchange
+Input [8]: [d_week_seq#60, sum#71, sum#72, sum#73, sum#74, sum#75, sum#76, sum#77]
+Arguments: hashpartitioning(d_week_seq#60, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
-(39) HashAggregate [codegen id : 11]
-Input [8]: [d_week_seq#61, sum#72, sum#73, sum#74, sum#75, sum#76, sum#77, sum#78]
-Keys [1]: [d_week_seq#61]
-Functions [7]: [sum(UnscaledValue(CASE WHEN (d_day_name#62 = Sunday   ) THEN sales_price#55 END)), sum(UnscaledValue(CASE WHEN (d_day_name#62 = Monday   ) THEN sales_price#55 END)), sum(UnscaledValue(CASE WHEN (d_day_name#62 = Tuesday  ) THEN sales_price#55 END)), sum(UnscaledValue(CASE WHEN (d_day_name#62 = Wednesday) THEN sales_price#55 END)), sum(UnscaledValue(CASE WHEN (d_day_name#62 = Thursday ) THEN sales_price#55 END)), sum(UnscaledValue(CASE WHEN (d_day_name#62 = Friday   ) THEN sales_price#55 END)), sum(UnscaledValue(CASE WHEN (d_day_name#62 = Saturday ) THEN sales_price#55 END))]
-Aggregate Attributes [7]: [sum(UnscaledValue(CASE WHEN (d_day_name#62 = Sunday   ) THEN sales_price#55 END))#28, sum(UnscaledValue(CASE WHEN (d_day_name#62 = Monday   ) THEN sales_price#55 END))#29, sum(UnscaledValue(CASE WHEN (d_day_name#62 = Tuesday  ) THEN sales_price#55 END))#30, sum(UnscaledValue(CASE WHEN (d_day_name#62 = Wednesday) THEN sales_price#55 END))#31, sum(UnscaledValue(CASE WHEN (d_day_name#62 = Thursday ) THEN sales_price#55 END))#32, sum(UnscaledValue(CASE WHEN (d_day_name#62 = Friday   ) THEN sales_price#55 END))#33, sum(UnscaledValue(CASE WHEN (d_day_name#62 = Saturday ) THEN sales_price#55 END))#34]
-Results [8]: [d_week_seq#61, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#62 = Sunday   ) THEN sales_price#55 END))#28,17,2) AS sun_sales#79, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#62 = Monday   ) THEN sales_price#55 END))#29,17,2) AS mon_sales#80, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#62 = Tuesday  ) THEN sales_price#55 END))#30,17,2) AS tue_sales#81, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#62 = Wednesday) THEN sales_price#55 END))#31,17,2) AS wed_sales#82, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#62 = Thursday ) THEN sales_price#55 END))#32,17,2) AS thu_sales#83, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#62 = Friday   ) THEN sales_price#55 END))#33,17,2) AS fri_sales#84, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#62 = Saturday ) THEN sales_price#55 END))#34,17,2) AS sat_sales#85]
+(35) HashAggregate [codegen id : 11]
+Input [8]: [d_week_seq#60, sum#71, sum#72, sum#73, sum#74, sum#75, sum#76, sum#77]
+Keys [1]: [d_week_seq#60]
+Functions [7]: [sum(UnscaledValue(CASE WHEN (d_day_name#61 = Sunday   ) THEN sales_price#54 END)), sum(UnscaledValue(CASE WHEN (d_day_name#61 = Monday   ) THEN sales_price#54 END)), sum(UnscaledValue(CASE WHEN (d_day_name#61 = Tuesday  ) THEN sales_price#54 END)), sum(UnscaledValue(CASE WHEN (d_day_name#61 = Wednesday) THEN sales_price#54 END)), sum(UnscaledValue(CASE WHEN (d_day_name#61 = Thursday ) THEN sales_price#54 END)), sum(UnscaledValue(CASE WHEN (d_day_name#61 = Friday   ) THEN sales_price#54 END)), sum(UnscaledValue(CASE WHEN (d_day_name#61 = Saturday ) THEN sales_price#54 END))]
+Aggregate Attributes [7]: [sum(UnscaledValue(CASE WHEN (d_day_name#61 = Sunday   ) THEN sales_price#54 END))#28, sum(UnscaledValue(CASE WHEN (d_day_name#61 = Monday   ) THEN sales_price#54 END))#29, sum(UnscaledValue(CASE WHEN (d_day_name#61 = Tuesday  ) THEN sales_price#54 END))#30, sum(UnscaledValue(CASE WHEN (d_day_name#61 = Wednesday) THEN sales_price#54 END))#31, sum(UnscaledValue(CASE WHEN (d_day_name#61 = Thursday ) THEN sales_price#54 END))#32, sum(UnscaledValue(CASE WHEN (d_day_name#61 = Friday   ) THEN sales_price#54 END))#33, sum(UnscaledValue(CASE WHEN (d_day_name#61 = Saturday ) THEN sales_price#54 END))#34]
+Results [8]: [d_week_seq#60, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#61 = Sunday   ) THEN sales_price#54 END))#28,17,2) AS sun_sales#78, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#61 = Monday   ) THEN sales_price#54 END))#29,17,2) AS mon_sales#79, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#61 = Tuesday  ) THEN sales_price#54 END))#30,17,2) AS tue_sales#80, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#61 = Wednesday) THEN sales_price#54 END))#31,17,2) AS wed_sales#81, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#61 = Thursday ) THEN sales_price#54 END))#32,17,2) AS thu_sales#82, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#61 = Friday   ) THEN sales_price#54 END))#33,17,2) AS fri_sales#83, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#61 = Saturday ) THEN sales_price#54 END))#34,17,2) AS sat_sales#84]
 
-(40) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_week_seq#86, d_year#87]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/date_dim]
-PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2002), IsNotNull(d_week_seq)]
-ReadSchema: struct<d_week_seq:int,d_year:int>
+(36) ReusedExchange [Reuses operator id: 58]
+Output [1]: [d_week_seq#85]
 
-(41) ColumnarToRow [codegen id : 10]
-Input [2]: [d_week_seq#86, d_year#87]
-
-(42) Filter [codegen id : 10]
-Input [2]: [d_week_seq#86, d_year#87]
-Condition : ((isnotnull(d_year#87) AND (d_year#87 = 2002)) AND isnotnull(d_week_seq#86))
-
-(43) Project [codegen id : 10]
-Output [1]: [d_week_seq#86]
-Input [2]: [d_week_seq#86, d_year#87]
-
-(44) BroadcastExchange
-Input [1]: [d_week_seq#86]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=6]
-
-(45) BroadcastHashJoin [codegen id : 11]
-Left keys [1]: [d_week_seq#61]
-Right keys [1]: [d_week_seq#86]
+(37) BroadcastHashJoin [codegen id : 11]
+Left keys [1]: [d_week_seq#60]
+Right keys [1]: [d_week_seq#85]
 Join type: Inner
 Join condition: None
 
-(46) Project [codegen id : 11]
-Output [8]: [d_week_seq#61 AS d_week_seq2#88, sun_sales#79 AS sun_sales2#89, mon_sales#80 AS mon_sales2#90, tue_sales#81 AS tue_sales2#91, wed_sales#82 AS wed_sales2#92, thu_sales#83 AS thu_sales2#93, fri_sales#84 AS fri_sales2#94, sat_sales#85 AS sat_sales2#95]
-Input [9]: [d_week_seq#61, sun_sales#79, mon_sales#80, tue_sales#81, wed_sales#82, thu_sales#83, fri_sales#84, sat_sales#85, d_week_seq#86]
+(38) Project [codegen id : 11]
+Output [8]: [d_week_seq#60 AS d_week_seq2#86, sun_sales#78 AS sun_sales2#87, mon_sales#79 AS mon_sales2#88, tue_sales#80 AS tue_sales2#89, wed_sales#81 AS wed_sales2#90, thu_sales#82 AS thu_sales2#91, fri_sales#83 AS fri_sales2#92, sat_sales#84 AS sat_sales2#93]
+Input [9]: [d_week_seq#60, sun_sales#78, mon_sales#79, tue_sales#80, wed_sales#81, thu_sales#82, fri_sales#83, sat_sales#84, d_week_seq#85]
 
-(47) BroadcastExchange
-Input [8]: [d_week_seq2#88, sun_sales2#89, mon_sales2#90, tue_sales2#91, wed_sales2#92, thu_sales2#93, fri_sales2#94, sat_sales2#95]
-Arguments: HashedRelationBroadcastMode(List(cast((input[0, int, true] - 53) as bigint)),false), [plan_id=7]
+(39) BroadcastExchange
+Input [8]: [d_week_seq2#86, sun_sales2#87, mon_sales2#88, tue_sales2#89, wed_sales2#90, thu_sales2#91, fri_sales2#92, sat_sales2#93]
+Arguments: HashedRelationBroadcastMode(List(cast((input[0, int, true] - 53) as bigint)),false), [plan_id=5]
 
-(48) BroadcastHashJoin [codegen id : 12]
-Left keys [1]: [d_week_seq1#44]
-Right keys [1]: [(d_week_seq2#88 - 53)]
+(40) BroadcastHashJoin [codegen id : 12]
+Left keys [1]: [d_week_seq1#43]
+Right keys [1]: [(d_week_seq2#86 - 53)]
 Join type: Inner
 Join condition: None
 
-(49) Project [codegen id : 12]
-Output [8]: [d_week_seq1#44, round((sun_sales1#45 / sun_sales2#89), 2) AS round((sun_sales1 / sun_sales2), 2)#96, round((mon_sales1#46 / mon_sales2#90), 2) AS round((mon_sales1 / mon_sales2), 2)#97, round((tue_sales1#47 / tue_sales2#91), 2) AS round((tue_sales1 / tue_sales2), 2)#98, round((wed_sales1#48 / wed_sales2#92), 2) AS round((wed_sales1 / wed_sales2), 2)#99, round((thu_sales1#49 / thu_sales2#93), 2) AS round((thu_sales1 / thu_sales2), 2)#100, round((fri_sales1#50 / fri_sales2#94), 2) AS round((fri_sales1 / fri_sales2), 2)#101, round((sat_sales1#51 / sat_sales2#95), 2) AS round((sat_sales1 / sat_sales2), 2)#102]
-Input [16]: [d_week_seq1#44, sun_sales1#45, mon_sales1#46, tue_sales1#47, wed_sales1#48, thu_sales1#49, fri_sales1#50, sat_sales1#51, d_week_seq2#88, sun_sales2#89, mon_sales2#90, tue_sales2#91, wed_sales2#92, thu_sales2#93, fri_sales2#94, sat_sales2#95]
+(41) Project [codegen id : 12]
+Output [8]: [d_week_seq1#43, round((sun_sales1#44 / sun_sales2#87), 2) AS round((sun_sales1 / sun_sales2), 2)#94, round((mon_sales1#45 / mon_sales2#88), 2) AS round((mon_sales1 / mon_sales2), 2)#95, round((tue_sales1#46 / tue_sales2#89), 2) AS round((tue_sales1 / tue_sales2), 2)#96, round((wed_sales1#47 / wed_sales2#90), 2) AS round((wed_sales1 / wed_sales2), 2)#97, round((thu_sales1#48 / thu_sales2#91), 2) AS round((thu_sales1 / thu_sales2), 2)#98, round((fri_sales1#49 / fri_sales2#92), 2) AS round((fri_sales1 / fri_sales2), 2)#99, round((sat_sales1#50 / sat_sales2#93), 2) AS round((sat_sales1 / sat_sales2), 2)#100]
+Input [16]: [d_week_seq1#43, sun_sales1#44, mon_sales1#45, tue_sales1#46, wed_sales1#47, thu_sales1#48, fri_sales1#49, sat_sales1#50, d_week_seq2#86, sun_sales2#87, mon_sales2#88, tue_sales2#89, wed_sales2#90, thu_sales2#91, fri_sales2#92, sat_sales2#93]
 
-(50) Exchange
-Input [8]: [d_week_seq1#44, round((sun_sales1 / sun_sales2), 2)#96, round((mon_sales1 / mon_sales2), 2)#97, round((tue_sales1 / tue_sales2), 2)#98, round((wed_sales1 / wed_sales2), 2)#99, round((thu_sales1 / thu_sales2), 2)#100, round((fri_sales1 / fri_sales2), 2)#101, round((sat_sales1 / sat_sales2), 2)#102]
-Arguments: rangepartitioning(d_week_seq1#44 ASC NULLS FIRST, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+(42) Exchange
+Input [8]: [d_week_seq1#43, round((sun_sales1 / sun_sales2), 2)#94, round((mon_sales1 / mon_sales2), 2)#95, round((tue_sales1 / tue_sales2), 2)#96, round((wed_sales1 / wed_sales2), 2)#97, round((thu_sales1 / thu_sales2), 2)#98, round((fri_sales1 / fri_sales2), 2)#99, round((sat_sales1 / sat_sales2), 2)#100]
+Arguments: rangepartitioning(d_week_seq1#43 ASC NULLS FIRST, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
-(51) Sort [codegen id : 13]
-Input [8]: [d_week_seq1#44, round((sun_sales1 / sun_sales2), 2)#96, round((mon_sales1 / mon_sales2), 2)#97, round((tue_sales1 / tue_sales2), 2)#98, round((wed_sales1 / wed_sales2), 2)#99, round((thu_sales1 / thu_sales2), 2)#100, round((fri_sales1 / fri_sales2), 2)#101, round((sat_sales1 / sat_sales2), 2)#102]
-Arguments: [d_week_seq1#44 ASC NULLS FIRST], true, 0
+(43) Sort [codegen id : 13]
+Input [8]: [d_week_seq1#43, round((sun_sales1 / sun_sales2), 2)#94, round((mon_sales1 / mon_sales2), 2)#95, round((tue_sales1 / tue_sales2), 2)#96, round((wed_sales1 / wed_sales2), 2)#97, round((thu_sales1 / thu_sales2), 2)#98, round((fri_sales1 / fri_sales2), 2)#99, round((sat_sales1 / sat_sales2), 2)#100]
+Arguments: [d_week_seq1#43 ASC NULLS FIRST], true, 0
 
 ===== Subqueries =====
 
 Subquery:1 Hosting operator id = 10 Hosting Expression = Subquery scalar-subquery#12, [id=#13]
-ObjectHashAggregate (58)
-+- Exchange (57)
-   +- ObjectHashAggregate (56)
-      +- * Project (55)
-         +- * Filter (54)
-            +- * ColumnarToRow (53)
-               +- Scan parquet spark_catalog.default.date_dim (52)
+ObjectHashAggregate (53)
++- Exchange (52)
+   +- ObjectHashAggregate (51)
+      +- BroadcastExchangeExecProxy (50)
 
 
-(52) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_week_seq#42, d_year#43]
+(44) Scan parquet spark_catalog.default.date_dim
+Output [2]: [d_week_seq#42, d_year#101]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2001), IsNotNull(d_week_seq)]
 ReadSchema: struct<d_week_seq:int,d_year:int>
 
-(53) ColumnarToRow [codegen id : 1]
-Input [2]: [d_week_seq#42, d_year#43]
+(45) ColumnarToRow [codegen id : 1]
+Input [2]: [d_week_seq#42, d_year#101]
 
-(54) Filter [codegen id : 1]
-Input [2]: [d_week_seq#42, d_year#43]
-Condition : ((isnotnull(d_year#43) AND (d_year#43 = 2001)) AND isnotnull(d_week_seq#42))
+(46) Filter [codegen id : 1]
+Input [2]: [d_week_seq#42, d_year#101]
+Condition : ((isnotnull(d_year#101) AND (d_year#101 = 2001)) AND isnotnull(d_week_seq#42))
 
-(55) Project [codegen id : 1]
+(47) Project [codegen id : 1]
 Output [1]: [d_week_seq#42]
-Input [2]: [d_week_seq#42, d_year#43]
+Input [2]: [d_week_seq#42, d_year#101]
 
-(56) ObjectHashAggregate
+(48) BroadcastExchange
+Input [1]: [d_week_seq#42]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=7]
+
+(49) SubqueryBroadcast
+Input [1]: [d_week_seq#42]
+Arguments: runtimefilter#12, 0, [d_week_seq#42], [id=#102]
+
+(50) BroadcastExchangeExecProxy
+Input [1]: [d_week_seq#103]
+Arguments: [d_week_seq#42]
+
+(51) ObjectHashAggregate
 Input [1]: [d_week_seq#42]
 Keys: []
 Functions [1]: [partial_bloom_filter_agg(xxhash64(d_week_seq#42, 42), 362, 9656, 0, 0)]
-Aggregate Attributes [1]: [buf#103]
-Results [1]: [buf#104]
+Aggregate Attributes [1]: [buf#104]
+Results [1]: [buf#105]
 
-(57) Exchange
-Input [1]: [buf#104]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=9]
+(52) Exchange
+Input [1]: [buf#105]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=8]
 
-(58) ObjectHashAggregate
-Input [1]: [buf#104]
+(53) ObjectHashAggregate
+Input [1]: [buf#105]
 Keys: []
 Functions [1]: [bloom_filter_agg(xxhash64(d_week_seq#42, 42), 362, 9656, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(d_week_seq#42, 42), 362, 9656, 0, 0)#105]
-Results [1]: [bloom_filter_agg(xxhash64(d_week_seq#42, 42), 362, 9656, 0, 0)#105 AS bloomFilter#106]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(d_week_seq#42, 42), 362, 9656, 0, 0)#106]
+Results [1]: [bloom_filter_agg(xxhash64(d_week_seq#42, 42), 362, 9656, 0, 0)#106 AS bloomFilter#107]
 
-Subquery:2 Hosting operator id = 33 Hosting Expression = Subquery scalar-subquery#63, [id=#64]
-ObjectHashAggregate (65)
-+- Exchange (64)
-   +- ObjectHashAggregate (63)
-      +- * Project (62)
-         +- * Filter (61)
-            +- * ColumnarToRow (60)
-               +- Scan parquet spark_catalog.default.date_dim (59)
+Subquery:2 Hosting operator id = 29 Hosting Expression = Subquery scalar-subquery#62, [id=#63]
+ObjectHashAggregate (63)
++- Exchange (62)
+   +- ObjectHashAggregate (61)
+      +- BroadcastExchangeExecProxy (60)
 
 
-(59) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_week_seq#86, d_year#87]
+(54) Scan parquet spark_catalog.default.date_dim
+Output [2]: [d_week_seq#85, d_year#108]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2002), IsNotNull(d_week_seq)]
 ReadSchema: struct<d_week_seq:int,d_year:int>
 
-(60) ColumnarToRow [codegen id : 1]
-Input [2]: [d_week_seq#86, d_year#87]
+(55) ColumnarToRow [codegen id : 1]
+Input [2]: [d_week_seq#85, d_year#108]
 
-(61) Filter [codegen id : 1]
-Input [2]: [d_week_seq#86, d_year#87]
-Condition : ((isnotnull(d_year#87) AND (d_year#87 = 2002)) AND isnotnull(d_week_seq#86))
+(56) Filter [codegen id : 1]
+Input [2]: [d_week_seq#85, d_year#108]
+Condition : ((isnotnull(d_year#108) AND (d_year#108 = 2002)) AND isnotnull(d_week_seq#85))
 
-(62) Project [codegen id : 1]
-Output [1]: [d_week_seq#86]
-Input [2]: [d_week_seq#86, d_year#87]
+(57) Project [codegen id : 1]
+Output [1]: [d_week_seq#85]
+Input [2]: [d_week_seq#85, d_year#108]
 
-(63) ObjectHashAggregate
-Input [1]: [d_week_seq#86]
+(58) BroadcastExchange
+Input [1]: [d_week_seq#85]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=9]
+
+(59) SubqueryBroadcast
+Input [1]: [d_week_seq#85]
+Arguments: runtimefilter#62, 0, [d_week_seq#85], [id=#109]
+
+(60) BroadcastExchangeExecProxy
+Input [1]: [d_week_seq#110]
+Arguments: [d_week_seq#85]
+
+(61) ObjectHashAggregate
+Input [1]: [d_week_seq#85]
 Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(d_week_seq#86, 42), 362, 9656, 0, 0)]
-Aggregate Attributes [1]: [buf#107]
-Results [1]: [buf#108]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(d_week_seq#85, 42), 362, 9656, 0, 0)]
+Aggregate Attributes [1]: [buf#111]
+Results [1]: [buf#112]
 
-(64) Exchange
-Input [1]: [buf#108]
+(62) Exchange
+Input [1]: [buf#112]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=10]
 
-(65) ObjectHashAggregate
-Input [1]: [buf#108]
+(63) ObjectHashAggregate
+Input [1]: [buf#112]
 Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(d_week_seq#86, 42), 362, 9656, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(d_week_seq#86, 42), 362, 9656, 0, 0)#109]
-Results [1]: [bloom_filter_agg(xxhash64(d_week_seq#86, 42), 362, 9656, 0, 0)#109 AS bloomFilter#110]
+Functions [1]: [bloom_filter_agg(xxhash64(d_week_seq#85, 42), 362, 9656, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(d_week_seq#85, 42), 362, 9656, 0, 0)#113]
+Results [1]: [bloom_filter_agg(xxhash64(d_week_seq#85, 42), 362, 9656, 0, 0)#113 AS bloomFilter#114]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q2.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q2.sf100/simplified.txt
@@ -34,23 +34,20 @@ WholeStageCodegen (13)
                                           ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(d_week_seq, 42), 362, 9656, 0, 0),bloomFilter,buf]
                                             Exchange #4
                                               ObjectHashAggregate [d_week_seq] [buf,buf]
-                                                WholeStageCodegen (1)
-                                                  Project [d_week_seq]
-                                                    Filter [d_year,d_week_seq]
-                                                      ColumnarToRow
-                                                        InputAdapter
-                                                          Scan parquet spark_catalog.default.date_dim [d_week_seq,d_year]
+                                                BroadcastExchangeExecProxy [d_week_seq]
+                                                  SubqueryBroadcast [d_week_seq] #2
+                                                    BroadcastExchange #5
+                                                      WholeStageCodegen (1)
+                                                        Project [d_week_seq]
+                                                          Filter [d_year,d_week_seq]
+                                                            ColumnarToRow
+                                                              InputAdapter
+                                                                Scan parquet spark_catalog.default.date_dim [d_week_seq,d_year]
                                         ColumnarToRow
                                           InputAdapter
                                             Scan parquet spark_catalog.default.date_dim [d_date_sk,d_week_seq,d_day_name]
                   InputAdapter
-                    BroadcastExchange #5
-                      WholeStageCodegen (5)
-                        Project [d_week_seq]
-                          Filter [d_year,d_week_seq]
-                            ColumnarToRow
-                              InputAdapter
-                                Scan parquet spark_catalog.default.date_dim [d_week_seq,d_year]
+                    ReusedExchange [d_week_seq] #5
               InputAdapter
                 BroadcastExchange #6
                   WholeStageCodegen (11)
@@ -79,24 +76,21 @@ WholeStageCodegen (13)
                                         BroadcastExchange #8
                                           WholeStageCodegen (8)
                                             Filter [d_date_sk,d_week_seq]
-                                              Subquery #2
+                                              Subquery #3
                                                 ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(d_week_seq, 42), 362, 9656, 0, 0),bloomFilter,buf]
                                                   Exchange #9
                                                     ObjectHashAggregate [d_week_seq] [buf,buf]
-                                                      WholeStageCodegen (1)
-                                                        Project [d_week_seq]
-                                                          Filter [d_year,d_week_seq]
-                                                            ColumnarToRow
-                                                              InputAdapter
-                                                                Scan parquet spark_catalog.default.date_dim [d_week_seq,d_year]
+                                                      BroadcastExchangeExecProxy [d_week_seq]
+                                                        SubqueryBroadcast [d_week_seq] #4
+                                                          BroadcastExchange #10
+                                                            WholeStageCodegen (1)
+                                                              Project [d_week_seq]
+                                                                Filter [d_year,d_week_seq]
+                                                                  ColumnarToRow
+                                                                    InputAdapter
+                                                                      Scan parquet spark_catalog.default.date_dim [d_week_seq,d_year]
                                               ColumnarToRow
                                                 InputAdapter
                                                   Scan parquet spark_catalog.default.date_dim [d_date_sk,d_week_seq,d_day_name]
                         InputAdapter
-                          BroadcastExchange #10
-                            WholeStageCodegen (10)
-                              Project [d_week_seq]
-                                Filter [d_year,d_week_seq]
-                                  ColumnarToRow
-                                    InputAdapter
-                                      Scan parquet spark_catalog.default.date_dim [d_week_seq,d_year]
+                          ReusedExchange [d_week_seq] #10

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24a.sf100/explain.txt
@@ -62,7 +62,7 @@ Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, s
 
 (3) Filter [codegen id : 2]
 Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, ss_sold_date_sk#6]
-Condition : ((((isnotnull(ss_ticket_number#4) AND isnotnull(ss_item_sk#1)) AND isnotnull(ss_store_sk#3)) AND isnotnull(ss_customer_sk#2)) AND might_contain(Subquery scalar-subquery#7, [id=#8], xxhash64(ss_store_sk#3, 42)))
+Condition : ((((isnotnull(ss_ticket_number#4) AND isnotnull(ss_item_sk#1)) AND isnotnull(ss_store_sk#3)) AND isnotnull(ss_customer_sk#2)) AND might_contain(runtimefilterexpression(Subquery scalar-subquery#7, [id=#8]), xxhash64(ss_store_sk#3, 42)))
 
 (4) Project [codegen id : 2]
 Output [5]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24b.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24b.sf100/explain.txt
@@ -62,7 +62,7 @@ Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, s
 
 (3) Filter [codegen id : 2]
 Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, ss_sold_date_sk#6]
-Condition : ((((isnotnull(ss_ticket_number#4) AND isnotnull(ss_item_sk#1)) AND isnotnull(ss_store_sk#3)) AND isnotnull(ss_customer_sk#2)) AND might_contain(Subquery scalar-subquery#7, [id=#8], xxhash64(ss_store_sk#3, 42)))
+Condition : ((((isnotnull(ss_ticket_number#4) AND isnotnull(ss_item_sk#1)) AND isnotnull(ss_store_sk#3)) AND isnotnull(ss_customer_sk#2)) AND might_contain(runtimefilterexpression(Subquery scalar-subquery#7, [id=#8]), xxhash64(ss_store_sk#3, 42)))
 
 (4) Project [codegen id : 2]
 Output [5]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q32.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q32.sf100/explain.txt
@@ -65,9 +65,9 @@ Input [3]: [cs_item_sk#3, cs_ext_discount_amt#4, cs_sold_date_sk#5]
 
 (8) Filter [codegen id : 3]
 Input [3]: [cs_item_sk#3, cs_ext_discount_amt#4, cs_sold_date_sk#5]
-Condition : (isnotnull(cs_item_sk#3) AND might_contain(Subquery scalar-subquery#7, [id=#8], xxhash64(cs_item_sk#3, 42)))
+Condition : (isnotnull(cs_item_sk#3) AND might_contain(runtimefilterexpression(Subquery scalar-subquery#7, [id=#8]), xxhash64(cs_item_sk#3, 42)))
 
-(9) ReusedExchange [Reuses operator id: 41]
+(9) ReusedExchange [Reuses operator id: 40]
 Output [1]: [d_date_sk#9]
 
 (10) BroadcastHashJoin [codegen id : 3]
@@ -141,7 +141,7 @@ Join condition: (cast(cs_ext_discount_amt#17 as decimal(14,7)) > (1.3 * avg(cs_e
 Output [2]: [cs_ext_discount_amt#17, cs_sold_date_sk#18]
 Input [5]: [i_item_sk#1, (1.3 * avg(cs_ext_discount_amt))#15, cs_item_sk#16, cs_ext_discount_amt#17, cs_sold_date_sk#18]
 
-(24) ReusedExchange [Reuses operator id: 41]
+(24) ReusedExchange [Reuses operator id: 40]
 Output [1]: [d_date_sk#19]
 
 (25) BroadcastHashJoin [codegen id : 6]
@@ -175,78 +175,68 @@ Results [1]: [MakeDecimal(sum(UnscaledValue(cs_ext_discount_amt#17))#22,17,2) AS
 ===== Subqueries =====
 
 Subquery:1 Hosting operator id = 8 Hosting Expression = Subquery scalar-subquery#7, [id=#8]
-ObjectHashAggregate (36)
-+- Exchange (35)
-   +- ObjectHashAggregate (34)
-      +- * Project (33)
-         +- * Filter (32)
-            +- * ColumnarToRow (31)
-               +- Scan parquet spark_catalog.default.item (30)
+ObjectHashAggregate (35)
++- Exchange (34)
+   +- ObjectHashAggregate (33)
+      +- BroadcastExchangeExecProxy (32)
 
 
-(30) Scan parquet spark_catalog.default.item
-Output [2]: [i_item_sk#1, i_manufact_id#2]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/item]
-PushedFilters: [IsNotNull(i_manufact_id), EqualTo(i_manufact_id,977), IsNotNull(i_item_sk)]
-ReadSchema: struct<i_item_sk:int,i_manufact_id:int>
-
-(31) ColumnarToRow [codegen id : 1]
-Input [2]: [i_item_sk#1, i_manufact_id#2]
-
-(32) Filter [codegen id : 1]
-Input [2]: [i_item_sk#1, i_manufact_id#2]
-Condition : ((isnotnull(i_manufact_id#2) AND (i_manufact_id#2 = 977)) AND isnotnull(i_item_sk#1))
-
-(33) Project [codegen id : 1]
+(30) ReusedExchange [Reuses operator id: 5]
 Output [1]: [i_item_sk#1]
-Input [2]: [i_item_sk#1, i_manufact_id#2]
 
-(34) ObjectHashAggregate
+(31) SubqueryBroadcast
+Input [1]: [i_item_sk#1]
+Arguments: runtimefilter#7, 0, [i_item_sk#1], [id=#24]
+
+(32) BroadcastExchangeExecProxy
+Input [1]: [i_item_sk#25]
+Arguments: [i_item_sk#1]
+
+(33) ObjectHashAggregate
 Input [1]: [i_item_sk#1]
 Keys: []
 Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#1, 42), 199, 5556, 0, 0)]
-Aggregate Attributes [1]: [buf#24]
-Results [1]: [buf#25]
+Aggregate Attributes [1]: [buf#26]
+Results [1]: [buf#27]
 
-(35) Exchange
-Input [1]: [buf#25]
+(34) Exchange
+Input [1]: [buf#27]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=5]
 
-(36) ObjectHashAggregate
-Input [1]: [buf#25]
+(35) ObjectHashAggregate
+Input [1]: [buf#27]
 Keys: []
 Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#1, 42), 199, 5556, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#1, 42), 199, 5556, 0, 0)#26]
-Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#1, 42), 199, 5556, 0, 0)#26 AS bloomFilter#27]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#1, 42), 199, 5556, 0, 0)#28]
+Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#1, 42), 199, 5556, 0, 0)#28 AS bloomFilter#29]
 
 Subquery:2 Hosting operator id = 6 Hosting Expression = cs_sold_date_sk#5 IN dynamicpruning#6
-BroadcastExchange (41)
-+- * Project (40)
-   +- * Filter (39)
-      +- * ColumnarToRow (38)
-         +- Scan parquet spark_catalog.default.date_dim (37)
+BroadcastExchange (40)
++- * Project (39)
+   +- * Filter (38)
+      +- * ColumnarToRow (37)
+         +- Scan parquet spark_catalog.default.date_dim (36)
 
 
-(37) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#9, d_date#28]
+(36) Scan parquet spark_catalog.default.date_dim
+Output [2]: [d_date_sk#9, d_date#30]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,2000-01-27), LessThanOrEqual(d_date,2000-04-26), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
-(38) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#9, d_date#28]
+(37) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#9, d_date#30]
 
-(39) Filter [codegen id : 1]
-Input [2]: [d_date_sk#9, d_date#28]
-Condition : (((isnotnull(d_date#28) AND (d_date#28 >= 2000-01-27)) AND (d_date#28 <= 2000-04-26)) AND isnotnull(d_date_sk#9))
+(38) Filter [codegen id : 1]
+Input [2]: [d_date_sk#9, d_date#30]
+Condition : (((isnotnull(d_date#30) AND (d_date#30 >= 2000-01-27)) AND (d_date#30 <= 2000-04-26)) AND isnotnull(d_date_sk#9))
 
-(40) Project [codegen id : 1]
+(39) Project [codegen id : 1]
 Output [1]: [d_date_sk#9]
-Input [2]: [d_date_sk#9, d_date#28]
+Input [2]: [d_date_sk#9, d_date#30]
 
-(41) BroadcastExchange
+(40) BroadcastExchange
 Input [1]: [d_date_sk#9]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=6]
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q32.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q32.sf100/simplified.txt
@@ -34,12 +34,9 @@ WholeStageCodegen (7)
                                                   ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(i_item_sk, 42), 199, 5556, 0, 0),bloomFilter,buf]
                                                     Exchange #6
                                                       ObjectHashAggregate [i_item_sk] [buf,buf]
-                                                        WholeStageCodegen (1)
-                                                          Project [i_item_sk]
-                                                            Filter [i_manufact_id,i_item_sk]
-                                                              ColumnarToRow
-                                                                InputAdapter
-                                                                  Scan parquet spark_catalog.default.item [i_item_sk,i_manufact_id]
+                                                        BroadcastExchangeExecProxy [i_item_sk]
+                                                          SubqueryBroadcast [i_item_sk] #3
+                                                            ReusedExchange [i_item_sk] #3
                                                 ColumnarToRow
                                                   InputAdapter
                                                     Scan parquet spark_catalog.default.catalog_sales [cs_item_sk,cs_ext_discount_amt,cs_sold_date_sk]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q37.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q37.sf100/explain.txt
@@ -113,7 +113,7 @@ Input [2]: [cs_item_sk#11, cs_sold_date_sk#12]
 
 (19) Filter [codegen id : 5]
 Input [2]: [cs_item_sk#11, cs_sold_date_sk#12]
-Condition : (isnotnull(cs_item_sk#11) AND might_contain(Subquery scalar-subquery#13, [id=#14], xxhash64(cs_item_sk#11, 42)))
+Condition : (isnotnull(cs_item_sk#11) AND might_contain(runtimefilterexpression(Subquery scalar-subquery#13, [id=#14]), xxhash64(cs_item_sk#11, 42)))
 
 (20) Project [codegen id : 5]
 Output [1]: [cs_item_sk#11]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q40.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q40.sf100/explain.txt
@@ -47,7 +47,7 @@ Input [5]: [cs_warehouse_sk#1, cs_item_sk#2, cs_order_number#3, cs_sales_price#4
 
 (3) Filter [codegen id : 1]
 Input [5]: [cs_warehouse_sk#1, cs_item_sk#2, cs_order_number#3, cs_sales_price#4, cs_sold_date_sk#5]
-Condition : ((isnotnull(cs_warehouse_sk#1) AND isnotnull(cs_item_sk#2)) AND might_contain(Subquery scalar-subquery#7, [id=#8], xxhash64(cs_item_sk#2, 42)))
+Condition : ((isnotnull(cs_warehouse_sk#1) AND isnotnull(cs_item_sk#2)) AND might_contain(runtimefilterexpression(Subquery scalar-subquery#7, [id=#8]), xxhash64(cs_item_sk#2, 42)))
 
 (4) Exchange
 Input [5]: [cs_warehouse_sk#1, cs_item_sk#2, cs_order_number#3, cs_sales_price#4, cs_sold_date_sk#5]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q59.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q59.sf100/explain.txt
@@ -1,9 +1,9 @@
 == Physical Plan ==
-TakeOrderedAndProject (54)
-+- * Project (53)
-   +- * BroadcastHashJoin Inner BuildRight (52)
-      :- * Project (25)
-      :  +- * BroadcastHashJoin Inner BuildRight (24)
+TakeOrderedAndProject (46)
++- * Project (45)
+   +- * BroadcastHashJoin Inner BuildRight (44)
+      :- * Project (21)
+      :  +- * BroadcastHashJoin Inner BuildRight (20)
       :     :- * Project (18)
       :     :  +- * BroadcastHashJoin Inner BuildRight (17)
       :     :     :- * HashAggregate (12)
@@ -22,37 +22,29 @@ TakeOrderedAndProject (54)
       :     :        +- * Filter (15)
       :     :           +- * ColumnarToRow (14)
       :     :              +- Scan parquet spark_catalog.default.store (13)
-      :     +- BroadcastExchange (23)
-      :        +- * Project (22)
-      :           +- * Filter (21)
-      :              +- * ColumnarToRow (20)
-      :                 +- Scan parquet spark_catalog.default.date_dim (19)
-      +- BroadcastExchange (51)
-         +- * Project (50)
-            +- * BroadcastHashJoin Inner BuildRight (49)
-               :- * Project (43)
-               :  +- * BroadcastHashJoin Inner BuildRight (42)
-               :     :- * HashAggregate (37)
-               :     :  +- Exchange (36)
-               :     :     +- * HashAggregate (35)
-               :     :        +- * Project (34)
-               :     :           +- * BroadcastHashJoin Inner BuildRight (33)
-               :     :              :- * Filter (28)
-               :     :              :  +- * ColumnarToRow (27)
-               :     :              :     +- Scan parquet spark_catalog.default.store_sales (26)
-               :     :              +- BroadcastExchange (32)
-               :     :                 +- * Filter (31)
-               :     :                    +- * ColumnarToRow (30)
-               :     :                       +- Scan parquet spark_catalog.default.date_dim (29)
-               :     +- BroadcastExchange (41)
-               :        +- * Filter (40)
-               :           +- * ColumnarToRow (39)
-               :              +- Scan parquet spark_catalog.default.store (38)
-               +- BroadcastExchange (48)
-                  +- * Project (47)
-                     +- * Filter (46)
-                        +- * ColumnarToRow (45)
-                           +- Scan parquet spark_catalog.default.date_dim (44)
+      :     +- ReusedExchange (19)
+      +- BroadcastExchange (43)
+         +- * Project (42)
+            +- * BroadcastHashJoin Inner BuildRight (41)
+               :- * Project (39)
+               :  +- * BroadcastHashJoin Inner BuildRight (38)
+               :     :- * HashAggregate (33)
+               :     :  +- Exchange (32)
+               :     :     +- * HashAggregate (31)
+               :     :        +- * Project (30)
+               :     :           +- * BroadcastHashJoin Inner BuildRight (29)
+               :     :              :- * Filter (24)
+               :     :              :  +- * ColumnarToRow (23)
+               :     :              :     +- Scan parquet spark_catalog.default.store_sales (22)
+               :     :              +- BroadcastExchange (28)
+               :     :                 +- * Filter (27)
+               :     :                    +- * ColumnarToRow (26)
+               :     :                       +- Scan parquet spark_catalog.default.date_dim (25)
+               :     +- BroadcastExchange (37)
+               :        +- * Filter (36)
+               :           +- * ColumnarToRow (35)
+               :              +- Scan parquet spark_catalog.default.store (34)
+               +- ReusedExchange (40)
 
 
 (1) Scan parquet spark_catalog.default.store_sales
@@ -82,7 +74,7 @@ Input [3]: [d_date_sk#4, d_week_seq#5, d_day_name#6]
 
 (6) Filter [codegen id : 1]
 Input [3]: [d_date_sk#4, d_week_seq#5, d_day_name#6]
-Condition : ((isnotnull(d_date_sk#4) AND isnotnull(d_week_seq#5)) AND might_contain(Subquery scalar-subquery#7, [id=#8], xxhash64(d_week_seq#5, 42)))
+Condition : ((isnotnull(d_date_sk#4) AND isnotnull(d_week_seq#5)) AND might_contain(runtimefilterexpression(Subquery scalar-subquery#7, [id=#8]), xxhash64(d_week_seq#5, 42)))
 
 (7) BroadcastExchange
 Input [3]: [d_date_sk#4, d_week_seq#5, d_day_name#6]
@@ -144,269 +136,249 @@ Join condition: None
 Output [10]: [d_week_seq#5, sun_sales#30, mon_sales#31, tue_sales#32, wed_sales#33, thu_sales#34, fri_sales#35, sat_sales#36, s_store_id#38, s_store_name#39]
 Input [12]: [d_week_seq#5, ss_store_sk#1, sun_sales#30, mon_sales#31, tue_sales#32, wed_sales#33, thu_sales#34, fri_sales#35, sat_sales#36, s_store_sk#37, s_store_id#38, s_store_name#39]
 
-(19) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_month_seq#40, d_week_seq#41]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/date_dim]
-PushedFilters: [IsNotNull(d_month_seq), GreaterThanOrEqual(d_month_seq,1212), LessThanOrEqual(d_month_seq,1223), IsNotNull(d_week_seq)]
-ReadSchema: struct<d_month_seq:int,d_week_seq:int>
+(19) ReusedExchange [Reuses operator id: 51]
+Output [1]: [d_week_seq#40]
 
-(20) ColumnarToRow [codegen id : 4]
-Input [2]: [d_month_seq#40, d_week_seq#41]
-
-(21) Filter [codegen id : 4]
-Input [2]: [d_month_seq#40, d_week_seq#41]
-Condition : (((isnotnull(d_month_seq#40) AND (d_month_seq#40 >= 1212)) AND (d_month_seq#40 <= 1223)) AND isnotnull(d_week_seq#41))
-
-(22) Project [codegen id : 4]
-Output [1]: [d_week_seq#41]
-Input [2]: [d_month_seq#40, d_week_seq#41]
-
-(23) BroadcastExchange
-Input [1]: [d_week_seq#41]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=4]
-
-(24) BroadcastHashJoin [codegen id : 10]
+(20) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [d_week_seq#5]
-Right keys [1]: [d_week_seq#41]
+Right keys [1]: [d_week_seq#40]
 Join type: Inner
 Join condition: None
 
-(25) Project [codegen id : 10]
-Output [10]: [s_store_name#39 AS s_store_name1#42, d_week_seq#5 AS d_week_seq1#43, s_store_id#38 AS s_store_id1#44, sun_sales#30 AS sun_sales1#45, mon_sales#31 AS mon_sales1#46, tue_sales#32 AS tue_sales1#47, wed_sales#33 AS wed_sales1#48, thu_sales#34 AS thu_sales1#49, fri_sales#35 AS fri_sales1#50, sat_sales#36 AS sat_sales1#51]
-Input [11]: [d_week_seq#5, sun_sales#30, mon_sales#31, tue_sales#32, wed_sales#33, thu_sales#34, fri_sales#35, sat_sales#36, s_store_id#38, s_store_name#39, d_week_seq#41]
+(21) Project [codegen id : 10]
+Output [10]: [s_store_name#39 AS s_store_name1#41, d_week_seq#5 AS d_week_seq1#42, s_store_id#38 AS s_store_id1#43, sun_sales#30 AS sun_sales1#44, mon_sales#31 AS mon_sales1#45, tue_sales#32 AS tue_sales1#46, wed_sales#33 AS wed_sales1#47, thu_sales#34 AS thu_sales1#48, fri_sales#35 AS fri_sales1#49, sat_sales#36 AS sat_sales1#50]
+Input [11]: [d_week_seq#5, sun_sales#30, mon_sales#31, tue_sales#32, wed_sales#33, thu_sales#34, fri_sales#35, sat_sales#36, s_store_id#38, s_store_name#39, d_week_seq#40]
 
-(26) Scan parquet spark_catalog.default.store_sales
-Output [3]: [ss_store_sk#52, ss_sales_price#53, ss_sold_date_sk#54]
+(22) Scan parquet spark_catalog.default.store_sales
+Output [3]: [ss_store_sk#51, ss_sales_price#52, ss_sold_date_sk#53]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#54)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#53)]
 PushedFilters: [IsNotNull(ss_store_sk)]
 ReadSchema: struct<ss_store_sk:int,ss_sales_price:decimal(7,2)>
 
-(27) ColumnarToRow [codegen id : 6]
-Input [3]: [ss_store_sk#52, ss_sales_price#53, ss_sold_date_sk#54]
+(23) ColumnarToRow [codegen id : 6]
+Input [3]: [ss_store_sk#51, ss_sales_price#52, ss_sold_date_sk#53]
 
-(28) Filter [codegen id : 6]
-Input [3]: [ss_store_sk#52, ss_sales_price#53, ss_sold_date_sk#54]
-Condition : isnotnull(ss_store_sk#52)
+(24) Filter [codegen id : 6]
+Input [3]: [ss_store_sk#51, ss_sales_price#52, ss_sold_date_sk#53]
+Condition : isnotnull(ss_store_sk#51)
 
-(29) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#55, d_week_seq#56, d_day_name#57]
+(25) Scan parquet spark_catalog.default.date_dim
+Output [3]: [d_date_sk#54, d_week_seq#55, d_day_name#56]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date_sk), IsNotNull(d_week_seq)]
 ReadSchema: struct<d_date_sk:int,d_week_seq:int,d_day_name:string>
 
-(30) ColumnarToRow [codegen id : 5]
-Input [3]: [d_date_sk#55, d_week_seq#56, d_day_name#57]
+(26) ColumnarToRow [codegen id : 5]
+Input [3]: [d_date_sk#54, d_week_seq#55, d_day_name#56]
 
-(31) Filter [codegen id : 5]
-Input [3]: [d_date_sk#55, d_week_seq#56, d_day_name#57]
-Condition : ((isnotnull(d_date_sk#55) AND isnotnull(d_week_seq#56)) AND might_contain(Subquery scalar-subquery#58, [id=#59], xxhash64(d_week_seq#56, 42)))
+(27) Filter [codegen id : 5]
+Input [3]: [d_date_sk#54, d_week_seq#55, d_day_name#56]
+Condition : ((isnotnull(d_date_sk#54) AND isnotnull(d_week_seq#55)) AND might_contain(runtimefilterexpression(Subquery scalar-subquery#57, [id=#58]), xxhash64(d_week_seq#55, 42)))
 
-(32) BroadcastExchange
-Input [3]: [d_date_sk#55, d_week_seq#56, d_day_name#57]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=5]
+(28) BroadcastExchange
+Input [3]: [d_date_sk#54, d_week_seq#55, d_day_name#56]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=4]
 
-(33) BroadcastHashJoin [codegen id : 6]
-Left keys [1]: [ss_sold_date_sk#54]
-Right keys [1]: [d_date_sk#55]
+(29) BroadcastHashJoin [codegen id : 6]
+Left keys [1]: [ss_sold_date_sk#53]
+Right keys [1]: [d_date_sk#54]
 Join type: Inner
 Join condition: None
 
-(34) Project [codegen id : 6]
-Output [4]: [ss_store_sk#52, ss_sales_price#53, d_week_seq#56, d_day_name#57]
-Input [6]: [ss_store_sk#52, ss_sales_price#53, ss_sold_date_sk#54, d_date_sk#55, d_week_seq#56, d_day_name#57]
+(30) Project [codegen id : 6]
+Output [4]: [ss_store_sk#51, ss_sales_price#52, d_week_seq#55, d_day_name#56]
+Input [6]: [ss_store_sk#51, ss_sales_price#52, ss_sold_date_sk#53, d_date_sk#54, d_week_seq#55, d_day_name#56]
 
-(35) HashAggregate [codegen id : 6]
-Input [4]: [ss_store_sk#52, ss_sales_price#53, d_week_seq#56, d_day_name#57]
-Keys [2]: [d_week_seq#56, ss_store_sk#52]
-Functions [7]: [partial_sum(UnscaledValue(CASE WHEN (d_day_name#57 = Sunday   ) THEN ss_sales_price#53 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#57 = Monday   ) THEN ss_sales_price#53 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#57 = Tuesday  ) THEN ss_sales_price#53 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#57 = Wednesday) THEN ss_sales_price#53 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#57 = Thursday ) THEN ss_sales_price#53 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#57 = Friday   ) THEN ss_sales_price#53 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#57 = Saturday ) THEN ss_sales_price#53 END))]
-Aggregate Attributes [7]: [sum#60, sum#61, sum#62, sum#63, sum#64, sum#65, sum#66]
-Results [9]: [d_week_seq#56, ss_store_sk#52, sum#67, sum#68, sum#69, sum#70, sum#71, sum#72, sum#73]
+(31) HashAggregate [codegen id : 6]
+Input [4]: [ss_store_sk#51, ss_sales_price#52, d_week_seq#55, d_day_name#56]
+Keys [2]: [d_week_seq#55, ss_store_sk#51]
+Functions [7]: [partial_sum(UnscaledValue(CASE WHEN (d_day_name#56 = Sunday   ) THEN ss_sales_price#52 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#56 = Monday   ) THEN ss_sales_price#52 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#56 = Tuesday  ) THEN ss_sales_price#52 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#56 = Wednesday) THEN ss_sales_price#52 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#56 = Thursday ) THEN ss_sales_price#52 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#56 = Friday   ) THEN ss_sales_price#52 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#56 = Saturday ) THEN ss_sales_price#52 END))]
+Aggregate Attributes [7]: [sum#59, sum#60, sum#61, sum#62, sum#63, sum#64, sum#65]
+Results [9]: [d_week_seq#55, ss_store_sk#51, sum#66, sum#67, sum#68, sum#69, sum#70, sum#71, sum#72]
 
-(36) Exchange
-Input [9]: [d_week_seq#56, ss_store_sk#52, sum#67, sum#68, sum#69, sum#70, sum#71, sum#72, sum#73]
-Arguments: hashpartitioning(d_week_seq#56, ss_store_sk#52, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+(32) Exchange
+Input [9]: [d_week_seq#55, ss_store_sk#51, sum#66, sum#67, sum#68, sum#69, sum#70, sum#71, sum#72]
+Arguments: hashpartitioning(d_week_seq#55, ss_store_sk#51, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
-(37) HashAggregate [codegen id : 9]
-Input [9]: [d_week_seq#56, ss_store_sk#52, sum#67, sum#68, sum#69, sum#70, sum#71, sum#72, sum#73]
-Keys [2]: [d_week_seq#56, ss_store_sk#52]
-Functions [7]: [sum(UnscaledValue(CASE WHEN (d_day_name#57 = Sunday   ) THEN ss_sales_price#53 END)), sum(UnscaledValue(CASE WHEN (d_day_name#57 = Monday   ) THEN ss_sales_price#53 END)), sum(UnscaledValue(CASE WHEN (d_day_name#57 = Tuesday  ) THEN ss_sales_price#53 END)), sum(UnscaledValue(CASE WHEN (d_day_name#57 = Wednesday) THEN ss_sales_price#53 END)), sum(UnscaledValue(CASE WHEN (d_day_name#57 = Thursday ) THEN ss_sales_price#53 END)), sum(UnscaledValue(CASE WHEN (d_day_name#57 = Friday   ) THEN ss_sales_price#53 END)), sum(UnscaledValue(CASE WHEN (d_day_name#57 = Saturday ) THEN ss_sales_price#53 END))]
-Aggregate Attributes [7]: [sum(UnscaledValue(CASE WHEN (d_day_name#57 = Sunday   ) THEN ss_sales_price#53 END))#23, sum(UnscaledValue(CASE WHEN (d_day_name#57 = Monday   ) THEN ss_sales_price#53 END))#24, sum(UnscaledValue(CASE WHEN (d_day_name#57 = Tuesday  ) THEN ss_sales_price#53 END))#25, sum(UnscaledValue(CASE WHEN (d_day_name#57 = Wednesday) THEN ss_sales_price#53 END))#26, sum(UnscaledValue(CASE WHEN (d_day_name#57 = Thursday ) THEN ss_sales_price#53 END))#27, sum(UnscaledValue(CASE WHEN (d_day_name#57 = Friday   ) THEN ss_sales_price#53 END))#28, sum(UnscaledValue(CASE WHEN (d_day_name#57 = Saturday ) THEN ss_sales_price#53 END))#29]
-Results [9]: [d_week_seq#56, ss_store_sk#52, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#57 = Sunday   ) THEN ss_sales_price#53 END))#23,17,2) AS sun_sales#74, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#57 = Monday   ) THEN ss_sales_price#53 END))#24,17,2) AS mon_sales#75, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#57 = Tuesday  ) THEN ss_sales_price#53 END))#25,17,2) AS tue_sales#76, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#57 = Wednesday) THEN ss_sales_price#53 END))#26,17,2) AS wed_sales#77, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#57 = Thursday ) THEN ss_sales_price#53 END))#27,17,2) AS thu_sales#78, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#57 = Friday   ) THEN ss_sales_price#53 END))#28,17,2) AS fri_sales#79, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#57 = Saturday ) THEN ss_sales_price#53 END))#29,17,2) AS sat_sales#80]
+(33) HashAggregate [codegen id : 9]
+Input [9]: [d_week_seq#55, ss_store_sk#51, sum#66, sum#67, sum#68, sum#69, sum#70, sum#71, sum#72]
+Keys [2]: [d_week_seq#55, ss_store_sk#51]
+Functions [7]: [sum(UnscaledValue(CASE WHEN (d_day_name#56 = Sunday   ) THEN ss_sales_price#52 END)), sum(UnscaledValue(CASE WHEN (d_day_name#56 = Monday   ) THEN ss_sales_price#52 END)), sum(UnscaledValue(CASE WHEN (d_day_name#56 = Tuesday  ) THEN ss_sales_price#52 END)), sum(UnscaledValue(CASE WHEN (d_day_name#56 = Wednesday) THEN ss_sales_price#52 END)), sum(UnscaledValue(CASE WHEN (d_day_name#56 = Thursday ) THEN ss_sales_price#52 END)), sum(UnscaledValue(CASE WHEN (d_day_name#56 = Friday   ) THEN ss_sales_price#52 END)), sum(UnscaledValue(CASE WHEN (d_day_name#56 = Saturday ) THEN ss_sales_price#52 END))]
+Aggregate Attributes [7]: [sum(UnscaledValue(CASE WHEN (d_day_name#56 = Sunday   ) THEN ss_sales_price#52 END))#23, sum(UnscaledValue(CASE WHEN (d_day_name#56 = Monday   ) THEN ss_sales_price#52 END))#24, sum(UnscaledValue(CASE WHEN (d_day_name#56 = Tuesday  ) THEN ss_sales_price#52 END))#25, sum(UnscaledValue(CASE WHEN (d_day_name#56 = Wednesday) THEN ss_sales_price#52 END))#26, sum(UnscaledValue(CASE WHEN (d_day_name#56 = Thursday ) THEN ss_sales_price#52 END))#27, sum(UnscaledValue(CASE WHEN (d_day_name#56 = Friday   ) THEN ss_sales_price#52 END))#28, sum(UnscaledValue(CASE WHEN (d_day_name#56 = Saturday ) THEN ss_sales_price#52 END))#29]
+Results [9]: [d_week_seq#55, ss_store_sk#51, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#56 = Sunday   ) THEN ss_sales_price#52 END))#23,17,2) AS sun_sales#73, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#56 = Monday   ) THEN ss_sales_price#52 END))#24,17,2) AS mon_sales#74, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#56 = Tuesday  ) THEN ss_sales_price#52 END))#25,17,2) AS tue_sales#75, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#56 = Wednesday) THEN ss_sales_price#52 END))#26,17,2) AS wed_sales#76, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#56 = Thursday ) THEN ss_sales_price#52 END))#27,17,2) AS thu_sales#77, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#56 = Friday   ) THEN ss_sales_price#52 END))#28,17,2) AS fri_sales#78, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#56 = Saturday ) THEN ss_sales_price#52 END))#29,17,2) AS sat_sales#79]
 
-(38) Scan parquet spark_catalog.default.store
-Output [2]: [s_store_sk#81, s_store_id#82]
+(34) Scan parquet spark_catalog.default.store
+Output [2]: [s_store_sk#80, s_store_id#81]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_store_sk), IsNotNull(s_store_id)]
 ReadSchema: struct<s_store_sk:int,s_store_id:string>
 
-(39) ColumnarToRow [codegen id : 7]
-Input [2]: [s_store_sk#81, s_store_id#82]
+(35) ColumnarToRow [codegen id : 7]
+Input [2]: [s_store_sk#80, s_store_id#81]
 
-(40) Filter [codegen id : 7]
-Input [2]: [s_store_sk#81, s_store_id#82]
-Condition : (isnotnull(s_store_sk#81) AND isnotnull(s_store_id#82))
+(36) Filter [codegen id : 7]
+Input [2]: [s_store_sk#80, s_store_id#81]
+Condition : (isnotnull(s_store_sk#80) AND isnotnull(s_store_id#81))
 
-(41) BroadcastExchange
-Input [2]: [s_store_sk#81, s_store_id#82]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=7]
+(37) BroadcastExchange
+Input [2]: [s_store_sk#80, s_store_id#81]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=6]
 
-(42) BroadcastHashJoin [codegen id : 9]
-Left keys [1]: [ss_store_sk#52]
-Right keys [1]: [s_store_sk#81]
+(38) BroadcastHashJoin [codegen id : 9]
+Left keys [1]: [ss_store_sk#51]
+Right keys [1]: [s_store_sk#80]
 Join type: Inner
 Join condition: None
 
-(43) Project [codegen id : 9]
-Output [9]: [d_week_seq#56, sun_sales#74, mon_sales#75, tue_sales#76, wed_sales#77, thu_sales#78, fri_sales#79, sat_sales#80, s_store_id#82]
-Input [11]: [d_week_seq#56, ss_store_sk#52, sun_sales#74, mon_sales#75, tue_sales#76, wed_sales#77, thu_sales#78, fri_sales#79, sat_sales#80, s_store_sk#81, s_store_id#82]
+(39) Project [codegen id : 9]
+Output [9]: [d_week_seq#55, sun_sales#73, mon_sales#74, tue_sales#75, wed_sales#76, thu_sales#77, fri_sales#78, sat_sales#79, s_store_id#81]
+Input [11]: [d_week_seq#55, ss_store_sk#51, sun_sales#73, mon_sales#74, tue_sales#75, wed_sales#76, thu_sales#77, fri_sales#78, sat_sales#79, s_store_sk#80, s_store_id#81]
 
-(44) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_month_seq#83, d_week_seq#84]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/date_dim]
-PushedFilters: [IsNotNull(d_month_seq), GreaterThanOrEqual(d_month_seq,1224), LessThanOrEqual(d_month_seq,1235), IsNotNull(d_week_seq)]
-ReadSchema: struct<d_month_seq:int,d_week_seq:int>
+(40) ReusedExchange [Reuses operator id: 61]
+Output [1]: [d_week_seq#82]
 
-(45) ColumnarToRow [codegen id : 8]
-Input [2]: [d_month_seq#83, d_week_seq#84]
-
-(46) Filter [codegen id : 8]
-Input [2]: [d_month_seq#83, d_week_seq#84]
-Condition : (((isnotnull(d_month_seq#83) AND (d_month_seq#83 >= 1224)) AND (d_month_seq#83 <= 1235)) AND isnotnull(d_week_seq#84))
-
-(47) Project [codegen id : 8]
-Output [1]: [d_week_seq#84]
-Input [2]: [d_month_seq#83, d_week_seq#84]
-
-(48) BroadcastExchange
-Input [1]: [d_week_seq#84]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=8]
-
-(49) BroadcastHashJoin [codegen id : 9]
-Left keys [1]: [d_week_seq#56]
-Right keys [1]: [d_week_seq#84]
+(41) BroadcastHashJoin [codegen id : 9]
+Left keys [1]: [d_week_seq#55]
+Right keys [1]: [d_week_seq#82]
 Join type: Inner
 Join condition: None
 
-(50) Project [codegen id : 9]
-Output [9]: [d_week_seq#56 AS d_week_seq2#85, s_store_id#82 AS s_store_id2#86, sun_sales#74 AS sun_sales2#87, mon_sales#75 AS mon_sales2#88, tue_sales#76 AS tue_sales2#89, wed_sales#77 AS wed_sales2#90, thu_sales#78 AS thu_sales2#91, fri_sales#79 AS fri_sales2#92, sat_sales#80 AS sat_sales2#93]
-Input [10]: [d_week_seq#56, sun_sales#74, mon_sales#75, tue_sales#76, wed_sales#77, thu_sales#78, fri_sales#79, sat_sales#80, s_store_id#82, d_week_seq#84]
+(42) Project [codegen id : 9]
+Output [9]: [d_week_seq#55 AS d_week_seq2#83, s_store_id#81 AS s_store_id2#84, sun_sales#73 AS sun_sales2#85, mon_sales#74 AS mon_sales2#86, tue_sales#75 AS tue_sales2#87, wed_sales#76 AS wed_sales2#88, thu_sales#77 AS thu_sales2#89, fri_sales#78 AS fri_sales2#90, sat_sales#79 AS sat_sales2#91]
+Input [10]: [d_week_seq#55, sun_sales#73, mon_sales#74, tue_sales#75, wed_sales#76, thu_sales#77, fri_sales#78, sat_sales#79, s_store_id#81, d_week_seq#82]
 
-(51) BroadcastExchange
-Input [9]: [d_week_seq2#85, s_store_id2#86, sun_sales2#87, mon_sales2#88, tue_sales2#89, wed_sales2#90, thu_sales2#91, fri_sales2#92, sat_sales2#93]
-Arguments: HashedRelationBroadcastMode(List(input[1, string, true], (input[0, int, true] - 52)),false), [plan_id=9]
+(43) BroadcastExchange
+Input [9]: [d_week_seq2#83, s_store_id2#84, sun_sales2#85, mon_sales2#86, tue_sales2#87, wed_sales2#88, thu_sales2#89, fri_sales2#90, sat_sales2#91]
+Arguments: HashedRelationBroadcastMode(List(input[1, string, true], (input[0, int, true] - 52)),false), [plan_id=7]
 
-(52) BroadcastHashJoin [codegen id : 10]
-Left keys [2]: [s_store_id1#44, d_week_seq1#43]
-Right keys [2]: [s_store_id2#86, (d_week_seq2#85 - 52)]
+(44) BroadcastHashJoin [codegen id : 10]
+Left keys [2]: [s_store_id1#43, d_week_seq1#42]
+Right keys [2]: [s_store_id2#84, (d_week_seq2#83 - 52)]
 Join type: Inner
 Join condition: None
 
-(53) Project [codegen id : 10]
-Output [10]: [s_store_name1#42, s_store_id1#44, d_week_seq1#43, (sun_sales1#45 / sun_sales2#87) AS (sun_sales1 / sun_sales2)#94, (mon_sales1#46 / mon_sales2#88) AS (mon_sales1 / mon_sales2)#95, (tue_sales1#47 / tue_sales2#89) AS (tue_sales1 / tue_sales2)#96, (wed_sales1#48 / wed_sales2#90) AS (wed_sales1 / wed_sales2)#97, (thu_sales1#49 / thu_sales2#91) AS (thu_sales1 / thu_sales2)#98, (fri_sales1#50 / fri_sales2#92) AS (fri_sales1 / fri_sales2)#99, (sat_sales1#51 / sat_sales2#93) AS (sat_sales1 / sat_sales2)#100]
-Input [19]: [s_store_name1#42, d_week_seq1#43, s_store_id1#44, sun_sales1#45, mon_sales1#46, tue_sales1#47, wed_sales1#48, thu_sales1#49, fri_sales1#50, sat_sales1#51, d_week_seq2#85, s_store_id2#86, sun_sales2#87, mon_sales2#88, tue_sales2#89, wed_sales2#90, thu_sales2#91, fri_sales2#92, sat_sales2#93]
+(45) Project [codegen id : 10]
+Output [10]: [s_store_name1#41, s_store_id1#43, d_week_seq1#42, (sun_sales1#44 / sun_sales2#85) AS (sun_sales1 / sun_sales2)#92, (mon_sales1#45 / mon_sales2#86) AS (mon_sales1 / mon_sales2)#93, (tue_sales1#46 / tue_sales2#87) AS (tue_sales1 / tue_sales2)#94, (wed_sales1#47 / wed_sales2#88) AS (wed_sales1 / wed_sales2)#95, (thu_sales1#48 / thu_sales2#89) AS (thu_sales1 / thu_sales2)#96, (fri_sales1#49 / fri_sales2#90) AS (fri_sales1 / fri_sales2)#97, (sat_sales1#50 / sat_sales2#91) AS (sat_sales1 / sat_sales2)#98]
+Input [19]: [s_store_name1#41, d_week_seq1#42, s_store_id1#43, sun_sales1#44, mon_sales1#45, tue_sales1#46, wed_sales1#47, thu_sales1#48, fri_sales1#49, sat_sales1#50, d_week_seq2#83, s_store_id2#84, sun_sales2#85, mon_sales2#86, tue_sales2#87, wed_sales2#88, thu_sales2#89, fri_sales2#90, sat_sales2#91]
 
-(54) TakeOrderedAndProject
-Input [10]: [s_store_name1#42, s_store_id1#44, d_week_seq1#43, (sun_sales1 / sun_sales2)#94, (mon_sales1 / mon_sales2)#95, (tue_sales1 / tue_sales2)#96, (wed_sales1 / wed_sales2)#97, (thu_sales1 / thu_sales2)#98, (fri_sales1 / fri_sales2)#99, (sat_sales1 / sat_sales2)#100]
-Arguments: 100, [s_store_name1#42 ASC NULLS FIRST, s_store_id1#44 ASC NULLS FIRST, d_week_seq1#43 ASC NULLS FIRST], [s_store_name1#42, s_store_id1#44, d_week_seq1#43, (sun_sales1 / sun_sales2)#94, (mon_sales1 / mon_sales2)#95, (tue_sales1 / tue_sales2)#96, (wed_sales1 / wed_sales2)#97, (thu_sales1 / thu_sales2)#98, (fri_sales1 / fri_sales2)#99, (sat_sales1 / sat_sales2)#100]
+(46) TakeOrderedAndProject
+Input [10]: [s_store_name1#41, s_store_id1#43, d_week_seq1#42, (sun_sales1 / sun_sales2)#92, (mon_sales1 / mon_sales2)#93, (tue_sales1 / tue_sales2)#94, (wed_sales1 / wed_sales2)#95, (thu_sales1 / thu_sales2)#96, (fri_sales1 / fri_sales2)#97, (sat_sales1 / sat_sales2)#98]
+Arguments: 100, [s_store_name1#41 ASC NULLS FIRST, s_store_id1#43 ASC NULLS FIRST, d_week_seq1#42 ASC NULLS FIRST], [s_store_name1#41, s_store_id1#43, d_week_seq1#42, (sun_sales1 / sun_sales2)#92, (mon_sales1 / mon_sales2)#93, (tue_sales1 / tue_sales2)#94, (wed_sales1 / wed_sales2)#95, (thu_sales1 / thu_sales2)#96, (fri_sales1 / fri_sales2)#97, (sat_sales1 / sat_sales2)#98]
 
 ===== Subqueries =====
 
 Subquery:1 Hosting operator id = 6 Hosting Expression = Subquery scalar-subquery#7, [id=#8]
-ObjectHashAggregate (61)
-+- Exchange (60)
-   +- ObjectHashAggregate (59)
-      +- * Project (58)
-         +- * Filter (57)
-            +- * ColumnarToRow (56)
-               +- Scan parquet spark_catalog.default.date_dim (55)
+ObjectHashAggregate (56)
++- Exchange (55)
+   +- ObjectHashAggregate (54)
+      +- BroadcastExchangeExecProxy (53)
 
 
-(55) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_month_seq#40, d_week_seq#41]
+(47) Scan parquet spark_catalog.default.date_dim
+Output [2]: [d_month_seq#99, d_week_seq#40]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_month_seq), GreaterThanOrEqual(d_month_seq,1212), LessThanOrEqual(d_month_seq,1223), IsNotNull(d_week_seq)]
 ReadSchema: struct<d_month_seq:int,d_week_seq:int>
 
-(56) ColumnarToRow [codegen id : 1]
-Input [2]: [d_month_seq#40, d_week_seq#41]
+(48) ColumnarToRow [codegen id : 1]
+Input [2]: [d_month_seq#99, d_week_seq#40]
 
-(57) Filter [codegen id : 1]
-Input [2]: [d_month_seq#40, d_week_seq#41]
-Condition : (((isnotnull(d_month_seq#40) AND (d_month_seq#40 >= 1212)) AND (d_month_seq#40 <= 1223)) AND isnotnull(d_week_seq#41))
+(49) Filter [codegen id : 1]
+Input [2]: [d_month_seq#99, d_week_seq#40]
+Condition : (((isnotnull(d_month_seq#99) AND (d_month_seq#99 >= 1212)) AND (d_month_seq#99 <= 1223)) AND isnotnull(d_week_seq#40))
 
-(58) Project [codegen id : 1]
-Output [1]: [d_week_seq#41]
-Input [2]: [d_month_seq#40, d_week_seq#41]
+(50) Project [codegen id : 1]
+Output [1]: [d_week_seq#40]
+Input [2]: [d_month_seq#99, d_week_seq#40]
 
-(59) ObjectHashAggregate
-Input [1]: [d_week_seq#41]
+(51) BroadcastExchange
+Input [1]: [d_week_seq#40]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=8]
+
+(52) SubqueryBroadcast
+Input [1]: [d_week_seq#40]
+Arguments: runtimefilter#7, 0, [d_week_seq#40], [id=#100]
+
+(53) BroadcastExchangeExecProxy
+Input [1]: [d_week_seq#101]
+Arguments: [d_week_seq#40]
+
+(54) ObjectHashAggregate
+Input [1]: [d_week_seq#40]
 Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(d_week_seq#41, 42), 335, 8990, 0, 0)]
-Aggregate Attributes [1]: [buf#101]
-Results [1]: [buf#102]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(d_week_seq#40, 42), 335, 8990, 0, 0)]
+Aggregate Attributes [1]: [buf#102]
+Results [1]: [buf#103]
 
-(60) Exchange
-Input [1]: [buf#102]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=10]
+(55) Exchange
+Input [1]: [buf#103]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=9]
 
-(61) ObjectHashAggregate
-Input [1]: [buf#102]
+(56) ObjectHashAggregate
+Input [1]: [buf#103]
 Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(d_week_seq#41, 42), 335, 8990, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(d_week_seq#41, 42), 335, 8990, 0, 0)#103]
-Results [1]: [bloom_filter_agg(xxhash64(d_week_seq#41, 42), 335, 8990, 0, 0)#103 AS bloomFilter#104]
+Functions [1]: [bloom_filter_agg(xxhash64(d_week_seq#40, 42), 335, 8990, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(d_week_seq#40, 42), 335, 8990, 0, 0)#104]
+Results [1]: [bloom_filter_agg(xxhash64(d_week_seq#40, 42), 335, 8990, 0, 0)#104 AS bloomFilter#105]
 
-Subquery:2 Hosting operator id = 31 Hosting Expression = Subquery scalar-subquery#58, [id=#59]
-ObjectHashAggregate (68)
-+- Exchange (67)
-   +- ObjectHashAggregate (66)
-      +- * Project (65)
-         +- * Filter (64)
-            +- * ColumnarToRow (63)
-               +- Scan parquet spark_catalog.default.date_dim (62)
+Subquery:2 Hosting operator id = 27 Hosting Expression = Subquery scalar-subquery#57, [id=#58]
+ObjectHashAggregate (66)
++- Exchange (65)
+   +- ObjectHashAggregate (64)
+      +- BroadcastExchangeExecProxy (63)
 
 
-(62) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_month_seq#83, d_week_seq#84]
+(57) Scan parquet spark_catalog.default.date_dim
+Output [2]: [d_month_seq#106, d_week_seq#82]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_month_seq), GreaterThanOrEqual(d_month_seq,1224), LessThanOrEqual(d_month_seq,1235), IsNotNull(d_week_seq)]
 ReadSchema: struct<d_month_seq:int,d_week_seq:int>
 
-(63) ColumnarToRow [codegen id : 1]
-Input [2]: [d_month_seq#83, d_week_seq#84]
+(58) ColumnarToRow [codegen id : 1]
+Input [2]: [d_month_seq#106, d_week_seq#82]
 
-(64) Filter [codegen id : 1]
-Input [2]: [d_month_seq#83, d_week_seq#84]
-Condition : (((isnotnull(d_month_seq#83) AND (d_month_seq#83 >= 1224)) AND (d_month_seq#83 <= 1235)) AND isnotnull(d_week_seq#84))
+(59) Filter [codegen id : 1]
+Input [2]: [d_month_seq#106, d_week_seq#82]
+Condition : (((isnotnull(d_month_seq#106) AND (d_month_seq#106 >= 1224)) AND (d_month_seq#106 <= 1235)) AND isnotnull(d_week_seq#82))
 
-(65) Project [codegen id : 1]
-Output [1]: [d_week_seq#84]
-Input [2]: [d_month_seq#83, d_week_seq#84]
+(60) Project [codegen id : 1]
+Output [1]: [d_week_seq#82]
+Input [2]: [d_month_seq#106, d_week_seq#82]
 
-(66) ObjectHashAggregate
-Input [1]: [d_week_seq#84]
+(61) BroadcastExchange
+Input [1]: [d_week_seq#82]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=10]
+
+(62) SubqueryBroadcast
+Input [1]: [d_week_seq#82]
+Arguments: runtimefilter#57, 0, [d_week_seq#82], [id=#107]
+
+(63) BroadcastExchangeExecProxy
+Input [1]: [d_week_seq#108]
+Arguments: [d_week_seq#82]
+
+(64) ObjectHashAggregate
+Input [1]: [d_week_seq#82]
 Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(d_week_seq#84, 42), 335, 8990, 0, 0)]
-Aggregate Attributes [1]: [buf#105]
-Results [1]: [buf#106]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(d_week_seq#82, 42), 335, 8990, 0, 0)]
+Aggregate Attributes [1]: [buf#109]
+Results [1]: [buf#110]
 
-(67) Exchange
-Input [1]: [buf#106]
+(65) Exchange
+Input [1]: [buf#110]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=11]
 
-(68) ObjectHashAggregate
-Input [1]: [buf#106]
+(66) ObjectHashAggregate
+Input [1]: [buf#110]
 Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(d_week_seq#84, 42), 335, 8990, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(d_week_seq#84, 42), 335, 8990, 0, 0)#107]
-Results [1]: [bloom_filter_agg(xxhash64(d_week_seq#84, 42), 335, 8990, 0, 0)#107 AS bloomFilter#108]
+Functions [1]: [bloom_filter_agg(xxhash64(d_week_seq#82, 42), 335, 8990, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(d_week_seq#82, 42), 335, 8990, 0, 0)#111]
+Results [1]: [bloom_filter_agg(xxhash64(d_week_seq#82, 42), 335, 8990, 0, 0)#111 AS bloomFilter#112]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q59.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q59.sf100/simplified.txt
@@ -25,30 +25,27 @@ TakeOrderedAndProject [s_store_name1,s_store_id1,d_week_seq1,(sun_sales1 / sun_s
                                         ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(d_week_seq, 42), 335, 8990, 0, 0),bloomFilter,buf]
                                           Exchange #3
                                             ObjectHashAggregate [d_week_seq] [buf,buf]
-                                              WholeStageCodegen (1)
-                                                Project [d_week_seq]
-                                                  Filter [d_month_seq,d_week_seq]
-                                                    ColumnarToRow
-                                                      InputAdapter
-                                                        Scan parquet spark_catalog.default.date_dim [d_month_seq,d_week_seq]
+                                              BroadcastExchangeExecProxy [d_week_seq]
+                                                SubqueryBroadcast [d_week_seq] #2
+                                                  BroadcastExchange #4
+                                                    WholeStageCodegen (1)
+                                                      Project [d_week_seq]
+                                                        Filter [d_month_seq,d_week_seq]
+                                                          ColumnarToRow
+                                                            InputAdapter
+                                                              Scan parquet spark_catalog.default.date_dim [d_month_seq,d_week_seq]
                                       ColumnarToRow
                                         InputAdapter
                                           Scan parquet spark_catalog.default.date_dim [d_date_sk,d_week_seq,d_day_name]
                 InputAdapter
-                  BroadcastExchange #4
+                  BroadcastExchange #5
                     WholeStageCodegen (3)
                       Filter [s_store_sk,s_store_id]
                         ColumnarToRow
                           InputAdapter
                             Scan parquet spark_catalog.default.store [s_store_sk,s_store_id,s_store_name]
             InputAdapter
-              BroadcastExchange #5
-                WholeStageCodegen (4)
-                  Project [d_week_seq]
-                    Filter [d_month_seq,d_week_seq]
-                      ColumnarToRow
-                        InputAdapter
-                          Scan parquet spark_catalog.default.date_dim [d_month_seq,d_week_seq]
+              ReusedExchange [d_week_seq] #4
         InputAdapter
           BroadcastExchange #6
             WholeStageCodegen (9)
@@ -71,31 +68,28 @@ TakeOrderedAndProject [s_store_name1,s_store_id1,d_week_seq1,(sun_sales1 / sun_s
                                       BroadcastExchange #8
                                         WholeStageCodegen (5)
                                           Filter [d_date_sk,d_week_seq]
-                                            Subquery #2
+                                            Subquery #3
                                               ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(d_week_seq, 42), 335, 8990, 0, 0),bloomFilter,buf]
                                                 Exchange #9
                                                   ObjectHashAggregate [d_week_seq] [buf,buf]
-                                                    WholeStageCodegen (1)
-                                                      Project [d_week_seq]
-                                                        Filter [d_month_seq,d_week_seq]
-                                                          ColumnarToRow
-                                                            InputAdapter
-                                                              Scan parquet spark_catalog.default.date_dim [d_month_seq,d_week_seq]
+                                                    BroadcastExchangeExecProxy [d_week_seq]
+                                                      SubqueryBroadcast [d_week_seq] #4
+                                                        BroadcastExchange #10
+                                                          WholeStageCodegen (1)
+                                                            Project [d_week_seq]
+                                                              Filter [d_month_seq,d_week_seq]
+                                                                ColumnarToRow
+                                                                  InputAdapter
+                                                                    Scan parquet spark_catalog.default.date_dim [d_month_seq,d_week_seq]
                                             ColumnarToRow
                                               InputAdapter
                                                 Scan parquet spark_catalog.default.date_dim [d_date_sk,d_week_seq,d_day_name]
                       InputAdapter
-                        BroadcastExchange #10
+                        BroadcastExchange #11
                           WholeStageCodegen (7)
                             Filter [s_store_sk,s_store_id]
                               ColumnarToRow
                                 InputAdapter
                                   Scan parquet spark_catalog.default.store [s_store_sk,s_store_id]
                   InputAdapter
-                    BroadcastExchange #11
-                      WholeStageCodegen (8)
-                        Project [d_week_seq]
-                          Filter [d_month_seq,d_week_seq]
-                            ColumnarToRow
-                              InputAdapter
-                                Scan parquet spark_catalog.default.date_dim [d_month_seq,d_week_seq]
+                    ReusedExchange [d_week_seq] #10

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q64.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q64.sf100/explain.txt
@@ -223,7 +223,7 @@ Input [12]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_ad
 
 (3) Filter [codegen id : 1]
 Input [12]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_ticket_number#8, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, ss_sold_date_sk#12]
-Condition : ((((((((isnotnull(ss_item_sk#1) AND isnotnull(ss_ticket_number#8)) AND isnotnull(ss_store_sk#6)) AND isnotnull(ss_customer_sk#2)) AND isnotnull(ss_cdemo_sk#3)) AND isnotnull(ss_promo_sk#7)) AND isnotnull(ss_hdemo_sk#4)) AND isnotnull(ss_addr_sk#5)) AND might_contain(Subquery scalar-subquery#14, [id=#15], xxhash64(ss_item_sk#1, 42)))
+Condition : ((((((((isnotnull(ss_item_sk#1) AND isnotnull(ss_ticket_number#8)) AND isnotnull(ss_store_sk#6)) AND isnotnull(ss_customer_sk#2)) AND isnotnull(ss_cdemo_sk#3)) AND isnotnull(ss_promo_sk#7)) AND isnotnull(ss_hdemo_sk#4)) AND isnotnull(ss_addr_sk#5)) AND might_contain(runtimefilterexpression(Subquery scalar-subquery#14, [id=#15]), xxhash64(ss_item_sk#1, 42)))
 
 (4) Exchange
 Input [12]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_ticket_number#8, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, ss_sold_date_sk#12]
@@ -804,7 +804,7 @@ Input [12]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#11
 
 (131) Filter [codegen id : 44]
 Input [12]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_store_sk#113, ss_promo_sk#114, ss_ticket_number#115, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, ss_sold_date_sk#119]
-Condition : ((((((((isnotnull(ss_item_sk#108) AND isnotnull(ss_ticket_number#115)) AND isnotnull(ss_store_sk#113)) AND isnotnull(ss_customer_sk#109)) AND isnotnull(ss_cdemo_sk#110)) AND isnotnull(ss_promo_sk#114)) AND isnotnull(ss_hdemo_sk#111)) AND isnotnull(ss_addr_sk#112)) AND might_contain(ReusedSubquery Subquery scalar-subquery#14, [id=#15], xxhash64(ss_item_sk#108, 42)))
+Condition : ((((((((isnotnull(ss_item_sk#108) AND isnotnull(ss_ticket_number#115)) AND isnotnull(ss_store_sk#113)) AND isnotnull(ss_customer_sk#109)) AND isnotnull(ss_cdemo_sk#110)) AND isnotnull(ss_promo_sk#114)) AND isnotnull(ss_hdemo_sk#111)) AND isnotnull(ss_addr_sk#112)) AND might_contain(runtimefilterexpression(ReusedSubquery Subquery scalar-subquery#14, [id=#15]), xxhash64(ss_item_sk#108, 42)))
 
 (132) Exchange
 Input [12]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_store_sk#113, ss_promo_sk#114, ss_ticket_number#115, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, ss_sold_date_sk#119]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q69.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q69.sf100/explain.txt
@@ -1,13 +1,13 @@
 == Physical Plan ==
-TakeOrderedAndProject (47)
-+- * HashAggregate (46)
-   +- Exchange (45)
-      +- * HashAggregate (44)
-         +- * Project (43)
-            +- * BroadcastHashJoin Inner BuildLeft (42)
-               :- BroadcastExchange (38)
-               :  +- * Project (37)
-               :     +- * BroadcastHashJoin Inner BuildRight (36)
+TakeOrderedAndProject (43)
++- * HashAggregate (42)
+   +- Exchange (41)
+      +- * HashAggregate (40)
+         +- * Project (39)
+            +- * BroadcastHashJoin Inner BuildLeft (38)
+               :- BroadcastExchange (34)
+               :  +- * Project (33)
+               :     +- * BroadcastHashJoin Inner BuildRight (32)
                :        :- * Project (30)
                :        :  +- * SortMergeJoin LeftAnti (29)
                :        :     :- * SortMergeJoin LeftAnti (21)
@@ -38,14 +38,10 @@ TakeOrderedAndProject (47)
                :        :                 :- * ColumnarToRow (23)
                :        :                 :  +- Scan parquet spark_catalog.default.catalog_sales (22)
                :        :                 +- ReusedExchange (24)
-               :        +- BroadcastExchange (35)
-               :           +- * Project (34)
-               :              +- * Filter (33)
-               :                 +- * ColumnarToRow (32)
-               :                    +- Scan parquet spark_catalog.default.customer_address (31)
-               +- * Filter (41)
-                  +- * ColumnarToRow (40)
-                     +- Scan parquet spark_catalog.default.customer_demographics (39)
+               :        +- ReusedExchange (31)
+               +- * Filter (37)
+                  +- * ColumnarToRow (36)
+                     +- Scan parquet spark_catalog.default.customer_demographics (35)
 
 
 (1) Scan parquet spark_catalog.default.customer
@@ -60,7 +56,7 @@ Input [3]: [c_customer_sk#1, c_current_cdemo_sk#2, c_current_addr_sk#3]
 
 (3) Filter [codegen id : 1]
 Input [3]: [c_customer_sk#1, c_current_cdemo_sk#2, c_current_addr_sk#3]
-Condition : ((isnotnull(c_current_addr_sk#3) AND isnotnull(c_current_cdemo_sk#2)) AND might_contain(Subquery scalar-subquery#4, [id=#5], xxhash64(c_current_addr_sk#3, 42)))
+Condition : ((isnotnull(c_current_addr_sk#3) AND isnotnull(c_current_cdemo_sk#2)) AND might_contain(runtimefilterexpression(Subquery scalar-subquery#4, [id=#5]), xxhash64(c_current_addr_sk#3, 42)))
 
 (4) Exchange
 Input [3]: [c_customer_sk#1, c_current_cdemo_sk#2, c_current_addr_sk#3]
@@ -80,7 +76,7 @@ ReadSchema: struct<ss_customer_sk:int>
 (7) ColumnarToRow [codegen id : 4]
 Input [2]: [ss_customer_sk#6, ss_sold_date_sk#7]
 
-(8) ReusedExchange [Reuses operator id: 59]
+(8) ReusedExchange [Reuses operator id: 58]
 Output [1]: [d_date_sk#9]
 
 (9) BroadcastHashJoin [codegen id : 4]
@@ -117,7 +113,7 @@ ReadSchema: struct<ws_bill_customer_sk:int>
 (15) ColumnarToRow [codegen id : 8]
 Input [2]: [ws_bill_customer_sk#10, ws_sold_date_sk#11]
 
-(16) ReusedExchange [Reuses operator id: 59]
+(16) ReusedExchange [Reuses operator id: 58]
 Output [1]: [d_date_sk#12]
 
 (17) BroadcastHashJoin [codegen id : 8]
@@ -154,7 +150,7 @@ ReadSchema: struct<cs_ship_customer_sk:int>
 (23) ColumnarToRow [codegen id : 12]
 Input [2]: [cs_ship_customer_sk#13, cs_sold_date_sk#14]
 
-(24) ReusedExchange [Reuses operator id: 59]
+(24) ReusedExchange [Reuses operator id: 58]
 Output [1]: [d_date_sk#15]
 
 (25) BroadcastHashJoin [codegen id : 12]
@@ -185,163 +181,153 @@ Join condition: None
 Output [2]: [c_current_cdemo_sk#2, c_current_addr_sk#3]
 Input [3]: [c_customer_sk#1, c_current_cdemo_sk#2, c_current_addr_sk#3]
 
-(31) Scan parquet spark_catalog.default.customer_address
-Output [2]: [ca_address_sk#16, ca_state#17]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer_address]
-PushedFilters: [In(ca_state, [GA,KY,NM]), IsNotNull(ca_address_sk)]
-ReadSchema: struct<ca_address_sk:int,ca_state:string>
-
-(32) ColumnarToRow [codegen id : 14]
-Input [2]: [ca_address_sk#16, ca_state#17]
-
-(33) Filter [codegen id : 14]
-Input [2]: [ca_address_sk#16, ca_state#17]
-Condition : (ca_state#17 IN (KY,GA,NM) AND isnotnull(ca_address_sk#16))
-
-(34) Project [codegen id : 14]
+(31) ReusedExchange [Reuses operator id: 48]
 Output [1]: [ca_address_sk#16]
-Input [2]: [ca_address_sk#16, ca_state#17]
 
-(35) BroadcastExchange
-Input [1]: [ca_address_sk#16]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
-
-(36) BroadcastHashJoin [codegen id : 15]
+(32) BroadcastHashJoin [codegen id : 15]
 Left keys [1]: [c_current_addr_sk#3]
 Right keys [1]: [ca_address_sk#16]
 Join type: Inner
 Join condition: None
 
-(37) Project [codegen id : 15]
+(33) Project [codegen id : 15]
 Output [1]: [c_current_cdemo_sk#2]
 Input [3]: [c_current_cdemo_sk#2, c_current_addr_sk#3, ca_address_sk#16]
 
-(38) BroadcastExchange
+(34) BroadcastExchange
 Input [1]: [c_current_cdemo_sk#2]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=6]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
 
-(39) Scan parquet spark_catalog.default.customer_demographics
-Output [6]: [cd_demo_sk#18, cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_purchase_estimate#22, cd_credit_rating#23]
+(35) Scan parquet spark_catalog.default.customer_demographics
+Output [6]: [cd_demo_sk#17, cd_gender#18, cd_marital_status#19, cd_education_status#20, cd_purchase_estimate#21, cd_credit_rating#22]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_demographics]
 PushedFilters: [IsNotNull(cd_demo_sk)]
 ReadSchema: struct<cd_demo_sk:int,cd_gender:string,cd_marital_status:string,cd_education_status:string,cd_purchase_estimate:int,cd_credit_rating:string>
 
-(40) ColumnarToRow
-Input [6]: [cd_demo_sk#18, cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_purchase_estimate#22, cd_credit_rating#23]
+(36) ColumnarToRow
+Input [6]: [cd_demo_sk#17, cd_gender#18, cd_marital_status#19, cd_education_status#20, cd_purchase_estimate#21, cd_credit_rating#22]
 
-(41) Filter
-Input [6]: [cd_demo_sk#18, cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_purchase_estimate#22, cd_credit_rating#23]
-Condition : isnotnull(cd_demo_sk#18)
+(37) Filter
+Input [6]: [cd_demo_sk#17, cd_gender#18, cd_marital_status#19, cd_education_status#20, cd_purchase_estimate#21, cd_credit_rating#22]
+Condition : isnotnull(cd_demo_sk#17)
 
-(42) BroadcastHashJoin [codegen id : 16]
+(38) BroadcastHashJoin [codegen id : 16]
 Left keys [1]: [c_current_cdemo_sk#2]
-Right keys [1]: [cd_demo_sk#18]
+Right keys [1]: [cd_demo_sk#17]
 Join type: Inner
 Join condition: None
 
-(43) Project [codegen id : 16]
-Output [5]: [cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_purchase_estimate#22, cd_credit_rating#23]
-Input [7]: [c_current_cdemo_sk#2, cd_demo_sk#18, cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_purchase_estimate#22, cd_credit_rating#23]
+(39) Project [codegen id : 16]
+Output [5]: [cd_gender#18, cd_marital_status#19, cd_education_status#20, cd_purchase_estimate#21, cd_credit_rating#22]
+Input [7]: [c_current_cdemo_sk#2, cd_demo_sk#17, cd_gender#18, cd_marital_status#19, cd_education_status#20, cd_purchase_estimate#21, cd_credit_rating#22]
 
-(44) HashAggregate [codegen id : 16]
-Input [5]: [cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_purchase_estimate#22, cd_credit_rating#23]
-Keys [5]: [cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_purchase_estimate#22, cd_credit_rating#23]
+(40) HashAggregate [codegen id : 16]
+Input [5]: [cd_gender#18, cd_marital_status#19, cd_education_status#20, cd_purchase_estimate#21, cd_credit_rating#22]
+Keys [5]: [cd_gender#18, cd_marital_status#19, cd_education_status#20, cd_purchase_estimate#21, cd_credit_rating#22]
 Functions [1]: [partial_count(1)]
-Aggregate Attributes [1]: [count#24]
-Results [6]: [cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_purchase_estimate#22, cd_credit_rating#23, count#25]
+Aggregate Attributes [1]: [count#23]
+Results [6]: [cd_gender#18, cd_marital_status#19, cd_education_status#20, cd_purchase_estimate#21, cd_credit_rating#22, count#24]
 
-(45) Exchange
-Input [6]: [cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_purchase_estimate#22, cd_credit_rating#23, count#25]
-Arguments: hashpartitioning(cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_purchase_estimate#22, cd_credit_rating#23, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+(41) Exchange
+Input [6]: [cd_gender#18, cd_marital_status#19, cd_education_status#20, cd_purchase_estimate#21, cd_credit_rating#22, count#24]
+Arguments: hashpartitioning(cd_gender#18, cd_marital_status#19, cd_education_status#20, cd_purchase_estimate#21, cd_credit_rating#22, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
-(46) HashAggregate [codegen id : 17]
-Input [6]: [cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_purchase_estimate#22, cd_credit_rating#23, count#25]
-Keys [5]: [cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_purchase_estimate#22, cd_credit_rating#23]
+(42) HashAggregate [codegen id : 17]
+Input [6]: [cd_gender#18, cd_marital_status#19, cd_education_status#20, cd_purchase_estimate#21, cd_credit_rating#22, count#24]
+Keys [5]: [cd_gender#18, cd_marital_status#19, cd_education_status#20, cd_purchase_estimate#21, cd_credit_rating#22]
 Functions [1]: [count(1)]
-Aggregate Attributes [1]: [count(1)#26]
-Results [8]: [cd_gender#19, cd_marital_status#20, cd_education_status#21, count(1)#26 AS cnt1#27, cd_purchase_estimate#22, count(1)#26 AS cnt2#28, cd_credit_rating#23, count(1)#26 AS cnt3#29]
+Aggregate Attributes [1]: [count(1)#25]
+Results [8]: [cd_gender#18, cd_marital_status#19, cd_education_status#20, count(1)#25 AS cnt1#26, cd_purchase_estimate#21, count(1)#25 AS cnt2#27, cd_credit_rating#22, count(1)#25 AS cnt3#28]
 
-(47) TakeOrderedAndProject
-Input [8]: [cd_gender#19, cd_marital_status#20, cd_education_status#21, cnt1#27, cd_purchase_estimate#22, cnt2#28, cd_credit_rating#23, cnt3#29]
-Arguments: 100, [cd_gender#19 ASC NULLS FIRST, cd_marital_status#20 ASC NULLS FIRST, cd_education_status#21 ASC NULLS FIRST, cd_purchase_estimate#22 ASC NULLS FIRST, cd_credit_rating#23 ASC NULLS FIRST], [cd_gender#19, cd_marital_status#20, cd_education_status#21, cnt1#27, cd_purchase_estimate#22, cnt2#28, cd_credit_rating#23, cnt3#29]
+(43) TakeOrderedAndProject
+Input [8]: [cd_gender#18, cd_marital_status#19, cd_education_status#20, cnt1#26, cd_purchase_estimate#21, cnt2#27, cd_credit_rating#22, cnt3#28]
+Arguments: 100, [cd_gender#18 ASC NULLS FIRST, cd_marital_status#19 ASC NULLS FIRST, cd_education_status#20 ASC NULLS FIRST, cd_purchase_estimate#21 ASC NULLS FIRST, cd_credit_rating#22 ASC NULLS FIRST], [cd_gender#18, cd_marital_status#19, cd_education_status#20, cnt1#26, cd_purchase_estimate#21, cnt2#27, cd_credit_rating#22, cnt3#28]
 
 ===== Subqueries =====
 
 Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#4, [id=#5]
-ObjectHashAggregate (54)
-+- Exchange (53)
-   +- ObjectHashAggregate (52)
-      +- * Project (51)
-         +- * Filter (50)
-            +- * ColumnarToRow (49)
-               +- Scan parquet spark_catalog.default.customer_address (48)
+ObjectHashAggregate (53)
++- Exchange (52)
+   +- ObjectHashAggregate (51)
+      +- BroadcastExchangeExecProxy (50)
 
 
-(48) Scan parquet spark_catalog.default.customer_address
-Output [2]: [ca_address_sk#16, ca_state#17]
+(44) Scan parquet spark_catalog.default.customer_address
+Output [2]: [ca_address_sk#16, ca_state#29]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [In(ca_state, [GA,KY,NM]), IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_state:string>
 
-(49) ColumnarToRow [codegen id : 1]
-Input [2]: [ca_address_sk#16, ca_state#17]
+(45) ColumnarToRow [codegen id : 1]
+Input [2]: [ca_address_sk#16, ca_state#29]
 
-(50) Filter [codegen id : 1]
-Input [2]: [ca_address_sk#16, ca_state#17]
-Condition : (ca_state#17 IN (KY,GA,NM) AND isnotnull(ca_address_sk#16))
+(46) Filter [codegen id : 1]
+Input [2]: [ca_address_sk#16, ca_state#29]
+Condition : (ca_state#29 IN (KY,GA,NM) AND isnotnull(ca_address_sk#16))
 
-(51) Project [codegen id : 1]
+(47) Project [codegen id : 1]
 Output [1]: [ca_address_sk#16]
-Input [2]: [ca_address_sk#16, ca_state#17]
+Input [2]: [ca_address_sk#16, ca_state#29]
 
-(52) ObjectHashAggregate
+(48) BroadcastExchange
+Input [1]: [ca_address_sk#16]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=7]
+
+(49) SubqueryBroadcast
+Input [1]: [ca_address_sk#16]
+Arguments: runtimefilter#4, 0, [ca_address_sk#16], [id=#30]
+
+(50) BroadcastExchangeExecProxy
+Input [1]: [ca_address_sk#31]
+Arguments: [ca_address_sk#16]
+
+(51) ObjectHashAggregate
 Input [1]: [ca_address_sk#16]
 Keys: []
 Functions [1]: [partial_bloom_filter_agg(xxhash64(ca_address_sk#16, 42), 55556, 899992, 0, 0)]
-Aggregate Attributes [1]: [buf#30]
-Results [1]: [buf#31]
+Aggregate Attributes [1]: [buf#32]
+Results [1]: [buf#33]
 
-(53) Exchange
-Input [1]: [buf#31]
+(52) Exchange
+Input [1]: [buf#33]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=8]
 
-(54) ObjectHashAggregate
-Input [1]: [buf#31]
+(53) ObjectHashAggregate
+Input [1]: [buf#33]
 Keys: []
 Functions [1]: [bloom_filter_agg(xxhash64(ca_address_sk#16, 42), 55556, 899992, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(ca_address_sk#16, 42), 55556, 899992, 0, 0)#32]
-Results [1]: [bloom_filter_agg(xxhash64(ca_address_sk#16, 42), 55556, 899992, 0, 0)#32 AS bloomFilter#33]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(ca_address_sk#16, 42), 55556, 899992, 0, 0)#34]
+Results [1]: [bloom_filter_agg(xxhash64(ca_address_sk#16, 42), 55556, 899992, 0, 0)#34 AS bloomFilter#35]
 
 Subquery:2 Hosting operator id = 6 Hosting Expression = ss_sold_date_sk#7 IN dynamicpruning#8
-BroadcastExchange (59)
-+- * Project (58)
-   +- * Filter (57)
-      +- * ColumnarToRow (56)
-         +- Scan parquet spark_catalog.default.date_dim (55)
+BroadcastExchange (58)
++- * Project (57)
+   +- * Filter (56)
+      +- * ColumnarToRow (55)
+         +- Scan parquet spark_catalog.default.date_dim (54)
 
 
-(55) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#9, d_year#34, d_moy#35]
+(54) Scan parquet spark_catalog.default.date_dim
+Output [3]: [d_date_sk#9, d_year#36, d_moy#37]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), EqualTo(d_year,2001), GreaterThanOrEqual(d_moy,4), LessThanOrEqual(d_moy,6), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
 
-(56) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#9, d_year#34, d_moy#35]
+(55) ColumnarToRow [codegen id : 1]
+Input [3]: [d_date_sk#9, d_year#36, d_moy#37]
 
-(57) Filter [codegen id : 1]
-Input [3]: [d_date_sk#9, d_year#34, d_moy#35]
-Condition : (((((isnotnull(d_year#34) AND isnotnull(d_moy#35)) AND (d_year#34 = 2001)) AND (d_moy#35 >= 4)) AND (d_moy#35 <= 6)) AND isnotnull(d_date_sk#9))
+(56) Filter [codegen id : 1]
+Input [3]: [d_date_sk#9, d_year#36, d_moy#37]
+Condition : (((((isnotnull(d_year#36) AND isnotnull(d_moy#37)) AND (d_year#36 = 2001)) AND (d_moy#37 >= 4)) AND (d_moy#37 <= 6)) AND isnotnull(d_date_sk#9))
 
-(58) Project [codegen id : 1]
+(57) Project [codegen id : 1]
 Output [1]: [d_date_sk#9]
-Input [3]: [d_date_sk#9, d_year#34, d_moy#35]
+Input [3]: [d_date_sk#9, d_year#36, d_moy#37]
 
-(59) BroadcastExchange
+(58) BroadcastExchange
 Input [1]: [d_date_sk#9]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=9]
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q69.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q69.sf100/simplified.txt
@@ -31,12 +31,15 @@ TakeOrderedAndProject [cd_gender,cd_marital_status,cd_education_status,cd_purcha
                                                             ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(ca_address_sk, 42), 55556, 899992, 0, 0),bloomFilter,buf]
                                                               Exchange #4
                                                                 ObjectHashAggregate [ca_address_sk] [buf,buf]
-                                                                  WholeStageCodegen (1)
-                                                                    Project [ca_address_sk]
-                                                                      Filter [ca_state,ca_address_sk]
-                                                                        ColumnarToRow
-                                                                          InputAdapter
-                                                                            Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state]
+                                                                  BroadcastExchangeExecProxy [ca_address_sk]
+                                                                    SubqueryBroadcast [ca_address_sk] #2
+                                                                      BroadcastExchange #5
+                                                                        WholeStageCodegen (1)
+                                                                          Project [ca_address_sk]
+                                                                            Filter [ca_state,ca_address_sk]
+                                                                              ColumnarToRow
+                                                                                InputAdapter
+                                                                                  Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state]
                                                           ColumnarToRow
                                                             InputAdapter
                                                               Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_cdemo_sk,c_current_addr_sk]
@@ -44,15 +47,15 @@ TakeOrderedAndProject [cd_gender,cd_marital_status,cd_education_status,cd_purcha
                                               WholeStageCodegen (5)
                                                 Sort [ss_customer_sk]
                                                   InputAdapter
-                                                    Exchange [ss_customer_sk] #5
+                                                    Exchange [ss_customer_sk] #6
                                                       WholeStageCodegen (4)
                                                         Project [ss_customer_sk]
                                                           BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                                             ColumnarToRow
                                                               InputAdapter
                                                                 Scan parquet spark_catalog.default.store_sales [ss_customer_sk,ss_sold_date_sk]
-                                                                  SubqueryBroadcast [d_date_sk] #2
-                                                                    BroadcastExchange #6
+                                                                  SubqueryBroadcast [d_date_sk] #3
+                                                                    BroadcastExchange #7
                                                                       WholeStageCodegen (1)
                                                                         Project [d_date_sk]
                                                                           Filter [d_year,d_moy,d_date_sk]
@@ -60,43 +63,37 @@ TakeOrderedAndProject [cd_gender,cd_marital_status,cd_education_status,cd_purcha
                                                                               InputAdapter
                                                                                 Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_moy]
                                                             InputAdapter
-                                                              ReusedExchange [d_date_sk] #6
+                                                              ReusedExchange [d_date_sk] #7
                                       InputAdapter
                                         WholeStageCodegen (9)
                                           Sort [ws_bill_customer_sk]
                                             InputAdapter
-                                              Exchange [ws_bill_customer_sk] #7
+                                              Exchange [ws_bill_customer_sk] #8
                                                 WholeStageCodegen (8)
                                                   Project [ws_bill_customer_sk]
                                                     BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
                                                       ColumnarToRow
                                                         InputAdapter
                                                           Scan parquet spark_catalog.default.web_sales [ws_bill_customer_sk,ws_sold_date_sk]
-                                                            ReusedSubquery [d_date_sk] #2
+                                                            ReusedSubquery [d_date_sk] #3
                                                       InputAdapter
-                                                        ReusedExchange [d_date_sk] #6
+                                                        ReusedExchange [d_date_sk] #7
                                 InputAdapter
                                   WholeStageCodegen (13)
                                     Sort [cs_ship_customer_sk]
                                       InputAdapter
-                                        Exchange [cs_ship_customer_sk] #8
+                                        Exchange [cs_ship_customer_sk] #9
                                           WholeStageCodegen (12)
                                             Project [cs_ship_customer_sk]
                                               BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
                                                 ColumnarToRow
                                                   InputAdapter
                                                     Scan parquet spark_catalog.default.catalog_sales [cs_ship_customer_sk,cs_sold_date_sk]
-                                                      ReusedSubquery [d_date_sk] #2
+                                                      ReusedSubquery [d_date_sk] #3
                                                 InputAdapter
-                                                  ReusedExchange [d_date_sk] #6
+                                                  ReusedExchange [d_date_sk] #7
                             InputAdapter
-                              BroadcastExchange #9
-                                WholeStageCodegen (14)
-                                  Project [ca_address_sk]
-                                    Filter [ca_state,ca_address_sk]
-                                      ColumnarToRow
-                                        InputAdapter
-                                          Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state]
+                              ReusedExchange [ca_address_sk] #5
                   Filter [cd_demo_sk]
                     ColumnarToRow
                       InputAdapter

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q80.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q80.sf100/explain.txt
@@ -1,21 +1,21 @@
 == Physical Plan ==
-TakeOrderedAndProject (107)
-+- * HashAggregate (106)
-   +- Exchange (105)
-      +- * HashAggregate (104)
-         +- * Expand (103)
-            +- Union (102)
-               :- * HashAggregate (39)
-               :  +- Exchange (38)
-               :     +- * HashAggregate (37)
-               :        +- * Project (36)
-               :           +- * BroadcastHashJoin Inner BuildRight (35)
-               :              :- * Project (30)
-               :              :  +- * BroadcastHashJoin Inner BuildRight (29)
-               :              :     :- * Project (27)
-               :              :     :  +- * BroadcastHashJoin Inner BuildRight (26)
-               :              :     :     :- * Project (20)
-               :              :     :     :  +- * BroadcastHashJoin Inner BuildRight (19)
+TakeOrderedAndProject (99)
++- * HashAggregate (98)
+   +- Exchange (97)
+      +- * HashAggregate (96)
+         +- * Expand (95)
+            +- Union (94)
+               :- * HashAggregate (31)
+               :  +- Exchange (30)
+               :     +- * HashAggregate (29)
+               :        +- * Project (28)
+               :           +- * BroadcastHashJoin Inner BuildRight (27)
+               :              :- * Project (22)
+               :              :  +- * BroadcastHashJoin Inner BuildRight (21)
+               :              :     :- * Project (19)
+               :              :     :  +- * BroadcastHashJoin Inner BuildRight (18)
+               :              :     :     :- * Project (16)
+               :              :     :     :  +- * BroadcastHashJoin Inner BuildRight (15)
                :              :     :     :     :- * Project (13)
                :              :     :     :     :  +- * SortMergeJoin LeftOuter (12)
                :              :     :     :     :     :- * Sort (5)
@@ -29,83 +29,75 @@ TakeOrderedAndProject (107)
                :              :     :     :     :              +- * Filter (8)
                :              :     :     :     :                 +- * ColumnarToRow (7)
                :              :     :     :     :                    +- Scan parquet spark_catalog.default.store_returns (6)
-               :              :     :     :     +- BroadcastExchange (18)
-               :              :     :     :        +- * Project (17)
-               :              :     :     :           +- * Filter (16)
-               :              :     :     :              +- * ColumnarToRow (15)
-               :              :     :     :                 +- Scan parquet spark_catalog.default.item (14)
-               :              :     :     +- BroadcastExchange (25)
-               :              :     :        +- * Project (24)
-               :              :     :           +- * Filter (23)
-               :              :     :              +- * ColumnarToRow (22)
-               :              :     :                 +- Scan parquet spark_catalog.default.promotion (21)
-               :              :     +- ReusedExchange (28)
-               :              +- BroadcastExchange (34)
-               :                 +- * Filter (33)
-               :                    +- * ColumnarToRow (32)
-               :                       +- Scan parquet spark_catalog.default.store (31)
-               :- * HashAggregate (70)
-               :  +- Exchange (69)
-               :     +- * HashAggregate (68)
-               :        +- * Project (67)
-               :           +- * BroadcastHashJoin Inner BuildRight (66)
-               :              :- * Project (61)
-               :              :  +- * BroadcastHashJoin Inner BuildRight (60)
-               :              :     :- * Project (58)
-               :              :     :  +- * BroadcastHashJoin Inner BuildRight (57)
-               :              :     :     :- * Project (55)
-               :              :     :     :  +- * BroadcastHashJoin Inner BuildRight (54)
-               :              :     :     :     :- * Project (52)
-               :              :     :     :     :  +- * SortMergeJoin LeftOuter (51)
-               :              :     :     :     :     :- * Sort (44)
-               :              :     :     :     :     :  +- Exchange (43)
-               :              :     :     :     :     :     +- * Filter (42)
-               :              :     :     :     :     :        +- * ColumnarToRow (41)
-               :              :     :     :     :     :           +- Scan parquet spark_catalog.default.catalog_sales (40)
-               :              :     :     :     :     +- * Sort (50)
-               :              :     :     :     :        +- Exchange (49)
-               :              :     :     :     :           +- * Project (48)
-               :              :     :     :     :              +- * Filter (47)
-               :              :     :     :     :                 +- * ColumnarToRow (46)
-               :              :     :     :     :                    +- Scan parquet spark_catalog.default.catalog_returns (45)
-               :              :     :     :     +- ReusedExchange (53)
-               :              :     :     +- ReusedExchange (56)
-               :              :     +- ReusedExchange (59)
-               :              +- BroadcastExchange (65)
-               :                 +- * Filter (64)
-               :                    +- * ColumnarToRow (63)
-               :                       +- Scan parquet spark_catalog.default.catalog_page (62)
-               +- * HashAggregate (101)
-                  +- Exchange (100)
-                     +- * HashAggregate (99)
-                        +- * Project (98)
-                           +- * BroadcastHashJoin Inner BuildRight (97)
-                              :- * Project (92)
-                              :  +- * BroadcastHashJoin Inner BuildRight (91)
-                              :     :- * Project (89)
-                              :     :  +- * BroadcastHashJoin Inner BuildRight (88)
-                              :     :     :- * Project (86)
-                              :     :     :  +- * BroadcastHashJoin Inner BuildRight (85)
-                              :     :     :     :- * Project (83)
-                              :     :     :     :  +- * SortMergeJoin LeftOuter (82)
-                              :     :     :     :     :- * Sort (75)
-                              :     :     :     :     :  +- Exchange (74)
-                              :     :     :     :     :     +- * Filter (73)
-                              :     :     :     :     :        +- * ColumnarToRow (72)
-                              :     :     :     :     :           +- Scan parquet spark_catalog.default.web_sales (71)
-                              :     :     :     :     +- * Sort (81)
-                              :     :     :     :        +- Exchange (80)
-                              :     :     :     :           +- * Project (79)
-                              :     :     :     :              +- * Filter (78)
-                              :     :     :     :                 +- * ColumnarToRow (77)
-                              :     :     :     :                    +- Scan parquet spark_catalog.default.web_returns (76)
-                              :     :     :     +- ReusedExchange (84)
-                              :     :     +- ReusedExchange (87)
-                              :     +- ReusedExchange (90)
-                              +- BroadcastExchange (96)
-                                 +- * Filter (95)
-                                    +- * ColumnarToRow (94)
-                                       +- Scan parquet spark_catalog.default.web_site (93)
+               :              :     :     :     +- ReusedExchange (14)
+               :              :     :     +- ReusedExchange (17)
+               :              :     +- ReusedExchange (20)
+               :              +- BroadcastExchange (26)
+               :                 +- * Filter (25)
+               :                    +- * ColumnarToRow (24)
+               :                       +- Scan parquet spark_catalog.default.store (23)
+               :- * HashAggregate (62)
+               :  +- Exchange (61)
+               :     +- * HashAggregate (60)
+               :        +- * Project (59)
+               :           +- * BroadcastHashJoin Inner BuildRight (58)
+               :              :- * Project (53)
+               :              :  +- * BroadcastHashJoin Inner BuildRight (52)
+               :              :     :- * Project (50)
+               :              :     :  +- * BroadcastHashJoin Inner BuildRight (49)
+               :              :     :     :- * Project (47)
+               :              :     :     :  +- * BroadcastHashJoin Inner BuildRight (46)
+               :              :     :     :     :- * Project (44)
+               :              :     :     :     :  +- * SortMergeJoin LeftOuter (43)
+               :              :     :     :     :     :- * Sort (36)
+               :              :     :     :     :     :  +- Exchange (35)
+               :              :     :     :     :     :     +- * Filter (34)
+               :              :     :     :     :     :        +- * ColumnarToRow (33)
+               :              :     :     :     :     :           +- Scan parquet spark_catalog.default.catalog_sales (32)
+               :              :     :     :     :     +- * Sort (42)
+               :              :     :     :     :        +- Exchange (41)
+               :              :     :     :     :           +- * Project (40)
+               :              :     :     :     :              +- * Filter (39)
+               :              :     :     :     :                 +- * ColumnarToRow (38)
+               :              :     :     :     :                    +- Scan parquet spark_catalog.default.catalog_returns (37)
+               :              :     :     :     +- ReusedExchange (45)
+               :              :     :     +- ReusedExchange (48)
+               :              :     +- ReusedExchange (51)
+               :              +- BroadcastExchange (57)
+               :                 +- * Filter (56)
+               :                    +- * ColumnarToRow (55)
+               :                       +- Scan parquet spark_catalog.default.catalog_page (54)
+               +- * HashAggregate (93)
+                  +- Exchange (92)
+                     +- * HashAggregate (91)
+                        +- * Project (90)
+                           +- * BroadcastHashJoin Inner BuildRight (89)
+                              :- * Project (84)
+                              :  +- * BroadcastHashJoin Inner BuildRight (83)
+                              :     :- * Project (81)
+                              :     :  +- * BroadcastHashJoin Inner BuildRight (80)
+                              :     :     :- * Project (78)
+                              :     :     :  +- * BroadcastHashJoin Inner BuildRight (77)
+                              :     :     :     :- * Project (75)
+                              :     :     :     :  +- * SortMergeJoin LeftOuter (74)
+                              :     :     :     :     :- * Sort (67)
+                              :     :     :     :     :  +- Exchange (66)
+                              :     :     :     :     :     +- * Filter (65)
+                              :     :     :     :     :        +- * ColumnarToRow (64)
+                              :     :     :     :     :           +- Scan parquet spark_catalog.default.web_sales (63)
+                              :     :     :     :     +- * Sort (73)
+                              :     :     :     :        +- Exchange (72)
+                              :     :     :     :           +- * Project (71)
+                              :     :     :     :              +- * Filter (70)
+                              :     :     :     :                 +- * ColumnarToRow (69)
+                              :     :     :     :                    +- Scan parquet spark_catalog.default.web_returns (68)
+                              :     :     :     +- ReusedExchange (76)
+                              :     :     +- ReusedExchange (79)
+                              :     +- ReusedExchange (82)
+                              +- BroadcastExchange (88)
+                                 +- * Filter (87)
+                                    +- * ColumnarToRow (86)
+                                       +- Scan parquet spark_catalog.default.web_site (85)
 
 
 (1) Scan parquet spark_catalog.default.store_sales
@@ -121,7 +113,7 @@ Input [7]: [ss_item_sk#1, ss_store_sk#2, ss_promo_sk#3, ss_ticket_number#4, ss_e
 
 (3) Filter [codegen id : 1]
 Input [7]: [ss_item_sk#1, ss_store_sk#2, ss_promo_sk#3, ss_ticket_number#4, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7]
-Condition : ((((isnotnull(ss_store_sk#2) AND isnotnull(ss_item_sk#1)) AND isnotnull(ss_promo_sk#3)) AND might_contain(Subquery scalar-subquery#9, [id=#10], xxhash64(ss_item_sk#1, 42))) AND might_contain(Subquery scalar-subquery#11, [id=#12], xxhash64(ss_promo_sk#3, 42)))
+Condition : ((((isnotnull(ss_store_sk#2) AND isnotnull(ss_item_sk#1)) AND isnotnull(ss_promo_sk#3)) AND might_contain(runtimefilterexpression(Subquery scalar-subquery#9, [id=#10]), xxhash64(ss_item_sk#1, 42))) AND might_contain(runtimefilterexpression(Subquery scalar-subquery#11, [id=#12]), xxhash64(ss_promo_sk#3, 42)))
 
 (4) Exchange
 Input [7]: [ss_item_sk#1, ss_store_sk#2, ss_promo_sk#3, ss_ticket_number#4, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7]
@@ -167,579 +159,559 @@ Join condition: None
 Output [8]: [ss_item_sk#1, ss_store_sk#2, ss_promo_sk#3, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7, sr_return_amt#15, sr_net_loss#16]
 Input [11]: [ss_item_sk#1, ss_store_sk#2, ss_promo_sk#3, ss_ticket_number#4, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7, sr_item_sk#13, sr_ticket_number#14, sr_return_amt#15, sr_net_loss#16]
 
-(14) Scan parquet spark_catalog.default.item
-Output [2]: [i_item_sk#18, i_current_price#19]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/item]
-PushedFilters: [IsNotNull(i_current_price), GreaterThan(i_current_price,50.00), IsNotNull(i_item_sk)]
-ReadSchema: struct<i_item_sk:int,i_current_price:decimal(7,2)>
-
-(15) ColumnarToRow [codegen id : 5]
-Input [2]: [i_item_sk#18, i_current_price#19]
-
-(16) Filter [codegen id : 5]
-Input [2]: [i_item_sk#18, i_current_price#19]
-Condition : ((isnotnull(i_current_price#19) AND (i_current_price#19 > 50.00)) AND isnotnull(i_item_sk#18))
-
-(17) Project [codegen id : 5]
+(14) ReusedExchange [Reuses operator id: 104]
 Output [1]: [i_item_sk#18]
-Input [2]: [i_item_sk#18, i_current_price#19]
 
-(18) BroadcastExchange
-Input [1]: [i_item_sk#18]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=3]
-
-(19) BroadcastHashJoin [codegen id : 9]
+(15) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#18]
 Join type: Inner
 Join condition: None
 
-(20) Project [codegen id : 9]
+(16) Project [codegen id : 9]
 Output [7]: [ss_store_sk#2, ss_promo_sk#3, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7, sr_return_amt#15, sr_net_loss#16]
 Input [9]: [ss_item_sk#1, ss_store_sk#2, ss_promo_sk#3, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7, sr_return_amt#15, sr_net_loss#16, i_item_sk#18]
 
-(21) Scan parquet spark_catalog.default.promotion
-Output [2]: [p_promo_sk#20, p_channel_tv#21]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/promotion]
-PushedFilters: [IsNotNull(p_channel_tv), EqualTo(p_channel_tv,N), IsNotNull(p_promo_sk)]
-ReadSchema: struct<p_promo_sk:int,p_channel_tv:string>
+(17) ReusedExchange [Reuses operator id: 114]
+Output [1]: [p_promo_sk#19]
 
-(22) ColumnarToRow [codegen id : 6]
-Input [2]: [p_promo_sk#20, p_channel_tv#21]
-
-(23) Filter [codegen id : 6]
-Input [2]: [p_promo_sk#20, p_channel_tv#21]
-Condition : ((isnotnull(p_channel_tv#21) AND (p_channel_tv#21 = N)) AND isnotnull(p_promo_sk#20))
-
-(24) Project [codegen id : 6]
-Output [1]: [p_promo_sk#20]
-Input [2]: [p_promo_sk#20, p_channel_tv#21]
-
-(25) BroadcastExchange
-Input [1]: [p_promo_sk#20]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=4]
-
-(26) BroadcastHashJoin [codegen id : 9]
+(18) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_promo_sk#3]
-Right keys [1]: [p_promo_sk#20]
+Right keys [1]: [p_promo_sk#19]
 Join type: Inner
 Join condition: None
 
-(27) Project [codegen id : 9]
+(19) Project [codegen id : 9]
 Output [6]: [ss_store_sk#2, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7, sr_return_amt#15, sr_net_loss#16]
-Input [8]: [ss_store_sk#2, ss_promo_sk#3, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7, sr_return_amt#15, sr_net_loss#16, p_promo_sk#20]
+Input [8]: [ss_store_sk#2, ss_promo_sk#3, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7, sr_return_amt#15, sr_net_loss#16, p_promo_sk#19]
 
-(28) ReusedExchange [Reuses operator id: 126]
-Output [1]: [d_date_sk#22]
+(20) ReusedExchange [Reuses operator id: 124]
+Output [1]: [d_date_sk#20]
 
-(29) BroadcastHashJoin [codegen id : 9]
+(21) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_sold_date_sk#7]
-Right keys [1]: [d_date_sk#22]
+Right keys [1]: [d_date_sk#20]
 Join type: Inner
 Join condition: None
 
-(30) Project [codegen id : 9]
+(22) Project [codegen id : 9]
 Output [5]: [ss_store_sk#2, ss_ext_sales_price#5, ss_net_profit#6, sr_return_amt#15, sr_net_loss#16]
-Input [7]: [ss_store_sk#2, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7, sr_return_amt#15, sr_net_loss#16, d_date_sk#22]
+Input [7]: [ss_store_sk#2, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7, sr_return_amt#15, sr_net_loss#16, d_date_sk#20]
 
-(31) Scan parquet spark_catalog.default.store
-Output [2]: [s_store_sk#23, s_store_id#24]
+(23) Scan parquet spark_catalog.default.store
+Output [2]: [s_store_sk#21, s_store_id#22]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_store_sk)]
 ReadSchema: struct<s_store_sk:int,s_store_id:string>
 
-(32) ColumnarToRow [codegen id : 8]
-Input [2]: [s_store_sk#23, s_store_id#24]
+(24) ColumnarToRow [codegen id : 8]
+Input [2]: [s_store_sk#21, s_store_id#22]
 
-(33) Filter [codegen id : 8]
-Input [2]: [s_store_sk#23, s_store_id#24]
-Condition : isnotnull(s_store_sk#23)
+(25) Filter [codegen id : 8]
+Input [2]: [s_store_sk#21, s_store_id#22]
+Condition : isnotnull(s_store_sk#21)
 
-(34) BroadcastExchange
-Input [2]: [s_store_sk#23, s_store_id#24]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=5]
+(26) BroadcastExchange
+Input [2]: [s_store_sk#21, s_store_id#22]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=3]
 
-(35) BroadcastHashJoin [codegen id : 9]
+(27) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_store_sk#2]
-Right keys [1]: [s_store_sk#23]
+Right keys [1]: [s_store_sk#21]
 Join type: Inner
 Join condition: None
 
-(36) Project [codegen id : 9]
-Output [5]: [ss_ext_sales_price#5, ss_net_profit#6, sr_return_amt#15, sr_net_loss#16, s_store_id#24]
-Input [7]: [ss_store_sk#2, ss_ext_sales_price#5, ss_net_profit#6, sr_return_amt#15, sr_net_loss#16, s_store_sk#23, s_store_id#24]
+(28) Project [codegen id : 9]
+Output [5]: [ss_ext_sales_price#5, ss_net_profit#6, sr_return_amt#15, sr_net_loss#16, s_store_id#22]
+Input [7]: [ss_store_sk#2, ss_ext_sales_price#5, ss_net_profit#6, sr_return_amt#15, sr_net_loss#16, s_store_sk#21, s_store_id#22]
 
-(37) HashAggregate [codegen id : 9]
-Input [5]: [ss_ext_sales_price#5, ss_net_profit#6, sr_return_amt#15, sr_net_loss#16, s_store_id#24]
-Keys [1]: [s_store_id#24]
+(29) HashAggregate [codegen id : 9]
+Input [5]: [ss_ext_sales_price#5, ss_net_profit#6, sr_return_amt#15, sr_net_loss#16, s_store_id#22]
+Keys [1]: [s_store_id#22]
 Functions [3]: [partial_sum(UnscaledValue(ss_ext_sales_price#5)), partial_sum(coalesce(cast(sr_return_amt#15 as decimal(12,2)), 0.00)), partial_sum((ss_net_profit#6 - coalesce(cast(sr_net_loss#16 as decimal(12,2)), 0.00)))]
-Aggregate Attributes [5]: [sum#25, sum#26, isEmpty#27, sum#28, isEmpty#29]
-Results [6]: [s_store_id#24, sum#30, sum#31, isEmpty#32, sum#33, isEmpty#34]
+Aggregate Attributes [5]: [sum#23, sum#24, isEmpty#25, sum#26, isEmpty#27]
+Results [6]: [s_store_id#22, sum#28, sum#29, isEmpty#30, sum#31, isEmpty#32]
 
-(38) Exchange
-Input [6]: [s_store_id#24, sum#30, sum#31, isEmpty#32, sum#33, isEmpty#34]
-Arguments: hashpartitioning(s_store_id#24, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+(30) Exchange
+Input [6]: [s_store_id#22, sum#28, sum#29, isEmpty#30, sum#31, isEmpty#32]
+Arguments: hashpartitioning(s_store_id#22, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
-(39) HashAggregate [codegen id : 10]
-Input [6]: [s_store_id#24, sum#30, sum#31, isEmpty#32, sum#33, isEmpty#34]
-Keys [1]: [s_store_id#24]
+(31) HashAggregate [codegen id : 10]
+Input [6]: [s_store_id#22, sum#28, sum#29, isEmpty#30, sum#31, isEmpty#32]
+Keys [1]: [s_store_id#22]
 Functions [3]: [sum(UnscaledValue(ss_ext_sales_price#5)), sum(coalesce(cast(sr_return_amt#15 as decimal(12,2)), 0.00)), sum((ss_net_profit#6 - coalesce(cast(sr_net_loss#16 as decimal(12,2)), 0.00)))]
-Aggregate Attributes [3]: [sum(UnscaledValue(ss_ext_sales_price#5))#35, sum(coalesce(cast(sr_return_amt#15 as decimal(12,2)), 0.00))#36, sum((ss_net_profit#6 - coalesce(cast(sr_net_loss#16 as decimal(12,2)), 0.00)))#37]
-Results [5]: [MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#5))#35,17,2) AS sales#38, sum(coalesce(cast(sr_return_amt#15 as decimal(12,2)), 0.00))#36 AS returns#39, sum((ss_net_profit#6 - coalesce(cast(sr_net_loss#16 as decimal(12,2)), 0.00)))#37 AS profit#40, store channel AS channel#41, concat(store, s_store_id#24) AS id#42]
+Aggregate Attributes [3]: [sum(UnscaledValue(ss_ext_sales_price#5))#33, sum(coalesce(cast(sr_return_amt#15 as decimal(12,2)), 0.00))#34, sum((ss_net_profit#6 - coalesce(cast(sr_net_loss#16 as decimal(12,2)), 0.00)))#35]
+Results [5]: [MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#5))#33,17,2) AS sales#36, sum(coalesce(cast(sr_return_amt#15 as decimal(12,2)), 0.00))#34 AS returns#37, sum((ss_net_profit#6 - coalesce(cast(sr_net_loss#16 as decimal(12,2)), 0.00)))#35 AS profit#38, store channel AS channel#39, concat(store, s_store_id#22) AS id#40]
 
-(40) Scan parquet spark_catalog.default.catalog_sales
-Output [7]: [cs_catalog_page_sk#43, cs_item_sk#44, cs_promo_sk#45, cs_order_number#46, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49]
+(32) Scan parquet spark_catalog.default.catalog_sales
+Output [7]: [cs_catalog_page_sk#41, cs_item_sk#42, cs_promo_sk#43, cs_order_number#44, cs_ext_sales_price#45, cs_net_profit#46, cs_sold_date_sk#47]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#49), dynamicpruningexpression(cs_sold_date_sk#49 IN dynamicpruning#8)]
+PartitionFilters: [isnotnull(cs_sold_date_sk#47), dynamicpruningexpression(cs_sold_date_sk#47 IN dynamicpruning#8)]
 PushedFilters: [IsNotNull(cs_catalog_page_sk), IsNotNull(cs_item_sk), IsNotNull(cs_promo_sk)]
 ReadSchema: struct<cs_catalog_page_sk:int,cs_item_sk:int,cs_promo_sk:int,cs_order_number:int,cs_ext_sales_price:decimal(7,2),cs_net_profit:decimal(7,2)>
 
-(41) ColumnarToRow [codegen id : 11]
-Input [7]: [cs_catalog_page_sk#43, cs_item_sk#44, cs_promo_sk#45, cs_order_number#46, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49]
+(33) ColumnarToRow [codegen id : 11]
+Input [7]: [cs_catalog_page_sk#41, cs_item_sk#42, cs_promo_sk#43, cs_order_number#44, cs_ext_sales_price#45, cs_net_profit#46, cs_sold_date_sk#47]
 
-(42) Filter [codegen id : 11]
-Input [7]: [cs_catalog_page_sk#43, cs_item_sk#44, cs_promo_sk#45, cs_order_number#46, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49]
-Condition : ((((isnotnull(cs_catalog_page_sk#43) AND isnotnull(cs_item_sk#44)) AND isnotnull(cs_promo_sk#45)) AND might_contain(ReusedSubquery Subquery scalar-subquery#9, [id=#10], xxhash64(cs_item_sk#44, 42))) AND might_contain(ReusedSubquery Subquery scalar-subquery#11, [id=#12], xxhash64(cs_promo_sk#45, 42)))
+(34) Filter [codegen id : 11]
+Input [7]: [cs_catalog_page_sk#41, cs_item_sk#42, cs_promo_sk#43, cs_order_number#44, cs_ext_sales_price#45, cs_net_profit#46, cs_sold_date_sk#47]
+Condition : ((((isnotnull(cs_catalog_page_sk#41) AND isnotnull(cs_item_sk#42)) AND isnotnull(cs_promo_sk#43)) AND might_contain(runtimefilterexpression(ReusedSubquery Subquery scalar-subquery#9, [id=#10]), xxhash64(cs_item_sk#42, 42))) AND might_contain(runtimefilterexpression(ReusedSubquery Subquery scalar-subquery#11, [id=#12]), xxhash64(cs_promo_sk#43, 42)))
 
-(43) Exchange
-Input [7]: [cs_catalog_page_sk#43, cs_item_sk#44, cs_promo_sk#45, cs_order_number#46, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49]
-Arguments: hashpartitioning(cs_item_sk#44, cs_order_number#46, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+(35) Exchange
+Input [7]: [cs_catalog_page_sk#41, cs_item_sk#42, cs_promo_sk#43, cs_order_number#44, cs_ext_sales_price#45, cs_net_profit#46, cs_sold_date_sk#47]
+Arguments: hashpartitioning(cs_item_sk#42, cs_order_number#44, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
-(44) Sort [codegen id : 12]
-Input [7]: [cs_catalog_page_sk#43, cs_item_sk#44, cs_promo_sk#45, cs_order_number#46, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49]
-Arguments: [cs_item_sk#44 ASC NULLS FIRST, cs_order_number#46 ASC NULLS FIRST], false, 0
+(36) Sort [codegen id : 12]
+Input [7]: [cs_catalog_page_sk#41, cs_item_sk#42, cs_promo_sk#43, cs_order_number#44, cs_ext_sales_price#45, cs_net_profit#46, cs_sold_date_sk#47]
+Arguments: [cs_item_sk#42 ASC NULLS FIRST, cs_order_number#44 ASC NULLS FIRST], false, 0
 
-(45) Scan parquet spark_catalog.default.catalog_returns
-Output [5]: [cr_item_sk#50, cr_order_number#51, cr_return_amount#52, cr_net_loss#53, cr_returned_date_sk#54]
+(37) Scan parquet spark_catalog.default.catalog_returns
+Output [5]: [cr_item_sk#48, cr_order_number#49, cr_return_amount#50, cr_net_loss#51, cr_returned_date_sk#52]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/catalog_returns]
 PushedFilters: [IsNotNull(cr_item_sk), IsNotNull(cr_order_number)]
 ReadSchema: struct<cr_item_sk:int,cr_order_number:int,cr_return_amount:decimal(7,2),cr_net_loss:decimal(7,2)>
 
-(46) ColumnarToRow [codegen id : 13]
-Input [5]: [cr_item_sk#50, cr_order_number#51, cr_return_amount#52, cr_net_loss#53, cr_returned_date_sk#54]
+(38) ColumnarToRow [codegen id : 13]
+Input [5]: [cr_item_sk#48, cr_order_number#49, cr_return_amount#50, cr_net_loss#51, cr_returned_date_sk#52]
 
-(47) Filter [codegen id : 13]
-Input [5]: [cr_item_sk#50, cr_order_number#51, cr_return_amount#52, cr_net_loss#53, cr_returned_date_sk#54]
-Condition : (isnotnull(cr_item_sk#50) AND isnotnull(cr_order_number#51))
+(39) Filter [codegen id : 13]
+Input [5]: [cr_item_sk#48, cr_order_number#49, cr_return_amount#50, cr_net_loss#51, cr_returned_date_sk#52]
+Condition : (isnotnull(cr_item_sk#48) AND isnotnull(cr_order_number#49))
 
-(48) Project [codegen id : 13]
-Output [4]: [cr_item_sk#50, cr_order_number#51, cr_return_amount#52, cr_net_loss#53]
-Input [5]: [cr_item_sk#50, cr_order_number#51, cr_return_amount#52, cr_net_loss#53, cr_returned_date_sk#54]
+(40) Project [codegen id : 13]
+Output [4]: [cr_item_sk#48, cr_order_number#49, cr_return_amount#50, cr_net_loss#51]
+Input [5]: [cr_item_sk#48, cr_order_number#49, cr_return_amount#50, cr_net_loss#51, cr_returned_date_sk#52]
 
-(49) Exchange
-Input [4]: [cr_item_sk#50, cr_order_number#51, cr_return_amount#52, cr_net_loss#53]
-Arguments: hashpartitioning(cr_item_sk#50, cr_order_number#51, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+(41) Exchange
+Input [4]: [cr_item_sk#48, cr_order_number#49, cr_return_amount#50, cr_net_loss#51]
+Arguments: hashpartitioning(cr_item_sk#48, cr_order_number#49, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
-(50) Sort [codegen id : 14]
-Input [4]: [cr_item_sk#50, cr_order_number#51, cr_return_amount#52, cr_net_loss#53]
-Arguments: [cr_item_sk#50 ASC NULLS FIRST, cr_order_number#51 ASC NULLS FIRST], false, 0
+(42) Sort [codegen id : 14]
+Input [4]: [cr_item_sk#48, cr_order_number#49, cr_return_amount#50, cr_net_loss#51]
+Arguments: [cr_item_sk#48 ASC NULLS FIRST, cr_order_number#49 ASC NULLS FIRST], false, 0
 
-(51) SortMergeJoin [codegen id : 19]
-Left keys [2]: [cs_item_sk#44, cs_order_number#46]
-Right keys [2]: [cr_item_sk#50, cr_order_number#51]
+(43) SortMergeJoin [codegen id : 19]
+Left keys [2]: [cs_item_sk#42, cs_order_number#44]
+Right keys [2]: [cr_item_sk#48, cr_order_number#49]
 Join type: LeftOuter
 Join condition: None
 
-(52) Project [codegen id : 19]
-Output [8]: [cs_catalog_page_sk#43, cs_item_sk#44, cs_promo_sk#45, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49, cr_return_amount#52, cr_net_loss#53]
-Input [11]: [cs_catalog_page_sk#43, cs_item_sk#44, cs_promo_sk#45, cs_order_number#46, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49, cr_item_sk#50, cr_order_number#51, cr_return_amount#52, cr_net_loss#53]
+(44) Project [codegen id : 19]
+Output [8]: [cs_catalog_page_sk#41, cs_item_sk#42, cs_promo_sk#43, cs_ext_sales_price#45, cs_net_profit#46, cs_sold_date_sk#47, cr_return_amount#50, cr_net_loss#51]
+Input [11]: [cs_catalog_page_sk#41, cs_item_sk#42, cs_promo_sk#43, cs_order_number#44, cs_ext_sales_price#45, cs_net_profit#46, cs_sold_date_sk#47, cr_item_sk#48, cr_order_number#49, cr_return_amount#50, cr_net_loss#51]
 
-(53) ReusedExchange [Reuses operator id: 18]
-Output [1]: [i_item_sk#55]
+(45) ReusedExchange [Reuses operator id: 104]
+Output [1]: [i_item_sk#53]
 
-(54) BroadcastHashJoin [codegen id : 19]
-Left keys [1]: [cs_item_sk#44]
-Right keys [1]: [i_item_sk#55]
+(46) BroadcastHashJoin [codegen id : 19]
+Left keys [1]: [cs_item_sk#42]
+Right keys [1]: [i_item_sk#53]
 Join type: Inner
 Join condition: None
 
-(55) Project [codegen id : 19]
-Output [7]: [cs_catalog_page_sk#43, cs_promo_sk#45, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49, cr_return_amount#52, cr_net_loss#53]
-Input [9]: [cs_catalog_page_sk#43, cs_item_sk#44, cs_promo_sk#45, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49, cr_return_amount#52, cr_net_loss#53, i_item_sk#55]
+(47) Project [codegen id : 19]
+Output [7]: [cs_catalog_page_sk#41, cs_promo_sk#43, cs_ext_sales_price#45, cs_net_profit#46, cs_sold_date_sk#47, cr_return_amount#50, cr_net_loss#51]
+Input [9]: [cs_catalog_page_sk#41, cs_item_sk#42, cs_promo_sk#43, cs_ext_sales_price#45, cs_net_profit#46, cs_sold_date_sk#47, cr_return_amount#50, cr_net_loss#51, i_item_sk#53]
 
-(56) ReusedExchange [Reuses operator id: 25]
-Output [1]: [p_promo_sk#56]
+(48) ReusedExchange [Reuses operator id: 114]
+Output [1]: [p_promo_sk#54]
 
-(57) BroadcastHashJoin [codegen id : 19]
-Left keys [1]: [cs_promo_sk#45]
-Right keys [1]: [p_promo_sk#56]
+(49) BroadcastHashJoin [codegen id : 19]
+Left keys [1]: [cs_promo_sk#43]
+Right keys [1]: [p_promo_sk#54]
 Join type: Inner
 Join condition: None
 
-(58) Project [codegen id : 19]
-Output [6]: [cs_catalog_page_sk#43, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49, cr_return_amount#52, cr_net_loss#53]
-Input [8]: [cs_catalog_page_sk#43, cs_promo_sk#45, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49, cr_return_amount#52, cr_net_loss#53, p_promo_sk#56]
+(50) Project [codegen id : 19]
+Output [6]: [cs_catalog_page_sk#41, cs_ext_sales_price#45, cs_net_profit#46, cs_sold_date_sk#47, cr_return_amount#50, cr_net_loss#51]
+Input [8]: [cs_catalog_page_sk#41, cs_promo_sk#43, cs_ext_sales_price#45, cs_net_profit#46, cs_sold_date_sk#47, cr_return_amount#50, cr_net_loss#51, p_promo_sk#54]
 
-(59) ReusedExchange [Reuses operator id: 126]
-Output [1]: [d_date_sk#57]
+(51) ReusedExchange [Reuses operator id: 124]
+Output [1]: [d_date_sk#55]
 
-(60) BroadcastHashJoin [codegen id : 19]
-Left keys [1]: [cs_sold_date_sk#49]
-Right keys [1]: [d_date_sk#57]
+(52) BroadcastHashJoin [codegen id : 19]
+Left keys [1]: [cs_sold_date_sk#47]
+Right keys [1]: [d_date_sk#55]
 Join type: Inner
 Join condition: None
 
-(61) Project [codegen id : 19]
-Output [5]: [cs_catalog_page_sk#43, cs_ext_sales_price#47, cs_net_profit#48, cr_return_amount#52, cr_net_loss#53]
-Input [7]: [cs_catalog_page_sk#43, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49, cr_return_amount#52, cr_net_loss#53, d_date_sk#57]
+(53) Project [codegen id : 19]
+Output [5]: [cs_catalog_page_sk#41, cs_ext_sales_price#45, cs_net_profit#46, cr_return_amount#50, cr_net_loss#51]
+Input [7]: [cs_catalog_page_sk#41, cs_ext_sales_price#45, cs_net_profit#46, cs_sold_date_sk#47, cr_return_amount#50, cr_net_loss#51, d_date_sk#55]
 
-(62) Scan parquet spark_catalog.default.catalog_page
-Output [2]: [cp_catalog_page_sk#58, cp_catalog_page_id#59]
+(54) Scan parquet spark_catalog.default.catalog_page
+Output [2]: [cp_catalog_page_sk#56, cp_catalog_page_id#57]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/catalog_page]
 PushedFilters: [IsNotNull(cp_catalog_page_sk)]
 ReadSchema: struct<cp_catalog_page_sk:int,cp_catalog_page_id:string>
 
-(63) ColumnarToRow [codegen id : 18]
-Input [2]: [cp_catalog_page_sk#58, cp_catalog_page_id#59]
+(55) ColumnarToRow [codegen id : 18]
+Input [2]: [cp_catalog_page_sk#56, cp_catalog_page_id#57]
 
-(64) Filter [codegen id : 18]
-Input [2]: [cp_catalog_page_sk#58, cp_catalog_page_id#59]
-Condition : isnotnull(cp_catalog_page_sk#58)
+(56) Filter [codegen id : 18]
+Input [2]: [cp_catalog_page_sk#56, cp_catalog_page_id#57]
+Condition : isnotnull(cp_catalog_page_sk#56)
 
-(65) BroadcastExchange
-Input [2]: [cp_catalog_page_sk#58, cp_catalog_page_id#59]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=9]
+(57) BroadcastExchange
+Input [2]: [cp_catalog_page_sk#56, cp_catalog_page_id#57]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=7]
 
-(66) BroadcastHashJoin [codegen id : 19]
-Left keys [1]: [cs_catalog_page_sk#43]
-Right keys [1]: [cp_catalog_page_sk#58]
+(58) BroadcastHashJoin [codegen id : 19]
+Left keys [1]: [cs_catalog_page_sk#41]
+Right keys [1]: [cp_catalog_page_sk#56]
 Join type: Inner
 Join condition: None
 
-(67) Project [codegen id : 19]
-Output [5]: [cs_ext_sales_price#47, cs_net_profit#48, cr_return_amount#52, cr_net_loss#53, cp_catalog_page_id#59]
-Input [7]: [cs_catalog_page_sk#43, cs_ext_sales_price#47, cs_net_profit#48, cr_return_amount#52, cr_net_loss#53, cp_catalog_page_sk#58, cp_catalog_page_id#59]
+(59) Project [codegen id : 19]
+Output [5]: [cs_ext_sales_price#45, cs_net_profit#46, cr_return_amount#50, cr_net_loss#51, cp_catalog_page_id#57]
+Input [7]: [cs_catalog_page_sk#41, cs_ext_sales_price#45, cs_net_profit#46, cr_return_amount#50, cr_net_loss#51, cp_catalog_page_sk#56, cp_catalog_page_id#57]
 
-(68) HashAggregate [codegen id : 19]
-Input [5]: [cs_ext_sales_price#47, cs_net_profit#48, cr_return_amount#52, cr_net_loss#53, cp_catalog_page_id#59]
-Keys [1]: [cp_catalog_page_id#59]
-Functions [3]: [partial_sum(UnscaledValue(cs_ext_sales_price#47)), partial_sum(coalesce(cast(cr_return_amount#52 as decimal(12,2)), 0.00)), partial_sum((cs_net_profit#48 - coalesce(cast(cr_net_loss#53 as decimal(12,2)), 0.00)))]
-Aggregate Attributes [5]: [sum#60, sum#61, isEmpty#62, sum#63, isEmpty#64]
-Results [6]: [cp_catalog_page_id#59, sum#65, sum#66, isEmpty#67, sum#68, isEmpty#69]
+(60) HashAggregate [codegen id : 19]
+Input [5]: [cs_ext_sales_price#45, cs_net_profit#46, cr_return_amount#50, cr_net_loss#51, cp_catalog_page_id#57]
+Keys [1]: [cp_catalog_page_id#57]
+Functions [3]: [partial_sum(UnscaledValue(cs_ext_sales_price#45)), partial_sum(coalesce(cast(cr_return_amount#50 as decimal(12,2)), 0.00)), partial_sum((cs_net_profit#46 - coalesce(cast(cr_net_loss#51 as decimal(12,2)), 0.00)))]
+Aggregate Attributes [5]: [sum#58, sum#59, isEmpty#60, sum#61, isEmpty#62]
+Results [6]: [cp_catalog_page_id#57, sum#63, sum#64, isEmpty#65, sum#66, isEmpty#67]
 
-(69) Exchange
-Input [6]: [cp_catalog_page_id#59, sum#65, sum#66, isEmpty#67, sum#68, isEmpty#69]
-Arguments: hashpartitioning(cp_catalog_page_id#59, 5), ENSURE_REQUIREMENTS, [plan_id=10]
+(61) Exchange
+Input [6]: [cp_catalog_page_id#57, sum#63, sum#64, isEmpty#65, sum#66, isEmpty#67]
+Arguments: hashpartitioning(cp_catalog_page_id#57, 5), ENSURE_REQUIREMENTS, [plan_id=8]
 
-(70) HashAggregate [codegen id : 20]
-Input [6]: [cp_catalog_page_id#59, sum#65, sum#66, isEmpty#67, sum#68, isEmpty#69]
-Keys [1]: [cp_catalog_page_id#59]
-Functions [3]: [sum(UnscaledValue(cs_ext_sales_price#47)), sum(coalesce(cast(cr_return_amount#52 as decimal(12,2)), 0.00)), sum((cs_net_profit#48 - coalesce(cast(cr_net_loss#53 as decimal(12,2)), 0.00)))]
-Aggregate Attributes [3]: [sum(UnscaledValue(cs_ext_sales_price#47))#70, sum(coalesce(cast(cr_return_amount#52 as decimal(12,2)), 0.00))#71, sum((cs_net_profit#48 - coalesce(cast(cr_net_loss#53 as decimal(12,2)), 0.00)))#72]
-Results [5]: [MakeDecimal(sum(UnscaledValue(cs_ext_sales_price#47))#70,17,2) AS sales#73, sum(coalesce(cast(cr_return_amount#52 as decimal(12,2)), 0.00))#71 AS returns#74, sum((cs_net_profit#48 - coalesce(cast(cr_net_loss#53 as decimal(12,2)), 0.00)))#72 AS profit#75, catalog channel AS channel#76, concat(catalog_page, cp_catalog_page_id#59) AS id#77]
+(62) HashAggregate [codegen id : 20]
+Input [6]: [cp_catalog_page_id#57, sum#63, sum#64, isEmpty#65, sum#66, isEmpty#67]
+Keys [1]: [cp_catalog_page_id#57]
+Functions [3]: [sum(UnscaledValue(cs_ext_sales_price#45)), sum(coalesce(cast(cr_return_amount#50 as decimal(12,2)), 0.00)), sum((cs_net_profit#46 - coalesce(cast(cr_net_loss#51 as decimal(12,2)), 0.00)))]
+Aggregate Attributes [3]: [sum(UnscaledValue(cs_ext_sales_price#45))#68, sum(coalesce(cast(cr_return_amount#50 as decimal(12,2)), 0.00))#69, sum((cs_net_profit#46 - coalesce(cast(cr_net_loss#51 as decimal(12,2)), 0.00)))#70]
+Results [5]: [MakeDecimal(sum(UnscaledValue(cs_ext_sales_price#45))#68,17,2) AS sales#71, sum(coalesce(cast(cr_return_amount#50 as decimal(12,2)), 0.00))#69 AS returns#72, sum((cs_net_profit#46 - coalesce(cast(cr_net_loss#51 as decimal(12,2)), 0.00)))#70 AS profit#73, catalog channel AS channel#74, concat(catalog_page, cp_catalog_page_id#57) AS id#75]
 
-(71) Scan parquet spark_catalog.default.web_sales
-Output [7]: [ws_item_sk#78, ws_web_site_sk#79, ws_promo_sk#80, ws_order_number#81, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84]
+(63) Scan parquet spark_catalog.default.web_sales
+Output [7]: [ws_item_sk#76, ws_web_site_sk#77, ws_promo_sk#78, ws_order_number#79, ws_ext_sales_price#80, ws_net_profit#81, ws_sold_date_sk#82]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#84), dynamicpruningexpression(ws_sold_date_sk#84 IN dynamicpruning#8)]
+PartitionFilters: [isnotnull(ws_sold_date_sk#82), dynamicpruningexpression(ws_sold_date_sk#82 IN dynamicpruning#8)]
 PushedFilters: [IsNotNull(ws_web_site_sk), IsNotNull(ws_item_sk), IsNotNull(ws_promo_sk)]
 ReadSchema: struct<ws_item_sk:int,ws_web_site_sk:int,ws_promo_sk:int,ws_order_number:int,ws_ext_sales_price:decimal(7,2),ws_net_profit:decimal(7,2)>
 
-(72) ColumnarToRow [codegen id : 21]
-Input [7]: [ws_item_sk#78, ws_web_site_sk#79, ws_promo_sk#80, ws_order_number#81, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84]
+(64) ColumnarToRow [codegen id : 21]
+Input [7]: [ws_item_sk#76, ws_web_site_sk#77, ws_promo_sk#78, ws_order_number#79, ws_ext_sales_price#80, ws_net_profit#81, ws_sold_date_sk#82]
 
-(73) Filter [codegen id : 21]
-Input [7]: [ws_item_sk#78, ws_web_site_sk#79, ws_promo_sk#80, ws_order_number#81, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84]
-Condition : ((((isnotnull(ws_web_site_sk#79) AND isnotnull(ws_item_sk#78)) AND isnotnull(ws_promo_sk#80)) AND might_contain(ReusedSubquery Subquery scalar-subquery#9, [id=#10], xxhash64(ws_item_sk#78, 42))) AND might_contain(ReusedSubquery Subquery scalar-subquery#11, [id=#12], xxhash64(ws_promo_sk#80, 42)))
+(65) Filter [codegen id : 21]
+Input [7]: [ws_item_sk#76, ws_web_site_sk#77, ws_promo_sk#78, ws_order_number#79, ws_ext_sales_price#80, ws_net_profit#81, ws_sold_date_sk#82]
+Condition : ((((isnotnull(ws_web_site_sk#77) AND isnotnull(ws_item_sk#76)) AND isnotnull(ws_promo_sk#78)) AND might_contain(runtimefilterexpression(ReusedSubquery Subquery scalar-subquery#9, [id=#10]), xxhash64(ws_item_sk#76, 42))) AND might_contain(runtimefilterexpression(ReusedSubquery Subquery scalar-subquery#11, [id=#12]), xxhash64(ws_promo_sk#78, 42)))
 
-(74) Exchange
-Input [7]: [ws_item_sk#78, ws_web_site_sk#79, ws_promo_sk#80, ws_order_number#81, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84]
-Arguments: hashpartitioning(ws_item_sk#78, ws_order_number#81, 5), ENSURE_REQUIREMENTS, [plan_id=11]
+(66) Exchange
+Input [7]: [ws_item_sk#76, ws_web_site_sk#77, ws_promo_sk#78, ws_order_number#79, ws_ext_sales_price#80, ws_net_profit#81, ws_sold_date_sk#82]
+Arguments: hashpartitioning(ws_item_sk#76, ws_order_number#79, 5), ENSURE_REQUIREMENTS, [plan_id=9]
 
-(75) Sort [codegen id : 22]
-Input [7]: [ws_item_sk#78, ws_web_site_sk#79, ws_promo_sk#80, ws_order_number#81, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84]
-Arguments: [ws_item_sk#78 ASC NULLS FIRST, ws_order_number#81 ASC NULLS FIRST], false, 0
+(67) Sort [codegen id : 22]
+Input [7]: [ws_item_sk#76, ws_web_site_sk#77, ws_promo_sk#78, ws_order_number#79, ws_ext_sales_price#80, ws_net_profit#81, ws_sold_date_sk#82]
+Arguments: [ws_item_sk#76 ASC NULLS FIRST, ws_order_number#79 ASC NULLS FIRST], false, 0
 
-(76) Scan parquet spark_catalog.default.web_returns
-Output [5]: [wr_item_sk#85, wr_order_number#86, wr_return_amt#87, wr_net_loss#88, wr_returned_date_sk#89]
+(68) Scan parquet spark_catalog.default.web_returns
+Output [5]: [wr_item_sk#83, wr_order_number#84, wr_return_amt#85, wr_net_loss#86, wr_returned_date_sk#87]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/web_returns]
 PushedFilters: [IsNotNull(wr_item_sk), IsNotNull(wr_order_number)]
 ReadSchema: struct<wr_item_sk:int,wr_order_number:int,wr_return_amt:decimal(7,2),wr_net_loss:decimal(7,2)>
 
-(77) ColumnarToRow [codegen id : 23]
-Input [5]: [wr_item_sk#85, wr_order_number#86, wr_return_amt#87, wr_net_loss#88, wr_returned_date_sk#89]
+(69) ColumnarToRow [codegen id : 23]
+Input [5]: [wr_item_sk#83, wr_order_number#84, wr_return_amt#85, wr_net_loss#86, wr_returned_date_sk#87]
 
-(78) Filter [codegen id : 23]
-Input [5]: [wr_item_sk#85, wr_order_number#86, wr_return_amt#87, wr_net_loss#88, wr_returned_date_sk#89]
-Condition : (isnotnull(wr_item_sk#85) AND isnotnull(wr_order_number#86))
+(70) Filter [codegen id : 23]
+Input [5]: [wr_item_sk#83, wr_order_number#84, wr_return_amt#85, wr_net_loss#86, wr_returned_date_sk#87]
+Condition : (isnotnull(wr_item_sk#83) AND isnotnull(wr_order_number#84))
 
-(79) Project [codegen id : 23]
-Output [4]: [wr_item_sk#85, wr_order_number#86, wr_return_amt#87, wr_net_loss#88]
-Input [5]: [wr_item_sk#85, wr_order_number#86, wr_return_amt#87, wr_net_loss#88, wr_returned_date_sk#89]
+(71) Project [codegen id : 23]
+Output [4]: [wr_item_sk#83, wr_order_number#84, wr_return_amt#85, wr_net_loss#86]
+Input [5]: [wr_item_sk#83, wr_order_number#84, wr_return_amt#85, wr_net_loss#86, wr_returned_date_sk#87]
 
-(80) Exchange
-Input [4]: [wr_item_sk#85, wr_order_number#86, wr_return_amt#87, wr_net_loss#88]
-Arguments: hashpartitioning(wr_item_sk#85, wr_order_number#86, 5), ENSURE_REQUIREMENTS, [plan_id=12]
+(72) Exchange
+Input [4]: [wr_item_sk#83, wr_order_number#84, wr_return_amt#85, wr_net_loss#86]
+Arguments: hashpartitioning(wr_item_sk#83, wr_order_number#84, 5), ENSURE_REQUIREMENTS, [plan_id=10]
 
-(81) Sort [codegen id : 24]
-Input [4]: [wr_item_sk#85, wr_order_number#86, wr_return_amt#87, wr_net_loss#88]
-Arguments: [wr_item_sk#85 ASC NULLS FIRST, wr_order_number#86 ASC NULLS FIRST], false, 0
+(73) Sort [codegen id : 24]
+Input [4]: [wr_item_sk#83, wr_order_number#84, wr_return_amt#85, wr_net_loss#86]
+Arguments: [wr_item_sk#83 ASC NULLS FIRST, wr_order_number#84 ASC NULLS FIRST], false, 0
 
-(82) SortMergeJoin [codegen id : 29]
-Left keys [2]: [ws_item_sk#78, ws_order_number#81]
-Right keys [2]: [wr_item_sk#85, wr_order_number#86]
+(74) SortMergeJoin [codegen id : 29]
+Left keys [2]: [ws_item_sk#76, ws_order_number#79]
+Right keys [2]: [wr_item_sk#83, wr_order_number#84]
 Join type: LeftOuter
 Join condition: None
 
-(83) Project [codegen id : 29]
-Output [8]: [ws_item_sk#78, ws_web_site_sk#79, ws_promo_sk#80, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84, wr_return_amt#87, wr_net_loss#88]
-Input [11]: [ws_item_sk#78, ws_web_site_sk#79, ws_promo_sk#80, ws_order_number#81, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84, wr_item_sk#85, wr_order_number#86, wr_return_amt#87, wr_net_loss#88]
+(75) Project [codegen id : 29]
+Output [8]: [ws_item_sk#76, ws_web_site_sk#77, ws_promo_sk#78, ws_ext_sales_price#80, ws_net_profit#81, ws_sold_date_sk#82, wr_return_amt#85, wr_net_loss#86]
+Input [11]: [ws_item_sk#76, ws_web_site_sk#77, ws_promo_sk#78, ws_order_number#79, ws_ext_sales_price#80, ws_net_profit#81, ws_sold_date_sk#82, wr_item_sk#83, wr_order_number#84, wr_return_amt#85, wr_net_loss#86]
 
-(84) ReusedExchange [Reuses operator id: 18]
-Output [1]: [i_item_sk#90]
+(76) ReusedExchange [Reuses operator id: 104]
+Output [1]: [i_item_sk#88]
 
-(85) BroadcastHashJoin [codegen id : 29]
-Left keys [1]: [ws_item_sk#78]
-Right keys [1]: [i_item_sk#90]
+(77) BroadcastHashJoin [codegen id : 29]
+Left keys [1]: [ws_item_sk#76]
+Right keys [1]: [i_item_sk#88]
 Join type: Inner
 Join condition: None
 
-(86) Project [codegen id : 29]
-Output [7]: [ws_web_site_sk#79, ws_promo_sk#80, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84, wr_return_amt#87, wr_net_loss#88]
-Input [9]: [ws_item_sk#78, ws_web_site_sk#79, ws_promo_sk#80, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84, wr_return_amt#87, wr_net_loss#88, i_item_sk#90]
+(78) Project [codegen id : 29]
+Output [7]: [ws_web_site_sk#77, ws_promo_sk#78, ws_ext_sales_price#80, ws_net_profit#81, ws_sold_date_sk#82, wr_return_amt#85, wr_net_loss#86]
+Input [9]: [ws_item_sk#76, ws_web_site_sk#77, ws_promo_sk#78, ws_ext_sales_price#80, ws_net_profit#81, ws_sold_date_sk#82, wr_return_amt#85, wr_net_loss#86, i_item_sk#88]
 
-(87) ReusedExchange [Reuses operator id: 25]
-Output [1]: [p_promo_sk#91]
+(79) ReusedExchange [Reuses operator id: 114]
+Output [1]: [p_promo_sk#89]
 
-(88) BroadcastHashJoin [codegen id : 29]
-Left keys [1]: [ws_promo_sk#80]
-Right keys [1]: [p_promo_sk#91]
+(80) BroadcastHashJoin [codegen id : 29]
+Left keys [1]: [ws_promo_sk#78]
+Right keys [1]: [p_promo_sk#89]
 Join type: Inner
 Join condition: None
 
-(89) Project [codegen id : 29]
-Output [6]: [ws_web_site_sk#79, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84, wr_return_amt#87, wr_net_loss#88]
-Input [8]: [ws_web_site_sk#79, ws_promo_sk#80, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84, wr_return_amt#87, wr_net_loss#88, p_promo_sk#91]
+(81) Project [codegen id : 29]
+Output [6]: [ws_web_site_sk#77, ws_ext_sales_price#80, ws_net_profit#81, ws_sold_date_sk#82, wr_return_amt#85, wr_net_loss#86]
+Input [8]: [ws_web_site_sk#77, ws_promo_sk#78, ws_ext_sales_price#80, ws_net_profit#81, ws_sold_date_sk#82, wr_return_amt#85, wr_net_loss#86, p_promo_sk#89]
 
-(90) ReusedExchange [Reuses operator id: 126]
-Output [1]: [d_date_sk#92]
+(82) ReusedExchange [Reuses operator id: 124]
+Output [1]: [d_date_sk#90]
 
-(91) BroadcastHashJoin [codegen id : 29]
-Left keys [1]: [ws_sold_date_sk#84]
-Right keys [1]: [d_date_sk#92]
+(83) BroadcastHashJoin [codegen id : 29]
+Left keys [1]: [ws_sold_date_sk#82]
+Right keys [1]: [d_date_sk#90]
 Join type: Inner
 Join condition: None
 
-(92) Project [codegen id : 29]
-Output [5]: [ws_web_site_sk#79, ws_ext_sales_price#82, ws_net_profit#83, wr_return_amt#87, wr_net_loss#88]
-Input [7]: [ws_web_site_sk#79, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84, wr_return_amt#87, wr_net_loss#88, d_date_sk#92]
+(84) Project [codegen id : 29]
+Output [5]: [ws_web_site_sk#77, ws_ext_sales_price#80, ws_net_profit#81, wr_return_amt#85, wr_net_loss#86]
+Input [7]: [ws_web_site_sk#77, ws_ext_sales_price#80, ws_net_profit#81, ws_sold_date_sk#82, wr_return_amt#85, wr_net_loss#86, d_date_sk#90]
 
-(93) Scan parquet spark_catalog.default.web_site
-Output [2]: [web_site_sk#93, web_site_id#94]
+(85) Scan parquet spark_catalog.default.web_site
+Output [2]: [web_site_sk#91, web_site_id#92]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/web_site]
 PushedFilters: [IsNotNull(web_site_sk)]
 ReadSchema: struct<web_site_sk:int,web_site_id:string>
 
-(94) ColumnarToRow [codegen id : 28]
-Input [2]: [web_site_sk#93, web_site_id#94]
+(86) ColumnarToRow [codegen id : 28]
+Input [2]: [web_site_sk#91, web_site_id#92]
 
-(95) Filter [codegen id : 28]
-Input [2]: [web_site_sk#93, web_site_id#94]
-Condition : isnotnull(web_site_sk#93)
+(87) Filter [codegen id : 28]
+Input [2]: [web_site_sk#91, web_site_id#92]
+Condition : isnotnull(web_site_sk#91)
 
-(96) BroadcastExchange
-Input [2]: [web_site_sk#93, web_site_id#94]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=13]
+(88) BroadcastExchange
+Input [2]: [web_site_sk#91, web_site_id#92]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=11]
 
-(97) BroadcastHashJoin [codegen id : 29]
-Left keys [1]: [ws_web_site_sk#79]
-Right keys [1]: [web_site_sk#93]
+(89) BroadcastHashJoin [codegen id : 29]
+Left keys [1]: [ws_web_site_sk#77]
+Right keys [1]: [web_site_sk#91]
 Join type: Inner
 Join condition: None
 
-(98) Project [codegen id : 29]
-Output [5]: [ws_ext_sales_price#82, ws_net_profit#83, wr_return_amt#87, wr_net_loss#88, web_site_id#94]
-Input [7]: [ws_web_site_sk#79, ws_ext_sales_price#82, ws_net_profit#83, wr_return_amt#87, wr_net_loss#88, web_site_sk#93, web_site_id#94]
+(90) Project [codegen id : 29]
+Output [5]: [ws_ext_sales_price#80, ws_net_profit#81, wr_return_amt#85, wr_net_loss#86, web_site_id#92]
+Input [7]: [ws_web_site_sk#77, ws_ext_sales_price#80, ws_net_profit#81, wr_return_amt#85, wr_net_loss#86, web_site_sk#91, web_site_id#92]
 
-(99) HashAggregate [codegen id : 29]
-Input [5]: [ws_ext_sales_price#82, ws_net_profit#83, wr_return_amt#87, wr_net_loss#88, web_site_id#94]
-Keys [1]: [web_site_id#94]
-Functions [3]: [partial_sum(UnscaledValue(ws_ext_sales_price#82)), partial_sum(coalesce(cast(wr_return_amt#87 as decimal(12,2)), 0.00)), partial_sum((ws_net_profit#83 - coalesce(cast(wr_net_loss#88 as decimal(12,2)), 0.00)))]
-Aggregate Attributes [5]: [sum#95, sum#96, isEmpty#97, sum#98, isEmpty#99]
-Results [6]: [web_site_id#94, sum#100, sum#101, isEmpty#102, sum#103, isEmpty#104]
+(91) HashAggregate [codegen id : 29]
+Input [5]: [ws_ext_sales_price#80, ws_net_profit#81, wr_return_amt#85, wr_net_loss#86, web_site_id#92]
+Keys [1]: [web_site_id#92]
+Functions [3]: [partial_sum(UnscaledValue(ws_ext_sales_price#80)), partial_sum(coalesce(cast(wr_return_amt#85 as decimal(12,2)), 0.00)), partial_sum((ws_net_profit#81 - coalesce(cast(wr_net_loss#86 as decimal(12,2)), 0.00)))]
+Aggregate Attributes [5]: [sum#93, sum#94, isEmpty#95, sum#96, isEmpty#97]
+Results [6]: [web_site_id#92, sum#98, sum#99, isEmpty#100, sum#101, isEmpty#102]
 
-(100) Exchange
-Input [6]: [web_site_id#94, sum#100, sum#101, isEmpty#102, sum#103, isEmpty#104]
-Arguments: hashpartitioning(web_site_id#94, 5), ENSURE_REQUIREMENTS, [plan_id=14]
+(92) Exchange
+Input [6]: [web_site_id#92, sum#98, sum#99, isEmpty#100, sum#101, isEmpty#102]
+Arguments: hashpartitioning(web_site_id#92, 5), ENSURE_REQUIREMENTS, [plan_id=12]
 
-(101) HashAggregate [codegen id : 30]
-Input [6]: [web_site_id#94, sum#100, sum#101, isEmpty#102, sum#103, isEmpty#104]
-Keys [1]: [web_site_id#94]
-Functions [3]: [sum(UnscaledValue(ws_ext_sales_price#82)), sum(coalesce(cast(wr_return_amt#87 as decimal(12,2)), 0.00)), sum((ws_net_profit#83 - coalesce(cast(wr_net_loss#88 as decimal(12,2)), 0.00)))]
-Aggregate Attributes [3]: [sum(UnscaledValue(ws_ext_sales_price#82))#105, sum(coalesce(cast(wr_return_amt#87 as decimal(12,2)), 0.00))#106, sum((ws_net_profit#83 - coalesce(cast(wr_net_loss#88 as decimal(12,2)), 0.00)))#107]
-Results [5]: [MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#82))#105,17,2) AS sales#108, sum(coalesce(cast(wr_return_amt#87 as decimal(12,2)), 0.00))#106 AS returns#109, sum((ws_net_profit#83 - coalesce(cast(wr_net_loss#88 as decimal(12,2)), 0.00)))#107 AS profit#110, web channel AS channel#111, concat(web_site, web_site_id#94) AS id#112]
+(93) HashAggregate [codegen id : 30]
+Input [6]: [web_site_id#92, sum#98, sum#99, isEmpty#100, sum#101, isEmpty#102]
+Keys [1]: [web_site_id#92]
+Functions [3]: [sum(UnscaledValue(ws_ext_sales_price#80)), sum(coalesce(cast(wr_return_amt#85 as decimal(12,2)), 0.00)), sum((ws_net_profit#81 - coalesce(cast(wr_net_loss#86 as decimal(12,2)), 0.00)))]
+Aggregate Attributes [3]: [sum(UnscaledValue(ws_ext_sales_price#80))#103, sum(coalesce(cast(wr_return_amt#85 as decimal(12,2)), 0.00))#104, sum((ws_net_profit#81 - coalesce(cast(wr_net_loss#86 as decimal(12,2)), 0.00)))#105]
+Results [5]: [MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#80))#103,17,2) AS sales#106, sum(coalesce(cast(wr_return_amt#85 as decimal(12,2)), 0.00))#104 AS returns#107, sum((ws_net_profit#81 - coalesce(cast(wr_net_loss#86 as decimal(12,2)), 0.00)))#105 AS profit#108, web channel AS channel#109, concat(web_site, web_site_id#92) AS id#110]
 
-(102) Union
+(94) Union
 
-(103) Expand [codegen id : 31]
-Input [5]: [sales#38, returns#39, profit#40, channel#41, id#42]
-Arguments: [[sales#38, returns#39, profit#40, channel#41, id#42, 0], [sales#38, returns#39, profit#40, channel#41, null, 1], [sales#38, returns#39, profit#40, null, null, 3]], [sales#38, returns#39, profit#40, channel#113, id#114, spark_grouping_id#115]
+(95) Expand [codegen id : 31]
+Input [5]: [sales#36, returns#37, profit#38, channel#39, id#40]
+Arguments: [[sales#36, returns#37, profit#38, channel#39, id#40, 0], [sales#36, returns#37, profit#38, channel#39, null, 1], [sales#36, returns#37, profit#38, null, null, 3]], [sales#36, returns#37, profit#38, channel#111, id#112, spark_grouping_id#113]
 
-(104) HashAggregate [codegen id : 31]
-Input [6]: [sales#38, returns#39, profit#40, channel#113, id#114, spark_grouping_id#115]
-Keys [3]: [channel#113, id#114, spark_grouping_id#115]
-Functions [3]: [partial_sum(sales#38), partial_sum(returns#39), partial_sum(profit#40)]
-Aggregate Attributes [6]: [sum#116, isEmpty#117, sum#118, isEmpty#119, sum#120, isEmpty#121]
-Results [9]: [channel#113, id#114, spark_grouping_id#115, sum#122, isEmpty#123, sum#124, isEmpty#125, sum#126, isEmpty#127]
+(96) HashAggregate [codegen id : 31]
+Input [6]: [sales#36, returns#37, profit#38, channel#111, id#112, spark_grouping_id#113]
+Keys [3]: [channel#111, id#112, spark_grouping_id#113]
+Functions [3]: [partial_sum(sales#36), partial_sum(returns#37), partial_sum(profit#38)]
+Aggregate Attributes [6]: [sum#114, isEmpty#115, sum#116, isEmpty#117, sum#118, isEmpty#119]
+Results [9]: [channel#111, id#112, spark_grouping_id#113, sum#120, isEmpty#121, sum#122, isEmpty#123, sum#124, isEmpty#125]
 
-(105) Exchange
-Input [9]: [channel#113, id#114, spark_grouping_id#115, sum#122, isEmpty#123, sum#124, isEmpty#125, sum#126, isEmpty#127]
-Arguments: hashpartitioning(channel#113, id#114, spark_grouping_id#115, 5), ENSURE_REQUIREMENTS, [plan_id=15]
+(97) Exchange
+Input [9]: [channel#111, id#112, spark_grouping_id#113, sum#120, isEmpty#121, sum#122, isEmpty#123, sum#124, isEmpty#125]
+Arguments: hashpartitioning(channel#111, id#112, spark_grouping_id#113, 5), ENSURE_REQUIREMENTS, [plan_id=13]
 
-(106) HashAggregate [codegen id : 32]
-Input [9]: [channel#113, id#114, spark_grouping_id#115, sum#122, isEmpty#123, sum#124, isEmpty#125, sum#126, isEmpty#127]
-Keys [3]: [channel#113, id#114, spark_grouping_id#115]
-Functions [3]: [sum(sales#38), sum(returns#39), sum(profit#40)]
-Aggregate Attributes [3]: [sum(sales#38)#128, sum(returns#39)#129, sum(profit#40)#130]
-Results [5]: [channel#113, id#114, sum(sales#38)#128 AS sales#131, sum(returns#39)#129 AS returns#132, sum(profit#40)#130 AS profit#133]
+(98) HashAggregate [codegen id : 32]
+Input [9]: [channel#111, id#112, spark_grouping_id#113, sum#120, isEmpty#121, sum#122, isEmpty#123, sum#124, isEmpty#125]
+Keys [3]: [channel#111, id#112, spark_grouping_id#113]
+Functions [3]: [sum(sales#36), sum(returns#37), sum(profit#38)]
+Aggregate Attributes [3]: [sum(sales#36)#126, sum(returns#37)#127, sum(profit#38)#128]
+Results [5]: [channel#111, id#112, sum(sales#36)#126 AS sales#129, sum(returns#37)#127 AS returns#130, sum(profit#38)#128 AS profit#131]
 
-(107) TakeOrderedAndProject
-Input [5]: [channel#113, id#114, sales#131, returns#132, profit#133]
-Arguments: 100, [channel#113 ASC NULLS FIRST, id#114 ASC NULLS FIRST], [channel#113, id#114, sales#131, returns#132, profit#133]
+(99) TakeOrderedAndProject
+Input [5]: [channel#111, id#112, sales#129, returns#130, profit#131]
+Arguments: 100, [channel#111 ASC NULLS FIRST, id#112 ASC NULLS FIRST], [channel#111, id#112, sales#129, returns#130, profit#131]
 
 ===== Subqueries =====
 
 Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#9, [id=#10]
-ObjectHashAggregate (114)
-+- Exchange (113)
-   +- ObjectHashAggregate (112)
-      +- * Project (111)
-         +- * Filter (110)
-            +- * ColumnarToRow (109)
-               +- Scan parquet spark_catalog.default.item (108)
+ObjectHashAggregate (109)
++- Exchange (108)
+   +- ObjectHashAggregate (107)
+      +- BroadcastExchangeExecProxy (106)
 
 
-(108) Scan parquet spark_catalog.default.item
-Output [2]: [i_item_sk#18, i_current_price#19]
+(100) Scan parquet spark_catalog.default.item
+Output [2]: [i_item_sk#18, i_current_price#132]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_current_price), GreaterThan(i_current_price,50.00), IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_current_price:decimal(7,2)>
 
-(109) ColumnarToRow [codegen id : 1]
-Input [2]: [i_item_sk#18, i_current_price#19]
+(101) ColumnarToRow [codegen id : 1]
+Input [2]: [i_item_sk#18, i_current_price#132]
 
-(110) Filter [codegen id : 1]
-Input [2]: [i_item_sk#18, i_current_price#19]
-Condition : ((isnotnull(i_current_price#19) AND (i_current_price#19 > 50.00)) AND isnotnull(i_item_sk#18))
+(102) Filter [codegen id : 1]
+Input [2]: [i_item_sk#18, i_current_price#132]
+Condition : ((isnotnull(i_current_price#132) AND (i_current_price#132 > 50.00)) AND isnotnull(i_item_sk#18))
 
-(111) Project [codegen id : 1]
+(103) Project [codegen id : 1]
 Output [1]: [i_item_sk#18]
-Input [2]: [i_item_sk#18, i_current_price#19]
+Input [2]: [i_item_sk#18, i_current_price#132]
 
-(112) ObjectHashAggregate
+(104) BroadcastExchange
+Input [1]: [i_item_sk#18]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=14]
+
+(105) SubqueryBroadcast
+Input [1]: [i_item_sk#18]
+Arguments: runtimefilter#9, 0, [i_item_sk#18], [id=#133]
+
+(106) BroadcastExchangeExecProxy
+Input [1]: [i_item_sk#134]
+Arguments: [i_item_sk#18]
+
+(107) ObjectHashAggregate
 Input [1]: [i_item_sk#18]
 Keys: []
 Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#18, 42), 101823, 1521109, 0, 0)]
-Aggregate Attributes [1]: [buf#134]
-Results [1]: [buf#135]
+Aggregate Attributes [1]: [buf#135]
+Results [1]: [buf#136]
 
-(113) Exchange
-Input [1]: [buf#135]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=16]
+(108) Exchange
+Input [1]: [buf#136]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=15]
 
-(114) ObjectHashAggregate
-Input [1]: [buf#135]
+(109) ObjectHashAggregate
+Input [1]: [buf#136]
 Keys: []
 Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#18, 42), 101823, 1521109, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#18, 42), 101823, 1521109, 0, 0)#136]
-Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#18, 42), 101823, 1521109, 0, 0)#136 AS bloomFilter#137]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#18, 42), 101823, 1521109, 0, 0)#137]
+Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#18, 42), 101823, 1521109, 0, 0)#137 AS bloomFilter#138]
 
 Subquery:2 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#11, [id=#12]
-ObjectHashAggregate (121)
-+- Exchange (120)
-   +- ObjectHashAggregate (119)
-      +- * Project (118)
-         +- * Filter (117)
-            +- * ColumnarToRow (116)
-               +- Scan parquet spark_catalog.default.promotion (115)
+ObjectHashAggregate (119)
++- Exchange (118)
+   +- ObjectHashAggregate (117)
+      +- BroadcastExchangeExecProxy (116)
 
 
-(115) Scan parquet spark_catalog.default.promotion
-Output [2]: [p_promo_sk#20, p_channel_tv#21]
+(110) Scan parquet spark_catalog.default.promotion
+Output [2]: [p_promo_sk#19, p_channel_tv#139]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/promotion]
 PushedFilters: [IsNotNull(p_channel_tv), EqualTo(p_channel_tv,N), IsNotNull(p_promo_sk)]
 ReadSchema: struct<p_promo_sk:int,p_channel_tv:string>
 
-(116) ColumnarToRow [codegen id : 1]
-Input [2]: [p_promo_sk#20, p_channel_tv#21]
+(111) ColumnarToRow [codegen id : 1]
+Input [2]: [p_promo_sk#19, p_channel_tv#139]
 
-(117) Filter [codegen id : 1]
-Input [2]: [p_promo_sk#20, p_channel_tv#21]
-Condition : ((isnotnull(p_channel_tv#21) AND (p_channel_tv#21 = N)) AND isnotnull(p_promo_sk#20))
+(112) Filter [codegen id : 1]
+Input [2]: [p_promo_sk#19, p_channel_tv#139]
+Condition : ((isnotnull(p_channel_tv#139) AND (p_channel_tv#139 = N)) AND isnotnull(p_promo_sk#19))
 
-(118) Project [codegen id : 1]
-Output [1]: [p_promo_sk#20]
-Input [2]: [p_promo_sk#20, p_channel_tv#21]
+(113) Project [codegen id : 1]
+Output [1]: [p_promo_sk#19]
+Input [2]: [p_promo_sk#19, p_channel_tv#139]
 
-(119) ObjectHashAggregate
-Input [1]: [p_promo_sk#20]
+(114) BroadcastExchange
+Input [1]: [p_promo_sk#19]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=16]
+
+(115) SubqueryBroadcast
+Input [1]: [p_promo_sk#19]
+Arguments: runtimefilter#11, 0, [p_promo_sk#19], [id=#140]
+
+(116) BroadcastExchangeExecProxy
+Input [1]: [p_promo_sk#141]
+Arguments: [p_promo_sk#19]
+
+(117) ObjectHashAggregate
+Input [1]: [p_promo_sk#19]
 Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(p_promo_sk#20, 42), 986, 24246, 0, 0)]
-Aggregate Attributes [1]: [buf#138]
-Results [1]: [buf#139]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(p_promo_sk#19, 42), 986, 24246, 0, 0)]
+Aggregate Attributes [1]: [buf#142]
+Results [1]: [buf#143]
 
-(120) Exchange
-Input [1]: [buf#139]
+(118) Exchange
+Input [1]: [buf#143]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=17]
 
-(121) ObjectHashAggregate
-Input [1]: [buf#139]
+(119) ObjectHashAggregate
+Input [1]: [buf#143]
 Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(p_promo_sk#20, 42), 986, 24246, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(p_promo_sk#20, 42), 986, 24246, 0, 0)#140]
-Results [1]: [bloom_filter_agg(xxhash64(p_promo_sk#20, 42), 986, 24246, 0, 0)#140 AS bloomFilter#141]
+Functions [1]: [bloom_filter_agg(xxhash64(p_promo_sk#19, 42), 986, 24246, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(p_promo_sk#19, 42), 986, 24246, 0, 0)#144]
+Results [1]: [bloom_filter_agg(xxhash64(p_promo_sk#19, 42), 986, 24246, 0, 0)#144 AS bloomFilter#145]
 
 Subquery:3 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#7 IN dynamicpruning#8
-BroadcastExchange (126)
-+- * Project (125)
-   +- * Filter (124)
-      +- * ColumnarToRow (123)
-         +- Scan parquet spark_catalog.default.date_dim (122)
+BroadcastExchange (124)
++- * Project (123)
+   +- * Filter (122)
+      +- * ColumnarToRow (121)
+         +- Scan parquet spark_catalog.default.date_dim (120)
 
 
-(122) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#22, d_date#142]
+(120) Scan parquet spark_catalog.default.date_dim
+Output [2]: [d_date_sk#20, d_date#146]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,2000-08-23), LessThanOrEqual(d_date,2000-09-22), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
-(123) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#22, d_date#142]
+(121) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#20, d_date#146]
 
-(124) Filter [codegen id : 1]
-Input [2]: [d_date_sk#22, d_date#142]
-Condition : (((isnotnull(d_date#142) AND (d_date#142 >= 2000-08-23)) AND (d_date#142 <= 2000-09-22)) AND isnotnull(d_date_sk#22))
+(122) Filter [codegen id : 1]
+Input [2]: [d_date_sk#20, d_date#146]
+Condition : (((isnotnull(d_date#146) AND (d_date#146 >= 2000-08-23)) AND (d_date#146 <= 2000-09-22)) AND isnotnull(d_date_sk#20))
 
-(125) Project [codegen id : 1]
-Output [1]: [d_date_sk#22]
-Input [2]: [d_date_sk#22, d_date#142]
+(123) Project [codegen id : 1]
+Output [1]: [d_date_sk#20]
+Input [2]: [d_date_sk#20, d_date#146]
 
-(126) BroadcastExchange
-Input [1]: [d_date_sk#22]
+(124) BroadcastExchange
+Input [1]: [d_date_sk#20]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=18]
 
-Subquery:4 Hosting operator id = 42 Hosting Expression = ReusedSubquery Subquery scalar-subquery#9, [id=#10]
+Subquery:4 Hosting operator id = 34 Hosting Expression = ReusedSubquery Subquery scalar-subquery#9, [id=#10]
 
-Subquery:5 Hosting operator id = 42 Hosting Expression = ReusedSubquery Subquery scalar-subquery#11, [id=#12]
+Subquery:5 Hosting operator id = 34 Hosting Expression = ReusedSubquery Subquery scalar-subquery#11, [id=#12]
 
-Subquery:6 Hosting operator id = 40 Hosting Expression = cs_sold_date_sk#49 IN dynamicpruning#8
+Subquery:6 Hosting operator id = 32 Hosting Expression = cs_sold_date_sk#47 IN dynamicpruning#8
 
-Subquery:7 Hosting operator id = 73 Hosting Expression = ReusedSubquery Subquery scalar-subquery#9, [id=#10]
+Subquery:7 Hosting operator id = 65 Hosting Expression = ReusedSubquery Subquery scalar-subquery#9, [id=#10]
 
-Subquery:8 Hosting operator id = 73 Hosting Expression = ReusedSubquery Subquery scalar-subquery#11, [id=#12]
+Subquery:8 Hosting operator id = 65 Hosting Expression = ReusedSubquery Subquery scalar-subquery#11, [id=#12]
 
-Subquery:9 Hosting operator id = 71 Hosting Expression = ws_sold_date_sk#84 IN dynamicpruning#8
+Subquery:9 Hosting operator id = 63 Hosting Expression = ws_sold_date_sk#82 IN dynamicpruning#8
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q80.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q80.sf100/simplified.txt
@@ -35,22 +35,28 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                                                     ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(i_item_sk, 42), 101823, 1521109, 0, 0),bloomFilter,buf]
                                                                       Exchange #5
                                                                         ObjectHashAggregate [i_item_sk] [buf,buf]
-                                                                          WholeStageCodegen (1)
-                                                                            Project [i_item_sk]
-                                                                              Filter [i_current_price,i_item_sk]
-                                                                                ColumnarToRow
-                                                                                  InputAdapter
-                                                                                    Scan parquet spark_catalog.default.item [i_item_sk,i_current_price]
-                                                                  Subquery #3
+                                                                          BroadcastExchangeExecProxy [i_item_sk]
+                                                                            SubqueryBroadcast [i_item_sk] #3
+                                                                              BroadcastExchange #6
+                                                                                WholeStageCodegen (1)
+                                                                                  Project [i_item_sk]
+                                                                                    Filter [i_current_price,i_item_sk]
+                                                                                      ColumnarToRow
+                                                                                        InputAdapter
+                                                                                          Scan parquet spark_catalog.default.item [i_item_sk,i_current_price]
+                                                                  Subquery #4
                                                                     ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(p_promo_sk, 42), 986, 24246, 0, 0),bloomFilter,buf]
-                                                                      Exchange #6
+                                                                      Exchange #7
                                                                         ObjectHashAggregate [p_promo_sk] [buf,buf]
-                                                                          WholeStageCodegen (1)
-                                                                            Project [p_promo_sk]
-                                                                              Filter [p_channel_tv,p_promo_sk]
-                                                                                ColumnarToRow
-                                                                                  InputAdapter
-                                                                                    Scan parquet spark_catalog.default.promotion [p_promo_sk,p_channel_tv]
+                                                                          BroadcastExchangeExecProxy [p_promo_sk]
+                                                                            SubqueryBroadcast [p_promo_sk] #5
+                                                                              BroadcastExchange #8
+                                                                                WholeStageCodegen (1)
+                                                                                  Project [p_promo_sk]
+                                                                                    Filter [p_channel_tv,p_promo_sk]
+                                                                                      ColumnarToRow
+                                                                                        InputAdapter
+                                                                                          Scan parquet spark_catalog.default.promotion [p_promo_sk,p_channel_tv]
                                                                   ColumnarToRow
                                                                     InputAdapter
                                                                       Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_store_sk,ss_promo_sk,ss_ticket_number,ss_ext_sales_price,ss_net_profit,ss_sold_date_sk]
@@ -66,7 +72,7 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                                       WholeStageCodegen (4)
                                                         Sort [sr_item_sk,sr_ticket_number]
                                                           InputAdapter
-                                                            Exchange [sr_item_sk,sr_ticket_number] #7
+                                                            Exchange [sr_item_sk,sr_ticket_number] #9
                                                               WholeStageCodegen (3)
                                                                 Project [sr_item_sk,sr_ticket_number,sr_return_amt,sr_net_loss]
                                                                   Filter [sr_item_sk,sr_ticket_number]
@@ -74,21 +80,9 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                                                       InputAdapter
                                                                         Scan parquet spark_catalog.default.store_returns [sr_item_sk,sr_ticket_number,sr_return_amt,sr_net_loss,sr_returned_date_sk]
                                                 InputAdapter
-                                                  BroadcastExchange #8
-                                                    WholeStageCodegen (5)
-                                                      Project [i_item_sk]
-                                                        Filter [i_current_price,i_item_sk]
-                                                          ColumnarToRow
-                                                            InputAdapter
-                                                              Scan parquet spark_catalog.default.item [i_item_sk,i_current_price]
+                                                  ReusedExchange [i_item_sk] #6
                                             InputAdapter
-                                              BroadcastExchange #9
-                                                WholeStageCodegen (6)
-                                                  Project [p_promo_sk]
-                                                    Filter [p_channel_tv,p_promo_sk]
-                                                      ColumnarToRow
-                                                        InputAdapter
-                                                          Scan parquet spark_catalog.default.promotion [p_promo_sk,p_channel_tv]
+                                              ReusedExchange [p_promo_sk] #8
                                         InputAdapter
                                           ReusedExchange [d_date_sk] #4
                                     InputAdapter
@@ -122,7 +116,7 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                                               WholeStageCodegen (11)
                                                                 Filter [cs_catalog_page_sk,cs_item_sk,cs_promo_sk]
                                                                   ReusedSubquery [bloomFilter] #2
-                                                                  ReusedSubquery [bloomFilter] #3
+                                                                  ReusedSubquery [bloomFilter] #4
                                                                   ColumnarToRow
                                                                     InputAdapter
                                                                       Scan parquet spark_catalog.default.catalog_sales [cs_catalog_page_sk,cs_item_sk,cs_promo_sk,cs_order_number,cs_ext_sales_price,cs_net_profit,cs_sold_date_sk]
@@ -139,9 +133,9 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                                                       InputAdapter
                                                                         Scan parquet spark_catalog.default.catalog_returns [cr_item_sk,cr_order_number,cr_return_amount,cr_net_loss,cr_returned_date_sk]
                                                 InputAdapter
-                                                  ReusedExchange [i_item_sk] #8
+                                                  ReusedExchange [i_item_sk] #6
                                             InputAdapter
-                                              ReusedExchange [p_promo_sk] #9
+                                              ReusedExchange [p_promo_sk] #8
                                         InputAdapter
                                           ReusedExchange [d_date_sk] #4
                                     InputAdapter
@@ -175,7 +169,7 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                                               WholeStageCodegen (21)
                                                                 Filter [ws_web_site_sk,ws_item_sk,ws_promo_sk]
                                                                   ReusedSubquery [bloomFilter] #2
-                                                                  ReusedSubquery [bloomFilter] #3
+                                                                  ReusedSubquery [bloomFilter] #4
                                                                   ColumnarToRow
                                                                     InputAdapter
                                                                       Scan parquet spark_catalog.default.web_sales [ws_item_sk,ws_web_site_sk,ws_promo_sk,ws_order_number,ws_ext_sales_price,ws_net_profit,ws_sold_date_sk]
@@ -192,9 +186,9 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                                                       InputAdapter
                                                                         Scan parquet spark_catalog.default.web_returns [wr_item_sk,wr_order_number,wr_return_amt,wr_net_loss,wr_returned_date_sk]
                                                 InputAdapter
-                                                  ReusedExchange [i_item_sk] #8
+                                                  ReusedExchange [i_item_sk] #6
                                             InputAdapter
-                                              ReusedExchange [p_promo_sk] #9
+                                              ReusedExchange [p_promo_sk] #8
                                         InputAdapter
                                           ReusedExchange [d_date_sk] #4
                                     InputAdapter

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q82.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q82.sf100/explain.txt
@@ -113,7 +113,7 @@ Input [2]: [ss_item_sk#11, ss_sold_date_sk#12]
 
 (19) Filter [codegen id : 5]
 Input [2]: [ss_item_sk#11, ss_sold_date_sk#12]
-Condition : (isnotnull(ss_item_sk#11) AND might_contain(Subquery scalar-subquery#13, [id=#14], xxhash64(ss_item_sk#11, 42)))
+Condition : (isnotnull(ss_item_sk#11) AND might_contain(runtimefilterexpression(Subquery scalar-subquery#13, [id=#14]), xxhash64(ss_item_sk#11, 42)))
 
 (20) Project [codegen id : 5]
 Output [1]: [ss_item_sk#11]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q85.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q85.sf100/explain.txt
@@ -118,7 +118,7 @@ Input [9]: [wr_item_sk#10, wr_refunded_cdemo_sk#11, wr_refunded_addr_sk#12, wr_r
 
 (14) Filter [codegen id : 4]
 Input [9]: [wr_item_sk#10, wr_refunded_cdemo_sk#11, wr_refunded_addr_sk#12, wr_returning_cdemo_sk#13, wr_reason_sk#14, wr_order_number#15, wr_fee#16, wr_refunded_cash#17, wr_returned_date_sk#18]
-Condition : (((((((isnotnull(wr_item_sk#10) AND isnotnull(wr_order_number#15)) AND isnotnull(wr_refunded_cdemo_sk#11)) AND isnotnull(wr_returning_cdemo_sk#13)) AND isnotnull(wr_refunded_addr_sk#12)) AND isnotnull(wr_reason_sk#14)) AND might_contain(Subquery scalar-subquery#19, [id=#20], xxhash64(wr_refunded_cdemo_sk#11, 42))) AND might_contain(Subquery scalar-subquery#21, [id=#22], xxhash64(wr_refunded_addr_sk#12, 42)))
+Condition : (((((((isnotnull(wr_item_sk#10) AND isnotnull(wr_order_number#15)) AND isnotnull(wr_refunded_cdemo_sk#11)) AND isnotnull(wr_returning_cdemo_sk#13)) AND isnotnull(wr_refunded_addr_sk#12)) AND isnotnull(wr_reason_sk#14)) AND might_contain(runtimefilterexpression(Subquery scalar-subquery#19, [id=#20]), xxhash64(wr_refunded_cdemo_sk#11, 42))) AND might_contain(runtimefilterexpression(Subquery scalar-subquery#21, [id=#22]), xxhash64(wr_refunded_addr_sk#12, 42)))
 
 (15) Project [codegen id : 4]
 Output [8]: [wr_item_sk#10, wr_refunded_cdemo_sk#11, wr_refunded_addr_sk#12, wr_returning_cdemo_sk#13, wr_reason_sk#14, wr_order_number#15, wr_fee#16, wr_refunded_cash#17]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q92.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q92.sf100/explain.txt
@@ -65,9 +65,9 @@ Input [3]: [ws_item_sk#3, ws_ext_discount_amt#4, ws_sold_date_sk#5]
 
 (8) Filter [codegen id : 3]
 Input [3]: [ws_item_sk#3, ws_ext_discount_amt#4, ws_sold_date_sk#5]
-Condition : (isnotnull(ws_item_sk#3) AND might_contain(Subquery scalar-subquery#7, [id=#8], xxhash64(ws_item_sk#3, 42)))
+Condition : (isnotnull(ws_item_sk#3) AND might_contain(runtimefilterexpression(Subquery scalar-subquery#7, [id=#8]), xxhash64(ws_item_sk#3, 42)))
 
-(9) ReusedExchange [Reuses operator id: 41]
+(9) ReusedExchange [Reuses operator id: 40]
 Output [1]: [d_date_sk#9]
 
 (10) BroadcastHashJoin [codegen id : 3]
@@ -141,7 +141,7 @@ Join condition: (cast(ws_ext_discount_amt#17 as decimal(14,7)) > (1.3 * avg(ws_e
 Output [2]: [ws_ext_discount_amt#17, ws_sold_date_sk#18]
 Input [5]: [i_item_sk#1, (1.3 * avg(ws_ext_discount_amt))#15, ws_item_sk#16, ws_ext_discount_amt#17, ws_sold_date_sk#18]
 
-(24) ReusedExchange [Reuses operator id: 41]
+(24) ReusedExchange [Reuses operator id: 40]
 Output [1]: [d_date_sk#19]
 
 (25) BroadcastHashJoin [codegen id : 6]
@@ -175,78 +175,68 @@ Results [1]: [MakeDecimal(sum(UnscaledValue(ws_ext_discount_amt#17))#22,17,2) AS
 ===== Subqueries =====
 
 Subquery:1 Hosting operator id = 8 Hosting Expression = Subquery scalar-subquery#7, [id=#8]
-ObjectHashAggregate (36)
-+- Exchange (35)
-   +- ObjectHashAggregate (34)
-      +- * Project (33)
-         +- * Filter (32)
-            +- * ColumnarToRow (31)
-               +- Scan parquet spark_catalog.default.item (30)
+ObjectHashAggregate (35)
++- Exchange (34)
+   +- ObjectHashAggregate (33)
+      +- BroadcastExchangeExecProxy (32)
 
 
-(30) Scan parquet spark_catalog.default.item
-Output [2]: [i_item_sk#1, i_manufact_id#2]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/item]
-PushedFilters: [IsNotNull(i_manufact_id), EqualTo(i_manufact_id,350), IsNotNull(i_item_sk)]
-ReadSchema: struct<i_item_sk:int,i_manufact_id:int>
-
-(31) ColumnarToRow [codegen id : 1]
-Input [2]: [i_item_sk#1, i_manufact_id#2]
-
-(32) Filter [codegen id : 1]
-Input [2]: [i_item_sk#1, i_manufact_id#2]
-Condition : ((isnotnull(i_manufact_id#2) AND (i_manufact_id#2 = 350)) AND isnotnull(i_item_sk#1))
-
-(33) Project [codegen id : 1]
+(30) ReusedExchange [Reuses operator id: 5]
 Output [1]: [i_item_sk#1]
-Input [2]: [i_item_sk#1, i_manufact_id#2]
 
-(34) ObjectHashAggregate
+(31) SubqueryBroadcast
+Input [1]: [i_item_sk#1]
+Arguments: runtimefilter#7, 0, [i_item_sk#1], [id=#24]
+
+(32) BroadcastExchangeExecProxy
+Input [1]: [i_item_sk#25]
+Arguments: [i_item_sk#1]
+
+(33) ObjectHashAggregate
 Input [1]: [i_item_sk#1]
 Keys: []
 Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#1, 42), 199, 5556, 0, 0)]
-Aggregate Attributes [1]: [buf#24]
-Results [1]: [buf#25]
+Aggregate Attributes [1]: [buf#26]
+Results [1]: [buf#27]
 
-(35) Exchange
-Input [1]: [buf#25]
+(34) Exchange
+Input [1]: [buf#27]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=5]
 
-(36) ObjectHashAggregate
-Input [1]: [buf#25]
+(35) ObjectHashAggregate
+Input [1]: [buf#27]
 Keys: []
 Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#1, 42), 199, 5556, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#1, 42), 199, 5556, 0, 0)#26]
-Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#1, 42), 199, 5556, 0, 0)#26 AS bloomFilter#27]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#1, 42), 199, 5556, 0, 0)#28]
+Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#1, 42), 199, 5556, 0, 0)#28 AS bloomFilter#29]
 
 Subquery:2 Hosting operator id = 6 Hosting Expression = ws_sold_date_sk#5 IN dynamicpruning#6
-BroadcastExchange (41)
-+- * Project (40)
-   +- * Filter (39)
-      +- * ColumnarToRow (38)
-         +- Scan parquet spark_catalog.default.date_dim (37)
+BroadcastExchange (40)
++- * Project (39)
+   +- * Filter (38)
+      +- * ColumnarToRow (37)
+         +- Scan parquet spark_catalog.default.date_dim (36)
 
 
-(37) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#9, d_date#28]
+(36) Scan parquet spark_catalog.default.date_dim
+Output [2]: [d_date_sk#9, d_date#30]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,2000-01-27), LessThanOrEqual(d_date,2000-04-26), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
-(38) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#9, d_date#28]
+(37) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#9, d_date#30]
 
-(39) Filter [codegen id : 1]
-Input [2]: [d_date_sk#9, d_date#28]
-Condition : (((isnotnull(d_date#28) AND (d_date#28 >= 2000-01-27)) AND (d_date#28 <= 2000-04-26)) AND isnotnull(d_date_sk#9))
+(38) Filter [codegen id : 1]
+Input [2]: [d_date_sk#9, d_date#30]
+Condition : (((isnotnull(d_date#30) AND (d_date#30 >= 2000-01-27)) AND (d_date#30 <= 2000-04-26)) AND isnotnull(d_date_sk#9))
 
-(40) Project [codegen id : 1]
+(39) Project [codegen id : 1]
 Output [1]: [d_date_sk#9]
-Input [2]: [d_date_sk#9, d_date#28]
+Input [2]: [d_date_sk#9, d_date#30]
 
-(41) BroadcastExchange
+(40) BroadcastExchange
 Input [1]: [d_date_sk#9]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=6]
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q92.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q92.sf100/simplified.txt
@@ -34,12 +34,9 @@ WholeStageCodegen (7)
                                                   ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(i_item_sk, 42), 199, 5556, 0, 0),bloomFilter,buf]
                                                     Exchange #6
                                                       ObjectHashAggregate [i_item_sk] [buf,buf]
-                                                        WholeStageCodegen (1)
-                                                          Project [i_item_sk]
-                                                            Filter [i_manufact_id,i_item_sk]
-                                                              ColumnarToRow
-                                                                InputAdapter
-                                                                  Scan parquet spark_catalog.default.item [i_item_sk,i_manufact_id]
+                                                        BroadcastExchangeExecProxy [i_item_sk]
+                                                          SubqueryBroadcast [i_item_sk] #3
+                                                            ReusedExchange [i_item_sk] #3
                                                 ColumnarToRow
                                                   InputAdapter
                                                     Scan parquet spark_catalog.default.web_sales [ws_item_sk,ws_ext_discount_amt,ws_sold_date_sk]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q94.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q94.sf100/explain.txt
@@ -1,15 +1,15 @@
 == Physical Plan ==
-* HashAggregate (45)
-+- Exchange (44)
-   +- * HashAggregate (43)
-      +- * HashAggregate (42)
-         +- * HashAggregate (41)
-            +- * Project (40)
-               +- * BroadcastHashJoin Inner BuildRight (39)
-                  :- * Project (33)
-                  :  +- * BroadcastHashJoin Inner BuildRight (32)
-                  :     :- * Project (26)
-                  :     :  +- * BroadcastHashJoin Inner BuildRight (25)
+* HashAggregate (33)
++- Exchange (32)
+   +- * HashAggregate (31)
+      +- * HashAggregate (30)
+         +- * HashAggregate (29)
+            +- * Project (28)
+               +- * BroadcastHashJoin Inner BuildRight (27)
+                  :- * Project (25)
+                  :  +- * BroadcastHashJoin Inner BuildRight (24)
+                  :     :- * Project (22)
+                  :     :  +- * BroadcastHashJoin Inner BuildRight (21)
                   :     :     :- * SortMergeJoin LeftAnti (19)
                   :     :     :  :- * Project (13)
                   :     :     :  :  +- * SortMergeJoin LeftSemi (12)
@@ -29,21 +29,9 @@
                   :     :     :        +- * Project (16)
                   :     :     :           +- * ColumnarToRow (15)
                   :     :     :              +- Scan parquet spark_catalog.default.web_returns (14)
-                  :     :     +- BroadcastExchange (24)
-                  :     :        +- * Project (23)
-                  :     :           +- * Filter (22)
-                  :     :              +- * ColumnarToRow (21)
-                  :     :                 +- Scan parquet spark_catalog.default.customer_address (20)
-                  :     +- BroadcastExchange (31)
-                  :        +- * Project (30)
-                  :           +- * Filter (29)
-                  :              +- * ColumnarToRow (28)
-                  :                 +- Scan parquet spark_catalog.default.web_site (27)
-                  +- BroadcastExchange (38)
-                     +- * Project (37)
-                        +- * Filter (36)
-                           +- * ColumnarToRow (35)
-                              +- Scan parquet spark_catalog.default.date_dim (34)
+                  :     :     +- ReusedExchange (20)
+                  :     +- ReusedExchange (23)
+                  +- ReusedExchange (26)
 
 
 (1) Scan parquet spark_catalog.default.web_sales
@@ -58,7 +46,7 @@ Input [8]: [ws_ship_date_sk#1, ws_ship_addr_sk#2, ws_web_site_sk#3, ws_warehouse
 
 (3) Filter [codegen id : 1]
 Input [8]: [ws_ship_date_sk#1, ws_ship_addr_sk#2, ws_web_site_sk#3, ws_warehouse_sk#4, ws_order_number#5, ws_ext_ship_cost#6, ws_net_profit#7, ws_sold_date_sk#8]
-Condition : (((((isnotnull(ws_ship_date_sk#1) AND isnotnull(ws_ship_addr_sk#2)) AND isnotnull(ws_web_site_sk#3)) AND might_contain(Subquery scalar-subquery#9, [id=#10], xxhash64(ws_ship_addr_sk#2, 42))) AND might_contain(Subquery scalar-subquery#11, [id=#12], xxhash64(ws_web_site_sk#3, 42))) AND might_contain(Subquery scalar-subquery#13, [id=#14], xxhash64(ws_ship_date_sk#1, 42)))
+Condition : (((((isnotnull(ws_ship_date_sk#1) AND isnotnull(ws_ship_addr_sk#2)) AND isnotnull(ws_web_site_sk#3)) AND might_contain(runtimefilterexpression(Subquery scalar-subquery#9, [id=#10]), xxhash64(ws_ship_addr_sk#2, 42))) AND might_contain(runtimefilterexpression(Subquery scalar-subquery#11, [id=#12]), xxhash64(ws_web_site_sk#3, 42))) AND might_contain(runtimefilterexpression(Subquery scalar-subquery#13, [id=#14]), xxhash64(ws_ship_date_sk#1, 42)))
 
 (4) Project [codegen id : 1]
 Output [7]: [ws_ship_date_sk#1, ws_ship_addr_sk#2, ws_web_site_sk#3, ws_warehouse_sk#4, ws_order_number#5, ws_ext_ship_cost#6, ws_net_profit#7]
@@ -130,176 +118,128 @@ Right keys [1]: [wr_order_number#18]
 Join type: LeftAnti
 Join condition: None
 
-(20) Scan parquet spark_catalog.default.customer_address
-Output [2]: [ca_address_sk#20, ca_state#21]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer_address]
-PushedFilters: [IsNotNull(ca_state), EqualTo(ca_state,IL), IsNotNull(ca_address_sk)]
-ReadSchema: struct<ca_address_sk:int,ca_state:string>
-
-(21) ColumnarToRow [codegen id : 8]
-Input [2]: [ca_address_sk#20, ca_state#21]
-
-(22) Filter [codegen id : 8]
-Input [2]: [ca_address_sk#20, ca_state#21]
-Condition : ((isnotnull(ca_state#21) AND (ca_state#21 = IL)) AND isnotnull(ca_address_sk#20))
-
-(23) Project [codegen id : 8]
+(20) ReusedExchange [Reuses operator id: 38]
 Output [1]: [ca_address_sk#20]
-Input [2]: [ca_address_sk#20, ca_state#21]
 
-(24) BroadcastExchange
-Input [1]: [ca_address_sk#20]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=4]
-
-(25) BroadcastHashJoin [codegen id : 11]
+(21) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ws_ship_addr_sk#2]
 Right keys [1]: [ca_address_sk#20]
 Join type: Inner
 Join condition: None
 
-(26) Project [codegen id : 11]
+(22) Project [codegen id : 11]
 Output [5]: [ws_ship_date_sk#1, ws_web_site_sk#3, ws_order_number#5, ws_ext_ship_cost#6, ws_net_profit#7]
 Input [7]: [ws_ship_date_sk#1, ws_ship_addr_sk#2, ws_web_site_sk#3, ws_order_number#5, ws_ext_ship_cost#6, ws_net_profit#7, ca_address_sk#20]
 
-(27) Scan parquet spark_catalog.default.web_site
-Output [2]: [web_site_sk#22, web_company_name#23]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/web_site]
-PushedFilters: [IsNotNull(web_company_name), EqualTo(web_company_name,pri                                               ), IsNotNull(web_site_sk)]
-ReadSchema: struct<web_site_sk:int,web_company_name:string>
+(23) ReusedExchange [Reuses operator id: 48]
+Output [1]: [web_site_sk#21]
 
-(28) ColumnarToRow [codegen id : 9]
-Input [2]: [web_site_sk#22, web_company_name#23]
-
-(29) Filter [codegen id : 9]
-Input [2]: [web_site_sk#22, web_company_name#23]
-Condition : ((isnotnull(web_company_name#23) AND (web_company_name#23 = pri                                               )) AND isnotnull(web_site_sk#22))
-
-(30) Project [codegen id : 9]
-Output [1]: [web_site_sk#22]
-Input [2]: [web_site_sk#22, web_company_name#23]
-
-(31) BroadcastExchange
-Input [1]: [web_site_sk#22]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
-
-(32) BroadcastHashJoin [codegen id : 11]
+(24) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ws_web_site_sk#3]
-Right keys [1]: [web_site_sk#22]
+Right keys [1]: [web_site_sk#21]
 Join type: Inner
 Join condition: None
 
-(33) Project [codegen id : 11]
+(25) Project [codegen id : 11]
 Output [4]: [ws_ship_date_sk#1, ws_order_number#5, ws_ext_ship_cost#6, ws_net_profit#7]
-Input [6]: [ws_ship_date_sk#1, ws_web_site_sk#3, ws_order_number#5, ws_ext_ship_cost#6, ws_net_profit#7, web_site_sk#22]
+Input [6]: [ws_ship_date_sk#1, ws_web_site_sk#3, ws_order_number#5, ws_ext_ship_cost#6, ws_net_profit#7, web_site_sk#21]
 
-(34) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#24, d_date#25]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/date_dim]
-PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,1999-02-01), LessThanOrEqual(d_date,1999-04-02), IsNotNull(d_date_sk)]
-ReadSchema: struct<d_date_sk:int,d_date:date>
+(26) ReusedExchange [Reuses operator id: 58]
+Output [1]: [d_date_sk#22]
 
-(35) ColumnarToRow [codegen id : 10]
-Input [2]: [d_date_sk#24, d_date#25]
-
-(36) Filter [codegen id : 10]
-Input [2]: [d_date_sk#24, d_date#25]
-Condition : (((isnotnull(d_date#25) AND (d_date#25 >= 1999-02-01)) AND (d_date#25 <= 1999-04-02)) AND isnotnull(d_date_sk#24))
-
-(37) Project [codegen id : 10]
-Output [1]: [d_date_sk#24]
-Input [2]: [d_date_sk#24, d_date#25]
-
-(38) BroadcastExchange
-Input [1]: [d_date_sk#24]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=6]
-
-(39) BroadcastHashJoin [codegen id : 11]
+(27) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ws_ship_date_sk#1]
-Right keys [1]: [d_date_sk#24]
+Right keys [1]: [d_date_sk#22]
 Join type: Inner
 Join condition: None
 
-(40) Project [codegen id : 11]
+(28) Project [codegen id : 11]
 Output [3]: [ws_order_number#5, ws_ext_ship_cost#6, ws_net_profit#7]
-Input [5]: [ws_ship_date_sk#1, ws_order_number#5, ws_ext_ship_cost#6, ws_net_profit#7, d_date_sk#24]
+Input [5]: [ws_ship_date_sk#1, ws_order_number#5, ws_ext_ship_cost#6, ws_net_profit#7, d_date_sk#22]
 
-(41) HashAggregate [codegen id : 11]
+(29) HashAggregate [codegen id : 11]
 Input [3]: [ws_order_number#5, ws_ext_ship_cost#6, ws_net_profit#7]
 Keys [1]: [ws_order_number#5]
 Functions [2]: [partial_sum(UnscaledValue(ws_ext_ship_cost#6)), partial_sum(UnscaledValue(ws_net_profit#7))]
-Aggregate Attributes [2]: [sum(UnscaledValue(ws_ext_ship_cost#6))#26, sum(UnscaledValue(ws_net_profit#7))#27]
-Results [3]: [ws_order_number#5, sum#28, sum#29]
+Aggregate Attributes [2]: [sum(UnscaledValue(ws_ext_ship_cost#6))#23, sum(UnscaledValue(ws_net_profit#7))#24]
+Results [3]: [ws_order_number#5, sum#25, sum#26]
 
-(42) HashAggregate [codegen id : 11]
-Input [3]: [ws_order_number#5, sum#28, sum#29]
+(30) HashAggregate [codegen id : 11]
+Input [3]: [ws_order_number#5, sum#25, sum#26]
 Keys [1]: [ws_order_number#5]
 Functions [2]: [merge_sum(UnscaledValue(ws_ext_ship_cost#6)), merge_sum(UnscaledValue(ws_net_profit#7))]
-Aggregate Attributes [2]: [sum(UnscaledValue(ws_ext_ship_cost#6))#26, sum(UnscaledValue(ws_net_profit#7))#27]
-Results [3]: [ws_order_number#5, sum#28, sum#29]
+Aggregate Attributes [2]: [sum(UnscaledValue(ws_ext_ship_cost#6))#23, sum(UnscaledValue(ws_net_profit#7))#24]
+Results [3]: [ws_order_number#5, sum#25, sum#26]
 
-(43) HashAggregate [codegen id : 11]
-Input [3]: [ws_order_number#5, sum#28, sum#29]
+(31) HashAggregate [codegen id : 11]
+Input [3]: [ws_order_number#5, sum#25, sum#26]
 Keys: []
 Functions [3]: [merge_sum(UnscaledValue(ws_ext_ship_cost#6)), merge_sum(UnscaledValue(ws_net_profit#7)), partial_count(distinct ws_order_number#5)]
-Aggregate Attributes [3]: [sum(UnscaledValue(ws_ext_ship_cost#6))#26, sum(UnscaledValue(ws_net_profit#7))#27, count(ws_order_number#5)#30]
-Results [3]: [sum#28, sum#29, count#31]
+Aggregate Attributes [3]: [sum(UnscaledValue(ws_ext_ship_cost#6))#23, sum(UnscaledValue(ws_net_profit#7))#24, count(ws_order_number#5)#27]
+Results [3]: [sum#25, sum#26, count#28]
 
-(44) Exchange
-Input [3]: [sum#28, sum#29, count#31]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=7]
+(32) Exchange
+Input [3]: [sum#25, sum#26, count#28]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=4]
 
-(45) HashAggregate [codegen id : 12]
-Input [3]: [sum#28, sum#29, count#31]
+(33) HashAggregate [codegen id : 12]
+Input [3]: [sum#25, sum#26, count#28]
 Keys: []
 Functions [3]: [sum(UnscaledValue(ws_ext_ship_cost#6)), sum(UnscaledValue(ws_net_profit#7)), count(distinct ws_order_number#5)]
-Aggregate Attributes [3]: [sum(UnscaledValue(ws_ext_ship_cost#6))#26, sum(UnscaledValue(ws_net_profit#7))#27, count(ws_order_number#5)#30]
-Results [3]: [count(ws_order_number#5)#30 AS order count #32, MakeDecimal(sum(UnscaledValue(ws_ext_ship_cost#6))#26,17,2) AS total shipping cost #33, MakeDecimal(sum(UnscaledValue(ws_net_profit#7))#27,17,2) AS total net profit #34]
+Aggregate Attributes [3]: [sum(UnscaledValue(ws_ext_ship_cost#6))#23, sum(UnscaledValue(ws_net_profit#7))#24, count(ws_order_number#5)#27]
+Results [3]: [count(ws_order_number#5)#27 AS order count #29, MakeDecimal(sum(UnscaledValue(ws_ext_ship_cost#6))#23,17,2) AS total shipping cost #30, MakeDecimal(sum(UnscaledValue(ws_net_profit#7))#24,17,2) AS total net profit #31]
 
 ===== Subqueries =====
 
 Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#9, [id=#10]
-ObjectHashAggregate (52)
-+- Exchange (51)
-   +- ObjectHashAggregate (50)
-      +- * Project (49)
-         +- * Filter (48)
-            +- * ColumnarToRow (47)
-               +- Scan parquet spark_catalog.default.customer_address (46)
+ObjectHashAggregate (43)
++- Exchange (42)
+   +- ObjectHashAggregate (41)
+      +- BroadcastExchangeExecProxy (40)
 
 
-(46) Scan parquet spark_catalog.default.customer_address
-Output [2]: [ca_address_sk#20, ca_state#21]
+(34) Scan parquet spark_catalog.default.customer_address
+Output [2]: [ca_address_sk#20, ca_state#32]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [IsNotNull(ca_state), EqualTo(ca_state,IL), IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_state:string>
 
-(47) ColumnarToRow [codegen id : 1]
-Input [2]: [ca_address_sk#20, ca_state#21]
+(35) ColumnarToRow [codegen id : 1]
+Input [2]: [ca_address_sk#20, ca_state#32]
 
-(48) Filter [codegen id : 1]
-Input [2]: [ca_address_sk#20, ca_state#21]
-Condition : ((isnotnull(ca_state#21) AND (ca_state#21 = IL)) AND isnotnull(ca_address_sk#20))
+(36) Filter [codegen id : 1]
+Input [2]: [ca_address_sk#20, ca_state#32]
+Condition : ((isnotnull(ca_state#32) AND (ca_state#32 = IL)) AND isnotnull(ca_address_sk#20))
 
-(49) Project [codegen id : 1]
+(37) Project [codegen id : 1]
 Output [1]: [ca_address_sk#20]
-Input [2]: [ca_address_sk#20, ca_state#21]
+Input [2]: [ca_address_sk#20, ca_state#32]
 
-(50) ObjectHashAggregate
+(38) BroadcastExchange
+Input [1]: [ca_address_sk#20]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
+
+(39) SubqueryBroadcast
+Input [1]: [ca_address_sk#20]
+Arguments: runtimefilter#9, 0, [ca_address_sk#20], [id=#33]
+
+(40) BroadcastExchangeExecProxy
+Input [1]: [ca_address_sk#34]
+Arguments: [ca_address_sk#20]
+
+(41) ObjectHashAggregate
 Input [1]: [ca_address_sk#20]
 Keys: []
 Functions [1]: [partial_bloom_filter_agg(xxhash64(ca_address_sk#20, 42), 17961, 333176, 0, 0)]
 Aggregate Attributes [1]: [buf#35]
 Results [1]: [buf#36]
 
-(51) Exchange
+(42) Exchange
 Input [1]: [buf#36]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=8]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=6]
 
-(52) ObjectHashAggregate
+(43) ObjectHashAggregate
 Input [1]: [buf#36]
 Keys: []
 Functions [1]: [bloom_filter_agg(xxhash64(ca_address_sk#20, 42), 17961, 333176, 0, 0)]
@@ -307,95 +247,113 @@ Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(ca_address_sk#20, 42), 1796
 Results [1]: [bloom_filter_agg(xxhash64(ca_address_sk#20, 42), 17961, 333176, 0, 0)#37 AS bloomFilter#38]
 
 Subquery:2 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#11, [id=#12]
-ObjectHashAggregate (59)
-+- Exchange (58)
-   +- ObjectHashAggregate (57)
-      +- * Project (56)
-         +- * Filter (55)
-            +- * ColumnarToRow (54)
-               +- Scan parquet spark_catalog.default.web_site (53)
+ObjectHashAggregate (53)
++- Exchange (52)
+   +- ObjectHashAggregate (51)
+      +- BroadcastExchangeExecProxy (50)
 
 
-(53) Scan parquet spark_catalog.default.web_site
-Output [2]: [web_site_sk#22, web_company_name#23]
+(44) Scan parquet spark_catalog.default.web_site
+Output [2]: [web_site_sk#21, web_company_name#39]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/web_site]
 PushedFilters: [IsNotNull(web_company_name), EqualTo(web_company_name,pri                                               ), IsNotNull(web_site_sk)]
 ReadSchema: struct<web_site_sk:int,web_company_name:string>
 
-(54) ColumnarToRow [codegen id : 1]
-Input [2]: [web_site_sk#22, web_company_name#23]
+(45) ColumnarToRow [codegen id : 1]
+Input [2]: [web_site_sk#21, web_company_name#39]
 
-(55) Filter [codegen id : 1]
-Input [2]: [web_site_sk#22, web_company_name#23]
-Condition : ((isnotnull(web_company_name#23) AND (web_company_name#23 = pri                                               )) AND isnotnull(web_site_sk#22))
+(46) Filter [codegen id : 1]
+Input [2]: [web_site_sk#21, web_company_name#39]
+Condition : ((isnotnull(web_company_name#39) AND (web_company_name#39 = pri                                               )) AND isnotnull(web_site_sk#21))
 
-(56) Project [codegen id : 1]
-Output [1]: [web_site_sk#22]
-Input [2]: [web_site_sk#22, web_company_name#23]
+(47) Project [codegen id : 1]
+Output [1]: [web_site_sk#21]
+Input [2]: [web_site_sk#21, web_company_name#39]
 
-(57) ObjectHashAggregate
-Input [1]: [web_site_sk#22]
+(48) BroadcastExchange
+Input [1]: [web_site_sk#21]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=7]
+
+(49) SubqueryBroadcast
+Input [1]: [web_site_sk#21]
+Arguments: runtimefilter#11, 0, [web_site_sk#21], [id=#40]
+
+(50) BroadcastExchangeExecProxy
+Input [1]: [web_site_sk#41]
+Arguments: [web_site_sk#21]
+
+(51) ObjectHashAggregate
+Input [1]: [web_site_sk#21]
 Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(web_site_sk#22, 42), 4, 144, 0, 0)]
-Aggregate Attributes [1]: [buf#39]
-Results [1]: [buf#40]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(web_site_sk#21, 42), 4, 144, 0, 0)]
+Aggregate Attributes [1]: [buf#42]
+Results [1]: [buf#43]
 
-(58) Exchange
-Input [1]: [buf#40]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=9]
+(52) Exchange
+Input [1]: [buf#43]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=8]
 
-(59) ObjectHashAggregate
-Input [1]: [buf#40]
+(53) ObjectHashAggregate
+Input [1]: [buf#43]
 Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(web_site_sk#22, 42), 4, 144, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(web_site_sk#22, 42), 4, 144, 0, 0)#41]
-Results [1]: [bloom_filter_agg(xxhash64(web_site_sk#22, 42), 4, 144, 0, 0)#41 AS bloomFilter#42]
+Functions [1]: [bloom_filter_agg(xxhash64(web_site_sk#21, 42), 4, 144, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(web_site_sk#21, 42), 4, 144, 0, 0)#44]
+Results [1]: [bloom_filter_agg(xxhash64(web_site_sk#21, 42), 4, 144, 0, 0)#44 AS bloomFilter#45]
 
 Subquery:3 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#13, [id=#14]
-ObjectHashAggregate (66)
-+- Exchange (65)
-   +- ObjectHashAggregate (64)
-      +- * Project (63)
-         +- * Filter (62)
-            +- * ColumnarToRow (61)
-               +- Scan parquet spark_catalog.default.date_dim (60)
+ObjectHashAggregate (63)
++- Exchange (62)
+   +- ObjectHashAggregate (61)
+      +- BroadcastExchangeExecProxy (60)
 
 
-(60) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#24, d_date#25]
+(54) Scan parquet spark_catalog.default.date_dim
+Output [2]: [d_date_sk#22, d_date#46]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,1999-02-01), LessThanOrEqual(d_date,1999-04-02), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
-(61) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#24, d_date#25]
+(55) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#22, d_date#46]
 
-(62) Filter [codegen id : 1]
-Input [2]: [d_date_sk#24, d_date#25]
-Condition : (((isnotnull(d_date#25) AND (d_date#25 >= 1999-02-01)) AND (d_date#25 <= 1999-04-02)) AND isnotnull(d_date_sk#24))
+(56) Filter [codegen id : 1]
+Input [2]: [d_date_sk#22, d_date#46]
+Condition : (((isnotnull(d_date#46) AND (d_date#46 >= 1999-02-01)) AND (d_date#46 <= 1999-04-02)) AND isnotnull(d_date_sk#22))
 
-(63) Project [codegen id : 1]
-Output [1]: [d_date_sk#24]
-Input [2]: [d_date_sk#24, d_date#25]
+(57) Project [codegen id : 1]
+Output [1]: [d_date_sk#22]
+Input [2]: [d_date_sk#22, d_date#46]
 
-(64) ObjectHashAggregate
-Input [1]: [d_date_sk#24]
+(58) BroadcastExchange
+Input [1]: [d_date_sk#22]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=9]
+
+(59) SubqueryBroadcast
+Input [1]: [d_date_sk#22]
+Arguments: runtimefilter#13, 0, [d_date_sk#22], [id=#47]
+
+(60) BroadcastExchangeExecProxy
+Input [1]: [d_date_sk#48]
+Arguments: [d_date_sk#22]
+
+(61) ObjectHashAggregate
+Input [1]: [d_date_sk#22]
 Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(d_date_sk#24, 42), 73049, 1141755, 0, 0)]
-Aggregate Attributes [1]: [buf#43]
-Results [1]: [buf#44]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(d_date_sk#22, 42), 73049, 1141755, 0, 0)]
+Aggregate Attributes [1]: [buf#49]
+Results [1]: [buf#50]
 
-(65) Exchange
-Input [1]: [buf#44]
+(62) Exchange
+Input [1]: [buf#50]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=10]
 
-(66) ObjectHashAggregate
-Input [1]: [buf#44]
+(63) ObjectHashAggregate
+Input [1]: [buf#50]
 Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(d_date_sk#24, 42), 73049, 1141755, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(d_date_sk#24, 42), 73049, 1141755, 0, 0)#45]
-Results [1]: [bloom_filter_agg(xxhash64(d_date_sk#24, 42), 73049, 1141755, 0, 0)#45 AS bloomFilter#46]
+Functions [1]: [bloom_filter_agg(xxhash64(d_date_sk#22, 42), 73049, 1141755, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(d_date_sk#22, 42), 73049, 1141755, 0, 0)#51]
+Results [1]: [bloom_filter_agg(xxhash64(d_date_sk#22, 42), 73049, 1141755, 0, 0)#51 AS bloomFilter#52]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q94.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q94.sf100/simplified.txt
@@ -29,32 +29,41 @@ WholeStageCodegen (12)
                                                         ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(ca_address_sk, 42), 17961, 333176, 0, 0),bloomFilter,buf]
                                                           Exchange #3
                                                             ObjectHashAggregate [ca_address_sk] [buf,buf]
-                                                              WholeStageCodegen (1)
-                                                                Project [ca_address_sk]
-                                                                  Filter [ca_state,ca_address_sk]
-                                                                    ColumnarToRow
-                                                                      InputAdapter
-                                                                        Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state]
-                                                      Subquery #2
-                                                        ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(web_site_sk, 42), 4, 144, 0, 0),bloomFilter,buf]
-                                                          Exchange #4
-                                                            ObjectHashAggregate [web_site_sk] [buf,buf]
-                                                              WholeStageCodegen (1)
-                                                                Project [web_site_sk]
-                                                                  Filter [web_company_name,web_site_sk]
-                                                                    ColumnarToRow
-                                                                      InputAdapter
-                                                                        Scan parquet spark_catalog.default.web_site [web_site_sk,web_company_name]
+                                                              BroadcastExchangeExecProxy [ca_address_sk]
+                                                                SubqueryBroadcast [ca_address_sk] #2
+                                                                  BroadcastExchange #4
+                                                                    WholeStageCodegen (1)
+                                                                      Project [ca_address_sk]
+                                                                        Filter [ca_state,ca_address_sk]
+                                                                          ColumnarToRow
+                                                                            InputAdapter
+                                                                              Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state]
                                                       Subquery #3
-                                                        ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(d_date_sk, 42), 73049, 1141755, 0, 0),bloomFilter,buf]
+                                                        ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(web_site_sk, 42), 4, 144, 0, 0),bloomFilter,buf]
                                                           Exchange #5
+                                                            ObjectHashAggregate [web_site_sk] [buf,buf]
+                                                              BroadcastExchangeExecProxy [web_site_sk]
+                                                                SubqueryBroadcast [web_site_sk] #4
+                                                                  BroadcastExchange #6
+                                                                    WholeStageCodegen (1)
+                                                                      Project [web_site_sk]
+                                                                        Filter [web_company_name,web_site_sk]
+                                                                          ColumnarToRow
+                                                                            InputAdapter
+                                                                              Scan parquet spark_catalog.default.web_site [web_site_sk,web_company_name]
+                                                      Subquery #5
+                                                        ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(d_date_sk, 42), 73049, 1141755, 0, 0),bloomFilter,buf]
+                                                          Exchange #7
                                                             ObjectHashAggregate [d_date_sk] [buf,buf]
-                                                              WholeStageCodegen (1)
-                                                                Project [d_date_sk]
-                                                                  Filter [d_date,d_date_sk]
-                                                                    ColumnarToRow
-                                                                      InputAdapter
-                                                                        Scan parquet spark_catalog.default.date_dim [d_date_sk,d_date]
+                                                              BroadcastExchangeExecProxy [d_date_sk]
+                                                                SubqueryBroadcast [d_date_sk] #6
+                                                                  BroadcastExchange #8
+                                                                    WholeStageCodegen (1)
+                                                                      Project [d_date_sk]
+                                                                        Filter [d_date,d_date_sk]
+                                                                          ColumnarToRow
+                                                                            InputAdapter
+                                                                              Scan parquet spark_catalog.default.date_dim [d_date_sk,d_date]
                                                       ColumnarToRow
                                                         InputAdapter
                                                           Scan parquet spark_catalog.default.web_sales [ws_ship_date_sk,ws_ship_addr_sk,ws_web_site_sk,ws_warehouse_sk,ws_order_number,ws_ext_ship_cost,ws_net_profit,ws_sold_date_sk]
@@ -62,7 +71,7 @@ WholeStageCodegen (12)
                                         WholeStageCodegen (4)
                                           Sort [ws_order_number]
                                             InputAdapter
-                                              Exchange [ws_order_number] #6
+                                              Exchange [ws_order_number] #9
                                                 WholeStageCodegen (3)
                                                   Project [ws_warehouse_sk,ws_order_number]
                                                     ColumnarToRow
@@ -72,33 +81,15 @@ WholeStageCodegen (12)
                                 WholeStageCodegen (7)
                                   Sort [wr_order_number]
                                     InputAdapter
-                                      Exchange [wr_order_number] #7
+                                      Exchange [wr_order_number] #10
                                         WholeStageCodegen (6)
                                           Project [wr_order_number]
                                             ColumnarToRow
                                               InputAdapter
                                                 Scan parquet spark_catalog.default.web_returns [wr_order_number,wr_returned_date_sk]
                             InputAdapter
-                              BroadcastExchange #8
-                                WholeStageCodegen (8)
-                                  Project [ca_address_sk]
-                                    Filter [ca_state,ca_address_sk]
-                                      ColumnarToRow
-                                        InputAdapter
-                                          Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state]
+                              ReusedExchange [ca_address_sk] #4
                         InputAdapter
-                          BroadcastExchange #9
-                            WholeStageCodegen (9)
-                              Project [web_site_sk]
-                                Filter [web_company_name,web_site_sk]
-                                  ColumnarToRow
-                                    InputAdapter
-                                      Scan parquet spark_catalog.default.web_site [web_site_sk,web_company_name]
+                          ReusedExchange [web_site_sk] #6
                     InputAdapter
-                      BroadcastExchange #10
-                        WholeStageCodegen (10)
-                          Project [d_date_sk]
-                            Filter [d_date,d_date_sk]
-                              ColumnarToRow
-                                InputAdapter
-                                  Scan parquet spark_catalog.default.date_dim [d_date_sk,d_date]
+                      ReusedExchange [d_date_sk] #8

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q95.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q95.sf100/explain.txt
@@ -1,15 +1,15 @@
 == Physical Plan ==
-* HashAggregate (57)
-+- Exchange (56)
-   +- * HashAggregate (55)
-      +- * HashAggregate (54)
-         +- * HashAggregate (53)
-            +- * Project (52)
-               +- * BroadcastHashJoin Inner BuildRight (51)
-                  :- * Project (45)
-                  :  +- * BroadcastHashJoin Inner BuildRight (44)
-                  :     :- * Project (38)
-                  :     :  +- * BroadcastHashJoin Inner BuildRight (37)
+* HashAggregate (45)
++- Exchange (44)
+   +- * HashAggregate (43)
+      +- * HashAggregate (42)
+         +- * HashAggregate (41)
+            +- * Project (40)
+               +- * BroadcastHashJoin Inner BuildRight (39)
+                  :- * Project (37)
+                  :  +- * BroadcastHashJoin Inner BuildRight (36)
+                  :     :- * Project (34)
+                  :     :  +- * BroadcastHashJoin Inner BuildRight (33)
                   :     :     :- * SortMergeJoin LeftSemi (31)
                   :     :     :  :- * SortMergeJoin LeftSemi (17)
                   :     :     :  :  :- * Sort (6)
@@ -41,21 +41,9 @@
                   :     :     :        :     +- ReusedExchange (24)
                   :     :     :        +- * Sort (28)
                   :     :     :           +- ReusedExchange (27)
-                  :     :     +- BroadcastExchange (36)
-                  :     :        +- * Project (35)
-                  :     :           +- * Filter (34)
-                  :     :              +- * ColumnarToRow (33)
-                  :     :                 +- Scan parquet spark_catalog.default.customer_address (32)
-                  :     +- BroadcastExchange (43)
-                  :        +- * Project (42)
-                  :           +- * Filter (41)
-                  :              +- * ColumnarToRow (40)
-                  :                 +- Scan parquet spark_catalog.default.web_site (39)
-                  +- BroadcastExchange (50)
-                     +- * Project (49)
-                        +- * Filter (48)
-                           +- * ColumnarToRow (47)
-                              +- Scan parquet spark_catalog.default.date_dim (46)
+                  :     :     +- ReusedExchange (32)
+                  :     +- ReusedExchange (35)
+                  +- ReusedExchange (38)
 
 
 (1) Scan parquet spark_catalog.default.web_sales
@@ -70,7 +58,7 @@ Input [7]: [ws_ship_date_sk#1, ws_ship_addr_sk#2, ws_web_site_sk#3, ws_order_num
 
 (3) Filter [codegen id : 1]
 Input [7]: [ws_ship_date_sk#1, ws_ship_addr_sk#2, ws_web_site_sk#3, ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6, ws_sold_date_sk#7]
-Condition : (((((isnotnull(ws_ship_date_sk#1) AND isnotnull(ws_ship_addr_sk#2)) AND isnotnull(ws_web_site_sk#3)) AND might_contain(Subquery scalar-subquery#8, [id=#9], xxhash64(ws_ship_addr_sk#2, 42))) AND might_contain(Subquery scalar-subquery#10, [id=#11], xxhash64(ws_web_site_sk#3, 42))) AND might_contain(Subquery scalar-subquery#12, [id=#13], xxhash64(ws_ship_date_sk#1, 42)))
+Condition : (((((isnotnull(ws_ship_date_sk#1) AND isnotnull(ws_ship_addr_sk#2)) AND isnotnull(ws_web_site_sk#3)) AND might_contain(runtimefilterexpression(Subquery scalar-subquery#8, [id=#9]), xxhash64(ws_ship_addr_sk#2, 42))) AND might_contain(runtimefilterexpression(Subquery scalar-subquery#10, [id=#11]), xxhash64(ws_web_site_sk#3, 42))) AND might_contain(runtimefilterexpression(Subquery scalar-subquery#12, [id=#13]), xxhash64(ws_ship_date_sk#1, 42)))
 
 (4) Project [codegen id : 1]
 Output [6]: [ws_ship_date_sk#1, ws_ship_addr_sk#2, ws_web_site_sk#3, ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6]
@@ -195,176 +183,128 @@ Right keys [1]: [wr_order_number#19]
 Join type: LeftSemi
 Join condition: None
 
-(32) Scan parquet spark_catalog.default.customer_address
-Output [2]: [ca_address_sk#25, ca_state#26]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer_address]
-PushedFilters: [IsNotNull(ca_state), EqualTo(ca_state,IL), IsNotNull(ca_address_sk)]
-ReadSchema: struct<ca_address_sk:int,ca_state:string>
-
-(33) ColumnarToRow [codegen id : 17]
-Input [2]: [ca_address_sk#25, ca_state#26]
-
-(34) Filter [codegen id : 17]
-Input [2]: [ca_address_sk#25, ca_state#26]
-Condition : ((isnotnull(ca_state#26) AND (ca_state#26 = IL)) AND isnotnull(ca_address_sk#25))
-
-(35) Project [codegen id : 17]
+(32) ReusedExchange [Reuses operator id: 50]
 Output [1]: [ca_address_sk#25]
-Input [2]: [ca_address_sk#25, ca_state#26]
 
-(36) BroadcastExchange
-Input [1]: [ca_address_sk#25]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=4]
-
-(37) BroadcastHashJoin [codegen id : 20]
+(33) BroadcastHashJoin [codegen id : 20]
 Left keys [1]: [ws_ship_addr_sk#2]
 Right keys [1]: [ca_address_sk#25]
 Join type: Inner
 Join condition: None
 
-(38) Project [codegen id : 20]
+(34) Project [codegen id : 20]
 Output [5]: [ws_ship_date_sk#1, ws_web_site_sk#3, ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6]
 Input [7]: [ws_ship_date_sk#1, ws_ship_addr_sk#2, ws_web_site_sk#3, ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6, ca_address_sk#25]
 
-(39) Scan parquet spark_catalog.default.web_site
-Output [2]: [web_site_sk#27, web_company_name#28]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/web_site]
-PushedFilters: [IsNotNull(web_company_name), EqualTo(web_company_name,pri                                               ), IsNotNull(web_site_sk)]
-ReadSchema: struct<web_site_sk:int,web_company_name:string>
+(35) ReusedExchange [Reuses operator id: 60]
+Output [1]: [web_site_sk#26]
 
-(40) ColumnarToRow [codegen id : 18]
-Input [2]: [web_site_sk#27, web_company_name#28]
-
-(41) Filter [codegen id : 18]
-Input [2]: [web_site_sk#27, web_company_name#28]
-Condition : ((isnotnull(web_company_name#28) AND (web_company_name#28 = pri                                               )) AND isnotnull(web_site_sk#27))
-
-(42) Project [codegen id : 18]
-Output [1]: [web_site_sk#27]
-Input [2]: [web_site_sk#27, web_company_name#28]
-
-(43) BroadcastExchange
-Input [1]: [web_site_sk#27]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
-
-(44) BroadcastHashJoin [codegen id : 20]
+(36) BroadcastHashJoin [codegen id : 20]
 Left keys [1]: [ws_web_site_sk#3]
-Right keys [1]: [web_site_sk#27]
+Right keys [1]: [web_site_sk#26]
 Join type: Inner
 Join condition: None
 
-(45) Project [codegen id : 20]
+(37) Project [codegen id : 20]
 Output [4]: [ws_ship_date_sk#1, ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6]
-Input [6]: [ws_ship_date_sk#1, ws_web_site_sk#3, ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6, web_site_sk#27]
+Input [6]: [ws_ship_date_sk#1, ws_web_site_sk#3, ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6, web_site_sk#26]
 
-(46) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#29, d_date#30]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/date_dim]
-PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,1999-02-01), LessThanOrEqual(d_date,1999-04-02), IsNotNull(d_date_sk)]
-ReadSchema: struct<d_date_sk:int,d_date:date>
+(38) ReusedExchange [Reuses operator id: 70]
+Output [1]: [d_date_sk#27]
 
-(47) ColumnarToRow [codegen id : 19]
-Input [2]: [d_date_sk#29, d_date#30]
-
-(48) Filter [codegen id : 19]
-Input [2]: [d_date_sk#29, d_date#30]
-Condition : (((isnotnull(d_date#30) AND (d_date#30 >= 1999-02-01)) AND (d_date#30 <= 1999-04-02)) AND isnotnull(d_date_sk#29))
-
-(49) Project [codegen id : 19]
-Output [1]: [d_date_sk#29]
-Input [2]: [d_date_sk#29, d_date#30]
-
-(50) BroadcastExchange
-Input [1]: [d_date_sk#29]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=6]
-
-(51) BroadcastHashJoin [codegen id : 20]
+(39) BroadcastHashJoin [codegen id : 20]
 Left keys [1]: [ws_ship_date_sk#1]
-Right keys [1]: [d_date_sk#29]
+Right keys [1]: [d_date_sk#27]
 Join type: Inner
 Join condition: None
 
-(52) Project [codegen id : 20]
+(40) Project [codegen id : 20]
 Output [3]: [ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6]
-Input [5]: [ws_ship_date_sk#1, ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6, d_date_sk#29]
+Input [5]: [ws_ship_date_sk#1, ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6, d_date_sk#27]
 
-(53) HashAggregate [codegen id : 20]
+(41) HashAggregate [codegen id : 20]
 Input [3]: [ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6]
 Keys [1]: [ws_order_number#4]
 Functions [2]: [partial_sum(UnscaledValue(ws_ext_ship_cost#5)), partial_sum(UnscaledValue(ws_net_profit#6))]
-Aggregate Attributes [2]: [sum(UnscaledValue(ws_ext_ship_cost#5))#31, sum(UnscaledValue(ws_net_profit#6))#32]
-Results [3]: [ws_order_number#4, sum#33, sum#34]
+Aggregate Attributes [2]: [sum(UnscaledValue(ws_ext_ship_cost#5))#28, sum(UnscaledValue(ws_net_profit#6))#29]
+Results [3]: [ws_order_number#4, sum#30, sum#31]
 
-(54) HashAggregate [codegen id : 20]
-Input [3]: [ws_order_number#4, sum#33, sum#34]
+(42) HashAggregate [codegen id : 20]
+Input [3]: [ws_order_number#4, sum#30, sum#31]
 Keys [1]: [ws_order_number#4]
 Functions [2]: [merge_sum(UnscaledValue(ws_ext_ship_cost#5)), merge_sum(UnscaledValue(ws_net_profit#6))]
-Aggregate Attributes [2]: [sum(UnscaledValue(ws_ext_ship_cost#5))#31, sum(UnscaledValue(ws_net_profit#6))#32]
-Results [3]: [ws_order_number#4, sum#33, sum#34]
+Aggregate Attributes [2]: [sum(UnscaledValue(ws_ext_ship_cost#5))#28, sum(UnscaledValue(ws_net_profit#6))#29]
+Results [3]: [ws_order_number#4, sum#30, sum#31]
 
-(55) HashAggregate [codegen id : 20]
-Input [3]: [ws_order_number#4, sum#33, sum#34]
+(43) HashAggregate [codegen id : 20]
+Input [3]: [ws_order_number#4, sum#30, sum#31]
 Keys: []
 Functions [3]: [merge_sum(UnscaledValue(ws_ext_ship_cost#5)), merge_sum(UnscaledValue(ws_net_profit#6)), partial_count(distinct ws_order_number#4)]
-Aggregate Attributes [3]: [sum(UnscaledValue(ws_ext_ship_cost#5))#31, sum(UnscaledValue(ws_net_profit#6))#32, count(ws_order_number#4)#35]
-Results [3]: [sum#33, sum#34, count#36]
+Aggregate Attributes [3]: [sum(UnscaledValue(ws_ext_ship_cost#5))#28, sum(UnscaledValue(ws_net_profit#6))#29, count(ws_order_number#4)#32]
+Results [3]: [sum#30, sum#31, count#33]
 
-(56) Exchange
-Input [3]: [sum#33, sum#34, count#36]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=7]
+(44) Exchange
+Input [3]: [sum#30, sum#31, count#33]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=4]
 
-(57) HashAggregate [codegen id : 21]
-Input [3]: [sum#33, sum#34, count#36]
+(45) HashAggregate [codegen id : 21]
+Input [3]: [sum#30, sum#31, count#33]
 Keys: []
 Functions [3]: [sum(UnscaledValue(ws_ext_ship_cost#5)), sum(UnscaledValue(ws_net_profit#6)), count(distinct ws_order_number#4)]
-Aggregate Attributes [3]: [sum(UnscaledValue(ws_ext_ship_cost#5))#31, sum(UnscaledValue(ws_net_profit#6))#32, count(ws_order_number#4)#35]
-Results [3]: [count(ws_order_number#4)#35 AS order count #37, MakeDecimal(sum(UnscaledValue(ws_ext_ship_cost#5))#31,17,2) AS total shipping cost #38, MakeDecimal(sum(UnscaledValue(ws_net_profit#6))#32,17,2) AS total net profit #39]
+Aggregate Attributes [3]: [sum(UnscaledValue(ws_ext_ship_cost#5))#28, sum(UnscaledValue(ws_net_profit#6))#29, count(ws_order_number#4)#32]
+Results [3]: [count(ws_order_number#4)#32 AS order count #34, MakeDecimal(sum(UnscaledValue(ws_ext_ship_cost#5))#28,17,2) AS total shipping cost #35, MakeDecimal(sum(UnscaledValue(ws_net_profit#6))#29,17,2) AS total net profit #36]
 
 ===== Subqueries =====
 
 Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#8, [id=#9]
-ObjectHashAggregate (64)
-+- Exchange (63)
-   +- ObjectHashAggregate (62)
-      +- * Project (61)
-         +- * Filter (60)
-            +- * ColumnarToRow (59)
-               +- Scan parquet spark_catalog.default.customer_address (58)
+ObjectHashAggregate (55)
++- Exchange (54)
+   +- ObjectHashAggregate (53)
+      +- BroadcastExchangeExecProxy (52)
 
 
-(58) Scan parquet spark_catalog.default.customer_address
-Output [2]: [ca_address_sk#25, ca_state#26]
+(46) Scan parquet spark_catalog.default.customer_address
+Output [2]: [ca_address_sk#25, ca_state#37]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [IsNotNull(ca_state), EqualTo(ca_state,IL), IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_state:string>
 
-(59) ColumnarToRow [codegen id : 1]
-Input [2]: [ca_address_sk#25, ca_state#26]
+(47) ColumnarToRow [codegen id : 1]
+Input [2]: [ca_address_sk#25, ca_state#37]
 
-(60) Filter [codegen id : 1]
-Input [2]: [ca_address_sk#25, ca_state#26]
-Condition : ((isnotnull(ca_state#26) AND (ca_state#26 = IL)) AND isnotnull(ca_address_sk#25))
+(48) Filter [codegen id : 1]
+Input [2]: [ca_address_sk#25, ca_state#37]
+Condition : ((isnotnull(ca_state#37) AND (ca_state#37 = IL)) AND isnotnull(ca_address_sk#25))
 
-(61) Project [codegen id : 1]
+(49) Project [codegen id : 1]
 Output [1]: [ca_address_sk#25]
-Input [2]: [ca_address_sk#25, ca_state#26]
+Input [2]: [ca_address_sk#25, ca_state#37]
 
-(62) ObjectHashAggregate
+(50) BroadcastExchange
+Input [1]: [ca_address_sk#25]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
+
+(51) SubqueryBroadcast
+Input [1]: [ca_address_sk#25]
+Arguments: runtimefilter#8, 0, [ca_address_sk#25], [id=#38]
+
+(52) BroadcastExchangeExecProxy
+Input [1]: [ca_address_sk#39]
+Arguments: [ca_address_sk#25]
+
+(53) ObjectHashAggregate
 Input [1]: [ca_address_sk#25]
 Keys: []
 Functions [1]: [partial_bloom_filter_agg(xxhash64(ca_address_sk#25, 42), 17961, 333176, 0, 0)]
 Aggregate Attributes [1]: [buf#40]
 Results [1]: [buf#41]
 
-(63) Exchange
+(54) Exchange
 Input [1]: [buf#41]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=8]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=6]
 
-(64) ObjectHashAggregate
+(55) ObjectHashAggregate
 Input [1]: [buf#41]
 Keys: []
 Functions [1]: [bloom_filter_agg(xxhash64(ca_address_sk#25, 42), 17961, 333176, 0, 0)]
@@ -372,95 +312,113 @@ Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(ca_address_sk#25, 42), 1796
 Results [1]: [bloom_filter_agg(xxhash64(ca_address_sk#25, 42), 17961, 333176, 0, 0)#42 AS bloomFilter#43]
 
 Subquery:2 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#10, [id=#11]
-ObjectHashAggregate (71)
-+- Exchange (70)
-   +- ObjectHashAggregate (69)
-      +- * Project (68)
-         +- * Filter (67)
-            +- * ColumnarToRow (66)
-               +- Scan parquet spark_catalog.default.web_site (65)
+ObjectHashAggregate (65)
++- Exchange (64)
+   +- ObjectHashAggregate (63)
+      +- BroadcastExchangeExecProxy (62)
 
 
-(65) Scan parquet spark_catalog.default.web_site
-Output [2]: [web_site_sk#27, web_company_name#28]
+(56) Scan parquet spark_catalog.default.web_site
+Output [2]: [web_site_sk#26, web_company_name#44]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/web_site]
 PushedFilters: [IsNotNull(web_company_name), EqualTo(web_company_name,pri                                               ), IsNotNull(web_site_sk)]
 ReadSchema: struct<web_site_sk:int,web_company_name:string>
 
-(66) ColumnarToRow [codegen id : 1]
-Input [2]: [web_site_sk#27, web_company_name#28]
+(57) ColumnarToRow [codegen id : 1]
+Input [2]: [web_site_sk#26, web_company_name#44]
 
-(67) Filter [codegen id : 1]
-Input [2]: [web_site_sk#27, web_company_name#28]
-Condition : ((isnotnull(web_company_name#28) AND (web_company_name#28 = pri                                               )) AND isnotnull(web_site_sk#27))
+(58) Filter [codegen id : 1]
+Input [2]: [web_site_sk#26, web_company_name#44]
+Condition : ((isnotnull(web_company_name#44) AND (web_company_name#44 = pri                                               )) AND isnotnull(web_site_sk#26))
 
-(68) Project [codegen id : 1]
-Output [1]: [web_site_sk#27]
-Input [2]: [web_site_sk#27, web_company_name#28]
+(59) Project [codegen id : 1]
+Output [1]: [web_site_sk#26]
+Input [2]: [web_site_sk#26, web_company_name#44]
 
-(69) ObjectHashAggregate
-Input [1]: [web_site_sk#27]
+(60) BroadcastExchange
+Input [1]: [web_site_sk#26]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=7]
+
+(61) SubqueryBroadcast
+Input [1]: [web_site_sk#26]
+Arguments: runtimefilter#10, 0, [web_site_sk#26], [id=#45]
+
+(62) BroadcastExchangeExecProxy
+Input [1]: [web_site_sk#46]
+Arguments: [web_site_sk#26]
+
+(63) ObjectHashAggregate
+Input [1]: [web_site_sk#26]
 Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(web_site_sk#27, 42), 4, 144, 0, 0)]
-Aggregate Attributes [1]: [buf#44]
-Results [1]: [buf#45]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(web_site_sk#26, 42), 4, 144, 0, 0)]
+Aggregate Attributes [1]: [buf#47]
+Results [1]: [buf#48]
 
-(70) Exchange
-Input [1]: [buf#45]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=9]
+(64) Exchange
+Input [1]: [buf#48]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=8]
 
-(71) ObjectHashAggregate
-Input [1]: [buf#45]
+(65) ObjectHashAggregate
+Input [1]: [buf#48]
 Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(web_site_sk#27, 42), 4, 144, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(web_site_sk#27, 42), 4, 144, 0, 0)#46]
-Results [1]: [bloom_filter_agg(xxhash64(web_site_sk#27, 42), 4, 144, 0, 0)#46 AS bloomFilter#47]
+Functions [1]: [bloom_filter_agg(xxhash64(web_site_sk#26, 42), 4, 144, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(web_site_sk#26, 42), 4, 144, 0, 0)#49]
+Results [1]: [bloom_filter_agg(xxhash64(web_site_sk#26, 42), 4, 144, 0, 0)#49 AS bloomFilter#50]
 
 Subquery:3 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#12, [id=#13]
-ObjectHashAggregate (78)
-+- Exchange (77)
-   +- ObjectHashAggregate (76)
-      +- * Project (75)
-         +- * Filter (74)
-            +- * ColumnarToRow (73)
-               +- Scan parquet spark_catalog.default.date_dim (72)
+ObjectHashAggregate (75)
++- Exchange (74)
+   +- ObjectHashAggregate (73)
+      +- BroadcastExchangeExecProxy (72)
 
 
-(72) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#29, d_date#30]
+(66) Scan parquet spark_catalog.default.date_dim
+Output [2]: [d_date_sk#27, d_date#51]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,1999-02-01), LessThanOrEqual(d_date,1999-04-02), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
-(73) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#29, d_date#30]
+(67) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#27, d_date#51]
 
-(74) Filter [codegen id : 1]
-Input [2]: [d_date_sk#29, d_date#30]
-Condition : (((isnotnull(d_date#30) AND (d_date#30 >= 1999-02-01)) AND (d_date#30 <= 1999-04-02)) AND isnotnull(d_date_sk#29))
+(68) Filter [codegen id : 1]
+Input [2]: [d_date_sk#27, d_date#51]
+Condition : (((isnotnull(d_date#51) AND (d_date#51 >= 1999-02-01)) AND (d_date#51 <= 1999-04-02)) AND isnotnull(d_date_sk#27))
 
-(75) Project [codegen id : 1]
-Output [1]: [d_date_sk#29]
-Input [2]: [d_date_sk#29, d_date#30]
+(69) Project [codegen id : 1]
+Output [1]: [d_date_sk#27]
+Input [2]: [d_date_sk#27, d_date#51]
 
-(76) ObjectHashAggregate
-Input [1]: [d_date_sk#29]
+(70) BroadcastExchange
+Input [1]: [d_date_sk#27]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=9]
+
+(71) SubqueryBroadcast
+Input [1]: [d_date_sk#27]
+Arguments: runtimefilter#12, 0, [d_date_sk#27], [id=#52]
+
+(72) BroadcastExchangeExecProxy
+Input [1]: [d_date_sk#53]
+Arguments: [d_date_sk#27]
+
+(73) ObjectHashAggregate
+Input [1]: [d_date_sk#27]
 Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(d_date_sk#29, 42), 73049, 1141755, 0, 0)]
-Aggregate Attributes [1]: [buf#48]
-Results [1]: [buf#49]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(d_date_sk#27, 42), 73049, 1141755, 0, 0)]
+Aggregate Attributes [1]: [buf#54]
+Results [1]: [buf#55]
 
-(77) Exchange
-Input [1]: [buf#49]
+(74) Exchange
+Input [1]: [buf#55]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=10]
 
-(78) ObjectHashAggregate
-Input [1]: [buf#49]
+(75) ObjectHashAggregate
+Input [1]: [buf#55]
 Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(d_date_sk#29, 42), 73049, 1141755, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(d_date_sk#29, 42), 73049, 1141755, 0, 0)#50]
-Results [1]: [bloom_filter_agg(xxhash64(d_date_sk#29, 42), 73049, 1141755, 0, 0)#50 AS bloomFilter#51]
+Functions [1]: [bloom_filter_agg(xxhash64(d_date_sk#27, 42), 73049, 1141755, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(d_date_sk#27, 42), 73049, 1141755, 0, 0)#56]
+Results [1]: [bloom_filter_agg(xxhash64(d_date_sk#27, 42), 73049, 1141755, 0, 0)#56 AS bloomFilter#57]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q95.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q95.sf100/simplified.txt
@@ -28,32 +28,41 @@ WholeStageCodegen (21)
                                                       ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(ca_address_sk, 42), 17961, 333176, 0, 0),bloomFilter,buf]
                                                         Exchange #3
                                                           ObjectHashAggregate [ca_address_sk] [buf,buf]
-                                                            WholeStageCodegen (1)
-                                                              Project [ca_address_sk]
-                                                                Filter [ca_state,ca_address_sk]
-                                                                  ColumnarToRow
-                                                                    InputAdapter
-                                                                      Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state]
-                                                    Subquery #2
-                                                      ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(web_site_sk, 42), 4, 144, 0, 0),bloomFilter,buf]
-                                                        Exchange #4
-                                                          ObjectHashAggregate [web_site_sk] [buf,buf]
-                                                            WholeStageCodegen (1)
-                                                              Project [web_site_sk]
-                                                                Filter [web_company_name,web_site_sk]
-                                                                  ColumnarToRow
-                                                                    InputAdapter
-                                                                      Scan parquet spark_catalog.default.web_site [web_site_sk,web_company_name]
+                                                            BroadcastExchangeExecProxy [ca_address_sk]
+                                                              SubqueryBroadcast [ca_address_sk] #2
+                                                                BroadcastExchange #4
+                                                                  WholeStageCodegen (1)
+                                                                    Project [ca_address_sk]
+                                                                      Filter [ca_state,ca_address_sk]
+                                                                        ColumnarToRow
+                                                                          InputAdapter
+                                                                            Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state]
                                                     Subquery #3
-                                                      ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(d_date_sk, 42), 73049, 1141755, 0, 0),bloomFilter,buf]
+                                                      ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(web_site_sk, 42), 4, 144, 0, 0),bloomFilter,buf]
                                                         Exchange #5
+                                                          ObjectHashAggregate [web_site_sk] [buf,buf]
+                                                            BroadcastExchangeExecProxy [web_site_sk]
+                                                              SubqueryBroadcast [web_site_sk] #4
+                                                                BroadcastExchange #6
+                                                                  WholeStageCodegen (1)
+                                                                    Project [web_site_sk]
+                                                                      Filter [web_company_name,web_site_sk]
+                                                                        ColumnarToRow
+                                                                          InputAdapter
+                                                                            Scan parquet spark_catalog.default.web_site [web_site_sk,web_company_name]
+                                                    Subquery #5
+                                                      ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(d_date_sk, 42), 73049, 1141755, 0, 0),bloomFilter,buf]
+                                                        Exchange #7
                                                           ObjectHashAggregate [d_date_sk] [buf,buf]
-                                                            WholeStageCodegen (1)
-                                                              Project [d_date_sk]
-                                                                Filter [d_date,d_date_sk]
-                                                                  ColumnarToRow
-                                                                    InputAdapter
-                                                                      Scan parquet spark_catalog.default.date_dim [d_date_sk,d_date]
+                                                            BroadcastExchangeExecProxy [d_date_sk]
+                                                              SubqueryBroadcast [d_date_sk] #6
+                                                                BroadcastExchange #8
+                                                                  WholeStageCodegen (1)
+                                                                    Project [d_date_sk]
+                                                                      Filter [d_date,d_date_sk]
+                                                                        ColumnarToRow
+                                                                          InputAdapter
+                                                                            Scan parquet spark_catalog.default.date_dim [d_date_sk,d_date]
                                                     ColumnarToRow
                                                       InputAdapter
                                                         Scan parquet spark_catalog.default.web_sales [ws_ship_date_sk,ws_ship_addr_sk,ws_web_site_sk,ws_order_number,ws_ext_ship_cost,ws_net_profit,ws_sold_date_sk]
@@ -65,7 +74,7 @@ WholeStageCodegen (21)
                                               WholeStageCodegen (4)
                                                 Sort [ws_order_number]
                                                   InputAdapter
-                                                    Exchange [ws_order_number] #6
+                                                    Exchange [ws_order_number] #9
                                                       WholeStageCodegen (3)
                                                         Project [ws_warehouse_sk,ws_order_number]
                                                           Filter [ws_order_number,ws_warehouse_sk]
@@ -76,7 +85,7 @@ WholeStageCodegen (21)
                                               WholeStageCodegen (6)
                                                 Sort [ws_order_number]
                                                   InputAdapter
-                                                    ReusedExchange [ws_warehouse_sk,ws_order_number] #6
+                                                    ReusedExchange [ws_warehouse_sk,ws_order_number] #9
                               InputAdapter
                                 WholeStageCodegen (16)
                                   Project [wr_order_number]
@@ -88,7 +97,7 @@ WholeStageCodegen (21)
                                               WholeStageCodegen (10)
                                                 Sort [wr_order_number]
                                                   InputAdapter
-                                                    Exchange [wr_order_number] #7
+                                                    Exchange [wr_order_number] #10
                                                       WholeStageCodegen (9)
                                                         Project [wr_order_number]
                                                           Filter [wr_order_number]
@@ -99,33 +108,15 @@ WholeStageCodegen (21)
                                               WholeStageCodegen (12)
                                                 Sort [ws_order_number]
                                                   InputAdapter
-                                                    ReusedExchange [ws_warehouse_sk,ws_order_number] #6
+                                                    ReusedExchange [ws_warehouse_sk,ws_order_number] #9
                                       InputAdapter
                                         WholeStageCodegen (15)
                                           Sort [ws_order_number]
                                             InputAdapter
-                                              ReusedExchange [ws_warehouse_sk,ws_order_number] #6
+                                              ReusedExchange [ws_warehouse_sk,ws_order_number] #9
                             InputAdapter
-                              BroadcastExchange #8
-                                WholeStageCodegen (17)
-                                  Project [ca_address_sk]
-                                    Filter [ca_state,ca_address_sk]
-                                      ColumnarToRow
-                                        InputAdapter
-                                          Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state]
+                              ReusedExchange [ca_address_sk] #4
                         InputAdapter
-                          BroadcastExchange #9
-                            WholeStageCodegen (18)
-                              Project [web_site_sk]
-                                Filter [web_company_name,web_site_sk]
-                                  ColumnarToRow
-                                    InputAdapter
-                                      Scan parquet spark_catalog.default.web_site [web_site_sk,web_company_name]
+                          ReusedExchange [web_site_sk] #6
                     InputAdapter
-                      BroadcastExchange #10
-                        WholeStageCodegen (19)
-                          Project [d_date_sk]
-                            Filter [d_date,d_date_sk]
-                              ColumnarToRow
-                                InputAdapter
-                                  Scan parquet spark_catalog.default.date_dim [d_date_sk,d_date]
+                      ReusedExchange [d_date_sk] #8

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q10a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q10a.sf100/explain.txt
@@ -1,13 +1,13 @@
 == Physical Plan ==
-TakeOrderedAndProject (45)
-+- * HashAggregate (44)
-   +- Exchange (43)
-      +- * HashAggregate (42)
-         +- * Project (41)
-            +- * BroadcastHashJoin Inner BuildLeft (40)
-               :- BroadcastExchange (36)
-               :  +- * Project (35)
-               :     +- * BroadcastHashJoin Inner BuildRight (34)
+TakeOrderedAndProject (41)
++- * HashAggregate (40)
+   +- Exchange (39)
+      +- * HashAggregate (38)
+         +- * Project (37)
+            +- * BroadcastHashJoin Inner BuildLeft (36)
+               :- BroadcastExchange (32)
+               :  +- * Project (31)
+               :     +- * BroadcastHashJoin Inner BuildRight (30)
                :        :- * Project (28)
                :        :  +- * SortMergeJoin LeftSemi (27)
                :        :     :- * SortMergeJoin LeftSemi (13)
@@ -36,14 +36,10 @@ TakeOrderedAndProject (45)
                :        :                    :- * ColumnarToRow (20)
                :        :                    :  +- Scan parquet spark_catalog.default.catalog_sales (19)
                :        :                    +- ReusedExchange (21)
-               :        +- BroadcastExchange (33)
-               :           +- * Project (32)
-               :              +- * Filter (31)
-               :                 +- * ColumnarToRow (30)
-               :                    +- Scan parquet spark_catalog.default.customer_address (29)
-               +- * Filter (39)
-                  +- * ColumnarToRow (38)
-                     +- Scan parquet spark_catalog.default.customer_demographics (37)
+               :        +- ReusedExchange (29)
+               +- * Filter (35)
+                  +- * ColumnarToRow (34)
+                     +- Scan parquet spark_catalog.default.customer_demographics (33)
 
 
 (1) Scan parquet spark_catalog.default.customer
@@ -58,7 +54,7 @@ Input [3]: [c_customer_sk#1, c_current_cdemo_sk#2, c_current_addr_sk#3]
 
 (3) Filter [codegen id : 1]
 Input [3]: [c_customer_sk#1, c_current_cdemo_sk#2, c_current_addr_sk#3]
-Condition : ((isnotnull(c_current_addr_sk#3) AND isnotnull(c_current_cdemo_sk#2)) AND might_contain(Subquery scalar-subquery#4, [id=#5], xxhash64(c_current_addr_sk#3, 42)))
+Condition : ((isnotnull(c_current_addr_sk#3) AND isnotnull(c_current_cdemo_sk#2)) AND might_contain(runtimefilterexpression(Subquery scalar-subquery#4, [id=#5]), xxhash64(c_current_addr_sk#3, 42)))
 
 (4) Exchange
 Input [3]: [c_customer_sk#1, c_current_cdemo_sk#2, c_current_addr_sk#3]
@@ -78,7 +74,7 @@ ReadSchema: struct<ss_customer_sk:int>
 (7) ColumnarToRow [codegen id : 4]
 Input [2]: [ss_customer_sk#6, ss_sold_date_sk#7]
 
-(8) ReusedExchange [Reuses operator id: 57]
+(8) ReusedExchange [Reuses operator id: 56]
 Output [1]: [d_date_sk#9]
 
 (9) BroadcastHashJoin [codegen id : 4]
@@ -115,7 +111,7 @@ ReadSchema: struct<ws_bill_customer_sk:int>
 (15) ColumnarToRow [codegen id : 8]
 Input [2]: [ws_bill_customer_sk#10, ws_sold_date_sk#11]
 
-(16) ReusedExchange [Reuses operator id: 57]
+(16) ReusedExchange [Reuses operator id: 56]
 Output [1]: [d_date_sk#12]
 
 (17) BroadcastHashJoin [codegen id : 8]
@@ -138,7 +134,7 @@ ReadSchema: struct<cs_ship_customer_sk:int>
 (20) ColumnarToRow [codegen id : 10]
 Input [2]: [cs_ship_customer_sk#14, cs_sold_date_sk#15]
 
-(21) ReusedExchange [Reuses operator id: 57]
+(21) ReusedExchange [Reuses operator id: 56]
 Output [1]: [d_date_sk#16]
 
 (22) BroadcastHashJoin [codegen id : 10]
@@ -171,163 +167,153 @@ Join condition: None
 Output [2]: [c_current_cdemo_sk#2, c_current_addr_sk#3]
 Input [3]: [c_customer_sk#1, c_current_cdemo_sk#2, c_current_addr_sk#3]
 
-(29) Scan parquet spark_catalog.default.customer_address
-Output [2]: [ca_address_sk#18, ca_county#19]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer_address]
-PushedFilters: [In(ca_county, [Dona Ana County,Douglas County,Gaines County,Richland County,Walker County]), IsNotNull(ca_address_sk)]
-ReadSchema: struct<ca_address_sk:int,ca_county:string>
-
-(30) ColumnarToRow [codegen id : 12]
-Input [2]: [ca_address_sk#18, ca_county#19]
-
-(31) Filter [codegen id : 12]
-Input [2]: [ca_address_sk#18, ca_county#19]
-Condition : (ca_county#19 IN (Walker County,Richland County,Gaines County,Douglas County,Dona Ana County) AND isnotnull(ca_address_sk#18))
-
-(32) Project [codegen id : 12]
+(29) ReusedExchange [Reuses operator id: 46]
 Output [1]: [ca_address_sk#18]
-Input [2]: [ca_address_sk#18, ca_county#19]
 
-(33) BroadcastExchange
-Input [1]: [ca_address_sk#18]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=4]
-
-(34) BroadcastHashJoin [codegen id : 13]
+(30) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [c_current_addr_sk#3]
 Right keys [1]: [ca_address_sk#18]
 Join type: Inner
 Join condition: None
 
-(35) Project [codegen id : 13]
+(31) Project [codegen id : 13]
 Output [1]: [c_current_cdemo_sk#2]
 Input [3]: [c_current_cdemo_sk#2, c_current_addr_sk#3, ca_address_sk#18]
 
-(36) BroadcastExchange
+(32) BroadcastExchange
 Input [1]: [c_current_cdemo_sk#2]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=4]
 
-(37) Scan parquet spark_catalog.default.customer_demographics
-Output [9]: [cd_demo_sk#20, cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
+(33) Scan parquet spark_catalog.default.customer_demographics
+Output [9]: [cd_demo_sk#19, cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_demographics]
 PushedFilters: [IsNotNull(cd_demo_sk)]
 ReadSchema: struct<cd_demo_sk:int,cd_gender:string,cd_marital_status:string,cd_education_status:string,cd_purchase_estimate:int,cd_credit_rating:string,cd_dep_count:int,cd_dep_employed_count:int,cd_dep_college_count:int>
 
-(38) ColumnarToRow
-Input [9]: [cd_demo_sk#20, cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
+(34) ColumnarToRow
+Input [9]: [cd_demo_sk#19, cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
 
-(39) Filter
-Input [9]: [cd_demo_sk#20, cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
-Condition : isnotnull(cd_demo_sk#20)
+(35) Filter
+Input [9]: [cd_demo_sk#19, cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
+Condition : isnotnull(cd_demo_sk#19)
 
-(40) BroadcastHashJoin [codegen id : 14]
+(36) BroadcastHashJoin [codegen id : 14]
 Left keys [1]: [c_current_cdemo_sk#2]
-Right keys [1]: [cd_demo_sk#20]
+Right keys [1]: [cd_demo_sk#19]
 Join type: Inner
 Join condition: None
 
-(41) Project [codegen id : 14]
-Output [8]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
-Input [10]: [c_current_cdemo_sk#2, cd_demo_sk#20, cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
+(37) Project [codegen id : 14]
+Output [8]: [cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
+Input [10]: [c_current_cdemo_sk#2, cd_demo_sk#19, cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
 
-(42) HashAggregate [codegen id : 14]
-Input [8]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
-Keys [8]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
+(38) HashAggregate [codegen id : 14]
+Input [8]: [cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
+Keys [8]: [cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
 Functions [1]: [partial_count(1)]
-Aggregate Attributes [1]: [count#29]
-Results [9]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28, count#30]
+Aggregate Attributes [1]: [count#28]
+Results [9]: [cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27, count#29]
 
-(43) Exchange
-Input [9]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28, count#30]
-Arguments: hashpartitioning(cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+(39) Exchange
+Input [9]: [cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27, count#29]
+Arguments: hashpartitioning(cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
-(44) HashAggregate [codegen id : 15]
-Input [9]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28, count#30]
-Keys [8]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
+(40) HashAggregate [codegen id : 15]
+Input [9]: [cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27, count#29]
+Keys [8]: [cd_gender#20, cd_marital_status#21, cd_education_status#22, cd_purchase_estimate#23, cd_credit_rating#24, cd_dep_count#25, cd_dep_employed_count#26, cd_dep_college_count#27]
 Functions [1]: [count(1)]
-Aggregate Attributes [1]: [count(1)#31]
-Results [14]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, count(1)#31 AS cnt1#32, cd_purchase_estimate#24, count(1)#31 AS cnt2#33, cd_credit_rating#25, count(1)#31 AS cnt3#34, cd_dep_count#26, count(1)#31 AS cnt4#35, cd_dep_employed_count#27, count(1)#31 AS cnt5#36, cd_dep_college_count#28, count(1)#31 AS cnt6#37]
+Aggregate Attributes [1]: [count(1)#30]
+Results [14]: [cd_gender#20, cd_marital_status#21, cd_education_status#22, count(1)#30 AS cnt1#31, cd_purchase_estimate#23, count(1)#30 AS cnt2#32, cd_credit_rating#24, count(1)#30 AS cnt3#33, cd_dep_count#25, count(1)#30 AS cnt4#34, cd_dep_employed_count#26, count(1)#30 AS cnt5#35, cd_dep_college_count#27, count(1)#30 AS cnt6#36]
 
-(45) TakeOrderedAndProject
-Input [14]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cnt1#32, cd_purchase_estimate#24, cnt2#33, cd_credit_rating#25, cnt3#34, cd_dep_count#26, cnt4#35, cd_dep_employed_count#27, cnt5#36, cd_dep_college_count#28, cnt6#37]
-Arguments: 100, [cd_gender#21 ASC NULLS FIRST, cd_marital_status#22 ASC NULLS FIRST, cd_education_status#23 ASC NULLS FIRST, cd_purchase_estimate#24 ASC NULLS FIRST, cd_credit_rating#25 ASC NULLS FIRST, cd_dep_count#26 ASC NULLS FIRST, cd_dep_employed_count#27 ASC NULLS FIRST, cd_dep_college_count#28 ASC NULLS FIRST], [cd_gender#21, cd_marital_status#22, cd_education_status#23, cnt1#32, cd_purchase_estimate#24, cnt2#33, cd_credit_rating#25, cnt3#34, cd_dep_count#26, cnt4#35, cd_dep_employed_count#27, cnt5#36, cd_dep_college_count#28, cnt6#37]
+(41) TakeOrderedAndProject
+Input [14]: [cd_gender#20, cd_marital_status#21, cd_education_status#22, cnt1#31, cd_purchase_estimate#23, cnt2#32, cd_credit_rating#24, cnt3#33, cd_dep_count#25, cnt4#34, cd_dep_employed_count#26, cnt5#35, cd_dep_college_count#27, cnt6#36]
+Arguments: 100, [cd_gender#20 ASC NULLS FIRST, cd_marital_status#21 ASC NULLS FIRST, cd_education_status#22 ASC NULLS FIRST, cd_purchase_estimate#23 ASC NULLS FIRST, cd_credit_rating#24 ASC NULLS FIRST, cd_dep_count#25 ASC NULLS FIRST, cd_dep_employed_count#26 ASC NULLS FIRST, cd_dep_college_count#27 ASC NULLS FIRST], [cd_gender#20, cd_marital_status#21, cd_education_status#22, cnt1#31, cd_purchase_estimate#23, cnt2#32, cd_credit_rating#24, cnt3#33, cd_dep_count#25, cnt4#34, cd_dep_employed_count#26, cnt5#35, cd_dep_college_count#27, cnt6#36]
 
 ===== Subqueries =====
 
 Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#4, [id=#5]
-ObjectHashAggregate (52)
-+- Exchange (51)
-   +- ObjectHashAggregate (50)
-      +- * Project (49)
-         +- * Filter (48)
-            +- * ColumnarToRow (47)
-               +- Scan parquet spark_catalog.default.customer_address (46)
+ObjectHashAggregate (51)
++- Exchange (50)
+   +- ObjectHashAggregate (49)
+      +- BroadcastExchangeExecProxy (48)
 
 
-(46) Scan parquet spark_catalog.default.customer_address
-Output [2]: [ca_address_sk#18, ca_county#19]
+(42) Scan parquet spark_catalog.default.customer_address
+Output [2]: [ca_address_sk#18, ca_county#37]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [In(ca_county, [Dona Ana County,Douglas County,Gaines County,Richland County,Walker County]), IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_county:string>
 
-(47) ColumnarToRow [codegen id : 1]
-Input [2]: [ca_address_sk#18, ca_county#19]
+(43) ColumnarToRow [codegen id : 1]
+Input [2]: [ca_address_sk#18, ca_county#37]
 
-(48) Filter [codegen id : 1]
-Input [2]: [ca_address_sk#18, ca_county#19]
-Condition : (ca_county#19 IN (Walker County,Richland County,Gaines County,Douglas County,Dona Ana County) AND isnotnull(ca_address_sk#18))
+(44) Filter [codegen id : 1]
+Input [2]: [ca_address_sk#18, ca_county#37]
+Condition : (ca_county#37 IN (Walker County,Richland County,Gaines County,Douglas County,Dona Ana County) AND isnotnull(ca_address_sk#18))
 
-(49) Project [codegen id : 1]
+(45) Project [codegen id : 1]
 Output [1]: [ca_address_sk#18]
-Input [2]: [ca_address_sk#18, ca_county#19]
+Input [2]: [ca_address_sk#18, ca_county#37]
 
-(50) ObjectHashAggregate
+(46) BroadcastExchange
+Input [1]: [ca_address_sk#18]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=6]
+
+(47) SubqueryBroadcast
+Input [1]: [ca_address_sk#18]
+Arguments: runtimefilter#4, 0, [ca_address_sk#18], [id=#38]
+
+(48) BroadcastExchangeExecProxy
+Input [1]: [ca_address_sk#39]
+Arguments: [ca_address_sk#18]
+
+(49) ObjectHashAggregate
 Input [1]: [ca_address_sk#18]
 Keys: []
 Functions [1]: [partial_bloom_filter_agg(xxhash64(ca_address_sk#18, 42), 2555, 57765, 0, 0)]
-Aggregate Attributes [1]: [buf#38]
-Results [1]: [buf#39]
+Aggregate Attributes [1]: [buf#40]
+Results [1]: [buf#41]
 
-(51) Exchange
-Input [1]: [buf#39]
+(50) Exchange
+Input [1]: [buf#41]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=7]
 
-(52) ObjectHashAggregate
-Input [1]: [buf#39]
+(51) ObjectHashAggregate
+Input [1]: [buf#41]
 Keys: []
 Functions [1]: [bloom_filter_agg(xxhash64(ca_address_sk#18, 42), 2555, 57765, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(ca_address_sk#18, 42), 2555, 57765, 0, 0)#40]
-Results [1]: [bloom_filter_agg(xxhash64(ca_address_sk#18, 42), 2555, 57765, 0, 0)#40 AS bloomFilter#41]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(ca_address_sk#18, 42), 2555, 57765, 0, 0)#42]
+Results [1]: [bloom_filter_agg(xxhash64(ca_address_sk#18, 42), 2555, 57765, 0, 0)#42 AS bloomFilter#43]
 
 Subquery:2 Hosting operator id = 6 Hosting Expression = ss_sold_date_sk#7 IN dynamicpruning#8
-BroadcastExchange (57)
-+- * Project (56)
-   +- * Filter (55)
-      +- * ColumnarToRow (54)
-         +- Scan parquet spark_catalog.default.date_dim (53)
+BroadcastExchange (56)
++- * Project (55)
+   +- * Filter (54)
+      +- * ColumnarToRow (53)
+         +- Scan parquet spark_catalog.default.date_dim (52)
 
 
-(53) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#9, d_year#42, d_moy#43]
+(52) Scan parquet spark_catalog.default.date_dim
+Output [3]: [d_date_sk#9, d_year#44, d_moy#45]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), EqualTo(d_year,2002), GreaterThanOrEqual(d_moy,4), LessThanOrEqual(d_moy,7), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
 
-(54) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#9, d_year#42, d_moy#43]
+(53) ColumnarToRow [codegen id : 1]
+Input [3]: [d_date_sk#9, d_year#44, d_moy#45]
 
-(55) Filter [codegen id : 1]
-Input [3]: [d_date_sk#9, d_year#42, d_moy#43]
-Condition : (((((isnotnull(d_year#42) AND isnotnull(d_moy#43)) AND (d_year#42 = 2002)) AND (d_moy#43 >= 4)) AND (d_moy#43 <= 7)) AND isnotnull(d_date_sk#9))
+(54) Filter [codegen id : 1]
+Input [3]: [d_date_sk#9, d_year#44, d_moy#45]
+Condition : (((((isnotnull(d_year#44) AND isnotnull(d_moy#45)) AND (d_year#44 = 2002)) AND (d_moy#45 >= 4)) AND (d_moy#45 <= 7)) AND isnotnull(d_date_sk#9))
 
-(56) Project [codegen id : 1]
+(55) Project [codegen id : 1]
 Output [1]: [d_date_sk#9]
-Input [3]: [d_date_sk#9, d_year#42, d_moy#43]
+Input [3]: [d_date_sk#9, d_year#44, d_moy#45]
 
-(57) BroadcastExchange
+(56) BroadcastExchange
 Input [1]: [d_date_sk#9]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=8]
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q10a.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q10a.sf100/simplified.txt
@@ -28,12 +28,15 @@ TakeOrderedAndProject [cd_gender,cd_marital_status,cd_education_status,cd_purcha
                                                       ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(ca_address_sk, 42), 2555, 57765, 0, 0),bloomFilter,buf]
                                                         Exchange #4
                                                           ObjectHashAggregate [ca_address_sk] [buf,buf]
-                                                            WholeStageCodegen (1)
-                                                              Project [ca_address_sk]
-                                                                Filter [ca_county,ca_address_sk]
-                                                                  ColumnarToRow
-                                                                    InputAdapter
-                                                                      Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_county]
+                                                            BroadcastExchangeExecProxy [ca_address_sk]
+                                                              SubqueryBroadcast [ca_address_sk] #2
+                                                                BroadcastExchange #5
+                                                                  WholeStageCodegen (1)
+                                                                    Project [ca_address_sk]
+                                                                      Filter [ca_county,ca_address_sk]
+                                                                        ColumnarToRow
+                                                                          InputAdapter
+                                                                            Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_county]
                                                     ColumnarToRow
                                                       InputAdapter
                                                         Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_cdemo_sk,c_current_addr_sk]
@@ -41,15 +44,15 @@ TakeOrderedAndProject [cd_gender,cd_marital_status,cd_education_status,cd_purcha
                                         WholeStageCodegen (5)
                                           Sort [ss_customer_sk]
                                             InputAdapter
-                                              Exchange [ss_customer_sk] #5
+                                              Exchange [ss_customer_sk] #6
                                                 WholeStageCodegen (4)
                                                   Project [ss_customer_sk]
                                                     BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                                       ColumnarToRow
                                                         InputAdapter
                                                           Scan parquet spark_catalog.default.store_sales [ss_customer_sk,ss_sold_date_sk]
-                                                            SubqueryBroadcast [d_date_sk] #2
-                                                              BroadcastExchange #6
+                                                            SubqueryBroadcast [d_date_sk] #3
+                                                              BroadcastExchange #7
                                                                 WholeStageCodegen (1)
                                                                   Project [d_date_sk]
                                                                     Filter [d_year,d_moy,d_date_sk]
@@ -57,12 +60,12 @@ TakeOrderedAndProject [cd_gender,cd_marital_status,cd_education_status,cd_purcha
                                                                         InputAdapter
                                                                           Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_moy]
                                                       InputAdapter
-                                                        ReusedExchange [d_date_sk] #6
+                                                        ReusedExchange [d_date_sk] #7
                                 InputAdapter
                                   WholeStageCodegen (11)
                                     Sort [customer_sk]
                                       InputAdapter
-                                        Exchange [customer_sk] #7
+                                        Exchange [customer_sk] #8
                                           Union
                                             WholeStageCodegen (8)
                                               Project [ws_bill_customer_sk]
@@ -70,26 +73,20 @@ TakeOrderedAndProject [cd_gender,cd_marital_status,cd_education_status,cd_purcha
                                                   ColumnarToRow
                                                     InputAdapter
                                                       Scan parquet spark_catalog.default.web_sales [ws_bill_customer_sk,ws_sold_date_sk]
-                                                        ReusedSubquery [d_date_sk] #2
+                                                        ReusedSubquery [d_date_sk] #3
                                                   InputAdapter
-                                                    ReusedExchange [d_date_sk] #6
+                                                    ReusedExchange [d_date_sk] #7
                                             WholeStageCodegen (10)
                                               Project [cs_ship_customer_sk]
                                                 BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
                                                   ColumnarToRow
                                                     InputAdapter
                                                       Scan parquet spark_catalog.default.catalog_sales [cs_ship_customer_sk,cs_sold_date_sk]
-                                                        ReusedSubquery [d_date_sk] #2
+                                                        ReusedSubquery [d_date_sk] #3
                                                   InputAdapter
-                                                    ReusedExchange [d_date_sk] #6
+                                                    ReusedExchange [d_date_sk] #7
                             InputAdapter
-                              BroadcastExchange #8
-                                WholeStageCodegen (12)
-                                  Project [ca_address_sk]
-                                    Filter [ca_county,ca_address_sk]
-                                      ColumnarToRow
-                                        InputAdapter
-                                          Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_county]
+                              ReusedExchange [ca_address_sk] #5
                   Filter [cd_demo_sk]
                     ColumnarToRow
                       InputAdapter

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q64.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q64.sf100/explain.txt
@@ -223,7 +223,7 @@ Input [12]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_ad
 
 (3) Filter [codegen id : 1]
 Input [12]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_ticket_number#8, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, ss_sold_date_sk#12]
-Condition : ((((((((isnotnull(ss_item_sk#1) AND isnotnull(ss_ticket_number#8)) AND isnotnull(ss_store_sk#6)) AND isnotnull(ss_customer_sk#2)) AND isnotnull(ss_cdemo_sk#3)) AND isnotnull(ss_promo_sk#7)) AND isnotnull(ss_hdemo_sk#4)) AND isnotnull(ss_addr_sk#5)) AND might_contain(Subquery scalar-subquery#14, [id=#15], xxhash64(ss_item_sk#1, 42)))
+Condition : ((((((((isnotnull(ss_item_sk#1) AND isnotnull(ss_ticket_number#8)) AND isnotnull(ss_store_sk#6)) AND isnotnull(ss_customer_sk#2)) AND isnotnull(ss_cdemo_sk#3)) AND isnotnull(ss_promo_sk#7)) AND isnotnull(ss_hdemo_sk#4)) AND isnotnull(ss_addr_sk#5)) AND might_contain(runtimefilterexpression(Subquery scalar-subquery#14, [id=#15]), xxhash64(ss_item_sk#1, 42)))
 
 (4) Exchange
 Input [12]: [ss_item_sk#1, ss_customer_sk#2, ss_cdemo_sk#3, ss_hdemo_sk#4, ss_addr_sk#5, ss_store_sk#6, ss_promo_sk#7, ss_ticket_number#8, ss_wholesale_cost#9, ss_list_price#10, ss_coupon_amt#11, ss_sold_date_sk#12]
@@ -804,7 +804,7 @@ Input [12]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#11
 
 (131) Filter [codegen id : 44]
 Input [12]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_store_sk#113, ss_promo_sk#114, ss_ticket_number#115, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, ss_sold_date_sk#119]
-Condition : ((((((((isnotnull(ss_item_sk#108) AND isnotnull(ss_ticket_number#115)) AND isnotnull(ss_store_sk#113)) AND isnotnull(ss_customer_sk#109)) AND isnotnull(ss_cdemo_sk#110)) AND isnotnull(ss_promo_sk#114)) AND isnotnull(ss_hdemo_sk#111)) AND isnotnull(ss_addr_sk#112)) AND might_contain(ReusedSubquery Subquery scalar-subquery#14, [id=#15], xxhash64(ss_item_sk#108, 42)))
+Condition : ((((((((isnotnull(ss_item_sk#108) AND isnotnull(ss_ticket_number#115)) AND isnotnull(ss_store_sk#113)) AND isnotnull(ss_customer_sk#109)) AND isnotnull(ss_cdemo_sk#110)) AND isnotnull(ss_promo_sk#114)) AND isnotnull(ss_hdemo_sk#111)) AND isnotnull(ss_addr_sk#112)) AND might_contain(runtimefilterexpression(ReusedSubquery Subquery scalar-subquery#14, [id=#15]), xxhash64(ss_item_sk#108, 42)))
 
 (132) Exchange
 Input [12]: [ss_item_sk#108, ss_customer_sk#109, ss_cdemo_sk#110, ss_hdemo_sk#111, ss_addr_sk#112, ss_store_sk#113, ss_promo_sk#114, ss_ticket_number#115, ss_wholesale_cost#116, ss_list_price#117, ss_coupon_amt#118, ss_sold_date_sk#119]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q80a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q80a.sf100/explain.txt
@@ -1,24 +1,24 @@
 == Physical Plan ==
-TakeOrderedAndProject (202)
-+- * HashAggregate (201)
-   +- Exchange (200)
-      +- * HashAggregate (199)
-         +- Union (198)
-            :- * HashAggregate (105)
-            :  +- Exchange (104)
-            :     +- * HashAggregate (103)
-            :        +- Union (102)
-            :           :- * HashAggregate (39)
-            :           :  +- Exchange (38)
-            :           :     +- * HashAggregate (37)
-            :           :        +- * Project (36)
-            :           :           +- * BroadcastHashJoin Inner BuildRight (35)
-            :           :              :- * Project (30)
-            :           :              :  +- * BroadcastHashJoin Inner BuildRight (29)
-            :           :              :     :- * Project (27)
-            :           :              :     :  +- * BroadcastHashJoin Inner BuildRight (26)
-            :           :              :     :     :- * Project (20)
-            :           :              :     :     :  +- * BroadcastHashJoin Inner BuildRight (19)
+TakeOrderedAndProject (194)
++- * HashAggregate (193)
+   +- Exchange (192)
+      +- * HashAggregate (191)
+         +- Union (190)
+            :- * HashAggregate (97)
+            :  +- Exchange (96)
+            :     +- * HashAggregate (95)
+            :        +- Union (94)
+            :           :- * HashAggregate (31)
+            :           :  +- Exchange (30)
+            :           :     +- * HashAggregate (29)
+            :           :        +- * Project (28)
+            :           :           +- * BroadcastHashJoin Inner BuildRight (27)
+            :           :              :- * Project (22)
+            :           :              :  +- * BroadcastHashJoin Inner BuildRight (21)
+            :           :              :     :- * Project (19)
+            :           :              :     :  +- * BroadcastHashJoin Inner BuildRight (18)
+            :           :              :     :     :- * Project (16)
+            :           :              :     :     :  +- * BroadcastHashJoin Inner BuildRight (15)
             :           :              :     :     :     :- * Project (13)
             :           :              :     :     :     :  +- * SortMergeJoin LeftOuter (12)
             :           :              :     :     :     :     :- * Sort (5)
@@ -32,175 +32,167 @@ TakeOrderedAndProject (202)
             :           :              :     :     :     :              +- * Filter (8)
             :           :              :     :     :     :                 +- * ColumnarToRow (7)
             :           :              :     :     :     :                    +- Scan parquet spark_catalog.default.store_returns (6)
-            :           :              :     :     :     +- BroadcastExchange (18)
-            :           :              :     :     :        +- * Project (17)
-            :           :              :     :     :           +- * Filter (16)
-            :           :              :     :     :              +- * ColumnarToRow (15)
-            :           :              :     :     :                 +- Scan parquet spark_catalog.default.item (14)
-            :           :              :     :     +- BroadcastExchange (25)
-            :           :              :     :        +- * Project (24)
-            :           :              :     :           +- * Filter (23)
-            :           :              :     :              +- * ColumnarToRow (22)
-            :           :              :     :                 +- Scan parquet spark_catalog.default.promotion (21)
-            :           :              :     +- ReusedExchange (28)
-            :           :              +- BroadcastExchange (34)
-            :           :                 +- * Filter (33)
-            :           :                    +- * ColumnarToRow (32)
-            :           :                       +- Scan parquet spark_catalog.default.store (31)
-            :           :- * HashAggregate (70)
-            :           :  +- Exchange (69)
-            :           :     +- * HashAggregate (68)
-            :           :        +- * Project (67)
-            :           :           +- * BroadcastHashJoin Inner BuildRight (66)
-            :           :              :- * Project (61)
-            :           :              :  +- * BroadcastHashJoin Inner BuildRight (60)
-            :           :              :     :- * Project (58)
-            :           :              :     :  +- * BroadcastHashJoin Inner BuildRight (57)
-            :           :              :     :     :- * Project (55)
-            :           :              :     :     :  +- * BroadcastHashJoin Inner BuildRight (54)
-            :           :              :     :     :     :- * Project (52)
-            :           :              :     :     :     :  +- * SortMergeJoin LeftOuter (51)
-            :           :              :     :     :     :     :- * Sort (44)
-            :           :              :     :     :     :     :  +- Exchange (43)
-            :           :              :     :     :     :     :     +- * Filter (42)
-            :           :              :     :     :     :     :        +- * ColumnarToRow (41)
-            :           :              :     :     :     :     :           +- Scan parquet spark_catalog.default.catalog_sales (40)
-            :           :              :     :     :     :     +- * Sort (50)
-            :           :              :     :     :     :        +- Exchange (49)
-            :           :              :     :     :     :           +- * Project (48)
-            :           :              :     :     :     :              +- * Filter (47)
-            :           :              :     :     :     :                 +- * ColumnarToRow (46)
-            :           :              :     :     :     :                    +- Scan parquet spark_catalog.default.catalog_returns (45)
-            :           :              :     :     :     +- ReusedExchange (53)
-            :           :              :     :     +- ReusedExchange (56)
-            :           :              :     +- ReusedExchange (59)
-            :           :              +- BroadcastExchange (65)
-            :           :                 +- * Filter (64)
-            :           :                    +- * ColumnarToRow (63)
-            :           :                       +- Scan parquet spark_catalog.default.catalog_page (62)
-            :           +- * HashAggregate (101)
-            :              +- Exchange (100)
-            :                 +- * HashAggregate (99)
-            :                    +- * Project (98)
-            :                       +- * BroadcastHashJoin Inner BuildRight (97)
-            :                          :- * Project (92)
-            :                          :  +- * BroadcastHashJoin Inner BuildRight (91)
-            :                          :     :- * Project (89)
-            :                          :     :  +- * BroadcastHashJoin Inner BuildRight (88)
-            :                          :     :     :- * Project (86)
-            :                          :     :     :  +- * BroadcastHashJoin Inner BuildRight (85)
-            :                          :     :     :     :- * Project (83)
-            :                          :     :     :     :  +- * SortMergeJoin LeftOuter (82)
-            :                          :     :     :     :     :- * Sort (75)
-            :                          :     :     :     :     :  +- Exchange (74)
-            :                          :     :     :     :     :     +- * Filter (73)
-            :                          :     :     :     :     :        +- * ColumnarToRow (72)
-            :                          :     :     :     :     :           +- Scan parquet spark_catalog.default.web_sales (71)
-            :                          :     :     :     :     +- * Sort (81)
-            :                          :     :     :     :        +- Exchange (80)
-            :                          :     :     :     :           +- * Project (79)
-            :                          :     :     :     :              +- * Filter (78)
-            :                          :     :     :     :                 +- * ColumnarToRow (77)
-            :                          :     :     :     :                    +- Scan parquet spark_catalog.default.web_returns (76)
-            :                          :     :     :     +- ReusedExchange (84)
-            :                          :     :     +- ReusedExchange (87)
-            :                          :     +- ReusedExchange (90)
-            :                          +- BroadcastExchange (96)
-            :                             +- * Filter (95)
-            :                                +- * ColumnarToRow (94)
-            :                                   +- Scan parquet spark_catalog.default.web_site (93)
-            :- * HashAggregate (140)
-            :  +- Exchange (139)
-            :     +- * HashAggregate (138)
-            :        +- * HashAggregate (137)
-            :           +- Exchange (136)
-            :              +- * HashAggregate (135)
-            :                 +- Union (134)
-            :                    :- * HashAggregate (107)
-            :                    :  +- ReusedExchange (106)
-            :                    :- * HashAggregate (109)
-            :                    :  +- ReusedExchange (108)
-            :                    +- * HashAggregate (133)
-            :                       +- Exchange (132)
-            :                          +- * HashAggregate (131)
-            :                             +- * Project (130)
-            :                                +- * BroadcastHashJoin Inner BuildRight (129)
-            :                                   :- * Project (127)
-            :                                   :  +- * BroadcastHashJoin Inner BuildRight (126)
-            :                                   :     :- * Project (124)
-            :                                   :     :  +- * BroadcastHashJoin Inner BuildRight (123)
-            :                                   :     :     :- * Project (121)
-            :                                   :     :     :  +- * BroadcastHashJoin Inner BuildRight (120)
-            :                                   :     :     :     :- * Project (118)
-            :                                   :     :     :     :  +- * SortMergeJoin LeftOuter (117)
-            :                                   :     :     :     :     :- * Sort (114)
-            :                                   :     :     :     :     :  +- Exchange (113)
-            :                                   :     :     :     :     :     +- * Filter (112)
-            :                                   :     :     :     :     :        +- * ColumnarToRow (111)
-            :                                   :     :     :     :     :           +- Scan parquet spark_catalog.default.web_sales (110)
-            :                                   :     :     :     :     +- * Sort (116)
-            :                                   :     :     :     :        +- ReusedExchange (115)
-            :                                   :     :     :     +- ReusedExchange (119)
-            :                                   :     :     +- ReusedExchange (122)
-            :                                   :     +- ReusedExchange (125)
-            :                                   +- ReusedExchange (128)
-            +- * HashAggregate (197)
-               +- Exchange (196)
-                  +- * HashAggregate (195)
-                     +- * HashAggregate (194)
-                        +- Exchange (193)
-                           +- * HashAggregate (192)
-                              +- Union (191)
-                                 :- * HashAggregate (164)
-                                 :  +- Exchange (163)
-                                 :     +- * HashAggregate (162)
-                                 :        +- * Project (161)
-                                 :           +- * BroadcastHashJoin Inner BuildRight (160)
-                                 :              :- * Project (158)
-                                 :              :  +- * BroadcastHashJoin Inner BuildRight (157)
-                                 :              :     :- * Project (155)
-                                 :              :     :  +- * BroadcastHashJoin Inner BuildRight (154)
-                                 :              :     :     :- * Project (152)
-                                 :              :     :     :  +- * BroadcastHashJoin Inner BuildRight (151)
-                                 :              :     :     :     :- * Project (149)
-                                 :              :     :     :     :  +- * SortMergeJoin LeftOuter (148)
-                                 :              :     :     :     :     :- * Sort (145)
-                                 :              :     :     :     :     :  +- Exchange (144)
-                                 :              :     :     :     :     :     +- * Filter (143)
-                                 :              :     :     :     :     :        +- * ColumnarToRow (142)
-                                 :              :     :     :     :     :           +- Scan parquet spark_catalog.default.store_sales (141)
-                                 :              :     :     :     :     +- * Sort (147)
-                                 :              :     :     :     :        +- ReusedExchange (146)
-                                 :              :     :     :     +- ReusedExchange (150)
-                                 :              :     :     +- ReusedExchange (153)
-                                 :              :     +- ReusedExchange (156)
-                                 :              +- ReusedExchange (159)
-                                 :- * HashAggregate (188)
-                                 :  +- Exchange (187)
-                                 :     +- * HashAggregate (186)
-                                 :        +- * Project (185)
-                                 :           +- * BroadcastHashJoin Inner BuildRight (184)
-                                 :              :- * Project (182)
-                                 :              :  +- * BroadcastHashJoin Inner BuildRight (181)
-                                 :              :     :- * Project (179)
-                                 :              :     :  +- * BroadcastHashJoin Inner BuildRight (178)
-                                 :              :     :     :- * Project (176)
-                                 :              :     :     :  +- * BroadcastHashJoin Inner BuildRight (175)
-                                 :              :     :     :     :- * Project (173)
-                                 :              :     :     :     :  +- * SortMergeJoin LeftOuter (172)
-                                 :              :     :     :     :     :- * Sort (169)
-                                 :              :     :     :     :     :  +- Exchange (168)
-                                 :              :     :     :     :     :     +- * Filter (167)
-                                 :              :     :     :     :     :        +- * ColumnarToRow (166)
-                                 :              :     :     :     :     :           +- Scan parquet spark_catalog.default.catalog_sales (165)
-                                 :              :     :     :     :     +- * Sort (171)
-                                 :              :     :     :     :        +- ReusedExchange (170)
-                                 :              :     :     :     +- ReusedExchange (174)
-                                 :              :     :     +- ReusedExchange (177)
-                                 :              :     +- ReusedExchange (180)
-                                 :              +- ReusedExchange (183)
-                                 +- * HashAggregate (190)
-                                    +- ReusedExchange (189)
+            :           :              :     :     :     +- ReusedExchange (14)
+            :           :              :     :     +- ReusedExchange (17)
+            :           :              :     +- ReusedExchange (20)
+            :           :              +- BroadcastExchange (26)
+            :           :                 +- * Filter (25)
+            :           :                    +- * ColumnarToRow (24)
+            :           :                       +- Scan parquet spark_catalog.default.store (23)
+            :           :- * HashAggregate (62)
+            :           :  +- Exchange (61)
+            :           :     +- * HashAggregate (60)
+            :           :        +- * Project (59)
+            :           :           +- * BroadcastHashJoin Inner BuildRight (58)
+            :           :              :- * Project (53)
+            :           :              :  +- * BroadcastHashJoin Inner BuildRight (52)
+            :           :              :     :- * Project (50)
+            :           :              :     :  +- * BroadcastHashJoin Inner BuildRight (49)
+            :           :              :     :     :- * Project (47)
+            :           :              :     :     :  +- * BroadcastHashJoin Inner BuildRight (46)
+            :           :              :     :     :     :- * Project (44)
+            :           :              :     :     :     :  +- * SortMergeJoin LeftOuter (43)
+            :           :              :     :     :     :     :- * Sort (36)
+            :           :              :     :     :     :     :  +- Exchange (35)
+            :           :              :     :     :     :     :     +- * Filter (34)
+            :           :              :     :     :     :     :        +- * ColumnarToRow (33)
+            :           :              :     :     :     :     :           +- Scan parquet spark_catalog.default.catalog_sales (32)
+            :           :              :     :     :     :     +- * Sort (42)
+            :           :              :     :     :     :        +- Exchange (41)
+            :           :              :     :     :     :           +- * Project (40)
+            :           :              :     :     :     :              +- * Filter (39)
+            :           :              :     :     :     :                 +- * ColumnarToRow (38)
+            :           :              :     :     :     :                    +- Scan parquet spark_catalog.default.catalog_returns (37)
+            :           :              :     :     :     +- ReusedExchange (45)
+            :           :              :     :     +- ReusedExchange (48)
+            :           :              :     +- ReusedExchange (51)
+            :           :              +- BroadcastExchange (57)
+            :           :                 +- * Filter (56)
+            :           :                    +- * ColumnarToRow (55)
+            :           :                       +- Scan parquet spark_catalog.default.catalog_page (54)
+            :           +- * HashAggregate (93)
+            :              +- Exchange (92)
+            :                 +- * HashAggregate (91)
+            :                    +- * Project (90)
+            :                       +- * BroadcastHashJoin Inner BuildRight (89)
+            :                          :- * Project (84)
+            :                          :  +- * BroadcastHashJoin Inner BuildRight (83)
+            :                          :     :- * Project (81)
+            :                          :     :  +- * BroadcastHashJoin Inner BuildRight (80)
+            :                          :     :     :- * Project (78)
+            :                          :     :     :  +- * BroadcastHashJoin Inner BuildRight (77)
+            :                          :     :     :     :- * Project (75)
+            :                          :     :     :     :  +- * SortMergeJoin LeftOuter (74)
+            :                          :     :     :     :     :- * Sort (67)
+            :                          :     :     :     :     :  +- Exchange (66)
+            :                          :     :     :     :     :     +- * Filter (65)
+            :                          :     :     :     :     :        +- * ColumnarToRow (64)
+            :                          :     :     :     :     :           +- Scan parquet spark_catalog.default.web_sales (63)
+            :                          :     :     :     :     +- * Sort (73)
+            :                          :     :     :     :        +- Exchange (72)
+            :                          :     :     :     :           +- * Project (71)
+            :                          :     :     :     :              +- * Filter (70)
+            :                          :     :     :     :                 +- * ColumnarToRow (69)
+            :                          :     :     :     :                    +- Scan parquet spark_catalog.default.web_returns (68)
+            :                          :     :     :     +- ReusedExchange (76)
+            :                          :     :     +- ReusedExchange (79)
+            :                          :     +- ReusedExchange (82)
+            :                          +- BroadcastExchange (88)
+            :                             +- * Filter (87)
+            :                                +- * ColumnarToRow (86)
+            :                                   +- Scan parquet spark_catalog.default.web_site (85)
+            :- * HashAggregate (132)
+            :  +- Exchange (131)
+            :     +- * HashAggregate (130)
+            :        +- * HashAggregate (129)
+            :           +- Exchange (128)
+            :              +- * HashAggregate (127)
+            :                 +- Union (126)
+            :                    :- * HashAggregate (99)
+            :                    :  +- ReusedExchange (98)
+            :                    :- * HashAggregate (101)
+            :                    :  +- ReusedExchange (100)
+            :                    +- * HashAggregate (125)
+            :                       +- Exchange (124)
+            :                          +- * HashAggregate (123)
+            :                             +- * Project (122)
+            :                                +- * BroadcastHashJoin Inner BuildRight (121)
+            :                                   :- * Project (119)
+            :                                   :  +- * BroadcastHashJoin Inner BuildRight (118)
+            :                                   :     :- * Project (116)
+            :                                   :     :  +- * BroadcastHashJoin Inner BuildRight (115)
+            :                                   :     :     :- * Project (113)
+            :                                   :     :     :  +- * BroadcastHashJoin Inner BuildRight (112)
+            :                                   :     :     :     :- * Project (110)
+            :                                   :     :     :     :  +- * SortMergeJoin LeftOuter (109)
+            :                                   :     :     :     :     :- * Sort (106)
+            :                                   :     :     :     :     :  +- Exchange (105)
+            :                                   :     :     :     :     :     +- * Filter (104)
+            :                                   :     :     :     :     :        +- * ColumnarToRow (103)
+            :                                   :     :     :     :     :           +- Scan parquet spark_catalog.default.web_sales (102)
+            :                                   :     :     :     :     +- * Sort (108)
+            :                                   :     :     :     :        +- ReusedExchange (107)
+            :                                   :     :     :     +- ReusedExchange (111)
+            :                                   :     :     +- ReusedExchange (114)
+            :                                   :     +- ReusedExchange (117)
+            :                                   +- ReusedExchange (120)
+            +- * HashAggregate (189)
+               +- Exchange (188)
+                  +- * HashAggregate (187)
+                     +- * HashAggregate (186)
+                        +- Exchange (185)
+                           +- * HashAggregate (184)
+                              +- Union (183)
+                                 :- * HashAggregate (156)
+                                 :  +- Exchange (155)
+                                 :     +- * HashAggregate (154)
+                                 :        +- * Project (153)
+                                 :           +- * BroadcastHashJoin Inner BuildRight (152)
+                                 :              :- * Project (150)
+                                 :              :  +- * BroadcastHashJoin Inner BuildRight (149)
+                                 :              :     :- * Project (147)
+                                 :              :     :  +- * BroadcastHashJoin Inner BuildRight (146)
+                                 :              :     :     :- * Project (144)
+                                 :              :     :     :  +- * BroadcastHashJoin Inner BuildRight (143)
+                                 :              :     :     :     :- * Project (141)
+                                 :              :     :     :     :  +- * SortMergeJoin LeftOuter (140)
+                                 :              :     :     :     :     :- * Sort (137)
+                                 :              :     :     :     :     :  +- Exchange (136)
+                                 :              :     :     :     :     :     +- * Filter (135)
+                                 :              :     :     :     :     :        +- * ColumnarToRow (134)
+                                 :              :     :     :     :     :           +- Scan parquet spark_catalog.default.store_sales (133)
+                                 :              :     :     :     :     +- * Sort (139)
+                                 :              :     :     :     :        +- ReusedExchange (138)
+                                 :              :     :     :     +- ReusedExchange (142)
+                                 :              :     :     +- ReusedExchange (145)
+                                 :              :     +- ReusedExchange (148)
+                                 :              +- ReusedExchange (151)
+                                 :- * HashAggregate (180)
+                                 :  +- Exchange (179)
+                                 :     +- * HashAggregate (178)
+                                 :        +- * Project (177)
+                                 :           +- * BroadcastHashJoin Inner BuildRight (176)
+                                 :              :- * Project (174)
+                                 :              :  +- * BroadcastHashJoin Inner BuildRight (173)
+                                 :              :     :- * Project (171)
+                                 :              :     :  +- * BroadcastHashJoin Inner BuildRight (170)
+                                 :              :     :     :- * Project (168)
+                                 :              :     :     :  +- * BroadcastHashJoin Inner BuildRight (167)
+                                 :              :     :     :     :- * Project (165)
+                                 :              :     :     :     :  +- * SortMergeJoin LeftOuter (164)
+                                 :              :     :     :     :     :- * Sort (161)
+                                 :              :     :     :     :     :  +- Exchange (160)
+                                 :              :     :     :     :     :     +- * Filter (159)
+                                 :              :     :     :     :     :        +- * ColumnarToRow (158)
+                                 :              :     :     :     :     :           +- Scan parquet spark_catalog.default.catalog_sales (157)
+                                 :              :     :     :     :     +- * Sort (163)
+                                 :              :     :     :     :        +- ReusedExchange (162)
+                                 :              :     :     :     +- ReusedExchange (166)
+                                 :              :     :     +- ReusedExchange (169)
+                                 :              :     +- ReusedExchange (172)
+                                 :              +- ReusedExchange (175)
+                                 +- * HashAggregate (182)
+                                    +- ReusedExchange (181)
 
 
 (1) Scan parquet spark_catalog.default.store_sales
@@ -216,7 +208,7 @@ Input [7]: [ss_item_sk#1, ss_store_sk#2, ss_promo_sk#3, ss_ticket_number#4, ss_e
 
 (3) Filter [codegen id : 1]
 Input [7]: [ss_item_sk#1, ss_store_sk#2, ss_promo_sk#3, ss_ticket_number#4, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7]
-Condition : ((((isnotnull(ss_store_sk#2) AND isnotnull(ss_item_sk#1)) AND isnotnull(ss_promo_sk#3)) AND might_contain(Subquery scalar-subquery#9, [id=#10], xxhash64(ss_item_sk#1, 42))) AND might_contain(Subquery scalar-subquery#11, [id=#12], xxhash64(ss_promo_sk#3, 42)))
+Condition : ((((isnotnull(ss_store_sk#2) AND isnotnull(ss_item_sk#1)) AND isnotnull(ss_promo_sk#3)) AND might_contain(runtimefilterexpression(Subquery scalar-subquery#9, [id=#10]), xxhash64(ss_item_sk#1, 42))) AND might_contain(runtimefilterexpression(Subquery scalar-subquery#11, [id=#12]), xxhash64(ss_promo_sk#3, 42)))
 
 (4) Exchange
 Input [7]: [ss_item_sk#1, ss_store_sk#2, ss_promo_sk#3, ss_ticket_number#4, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7]
@@ -262,1037 +254,1017 @@ Join condition: None
 Output [8]: [ss_item_sk#1, ss_store_sk#2, ss_promo_sk#3, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7, sr_return_amt#15, sr_net_loss#16]
 Input [11]: [ss_item_sk#1, ss_store_sk#2, ss_promo_sk#3, ss_ticket_number#4, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7, sr_item_sk#13, sr_ticket_number#14, sr_return_amt#15, sr_net_loss#16]
 
-(14) Scan parquet spark_catalog.default.item
-Output [2]: [i_item_sk#18, i_current_price#19]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/item]
-PushedFilters: [IsNotNull(i_current_price), GreaterThan(i_current_price,50.00), IsNotNull(i_item_sk)]
-ReadSchema: struct<i_item_sk:int,i_current_price:decimal(7,2)>
-
-(15) ColumnarToRow [codegen id : 5]
-Input [2]: [i_item_sk#18, i_current_price#19]
-
-(16) Filter [codegen id : 5]
-Input [2]: [i_item_sk#18, i_current_price#19]
-Condition : ((isnotnull(i_current_price#19) AND (i_current_price#19 > 50.00)) AND isnotnull(i_item_sk#18))
-
-(17) Project [codegen id : 5]
+(14) ReusedExchange [Reuses operator id: 199]
 Output [1]: [i_item_sk#18]
-Input [2]: [i_item_sk#18, i_current_price#19]
 
-(18) BroadcastExchange
-Input [1]: [i_item_sk#18]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=3]
-
-(19) BroadcastHashJoin [codegen id : 9]
+(15) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#18]
 Join type: Inner
 Join condition: None
 
-(20) Project [codegen id : 9]
+(16) Project [codegen id : 9]
 Output [7]: [ss_store_sk#2, ss_promo_sk#3, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7, sr_return_amt#15, sr_net_loss#16]
 Input [9]: [ss_item_sk#1, ss_store_sk#2, ss_promo_sk#3, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7, sr_return_amt#15, sr_net_loss#16, i_item_sk#18]
 
-(21) Scan parquet spark_catalog.default.promotion
-Output [2]: [p_promo_sk#20, p_channel_tv#21]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/promotion]
-PushedFilters: [IsNotNull(p_channel_tv), EqualTo(p_channel_tv,N), IsNotNull(p_promo_sk)]
-ReadSchema: struct<p_promo_sk:int,p_channel_tv:string>
+(17) ReusedExchange [Reuses operator id: 209]
+Output [1]: [p_promo_sk#19]
 
-(22) ColumnarToRow [codegen id : 6]
-Input [2]: [p_promo_sk#20, p_channel_tv#21]
-
-(23) Filter [codegen id : 6]
-Input [2]: [p_promo_sk#20, p_channel_tv#21]
-Condition : ((isnotnull(p_channel_tv#21) AND (p_channel_tv#21 = N)) AND isnotnull(p_promo_sk#20))
-
-(24) Project [codegen id : 6]
-Output [1]: [p_promo_sk#20]
-Input [2]: [p_promo_sk#20, p_channel_tv#21]
-
-(25) BroadcastExchange
-Input [1]: [p_promo_sk#20]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=4]
-
-(26) BroadcastHashJoin [codegen id : 9]
+(18) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_promo_sk#3]
-Right keys [1]: [p_promo_sk#20]
+Right keys [1]: [p_promo_sk#19]
 Join type: Inner
 Join condition: None
 
-(27) Project [codegen id : 9]
+(19) Project [codegen id : 9]
 Output [6]: [ss_store_sk#2, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7, sr_return_amt#15, sr_net_loss#16]
-Input [8]: [ss_store_sk#2, ss_promo_sk#3, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7, sr_return_amt#15, sr_net_loss#16, p_promo_sk#20]
+Input [8]: [ss_store_sk#2, ss_promo_sk#3, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7, sr_return_amt#15, sr_net_loss#16, p_promo_sk#19]
 
-(28) ReusedExchange [Reuses operator id: 221]
-Output [1]: [d_date_sk#22]
+(20) ReusedExchange [Reuses operator id: 219]
+Output [1]: [d_date_sk#20]
 
-(29) BroadcastHashJoin [codegen id : 9]
+(21) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_sold_date_sk#7]
-Right keys [1]: [d_date_sk#22]
+Right keys [1]: [d_date_sk#20]
 Join type: Inner
 Join condition: None
 
-(30) Project [codegen id : 9]
+(22) Project [codegen id : 9]
 Output [5]: [ss_store_sk#2, ss_ext_sales_price#5, ss_net_profit#6, sr_return_amt#15, sr_net_loss#16]
-Input [7]: [ss_store_sk#2, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7, sr_return_amt#15, sr_net_loss#16, d_date_sk#22]
+Input [7]: [ss_store_sk#2, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7, sr_return_amt#15, sr_net_loss#16, d_date_sk#20]
 
-(31) Scan parquet spark_catalog.default.store
-Output [2]: [s_store_sk#23, s_store_id#24]
+(23) Scan parquet spark_catalog.default.store
+Output [2]: [s_store_sk#21, s_store_id#22]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_store_sk)]
 ReadSchema: struct<s_store_sk:int,s_store_id:string>
 
-(32) ColumnarToRow [codegen id : 8]
-Input [2]: [s_store_sk#23, s_store_id#24]
+(24) ColumnarToRow [codegen id : 8]
+Input [2]: [s_store_sk#21, s_store_id#22]
 
-(33) Filter [codegen id : 8]
-Input [2]: [s_store_sk#23, s_store_id#24]
-Condition : isnotnull(s_store_sk#23)
+(25) Filter [codegen id : 8]
+Input [2]: [s_store_sk#21, s_store_id#22]
+Condition : isnotnull(s_store_sk#21)
 
-(34) BroadcastExchange
-Input [2]: [s_store_sk#23, s_store_id#24]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=5]
+(26) BroadcastExchange
+Input [2]: [s_store_sk#21, s_store_id#22]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=3]
 
-(35) BroadcastHashJoin [codegen id : 9]
+(27) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_store_sk#2]
-Right keys [1]: [s_store_sk#23]
+Right keys [1]: [s_store_sk#21]
 Join type: Inner
 Join condition: None
 
-(36) Project [codegen id : 9]
-Output [5]: [ss_ext_sales_price#5, ss_net_profit#6, sr_return_amt#15, sr_net_loss#16, s_store_id#24]
-Input [7]: [ss_store_sk#2, ss_ext_sales_price#5, ss_net_profit#6, sr_return_amt#15, sr_net_loss#16, s_store_sk#23, s_store_id#24]
+(28) Project [codegen id : 9]
+Output [5]: [ss_ext_sales_price#5, ss_net_profit#6, sr_return_amt#15, sr_net_loss#16, s_store_id#22]
+Input [7]: [ss_store_sk#2, ss_ext_sales_price#5, ss_net_profit#6, sr_return_amt#15, sr_net_loss#16, s_store_sk#21, s_store_id#22]
 
-(37) HashAggregate [codegen id : 9]
-Input [5]: [ss_ext_sales_price#5, ss_net_profit#6, sr_return_amt#15, sr_net_loss#16, s_store_id#24]
-Keys [1]: [s_store_id#24]
+(29) HashAggregate [codegen id : 9]
+Input [5]: [ss_ext_sales_price#5, ss_net_profit#6, sr_return_amt#15, sr_net_loss#16, s_store_id#22]
+Keys [1]: [s_store_id#22]
 Functions [3]: [partial_sum(UnscaledValue(ss_ext_sales_price#5)), partial_sum(coalesce(cast(sr_return_amt#15 as decimal(12,2)), 0.00)), partial_sum((ss_net_profit#6 - coalesce(cast(sr_net_loss#16 as decimal(12,2)), 0.00)))]
-Aggregate Attributes [5]: [sum#25, sum#26, isEmpty#27, sum#28, isEmpty#29]
-Results [6]: [s_store_id#24, sum#30, sum#31, isEmpty#32, sum#33, isEmpty#34]
+Aggregate Attributes [5]: [sum#23, sum#24, isEmpty#25, sum#26, isEmpty#27]
+Results [6]: [s_store_id#22, sum#28, sum#29, isEmpty#30, sum#31, isEmpty#32]
 
-(38) Exchange
-Input [6]: [s_store_id#24, sum#30, sum#31, isEmpty#32, sum#33, isEmpty#34]
-Arguments: hashpartitioning(s_store_id#24, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+(30) Exchange
+Input [6]: [s_store_id#22, sum#28, sum#29, isEmpty#30, sum#31, isEmpty#32]
+Arguments: hashpartitioning(s_store_id#22, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
-(39) HashAggregate [codegen id : 10]
-Input [6]: [s_store_id#24, sum#30, sum#31, isEmpty#32, sum#33, isEmpty#34]
-Keys [1]: [s_store_id#24]
+(31) HashAggregate [codegen id : 10]
+Input [6]: [s_store_id#22, sum#28, sum#29, isEmpty#30, sum#31, isEmpty#32]
+Keys [1]: [s_store_id#22]
 Functions [3]: [sum(UnscaledValue(ss_ext_sales_price#5)), sum(coalesce(cast(sr_return_amt#15 as decimal(12,2)), 0.00)), sum((ss_net_profit#6 - coalesce(cast(sr_net_loss#16 as decimal(12,2)), 0.00)))]
-Aggregate Attributes [3]: [sum(UnscaledValue(ss_ext_sales_price#5))#35, sum(coalesce(cast(sr_return_amt#15 as decimal(12,2)), 0.00))#36, sum((ss_net_profit#6 - coalesce(cast(sr_net_loss#16 as decimal(12,2)), 0.00)))#37]
-Results [5]: [store channel AS channel#38, concat(store, s_store_id#24) AS id#39, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#5))#35,17,2) AS sales#40, sum(coalesce(cast(sr_return_amt#15 as decimal(12,2)), 0.00))#36 AS returns#41, sum((ss_net_profit#6 - coalesce(cast(sr_net_loss#16 as decimal(12,2)), 0.00)))#37 AS profit#42]
+Aggregate Attributes [3]: [sum(UnscaledValue(ss_ext_sales_price#5))#33, sum(coalesce(cast(sr_return_amt#15 as decimal(12,2)), 0.00))#34, sum((ss_net_profit#6 - coalesce(cast(sr_net_loss#16 as decimal(12,2)), 0.00)))#35]
+Results [5]: [store channel AS channel#36, concat(store, s_store_id#22) AS id#37, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#5))#33,17,2) AS sales#38, sum(coalesce(cast(sr_return_amt#15 as decimal(12,2)), 0.00))#34 AS returns#39, sum((ss_net_profit#6 - coalesce(cast(sr_net_loss#16 as decimal(12,2)), 0.00)))#35 AS profit#40]
 
-(40) Scan parquet spark_catalog.default.catalog_sales
-Output [7]: [cs_catalog_page_sk#43, cs_item_sk#44, cs_promo_sk#45, cs_order_number#46, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49]
+(32) Scan parquet spark_catalog.default.catalog_sales
+Output [7]: [cs_catalog_page_sk#41, cs_item_sk#42, cs_promo_sk#43, cs_order_number#44, cs_ext_sales_price#45, cs_net_profit#46, cs_sold_date_sk#47]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#49), dynamicpruningexpression(cs_sold_date_sk#49 IN dynamicpruning#8)]
+PartitionFilters: [isnotnull(cs_sold_date_sk#47), dynamicpruningexpression(cs_sold_date_sk#47 IN dynamicpruning#8)]
 PushedFilters: [IsNotNull(cs_catalog_page_sk), IsNotNull(cs_item_sk), IsNotNull(cs_promo_sk)]
 ReadSchema: struct<cs_catalog_page_sk:int,cs_item_sk:int,cs_promo_sk:int,cs_order_number:int,cs_ext_sales_price:decimal(7,2),cs_net_profit:decimal(7,2)>
 
-(41) ColumnarToRow [codegen id : 11]
-Input [7]: [cs_catalog_page_sk#43, cs_item_sk#44, cs_promo_sk#45, cs_order_number#46, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49]
+(33) ColumnarToRow [codegen id : 11]
+Input [7]: [cs_catalog_page_sk#41, cs_item_sk#42, cs_promo_sk#43, cs_order_number#44, cs_ext_sales_price#45, cs_net_profit#46, cs_sold_date_sk#47]
 
-(42) Filter [codegen id : 11]
-Input [7]: [cs_catalog_page_sk#43, cs_item_sk#44, cs_promo_sk#45, cs_order_number#46, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49]
-Condition : ((((isnotnull(cs_catalog_page_sk#43) AND isnotnull(cs_item_sk#44)) AND isnotnull(cs_promo_sk#45)) AND might_contain(ReusedSubquery Subquery scalar-subquery#9, [id=#10], xxhash64(cs_item_sk#44, 42))) AND might_contain(ReusedSubquery Subquery scalar-subquery#11, [id=#12], xxhash64(cs_promo_sk#45, 42)))
+(34) Filter [codegen id : 11]
+Input [7]: [cs_catalog_page_sk#41, cs_item_sk#42, cs_promo_sk#43, cs_order_number#44, cs_ext_sales_price#45, cs_net_profit#46, cs_sold_date_sk#47]
+Condition : ((((isnotnull(cs_catalog_page_sk#41) AND isnotnull(cs_item_sk#42)) AND isnotnull(cs_promo_sk#43)) AND might_contain(runtimefilterexpression(ReusedSubquery Subquery scalar-subquery#9, [id=#10]), xxhash64(cs_item_sk#42, 42))) AND might_contain(runtimefilterexpression(ReusedSubquery Subquery scalar-subquery#11, [id=#12]), xxhash64(cs_promo_sk#43, 42)))
 
-(43) Exchange
-Input [7]: [cs_catalog_page_sk#43, cs_item_sk#44, cs_promo_sk#45, cs_order_number#46, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49]
-Arguments: hashpartitioning(cs_item_sk#44, cs_order_number#46, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+(35) Exchange
+Input [7]: [cs_catalog_page_sk#41, cs_item_sk#42, cs_promo_sk#43, cs_order_number#44, cs_ext_sales_price#45, cs_net_profit#46, cs_sold_date_sk#47]
+Arguments: hashpartitioning(cs_item_sk#42, cs_order_number#44, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
-(44) Sort [codegen id : 12]
-Input [7]: [cs_catalog_page_sk#43, cs_item_sk#44, cs_promo_sk#45, cs_order_number#46, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49]
-Arguments: [cs_item_sk#44 ASC NULLS FIRST, cs_order_number#46 ASC NULLS FIRST], false, 0
+(36) Sort [codegen id : 12]
+Input [7]: [cs_catalog_page_sk#41, cs_item_sk#42, cs_promo_sk#43, cs_order_number#44, cs_ext_sales_price#45, cs_net_profit#46, cs_sold_date_sk#47]
+Arguments: [cs_item_sk#42 ASC NULLS FIRST, cs_order_number#44 ASC NULLS FIRST], false, 0
 
-(45) Scan parquet spark_catalog.default.catalog_returns
-Output [5]: [cr_item_sk#50, cr_order_number#51, cr_return_amount#52, cr_net_loss#53, cr_returned_date_sk#54]
+(37) Scan parquet spark_catalog.default.catalog_returns
+Output [5]: [cr_item_sk#48, cr_order_number#49, cr_return_amount#50, cr_net_loss#51, cr_returned_date_sk#52]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/catalog_returns]
 PushedFilters: [IsNotNull(cr_item_sk), IsNotNull(cr_order_number)]
 ReadSchema: struct<cr_item_sk:int,cr_order_number:int,cr_return_amount:decimal(7,2),cr_net_loss:decimal(7,2)>
 
-(46) ColumnarToRow [codegen id : 13]
-Input [5]: [cr_item_sk#50, cr_order_number#51, cr_return_amount#52, cr_net_loss#53, cr_returned_date_sk#54]
+(38) ColumnarToRow [codegen id : 13]
+Input [5]: [cr_item_sk#48, cr_order_number#49, cr_return_amount#50, cr_net_loss#51, cr_returned_date_sk#52]
 
-(47) Filter [codegen id : 13]
-Input [5]: [cr_item_sk#50, cr_order_number#51, cr_return_amount#52, cr_net_loss#53, cr_returned_date_sk#54]
-Condition : (isnotnull(cr_item_sk#50) AND isnotnull(cr_order_number#51))
+(39) Filter [codegen id : 13]
+Input [5]: [cr_item_sk#48, cr_order_number#49, cr_return_amount#50, cr_net_loss#51, cr_returned_date_sk#52]
+Condition : (isnotnull(cr_item_sk#48) AND isnotnull(cr_order_number#49))
 
-(48) Project [codegen id : 13]
-Output [4]: [cr_item_sk#50, cr_order_number#51, cr_return_amount#52, cr_net_loss#53]
-Input [5]: [cr_item_sk#50, cr_order_number#51, cr_return_amount#52, cr_net_loss#53, cr_returned_date_sk#54]
+(40) Project [codegen id : 13]
+Output [4]: [cr_item_sk#48, cr_order_number#49, cr_return_amount#50, cr_net_loss#51]
+Input [5]: [cr_item_sk#48, cr_order_number#49, cr_return_amount#50, cr_net_loss#51, cr_returned_date_sk#52]
 
-(49) Exchange
-Input [4]: [cr_item_sk#50, cr_order_number#51, cr_return_amount#52, cr_net_loss#53]
-Arguments: hashpartitioning(cr_item_sk#50, cr_order_number#51, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+(41) Exchange
+Input [4]: [cr_item_sk#48, cr_order_number#49, cr_return_amount#50, cr_net_loss#51]
+Arguments: hashpartitioning(cr_item_sk#48, cr_order_number#49, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
-(50) Sort [codegen id : 14]
-Input [4]: [cr_item_sk#50, cr_order_number#51, cr_return_amount#52, cr_net_loss#53]
-Arguments: [cr_item_sk#50 ASC NULLS FIRST, cr_order_number#51 ASC NULLS FIRST], false, 0
+(42) Sort [codegen id : 14]
+Input [4]: [cr_item_sk#48, cr_order_number#49, cr_return_amount#50, cr_net_loss#51]
+Arguments: [cr_item_sk#48 ASC NULLS FIRST, cr_order_number#49 ASC NULLS FIRST], false, 0
 
-(51) SortMergeJoin [codegen id : 19]
-Left keys [2]: [cs_item_sk#44, cs_order_number#46]
-Right keys [2]: [cr_item_sk#50, cr_order_number#51]
+(43) SortMergeJoin [codegen id : 19]
+Left keys [2]: [cs_item_sk#42, cs_order_number#44]
+Right keys [2]: [cr_item_sk#48, cr_order_number#49]
 Join type: LeftOuter
 Join condition: None
 
-(52) Project [codegen id : 19]
-Output [8]: [cs_catalog_page_sk#43, cs_item_sk#44, cs_promo_sk#45, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49, cr_return_amount#52, cr_net_loss#53]
-Input [11]: [cs_catalog_page_sk#43, cs_item_sk#44, cs_promo_sk#45, cs_order_number#46, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49, cr_item_sk#50, cr_order_number#51, cr_return_amount#52, cr_net_loss#53]
+(44) Project [codegen id : 19]
+Output [8]: [cs_catalog_page_sk#41, cs_item_sk#42, cs_promo_sk#43, cs_ext_sales_price#45, cs_net_profit#46, cs_sold_date_sk#47, cr_return_amount#50, cr_net_loss#51]
+Input [11]: [cs_catalog_page_sk#41, cs_item_sk#42, cs_promo_sk#43, cs_order_number#44, cs_ext_sales_price#45, cs_net_profit#46, cs_sold_date_sk#47, cr_item_sk#48, cr_order_number#49, cr_return_amount#50, cr_net_loss#51]
 
-(53) ReusedExchange [Reuses operator id: 18]
-Output [1]: [i_item_sk#55]
+(45) ReusedExchange [Reuses operator id: 199]
+Output [1]: [i_item_sk#53]
 
-(54) BroadcastHashJoin [codegen id : 19]
-Left keys [1]: [cs_item_sk#44]
-Right keys [1]: [i_item_sk#55]
+(46) BroadcastHashJoin [codegen id : 19]
+Left keys [1]: [cs_item_sk#42]
+Right keys [1]: [i_item_sk#53]
 Join type: Inner
 Join condition: None
 
-(55) Project [codegen id : 19]
-Output [7]: [cs_catalog_page_sk#43, cs_promo_sk#45, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49, cr_return_amount#52, cr_net_loss#53]
-Input [9]: [cs_catalog_page_sk#43, cs_item_sk#44, cs_promo_sk#45, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49, cr_return_amount#52, cr_net_loss#53, i_item_sk#55]
+(47) Project [codegen id : 19]
+Output [7]: [cs_catalog_page_sk#41, cs_promo_sk#43, cs_ext_sales_price#45, cs_net_profit#46, cs_sold_date_sk#47, cr_return_amount#50, cr_net_loss#51]
+Input [9]: [cs_catalog_page_sk#41, cs_item_sk#42, cs_promo_sk#43, cs_ext_sales_price#45, cs_net_profit#46, cs_sold_date_sk#47, cr_return_amount#50, cr_net_loss#51, i_item_sk#53]
 
-(56) ReusedExchange [Reuses operator id: 25]
-Output [1]: [p_promo_sk#56]
+(48) ReusedExchange [Reuses operator id: 209]
+Output [1]: [p_promo_sk#54]
 
-(57) BroadcastHashJoin [codegen id : 19]
-Left keys [1]: [cs_promo_sk#45]
-Right keys [1]: [p_promo_sk#56]
+(49) BroadcastHashJoin [codegen id : 19]
+Left keys [1]: [cs_promo_sk#43]
+Right keys [1]: [p_promo_sk#54]
 Join type: Inner
 Join condition: None
 
-(58) Project [codegen id : 19]
-Output [6]: [cs_catalog_page_sk#43, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49, cr_return_amount#52, cr_net_loss#53]
-Input [8]: [cs_catalog_page_sk#43, cs_promo_sk#45, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49, cr_return_amount#52, cr_net_loss#53, p_promo_sk#56]
+(50) Project [codegen id : 19]
+Output [6]: [cs_catalog_page_sk#41, cs_ext_sales_price#45, cs_net_profit#46, cs_sold_date_sk#47, cr_return_amount#50, cr_net_loss#51]
+Input [8]: [cs_catalog_page_sk#41, cs_promo_sk#43, cs_ext_sales_price#45, cs_net_profit#46, cs_sold_date_sk#47, cr_return_amount#50, cr_net_loss#51, p_promo_sk#54]
 
-(59) ReusedExchange [Reuses operator id: 221]
-Output [1]: [d_date_sk#57]
+(51) ReusedExchange [Reuses operator id: 219]
+Output [1]: [d_date_sk#55]
 
-(60) BroadcastHashJoin [codegen id : 19]
-Left keys [1]: [cs_sold_date_sk#49]
-Right keys [1]: [d_date_sk#57]
+(52) BroadcastHashJoin [codegen id : 19]
+Left keys [1]: [cs_sold_date_sk#47]
+Right keys [1]: [d_date_sk#55]
 Join type: Inner
 Join condition: None
 
-(61) Project [codegen id : 19]
-Output [5]: [cs_catalog_page_sk#43, cs_ext_sales_price#47, cs_net_profit#48, cr_return_amount#52, cr_net_loss#53]
-Input [7]: [cs_catalog_page_sk#43, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49, cr_return_amount#52, cr_net_loss#53, d_date_sk#57]
+(53) Project [codegen id : 19]
+Output [5]: [cs_catalog_page_sk#41, cs_ext_sales_price#45, cs_net_profit#46, cr_return_amount#50, cr_net_loss#51]
+Input [7]: [cs_catalog_page_sk#41, cs_ext_sales_price#45, cs_net_profit#46, cs_sold_date_sk#47, cr_return_amount#50, cr_net_loss#51, d_date_sk#55]
 
-(62) Scan parquet spark_catalog.default.catalog_page
-Output [2]: [cp_catalog_page_sk#58, cp_catalog_page_id#59]
+(54) Scan parquet spark_catalog.default.catalog_page
+Output [2]: [cp_catalog_page_sk#56, cp_catalog_page_id#57]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/catalog_page]
 PushedFilters: [IsNotNull(cp_catalog_page_sk)]
 ReadSchema: struct<cp_catalog_page_sk:int,cp_catalog_page_id:string>
 
-(63) ColumnarToRow [codegen id : 18]
-Input [2]: [cp_catalog_page_sk#58, cp_catalog_page_id#59]
+(55) ColumnarToRow [codegen id : 18]
+Input [2]: [cp_catalog_page_sk#56, cp_catalog_page_id#57]
 
-(64) Filter [codegen id : 18]
-Input [2]: [cp_catalog_page_sk#58, cp_catalog_page_id#59]
-Condition : isnotnull(cp_catalog_page_sk#58)
+(56) Filter [codegen id : 18]
+Input [2]: [cp_catalog_page_sk#56, cp_catalog_page_id#57]
+Condition : isnotnull(cp_catalog_page_sk#56)
 
-(65) BroadcastExchange
-Input [2]: [cp_catalog_page_sk#58, cp_catalog_page_id#59]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=9]
+(57) BroadcastExchange
+Input [2]: [cp_catalog_page_sk#56, cp_catalog_page_id#57]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=7]
 
-(66) BroadcastHashJoin [codegen id : 19]
-Left keys [1]: [cs_catalog_page_sk#43]
-Right keys [1]: [cp_catalog_page_sk#58]
+(58) BroadcastHashJoin [codegen id : 19]
+Left keys [1]: [cs_catalog_page_sk#41]
+Right keys [1]: [cp_catalog_page_sk#56]
 Join type: Inner
 Join condition: None
 
-(67) Project [codegen id : 19]
-Output [5]: [cs_ext_sales_price#47, cs_net_profit#48, cr_return_amount#52, cr_net_loss#53, cp_catalog_page_id#59]
-Input [7]: [cs_catalog_page_sk#43, cs_ext_sales_price#47, cs_net_profit#48, cr_return_amount#52, cr_net_loss#53, cp_catalog_page_sk#58, cp_catalog_page_id#59]
+(59) Project [codegen id : 19]
+Output [5]: [cs_ext_sales_price#45, cs_net_profit#46, cr_return_amount#50, cr_net_loss#51, cp_catalog_page_id#57]
+Input [7]: [cs_catalog_page_sk#41, cs_ext_sales_price#45, cs_net_profit#46, cr_return_amount#50, cr_net_loss#51, cp_catalog_page_sk#56, cp_catalog_page_id#57]
 
-(68) HashAggregate [codegen id : 19]
-Input [5]: [cs_ext_sales_price#47, cs_net_profit#48, cr_return_amount#52, cr_net_loss#53, cp_catalog_page_id#59]
-Keys [1]: [cp_catalog_page_id#59]
-Functions [3]: [partial_sum(UnscaledValue(cs_ext_sales_price#47)), partial_sum(coalesce(cast(cr_return_amount#52 as decimal(12,2)), 0.00)), partial_sum((cs_net_profit#48 - coalesce(cast(cr_net_loss#53 as decimal(12,2)), 0.00)))]
-Aggregate Attributes [5]: [sum#60, sum#61, isEmpty#62, sum#63, isEmpty#64]
-Results [6]: [cp_catalog_page_id#59, sum#65, sum#66, isEmpty#67, sum#68, isEmpty#69]
+(60) HashAggregate [codegen id : 19]
+Input [5]: [cs_ext_sales_price#45, cs_net_profit#46, cr_return_amount#50, cr_net_loss#51, cp_catalog_page_id#57]
+Keys [1]: [cp_catalog_page_id#57]
+Functions [3]: [partial_sum(UnscaledValue(cs_ext_sales_price#45)), partial_sum(coalesce(cast(cr_return_amount#50 as decimal(12,2)), 0.00)), partial_sum((cs_net_profit#46 - coalesce(cast(cr_net_loss#51 as decimal(12,2)), 0.00)))]
+Aggregate Attributes [5]: [sum#58, sum#59, isEmpty#60, sum#61, isEmpty#62]
+Results [6]: [cp_catalog_page_id#57, sum#63, sum#64, isEmpty#65, sum#66, isEmpty#67]
 
-(69) Exchange
-Input [6]: [cp_catalog_page_id#59, sum#65, sum#66, isEmpty#67, sum#68, isEmpty#69]
-Arguments: hashpartitioning(cp_catalog_page_id#59, 5), ENSURE_REQUIREMENTS, [plan_id=10]
+(61) Exchange
+Input [6]: [cp_catalog_page_id#57, sum#63, sum#64, isEmpty#65, sum#66, isEmpty#67]
+Arguments: hashpartitioning(cp_catalog_page_id#57, 5), ENSURE_REQUIREMENTS, [plan_id=8]
 
-(70) HashAggregate [codegen id : 20]
-Input [6]: [cp_catalog_page_id#59, sum#65, sum#66, isEmpty#67, sum#68, isEmpty#69]
-Keys [1]: [cp_catalog_page_id#59]
-Functions [3]: [sum(UnscaledValue(cs_ext_sales_price#47)), sum(coalesce(cast(cr_return_amount#52 as decimal(12,2)), 0.00)), sum((cs_net_profit#48 - coalesce(cast(cr_net_loss#53 as decimal(12,2)), 0.00)))]
-Aggregate Attributes [3]: [sum(UnscaledValue(cs_ext_sales_price#47))#70, sum(coalesce(cast(cr_return_amount#52 as decimal(12,2)), 0.00))#71, sum((cs_net_profit#48 - coalesce(cast(cr_net_loss#53 as decimal(12,2)), 0.00)))#72]
-Results [5]: [catalog channel AS channel#73, concat(catalog_page, cp_catalog_page_id#59) AS id#74, MakeDecimal(sum(UnscaledValue(cs_ext_sales_price#47))#70,17,2) AS sales#75, sum(coalesce(cast(cr_return_amount#52 as decimal(12,2)), 0.00))#71 AS returns#76, sum((cs_net_profit#48 - coalesce(cast(cr_net_loss#53 as decimal(12,2)), 0.00)))#72 AS profit#77]
+(62) HashAggregate [codegen id : 20]
+Input [6]: [cp_catalog_page_id#57, sum#63, sum#64, isEmpty#65, sum#66, isEmpty#67]
+Keys [1]: [cp_catalog_page_id#57]
+Functions [3]: [sum(UnscaledValue(cs_ext_sales_price#45)), sum(coalesce(cast(cr_return_amount#50 as decimal(12,2)), 0.00)), sum((cs_net_profit#46 - coalesce(cast(cr_net_loss#51 as decimal(12,2)), 0.00)))]
+Aggregate Attributes [3]: [sum(UnscaledValue(cs_ext_sales_price#45))#68, sum(coalesce(cast(cr_return_amount#50 as decimal(12,2)), 0.00))#69, sum((cs_net_profit#46 - coalesce(cast(cr_net_loss#51 as decimal(12,2)), 0.00)))#70]
+Results [5]: [catalog channel AS channel#71, concat(catalog_page, cp_catalog_page_id#57) AS id#72, MakeDecimal(sum(UnscaledValue(cs_ext_sales_price#45))#68,17,2) AS sales#73, sum(coalesce(cast(cr_return_amount#50 as decimal(12,2)), 0.00))#69 AS returns#74, sum((cs_net_profit#46 - coalesce(cast(cr_net_loss#51 as decimal(12,2)), 0.00)))#70 AS profit#75]
 
-(71) Scan parquet spark_catalog.default.web_sales
-Output [7]: [ws_item_sk#78, ws_web_site_sk#79, ws_promo_sk#80, ws_order_number#81, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84]
+(63) Scan parquet spark_catalog.default.web_sales
+Output [7]: [ws_item_sk#76, ws_web_site_sk#77, ws_promo_sk#78, ws_order_number#79, ws_ext_sales_price#80, ws_net_profit#81, ws_sold_date_sk#82]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#84), dynamicpruningexpression(ws_sold_date_sk#84 IN dynamicpruning#8)]
+PartitionFilters: [isnotnull(ws_sold_date_sk#82), dynamicpruningexpression(ws_sold_date_sk#82 IN dynamicpruning#8)]
 PushedFilters: [IsNotNull(ws_web_site_sk), IsNotNull(ws_item_sk), IsNotNull(ws_promo_sk)]
 ReadSchema: struct<ws_item_sk:int,ws_web_site_sk:int,ws_promo_sk:int,ws_order_number:int,ws_ext_sales_price:decimal(7,2),ws_net_profit:decimal(7,2)>
 
-(72) ColumnarToRow [codegen id : 21]
-Input [7]: [ws_item_sk#78, ws_web_site_sk#79, ws_promo_sk#80, ws_order_number#81, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84]
+(64) ColumnarToRow [codegen id : 21]
+Input [7]: [ws_item_sk#76, ws_web_site_sk#77, ws_promo_sk#78, ws_order_number#79, ws_ext_sales_price#80, ws_net_profit#81, ws_sold_date_sk#82]
 
-(73) Filter [codegen id : 21]
-Input [7]: [ws_item_sk#78, ws_web_site_sk#79, ws_promo_sk#80, ws_order_number#81, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84]
-Condition : ((((isnotnull(ws_web_site_sk#79) AND isnotnull(ws_item_sk#78)) AND isnotnull(ws_promo_sk#80)) AND might_contain(ReusedSubquery Subquery scalar-subquery#9, [id=#10], xxhash64(ws_item_sk#78, 42))) AND might_contain(ReusedSubquery Subquery scalar-subquery#11, [id=#12], xxhash64(ws_promo_sk#80, 42)))
+(65) Filter [codegen id : 21]
+Input [7]: [ws_item_sk#76, ws_web_site_sk#77, ws_promo_sk#78, ws_order_number#79, ws_ext_sales_price#80, ws_net_profit#81, ws_sold_date_sk#82]
+Condition : ((((isnotnull(ws_web_site_sk#77) AND isnotnull(ws_item_sk#76)) AND isnotnull(ws_promo_sk#78)) AND might_contain(runtimefilterexpression(ReusedSubquery Subquery scalar-subquery#9, [id=#10]), xxhash64(ws_item_sk#76, 42))) AND might_contain(runtimefilterexpression(ReusedSubquery Subquery scalar-subquery#11, [id=#12]), xxhash64(ws_promo_sk#78, 42)))
 
-(74) Exchange
-Input [7]: [ws_item_sk#78, ws_web_site_sk#79, ws_promo_sk#80, ws_order_number#81, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84]
-Arguments: hashpartitioning(ws_item_sk#78, ws_order_number#81, 5), ENSURE_REQUIREMENTS, [plan_id=11]
+(66) Exchange
+Input [7]: [ws_item_sk#76, ws_web_site_sk#77, ws_promo_sk#78, ws_order_number#79, ws_ext_sales_price#80, ws_net_profit#81, ws_sold_date_sk#82]
+Arguments: hashpartitioning(ws_item_sk#76, ws_order_number#79, 5), ENSURE_REQUIREMENTS, [plan_id=9]
 
-(75) Sort [codegen id : 22]
-Input [7]: [ws_item_sk#78, ws_web_site_sk#79, ws_promo_sk#80, ws_order_number#81, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84]
-Arguments: [ws_item_sk#78 ASC NULLS FIRST, ws_order_number#81 ASC NULLS FIRST], false, 0
+(67) Sort [codegen id : 22]
+Input [7]: [ws_item_sk#76, ws_web_site_sk#77, ws_promo_sk#78, ws_order_number#79, ws_ext_sales_price#80, ws_net_profit#81, ws_sold_date_sk#82]
+Arguments: [ws_item_sk#76 ASC NULLS FIRST, ws_order_number#79 ASC NULLS FIRST], false, 0
 
-(76) Scan parquet spark_catalog.default.web_returns
-Output [5]: [wr_item_sk#85, wr_order_number#86, wr_return_amt#87, wr_net_loss#88, wr_returned_date_sk#89]
+(68) Scan parquet spark_catalog.default.web_returns
+Output [5]: [wr_item_sk#83, wr_order_number#84, wr_return_amt#85, wr_net_loss#86, wr_returned_date_sk#87]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/web_returns]
 PushedFilters: [IsNotNull(wr_item_sk), IsNotNull(wr_order_number)]
 ReadSchema: struct<wr_item_sk:int,wr_order_number:int,wr_return_amt:decimal(7,2),wr_net_loss:decimal(7,2)>
 
-(77) ColumnarToRow [codegen id : 23]
-Input [5]: [wr_item_sk#85, wr_order_number#86, wr_return_amt#87, wr_net_loss#88, wr_returned_date_sk#89]
+(69) ColumnarToRow [codegen id : 23]
+Input [5]: [wr_item_sk#83, wr_order_number#84, wr_return_amt#85, wr_net_loss#86, wr_returned_date_sk#87]
 
-(78) Filter [codegen id : 23]
-Input [5]: [wr_item_sk#85, wr_order_number#86, wr_return_amt#87, wr_net_loss#88, wr_returned_date_sk#89]
-Condition : (isnotnull(wr_item_sk#85) AND isnotnull(wr_order_number#86))
+(70) Filter [codegen id : 23]
+Input [5]: [wr_item_sk#83, wr_order_number#84, wr_return_amt#85, wr_net_loss#86, wr_returned_date_sk#87]
+Condition : (isnotnull(wr_item_sk#83) AND isnotnull(wr_order_number#84))
 
-(79) Project [codegen id : 23]
-Output [4]: [wr_item_sk#85, wr_order_number#86, wr_return_amt#87, wr_net_loss#88]
-Input [5]: [wr_item_sk#85, wr_order_number#86, wr_return_amt#87, wr_net_loss#88, wr_returned_date_sk#89]
+(71) Project [codegen id : 23]
+Output [4]: [wr_item_sk#83, wr_order_number#84, wr_return_amt#85, wr_net_loss#86]
+Input [5]: [wr_item_sk#83, wr_order_number#84, wr_return_amt#85, wr_net_loss#86, wr_returned_date_sk#87]
 
-(80) Exchange
-Input [4]: [wr_item_sk#85, wr_order_number#86, wr_return_amt#87, wr_net_loss#88]
-Arguments: hashpartitioning(wr_item_sk#85, wr_order_number#86, 5), ENSURE_REQUIREMENTS, [plan_id=12]
+(72) Exchange
+Input [4]: [wr_item_sk#83, wr_order_number#84, wr_return_amt#85, wr_net_loss#86]
+Arguments: hashpartitioning(wr_item_sk#83, wr_order_number#84, 5), ENSURE_REQUIREMENTS, [plan_id=10]
 
-(81) Sort [codegen id : 24]
-Input [4]: [wr_item_sk#85, wr_order_number#86, wr_return_amt#87, wr_net_loss#88]
-Arguments: [wr_item_sk#85 ASC NULLS FIRST, wr_order_number#86 ASC NULLS FIRST], false, 0
+(73) Sort [codegen id : 24]
+Input [4]: [wr_item_sk#83, wr_order_number#84, wr_return_amt#85, wr_net_loss#86]
+Arguments: [wr_item_sk#83 ASC NULLS FIRST, wr_order_number#84 ASC NULLS FIRST], false, 0
 
-(82) SortMergeJoin [codegen id : 29]
-Left keys [2]: [ws_item_sk#78, ws_order_number#81]
-Right keys [2]: [wr_item_sk#85, wr_order_number#86]
+(74) SortMergeJoin [codegen id : 29]
+Left keys [2]: [ws_item_sk#76, ws_order_number#79]
+Right keys [2]: [wr_item_sk#83, wr_order_number#84]
 Join type: LeftOuter
 Join condition: None
 
-(83) Project [codegen id : 29]
-Output [8]: [ws_item_sk#78, ws_web_site_sk#79, ws_promo_sk#80, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84, wr_return_amt#87, wr_net_loss#88]
-Input [11]: [ws_item_sk#78, ws_web_site_sk#79, ws_promo_sk#80, ws_order_number#81, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84, wr_item_sk#85, wr_order_number#86, wr_return_amt#87, wr_net_loss#88]
+(75) Project [codegen id : 29]
+Output [8]: [ws_item_sk#76, ws_web_site_sk#77, ws_promo_sk#78, ws_ext_sales_price#80, ws_net_profit#81, ws_sold_date_sk#82, wr_return_amt#85, wr_net_loss#86]
+Input [11]: [ws_item_sk#76, ws_web_site_sk#77, ws_promo_sk#78, ws_order_number#79, ws_ext_sales_price#80, ws_net_profit#81, ws_sold_date_sk#82, wr_item_sk#83, wr_order_number#84, wr_return_amt#85, wr_net_loss#86]
 
-(84) ReusedExchange [Reuses operator id: 18]
-Output [1]: [i_item_sk#90]
+(76) ReusedExchange [Reuses operator id: 199]
+Output [1]: [i_item_sk#88]
 
-(85) BroadcastHashJoin [codegen id : 29]
-Left keys [1]: [ws_item_sk#78]
-Right keys [1]: [i_item_sk#90]
+(77) BroadcastHashJoin [codegen id : 29]
+Left keys [1]: [ws_item_sk#76]
+Right keys [1]: [i_item_sk#88]
 Join type: Inner
 Join condition: None
 
-(86) Project [codegen id : 29]
-Output [7]: [ws_web_site_sk#79, ws_promo_sk#80, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84, wr_return_amt#87, wr_net_loss#88]
-Input [9]: [ws_item_sk#78, ws_web_site_sk#79, ws_promo_sk#80, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84, wr_return_amt#87, wr_net_loss#88, i_item_sk#90]
+(78) Project [codegen id : 29]
+Output [7]: [ws_web_site_sk#77, ws_promo_sk#78, ws_ext_sales_price#80, ws_net_profit#81, ws_sold_date_sk#82, wr_return_amt#85, wr_net_loss#86]
+Input [9]: [ws_item_sk#76, ws_web_site_sk#77, ws_promo_sk#78, ws_ext_sales_price#80, ws_net_profit#81, ws_sold_date_sk#82, wr_return_amt#85, wr_net_loss#86, i_item_sk#88]
 
-(87) ReusedExchange [Reuses operator id: 25]
-Output [1]: [p_promo_sk#91]
+(79) ReusedExchange [Reuses operator id: 209]
+Output [1]: [p_promo_sk#89]
 
-(88) BroadcastHashJoin [codegen id : 29]
-Left keys [1]: [ws_promo_sk#80]
-Right keys [1]: [p_promo_sk#91]
+(80) BroadcastHashJoin [codegen id : 29]
+Left keys [1]: [ws_promo_sk#78]
+Right keys [1]: [p_promo_sk#89]
 Join type: Inner
 Join condition: None
 
-(89) Project [codegen id : 29]
-Output [6]: [ws_web_site_sk#79, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84, wr_return_amt#87, wr_net_loss#88]
-Input [8]: [ws_web_site_sk#79, ws_promo_sk#80, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84, wr_return_amt#87, wr_net_loss#88, p_promo_sk#91]
+(81) Project [codegen id : 29]
+Output [6]: [ws_web_site_sk#77, ws_ext_sales_price#80, ws_net_profit#81, ws_sold_date_sk#82, wr_return_amt#85, wr_net_loss#86]
+Input [8]: [ws_web_site_sk#77, ws_promo_sk#78, ws_ext_sales_price#80, ws_net_profit#81, ws_sold_date_sk#82, wr_return_amt#85, wr_net_loss#86, p_promo_sk#89]
 
-(90) ReusedExchange [Reuses operator id: 221]
-Output [1]: [d_date_sk#92]
+(82) ReusedExchange [Reuses operator id: 219]
+Output [1]: [d_date_sk#90]
 
-(91) BroadcastHashJoin [codegen id : 29]
-Left keys [1]: [ws_sold_date_sk#84]
-Right keys [1]: [d_date_sk#92]
+(83) BroadcastHashJoin [codegen id : 29]
+Left keys [1]: [ws_sold_date_sk#82]
+Right keys [1]: [d_date_sk#90]
 Join type: Inner
 Join condition: None
 
-(92) Project [codegen id : 29]
-Output [5]: [ws_web_site_sk#79, ws_ext_sales_price#82, ws_net_profit#83, wr_return_amt#87, wr_net_loss#88]
-Input [7]: [ws_web_site_sk#79, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84, wr_return_amt#87, wr_net_loss#88, d_date_sk#92]
+(84) Project [codegen id : 29]
+Output [5]: [ws_web_site_sk#77, ws_ext_sales_price#80, ws_net_profit#81, wr_return_amt#85, wr_net_loss#86]
+Input [7]: [ws_web_site_sk#77, ws_ext_sales_price#80, ws_net_profit#81, ws_sold_date_sk#82, wr_return_amt#85, wr_net_loss#86, d_date_sk#90]
 
-(93) Scan parquet spark_catalog.default.web_site
-Output [2]: [web_site_sk#93, web_site_id#94]
+(85) Scan parquet spark_catalog.default.web_site
+Output [2]: [web_site_sk#91, web_site_id#92]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/web_site]
 PushedFilters: [IsNotNull(web_site_sk)]
 ReadSchema: struct<web_site_sk:int,web_site_id:string>
 
-(94) ColumnarToRow [codegen id : 28]
-Input [2]: [web_site_sk#93, web_site_id#94]
+(86) ColumnarToRow [codegen id : 28]
+Input [2]: [web_site_sk#91, web_site_id#92]
 
-(95) Filter [codegen id : 28]
-Input [2]: [web_site_sk#93, web_site_id#94]
-Condition : isnotnull(web_site_sk#93)
+(87) Filter [codegen id : 28]
+Input [2]: [web_site_sk#91, web_site_id#92]
+Condition : isnotnull(web_site_sk#91)
 
-(96) BroadcastExchange
-Input [2]: [web_site_sk#93, web_site_id#94]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=13]
+(88) BroadcastExchange
+Input [2]: [web_site_sk#91, web_site_id#92]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=11]
 
-(97) BroadcastHashJoin [codegen id : 29]
-Left keys [1]: [ws_web_site_sk#79]
-Right keys [1]: [web_site_sk#93]
+(89) BroadcastHashJoin [codegen id : 29]
+Left keys [1]: [ws_web_site_sk#77]
+Right keys [1]: [web_site_sk#91]
 Join type: Inner
 Join condition: None
 
-(98) Project [codegen id : 29]
-Output [5]: [ws_ext_sales_price#82, ws_net_profit#83, wr_return_amt#87, wr_net_loss#88, web_site_id#94]
-Input [7]: [ws_web_site_sk#79, ws_ext_sales_price#82, ws_net_profit#83, wr_return_amt#87, wr_net_loss#88, web_site_sk#93, web_site_id#94]
+(90) Project [codegen id : 29]
+Output [5]: [ws_ext_sales_price#80, ws_net_profit#81, wr_return_amt#85, wr_net_loss#86, web_site_id#92]
+Input [7]: [ws_web_site_sk#77, ws_ext_sales_price#80, ws_net_profit#81, wr_return_amt#85, wr_net_loss#86, web_site_sk#91, web_site_id#92]
 
-(99) HashAggregate [codegen id : 29]
-Input [5]: [ws_ext_sales_price#82, ws_net_profit#83, wr_return_amt#87, wr_net_loss#88, web_site_id#94]
-Keys [1]: [web_site_id#94]
-Functions [3]: [partial_sum(UnscaledValue(ws_ext_sales_price#82)), partial_sum(coalesce(cast(wr_return_amt#87 as decimal(12,2)), 0.00)), partial_sum((ws_net_profit#83 - coalesce(cast(wr_net_loss#88 as decimal(12,2)), 0.00)))]
-Aggregate Attributes [5]: [sum#95, sum#96, isEmpty#97, sum#98, isEmpty#99]
-Results [6]: [web_site_id#94, sum#100, sum#101, isEmpty#102, sum#103, isEmpty#104]
+(91) HashAggregate [codegen id : 29]
+Input [5]: [ws_ext_sales_price#80, ws_net_profit#81, wr_return_amt#85, wr_net_loss#86, web_site_id#92]
+Keys [1]: [web_site_id#92]
+Functions [3]: [partial_sum(UnscaledValue(ws_ext_sales_price#80)), partial_sum(coalesce(cast(wr_return_amt#85 as decimal(12,2)), 0.00)), partial_sum((ws_net_profit#81 - coalesce(cast(wr_net_loss#86 as decimal(12,2)), 0.00)))]
+Aggregate Attributes [5]: [sum#93, sum#94, isEmpty#95, sum#96, isEmpty#97]
+Results [6]: [web_site_id#92, sum#98, sum#99, isEmpty#100, sum#101, isEmpty#102]
 
-(100) Exchange
-Input [6]: [web_site_id#94, sum#100, sum#101, isEmpty#102, sum#103, isEmpty#104]
-Arguments: hashpartitioning(web_site_id#94, 5), ENSURE_REQUIREMENTS, [plan_id=14]
+(92) Exchange
+Input [6]: [web_site_id#92, sum#98, sum#99, isEmpty#100, sum#101, isEmpty#102]
+Arguments: hashpartitioning(web_site_id#92, 5), ENSURE_REQUIREMENTS, [plan_id=12]
 
-(101) HashAggregate [codegen id : 30]
-Input [6]: [web_site_id#94, sum#100, sum#101, isEmpty#102, sum#103, isEmpty#104]
-Keys [1]: [web_site_id#94]
-Functions [3]: [sum(UnscaledValue(ws_ext_sales_price#82)), sum(coalesce(cast(wr_return_amt#87 as decimal(12,2)), 0.00)), sum((ws_net_profit#83 - coalesce(cast(wr_net_loss#88 as decimal(12,2)), 0.00)))]
-Aggregate Attributes [3]: [sum(UnscaledValue(ws_ext_sales_price#82))#105, sum(coalesce(cast(wr_return_amt#87 as decimal(12,2)), 0.00))#106, sum((ws_net_profit#83 - coalesce(cast(wr_net_loss#88 as decimal(12,2)), 0.00)))#107]
-Results [5]: [web channel AS channel#108, concat(web_site, web_site_id#94) AS id#109, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#82))#105,17,2) AS sales#110, sum(coalesce(cast(wr_return_amt#87 as decimal(12,2)), 0.00))#106 AS returns#111, sum((ws_net_profit#83 - coalesce(cast(wr_net_loss#88 as decimal(12,2)), 0.00)))#107 AS profit#112]
+(93) HashAggregate [codegen id : 30]
+Input [6]: [web_site_id#92, sum#98, sum#99, isEmpty#100, sum#101, isEmpty#102]
+Keys [1]: [web_site_id#92]
+Functions [3]: [sum(UnscaledValue(ws_ext_sales_price#80)), sum(coalesce(cast(wr_return_amt#85 as decimal(12,2)), 0.00)), sum((ws_net_profit#81 - coalesce(cast(wr_net_loss#86 as decimal(12,2)), 0.00)))]
+Aggregate Attributes [3]: [sum(UnscaledValue(ws_ext_sales_price#80))#103, sum(coalesce(cast(wr_return_amt#85 as decimal(12,2)), 0.00))#104, sum((ws_net_profit#81 - coalesce(cast(wr_net_loss#86 as decimal(12,2)), 0.00)))#105]
+Results [5]: [web channel AS channel#106, concat(web_site, web_site_id#92) AS id#107, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#80))#103,17,2) AS sales#108, sum(coalesce(cast(wr_return_amt#85 as decimal(12,2)), 0.00))#104 AS returns#109, sum((ws_net_profit#81 - coalesce(cast(wr_net_loss#86 as decimal(12,2)), 0.00)))#105 AS profit#110]
 
-(102) Union
+(94) Union
 
-(103) HashAggregate [codegen id : 31]
-Input [5]: [channel#38, id#39, sales#40, returns#41, profit#42]
-Keys [2]: [channel#38, id#39]
-Functions [3]: [partial_sum(sales#40), partial_sum(returns#41), partial_sum(profit#42)]
-Aggregate Attributes [6]: [sum#113, isEmpty#114, sum#115, isEmpty#116, sum#117, isEmpty#118]
-Results [8]: [channel#38, id#39, sum#119, isEmpty#120, sum#121, isEmpty#122, sum#123, isEmpty#124]
+(95) HashAggregate [codegen id : 31]
+Input [5]: [channel#36, id#37, sales#38, returns#39, profit#40]
+Keys [2]: [channel#36, id#37]
+Functions [3]: [partial_sum(sales#38), partial_sum(returns#39), partial_sum(profit#40)]
+Aggregate Attributes [6]: [sum#111, isEmpty#112, sum#113, isEmpty#114, sum#115, isEmpty#116]
+Results [8]: [channel#36, id#37, sum#117, isEmpty#118, sum#119, isEmpty#120, sum#121, isEmpty#122]
 
-(104) Exchange
-Input [8]: [channel#38, id#39, sum#119, isEmpty#120, sum#121, isEmpty#122, sum#123, isEmpty#124]
-Arguments: hashpartitioning(channel#38, id#39, 5), ENSURE_REQUIREMENTS, [plan_id=15]
+(96) Exchange
+Input [8]: [channel#36, id#37, sum#117, isEmpty#118, sum#119, isEmpty#120, sum#121, isEmpty#122]
+Arguments: hashpartitioning(channel#36, id#37, 5), ENSURE_REQUIREMENTS, [plan_id=13]
 
-(105) HashAggregate [codegen id : 32]
-Input [8]: [channel#38, id#39, sum#119, isEmpty#120, sum#121, isEmpty#122, sum#123, isEmpty#124]
-Keys [2]: [channel#38, id#39]
-Functions [3]: [sum(sales#40), sum(returns#41), sum(profit#42)]
-Aggregate Attributes [3]: [sum(sales#40)#125, sum(returns#41)#126, sum(profit#42)#127]
-Results [5]: [channel#38, id#39, cast(sum(sales#40)#125 as decimal(37,2)) AS sales#128, cast(sum(returns#41)#126 as decimal(38,2)) AS returns#129, cast(sum(profit#42)#127 as decimal(38,2)) AS profit#130]
+(97) HashAggregate [codegen id : 32]
+Input [8]: [channel#36, id#37, sum#117, isEmpty#118, sum#119, isEmpty#120, sum#121, isEmpty#122]
+Keys [2]: [channel#36, id#37]
+Functions [3]: [sum(sales#38), sum(returns#39), sum(profit#40)]
+Aggregate Attributes [3]: [sum(sales#38)#123, sum(returns#39)#124, sum(profit#40)#125]
+Results [5]: [channel#36, id#37, cast(sum(sales#38)#123 as decimal(37,2)) AS sales#126, cast(sum(returns#39)#124 as decimal(38,2)) AS returns#127, cast(sum(profit#40)#125 as decimal(38,2)) AS profit#128]
 
-(106) ReusedExchange [Reuses operator id: 38]
-Output [6]: [s_store_id#131, sum#132, sum#133, isEmpty#134, sum#135, isEmpty#136]
+(98) ReusedExchange [Reuses operator id: 30]
+Output [6]: [s_store_id#129, sum#130, sum#131, isEmpty#132, sum#133, isEmpty#134]
 
-(107) HashAggregate [codegen id : 42]
-Input [6]: [s_store_id#131, sum#132, sum#133, isEmpty#134, sum#135, isEmpty#136]
-Keys [1]: [s_store_id#131]
-Functions [3]: [sum(UnscaledValue(ss_ext_sales_price#137)), sum(coalesce(cast(sr_return_amt#138 as decimal(12,2)), 0.00)), sum((ss_net_profit#139 - coalesce(cast(sr_net_loss#140 as decimal(12,2)), 0.00)))]
-Aggregate Attributes [3]: [sum(UnscaledValue(ss_ext_sales_price#137))#35, sum(coalesce(cast(sr_return_amt#138 as decimal(12,2)), 0.00))#36, sum((ss_net_profit#139 - coalesce(cast(sr_net_loss#140 as decimal(12,2)), 0.00)))#37]
-Results [5]: [store channel AS channel#141, concat(store, s_store_id#131) AS id#142, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#137))#35,17,2) AS sales#143, sum(coalesce(cast(sr_return_amt#138 as decimal(12,2)), 0.00))#36 AS returns#144, sum((ss_net_profit#139 - coalesce(cast(sr_net_loss#140 as decimal(12,2)), 0.00)))#37 AS profit#145]
+(99) HashAggregate [codegen id : 42]
+Input [6]: [s_store_id#129, sum#130, sum#131, isEmpty#132, sum#133, isEmpty#134]
+Keys [1]: [s_store_id#129]
+Functions [3]: [sum(UnscaledValue(ss_ext_sales_price#135)), sum(coalesce(cast(sr_return_amt#136 as decimal(12,2)), 0.00)), sum((ss_net_profit#137 - coalesce(cast(sr_net_loss#138 as decimal(12,2)), 0.00)))]
+Aggregate Attributes [3]: [sum(UnscaledValue(ss_ext_sales_price#135))#33, sum(coalesce(cast(sr_return_amt#136 as decimal(12,2)), 0.00))#34, sum((ss_net_profit#137 - coalesce(cast(sr_net_loss#138 as decimal(12,2)), 0.00)))#35]
+Results [5]: [store channel AS channel#139, concat(store, s_store_id#129) AS id#140, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#135))#33,17,2) AS sales#141, sum(coalesce(cast(sr_return_amt#136 as decimal(12,2)), 0.00))#34 AS returns#142, sum((ss_net_profit#137 - coalesce(cast(sr_net_loss#138 as decimal(12,2)), 0.00)))#35 AS profit#143]
 
-(108) ReusedExchange [Reuses operator id: 69]
-Output [6]: [cp_catalog_page_id#146, sum#147, sum#148, isEmpty#149, sum#150, isEmpty#151]
+(100) ReusedExchange [Reuses operator id: 61]
+Output [6]: [cp_catalog_page_id#144, sum#145, sum#146, isEmpty#147, sum#148, isEmpty#149]
 
-(109) HashAggregate [codegen id : 52]
-Input [6]: [cp_catalog_page_id#146, sum#147, sum#148, isEmpty#149, sum#150, isEmpty#151]
-Keys [1]: [cp_catalog_page_id#146]
-Functions [3]: [sum(UnscaledValue(cs_ext_sales_price#152)), sum(coalesce(cast(cr_return_amount#153 as decimal(12,2)), 0.00)), sum((cs_net_profit#154 - coalesce(cast(cr_net_loss#155 as decimal(12,2)), 0.00)))]
-Aggregate Attributes [3]: [sum(UnscaledValue(cs_ext_sales_price#152))#70, sum(coalesce(cast(cr_return_amount#153 as decimal(12,2)), 0.00))#71, sum((cs_net_profit#154 - coalesce(cast(cr_net_loss#155 as decimal(12,2)), 0.00)))#72]
-Results [5]: [catalog channel AS channel#156, concat(catalog_page, cp_catalog_page_id#146) AS id#157, MakeDecimal(sum(UnscaledValue(cs_ext_sales_price#152))#70,17,2) AS sales#158, sum(coalesce(cast(cr_return_amount#153 as decimal(12,2)), 0.00))#71 AS returns#159, sum((cs_net_profit#154 - coalesce(cast(cr_net_loss#155 as decimal(12,2)), 0.00)))#72 AS profit#160]
+(101) HashAggregate [codegen id : 52]
+Input [6]: [cp_catalog_page_id#144, sum#145, sum#146, isEmpty#147, sum#148, isEmpty#149]
+Keys [1]: [cp_catalog_page_id#144]
+Functions [3]: [sum(UnscaledValue(cs_ext_sales_price#150)), sum(coalesce(cast(cr_return_amount#151 as decimal(12,2)), 0.00)), sum((cs_net_profit#152 - coalesce(cast(cr_net_loss#153 as decimal(12,2)), 0.00)))]
+Aggregate Attributes [3]: [sum(UnscaledValue(cs_ext_sales_price#150))#68, sum(coalesce(cast(cr_return_amount#151 as decimal(12,2)), 0.00))#69, sum((cs_net_profit#152 - coalesce(cast(cr_net_loss#153 as decimal(12,2)), 0.00)))#70]
+Results [5]: [catalog channel AS channel#154, concat(catalog_page, cp_catalog_page_id#144) AS id#155, MakeDecimal(sum(UnscaledValue(cs_ext_sales_price#150))#68,17,2) AS sales#156, sum(coalesce(cast(cr_return_amount#151 as decimal(12,2)), 0.00))#69 AS returns#157, sum((cs_net_profit#152 - coalesce(cast(cr_net_loss#153 as decimal(12,2)), 0.00)))#70 AS profit#158]
 
-(110) Scan parquet spark_catalog.default.web_sales
-Output [7]: [ws_item_sk#161, ws_web_site_sk#162, ws_promo_sk#163, ws_order_number#164, ws_ext_sales_price#165, ws_net_profit#166, ws_sold_date_sk#167]
+(102) Scan parquet spark_catalog.default.web_sales
+Output [7]: [ws_item_sk#159, ws_web_site_sk#160, ws_promo_sk#161, ws_order_number#162, ws_ext_sales_price#163, ws_net_profit#164, ws_sold_date_sk#165]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#167), dynamicpruningexpression(ws_sold_date_sk#167 IN dynamicpruning#8)]
+PartitionFilters: [isnotnull(ws_sold_date_sk#165), dynamicpruningexpression(ws_sold_date_sk#165 IN dynamicpruning#8)]
 PushedFilters: [IsNotNull(ws_web_site_sk), IsNotNull(ws_item_sk), IsNotNull(ws_promo_sk)]
 ReadSchema: struct<ws_item_sk:int,ws_web_site_sk:int,ws_promo_sk:int,ws_order_number:int,ws_ext_sales_price:decimal(7,2),ws_net_profit:decimal(7,2)>
 
-(111) ColumnarToRow [codegen id : 53]
-Input [7]: [ws_item_sk#161, ws_web_site_sk#162, ws_promo_sk#163, ws_order_number#164, ws_ext_sales_price#165, ws_net_profit#166, ws_sold_date_sk#167]
+(103) ColumnarToRow [codegen id : 53]
+Input [7]: [ws_item_sk#159, ws_web_site_sk#160, ws_promo_sk#161, ws_order_number#162, ws_ext_sales_price#163, ws_net_profit#164, ws_sold_date_sk#165]
 
-(112) Filter [codegen id : 53]
-Input [7]: [ws_item_sk#161, ws_web_site_sk#162, ws_promo_sk#163, ws_order_number#164, ws_ext_sales_price#165, ws_net_profit#166, ws_sold_date_sk#167]
-Condition : ((isnotnull(ws_web_site_sk#162) AND isnotnull(ws_item_sk#161)) AND isnotnull(ws_promo_sk#163))
+(104) Filter [codegen id : 53]
+Input [7]: [ws_item_sk#159, ws_web_site_sk#160, ws_promo_sk#161, ws_order_number#162, ws_ext_sales_price#163, ws_net_profit#164, ws_sold_date_sk#165]
+Condition : ((isnotnull(ws_web_site_sk#160) AND isnotnull(ws_item_sk#159)) AND isnotnull(ws_promo_sk#161))
 
-(113) Exchange
-Input [7]: [ws_item_sk#161, ws_web_site_sk#162, ws_promo_sk#163, ws_order_number#164, ws_ext_sales_price#165, ws_net_profit#166, ws_sold_date_sk#167]
-Arguments: hashpartitioning(ws_item_sk#161, ws_order_number#164, 5), ENSURE_REQUIREMENTS, [plan_id=16]
+(105) Exchange
+Input [7]: [ws_item_sk#159, ws_web_site_sk#160, ws_promo_sk#161, ws_order_number#162, ws_ext_sales_price#163, ws_net_profit#164, ws_sold_date_sk#165]
+Arguments: hashpartitioning(ws_item_sk#159, ws_order_number#162, 5), ENSURE_REQUIREMENTS, [plan_id=14]
 
-(114) Sort [codegen id : 54]
-Input [7]: [ws_item_sk#161, ws_web_site_sk#162, ws_promo_sk#163, ws_order_number#164, ws_ext_sales_price#165, ws_net_profit#166, ws_sold_date_sk#167]
-Arguments: [ws_item_sk#161 ASC NULLS FIRST, ws_order_number#164 ASC NULLS FIRST], false, 0
+(106) Sort [codegen id : 54]
+Input [7]: [ws_item_sk#159, ws_web_site_sk#160, ws_promo_sk#161, ws_order_number#162, ws_ext_sales_price#163, ws_net_profit#164, ws_sold_date_sk#165]
+Arguments: [ws_item_sk#159 ASC NULLS FIRST, ws_order_number#162 ASC NULLS FIRST], false, 0
 
-(115) ReusedExchange [Reuses operator id: 80]
-Output [4]: [wr_item_sk#168, wr_order_number#169, wr_return_amt#170, wr_net_loss#171]
+(107) ReusedExchange [Reuses operator id: 72]
+Output [4]: [wr_item_sk#166, wr_order_number#167, wr_return_amt#168, wr_net_loss#169]
 
-(116) Sort [codegen id : 56]
-Input [4]: [wr_item_sk#168, wr_order_number#169, wr_return_amt#170, wr_net_loss#171]
-Arguments: [wr_item_sk#168 ASC NULLS FIRST, wr_order_number#169 ASC NULLS FIRST], false, 0
+(108) Sort [codegen id : 56]
+Input [4]: [wr_item_sk#166, wr_order_number#167, wr_return_amt#168, wr_net_loss#169]
+Arguments: [wr_item_sk#166 ASC NULLS FIRST, wr_order_number#167 ASC NULLS FIRST], false, 0
 
-(117) SortMergeJoin [codegen id : 61]
-Left keys [2]: [ws_item_sk#161, ws_order_number#164]
-Right keys [2]: [wr_item_sk#168, wr_order_number#169]
+(109) SortMergeJoin [codegen id : 61]
+Left keys [2]: [ws_item_sk#159, ws_order_number#162]
+Right keys [2]: [wr_item_sk#166, wr_order_number#167]
 Join type: LeftOuter
 Join condition: None
 
-(118) Project [codegen id : 61]
-Output [8]: [ws_item_sk#161, ws_web_site_sk#162, ws_promo_sk#163, ws_ext_sales_price#165, ws_net_profit#166, ws_sold_date_sk#167, wr_return_amt#170, wr_net_loss#171]
-Input [11]: [ws_item_sk#161, ws_web_site_sk#162, ws_promo_sk#163, ws_order_number#164, ws_ext_sales_price#165, ws_net_profit#166, ws_sold_date_sk#167, wr_item_sk#168, wr_order_number#169, wr_return_amt#170, wr_net_loss#171]
+(110) Project [codegen id : 61]
+Output [8]: [ws_item_sk#159, ws_web_site_sk#160, ws_promo_sk#161, ws_ext_sales_price#163, ws_net_profit#164, ws_sold_date_sk#165, wr_return_amt#168, wr_net_loss#169]
+Input [11]: [ws_item_sk#159, ws_web_site_sk#160, ws_promo_sk#161, ws_order_number#162, ws_ext_sales_price#163, ws_net_profit#164, ws_sold_date_sk#165, wr_item_sk#166, wr_order_number#167, wr_return_amt#168, wr_net_loss#169]
 
-(119) ReusedExchange [Reuses operator id: 18]
-Output [1]: [i_item_sk#172]
+(111) ReusedExchange [Reuses operator id: 199]
+Output [1]: [i_item_sk#170]
 
-(120) BroadcastHashJoin [codegen id : 61]
-Left keys [1]: [ws_item_sk#161]
-Right keys [1]: [i_item_sk#172]
+(112) BroadcastHashJoin [codegen id : 61]
+Left keys [1]: [ws_item_sk#159]
+Right keys [1]: [i_item_sk#170]
 Join type: Inner
 Join condition: None
 
-(121) Project [codegen id : 61]
-Output [7]: [ws_web_site_sk#162, ws_promo_sk#163, ws_ext_sales_price#165, ws_net_profit#166, ws_sold_date_sk#167, wr_return_amt#170, wr_net_loss#171]
-Input [9]: [ws_item_sk#161, ws_web_site_sk#162, ws_promo_sk#163, ws_ext_sales_price#165, ws_net_profit#166, ws_sold_date_sk#167, wr_return_amt#170, wr_net_loss#171, i_item_sk#172]
+(113) Project [codegen id : 61]
+Output [7]: [ws_web_site_sk#160, ws_promo_sk#161, ws_ext_sales_price#163, ws_net_profit#164, ws_sold_date_sk#165, wr_return_amt#168, wr_net_loss#169]
+Input [9]: [ws_item_sk#159, ws_web_site_sk#160, ws_promo_sk#161, ws_ext_sales_price#163, ws_net_profit#164, ws_sold_date_sk#165, wr_return_amt#168, wr_net_loss#169, i_item_sk#170]
 
-(122) ReusedExchange [Reuses operator id: 25]
-Output [1]: [p_promo_sk#173]
+(114) ReusedExchange [Reuses operator id: 209]
+Output [1]: [p_promo_sk#171]
 
-(123) BroadcastHashJoin [codegen id : 61]
-Left keys [1]: [ws_promo_sk#163]
-Right keys [1]: [p_promo_sk#173]
+(115) BroadcastHashJoin [codegen id : 61]
+Left keys [1]: [ws_promo_sk#161]
+Right keys [1]: [p_promo_sk#171]
 Join type: Inner
 Join condition: None
 
-(124) Project [codegen id : 61]
-Output [6]: [ws_web_site_sk#162, ws_ext_sales_price#165, ws_net_profit#166, ws_sold_date_sk#167, wr_return_amt#170, wr_net_loss#171]
-Input [8]: [ws_web_site_sk#162, ws_promo_sk#163, ws_ext_sales_price#165, ws_net_profit#166, ws_sold_date_sk#167, wr_return_amt#170, wr_net_loss#171, p_promo_sk#173]
+(116) Project [codegen id : 61]
+Output [6]: [ws_web_site_sk#160, ws_ext_sales_price#163, ws_net_profit#164, ws_sold_date_sk#165, wr_return_amt#168, wr_net_loss#169]
+Input [8]: [ws_web_site_sk#160, ws_promo_sk#161, ws_ext_sales_price#163, ws_net_profit#164, ws_sold_date_sk#165, wr_return_amt#168, wr_net_loss#169, p_promo_sk#171]
 
-(125) ReusedExchange [Reuses operator id: 221]
-Output [1]: [d_date_sk#174]
+(117) ReusedExchange [Reuses operator id: 219]
+Output [1]: [d_date_sk#172]
 
-(126) BroadcastHashJoin [codegen id : 61]
-Left keys [1]: [ws_sold_date_sk#167]
-Right keys [1]: [d_date_sk#174]
+(118) BroadcastHashJoin [codegen id : 61]
+Left keys [1]: [ws_sold_date_sk#165]
+Right keys [1]: [d_date_sk#172]
 Join type: Inner
 Join condition: None
 
-(127) Project [codegen id : 61]
-Output [5]: [ws_web_site_sk#162, ws_ext_sales_price#165, ws_net_profit#166, wr_return_amt#170, wr_net_loss#171]
-Input [7]: [ws_web_site_sk#162, ws_ext_sales_price#165, ws_net_profit#166, ws_sold_date_sk#167, wr_return_amt#170, wr_net_loss#171, d_date_sk#174]
+(119) Project [codegen id : 61]
+Output [5]: [ws_web_site_sk#160, ws_ext_sales_price#163, ws_net_profit#164, wr_return_amt#168, wr_net_loss#169]
+Input [7]: [ws_web_site_sk#160, ws_ext_sales_price#163, ws_net_profit#164, ws_sold_date_sk#165, wr_return_amt#168, wr_net_loss#169, d_date_sk#172]
 
-(128) ReusedExchange [Reuses operator id: 96]
-Output [2]: [web_site_sk#175, web_site_id#176]
+(120) ReusedExchange [Reuses operator id: 88]
+Output [2]: [web_site_sk#173, web_site_id#174]
 
-(129) BroadcastHashJoin [codegen id : 61]
-Left keys [1]: [ws_web_site_sk#162]
-Right keys [1]: [web_site_sk#175]
+(121) BroadcastHashJoin [codegen id : 61]
+Left keys [1]: [ws_web_site_sk#160]
+Right keys [1]: [web_site_sk#173]
 Join type: Inner
 Join condition: None
 
-(130) Project [codegen id : 61]
-Output [5]: [ws_ext_sales_price#165, ws_net_profit#166, wr_return_amt#170, wr_net_loss#171, web_site_id#176]
-Input [7]: [ws_web_site_sk#162, ws_ext_sales_price#165, ws_net_profit#166, wr_return_amt#170, wr_net_loss#171, web_site_sk#175, web_site_id#176]
+(122) Project [codegen id : 61]
+Output [5]: [ws_ext_sales_price#163, ws_net_profit#164, wr_return_amt#168, wr_net_loss#169, web_site_id#174]
+Input [7]: [ws_web_site_sk#160, ws_ext_sales_price#163, ws_net_profit#164, wr_return_amt#168, wr_net_loss#169, web_site_sk#173, web_site_id#174]
 
-(131) HashAggregate [codegen id : 61]
-Input [5]: [ws_ext_sales_price#165, ws_net_profit#166, wr_return_amt#170, wr_net_loss#171, web_site_id#176]
-Keys [1]: [web_site_id#176]
-Functions [3]: [partial_sum(UnscaledValue(ws_ext_sales_price#165)), partial_sum(coalesce(cast(wr_return_amt#170 as decimal(12,2)), 0.00)), partial_sum((ws_net_profit#166 - coalesce(cast(wr_net_loss#171 as decimal(12,2)), 0.00)))]
-Aggregate Attributes [5]: [sum#177, sum#178, isEmpty#179, sum#180, isEmpty#181]
-Results [6]: [web_site_id#176, sum#182, sum#183, isEmpty#184, sum#185, isEmpty#186]
+(123) HashAggregate [codegen id : 61]
+Input [5]: [ws_ext_sales_price#163, ws_net_profit#164, wr_return_amt#168, wr_net_loss#169, web_site_id#174]
+Keys [1]: [web_site_id#174]
+Functions [3]: [partial_sum(UnscaledValue(ws_ext_sales_price#163)), partial_sum(coalesce(cast(wr_return_amt#168 as decimal(12,2)), 0.00)), partial_sum((ws_net_profit#164 - coalesce(cast(wr_net_loss#169 as decimal(12,2)), 0.00)))]
+Aggregate Attributes [5]: [sum#175, sum#176, isEmpty#177, sum#178, isEmpty#179]
+Results [6]: [web_site_id#174, sum#180, sum#181, isEmpty#182, sum#183, isEmpty#184]
 
-(132) Exchange
-Input [6]: [web_site_id#176, sum#182, sum#183, isEmpty#184, sum#185, isEmpty#186]
-Arguments: hashpartitioning(web_site_id#176, 5), ENSURE_REQUIREMENTS, [plan_id=17]
+(124) Exchange
+Input [6]: [web_site_id#174, sum#180, sum#181, isEmpty#182, sum#183, isEmpty#184]
+Arguments: hashpartitioning(web_site_id#174, 5), ENSURE_REQUIREMENTS, [plan_id=15]
 
-(133) HashAggregate [codegen id : 62]
-Input [6]: [web_site_id#176, sum#182, sum#183, isEmpty#184, sum#185, isEmpty#186]
-Keys [1]: [web_site_id#176]
-Functions [3]: [sum(UnscaledValue(ws_ext_sales_price#165)), sum(coalesce(cast(wr_return_amt#170 as decimal(12,2)), 0.00)), sum((ws_net_profit#166 - coalesce(cast(wr_net_loss#171 as decimal(12,2)), 0.00)))]
-Aggregate Attributes [3]: [sum(UnscaledValue(ws_ext_sales_price#165))#105, sum(coalesce(cast(wr_return_amt#170 as decimal(12,2)), 0.00))#106, sum((ws_net_profit#166 - coalesce(cast(wr_net_loss#171 as decimal(12,2)), 0.00)))#107]
-Results [5]: [web channel AS channel#187, concat(web_site, web_site_id#176) AS id#188, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#165))#105,17,2) AS sales#189, sum(coalesce(cast(wr_return_amt#170 as decimal(12,2)), 0.00))#106 AS returns#190, sum((ws_net_profit#166 - coalesce(cast(wr_net_loss#171 as decimal(12,2)), 0.00)))#107 AS profit#191]
+(125) HashAggregate [codegen id : 62]
+Input [6]: [web_site_id#174, sum#180, sum#181, isEmpty#182, sum#183, isEmpty#184]
+Keys [1]: [web_site_id#174]
+Functions [3]: [sum(UnscaledValue(ws_ext_sales_price#163)), sum(coalesce(cast(wr_return_amt#168 as decimal(12,2)), 0.00)), sum((ws_net_profit#164 - coalesce(cast(wr_net_loss#169 as decimal(12,2)), 0.00)))]
+Aggregate Attributes [3]: [sum(UnscaledValue(ws_ext_sales_price#163))#103, sum(coalesce(cast(wr_return_amt#168 as decimal(12,2)), 0.00))#104, sum((ws_net_profit#164 - coalesce(cast(wr_net_loss#169 as decimal(12,2)), 0.00)))#105]
+Results [5]: [web channel AS channel#185, concat(web_site, web_site_id#174) AS id#186, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#163))#103,17,2) AS sales#187, sum(coalesce(cast(wr_return_amt#168 as decimal(12,2)), 0.00))#104 AS returns#188, sum((ws_net_profit#164 - coalesce(cast(wr_net_loss#169 as decimal(12,2)), 0.00)))#105 AS profit#189]
 
-(134) Union
+(126) Union
 
-(135) HashAggregate [codegen id : 63]
-Input [5]: [channel#141, id#142, sales#143, returns#144, profit#145]
-Keys [2]: [channel#141, id#142]
-Functions [3]: [partial_sum(sales#143), partial_sum(returns#144), partial_sum(profit#145)]
-Aggregate Attributes [6]: [sum#192, isEmpty#193, sum#194, isEmpty#195, sum#196, isEmpty#197]
-Results [8]: [channel#141, id#142, sum#198, isEmpty#199, sum#200, isEmpty#201, sum#202, isEmpty#203]
+(127) HashAggregate [codegen id : 63]
+Input [5]: [channel#139, id#140, sales#141, returns#142, profit#143]
+Keys [2]: [channel#139, id#140]
+Functions [3]: [partial_sum(sales#141), partial_sum(returns#142), partial_sum(profit#143)]
+Aggregate Attributes [6]: [sum#190, isEmpty#191, sum#192, isEmpty#193, sum#194, isEmpty#195]
+Results [8]: [channel#139, id#140, sum#196, isEmpty#197, sum#198, isEmpty#199, sum#200, isEmpty#201]
 
-(136) Exchange
-Input [8]: [channel#141, id#142, sum#198, isEmpty#199, sum#200, isEmpty#201, sum#202, isEmpty#203]
-Arguments: hashpartitioning(channel#141, id#142, 5), ENSURE_REQUIREMENTS, [plan_id=18]
+(128) Exchange
+Input [8]: [channel#139, id#140, sum#196, isEmpty#197, sum#198, isEmpty#199, sum#200, isEmpty#201]
+Arguments: hashpartitioning(channel#139, id#140, 5), ENSURE_REQUIREMENTS, [plan_id=16]
 
-(137) HashAggregate [codegen id : 64]
-Input [8]: [channel#141, id#142, sum#198, isEmpty#199, sum#200, isEmpty#201, sum#202, isEmpty#203]
-Keys [2]: [channel#141, id#142]
-Functions [3]: [sum(sales#143), sum(returns#144), sum(profit#145)]
-Aggregate Attributes [3]: [sum(sales#143)#125, sum(returns#144)#126, sum(profit#145)#127]
-Results [4]: [channel#141, sum(sales#143)#125 AS sales#204, sum(returns#144)#126 AS returns#205, sum(profit#145)#127 AS profit#206]
+(129) HashAggregate [codegen id : 64]
+Input [8]: [channel#139, id#140, sum#196, isEmpty#197, sum#198, isEmpty#199, sum#200, isEmpty#201]
+Keys [2]: [channel#139, id#140]
+Functions [3]: [sum(sales#141), sum(returns#142), sum(profit#143)]
+Aggregate Attributes [3]: [sum(sales#141)#123, sum(returns#142)#124, sum(profit#143)#125]
+Results [4]: [channel#139, sum(sales#141)#123 AS sales#202, sum(returns#142)#124 AS returns#203, sum(profit#143)#125 AS profit#204]
 
-(138) HashAggregate [codegen id : 64]
-Input [4]: [channel#141, sales#204, returns#205, profit#206]
-Keys [1]: [channel#141]
-Functions [3]: [partial_sum(sales#204), partial_sum(returns#205), partial_sum(profit#206)]
-Aggregate Attributes [6]: [sum#207, isEmpty#208, sum#209, isEmpty#210, sum#211, isEmpty#212]
-Results [7]: [channel#141, sum#213, isEmpty#214, sum#215, isEmpty#216, sum#217, isEmpty#218]
+(130) HashAggregate [codegen id : 64]
+Input [4]: [channel#139, sales#202, returns#203, profit#204]
+Keys [1]: [channel#139]
+Functions [3]: [partial_sum(sales#202), partial_sum(returns#203), partial_sum(profit#204)]
+Aggregate Attributes [6]: [sum#205, isEmpty#206, sum#207, isEmpty#208, sum#209, isEmpty#210]
+Results [7]: [channel#139, sum#211, isEmpty#212, sum#213, isEmpty#214, sum#215, isEmpty#216]
 
-(139) Exchange
-Input [7]: [channel#141, sum#213, isEmpty#214, sum#215, isEmpty#216, sum#217, isEmpty#218]
-Arguments: hashpartitioning(channel#141, 5), ENSURE_REQUIREMENTS, [plan_id=19]
+(131) Exchange
+Input [7]: [channel#139, sum#211, isEmpty#212, sum#213, isEmpty#214, sum#215, isEmpty#216]
+Arguments: hashpartitioning(channel#139, 5), ENSURE_REQUIREMENTS, [plan_id=17]
 
-(140) HashAggregate [codegen id : 65]
-Input [7]: [channel#141, sum#213, isEmpty#214, sum#215, isEmpty#216, sum#217, isEmpty#218]
-Keys [1]: [channel#141]
-Functions [3]: [sum(sales#204), sum(returns#205), sum(profit#206)]
-Aggregate Attributes [3]: [sum(sales#204)#219, sum(returns#205)#220, sum(profit#206)#221]
-Results [5]: [channel#141, null AS id#222, sum(sales#204)#219 AS sales#223, sum(returns#205)#220 AS returns#224, sum(profit#206)#221 AS profit#225]
+(132) HashAggregate [codegen id : 65]
+Input [7]: [channel#139, sum#211, isEmpty#212, sum#213, isEmpty#214, sum#215, isEmpty#216]
+Keys [1]: [channel#139]
+Functions [3]: [sum(sales#202), sum(returns#203), sum(profit#204)]
+Aggregate Attributes [3]: [sum(sales#202)#217, sum(returns#203)#218, sum(profit#204)#219]
+Results [5]: [channel#139, null AS id#220, sum(sales#202)#217 AS sales#221, sum(returns#203)#218 AS returns#222, sum(profit#204)#219 AS profit#223]
 
-(141) Scan parquet spark_catalog.default.store_sales
-Output [7]: [ss_item_sk#226, ss_store_sk#227, ss_promo_sk#228, ss_ticket_number#229, ss_ext_sales_price#230, ss_net_profit#231, ss_sold_date_sk#232]
+(133) Scan parquet spark_catalog.default.store_sales
+Output [7]: [ss_item_sk#224, ss_store_sk#225, ss_promo_sk#226, ss_ticket_number#227, ss_ext_sales_price#228, ss_net_profit#229, ss_sold_date_sk#230]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#232), dynamicpruningexpression(ss_sold_date_sk#232 IN dynamicpruning#8)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#230), dynamicpruningexpression(ss_sold_date_sk#230 IN dynamicpruning#8)]
 PushedFilters: [IsNotNull(ss_store_sk), IsNotNull(ss_item_sk), IsNotNull(ss_promo_sk)]
 ReadSchema: struct<ss_item_sk:int,ss_store_sk:int,ss_promo_sk:int,ss_ticket_number:int,ss_ext_sales_price:decimal(7,2),ss_net_profit:decimal(7,2)>
 
-(142) ColumnarToRow [codegen id : 66]
-Input [7]: [ss_item_sk#226, ss_store_sk#227, ss_promo_sk#228, ss_ticket_number#229, ss_ext_sales_price#230, ss_net_profit#231, ss_sold_date_sk#232]
+(134) ColumnarToRow [codegen id : 66]
+Input [7]: [ss_item_sk#224, ss_store_sk#225, ss_promo_sk#226, ss_ticket_number#227, ss_ext_sales_price#228, ss_net_profit#229, ss_sold_date_sk#230]
 
-(143) Filter [codegen id : 66]
-Input [7]: [ss_item_sk#226, ss_store_sk#227, ss_promo_sk#228, ss_ticket_number#229, ss_ext_sales_price#230, ss_net_profit#231, ss_sold_date_sk#232]
-Condition : ((isnotnull(ss_store_sk#227) AND isnotnull(ss_item_sk#226)) AND isnotnull(ss_promo_sk#228))
+(135) Filter [codegen id : 66]
+Input [7]: [ss_item_sk#224, ss_store_sk#225, ss_promo_sk#226, ss_ticket_number#227, ss_ext_sales_price#228, ss_net_profit#229, ss_sold_date_sk#230]
+Condition : ((isnotnull(ss_store_sk#225) AND isnotnull(ss_item_sk#224)) AND isnotnull(ss_promo_sk#226))
 
-(144) Exchange
-Input [7]: [ss_item_sk#226, ss_store_sk#227, ss_promo_sk#228, ss_ticket_number#229, ss_ext_sales_price#230, ss_net_profit#231, ss_sold_date_sk#232]
-Arguments: hashpartitioning(ss_item_sk#226, ss_ticket_number#229, 5), ENSURE_REQUIREMENTS, [plan_id=20]
+(136) Exchange
+Input [7]: [ss_item_sk#224, ss_store_sk#225, ss_promo_sk#226, ss_ticket_number#227, ss_ext_sales_price#228, ss_net_profit#229, ss_sold_date_sk#230]
+Arguments: hashpartitioning(ss_item_sk#224, ss_ticket_number#227, 5), ENSURE_REQUIREMENTS, [plan_id=18]
 
-(145) Sort [codegen id : 67]
-Input [7]: [ss_item_sk#226, ss_store_sk#227, ss_promo_sk#228, ss_ticket_number#229, ss_ext_sales_price#230, ss_net_profit#231, ss_sold_date_sk#232]
-Arguments: [ss_item_sk#226 ASC NULLS FIRST, ss_ticket_number#229 ASC NULLS FIRST], false, 0
+(137) Sort [codegen id : 67]
+Input [7]: [ss_item_sk#224, ss_store_sk#225, ss_promo_sk#226, ss_ticket_number#227, ss_ext_sales_price#228, ss_net_profit#229, ss_sold_date_sk#230]
+Arguments: [ss_item_sk#224 ASC NULLS FIRST, ss_ticket_number#227 ASC NULLS FIRST], false, 0
 
-(146) ReusedExchange [Reuses operator id: 10]
-Output [4]: [sr_item_sk#233, sr_ticket_number#234, sr_return_amt#235, sr_net_loss#236]
+(138) ReusedExchange [Reuses operator id: 10]
+Output [4]: [sr_item_sk#231, sr_ticket_number#232, sr_return_amt#233, sr_net_loss#234]
 
-(147) Sort [codegen id : 69]
-Input [4]: [sr_item_sk#233, sr_ticket_number#234, sr_return_amt#235, sr_net_loss#236]
-Arguments: [sr_item_sk#233 ASC NULLS FIRST, sr_ticket_number#234 ASC NULLS FIRST], false, 0
+(139) Sort [codegen id : 69]
+Input [4]: [sr_item_sk#231, sr_ticket_number#232, sr_return_amt#233, sr_net_loss#234]
+Arguments: [sr_item_sk#231 ASC NULLS FIRST, sr_ticket_number#232 ASC NULLS FIRST], false, 0
 
-(148) SortMergeJoin [codegen id : 74]
-Left keys [2]: [ss_item_sk#226, ss_ticket_number#229]
-Right keys [2]: [sr_item_sk#233, sr_ticket_number#234]
+(140) SortMergeJoin [codegen id : 74]
+Left keys [2]: [ss_item_sk#224, ss_ticket_number#227]
+Right keys [2]: [sr_item_sk#231, sr_ticket_number#232]
 Join type: LeftOuter
 Join condition: None
 
-(149) Project [codegen id : 74]
-Output [8]: [ss_item_sk#226, ss_store_sk#227, ss_promo_sk#228, ss_ext_sales_price#230, ss_net_profit#231, ss_sold_date_sk#232, sr_return_amt#235, sr_net_loss#236]
-Input [11]: [ss_item_sk#226, ss_store_sk#227, ss_promo_sk#228, ss_ticket_number#229, ss_ext_sales_price#230, ss_net_profit#231, ss_sold_date_sk#232, sr_item_sk#233, sr_ticket_number#234, sr_return_amt#235, sr_net_loss#236]
+(141) Project [codegen id : 74]
+Output [8]: [ss_item_sk#224, ss_store_sk#225, ss_promo_sk#226, ss_ext_sales_price#228, ss_net_profit#229, ss_sold_date_sk#230, sr_return_amt#233, sr_net_loss#234]
+Input [11]: [ss_item_sk#224, ss_store_sk#225, ss_promo_sk#226, ss_ticket_number#227, ss_ext_sales_price#228, ss_net_profit#229, ss_sold_date_sk#230, sr_item_sk#231, sr_ticket_number#232, sr_return_amt#233, sr_net_loss#234]
 
-(150) ReusedExchange [Reuses operator id: 18]
-Output [1]: [i_item_sk#237]
+(142) ReusedExchange [Reuses operator id: 199]
+Output [1]: [i_item_sk#235]
 
-(151) BroadcastHashJoin [codegen id : 74]
-Left keys [1]: [ss_item_sk#226]
-Right keys [1]: [i_item_sk#237]
+(143) BroadcastHashJoin [codegen id : 74]
+Left keys [1]: [ss_item_sk#224]
+Right keys [1]: [i_item_sk#235]
 Join type: Inner
 Join condition: None
 
-(152) Project [codegen id : 74]
-Output [7]: [ss_store_sk#227, ss_promo_sk#228, ss_ext_sales_price#230, ss_net_profit#231, ss_sold_date_sk#232, sr_return_amt#235, sr_net_loss#236]
-Input [9]: [ss_item_sk#226, ss_store_sk#227, ss_promo_sk#228, ss_ext_sales_price#230, ss_net_profit#231, ss_sold_date_sk#232, sr_return_amt#235, sr_net_loss#236, i_item_sk#237]
+(144) Project [codegen id : 74]
+Output [7]: [ss_store_sk#225, ss_promo_sk#226, ss_ext_sales_price#228, ss_net_profit#229, ss_sold_date_sk#230, sr_return_amt#233, sr_net_loss#234]
+Input [9]: [ss_item_sk#224, ss_store_sk#225, ss_promo_sk#226, ss_ext_sales_price#228, ss_net_profit#229, ss_sold_date_sk#230, sr_return_amt#233, sr_net_loss#234, i_item_sk#235]
 
-(153) ReusedExchange [Reuses operator id: 25]
-Output [1]: [p_promo_sk#238]
+(145) ReusedExchange [Reuses operator id: 209]
+Output [1]: [p_promo_sk#236]
 
-(154) BroadcastHashJoin [codegen id : 74]
-Left keys [1]: [ss_promo_sk#228]
-Right keys [1]: [p_promo_sk#238]
+(146) BroadcastHashJoin [codegen id : 74]
+Left keys [1]: [ss_promo_sk#226]
+Right keys [1]: [p_promo_sk#236]
 Join type: Inner
 Join condition: None
 
-(155) Project [codegen id : 74]
-Output [6]: [ss_store_sk#227, ss_ext_sales_price#230, ss_net_profit#231, ss_sold_date_sk#232, sr_return_amt#235, sr_net_loss#236]
-Input [8]: [ss_store_sk#227, ss_promo_sk#228, ss_ext_sales_price#230, ss_net_profit#231, ss_sold_date_sk#232, sr_return_amt#235, sr_net_loss#236, p_promo_sk#238]
+(147) Project [codegen id : 74]
+Output [6]: [ss_store_sk#225, ss_ext_sales_price#228, ss_net_profit#229, ss_sold_date_sk#230, sr_return_amt#233, sr_net_loss#234]
+Input [8]: [ss_store_sk#225, ss_promo_sk#226, ss_ext_sales_price#228, ss_net_profit#229, ss_sold_date_sk#230, sr_return_amt#233, sr_net_loss#234, p_promo_sk#236]
 
-(156) ReusedExchange [Reuses operator id: 221]
-Output [1]: [d_date_sk#239]
+(148) ReusedExchange [Reuses operator id: 219]
+Output [1]: [d_date_sk#237]
 
-(157) BroadcastHashJoin [codegen id : 74]
-Left keys [1]: [ss_sold_date_sk#232]
-Right keys [1]: [d_date_sk#239]
+(149) BroadcastHashJoin [codegen id : 74]
+Left keys [1]: [ss_sold_date_sk#230]
+Right keys [1]: [d_date_sk#237]
 Join type: Inner
 Join condition: None
 
-(158) Project [codegen id : 74]
-Output [5]: [ss_store_sk#227, ss_ext_sales_price#230, ss_net_profit#231, sr_return_amt#235, sr_net_loss#236]
-Input [7]: [ss_store_sk#227, ss_ext_sales_price#230, ss_net_profit#231, ss_sold_date_sk#232, sr_return_amt#235, sr_net_loss#236, d_date_sk#239]
+(150) Project [codegen id : 74]
+Output [5]: [ss_store_sk#225, ss_ext_sales_price#228, ss_net_profit#229, sr_return_amt#233, sr_net_loss#234]
+Input [7]: [ss_store_sk#225, ss_ext_sales_price#228, ss_net_profit#229, ss_sold_date_sk#230, sr_return_amt#233, sr_net_loss#234, d_date_sk#237]
 
-(159) ReusedExchange [Reuses operator id: 34]
-Output [2]: [s_store_sk#240, s_store_id#241]
+(151) ReusedExchange [Reuses operator id: 26]
+Output [2]: [s_store_sk#238, s_store_id#239]
 
-(160) BroadcastHashJoin [codegen id : 74]
-Left keys [1]: [ss_store_sk#227]
-Right keys [1]: [s_store_sk#240]
+(152) BroadcastHashJoin [codegen id : 74]
+Left keys [1]: [ss_store_sk#225]
+Right keys [1]: [s_store_sk#238]
 Join type: Inner
 Join condition: None
 
-(161) Project [codegen id : 74]
-Output [5]: [ss_ext_sales_price#230, ss_net_profit#231, sr_return_amt#235, sr_net_loss#236, s_store_id#241]
-Input [7]: [ss_store_sk#227, ss_ext_sales_price#230, ss_net_profit#231, sr_return_amt#235, sr_net_loss#236, s_store_sk#240, s_store_id#241]
+(153) Project [codegen id : 74]
+Output [5]: [ss_ext_sales_price#228, ss_net_profit#229, sr_return_amt#233, sr_net_loss#234, s_store_id#239]
+Input [7]: [ss_store_sk#225, ss_ext_sales_price#228, ss_net_profit#229, sr_return_amt#233, sr_net_loss#234, s_store_sk#238, s_store_id#239]
 
-(162) HashAggregate [codegen id : 74]
-Input [5]: [ss_ext_sales_price#230, ss_net_profit#231, sr_return_amt#235, sr_net_loss#236, s_store_id#241]
-Keys [1]: [s_store_id#241]
-Functions [3]: [partial_sum(UnscaledValue(ss_ext_sales_price#230)), partial_sum(coalesce(cast(sr_return_amt#235 as decimal(12,2)), 0.00)), partial_sum((ss_net_profit#231 - coalesce(cast(sr_net_loss#236 as decimal(12,2)), 0.00)))]
-Aggregate Attributes [5]: [sum#242, sum#243, isEmpty#244, sum#245, isEmpty#246]
-Results [6]: [s_store_id#241, sum#247, sum#248, isEmpty#249, sum#250, isEmpty#251]
+(154) HashAggregate [codegen id : 74]
+Input [5]: [ss_ext_sales_price#228, ss_net_profit#229, sr_return_amt#233, sr_net_loss#234, s_store_id#239]
+Keys [1]: [s_store_id#239]
+Functions [3]: [partial_sum(UnscaledValue(ss_ext_sales_price#228)), partial_sum(coalesce(cast(sr_return_amt#233 as decimal(12,2)), 0.00)), partial_sum((ss_net_profit#229 - coalesce(cast(sr_net_loss#234 as decimal(12,2)), 0.00)))]
+Aggregate Attributes [5]: [sum#240, sum#241, isEmpty#242, sum#243, isEmpty#244]
+Results [6]: [s_store_id#239, sum#245, sum#246, isEmpty#247, sum#248, isEmpty#249]
 
-(163) Exchange
-Input [6]: [s_store_id#241, sum#247, sum#248, isEmpty#249, sum#250, isEmpty#251]
-Arguments: hashpartitioning(s_store_id#241, 5), ENSURE_REQUIREMENTS, [plan_id=21]
+(155) Exchange
+Input [6]: [s_store_id#239, sum#245, sum#246, isEmpty#247, sum#248, isEmpty#249]
+Arguments: hashpartitioning(s_store_id#239, 5), ENSURE_REQUIREMENTS, [plan_id=19]
 
-(164) HashAggregate [codegen id : 75]
-Input [6]: [s_store_id#241, sum#247, sum#248, isEmpty#249, sum#250, isEmpty#251]
-Keys [1]: [s_store_id#241]
-Functions [3]: [sum(UnscaledValue(ss_ext_sales_price#230)), sum(coalesce(cast(sr_return_amt#235 as decimal(12,2)), 0.00)), sum((ss_net_profit#231 - coalesce(cast(sr_net_loss#236 as decimal(12,2)), 0.00)))]
-Aggregate Attributes [3]: [sum(UnscaledValue(ss_ext_sales_price#230))#35, sum(coalesce(cast(sr_return_amt#235 as decimal(12,2)), 0.00))#36, sum((ss_net_profit#231 - coalesce(cast(sr_net_loss#236 as decimal(12,2)), 0.00)))#37]
-Results [5]: [store channel AS channel#252, concat(store, s_store_id#241) AS id#253, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#230))#35,17,2) AS sales#254, sum(coalesce(cast(sr_return_amt#235 as decimal(12,2)), 0.00))#36 AS returns#255, sum((ss_net_profit#231 - coalesce(cast(sr_net_loss#236 as decimal(12,2)), 0.00)))#37 AS profit#256]
+(156) HashAggregate [codegen id : 75]
+Input [6]: [s_store_id#239, sum#245, sum#246, isEmpty#247, sum#248, isEmpty#249]
+Keys [1]: [s_store_id#239]
+Functions [3]: [sum(UnscaledValue(ss_ext_sales_price#228)), sum(coalesce(cast(sr_return_amt#233 as decimal(12,2)), 0.00)), sum((ss_net_profit#229 - coalesce(cast(sr_net_loss#234 as decimal(12,2)), 0.00)))]
+Aggregate Attributes [3]: [sum(UnscaledValue(ss_ext_sales_price#228))#33, sum(coalesce(cast(sr_return_amt#233 as decimal(12,2)), 0.00))#34, sum((ss_net_profit#229 - coalesce(cast(sr_net_loss#234 as decimal(12,2)), 0.00)))#35]
+Results [5]: [store channel AS channel#250, concat(store, s_store_id#239) AS id#251, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#228))#33,17,2) AS sales#252, sum(coalesce(cast(sr_return_amt#233 as decimal(12,2)), 0.00))#34 AS returns#253, sum((ss_net_profit#229 - coalesce(cast(sr_net_loss#234 as decimal(12,2)), 0.00)))#35 AS profit#254]
 
-(165) Scan parquet spark_catalog.default.catalog_sales
-Output [7]: [cs_catalog_page_sk#257, cs_item_sk#258, cs_promo_sk#259, cs_order_number#260, cs_ext_sales_price#261, cs_net_profit#262, cs_sold_date_sk#263]
+(157) Scan parquet spark_catalog.default.catalog_sales
+Output [7]: [cs_catalog_page_sk#255, cs_item_sk#256, cs_promo_sk#257, cs_order_number#258, cs_ext_sales_price#259, cs_net_profit#260, cs_sold_date_sk#261]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#263), dynamicpruningexpression(cs_sold_date_sk#263 IN dynamicpruning#8)]
+PartitionFilters: [isnotnull(cs_sold_date_sk#261), dynamicpruningexpression(cs_sold_date_sk#261 IN dynamicpruning#8)]
 PushedFilters: [IsNotNull(cs_catalog_page_sk), IsNotNull(cs_item_sk), IsNotNull(cs_promo_sk)]
 ReadSchema: struct<cs_catalog_page_sk:int,cs_item_sk:int,cs_promo_sk:int,cs_order_number:int,cs_ext_sales_price:decimal(7,2),cs_net_profit:decimal(7,2)>
 
-(166) ColumnarToRow [codegen id : 76]
-Input [7]: [cs_catalog_page_sk#257, cs_item_sk#258, cs_promo_sk#259, cs_order_number#260, cs_ext_sales_price#261, cs_net_profit#262, cs_sold_date_sk#263]
+(158) ColumnarToRow [codegen id : 76]
+Input [7]: [cs_catalog_page_sk#255, cs_item_sk#256, cs_promo_sk#257, cs_order_number#258, cs_ext_sales_price#259, cs_net_profit#260, cs_sold_date_sk#261]
 
-(167) Filter [codegen id : 76]
-Input [7]: [cs_catalog_page_sk#257, cs_item_sk#258, cs_promo_sk#259, cs_order_number#260, cs_ext_sales_price#261, cs_net_profit#262, cs_sold_date_sk#263]
-Condition : ((isnotnull(cs_catalog_page_sk#257) AND isnotnull(cs_item_sk#258)) AND isnotnull(cs_promo_sk#259))
+(159) Filter [codegen id : 76]
+Input [7]: [cs_catalog_page_sk#255, cs_item_sk#256, cs_promo_sk#257, cs_order_number#258, cs_ext_sales_price#259, cs_net_profit#260, cs_sold_date_sk#261]
+Condition : ((isnotnull(cs_catalog_page_sk#255) AND isnotnull(cs_item_sk#256)) AND isnotnull(cs_promo_sk#257))
 
-(168) Exchange
-Input [7]: [cs_catalog_page_sk#257, cs_item_sk#258, cs_promo_sk#259, cs_order_number#260, cs_ext_sales_price#261, cs_net_profit#262, cs_sold_date_sk#263]
-Arguments: hashpartitioning(cs_item_sk#258, cs_order_number#260, 5), ENSURE_REQUIREMENTS, [plan_id=22]
+(160) Exchange
+Input [7]: [cs_catalog_page_sk#255, cs_item_sk#256, cs_promo_sk#257, cs_order_number#258, cs_ext_sales_price#259, cs_net_profit#260, cs_sold_date_sk#261]
+Arguments: hashpartitioning(cs_item_sk#256, cs_order_number#258, 5), ENSURE_REQUIREMENTS, [plan_id=20]
 
-(169) Sort [codegen id : 77]
-Input [7]: [cs_catalog_page_sk#257, cs_item_sk#258, cs_promo_sk#259, cs_order_number#260, cs_ext_sales_price#261, cs_net_profit#262, cs_sold_date_sk#263]
-Arguments: [cs_item_sk#258 ASC NULLS FIRST, cs_order_number#260 ASC NULLS FIRST], false, 0
+(161) Sort [codegen id : 77]
+Input [7]: [cs_catalog_page_sk#255, cs_item_sk#256, cs_promo_sk#257, cs_order_number#258, cs_ext_sales_price#259, cs_net_profit#260, cs_sold_date_sk#261]
+Arguments: [cs_item_sk#256 ASC NULLS FIRST, cs_order_number#258 ASC NULLS FIRST], false, 0
 
-(170) ReusedExchange [Reuses operator id: 49]
-Output [4]: [cr_item_sk#264, cr_order_number#265, cr_return_amount#266, cr_net_loss#267]
+(162) ReusedExchange [Reuses operator id: 41]
+Output [4]: [cr_item_sk#262, cr_order_number#263, cr_return_amount#264, cr_net_loss#265]
 
-(171) Sort [codegen id : 79]
-Input [4]: [cr_item_sk#264, cr_order_number#265, cr_return_amount#266, cr_net_loss#267]
-Arguments: [cr_item_sk#264 ASC NULLS FIRST, cr_order_number#265 ASC NULLS FIRST], false, 0
+(163) Sort [codegen id : 79]
+Input [4]: [cr_item_sk#262, cr_order_number#263, cr_return_amount#264, cr_net_loss#265]
+Arguments: [cr_item_sk#262 ASC NULLS FIRST, cr_order_number#263 ASC NULLS FIRST], false, 0
 
-(172) SortMergeJoin [codegen id : 84]
-Left keys [2]: [cs_item_sk#258, cs_order_number#260]
-Right keys [2]: [cr_item_sk#264, cr_order_number#265]
+(164) SortMergeJoin [codegen id : 84]
+Left keys [2]: [cs_item_sk#256, cs_order_number#258]
+Right keys [2]: [cr_item_sk#262, cr_order_number#263]
 Join type: LeftOuter
 Join condition: None
 
-(173) Project [codegen id : 84]
-Output [8]: [cs_catalog_page_sk#257, cs_item_sk#258, cs_promo_sk#259, cs_ext_sales_price#261, cs_net_profit#262, cs_sold_date_sk#263, cr_return_amount#266, cr_net_loss#267]
-Input [11]: [cs_catalog_page_sk#257, cs_item_sk#258, cs_promo_sk#259, cs_order_number#260, cs_ext_sales_price#261, cs_net_profit#262, cs_sold_date_sk#263, cr_item_sk#264, cr_order_number#265, cr_return_amount#266, cr_net_loss#267]
+(165) Project [codegen id : 84]
+Output [8]: [cs_catalog_page_sk#255, cs_item_sk#256, cs_promo_sk#257, cs_ext_sales_price#259, cs_net_profit#260, cs_sold_date_sk#261, cr_return_amount#264, cr_net_loss#265]
+Input [11]: [cs_catalog_page_sk#255, cs_item_sk#256, cs_promo_sk#257, cs_order_number#258, cs_ext_sales_price#259, cs_net_profit#260, cs_sold_date_sk#261, cr_item_sk#262, cr_order_number#263, cr_return_amount#264, cr_net_loss#265]
 
-(174) ReusedExchange [Reuses operator id: 18]
-Output [1]: [i_item_sk#268]
+(166) ReusedExchange [Reuses operator id: 199]
+Output [1]: [i_item_sk#266]
 
-(175) BroadcastHashJoin [codegen id : 84]
-Left keys [1]: [cs_item_sk#258]
-Right keys [1]: [i_item_sk#268]
+(167) BroadcastHashJoin [codegen id : 84]
+Left keys [1]: [cs_item_sk#256]
+Right keys [1]: [i_item_sk#266]
 Join type: Inner
 Join condition: None
 
-(176) Project [codegen id : 84]
-Output [7]: [cs_catalog_page_sk#257, cs_promo_sk#259, cs_ext_sales_price#261, cs_net_profit#262, cs_sold_date_sk#263, cr_return_amount#266, cr_net_loss#267]
-Input [9]: [cs_catalog_page_sk#257, cs_item_sk#258, cs_promo_sk#259, cs_ext_sales_price#261, cs_net_profit#262, cs_sold_date_sk#263, cr_return_amount#266, cr_net_loss#267, i_item_sk#268]
+(168) Project [codegen id : 84]
+Output [7]: [cs_catalog_page_sk#255, cs_promo_sk#257, cs_ext_sales_price#259, cs_net_profit#260, cs_sold_date_sk#261, cr_return_amount#264, cr_net_loss#265]
+Input [9]: [cs_catalog_page_sk#255, cs_item_sk#256, cs_promo_sk#257, cs_ext_sales_price#259, cs_net_profit#260, cs_sold_date_sk#261, cr_return_amount#264, cr_net_loss#265, i_item_sk#266]
 
-(177) ReusedExchange [Reuses operator id: 25]
-Output [1]: [p_promo_sk#269]
+(169) ReusedExchange [Reuses operator id: 209]
+Output [1]: [p_promo_sk#267]
 
-(178) BroadcastHashJoin [codegen id : 84]
-Left keys [1]: [cs_promo_sk#259]
-Right keys [1]: [p_promo_sk#269]
+(170) BroadcastHashJoin [codegen id : 84]
+Left keys [1]: [cs_promo_sk#257]
+Right keys [1]: [p_promo_sk#267]
 Join type: Inner
 Join condition: None
 
-(179) Project [codegen id : 84]
-Output [6]: [cs_catalog_page_sk#257, cs_ext_sales_price#261, cs_net_profit#262, cs_sold_date_sk#263, cr_return_amount#266, cr_net_loss#267]
-Input [8]: [cs_catalog_page_sk#257, cs_promo_sk#259, cs_ext_sales_price#261, cs_net_profit#262, cs_sold_date_sk#263, cr_return_amount#266, cr_net_loss#267, p_promo_sk#269]
+(171) Project [codegen id : 84]
+Output [6]: [cs_catalog_page_sk#255, cs_ext_sales_price#259, cs_net_profit#260, cs_sold_date_sk#261, cr_return_amount#264, cr_net_loss#265]
+Input [8]: [cs_catalog_page_sk#255, cs_promo_sk#257, cs_ext_sales_price#259, cs_net_profit#260, cs_sold_date_sk#261, cr_return_amount#264, cr_net_loss#265, p_promo_sk#267]
 
-(180) ReusedExchange [Reuses operator id: 221]
-Output [1]: [d_date_sk#270]
+(172) ReusedExchange [Reuses operator id: 219]
+Output [1]: [d_date_sk#268]
 
-(181) BroadcastHashJoin [codegen id : 84]
-Left keys [1]: [cs_sold_date_sk#263]
-Right keys [1]: [d_date_sk#270]
+(173) BroadcastHashJoin [codegen id : 84]
+Left keys [1]: [cs_sold_date_sk#261]
+Right keys [1]: [d_date_sk#268]
 Join type: Inner
 Join condition: None
 
-(182) Project [codegen id : 84]
-Output [5]: [cs_catalog_page_sk#257, cs_ext_sales_price#261, cs_net_profit#262, cr_return_amount#266, cr_net_loss#267]
-Input [7]: [cs_catalog_page_sk#257, cs_ext_sales_price#261, cs_net_profit#262, cs_sold_date_sk#263, cr_return_amount#266, cr_net_loss#267, d_date_sk#270]
+(174) Project [codegen id : 84]
+Output [5]: [cs_catalog_page_sk#255, cs_ext_sales_price#259, cs_net_profit#260, cr_return_amount#264, cr_net_loss#265]
+Input [7]: [cs_catalog_page_sk#255, cs_ext_sales_price#259, cs_net_profit#260, cs_sold_date_sk#261, cr_return_amount#264, cr_net_loss#265, d_date_sk#268]
 
-(183) ReusedExchange [Reuses operator id: 65]
-Output [2]: [cp_catalog_page_sk#271, cp_catalog_page_id#272]
+(175) ReusedExchange [Reuses operator id: 57]
+Output [2]: [cp_catalog_page_sk#269, cp_catalog_page_id#270]
 
-(184) BroadcastHashJoin [codegen id : 84]
-Left keys [1]: [cs_catalog_page_sk#257]
-Right keys [1]: [cp_catalog_page_sk#271]
+(176) BroadcastHashJoin [codegen id : 84]
+Left keys [1]: [cs_catalog_page_sk#255]
+Right keys [1]: [cp_catalog_page_sk#269]
 Join type: Inner
 Join condition: None
 
-(185) Project [codegen id : 84]
-Output [5]: [cs_ext_sales_price#261, cs_net_profit#262, cr_return_amount#266, cr_net_loss#267, cp_catalog_page_id#272]
-Input [7]: [cs_catalog_page_sk#257, cs_ext_sales_price#261, cs_net_profit#262, cr_return_amount#266, cr_net_loss#267, cp_catalog_page_sk#271, cp_catalog_page_id#272]
+(177) Project [codegen id : 84]
+Output [5]: [cs_ext_sales_price#259, cs_net_profit#260, cr_return_amount#264, cr_net_loss#265, cp_catalog_page_id#270]
+Input [7]: [cs_catalog_page_sk#255, cs_ext_sales_price#259, cs_net_profit#260, cr_return_amount#264, cr_net_loss#265, cp_catalog_page_sk#269, cp_catalog_page_id#270]
 
-(186) HashAggregate [codegen id : 84]
-Input [5]: [cs_ext_sales_price#261, cs_net_profit#262, cr_return_amount#266, cr_net_loss#267, cp_catalog_page_id#272]
-Keys [1]: [cp_catalog_page_id#272]
-Functions [3]: [partial_sum(UnscaledValue(cs_ext_sales_price#261)), partial_sum(coalesce(cast(cr_return_amount#266 as decimal(12,2)), 0.00)), partial_sum((cs_net_profit#262 - coalesce(cast(cr_net_loss#267 as decimal(12,2)), 0.00)))]
-Aggregate Attributes [5]: [sum#273, sum#274, isEmpty#275, sum#276, isEmpty#277]
-Results [6]: [cp_catalog_page_id#272, sum#278, sum#279, isEmpty#280, sum#281, isEmpty#282]
+(178) HashAggregate [codegen id : 84]
+Input [5]: [cs_ext_sales_price#259, cs_net_profit#260, cr_return_amount#264, cr_net_loss#265, cp_catalog_page_id#270]
+Keys [1]: [cp_catalog_page_id#270]
+Functions [3]: [partial_sum(UnscaledValue(cs_ext_sales_price#259)), partial_sum(coalesce(cast(cr_return_amount#264 as decimal(12,2)), 0.00)), partial_sum((cs_net_profit#260 - coalesce(cast(cr_net_loss#265 as decimal(12,2)), 0.00)))]
+Aggregate Attributes [5]: [sum#271, sum#272, isEmpty#273, sum#274, isEmpty#275]
+Results [6]: [cp_catalog_page_id#270, sum#276, sum#277, isEmpty#278, sum#279, isEmpty#280]
 
-(187) Exchange
-Input [6]: [cp_catalog_page_id#272, sum#278, sum#279, isEmpty#280, sum#281, isEmpty#282]
-Arguments: hashpartitioning(cp_catalog_page_id#272, 5), ENSURE_REQUIREMENTS, [plan_id=23]
+(179) Exchange
+Input [6]: [cp_catalog_page_id#270, sum#276, sum#277, isEmpty#278, sum#279, isEmpty#280]
+Arguments: hashpartitioning(cp_catalog_page_id#270, 5), ENSURE_REQUIREMENTS, [plan_id=21]
 
-(188) HashAggregate [codegen id : 85]
-Input [6]: [cp_catalog_page_id#272, sum#278, sum#279, isEmpty#280, sum#281, isEmpty#282]
-Keys [1]: [cp_catalog_page_id#272]
-Functions [3]: [sum(UnscaledValue(cs_ext_sales_price#261)), sum(coalesce(cast(cr_return_amount#266 as decimal(12,2)), 0.00)), sum((cs_net_profit#262 - coalesce(cast(cr_net_loss#267 as decimal(12,2)), 0.00)))]
-Aggregate Attributes [3]: [sum(UnscaledValue(cs_ext_sales_price#261))#70, sum(coalesce(cast(cr_return_amount#266 as decimal(12,2)), 0.00))#71, sum((cs_net_profit#262 - coalesce(cast(cr_net_loss#267 as decimal(12,2)), 0.00)))#72]
-Results [5]: [catalog channel AS channel#283, concat(catalog_page, cp_catalog_page_id#272) AS id#284, MakeDecimal(sum(UnscaledValue(cs_ext_sales_price#261))#70,17,2) AS sales#285, sum(coalesce(cast(cr_return_amount#266 as decimal(12,2)), 0.00))#71 AS returns#286, sum((cs_net_profit#262 - coalesce(cast(cr_net_loss#267 as decimal(12,2)), 0.00)))#72 AS profit#287]
+(180) HashAggregate [codegen id : 85]
+Input [6]: [cp_catalog_page_id#270, sum#276, sum#277, isEmpty#278, sum#279, isEmpty#280]
+Keys [1]: [cp_catalog_page_id#270]
+Functions [3]: [sum(UnscaledValue(cs_ext_sales_price#259)), sum(coalesce(cast(cr_return_amount#264 as decimal(12,2)), 0.00)), sum((cs_net_profit#260 - coalesce(cast(cr_net_loss#265 as decimal(12,2)), 0.00)))]
+Aggregate Attributes [3]: [sum(UnscaledValue(cs_ext_sales_price#259))#68, sum(coalesce(cast(cr_return_amount#264 as decimal(12,2)), 0.00))#69, sum((cs_net_profit#260 - coalesce(cast(cr_net_loss#265 as decimal(12,2)), 0.00)))#70]
+Results [5]: [catalog channel AS channel#281, concat(catalog_page, cp_catalog_page_id#270) AS id#282, MakeDecimal(sum(UnscaledValue(cs_ext_sales_price#259))#68,17,2) AS sales#283, sum(coalesce(cast(cr_return_amount#264 as decimal(12,2)), 0.00))#69 AS returns#284, sum((cs_net_profit#260 - coalesce(cast(cr_net_loss#265 as decimal(12,2)), 0.00)))#70 AS profit#285]
 
-(189) ReusedExchange [Reuses operator id: 132]
-Output [6]: [web_site_id#288, sum#289, sum#290, isEmpty#291, sum#292, isEmpty#293]
+(181) ReusedExchange [Reuses operator id: 124]
+Output [6]: [web_site_id#286, sum#287, sum#288, isEmpty#289, sum#290, isEmpty#291]
 
-(190) HashAggregate [codegen id : 95]
-Input [6]: [web_site_id#288, sum#289, sum#290, isEmpty#291, sum#292, isEmpty#293]
-Keys [1]: [web_site_id#288]
-Functions [3]: [sum(UnscaledValue(ws_ext_sales_price#294)), sum(coalesce(cast(wr_return_amt#295 as decimal(12,2)), 0.00)), sum((ws_net_profit#296 - coalesce(cast(wr_net_loss#297 as decimal(12,2)), 0.00)))]
-Aggregate Attributes [3]: [sum(UnscaledValue(ws_ext_sales_price#294))#105, sum(coalesce(cast(wr_return_amt#295 as decimal(12,2)), 0.00))#106, sum((ws_net_profit#296 - coalesce(cast(wr_net_loss#297 as decimal(12,2)), 0.00)))#107]
-Results [5]: [web channel AS channel#298, concat(web_site, web_site_id#288) AS id#299, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#294))#105,17,2) AS sales#300, sum(coalesce(cast(wr_return_amt#295 as decimal(12,2)), 0.00))#106 AS returns#301, sum((ws_net_profit#296 - coalesce(cast(wr_net_loss#297 as decimal(12,2)), 0.00)))#107 AS profit#302]
+(182) HashAggregate [codegen id : 95]
+Input [6]: [web_site_id#286, sum#287, sum#288, isEmpty#289, sum#290, isEmpty#291]
+Keys [1]: [web_site_id#286]
+Functions [3]: [sum(UnscaledValue(ws_ext_sales_price#292)), sum(coalesce(cast(wr_return_amt#293 as decimal(12,2)), 0.00)), sum((ws_net_profit#294 - coalesce(cast(wr_net_loss#295 as decimal(12,2)), 0.00)))]
+Aggregate Attributes [3]: [sum(UnscaledValue(ws_ext_sales_price#292))#103, sum(coalesce(cast(wr_return_amt#293 as decimal(12,2)), 0.00))#104, sum((ws_net_profit#294 - coalesce(cast(wr_net_loss#295 as decimal(12,2)), 0.00)))#105]
+Results [5]: [web channel AS channel#296, concat(web_site, web_site_id#286) AS id#297, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#292))#103,17,2) AS sales#298, sum(coalesce(cast(wr_return_amt#293 as decimal(12,2)), 0.00))#104 AS returns#299, sum((ws_net_profit#294 - coalesce(cast(wr_net_loss#295 as decimal(12,2)), 0.00)))#105 AS profit#300]
 
-(191) Union
+(183) Union
 
-(192) HashAggregate [codegen id : 96]
-Input [5]: [channel#252, id#253, sales#254, returns#255, profit#256]
-Keys [2]: [channel#252, id#253]
-Functions [3]: [partial_sum(sales#254), partial_sum(returns#255), partial_sum(profit#256)]
-Aggregate Attributes [6]: [sum#303, isEmpty#304, sum#305, isEmpty#306, sum#307, isEmpty#308]
-Results [8]: [channel#252, id#253, sum#309, isEmpty#310, sum#311, isEmpty#312, sum#313, isEmpty#314]
+(184) HashAggregate [codegen id : 96]
+Input [5]: [channel#250, id#251, sales#252, returns#253, profit#254]
+Keys [2]: [channel#250, id#251]
+Functions [3]: [partial_sum(sales#252), partial_sum(returns#253), partial_sum(profit#254)]
+Aggregate Attributes [6]: [sum#301, isEmpty#302, sum#303, isEmpty#304, sum#305, isEmpty#306]
+Results [8]: [channel#250, id#251, sum#307, isEmpty#308, sum#309, isEmpty#310, sum#311, isEmpty#312]
 
-(193) Exchange
-Input [8]: [channel#252, id#253, sum#309, isEmpty#310, sum#311, isEmpty#312, sum#313, isEmpty#314]
-Arguments: hashpartitioning(channel#252, id#253, 5), ENSURE_REQUIREMENTS, [plan_id=24]
+(185) Exchange
+Input [8]: [channel#250, id#251, sum#307, isEmpty#308, sum#309, isEmpty#310, sum#311, isEmpty#312]
+Arguments: hashpartitioning(channel#250, id#251, 5), ENSURE_REQUIREMENTS, [plan_id=22]
 
-(194) HashAggregate [codegen id : 97]
-Input [8]: [channel#252, id#253, sum#309, isEmpty#310, sum#311, isEmpty#312, sum#313, isEmpty#314]
-Keys [2]: [channel#252, id#253]
-Functions [3]: [sum(sales#254), sum(returns#255), sum(profit#256)]
-Aggregate Attributes [3]: [sum(sales#254)#125, sum(returns#255)#126, sum(profit#256)#127]
-Results [3]: [sum(sales#254)#125 AS sales#315, sum(returns#255)#126 AS returns#316, sum(profit#256)#127 AS profit#317]
+(186) HashAggregate [codegen id : 97]
+Input [8]: [channel#250, id#251, sum#307, isEmpty#308, sum#309, isEmpty#310, sum#311, isEmpty#312]
+Keys [2]: [channel#250, id#251]
+Functions [3]: [sum(sales#252), sum(returns#253), sum(profit#254)]
+Aggregate Attributes [3]: [sum(sales#252)#123, sum(returns#253)#124, sum(profit#254)#125]
+Results [3]: [sum(sales#252)#123 AS sales#313, sum(returns#253)#124 AS returns#314, sum(profit#254)#125 AS profit#315]
 
-(195) HashAggregate [codegen id : 97]
-Input [3]: [sales#315, returns#316, profit#317]
+(187) HashAggregate [codegen id : 97]
+Input [3]: [sales#313, returns#314, profit#315]
 Keys: []
-Functions [3]: [partial_sum(sales#315), partial_sum(returns#316), partial_sum(profit#317)]
-Aggregate Attributes [6]: [sum#318, isEmpty#319, sum#320, isEmpty#321, sum#322, isEmpty#323]
-Results [6]: [sum#324, isEmpty#325, sum#326, isEmpty#327, sum#328, isEmpty#329]
+Functions [3]: [partial_sum(sales#313), partial_sum(returns#314), partial_sum(profit#315)]
+Aggregate Attributes [6]: [sum#316, isEmpty#317, sum#318, isEmpty#319, sum#320, isEmpty#321]
+Results [6]: [sum#322, isEmpty#323, sum#324, isEmpty#325, sum#326, isEmpty#327]
 
-(196) Exchange
-Input [6]: [sum#324, isEmpty#325, sum#326, isEmpty#327, sum#328, isEmpty#329]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=25]
+(188) Exchange
+Input [6]: [sum#322, isEmpty#323, sum#324, isEmpty#325, sum#326, isEmpty#327]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=23]
 
-(197) HashAggregate [codegen id : 98]
-Input [6]: [sum#324, isEmpty#325, sum#326, isEmpty#327, sum#328, isEmpty#329]
+(189) HashAggregate [codegen id : 98]
+Input [6]: [sum#322, isEmpty#323, sum#324, isEmpty#325, sum#326, isEmpty#327]
 Keys: []
-Functions [3]: [sum(sales#315), sum(returns#316), sum(profit#317)]
-Aggregate Attributes [3]: [sum(sales#315)#330, sum(returns#316)#331, sum(profit#317)#332]
-Results [5]: [null AS channel#333, null AS id#334, sum(sales#315)#330 AS sales#335, sum(returns#316)#331 AS returns#336, sum(profit#317)#332 AS profit#337]
+Functions [3]: [sum(sales#313), sum(returns#314), sum(profit#315)]
+Aggregate Attributes [3]: [sum(sales#313)#328, sum(returns#314)#329, sum(profit#315)#330]
+Results [5]: [null AS channel#331, null AS id#332, sum(sales#313)#328 AS sales#333, sum(returns#314)#329 AS returns#334, sum(profit#315)#330 AS profit#335]
 
-(198) Union
+(190) Union
 
-(199) HashAggregate [codegen id : 99]
-Input [5]: [channel#38, id#39, sales#128, returns#129, profit#130]
-Keys [5]: [channel#38, id#39, sales#128, returns#129, profit#130]
+(191) HashAggregate [codegen id : 99]
+Input [5]: [channel#36, id#37, sales#126, returns#127, profit#128]
+Keys [5]: [channel#36, id#37, sales#126, returns#127, profit#128]
 Functions: []
 Aggregate Attributes: []
-Results [5]: [channel#38, id#39, sales#128, returns#129, profit#130]
+Results [5]: [channel#36, id#37, sales#126, returns#127, profit#128]
 
-(200) Exchange
-Input [5]: [channel#38, id#39, sales#128, returns#129, profit#130]
-Arguments: hashpartitioning(channel#38, id#39, sales#128, returns#129, profit#130, 5), ENSURE_REQUIREMENTS, [plan_id=26]
+(192) Exchange
+Input [5]: [channel#36, id#37, sales#126, returns#127, profit#128]
+Arguments: hashpartitioning(channel#36, id#37, sales#126, returns#127, profit#128, 5), ENSURE_REQUIREMENTS, [plan_id=24]
 
-(201) HashAggregate [codegen id : 100]
-Input [5]: [channel#38, id#39, sales#128, returns#129, profit#130]
-Keys [5]: [channel#38, id#39, sales#128, returns#129, profit#130]
+(193) HashAggregate [codegen id : 100]
+Input [5]: [channel#36, id#37, sales#126, returns#127, profit#128]
+Keys [5]: [channel#36, id#37, sales#126, returns#127, profit#128]
 Functions: []
 Aggregate Attributes: []
-Results [5]: [channel#38, id#39, sales#128, returns#129, profit#130]
+Results [5]: [channel#36, id#37, sales#126, returns#127, profit#128]
 
-(202) TakeOrderedAndProject
-Input [5]: [channel#38, id#39, sales#128, returns#129, profit#130]
-Arguments: 100, [channel#38 ASC NULLS FIRST, id#39 ASC NULLS FIRST], [channel#38, id#39, sales#128, returns#129, profit#130]
+(194) TakeOrderedAndProject
+Input [5]: [channel#36, id#37, sales#126, returns#127, profit#128]
+Arguments: 100, [channel#36 ASC NULLS FIRST, id#37 ASC NULLS FIRST], [channel#36, id#37, sales#126, returns#127, profit#128]
 
 ===== Subqueries =====
 
 Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#9, [id=#10]
-ObjectHashAggregate (209)
-+- Exchange (208)
-   +- ObjectHashAggregate (207)
-      +- * Project (206)
-         +- * Filter (205)
-            +- * ColumnarToRow (204)
-               +- Scan parquet spark_catalog.default.item (203)
+ObjectHashAggregate (204)
++- Exchange (203)
+   +- ObjectHashAggregate (202)
+      +- BroadcastExchangeExecProxy (201)
 
 
-(203) Scan parquet spark_catalog.default.item
-Output [2]: [i_item_sk#18, i_current_price#19]
+(195) Scan parquet spark_catalog.default.item
+Output [2]: [i_item_sk#18, i_current_price#336]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_current_price), GreaterThan(i_current_price,50.00), IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_current_price:decimal(7,2)>
 
-(204) ColumnarToRow [codegen id : 1]
-Input [2]: [i_item_sk#18, i_current_price#19]
+(196) ColumnarToRow [codegen id : 1]
+Input [2]: [i_item_sk#18, i_current_price#336]
 
-(205) Filter [codegen id : 1]
-Input [2]: [i_item_sk#18, i_current_price#19]
-Condition : ((isnotnull(i_current_price#19) AND (i_current_price#19 > 50.00)) AND isnotnull(i_item_sk#18))
+(197) Filter [codegen id : 1]
+Input [2]: [i_item_sk#18, i_current_price#336]
+Condition : ((isnotnull(i_current_price#336) AND (i_current_price#336 > 50.00)) AND isnotnull(i_item_sk#18))
 
-(206) Project [codegen id : 1]
+(198) Project [codegen id : 1]
 Output [1]: [i_item_sk#18]
-Input [2]: [i_item_sk#18, i_current_price#19]
+Input [2]: [i_item_sk#18, i_current_price#336]
 
-(207) ObjectHashAggregate
+(199) BroadcastExchange
+Input [1]: [i_item_sk#18]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=25]
+
+(200) SubqueryBroadcast
+Input [1]: [i_item_sk#18]
+Arguments: runtimefilter#9, 0, [i_item_sk#18], [id=#337]
+
+(201) BroadcastExchangeExecProxy
+Input [1]: [i_item_sk#338]
+Arguments: [i_item_sk#18]
+
+(202) ObjectHashAggregate
 Input [1]: [i_item_sk#18]
 Keys: []
 Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#18, 42), 101823, 1521109, 0, 0)]
-Aggregate Attributes [1]: [buf#338]
-Results [1]: [buf#339]
+Aggregate Attributes [1]: [buf#339]
+Results [1]: [buf#340]
 
-(208) Exchange
-Input [1]: [buf#339]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=27]
+(203) Exchange
+Input [1]: [buf#340]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=26]
 
-(209) ObjectHashAggregate
-Input [1]: [buf#339]
+(204) ObjectHashAggregate
+Input [1]: [buf#340]
 Keys: []
 Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#18, 42), 101823, 1521109, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#18, 42), 101823, 1521109, 0, 0)#340]
-Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#18, 42), 101823, 1521109, 0, 0)#340 AS bloomFilter#341]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#18, 42), 101823, 1521109, 0, 0)#341]
+Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#18, 42), 101823, 1521109, 0, 0)#341 AS bloomFilter#342]
 
 Subquery:2 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#11, [id=#12]
-ObjectHashAggregate (216)
-+- Exchange (215)
-   +- ObjectHashAggregate (214)
-      +- * Project (213)
-         +- * Filter (212)
-            +- * ColumnarToRow (211)
-               +- Scan parquet spark_catalog.default.promotion (210)
+ObjectHashAggregate (214)
++- Exchange (213)
+   +- ObjectHashAggregate (212)
+      +- BroadcastExchangeExecProxy (211)
 
 
-(210) Scan parquet spark_catalog.default.promotion
-Output [2]: [p_promo_sk#20, p_channel_tv#21]
+(205) Scan parquet spark_catalog.default.promotion
+Output [2]: [p_promo_sk#19, p_channel_tv#343]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/promotion]
 PushedFilters: [IsNotNull(p_channel_tv), EqualTo(p_channel_tv,N), IsNotNull(p_promo_sk)]
 ReadSchema: struct<p_promo_sk:int,p_channel_tv:string>
 
-(211) ColumnarToRow [codegen id : 1]
-Input [2]: [p_promo_sk#20, p_channel_tv#21]
+(206) ColumnarToRow [codegen id : 1]
+Input [2]: [p_promo_sk#19, p_channel_tv#343]
 
-(212) Filter [codegen id : 1]
-Input [2]: [p_promo_sk#20, p_channel_tv#21]
-Condition : ((isnotnull(p_channel_tv#21) AND (p_channel_tv#21 = N)) AND isnotnull(p_promo_sk#20))
+(207) Filter [codegen id : 1]
+Input [2]: [p_promo_sk#19, p_channel_tv#343]
+Condition : ((isnotnull(p_channel_tv#343) AND (p_channel_tv#343 = N)) AND isnotnull(p_promo_sk#19))
 
-(213) Project [codegen id : 1]
-Output [1]: [p_promo_sk#20]
-Input [2]: [p_promo_sk#20, p_channel_tv#21]
+(208) Project [codegen id : 1]
+Output [1]: [p_promo_sk#19]
+Input [2]: [p_promo_sk#19, p_channel_tv#343]
 
-(214) ObjectHashAggregate
-Input [1]: [p_promo_sk#20]
+(209) BroadcastExchange
+Input [1]: [p_promo_sk#19]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=27]
+
+(210) SubqueryBroadcast
+Input [1]: [p_promo_sk#19]
+Arguments: runtimefilter#11, 0, [p_promo_sk#19], [id=#344]
+
+(211) BroadcastExchangeExecProxy
+Input [1]: [p_promo_sk#345]
+Arguments: [p_promo_sk#19]
+
+(212) ObjectHashAggregate
+Input [1]: [p_promo_sk#19]
 Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(p_promo_sk#20, 42), 986, 24246, 0, 0)]
-Aggregate Attributes [1]: [buf#342]
-Results [1]: [buf#343]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(p_promo_sk#19, 42), 986, 24246, 0, 0)]
+Aggregate Attributes [1]: [buf#346]
+Results [1]: [buf#347]
 
-(215) Exchange
-Input [1]: [buf#343]
+(213) Exchange
+Input [1]: [buf#347]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=28]
 
-(216) ObjectHashAggregate
-Input [1]: [buf#343]
+(214) ObjectHashAggregate
+Input [1]: [buf#347]
 Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(p_promo_sk#20, 42), 986, 24246, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(p_promo_sk#20, 42), 986, 24246, 0, 0)#344]
-Results [1]: [bloom_filter_agg(xxhash64(p_promo_sk#20, 42), 986, 24246, 0, 0)#344 AS bloomFilter#345]
+Functions [1]: [bloom_filter_agg(xxhash64(p_promo_sk#19, 42), 986, 24246, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(p_promo_sk#19, 42), 986, 24246, 0, 0)#348]
+Results [1]: [bloom_filter_agg(xxhash64(p_promo_sk#19, 42), 986, 24246, 0, 0)#348 AS bloomFilter#349]
 
 Subquery:3 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#7 IN dynamicpruning#8
-BroadcastExchange (221)
-+- * Project (220)
-   +- * Filter (219)
-      +- * ColumnarToRow (218)
-         +- Scan parquet spark_catalog.default.date_dim (217)
+BroadcastExchange (219)
++- * Project (218)
+   +- * Filter (217)
+      +- * ColumnarToRow (216)
+         +- Scan parquet spark_catalog.default.date_dim (215)
 
 
-(217) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#22, d_date#346]
+(215) Scan parquet spark_catalog.default.date_dim
+Output [2]: [d_date_sk#20, d_date#350]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,1998-08-04), LessThanOrEqual(d_date,1998-09-03), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
-(218) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#22, d_date#346]
+(216) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#20, d_date#350]
 
-(219) Filter [codegen id : 1]
-Input [2]: [d_date_sk#22, d_date#346]
-Condition : (((isnotnull(d_date#346) AND (d_date#346 >= 1998-08-04)) AND (d_date#346 <= 1998-09-03)) AND isnotnull(d_date_sk#22))
+(217) Filter [codegen id : 1]
+Input [2]: [d_date_sk#20, d_date#350]
+Condition : (((isnotnull(d_date#350) AND (d_date#350 >= 1998-08-04)) AND (d_date#350 <= 1998-09-03)) AND isnotnull(d_date_sk#20))
 
-(220) Project [codegen id : 1]
-Output [1]: [d_date_sk#22]
-Input [2]: [d_date_sk#22, d_date#346]
+(218) Project [codegen id : 1]
+Output [1]: [d_date_sk#20]
+Input [2]: [d_date_sk#20, d_date#350]
 
-(221) BroadcastExchange
-Input [1]: [d_date_sk#22]
+(219) BroadcastExchange
+Input [1]: [d_date_sk#20]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=29]
 
-Subquery:4 Hosting operator id = 42 Hosting Expression = ReusedSubquery Subquery scalar-subquery#9, [id=#10]
+Subquery:4 Hosting operator id = 34 Hosting Expression = ReusedSubquery Subquery scalar-subquery#9, [id=#10]
 
-Subquery:5 Hosting operator id = 42 Hosting Expression = ReusedSubquery Subquery scalar-subquery#11, [id=#12]
+Subquery:5 Hosting operator id = 34 Hosting Expression = ReusedSubquery Subquery scalar-subquery#11, [id=#12]
 
-Subquery:6 Hosting operator id = 40 Hosting Expression = cs_sold_date_sk#49 IN dynamicpruning#8
+Subquery:6 Hosting operator id = 32 Hosting Expression = cs_sold_date_sk#47 IN dynamicpruning#8
 
-Subquery:7 Hosting operator id = 73 Hosting Expression = ReusedSubquery Subquery scalar-subquery#9, [id=#10]
+Subquery:7 Hosting operator id = 65 Hosting Expression = ReusedSubquery Subquery scalar-subquery#9, [id=#10]
 
-Subquery:8 Hosting operator id = 73 Hosting Expression = ReusedSubquery Subquery scalar-subquery#11, [id=#12]
+Subquery:8 Hosting operator id = 65 Hosting Expression = ReusedSubquery Subquery scalar-subquery#11, [id=#12]
 
-Subquery:9 Hosting operator id = 71 Hosting Expression = ws_sold_date_sk#84 IN dynamicpruning#8
+Subquery:9 Hosting operator id = 63 Hosting Expression = ws_sold_date_sk#82 IN dynamicpruning#8
 
-Subquery:10 Hosting operator id = 110 Hosting Expression = ws_sold_date_sk#167 IN dynamicpruning#8
+Subquery:10 Hosting operator id = 102 Hosting Expression = ws_sold_date_sk#165 IN dynamicpruning#8
 
-Subquery:11 Hosting operator id = 141 Hosting Expression = ss_sold_date_sk#232 IN dynamicpruning#8
+Subquery:11 Hosting operator id = 133 Hosting Expression = ss_sold_date_sk#230 IN dynamicpruning#8
 
-Subquery:12 Hosting operator id = 165 Hosting Expression = cs_sold_date_sk#263 IN dynamicpruning#8
+Subquery:12 Hosting operator id = 157 Hosting Expression = cs_sold_date_sk#261 IN dynamicpruning#8
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q80a.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q80a.sf100/simplified.txt
@@ -42,22 +42,28 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                                                                   ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(i_item_sk, 42), 101823, 1521109, 0, 0),bloomFilter,buf]
                                                                                     Exchange #6
                                                                                       ObjectHashAggregate [i_item_sk] [buf,buf]
-                                                                                        WholeStageCodegen (1)
-                                                                                          Project [i_item_sk]
-                                                                                            Filter [i_current_price,i_item_sk]
-                                                                                              ColumnarToRow
-                                                                                                InputAdapter
-                                                                                                  Scan parquet spark_catalog.default.item [i_item_sk,i_current_price]
-                                                                                Subquery #3
+                                                                                        BroadcastExchangeExecProxy [i_item_sk]
+                                                                                          SubqueryBroadcast [i_item_sk] #3
+                                                                                            BroadcastExchange #7
+                                                                                              WholeStageCodegen (1)
+                                                                                                Project [i_item_sk]
+                                                                                                  Filter [i_current_price,i_item_sk]
+                                                                                                    ColumnarToRow
+                                                                                                      InputAdapter
+                                                                                                        Scan parquet spark_catalog.default.item [i_item_sk,i_current_price]
+                                                                                Subquery #4
                                                                                   ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(p_promo_sk, 42), 986, 24246, 0, 0),bloomFilter,buf]
-                                                                                    Exchange #7
+                                                                                    Exchange #8
                                                                                       ObjectHashAggregate [p_promo_sk] [buf,buf]
-                                                                                        WholeStageCodegen (1)
-                                                                                          Project [p_promo_sk]
-                                                                                            Filter [p_channel_tv,p_promo_sk]
-                                                                                              ColumnarToRow
-                                                                                                InputAdapter
-                                                                                                  Scan parquet spark_catalog.default.promotion [p_promo_sk,p_channel_tv]
+                                                                                        BroadcastExchangeExecProxy [p_promo_sk]
+                                                                                          SubqueryBroadcast [p_promo_sk] #5
+                                                                                            BroadcastExchange #9
+                                                                                              WholeStageCodegen (1)
+                                                                                                Project [p_promo_sk]
+                                                                                                  Filter [p_channel_tv,p_promo_sk]
+                                                                                                    ColumnarToRow
+                                                                                                      InputAdapter
+                                                                                                        Scan parquet spark_catalog.default.promotion [p_promo_sk,p_channel_tv]
                                                                                 ColumnarToRow
                                                                                   InputAdapter
                                                                                     Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_store_sk,ss_promo_sk,ss_ticket_number,ss_ext_sales_price,ss_net_profit,ss_sold_date_sk]
@@ -73,7 +79,7 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                                                     WholeStageCodegen (4)
                                                                       Sort [sr_item_sk,sr_ticket_number]
                                                                         InputAdapter
-                                                                          Exchange [sr_item_sk,sr_ticket_number] #8
+                                                                          Exchange [sr_item_sk,sr_ticket_number] #10
                                                                             WholeStageCodegen (3)
                                                                               Project [sr_item_sk,sr_ticket_number,sr_return_amt,sr_net_loss]
                                                                                 Filter [sr_item_sk,sr_ticket_number]
@@ -81,21 +87,9 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                                                                     InputAdapter
                                                                                       Scan parquet spark_catalog.default.store_returns [sr_item_sk,sr_ticket_number,sr_return_amt,sr_net_loss,sr_returned_date_sk]
                                                               InputAdapter
-                                                                BroadcastExchange #9
-                                                                  WholeStageCodegen (5)
-                                                                    Project [i_item_sk]
-                                                                      Filter [i_current_price,i_item_sk]
-                                                                        ColumnarToRow
-                                                                          InputAdapter
-                                                                            Scan parquet spark_catalog.default.item [i_item_sk,i_current_price]
+                                                                ReusedExchange [i_item_sk] #7
                                                           InputAdapter
-                                                            BroadcastExchange #10
-                                                              WholeStageCodegen (6)
-                                                                Project [p_promo_sk]
-                                                                  Filter [p_channel_tv,p_promo_sk]
-                                                                    ColumnarToRow
-                                                                      InputAdapter
-                                                                        Scan parquet spark_catalog.default.promotion [p_promo_sk,p_channel_tv]
+                                                            ReusedExchange [p_promo_sk] #9
                                                       InputAdapter
                                                         ReusedExchange [d_date_sk] #5
                                                   InputAdapter
@@ -129,7 +123,7 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                                                             WholeStageCodegen (11)
                                                                               Filter [cs_catalog_page_sk,cs_item_sk,cs_promo_sk]
                                                                                 ReusedSubquery [bloomFilter] #2
-                                                                                ReusedSubquery [bloomFilter] #3
+                                                                                ReusedSubquery [bloomFilter] #4
                                                                                 ColumnarToRow
                                                                                   InputAdapter
                                                                                     Scan parquet spark_catalog.default.catalog_sales [cs_catalog_page_sk,cs_item_sk,cs_promo_sk,cs_order_number,cs_ext_sales_price,cs_net_profit,cs_sold_date_sk]
@@ -146,9 +140,9 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                                                                     InputAdapter
                                                                                       Scan parquet spark_catalog.default.catalog_returns [cr_item_sk,cr_order_number,cr_return_amount,cr_net_loss,cr_returned_date_sk]
                                                               InputAdapter
-                                                                ReusedExchange [i_item_sk] #9
+                                                                ReusedExchange [i_item_sk] #7
                                                           InputAdapter
-                                                            ReusedExchange [p_promo_sk] #10
+                                                            ReusedExchange [p_promo_sk] #9
                                                       InputAdapter
                                                         ReusedExchange [d_date_sk] #5
                                                   InputAdapter
@@ -182,7 +176,7 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                                                             WholeStageCodegen (21)
                                                                               Filter [ws_web_site_sk,ws_item_sk,ws_promo_sk]
                                                                                 ReusedSubquery [bloomFilter] #2
-                                                                                ReusedSubquery [bloomFilter] #3
+                                                                                ReusedSubquery [bloomFilter] #4
                                                                                 ColumnarToRow
                                                                                   InputAdapter
                                                                                     Scan parquet spark_catalog.default.web_sales [ws_item_sk,ws_web_site_sk,ws_promo_sk,ws_order_number,ws_ext_sales_price,ws_net_profit,ws_sold_date_sk]
@@ -199,9 +193,9 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                                                                     InputAdapter
                                                                                       Scan parquet spark_catalog.default.web_returns [wr_item_sk,wr_order_number,wr_return_amt,wr_net_loss,wr_returned_date_sk]
                                                               InputAdapter
-                                                                ReusedExchange [i_item_sk] #9
+                                                                ReusedExchange [i_item_sk] #7
                                                           InputAdapter
-                                                            ReusedExchange [p_promo_sk] #10
+                                                            ReusedExchange [p_promo_sk] #9
                                                       InputAdapter
                                                         ReusedExchange [d_date_sk] #5
                                                   InputAdapter
@@ -265,9 +259,9 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                                                                   InputAdapter
                                                                                     ReusedExchange [wr_item_sk,wr_order_number,wr_return_amt,wr_net_loss] #18
                                                                         InputAdapter
-                                                                          ReusedExchange [i_item_sk] #9
+                                                                          ReusedExchange [i_item_sk] #7
                                                                     InputAdapter
-                                                                      ReusedExchange [p_promo_sk] #10
+                                                                      ReusedExchange [p_promo_sk] #9
                                                                 InputAdapter
                                                                   ReusedExchange [d_date_sk] #5
                                                             InputAdapter
@@ -316,11 +310,11 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                                                               WholeStageCodegen (69)
                                                                                 Sort [sr_item_sk,sr_ticket_number]
                                                                                   InputAdapter
-                                                                                    ReusedExchange [sr_item_sk,sr_ticket_number,sr_return_amt,sr_net_loss] #8
+                                                                                    ReusedExchange [sr_item_sk,sr_ticket_number,sr_return_amt,sr_net_loss] #10
                                                                         InputAdapter
-                                                                          ReusedExchange [i_item_sk] #9
+                                                                          ReusedExchange [i_item_sk] #7
                                                                     InputAdapter
-                                                                      ReusedExchange [p_promo_sk] #10
+                                                                      ReusedExchange [p_promo_sk] #9
                                                                 InputAdapter
                                                                   ReusedExchange [d_date_sk] #5
                                                             InputAdapter
@@ -358,9 +352,9 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                                                                   InputAdapter
                                                                                     ReusedExchange [cr_item_sk,cr_order_number,cr_return_amount,cr_net_loss] #14
                                                                         InputAdapter
-                                                                          ReusedExchange [i_item_sk] #9
+                                                                          ReusedExchange [i_item_sk] #7
                                                                     InputAdapter
-                                                                      ReusedExchange [p_promo_sk] #10
+                                                                      ReusedExchange [p_promo_sk] #9
                                                                 InputAdapter
                                                                   ReusedExchange [d_date_sk] #5
                                                             InputAdapter


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently, if the creation side of runtime filter could be broadcasted, Spark will not inject a bloom filter or `InSunquery` filter into the application side. I think at first we thought broadcast was cheaper than submit a new job for runtime filter. This behavior is contrary to the join has a shuffle below broadcast hash join described in the design document.
![image](https://user-images.githubusercontent.com/8486025/194822331-7a36b018-dfd9-48ce-a867-7c30a6914791.png)

In fact, we just need the creation side is small enough and inject bloom filter which could reuse the broadcast exchange and improve performance.

As we know, bloom filter ensures creation side is small enough with the code below.
```
    // Skip if the filter creation side is too big
    if (filterCreationSidePlan.stats.sizeInBytes > conf.runtimeFilterCreationSideThreshold) {
      return filterApplicationSidePlan
    }
```
`InSunquery` filter ensures creation side is small enough with the code below.
```
    val aggregate = Aggregate(Seq(alias), Seq(alias), filterCreationSidePlan)
    if (!canBroadcastBySize(aggregate, conf)) {
      // Skip the InSubquery filter if the size of `aggregate` is beyond broadcast join threshold,
      // i.e., the semi-join will be a shuffled join, which is not worthwhile.
      return filterApplicationSidePlan
    }
```

After this PR, we can support below scenes.
![image](https://user-images.githubusercontent.com/8486025/212868325-154d21ee-cfc1-4e6c-a27a-a4fd3908e029.png)


**Query Performance Benchmarks: TPC-DS Performance Evaluation**
Here are the test cases this PR can trigger the runtime filter. This PR is useful for large queries.
The tpcds data size is 3TB.
Open AQE(Default)
| TPC-DS Query   | Default(Seconds)  | After(Seconds)  | Speedup(Percent)  |
|  ----  | ----  | ----  | ----  |
| q14a | 169.103 | 166.837 | 1% |
| q14b | 162.32 | 162.40 | 0% |
| q23a | 169.103 | 166.837 | 1% |
| q23b | 596.88 | 596.65 | 0% |
| q24a | 430.36 | 427.85 | 1% |
| q24b | 427.37 | 407.36 | 5% |
| q50 | 179.97 | 171.96 | 5% |
| q64 | 195.88 | 196.83 | 0% |
| q67 | 1,244.59 | 1,172.70 | 6% |
| q75 | 102.48 | 109.66 | -7% |
| q78 | 236.50 | 236.15 | 0% |
| q93 | 338.32 | 328.83 | 3% |
| q95 | 192.69 | 186.25 | 3% |

### Why are the changes needed?

1. Relax the restrictions of broadcast join on bloom filter, so as the runtime filter applicable to more scenarios.
2. Reuse the broadcast exchange for bloom filter.


### Does this PR introduce _any_ user-facing change?
'No'.
Just update the inner implementation.


### How was this patch tested?
New tests.
