### PR TITLE
[SPARK-44722][CONNECT] ExecutePlanResponseReattachableIterator._call_iter: AttributeError: 'NoneType' object has no attribute 'message'

### DIFF
--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/connect/client/ExecutePlanResponseReattachableIterator.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/connect/client/ExecutePlanResponseReattachableIterator.scala
@@ -211,10 +211,8 @@ class ExecutePlanResponseReattachableIterator(
       iterFun(iter)
     } catch {
       case ex: StatusRuntimeException
-          if StatusProto
-            .fromThrowable(ex)
-            .getMessage
-            .contains("INVALID_HANDLE.OPERATION_NOT_FOUND") =>
+          if Option(StatusProto.fromThrowable(ex))
+            .exists(_.getMessage.contains("INVALID_HANDLE.OPERATION_NOT_FOUND")) =>
         if (lastReturnedResponseId.isDefined) {
           throw new IllegalStateException(
             "OPERATION_NOT_FOUND on the server but responses were already received from it.",

--- a/python/pyspark/sql/connect/client/reattach.py
+++ b/python/pyspark/sql/connect/client/reattach.py
@@ -239,7 +239,7 @@ class ExecutePlanResponseReattachableIterator(Generator):
             return iter_fun()
         except grpc.RpcError as e:
             status = rpc_status.from_call(cast(grpc.Call, e))
-            if "INVALID_HANDLE.OPERATION_NOT_FOUND" in status.message:
+            if status is not None and "INVALID_HANDLE.OPERATION_NOT_FOUND" in status.message:
                 if self._last_returned_response_id is not None:
                     raise RuntimeError(
                         "OPERATION_NOT_FOUND on the server but "


### PR DESCRIPTION
### What changes were proposed in this pull request?

Tiny error during exception handling: status might in some cases be None.

Make a similar change in scala client just to be defensive, because there it appears that it may never happen (when we catch `StatusRuntimeException`, `StatusProto.fromThrowable` should never return null).

### Why are the changes needed?

Fix an error during reattach retry handling.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Tests that will be published in a followup.