### PR TITLE
[SPARK-44725][DOCS] Document `spark.network.timeoutInterval`

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2398,6 +2398,14 @@ Apart from these, the following properties are also available, and may be useful
   <td>1.3.0</td>
 </tr>
 <tr>
+  <td><code>spark.network.timeoutInterval</code></td>
+  <td>60s</td>
+  <td>
+    Interval for the driver to check and expire dead executors.
+  </td>
+  <td>1.3.2</td>
+</tr>
+<tr>
   <td><code>spark.network.io.preferDirectBufs</code></td>
   <td>true</td>
   <td>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to document `spark.network.timeoutInterval` configuration.

### Why are the changes needed?

Like `spark.network.timeout`, `spark.network.timeoutInterval` exists since Apache Spark 1.3.x.

https://github.com/apache/spark/blob/418bba5ad6053449a141f3c9c31ed3ad998995b8/core/src/main/scala/org/apache/spark/internal/config/Network.scala#L48-L52

Since this is a user-facing configuration like the following, we had better document it.
https://github.com/apache/spark/blob/418bba5ad6053449a141f3c9c31ed3ad998995b8/core/src/main/scala/org/apache/spark/HeartbeatReceiver.scala#L91-L93


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual because this is a doc-only change.