### PR TITLE
[SPARK-44726][CORE] Improve `HeartbeatReceiver` config validation error message

### DIFF
--- a/core/src/main/scala/org/apache/spark/HeartbeatReceiver.scala
+++ b/core/src/main/scala/org/apache/spark/HeartbeatReceiver.scala
@@ -88,9 +88,15 @@ private[spark] class HeartbeatReceiver(sc: SparkContext, clock: Clock)
 
   private val executorHeartbeatIntervalMs = sc.conf.get(config.EXECUTOR_HEARTBEAT_INTERVAL)
 
-  require(checkTimeoutIntervalMs <= executorTimeoutMs,
-    s"${Network.NETWORK_TIMEOUT_INTERVAL.key} should be less than or " +
-      s"equal to ${config.STORAGE_BLOCKMANAGER_HEARTBEAT_TIMEOUT.key}.")
+  if (sc.conf.get(config.STORAGE_BLOCKMANAGER_HEARTBEAT_TIMEOUT).isEmpty) {
+    require(checkTimeoutIntervalMs <= executorTimeoutMs,
+      s"${Network.NETWORK_TIMEOUT_INTERVAL.key} should be less than or " +
+        s"equal to ${Network.NETWORK_TIMEOUT.key}.")
+  } else {
+    require(checkTimeoutIntervalMs <= executorTimeoutMs,
+      s"${Network.NETWORK_TIMEOUT_INTERVAL.key} should be less than or " +
+        s"equal to ${config.STORAGE_BLOCKMANAGER_HEARTBEAT_TIMEOUT.key}.")
+  }
   require(executorHeartbeatIntervalMs <= executorTimeoutMs,
     s"${config.EXECUTOR_HEARTBEAT_INTERVAL.key} should be less than or " +
       s"equal to ${config.STORAGE_BLOCKMANAGER_HEARTBEAT_TIMEOUT.key}")

--- a/core/src/test/scala/org/apache/spark/HeartbeatReceiverSuite.scala
+++ b/core/src/test/scala/org/apache/spark/HeartbeatReceiverSuite.scala
@@ -262,7 +262,6 @@ class HeartbeatReceiverSuite
     }.getMessage
     assert(m.contains("spark.network.timeoutInterval should be less than or equal to " +
       STORAGE_BLOCKMANAGER_HEARTBEAT_TIMEOUT.key))
-    sc.stop()
   }
 
   /** Manually send a heartbeat and return the response. */

--- a/core/src/test/scala/org/apache/spark/HeartbeatReceiverSuite.scala
+++ b/core/src/test/scala/org/apache/spark/HeartbeatReceiverSuite.scala
@@ -29,7 +29,8 @@ import org.scalatest.{BeforeAndAfterEach, PrivateMethodTester}
 import org.scalatest.concurrent.Eventually._
 
 import org.apache.spark.executor.{ExecutorMetrics, TaskMetrics}
-import org.apache.spark.internal.config.DYN_ALLOCATION_TESTING
+import org.apache.spark.internal.config.{DYN_ALLOCATION_TESTING, STORAGE_BLOCKMANAGER_HEARTBEAT_TIMEOUT}
+import org.apache.spark.internal.config.Network.NETWORK_TIMEOUT
 import org.apache.spark.resource.{ResourceProfile, ResourceProfileManager}
 import org.apache.spark.rpc.{RpcCallContext, RpcEndpoint, RpcEndpointRef, RpcEnv}
 import org.apache.spark.scheduler._
@@ -235,6 +236,33 @@ class HeartbeatReceiverSuite
     } finally {
       sc.stopped.set(false)
     }
+  }
+
+  test("SPARK-44726: Show spark.network.timeout config error message") {
+    sc.stop()
+    val conf = new SparkConf()
+      .setMaster("local[2]")
+      .setAppName("test")
+      .set(NETWORK_TIMEOUT.key, "30s")
+    val m = intercept[IllegalArgumentException] {
+      new SparkContext(conf)
+    }.getMessage
+    assert(m.contains("spark.network.timeoutInterval should be less than or equal to " +
+      NETWORK_TIMEOUT.key))
+  }
+
+  test("SPARK-44726: Show spark.storage.blockManagerHeartbeatTimeoutMs error message") {
+    sc.stop()
+    val conf = new SparkConf()
+      .setMaster("local[2]")
+      .setAppName("test")
+      .set(STORAGE_BLOCKMANAGER_HEARTBEAT_TIMEOUT.key, "30s")
+    val m = intercept[IllegalArgumentException] {
+      new SparkContext(conf)
+    }.getMessage
+    assert(m.contains("spark.network.timeoutInterval should be less than or equal to " +
+      STORAGE_BLOCKMANAGER_HEARTBEAT_TIMEOUT.key))
+    sc.stop()
   }
 
   /** Manually send a heartbeat and return the response. */


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to improve `HeartbeatReceiver` to give a clear directional message for Apache Spark 4.0.

### Why are the changes needed?

Currently, when we set improper `spark.network.timeout` value, the error message is misleading because it complains about the relationship between `spark.network.timeoutInterval` and `spark.storage.blockManagerHeartbeatTimeoutMs` which the users never have in their Spark jobs.

```
$ bin/spark-shell -c spark.network.timeout=30s
...
java.lang.IllegalArgumentException: requirement failed:
spark.network.timeoutInterval should be less than or equal to
spark.storage.blockManagerHeartbeatTimeoutMs.
```

### Does this PR introduce _any_ user-facing change?

No. This PR gives more direct messages based on the users' configuration.

### How was this patch tested?

Pass the CIs with the newly added test cases.