### PR TITLE
[SPARK-44737][SQL][UI] Should not display json format errors on SQL page for non-SparkThrowables on SQL Tab

### DIFF
--- a/common/utils/src/main/scala/org/apache/spark/SparkThrowableHelper.scala
+++ b/common/utils/src/main/scala/org/apache/spark/SparkThrowableHelper.scala
@@ -121,16 +121,4 @@ private[spark] object SparkThrowableHelper {
         }
     }
   }
-
-  def getMessage(throwable: Throwable): String = {
-    toJsonString { generator =>
-      val g = generator.setPrettyPrinter(new MinimalPrettyPrinter)
-      g.writeStartObject()
-      g.writeStringField("errorClass", throwable.getClass.getCanonicalName)
-      g.writeObjectFieldStart("messageParameters")
-      g.writeStringField("message", throwable.getMessage)
-      g.writeEndObject()
-      g.writeEndObject()
-    }
-  }
 }

--- a/common/utils/src/main/scala/org/apache/spark/SparkThrowableHelper.scala
+++ b/common/utils/src/main/scala/org/apache/spark/SparkThrowableHelper.scala
@@ -19,8 +19,6 @@ package org.apache.spark
 
 import scala.collection.JavaConverters._
 
-import com.fasterxml.jackson.core.util.MinimalPrettyPrinter
-
 import org.apache.spark.util.JsonUtils.toJsonString
 import org.apache.spark.util.SparkClassUtils
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala
@@ -140,8 +140,7 @@ object SQLExecution {
             case e: SparkThrowable =>
               SparkThrowableHelper.getMessage(e, ErrorMessageFormat.PRETTY)
             case e =>
-              // unexpected behavior
-              SparkThrowableHelper.getMessage(e)
+              Utils.exceptionString(e)
           }
           val event = SparkListenerSQLExecutionEnd(
             executionId,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/UISeleniumSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/UISeleniumSuite.scala
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.ui
+
+import scala.concurrent.duration.DurationInt
+
+import org.openqa.selenium.htmlunit.HtmlUnitDriver
+import org.scalatest.concurrent.Eventually.eventually
+import org.scalatest.concurrent.Futures.{interval, timeout}
+import org.scalatestplus.selenium.WebBrowser
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.ui.SparkUICssErrorHandler
+
+class UISeleniumSuite extends SparkFunSuite with WebBrowser {
+
+  private var spark: SparkSession = _
+
+  implicit val webDriver: HtmlUnitDriver = new HtmlUnitDriver {
+    getWebClient.setCssErrorHandler(new SparkUICssErrorHandler)
+  }
+
+  override def afterAll(): Unit = {
+    try {
+      webDriver.quit()
+    } finally {
+      super.afterAll()
+    }
+  }
+
+  override def afterEach(): Unit = {
+    SparkSession.clearActiveSession()
+    SparkSession.clearDefaultSession()
+    if (spark != null) {
+      spark.stop()
+      spark = null
+    }
+  }
+
+  test("SPARK-44737: Should not display json format errors on SQL page for non-SparkThrowables") {
+    spark = SparkSession.builder()
+      .master("local[1,1]")
+      .appName("sql ui test")
+      .config("spark.ui.enabled", "true")
+      .config("spark.ui.port", "0")
+      .getOrCreate()
+
+    intercept[Exception](spark.sql("SET mapreduce.job.reduces = 0").isEmpty)
+    eventually(timeout(10.seconds), interval(100.milliseconds)) {
+      val webUrl = spark.sparkContext.uiWebUrl
+      assert(webUrl.isDefined, "please turn on spark.ui.enabled")
+      go to s"${webUrl.get}/SQL"
+      val sd = findAll(cssSelector("""#failed-table td .stacktrace-details""")).map(_.text).toList
+      assert(sd.size === 1, "SET mapreduce.job.reduces = 0 shall fail")
+      assert(sd.head.startsWith("java.lang.IllegalArgumentException:"))
+    }
+  }
+}


### PR DESCRIPTION


<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This pull request addresses the issue of inconsistent display for SparkThrowables and others. Currently, SparkThrowables appear as plain text while others are displayed in JSON format on SQL Tab. This fix aims to make the display consistent across all items.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

To fix the inconsistent behavior, and the JSON format is not correctly displayed.

For those non-SparkThrowables thrown by SQLExecution may contain errors either that we are not ready covered by the new error handling framework or some critical path(what I have met is OOM in RDD.getPartitions), we shall supply the stacktraces 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

no

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

add a unit test