### PR TITLE
[SPARK-44701][PYTHON][TESTS][FOLLOWUP] Keep `torch` in 3.5 daily GA

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -378,6 +378,7 @@ jobs:
       SKIP_MIMA: true
       SKIP_PACKAGING: true
       METASPACE_SIZE: 1g
+      BRANCH: ${{ inputs.branch }}
     steps:
     - name: Checkout Spark repository
       uses: actions/checkout@v3
@@ -418,7 +419,7 @@ jobs:
     - name: Free up disk space
       shell: 'script -q -e -c "bash {0}"'
       run: |
-        if [[ "$MODULES_TO_TEST" != *"pyspark-ml"* ]]; then
+        if [[ "$MODULES_TO_TEST" != *"pyspark-ml"* ]] && [[ "$BRANCH" != "branch-3.5" ]]; then
           # uninstall libraries dedicated for ML testing
           python3.9 -m pip uninstall -y torch torchvision torcheval torchtnt tensorboard mlflow
         fi


### PR DESCRIPTION
### What changes were proposed in this pull request?
after https://github.com/apache/spark/pull/42375, the `pyspark-connect` in 3.5 daily GA still fails (see https://github.com/apache/spark/actions/runs/5805901293)

We don't have similar issue in 3.3 and 3.4.


### Why are the changes needed?
I take a cursory look, `torch` is a must in pyspark-ml now, if we want to fix this failure, need to touch many files to change the imports.

I think it not worthwhile, so make this change.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
ci
