### PR TITLE
[SPARK-44554][INFRA][FOLLOWUP] Install `IPython` for the Python linter check in the daily test for branch-3.3

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -663,7 +663,7 @@ jobs:
         # SPARK-44554: Copy from https://github.com/apache/spark/blob/073d0b60d31bf68ebacdc005f59b928a5902670f/.github/workflows/build_and_test.yml#L501-L508
         # Should delete this section after SPARK 3.3 EOL.
         python3.9 -m pip install 'flake8==3.9.0' pydata_sphinx_theme 'mypy==0.920' 'pytest==7.1.3' 'pytest-mypy-plugins==1.9.3' numpydoc 'jinja2<3.0.0' 'black==21.12b0'
-        python3.9 -m pip install 'pandas-stubs==1.2.0.53'
+        python3.9 -m pip install 'pandas-stubs==1.2.0.53' ipython
     - name: Install Python linter dependencies for branch-3.4
       if: inputs.branch == 'branch-3.4'
       run: |


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to install `IPython` for the Python linter check in the daily test for branch-3.3.

### Why are the changes needed?
To fix the Python linter check in the daily test of branch-3.3.

https://github.com/apache/spark/actions/runs/5805901293/job/15737802378

<img width="1030" alt="image" src="https://github.com/apache/spark/assets/1475305/59896b6a-b710-4772-9139-189c7ea73fe5">



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Monitor GA
