### PR TITLE
[SPARK-44747][CONNECT] Add missing SparkSession.Builder methods.

### DIFF
--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/SparkSessionE2ESuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/SparkSessionE2ESuite.scala
@@ -249,4 +249,50 @@ class SparkSessionE2ESuite extends RemoteSparkSession {
     }
     assert(e.getMessage contains "OPERATION_CANCELED")
   }
+
+  test("option propagation") {
+    val remote = s"sc://localhost:$serverPort"
+    val session1 = SparkSession
+      .builder()
+      .remote(remote)
+      .config("foo", 12L)
+      .config("bar", value = true)
+      .config("bob", 12.0)
+      .config("heading", "north")
+      .getOrCreate()
+    assert(session1.conf.get("foo") == "12")
+    assert(session1.conf.get("bar") == "true")
+    assert(session1.conf.get("bob") == String.valueOf(12.0))
+    assert(session1.conf.get("heading") == "north")
+
+    // Check if new options are applied to an existing session.
+    val session2 = SparkSession
+      .builder()
+      .remote(remote)
+      .config("heading", "south")
+      .getOrCreate()
+    assert(session2 == session1)
+    assert(session2.conf.get("heading") == "south")
+
+    // Create a completely different session, confs are not support to leak.
+    val session3 = SparkSession
+      .builder()
+      .remote(remote)
+      .config(Map("foo" -> "13", "baar" -> "false", "heading" -> "east"))
+      .create()
+    assert(session3 != session1)
+    assert(session3.conf.get("foo") == "13")
+    assert(session3.conf.get("baar") == "false")
+    assert(session3.conf.getOption("bob").isEmpty)
+    assert(session3.conf.get("heading") == "east")
+
+    // Try to set a static conf.
+    intercept[Exception] {
+      SparkSession
+        .builder()
+        .remote(remote)
+        .config("spark.sql.globalTempDatabase", "not_gonna_happen")
+        .create()
+    }
+  }
 }

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/SparkSessionSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/SparkSessionSuite.scala
@@ -251,4 +251,14 @@ class SparkSessionSuite extends ConnectFunSuite {
       executor.shutdown()
     }
   }
+
+  test("deprecated methods") {
+    SparkSession
+      .builder()
+      .master("yayay")
+      .appName("bob")
+      .enableHiveSupport()
+      .create()
+      .close()
+  }
 }

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/CheckConnectJvmClientCompatibility.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/CheckConnectJvmClientCompatibility.scala
@@ -224,13 +224,7 @@ object CheckConnectJvmClientCompatibility {
 
       // SparkSession#Builder
       ProblemFilters.exclude[DirectMissingMethodProblem](
-        "org.apache.spark.sql.SparkSession#Builder.appName"),
-      ProblemFilters.exclude[DirectMissingMethodProblem](
         "org.apache.spark.sql.SparkSession#Builder.config"),
-      ProblemFilters.exclude[DirectMissingMethodProblem](
-        "org.apache.spark.sql.SparkSession#Builder.master"),
-      ProblemFilters.exclude[DirectMissingMethodProblem](
-        "org.apache.spark.sql.SparkSession#Builder.enableHiveSupport"),
       ProblemFilters.exclude[DirectMissingMethodProblem](
         "org.apache.spark.sql.SparkSession#Builder.withExtensions"),
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR adds a couple methods to SparkSession.Builder:
- `conf` - this group of methods allows you to set runtime configurations on the Spark Connect Session.
- `master` - this is a no-op, it is only added for compatibility.
- `appName` - this is a no-op, it is only added for compatibility.
- `enableHiveSupport ` - this is a no-op, it is only added for compatibility.

### Why are the changes needed?
We want to maximize compatiblity with the existing API in sql/core.

### Does this PR introduce _any_ user-facing change?
Yes. It adds a couple of builder methods.

### How was this patch tested?
Add tests to `SparkSessionSuite` and `SparkSessionE2ESuite`.