### PR TITLE
[SPARK-44756][CORE] Executor hangs when RetryingBlockTransferor fails to initiate retry

### DIFF
--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RetryingBlockTransferor.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RetryingBlockTransferor.java
@@ -211,7 +211,7 @@ public class RetryingBlockTransferor {
       retryWaitTime);
 
     try {
-      executorService.submit(() -> {
+      executorService.execute(() -> {
         Uninterruptibles.sleepUninterruptibly(retryWaitTime, TimeUnit.MILLISECONDS);
         transferAllOutstanding();
       });

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RetryingBlockTransferor.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RetryingBlockTransferor.java
@@ -149,6 +149,7 @@ public class RetryingBlockTransferor {
    * in the event of transient IOExceptions.
    */
   public void start() {
+    currentListener = new RetryingBlockTransferListener();
     transferAllOutstanding();
   }
 
@@ -196,7 +197,8 @@ public class RetryingBlockTransferor {
    * Lightweight method which initiates a retry in a different thread. The retry will involve
    * calling transferAllOutstanding() after a configured wait time.
    */
-  private synchronized void initiateRetry(Throwable e) {
+  @VisibleForTesting
+  public synchronized void initiateRetry(Throwable e) {
     if (enableSaslRetries && e instanceof SaslTimeoutException) {
       saslRetryCount += 1;
     }

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/RetryingBlockTransferorSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/RetryingBlockTransferorSuite.java
@@ -386,8 +386,8 @@ public class RetryingBlockTransferorSuite {
 
     configureInteractions(interactions, listener);
     _retryingBlockTransferor = spy(_retryingBlockTransferor);
-    // Throw an OOM when initiating retries.
-    doThrow(OutOfMemoryError.class).when(_retryingBlockTransferor).initiateRetry(any());
+    // Simulate a failure to initiate a retry.
+    doReturn(false).when(_retryingBlockTransferor).initiateRetry(any());
     // Override listener, so that it delegates to the spied instance and not the original class.
     _retryingBlockTransferor.setCurrentListener(
         _retryingBlockTransferor.new RetryingBlockTransferListener());

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/RetryingBlockTransferorSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/RetryingBlockTransferorSuite.java
@@ -404,7 +404,8 @@ public class RetryingBlockTransferorSuite {
    * If mockInitiateRetryFailure is set to true, we mock initiateRetry() and throw an exception.
    */
   private static void performInteractions(List<? extends Map<String, Object>> interactions,
-                                          BlockFetchingListener listener, boolean mockInitiateRetryFailure)
+                                          BlockFetchingListener listener,
+                                          boolean mockInitiateRetryFailure)
     throws IOException, InterruptedException {
 
     MapConfigProvider provider = new MapConfigProvider(configMap);

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/RetryingBlockTransferorSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/RetryingBlockTransferorSuite.java
@@ -80,7 +80,7 @@ public class RetryingBlockTransferorSuite {
         .build()
       );
 
-    performInteractions(interactions, listener, false);
+    performInteractions(interactions, listener);
 
     verify(listener).onBlockTransferSuccess("b0", block0);
     verify(listener).onBlockTransferSuccess("b1", block1);
@@ -99,7 +99,7 @@ public class RetryingBlockTransferorSuite {
         .build()
     );
 
-    performInteractions(interactions, listener, false);
+    performInteractions(interactions, listener);
 
     verify(listener).onBlockTransferFailure(eq("b0"), any());
     verify(listener).onBlockTransferSuccess("b1", block1);
@@ -123,7 +123,7 @@ public class RetryingBlockTransferorSuite {
         .build()
     );
 
-    performInteractions(interactions, listener, false);
+    performInteractions(interactions, listener);
 
     verify(listener, timeout(5000)).onBlockTransferSuccess("b0", block0);
     verify(listener, timeout(5000)).onBlockTransferSuccess("b1", block1);
@@ -146,7 +146,7 @@ public class RetryingBlockTransferorSuite {
         .build()
     );
 
-    performInteractions(interactions, listener, false);
+    performInteractions(interactions, listener);
 
     verify(listener, timeout(5000)).onBlockTransferSuccess("b0", block0);
     verify(listener, timeout(5000)).onBlockTransferSuccess("b1", block1);
@@ -175,7 +175,7 @@ public class RetryingBlockTransferorSuite {
         .build()
     );
 
-    performInteractions(interactions, listener, false);
+    performInteractions(interactions, listener);
 
     verify(listener, timeout(5000)).onBlockTransferSuccess("b0", block0);
     verify(listener, timeout(5000)).onBlockTransferSuccess("b1", block1);
@@ -208,7 +208,7 @@ public class RetryingBlockTransferorSuite {
         .build()
     );
 
-    performInteractions(interactions, listener, false);
+    performInteractions(interactions, listener);
 
     verify(listener, timeout(5000)).onBlockTransferSuccess("b0", block0);
     verify(listener, timeout(5000)).onBlockTransferFailure(eq("b1"), any());
@@ -239,7 +239,7 @@ public class RetryingBlockTransferorSuite {
         .build()
     );
 
-    performInteractions(interactions, listener, false);
+    performInteractions(interactions, listener);
 
     verify(listener, timeout(5000)).onBlockTransferSuccess("b0", block0);
     verify(listener, timeout(5000)).onBlockTransferFailure(eq("b1"), any());
@@ -263,7 +263,7 @@ public class RetryingBlockTransferorSuite {
             .build()
     );
 
-    performInteractions(interactions, listener, false);
+    performInteractions(interactions, listener);
 
     verify(listener, timeout(5000)).onBlockTransferFailure("b0", saslTimeoutException);
     verify(listener).getTransferType();
@@ -284,7 +284,7 @@ public class RetryingBlockTransferorSuite {
             .build()
     );
     configMap.put("spark.shuffle.sasl.enableRetries", "true");
-    performInteractions(interactions, listener, false);
+    performInteractions(interactions, listener);
 
     verify(listener, timeout(5000)).onBlockTransferSuccess("b0", block0);
     verify(listener).getTransferType();
@@ -307,7 +307,7 @@ public class RetryingBlockTransferorSuite {
       );
     }
     configMap.put("spark.shuffle.sasl.enableRetries", "true");
-    performInteractions(interactions, listener, false);
+    performInteractions(interactions, listener);
     verify(listener, timeout(5000)).onBlockTransferFailure("b0", saslTimeoutException);
     verify(listener, times(3)).getTransferType();
     verifyNoMoreInteractions(listener);
@@ -332,7 +332,7 @@ public class RetryingBlockTransferorSuite {
           .build()
     );
     configMap.put("spark.shuffle.sasl.enableRetries", "true");
-    performInteractions(interactions, listener, false);
+    performInteractions(interactions, listener);
     verify(listener, timeout(5000)).onBlockTransferSuccess("b0", block0);
     verify(listener, timeout(5000)).onBlockTransferSuccess("b1", block1);
     verify(listener, atLeastOnce()).getTransferType();
@@ -365,7 +365,7 @@ public class RetryingBlockTransferorSuite {
             ImmutableMap.of("b0", block0)
     );
     configMap.put("spark.shuffle.sasl.enableRetries", "true");
-    performInteractions(interactions, listener, false);
+    performInteractions(interactions, listener);
     verify(listener, timeout(5000)).onBlockTransferFailure("b0", saslExceptionFinal);
     verify(listener, atLeastOnce()).getTransferType();
     verifyNoMoreInteractions(listener);
@@ -384,7 +384,14 @@ public class RetryingBlockTransferorSuite {
             .build()
     );
 
-    performInteractions(interactions, listener, true);
+    configureInteractions(interactions, listener);
+    _retryingBlockTransferor = spy(_retryingBlockTransferor);
+    // Throw an OOM when initiating retries.
+    doThrow(OutOfMemoryError.class).when(_retryingBlockTransferor).initiateRetry(any());
+    // Override listener, so that it delegates to the spied instance and not the original class.
+    _retryingBlockTransferor.setCurrentListener(
+        _retryingBlockTransferor.new RetryingBlockTransferListener());
+    _retryingBlockTransferor.start();
 
     verify(listener, timeout(5000)).onBlockTransferFailure(eq("b0"), any());
     verify(listener, timeout(5000)).onBlockTransferSuccess("b1", block1);
@@ -400,12 +407,16 @@ public class RetryingBlockTransferorSuite {
    * If multiple interactions are supplied, they will be used in order. This is useful for encoding
    * retries -- the first interaction may include an IOException, which causes a retry of some
    * subset of the original blocks in a second interaction.
-   *
-   * If mockInitiateRetryFailure is set to true, we mock initiateRetry() and throw an exception.
    */
   private static void performInteractions(List<? extends Map<String, Object>> interactions,
-                                          BlockFetchingListener listener,
-                                          boolean mockInitiateRetryFailure)
+                                          BlockFetchingListener listener)
+      throws IOException, InterruptedException {
+    configureInteractions(interactions, listener);
+    _retryingBlockTransferor.start();
+  }
+
+  private static void configureInteractions(List<? extends Map<String, Object>> interactions,
+                                          BlockFetchingListener listener)
     throws IOException, InterruptedException {
 
     MapConfigProvider provider = new MapConfigProvider(configMap);
@@ -461,10 +472,6 @@ public class RetryingBlockTransferorSuite {
     stub.when(fetchStarter).createAndStart(any(), any());
     String[] blockIdArray = blockIds.toArray(new String[blockIds.size()]);
     _retryingBlockTransferor =
-        spy(new RetryingBlockTransferor(conf, fetchStarter, blockIdArray, listener));
-    if (mockInitiateRetryFailure) {
-      doThrow(OutOfMemoryError.class).when(_retryingBlockTransferor).initiateRetry(any());
-    }
-    _retryingBlockTransferor.start();
+        new RetryingBlockTransferor(conf, fetchStarter, blockIdArray, listener);
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR fixes a bug in `RetryingBlockTransferor` that happens when retry initiation has failed.

With this patch, the callers of `RetryingBlockTransfeathror#initiateRetry()` will catch any error and invoke the parent listener's exception handler.

### Why are the changes needed?
This is needed to prevent an edge case where retry initiation fails and executor gets stuck.

More details in SPARK-44756

### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?
Added a new test case in `RetryingBlockTransferorSuite` that simulates the problematic scenario.

<img width="772" alt="image" src="https://github.com/apache/spark/assets/17327104/f20ec327-f5c9-4d74-b861-1ea4e05eb46b">
