### PR TITLE
[SPARK-44758][K8S] Support memory limits configurable

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -333,6 +333,20 @@ private[spark] object Config extends Logging {
       .stringConf
       .createOptional
 
+  val KUBERNETES_DRIVER_LIMIT_MEMORY =
+    ConfigBuilder("spark.kubernetes.driver.limit.memory")
+      .doc("Specify the hard memory limit for each driver pod")
+      .version("3.5.0")
+      .stringConf
+      .createOptional
+
+  val KUBERNETES_EXECUTOR_LIMIT_MEMORY =
+    ConfigBuilder("spark.kubernetes.executor.limit.memory")
+      .doc("Specify the hard memory limit for each executor pod")
+      .version("3.5.0")
+      .stringConf
+      .createOptional
+
   val KUBERNETES_DRIVER_POD_NAME =
     ConfigBuilder("spark.kubernetes.driver.pod.name")
       .doc("Name of the driver pod.")

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicDriverFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicDriverFeatureStepSuite.scala
@@ -59,6 +59,7 @@ class BasicDriverFeatureStepSuite extends SparkFunSuite {
       .set(KUBERNETES_DRIVER_LIMIT_CORES, "4")
       .set(DRIVER_MEMORY.key, "256M")
       .set(DRIVER_MEMORY_OVERHEAD, 200L)
+      .set(KUBERNETES_DRIVER_LIMIT_MEMORY, "1024M")
       .set(CONTAINER_IMAGE, "spark-driver:latest")
       .set(IMAGE_PULL_SECRETS, TEST_IMAGE_PULL_SECRETS)
     resources.foreach { case (_, testRInfo) =>
@@ -111,7 +112,7 @@ class BasicDriverFeatureStepSuite extends SparkFunSuite {
     assert(amountAndFormat(requests("cpu")) === "2")
     assert(amountAndFormat(requests("memory")) === "456Mi")
     val limits = resourceRequirements.getLimits.asScala
-    assert(amountAndFormat(limits("memory")) === "456Mi")
+    assert(amountAndFormat(limits("memory")) === "1024M")
     assert(amountAndFormat(limits("cpu")) === "4")
     resources.foreach { case (k8sName, testRInfo) =>
       assert(amountAndFormat(limits(k8sName)) === testRInfo.count)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Add conf `spark.kubernetes.driver.limit.memory` and `spark.kubernetes.executor.limit.memory` to config memory limits.


### Why are the changes needed?
Supporting memory limits configurable can bring some benefits. For example, use unfixed memory to use page cache, reduce disk IO of shuffle read to improve performance.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
UT
