### PR TITLE
[SPARK-44760][INFRA] Fix list index out of range for JIRA resolution in merge_spark_pr

### DIFF
--- a/dev/merge_spark_pr.py
+++ b/dev/merge_spark_pr.py
@@ -282,14 +282,21 @@ def resolve_jira_issue(merge_branches, comment, default_jira_id=""):
     default_fix_versions = []
     for b in merge_branches:
         if b == "master":
-            default_fix_versions.append(versions[0])
+            default_fix_versions.append(versions[0].name)
         else:
             found = False
+            found_versions = []
             for v in versions:
                 if v.name.startswith(b.replace("branch-", "")):
-                    default_fix_versions.append(v)
+                    found_versions.append(v.name)
                     found = True
-            if not found:
+            if found:
+                # There might be several unreleased versions for specific branches
+                # For example, assuming
+                # versions = ['4.0.0', '3.5.1', '3.5.0', '3.4.2', '3.3.4', '3.3.3']
+                # we've found two candidates for branch-3.5, we pick the last/smallest one
+                default_fix_versions.append(found_versions[-1])
+            else:
                 print(
                     "Target version for %s is not found on JIRA, it may be archived or "
                     "not created. Skipping it." % b

--- a/dev/merge_spark_pr.py
+++ b/dev/merge_spark_pr.py
@@ -272,7 +272,11 @@ def resolve_jira_issue(merge_branches, comment, default_jira_id=""):
 
     versions = asf_jira.project_versions("SPARK")
     # Consider only x.y.z, unreleased, unarchived versions
-    versions = [x for x in versions if not x.raw["released"] and not x.raw["archived"] and re.match(r"\d+\.\d+\.\d+", x.name)]
+    versions = [
+        x
+        for x in versions
+        if not x.raw["released"] and not x.raw["archived"] and re.match(r"\d+\.\d+\.\d+", x.name)
+    ]
     versions = sorted(versions, key=lambda x: x.name, reverse=True)
 
     default_fix_versions = []
@@ -288,7 +292,8 @@ def resolve_jira_issue(merge_branches, comment, default_jira_id=""):
             if not found:
                 print(
                     "Target version for %s is not found on JIRA, it may be archived or "
-                    "not created. Skipping it." % b)
+                    "not created. Skipping it." % b
+                )
 
     for v in default_fix_versions:
         # Handles the case where we have forked a release branch but not yet made the release.

--- a/dev/merge_spark_pr.py
+++ b/dev/merge_spark_pr.py
@@ -237,15 +237,6 @@ def cherry_pick(pr_num, merge_hash, default_branch):
     return pick_ref
 
 
-def fix_version_from_branch(branch, versions):
-    # Note: Assumes this is a sorted (newest->oldest) list of un-released versions
-    if branch == "master":
-        return versions[0]
-    else:
-        branch_ver = branch.replace("branch-", "")
-        return list(filter(lambda x: x.name.startswith(branch_ver), versions))[-1]
-
-
 def resolve_jira_issue(merge_branches, comment, default_jira_id=""):
     asf_jira = jira.client.JIRA(
         {"server": JIRA_API_BASE}, basic_auth=(JIRA_USERNAME, JIRA_PASSWORD)
@@ -280,14 +271,25 @@ def resolve_jira_issue(merge_branches, comment, default_jira_id=""):
     )
 
     versions = asf_jira.project_versions("SPARK")
+    # Consider only x.y.z, unreleased, unarchived versions
+    versions = [x for x in versions if not x.raw["released"] and not x.raw["archived"] and re.match(r"\d+\.\d+\.\d+", x.name)]
     versions = sorted(versions, key=lambda x: x.name, reverse=True)
-    versions = list(filter(lambda x: x.raw["released"] is False, versions))
-    # Consider only x.y.z versions
-    versions = list(filter(lambda x: re.match(r"\d+\.\d+\.\d+", x.name), versions))
 
-    default_fix_versions = list(
-        map(lambda x: fix_version_from_branch(x, versions).name, merge_branches)
-    )
+    default_fix_versions = []
+    for b in merge_branches:
+        if b == "master":
+            default_fix_versions.append(versions[0])
+        else:
+            found = False
+            for v in versions:
+                if v.name.startswith(b.replace("branch-", "")):
+                    default_fix_versions.append(v)
+                    found = True
+            if not found:
+                print(
+                    "Target version for %s is not found on JIRA, it may be archived or "
+                    "not created. Skipping it." % b)
+
     for v in default_fix_versions:
         # Handles the case where we have forked a release branch but not yet made the release.
         # In this case, if the PR is committed to the master branch and the release branch, we


### PR DESCRIPTION


<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR fixes list index out-of-range error for the merge_spark_pr script

The error occurs when the branch we merge into does not have a jira project version.

```python
>>> versions = sorted(versions, key=lambda x: x.name, reverse=True)
>>> versions
[<JIRA Version: name='4.0.0', id='12353359'>, <JIRA Version: name='3.5.1', id='12353495'>, <JIRA Version: name='3.5.0', id='12352848'>, <JIRA Version: name='3.4.2', id='12353368'>, <JIRA Version: name='3.3.4', id='12353505'>, <JIRA Version: name='3.3.3', id='12352932'>]
>>> list(filter(lambda x: x.name.startswith(""), versions))[-1]
<JIRA Version: name='3.3.3', id='12352932'>
>>> list(filter(lambda x: x.name.startswith("3.2"), versions))[-1]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
IndexError: list index out of range
```

Unlike other archived branches or versions, v3.2.5 is missing from our JIRA. This crushes the merging scripts during JIRA resolution if branch-3.2 is chosen.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

happy merging

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

no, infra only change

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

manually tested 

```python
>>> default_fix_versions = []
>>> for b in merge_branches:
...     if b == "master":
...         default_fix_versions.append(versions[0])
...     else:
...         found = False
...         for v in versions:
...             if v.name.startswith(b.replace("branch-", "")):
...                 default_fix_versions.append(v)
...                 found = True
...         if not found:
...             print(
...                 "Target version for %s is not found on JIRA, it may be archived or "
...                 "not created. Skipping it." % b)
...
Target version for branch-3.2 is not found on JIRA, it may be archived or not created. Skipping it.
>>> default_fix_versions
[<JIRA Version: name='4.0.0', id='12353359'>, <JIRA Version: name='3.5.0', id='12352848'>, <JIRA Version: name='3.5.1', id='12353495'>, <JIRA Version: name='3.4.2', id='12353368'>, <JIRA Version: name='3.3.3', id='12352932'>, <JIRA Version: name='3.3.4', id='12353505'>]
>>> quit
```