### PR TITLE
[SPARK-42905][MLLIB] fix spearman correlation incorrect and inconsistent results when data has huge amount of ties

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/stat/correlation/SpearmanCorrelation.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/stat/correlation/SpearmanCorrelation.scala
@@ -65,8 +65,8 @@ private[stat] object SpearmanCorrelation extends Correlation with Logging {
         output
       }
       iter.flatMap { case (((j, v), uid), rank) =>
-        // If we see a new value or cachedUids is too big, we flush ids with their average rank.
-        if (j != preCol || v != preVal || cachedUids.size >= 10000000) {
+        // If we see a new value, we flush ids with their average rank.
+        if (j != preCol || v != preVal) {
           val output = flush()
           preCol = j
           preVal = v

--- a/mllib/src/test/scala/org/apache/spark/mllib/stat/CorrelationSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/stat/CorrelationSuite.scala
@@ -121,6 +121,15 @@ class CorrelationSuite extends SparkFunSuite with MLlibTestSparkContext {
     assert(matrixApproxEqual(spearmanMat.asBreeze, expected))
   }
 
+  test("SPARK-42905: spearman corr(x, y) when data has huge amount of ties") {
+    val N = 10000002
+    val x = sc.range(0, N).map(i => if (i < N - 1) 1.0 else 2.0)
+    val y = sc.range(0, N).map(i => if (i < N - 1) 2.0 else 1.0)
+    val expected = -1.0
+    val s1 = Statistics.corr(x, y, "spearman")
+    assert(expected ~== s1 absTol 1e-6)
+  }
+
   test("method identification") {
     val pearson = PearsonCorrelation
     val spearman = SpearmanCorrelation

--- a/mllib/src/test/scala/org/apache/spark/mllib/stat/CorrelationSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/stat/CorrelationSuite.scala
@@ -121,6 +121,15 @@ class CorrelationSuite extends SparkFunSuite with MLlibTestSparkContext {
     assert(matrixApproxEqual(spearmanMat.asBreeze, expected))
   }
 
+  test("SPARK-42905: spearman corr(x, y) when data has huge amount of ties") {
+    val N = 10000002
+    val x = sc.range(0, N).map(i => if (i < N - 1) 1.0 else 2.0)
+    val y = sc.range(0, N).map(i => if (i < N - 1) 2.0 else 1.0)
+    val expected = 1.0
+    val s1 = Statistics.corr(x, y, "spearman")
+    assert(expected ~== s1 absTol 1e-6)
+  }
+
   test("method identification") {
     val pearson = PearsonCorrelation
     val spearman = SpearmanCorrelation

--- a/mllib/src/test/scala/org/apache/spark/mllib/stat/CorrelationSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/stat/CorrelationSuite.scala
@@ -121,7 +121,7 @@ class CorrelationSuite extends SparkFunSuite with MLlibTestSparkContext {
     assert(matrixApproxEqual(spearmanMat.asBreeze, expected))
   }
 
-  test("SPARK-42905: spearman corr(x, y) when data has huge amount of ties") {
+  ignore("SPARK-42905: spearman corr(x, y) when data has huge amount of ties") {
     val N = 10000002
     val x = sc.range(0, N).map(i => if (i < N - 1) 1.0 else 2.0)
     val y = sc.range(0, N).map(i => if (i < N - 1) 2.0 else 1.0)


### PR DESCRIPTION
### What changes were proposed in this pull request?

don't flush when ties size exceed 10_000_000, the old behavior results wrong average rank

### Why are the changes needed?

when data has huge amount of Ties( > 10_000_000), old implementation give incorrect and inconsistent result. for example

#### scala
```scala
import org.apache.spark.ml.linalg.{Matrix, Vectors, Vector}
import org.apache.spark.ml.stat.Correlation
import org.apache.spark.sql.Row

val N = 10000002
val x = sc.range(0, N).map(i => if (i < N - 1) 1.0 else 2.0)
val y = sc.range(0, N).map(i => if (i < N - 1) 2.0 else 1.0)
//val s1 = Statistics.corr(x, y, "spearman")
val df = x.zip(y)
  .map{case (x, y) => Vectors.dense(x, y)}
  .map(Tuple1.apply)
  .repartition(1) 
  .toDF("features")
  
val Row(coeff1: Matrix) = Correlation.corr(df, "features", "spearman").head
val r = coeff1(0, 1)
println(s"pearson correlation in spark: $r")
// pearson correlation in spark: -9.999990476024495E-8
```

current implementation result is -9.999990476024495E-8(unstable), and correct result is -1.0(in R/python and manual calculation)

#### r
```r
N = 10000002
x = ifelse(0:(N - 1) < N - 1, 1.0, 2.0)
y = ifelse(0:(N - 1) < N - 1, 2.0, 1.0)
r = cor(x, y, method = 'spearman') 
sprintf("pearson correlation in r: %0.6f", r)
# pearson correlation in r: -1.000000
```

#### python
```python
import numpy as np
from scipy import stats

N = 10000002
x = np.array(list(1.0 if i < N - 1 else 2.0 for i in range(N)))
y = np.array(list(2.0 if i < N - 1 else 1.0 for i in range(N)))
r = stats.spearmanr(x, y).correlation
print(f"pearson correlation in python scipy.stats: {r}")
# pearson correlation in python scipy.stats: -1.0
```
### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

add new test