### PR TITLE
[SPARK-27997][K8S] Support user-provided OAuth Token Providers

### DIFF
--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -722,6 +722,16 @@ See the [configuration page](configuration.html) for information on Spark config
   <td>2.3.0</td>
 </tr>
 <tr>
+  <td><code>spark.kubernetes.authenticate.submission.oauthTokenProvider</code></td>
+  <td>(none)</td>
+  <td>
+    The name of the class that implements OAuthTokenProvider interface to provide an OAuth token refresh mechanism for
+    long-running jobs. The class will be used to fetch the OAuth token to use when authenticating against the Kubernetes
+    API server when starting the driver. The class must be in a driver's classpath.
+  </td>
+  <td>4.0.0</td>
+</tr>
+<tr>
   <td><code>spark.kubernetes.authenticate.driver.caCertFile</code></td>
   <td>(none)</td>
   <td>
@@ -775,6 +785,16 @@ See the [configuration page](configuration.html) for information on Spark config
     <code>spark.kubernetes.authenticate.oauthTokenFile</code> instead.
   </td>
   <td>2.3.0</td>
+</tr>
+<tr>
+  <td><code>spark.kubernetes.authenticate.driver.oauthTokenProvider</code></td>
+  <td>(none)</td>
+  <td>
+    The name of the class that implements OAuthTokenProvider interface to provide an OAuth token refresh mechanism for
+    long running jobs. The class will be used to fetch the OAuth token to use when authenticating against the Kubernetes
+    API server from the driver pod when requesting executors. The class must be in a driver's classpath.
+  </td>
+  <td>4.0.0</td>
 </tr>
 <tr>
   <td><code>spark.kubernetes.authenticate.driver.mounted.caCertFile</code></td>
@@ -884,6 +904,15 @@ See the [configuration page](configuration.html) for information on Spark config
     server when requesting executors.
   </td>
   <td>2.4.0</td>
+</tr>
+<tr>
+  <td><code>spark.kubernetes.authenticate.oauthTokenProvider</code></td>
+  <td>(none)</td>
+  <td>
+    In client mode, the name of a class that implements OAuthTokenProvider interface to provide an OAuth token refresh
+    mechanism for long running jobs. The class must be in a driver's classpath.
+  </td>
+  <td>4.0.0</td>
 </tr>
 <tr>
   <td><code>spark.kubernetes.driver.label.[LabelName]</code></td>

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -225,6 +225,7 @@ private[spark] object Config extends Logging {
   val KUBERNETES_AUTH_CLIENT_MODE_PREFIX = "spark.kubernetes.authenticate"
   val OAUTH_TOKEN_CONF_SUFFIX = "oauthToken"
   val OAUTH_TOKEN_FILE_CONF_SUFFIX = "oauthTokenFile"
+  val OAUTH_TOKEN_PROVIDER_CONF_SUFFIX = "oauthTokenProvider"
   val CLIENT_KEY_FILE_CONF_SUFFIX = "clientKeyFile"
   val CLIENT_CERT_FILE_CONF_SUFFIX = "clientCertFile"
   val CA_CERT_FILE_CONF_SUFFIX = "caCertFile"

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/SparkKubernetesClientFactory.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/SparkKubernetesClientFactory.scala
@@ -57,14 +57,14 @@ private[spark] object SparkKubernetesClientFactory extends Logging {
       .orElse(defaultServiceAccountToken)
     val oauthTokenValue = sparkConf.getOption(oauthTokenConf)
     val oauthTokenProviderConf = s"$kubernetesAuthConfPrefix.$OAUTH_TOKEN_PROVIDER_CONF_SUFFIX"
-    val oauthTokenProviderInstance = sparkConf.getOption(oauthTokenProviderConf)
+    val oauthTokenProvider = sparkConf.getOption(oauthTokenProviderConf)
       .map(Utils.classForName(_)
         .getDeclaredConstructor()
         .newInstance()
         .asInstanceOf[OAuthTokenProvider])
 
     require(
-      Seq(oauthTokenFile, oauthTokenValue, oauthTokenProviderInstance).count(_.isDefined) <= 1,
+      Seq(oauthTokenFile, oauthTokenValue, oauthTokenProvider).count(_.isDefined) <= 1,
       s"OAuth token should be specified via only one of $oauthTokenFileConf, $oauthTokenConf " +
         s"or $oauthTokenProviderConf."
     )
@@ -101,7 +101,7 @@ private[spark] object SparkKubernetesClientFactory extends Logging {
       .withRequestTimeout(clientType.requestTimeout(sparkConf))
       .withConnectionTimeout(clientType.connectionTimeout(sparkConf))
       .withTrustCerts(sparkConf.get(KUBERNETES_TRUST_CERTIFICATES))
-      .withOption(oauthTokenProviderInstance) {
+      .withOption(oauthTokenProvider) {
         (provider, configBuilder) => configBuilder.withOauthTokenProvider(provider)
       }.withOption(oauthTokenValue) {
         (token, configBuilder) => configBuilder.withOauthToken(token)

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/SparkKubernetesClientFactory.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/SparkKubernetesClientFactory.scala
@@ -21,7 +21,7 @@ import java.io.File
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.google.common.base.Charsets
 import com.google.common.io.Files
-import io.fabric8.kubernetes.client.{ConfigBuilder, KubernetesClient, KubernetesClientBuilder}
+import io.fabric8.kubernetes.client.{ConfigBuilder, KubernetesClient, KubernetesClientBuilder, OAuthTokenProvider}
 import io.fabric8.kubernetes.client.Config.KUBERNETES_REQUEST_RETRY_BACKOFFLIMIT_SYSTEM_PROPERTY
 import io.fabric8.kubernetes.client.Config.autoConfigure
 import io.fabric8.kubernetes.client.okhttp.OkHttpClientFactory
@@ -33,7 +33,7 @@ import org.apache.spark.SparkConf
 import org.apache.spark.deploy.k8s.Config._
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config.ConfigEntry
-import org.apache.spark.util.ThreadUtils
+import org.apache.spark.util.{ThreadUtils, Utils}
 
 /**
  * Spark-opinionated builder for Kubernetes clients. It uses a prefix plus common suffixes to
@@ -56,11 +56,18 @@ private[spark] object SparkKubernetesClientFactory extends Logging {
       .map(new File(_))
       .orElse(defaultServiceAccountToken)
     val oauthTokenValue = sparkConf.getOption(oauthTokenConf)
-    KubernetesUtils.requireNandDefined(
-      oauthTokenFile,
-      oauthTokenValue,
-      s"Cannot specify OAuth token through both a file $oauthTokenFileConf and a " +
-        s"value $oauthTokenConf.")
+    val oauthTokenProviderConf = s"$kubernetesAuthConfPrefix.$OAUTH_TOKEN_PROVIDER_CONF_SUFFIX"
+    val oauthTokenProviderInstance = sparkConf.getOption(oauthTokenProviderConf)
+      .map(Utils.classForName(_)
+        .getDeclaredConstructor()
+        .newInstance()
+        .asInstanceOf[OAuthTokenProvider])
+
+    require(
+      Seq(oauthTokenFile, oauthTokenValue, oauthTokenProviderInstance).count(_.isDefined) <= 1,
+      s"OAuth token should be specified via only one of $oauthTokenFileConf, $oauthTokenConf " +
+        s"or $oauthTokenProviderConf."
+    )
 
     val caCertFile = sparkConf
       .getOption(s"$kubernetesAuthConfPrefix.$CA_CERT_FILE_CONF_SUFFIX")
@@ -94,7 +101,9 @@ private[spark] object SparkKubernetesClientFactory extends Logging {
       .withRequestTimeout(clientType.requestTimeout(sparkConf))
       .withConnectionTimeout(clientType.connectionTimeout(sparkConf))
       .withTrustCerts(sparkConf.get(KUBERNETES_TRUST_CERTIFICATES))
-      .withOption(oauthTokenValue) {
+      .withOption(oauthTokenProviderInstance) {
+        (provider, configBuilder) => configBuilder.withOauthTokenProvider(provider)
+      }.withOption(oauthTokenValue) {
         (token, configBuilder) => configBuilder.withOauthToken(token)
       }.withOption(oauthTokenFile) {
         (file, configBuilder) =>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support user-provided `OAuthTokenProvider` implementations to refresh tokens throughout the life of the spark app.

```
spark.kubernetes.authenticate.submission.oauthTokenProvider=<token>
spark.kubernetes.authenticate.driver.oauthTokenProvider=<token>
spark.kubernetes.authenticate.oauthTokenProvider=<token>
```

[OAuthTokenProvider](https://github.com/fabric8io/kubernetes-client/blob/eb2e86b49366cb6db8d71965c319efa5d5ce2e17/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/OAuthTokenProvider.java#L18-L28
) interface has been stable for two years.

```java
public interface OAuthTokenProvider {
  /**
   * Returns a Bearer token used for authorization between a client
   * and a kubernetes cluster. The token will be injected into an Authorization header.
   *
   * @return oauth token
   */
  String getToken();
}
```


### Why are the changes needed?


- [KEP-1205 Bound Service Account Tokens](https://github.com/kubernetes/enhancements/blob/master/keps/sig-auth/1205-bound-service-account-tokens/README.md#boundserviceaccounttokenvolume-1) : **BoundServiceAccountTokenVolume**


Alpha | Beta | GA
-- | -- | --
1.13 | 1.21 | 1.22

- [EKS Service Account with 90 Days Expiration](https://docs.aws.amazon.com/eks/latest/userguide/service-accounts.html)
  > For Amazon EKS clusters, the extended expiry period is 90 days. Your Amazon EKS cluster's Kubernetes API server rejects requests with tokens that are greater than 90 days old.

### Does this PR introduce _any_ user-facing change?

No, this is a framework to support new features. In the future, we may need proper built-in provider implementations for public cloud environments like EKS/GKE/AKS.

### How was this patch tested?

N/A