### PR TITLE
[WIP][SPARK-43063][SQL][FOLLOWUP] Add a space between -> and value in codegen when first value is null

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ToStringBase.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ToStringBase.scala
@@ -302,6 +302,7 @@ trait ToStringBase { self: UnaryExpression with TimeZoneAwareExpression =>
        |  for (int $loopIndex = 1; $loopIndex < $array.numElements(); $loopIndex++) {
        |    $buffer.append(",");
        |    if ($array.isNullAt($loopIndex)) {
+       |      $buffer.append(" ");
        |      ${appendNull(buffer, isFirstElement = false)}
        |    } else {
        |      $buffer.append(" ");

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ToStringBase.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ToStringBase.scala
@@ -352,6 +352,7 @@ trait ToStringBase { self: UnaryExpression with TimeZoneAwareExpression =>
        |  $buffer.append($keyToStringFunc($getMapFirstKey));
        |  $buffer.append(" ->");
        |  if ($map.valueArray().isNullAt(0)) {
+       |    $buffer.append(" ");
        |    ${appendNull(buffer, isFirstElement = true)}
        |  } else {
        |    $buffer.append(" ");


### PR DESCRIPTION
As noted by @cloud-fan [here](https://github.com/apache/spark/pull/41432#discussion_r1242593592), https://github.com/apache/spark/pull/41432 fixed a formatting issue when casting map to string but did not fix it in the codegen case.

The fix is a one-liner, but I am not sure how to add a unit test for this and could use some guidance.