### PR TITLE
[SPARK-43063][SQL][FOLLOWUP] Add a space between -> and value when first value is null

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ToStringBase.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ToStringBase.scala
@@ -352,7 +352,7 @@ trait ToStringBase { self: UnaryExpression with TimeZoneAwareExpression =>
        |  $buffer.append($keyToStringFunc($getMapFirstKey));
        |  $buffer.append(" ->");
        |  if ($map.valueArray().isNullAt(0)) {
-       |    ${appendNull(buffer, isFirstElement = true)}
+       |    ${appendNull(buffer, isFirstElement = false)}
        |  } else {
        |    $buffer.append(" ");
        |    $buffer.append($valueToStringFunc($getMapFirstValue));

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
@@ -828,11 +828,7 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
         val ret2 = cast(
           Literal.create(Map("1" -> null, "2" -> "a".getBytes, "3" -> "c".getBytes)),
           StringType)
-        // test with and without codegen
-        Seq(false, true).foreach { withCodegen =>
-          checkEvaluation(ret2, s"${lb}1 ->${if (legacyCast) "" else " null"}, 2 -> a, 3 -> c$rb",
-            withCodegen = withCodegen)
-        }
+        checkEvaluation(ret2, s"${lb}1 ->${if (legacyCast) "" else " null"}, 2 -> a, 3 -> c$rb")
         val ret3 = cast(
           Literal.create(Map(
             1 -> Date.valueOf("2014-12-03"),

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
@@ -828,8 +828,11 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
         val ret2 = cast(
           Literal.create(Map("1" -> null, "2" -> "a".getBytes, "3" -> "c".getBytes)),
           StringType)
-        checkEvaluation(ret2, s"${lb}1 ->${if (legacyCast) "" else " null"}, 2 -> a, 3 -> c$rb",
-          withCodegen = true)
+        // test with and without codegen
+        Seq(false, true).foreach { withCodegen =>
+          checkEvaluation(ret2, s"${lb}1 ->${if (legacyCast) "" else " null"}, 2 -> a, 3 -> c$rb",
+            withCodegen = withCodegen)
+        }
         val ret3 = cast(
           Literal.create(Map(
             1 -> Date.valueOf("2014-12-03"),

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
@@ -826,9 +826,10 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
         val ret1 = cast(Literal.create(Map(1 -> "a", 2 -> "b", 3 -> "c")), StringType)
         checkEvaluation(ret1, s"${lb}1 -> a, 2 -> b, 3 -> c$rb")
         val ret2 = cast(
-          Literal.create(Map("1" -> "a".getBytes, "2" -> null, "3" -> "c".getBytes)),
+          Literal.create(Map("1" -> null, "2" -> "a".getBytes, "3" -> "c".getBytes)),
           StringType)
-        checkEvaluation(ret2, s"${lb}1 -> a, 2 ->${if (legacyCast) "" else " null"}, 3 -> c$rb")
+        checkEvaluation(ret2, s"${lb}1 ->${if (legacyCast) "" else " null"}, 2 -> a, 3 -> c$rb",
+          withCodegen = true)
         val ret3 = cast(
           Literal.create(Map(
             1 -> Date.valueOf("2014-12-03"),

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
@@ -826,9 +826,10 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
         val ret1 = cast(Literal.create(Map(1 -> "a", 2 -> "b", 3 -> "c")), StringType)
         checkEvaluation(ret1, s"${lb}1 -> a, 2 -> b, 3 -> c$rb")
         val ret2 = cast(
-          Literal.create(Map("1" -> null, "2" -> "a".getBytes, "3" -> "c".getBytes)),
+          Literal.create(Map("1" -> null, "2" -> "a".getBytes, "3" -> null, "4" -> "c".getBytes)),
           StringType)
-        checkEvaluation(ret2, s"${lb}1 ->${if (legacyCast) "" else " null"}, 2 -> a, 3 -> c$rb")
+        val nullStr = if (legacyCast) "" else " null"
+        checkEvaluation(ret2, s"${lb}1 ->$nullStr, 2 -> a, 3 ->$nullStr, 4 -> c$rb")
         val ret3 = cast(
           Literal.create(Map(
             1 -> Date.valueOf("2014-12-03"),

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ExpressionEvalHelper.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ExpressionEvalHelper.scala
@@ -85,9 +85,10 @@ trait ExpressionEvalHelper extends ScalaCheckDrivenPropertyChecks with PlanTestB
     // Make it as method to obtain fresh expression everytime.
     def expr = prepareEvaluation(expression)
     val catalystValue = CatalystTypeConverters.convertToCatalyst(expected)
-    checkEvaluationWithoutCodegen(expr, catalystValue, inputRow)
     if (withCodegen) {
       checkEvaluation(expr, catalystValue, inputRow)
+    } else {
+      checkEvaluationWithoutCodegen(expr, catalystValue, inputRow)
     }
     checkEvaluationWithMutableProjection(expr, catalystValue, inputRow)
     if (GenerateUnsafeProjection.canSupport(expr.dataType)) {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ExpressionEvalHelper.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ExpressionEvalHelper.scala
@@ -80,11 +80,15 @@ trait ExpressionEvalHelper extends ScalaCheckDrivenPropertyChecks with PlanTestB
   }
 
   protected def checkEvaluation(
-      expression: => Expression, expected: Any, inputRow: InternalRow = EmptyRow): Unit = {
+      expression: => Expression, expected: Any, inputRow: InternalRow = EmptyRow,
+      withCodegen: Boolean = false): Unit = {
     // Make it as method to obtain fresh expression everytime.
     def expr = prepareEvaluation(expression)
     val catalystValue = CatalystTypeConverters.convertToCatalyst(expected)
     checkEvaluationWithoutCodegen(expr, catalystValue, inputRow)
+    if (withCodegen) {
+      checkEvaluation(expr, catalystValue, inputRow)
+    }
     checkEvaluationWithMutableProjection(expr, catalystValue, inputRow)
     if (GenerateUnsafeProjection.canSupport(expr.dataType)) {
       checkEvaluationWithUnsafeProjection(expr, catalystValue, inputRow)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ExpressionEvalHelper.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ExpressionEvalHelper.scala
@@ -80,16 +80,11 @@ trait ExpressionEvalHelper extends ScalaCheckDrivenPropertyChecks with PlanTestB
   }
 
   protected def checkEvaluation(
-      expression: => Expression, expected: Any, inputRow: InternalRow = EmptyRow,
-      withCodegen: Boolean = false): Unit = {
+      expression: => Expression, expected: Any, inputRow: InternalRow = EmptyRow): Unit = {
     // Make it as method to obtain fresh expression everytime.
     def expr = prepareEvaluation(expression)
     val catalystValue = CatalystTypeConverters.convertToCatalyst(expected)
-    if (withCodegen) {
-      checkEvaluation(expr, catalystValue, inputRow)
-    } else {
-      checkEvaluationWithoutCodegen(expr, catalystValue, inputRow)
-    }
+    checkEvaluationWithoutCodegen(expr, catalystValue, inputRow)
     checkEvaluationWithMutableProjection(expr, catalystValue, inputRow)
     if (GenerateUnsafeProjection.canSupport(expr.dataType)) {
       checkEvaluationWithUnsafeProjection(expr, catalystValue, inputRow)


### PR DESCRIPTION
As noted by @cloud-fan https://github.com/apache/spark/pull/41432#discussion_r1242593592, https://github.com/apache/spark/pull/41432 fixed a formatting issue when casting map to string but did not fix it in the codegen case.

This PR fixes the issue and updates a unit test to test the codegen path. Without the fix, the test fails with:

```
- SPARK-22973 Cast map to string *** FAILED ***
  Incorrect evaluation (fallback mode = CODEGEN_ONLY): cast(map(keys: [1,2,3], values: [null,[B@5c3fd9f3,[B@70f84210]) as string), 
  actual: {1 ->null, 2 -> a, 3 -> c}, 
expected: {1 -> null, 2 -> a, 3 -> c} (ExpressionEvalHelper.scala:270)
```