### PR TITLE
[SPARK-44767] Plugin API for PySpark and SparkR workers

### DIFF
--- a/core/src/main/java/org/apache/spark/api/plugin/SparkWorkerPlugin.java
+++ b/core/src/main/java/org/apache/spark/api/plugin/SparkWorkerPlugin.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.api.plugin;
+
+import org.apache.spark.annotation.*;
+
+/**
+ * :: DeveloperApi ::
+ * A plugin to customize the creation of PySpark and SparkR workers.
+ * <p>
+ * The plugin accepts a {@link ProcessBuilder} whose command and environment is pre-configured by Spark. Plugins can
+ * modify the {@link ProcessBuilder} before Spark calls {@link ProcessBuilder#start()} to launch a subprocess.
+ */
+@DeveloperApi
+@Evolving
+@Unstable
+public interface SparkWorkerPlugin {
+
+    /**
+     * Modify the provided {@link ProcessBuilder}. Spark will then call {@link ProcessBuilder#start()} to launch a new
+     * subprocess with this plugin's modification.
+     * <p>
+     * The {@link ProcessBuilder} will have command and environment already set by Spark before being provided here.
+     *
+     * @param pb The process builder to modify.
+     */
+    void apply(ProcessBuilder pb);
+}

--- a/core/src/main/scala/org/apache/spark/api/python/PythonWorkerFactory.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonWorkerFactory.scala
@@ -31,6 +31,7 @@ import org.apache.spark._
 import org.apache.spark.errors.SparkCoreErrors
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config.Python._
+import org.apache.spark.internal.plugin.WorkerPluginContainer
 import org.apache.spark.security.SocketAuthHelper
 import org.apache.spark.util.{RedirectThread, Utils}
 
@@ -178,6 +179,10 @@ private[spark] class PythonWorkerFactory(
       if (Utils.preferIPv6) {
         workerEnv.put("SPARK_PREFER_IPV6", "True")
       }
+
+      // Apply overrides from worker plugins
+      WorkerPluginContainer(SparkEnv.get.conf)(pb)
+
       val workerProcess = pb.start()
 
       // Redirect worker stdout and stderr
@@ -246,6 +251,10 @@ private[spark] class PythonWorkerFactory(
         }
         // This is equivalent to setting the -u flag; we use it because ipython doesn't support -u:
         workerEnv.put("PYTHONUNBUFFERED", "YES")
+
+        // Apply overrides from worker plugins
+        WorkerPluginContainer(SparkEnv.get.conf)(pb)
+
         daemon = pb.start()
 
         val in = new DataInputStream(daemon.getInputStream)

--- a/core/src/main/scala/org/apache/spark/api/r/BaseRRunner.scala
+++ b/core/src/main/scala/org/apache/spark/api/r/BaseRRunner.scala
@@ -29,6 +29,7 @@ import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config.BUFFER_SIZE
 import org.apache.spark.internal.config.R._
+import org.apache.spark.internal.plugin.WorkerPluginContainer
 import org.apache.spark.util.Utils
 
 /**
@@ -312,6 +313,10 @@ private[r] object BaseRRunner {
     pb.environment().put("SPARKR_IS_RUNNING_ON_WORKER", "TRUE")
     pb.environment().put("SPARKR_WORKER_SECRET", authHelper.secret)
     pb.redirectErrorStream(true)  // redirect stderr into stdout
+
+    // Apply overrides from worker plugins
+    WorkerPluginContainer(SparkEnv.get.conf)(pb)
+
     val proc = pb.start()
     val errThread = startStdoutThread(proc)
     errThread

--- a/core/src/main/scala/org/apache/spark/deploy/PythonRunner.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/PythonRunner.scala
@@ -28,6 +28,7 @@ import scala.util.Try
 import org.apache.spark.{SparkConf, SparkUserAppException}
 import org.apache.spark.api.python.{Py4JServer, PythonUtils}
 import org.apache.spark.internal.config._
+import org.apache.spark.internal.plugin.WorkerPluginContainer
 import org.apache.spark.util.{RedirectThread, Utils}
 
 /**
@@ -94,6 +95,10 @@ object PythonRunner {
       sparkConf.getOption("spark.driver.cores").foreach(env.put("OMP_NUM_THREADS", _))
     }
     builder.redirectErrorStream(true) // Ugly but needed for stdout and stderr to synchronize
+
+    // Apply overrides from worker plugins
+    WorkerPluginContainer(sparkConf).apply(builder)
+
     try {
       val process = builder.start()
 

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1756,6 +1756,15 @@ package object config {
       .toSequence
       .createWithDefault(Nil)
 
+  private[spark] val SUBPROCESS_PLUGINS =
+    ConfigBuilder("spark.worker.plugins")
+      .doc("Comma-separated list of class names implementing " +
+        "org.apache.spark.api.plugin.SparkSubprocessPlugin to apply when " +
+        "creating Python and R subprocesses.")
+      .stringConf
+      .toSequence
+      .createWithDefault(Nil)
+
   private[spark] val CLEANER_PERIODIC_GC_INTERVAL =
     ConfigBuilder("spark.cleaner.periodicGC.interval")
       .version("1.6.0")

--- a/core/src/main/scala/org/apache/spark/internal/plugin/WorkerPluginContainer.scala
+++ b/core/src/main/scala/org/apache/spark/internal/plugin/WorkerPluginContainer.scala
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.internal.plugin
+
+import org.apache.spark.SparkConf
+import org.apache.spark.api.plugin.SparkWorkerPlugin
+import org.apache.spark.internal.config.SUBPROCESS_PLUGINS
+import org.apache.spark.util.Utils
+
+/**
+ * A container that delegates to a collection of [[SparkWorkerPlugin]] instances.
+ */
+class WorkerPluginContainer(plugins: Seq[SparkWorkerPlugin]) extends SparkWorkerPlugin {
+
+  /**
+   * Apply all contained plugins to the provided process builder.
+   */
+  override def apply(pb: ProcessBuilder): Unit = plugins.foreach(_.apply(pb))
+}
+
+object WorkerPluginContainer {
+
+  def apply(conf: SparkConf): WorkerPluginContainer =
+    new WorkerPluginContainer(
+      Utils.loadExtensions(classOf[SparkWorkerPlugin], conf.get(SUBPROCESS_PLUGINS), conf))
+}

--- a/core/src/test/scala/org/apache/spark/internal/plugin/WorkerPluginContainerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/internal/plugin/WorkerPluginContainerSuite.scala
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.spark.internal.plugin
+
+import org.apache.spark.{LocalSparkContext, SparkConf, SparkFunSuite}
+import org.apache.spark.api.plugin.SparkWorkerPlugin
+import org.apache.spark.internal.config.SUBPROCESS_PLUGINS
+
+class WorkerPluginContainerSuite extends SparkFunSuite with LocalSparkContext {
+
+  test("plugin container applies to process builder") {
+    val conf = new SparkConf()
+      .set(SUBPROCESS_PLUGINS, Seq(classOf[TestWorkerPlugin].getName))
+    val pb = new ProcessBuilder()
+
+    WorkerPluginContainer(conf)(pb)
+
+    assert(pb.environment().containsKey("plugin-override"))
+  }
+
+  test("plugin container does not fail on empty plugin list") {
+    val pb = new ProcessBuilder()
+
+    WorkerPluginContainer(new SparkConf())(pb)
+  }
+}
+
+private class TestWorkerPlugin extends SparkWorkerPlugin {
+
+  override def apply(pb: ProcessBuilder): Unit =
+    pb.environment().put("plugin-override", "plugin-override")
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
This provides an API to customize the `ProcessBuilder` instances used to launch SparkR and PySpark workers. This allows dynamic overrides of the command, environment variables, and the standard output stream.

```yaml
spark.worker.plugins: package.MyWorkerPlugin
```
```java
class MyWorkerPlugin implements SparkWorkerPlugin {

  public void apply(ProcessBuilder pb) {
    // Example use cases:
    // pb.environment() to set environment variables
    // pb.command("...") to override the executed command
    // pb.getInputStream() to do things with the worker's stdout
  }
}
```

### Why are the changes needed?
This is a new API is needed to express customizations that cannot be expressed using static configs or environment variables (`spark.pyspark.python` or `spark.executorEnv.*`).

As described in SPARK-44767, this came up for us when using conda-packs and `spark.archives`. On drivers, packs are unarchived into `driverTmpDir` which has a dynamic name. That means we can't point to the driver-side environment statically in `PATH` or `PYTHONPATH` environment variables.

### Does this PR introduce _any_ user-facing change?
Developers have a new set of APIs that are marked as `@DeveloperApi` and `@Unstable`.

### How was this patch tested?
Added a test for the `WorkerPluginContainer`.