### PR TITLE
[SPARK-44773][SQL] Code-gen CodegenFallback expression in WholeStageCodegen if possible

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/EquivalentExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/EquivalentExpressions.scala
@@ -150,7 +150,7 @@ class EquivalentExpressions(
   //   1. CodegenFallback: it's children will not be used to generate code (call eval() instead)
   //   2. ConditionalExpression: use its children that will always be evaluated.
   private def childrenToRecurse(expr: Expression): Seq[Expression] = expr match {
-    case _: CodegenFallback => Nil
+    case e: CodegenFallback if !e.supportWholeStageCodegen() => Nil
     case c: ConditionalExpression => c.alwaysEvaluatedInputs.map(skipForShortcut)
     case other => skipForShortcut(other).children
   }
@@ -158,7 +158,7 @@ class EquivalentExpressions(
   // For some special expressions we cannot just recurse into all of its children, but we can
   // recursively add the common expressions shared between all of its children.
   private def commonChildrenToRecurse(expr: Expression): Seq[Seq[Expression]] = expr match {
-    case _: CodegenFallback => Nil
+    case e: CodegenFallback if !e.supportWholeStageCodegen() => Nil
     case c: ConditionalExpression => c.branchGroups
     case _ => Nil
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
@@ -368,6 +368,12 @@ abstract class Expression extends TreeNode[Expression] {
     } else {
       ""
     }
+
+
+  def supportWholeStageCodegen(): Boolean = {
+    this.getClass.getDeclaredMethods.exists(_.getName == "nullSafeEval") &&
+      !this.exists(e => !e.supportWholeStageCodegen())
+  }
 }
 
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
@@ -372,7 +372,10 @@ abstract class Expression extends TreeNode[Expression] {
 
   def supportWholeStageCodegen(): Boolean = {
     this.getClass.getDeclaredMethods.exists(_.getName == "nullSafeEval") &&
-      !this.children.exists(e => !e.supportWholeStageCodegen())
+      !this.children.exists {
+        case e: CodegenFallback => !e.supportWholeStageCodegen()
+        case _ => false
+      }
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
@@ -372,7 +372,7 @@ abstract class Expression extends TreeNode[Expression] {
 
   def supportWholeStageCodegen(): Boolean = {
     this.getClass.getDeclaredMethods.exists(_.getName == "nullSafeEval") &&
-      !this.exists(e => !e.supportWholeStageCodegen())
+      !this.children.exists(e => !e.supportWholeStageCodegen())
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodegenFallback.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodegenFallback.scala
@@ -96,7 +96,4 @@ trait CodegenFallback extends Expression {
     }
   }
 
-  def supportWholeStageCodegen(): Boolean = {
-    this.getClass.getDeclaredMethods.exists(_.getName == "nullSafeEval")
-  }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/WholeStageCodegenExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/WholeStageCodegenExec.scala
@@ -878,7 +878,7 @@ case class CollapseCodegenStages(
   private def supportCodegen(e: Expression): Boolean = e match {
     case e: LeafExpression => true
     // CodegenFallback requires the input to be an InternalRow
-    case e: CodegenFallback => false
+    case e: CodegenFallback if !e.supportWholeStageCodegen() => false
     case _ => true
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
@@ -33,7 +33,7 @@ import org.apache.spark.sql.catalyst.expressions.{Alias, ArraysZip, AttributeRef
 import org.apache.spark.sql.catalyst.expressions.Cast._
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
 import org.apache.spark.sql.catalyst.plans.logical.OneRowRelation
-import org.apache.spark.sql.catalyst.util.DateTimeTestUtils.{UTC, withDefaultTimeZone}
+import org.apache.spark.sql.catalyst.util.DateTimeTestUtils.{withDefaultTimeZone, UTC}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
@@ -5951,7 +5951,7 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSparkSession {
         s"""SELECT from_json(regexp_replace(s, 'a', 'x'), 'x INT, b DOUBLE').x,
            |       from_json(regexp_replace(s, 'a', 'x'), 'x INT, b DOUBLE').b
            |FROM values('{"a":1, "b":0.8}') t(s)
-           |""".stripMargin).explain("codegen")
+           |""".stripMargin).collect()
     }
     val logMsgs =
       logAppender.loggingEvents.map(_.getMessage.getFormattedMessage).flatten(_.split("\n"))


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

If a CodegenFallback expression has nullSafeEval method, code-gen it in the WholeStageCodegen class, and then the common sub-expressions will be eliminated.
For example:
```sql
SELECT from_json(regexp_replace(s, 'a', 'x'), 'x INT, b DOUBLE').x,
       from_json(regexp_replace(s, 'a', 'x'), 'x INT, b DOUBLE').b
FROM values('{"a":1, "b":0.8}') t(s)
```
plan:
```
*(1) Project [from_json(StructField(x,IntegerType,true), regexp_replace(s#218, a, x, 1), Some(America/Los_Angeles)).x AS from_json(regexp_replace(s, a, x, 1)).x#219, from_json(StructField(b,DoubleType,true), regexp_replace(s#218, a, x, 1), Some(America/Los_Angeles)).b AS from_json(regexp_replace(s, a, x, 1)).b#220]
+- *(1) LocalTableScan [s#218]
```
the common subexpression will only be executed once.

Before this PR, the generate code of the project:

```java
/* 001 */ public java.lang.Object generate(Object[] references) {
/* 002 */   return new SpecificUnsafeProjection(references);
/* 003 */ }
/* 004 */
/* 005 */ class SpecificUnsafeProjection extends org.apache.spark.sql.catalyst.expressions.UnsafeProjection {
/* 006 */
/* 007 */   private Object[] references;
/* 008 */   private org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter[] mutableStateArray_3 = new org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter[1];
/* 009 */   private java.util.regex.Pattern[] mutableStateArray_1 = new java.util.regex.Pattern[2];
/* 010 */   private String[] mutableStateArray_2 = new String[2];
/* 011 */   private UTF8String[] mutableStateArray_0 = new UTF8String[4];
/* 012 */
/* 013 */   public SpecificUnsafeProjection(Object[] references) {
/* 014 */     this.references = references;
/* 015 */
/* 016 */     mutableStateArray_3[0] = new org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter(2, 64);
/* 017 */
/* 018 */   }
/* 019 */
/* 020 */   public void initialize(int partitionIndex) {
/* 021 */
/* 022 */   }
/* 023 */
/* 024 */   // Scala.Function1 need this
/* 025 */   public java.lang.Object apply(java.lang.Object row) {
/* 026 */     return apply((InternalRow) row);
/* 027 */   }
/* 028 */
/* 029 */   public UnsafeRow apply(InternalRow i) {
/* 030 */     mutableStateArray_3[0].reset();
/* 031 */
/* 032 */
/* 033 */
/* 034 */
/* 035 */     Object obj_0 = ((Expression) references[0]).eval(i);
/* 036 */     boolean isNull_2 = obj_0 == null;
/* 037 */     InternalRow value_2 = null;
/* 038 */     if (!isNull_2) {
/* 039 */       value_2 = (InternalRow) obj_0;
/* 040 */     }
/* 041 */     boolean isNull_1 = isNull_2;
/* 042 */     int value_1 = -1;
/* 043 */
/* 044 */     if (!isNull_2) {
/* 045 */
/* 046 */       if (value_2.isNullAt(0)) {
/* 047 */         isNull_1 = true;
/* 048 */       } else {
/* 049 */         value_1 = value_2.getInt(0);
/* 050 */       }
/* 051 */
/* 052 */     }
/* 053 */     UTF8String value_0;
/* 054 */     if (isNull_1) {
/* 055 */       value_0 = UTF8String.fromString("NULL");
/* 056 */     } else {
/* 057 */       value_0 = UTF8String.fromString(String.valueOf(value_1));
/* 058 */     }
/* 059 */     mutableStateArray_3[0].write(0, value_0);
/* 060 */
/* 061 */     Object obj_1 = ((Expression) references[3]).eval(i);
/* 062 */     boolean isNull_10 = obj_1 == null;
/* 063 */     InternalRow value_11 = null;
/* 064 */     if (!isNull_10) {
/* 065 */       value_11 = (InternalRow) obj_1;
/* 066 */     }
/* 067 */     boolean isNull_9 = isNull_10;
/* 068 */     double value_10 = -1.0;
/* 069 */
/* 070 */     if (!isNull_10) {
/* 071 */
/* 072 */       if (value_11.isNullAt(0)) {
/* 073 */         isNull_9 = true;
/* 074 */       } else {
/* 075 */         value_10 = value_11.getDouble(0);
/* 076 */       }
/* 077 */
/* 078 */     }
/* 079 */     UTF8String value_9;
/* 080 */     if (isNull_9) {
/* 081 */       value_9 = UTF8String.fromString("NULL");
/* 082 */     } else {
/* 083 */       value_9 = UTF8String.fromString(String.valueOf(value_10));
/* 084 */     }
/* 085 */     mutableStateArray_3[0].write(1, value_9);
/* 086 */     return (mutableStateArray_3[0].getRow());
/* 087 */   }
/* 088 */
/* 089 */
/* 090 */   private UTF8String RegExpReplace_1(InternalRow i) {
/* 091 */     UTF8String value_13 = i.getUTF8String(0);
/* 092 */
/* 093 */
/* 094 */
/* 095 */     UTF8String value_12 = null;
/* 096 */
/* 097 */     if (!((UTF8String) references[4] /* literal */).equals(mutableStateArray_0[2])) {
/* 098 */       // regex value changed
/* 099 */       mutableStateArray_0[2] = ((UTF8String) references[4] /* literal */).clone();
/* 100 */       try {
/* 101 */         mutableStateArray_1[1] = java.util.regex.Pattern.compile(mutableStateArray_0[2].toString());
/* 102 */       } catch (java.util.regex.PatternSyntaxException e) {
/* 103 */         throw QueryExecutionErrors.invalidPatternError("regexp_replace", e.getPattern(), e);
/* 104 */       }
/* 105 */     }
/* 106 */     if (!((UTF8String) references[5] /* literal */).equals(mutableStateArray_0[3])) {
/* 107 */       // replacement string changed
/* 108 */       mutableStateArray_0[3] = ((UTF8String) references[5] /* literal */).clone();
/* 109 */       mutableStateArray_2[1] = mutableStateArray_0[3].toString();
/* 110 */     }
/* 111 */     String source_1 = value_13.toString();
/* 112 */     int position_1 = 1 - 1;
/* 113 */     if (position_1 == 0 || position_1 < source_1.length()) {
/* 114 */       java.lang.StringBuffer termResult_1 = new java.lang.StringBuffer();
/* 115 */       java.util.regex.Matcher matcher_1 = mutableStateArray_1[1].matcher(source_1);
/* 116 */       matcher_1.region(position_1, source_1.length());
/* 117 */
/* 118 */       while (matcher_1.find()) {
/* 119 */         matcher_1.appendReplacement(termResult_1, mutableStateArray_2[1]);
/* 120 */       }
/* 121 */       matcher_1.appendTail(termResult_1);
/* 122 */       value_12 = UTF8String.fromString(termResult_1.toString());
/* 123 */       termResult_1 = null;
/* 124 */     } else {
/* 125 */       value_12 = value_13;
/* 126 */     }
/* 127 */
/* 128 */     return value_12;
/* 129 */   }
/* 130 */
/* 131 */
/* 132 */   private UTF8String RegExpReplace_0(InternalRow i) {
/* 133 */     UTF8String value_4 = i.getUTF8String(0);
/* 134 */
/* 135 */
/* 136 */
/* 137 */     UTF8String value_3 = null;
/* 138 */
/* 139 */     if (!((UTF8String) references[1] /* literal */).equals(mutableStateArray_0[0])) {
/* 140 */       // regex value changed
/* 141 */       mutableStateArray_0[0] = ((UTF8String) references[1] /* literal */).clone();
/* 142 */       try {
/* 143 */         mutableStateArray_1[0] = java.util.regex.Pattern.compile(mutableStateArray_0[0].toString());
/* 144 */       } catch (java.util.regex.PatternSyntaxException e) {
/* 145 */         throw QueryExecutionErrors.invalidPatternError("regexp_replace", e.getPattern(), e);
/* 146 */       }
/* 147 */     }
/* 148 */     if (!((UTF8String) references[2] /* literal */).equals(mutableStateArray_0[1])) {
/* 149 */       // replacement string changed
/* 150 */       mutableStateArray_0[1] = ((UTF8String) references[2] /* literal */).clone();
/* 151 */       mutableStateArray_2[0] = mutableStateArray_0[1].toString();
/* 152 */     }
/* 153 */     String source_0 = value_4.toString();
/* 154 */     int position_0 = 1 - 1;
/* 155 */     if (position_0 == 0 || position_0 < source_0.length()) {
/* 156 */       java.lang.StringBuffer termResult_0 = new java.lang.StringBuffer();
/* 157 */       java.util.regex.Matcher matcher_0 = mutableStateArray_1[0].matcher(source_0);
/* 158 */       matcher_0.region(position_0, source_0.length());
/* 159 */
/* 160 */       while (matcher_0.find()) {
/* 161 */         matcher_0.appendReplacement(termResult_0, mutableStateArray_2[0]);
/* 162 */       }
/* 163 */       matcher_0.appendTail(termResult_0);
/* 164 */       value_3 = UTF8String.fromString(termResult_0.toString());
/* 165 */       termResult_0 = null;
/* 166 */     } else {
/* 167 */       value_3 = value_4;
/* 168 */     }
/* 169 */
/* 170 */     return value_3;
/* 171 */   }
/* 172 */
/* 173 */ }
```

After this PR, the generate code of the project:
```java
/* 028 */   private void project_doConsume_0(InternalRow localtablescan_row_0, UTF8String project_expr_0_0) throws java.io.IOException {
/* 029 */     // common sub-expressions
/* 030 */
/* 031 */     project_subExpr_0(project_expr_0_0);
/* 032 */
/* 033 */     Object project_obj_0 = null;
/* 034 */     if(false) {
/* 035 */       project_obj_0 = null;
/* 036 */     } else {
/* 037 */       project_obj_0 = ((org.apache.spark.sql.catalyst.expressions.JsonToStructs) references[5]).nullSafeEval(project_mutableStateArray_0[4]);
/* 038 */     }
/* 039 */     boolean project_isNull_12 = project_obj_0 == null;
/* 040 */     InternalRow project_value_12 = null;
/* 041 */     if (!project_isNull_12) {
/* 042 */       project_value_12 = (InternalRow) project_obj_0;
/* 043 */     }
/* 044 */     boolean project_isNull_11 = project_isNull_12;
/* 045 */     int project_value_11 = -1;
/* 046 */
/* 047 */     if (!project_isNull_12) {
/* 048 */       if (project_value_12.isNullAt(0)) {
/* 049 */         project_isNull_11 = true;
/* 050 */       } else {
/* 051 */         project_value_11 = project_value_12.getInt(0);
/* 052 */       }
/* 053 */
/* 054 */     }
/* 055 */     UTF8String project_value_10;
/* 056 */     if (project_isNull_11) {
/* 057 */       project_value_10 = UTF8String.fromString("NULL");
/* 058 */     } else {
/* 059 */       project_value_10 = UTF8String.fromString(String.valueOf(project_value_11));
/* 060 */     }
/* 061 */     Object project_obj_1 = null;
/* 062 */     if(false) {
/* 063 */       project_obj_1 = null;
/* 064 */     } else {
/* 065 */       project_obj_1 = ((org.apache.spark.sql.catalyst.expressions.JsonToStructs) references[6]).nullSafeEval(project_mutableStateArray_0[4]);
/* 066 */     }
/* 067 */     boolean project_isNull_15 = project_obj_1 == null;
/* 068 */     InternalRow project_value_15 = null;
/* 069 */     if (!project_isNull_15) {
/* 070 */       project_value_15 = (InternalRow) project_obj_1;
/* 071 */     }
/* 072 */     boolean project_isNull_14 = project_isNull_15;
/* 073 */     double project_value_14 = -1.0;
/* 074 */
/* 075 */     if (!project_isNull_15) {
/* 076 */       if (project_value_15.isNullAt(0)) {
/* 077 */         project_isNull_14 = true;
/* 078 */       } else {
/* 079 */         project_value_14 = project_value_15.getDouble(0);
/* 080 */       }
/* 081 */
/* 082 */     }
/* 083 */     UTF8String project_value_13;
/* 084 */     if (project_isNull_14) {
/* 085 */       project_value_13 = UTF8String.fromString("NULL");
/* 086 */     } else {
/* 087 */       project_value_13 = UTF8String.fromString(String.valueOf(project_value_14));
/* 088 */     }
/* 089 */     project_mutableStateArray_3[0].reset();
/* 090 */
/* 091 */     project_mutableStateArray_3[0].write(0, project_value_10);
/* 092 */
/* 093 */     project_mutableStateArray_3[0].write(1, project_value_13);
/* 094 */     append((project_mutableStateArray_3[0].getRow()));
/* 095 */
/* 096 */   }
/* 097 */
/* 098 */   private void project_subExpr_0(org.apache.spark.unsafe.types.UTF8String project_expr_0_0) {
/* 099 */     UTF8String project_value_5 = null;
/* 100 */
/* 101 */     if (!((UTF8String) references[3] /* literal */).equals(project_mutableStateArray_0[2])) {
/* 102 */       // regex value changed
/* 103 */       project_mutableStateArray_0[2] = ((UTF8String) references[3] /* literal */).clone();
/* 104 */       try {
/* 105 */         project_mutableStateArray_1[1] = java.util.regex.Pattern.compile(project_mutableStateArray_0[2].toString());
/* 106 */       } catch (java.util.regex.PatternSyntaxException e) {
/* 107 */         throw QueryExecutionErrors.invalidPatternError("regexp_replace", e.getPattern(), e);
/* 108 */       }
/* 109 */     }
/* 110 */     if (!((UTF8String) references[4] /* literal */).equals(project_mutableStateArray_0[3])) {
/* 111 */       // replacement string changed
/* 112 */       project_mutableStateArray_0[3] = ((UTF8String) references[4] /* literal */).clone();
/* 113 */       project_mutableStateArray_2[1] = project_mutableStateArray_0[3].toString();
/* 114 */     }
/* 115 */     String project_source_1 = project_expr_0_0.toString();
/* 116 */     int project_position_1 = 1 - 1;
/* 117 */     if (project_position_1 == 0 || project_position_1 < project_source_1.length()) {
/* 118 */       java.lang.StringBuffer project_termResult_1 = new java.lang.StringBuffer();
/* 119 */       java.util.regex.Matcher project_matcher_1 = project_mutableStateArray_1[1].matcher(project_source_1);
/* 120 */       project_matcher_1.region(project_position_1, project_source_1.length());
/* 121 */
/* 122 */       while (project_matcher_1.find()) {
/* 123 */         project_matcher_1.appendReplacement(project_termResult_1, project_mutableStateArray_2[1]);
/* 124 */       }
/* 125 */       project_matcher_1.appendTail(project_termResult_1);
/* 126 */       project_value_5 = UTF8String.fromString(project_termResult_1.toString());
/* 127 */       project_termResult_1 = null;
/* 128 */     } else {
/* 129 */       project_value_5 = project_expr_0_0;
/* 130 */     }
/* 131 */
/* 132 */     project_mutableStateArray_0[4] = project_value_5;
/* 133 */   }
```

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
