### PR TITLE
[SPARK-44776][CONNECT] Add ProducedRowCount to SparkListenerConnectOperationFinished

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/SparkConnectPlanExecution.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/SparkConnectPlanExecution.scala
@@ -126,10 +126,10 @@ private[execution] class SparkConnectPlanExecution(executeHolder: ExecuteHolder)
 
     dataframe.queryExecution.executedPlan match {
       case LocalTableScanExec(_, rows) =>
-        executePlan.eventsManager.postFinished(Some(totalNumRows))
         converter(rows.iterator).foreach { case (bytes, count) =>
           sendBatch(bytes, count)
         }
+        executePlan.eventsManager.postFinished(Some(totalNumRows))
       case _ =>
         SQLExecution.withNewExecutionId(dataframe.queryExecution, Some("collectArrow")) {
           val rows = dataframe.queryExecution.executedPlan.execute()

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/SparkConnectPlanExecution.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/SparkConnectPlanExecution.scala
@@ -165,7 +165,6 @@ private[execution] class SparkConnectPlanExecution(executeHolder: ExecuteHolder)
               // Collect errors and propagate them to the main thread.
               .andThen {
                 case Success(_) =>
-                  executePlan.eventsManager.postFinished(Some(totalNumRows))
                 case Failure(throwable) =>
                   signal.synchronized {
                     error = Some(throwable)
@@ -202,6 +201,7 @@ private[execution] class SparkConnectPlanExecution(executeHolder: ExecuteHolder)
               currentPartitionId += 1
             }
             ThreadUtils.awaitReady(future, Duration.Inf)
+            executePlan.eventsManager.postFinished(Some(totalNumRows))
           } else {
             executePlan.eventsManager.postFinished(Some(totalNumRows))
           }

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/SparkConnectPlanExecution.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/SparkConnectPlanExecution.scala
@@ -164,7 +164,7 @@ private[execution] class SparkConnectPlanExecution(executeHolder: ExecuteHolder)
                 resultFunc = () => ())
               // Collect errors and propagate them to the main thread.
               .andThen {
-                case Success(_) =>
+                case Success(_) => // do nothing
                 case Failure(throwable) =>
                   signal.synchronized {
                     error = Some(throwable)

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -2480,7 +2480,7 @@ class SparkConnectPlanner(val sessionHolder: SessionHolder) extends Logging {
               .putAllArgs(getSqlCommand.getArgsMap)
               .addAllPosArgs(getSqlCommand.getPosArgsList)))
     }
-    executeHolder.eventsManager.postFinished()
+    executeHolder.eventsManager.postFinished(Some(rows.size))
     // Exactly one SQL Command Result Batch
     responseObserver.onNext(
       ExecutePlanResponse

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/ExecuteEventsManager.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/ExecuteEventsManager.scala
@@ -414,11 +414,11 @@ case class SparkListenerConnectOperationFailed(
  *   36 characters UUID assigned by Connect during a request.
  * @param eventTime:
  *   The time in ms when the event was generated.
- * @param extraTags:
- *   Additional metadata during the request.
  * @param producedRowCount:
  *   Number of rows that are returned to the user. None is expected when the operation does not
  *   return any rows.
+ * @param extraTags:
+ *   Additional metadata during the request.
  */
 case class SparkListenerConnectOperationFinished(
     jobTag: String,

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/ExecuteEventsManager.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/ExecuteEventsManager.scala
@@ -99,8 +99,8 @@ case class ExecuteEventsManager(executeHolder: ExecuteHolder, clock: Clock) {
 
   /**
    * @return
-   * How many rows the Connect request has produced @link
-   * org.apache.spark.sql.connect.service.SparkListenerConnectOperationFinished
+   *   How many rows the Connect request has produced @link
+   *   org.apache.spark.sql.connect.service.SparkListenerConnectOperationFinished
    */
   private[connect] def getProducedRowCount: Option[Long] = producedRowCount
 
@@ -201,12 +201,15 @@ case class ExecuteEventsManager(executeHolder: ExecuteHolder, clock: Clock) {
 
   /**
    * Post @link org.apache.spark.sql.connect.service.SparkListenerConnectOperationFinished.
+   * @param producedRowsCountOpt
+   *   Number of rows that are returned to the user. None is expected when the operation does not
+   *   return any rows.
    */
-  def postFinished(totalNumRowsOpt: Option[Long] = None): Unit = {
+  def postFinished(producedRowsCountOpt: Option[Long] = None): Unit = {
     assertStatus(
       List(ExecuteStatus.Started, ExecuteStatus.ReadyForExecution),
       ExecuteStatus.Finished)
-    producedRowCount = totalNumRowsOpt
+    producedRowCount = producedRowsCountOpt
 
     listenerBus
       .post(
@@ -214,9 +217,7 @@ case class ExecuteEventsManager(executeHolder: ExecuteHolder, clock: Clock) {
           jobTag,
           operationId,
           clock.getTimeMillis(),
-          producedRowCount
-        )
-      )
+          producedRowCount))
   }
 
   /**
@@ -415,6 +416,9 @@ case class SparkListenerConnectOperationFailed(
  *   The time in ms when the event was generated.
  * @param extraTags:
  *   Additional metadata during the request.
+ * @param producedRowCount:
+ *   Number of rows that are returned to the user. None is expected when the operation does not
+ *   return any rows.
  */
 case class SparkListenerConnectOperationFinished(
     jobTag: String,

--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectServiceSuite.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectServiceSuite.scala
@@ -190,7 +190,7 @@ class SparkConnectServiceSuite extends SharedSparkSession with MockitoSugar with
             done = true
           }
         })
-      verifyEvents.onCompleted()
+      verifyEvents.onCompleted(Some(100))
       // The current implementation is expected to be blocking. This is here to make sure it is.
       assert(done)
 
@@ -788,8 +788,9 @@ class SparkConnectServiceSuite extends SharedSparkSession with MockitoSugar with
       assert(executeHolder.eventsManager.hasCanceled.isEmpty)
       assert(executeHolder.eventsManager.hasError.isDefined)
     }
-    def onCompleted(): Unit = {
+    def onCompleted(producedRowCount: Option[Long] = None): Unit = {
       assert(executeHolder.eventsManager.status == ExecuteStatus.Closed)
+      assert(executeHolder.eventsManager.getProducedRowCount == producedRowCount)
     }
     def onCanceled(): Unit = {
       assert(executeHolder.eventsManager.hasCanceled.contains(true))

--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectServiceSuite.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectServiceSuite.scala
@@ -58,10 +58,10 @@ import org.apache.spark.util.Utils
  * Testing Connect Service implementation.
  */
 class SparkConnectServiceSuite
-  extends SharedSparkSession
+    extends SharedSparkSession
     with MockitoSugar
     with Logging
-    with SparkConnectPlanTest{
+    with SparkConnectPlanTest {
 
   private def sparkSessionHolder = SessionHolder.forTesting(spark)
   private def DEFAULT_UUID = UUID.fromString("89ea6117-1f45-4c03-ae27-f47c6aded093")
@@ -268,9 +268,7 @@ class SparkConnectServiceSuite
       val localRelation = createLocalRelationProto(schema, inputRows)
       val plan = proto.Plan
         .newBuilder()
-        .setRoot(
-          localRelation
-        )
+        .setRoot(localRelation)
         .build()
 
       val request = proto.ExecutePlanRequest
@@ -382,132 +380,121 @@ class SparkConnectServiceSuite
     Seq(
       (
         proto.Command
-        .newBuilder()
-        .setSqlCommand(proto.SqlCommand.newBuilder().setSql("select 1").build()),
-        Some(0L)
-      ),
+          .newBuilder()
+          .setSqlCommand(proto.SqlCommand.newBuilder().setSql("select 1").build()),
+        Some(0L)),
       (
         proto.Command
-        .newBuilder()
-        .setSqlCommand(proto.SqlCommand.newBuilder().setSql("show databases").build()),
-        Some(1L)
-      ),
+          .newBuilder()
+          .setSqlCommand(proto.SqlCommand.newBuilder().setSql("show databases").build()),
+        Some(1L)),
       (
         proto.Command
-        .newBuilder()
-        .setWriteOperation(
-          proto.WriteOperation
-            .newBuilder()
-            .setInput(
-              proto.Relation.newBuilder().setSql(proto.SQL.newBuilder().setQuery("select 1")))
-            .setPath(Utils.createTempDir().getAbsolutePath)
-            .setMode(proto.WriteOperation.SaveMode.SAVE_MODE_OVERWRITE)),
-        None
-      ),
-      (
-        proto.Command
-        .newBuilder()
-        .setWriteOperationV2(
-          proto.WriteOperationV2
-            .newBuilder()
-            .setInput(proto.Relation.newBuilder.setRange(
-              proto.Range.newBuilder().setStart(0).setEnd(2).setStep(1L)))
-            .setTableName("testcat.testtable")
-            .setMode(proto.WriteOperationV2.Mode.MODE_CREATE)),
-        None
-      ),
-      (
-        proto.Command
-        .newBuilder()
-        .setCreateDataframeView(
-          CreateDataFrameViewCommand
-            .newBuilder()
-            .setName("testview")
-            .setInput(
-              proto.Relation.newBuilder().setSql(proto.SQL.newBuilder().setQuery("select 1")))),
-        None
-      ),
-      (proto.Command
-        .newBuilder()
-        .setGetResourcesCommand(proto.GetResourcesCommand.newBuilder()),
+          .newBuilder()
+          .setWriteOperation(
+            proto.WriteOperation
+              .newBuilder()
+              .setInput(
+                proto.Relation.newBuilder().setSql(proto.SQL.newBuilder().setQuery("select 1")))
+              .setPath(Utils.createTempDir().getAbsolutePath)
+              .setMode(proto.WriteOperation.SaveMode.SAVE_MODE_OVERWRITE)),
         None),
       (
         proto.Command
-        .newBuilder()
-        .setExtension(
-          protobuf.Any.pack(
-            proto.ExamplePluginCommand
-              .newBuilder()
-              .setCustomField("SPARK-43923")
-              .build())),
-        None
-      ),
-      (
-        proto.Command
-        .newBuilder()
-        .setWriteStreamOperationStart(
-          proto.WriteStreamOperationStart
-            .newBuilder()
-            .setInput(
-              proto.Relation
-                .newBuilder()
-                .setRead(proto.Read
-                  .newBuilder()
-                  .setIsStreaming(true)
-                  .setDataSource(proto.Read.DataSource.newBuilder().setFormat("rate").build())
-                  .build())
-                .build())
-            .setOutputMode("Append")
-            .setAvailableNow(true)
-            .setQueryName("test")
-            .setFormat("memory")
-            .putOptions("checkpointLocation", Utils.createTempDir().getAbsolutePath)
-            .setPath("test-path")
-            .build()),
-        None
-      ),
-      (
-        proto.Command
-        .newBuilder()
-        .setStreamingQueryCommand(
-          proto.StreamingQueryCommand
-            .newBuilder()
-            .setQueryId(
-              proto.StreamingQueryInstanceId
-                .newBuilder()
-                .setId(DEFAULT_UUID.toString)
-                .setRunId(DEFAULT_UUID.toString)
-                .build())
-            .setStop(true)),
-        None
-      ),
-      (
-        proto.Command
-        .newBuilder()
-        .setStreamingQueryManagerCommand(proto.StreamingQueryManagerCommand
           .newBuilder()
-          .setListListeners(true)),
-        None
-      ),
+          .setWriteOperationV2(
+            proto.WriteOperationV2
+              .newBuilder()
+              .setInput(proto.Relation.newBuilder.setRange(
+                proto.Range.newBuilder().setStart(0).setEnd(2).setStep(1L)))
+              .setTableName("testcat.testtable")
+              .setMode(proto.WriteOperationV2.Mode.MODE_CREATE)),
+        None),
       (
         proto.Command
-        .newBuilder()
-        .setRegisterFunction(
-          proto.CommonInlineUserDefinedFunction
-            .newBuilder()
-            .setFunctionName("function")
-            .setPythonUdf(
-              proto.PythonUDF
+          .newBuilder()
+          .setCreateDataframeView(
+            CreateDataFrameViewCommand
+              .newBuilder()
+              .setName("testview")
+              .setInput(
+                proto.Relation.newBuilder().setSql(proto.SQL.newBuilder().setQuery("select 1")))),
+        None),
+      (
+        proto.Command
+          .newBuilder()
+          .setGetResourcesCommand(proto.GetResourcesCommand.newBuilder()),
+        None),
+      (
+        proto.Command
+          .newBuilder()
+          .setExtension(
+            protobuf.Any.pack(
+              proto.ExamplePluginCommand
                 .newBuilder()
-                .setEvalType(100)
-                .setOutputType(DataTypeProtoConverter.toConnectProtoType(IntegerType))
-                .setCommand(ByteString.copyFrom("command".getBytes()))
-                .setPythonVer("3.10")
+                .setCustomField("SPARK-43923")
                 .build())),
-        None
-      )
-    )
-  ) { case (command, producedNumRows) =>
+        None),
+      (
+        proto.Command
+          .newBuilder()
+          .setWriteStreamOperationStart(
+            proto.WriteStreamOperationStart
+              .newBuilder()
+              .setInput(
+                proto.Relation
+                  .newBuilder()
+                  .setRead(proto.Read
+                    .newBuilder()
+                    .setIsStreaming(true)
+                    .setDataSource(proto.Read.DataSource.newBuilder().setFormat("rate").build())
+                    .build())
+                  .build())
+              .setOutputMode("Append")
+              .setAvailableNow(true)
+              .setQueryName("test")
+              .setFormat("memory")
+              .putOptions("checkpointLocation", Utils.createTempDir().getAbsolutePath)
+              .setPath("test-path")
+              .build()),
+        None),
+      (
+        proto.Command
+          .newBuilder()
+          .setStreamingQueryCommand(
+            proto.StreamingQueryCommand
+              .newBuilder()
+              .setQueryId(
+                proto.StreamingQueryInstanceId
+                  .newBuilder()
+                  .setId(DEFAULT_UUID.toString)
+                  .setRunId(DEFAULT_UUID.toString)
+                  .build())
+              .setStop(true)),
+        None),
+      (
+        proto.Command
+          .newBuilder()
+          .setStreamingQueryManagerCommand(proto.StreamingQueryManagerCommand
+            .newBuilder()
+            .setListListeners(true)),
+        None),
+      (
+        proto.Command
+          .newBuilder()
+          .setRegisterFunction(
+            proto.CommonInlineUserDefinedFunction
+              .newBuilder()
+              .setFunctionName("function")
+              .setPythonUdf(
+                proto.PythonUDF
+                  .newBuilder()
+                  .setEvalType(100)
+                  .setOutputType(DataTypeProtoConverter.toConnectProtoType(IntegerType))
+                  .setCommand(ByteString.copyFrom("command".getBytes()))
+                  .setPythonVer("3.10")
+                  .build())),
+        None))) { case (command, producedNumRows) =>
     val sessionId = UUID.randomUUID.toString()
     withCommandTest(sessionId) { verifyEvents =>
       val instance = new SparkConnectService(false)

--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/service/ExecuteEventsManagerSuite.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/service/ExecuteEventsManagerSuite.scala
@@ -141,6 +141,19 @@ class ExecuteEventsManagerSuite
           DEFAULT_CLOCK.getTimeMillis()))
   }
 
+  test("SPARK-44776: post finished with row number") {
+    val events = setupEvents(ExecuteStatus.Started)
+    events.postFinished(Some(100))
+    verify(events.executeHolder.sessionHolder.session.sparkContext.listenerBus, times(1))
+      .post(
+        SparkListenerConnectOperationFinished(
+          events.executeHolder.jobTag,
+          DEFAULT_QUERY_ID,
+          DEFAULT_CLOCK.getTimeMillis(),
+          Some(100)
+        ))
+  }
+
   test("SPARK-43923: post closed") {
     val events = setupEvents(ExecuteStatus.Finished)
     events.postClosed()

--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/service/ExecuteEventsManagerSuite.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/service/ExecuteEventsManagerSuite.scala
@@ -150,8 +150,7 @@ class ExecuteEventsManagerSuite
           events.executeHolder.jobTag,
           DEFAULT_QUERY_ID,
           DEFAULT_CLOCK.getTimeMillis(),
-          Some(100)
-        ))
+          Some(100)))
   }
 
   test("SPARK-43923: post closed") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Add ProducedRowCount field to SparkListenerConnectOperationFinished

### Why are the changes needed?
Needed for showing number of rows getting produced

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Added Unit test