### PR TITLE
[SPARK-44422][FOLLOWUP][CONNECT] Fix typo in ProtoUtils

### DIFF
--- a/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/common/ProtoUtils.scala
+++ b/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/common/ProtoUtils.scala
@@ -84,7 +84,7 @@ private[connect] object ProtoUtils {
 
   // Because Spark Connect operation tags are also set as SparkContext Job tags, they cannot contain
   // SparkContext.SPARK_JOB_TAGS_SEP
-  private var SPARK_JOB_TAGS_SEP = ',' // SparkContext.SPARK_JOB_TAGS_SEP
+  private val SPARK_JOB_TAGS_SEP = ',' // SparkContext.SPARK_JOB_TAGS_SEP
 
   /**
    * Validate if a tag for ExecutePlanRequest.tags is valid. Throw IllegalArgumentException if


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix typo - the constant should be a val, not var.

Triggered a style warning for me that got turned into error in my dev environment:
```
[error] vendor/connect/common/src/main/scala/org/apache/spark/sql/connect/common/ProtoUtils.scala:87:15
[error] private var SPARK_JOB_TAGS_SEP in object ProtoUtils is never updated: consider using immutable val
[error]   private var SPARK_JOB_TAGS_SEP = ',' // SparkContext.SPARK_JOB_TAGS_SEP
[error]               ^
[error] one error found
```

### Why are the changes needed?

Typo in previous work.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI