### PR TITLE
[SPARK-44625][CONNECT][FOLLOWUP] Make initialization of SparkConnectExecutionManager lazy

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
@@ -278,7 +278,7 @@ object SparkConnectService extends Logging {
   private val userSessionMapping =
     cacheBuilder(CACHE_SIZE, CACHE_TIMEOUT_SECONDS).build[SessionCacheKey, SessionHolder]()
 
-  private[connect] val executionManager = new SparkConnectExecutionManager()
+  private[connect] lazy val executionManager = new SparkConnectExecutionManager()
 
   private[connect] val streamingSessionManager =
     new SparkConnectStreamingQueryCache()


### PR DESCRIPTION
### What changes were proposed in this pull request?

SparkConnectExecutionManager is a val field in SparkConnectService, so it gets initialized the first time SparkConnectService object is touched. In some scenarios, this can accidentally happen too early, before anything is initialized. SparkConnectExecutionManager wants to read configs from SparkEnv, and when it's not initialized yet it can fail.

Make SparkConnectExecutionManager lazy. Since it is `private[connect]` it should not then be initialized before the service is started.

Raised https://issues.apache.org/jira/browse/SPARK-44779 as a followup to look at the Spark Connect initialization in general.

### Why are the changes needed?

Fix initialization order.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Got one test failure in one specific environment that failed because of wrong initialization order.