### PR TITLE
[SPARK-44770][WEBUI] Add a displayOrder variable to WebUITab to specify the order in which tabs appear 

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/ui/SparkConnectServerTab.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/ui/SparkConnectServerTab.scala
@@ -46,6 +46,8 @@ private[connect] class SparkConnectServerTab(
   def detach(): Unit = {
     parent.detachTab(this)
   }
+
+  override def displayOrder: Int = 3
 }
 
 private[connect] object SparkConnectServerTab {

--- a/core/src/main/scala/org/apache/spark/ui/WebUI.scala
+++ b/core/src/main/scala/org/apache/spark/ui/WebUI.scala
@@ -198,10 +198,12 @@ private[spark] abstract class WebUITab(parent: WebUI, val prefix: String) {
     pages += page
   }
 
-  /** Get a list of header tabs from the parent UI. */
-  def headerTabs: Seq[WebUITab] = parent.getTabs
+  /** Get a list of header tabs from the parent UI sorted by displayOrder. */
+  def headerTabs: Seq[WebUITab] = parent.getTabs.sortBy(_.displayOrder)
 
   def basePath: String = parent.getBasePath
+
+  def displayOrder: Int = Integer.MIN_VALUE
 }
 
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SQLTab.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SQLTab.scala
@@ -35,6 +35,8 @@ class SQLTab(val sqlStore: SQLAppStatusStore, sparkUI: SparkUI)
   parent.attachTab(this)
 
   parent.addStaticHandler(SQLTab.STATIC_RESOURCE_DIR, "/static/sql")
+
+  override def displayOrder: Int = 0
 }
 
 object SQLTab {

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/ui/StreamingQueryTab.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/ui/StreamingQueryTab.scala
@@ -33,6 +33,8 @@ private[sql] class StreamingQueryTab(
   parent.attachTab(this)
 
   parent.addStaticHandler(StreamingQueryTab.STATIC_RESOURCE_DIR, "/static/sql")
+
+  override def displayOrder: Int = 2
 }
 
 private[sql] object StreamingQueryTab {

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/ui/ThriftServerTab.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/ui/ThriftServerTab.scala
@@ -40,6 +40,8 @@ private[thriftserver] class ThriftServerTab(
   def detach(): Unit = {
     sparkUI.detachTab(this)
   }
+
+  override def displayOrder: Int = 1
 }
 
 private[thriftserver] object ThriftServerTab {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Add a displayOrder variable to WebUITab to specify the order in which tabs appear. Currently, the tabs are ordered by when they get attached, which isn't always desired. The default is MIN_VALUE, meaning if it's not specified, it will appear in the order added before any tabs with a non-default displayOrder. 

### Why are the changes needed?
These changes allow control over the order which tabs appear in the UI. Currently, the tabs are ordered by when they get attached, but this doesn't always match the desired order. For example, we would like to have the SQL Tab appear before the Connect tab; however, based on the code flow, the Connect tab will be attached first and with the current logic, that tab would also appear first.


### Does this PR introduce _any_ user-facing change?
Yes, minor user-facing change affecting the order in which tabs appear in the Spark UI


### How was this patch tested?
Manually tested

Before:
<img width="1696" alt="Screenshot 2023-08-10 at 3 54 26 PM" src="https://github.com/apache/spark/assets/65624911/a04ac6a9-c845-4a13-8780-ffe85de15285">

After:
<img width="1679" alt="Screenshot 2023-08-10 at 3 54 42 PM" src="https://github.com/apache/spark/assets/65624911/fb332f73-5e3e-4b03-adfc-15402db01197">

