### PR TITLE
[CONNECT][POC] Have real server and real simple client in tests - connect-client-jvm-shaded

### DIFF
--- a/connector/connect/client/jvm-shaded/pom.xml
+++ b/connector/connect/client/jvm-shaded/pom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.spark</groupId>
+        <artifactId>spark-parent_2.12</artifactId>
+        <version>4.0.0-SNAPSHOT</version>
+        <relativePath>../../../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>spark-connect-client-jvm-shaded_2.12</artifactId>
+    <packaging>jar</packaging>
+    <name>Spark Project Connect Client Shaded</name>
+    <url>https://spark.apache.org/</url>
+    <properties>
+        <sbt.project.name>connect-client-jvm-shaded</sbt.project.name>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-connect-client-jvm_${scala.binary.version}</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <outputDirectory>target/scala-${scala.binary.version}/classes</outputDirectory>
+        <testOutputDirectory>target/scala-${scala.binary.version}/test-classes</testOutputDirectory>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.5.0</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.apache.spark:*</include>
+                                </includes>
+                            </artifactSet>
+                            <relocations>
+                                <relocation>
+                                    <pattern>org.apache.spark</pattern>
+                                    <shadedPattern>org.apache.sparkconnectclient</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/connector/connect/server/pom.xml
+++ b/connector/connect/server/pom.xml
@@ -115,6 +115,12 @@
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
+      <artifactId>spark-connect-client-jvm-shaded_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
       <artifactId>spark-catalyst_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>

--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/SparkConnectReattachableExecuteSuite.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/SparkConnectReattachableExecuteSuite.scala
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.connect
+
+import java.util.UUID
+
+import org.apache.sparkconnectclient.sql.connect.client.SparkConnectClient
+
+import org.apache.spark.connect.proto
+import org.apache.spark.sql.connect.dsl.MockRemoteSession
+import org.apache.spark.sql.connect.dsl.plans._
+import org.apache.spark.sql.connect.service.SparkConnectService
+import org.apache.spark.sql.test.SharedSparkSession
+
+class SparkConnectReattachableExecuteSuite extends SharedSparkSession {
+
+  private val sessionId = UUID.randomUUID.toString()
+  private val userContext = proto.UserContext
+    .newBuilder()
+    .setUserId("c1")
+    .build()
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    SparkConnectService.start(spark.sparkContext)
+  }
+
+  override def afterAll(): Unit = {
+    SparkConnectService.stop()
+  }
+
+  test("test") {
+    val client = SparkConnectClient.builder().build()
+    val connect = new MockRemoteSession()
+    val plan = proto.Plan
+      .newBuilder()
+      .setRoot(connect.sql("select * from range(1000)"))
+      .build()
+    val request = proto.ExecutePlanRequest
+      .newBuilder()
+      .setUserContext(userContext)
+      .setSessionId(sessionId)
+      .setOperationId(UUID.randomUUID().toString)
+      .setPlan(plan)
+      .build()
+
+    val iter = client.execute(plan)
+    iter.next()
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,7 @@
     <module>connector/connect/server</module>
     <module>connector/connect/common</module>
     <module>connector/connect/client/jvm</module>
+    <module>connector/connect/client/jvm-shaded</module>
     <module>connector/protobuf</module>
     <!-- See additional modules enabled by profiles below -->
   </modules>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Try to create a `connect-client-jvm-shaded` so that I could pull a shaded version of the client into connect

Other approach https://github.com/apache/spark/pull/42441

### Why are the changes needed?


### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

