### PR TITLE
[SPARK-44791][CONNECT][TESTS][FOLLOWUP] Fix test case `Collect REPL generated class` for Scala 2.13

### DIFF
--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/application/ReplE2ESuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/application/ReplE2ESuite.scala
@@ -274,6 +274,12 @@ class ReplE2ESuite extends RemoteSparkSession with BeforeAndAfterEach {
         |  collect()
       """.stripMargin
     val output = runCommandsInShell(input)
-    assertContains("Array[MyTestClass] = Array(MyTestClass(1), MyTestClass(3))", output)
+    if (Properties.versionNumberString.startsWith("2.13")) {
+      assertContains(
+        "Array[MyTestClass] = Array(MyTestClass(value = 1), MyTestClass(value = 3))",
+        output)
+    } else {
+      assertContains("Array[MyTestClass] = Array(MyTestClass(1), MyTestClass(3))", output)
+    }
   }
 }

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/application/ReplE2ESuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/application/ReplE2ESuite.scala
@@ -274,12 +274,11 @@ class ReplE2ESuite extends RemoteSparkSession with BeforeAndAfterEach {
         |  collect()
       """.stripMargin
     val output = runCommandsInShell(input)
-    if (Properties.versionNumberString.startsWith("2.13")) {
-      assertContains(
-        "Array[MyTestClass] = Array(MyTestClass(value = 1), MyTestClass(value = 3))",
-        output)
-    } else {
-      assertContains("Array[MyTestClass] = Array(MyTestClass(1), MyTestClass(3))", output)
-    }
+    // SPARK-44791: The result printed by Scala 2.13 is
+    // `Array[MyTestClass] = Array(MyTestClass(value = 1), MyTestClass(value = 3))`,
+    // remove all `value =` from output to keep it the same as the result of Scala 2.12.
+    assertContains(
+      "Array[MyTestClass] = Array(MyTestClass(1), MyTestClass(3))",
+      output.replaceAll("value = ", ""))
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR refactors the test case `Collect REPL generated class` to ensure that Scala 2.12 and Scala 2.13 use the same results for assertion.

### Why are the changes needed?
Fix `Collect REPL generated class` test failed with Scala 2.13.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass Github Actions
- Manually check

```
dev/change-scala-version.sh 2.13
build/sbt clean "connect-client-jvm/testOnly org.apache.spark.sql.application.ReplE2ESuite" -Phive -Pscala-2.13
```

**Before**

```
res53: Array[MyTestClass] = Array(MyTestClass(value = 1), MyTestClass(value = 3))
[info]   
[info]   @        

[info]   @ semaphore.release() 

[info]   Error Output: Compiling (synthetic)/ammonite/predef/ArgsPredef.sc
[info]   Compiling /Users/yangjie01/SourceCode/git/spark-mine-sbt/connector/connect/client/jvm/(console) (ReplE2ESuite.scala:111)
[info]   org.scalatest.exceptions.TestFailedException:
[info]   at org.scalatest.Assertions.newAssertionFailedException(Assertions.scala:472)
[info]   at org.scalatest.Assertions.newAssertionFailedException$(Assertions.scala:471)
[info]   at org.scalatest.Assertions$.newAssertionFailedException(Assertions.scala:1231)
[info]   at org.scalatest.Assertions$AssertionsHelper.macroAssert(Assertions.scala:1295)
[info]   at org.apache.spark.sql.application.ReplE2ESuite.assertContains(ReplE2ESuite.scala:111)
[info]   at org.apache.spark.sql.application.ReplE2ESuite.$anonfun$new$13(ReplE2ESuite.scala:277)
[info]   at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18)
[info]   at org.apache.spark.sql.connect.client.util.RemoteSparkSession.$anonfun$test$1(RemoteSparkSession.scala:243)
...
[info] Run completed in 37 seconds, 954 milliseconds.
[info] Total number of tests run: 13
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 12, failed 1, canceled 0, ignored 0, pending 0
[info] *** 1 TEST FAILED ***
```

**After**

```
[info] ReplE2ESuite:
[info] - Simple query (4 seconds, 335 milliseconds)
[info] - UDF containing 'def' (1 second, 479 milliseconds)
[info] - UDF containing in-place lambda (828 milliseconds)
[info] - Updating UDF properties (906 milliseconds)
[info] - SPARK-43198: Filter does not throw ammonite-related class initialization exception (1 second, 87 milliseconds)
[info] - Client-side JAR (1 second, 304 milliseconds)
[info] - Java UDF (972 milliseconds)
[info] - Java UDF Registration (986 milliseconds)
[info] - UDF Registration (931 milliseconds)
[info] - UDF closure registration (795 milliseconds)
[info] - call_udf (1 second, 233 milliseconds)
[info] - call_function (892 milliseconds)
[info] - Collect REPL generated class (1 second, 166 milliseconds)
[info] Run completed in 37 seconds, 775 milliseconds.
[info] Total number of tests run: 13
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 13, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
 ```