### PR TITLE
[SPARK-44777][CORE]  Eager checkpointing on RDDs

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -1670,32 +1670,16 @@ abstract class RDD[T: ClassTag](
   }
 
   /**
-   * Mark this RDD for checkpointing. It will be saved to a file inside the checkpoint
-   * directory set with `SparkContext#setCheckpointDir` and all references to its parent
-   * RDDs will be removed. This function must be called before any job has been
-   * executed on this RDD. It is strongly recommended that this RDD is persisted in
-   * memory, otherwise saving it on a file will require recomputation.
+   * Mark this RDD for lazy checkpointing.
+   *
+   * @see [[RDD#checkpoint(eager:Boolean):RDD\.this\.type*]].
    */
   def checkpoint(): Unit = checkpoint(eager = false)
 
   /**
-   * Mark this RDD for local checkpointing using Spark's existing caching layer.
+   * Mark this RDD for lazy local checkpointing.
    *
-   * This method is for users who wish to truncate RDD lineages while skipping the expensive
-   * step of replicating the materialized data in a reliable distributed file system. This is
-   * useful for RDDs with long lineages that need to be truncated periodically (e.g. GraphX).
-   *
-   * Local checkpointing sacrifices fault-tolerance for performance. In particular, checkpointed
-   * data is written to ephemeral local storage in the executors instead of to a reliable,
-   * fault-tolerant storage. The effect is that if an executor fails during the computation,
-   * the checkpointed data may no longer be accessible, causing an irrecoverable job failure.
-   *
-   * This is NOT safe to use with dynamic allocation, which removes executors along
-   * with their cached blocks. If you must use both features, you are advised to set
-   * `spark.dynamicAllocation.cachedExecutorIdleTimeout` to a high value.
-   *
-   * The checkpoint directory set through `SparkContext#setCheckpointDir` is not used.
-   *
+   * @see [[RDD#localCheckpoint(eager:Boolean):RDD\.this\.type*]].
    */
   def localCheckpoint(): this.type = localCheckpoint(eager = false)
 

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -1672,14 +1672,14 @@ abstract class RDD[T: ClassTag](
   /**
    * Mark this RDD for lazy checkpointing.
    *
-   * @see [[RDD#checkpoint(eager:Boolean):RDD\.this\.type*]].
+   * @see [[RDD#checkpoint]]
    */
   def checkpoint(): Unit = checkpoint(eager = false)
 
   /**
    * Mark this RDD for lazy local checkpointing.
    *
-   * @see [[RDD#localCheckpoint(eager:Boolean):RDD\.this\.type*]].
+   * @see [[RDD#localCheckpoint]]
    */
   def localCheckpoint(): this.type = localCheckpoint(eager = false)
 

--- a/core/src/test/scala/org/apache/spark/CheckpointSuite.scala
+++ b/core/src/test/scala/org/apache/spark/CheckpointSuite.scala
@@ -538,6 +538,13 @@ class CheckpointSuite extends SparkFunSuite with RDDCheckpointTester with LocalS
       sc.setLocalProperty(RDD.CHECKPOINT_ALL_MARKED_ANCESTORS, null)
     }
   }
+
+  runTest("eager checkpointing") { reliableCheckpoint: Boolean =>
+    val rdd = sc.makeRDD(1 to 4)
+    rdd.checkpoint(eager = true)
+    assert(rdd.isCheckpointed)
+    assert(rdd.isCheckpointedAndMaterialized)
+  }
 }
 
 /** RDD partition that has large serialized size. */

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -554,7 +554,7 @@ class RDD(Generic[T_co]):
         self._jrdd.unpersist(blocking)
         return self
 
-    def checkpoint(self) -> None:
+    def checkpoint(self, eager: bool = False) -> None:
         """
         Mark this RDD for checkpointing. It will be saved to a file inside the
         checkpoint directory set with :meth:`SparkContext.setCheckpointDir` and
@@ -564,6 +564,13 @@ class RDD(Generic[T_co]):
         on a file will require recomputation.
 
         .. versionadded:: 0.7.0
+
+        Parameters
+        ----------
+        eager : bool, optional, default False
+            Whether to checkpoint this :class:`RDD` immediately.
+
+            .. versionadded:: 4.0.0
 
         See Also
         --------
@@ -593,9 +600,16 @@ class RDD(Generic[T_co]):
         True
         >>> rdd.getCheckpointFile() == None
         False
+
+        >>> rdd2 = sc.range(5)
+        >>> rdd2.checkpoint(True)
+        >>> rdd2.is_checkpointed
+        True
+        >>> rdd2.getCheckpointFile() == None
+        False
         """
         self.is_checkpointed = True
-        self._jrdd.rdd().checkpoint()
+        self._jrdd.rdd().checkpoint(eager)
 
     def isCheckpointed(self) -> bool:
         """

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -727,13 +727,9 @@ class Dataset[T] private[sql](
     withAction(actionName, queryExecution) { physicalPlan =>
       val internalRdd = physicalPlan.execute().map(_.copy())
       if (reliableCheckpoint) {
-        internalRdd.checkpoint()
+        internalRdd.checkpoint(eager)
       } else {
-        internalRdd.localCheckpoint()
-      }
-
-      if (eager) {
-        internalRdd.doCheckpoint()
+        internalRdd.localCheckpoint(eager)
       }
 
       Dataset.ofRows(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
This patch makes it possible to perform checkpoints on RDD eagerly, the same way we currently do it for `Dataset` and `Dataframe`. 

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
Being able to perform the checkpoint eagerly is useful as it might sometime lead to less jobs when creating the checkpoint. That it useful it also indicating by the existence (and being the default) of the same API for Dataset.


### Does this PR introduce _any_ user-facing change?
Yes, it introduces a new overload for RDD.checkpoint that takes a boolean indicating whether the checkpoint should be done eagerly or not.
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
Existing and new unittests.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
