### PR TITLE
[SPARK-44804][SQL] SortMergeJoin should respect the streamed side ordering

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
@@ -54,6 +54,8 @@ case class SortMergeJoinExec(
     case _: InnerLike =>
       val leftKeyOrdering = getKeyOrdering(leftKeys, left.outputOrdering)
       val rightKeyOrdering = getKeyOrdering(rightKeys, right.outputOrdering, false)
+      // The streamed side of InnerLike always be the left side, keep all the left side orderings.
+      // The buffered size may spill, so we should not keep the right side orderings.
       leftKeyOrdering.zip(rightKeyOrdering).map { case (lKey, rKey) =>
         // Also add expressions from right side sort order
         val sameOrderExpressions = ExpressionSet(lKey.sameOrderExpressions ++ rKey.children)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
@@ -58,7 +58,7 @@ case class SortMergeJoinExec(
         // Also add expressions from right side sort order
         val sameOrderExpressions = ExpressionSet(lKey.sameOrderExpressions ++ rKey.children)
         SortOrder(lKey.child, Ascending, sameOrderExpressions.toSeq)
-      }
+      } ++ leftKeyOrdering.drop(rightKeyOrdering.size)
     // For left and right outer joins, the output is ordered by the streamed input's join keys.
     case LeftOuter => getKeyOrdering(leftKeys, left.outputOrdering)
     case RightOuter => getKeyOrdering(rightKeys, right.outputOrdering)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/exchange/EnsureRequirementsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/exchange/EnsureRequirementsSuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.execution.exchange
 import org.apache.spark.api.python.PythonEvalType
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate.Sum
-import org.apache.spark.sql.catalyst.plans.{Inner, LeftOuter, RightOuter}
+import org.apache.spark.sql.catalyst.plans.Inner
 import org.apache.spark.sql.catalyst.plans.physical._
 import org.apache.spark.sql.catalyst.statsEstimation.StatsTestPlan
 import org.apache.spark.sql.connector.catalog.functions._
@@ -1158,43 +1158,6 @@ class EnsureRequirementsSuite extends SharedSparkSession {
         assert(rightKeys.map(k => SortOrder(k, Ascending)) === rightOrder)
       case other => fail(other.toString)
     }
-  }
-
-  test("SPARK-44804: SortMergeJoin should respect the streamed side ordering") {
-    val col_a = AttributeReference("a", IntegerType)()
-    val col_b = AttributeReference("b", IntegerType)()
-    val col_c = AttributeReference("c", IntegerType)()
-    val col_d = AttributeReference("d", IntegerType)()
-    val col_e = AttributeReference("e", IntegerType)()
-
-    val r = DummySparkPlan()
-    val w = WindowExec(
-      Alias(
-        WindowExpression(
-          RowNumber().toAggregateExpression(),
-          WindowSpecDefinition(
-            Seq(col_a),
-            Seq(SortOrder(col_a, Ascending), SortOrder(col_b, Ascending)),
-            SpecifiedWindowFrame(RowFrame, UnboundedPreceding, UnboundedFollowing)
-          )
-        ), "rn")() :: Nil,
-      Seq(col_a),
-      Seq(SortOrder(col_b, Ascending)),
-      DummySparkPlan()
-    )
-
-    assert(applyEnsureRequirementsWithSubsetKeys(
-      SortMergeJoinExec(col_a :: col_b :: Nil, col_d :: col_e :: Nil, Inner, None,
-        SortMergeJoinExec(col_a :: Nil, col_c :: Nil, Inner, None, w, r), r)
-    ).collect { case s: SortExec => s }.length == 3)
-    assert(applyEnsureRequirementsWithSubsetKeys(
-      SortMergeJoinExec(col_a :: col_b :: Nil, col_d :: col_e :: Nil, Inner, None,
-        SortMergeJoinExec(col_a :: Nil, col_c :: Nil, LeftOuter, None, w, r), r)
-    ).collect { case s: SortExec => s }.length == 3)
-    assert(applyEnsureRequirementsWithSubsetKeys(
-      SortMergeJoinExec(col_a :: col_b :: Nil, col_d :: col_e :: Nil, Inner, None,
-        SortMergeJoinExec(col_a :: Nil, col_c :: Nil, RightOuter, None, w, r), r)
-    ).collect { case s: SortExec => s }.length == 4)
   }
 
   def bucket(numBuckets: Int, expr: Expression): TransformExpression = {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

In each partition, SortMergeJoin will compute one by one from the streamed side, so we could respect the streamed side ordering to remove unnecessary sort.
For example, when REQUIRE_ALL_CLUSTER_KEYS_FOR_CO_PARTITION is false:

```sql
SELECT *
FROM (
    SELECT t1.*, row_number() over(partition by a order by b) rn
    FROM values(1, 1) t1(a, b)
) t1
JOIN values(1) t2(c)
ON a = c
JOIN values(1, 1) t3(d, e)
ON a = d
AND b = e
```

Before this PR:

```
AdaptiveSparkPlan isFinalPlan=false
+- SortMergeJoin [a#220, b#221], [d#223, e#224], Inner
   :- Sort [a#220 ASC NULLS FIRST, b#221 ASC NULLS FIRST], false, 0
   :  +- SortMergeJoin [a#220], [c#222], Inner
   :     :- Window [row_number() windowspecdefinition(a#220, b#221 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rn#218], [a#220], [b#221 ASC NULLS FIRST]
   :     :  +- Sort [a#220 ASC NULLS FIRST, b#221 ASC NULLS FIRST], false, 0
   :     :     +- Exchange hashpartitioning(a#220, 5), ENSURE_REQUIREMENTS, [plan_id=93]
   :     :        +- LocalTableScan [a#220, b#221]
   :     +- Sort [c#222 ASC NULLS FIRST], false, 0
   :        +- Exchange hashpartitioning(c#222, 5), ENSURE_REQUIREMENTS, [plan_id=98]
   :           +- LocalTableScan [c#222]
   +- Sort [d#223 ASC NULLS FIRST, e#224 ASC NULLS FIRST], false, 0
      +- Exchange hashpartitioning(d#223, 5), ENSURE_REQUIREMENTS, [plan_id=104]
         +- LocalTableScan [d#223, e#224]
```

After this PR:

```
AdaptiveSparkPlan isFinalPlan=false
+- SortMergeJoin [a#220, b#221], [d#223, e#224], Inner
   :- SortMergeJoin [a#220], [c#222], Inner
   :  :- Window [row_number() windowspecdefinition(a#220, b#221 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rn#218], [a#220], [b#221 ASC NULLS FIRST]
   :  :  +- Sort [a#220 ASC NULLS FIRST, b#221 ASC NULLS FIRST], false, 0
   :  :     +- Exchange hashpartitioning(a#220, 5), ENSURE_REQUIREMENTS, [plan_id=93]
   :  :        +- LocalTableScan [a#220, b#221]
   :  +- Sort [c#222 ASC NULLS FIRST], false, 0
   :     +- Exchange hashpartitioning(c#222, 5), ENSURE_REQUIREMENTS, [plan_id=98]
   :        +- LocalTableScan [c#222]
   +- Sort [d#223 ASC NULLS FIRST, e#224 ASC NULLS FIRST], false, 0
      +- Exchange hashpartitioning(d#223, 5), ENSURE_REQUIREMENTS, [plan_id=104]
         +- LocalTableScan [d#223, e#224]
```

### Why are the changes needed?

Remove unnecessary sort to improve SortMergeJoin performance.


### Does this PR introduce _any_ user-facing change?

No


### How was this patch tested?

Added UT
