### PR TITLE
[SPARK-44705][FOLLOWUP] Fix Deprecation Version of ContetAwareIterator

### DIFF
--- a/core/src/main/scala/org/apache/spark/ContextAwareIterator.scala
+++ b/core/src/main/scala/org/apache/spark/ContextAwareIterator.scala
@@ -33,7 +33,7 @@ import org.apache.spark.annotation.DeveloperApi
  * @deprecated since 4.0.0 as its only usage for Python evaluation is now extinct
  */
 @DeveloperApi
-@deprecated("Only usage for Python evaluation is now extinct", "3.5.0")
+@deprecated("Only usage for Python evaluation is now extinct", "4.0.0")
 class ContextAwareIterator[+T](val context: TaskContext, val delegate: Iterator[T])
   extends Iterator[T] {
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
https://github.com/apache/spark/pull/42385 deprecated `ContextAwareIterator` but the deprecation version was incorrectly set to 3.5. This PR fixes it to be 4.0. 


### Why are the changes needed?
Fix deprecation version.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Not needed.
