### PR TITLE
[SPARK-44814][CONNECT][PYTHON]Test to protect from faulty protobuf versions

### DIFF
--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -3251,8 +3251,8 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
 
     def test_deep_recursion_of_proto_messages(self):
         """SPARK-44814 - Test to trigger a crash in protobuf 4.23.3."""
-        df_base = self.connect.createDataFrame(("a", "b"), ["colA", "colB"])
-        df_other = self.connect.createDataFrame(("a", "b"), ["colA", "colB"])
+        df_base = self.connect.createDataFrame((("a", "b"),), ["colA", "colB"])
+        df_other = self.connect.createDataFrame((("a", "b"),), ["colA", "colB"])
         for x in range(60):
             df_base = df_base.union(df_other)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Certain versions of protobuf contain a bug that triggers a segmentation fault when the protobuf messages are deeply nested. This patch adds a test for this case to avoid hitting it if we intend to upgrade our dependencies to such a version.
 
### Why are the changes needed?
Stability

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
UT