### PR TITLE
[SPARK-44802][INFRA][FOLLOWUP] Fix to consider JIRA_ACCESS_TOKEN in precheck conditions

### DIFF
--- a/dev/merge_spark_pr.py
+++ b/dev/merge_spark_pr.py
@@ -496,8 +496,8 @@ def main():
     # Check this up front to avoid failing the JIRA update at the very end
     if not JIRA_ACCESS_TOKEN and (not JIRA_USERNAME or not JIRA_PASSWORD):
         msg = (
-            "The env-vars JIRA_ACCESS_TOKEN, JIRA_USERNAME and/or JIRA_PASSWORD are not set. "
-            + "Continue?"
+            "The env-vars JIRA_ACCESS_TOKEN or JIRA_USERNAME/JIRA_PA
+SSWORD are not set. Continue?"
         )
         continue_maybe(msg)
 

--- a/dev/merge_spark_pr.py
+++ b/dev/merge_spark_pr.py
@@ -494,8 +494,8 @@ def main():
     original_head = get_current_ref()
 
     # Check this up front to avoid failing the JIRA update at the very end
-    if not JIRA_USERNAME or not JIRA_PASSWORD:
-        continue_maybe("The env-vars JIRA_USERNAME and/or JIRA_PASSWORD are not set. Continue?")
+    if not JIRA_ACCESS_TOKEN and (not JIRA_USERNAME or not JIRA_PASSWORD):
+        continue_maybe("The env-vars JIRA_ACCESS_TOKEN, JIRA_USERNAME and/or JIRA_PASSWORD are not set. Continue?")
 
     branches = get_json("%s/branches" % GITHUB_API_BASE)
     branch_names = list(filter(lambda x: x.startswith("branch-"), [x["name"] for x in branches]))
@@ -595,7 +595,7 @@ def main():
         merged_refs = merged_refs + [cherry_pick(pr_num, merge_hash, latest_branch)]
 
     if JIRA_IMPORTED:
-        if JIRA_USERNAME and JIRA_PASSWORD:
+        if JIRA_ACCESS_TOKEN or (JIRA_USERNAME and JIRA_PASSWORD):
             continue_maybe("Would you like to update an associated JIRA?")
             jira_comment = "Issue resolved by pull request %s\n[%s/%s]" % (
                 pr_num,

--- a/dev/merge_spark_pr.py
+++ b/dev/merge_spark_pr.py
@@ -495,10 +495,7 @@ def main():
 
     # Check this up front to avoid failing the JIRA update at the very end
     if not JIRA_ACCESS_TOKEN and (not JIRA_USERNAME or not JIRA_PASSWORD):
-        msg = (
-            "The env-vars JIRA_ACCESS_TOKEN or JIRA_USERNAME/JIRA_PA
-SSWORD are not set. Continue?"
-        )
+        msg = "The env-vars JIRA_ACCESS_TOKEN or JIRA_USERNAME/JIRA_PASSWORD are not set. Continue?"
         continue_maybe(msg)
 
     branches = get_json("%s/branches" % GITHUB_API_BASE)
@@ -608,7 +605,7 @@ SSWORD are not set. Continue?"
             )
             resolve_jira_issues(title, merged_refs, jira_comment)
         else:
-            print("JIRA_USERNAME and JIRA_PASSWORD not set")
+            print("Neither JIRA_ACCESS_TOKEN nor JIRA_USERNAME/JIRA_PASSWORD are set.")
             print("Exiting without trying to close the associated JIRA.")
     else:
         print("Could not find jira-python library. Run 'pip3 install jira' to install.")

--- a/dev/merge_spark_pr.py
+++ b/dev/merge_spark_pr.py
@@ -495,9 +495,11 @@ def main():
 
     # Check this up front to avoid failing the JIRA update at the very end
     if not JIRA_ACCESS_TOKEN and (not JIRA_USERNAME or not JIRA_PASSWORD):
-        continue_maybe(
-            "The env-vars JIRA_ACCESS_TOKEN, JIRA_USERNAME and/or JIRA_PASSWORD are not set. Continue?"
+        msg = (
+            "The env-vars JIRA_ACCESS_TOKEN, JIRA_USERNAME and/or JIRA_PASSWORD are not set. "
+            + "Continue?"
         )
+        continue_maybe(msg)
 
     branches = get_json("%s/branches" % GITHUB_API_BASE)
     branch_names = list(filter(lambda x: x.startswith("branch-"), [x["name"] for x in branches]))

--- a/dev/merge_spark_pr.py
+++ b/dev/merge_spark_pr.py
@@ -495,7 +495,9 @@ def main():
 
     # Check this up front to avoid failing the JIRA update at the very end
     if not JIRA_ACCESS_TOKEN and (not JIRA_USERNAME or not JIRA_PASSWORD):
-        continue_maybe("The env-vars JIRA_ACCESS_TOKEN, JIRA_USERNAME and/or JIRA_PASSWORD are not set. Continue?")
+        continue_maybe(
+            "The env-vars JIRA_ACCESS_TOKEN, JIRA_USERNAME and/or JIRA_PASSWORD are not set. Continue?"
+        )
 
     branches = get_json("%s/branches" % GITHUB_API_BASE)
     branch_names = list(filter(lambda x: x.startswith("branch-"), [x["name"] for x in branches]))


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up of #42484 to fix the recheck conditions.

### Why are the changes needed?

1. Currently, the merge script fails at the last update stage because the rest of code requires JIRA_USERNAME **and** JIRA_PASSWORD still.
```
Would you like to pick afe18868 into another branch? (y/n): n
JIRA_USERNAME and JIRA_PASSWORD not set
Exiting without trying to close the associated JIRA.
```

2. In addition, it shows improper warning at the initial stage.
```
$ dev/merge_spark_pr.py
git rev-parse --abbrev-ref HEAD

The env-vars JIRA_USERNAME and/or JIRA_PASSWORD are not set. Continue? (y/n): y
Which pull request would you like to merge? (e.g. 34):
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual tests