### PR TITLE
[SPARK-44828][BUILD] Upgrade ORC to 1.9.1

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -4,7 +4,7 @@ JTransforms/3.1//JTransforms-3.1.jar
 RoaringBitmap/0.9.45//RoaringBitmap-0.9.45.jar
 ST4/4.0.4//ST4-4.0.4.jar
 activation/1.1.1//activation-1.1.1.jar
-aircompressor/0.24//aircompressor-0.24.jar
+aircompressor/0.25//aircompressor-0.25.jar
 algebra_2.12/2.0.1//algebra_2.12-2.0.1.jar
 aliyun-java-sdk-core/4.5.10//aliyun-java-sdk-core-4.5.10.jar
 aliyun-java-sdk-kms/2.11.0//aliyun-java-sdk-kms-2.11.0.jar
@@ -210,9 +210,9 @@ opencsv/2.3//opencsv-2.3.jar
 opentracing-api/0.33.0//opentracing-api-0.33.0.jar
 opentracing-noop/0.33.0//opentracing-noop-0.33.0.jar
 opentracing-util/0.33.0//opentracing-util-0.33.0.jar
-orc-core/1.9.0/shaded-protobuf/orc-core-1.9.0-shaded-protobuf.jar
-orc-mapreduce/1.9.0/shaded-protobuf/orc-mapreduce-1.9.0-shaded-protobuf.jar
-orc-shims/1.9.0//orc-shims-1.9.0.jar
+orc-core/1.9.1/shaded-protobuf/orc-core-1.9.1-shaded-protobuf.jar
+orc-mapreduce/1.9.1/shaded-protobuf/orc-mapreduce-1.9.1-shaded-protobuf.jar
+orc-shims/1.9.1//orc-shims-1.9.1.jar
 oro/2.0.8//oro-2.0.8.jar
 osgi-resource-locator/1.0.3//osgi-resource-locator-1.0.3.jar
 paranamer/2.8//paranamer-2.8.jar

--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
     <!-- After 10.15.1.3, the minimum required version is JDK9 -->
     <derby.version>10.14.2.0</derby.version>
     <parquet.version>1.13.1</parquet.version>
-    <orc.version>1.9.0</orc.version>
+    <orc.version>1.9.1</orc.version>
     <orc.classifier>shaded-protobuf</orc.classifier>
     <jetty.version>9.4.51.v20230217</jetty.version>
     <jakartaservlet.version>4.0.3</jakartaservlet.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade ORC to 1.9.1 for Apache Spark 3.5.0.

### Why are the changes needed?

To bring the following bug fix.

- [ORC-1462](https://issues.apache.org/jira/browse/ORC-1462) Bump aircompressor to 0.25 to fix JDK-8081450

Here is the full release note for more bug fixes.
- https://orc.apache.org/news/2023/08/16/ORC-1.9.1/

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.