### PR TITLE
[SPARK-44829][CONNECT] Expose uploadAllArtifactClasses in ArtifactManager to `sql` package

### DIFF
--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/connect/client/SparkConnectClient.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/connect/client/SparkConnectClient.scala
@@ -63,6 +63,12 @@ private[sql] class SparkConnectClient(
   }
 
   /**
+   * Manually triggers upload of all classfile artifacts to the Spark Connect Server
+   */
+  private[sql] def uploadAllClassFileArtifacts(): Unit =
+    artifactManager.uploadAllClassFileArtifacts()
+
+  /**
    * Dispatch the [[proto.AnalyzePlanRequest]] to the Spark Connect server.
    * @return
    *   A [[proto.AnalyzePlanResponse]] from the Spark Connect server.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
This PR exposes `SparkConnectClient`'s `artifactManager.uploadAllArtifactClasses` to `sql` package. 

### Why are the changes needed?
Currently, UDF classfiles are uploaded in all analyze/execute operations. However, if codepath used to call Scala UDF bypasses we'll need to manually call this method to make sure that all classfiles are uploaded

### How was this patch tested?
No tests needed - this PR only exposes a method to sql package