### PR TITLE
[SPARK-44836][PYTHON][3.5] Refactor Arrow Python UDTF

### DIFF
--- a/python/pyspark/sql/udtf.py
+++ b/python/pyspark/sql/udtf.py
@@ -20,8 +20,7 @@ User-defined table function related classes and functions
 import pickle
 import sys
 import warnings
-from functools import wraps
-from typing import Any, Iterable, Iterator, Type, TYPE_CHECKING, Optional, Union, Callable
+from typing import Any, Type, TYPE_CHECKING, Optional, Union
 
 from py4j.java_gateway import JavaObject
 
@@ -76,90 +75,28 @@ def _create_py_udtf(
             if isinstance(value, str) and value.lower() == "true":
                 arrow_enabled = True
 
-    # Create a regular Python UDTF and check for invalid handler class.
-    regular_udtf = _create_udtf(cls, returnType, name, PythonEvalType.SQL_TABLE_UDF, deterministic)
+    eval_type: int = PythonEvalType.SQL_TABLE_UDF
 
-    if not arrow_enabled:
-        return regular_udtf
+    if arrow_enabled:
+        # Return the regular UDTF if the required dependencies are not satisfied.
+        try:
+            require_minimum_pandas_version()
+            require_minimum_pyarrow_version()
+            eval_type = PythonEvalType.SQL_ARROW_TABLE_UDF
+        except ImportError as e:
+            warnings.warn(
+                f"Arrow optimization for Python UDTFs cannot be enabled: {str(e)}. "
+                f"Falling back to using regular Python UDTFs.",
+                UserWarning,
+            )
 
-    # Return the regular UDTF if the required dependencies are not satisfied.
-    try:
-        require_minimum_pandas_version()
-        require_minimum_pyarrow_version()
-    except ImportError as e:
-        warnings.warn(
-            f"Arrow optimization for Python UDTFs cannot be enabled: {str(e)}. "
-            f"Falling back to using regular Python UDTFs.",
-            UserWarning,
-        )
-        return regular_udtf
-
-    # Return the vectorized UDTF.
-    vectorized_udtf = _vectorize_udtf(cls)
     return _create_udtf(
-        cls=vectorized_udtf,
+        cls=cls,
         returnType=returnType,
         name=name,
-        evalType=PythonEvalType.SQL_ARROW_TABLE_UDF,
-        deterministic=regular_udtf.deterministic,
+        evalType=eval_type,
+        deterministic=deterministic,
     )
-
-
-def _vectorize_udtf(cls: Type) -> Type:
-    """Vectorize a Python UDTF handler class."""
-    import pandas as pd
-
-    # Wrap the exception thrown from the UDTF in a PySparkRuntimeError.
-    def wrap_func(f: Callable[..., Any]) -> Callable[..., Any]:
-        @wraps(f)
-        def evaluate(*a: Any) -> Any:
-            try:
-                return f(*a)
-            except Exception as e:
-                raise PySparkRuntimeError(
-                    error_class="UDTF_EXEC_ERROR",
-                    message_parameters={"method_name": f.__name__, "error": str(e)},
-                )
-
-        return evaluate
-
-    class VectorizedUDTF:
-        def __init__(self) -> None:
-            self.func = cls()
-
-        def eval(self, *args: pd.Series) -> Iterator[pd.DataFrame]:
-            if len(args) == 0:
-                yield pd.DataFrame(wrap_func(self.func.eval)())
-            else:
-                # Create tuples from the input pandas Series, each tuple
-                # represents a row across all Series.
-                row_tuples = zip(*args)
-                for row in row_tuples:
-                    res = wrap_func(self.func.eval)(*row)
-                    if res is not None and not isinstance(res, Iterable):
-                        raise PySparkRuntimeError(
-                            error_class="UDTF_RETURN_NOT_ITERABLE",
-                            message_parameters={
-                                "type": type(res).__name__,
-                            },
-                        )
-                    yield pd.DataFrame(res)
-
-        if hasattr(cls, "terminate"):
-
-            def terminate(self) -> Iterator[pd.DataFrame]:
-                yield pd.DataFrame(wrap_func(self.func.terminate)())
-
-    vectorized_udtf = VectorizedUDTF
-    vectorized_udtf.__name__ = cls.__name__
-    vectorized_udtf.__module__ = cls.__module__
-    vectorized_udtf.__doc__ = cls.__doc__
-    vectorized_udtf.__init__.__doc__ = cls.__init__.__doc__
-    vectorized_udtf.eval.__doc__ = getattr(cls, "eval").__doc__
-    if hasattr(cls, "terminate"):
-        getattr(vectorized_udtf, "terminate").__doc__ = getattr(cls, "terminate").__doc__
-
-    return vectorized_udtf
 
 
 def _validate_udtf_handler(cls: Any) -> None:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a backport of https://github.com/apache/spark/pull/42520.

Refactors Arrow Python UDTF.

### Why are the changes needed?

Arrow Python UDTF is not need to be redefined when creating it. It can be handled in `worker.py`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

The existing tests.