### PR TITLE
[SPARK-43462][SPARK-43871][PS][TESTS] Enable `SeriesDateTimeTests` for pandas 2.0.0 and above

### DIFF
--- a/python/pyspark/pandas/tests/test_series_datetime.py
+++ b/python/pyspark/pandas/tests/test_series_datetime.py
@@ -116,27 +116,23 @@ class SeriesDateTimeTestsMixin:
         self.assertRaisesRegex(TypeError, expected_err_msg, lambda: psser - other)
         self.assertRaises(NotImplementedError, lambda: py_datetime - psser)
 
-    @unittest.skipIf(
-        LooseVersion(pd.__version__) >= LooseVersion("2.0.0"),
-        "TODO(SPARK-43462): Enable SeriesDateTimeTests.test_date_subtraction for pandas 2.0.0.",
-    )
     def test_date_subtraction(self):
         pdf = self.pdf1
         psdf = ps.from_pandas(pdf)
 
         self.assert_eq(
             psdf["end_date"].dt.date - psdf["start_date"].dt.date,
-            (pdf["end_date"].dt.date - pdf["start_date"].dt.date).dt.days,
+            (pdf["end_date"].dt.date - pdf["start_date"].dt.date).apply(lambda x: x.days),
         )
 
         self.assert_eq(
             psdf["end_date"].dt.date - datetime.date(2012, 1, 1),
-            (pdf["end_date"].dt.date - datetime.date(2012, 1, 1)).dt.days,
+            (pdf["end_date"].dt.date - datetime.date(2012, 1, 1)).apply(lambda x: x.days),
         )
 
         self.assert_eq(
             datetime.date(2013, 3, 11) - psdf["start_date"].dt.date,
-            (datetime.date(2013, 3, 11) - pdf["start_date"].dt.date).dt.days,
+            (datetime.date(2013, 3, 11) - pdf["start_date"].dt.date).apply(lambda x: x.days),
         )
 
         psdf = ps.DataFrame(
@@ -176,52 +172,24 @@ class SeriesDateTimeTestsMixin:
         with self.assertRaises(NotImplementedError):
             self.check_func(lambda x: x.dt.timetz)
 
-    @unittest.skipIf(
-        LooseVersion(pd.__version__) >= LooseVersion("2.0.0"),
-        "TODO(SPARK-43736): Enable SeriesDateTimeTests.test_year for pandas 2.0.0.",
-    )
     def test_year(self):
         self.check_func(lambda x: x.dt.year)
 
-    @unittest.skipIf(
-        LooseVersion(pd.__version__) >= LooseVersion("2.0.0"),
-        "TODO(SPARK-43731): Enable SeriesDateTimeTests.test_month for pandas 2.0.0.",
-    )
     def test_month(self):
         self.check_func(lambda x: x.dt.month)
 
-    @unittest.skipIf(
-        LooseVersion(pd.__version__) >= LooseVersion("2.0.0"),
-        "TODO(SPARK-43722): Enable SeriesDateTimeTests.test_day for pandas 2.0.0.",
-    )
     def test_day(self):
         self.check_func(lambda x: x.dt.day)
 
-    @unittest.skipIf(
-        LooseVersion(pd.__version__) >= LooseVersion("2.0.0"),
-        "TODO(SPARK-43728): Enable SeriesDateTimeTests.test_hour for pandas 2.0.0.",
-    )
     def test_hour(self):
         self.check_func(lambda x: x.dt.hour)
 
-    @unittest.skipIf(
-        LooseVersion(pd.__version__) >= LooseVersion("2.0.0"),
-        "TODO(SPARK-43730): Enable SeriesDateTimeTests.test_minute for pandas 2.0.0.",
-    )
     def test_minute(self):
         self.check_func(lambda x: x.dt.minute)
 
-    @unittest.skipIf(
-        LooseVersion(pd.__version__) >= LooseVersion("2.0.0"),
-        "TODO(SPARK-43733): Enable SeriesDateTimeTests.test_second for pandas 2.0.0.",
-    )
     def test_second(self):
         self.check_func(lambda x: x.dt.second)
 
-    @unittest.skipIf(
-        LooseVersion(pd.__version__) >= LooseVersion("2.0.0"),
-        "TODO(SPARK-43729): Enable SeriesDateTimeTests.test_microsecond for pandas 2.0.0.",
-    )
     def test_microsecond(self):
         self.check_func(lambda x: x.dt.microsecond)
 
@@ -243,31 +211,15 @@ class SeriesDateTimeTestsMixin:
     def test_weekofyear(self):
         self.check_func(lambda x: x.dt.weekofyear)
 
-    @unittest.skipIf(
-        LooseVersion(pd.__version__) >= LooseVersion("2.0.0"),
-        "TODO(SPARK-43723): Enable SeriesDateTimeTests.test_dayofweek for pandas 2.0.0.",
-    )
     def test_dayofweek(self):
         self.check_func(lambda x: x.dt.dayofweek)
 
-    @unittest.skipIf(
-        LooseVersion(pd.__version__) >= LooseVersion("2.0.0"),
-        "TODO(SPARK-43735): Enable SeriesDateTimeTests.test_weekday for pandas 2.0.0.",
-    )
     def test_weekday(self):
         self.check_func(lambda x: x.dt.weekday)
 
-    @unittest.skipIf(
-        LooseVersion(pd.__version__) >= LooseVersion("2.0.0"),
-        "TODO(SPARK-43724): Enable SeriesDateTimeTests.test_dayofyear for pandas 2.0.0.",
-    )
     def test_dayofyear(self):
         self.check_func(lambda x: x.dt.dayofyear)
 
-    @unittest.skipIf(
-        LooseVersion(pd.__version__) >= LooseVersion("2.0.0"),
-        "TODO(SPARK-43732): Enable SeriesDateTimeTests.test_quarter for pandas 2.0.0.",
-    )
     def test_quarter(self):
         self.check_func(lambda x: x.dt.quarter)
 
@@ -292,17 +244,9 @@ class SeriesDateTimeTestsMixin:
     def test_is_leap_year(self):
         self.check_func(lambda x: x.dt.is_leap_year)
 
-    @unittest.skipIf(
-        LooseVersion(pd.__version__) >= LooseVersion("2.0.0"),
-        "TODO(SPARK-43726): Enable SeriesDateTimeTests.test_daysinmonth for pandas 2.0.0.",
-    )
     def test_daysinmonth(self):
         self.check_func(lambda x: x.dt.daysinmonth)
 
-    @unittest.skipIf(
-        LooseVersion(pd.__version__) >= LooseVersion("2.0.0"),
-        "TODO(SPARK-43725): Enable SeriesDateTimeTests.test_days_in_month for pandas 2.0.0.",
-    )
     def test_days_in_month(self):
         self.check_func(lambda x: x.dt.days_in_month)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to enable `SeriesDateTimeTests`.


### Why are the changes needed?

For increasing the test coverage with pandas 2.0.0.


### Does this PR introduce _any_ user-facing change?

No, it's test-only.


### How was this patch tested?

Enabling & updating the existing tests.
