### PR TITLE
[SPARK-44849] Expose SparkConnectExecutionManager.listActiveExecutions

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
@@ -349,6 +349,12 @@ object SparkConnectService extends Logging {
   }
 
   /**
+   * If there are no executions, return Left with System.currentTimeMillis of last active
+   * execution. Otherwise return Right with list of ExecuteInfo of all executions.
+   */
+  def listActiveExecutions: Either[Long, Seq[ExecuteInfo]] = executionManager.listActiveExecutions
+
+  /**
    * Used for testing
    */
   private[connect] def invalidateAllSessions(): Unit = {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Make list of active executions accessible via SparkConnectService.listActiveExecutions

### Why are the changes needed?

Some internal components outside `connect` would like to have access to that. Add a method to expose it.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI