### PR TITLE
[SPARK-44854][PYTHON] Python timedelta to DayTimeIntervalType edge case bug

### DIFF
--- a/python/pyspark/sql/tests/test_types.py
+++ b/python/pyspark/sql/tests/test_types.py
@@ -1204,6 +1204,8 @@ class TypesTestsMixin:
             ),
             (datetime.timedelta(microseconds=-123),),
             (datetime.timedelta(days=-1),),
+            (datetime.timedelta(microseconds=388629894454999981),),
+            (datetime.timedelta(days=-1, seconds=86399, microseconds=999999),),  # -1 microsecond
         ]
         df = self.spark.createDataFrame(timedetlas, schema="td interval day to second")
         self.assertEqual(set(r.td for r in df.collect()), set(set(r[0] for r in timedetlas)))
@@ -1219,6 +1221,7 @@ class TypesTestsMixin:
             "INTERVAL '1563:04' MINUTE TO SECOND AS h",
             "INTERVAL '1563' MINUTE AS i",
             "INTERVAL '93784' SECOND AS j",
+            # "INTERVAL '50357692 00:00:56144.999980' DAY TO SECOND AS k",
         ]
         df = self.spark.range(1).selectExpr(exprs)
 
@@ -1234,6 +1237,7 @@ class TypesTestsMixin:
             datetime.timedelta(minutes=1563, seconds=4),
             datetime.timedelta(minutes=1563),
             datetime.timedelta(seconds=93784),
+            # datetime.timedelta(days=50357692, seconds=56144, microseconds=999980)
         ]
 
         for n, (a, e) in enumerate(zip(actual, expected)):

--- a/python/pyspark/sql/tests/test_types.py
+++ b/python/pyspark/sql/tests/test_types.py
@@ -1221,7 +1221,6 @@ class TypesTestsMixin:
             "INTERVAL '1563:04' MINUTE TO SECOND AS h",
             "INTERVAL '1563' MINUTE AS i",
             "INTERVAL '93784' SECOND AS j",
-            # "INTERVAL '50357692 00:00:56144.999980' DAY TO SECOND AS k",
         ]
         df = self.spark.range(1).selectExpr(exprs)
 
@@ -1237,7 +1236,6 @@ class TypesTestsMixin:
             datetime.timedelta(minutes=1563, seconds=4),
             datetime.timedelta(minutes=1563),
             datetime.timedelta(seconds=93784),
-            # datetime.timedelta(days=50357692, seconds=56144, microseconds=999980)
         ]
 
         for n, (a, e) in enumerate(zip(actual, expected)):

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -442,7 +442,7 @@ class DayTimeIntervalType(AnsiIntervalType):
 
     def toInternal(self, dt: datetime.timedelta) -> Optional[int]:
         if dt is not None:
-            return (math.floor(dt.total_seconds()) * 1000000) + dt.microseconds
+            return (((dt.days * 86400) + dt.seconds) * 1_000_000) + dt.microseconds
 
     def fromInternal(self, micros: int) -> Optional[datetime.timedelta]:
         if micros is not None:


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR proposes to change the way that python `datetime.timedelta` objects are converted to `pyspark.sql.types.DayTimeIntervalType` objects. Specifically, it modifies the logic inside `toInternal` which returns the timedelta as a python integer (would be int64 in other languages) storing the timedelta as microseconds. The current logic inadvertently adds an extra second when doing the conversion for certain python timedelta objects, thereby returning an incorrect value.

An illustrative example is as follows:

```
from datetime import timedelta
from pyspark.sql.types import DayTimeIntervalType, StructField, StructType

spark = ...spark session setup here...

td = timedelta(days=4498031, seconds=16054, microseconds=999981)
df = spark.createDataFrame([(td,)], StructType([StructField(name="timedelta_col", dataType=DayTimeIntervalType(), nullable=False)]))
df.show(truncate=False)

> +------------------------------------------------+
> |timedelta_col                                   | 
> +------------------------------------------------+ 
> |INTERVAL '4498031 04:27:35.999981' DAY TO SECOND| 
> +------------------------------------------------+

print(str(td))

>  '4498031 days, 4:27:34.999981' 
```

In the above example, look at the seconds. The original python timedelta object has 34 seconds, the pyspark DayTimeIntervalType column has 35 seconds.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To fix a bug. It is a bug because the wrong value is returned after conversion. Adding the above timedelta entry to existing unit tests causes the test to fail.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. Users should now see the correct timedelta values in pyspark dataframes for similar such edge cases.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Illustrative edge case examples were added to the unit test (`python/pyspark/sql/tests/test_types.py` the `test_daytime_interval_type` test), verified that the existing code failed the test, new code was added, and verified that the unit test now passes.

### JIRA ticket link
This PR should close https://issues.apache.org/jira/browse/SPARK-44854
