### PR TITLE
[SPARK-44866][SQL] Add `SnowflakeDialect` to handle BOOLEAN type correctly

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -702,6 +702,7 @@ object JdbcDialects {
   registerDialect(OracleDialect)
   registerDialect(TeradataDialect)
   registerDialect(H2Dialect)
+  registerDialect(SnowflakeDialect)
 
   /**
    * Fetch the JdbcDialect class corresponding to a given database url.

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/SnowflakeDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/SnowflakeDialect.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.catalyst.SQLConfHelper
 import org.apache.spark.sql.execution.datasources.jdbc.JdbcUtils
 import org.apache.spark.sql.types.{BooleanType, DataType}
 
-private case object SnowflakeDialect extends JdbcDialect with SQLConfHelper {
+private case object SnowflakeDialect extends JdbcDialect {
   override def canHandle(url: String): Boolean =
     url.toLowerCase(Locale.ROOT).startsWith("jdbc:snowflake")
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/SnowflakeDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/SnowflakeDialect.scala
@@ -29,7 +29,7 @@ private case object SnowflakeDialect extends JdbcDialect {
 
   override def getJDBCType(dt: DataType): Option[JdbcType] = dt match {
     case BooleanType =>
-      // By default, BOOLEAN is mapped to BIT(1) in Snowflake.
+      // By default, BOOLEAN is mapped to BIT(1).
       // but Snowflake does not have a BIT type. It uses BOOLEAN instead.
       Some(JdbcType("BOOLEAN", java.sql.Types.BOOLEAN))
     case _ => JdbcUtils.getCommonJDBCType(dt)

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/SnowflakeDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/SnowflakeDialect.scala
@@ -29,7 +29,7 @@ private case object SnowflakeDialect extends JdbcDialect {
 
   override def getJDBCType(dt: DataType): Option[JdbcType] = dt match {
     case BooleanType =>
-      // By default, BOOLEAN is mapped to BIT
+      // By default, BOOLEAN is mapped to BIT(1) in Snowflake.
       // but Snowflake does not have a BIT type. It uses BOOLEAN instead.
       Some(JdbcType("BOOLEAN", java.sql.Types.BOOLEAN))
     case _ => JdbcUtils.getCommonJDBCType(dt)

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/SnowflakeDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/SnowflakeDialect.scala
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.jdbc
+
+import java.util.Locale
+
+import org.apache.spark.sql.catalyst.SQLConfHelper
+import org.apache.spark.sql.execution.datasources.jdbc.JdbcUtils
+import org.apache.spark.sql.types.{BooleanType, DataType}
+
+private case object SnowflakeDialect extends JdbcDialect with SQLConfHelper {
+  override def canHandle(url: String): Boolean =
+    url.toLowerCase(Locale.ROOT).startsWith("jdbc:snowflake")
+
+  override def getJDBCType(dt: DataType): Option[JdbcType] = dt match {
+    case BooleanType =>
+      // By default, BOOLEAN is mapped to BIT
+      // but Snowflake does not have a BIT type. It uses BOOLEAN instead.
+      Some(JdbcType("BOOLEAN", java.sql.Types.BOOLEAN))
+    case _ => JdbcUtils.getCommonJDBCType(dt)
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/SnowflakeDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/SnowflakeDialect.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql.jdbc
 
 import java.util.Locale
 
-import org.apache.spark.sql.catalyst.SQLConfHelper
 import org.apache.spark.sql.execution.datasources.jdbc.JdbcUtils
 import org.apache.spark.sql.types.{BooleanType, DataType}
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -2062,6 +2062,4 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
     val snowflakeDialect = JdbcDialects.get("jdbc:snowflake://account.snowflakecomputing.com")
     assert(snowflakeDialect.getJDBCType(BooleanType).map(_.databaseTypeDefinition).get == "BOOLEAN")
   }
-
-
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -2058,7 +2058,7 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
     assert(df.collect.toSet === Set(Row("smith", 1)))
   }
 
-  test(" SnowflakeDialect type mapping of BOOLEAN") {
+  test("SPARK-44866: SnowflakeDialect BOOLEAN type mapping") {
     val snowflakeDialect = JdbcDialects.get("jdbc:snowflake://account.snowflakecomputing.com")
     assert(snowflakeDialect.getJDBCType(BooleanType).map(_.databaseTypeDefinition).get == "BOOLEAN")
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -2057,4 +2057,11 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
     val df = sql("SELECT * FROM composite_name WHERE `last name` = 'smith'")
     assert(df.collect.toSet === Set(Row("smith", 1)))
   }
+
+  test(" SnowflakeDialect type mapping of BOOLEAN") {
+    val snowflakeDialect = JdbcDialects.get("jdbc:snowflake://account.snowflakecomputing.com")
+    assert(snowflakeDialect.getJDBCType(BooleanType).map(_.databaseTypeDefinition).get == "BOOLEAN")
+  }
+
+
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

In Snowflake a BOOLEAN data type exist but not the BIT data type.
This PR adds `SnowflakeDialect` to override the default JdbcDialect and redefine the default mapping behaviour for the _boolean_ type.  Currently, it's mapped to `BIT(1)` type.

https://github.com/apache/spark/blob/a663c0bf0c5b104170c0612f37a0b0cdf75cd45b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala#L149

### Why are the changes needed?

The BIT type does not exist in Snowflake. This cause the Spark Job to fail on table creation.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Unit test and directly on Snowflake