### PR TITLE
[SPARK-44857][CORE][UI] Fix `getBaseURI` error in Spark Worker LogPage UI buttons

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/worker/ui/LogPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/ui/LogPage.scala
@@ -102,6 +102,7 @@ private[ui] class LogPage(parent: WorkerWebUI) extends WebUIPage("logPage") with
       s"initLogPage('$logParams', $curLogLength, $startByte, $endByte, $logLength, $byteLength);"
 
     val content =
+      <script src={UIUtils.prependBaseUri(request, "/static/utils.js")}></script> ++
       <div>
         {linkToMaster}
         {range}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `getBaseURI` errors when we clicks Spark Worker LogPage UI buttons in Apache Spark 3.2.0+.

### Why are the changes needed?

Run a Spark job and open the Spark Worker UI, http://localhost:8081 .
```
$ sbin/start-master.sh
$ sbin/start-worker.sh spark://127.0.0.1:7077
$ bin/spark-shell --master spark://127.0.0.1:7077
```

Click `stderr` and `Load New` button. The button is out of order currently due to the following error because `getBaseURI` is defined in `utils.js`.

![Screenshot 2023-08-17 at 2 38 45 PM](https://github.com/apache/spark/assets/9700541/c2358ae3-46d2-43fe-9cc1-ce343725ce4c)


### Does this PR introduce _any_ user-facing change?

This will make the buttons work.

### How was this patch tested?

Manual.