### PR TITLE
[SPARK-44750][PYTHON][CONNECT] Apply configuration to sparksession during creation

### DIFF
--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 from pyspark.sql.connect.utils import check_dependencies
 
 check_dependencies(__name__)

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -14,10 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import sys
-from inspect import currentframe, getframeinfo
 
-from pyspark.errors.exceptions.connect import AnalysisException
 from pyspark.sql.connect.utils import check_dependencies
 
 check_dependencies(__name__)
@@ -185,21 +182,8 @@ class SparkSession:
                 for k, v in self._options.items():
                     try:
                         session.conf.set(k, v)
-                    except AnalysisException as e:
-                        current = currentframe()
-                        lineno = getframeinfo(current).lineno + 1 if current is not None else 0
-                        print(
-                            warnings.formatwarning(
-                                """Failed to set spark runtime configuration: {0}={1}
-                                   Complete error message: {2}""".format(
-                                    k, v, e.message
-                                ),
-                                RuntimeWarning,
-                                __file__ if "__file__" in globals() else "",
-                                lineno,
-                            ),
-                            file=sys.stderr,
-                        )
+                    except Exception as e:
+                        warnings.warn(str(e))
 
         def create(self) -> "SparkSession":
             has_channel_builder = self._channel_builder is not None

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -215,8 +215,7 @@ class SparkSession:
                     session = SparkSession._default_session
                     if session is None:
                         session = self.create()
-                else:
-                    self._apply_options(session)
+                self._apply_options(session)
                 return session
 
     _client: SparkConnectClient

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -176,6 +176,11 @@ class SparkSession:
                 error_class="NOT_IMPLEMENTED", message_parameters={"feature": "enableHiveSupport"}
             )
 
+        def _apply_options(self, session: "SparkSession") -> None:
+            with self._lock:
+                for k, v in self._options.items():
+                    session.conf.set(k, v)
+
         def create(self) -> "SparkSession":
             has_channel_builder = self._channel_builder is not None
             has_spark_remote = "spark.remote" in self._options
@@ -200,6 +205,7 @@ class SparkSession:
                 session = SparkSession(connection=spark_remote)
 
             SparkSession._set_default_and_active_session(session)
+            self._apply_options(session)
             return session
 
         def getOrCreate(self) -> "SparkSession":
@@ -209,6 +215,8 @@ class SparkSession:
                     session = SparkSession._default_session
                     if session is None:
                         session = self.create()
+                else:
+                    self._apply_options(session)
                 return session
 
     _client: SparkConnectClient

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -14,6 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import sys
+from inspect import currentframe, getframeinfo
+
+from pyspark.errors.exceptions.connect import AnalysisException
 from pyspark.sql.connect.utils import check_dependencies
 
 check_dependencies(__name__)
@@ -179,7 +183,23 @@ class SparkSession:
         def _apply_options(self, session: "SparkSession") -> None:
             with self._lock:
                 for k, v in self._options.items():
-                    session.conf.set(k, v)
+                    try:
+                        session.conf.set(k, v)
+                    except AnalysisException as e:
+                        current = currentframe()
+                        lineno = getframeinfo(current).lineno + 1 if current is not None else 0
+                        print(
+                            warnings.formatwarning(
+                                """Failed to set spark runtime configuration: {0}={1}
+                                   Complete error message: {2}""".format(
+                                    k, v, e.message
+                                ),
+                                RuntimeWarning,
+                                __file__ if "__file__" in globals() else "",
+                                lineno,
+                            ),
+                            file=sys.stderr,
+                        )
 
         def create(self) -> "SparkSession":
             has_channel_builder = self._channel_builder is not None

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -3350,7 +3350,9 @@ class SparkConnectSessionTests(ReusedConnectTestCase):
 class SparkConnectSessionWithOptionsTest(ReusedConnectTestCase):
     def setUp(self) -> None:
         self.spark = (
-            PySparkSession.builder.config("spark.sql.adaptive.enabled", False)
+            PySparkSession.builder.config("string", "foo")
+            .config("integer", 1)
+            .config("boolean", False)
             .appName(self.__class__.__name__)
             .remote("local[4]")
             .getOrCreate()
@@ -3361,7 +3363,10 @@ class SparkConnectSessionWithOptionsTest(ReusedConnectTestCase):
 
     def test_config(self):
         # Config
-        self.assertEqual(self.spark.conf.get("spark.sql.adaptive.enabled"), "false")
+        self.assertEqual(self.spark.conf.get("string"), "foo")
+        self.assertEqual(self.spark.conf.get("boolean"), "false")
+        self.assertEqual(self.spark.conf.get("integer"), "1")
+
 
 @unittest.skipIf(not should_test_connect, connect_requirement_message)
 class ClientTests(unittest.TestCase):

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -3346,6 +3346,25 @@ class SparkConnectSessionTests(ReusedConnectTestCase):
             PySparkSession.builder.create()
             self.assertIn("Create a new SparkSession is only supported with SparkConnect.", str(e))
 
+class SparkConnectSessionWithOptionsTest(ReusedConnectTestCase):
+    def setUp(self) -> None:
+        self.spark = (
+            PySparkSession.builder
+            .config("spark.sql.adaptive.enabled", False)
+            .appName(self.__class__.__name__)
+            .remote("local[4]")
+            .getOrCreate()
+        )
+
+    def tearDown(self):
+        self.spark.stop()
+
+    def test_config(self):
+        # Config
+        self.assertEqual(self.spark.conf.get("spark.sql.adaptive.enabled"), "false")
+        with self.assertRaises(SparkConnectException) as e:
+            self.spark.conf.get("some.conf")
+
 
 @unittest.skipIf(not should_test_connect, connect_requirement_message)
 class ClientTests(unittest.TestCase):

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -3346,11 +3346,11 @@ class SparkConnectSessionTests(ReusedConnectTestCase):
             PySparkSession.builder.create()
             self.assertIn("Create a new SparkSession is only supported with SparkConnect.", str(e))
 
+
 class SparkConnectSessionWithOptionsTest(ReusedConnectTestCase):
     def setUp(self) -> None:
         self.spark = (
-            PySparkSession.builder
-            .config("spark.sql.adaptive.enabled", False)
+            PySparkSession.builder.config("spark.sql.adaptive.enabled", False)
             .appName(self.__class__.__name__)
             .remote("local[4]")
             .getOrCreate()
@@ -3362,9 +3362,6 @@ class SparkConnectSessionWithOptionsTest(ReusedConnectTestCase):
     def test_config(self):
         # Config
         self.assertEqual(self.spark.conf.get("spark.sql.adaptive.enabled"), "false")
-        with self.assertRaises(SparkConnectException) as e:
-            self.spark.conf.get("some.conf")
-
 
 @unittest.skipIf(not should_test_connect, connect_requirement_message)
 class ClientTests(unittest.TestCase):

--- a/python/pyspark/testing/connectutils.py
+++ b/python/pyspark/testing/connectutils.py
@@ -167,6 +167,7 @@ class ReusedConnectTestCase(unittest.TestCase, SQLTestUtils, PySparkErrorTestUti
         Override this in subclasses to supply a more specific conf
         """
         conf = SparkConf(loadDefaults=False)
+        conf.set("spark.sql.legacy.setCommandRejectsSparkCoreConfs", "false")
         # Disable JVM stack trace in Spark Connect tests to prevent the
         # HTTP header size from exceeding the maximum allowed size.
         conf.set("spark.sql.pyspark.jvmStacktrace.enabled", "false")

--- a/python/pyspark/testing/connectutils.py
+++ b/python/pyspark/testing/connectutils.py
@@ -167,7 +167,6 @@ class ReusedConnectTestCase(unittest.TestCase, SQLTestUtils, PySparkErrorTestUti
         Override this in subclasses to supply a more specific conf
         """
         conf = SparkConf(loadDefaults=False)
-        conf.set("spark.sql.legacy.setCommandRejectsSparkCoreConfs", "false")
         # Disable JVM stack trace in Spark Connect tests to prevent the
         # HTTP header size from exceeding the maximum allowed size.
         conf.set("spark.sql.pyspark.jvmStacktrace.enabled", "false")


### PR DESCRIPTION
### What changes were proposed in this pull request?

`SparkSession.Builder` now applies configuration options to the create `SparkSession`.

### Why are the changes needed?

It is reasonable to expect PySpark connect `SparkSession.Builder` to behave in the same way as other `SparkSession.Builder`s in Spark Connect. The `SparkSession.Builder` should apply the provided configuration options to the created `SparkSesssion`. 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Tests were added to verify that configuration options were applied to the `SparkSession`.