### PR TITLE
[SPARK-44864] Align streaming statistics link format with other page links

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/ui/StreamingQueryPage.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/ui/StreamingQueryPage.scala
@@ -174,7 +174,7 @@ private[ui] class StreamingQueryPagedTable(
 
   override def row(query: StructuredStreamingRow): Seq[Node] = {
     val streamingQuery = query.streamingUIData
-    val statisticsLink = "%s/%s/statistics?id=%s"
+    val statisticsLink = "%s/%s/statistics/?id=%s"
       .format(SparkUIUtils.prependBaseUri(request, parent.basePath), parent.prefix,
         streamingQuery.summary.runId)
 


### PR DESCRIPTION


### What changes were proposed in this pull request?
Align streaming statistics link format with other page links. Which means change StreamingQueryPage`%s/%s/statistics?id=%s` to `%s/%s/statistics/?id=%s`, this aligns with other page links such as Stages Page `/stages/stage/?id=xxx` , SQL Page `SQL/execution/?id`


### Why are the changes needed?
Aligns the link format.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Manually tested.
