### PR TITLE
[SPARK-44870][SQL] Convert HashAggregate to SortAggregate if all grouping expressions are in child output orderings

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SortOrder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SortOrder.scala
@@ -119,6 +119,25 @@ object SortOrder {
       }
     }
   }
+
+  /**
+   * Returns if a sequence of SortOrder satisfies a sequence of expressions.
+   * @param orderings the sequence of SortOrder
+   * @param groupExpressions the sequence of expressions
+   * @return
+   */
+  def satisfiesExpressions(
+      orderings: Seq[SortOrder],
+      groupExpressions: Seq[Expression]): Boolean = {
+    var collectedExpr = Seq[Expression]()
+    orderings.foreach { order =>
+      groupExpressions.foreach {
+        case e if order.children.exists(_.semanticEquals(e)) => collectedExpr :+= e
+        case _ =>
+      }
+    }
+    groupExpressions.toSet == collectedExpr.toSet
+  }
 }
 
 /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ReplaceHashWithSortAgg.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ReplaceHashWithSortAgg.scala
@@ -71,8 +71,8 @@ object ReplaceHashWithSortAgg extends Rule[SparkPlan] {
         hashAgg.child match {
           case partialAgg: BaseAggregateExec
             if isHashBasedAggWithKeys(partialAgg) && isPartialAgg(partialAgg, hashAgg) =>
-            if (SortOrder.orderingSatisfies(
-                partialAgg.child.outputOrdering, sortAgg.requiredChildOrdering.head)) {
+            if (SortOrder.satisfiesExpressions(
+                partialAgg.child.outputOrdering, hashAgg.groupingExpressions)) {
               sortAgg.copy(
                 aggregateExpressions = sortAgg.aggregateExpressions.map(_.copy(mode = Complete)),
                 child = partialAgg.child)
@@ -80,8 +80,8 @@ object ReplaceHashWithSortAgg extends Rule[SparkPlan] {
               hashAgg
             }
           case other =>
-            if (SortOrder.orderingSatisfies(
-                other.outputOrdering, sortAgg.requiredChildOrdering.head)) {
+            if (SortOrder.satisfiesExpressions(
+                other.outputOrdering, hashAgg.groupingExpressions)) {
               sortAgg
             } else {
               hashAgg


### PR DESCRIPTION
### What changes were proposed in this pull request?

 When we try to convert a HashAggregate to SortAggregate in rule ReplaceHashWithSortAgg, add a new function `SortOrder.satisfiesExpressions(orderings: Seq[SortOrder], groupExpressions: Seq[Expression])` to determine if the child output ordering satisfies the grouping expressions.

example query 1 : 
```sql
SELECT a, b, count(1)
FROM values(1, 1, 1), (2, 2, 2) t1(a, b, c)
JOIN values(1, 1, 1), (2, 2, 2) t2(d, e, f)
ON a = d
AND b = e
GROUP by b, a
```
The grouping expressions are b, a, and the child output orderings are a.asc, b.asc, SortOrder.satisfiesExpressions() is true.

example query 2 : 
```sql
SELECT a, b, count(1)
FROM values(1, 1, 1), (2, 2, 2) t1(a, b, c)
JOIN values(1, 1, 1), (2, 2, 2) t2(d, e, f)
ON a = d
AND b = e
GROUP by a, b, d
```

The grouping expressions are a, b, d, and the child output orderings are a.asc, b.asc, but we still can find d in a.asc.children, so SortOrder.satisfiesExpressions() is true..

### Why are the changes needed?

Convert more HashAggregate to SortAggregate to improve aggregate performance.

### Does this PR introduce _any_ user-facing change?

No


### How was this patch tested?

Added UT
