### PR TITLE
[SPARK-44872][CONNECT] Server testing infra and ReattachableExecuteSuite

### DIFF
--- a/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/client/CloseableIterator.scala
+++ b/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/client/CloseableIterator.scala
@@ -27,6 +27,20 @@ private[sql] trait CloseableIterator[E] extends Iterator[E] with AutoCloseable {
   }
 }
 
+private[sql] abstract class WrappedCloseableIterator[E] extends CloseableIterator[E] {
+
+  def innerIterator: Iterator[E]
+
+  override def next(): E = innerIterator.next()
+
+  override def hasNext(): Boolean = innerIterator.hasNext
+
+  override def close(): Unit = innerIterator match {
+    case it: CloseableIterator[E] => it.close()
+    case _ => // nothing
+  }
+}
+
 private[sql] object CloseableIterator {
 
   /**
@@ -35,12 +49,8 @@ private[sql] object CloseableIterator {
   def apply[T](iterator: Iterator[T]): CloseableIterator[T] = iterator match {
     case closeable: CloseableIterator[T] => closeable
     case _ =>
-      new CloseableIterator[T] {
-        override def next(): T = iterator.next()
-
-        override def hasNext(): Boolean = iterator.hasNext
-
-        override def close() = { /* empty */ }
+      new WrappedCloseableIterator[T] {
+        override def innerIterator = iterator
       }
   }
 }

--- a/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/client/CustomSparkConnectBlockingStub.scala
+++ b/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/client/CustomSparkConnectBlockingStub.scala
@@ -22,7 +22,7 @@ import io.grpc.ManagedChannel
 
 import org.apache.spark.connect.proto._
 
-private[client] class CustomSparkConnectBlockingStub(
+private[connect] class CustomSparkConnectBlockingStub(
     channel: ManagedChannel,
     retryPolicy: GrpcRetryHandler.RetryPolicy) {
 

--- a/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/client/GrpcExceptionConverter.scala
+++ b/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/client/GrpcExceptionConverter.scala
@@ -43,7 +43,10 @@ private[client] object GrpcExceptionConverter extends JsonUtils {
   }
 
   def convertIterator[T](iter: CloseableIterator[T]): CloseableIterator[T] = {
-    new CloseableIterator[T] {
+    new WrappedCloseableIterator[T] {
+
+      override def innerIterator: Iterator[T] = iter
+
       override def hasNext: Boolean = {
         convert {
           iter.hasNext

--- a/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/client/GrpcRetryHandler.scala
+++ b/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/client/GrpcRetryHandler.scala
@@ -48,10 +48,12 @@ private[sql] class GrpcRetryHandler(
    *   The type of the response.
    */
   class RetryIterator[T, U](request: T, call: T => CloseableIterator[U])
-      extends CloseableIterator[U] {
+      extends WrappedCloseableIterator[U] {
 
     private var opened = false // we only retry if it fails on first call when using the iterator
     private var iter = call(request)
+
+    override def innerIterator: Iterator[U] = iter
 
     private def retryIter[V](f: Iterator[U] => V) = {
       if (!opened) {

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/ExecuteGrpcResponseSender.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/ExecuteGrpcResponseSender.scala
@@ -241,8 +241,8 @@ private[connect] class ExecuteGrpcResponseSender[T <: Message](
           assert(finished == false)
         } else {
           // If it wasn't sent, time deadline must have been reached before stream became available,
-          // will exit in the enxt loop iterattion.
-          assert(deadlineLimitReached)
+          // or it was intterupted. Will exit in the next loop iterattion.
+          assert(deadlineLimitReached || interrupted)
         }
       } else if (streamFinished) {
         // Stream is finished and all responses have been sent
@@ -310,7 +310,7 @@ private[connect] class ExecuteGrpcResponseSender[T <: Message](
         val sleepStart = System.nanoTime()
         var sleepEnd = 0L
         // Conditions for exiting the inner loop
-        // 1. was detached
+        // 1. was interrupted
         // 2. grpcCallObserver is ready to send more data
         // 3. time deadline is reached
         while (!interrupted &&

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/ExecuteResponseObserver.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/ExecuteResponseObserver.scala
@@ -73,11 +73,15 @@ private[connect] class ExecuteResponseObserver[T <: Message](val executeHolder: 
   /** The index of the last response produced by execution. */
   private var lastProducedIndex: Long = 0 // first response will have index 1
 
+  // For testing
+  private[connect] var releasedUntilIndex: Long = 0
+
   /**
    * Highest response index that was consumed. Keeps track of it to decide which responses needs
    * to be cached, and to assert that all responses are consumed.
+   * Visible for testing.
    */
-  private var highestConsumedIndex: Long = 0
+  private[connect] var highestConsumedIndex: Long = 0
 
   /**
    * Consumer that waits for available responses. There can be only one at a time, @see
@@ -284,6 +288,7 @@ private[connect] class ExecuteResponseObserver[T <: Message](val executeHolder: 
       responses.remove(i)
       i -= 1
     }
+    releasedUntilIndex = index
   }
 
   /**

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/ExecuteResponseObserver.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/ExecuteResponseObserver.scala
@@ -79,6 +79,7 @@ private[connect] class ExecuteResponseObserver[T <: Message](val executeHolder: 
   /**
    * Highest response index that was consumed. Keeps track of it to decide which responses needs
    * to be cached, and to assert that all responses are consumed.
+   *
    * Visible for testing.
    */
   private[connect] var highestConsumedIndex: Long = 0

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/ExecuteHolder.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/ExecuteHolder.scala
@@ -183,6 +183,16 @@ private[connect] class ExecuteHolder(
     }
   }
 
+  // For testing.
+  private[connect] def setGrpcResponseSendersDeadline(deadlineMs: Long) = synchronized {
+    grpcResponseSenders.foreach(_.setDeadline(deadlineMs))
+  }
+
+  // For testing
+  private[connect] def interruptGrpcResponseSenders() = synchronized {
+    grpcResponseSenders.foreach(_.interrupt())
+  }
+
   /**
    * For a short period in ExecutePlan after creation and until runGrpcResponseSender is called,
    * there is no attached response sender, but yet we start with lastAttachedRpcTime = None, so we

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectExecutionManager.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectExecutionManager.scala
@@ -71,15 +71,14 @@ private[connect] class SparkConnectExecutionManager() extends Logging {
       // The latter is to prevent double execution when a client retries execution, thinking it
       // never reached the server, but in fact it did, and already got removed as abandoned.
       if (executions.get(executeHolder.key).isDefined) {
-        if (getAbandonedTombstone(executeHolder.key).isDefined) {
-          throw new SparkSQLException(
-            errorClass = "INVALID_HANDLE.OPERATION_ABANDONED",
-            messageParameters = Map("handle" -> executeHolder.operationId))
-        } else {
-          throw new SparkSQLException(
-            errorClass = "INVALID_HANDLE.OPERATION_ALREADY_EXISTS",
-            messageParameters = Map("handle" -> executeHolder.operationId))
-        }
+        throw new SparkSQLException(
+          errorClass = "INVALID_HANDLE.OPERATION_ALREADY_EXISTS",
+          messageParameters = Map("handle" -> executeHolder.operationId))
+      }
+      if (getAbandonedTombstone(executeHolder.key).isDefined) {
+        throw new SparkSQLException(
+          errorClass = "INVALID_HANDLE.OPERATION_ABANDONED",
+          messageParameters = Map("handle" -> executeHolder.operationId))
       }
       sessionHolder.addExecuteHolder(executeHolder)
       executions.put(executeHolder.key, executeHolder)
@@ -141,12 +140,17 @@ private[connect] class SparkConnectExecutionManager() extends Logging {
     abandonedTombstones.asMap.asScala.values.toBuffer.toSeq
   }
 
-  private[service] def shutdown(): Unit = executionsLock.synchronized {
+  private[connect] def shutdown(): Unit = executionsLock.synchronized {
     scheduledExecutor.foreach { executor =>
       executor.shutdown()
       executor.awaitTermination(1, TimeUnit.MINUTES)
     }
     scheduledExecutor = None
+    executions.clear()
+    abandonedTombstones.invalidateAll()
+    if (!lastExecutionTime.isDefined) {
+      lastExecutionTime = Some(System.currentTimeMillis())
+    }
   }
 
   /**
@@ -205,5 +209,15 @@ private[connect] class SparkConnectExecutionManager() extends Logging {
       }
     }
     logInfo("Finished periodic run of SparkConnectExecutionManager maintenance.")
+  }
+
+  // For testing.
+  private[connect] def setAllRPCsDeadline(deadlineMs: Long) = executionsLock.synchronized {
+    executions.values.foreach(_.setGrpcResponseSendersDeadline(deadlineMs))
+  }
+
+  // For testing.
+  private[connect] def interruptAllRPCs() = executionsLock.synchronized {
+    executions.values.foreach(_.interruptGrpcResponseSenders())
   }
 }

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectExecutionManager.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectExecutionManager.scala
@@ -192,7 +192,7 @@ private[connect] class SparkConnectExecutionManager() extends Logging {
       executions.values.foreach { executeHolder =>
         executeHolder.lastAttachedRpcTime match {
           case Some(detached) =>
-            if (detached + timeout < nowMs) {
+            if (detached + timeout <= nowMs) {
               toRemove += executeHolder
             }
           case _ => // execution is active
@@ -219,5 +219,9 @@ private[connect] class SparkConnectExecutionManager() extends Logging {
   // For testing.
   private[connect] def interruptAllRPCs() = executionsLock.synchronized {
     executions.values.foreach(_.interruptGrpcResponseSenders())
+  }
+
+  private[connect] def listExecuteHolders = executionsLock.synchronized {
+    executions.values.toBuffer.toSeq
   }
 }

--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/SparkConnectServerTest.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/SparkConnectServerTest.scala
@@ -1,0 +1,222 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.connect
+
+import java.util.UUID
+
+import org.scalatest.concurrent.{Eventually, TimeLimits}
+import org.scalatest.time.Span
+import org.scalatest.time.SpanSugar._
+
+import org.apache.spark.connect.proto
+import org.apache.spark.sql.connect.client.{CloseableIterator, CustomSparkConnectBlockingStub, ExecutePlanResponseReattachableIterator, GrpcRetryHandler, SparkConnectClient, WrappedCloseableIterator}
+import org.apache.spark.sql.connect.common.config.ConnectCommon
+import org.apache.spark.sql.connect.config.Connect
+import org.apache.spark.sql.connect.dsl.MockRemoteSession
+import org.apache.spark.sql.connect.dsl.plans._
+import org.apache.spark.sql.connect.service.SparkConnectService
+import org.apache.spark.sql.test.SharedSparkSession
+
+/**
+ * Base class and utilities for a test suite that starts and tests the real SparkConnectService
+ * with a real SparkConnectClient, communicating over RPC, but both in-process.
+ */
+class SparkConnectServerTest extends SharedSparkSession {
+
+  // Server port
+  val serverPort: Int =
+    ConnectCommon.CONNECT_GRPC_BINDING_PORT + util.Random.nextInt(1000)
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    // Other suites using mocks leave a mess in the global executionManager,
+    // shut it down so that it's cleared before starting server.
+    SparkConnectService.executionManager.shutdown()
+    // Start the real service.
+    withSparkEnvConfs((Connect.CONNECT_GRPC_BINDING_PORT.key, serverPort.toString)) {
+      SparkConnectService.start(spark.sparkContext)
+    }
+    // register udf directly on the server, we're not testing client UDFs here...
+    val serverSession =
+      SparkConnectService.getOrCreateIsolatedSession(defaultUserId, defaultSessionId).session
+    serverSession.udf.register("sleep", ((ms: Int) => { Thread.sleep(ms); ms }))
+  }
+
+  override def afterAll(): Unit = {
+    SparkConnectService.stop()
+    super.afterAll()
+  }
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    clearAllExecutions()
+  }
+
+  override def afterEach(): Unit = {
+    clearAllExecutions()
+    super.afterEach()
+  }
+
+  protected def clearAllExecutions(): Unit = {
+    SparkConnectService.executionManager.interruptAllRPCs()
+    assertNoActiveRpcs()
+    SparkConnectService.executionManager.periodicMaintenance(0)
+    assertNoActiveExecutions()
+  }
+
+  protected val defaultSessionId = UUID.randomUUID.toString()
+  protected val defaultUserId = UUID.randomUUID.toString()
+
+  // We don't have the real SparkSession/Dataset api available,
+  // so use mock for generating simple query plans.
+  protected val dsl = new MockRemoteSession()
+
+  protected val userContext = proto.UserContext
+    .newBuilder()
+    .setUserId(defaultUserId)
+    .build()
+
+  protected def buildExecutePlanRequest(
+      plan: proto.Plan,
+      sessionId: String = defaultSessionId,
+      operationId: String = UUID.randomUUID.toString) = {
+    proto.ExecutePlanRequest
+      .newBuilder()
+      .setUserContext(userContext)
+      .setSessionId(sessionId)
+      .setOperationId(operationId)
+      .setPlan(plan)
+      .addRequestOptions(
+        proto.ExecutePlanRequest.RequestOption
+          .newBuilder()
+          .setReattachOptions(proto.ReattachOptions.newBuilder().setReattachable(true).build())
+          .build())
+      .build()
+  }
+
+  protected def buildReattachExecuteRequest(operationId: String, responseId: Option[String]) = {
+    val req = proto.ReattachExecuteRequest
+      .newBuilder()
+      .setUserContext(userContext)
+      .setSessionId(defaultSessionId)
+      .setOperationId(operationId)
+
+    if (responseId.isDefined) {
+      req.setLastResponseId(responseId.get)
+    }
+
+    req.build()
+  }
+
+  protected def buildPlan(query: String) = {
+    proto.Plan.newBuilder().setRoot(dsl.sql(query)).build()
+  }
+
+  protected def getReattachableIterator(
+      stubIterator: CloseableIterator[proto.ExecutePlanResponse]) = {
+    // This depends on the wrapping in CustomSparkConnectBlockingStub.executePlanReattachable:
+    // GrpcExceptionConverter.convertIterator
+    stubIterator
+      .asInstanceOf[WrappedCloseableIterator[proto.ExecutePlanResponse]]
+      // ExecutePlanResponseReattachableIterator
+      .innerIterator
+      .asInstanceOf[ExecutePlanResponseReattachableIterator]
+  }
+
+  protected def assertNoActiveRpcs(): Unit = {
+    Eventually.eventually(timeout(30.seconds)) {
+      SparkConnectService.executionManager.listActiveExecutions match {
+        case Left(_) => true // nothing running, good
+        case Right(executions) =>
+          // all rpc detached.
+          assert(
+            executions.forall(_.lastAttachedRpcTime.isDefined),
+            s"Expected no RPCs, but got $executions")
+      }
+    }
+  }
+
+  protected def assertNoActiveExecutions(): Unit = {
+    Eventually.eventually(timeout(30.seconds)) {
+      SparkConnectService.executionManager.listActiveExecutions match {
+        case Left(_) => // cleaned up
+        case Right(executions) => fail(s"Expected empty, but got $executions")
+      }
+    }
+  }
+
+  protected def withClient(f: SparkConnectClient => Unit): Unit = {
+    val client = SparkConnectClient
+      .builder()
+      .port(serverPort)
+      .sessionId(defaultSessionId)
+      .userId(defaultUserId)
+      .enableReattachableExecute()
+      .build()
+    try f(client)
+    finally {
+      client.shutdown()
+    }
+  }
+
+  protected def withRawBlockingStub(
+      f: proto.SparkConnectServiceGrpc.SparkConnectServiceBlockingStub => Unit): Unit = {
+    val conf = SparkConnectClient.Configuration(port = serverPort)
+    val channel = conf.createChannel()
+    val bstub = proto.SparkConnectServiceGrpc.newBlockingStub(channel)
+    try f(bstub)
+    finally {
+      channel.shutdownNow()
+    }
+  }
+
+  protected def withCustomBlockingStub(
+      retryPolicy: GrpcRetryHandler.RetryPolicy = GrpcRetryHandler.RetryPolicy())(
+      f: CustomSparkConnectBlockingStub => Unit): Unit = {
+    val conf = SparkConnectClient.Configuration(port = serverPort)
+    val channel = conf.createChannel()
+    val bstub = new CustomSparkConnectBlockingStub(channel, retryPolicy)
+    try f(bstub)
+    finally {
+      channel.shutdownNow()
+    }
+  }
+
+  protected def runQuery(plan: proto.Plan, queryTimeout: Span, iterSleep: Long): Unit = {
+    withClient { client =>
+      TimeLimits.failAfter(queryTimeout) {
+        val iter = client.execute(plan)
+        val reattachableIter = getReattachableIterator(iter)
+        while (iter.hasNext) {
+          iter.next()
+          if (iterSleep > 0) {
+            Thread.sleep(iterSleep)
+          }
+        }
+        // Check that client released execution
+        assert(reattachableIter.resultComplete)
+      }
+      // Check that execution is released on the server.
+      assertNoActiveExecutions()
+    }
+  }
+
+  protected def runQuery(query: String, queryTimeout: Span, iterSleep: Long = 0): Unit = {
+    val plan = buildPlan(query)
+    runQuery(plan, queryTimeout, iterSleep)
+  }
+}

--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/execution/ReattachableExecuteSuite.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/execution/ReattachableExecuteSuite.scala
@@ -1,0 +1,242 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.connect.execution
+
+import java.util.UUID
+
+import org.scalatest.time.SpanSugar._
+
+import org.apache.spark.SparkException
+import org.apache.spark.sql.connect.SparkConnectServerTest
+import org.apache.spark.sql.connect.config.Connect
+import org.apache.spark.sql.connect.service.SparkConnectService
+
+class ReattachableExecuteSuite extends SparkConnectServerTest {
+
+  // Tests assume that this query will result in at least a couple ExecutePlanResponses on the
+  // stream. If this is no longer the case because of changes in how much is returned in a single
+  // ExecutePlanResponse, it may need to be adjusted.
+  val MEDIUM_RESULTS_QUERY = "select * from range(100000)"
+
+  test("reattach after initial RPC ends") {
+    withClient { client =>
+      val iter = client.execute(buildPlan(MEDIUM_RESULTS_QUERY))
+      val reattachableIter = getReattachableIterator(iter)
+      val initialInnerIter = reattachableIter.iter.get
+
+      // open the iterator
+      assert(iter.hasNext)
+      iter.next()
+      // expire all RPCs on server
+      SparkConnectService.executionManager.setAllRPCsDeadline(System.currentTimeMillis() - 1)
+      assertNoActiveRpcs()
+      // iterator should reattach
+      // (but not necessarily at first next, as there might have been messages buffered client side)
+      while (iter.hasNext && (reattachableIter.iter.get eq initialInnerIter)) {
+        iter.next()
+      }
+      assert(reattachableIter.iter.get ne initialInnerIter) // reattach changed the inner iterator.
+
+      iter.close()
+      reattachableIter.close()
+    }
+  }
+
+  test("interrupted RPC results in INVALID_CURSOR.DISCONNECTED error") {
+    withRawBlockingStub { stub =>
+      val iter = stub.executePlan(buildExecutePlanRequest(buildPlan(MEDIUM_RESULTS_QUERY)))
+      assert(iter.hasNext)
+      iter.next() // open the iterator
+      // interrupt all RPCs on server
+      SparkConnectService.executionManager.interruptAllRPCs()
+      assertNoActiveRpcs()
+      val e = intercept[SparkException] {
+        while (iter.hasNext) iter.next()
+      }
+      assert(e.getMessage.contains("INVALID_CURSOR.DISCONNECTED"))
+    }
+  }
+
+  test("new RPC interrupts previous RPC with INVALID_CURSOR.DISCONNECTED error") {
+    // Raw stub does not have retries, auto reattach etc.
+    withRawBlockingStub { stub =>
+      val operationId = UUID.randomUUID()
+      val iter = stub.executePlan(
+        buildExecutePlanRequest(buildPlan(MEDIUM_RESULTS_QUERY), operationId = operationId))
+      assert(iter.hasNext)
+      iter.next() // open the iterator
+
+      // send reattach
+      val iter2 = stub.reattachExecute(buildReattachExecuteRequest(operationId, None))
+      assert(iter2.hasNext)
+      iter2.next() // open the iterator
+
+      // should result in INVALID_CURSOR.DISCONNECTED error on the original iterator
+      val e = intercept[SparkException] {
+        while (iter.hasNext) iter.next()
+      }
+      assert(e.getMessage.contains("INVALID_CURSOR.DISCONNECTED"))
+
+      // send another reattach
+      val iter3 = stub.reattachExecute(buildReattachExecuteRequest(operationId, None))
+      assert(iter3.hasNext)
+      iter3.next() // open the iterator
+
+      // should result in INVALID_CURSOR.DISCONNECTED error on the previous reattach iterator
+      val e2 = intercept[SparkException] {
+        while (iter2.hasNext) iter2.next()
+      }
+      assert(e2.getMessage.contains("INVALID_CURSOR.DISCONNECTED"))
+    }
+  }
+
+  test("INVALID_CURSOR.DISCONNECTED error is retried when rpc sender gets interrupted") {
+    withClient { client =>
+      val iter = client.execute(buildPlan(MEDIUM_RESULTS_QUERY))
+      val reattachableIter = getReattachableIterator(iter)
+      val operationId = getReattachableIterator(iter).operationId
+
+      // open the iterator
+      assert(iter.hasNext)
+      iter.next()
+
+      // interrupt all RPCs on server
+      SparkConnectService.executionManager.interruptAllRPCs()
+      assertNoActiveRpcs()
+
+      // Nevertheless, the original iterator will handle the INVALID_CURSOR.DISCONNECTED error
+      assert(iter.hasNext)
+      while (iter.hasNext) iter.next()
+    }
+  }
+
+  test("INVALID_CURSOR.DISCONNECTED error is retried when other RPC preempts this one") {
+    withClient { client =>
+      val iter = client.execute(buildPlan(MEDIUM_RESULTS_QUERY))
+      val reattachableIter = getReattachableIterator(iter)
+      val operationId = getReattachableIterator(iter).operationId
+
+      // open the iterator
+      assert(iter.hasNext)
+      iter.next()
+
+      // Send another Reattach request, it should preempt this request with an
+      // INVALID_CURSOR.DISCONNECTED error.
+      withRawBlockingStub() { stub =>
+        val reattachReq = buildReattachExecuteRequest(operationId, None)
+        val reattachIter = stub.reattachExecute(reattachReq)
+        assert(reattachIter.hasNext)
+        reattachIter.next()
+
+        // Nevertheless, the original iterator will handle the INVALID_CURSOR.DISCONNECTED error
+        assert(iter.hasNext)
+        while (iter.hasNext) iter.next()
+
+        // ... and in turn disconnect the reattachIter
+        val e = intercept[SparkException] {
+          while (reattachIter.hasNext) reattachIter.next()
+        }
+        assert(e.getMessage.contains("INVALID_CURSOR.DISCONNECTED"))
+      }
+  }
+
+  test("abandoned query gets INVALID_HANDLE.OPERATION_ABANDONED error") {
+    withClient { client =>
+      val plan = buildPlan("select * from range(100000)")
+      val iter = client.execute(buildPlan(MEDIUM_RESULTS_QUERY))
+      val operationId = getReattachableIterator(iter).operationId
+      // open the iterator
+      assert(iter.hasNext)
+      iter.next()
+      // disconnect and remove on server
+      SparkConnectService.executionManager.setAllRPCsDeadline(System.currentTimeMillis() - 1)
+      assertNoActiveRpcs()
+      SparkConnectService.executionManager.periodicMaintenance(0)
+      assertNoActiveExecutions()
+      // check that it throws abandoned error
+      val e = intercept[SparkException] {
+        while (iter.hasNext) iter.next()
+      }
+      assert(e.getMessage.contains("INVALID_HANDLE.OPERATION_ABANDONED"))
+      // check that afterwards, new operation can't be created with the same operationId.
+      withCustomBlockingStub() { stub =>
+        val executePlanReq = buildExecutePlanRequest(plan, operationId = operationId)
+
+        val iterNonReattachable = stub.executePlan(executePlanReq)
+        val eNonReattachable = intercept[SparkException] {
+          iterNonReattachable.hasNext
+        }
+        assert(eNonReattachable.getMessage.contains("INVALID_HANDLE.OPERATION_ABANDONED"))
+
+        val iterReattachable = stub.executePlanReattachable(executePlanReq)
+        val eReattachable = intercept[SparkException] {
+          iterReattachable.hasNext
+        }
+        assert(eReattachable.getMessage.contains("INVALID_HANDLE.OPERATION_ABANDONED"))
+      }
+    }
+  }
+
+  // A few integration tests with large results.
+  // They should run significantly faster than the LARGE_QUERY_TIMEOUT
+  // - big query (4 seconds, 871 milliseconds)
+  // - big query and slow client (7 seconds, 288 milliseconds)
+  // - big query with frequent reattach (1 second, 527 milliseconds)
+  // - big query with frequent reattach and slow client (7 seconds, 365 milliseconds)
+  // - long sleeping query (10 seconds, 805 milliseconds)
+
+  // intentionally smaller than CONNECT_EXECUTE_REATTACHABLE_SENDER_MAX_STREAM_DURATION,
+  // so that reattach deadline doesn't "unstuck" if something got stuck.
+  val LARGE_QUERY_TIMEOUT = 100.seconds
+
+  val LARGE_RESULTS_QUERY = s"select id, " +
+    (1 to 20).map(i => s"cast(id as string) c$i").mkString(", ") +
+    s" from range(1000000)"
+
+  test("big query") {
+    // regular query with large results
+    runQuery(LARGE_RESULTS_QUERY, LARGE_QUERY_TIMEOUT)
+  }
+
+  test("big query and slow client") {
+    // regular query with large results, but client is slow so sender will need to control flow
+    runQuery(LARGE_RESULTS_QUERY, LARGE_QUERY_TIMEOUT, 50)
+  }
+
+  test("big query with frequent reattach") {
+    // will reattach every 100kB
+    withSparkEnvConfs((Connect.CONNECT_EXECUTE_REATTACHABLE_SENDER_MAX_STREAM_SIZE.key, "100k")) {
+      runQuery(LARGE_RESULTS_QUERY, LARGE_QUERY_TIMEOUT)
+    }
+  }
+
+  test("big query with frequent reattach and slow client") {
+    // will reattach every 100kB, and in addition the client is slow,
+    // so sender will need to control flow
+    withSparkEnvConfs((Connect.CONNECT_EXECUTE_REATTACHABLE_SENDER_MAX_STREAM_SIZE.key, "100k")) {
+      runQuery(LARGE_RESULTS_QUERY, LARGE_QUERY_TIMEOUT, 50)
+    }
+  }
+
+  test("long sleeping query") {
+    // query will be sleeping and not returning results, while having multiple reattach
+    withSparkEnvConfs(
+      (Connect.CONNECT_EXECUTE_REATTACHABLE_SENDER_MAX_STREAM_DURATION.key, "1s")) {
+      runQuery("select sleep(10000) as s", 30.seconds)
+    }
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add `SparkConnectServerTest` with infra to test real server with real client in the same process, but communicating over RPC.

Add `ReattachableExecuteSuite` with some tests for reattachable execute.

Two bugs were found by the tests:
* Fix bug in `SparkConnectExecutionManager.createExecuteHolder` when attempting to resubmit an operation that was deemed abandoned. This bug is benign in reattachable execute, because reattachable execute would first send a ReattachExecute, which would be handled correctly in SparkConnectReattachExecuteHandler. For non-reattachable execute (disabled or old client), this is also a very unlikely scenario, because the retrying mechanism should be able to resubmit before the query is declared abandoned, and hence get an INVALID_HANDLE.OPERATION_ALREADY_EXISTS. This bug can manifest only if a non-reattachable execution is retried with so much delay that the operation was declared abandoned.
* In `ExecuteGrpcResponseSender` there was an assertion that assumed that if `sendResponse` did not send, it was because deadline was reached. But it can also be because of interrupt. This would have resulted in interrupt returning an assertion error instead of CURSOR_DISCONNECTED in testing. Outside of testing assertions are not enabled, so this was not a problem outside of testing.

### Why are the changes needed?

Testing of reattachable execute.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Tests added.