### PR TITLE
[SPARK-22876][YARN] Respect YARN AM failure validity interval

### DIFF
--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -99,6 +99,8 @@ private[spark] class ApplicationMaster(
 
   private val maxNumExecutorFailures = ExecutorFailureTracker.maxNumExecutorFailures(sparkConf)
 
+  private val amFailureValidity = sparkConf.get(AM_ATTEMPT_FAILURE_VALIDITY_INTERVAL_MS)
+
   @volatile private var exitCode = 0
   @volatile private var unregistered = false
   @volatile private var finished = false
@@ -189,6 +191,45 @@ private[spark] class ApplicationMaster(
     resources.toMap
   }
 
+  /**
+   * Determines if this should be the last attempt or not. If no validity interval was defined,
+   * this simply compares the current attempt ID to the max number of attempts. If a validity
+   * interval is defined, we do our best to replicate Yarn's logic for determining which previous
+   * attempts should count toward the max attempt limit.
+   *
+   * Adapted from RMAppAttemptImpl.shouldCountTowardsMaxAttemptRetry.
+   */
+  private def isLastAttempt: Boolean = {
+    val maxAppAttempts = client.getMaxRegAttempts(sparkConf, yarnConf)
+    amFailureValidity.map { interval =>
+      logInfo("Loading previous ApplicationMaster attempts")
+      val previousAttempts = client.getPreviousAttempts(yarnConf, appAttemptId)
+
+      val ignoredExitStatuses = Seq(
+        ContainerExitStatus.PREEMPTED,
+        ContainerExitStatus.ABORTED,
+        ContainerExitStatus.DISKS_FAILED,
+        ContainerExitStatus.KILLED_BY_RESOURCEMANAGER
+      )
+      val validAfter = System.currentTimeMillis() - interval
+      val validAttempts = previousAttempts.filter { case (attempt, exitStatus) =>
+        val validFinishTime = attempt.getFinishTime() >= validAfter
+
+        // If we don't have the exit status, or it's not one of the statuses yarn ignores, count it
+        // toward out total failures.
+        val validStatusCode = !exitStatus.exists(ignoredExitStatuses.contains(_))
+
+        val valid = validFinishTime && validStatusCode
+        valid
+      }
+
+      // Include this attempt
+      validAttempts.length + 1 >= maxAppAttempts
+    }.getOrElse {
+      appAttemptId.getAttemptId() >= maxAppAttempts
+    }
+  }
+
   final def run(): Int = {
     try {
       val attemptID = if (isClusterMode) {
@@ -226,9 +267,6 @@ private[spark] class ApplicationMaster(
       val priority = ShutdownHookManager.SPARK_CONTEXT_SHUTDOWN_PRIORITY - 1
       ShutdownHookManager.addShutdownHook(priority) { () =>
         try {
-          val maxAppAttempts = client.getMaxRegAttempts(sparkConf, yarnConf)
-          val isLastAttempt = appAttemptId.getAttemptId() >= maxAppAttempts
-
           if (!finished) {
             // The default state of ApplicationMaster is failed if it is invoked by shut down hook.
             // This behavior is different compared to 1.x version.

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
@@ -27,6 +27,7 @@ import scala.collection.mutable
 import scala.concurrent.duration._
 import scala.io.Source
 
+import org.apache.hadoop.yarn.api.records._
 import org.apache.hadoop.yarn.conf.YarnConfiguration
 import org.scalatest.concurrent.Eventually._
 import org.scalatest.exceptions.TestFailedException
@@ -395,6 +396,19 @@ class YarnClusterSuite extends BaseYarnClusterSuite {
 
   test("executor env overwrite AM env in cluster mode") {
     testExecutorEnv(false)
+  }
+
+  test("SPARK-22876: Respect Yarn AM failure validity interval") {
+    val result = File.createTempFile("result", null, tempDir)
+    val output = File.createTempFile("output", null, tempDir)
+    val finalState = runSpark(false, mainClassName(YarnAMFailureValidityIntervalApp.getClass),
+      appArgs = Seq(result.getAbsolutePath()),
+      extraConf = Map(AM_ATTEMPT_FAILURE_VALIDITY_INTERVAL_MS.key -> "20s"))
+    assert(finalState === SparkAppHandle.State.FAILED)
+
+    val resultString = Files.readString(result.toPath)
+    val finalAttemptId = ApplicationAttemptId.fromString(resultString)
+    assert(finalAttemptId.getAttemptId() === 3)
   }
 
   private def testBasicYarnApp(clientMode: Boolean, conf: Map[String, String] = Map()): Unit = {
@@ -901,5 +915,22 @@ private class PyConnectDepChecker(python: String, libPath: Seq[String]) {
       fail("spark.test.home or SPARK_HOME is not set.")
     }
     sys.props.getOrElse("spark.test.home", sys.env("SPARK_HOME"))
+  }
+}
+
+private object YarnAMFailureValidityIntervalApp {
+
+  def main(args: Array[String]): Unit = {
+    val result = new File(args(0))
+
+    val sc = new SparkContext(new SparkConf())
+    val attemptId = YarnSparkHadoopUtil.getContainerId.getApplicationAttemptId()
+    Files.writeString(result.toPath(), attemptId.toString)
+    if (attemptId.getAttemptId() == 2) {
+      // Sleep on the second attempt to age out the first failure
+      Thread.sleep(30000)
+    }
+    sc.stop()
+    System.exit(-1)
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Adds support for using the YARN application master failure validity interval for determining whether an attempt is the last attempt during shutdown. During the application master shutdown hook, if the validity interval is specified, we get previous attempt information from the resource manager to make a best attempt at mirroring whether YARN is going to retry the application or not. This is because, AFAIK, there is no way for Spark to know 100% if YARN will retry the application or not. 

This can lead to two scenarios where Spark is wrong about whether YARN will retry it or not:
- Spark thinks it is the last attempt but YARN will retry the application. This is what can already happen by not respecting the failure validity at all.
- Spark thinks the application will retry but YARN thinks it was the last attempt. This will result in the staging directory not be cleaned up, but that can already happen if Spark gets killed during the last attempt and doesn't run it's shutdown hooks.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Spark supports passing the AM application validity interval to YARN using the `spark.yarn.am.attemptFailuresValidityInterval` setting, but then ignores this during shutdown when determining whether it's the last attempt and whether to cleanup the staging directory. Currently if you try to use this setting, YARN will respect the setting and attempt to retry the application, but only if the last attempt was killed with a hard shutdown (like OOM) that prevents the shutdown logic from occurring. During a graceful shutdown, Spark will delete the staging directory and unregister the application from YARN, preventing any further attempts.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, Spark on YARN better supports graceful recovery and retry of jobs to better enable long running Spark Streaming jobs.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New UT. It unfortunately relies on sleeping to test the validity timing, which seems very prone to flakiness, but I couldn't think of any other way to test it. If the approach seems sound, it might be worth just removing the test. I don't see any tests for simply the max YARN attempts.


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No