### PR TITLE
[SPARK-44882][PYTHON][CONNECT] Remove function uuid/random/chr from PySpark

### DIFF
--- a/python/docs/source/reference/pyspark.sql/functions.rst
+++ b/python/docs/source/reference/pyspark.sql/functions.rst
@@ -387,7 +387,6 @@ String Functions
     char
     character_length
     char_length
-    chr
     concat_ws
     contains
     decode
@@ -503,12 +502,10 @@ Misc Functions
     hll_sketch_estimate
     hll_union
     java_method
-    random
     stack
     try_aes_decrypt
     typeof
     user
-    uuid
     version
 
 Predicate Functions

--- a/python/pyspark/sql/connect/functions.py
+++ b/python/pyspark/sql/connect/functions.py
@@ -2653,13 +2653,6 @@ def character_length(str: "ColumnOrName") -> Column:
 character_length.__doc__ = pysparkfuncs.character_length.__doc__
 
 
-def chr(col: "ColumnOrName") -> Column:
-    return _invoke_function_over_columns("chr", col)
-
-
-chr.__doc__ = pysparkfuncs.chr.__doc__
-
-
 def contains(left: "ColumnOrName", right: "ColumnOrName") -> Column:
     return _invoke_function_over_columns("contains", left, right)
 
@@ -3695,13 +3688,6 @@ def nvl2(col1: "ColumnOrName", col2: "ColumnOrName", col3: "ColumnOrName") -> Co
 nvl2.__doc__ = pysparkfuncs.nvl2.__doc__
 
 
-def uuid() -> Column:
-    return _invoke_function_over_columns("uuid")
-
-
-uuid.__doc__ = pysparkfuncs.uuid.__doc__
-
-
 def aes_encrypt(
     input: "ColumnOrName",
     key: "ColumnOrName",
@@ -3809,18 +3795,6 @@ def stack(*cols: "ColumnOrName") -> Column:
 
 
 stack.__doc__ = pysparkfuncs.stack.__doc__
-
-
-def random(
-    seed: Optional["ColumnOrName"] = None,
-) -> Column:
-    if seed is not None:
-        return _invoke_function_over_columns("random", seed)
-    else:
-        return _invoke_function_over_columns("random")
-
-
-random.__doc__ = pysparkfuncs.random.__doc__
 
 
 def bitmap_bit_position(col: "ColumnOrName") -> Column:

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -10332,28 +10332,6 @@ def character_length(str: "ColumnOrName") -> Column:
     return _invoke_function_over_columns("character_length", str)
 
 
-@try_remote_functions
-def chr(col: "ColumnOrName") -> Column:
-    """
-    Returns the ASCII character having the binary equivalent to `col`.
-    If col is larger than 256 the result is equivalent to chr(col % 256)
-
-    .. versionadded:: 3.5.0
-
-    Parameters
-    ----------
-    col : :class:`~pyspark.sql.Column` or str
-        Input column or strings.
-
-    Examples
-    --------
-    >>> df = spark.createDataFrame([(65,)], ['a'])
-    >>> df.select(chr(df.a).alias('r')).collect()
-    [Row(r='A')]
-    """
-    return _invoke_function_over_columns("chr", col)
-
-
 def try_to_binary(col: "ColumnOrName", format: Optional["ColumnOrName"] = None) -> Column:
     """
     This is a special version of `to_binary` that performs the same operation, but returns a NULL
@@ -14813,27 +14791,6 @@ def nvl2(col1: "ColumnOrName", col2: "ColumnOrName", col3: "ColumnOrName") -> Co
 
 
 @try_remote_functions
-def uuid() -> Column:
-    """
-    Returns an universally unique identifier (UUID) string. The value is returned as a canonical
-    UUID 36-character string.
-
-    .. versionadded:: 3.5.0
-
-    Examples
-    --------
-    >>> df = spark.range(1)
-    >>> df.select(uuid()).show(truncate=False) # doctest: +SKIP
-    +------------------------------------+
-    |uuid()                              |
-    +------------------------------------+
-    |3dcc5174-9da9-41ca-815f-34c05c6d3926|
-    +------------------------------------+
-    """
-    return _invoke_function_over_columns("uuid")
-
-
-@try_remote_functions
 def aes_encrypt(
     input: "ColumnOrName",
     key: "ColumnOrName",
@@ -15245,44 +15202,6 @@ def stack(*cols: "ColumnOrName") -> Column:
     +----+----+
     """
     return _invoke_function_over_seq_of_columns("stack", cols)
-
-
-@try_remote_functions
-def random(
-    seed: Optional["ColumnOrName"] = None,
-) -> Column:
-    """
-    Returns a random value with independent and identically distributed (i.i.d.) uniformly
-    distributed values in [0, 1).
-
-    .. versionadded:: 3.5.0
-
-    Parameters
-    ----------
-    cols : :class:`~pyspark.sql.Column` or str
-        The seed for the random generator.
-
-    Examples
-    --------
-    >>> df = spark.range(1)
-    >>> df.select(random()).show(truncate=False) # doctest: +SKIP
-    +--------------------+
-    |rand()              |
-    +--------------------+
-    |0.026810514415005593|
-    +--------------------+
-
-    >>> df.select(random(lit(1))).show(truncate=False) # doctest: +SKIP
-    +------------------+
-    |rand(1)           |
-    +------------------+
-    |0.4836508543933039|
-    +------------------+
-    """
-    if seed is not None:
-        return _invoke_function_over_columns("random", seed)
-    else:
-        return _invoke_function_over_columns("random")
 
 
 @try_remote_functions

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -63,6 +63,9 @@ class FunctionsTestsMixin:
             "any",  # equivalent to python ~some
             "len",  # equivalent to python ~length
             "udaf",  # used for creating UDAF's which are not supported in PySpark
+            "random",  # namespace conflict with python built-in module
+            "uuid",  # namespace conflict with python built-in module
+            "chr",  # namespace conflict with python built-in function
         ]
 
         jvm_fn_set.difference_update(jvm_excluded_fn)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Remove function uuid/random/chr from PySpark


### Why are the changes needed?
The three functions are controversial and needs further discussion, we can add them back in the future.

- `uuid` and `random` are also the names of [built-in modules](https://docs.python.org/3/library/index.html),

- `chr` is the name of a [built-in function](https://docs.python.org/3/library/functions.html)


This PR is to avoid namespace conflict which may break existing workloads, e.g.
```
import uuid
from pyspark.sql.functions import *
print(uuid.uuid4())
```



### Does this PR introduce _any_ user-facing change?
yes


### How was this patch tested?
updated CI


### Was this patch authored or co-authored using generative AI tooling?
NO
