### PR TITLE
[SPARK-43149][SQL] `CreateDataSourceTableCommand` should create metadata first

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/createDataSourceTables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/createDataSourceTables.scala
@@ -181,7 +181,8 @@ case class CreateDataSourceTableAsSelectCommand(
       }
       val outputColumns = DataWritingCommand.logicalPlanOutputWithNames(query, outputColumnNames)
       val tableSchema = CharVarcharUtils.getRawSchema(
-        removeInternalMetadata(outputColumns.toStructType), sparkSession.sessionState.conf)
+        removeInternalMetadata(outputColumns.toStructType.asNullable),
+        sparkSession.sessionState.conf)
       val newTable = table.copy(
         storage = table.storage.copy(locationUri = tableLocation),
         // We will use the schema of resolved.relation as the schema of the table (instead of

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/CreateTableAsSelectSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/CreateTableAsSelectSuite.scala
@@ -78,27 +78,29 @@ class CreateTableAsSelectSuite extends DataSourceTest with SharedSparkSession {
   }
 
   test("CREATE TABLE USING AS SELECT based on the file without write permission") {
-    // setWritable(...) does not work on Windows. Please refer JDK-6728842.
-    assume(!Utils.isWindows)
-    val childPath = new File(path.toString, "child")
-    path.mkdir()
-    path.setWritable(false)
+    withTable("jsonTable") {
+      // setWritable(...) does not work on Windows. Please refer JDK-6728842.
+      assume(!Utils.isWindows)
+      val childPath = new File(path.toString, "child")
+      path.mkdir()
+      path.setWritable(false)
 
-    val e = intercept[SparkException] {
-      sql(
-        s"""
-           |CREATE TABLE jsonTable
-           |USING json
-           |OPTIONS (
-           |  path '${childPath.toURI}'
-           |) AS
-           |SELECT a, b FROM jt
+      val e = intercept[SparkException] {
+        sql(
+          s"""
+             |CREATE TABLE jsonTable
+             |USING json
+             |OPTIONS (
+             |  path '${childPath.toURI}'
+             |) AS
+             |SELECT a, b FROM jt
          """.stripMargin)
-      sql("SELECT a, b FROM jsonTable").collect()
-    }
+        sql("SELECT a, b FROM jsonTable").collect()
+      }
 
-    assert(e.getMessage().contains("Job aborted"))
-    path.setWritable(true)
+      assert(e.getMessage().contains("Job aborted"))
+      path.setWritable(true)
+    }
   }
 
   test("create a table, drop it and create another one with the same name") {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/sources/ParquetHadoopFsRelationSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/sources/ParquetHadoopFsRelationSuite.scala
@@ -246,4 +246,25 @@ class ParquetHadoopFsRelationSuite extends HadoopFsRelationTest {
       }
     }
   }
+
+  test("SPARK-43149: create a table with exception, location should not exist") {
+    withTempPath { dir =>
+      withTable("test") {
+        val path = dir
+        intercept[AnalysisException] {
+          sql(
+            s"""
+               |CREATE TABLE test
+               |USING parquet
+               |OPTIONS (
+               |  path '${path.toURI}'
+               |) AS
+               |SELECT make_dt_interval(0, 1)
+         """.stripMargin)
+        }
+
+        assert(!path.exists())
+      }
+    }
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


`CreateDataSourceTableCommand` now create data at first. When using hive catalog and writing metadata error, the table does not exist but the data exists.

like :

```
// error with AnalysisException but data would be create
spark.sql(" CREATE TABLE test USING parquet  AS SELECT make_dt_interval(0, 1)")

// create table again with correct schema , i get [LOCATION_ALREADY_EXISTS] exception
spark.sql(" CREATE TABLE test USING parquet  AS SELECT make_dt_interval(0, 1) as dt")

//Exception in thread "main" org.apache.spark.SparkRuntimeException: [LOCATION_ALREADY_EXISTS]

```

So `CreateDataSourceTableCommand` should create metadata first




### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

as above
### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

no
### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

add UT
### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
no