### PR TITLE
[SPARK-44888][SQL][TESTS] Regenerate golden files of `SQLQueryTestSuite` for Java 21

### DIFF
--- a/sql/core/src/test/resources/sql-tests/results/datetime-formatting.sql.out.java21
+++ b/sql/core/src/test/resources/sql-tests/results/datetime-formatting.sql.out.java21
@@ -15,414 +15,438 @@ struct<>
 
 
 -- !query
-select col, date_format(col, 'G GG GGG GGGG') from v
+select col, date_format(col, 'G GG GGG GGGG'), to_char(col, 'G GG GGG GGGG'), to_varchar(col, 'G GG GGG GGGG') from v
 -- !query schema
-struct<col:timestamp,date_format(col, G GG GGG GGGG):string>
+struct<col:timestamp,date_format(col, G GG GGG GGGG):string,date_format(col, G GG GGG GGGG):string,date_format(col, G GG GGG GGGG):string>
 -- !query output
-1582-05-31 19:40:35.123	AD AD AD Anno Domini
-1969-12-31 15:00:00	AD AD AD Anno Domini
-1970-12-31 04:59:59.999	AD AD AD Anno Domini
-1996-03-31 07:03:33.123	AD AD AD Anno Domini
-2018-11-17 05:33:33.123	AD AD AD Anno Domini
-2019-12-31 09:33:33.123	AD AD AD Anno Domini
-2100-01-01 01:33:33.123	AD AD AD Anno Domini
+1582-05-31 19:40:35.123	AD AD AD Anno Domini	AD AD AD Anno Domini	AD AD AD Anno Domini
+1969-12-31 15:00:00	AD AD AD Anno Domini	AD AD AD Anno Domini	AD AD AD Anno Domini
+1970-12-31 04:59:59.999	AD AD AD Anno Domini	AD AD AD Anno Domini	AD AD AD Anno Domini
+1996-03-31 07:03:33.123	AD AD AD Anno Domini	AD AD AD Anno Domini	AD AD AD Anno Domini
+2018-11-17 05:33:33.123	AD AD AD Anno Domini	AD AD AD Anno Domini	AD AD AD Anno Domini
+2019-12-31 09:33:33.123	AD AD AD Anno Domini	AD AD AD Anno Domini	AD AD AD Anno Domini
+2100-01-01 01:33:33.123	AD AD AD Anno Domini	AD AD AD Anno Domini	AD AD AD Anno Domini
 
 
 -- !query
-select col, date_format(col, 'y yy yyy yyyy yyyyy yyyyyy') from v
+select col, date_format(col, 'y yy yyy yyyy yyyyy yyyyyy'), to_char(col, 'y yy yyy yyyy yyyyy yyyyyy'), to_varchar(col, 'y yy yyy yyyy yyyyy yyyyyy') from v
 -- !query schema
-struct<col:timestamp,date_format(col, y yy yyy yyyy yyyyy yyyyyy):string>
+struct<col:timestamp,date_format(col, y yy yyy yyyy yyyyy yyyyyy):string,date_format(col, y yy yyy yyyy yyyyy yyyyyy):string,date_format(col, y yy yyy yyyy yyyyy yyyyyy):string>
 -- !query output
-1582-05-31 19:40:35.123	1582 82 1582 1582 01582 001582
-1969-12-31 15:00:00	1969 69 1969 1969 01969 001969
-1970-12-31 04:59:59.999	1970 70 1970 1970 01970 001970
-1996-03-31 07:03:33.123	1996 96 1996 1996 01996 001996
-2018-11-17 05:33:33.123	2018 18 2018 2018 02018 002018
-2019-12-31 09:33:33.123	2019 19 2019 2019 02019 002019
-2100-01-01 01:33:33.123	2100 00 2100 2100 02100 002100
+1582-05-31 19:40:35.123	1582 82 1582 1582 01582 001582	1582 82 1582 1582 01582 001582	1582 82 1582 1582 01582 001582
+1969-12-31 15:00:00	1969 69 1969 1969 01969 001969	1969 69 1969 1969 01969 001969	1969 69 1969 1969 01969 001969
+1970-12-31 04:59:59.999	1970 70 1970 1970 01970 001970	1970 70 1970 1970 01970 001970	1970 70 1970 1970 01970 001970
+1996-03-31 07:03:33.123	1996 96 1996 1996 01996 001996	1996 96 1996 1996 01996 001996	1996 96 1996 1996 01996 001996
+2018-11-17 05:33:33.123	2018 18 2018 2018 02018 002018	2018 18 2018 2018 02018 002018	2018 18 2018 2018 02018 002018
+2019-12-31 09:33:33.123	2019 19 2019 2019 02019 002019	2019 19 2019 2019 02019 002019	2019 19 2019 2019 02019 002019
+2100-01-01 01:33:33.123	2100 00 2100 2100 02100 002100	2100 00 2100 2100 02100 002100	2100 00 2100 2100 02100 002100
 
 
 -- !query
-select col, date_format(col, 'q qq') from v
+select col, date_format(col, 'q qq'), to_char(col, 'q qq'), to_varchar(col, 'q qq') from v
 -- !query schema
-struct<col:timestamp,date_format(col, q qq):string>
+struct<col:timestamp,date_format(col, q qq):string,date_format(col, q qq):string,date_format(col, q qq):string>
 -- !query output
-1582-05-31 19:40:35.123	2 02
-1969-12-31 15:00:00	4 04
-1970-12-31 04:59:59.999	4 04
-1996-03-31 07:03:33.123	1 01
-2018-11-17 05:33:33.123	4 04
-2019-12-31 09:33:33.123	4 04
-2100-01-01 01:33:33.123	1 01
+1582-05-31 19:40:35.123	2 02	2 02	2 02
+1969-12-31 15:00:00	4 04	4 04	4 04
+1970-12-31 04:59:59.999	4 04	4 04	4 04
+1996-03-31 07:03:33.123	1 01	1 01	1 01
+2018-11-17 05:33:33.123	4 04	4 04	4 04
+2019-12-31 09:33:33.123	4 04	4 04	4 04
+2100-01-01 01:33:33.123	1 01	1 01	1 01
 
 
 -- !query
-select col, date_format(col, 'Q QQ QQQ QQQQ') from v
+select col, date_format(col, 'Q QQ QQQ QQQQ'), to_char(col, 'Q QQ QQQ QQQQ'), to_varchar(col, 'Q QQ QQQ QQQQ') from v
 -- !query schema
-struct<col:timestamp,date_format(col, Q QQ QQQ QQQQ):string>
+struct<col:timestamp,date_format(col, Q QQ QQQ QQQQ):string,date_format(col, Q QQ QQQ QQQQ):string,date_format(col, Q QQ QQQ QQQQ):string>
 -- !query output
-1582-05-31 19:40:35.123	2 02 Q2 2nd quarter
-1969-12-31 15:00:00	4 04 Q4 4th quarter
-1970-12-31 04:59:59.999	4 04 Q4 4th quarter
-1996-03-31 07:03:33.123	1 01 Q1 1st quarter
-2018-11-17 05:33:33.123	4 04 Q4 4th quarter
-2019-12-31 09:33:33.123	4 04 Q4 4th quarter
-2100-01-01 01:33:33.123	1 01 Q1 1st quarter
+1582-05-31 19:40:35.123	2 02 Q2 2nd quarter	2 02 Q2 2nd quarter	2 02 Q2 2nd quarter
+1969-12-31 15:00:00	4 04 Q4 4th quarter	4 04 Q4 4th quarter	4 04 Q4 4th quarter
+1970-12-31 04:59:59.999	4 04 Q4 4th quarter	4 04 Q4 4th quarter	4 04 Q4 4th quarter
+1996-03-31 07:03:33.123	1 01 Q1 1st quarter	1 01 Q1 1st quarter	1 01 Q1 1st quarter
+2018-11-17 05:33:33.123	4 04 Q4 4th quarter	4 04 Q4 4th quarter	4 04 Q4 4th quarter
+2019-12-31 09:33:33.123	4 04 Q4 4th quarter	4 04 Q4 4th quarter	4 04 Q4 4th quarter
+2100-01-01 01:33:33.123	1 01 Q1 1st quarter	1 01 Q1 1st quarter	1 01 Q1 1st quarter
 
 
 -- !query
-select col, date_format(col, 'M MM MMM MMMM') from v
+select col, date_format(col, 'M MM MMM MMMM'), to_char(col, 'M MM MMM MMMM'), to_varchar(col, 'M MM MMM MMMM') from v
 -- !query schema
-struct<col:timestamp,date_format(col, M MM MMM MMMM):string>
+struct<col:timestamp,date_format(col, M MM MMM MMMM):string,date_format(col, M MM MMM MMMM):string,date_format(col, M MM MMM MMMM):string>
 -- !query output
-1582-05-31 19:40:35.123	5 05 May May
-1969-12-31 15:00:00	12 12 Dec December
-1970-12-31 04:59:59.999	12 12 Dec December
-1996-03-31 07:03:33.123	3 03 Mar March
-2018-11-17 05:33:33.123	11 11 Nov November
-2019-12-31 09:33:33.123	12 12 Dec December
-2100-01-01 01:33:33.123	1 01 Jan January
+1582-05-31 19:40:35.123	5 05 May May	5 05 May May	5 05 May May
+1969-12-31 15:00:00	12 12 Dec December	12 12 Dec December	12 12 Dec December
+1970-12-31 04:59:59.999	12 12 Dec December	12 12 Dec December	12 12 Dec December
+1996-03-31 07:03:33.123	3 03 Mar March	3 03 Mar March	3 03 Mar March
+2018-11-17 05:33:33.123	11 11 Nov November	11 11 Nov November	11 11 Nov November
+2019-12-31 09:33:33.123	12 12 Dec December	12 12 Dec December	12 12 Dec December
+2100-01-01 01:33:33.123	1 01 Jan January	1 01 Jan January	1 01 Jan January
 
 
 -- !query
-select col, date_format(col, 'L LL') from v
+select col, date_format(col, 'L LL'), to_char(col, 'L LL'), to_varchar(col, 'L LL') from v
 -- !query schema
-struct<col:timestamp,date_format(col, L LL):string>
+struct<col:timestamp,date_format(col, L LL):string,date_format(col, L LL):string,date_format(col, L LL):string>
 -- !query output
-1582-05-31 19:40:35.123	5 05
-1969-12-31 15:00:00	12 12
-1970-12-31 04:59:59.999	12 12
-1996-03-31 07:03:33.123	3 03
-2018-11-17 05:33:33.123	11 11
-2019-12-31 09:33:33.123	12 12
-2100-01-01 01:33:33.123	1 01
+1582-05-31 19:40:35.123	5 05	5 05	5 05
+1969-12-31 15:00:00	12 12	12 12	12 12
+1970-12-31 04:59:59.999	12 12	12 12	12 12
+1996-03-31 07:03:33.123	3 03	3 03	3 03
+2018-11-17 05:33:33.123	11 11	11 11	11 11
+2019-12-31 09:33:33.123	12 12	12 12	12 12
+2100-01-01 01:33:33.123	1 01	1 01	1 01
 
 
 -- !query
-select col, date_format(col, 'E EE EEE EEEE') from v
+select col, date_format(col, 'E EE EEE EEEE'), to_char(col, 'E EE EEE EEEE'), to_varchar(col, 'E EE EEE EEEE') from v
 -- !query schema
-struct<col:timestamp,date_format(col, E EE EEE EEEE):string>
+struct<col:timestamp,date_format(col, E EE EEE EEEE):string,date_format(col, E EE EEE EEEE):string,date_format(col, E EE EEE EEEE):string>
 -- !query output
-1582-05-31 19:40:35.123	Mon Mon Mon Monday
-1969-12-31 15:00:00	Wed Wed Wed Wednesday
-1970-12-31 04:59:59.999	Thu Thu Thu Thursday
-1996-03-31 07:03:33.123	Sun Sun Sun Sunday
-2018-11-17 05:33:33.123	Sat Sat Sat Saturday
-2019-12-31 09:33:33.123	Tue Tue Tue Tuesday
-2100-01-01 01:33:33.123	Fri Fri Fri Friday
+1582-05-31 19:40:35.123	Mon Mon Mon Monday	Mon Mon Mon Monday	Mon Mon Mon Monday
+1969-12-31 15:00:00	Wed Wed Wed Wednesday	Wed Wed Wed Wednesday	Wed Wed Wed Wednesday
+1970-12-31 04:59:59.999	Thu Thu Thu Thursday	Thu Thu Thu Thursday	Thu Thu Thu Thursday
+1996-03-31 07:03:33.123	Sun Sun Sun Sunday	Sun Sun Sun Sunday	Sun Sun Sun Sunday
+2018-11-17 05:33:33.123	Sat Sat Sat Saturday	Sat Sat Sat Saturday	Sat Sat Sat Saturday
+2019-12-31 09:33:33.123	Tue Tue Tue Tuesday	Tue Tue Tue Tuesday	Tue Tue Tue Tuesday
+2100-01-01 01:33:33.123	Fri Fri Fri Friday	Fri Fri Fri Friday	Fri Fri Fri Friday
 
 
 -- !query
-select col, date_format(col, 'F') from v
+select col, date_format(col, 'F'), to_char(col, 'F'), to_varchar(col, 'F') from v
 -- !query schema
-struct<col:timestamp,date_format(col, F):string>
+struct<col:timestamp,date_format(col, F):string,date_format(col, F):string,date_format(col, F):string>
 -- !query output
-1582-05-31 19:40:35.123	5
-1969-12-31 15:00:00	5
-1970-12-31 04:59:59.999	5
-1996-03-31 07:03:33.123	5
-2018-11-17 05:33:33.123	3
-2019-12-31 09:33:33.123	5
-2100-01-01 01:33:33.123	1
+1582-05-31 19:40:35.123	5	5	5
+1969-12-31 15:00:00	5	5	5
+1970-12-31 04:59:59.999	5	5	5
+1996-03-31 07:03:33.123	5	5	5
+2018-11-17 05:33:33.123	3	3	3
+2019-12-31 09:33:33.123	5	5	5
+2100-01-01 01:33:33.123	1	1	1
 
 
 -- !query
-select col, date_format(col, 'd dd') from v
+select col, date_format(col, 'd dd'), to_char(col, 'd dd'), to_varchar(col, 'd dd') from v
 -- !query schema
-struct<col:timestamp,date_format(col, d dd):string>
+struct<col:timestamp,date_format(col, d dd):string,date_format(col, d dd):string,date_format(col, d dd):string>
 -- !query output
-1582-05-31 19:40:35.123	31 31
-1969-12-31 15:00:00	31 31
-1970-12-31 04:59:59.999	31 31
-1996-03-31 07:03:33.123	31 31
-2018-11-17 05:33:33.123	17 17
-2019-12-31 09:33:33.123	31 31
-2100-01-01 01:33:33.123	1 01
+1582-05-31 19:40:35.123	31 31	31 31	31 31
+1969-12-31 15:00:00	31 31	31 31	31 31
+1970-12-31 04:59:59.999	31 31	31 31	31 31
+1996-03-31 07:03:33.123	31 31	31 31	31 31
+2018-11-17 05:33:33.123	17 17	17 17	17 17
+2019-12-31 09:33:33.123	31 31	31 31	31 31
+2100-01-01 01:33:33.123	1 01	1 01	1 01
 
 
 -- !query
-select col, date_format(col, 'DD') from v where col = timestamp '2100-01-01 01:33:33.123America/Los_Angeles'
+select col, date_format(col, 'DD'), to_char(col, 'DD'), to_varchar(col, 'DD') from v where col = timestamp '2100-01-01 01:33:33.123America/Los_Angeles'
 -- !query schema
-struct<col:timestamp,date_format(col, DD):string>
+struct<col:timestamp,date_format(col, DD):string,date_format(col, DD):string,date_format(col, DD):string>
 -- !query output
-2100-01-01 01:33:33.123	01
+2100-01-01 01:33:33.123	01	01	01
 
 
 -- !query
-select col, date_format(col, 'D DDD') from v
+select col, date_format(col, 'D DDD'), to_char(col, 'D DDD'), to_varchar(col, 'D DDD') from v
 -- !query schema
-struct<col:timestamp,date_format(col, D DDD):string>
+struct<col:timestamp,date_format(col, D DDD):string,date_format(col, D DDD):string,date_format(col, D DDD):string>
 -- !query output
-1582-05-31 19:40:35.123	151 151
-1969-12-31 15:00:00	365 365
-1970-12-31 04:59:59.999	365 365
-1996-03-31 07:03:33.123	91 091
-2018-11-17 05:33:33.123	321 321
-2019-12-31 09:33:33.123	365 365
-2100-01-01 01:33:33.123	1 001
+1582-05-31 19:40:35.123	151 151	151 151	151 151
+1969-12-31 15:00:00	365 365	365 365	365 365
+1970-12-31 04:59:59.999	365 365	365 365	365 365
+1996-03-31 07:03:33.123	91 091	91 091	91 091
+2018-11-17 05:33:33.123	321 321	321 321	321 321
+2019-12-31 09:33:33.123	365 365	365 365	365 365
+2100-01-01 01:33:33.123	1 001	1 001	1 001
 
 
 -- !query
-select col, date_format(col, 'H HH') from v
+select col, date_format(col, 'H HH'), to_char(col, 'H HH'), to_varchar(col, 'H HH') from v
 -- !query schema
-struct<col:timestamp,date_format(col, H HH):string>
+struct<col:timestamp,date_format(col, H HH):string,date_format(col, H HH):string,date_format(col, H HH):string>
 -- !query output
-1582-05-31 19:40:35.123	19 19
-1969-12-31 15:00:00	15 15
-1970-12-31 04:59:59.999	4 04
-1996-03-31 07:03:33.123	7 07
-2018-11-17 05:33:33.123	5 05
-2019-12-31 09:33:33.123	9 09
-2100-01-01 01:33:33.123	1 01
+1582-05-31 19:40:35.123	19 19	19 19	19 19
+1969-12-31 15:00:00	15 15	15 15	15 15
+1970-12-31 04:59:59.999	4 04	4 04	4 04
+1996-03-31 07:03:33.123	7 07	7 07	7 07
+2018-11-17 05:33:33.123	5 05	5 05	5 05
+2019-12-31 09:33:33.123	9 09	9 09	9 09
+2100-01-01 01:33:33.123	1 01	1 01	1 01
 
 
 -- !query
-select col, date_format(col, 'h hh') from v
+select col, date_format(col, 'h hh'), to_char(col, 'h hh'), to_varchar(col, 'h hh') from v
 -- !query schema
-struct<col:timestamp,date_format(col, h hh):string>
+struct<col:timestamp,date_format(col, h hh):string,date_format(col, h hh):string,date_format(col, h hh):string>
 -- !query output
-1582-05-31 19:40:35.123	7 07
-1969-12-31 15:00:00	3 03
-1970-12-31 04:59:59.999	4 04
-1996-03-31 07:03:33.123	7 07
-2018-11-17 05:33:33.123	5 05
-2019-12-31 09:33:33.123	9 09
-2100-01-01 01:33:33.123	1 01
+1582-05-31 19:40:35.123	7 07	7 07	7 07
+1969-12-31 15:00:00	3 03	3 03	3 03
+1970-12-31 04:59:59.999	4 04	4 04	4 04
+1996-03-31 07:03:33.123	7 07	7 07	7 07
+2018-11-17 05:33:33.123	5 05	5 05	5 05
+2019-12-31 09:33:33.123	9 09	9 09	9 09
+2100-01-01 01:33:33.123	1 01	1 01	1 01
 
 
 -- !query
-select col, date_format(col, 'k kk') from v
+select col, date_format(col, 'k kk'), to_char(col, 'k kk'), to_varchar(col, 'k kk') from v
 -- !query schema
-struct<col:timestamp,date_format(col, k kk):string>
+struct<col:timestamp,date_format(col, k kk):string,date_format(col, k kk):string,date_format(col, k kk):string>
 -- !query output
-1582-05-31 19:40:35.123	19 19
-1969-12-31 15:00:00	15 15
-1970-12-31 04:59:59.999	4 04
-1996-03-31 07:03:33.123	7 07
-2018-11-17 05:33:33.123	5 05
-2019-12-31 09:33:33.123	9 09
-2100-01-01 01:33:33.123	1 01
+1582-05-31 19:40:35.123	19 19	19 19	19 19
+1969-12-31 15:00:00	15 15	15 15	15 15
+1970-12-31 04:59:59.999	4 04	4 04	4 04
+1996-03-31 07:03:33.123	7 07	7 07	7 07
+2018-11-17 05:33:33.123	5 05	5 05	5 05
+2019-12-31 09:33:33.123	9 09	9 09	9 09
+2100-01-01 01:33:33.123	1 01	1 01	1 01
 
 
 -- !query
-select col, date_format(col, 'K KK') from v
+select col, date_format(col, 'K KK'), to_char(col, 'K KK'), to_varchar(col, 'K KK') from v
 -- !query schema
-struct<col:timestamp,date_format(col, K KK):string>
+struct<col:timestamp,date_format(col, K KK):string,date_format(col, K KK):string,date_format(col, K KK):string>
 -- !query output
-1582-05-31 19:40:35.123	7 07
-1969-12-31 15:00:00	3 03
-1970-12-31 04:59:59.999	4 04
-1996-03-31 07:03:33.123	7 07
-2018-11-17 05:33:33.123	5 05
-2019-12-31 09:33:33.123	9 09
-2100-01-01 01:33:33.123	1 01
+1582-05-31 19:40:35.123	7 07	7 07	7 07
+1969-12-31 15:00:00	3 03	3 03	3 03
+1970-12-31 04:59:59.999	4 04	4 04	4 04
+1996-03-31 07:03:33.123	7 07	7 07	7 07
+2018-11-17 05:33:33.123	5 05	5 05	5 05
+2019-12-31 09:33:33.123	9 09	9 09	9 09
+2100-01-01 01:33:33.123	1 01	1 01	1 01
 
 
 -- !query
-select col, date_format(col, 'm mm') from v
+select col, date_format(col, 'm mm'), to_char(col, 'm mm'), to_varchar(col, 'm mm') from v
 -- !query schema
-struct<col:timestamp,date_format(col, m mm):string>
+struct<col:timestamp,date_format(col, m mm):string,date_format(col, m mm):string,date_format(col, m mm):string>
 -- !query output
-1582-05-31 19:40:35.123	40 40
-1969-12-31 15:00:00	0 00
-1970-12-31 04:59:59.999	59 59
-1996-03-31 07:03:33.123	3 03
-2018-11-17 05:33:33.123	33 33
-2019-12-31 09:33:33.123	33 33
-2100-01-01 01:33:33.123	33 33
+1582-05-31 19:40:35.123	40 40	40 40	40 40
+1969-12-31 15:00:00	0 00	0 00	0 00
+1970-12-31 04:59:59.999	59 59	59 59	59 59
+1996-03-31 07:03:33.123	3 03	3 03	3 03
+2018-11-17 05:33:33.123	33 33	33 33	33 33
+2019-12-31 09:33:33.123	33 33	33 33	33 33
+2100-01-01 01:33:33.123	33 33	33 33	33 33
 
 
 -- !query
-select col, date_format(col, 's ss') from v
+select col, date_format(col, 's ss'), to_char(col, 's ss'), to_varchar(col, 's ss') from v
 -- !query schema
-struct<col:timestamp,date_format(col, s ss):string>
+struct<col:timestamp,date_format(col, s ss):string,date_format(col, s ss):string,date_format(col, s ss):string>
 -- !query output
-1582-05-31 19:40:35.123	35 35
-1969-12-31 15:00:00	0 00
-1970-12-31 04:59:59.999	59 59
-1996-03-31 07:03:33.123	33 33
-2018-11-17 05:33:33.123	33 33
-2019-12-31 09:33:33.123	33 33
-2100-01-01 01:33:33.123	33 33
+1582-05-31 19:40:35.123	35 35	35 35	35 35
+1969-12-31 15:00:00	0 00	0 00	0 00
+1970-12-31 04:59:59.999	59 59	59 59	59 59
+1996-03-31 07:03:33.123	33 33	33 33	33 33
+2018-11-17 05:33:33.123	33 33	33 33	33 33
+2019-12-31 09:33:33.123	33 33	33 33	33 33
+2100-01-01 01:33:33.123	33 33	33 33	33 33
 
 
 -- !query
-select col, date_format(col, 'S SS SSS SSSS SSSSS SSSSSS SSSSSSS SSSSSSSS SSSSSSSSS') from v
+select col, date_format(col, 'S SS SSS SSSS SSSSS SSSSSS SSSSSSS SSSSSSSS SSSSSSSSS'), to_char(col, 'S SS SSS SSSS SSSSS SSSSSS SSSSSSS SSSSSSSS SSSSSSSSS'), to_varchar(col, 'S SS SSS SSSS SSSSS SSSSSS SSSSSSS SSSSSSSS SSSSSSSSS') from v
 -- !query schema
-struct<col:timestamp,date_format(col, S SS SSS SSSS SSSSS SSSSSS SSSSSSS SSSSSSSS SSSSSSSSS):string>
+struct<col:timestamp,date_format(col, S SS SSS SSSS SSSSS SSSSSS SSSSSSS SSSSSSSS SSSSSSSSS):string,date_format(col, S SS SSS SSSS SSSSS SSSSSS SSSSSSS SSSSSSSS SSSSSSSSS):string,date_format(col, S SS SSS SSSS SSSSS SSSSSS SSSSSSS SSSSSSSS SSSSSSSSS):string>
 -- !query output
-1582-05-31 19:40:35.123	1 12 123 1230 12300 123000 1230000 12300000 123000000
-1969-12-31 15:00:00	0 00 000 0000 00000 000000 0000000 00000000 000000000
-1970-12-31 04:59:59.999	9 99 999 9990 99900 999000 9990000 99900000 999000000
-1996-03-31 07:03:33.123	1 12 123 1230 12300 123000 1230000 12300000 123000000
-2018-11-17 05:33:33.123	1 12 123 1230 12300 123000 1230000 12300000 123000000
-2019-12-31 09:33:33.123	1 12 123 1230 12300 123000 1230000 12300000 123000000
-2100-01-01 01:33:33.123	1 12 123 1230 12300 123000 1230000 12300000 123000000
+1582-05-31 19:40:35.123	1 12 123 1230 12300 123000 1230000 12300000 123000000	1 12 123 1230 12300 123000 1230000 12300000 123000000	1 12 123 1230 12300 123000 1230000 12300000 123000000
+1969-12-31 15:00:00	0 00 000 0000 00000 000000 0000000 00000000 000000000	0 00 000 0000 00000 000000 0000000 00000000 000000000	0 00 000 0000 00000 000000 0000000 00000000 000000000
+1970-12-31 04:59:59.999	9 99 999 9990 99900 999000 9990000 99900000 999000000	9 99 999 9990 99900 999000 9990000 99900000 999000000	9 99 999 9990 99900 999000 9990000 99900000 999000000
+1996-03-31 07:03:33.123	1 12 123 1230 12300 123000 1230000 12300000 123000000	1 12 123 1230 12300 123000 1230000 12300000 123000000	1 12 123 1230 12300 123000 1230000 12300000 123000000
+2018-11-17 05:33:33.123	1 12 123 1230 12300 123000 1230000 12300000 123000000	1 12 123 1230 12300 123000 1230000 12300000 123000000	1 12 123 1230 12300 123000 1230000 12300000 123000000
+2019-12-31 09:33:33.123	1 12 123 1230 12300 123000 1230000 12300000 123000000	1 12 123 1230 12300 123000 1230000 12300000 123000000	1 12 123 1230 12300 123000 1230000 12300000 123000000
+2100-01-01 01:33:33.123	1 12 123 1230 12300 123000 1230000 12300000 123000000	1 12 123 1230 12300 123000 1230000 12300000 123000000	1 12 123 1230 12300 123000 1230000 12300000 123000000
 
 
 -- !query
-select col, date_format(col, 'a') from v
+select col, date_format(col, 'a'), to_char(col, 'a'), to_varchar(col, 'a') from v
 -- !query schema
-struct<col:timestamp,date_format(col, a):string>
+struct<col:timestamp,date_format(col, a):string,date_format(col, a):string,date_format(col, a):string>
 -- !query output
-1582-05-31 19:40:35.123	PM
-1969-12-31 15:00:00	PM
-1970-12-31 04:59:59.999	AM
-1996-03-31 07:03:33.123	AM
-2018-11-17 05:33:33.123	AM
-2019-12-31 09:33:33.123	AM
-2100-01-01 01:33:33.123	AM
+1582-05-31 19:40:35.123	PM	PM	PM
+1969-12-31 15:00:00	PM	PM	PM
+1970-12-31 04:59:59.999	AM	AM	AM
+1996-03-31 07:03:33.123	AM	AM	AM
+2018-11-17 05:33:33.123	AM	AM	AM
+2019-12-31 09:33:33.123	AM	AM	AM
+2100-01-01 01:33:33.123	AM	AM	AM
 
 
 -- !query
-select col, date_format(col, 'VV') from v
+select col, date_format(col, 'VV'), to_char(col, 'VV'), to_varchar(col, 'VV') from v
 -- !query schema
-struct<col:timestamp,date_format(col, VV):string>
+struct<col:timestamp,date_format(col, VV):string,date_format(col, VV):string,date_format(col, VV):string>
 -- !query output
-1582-05-31 19:40:35.123	America/Los_Angeles
-1969-12-31 15:00:00	America/Los_Angeles
-1970-12-31 04:59:59.999	America/Los_Angeles
-1996-03-31 07:03:33.123	America/Los_Angeles
-2018-11-17 05:33:33.123	America/Los_Angeles
-2019-12-31 09:33:33.123	America/Los_Angeles
-2100-01-01 01:33:33.123	America/Los_Angeles
+1582-05-31 19:40:35.123	America/Los_Angeles	America/Los_Angeles	America/Los_Angeles
+1969-12-31 15:00:00	America/Los_Angeles	America/Los_Angeles	America/Los_Angeles
+1970-12-31 04:59:59.999	America/Los_Angeles	America/Los_Angeles	America/Los_Angeles
+1996-03-31 07:03:33.123	America/Los_Angeles	America/Los_Angeles	America/Los_Angeles
+2018-11-17 05:33:33.123	America/Los_Angeles	America/Los_Angeles	America/Los_Angeles
+2019-12-31 09:33:33.123	America/Los_Angeles	America/Los_Angeles	America/Los_Angeles
+2100-01-01 01:33:33.123	America/Los_Angeles	America/Los_Angeles	America/Los_Angeles
 
 
 -- !query
-select col, date_format(col, 'z zz zzz zzzz') from v
+select col, date_format(col, 'z zz zzz zzzz'), to_char(col, 'z zz zzz zzzz'), to_varchar(col, 'z zz zzz zzzz') from v
 -- !query schema
-struct<col:timestamp,date_format(col, z zz zzz zzzz):string>
+struct<col:timestamp,date_format(col, z zz zzz zzzz):string,date_format(col, z zz zzz zzzz):string,date_format(col, z zz zzz zzzz):string>
 -- !query output
-1582-05-31 19:40:35.123	PST PST PST Pacific Standard Time
-1969-12-31 15:00:00	PST PST PST Pacific Standard Time
-1970-12-31 04:59:59.999	PST PST PST Pacific Standard Time
-1996-03-31 07:03:33.123	PST PST PST Pacific Standard Time
-2018-11-17 05:33:33.123	PST PST PST Pacific Standard Time
-2019-12-31 09:33:33.123	PST PST PST Pacific Standard Time
-2100-01-01 01:33:33.123	PST PST PST Pacific Standard Time
+1582-05-31 19:40:35.123	PST PST PST Pacific Standard Time	PST PST PST Pacific Standard Time	PST PST PST Pacific Standard Time
+1969-12-31 15:00:00	PST PST PST Pacific Standard Time	PST PST PST Pacific Standard Time	PST PST PST Pacific Standard Time
+1970-12-31 04:59:59.999	PST PST PST Pacific Standard Time	PST PST PST Pacific Standard Time	PST PST PST Pacific Standard Time
+1996-03-31 07:03:33.123	PST PST PST Pacific Standard Time	PST PST PST Pacific Standard Time	PST PST PST Pacific Standard Time
+2018-11-17 05:33:33.123	PST PST PST Pacific Standard Time	PST PST PST Pacific Standard Time	PST PST PST Pacific Standard Time
+2019-12-31 09:33:33.123	PST PST PST Pacific Standard Time	PST PST PST Pacific Standard Time	PST PST PST Pacific Standard Time
+2100-01-01 01:33:33.123	PST PST PST Pacific Standard Time	PST PST PST Pacific Standard Time	PST PST PST Pacific Standard Time
 
 
 -- !query
-select col, date_format(col, 'X XX XXX') from v
+select col, date_format(col, 'X XX XXX'), to_char(col, 'X XX XXX'), to_varchar(col, 'X XX XXX') from v
 -- !query schema
-struct<col:timestamp,date_format(col, X XX XXX):string>
+struct<col:timestamp,date_format(col, X XX XXX):string,date_format(col, X XX XXX):string,date_format(col, X XX XXX):string>
 -- !query output
-1582-05-31 19:40:35.123	-0752 -0752 -07:52
-1969-12-31 15:00:00	-08 -0800 -08:00
-1970-12-31 04:59:59.999	-08 -0800 -08:00
-1996-03-31 07:03:33.123	-08 -0800 -08:00
-2018-11-17 05:33:33.123	-08 -0800 -08:00
-2019-12-31 09:33:33.123	-08 -0800 -08:00
-2100-01-01 01:33:33.123	-08 -0800 -08:00
+1582-05-31 19:40:35.123	-0752 -0752 -07:52	-0752 -0752 -07:52	-0752 -0752 -07:52
+1969-12-31 15:00:00	-08 -0800 -08:00	-08 -0800 -08:00	-08 -0800 -08:00
+1970-12-31 04:59:59.999	-08 -0800 -08:00	-08 -0800 -08:00	-08 -0800 -08:00
+1996-03-31 07:03:33.123	-08 -0800 -08:00	-08 -0800 -08:00	-08 -0800 -08:00
+2018-11-17 05:33:33.123	-08 -0800 -08:00	-08 -0800 -08:00	-08 -0800 -08:00
+2019-12-31 09:33:33.123	-08 -0800 -08:00	-08 -0800 -08:00	-08 -0800 -08:00
+2100-01-01 01:33:33.123	-08 -0800 -08:00	-08 -0800 -08:00	-08 -0800 -08:00
 
 
 -- !query
-select col, date_format(col, 'XXXX XXXXX') from v
+select col, date_format(col, 'XXXX XXXXX'), to_char(col, 'XXXX XXXXX'), to_varchar(col, 'XXXX XXXXX') from v
 -- !query schema
-struct<col:timestamp,date_format(col, XXXX XXXXX):string>
+struct<col:timestamp,date_format(col, XXXX XXXXX):string,date_format(col, XXXX XXXXX):string,date_format(col, XXXX XXXXX):string>
 -- !query output
-1582-05-31 19:40:35.123	-075258 -07:52:58
-1969-12-31 15:00:00	-0800 -08:00
-1970-12-31 04:59:59.999	-0800 -08:00
-1996-03-31 07:03:33.123	-0800 -08:00
-2018-11-17 05:33:33.123	-0800 -08:00
-2019-12-31 09:33:33.123	-0800 -08:00
-2100-01-01 01:33:33.123	-0800 -08:00
+1582-05-31 19:40:35.123	-075258 -07:52:58	-075258 -07:52:58	-075258 -07:52:58
+1969-12-31 15:00:00	-0800 -08:00	-0800 -08:00	-0800 -08:00
+1970-12-31 04:59:59.999	-0800 -08:00	-0800 -08:00	-0800 -08:00
+1996-03-31 07:03:33.123	-0800 -08:00	-0800 -08:00	-0800 -08:00
+2018-11-17 05:33:33.123	-0800 -08:00	-0800 -08:00	-0800 -08:00
+2019-12-31 09:33:33.123	-0800 -08:00	-0800 -08:00	-0800 -08:00
+2100-01-01 01:33:33.123	-0800 -08:00	-0800 -08:00	-0800 -08:00
 
 
 -- !query
-select col, date_format(col, 'Z ZZ ZZZ ZZZZ ZZZZZ') from v
+select col, date_format(col, 'Z ZZ ZZZ ZZZZ ZZZZZ'), to_char(col, 'Z ZZ ZZZ ZZZZ ZZZZZ'), to_varchar(col, 'Z ZZ ZZZ ZZZZ ZZZZZ') from v
 -- !query schema
-struct<col:timestamp,date_format(col, Z ZZ ZZZ ZZZZ ZZZZZ):string>
+struct<col:timestamp,date_format(col, Z ZZ ZZZ ZZZZ ZZZZZ):string,date_format(col, Z ZZ ZZZ ZZZZ ZZZZZ):string,date_format(col, Z ZZ ZZZ ZZZZ ZZZZZ):string>
 -- !query output
-1582-05-31 19:40:35.123	-0752 -0752 -0752 GMT-07:52:58 -07:52:58
-1969-12-31 15:00:00	-0800 -0800 -0800 GMT-08:00 -08:00
-1970-12-31 04:59:59.999	-0800 -0800 -0800 GMT-08:00 -08:00
-1996-03-31 07:03:33.123	-0800 -0800 -0800 GMT-08:00 -08:00
-2018-11-17 05:33:33.123	-0800 -0800 -0800 GMT-08:00 -08:00
-2019-12-31 09:33:33.123	-0800 -0800 -0800 GMT-08:00 -08:00
-2100-01-01 01:33:33.123	-0800 -0800 -0800 GMT-08:00 -08:00
+1582-05-31 19:40:35.123	-0752 -0752 -0752 GMT-07:52:58 -07:52:58	-0752 -0752 -0752 GMT-07:52:58 -07:52:58	-0752 -0752 -0752 GMT-07:52:58 -07:52:58
+1969-12-31 15:00:00	-0800 -0800 -0800 GMT-08:00 -08:00	-0800 -0800 -0800 GMT-08:00 -08:00	-0800 -0800 -0800 GMT-08:00 -08:00
+1970-12-31 04:59:59.999	-0800 -0800 -0800 GMT-08:00 -08:00	-0800 -0800 -0800 GMT-08:00 -08:00	-0800 -0800 -0800 GMT-08:00 -08:00
+1996-03-31 07:03:33.123	-0800 -0800 -0800 GMT-08:00 -08:00	-0800 -0800 -0800 GMT-08:00 -08:00	-0800 -0800 -0800 GMT-08:00 -08:00
+2018-11-17 05:33:33.123	-0800 -0800 -0800 GMT-08:00 -08:00	-0800 -0800 -0800 GMT-08:00 -08:00	-0800 -0800 -0800 GMT-08:00 -08:00
+2019-12-31 09:33:33.123	-0800 -0800 -0800 GMT-08:00 -08:00	-0800 -0800 -0800 GMT-08:00 -08:00	-0800 -0800 -0800 GMT-08:00 -08:00
+2100-01-01 01:33:33.123	-0800 -0800 -0800 GMT-08:00 -08:00	-0800 -0800 -0800 GMT-08:00 -08:00	-0800 -0800 -0800 GMT-08:00 -08:00
 
 
 -- !query
-select col, date_format(col, 'O OOOO') from v
+select col, date_format(col, 'O OOOO'), to_char(col, 'O OOOO'), to_varchar(col, 'O OOOO') from v
 -- !query schema
-struct<col:timestamp,date_format(col, O OOOO):string>
+struct<col:timestamp,date_format(col, O OOOO):string,date_format(col, O OOOO):string,date_format(col, O OOOO):string>
 -- !query output
-1582-05-31 19:40:35.123	GMT-7:52:58 GMT-07:52:58
-1969-12-31 15:00:00	GMT-8 GMT-08:00
-1970-12-31 04:59:59.999	GMT-8 GMT-08:00
-1996-03-31 07:03:33.123	GMT-8 GMT-08:00
-2018-11-17 05:33:33.123	GMT-8 GMT-08:00
-2019-12-31 09:33:33.123	GMT-8 GMT-08:00
-2100-01-01 01:33:33.123	GMT-8 GMT-08:00
+1582-05-31 19:40:35.123	GMT-7:52:58 GMT-07:52:58	GMT-7:52:58 GMT-07:52:58	GMT-7:52:58 GMT-07:52:58
+1969-12-31 15:00:00	GMT-8 GMT-08:00	GMT-8 GMT-08:00	GMT-8 GMT-08:00
+1970-12-31 04:59:59.999	GMT-8 GMT-08:00	GMT-8 GMT-08:00	GMT-8 GMT-08:00
+1996-03-31 07:03:33.123	GMT-8 GMT-08:00	GMT-8 GMT-08:00	GMT-8 GMT-08:00
+2018-11-17 05:33:33.123	GMT-8 GMT-08:00	GMT-8 GMT-08:00	GMT-8 GMT-08:00
+2019-12-31 09:33:33.123	GMT-8 GMT-08:00	GMT-8 GMT-08:00	GMT-8 GMT-08:00
+2100-01-01 01:33:33.123	GMT-8 GMT-08:00	GMT-8 GMT-08:00	GMT-8 GMT-08:00
 
 
 -- !query
-select col, date_format(col, 'x xx xxx xxxx xxxx xxxxx') from v
+select col, date_format(col, 'x xx xxx xxxx xxxx xxxxx'), to_char(col, 'x xx xxx xxxx xxxx xxxxx'), to_varchar(col, 'x xx xxx xxxx xxxx xxxxx') from v
 -- !query schema
-struct<col:timestamp,date_format(col, x xx xxx xxxx xxxx xxxxx):string>
+struct<col:timestamp,date_format(col, x xx xxx xxxx xxxx xxxxx):string,date_format(col, x xx xxx xxxx xxxx xxxxx):string,date_format(col, x xx xxx xxxx xxxx xxxxx):string>
 -- !query output
-1582-05-31 19:40:35.123	-0752 -0752 -07:52 -075258 -075258 -07:52:58
-1969-12-31 15:00:00	-08 -0800 -08:00 -0800 -0800 -08:00
-1970-12-31 04:59:59.999	-08 -0800 -08:00 -0800 -0800 -08:00
-1996-03-31 07:03:33.123	-08 -0800 -08:00 -0800 -0800 -08:00
-2018-11-17 05:33:33.123	-08 -0800 -08:00 -0800 -0800 -08:00
-2019-12-31 09:33:33.123	-08 -0800 -08:00 -0800 -0800 -08:00
-2100-01-01 01:33:33.123	-08 -0800 -08:00 -0800 -0800 -08:00
+1582-05-31 19:40:35.123	-0752 -0752 -07:52 -075258 -075258 -07:52:58	-0752 -0752 -07:52 -075258 -075258 -07:52:58	-0752 -0752 -07:52 -075258 -075258 -07:52:58
+1969-12-31 15:00:00	-08 -0800 -08:00 -0800 -0800 -08:00	-08 -0800 -08:00 -0800 -0800 -08:00	-08 -0800 -08:00 -0800 -0800 -08:00
+1970-12-31 04:59:59.999	-08 -0800 -08:00 -0800 -0800 -08:00	-08 -0800 -08:00 -0800 -0800 -08:00	-08 -0800 -08:00 -0800 -0800 -08:00
+1996-03-31 07:03:33.123	-08 -0800 -08:00 -0800 -0800 -08:00	-08 -0800 -08:00 -0800 -0800 -08:00	-08 -0800 -08:00 -0800 -0800 -08:00
+2018-11-17 05:33:33.123	-08 -0800 -08:00 -0800 -0800 -08:00	-08 -0800 -08:00 -0800 -0800 -08:00	-08 -0800 -08:00 -0800 -0800 -08:00
+2019-12-31 09:33:33.123	-08 -0800 -08:00 -0800 -0800 -08:00	-08 -0800 -08:00 -0800 -0800 -08:00	-08 -0800 -08:00 -0800 -0800 -08:00
+2100-01-01 01:33:33.123	-08 -0800 -08:00 -0800 -0800 -08:00	-08 -0800 -08:00 -0800 -0800 -08:00	-08 -0800 -08:00 -0800 -0800 -08:00
 
 
 -- !query
-select col, date_format(col, '[yyyy-MM-dd HH:mm:ss]') from v
+select col, date_format(col, '[yyyy-MM-dd HH:mm:ss]'), to_char(col, '[yyyy-MM-dd HH:mm:ss]'), to_varchar(col, '[yyyy-MM-dd HH:mm:ss]') from v
 -- !query schema
-struct<col:timestamp,date_format(col, [yyyy-MM-dd HH:mm:ss]):string>
+struct<col:timestamp,date_format(col, [yyyy-MM-dd HH:mm:ss]):string,date_format(col, [yyyy-MM-dd HH:mm:ss]):string,date_format(col, [yyyy-MM-dd HH:mm:ss]):string>
 -- !query output
-1582-05-31 19:40:35.123	1582-05-31 19:40:35
-1969-12-31 15:00:00	1969-12-31 15:00:00
-1970-12-31 04:59:59.999	1970-12-31 04:59:59
-1996-03-31 07:03:33.123	1996-03-31 07:03:33
-2018-11-17 05:33:33.123	2018-11-17 05:33:33
-2019-12-31 09:33:33.123	2019-12-31 09:33:33
-2100-01-01 01:33:33.123	2100-01-01 01:33:33
+1582-05-31 19:40:35.123	1582-05-31 19:40:35	1582-05-31 19:40:35	1582-05-31 19:40:35
+1969-12-31 15:00:00	1969-12-31 15:00:00	1969-12-31 15:00:00	1969-12-31 15:00:00
+1970-12-31 04:59:59.999	1970-12-31 04:59:59	1970-12-31 04:59:59	1970-12-31 04:59:59
+1996-03-31 07:03:33.123	1996-03-31 07:03:33	1996-03-31 07:03:33	1996-03-31 07:03:33
+2018-11-17 05:33:33.123	2018-11-17 05:33:33	2018-11-17 05:33:33	2018-11-17 05:33:33
+2019-12-31 09:33:33.123	2019-12-31 09:33:33	2019-12-31 09:33:33	2019-12-31 09:33:33
+2100-01-01 01:33:33.123	2100-01-01 01:33:33	2100-01-01 01:33:33	2100-01-01 01:33:33
 
 
 -- !query
-select col, date_format(col, "姚123'GyYqQMLwWuEFDdhHmsSaVzZxXOV'") from v
+select col, date_format(col, "姚123'GyYqQMLwWuEFDdhHmsSaVzZxXOV'"), to_char(col, "姚123'GyYqQMLwWuEFDdhHmsSaVzZxXOV'"), to_varchar(col, "姚123'GyYqQMLwWuEFDdhHmsSaVzZxXOV'") from v
 -- !query schema
-struct<col:timestamp,date_format(col, 姚123'GyYqQMLwWuEFDdhHmsSaVzZxXOV'):string>
+struct<col:timestamp,date_format(col, 姚123'GyYqQMLwWuEFDdhHmsSaVzZxXOV'):string,date_format(col, 姚123'GyYqQMLwWuEFDdhHmsSaVzZxXOV'):string,date_format(col, 姚123'GyYqQMLwWuEFDdhHmsSaVzZxXOV'):string>
 -- !query output
-1582-05-31 19:40:35.123	姚123GyYqQMLwWuEFDdhHmsSaVzZxXOV
-1969-12-31 15:00:00	姚123GyYqQMLwWuEFDdhHmsSaVzZxXOV
-1970-12-31 04:59:59.999	姚123GyYqQMLwWuEFDdhHmsSaVzZxXOV
-1996-03-31 07:03:33.123	姚123GyYqQMLwWuEFDdhHmsSaVzZxXOV
-2018-11-17 05:33:33.123	姚123GyYqQMLwWuEFDdhHmsSaVzZxXOV
-2019-12-31 09:33:33.123	姚123GyYqQMLwWuEFDdhHmsSaVzZxXOV
-2100-01-01 01:33:33.123	姚123GyYqQMLwWuEFDdhHmsSaVzZxXOV
+1582-05-31 19:40:35.123	姚123GyYqQMLwWuEFDdhHmsSaVzZxXOV	姚123GyYqQMLwWuEFDdhHmsSaVzZxXOV	姚123GyYqQMLwWuEFDdhHmsSaVzZxXOV
+1969-12-31 15:00:00	姚123GyYqQMLwWuEFDdhHmsSaVzZxXOV	姚123GyYqQMLwWuEFDdhHmsSaVzZxXOV	姚123GyYqQMLwWuEFDdhHmsSaVzZxXOV
+1970-12-31 04:59:59.999	姚123GyYqQMLwWuEFDdhHmsSaVzZxXOV	姚123GyYqQMLwWuEFDdhHmsSaVzZxXOV	姚123GyYqQMLwWuEFDdhHmsSaVzZxXOV
+1996-03-31 07:03:33.123	姚123GyYqQMLwWuEFDdhHmsSaVzZxXOV	姚123GyYqQMLwWuEFDdhHmsSaVzZxXOV	姚123GyYqQMLwWuEFDdhHmsSaVzZxXOV
+2018-11-17 05:33:33.123	姚123GyYqQMLwWuEFDdhHmsSaVzZxXOV	姚123GyYqQMLwWuEFDdhHmsSaVzZxXOV	姚123GyYqQMLwWuEFDdhHmsSaVzZxXOV
+2019-12-31 09:33:33.123	姚123GyYqQMLwWuEFDdhHmsSaVzZxXOV	姚123GyYqQMLwWuEFDdhHmsSaVzZxXOV	姚123GyYqQMLwWuEFDdhHmsSaVzZxXOV
+2100-01-01 01:33:33.123	姚123GyYqQMLwWuEFDdhHmsSaVzZxXOV	姚123GyYqQMLwWuEFDdhHmsSaVzZxXOV	姚123GyYqQMLwWuEFDdhHmsSaVzZxXOV
 
 
 -- !query
-select col, date_format(col, "''") from v
+select col, date_format(col, "''"), to_char(col, "''"), to_varchar(col, "''") from v
 -- !query schema
-struct<col:timestamp,date_format(col, ''):string>
+struct<col:timestamp,date_format(col, ''):string,date_format(col, ''):string,date_format(col, ''):string>
 -- !query output
-1582-05-31 19:40:35.123	'
-1969-12-31 15:00:00	'
-1970-12-31 04:59:59.999	'
-1996-03-31 07:03:33.123	'
-2018-11-17 05:33:33.123	'
-2019-12-31 09:33:33.123	'
-2100-01-01 01:33:33.123	'
+1582-05-31 19:40:35.123	'	'	'
+1969-12-31 15:00:00	'	'	'
+1970-12-31 04:59:59.999	'	'	'
+1996-03-31 07:03:33.123	'	'	'
+2018-11-17 05:33:33.123	'	'	'
+2019-12-31 09:33:33.123	'	'	'
+2100-01-01 01:33:33.123	'	'	'
 
 
 -- !query
-select col, date_format(col, '') from v
+select col, date_format(col, ''), to_char(col, ''), to_varchar(col, '') from v
 -- !query schema
-struct<col:timestamp,date_format(col, ):string>
+struct<col:timestamp,date_format(col, ):string,date_format(col, ):string,date_format(col, ):string>
 -- !query output
-1582-05-31 19:40:35.123	
-1969-12-31 15:00:00	
-1970-12-31 04:59:59.999	
-1996-03-31 07:03:33.123	
-2018-11-17 05:33:33.123	
-2019-12-31 09:33:33.123	
+1582-05-31 19:40:35.123			
+1969-12-31 15:00:00			
+1970-12-31 04:59:59.999			
+1996-03-31 07:03:33.123			
+2018-11-17 05:33:33.123			
+2019-12-31 09:33:33.123			
 2100-01-01 01:33:33.123
+
+
+-- !query
+select date_format(date'2023-08-18', 'yyyy-MM-dd'), to_char(date'2023-08-18', 'yyyy-MM-dd'), to_varchar(date'2023-08-18', 'yyyy-MM-dd')
+-- !query schema
+struct<date_format(DATE '2023-08-18', yyyy-MM-dd):string,date_format(DATE '2023-08-18', yyyy-MM-dd):string,date_format(DATE '2023-08-18', yyyy-MM-dd):string>
+-- !query output
+2023-08-18	2023-08-18	2023-08-18
+
+
+-- !query
+select date_format(timestamp_ltz'2023-08-18 09:13:14.123456Z', 'yyyy-MM-dd HH:mm:ss.SSSSSSZ'), to_char(timestamp_ltz'2023-08-18 09:13:14.123456Z', 'yyyy-MM-dd HH:mm:ss.SSSSSSZ'), to_varchar(timestamp_ltz'2023-08-18 09:13:14.123456Z', 'yyyy-MM-dd HH:mm:ss.SSSSSSZ')
+-- !query schema
+struct<date_format(TIMESTAMP '2023-08-18 02:13:14.123456', yyyy-MM-dd HH:mm:ss.SSSSSSZ):string,date_format(TIMESTAMP '2023-08-18 02:13:14.123456', yyyy-MM-dd HH:mm:ss.SSSSSSZ):string,date_format(TIMESTAMP '2023-08-18 02:13:14.123456', yyyy-MM-dd HH:mm:ss.SSSSSSZ):string>
+-- !query output
+2023-08-18 02:13:14.123456-0700	2023-08-18 02:13:14.123456-0700	2023-08-18 02:13:14.123456-0700
+
+
+-- !query
+select date_format(timestamp_ntz'2023-08-18 09:13:14.123456', 'yyyy-MM-dd HH:mm:ss.SSSSSS'), to_char(timestamp_ntz'2023-08-18 09:13:14.123456', 'yyyy-MM-dd HH:mm:ss.SSSSSS'), to_varchar(timestamp_ntz'2023-08-18 09:13:14.123456', 'yyyy-MM-dd HH:mm:ss.SSSSSS')
+-- !query schema
+struct<date_format(TIMESTAMP_NTZ '2023-08-18 09:13:14.123456', yyyy-MM-dd HH:mm:ss.SSSSSS):string,date_format(TIMESTAMP_NTZ '2023-08-18 09:13:14.123456', yyyy-MM-dd HH:mm:ss.SSSSSS):string,date_format(TIMESTAMP_NTZ '2023-08-18 09:13:14.123456', yyyy-MM-dd HH:mm:ss.SSSSSS):string>
+-- !query output
+2023-08-18 09:13:14.123456	2023-08-18 09:13:14.123456	2023-08-18 09:13:14.123456

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/numeric.sql.out.java21
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/numeric.sql.out.java21
@@ -4712,7 +4712,7 @@ SELECT '' AS to_number_2,  to_number('-34,338,492.654,878', '99G999G999D999G999'
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.sql.AnalysisException
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
 {
   "errorClass" : "INVALID_FORMAT.THOUSANDS_SEPS_MUST_BEFORE_DEC",
   "sqlState" : "42601",
@@ -4774,7 +4774,7 @@ SELECT '' AS to_number_15, to_number('123,000','999G')
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.sql.AnalysisException
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
 {
   "errorClass" : "INVALID_FORMAT.CONT_THOUSANDS_SEPS",
   "sqlState" : "42601",

--- a/sql/core/src/test/resources/sql-tests/results/try_arithmetic.sql.out.java21
+++ b/sql/core/src/test/resources/sql-tests/results/try_arithmetic.sql.out.java21
@@ -164,7 +164,7 @@ SELECT try_add(interval 2 year, interval 2 second)
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.sql.AnalysisException
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
 {
   "errorClass" : "DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE",
   "sqlState" : "42K09",


### PR DESCRIPTION
### What changes were proposed in this pull request?

SPARK-44507(https://github.com/apache/spark/pull/42130) updated `try_arithmetic.sql.out` and `numeric.sql.out`, SPARK-44868(https://github.com/apache/spark/pull/42534) updated `datetime-formatting.sql.out`, but these PRs didn’t pay attention to the test health on Java 21. So this PR has regenerated the golden files `try_arithmetic.sql.out.java21`, `numeric.sql.out.java21`, and `datetime-formatting.sql.out.java21` of `SQLQueryTestSuite` so that `SQLQueryTestSuite` can be tested with Java 21.


### Why are the changes needed?
Restore `SQLQueryTestSuite` to be tested with Java 21.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass GitHub Actions
- Manual checked:

```
java -version
openjdk version "21-ea" 2023-09-19
OpenJDK Runtime Environment Zulu21+69-CA (build 21-ea+28)
OpenJDK 64-Bit Server VM Zulu21+69-CA (build 21-ea+28, mixed mode, sharing)
```

```
SPARK_GENERATE_GOLDEN_FILES=0 build/sbt "sql/testOnly org.apache.spark.sql.SQLQueryTestSuite"
```

**Before**

```
...
[info] - datetime-formatting.sql *** FAILED *** (316 milliseconds)
[info]   datetime-formatting.sql
[info]   Array("-- Automatically generated by SQLQueryTestSuite
[info]   ", "create temporary view v as select col from values
[info]    (timestamp '1582-06-01 11:33:33.123UTC+080000'),
[info]    (timestamp '1970-01-01 00:00:00.000Europe/Paris'),
[info]    (timestamp '1970-12-31 23:59:59.999Asia/Srednekolymsk'),
[info]    (timestamp '1996-04-01 00:33:33.123Australia/Darwin'),
[info]    (timestamp '2018-11-17 13:33:33.123Z'),
[info]    (timestamp '2020-01-01 01:33:33.123Asia/Shanghai'),
[info]    (timestamp '2100-01-01 01:33:33.123America/Los_Angeles') t(col)
[info]   ", "struct<>
[info]   ", "
[info]   
[info]   
[info]   ", "select col, date_format(col, 'G GG GGG GGGG') from v
[info]   ", "struct<col:timestamp,date_format(col, G GG GGG GGGG):string>
[info]   ", "1582-05-31 19:40:35.123	AD AD AD Anno Domini
[info]   1969-12-31 15:00:00	AD AD AD Anno Domini
[info]   1970-12-31 04:59:59.999	AD AD AD Anno Domini
[info]   1996-03-31 07:03:33.123	AD AD AD Anno Domini
[info]   2018-11-17 05:33:33.123	AD AD AD Anno Domini
[info]   2019-12-31 09:33:33.123	AD AD AD Anno Domini
[info]   2100-01-01 01:33:33.123	AD AD AD Anno Domini
[info]   
[info]   
[info]   ", "select col, date_format(col, 'y yy yyy yyyy yyyyy yyyyyy') from v
[info]   ", "struct<col:timestamp,date_format(col, y yy yyy yyyy yyyyy yyyyyy):string>
[info]   ", "1582-05-31 19:40:35.123	1582 82 1582 1582 01582 001582
[info]   1969-12-31 15:00:00	1969 69 1969 1969 01969 001969
[info]   1970-12-31 04:59:59.999	1970 70 1970 1970 01970 001970
[info]   1996-03-31 07:03:33.123	1996 96 1996 1996 01996 001996
[info]   2018-11-17 05:33:33.123	2018 18 2018 2018 02018 002018
[info]   2019-12-31 09:33:33.123	2019 19 2019 2019 02019 002019
[info]   2100-01-01 01:33:33.123	2100 00 2100 2100 02100 002100
[info]   
...
[info] - postgreSQL/numeric.sql *** FAILED *** (35 seconds, 848 milliseconds)
[info]   postgreSQL/numeric.sql
[info]   Expected "...rg.apache.spark.sql.[]AnalysisException
[info]   {
[info]   ...", but got "...rg.apache.spark.sql.[catalyst.Extended]AnalysisException
[info]   {
[info]   ..." Result did not match for query #544
[info]   SELECT '' AS to_number_2,  to_number('-34,338,492.654,878', '99G999G999D999G999') (SQLQueryTestSuite.scala:876)
[info]   org.scalatest.exceptions.TestFailedException:
...
[info] - try_arithmetic.sql *** FAILED *** (314 milliseconds)
[info]   try_arithmetic.sql
[info]   Expected "...rg.apache.spark.sql.[]AnalysisException
[info]   {
[info]   ...", but got "...rg.apache.spark.sql.[catalyst.Extended]AnalysisException
[info]   {
[info]   ..." Result did not match for query #20
[info]   SELECT try_add(interval 2 year, interval 2 second) (SQLQueryTestSuite.scala:876)
[info]   org.scalatest.exceptions.TestFailedException:
```

**After**
```
[info] Run completed in 9 minutes, 10 seconds.
[info] Total number of tests run: 572
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 572, failed 0, canceled 0, ignored 59, pending 0
[info] All tests passed.
```



### Was this patch authored or co-authored using generative AI tooling?
No
