### PR TITLE
[SPARK-44897][SQL] Propagating local properties to subquery broadcast exec

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/ExecutorSideSQLConfSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/ExecutorSideSQLConfSuite.scala
@@ -191,6 +191,52 @@ class ExecutorSideSQLConfSuite extends SparkFunSuite with SQLTestUtils {
       assert(checks2.forall(_.toSeq == Seq(true, true)))
     }
   }
+
+  test("SPARK-44897 propagate local properties to subquery broadcast execuction thread") {
+    withSQLConf(StaticSQLConf.BROADCAST_EXCHANGE_MAX_THREAD_THRESHOLD.key -> "1") {
+      withTable("a", "b") {
+        val confKey = "spark.sql.y"
+        val confValue1 = UUID.randomUUID().toString()
+        val confValue2 = UUID.randomUUID().toString()
+        Seq((confValue1, "1")).toDF("key", "value")
+          .write
+          .format("parquet")
+          .partitionBy("key")
+          .mode("overwrite")
+          .saveAsTable("a")
+        val df1 = spark.table("a")
+
+        def generateBroadcastDataFrame(confKey: String, confValue: String): Dataset[String] = {
+          val df = spark.range(1).mapPartitions { _ =>
+            Iterator(TaskContext.get.getLocalProperty(confKey))
+          }.filter($"value".contains(confValue)).as("c")
+          df.hint("broadcast")
+        }
+
+        // set local property and assert
+        val df2 = generateBroadcastDataFrame(confKey, confValue1)
+        spark.sparkContext.setLocalProperty(confKey, confValue1)
+        val checkDF = df1.join(df2).where($"a.key" === $"c.value").select($"a.key", $"c.value")
+        val checks = checkDF.collect()
+        assert(checks.forall(_.toSeq == Seq(confValue1, confValue1)))
+
+        // change local property and re-assert
+        Seq((confValue2, "1")).toDF("key", "value")
+          .write
+          .format("parquet")
+          .partitionBy("key")
+          .mode("overwrite")
+          .saveAsTable("b")
+        val df3 = spark.table("b")
+        val df4 = generateBroadcastDataFrame(confKey, confValue2)
+        spark.sparkContext.setLocalProperty(confKey, confValue2)
+        val checks2DF = df3.join(df4).where($"b.key" === $"c.value").select($"b.key", $"c.value")
+        val checks2 = checks2DF.collect()
+        assert(checks2.forall(_.toSeq == Seq(confValue2, confValue2)))
+        assert(checks2.nonEmpty)
+      }
+    }
+  }
 }
 
 case class SQLConfAssertPlan(confToCheck: Seq[(String, String)]) extends LeafExecNode {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
https://issues.apache.org/jira/browse/SPARK-32748 previously proposed propagating these local properties to the subquery broadcast exec threads but was then reverted since it was said that local properties would already be propagated to the broadcast threads.
I believe this is not always true. In the scenario where a separate `BroadcastExchangeExec` is the first to compute the broadcast, this is fine. However, in the scenario where the `SubqueryBroadcastExec` is the first to compute the broadcast, then the local properties that are propagated to the broadcast threads would not have been propagated correctly. This is because the local properties from the subquery broadcast exec were not propagated to its Future thread.
It is difficult to write a unit test that reproduces this behavior because usually `BroadcastExchangeExec` is the first computing the broadcast variable. However, by adding a `Thread.sleep(10)` to `SubqueryBroadcastExec.doPrepare` after `relationFuture` is initialized, the added test will consistently fail. 
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
Local properties are not propagated correctly to `SubqueryBroadcastExec`
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
No
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
Following test can reproduce the bug and test the solution by adding sleep to `SubqueryBroadcastExec.doPrepare`
```
protected override def doPrepare(): Unit = {
    relationFuture
    Thread.sleep(10)
}
```

```test("SPARK-44897 propagate local properties to subquery broadcast execuction thread") {
    withSQLConf(StaticSQLConf.BROADCAST_EXCHANGE_MAX_THREAD_THRESHOLD.key -> "1") {
      withTable("a", "b") {
        val confKey = "spark.sql.y"
        val confValue1 = UUID.randomUUID().toString()
        val confValue2 = UUID.randomUUID().toString()
        Seq((confValue1, "1")).toDF("key", "value")
          .write
          .format("parquet")
          .partitionBy("key")
          .mode("overwrite")
          .saveAsTable("a")
        val df1 = spark.table("a")

        def generateBroadcastDataFrame(confKey: String, confValue: String): Dataset[String] = {
          val df = spark.range(1).mapPartitions { _ =>
            Iterator(TaskContext.get.getLocalProperty(confKey))
          }.filter($"value".contains(confValue)).as("c")
          df.hint("broadcast")
        }

        // set local property and assert
        val df2 = generateBroadcastDataFrame(confKey, confValue1)
        spark.sparkContext.setLocalProperty(confKey, confValue1)
        val checkDF = df1.join(df2).where($"a.key" === $"c.value").select($"a.key", $"c.value")
        val checks = checkDF.collect()
        assert(checks.forall(_.toSeq == Seq(confValue1, confValue1)))

        // change local property and re-assert
        Seq((confValue2, "1")).toDF("key", "value")
          .write
          .format("parquet")
          .partitionBy("key")
          .mode("overwrite")
          .saveAsTable("b")
        val df3 = spark.table("b")
        val df4 = generateBroadcastDataFrame(confKey, confValue2)
        spark.sparkContext.setLocalProperty(confKey, confValue2)
        val checks2DF = df3.join(df4).where($"b.key" === $"c.value").select($"b.key", $"c.value")
        val checks2 = checks2DF.collect()
        assert(checks2.forall(_.toSeq == Seq(confValue2, confValue2)))
        assert(checks2.nonEmpty)
      }
    }
  }
  ```

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
No
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
