### PR TITLE
[SPARK-44904][PYTHON][DOCS] Correct the `versionadded` of `sql.functions.approx_percentile` to 3.5.0

### DIFF
--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -4524,10 +4524,7 @@ def approx_percentile(
     of `col` values is less than the value or equal to that value.
 
 
-    .. versionadded:: 3.1.0
-
-    .. versionchanged:: 3.5.0
-        Supports Spark Connect.
+    .. versionadded:: 3.5.0
 
     Parameters
     ----------

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -4528,7 +4528,7 @@ def approx_percentile(
 
     Notes
     -----
-    The function supports Spark Connect.
+    Supports Spark Connect.
 
     Parameters
     ----------

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -4526,6 +4526,10 @@ def approx_percentile(
 
     .. versionadded:: 3.5.0
 
+    Notes
+    -----
+    The function supports Spark Connect.
+
     Parameters
     ----------
     col : :class:`~pyspark.sql.Column` or str

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -4526,7 +4526,7 @@ def approx_percentile(
 
     .. versionadded:: 3.1.0
 
-    .. versionchanged:: 3.4.0
+    .. versionchanged:: 3.5.0
         Supports Spark Connect.
 
     Parameters


### PR DESCRIPTION
### What changes were proposed in this pull request?
`sql.functions.approx_percentile`  was introduced in SPARK-43941 (https://github.com/apache/spark/pull/41588). This is a pr for the Spark 3.5.0 and it does not belong to Spark 3.4.0. Therefore, this pr corrects the `versionadded` of `sql.functions.approx_percentile` to 3.5.0 and removed `versionchanged`.

### Why are the changes needed?
Correct the `versionadded` of `sql.functions.approx_percentile`.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No