### PR TITLE
[SPARK-45292][SQL][HIVE] Remove Guava from shared classes from IsolatedClientLoader

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/IsolatedClientLoader.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/IsolatedClientLoader.scala
@@ -124,8 +124,7 @@ private[hive] object IsolatedClientLoader extends Logging {
     }
     val hiveArtifacts = version.extraDeps ++
       Seq("hive-metastore", "hive-exec", "hive-common", "hive-serde")
-        .map(a => s"org.apache.hive:$a:${version.fullVersion}") ++
-      Seq("com.google.guava:guava:14.0.1") ++ hadoopJarNames
+        .map(a => s"org.apache.hive:$a:${version.fullVersion}") ++ hadoopJarNames
 
     implicit val printStream: PrintStream = SparkSubmit.printStream
     val classpaths = quietly {
@@ -207,7 +206,6 @@ private[hive] class IsolatedClientLoader(
     name.startsWith("org.apache.spark.") ||
     isHadoopClass ||
     name.startsWith("scala.") ||
-    (name.startsWith("com.google") && !name.startsWith("com.google.cloud")) ||
     name.startsWith("java.") ||
     name.startsWith("javax.sql.") ||
     sharedPrefixes.exists(name.startsWith)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/IsolatedClientLoader.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/IsolatedClientLoader.scala
@@ -124,8 +124,7 @@ private[hive] object IsolatedClientLoader extends Logging {
     }
     val hiveArtifacts = version.extraDeps ++
       Seq("hive-metastore", "hive-exec", "hive-common", "hive-serde")
-        .map(a => s"org.apache.hive:$a:${version.fullVersion}") ++
-      Seq("com.google.guava:guava:14.0.1") ++ hadoopJarNames
+        .map(a => s"org.apache.hive:$a:${version.fullVersion}") ++ hadoopJarNames
 
     implicit val printStream: PrintStream = SparkSubmit.printStream
     val classpaths = quietly {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/IsolatedClientLoader.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/IsolatedClientLoader.scala
@@ -124,7 +124,8 @@ private[hive] object IsolatedClientLoader extends Logging {
     }
     val hiveArtifacts = version.extraDeps ++
       Seq("hive-metastore", "hive-exec", "hive-common", "hive-serde")
-        .map(a => s"org.apache.hive:$a:${version.fullVersion}") ++ hadoopJarNames
+        .map(a => s"org.apache.hive:$a:${version.fullVersion}") ++
+      Seq("com.google.guava:guava:14.0.1") ++ hadoopJarNames
 
     implicit val printStream: PrintStream = SparkSubmit.printStream
     val classpaths = quietly {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Try removing Guava from `sharedClasses` as suggested by @JoshRosen in https://github.com/apache/spark/pull/33989#issuecomment-928616327 and https://github.com/apache/spark/pull/42493#issuecomment-1687092403

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Unblock Guava upgrading.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
CI passed (embedded HMS) and verified in the internal YARN cluster (remote HMS with kerberos-enabled).

```
# already setup hive-site.xml stuff properly to make sure to use remote HMS
bin/spark-shell --conf spark.sql.hive.metastore.jars=maven

...

scala> spark.sql("show databases").show
warning: 1 deprecation (since 2.13.3); for details, enable `:setting -deprecation` or `:replay -deprecation`
https://maven-central.storage-download.googleapis.com/maven2/ added as a remote repository with the name: repo-1
Ivy Default Cache set to: /home/hadoop/.ivy2/cache
The jars for the packages stored in: /home/hadoop/.ivy2/jars
org.apache.hive#hive-metastore added as a dependency
org.apache.hive#hive-exec added as a dependency
org.apache.hive#hive-common added as a dependency
org.apache.hive#hive-serde added as a dependency
org.apache.hadoop#hadoop-client-api added as a dependency
org.apache.hadoop#hadoop-client-runtime added as a dependency
:: resolving dependencies :: org.apache.spark#spark-submit-parent-d0d2962d-ae27-4526-a0c7-040a542e1e54;1.0
	confs: [default]
	found org.apache.hive#hive-metastore;2.3.9 in central
	found org.apache.hive#hive-serde;2.3.9 in central
	found org.apache.hive#hive-common;2.3.9 in central
	found org.apache.hive#hive-shims;2.3.9 in central
	found org.apache.hive.shims#hive-shims-common;2.3.9 in central
	found org.apache.logging.log4j#log4j-slf4j-impl;2.6.2 in central
	found org.slf4j#slf4j-api;1.7.10 in central
	found com.google.guava#guava;14.0.1 in central
	found commons-lang#commons-lang;2.6 in central
	found org.apache.thrift#libthrift;0.9.3 in central
	found org.apache.httpcomponents#httpclient;4.4 in central
	found org.apache.httpcomponents#httpcore;4.4 in central
	found commons-logging#commons-logging;1.2 in central
	found commons-codec#commons-codec;1.4 in central
	found org.apache.zookeeper#zookeeper;3.4.6 in central
	found org.slf4j#slf4j-log4j12;1.6.1 in central
	found log4j#log4j;1.2.16 in central
	found jline#jline;2.12 in central
	found io.netty#netty;3.7.0.Final in central
	found org.apache.hive.shims#hive-shims-0.23;2.3.9 in central
	found org.apache.hadoop#hadoop-yarn-server-resourcemanager;2.7.2 in central
	found org.apache.hadoop#hadoop-annotations;2.7.2 in central
	found com.google.inject.extensions#guice-servlet;3.0 in central
	found com.google.inject#guice;3.0 in central
	found javax.inject#javax.inject;1 in central
	found aopalliance#aopalliance;1.0 in central
	found org.sonatype.sisu.inject#cglib;2.2.1-v20090111 in central
	found asm#asm;3.2 in central
	found com.google.protobuf#protobuf-java;2.5.0 in central
	found commons-io#commons-io;2.4 in central
	found com.sun.jersey#jersey-json;1.14 in central
	found org.codehaus.jettison#jettison;1.1 in central
	found com.sun.xml.bind#jaxb-impl;2.2.3-1 in central
	found javax.xml.bind#jaxb-api;2.2.2 in central
	found javax.xml.stream#stax-api;1.0-2 in central
	found javax.activation#activation;1.1 in central
	found org.codehaus.jackson#jackson-core-asl;1.9.13 in central
	found org.codehaus.jackson#jackson-mapper-asl;1.9.13 in central
	found org.codehaus.jackson#jackson-jaxrs;1.9.13 in central
	found org.codehaus.jackson#jackson-xc;1.9.13 in central
	found com.sun.jersey#jersey-core;1.14 in central
	found com.sun.jersey.contribs#jersey-guice;1.9 in central
	found com.sun.jersey#jersey-server;1.14 in central
	found org.apache.hadoop#hadoop-yarn-common;2.7.2 in central
	found org.apache.hadoop#hadoop-yarn-api;2.7.2 in central
	found org.apache.commons#commons-compress;1.9 in central
	found org.mortbay.jetty#jetty-util;6.1.26 in central
	found com.sun.jersey#jersey-client;1.9 in central
	found commons-cli#commons-cli;1.2 in central
	found log4j#log4j;1.2.17 in central
	found org.apache.hadoop#hadoop-yarn-server-common;2.7.2 in central
	found org.fusesource.leveldbjni#leveldbjni-all;1.8 in central
	found org.apache.hadoop#hadoop-yarn-server-applicationhistoryservice;2.7.2 in central
	found commons-collections#commons-collections;3.2.2 in central
	found org.apache.hadoop#hadoop-yarn-server-web-proxy;2.7.2 in central
	found org.mortbay.jetty#jetty;6.1.26 in central
	found org.apache.hive.shims#hive-shims-scheduler;2.3.9 in central
	found org.apache.hive#hive-storage-api;2.4.0 in central
	found org.apache.commons#commons-lang3;3.1 in central
	found org.apache.orc#orc-core;1.3.4 in central
	found io.airlift#aircompressor;0.8 in central
	found io.airlift#slice;0.29 in central
	found org.openjdk.jol#jol-core;0.2 in central
	found org.eclipse.jetty.aggregate#jetty-all;7.6.0.v20120127 in central
	found org.apache.geronimo.specs#geronimo-jta_1.1_spec;1.1.1 in central
	found javax.mail#mail;1.4.1 in central
	found org.apache.geronimo.specs#geronimo-jaspic_1.0_spec;1.0 in central
	found org.apache.geronimo.specs#geronimo-annotation_1.0_spec;1.1.1 in central
	found asm#asm-commons;3.1 in central
	found asm#asm-tree;3.1 in central
	found org.eclipse.jetty.orbit#javax.servlet;3.0.0.v201112011016 in central
	found joda-time#joda-time;2.8.1 in central
	found org.apache.logging.log4j#log4j-1.2-api;2.6.2 in central
	found org.apache.logging.log4j#log4j-web;2.6.2 in central
	found org.apache.ant#ant;1.9.1 in central
	found org.apache.ant#ant-launcher;1.9.1 in central
	found com.tdunning#json;1.8 in central
	found io.dropwizard.metrics#metrics-core;3.1.0 in central
	found io.dropwizard.metrics#metrics-jvm;3.1.0 in central
	found io.dropwizard.metrics#metrics-json;3.1.0 in central
	found com.github.joshelser#dropwizard-metrics-hadoop-metrics2-reporter;0.1.2 in central
	found org.apache.hadoop#hadoop-common;2.7.2 in central
	found org.apache.commons#commons-math3;3.1.1 in central
	found xmlenc#xmlenc;0.52 in central
	found commons-httpclient#commons-httpclient;3.1 in central
	found commons-net#commons-net;3.1 in central
	found javax.servlet#servlet-api;2.5 in central
	found net.java.dev.jets3t#jets3t;0.9.0 in central
	found com.jamesmurty.utils#java-xmlbuilder;0.4 in central
	found commons-configuration#commons-configuration;1.6 in central
	found commons-digester#commons-digester;1.8 in central
	found commons-beanutils#commons-beanutils;1.7.0 in central
	found commons-beanutils#commons-beanutils-core;1.8.0 in central
	found org.apache.avro#avro;1.8.2 in central
	found com.thoughtworks.paranamer#paranamer;2.7 in central
	found org.xerial.snappy#snappy-java;1.1.1.3 in central
	found org.tukaani#xz;1.5 in central
	found com.google.code.gson#gson;2.2.4 in central
	found org.apache.hadoop#hadoop-auth;2.7.2 in central
	found org.apache.directory.server#apacheds-kerberos-codec;2.0.0-M15 in central
	found org.apache.directory.server#apacheds-i18n;2.0.0-M15 in central
	found org.apache.directory.api#api-asn1-api;1.0.0-M20 in central
	found org.apache.directory.api#api-util;1.0.0-M20 in central
	found com.jcraft#jsch;0.1.42 in central
	found com.google.code.findbugs#jsr305;3.0.0 in central
	found org.apache.htrace#htrace-core;3.1.0-incubating in central
	found javax.servlet.jsp#jsp-api;2.1 in central
	found org.slf4j#slf4j-log4j12;1.7.14 in central
	found org.apache.hive#hive-service-rpc;2.3.9 in central
	found tomcat#jasper-compiler;5.5.23 in central
	found javax.servlet#jsp-api;2.0 in central
	found ant#ant;1.6.5 in central
	found tomcat#jasper-runtime;5.5.23 in central
	found commons-el#commons-el;1.0 in central
	found org.apache.thrift#libfb303;0.9.3 in central
	found net.sf.opencsv#opencsv;2.3 in central
	found org.apache.parquet#parquet-hadoop-bundle;1.8.1 in central
	found javolution#javolution;5.5.1 in central
	found org.apache.hbase#hbase-client;1.1.1 in central
	found org.apache.hbase#hbase-annotations;1.1.1 in central
	found com.github.stephenc.findbugs#findbugs-annotations;1.3.9-1 in central
	found junit#junit;4.11 in central
	found org.hamcrest#hamcrest-core;1.3 in central
	found org.apache.hbase#hbase-protocol;1.1.1 in central
	found io.netty#netty-all;4.0.52.Final in central
	found org.jruby.jcodings#jcodings;1.0.8 in central
	found org.jruby.joni#joni;2.1.2 in central
	found org.apache.hadoop#hadoop-mapreduce-client-core;2.7.2 in central
	found com.jolbox#bonecp;0.8.0.RELEASE in central
	found com.zaxxer#HikariCP;2.5.1 in central
	found org.apache.derby#derby;10.10.2.0 in central
	found org.datanucleus#datanucleus-api-jdo;4.2.4 in central
	found org.datanucleus#datanucleus-core;4.1.17 in central
	found org.datanucleus#datanucleus-rdbms;4.1.19 in central
	found commons-pool#commons-pool;1.5.4 in central
	found commons-dbcp#commons-dbcp;1.4 in central
	found javax.jdo#jdo-api;3.0.1 in central
	found javax.transaction#jta;1.1 in central
	found org.datanucleus#javax.jdo;3.2.0-m3 in central
	found javax.transaction#transaction-api;1.1 in central
	found org.antlr#antlr-runtime;3.5.2 in central
	found co.cask.tephra#tephra-api;0.6.0 in central
	found co.cask.tephra#tephra-core;0.6.0 in central
	found com.google.inject.extensions#guice-assistedinject;3.0 in central
	found it.unimi.dsi#fastutil;6.5.6 in central
	found org.apache.twill#twill-common;0.6.0-incubating in central
	found org.apache.twill#twill-core;0.6.0-incubating in central
	found org.apache.twill#twill-api;0.6.0-incubating in central
	found org.apache.twill#twill-discovery-api;0.6.0-incubating in central
	found org.apache.twill#twill-zookeeper;0.6.0-incubating in central
	found org.apache.twill#twill-discovery-core;0.6.0-incubating in central
	found co.cask.tephra#tephra-hbase-compat-1.0;0.6.0 in central
	found org.apache.hive#hive-exec;2.3.9 in central
	found org.apache.hive#hive-llap-tez;2.3.9 in central
	found org.apache.hive#hive-llap-client;2.3.9 in central
	found org.apache.hive#hive-llap-common;2.3.9 in central
	found org.antlr#ST4;4.0.4 in central
	found org.apache.ivy#ivy;2.4.0 in central
	found org.codehaus.groovy#groovy-all;2.4.4 in central
	found stax#stax-api;1.0.1 in central
	found net.hydromatic#eigenbase-properties;1.1.5 in central
	found org.codehaus.janino#commons-compiler;2.7.6 in central
	found org.codehaus.janino#janino;2.7.6 in central
	found org.apache.hadoop#hadoop-client-api;3.3.6 in central
	found org.xerial.snappy#snappy-java;1.1.8.2 in central
	found org.apache.hadoop#hadoop-client-runtime;3.3.6 in central
	found org.slf4j#slf4j-api;1.7.36 in central
	found com.google.code.findbugs#jsr305;3.0.2 in central
downloading https://repo1.maven.org/maven2/org/apache/hive/hive-metastore/2.3.9/hive-metastore-2.3.9.jar ...
	[SUCCESSFUL ] org.apache.hive#hive-metastore;2.3.9!hive-metastore.jar (1292ms)
downloading https://repo1.maven.org/maven2/org/apache/hive/hive-exec/2.3.9/hive-exec-2.3.9.jar ...
	[SUCCESSFUL ] org.apache.hive#hive-exec;2.3.9!hive-exec.jar (1769ms)
downloading https://repo1.maven.org/maven2/org/apache/hive/hive-common/2.3.9/hive-common-2.3.9.jar ...
	[SUCCESSFUL ] org.apache.hive#hive-common;2.3.9!hive-common.jar (360ms)
downloading https://repo1.maven.org/maven2/org/apache/hive/hive-serde/2.3.9/hive-serde-2.3.9.jar ...
	[SUCCESSFUL ] org.apache.hive#hive-serde;2.3.9!hive-serde.jar (370ms)
downloading https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-client-api/3.3.6/hadoop-client-api-3.3.6.jar ...
	[SUCCESSFUL ] org.apache.hadoop#hadoop-client-api;3.3.6!hadoop-client-api.jar (936ms)
downloading https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-client-runtime/3.3.6/hadoop-client-runtime-3.3.6.jar ...
	[SUCCESSFUL ] org.apache.hadoop#hadoop-client-runtime;3.3.6!hadoop-client-runtime.jar (1418ms)
downloading https://repo1.maven.org/maven2/org/apache/hive/hive-shims/2.3.9/hive-shims-2.3.9.jar ...
	[SUCCESSFUL ] org.apache.hive#hive-shims;2.3.9!hive-shims.jar (361ms)
downloading https://repo1.maven.org/maven2/javolution/javolution/5.5.1/javolution-5.5.1.jar ...
	[SUCCESSFUL ] javolution#javolution;5.5.1!javolution.jar(bundle) (359ms)
downloading https://repo1.maven.org/maven2/com/google/guava/guava/14.0.1/guava-14.0.1.jar ...
	[SUCCESSFUL ] com.google.guava#guava;14.0.1!guava.jar(bundle) (385ms)
downloading https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java/2.5.0/protobuf-java-2.5.0.jar ...
	[SUCCESSFUL ] com.google.protobuf#protobuf-java;2.5.0!protobuf-java.jar(bundle) (362ms)
downloading https://repo1.maven.org/maven2/org/apache/hbase/hbase-client/1.1.1/hbase-client-1.1.1.jar ...
	[SUCCESSFUL ] org.apache.hbase#hbase-client;1.1.1!hbase-client.jar (378ms)
downloading https://repo1.maven.org/maven2/com/jolbox/bonecp/0.8.0.RELEASE/bonecp-0.8.0.RELEASE.jar ...
	[SUCCESSFUL ] com.jolbox#bonecp;0.8.0.RELEASE!bonecp.jar(bundle) (356ms)
downloading https://repo1.maven.org/maven2/com/zaxxer/HikariCP/2.5.1/HikariCP-2.5.1.jar ...
	[SUCCESSFUL ] com.zaxxer#HikariCP;2.5.1!HikariCP.jar(bundle) (356ms)
downloading https://repo1.maven.org/maven2/commons-cli/commons-cli/1.2/commons-cli-1.2.jar ...
	[SUCCESSFUL ] commons-cli#commons-cli;1.2!commons-cli.jar (353ms)
downloading https://repo1.maven.org/maven2/commons-lang/commons-lang/2.6/commons-lang-2.6.jar ...
	[SUCCESSFUL ] commons-lang#commons-lang;2.6!commons-lang.jar (372ms)
downloading https://repo1.maven.org/maven2/org/apache/derby/derby/10.10.2.0/derby-10.10.2.0.jar ...
	[SUCCESSFUL ] org.apache.derby#derby;10.10.2.0!derby.jar (398ms)
downloading https://repo1.maven.org/maven2/org/datanucleus/datanucleus-api-jdo/4.2.4/datanucleus-api-jdo-4.2.4.jar ...
	[SUCCESSFUL ] org.datanucleus#datanucleus-api-jdo;4.2.4!datanucleus-api-jdo.jar (361ms)
downloading https://repo1.maven.org/maven2/org/datanucleus/datanucleus-core/4.1.17/datanucleus-core-4.1.17.jar ...
	[SUCCESSFUL ] org.datanucleus#datanucleus-core;4.1.17!datanucleus-core.jar (391ms)
downloading https://repo1.maven.org/maven2/org/datanucleus/datanucleus-rdbms/4.1.19/datanucleus-rdbms-4.1.19.jar ...
	[SUCCESSFUL ] org.datanucleus#datanucleus-rdbms;4.1.19!datanucleus-rdbms.jar (384ms)
downloading https://repo1.maven.org/maven2/commons-pool/commons-pool/1.5.4/commons-pool-1.5.4.jar ...
	[SUCCESSFUL ] commons-pool#commons-pool;1.5.4!commons-pool.jar (354ms)
downloading https://repo1.maven.org/maven2/commons-dbcp/commons-dbcp/1.4/commons-dbcp-1.4.jar ...
	[SUCCESSFUL ] commons-dbcp#commons-dbcp;1.4!commons-dbcp.jar (355ms)
downloading https://repo1.maven.org/maven2/javax/jdo/jdo-api/3.0.1/jdo-api-3.0.1.jar ...
	[SUCCESSFUL ] javax.jdo#jdo-api;3.0.1!jdo-api.jar (357ms)
downloading https://repo1.maven.org/maven2/org/datanucleus/javax.jdo/3.2.0-m3/javax.jdo-3.2.0-m3.jar ...
	[SUCCESSFUL ] org.datanucleus#javax.jdo;3.2.0-m3!javax.jdo.jar (357ms)
downloading https://repo1.maven.org/maven2/org/antlr/antlr-runtime/3.5.2/antlr-runtime-3.5.2.jar ...
	[SUCCESSFUL ] org.antlr#antlr-runtime;3.5.2!antlr-runtime.jar (355ms)
downloading https://repo1.maven.org/maven2/org/apache/thrift/libfb303/0.9.3/libfb303-0.9.3.jar ...
	[SUCCESSFUL ] org.apache.thrift#libfb303;0.9.3!libfb303.jar (181ms)
downloading https://repo1.maven.org/maven2/org/apache/thrift/libthrift/0.9.3/libthrift-0.9.3.jar ...
	[SUCCESSFUL ] org.apache.thrift#libthrift;0.9.3!libthrift.jar (183ms)
downloading https://repo1.maven.org/maven2/co/cask/tephra/tephra-api/0.6.0/tephra-api-0.6.0.jar ...
	[SUCCESSFUL ] co.cask.tephra#tephra-api;0.6.0!tephra-api.jar (353ms)
downloading https://repo1.maven.org/maven2/co/cask/tephra/tephra-core/0.6.0/tephra-core-0.6.0.jar ...
	[SUCCESSFUL ] co.cask.tephra#tephra-core;0.6.0!tephra-core.jar (363ms)
downloading https://repo1.maven.org/maven2/co/cask/tephra/tephra-hbase-compat-1.0/0.6.0/tephra-hbase-compat-1.0-0.6.0.jar ...
	[SUCCESSFUL ] co.cask.tephra#tephra-hbase-compat-1.0;0.6.0!tephra-hbase-compat-1.0.jar (354ms)
downloading https://repo1.maven.org/maven2/org/apache/hive/hive-service-rpc/2.3.9/hive-service-rpc-2.3.9.jar ...
	[SUCCESSFUL ] org.apache.hive#hive-service-rpc;2.3.9!hive-service-rpc.jar (379ms)
downloading https://repo1.maven.org/maven2/commons-codec/commons-codec/1.4/commons-codec-1.4.jar ...
	[SUCCESSFUL ] commons-codec#commons-codec;1.4!commons-codec.jar (355ms)
downloading https://repo1.maven.org/maven2/org/apache/avro/avro/1.8.2/avro-1.8.2.jar ...
	[SUCCESSFUL ] org.apache.avro#avro;1.8.2!avro.jar(bundle) (392ms)
downloading https://repo1.maven.org/maven2/net/sf/opencsv/opencsv/2.3/opencsv-2.3.jar ...
	[SUCCESSFUL ] net.sf.opencsv#opencsv;2.3!opencsv.jar (354ms)
downloading https://repo1.maven.org/maven2/org/apache/parquet/parquet-hadoop-bundle/1.8.1/parquet-hadoop-bundle-1.8.1.jar ...
	[SUCCESSFUL ] org.apache.parquet#parquet-hadoop-bundle;1.8.1!parquet-hadoop-bundle.jar (408ms)
downloading https://repo1.maven.org/maven2/org/apache/hive/hive-storage-api/2.4.0/hive-storage-api-2.4.0.jar ...
	[SUCCESSFUL ] org.apache.hive#hive-storage-api;2.4.0!hive-storage-api.jar (356ms)
downloading https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.1/commons-lang3-3.1.jar ...
	[SUCCESSFUL ] org.apache.commons#commons-lang3;3.1!commons-lang3.jar (358ms)
downloading https://repo1.maven.org/maven2/org/apache/orc/orc-core/1.3.4/orc-core-1.3.4.jar ...
	[SUCCESSFUL ] org.apache.orc#orc-core;1.3.4!orc-core.jar (391ms)
downloading https://repo1.maven.org/maven2/jline/jline/2.12/jline-2.12.jar ...
	[SUCCESSFUL ] jline#jline;2.12!jline.jar (357ms)
downloading https://repo1.maven.org/maven2/org/eclipse/jetty/aggregate/jetty-all/7.6.0.v20120127/jetty-all-7.6.0.v20120127.jar ...
	[SUCCESSFUL ] org.eclipse.jetty.aggregate#jetty-all;7.6.0.v20120127!jetty-all.jar (379ms)
downloading https://repo1.maven.org/maven2/org/eclipse/jetty/orbit/javax.servlet/3.0.0.v201112011016/javax.servlet-3.0.0.v201112011016.jar ...
	[SUCCESSFUL ] org.eclipse.jetty.orbit#javax.servlet;3.0.0.v201112011016!javax.servlet.jar(orbit) (359ms)
downloading https://repo1.maven.org/maven2/joda-time/joda-time/2.8.1/joda-time-2.8.1.jar ...
	[SUCCESSFUL ] joda-time#joda-time;2.8.1!joda-time.jar (361ms)
downloading https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-1.2-api/2.6.2/log4j-1.2-api-2.6.2.jar ...
	[SUCCESSFUL ] org.apache.logging.log4j#log4j-1.2-api;2.6.2!log4j-1.2-api.jar(bundle) (354ms)
downloading https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-web/2.6.2/log4j-web-2.6.2.jar ...
	[SUCCESSFUL ] org.apache.logging.log4j#log4j-web;2.6.2!log4j-web.jar (354ms)
downloading https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-slf4j-impl/2.6.2/log4j-slf4j-impl-2.6.2.jar ...
	[SUCCESSFUL ] org.apache.logging.log4j#log4j-slf4j-impl;2.6.2!log4j-slf4j-impl.jar (354ms)
downloading https://repo1.maven.org/maven2/org/apache/commons/commons-compress/1.9/commons-compress-1.9.jar ...
	[SUCCESSFUL ] org.apache.commons#commons-compress;1.9!commons-compress.jar (359ms)
downloading https://repo1.maven.org/maven2/org/apache/ant/ant/1.9.1/ant-1.9.1.jar ...
	[SUCCESSFUL ] org.apache.ant#ant;1.9.1!ant.jar (390ms)
downloading https://repo1.maven.org/maven2/com/tdunning/json/1.8/json-1.8.jar ...
	[SUCCESSFUL ] com.tdunning#json;1.8!json.jar (353ms)
downloading https://repo1.maven.org/maven2/io/dropwizard/metrics/metrics-core/3.1.0/metrics-core-3.1.0.jar ...
	[SUCCESSFUL ] io.dropwizard.metrics#metrics-core;3.1.0!metrics-core.jar(bundle) (356ms)
downloading https://repo1.maven.org/maven2/io/dropwizard/metrics/metrics-jvm/3.1.0/metrics-jvm-3.1.0.jar ...
	[SUCCESSFUL ] io.dropwizard.metrics#metrics-jvm;3.1.0!metrics-jvm.jar(bundle) (354ms)
downloading https://repo1.maven.org/maven2/io/dropwizard/metrics/metrics-json/3.1.0/metrics-json-3.1.0.jar ...
	[SUCCESSFUL ] io.dropwizard.metrics#metrics-json;3.1.0!metrics-json.jar(bundle) (354ms)
downloading https://repo1.maven.org/maven2/com/github/joshelser/dropwizard-metrics-hadoop-metrics2-reporter/0.1.2/dropwizard-metrics-hadoop-metrics2-reporter-0.1.2.jar ...
	[SUCCESSFUL ] com.github.joshelser#dropwizard-metrics-hadoop-metrics2-reporter;0.1.2!dropwizard-metrics-hadoop-metrics2-reporter.jar (354ms)
downloading https://repo1.maven.org/maven2/org/apache/hive/shims/hive-shims-common/2.3.9/hive-shims-common-2.3.9.jar ...
	[SUCCESSFUL ] org.apache.hive.shims#hive-shims-common;2.3.9!hive-shims-common.jar (355ms)
downloading https://repo1.maven.org/maven2/org/apache/zookeeper/zookeeper/3.4.6/zookeeper-3.4.6-tests.jar ...
	[SUCCESSFUL ] org.apache.zookeeper#zookeeper;3.4.6!zookeeper.jar(test-jar) (362ms)
downloading https://repo1.maven.org/maven2/org/apache/zookeeper/zookeeper/3.4.6/zookeeper-3.4.6.jar ...
	[SUCCESSFUL ] org.apache.zookeeper#zookeeper;3.4.6!zookeeper.jar (188ms)
downloading https://repo1.maven.org/maven2/org/apache/httpcomponents/httpclient/4.4/httpclient-4.4.jar ...
	[SUCCESSFUL ] org.apache.httpcomponents#httpclient;4.4!httpclient.jar (368ms)
downloading https://repo1.maven.org/maven2/org/apache/httpcomponents/httpcore/4.4/httpcore-4.4.jar ...
	[SUCCESSFUL ] org.apache.httpcomponents#httpcore;4.4!httpcore.jar (359ms)
downloading https://repo1.maven.org/maven2/commons-logging/commons-logging/1.2/commons-logging-1.2.jar ...
	[SUCCESSFUL ] commons-logging#commons-logging;1.2!commons-logging.jar (353ms)
downloading https://repo1.maven.org/maven2/io/netty/netty/3.7.0.Final/netty-3.7.0.Final.jar ...
	[SUCCESSFUL ] io.netty#netty;3.7.0.Final!netty.jar(bundle) (373ms)
downloading https://repo1.maven.org/maven2/org/apache/hive/shims/hive-shims-0.23/2.3.9/hive-shims-0.23-2.3.9.jar ...
	[SUCCESSFUL ] org.apache.hive.shims#hive-shims-0.23;2.3.9!hive-shims-0.23.jar (359ms)
downloading https://repo1.maven.org/maven2/org/apache/hive/shims/hive-shims-scheduler/2.3.9/hive-shims-scheduler-2.3.9.jar ...
	[SUCCESSFUL ] org.apache.hive.shims#hive-shims-scheduler;2.3.9!hive-shims-scheduler.jar (355ms)
downloading https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-yarn-server-resourcemanager/2.7.2/hadoop-yarn-server-resourcemanager-2.7.2.jar ...
	[SUCCESSFUL ] org.apache.hadoop#hadoop-yarn-server-resourcemanager;2.7.2!hadoop-yarn-server-resourcemanager.jar (375ms)
downloading https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-annotations/2.7.2/hadoop-annotations-2.7.2.jar ...
	[SUCCESSFUL ] org.apache.hadoop#hadoop-annotations;2.7.2!hadoop-annotations.jar (361ms)
downloading https://repo1.maven.org/maven2/com/google/inject/extensions/guice-servlet/3.0/guice-servlet-3.0.jar ...
	[SUCCESSFUL ] com.google.inject.extensions#guice-servlet;3.0!guice-servlet.jar (355ms)
downloading https://repo1.maven.org/maven2/commons-io/commons-io/2.4/commons-io-2.4.jar ...
	[SUCCESSFUL ] commons-io#commons-io;2.4!commons-io.jar (357ms)
downloading https://repo1.maven.org/maven2/com/google/inject/guice/3.0/guice-3.0.jar ...
	[SUCCESSFUL ] com.google.inject#guice;3.0!guice.jar (368ms)
downloading https://repo1.maven.org/maven2/com/sun/jersey/jersey-json/1.14/jersey-json-1.14.jar ...
	[SUCCESSFUL ] com.sun.jersey#jersey-json;1.14!jersey-json.jar (356ms)
downloading https://repo1.maven.org/maven2/com/sun/jersey/contribs/jersey-guice/1.9/jersey-guice-1.9.jar ...
	[SUCCESSFUL ] com.sun.jersey.contribs#jersey-guice;1.9!jersey-guice.jar (354ms)
downloading https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-yarn-common/2.7.2/hadoop-yarn-common-2.7.2.jar ...
	[SUCCESSFUL ] org.apache.hadoop#hadoop-yarn-common;2.7.2!hadoop-yarn-common.jar (379ms)
downloading https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-yarn-api/2.7.2/hadoop-yarn-api-2.7.2.jar ...
	[SUCCESSFUL ] org.apache.hadoop#hadoop-yarn-api;2.7.2!hadoop-yarn-api.jar (386ms)
downloading https://repo1.maven.org/maven2/javax/xml/bind/jaxb-api/2.2.2/jaxb-api-2.2.2.jar ...
	[SUCCESSFUL ] javax.xml.bind#jaxb-api;2.2.2!jaxb-api.jar (356ms)
downloading https://repo1.maven.org/maven2/org/codehaus/jettison/jettison/1.1/jettison-1.1.jar ...
	[SUCCESSFUL ] org.codehaus.jettison#jettison;1.1!jettison.jar(bundle) (354ms)
downloading https://repo1.maven.org/maven2/com/sun/jersey/jersey-core/1.14/jersey-core-1.14.jar ...
	[SUCCESSFUL ] com.sun.jersey#jersey-core;1.14!jersey-core.jar (360ms)
downloading https://repo1.maven.org/maven2/com/sun/jersey/jersey-client/1.9/jersey-client-1.9.jar ...
	[SUCCESSFUL ] com.sun.jersey#jersey-client;1.9!jersey-client.jar(bundle) (355ms)
downloading https://repo1.maven.org/maven2/org/mortbay/jetty/jetty-util/6.1.26/jetty-util-6.1.26.jar ...
	[SUCCESSFUL ] org.mortbay.jetty#jetty-util;6.1.26!jetty-util.jar (355ms)
downloading https://repo1.maven.org/maven2/log4j/log4j/1.2.17/log4j-1.2.17.jar ...
	[SUCCESSFUL ] log4j#log4j;1.2.17!log4j.jar(bundle) (361ms)
downloading https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-yarn-server-common/2.7.2/hadoop-yarn-server-common-2.7.2.jar ...
	[SUCCESSFUL ] org.apache.hadoop#hadoop-yarn-server-common;2.7.2!hadoop-yarn-server-common.jar (367ms)
downloading https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-yarn-server-applicationhistoryservice/2.7.2/hadoop-yarn-server-applicationhistoryservice-2.7.2.jar ...
	[SUCCESSFUL ] org.apache.hadoop#hadoop-yarn-server-applicationhistoryservice;2.7.2!hadoop-yarn-server-applicationhistoryservice.jar (363ms)
downloading https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-yarn-server-web-proxy/2.7.2/hadoop-yarn-server-web-proxy-2.7.2.jar ...
	[SUCCESSFUL ] org.apache.hadoop#hadoop-yarn-server-web-proxy;2.7.2!hadoop-yarn-server-web-proxy.jar (354ms)
downloading https://repo1.maven.org/maven2/org/fusesource/leveldbjni/leveldbjni-all/1.8/leveldbjni-all-1.8.jar ...
	[SUCCESSFUL ] org.fusesource.leveldbjni#leveldbjni-all;1.8!leveldbjni-all.jar(bundle) (372ms)
downloading https://repo1.maven.org/maven2/javax/inject/javax.inject/1/javax.inject-1.jar ...
	[SUCCESSFUL ] javax.inject#javax.inject;1!javax.inject.jar (355ms)
downloading https://repo1.maven.org/maven2/aopalliance/aopalliance/1.0/aopalliance-1.0.jar ...
	[SUCCESSFUL ] aopalliance#aopalliance;1.0!aopalliance.jar (368ms)
downloading https://repo1.maven.org/maven2/org/sonatype/sisu/inject/cglib/2.2.1-v20090111/cglib-2.2.1-v20090111.jar ...
	[SUCCESSFUL ] org.sonatype.sisu.inject#cglib;2.2.1-v20090111!cglib.jar (384ms)
downloading https://repo1.maven.org/maven2/asm/asm/3.2/asm-3.2.jar ...
	[SUCCESSFUL ] asm#asm;3.2!asm.jar (355ms)
downloading https://repo1.maven.org/maven2/com/sun/xml/bind/jaxb-impl/2.2.3-1/jaxb-impl-2.2.3-1.jar ...
	[SUCCESSFUL ] com.sun.xml.bind#jaxb-impl;2.2.3-1!jaxb-impl.jar (367ms)
downloading https://repo1.maven.org/maven2/org/codehaus/jackson/jackson-core-asl/1.9.13/jackson-core-asl-1.9.13.jar ...
	[SUCCESSFUL ] org.codehaus.jackson#jackson-core-asl;1.9.13!jackson-core-asl.jar (357ms)
downloading https://repo1.maven.org/maven2/org/codehaus/jackson/jackson-mapper-asl/1.9.13/jackson-mapper-asl-1.9.13.jar ...
	[SUCCESSFUL ] org.codehaus.jackson#jackson-mapper-asl;1.9.13!jackson-mapper-asl.jar (365ms)
downloading https://repo1.maven.org/maven2/org/codehaus/jackson/jackson-jaxrs/1.9.13/jackson-jaxrs-1.9.13.jar ...
	[SUCCESSFUL ] org.codehaus.jackson#jackson-jaxrs;1.9.13!jackson-jaxrs.jar (356ms)
downloading https://repo1.maven.org/maven2/org/codehaus/jackson/jackson-xc/1.9.13/jackson-xc-1.9.13.jar ...
	[SUCCESSFUL ] org.codehaus.jackson#jackson-xc;1.9.13!jackson-xc.jar (354ms)
downloading https://repo1.maven.org/maven2/javax/xml/stream/stax-api/1.0-2/stax-api-1.0-2.jar ...
	[SUCCESSFUL ] javax.xml.stream#stax-api;1.0-2!stax-api.jar (354ms)
downloading https://repo1.maven.org/maven2/javax/activation/activation/1.1/activation-1.1.jar ...
	[SUCCESSFUL ] javax.activation#activation;1.1!activation.jar (354ms)
downloading https://repo1.maven.org/maven2/com/sun/jersey/jersey-server/1.14/jersey-server-1.14.jar ...
	[SUCCESSFUL ] com.sun.jersey#jersey-server;1.14!jersey-server.jar (362ms)
downloading https://repo1.maven.org/maven2/commons-collections/commons-collections/3.2.2/commons-collections-3.2.2.jar ...
	[SUCCESSFUL ] commons-collections#commons-collections;3.2.2!commons-collections.jar (366ms)
downloading https://repo1.maven.org/maven2/org/mortbay/jetty/jetty/6.1.26/jetty-6.1.26.jar ...
	[SUCCESSFUL ] org.mortbay.jetty#jetty;6.1.26!jetty.jar (362ms)
downloading https://repo1.maven.org/maven2/io/airlift/aircompressor/0.8/aircompressor-0.8.jar ...
	[SUCCESSFUL ] io.airlift#aircompressor;0.8!aircompressor.jar (358ms)
downloading https://repo1.maven.org/maven2/io/airlift/slice/0.29/slice-0.29.jar ...
	[SUCCESSFUL ] io.airlift#slice;0.29!slice.jar (355ms)
downloading https://repo1.maven.org/maven2/org/openjdk/jol/jol-core/0.2/jol-core-0.2.jar ...
	[SUCCESSFUL ] org.openjdk.jol#jol-core;0.2!jol-core.jar (357ms)
downloading https://repo1.maven.org/maven2/org/apache/geronimo/specs/geronimo-jta_1.1_spec/1.1.1/geronimo-jta_1.1_spec-1.1.1.jar ...
	[SUCCESSFUL ] org.apache.geronimo.specs#geronimo-jta_1.1_spec;1.1.1!geronimo-jta_1.1_spec.jar (354ms)
downloading https://repo1.maven.org/maven2/javax/mail/mail/1.4.1/mail-1.4.1.jar ...
	[SUCCESSFUL ] javax.mail#mail;1.4.1!mail.jar (361ms)
downloading https://repo1.maven.org/maven2/org/apache/geronimo/specs/geronimo-jaspic_1.0_spec/1.0/geronimo-jaspic_1.0_spec-1.0.jar ...
	[SUCCESSFUL ] org.apache.geronimo.specs#geronimo-jaspic_1.0_spec;1.0!geronimo-jaspic_1.0_spec.jar(bundle) (354ms)
downloading https://repo1.maven.org/maven2/org/apache/geronimo/specs/geronimo-annotation_1.0_spec/1.1.1/geronimo-annotation_1.0_spec-1.1.1.jar ...
	[SUCCESSFUL ] org.apache.geronimo.specs#geronimo-annotation_1.0_spec;1.1.1!geronimo-annotation_1.0_spec.jar (354ms)
downloading https://repo1.maven.org/maven2/asm/asm-commons/3.1/asm-commons-3.1.jar ...
	[SUCCESSFUL ] asm#asm-commons;3.1!asm-commons.jar (354ms)
downloading https://repo1.maven.org/maven2/asm/asm-tree/3.1/asm-tree-3.1.jar ...
	[SUCCESSFUL ] asm#asm-tree;3.1!asm-tree.jar (356ms)
downloading https://repo1.maven.org/maven2/org/apache/ant/ant-launcher/1.9.1/ant-launcher-1.9.1.jar ...
	[SUCCESSFUL ] org.apache.ant#ant-launcher;1.9.1!ant-launcher.jar (353ms)
downloading https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-common/2.7.2/hadoop-common-2.7.2.jar ...
	[SUCCESSFUL ] org.apache.hadoop#hadoop-common;2.7.2!hadoop-common.jar (424ms)
downloading https://repo1.maven.org/maven2/org/apache/commons/commons-math3/3.1.1/commons-math3-3.1.1.jar ...
	[SUCCESSFUL ] org.apache.commons#commons-math3;3.1.1!commons-math3.jar (388ms)
downloading https://repo1.maven.org/maven2/xmlenc/xmlenc/0.52/xmlenc-0.52.jar ...
	[SUCCESSFUL ] xmlenc#xmlenc;0.52!xmlenc.jar (354ms)
downloading https://repo1.maven.org/maven2/commons-httpclient/commons-httpclient/3.1/commons-httpclient-3.1.jar ...
	[SUCCESSFUL ] commons-httpclient#commons-httpclient;3.1!commons-httpclient.jar (363ms)
downloading https://repo1.maven.org/maven2/commons-net/commons-net/3.1/commons-net-3.1.jar ...
	[SUCCESSFUL ] commons-net#commons-net;3.1!commons-net.jar (360ms)
downloading https://repo1.maven.org/maven2/javax/servlet/servlet-api/2.5/servlet-api-2.5.jar ...
	[SUCCESSFUL ] javax.servlet#servlet-api;2.5!servlet-api.jar (360ms)
downloading https://repo1.maven.org/maven2/net/java/dev/jets3t/jets3t/0.9.0/jets3t-0.9.0.jar ...
	[SUCCESSFUL ] net.java.dev.jets3t#jets3t;0.9.0!jets3t.jar (363ms)
downloading https://repo1.maven.org/maven2/commons-configuration/commons-configuration/1.6/commons-configuration-1.6.jar ...
	[SUCCESSFUL ] commons-configuration#commons-configuration;1.6!commons-configuration.jar (366ms)
downloading https://repo1.maven.org/maven2/com/google/code/gson/gson/2.2.4/gson-2.2.4.jar ...
	[SUCCESSFUL ] com.google.code.gson#gson;2.2.4!gson.jar (367ms)
downloading https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-auth/2.7.2/hadoop-auth-2.7.2.jar ...
	[SUCCESSFUL ] org.apache.hadoop#hadoop-auth;2.7.2!hadoop-auth.jar (360ms)
downloading https://repo1.maven.org/maven2/com/jcraft/jsch/0.1.42/jsch-0.1.42.jar ...
	[SUCCESSFUL ] com.jcraft#jsch;0.1.42!jsch.jar (360ms)
downloading https://repo1.maven.org/maven2/org/apache/htrace/htrace-core/3.1.0-incubating/htrace-core-3.1.0-incubating.jar ...
	[SUCCESSFUL ] org.apache.htrace#htrace-core;3.1.0-incubating!htrace-core.jar (375ms)
downloading https://repo1.maven.org/maven2/com/jamesmurty/utils/java-xmlbuilder/0.4/java-xmlbuilder-0.4.jar ...
	[SUCCESSFUL ] com.jamesmurty.utils#java-xmlbuilder;0.4!java-xmlbuilder.jar (354ms)
downloading https://repo1.maven.org/maven2/commons-digester/commons-digester/1.8/commons-digester-1.8.jar ...
	[SUCCESSFUL ] commons-digester#commons-digester;1.8!commons-digester.jar (355ms)
downloading https://repo1.maven.org/maven2/commons-beanutils/commons-beanutils-core/1.8.0/commons-beanutils-core-1.8.0.jar ...
	[SUCCESSFUL ] commons-beanutils#commons-beanutils-core;1.8.0!commons-beanutils-core.jar (357ms)
downloading https://repo1.maven.org/maven2/commons-beanutils/commons-beanutils/1.7.0/commons-beanutils-1.7.0.jar ...
	[SUCCESSFUL ] commons-beanutils#commons-beanutils;1.7.0!commons-beanutils.jar (356ms)
downloading https://repo1.maven.org/maven2/com/thoughtworks/paranamer/paranamer/2.7/paranamer-2.7.jar ...
	[SUCCESSFUL ] com.thoughtworks.paranamer#paranamer;2.7!paranamer.jar(bundle) (354ms)
downloading https://repo1.maven.org/maven2/org/tukaani/xz/1.5/xz-1.5.jar ...
	[SUCCESSFUL ] org.tukaani#xz;1.5!xz.jar (369ms)
downloading https://repo1.maven.org/maven2/org/apache/directory/server/apacheds-kerberos-codec/2.0.0-M15/apacheds-kerberos-codec-2.0.0-M15.jar ...
	[SUCCESSFUL ] org.apache.directory.server#apacheds-kerberos-codec;2.0.0-M15!apacheds-kerberos-codec.jar(bundle) (364ms)
downloading https://repo1.maven.org/maven2/org/apache/directory/server/apacheds-i18n/2.0.0-M15/apacheds-i18n-2.0.0-M15.jar ...
	[SUCCESSFUL ] org.apache.directory.server#apacheds-i18n;2.0.0-M15!apacheds-i18n.jar(bundle) (354ms)
downloading https://repo1.maven.org/maven2/org/apache/directory/api/api-asn1-api/1.0.0-M20/api-asn1-api-1.0.0-M20.jar ...
	[SUCCESSFUL ] org.apache.directory.api#api-asn1-api;1.0.0-M20!api-asn1-api.jar(bundle) (354ms)
downloading https://repo1.maven.org/maven2/org/apache/directory/api/api-util/1.0.0-M20/api-util-1.0.0-M20.jar ...
	[SUCCESSFUL ] org.apache.directory.api#api-util;1.0.0-M20!api-util.jar(bundle) (355ms)
downloading https://repo1.maven.org/maven2/javax/servlet/jsp/jsp-api/2.1/jsp-api-2.1.jar ...
	[SUCCESSFUL ] javax.servlet.jsp#jsp-api;2.1!jsp-api.jar (356ms)
downloading https://repo1.maven.org/maven2/org/slf4j/slf4j-log4j12/1.7.14/slf4j-log4j12-1.7.14.jar ...
	[SUCCESSFUL ] org.slf4j#slf4j-log4j12;1.7.14!slf4j-log4j12.jar (354ms)
downloading https://repo1.maven.org/maven2/tomcat/jasper-compiler/5.5.23/jasper-compiler-5.5.23.jar ...
	[SUCCESSFUL ] tomcat#jasper-compiler;5.5.23!jasper-compiler.jar (360ms)
downloading https://repo1.maven.org/maven2/tomcat/jasper-runtime/5.5.23/jasper-runtime-5.5.23.jar ...
	[SUCCESSFUL ] tomcat#jasper-runtime;5.5.23!jasper-runtime.jar (355ms)
downloading https://repo1.maven.org/maven2/javax/servlet/jsp-api/2.0/jsp-api-2.0.jar ...
	[SUCCESSFUL ] javax.servlet#jsp-api;2.0!jsp-api.jar (355ms)
downloading https://repo1.maven.org/maven2/ant/ant/1.6.5/ant-1.6.5.jar ...
	[SUCCESSFUL ] ant#ant;1.6.5!ant.jar (371ms)
downloading https://repo1.maven.org/maven2/commons-el/commons-el/1.0/commons-el-1.0.jar ...
	[SUCCESSFUL ] commons-el#commons-el;1.0!commons-el.jar (355ms)
downloading https://repo1.maven.org/maven2/org/apache/hbase/hbase-annotations/1.1.1/hbase-annotations-1.1.1.jar ...
	[SUCCESSFUL ] org.apache.hbase#hbase-annotations;1.1.1!hbase-annotations.jar (354ms)
downloading https://repo1.maven.org/maven2/org/apache/hbase/hbase-protocol/1.1.1/hbase-protocol-1.1.1.jar ...
	[SUCCESSFUL ] org.apache.hbase#hbase-protocol;1.1.1!hbase-protocol.jar (414ms)
downloading https://repo1.maven.org/maven2/io/netty/netty-all/4.0.52.Final/netty-all-4.0.52.Final.jar ...
	[SUCCESSFUL ] io.netty#netty-all;4.0.52.Final!netty-all.jar (400ms)
downloading https://repo1.maven.org/maven2/org/jruby/jcodings/jcodings/1.0.8/jcodings-1.0.8.jar ...
	[SUCCESSFUL ] org.jruby.jcodings#jcodings;1.0.8!jcodings.jar (419ms)
downloading https://repo1.maven.org/maven2/org/jruby/joni/joni/2.1.2/joni-2.1.2.jar ...
	[SUCCESSFUL ] org.jruby.joni#joni;2.1.2!joni.jar (369ms)
downloading https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-mapreduce-client-core/2.7.2/hadoop-mapreduce-client-core-2.7.2.jar ...
	[SUCCESSFUL ] org.apache.hadoop#hadoop-mapreduce-client-core;2.7.2!hadoop-mapreduce-client-core.jar (393ms)
downloading https://repo1.maven.org/maven2/com/github/stephenc/findbugs/findbugs-annotations/1.3.9-1/findbugs-annotations-1.3.9-1.jar ...
	[SUCCESSFUL ] com.github.stephenc.findbugs#findbugs-annotations;1.3.9-1!findbugs-annotations.jar (354ms)
downloading https://repo1.maven.org/maven2/junit/junit/4.11/junit-4.11.jar ...
	[SUCCESSFUL ] junit#junit;4.11!junit.jar (357ms)
downloading https://repo1.maven.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar ...
	[SUCCESSFUL ] org.hamcrest#hamcrest-core;1.3!hamcrest-core.jar (353ms)
downloading https://repo1.maven.org/maven2/javax/transaction/jta/1.1/jta-1.1.jar ...
	[SUCCESSFUL ] javax.transaction#jta;1.1!jta.jar (354ms)
downloading https://repo1.maven.org/maven2/javax/transaction/transaction-api/1.1/transaction-api-1.1.jar ...
	[SUCCESSFUL ] javax.transaction#transaction-api;1.1!transaction-api.jar (368ms)
downloading https://repo1.maven.org/maven2/com/google/inject/extensions/guice-assistedinject/3.0/guice-assistedinject-3.0.jar ...
	[SUCCESSFUL ] com.google.inject.extensions#guice-assistedinject;3.0!guice-assistedinject.jar (355ms)
downloading https://repo1.maven.org/maven2/it/unimi/dsi/fastutil/6.5.6/fastutil-6.5.6.jar ...
	[SUCCESSFUL ] it.unimi.dsi#fastutil;6.5.6!fastutil.jar (894ms)
downloading https://repo1.maven.org/maven2/org/apache/twill/twill-common/0.6.0-incubating/twill-common-0.6.0-incubating.jar ...
	[SUCCESSFUL ] org.apache.twill#twill-common;0.6.0-incubating!twill-common.jar (355ms)
downloading https://repo1.maven.org/maven2/org/apache/twill/twill-core/0.6.0-incubating/twill-core-0.6.0-incubating.jar ...
	[SUCCESSFUL ] org.apache.twill#twill-core;0.6.0-incubating!twill-core.jar (358ms)
downloading https://repo1.maven.org/maven2/org/apache/twill/twill-discovery-api/0.6.0-incubating/twill-discovery-api-0.6.0-incubating.jar ...
	[SUCCESSFUL ] org.apache.twill#twill-discovery-api;0.6.0-incubating!twill-discovery-api.jar (354ms)
downloading https://repo1.maven.org/maven2/org/apache/twill/twill-discovery-core/0.6.0-incubating/twill-discovery-core-0.6.0-incubating.jar ...
	[SUCCESSFUL ] org.apache.twill#twill-discovery-core;0.6.0-incubating!twill-discovery-core.jar (354ms)
downloading https://repo1.maven.org/maven2/org/apache/twill/twill-zookeeper/0.6.0-incubating/twill-zookeeper-0.6.0-incubating.jar ...
	[SUCCESSFUL ] org.apache.twill#twill-zookeeper;0.6.0-incubating!twill-zookeeper.jar (357ms)
downloading https://repo1.maven.org/maven2/org/apache/twill/twill-api/0.6.0-incubating/twill-api-0.6.0-incubating.jar ...
	[SUCCESSFUL ] org.apache.twill#twill-api;0.6.0-incubating!twill-api.jar (354ms)
downloading https://repo1.maven.org/maven2/org/apache/hive/hive-llap-tez/2.3.9/hive-llap-tez-2.3.9.jar ...
	[SUCCESSFUL ] org.apache.hive#hive-llap-tez;2.3.9!hive-llap-tez.jar (357ms)
downloading https://repo1.maven.org/maven2/org/antlr/ST4/4.0.4/ST4-4.0.4.jar ...
	[SUCCESSFUL ] org.antlr#ST4;4.0.4!ST4.jar (356ms)
downloading https://repo1.maven.org/maven2/org/apache/ivy/ivy/2.4.0/ivy-2.4.0.jar ...
	[SUCCESSFUL ] org.apache.ivy#ivy;2.4.0!ivy.jar (372ms)
downloading https://repo1.maven.org/maven2/org/codehaus/groovy/groovy-all/2.4.4/groovy-all-2.4.4.jar ...
	[SUCCESSFUL ] org.codehaus.groovy#groovy-all;2.4.4!groovy-all.jar (549ms)
downloading https://repo1.maven.org/maven2/stax/stax-api/1.0.1/stax-api-1.0.1.jar ...
	[SUCCESSFUL ] stax#stax-api;1.0.1!stax-api.jar (354ms)
downloading https://repo1.maven.org/maven2/net/hydromatic/eigenbase-properties/1.1.5/eigenbase-properties-1.1.5.jar ...
	[SUCCESSFUL ] net.hydromatic#eigenbase-properties;1.1.5!eigenbase-properties.jar(bundle) (356ms)
downloading https://repo1.maven.org/maven2/org/codehaus/janino/commons-compiler/2.7.6/commons-compiler-2.7.6.jar ...
	[SUCCESSFUL ] org.codehaus.janino#commons-compiler;2.7.6!commons-compiler.jar (354ms)
downloading https://repo1.maven.org/maven2/org/codehaus/janino/janino/2.7.6/janino-2.7.6.jar ...
	[SUCCESSFUL ] org.codehaus.janino#janino;2.7.6!janino.jar (363ms)
downloading https://repo1.maven.org/maven2/org/apache/hive/hive-llap-client/2.3.9/hive-llap-client-2.3.9.jar ...
	[SUCCESSFUL ] org.apache.hive#hive-llap-client;2.3.9!hive-llap-client.jar (356ms)
downloading https://repo1.maven.org/maven2/org/apache/hive/hive-llap-common/2.3.9/hive-llap-common-2.3.9.jar ...
	[SUCCESSFUL ] org.apache.hive#hive-llap-common;2.3.9!hive-llap-common.jar (358ms)
downloading https://repo1.maven.org/maven2/org/xerial/snappy/snappy-java/1.1.8.2/snappy-java-1.1.8.2.jar ...
	[SUCCESSFUL ] org.xerial.snappy#snappy-java;1.1.8.2!snappy-java.jar(bundle) (383ms)
downloading https://repo1.maven.org/maven2/org/slf4j/slf4j-api/1.7.36/slf4j-api-1.7.36.jar ...
	[SUCCESSFUL ] org.slf4j#slf4j-api;1.7.36!slf4j-api.jar (353ms)
downloading https://repo1.maven.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar ...
	[SUCCESSFUL ] com.google.code.findbugs#jsr305;3.0.2!jsr305.jar (353ms)
:: resolution report :: resolve 193214ms :: artifacts dl 63795ms
	:: modules in use:
	ant#ant;1.6.5 from central in [default]
	aopalliance#aopalliance;1.0 from central in [default]
	asm#asm;3.2 from central in [default]
	asm#asm-commons;3.1 from central in [default]
	asm#asm-tree;3.1 from central in [default]
	co.cask.tephra#tephra-api;0.6.0 from central in [default]
	co.cask.tephra#tephra-core;0.6.0 from central in [default]
	co.cask.tephra#tephra-hbase-compat-1.0;0.6.0 from central in [default]
	com.github.joshelser#dropwizard-metrics-hadoop-metrics2-reporter;0.1.2 from central in [default]
	com.github.stephenc.findbugs#findbugs-annotations;1.3.9-1 from central in [default]
	com.google.code.findbugs#jsr305;3.0.2 from central in [default]
	com.google.code.gson#gson;2.2.4 from central in [default]
	com.google.guava#guava;14.0.1 from central in [default]
	com.google.inject#guice;3.0 from central in [default]
	com.google.inject.extensions#guice-assistedinject;3.0 from central in [default]
	com.google.inject.extensions#guice-servlet;3.0 from central in [default]
	com.google.protobuf#protobuf-java;2.5.0 from central in [default]
	com.jamesmurty.utils#java-xmlbuilder;0.4 from central in [default]
	com.jcraft#jsch;0.1.42 from central in [default]
	com.jolbox#bonecp;0.8.0.RELEASE from central in [default]
	com.sun.jersey#jersey-client;1.9 from central in [default]
	com.sun.jersey#jersey-core;1.14 from central in [default]
	com.sun.jersey#jersey-json;1.14 from central in [default]
	com.sun.jersey#jersey-server;1.14 from central in [default]
	com.sun.jersey.contribs#jersey-guice;1.9 from central in [default]
	com.sun.xml.bind#jaxb-impl;2.2.3-1 from central in [default]
	com.tdunning#json;1.8 from central in [default]
	com.thoughtworks.paranamer#paranamer;2.7 from central in [default]
	com.zaxxer#HikariCP;2.5.1 from central in [default]
	commons-beanutils#commons-beanutils;1.7.0 from central in [default]
	commons-beanutils#commons-beanutils-core;1.8.0 from central in [default]
	commons-cli#commons-cli;1.2 from central in [default]
	commons-codec#commons-codec;1.4 from central in [default]
	commons-collections#commons-collections;3.2.2 from central in [default]
	commons-configuration#commons-configuration;1.6 from central in [default]
	commons-dbcp#commons-dbcp;1.4 from central in [default]
	commons-digester#commons-digester;1.8 from central in [default]
	commons-el#commons-el;1.0 from central in [default]
	commons-httpclient#commons-httpclient;3.1 from central in [default]
	commons-io#commons-io;2.4 from central in [default]
	commons-lang#commons-lang;2.6 from central in [default]
	commons-logging#commons-logging;1.2 from central in [default]
	commons-net#commons-net;3.1 from central in [default]
	commons-pool#commons-pool;1.5.4 from central in [default]
	io.airlift#aircompressor;0.8 from central in [default]
	io.airlift#slice;0.29 from central in [default]
	io.dropwizard.metrics#metrics-core;3.1.0 from central in [default]
	io.dropwizard.metrics#metrics-json;3.1.0 from central in [default]
	io.dropwizard.metrics#metrics-jvm;3.1.0 from central in [default]
	io.netty#netty;3.7.0.Final from central in [default]
	io.netty#netty-all;4.0.52.Final from central in [default]
	it.unimi.dsi#fastutil;6.5.6 from central in [default]
	javax.activation#activation;1.1 from central in [default]
	javax.inject#javax.inject;1 from central in [default]
	javax.jdo#jdo-api;3.0.1 from central in [default]
	javax.mail#mail;1.4.1 from central in [default]
	javax.servlet#jsp-api;2.0 from central in [default]
	javax.servlet#servlet-api;2.5 from central in [default]
	javax.servlet.jsp#jsp-api;2.1 from central in [default]
	javax.transaction#jta;1.1 from central in [default]
	javax.transaction#transaction-api;1.1 from central in [default]
	javax.xml.bind#jaxb-api;2.2.2 from central in [default]
	javax.xml.stream#stax-api;1.0-2 from central in [default]
	javolution#javolution;5.5.1 from central in [default]
	jline#jline;2.12 from central in [default]
	joda-time#joda-time;2.8.1 from central in [default]
	junit#junit;4.11 from central in [default]
	log4j#log4j;1.2.17 from central in [default]
	net.hydromatic#eigenbase-properties;1.1.5 from central in [default]
	net.java.dev.jets3t#jets3t;0.9.0 from central in [default]
	net.sf.opencsv#opencsv;2.3 from central in [default]
	org.antlr#ST4;4.0.4 from central in [default]
	org.antlr#antlr-runtime;3.5.2 from central in [default]
	org.apache.ant#ant;1.9.1 from central in [default]
	org.apache.ant#ant-launcher;1.9.1 from central in [default]
	org.apache.avro#avro;1.8.2 from central in [default]
	org.apache.commons#commons-compress;1.9 from central in [default]
	org.apache.commons#commons-lang3;3.1 from central in [default]
	org.apache.commons#commons-math3;3.1.1 from central in [default]
	org.apache.derby#derby;10.10.2.0 from central in [default]
	org.apache.directory.api#api-asn1-api;1.0.0-M20 from central in [default]
	org.apache.directory.api#api-util;1.0.0-M20 from central in [default]
	org.apache.directory.server#apacheds-i18n;2.0.0-M15 from central in [default]
	org.apache.directory.server#apacheds-kerberos-codec;2.0.0-M15 from central in [default]
	org.apache.geronimo.specs#geronimo-annotation_1.0_spec;1.1.1 from central in [default]
	org.apache.geronimo.specs#geronimo-jaspic_1.0_spec;1.0 from central in [default]
	org.apache.geronimo.specs#geronimo-jta_1.1_spec;1.1.1 from central in [default]
	org.apache.hadoop#hadoop-annotations;2.7.2 from central in [default]
	org.apache.hadoop#hadoop-auth;2.7.2 from central in [default]
	org.apache.hadoop#hadoop-client-api;3.3.6 from central in [default]
	org.apache.hadoop#hadoop-client-runtime;3.3.6 from central in [default]
	org.apache.hadoop#hadoop-common;2.7.2 from central in [default]
	org.apache.hadoop#hadoop-mapreduce-client-core;2.7.2 from central in [default]
	org.apache.hadoop#hadoop-yarn-api;2.7.2 from central in [default]
	org.apache.hadoop#hadoop-yarn-common;2.7.2 from central in [default]
	org.apache.hadoop#hadoop-yarn-server-applicationhistoryservice;2.7.2 from central in [default]
	org.apache.hadoop#hadoop-yarn-server-common;2.7.2 from central in [default]
	org.apache.hadoop#hadoop-yarn-server-resourcemanager;2.7.2 from central in [default]
	org.apache.hadoop#hadoop-yarn-server-web-proxy;2.7.2 from central in [default]
	org.apache.hbase#hbase-annotations;1.1.1 from central in [default]
	org.apache.hbase#hbase-client;1.1.1 from central in [default]
	org.apache.hbase#hbase-protocol;1.1.1 from central in [default]
	org.apache.hive#hive-common;2.3.9 from central in [default]
	org.apache.hive#hive-exec;2.3.9 from central in [default]
	org.apache.hive#hive-llap-client;2.3.9 from central in [default]
	org.apache.hive#hive-llap-common;2.3.9 from central in [default]
	org.apache.hive#hive-llap-tez;2.3.9 from central in [default]
	org.apache.hive#hive-metastore;2.3.9 from central in [default]
	org.apache.hive#hive-serde;2.3.9 from central in [default]
	org.apache.hive#hive-service-rpc;2.3.9 from central in [default]
	org.apache.hive#hive-shims;2.3.9 from central in [default]
	org.apache.hive#hive-storage-api;2.4.0 from central in [default]
	org.apache.hive.shims#hive-shims-0.23;2.3.9 from central in [default]
	org.apache.hive.shims#hive-shims-common;2.3.9 from central in [default]
	org.apache.hive.shims#hive-shims-scheduler;2.3.9 from central in [default]
	org.apache.htrace#htrace-core;3.1.0-incubating from central in [default]
	org.apache.httpcomponents#httpclient;4.4 from central in [default]
	org.apache.httpcomponents#httpcore;4.4 from central in [default]
	org.apache.ivy#ivy;2.4.0 from central in [default]
	org.apache.logging.log4j#log4j-1.2-api;2.6.2 from central in [default]
	org.apache.logging.log4j#log4j-slf4j-impl;2.6.2 from central in [default]
	org.apache.logging.log4j#log4j-web;2.6.2 from central in [default]
	org.apache.orc#orc-core;1.3.4 from central in [default]
	org.apache.parquet#parquet-hadoop-bundle;1.8.1 from central in [default]
	org.apache.thrift#libfb303;0.9.3 from central in [default]
	org.apache.thrift#libthrift;0.9.3 from central in [default]
	org.apache.twill#twill-api;0.6.0-incubating from central in [default]
	org.apache.twill#twill-common;0.6.0-incubating from central in [default]
	org.apache.twill#twill-core;0.6.0-incubating from central in [default]
	org.apache.twill#twill-discovery-api;0.6.0-incubating from central in [default]
	org.apache.twill#twill-discovery-core;0.6.0-incubating from central in [default]
	org.apache.twill#twill-zookeeper;0.6.0-incubating from central in [default]
	org.apache.zookeeper#zookeeper;3.4.6 from central in [default]
	org.codehaus.groovy#groovy-all;2.4.4 from central in [default]
	org.codehaus.jackson#jackson-core-asl;1.9.13 from central in [default]
	org.codehaus.jackson#jackson-jaxrs;1.9.13 from central in [default]
	org.codehaus.jackson#jackson-mapper-asl;1.9.13 from central in [default]
	org.codehaus.jackson#jackson-xc;1.9.13 from central in [default]
	org.codehaus.janino#commons-compiler;2.7.6 from central in [default]
	org.codehaus.janino#janino;2.7.6 from central in [default]
	org.codehaus.jettison#jettison;1.1 from central in [default]
	org.datanucleus#datanucleus-api-jdo;4.2.4 from central in [default]
	org.datanucleus#datanucleus-core;4.1.17 from central in [default]
	org.datanucleus#datanucleus-rdbms;4.1.19 from central in [default]
	org.datanucleus#javax.jdo;3.2.0-m3 from central in [default]
	org.eclipse.jetty.aggregate#jetty-all;7.6.0.v20120127 from central in [default]
	org.eclipse.jetty.orbit#javax.servlet;3.0.0.v201112011016 from central in [default]
	org.fusesource.leveldbjni#leveldbjni-all;1.8 from central in [default]
	org.hamcrest#hamcrest-core;1.3 from central in [default]
	org.jruby.jcodings#jcodings;1.0.8 from central in [default]
	org.jruby.joni#joni;2.1.2 from central in [default]
	org.mortbay.jetty#jetty;6.1.26 from central in [default]
	org.mortbay.jetty#jetty-util;6.1.26 from central in [default]
	org.openjdk.jol#jol-core;0.2 from central in [default]
	org.slf4j#slf4j-api;1.7.36 from central in [default]
	org.slf4j#slf4j-log4j12;1.7.14 from central in [default]
	org.sonatype.sisu.inject#cglib;2.2.1-v20090111 from central in [default]
	org.tukaani#xz;1.5 from central in [default]
	org.xerial.snappy#snappy-java;1.1.8.2 from central in [default]
	stax#stax-api;1.0.1 from central in [default]
	tomcat#jasper-compiler;5.5.23 from central in [default]
	tomcat#jasper-runtime;5.5.23 from central in [default]
	xmlenc#xmlenc;0.52 from central in [default]
	:: evicted modules:
	org.slf4j#slf4j-api;1.7.10 by [org.slf4j#slf4j-api;1.7.36] in [default]
	org.slf4j#slf4j-log4j12;1.6.1 by [org.slf4j#slf4j-log4j12;1.7.14] in [default]
	log4j#log4j;1.2.16 by [log4j#log4j;1.2.17] in [default]
	commons-logging#commons-logging;1.1.3 by [commons-logging#commons-logging;1.2] in [default]
	asm#asm;3.1 by [asm#asm;3.2] in [default]
	io.dropwizard.metrics#metrics-core;3.1.2 by [io.dropwizard.metrics#metrics-core;3.1.0] in [default]
	org.xerial.snappy#snappy-java;1.1.1.3 by [org.xerial.snappy#snappy-java;1.1.8.2] in [default]
	com.google.code.findbugs#jsr305;3.0.0 by [com.google.code.findbugs#jsr305;3.0.2] in [default]
	javax.servlet#servlet-api;2.4 by [javax.servlet#servlet-api;2.5] in [default]
	commons-logging#commons-logging;1.0.3 by [commons-logging#commons-logging;1.2] in [default]
	org.apache.hadoop#hadoop-auth;2.5.1 by [org.apache.hadoop#hadoop-auth;2.7.2] in [default]
	io.netty#netty;3.6.2.Final by [io.netty#netty;3.7.0.Final] in [default]
	com.google.code.findbugs#jsr305;2.0.1 by [com.google.code.findbugs#jsr305;3.0.0] in [default]
	---------------------------------------------------------------------
	|                  |            modules            ||   artifacts   |
	|       conf       | number| search|dwnlded|evicted|| number|dwnlded|
	---------------------------------------------------------------------
	|      default     |  176  |  168  |  168  |   13  ||  164  |  164  |
	---------------------------------------------------------------------

:: USE VERBOSE OR DEBUG MESSAGE LEVEL FOR MORE DETAILS
:: retrieving :: org.apache.spark#spark-submit-parent-d0d2962d-ae27-4526-a0c7-040a542e1e54
	confs: [default]
	164 artifacts copied, 0 already retrieved (195815kB/314ms)
+--------------------+
|           namespace|
+--------------------+
|                  a1|
|              a1_dev|
|                  a2|
|              access|
|        access_xzx01|
|        access_xzx02|
|            activity|
|                 ...|
+--------------------+
only showing top 20 rows


scala>
```

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.