### PR TITLE
[SPARK-43780][SQL][FOLLOWUP] Fix the config doc `spark.sql.optimizer.decorrelateJoinPredicate.enabled`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4363,7 +4363,7 @@ object SQLConf {
       .internal()
       .doc("Decorrelate scalar and lateral subqueries with correlated references in join " +
         "predicates. This configuration is only effective when " +
-        "'${DECORRELATE_INNER_QUERY_ENABLED.key}' is true.")
+        s"'${DECORRELATE_INNER_QUERY_ENABLED.key}' is true.")
       .version("4.0.0")
       .booleanConf
       .createWithDefault(true)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add s" to the doc of the SQL config `spark.sql.optimizer.decorrelateJoinPredicate.enabled`.

### Why are the changes needed?
To output the desired config name.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By running CI.

### Was this patch authored or co-authored using generative AI tooling?
No.