### PR TITLE
[SPARK-42017][PYTHON][CONNECT] `df['col_name']` should validate the column name

### DIFF
--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -1625,7 +1625,7 @@ class DataFrame:
                 raise SparkConnectException("Cannot analyze on empty plan.")
 
             # validate the column name
-            if self._session is not None and self._session._client is not None:
+            if not self._session.is_stopped:
                 self.select(item).isLocal()
 
             return _to_col_with_plan_id(

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -54,7 +54,6 @@ from pyspark.sql.dataframe import (
 )
 
 from pyspark.errors import (
-    AnalysisException,
     PySparkTypeError,
     PySparkAttributeError,
     PySparkValueError,
@@ -1625,8 +1624,8 @@ class DataFrame:
             if self._plan is None:
                 raise SparkConnectException("Cannot analyze on empty plan.")
 
-            if "." not in item and "*" not in item and "`" not in item and item not in self.columns:
-                raise AnalysisException(f"Column {item} doesn't exist")
+            # validate the column name
+            self.select(item).isLocal()
 
             return _to_col_with_plan_id(
                 col=alias if alias is not None else item,

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -1625,7 +1625,7 @@ class DataFrame:
                 raise SparkConnectException("Cannot analyze on empty plan.")
 
             # validate the column name
-            if not self._session.is_stopped:
+            if not hasattr(self._session, "is_mock_session"):
                 self.select(item).isLocal()
 
             return _to_col_with_plan_id(

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -1625,7 +1625,8 @@ class DataFrame:
                 raise SparkConnectException("Cannot analyze on empty plan.")
 
             # validate the column name
-            self.select(item).isLocal()
+            if self._session is not None and self._session._client is not None:
+                self.select(item).isLocal()
 
             return _to_col_with_plan_id(
                 col=alias if alias is not None else item,

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -54,6 +54,7 @@ from pyspark.sql.dataframe import (
 )
 
 from pyspark.errors import (
+    AnalysisException,
     PySparkTypeError,
     PySparkAttributeError,
     PySparkValueError,
@@ -1623,6 +1624,10 @@ class DataFrame:
             alias = self._get_alias()
             if self._plan is None:
                 raise SparkConnectException("Cannot analyze on empty plan.")
+
+            if "." not in item and "*" not in item and "`" not in item and item not in self.columns:
+                raise AnalysisException(f"Column {item} doesn't exist")
+
             return _to_col_with_plan_id(
                 col=alias if alias is not None else item,
                 plan_id=self._plan._plan_id,

--- a/python/pyspark/sql/tests/connect/test_parity_column.py
+++ b/python/pyspark/sql/tests/connect/test_parity_column.py
@@ -32,11 +32,6 @@ from pyspark.testing.connectutils import ReusedConnectTestCase
 
 
 class ColumnParityTests(ColumnTestsMixin, ReusedConnectTestCase):
-    # TODO(SPARK-42017): df["bad_key"] does not raise AnalysisException
-    @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_access_column(self):
-        super().test_access_column()
-
     @unittest.skip("Requires JVM access.")
     def test_validate_column_types(self):
         super().test_validate_column_types()

--- a/python/pyspark/testing/connectutils.py
+++ b/python/pyspark/testing/connectutils.py
@@ -76,7 +76,7 @@ class MockRemoteSession:
     def __init__(self):
         self.hooks = {}
         self.session_id = str(uuid.uuid4())
-        self.is_stopped = True
+        self.is_mock_session = True
 
     def set_hook(self, name, hook):
         self.hooks[name] = hook

--- a/python/pyspark/testing/connectutils.py
+++ b/python/pyspark/testing/connectutils.py
@@ -76,7 +76,7 @@ class MockRemoteSession:
     def __init__(self):
         self.hooks = {}
         self.session_id = str(uuid.uuid4())
-        self._client = None
+        self.is_stopped = True
 
     def set_hook(self, name, hook):
         self.hooks[name] = hook

--- a/python/pyspark/testing/connectutils.py
+++ b/python/pyspark/testing/connectutils.py
@@ -76,6 +76,7 @@ class MockRemoteSession:
     def __init__(self):
         self.hooks = {}
         self.session_id = str(uuid.uuid4())
+        self._client = None
 
     def set_hook(self, name, hook):
         self.hooks[name] = hook


### PR DESCRIPTION
### What changes were proposed in this pull request?
make `df['col_name']` validate the column name 

### Why are the changes needed?
for parity


### Does this PR introduce _any_ user-facing change?
yes

before

```
In [1]: df = spark.range(0, 10)

In [2]: df["bad_key"]
Out[2]: Column<'bad_key'>

```

after

```
In [1]: df = spark.range(0, 10)

In [2]: df["bad_key"]
23/08/23 17:23:35 ERROR ErrorUtils: Spark Connect RPC error during: analyze. UserId: ruifeng.zheng. SessionId: 59de3f10-14b6-4239-be85-4156da43d495.
org.apache.spark.sql.AnalysisException: [UNRESOLVED_COLUMN.WITH_SUGGESTION] A column, variable, or function parameter with name `bad_key` cannot be resolved. Did you mean one of the following? [`id`].;
'Project ['bad_key]
+- Range (0, 10, step=1, splits=Some(12))

...

AnalysisException: [UNRESOLVED_COLUMN.WITH_SUGGESTION] A column, variable, or function parameter with name `bad_key` cannot be resolved. Did you mean one of the following? [`id`].;
'Project ['bad_key]
+- Range (0, 10, step=1, splits=Some(12))
```


### How was this patch tested?
enabled UT


### Was this patch authored or co-authored using generative AI tooling?
NO
