### PR TITLE
[SPARK-44922][TESTS] Disable o.a.p.h.InternalParquetRecordWriter logs for tests

### DIFF
--- a/connector/connect/server/src/test/resources/log4j2.properties
+++ b/connector/connect/server/src/test/resources/log4j2.properties
@@ -37,3 +37,8 @@ appender.console.layout.pattern = %t: %m%n%ex
 # Ignore messages below warning level from Jetty, because it's a bit verbose
 logger.jetty.name = org.sparkproject.jetty
 logger.jetty.level = warn
+
+# SPARK-44922: Disable o.a.p.h.InternalParquetRecordWriter logs for tests
+logger.parquet_recordwriter.name = org.apache.parquet.hadoop.InternalParquetRecordWriter
+logger.parquet_recordwriter.additivity = false
+logger.parquet_recordwriter.level = off

--- a/sql/core/src/test/resources/log4j2.properties
+++ b/sql/core/src/test/resources/log4j2.properties
@@ -45,6 +45,7 @@ logger.parquet_recordreader.name = org.apache.parquet.hadoop.ParquetRecordReader
 logger.parquet_recordreader.additivity = false
 logger.parquet_recordreader.level = off
 
+# SPARK-44922: Disable o.a.p.h.InternalParquetRecordWriter logs for tests
 logger.parquet_recordwriter.name = org.apache.parquet.hadoop.InternalParquetRecordWriter
 logger.parquet_recordwriter.additivity = false
 logger.parquet_recordwriter.level = off

--- a/sql/core/src/test/resources/log4j2.properties
+++ b/sql/core/src/test/resources/log4j2.properties
@@ -45,6 +45,10 @@ logger.parquet_recordreader.name = org.apache.parquet.hadoop.ParquetRecordReader
 logger.parquet_recordreader.additivity = false
 logger.parquet_recordreader.level = off
 
+logger.parquet_recordwriter.name = org.apache.parquet.hadoop.InternalParquetRecordWriter
+logger.parquet_recordwriter.additivity = false
+logger.parquet_recordwriter.level = off
+
 logger.parquet_outputcommitter.name = org.apache.parquet.hadoop.ParquetOutputCommitter
 logger.parquet_outputcommitter.additivity = false
 logger.parquet_outputcommitter.level = off

--- a/sql/hive-thriftserver/src/test/resources/log4j2.properties
+++ b/sql/hive-thriftserver/src/test/resources/log4j2.properties
@@ -61,6 +61,10 @@ logger.parquet_recordreader.name = org.apache.parquet.hadoop.ParquetRecordReader
 logger.parquet_recordreader.additivity = false
 logger.parquet_recordreader.level = off
 
+logger.parquet_recordwriter.name = org.apache.parquet.hadoop.InternalParquetRecordWriter
+logger.parquet_recordwriter.additivity = false
+logger.parquet_recordwriter.level = off
+
 logger.parquet_outputcommitter.name = org.apache.parquet.hadoop.ParquetOutputCommitter
 logger.parquet_outputcommitter.additivity = false
 logger.parquet_outputcommitter.level = off

--- a/sql/hive-thriftserver/src/test/resources/log4j2.properties
+++ b/sql/hive-thriftserver/src/test/resources/log4j2.properties
@@ -61,6 +61,7 @@ logger.parquet_recordreader.name = org.apache.parquet.hadoop.ParquetRecordReader
 logger.parquet_recordreader.additivity = false
 logger.parquet_recordreader.level = off
 
+# SPARK-44922: Disable o.a.p.h.InternalParquetRecordWriter logs for tests
 logger.parquet_recordwriter.name = org.apache.parquet.hadoop.InternalParquetRecordWriter
 logger.parquet_recordwriter.additivity = false
 logger.parquet_recordwriter.level = off

--- a/sql/hive/src/test/resources/log4j2.properties
+++ b/sql/hive/src/test/resources/log4j2.properties
@@ -45,6 +45,7 @@ logger.parquet_recordreader.name = org.apache.parquet.hadoop.ParquetRecordReader
 logger.parquet_recordreader.additivity = false
 logger.parquet_recordreader.level = off
 
+# SPARK-44922: Disable o.a.p.h.InternalParquetRecordWriter logs for tests
 logger.parquet_recordwriter.name = org.apache.parquet.hadoop.InternalParquetRecordWriter
 logger.parquet_recordwriter.additivity = false
 logger.parquet_recordwriter.level = off

--- a/sql/hive/src/test/resources/log4j2.properties
+++ b/sql/hive/src/test/resources/log4j2.properties
@@ -45,6 +45,10 @@ logger.parquet_recordreader.name = org.apache.parquet.hadoop.ParquetRecordReader
 logger.parquet_recordreader.additivity = false
 logger.parquet_recordreader.level = off
 
+logger.parquet_recordwriter.name = org.apache.parquet.hadoop.InternalParquetRecordWriter
+logger.parquet_recordwriter.additivity = false
+logger.parquet_recordwriter.level = off
+
 logger.parquet_outputcommitter.name = org.apache.parquet.hadoop.ParquetOutputCommitter
 logger.parquet_outputcommitter.additivity = false
 logger.parquet_outputcommitter.level = off


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR disable InternalParquetRecordWriter logs for SQL tests

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


The InternalParquetRecordWriter creates over 1,800 records, which equates to more than 80,000 lines of code. This accounts for 80% of the volume of the "slow tests" before the GitHub action truncates it.

#### A record for example
```
2023-08-22T13:38:14.5103112Z 13:38:14.406 WARN org.apache.parquet.hadoop.InternalParquetRecordWriter: Too much memory used: Store {
2023-08-22T13:38:14.5103259Z  [dummy_col] optional int32 dummy_col {
2023-08-22T13:38:14.5103352Z   r:0 bytes
2023-08-22T13:38:14.5103444Z   d:0 bytes
2023-08-22T13:38:14.5103580Z    data: FallbackValuesWriter{
2023-08-22T13:38:14.5103739Z    data: initial: DictionaryValuesWriter{
2023-08-22T13:38:14.5103854Z    data: initial: dict:8
2023-08-22T13:38:14.5103976Z    data: initial: values:400
2023-08-22T13:38:14.5104079Z    data: initial:}
2023-08-22T13:38:14.5104087Z 
2023-08-22T13:38:14.5104325Z    data: fallback: PLAIN CapacityByteArrayOutputStream 0 slabs, 0 bytes
2023-08-22T13:38:14.5104418Z    data:}
2023-08-22T13:38:14.5104426Z 
2023-08-22T13:38:14.5104695Z    pages: ColumnChunkPageWriter ConcatenatingByteArrayCollector 0 slabs, 0 bytes
2023-08-22T13:38:14.5104795Z    total: 400/408
2023-08-22T13:38:14.5104936Z  }
2023-08-22T13:38:14.5105129Z  [expected_rowIdx_col] optional int32 expected_rowIdx_col {
2023-08-22T13:38:14.5105291Z   r:0 bytes
2023-08-22T13:38:14.5105383Z   d:0 bytes
2023-08-22T13:38:14.5105518Z    data: FallbackValuesWriter{
2023-08-22T13:38:14.5105679Z    data: initial: DictionaryValuesWriter{
2023-08-22T13:38:14.5105797Z    data: initial: dict:400
2023-08-22T13:38:14.5105919Z    data: initial: values:400
2023-08-22T13:38:14.5106022Z    data: initial:}
2023-08-22T13:38:14.5106030Z 
2023-08-22T13:38:14.5106267Z    data: fallback: PLAIN CapacityByteArrayOutputStream 0 slabs, 0 bytes
2023-08-22T13:38:14.5106356Z    data:}
2023-08-22T13:38:14.5106364Z 
2023-08-22T13:38:14.5106636Z    pages: ColumnChunkPageWriter ConcatenatingByteArrayCollector 0 slabs, 0 bytes
2023-08-22T13:38:14.5106736Z    total: 400/800
2023-08-22T13:38:14.5106820Z  }
2023-08-22T13:38:14.5106942Z  [id] required int64 id {
2023-08-22T13:38:14.5107037Z   r:0 bytes
2023-08-22T13:38:14.5107133Z   d:0 bytes
2023-08-22T13:38:14.5107275Z    data: FallbackValuesWriter{
2023-08-22T13:38:14.5107436Z    data: initial: DictionaryValuesWriter{
2023-08-22T13:38:14.5107557Z    data: initial: dict:800
2023-08-22T13:38:14.5107677Z    data: initial: values:400
2023-08-22T13:38:14.5107779Z    data: initial:}
2023-08-22T13:38:14.5107787Z 
2023-08-22T13:38:14.5108022Z    data: fallback: PLAIN CapacityByteArrayOutputStream 0 slabs, 0 bytes
2023-08-22T13:38:14.5108113Z    data:}
2023-08-22T13:38:14.5108121Z 
2023-08-22T13:38:14.5108384Z    pages: ColumnChunkPageWriter ConcatenatingByteArrayCollector 0 slabs, 0 bytes
2023-08-22T13:38:14.5108485Z    total: 800/1,200
2023-08-22T13:38:14.5108570Z  }
2023-08-22T13:38:14.5108655Z }
2023-08-22T13:38:14.5108664Z 
```
### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

no

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

see log volume of SQL tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
no