### PR TITLE
[SPARK-44920][CORE] Use await() instead of awaitUninterruptibly() in TransportClientFactory.createClient()

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/client/TransportClientFactory.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/client/TransportClientFactory.java
@@ -279,7 +279,7 @@ public class TransportClientFactory implements Closeable {
     ChannelFuture cf = bootstrap.connect(address);
 
     if (connCreateTimeout <= 0) {
-      cf.awaitUninterruptibly();
+      cf.await();
       assert cf.isDone();
       if (cf.isCancelled()) {
         throw new IOException(String.format("Connecting to %s cancelled", address));


### PR DESCRIPTION
### What changes were proposed in this pull request?

https://github.com/apache/spark/pull/41785 / SPARK-44241 introduced a new `awaitUninterruptibly()` call in one branch of `TrasportClientFactory.createClient()` (executed when the connection create timeout is non-positive). This PR replaces that call with an interruptible `await()` call.

Note that the other pre-existing branches in this method were already using `await()`.

### Why are the changes needed?

Uninterruptible waiting can cause problems when cancelling tasks. For details, see https://github.com/apache/spark/pull/16866 / SPARK-19529, an older PR fixing a similar issue in this same `TransportClientFactory.createClient()` method.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests.

### Was this patch authored or co-authored using generative AI tooling?

No.
