### PR TITLE
[SPARK-44925][K8S] K8s default service token file should not be materialized into token

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/SparkKubernetesClientFactory.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/SparkKubernetesClientFactory.scala
@@ -48,13 +48,11 @@ private[spark] object SparkKubernetesClientFactory extends Logging {
       kubernetesAuthConfPrefix: String,
       clientType: ClientType.Value,
       sparkConf: SparkConf,
-      defaultServiceAccountToken: Option[File],
       defaultServiceAccountCaCert: Option[File]): KubernetesClient = {
     val oauthTokenFileConf = s"$kubernetesAuthConfPrefix.$OAUTH_TOKEN_FILE_CONF_SUFFIX"
     val oauthTokenConf = s"$kubernetesAuthConfPrefix.$OAUTH_TOKEN_CONF_SUFFIX"
     val oauthTokenFile = sparkConf.getOption(oauthTokenFileConf)
       .map(new File(_))
-      .orElse(defaultServiceAccountToken)
     val oauthTokenValue = sparkConf.getOption(oauthTokenConf)
     KubernetesUtils.requireNandDefined(
       oauthTokenFile,

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/K8sSubmitOps.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/K8sSubmitOps.scala
@@ -120,7 +120,6 @@ private[spark] class K8SSparkSubmitOperation extends SparkSubmitOperation
           KUBERNETES_AUTH_SUBMISSION_CONF_PREFIX,
           SparkKubernetesClientFactory.ClientType.Submission,
           sparkConf,
-          None,
           None)
         ) { kubernetesClient =>
           implicit val client: KubernetesClient = kubernetesClient

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientApplication.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientApplication.scala
@@ -247,7 +247,6 @@ private[spark] class KubernetesClientApplication extends SparkApplication {
       KUBERNETES_AUTH_SUBMISSION_CONF_PREFIX,
       SparkKubernetesClientFactory.ClientType.Submission,
       sparkConf,
-      None,
       None)) { kubernetesClient =>
         val client = new Client(
           kubernetesConf,

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterManager.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterManager.scala
@@ -70,23 +70,18 @@ private[spark] class KubernetesClusterManager extends ExternalClusterManager wit
     val wasSparkSubmittedInClusterMode = sc.conf.get(KUBERNETES_DRIVER_SUBMIT_CHECK)
     val (authConfPrefix,
       apiServerUri,
-      defaultServiceAccountToken,
       defaultServiceAccountCaCrt) = if (wasSparkSubmittedInClusterMode) {
       require(sc.conf.get(KUBERNETES_DRIVER_POD_NAME).isDefined,
         "If the application is deployed using spark-submit in cluster mode, the driver pod name " +
           "must be provided.")
-      val serviceAccountToken =
-        Some(new File(Config.KUBERNETES_SERVICE_ACCOUNT_TOKEN_PATH)).filter(_.exists)
       val serviceAccountCaCrt =
         Some(new File(Config.KUBERNETES_SERVICE_ACCOUNT_CA_CRT_PATH)).filter(_.exists)
       (KUBERNETES_AUTH_DRIVER_MOUNTED_CONF_PREFIX,
         sc.conf.get(KUBERNETES_DRIVER_MASTER_URL),
-        serviceAccountToken,
         serviceAccountCaCrt)
     } else {
       (KUBERNETES_AUTH_CLIENT_MODE_PREFIX,
         KubernetesUtils.parseMasterUrl(masterURL),
-        None,
         None)
     }
 
@@ -107,7 +102,6 @@ private[spark] class KubernetesClusterManager extends ExternalClusterManager wit
       authConfPrefix,
       SparkKubernetesClientFactory.ClientType.Driver,
       sc.conf,
-      defaultServiceAccountToken,
       defaultServiceAccountCaCrt)
 
     if (sc.conf.get(KUBERNETES_EXECUTOR_PODTEMPLATE_FILE).isDefined) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to stop materializing `OAuth token` from the default service token file, `/var/run/secrets/kubernetes.io/serviceaccount/token`, because the content of volumes varies which means being renewed or expired by K8s control plane. We need to read the content in a on-demand manner to be in the up-to-date status.

Note the followings:

- Since we use `autoConfigure` for K8s client, K8s client still uses the default service tokens if exists and needed.

https://github.com/apache/spark/blob/13588c10cbc380ecba1231223425eaad2eb9ec80/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/SparkKubernetesClientFactory.scala#L91

- This PR doesn't change Spark's behavior for the user-provided token file location. Spark will load the content of the user-provided token file locations to get `OAuth token` because Spark cannot assume that the files of that locations are refreshed or not in the future.

### Why are the changes needed?

[BoundServiceAccountTokenVolume](https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/#bound-service-account-token-volume) became `Stable` at K8s 1.22.

- [KEP-1205 Bound Service Account Tokens](https://github.com/kubernetes/enhancements/blob/master/keps/sig-auth/1205-bound-service-account-tokens/README.md#boundserviceaccounttokenvolume-1) : **BoundServiceAccountTokenVolume**

Alpha | Beta | GA
-- | -- | --
1.13 | 1.21 | 1.22

- [EKS Service Account with 90 Days Expiration](https://docs.aws.amazon.com/eks/latest/userguide/service-accounts.html)
  > For Amazon EKS clusters, the extended expiry period is 90 days. Your Amazon EKS cluster's Kubernetes API server rejects requests with tokens that are greater than 90 days old.

- As of today, [all supported EKS clusters are from 1.23 to 1.27](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html) which means we always use `BoundServiceAccountTokenVolume`.

### Does this PR introduce _any_ user-facing change?

No. This fixes only the bugs caused by some outdated tokens where K8s control plane denies Spark's K8s API invocation.

### How was this patch tested?

Pass the CIs with the all existing unit tests and integration tests.

### Was this patch authored or co-authored using generative AI tooling?

No.