### PR TITLE
[SPARK-44935][K8S] Fix `RELEASE` file to have the correct information in Docker images if exists

### DIFF
--- a/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile
+++ b/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile
@@ -42,6 +42,8 @@ RUN set -ex && \
     rm -rf /var/cache/apt/* && rm -rf /var/lib/apt/lists/*
 
 COPY jars /opt/spark/jars
+# Copy RELEASE file if exists
+COPY RELEAS[E] /opt/spark/RELEASE
 COPY bin /opt/spark/bin
 COPY sbin /opt/spark/sbin
 COPY kubernetes/dockerfiles/spark/entrypoint.sh /opt/


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `RELEASE` file to have the correct information in Docker images if `RELEASE` file exists.

Please note that `RELEASE` file doesn't exists in SPARK_HOME directory when we run the K8s integration test from Spark Git repository. So, we keep the following empty `RELEASE` file generation and use `COPY` conditionally via glob syntax.

https://github.com/apache/spark/blob/2a3aec1f9040e08999a2df88f92340cd2710e552/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile#L37

### Why are the changes needed?

Currently, it's an empty file in the official Apache Spark Docker images.

```
$ docker run -it --rm apache/spark:latest ls -al /opt/spark/RELEASE
-rw-r--r-- 1 spark spark 0 Jun 25 03:13 /opt/spark/RELEASE

$ docker run -it --rm apache/spark:v3.1.3 ls -al /opt/spark/RELEASE | tail -n1
-rw-r--r-- 1 root root 0 Feb 21  2022 /opt/spark/RELEASE
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manually build image and check it with `docker run -it --rm NEW_IMAGE ls -al /opt/spark/RELEASE`

I copied this `Dockerfile` into Apache Spark 3.5.0 RC2 binary distribution and tested in the following way.
```
$ cd spark-3.5.0-rc2-bin-hadoop3

$ cp /tmp/Dockerfile kubernetes/dockerfiles/spark/Dockerfile

$ bin/docker-image-tool.sh -t SPARK-44935 build

$ docker run -it --rm docker.io/library/spark:SPARK-44935 ls -al /opt/spark/RELEASE | tail -n1
-rw-r--r-- 1 root root 165 Aug 18 21:10 /opt/spark/RELEASE

$ docker run -it --rm docker.io/library/spark:SPARK-44935 cat /opt/spark/RELEASE | tail -n2
Spark 3.5.0 (git revision 010c4a6a05) built for Hadoop 3.3.4
Build flags: -B -Pmesos -Pyarn -Pkubernetes -Psparkr -Pscala-2.12 -Phadoop-3 -Phive -Phive-thriftserver
```
### Was this patch authored or co-authored using generative AI tooling?

No.