### PR TITLE
[SPARK-44728][PYTHON][DOCS]Add examples to approxQuantile docstring

### DIFF
--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -4825,10 +4825,10 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
             .. versionchanged:: 2.2.0
                Added support for multiple columns.
-        probabilities : list or tuple
+        probabilities : list or tuple of floats
             a list of quantile probabilities
-            Each number must belong to [0, 1].
-            For example 0 is the minimum, 0.5 is the median, 1 is the maximum.
+            Each number must be a float in the range [0, 1].
+            For example 0.0 is the minimum, 0.5 is the median, 1.0 is the maximum.
         relativeError : float
             The relative target precision to achieve
             (>= 0). If set to zero, the exact quantiles are computed, which
@@ -4852,28 +4852,36 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         For columns only containing null values, an empty list is returned.
 
         Examples
-        ________
+        --------
+        Example 1: Calculating quantiles for a single column
+
         >>> data = [(1,), (2,), (3,), (4,), (5,)]
         >>> df = spark.createDataFrame(data, ["values"])
-        >>> quantiles = df.approxQuantile("values", [0, 0.5, 1], 0.05)
+        >>> quantiles = df.approxQuantile("values", [0.0, 0.5, 1.0], 0.05)
         >>> quantiles
         [1.0, 3.0, 5.0]
 
+        Example 2: Calculating quantiles for multiple columns
+
         >>> data = [(1, 10), (2, 20), (3, 30), (4, 40), (5, 50)]
         >>> df = spark.createDataFrame(data, ["col1", "col2"])
-        >>> quantiles = df.approxQuantile(["col1", "col2"], [0, 0.5, 1], 0.05)
+        >>> quantiles = df.approxQuantile(["col1", "col2"], [0.0, 0.5, 1.0], 0.05)
         >>> quantiles
         [[1.0, 10.0], [3.0, 30.0], [5.0, 50.0]]
 
+        Example 3: Handling null values
+
         >>> data = [(1,), (None,), (3,), (4,), (None,)]
         >>> df = spark.createDataFrame(data, ["values"])
-        >>> quantiles = df.approxQuantile("values", [0, 0.5, 1], 0.05)
+        >>> quantiles = df.approxQuantile("values", [0.0, 0.5, 1.0], 0.05)
         >>> quantiles
-        [1.0, 3.0, None]
+        [1.0, 3.0, 4.0]
+
+        Example 4: Calculating quantiles with different target precision
 
         >>> data = [(1,), (2,), (3,), (4,), (5,)]
         >>> df = spark.createDataFrame(data, ["values"])
-        >>> quantiles = df.approxQuantile("values", [0, 0.5, 1], 0.2)
+        >>> quantiles = df.approxQuantile("values", [0.0, 0.5, 1.0], 0.2)
         >>> quantiles
         [1.0, 3.0, 5.0]  # (with a larger error bound)
         """

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -4850,6 +4850,32 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         -----
         Null values will be ignored in numerical columns before calculation.
         For columns only containing null values, an empty list is returned.
+
+        Examples
+        ________
+        >>> data = [(1,), (2,), (3,), (4,), (5,)]
+        >>> df = spark.createDataFrame(data, ["values"])
+        >>> quantiles = df.approxQuantile("values", [0, 0.5, 1], 0.05)
+        >>> quantiles
+        [1.0, 3.0, 5.0]
+
+        >>> data = [(1, 10), (2, 20), (3, 30), (4, 40), (5, 50)]
+        >>> df = spark.createDataFrame(data, ["col1", "col2"])
+        >>> quantiles = df.approxQuantile(["col1", "col2"], [0, 0.5, 1], 0.05)
+        >>> quantiles
+        [[1.0, 10.0], [3.0, 30.0], [5.0, 50.0]]
+
+        >>> data = [(1,), (None,), (3,), (4,), (None,)]
+        >>> df = spark.createDataFrame(data, ["values"])
+        >>> quantiles = df.approxQuantile("values", [0, 0.5, 1], 0.05)
+        >>> quantiles
+        [1.0, 3.0, None]
+
+        >>> data = [(1,), (2,), (3,), (4,), (5,)]
+        >>> df = spark.createDataFrame(data, ["values"])
+        >>> quantiles = df.approxQuantile("values", [0, 0.5, 1], 0.2)
+        >>> quantiles
+        [1.0, 3.0, 5.0]  # (with a larger error bound)
         """
 
         if not isinstance(col, (str, list, tuple)):

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -4867,7 +4867,7 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         >>> df = spark.createDataFrame(data, ["col1", "col2"])
         >>> quantiles = df.approxQuantile(["col1", "col2"], [0.0, 0.5, 1.0], 0.05)
         >>> quantiles
-        [[1.0, 10.0], [3.0, 30.0], [5.0, 50.0]]
+        [[1.0, 3.0, 5.0], [10.0, 30.0, 50.0]]
 
         Example 3: Handling null values
 
@@ -4881,9 +4881,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
         >>> data = [(1,), (2,), (3,), (4,), (5,)]
         >>> df = spark.createDataFrame(data, ["values"])
-        >>> quantiles = df.approxQuantile("values", [0.0, 0.5, 1.0], 0.2)
+        >>> quantiles = df.approxQuantile("values", [0.0, 0.2, 1.0], 0.1)
         >>> quantiles
-        [1.0, 3.0, 5.0]  # (with a larger error bound)
+        [1.0, 1.0, 5.0]
         """
 
         if not isinstance(col, (str, list, tuple)):

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -4877,7 +4877,7 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         >>> quantiles
         [1.0, 3.0, 4.0]
 
-        Example 4: Calculating quantiles with different target precision
+        Example 4: Calculating quantiles with low precision
 
         >>> data = [(1,), (2,), (3,), (4,), (5,)]
         >>> df = spark.createDataFrame(data, ["values"])


### PR DESCRIPTION

### What changes were proposed in this pull request?

Added examples to `DataFrame.approxQuantile`. Also updated the expected input description to reflect input types.

### Why are the changes needed?

To improve pyspark documentation

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

DocTest.

### Was this patch authored or co-authored using generative AI tooling?

No
