### PR TITLE
[SPARK-44938][SQL] Change default value of `spark.sql.maxSinglePartitionBytes` to 128m

### DIFF
--- a/docs/sql-migration-guide.md
+++ b/docs/sql-migration-guide.md
@@ -24,7 +24,7 @@ license: |
 
 ## Upgrading from Spark SQL 3.5 to 4.0
 
-- Since Spark 4.0, the default value of `spark.sql.maxSinglePartitionBytes` is changed from `Long.MaxValue` to `128m`. To restore the previous behavior, set `spark.sql.maxSinglePartitionBytes` to `9223372036854775807`(the value of `Long.MaxValue`).
+- Since Spark 4.0, the default value of `spark.sql.maxSinglePartitionBytes` is changed from `Long.MaxValue` to `128m`. To restore the previous behavior, set `spark.sql.maxSinglePartitionBytes` to `9223372036854775807`(`Long.MaxValue`).
 
 ## Upgrading from Spark SQL 3.4 to 3.5
 

--- a/docs/sql-migration-guide.md
+++ b/docs/sql-migration-guide.md
@@ -24,7 +24,7 @@ license: |
 
 ## Upgrading from Spark SQL 3.5 to 4.0
 
-- Since Spark 4.0, the default value of `spark.sql.maxSinglePartitionBytes` is changed from `Long.MaxValue` to `128m`.
+- Since Spark 4.0, the default value of `spark.sql.maxSinglePartitionBytes` is changed from `Long.MaxValue` to `128m`. To restore the previous behavior, set `spark.sql.maxSinglePartitionBytes` to `9223372036854775807`(the value of `Long.MaxValue`).
 
 ## Upgrading from Spark SQL 3.4 to 3.5
 

--- a/docs/sql-migration-guide.md
+++ b/docs/sql-migration-guide.md
@@ -30,6 +30,7 @@ license: |
 - Since Spark 3.5, the `plan` field is moved from `AnalysisException` to `EnhancedAnalysisException`.
 - Since Spark 3.5, `spark.sql.optimizer.canChangeCachedPlanOutputPartitioning` is enabled by default. To restore the previous behavior, set `spark.sql.optimizer.canChangeCachedPlanOutputPartitioning` to `false`.
 - Since Spark 3.5, the `array_insert` function is 1-based for negative indexes. It inserts new element at the end of input arrays for the index -1. To restore the previous behavior, set `spark.sql.legacy.negativeIndexInArrayInsert` to `true`.
+- Since Spark 3.5, the default value of `spark.sql.maxSinglePartitionBytes` is changed from `Long.MaxValue` to `128m`.
 
 ## Upgrading from Spark SQL 3.3 to 3.4
 

--- a/docs/sql-migration-guide.md
+++ b/docs/sql-migration-guide.md
@@ -22,6 +22,10 @@ license: |
 * Table of contents
 {:toc}
 
+## Upgrading from Spark SQL 3.5 to 4.0
+
+- Since Spark 4.0, the default value of `spark.sql.maxSinglePartitionBytes` is changed from `Long.MaxValue` to `128m`.
+
 ## Upgrading from Spark SQL 3.4 to 3.5
 
 - Since Spark 3.5, the JDBC options related to DS V2 pushdown are `true` by default. These options include: `pushDownAggregate`, `pushDownLimit`, `pushDownOffset` and `pushDownTableSample`. To restore the legacy behavior, please set them to `false`. e.g. set `spark.sql.catalog.your_catalog_name.pushDownAggregate` to `false`.
@@ -30,7 +34,6 @@ license: |
 - Since Spark 3.5, the `plan` field is moved from `AnalysisException` to `EnhancedAnalysisException`.
 - Since Spark 3.5, `spark.sql.optimizer.canChangeCachedPlanOutputPartitioning` is enabled by default. To restore the previous behavior, set `spark.sql.optimizer.canChangeCachedPlanOutputPartitioning` to `false`.
 - Since Spark 3.5, the `array_insert` function is 1-based for negative indexes. It inserts new element at the end of input arrays for the index -1. To restore the previous behavior, set `spark.sql.legacy.negativeIndexInArrayInsert` to `true`.
-- Since Spark 3.5, the default value of `spark.sql.maxSinglePartitionBytes` is changed from `Long.MaxValue` to `128m`.
 
 ## Upgrading from Spark SQL 3.3 to 3.4
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -556,7 +556,7 @@ object SQLConf {
       "will introduce shuffle to improve parallelism.")
     .version("3.4.0")
     .bytesConf(ByteUnit.BYTE)
-    .createWithDefault(Long.MaxValue)
+    .createWithDefaultString("128m")
 
   val RADIX_SORT_ENABLED = buildConf("spark.sql.sort.enableRadixSort")
     .internal()

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q44/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q44/explain.txt
@@ -1,45 +1,47 @@
 == Physical Plan ==
-TakeOrderedAndProject (41)
-+- * Project (40)
-   +- * BroadcastHashJoin Inner BuildRight (39)
-      :- * Project (37)
-      :  +- * BroadcastHashJoin Inner BuildRight (36)
-      :     :- * Project (31)
-      :     :  +- * SortMergeJoin Inner (30)
-      :     :     :- * Sort (17)
-      :     :     :  +- * Project (16)
-      :     :     :     +- * Filter (15)
-      :     :     :        +- Window (14)
-      :     :     :           +- WindowGroupLimit (13)
-      :     :     :              +- * Sort (12)
-      :     :     :                 +- Exchange (11)
-      :     :     :                    +- WindowGroupLimit (10)
-      :     :     :                       +- * Sort (9)
-      :     :     :                          +- * Filter (8)
-      :     :     :                             +- * HashAggregate (7)
-      :     :     :                                +- Exchange (6)
-      :     :     :                                   +- * HashAggregate (5)
-      :     :     :                                      +- * Project (4)
-      :     :     :                                         +- * Filter (3)
-      :     :     :                                            +- * ColumnarToRow (2)
-      :     :     :                                               +- Scan parquet spark_catalog.default.store_sales (1)
-      :     :     +- * Sort (29)
-      :     :        +- * Project (28)
-      :     :           +- * Filter (27)
-      :     :              +- Window (26)
-      :     :                 +- WindowGroupLimit (25)
-      :     :                    +- * Sort (24)
-      :     :                       +- Exchange (23)
-      :     :                          +- WindowGroupLimit (22)
-      :     :                             +- * Sort (21)
-      :     :                                +- * Filter (20)
-      :     :                                   +- * HashAggregate (19)
-      :     :                                      +- ReusedExchange (18)
-      :     +- BroadcastExchange (35)
-      :        +- * Filter (34)
-      :           +- * ColumnarToRow (33)
-      :              +- Scan parquet spark_catalog.default.item (32)
-      +- ReusedExchange (38)
+TakeOrderedAndProject (43)
++- * Project (42)
+   +- * BroadcastHashJoin Inner BuildRight (41)
+      :- * Project (39)
+      :  +- * BroadcastHashJoin Inner BuildRight (38)
+      :     :- * Project (33)
+      :     :  +- * SortMergeJoin Inner (32)
+      :     :     :- * Sort (18)
+      :     :     :  +- Exchange (17)
+      :     :     :     +- * Project (16)
+      :     :     :        +- * Filter (15)
+      :     :     :           +- Window (14)
+      :     :     :              +- WindowGroupLimit (13)
+      :     :     :                 +- * Sort (12)
+      :     :     :                    +- Exchange (11)
+      :     :     :                       +- WindowGroupLimit (10)
+      :     :     :                          +- * Sort (9)
+      :     :     :                             +- * Filter (8)
+      :     :     :                                +- * HashAggregate (7)
+      :     :     :                                   +- Exchange (6)
+      :     :     :                                      +- * HashAggregate (5)
+      :     :     :                                         +- * Project (4)
+      :     :     :                                            +- * Filter (3)
+      :     :     :                                               +- * ColumnarToRow (2)
+      :     :     :                                                  +- Scan parquet spark_catalog.default.store_sales (1)
+      :     :     +- * Sort (31)
+      :     :        +- Exchange (30)
+      :     :           +- * Project (29)
+      :     :              +- * Filter (28)
+      :     :                 +- Window (27)
+      :     :                    +- WindowGroupLimit (26)
+      :     :                       +- * Sort (25)
+      :     :                          +- Exchange (24)
+      :     :                             +- WindowGroupLimit (23)
+      :     :                                +- * Sort (22)
+      :     :                                   +- * Filter (21)
+      :     :                                      +- * HashAggregate (20)
+      :     :                                         +- ReusedExchange (19)
+      :     +- BroadcastExchange (37)
+      :        +- * Filter (36)
+      :           +- * ColumnarToRow (35)
+      :              +- Scan parquet spark_catalog.default.item (34)
+      +- ReusedExchange (40)
 
 
 (1) Scan parquet spark_catalog.default.store_sales
@@ -114,163 +116,171 @@ Condition : ((rnk#14 < 11) AND isnotnull(item_sk#10))
 Output [2]: [item_sk#10, rnk#14]
 Input [3]: [item_sk#10, rank_col#11, rnk#14]
 
-(17) Sort [codegen id : 4]
+(17) Exchange
+Input [2]: [item_sk#10, rnk#14]
+Arguments: hashpartitioning(rnk#14, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+
+(18) Sort [codegen id : 5]
 Input [2]: [item_sk#10, rnk#14]
 Arguments: [rnk#14 ASC NULLS FIRST], false, 0
 
-(18) ReusedExchange [Reuses operator id: 6]
+(19) ReusedExchange [Reuses operator id: 6]
 Output [3]: [ss_item_sk#15, sum#16, count#17]
 
-(19) HashAggregate [codegen id : 6]
+(20) HashAggregate [codegen id : 7]
 Input [3]: [ss_item_sk#15, sum#16, count#17]
 Keys [1]: [ss_item_sk#15]
 Functions [1]: [avg(UnscaledValue(ss_net_profit#18))]
 Aggregate Attributes [1]: [avg(UnscaledValue(ss_net_profit#18))#19]
 Results [2]: [ss_item_sk#15 AS item_sk#20, cast((avg(UnscaledValue(ss_net_profit#18))#19 / 100.0) as decimal(11,6)) AS rank_col#21]
 
-(20) Filter [codegen id : 6]
+(21) Filter [codegen id : 7]
 Input [2]: [item_sk#20, rank_col#21]
 Condition : (isnotnull(rank_col#21) AND (cast(rank_col#21 as decimal(13,7)) > (0.9 * ReusedSubquery Subquery scalar-subquery#12, [id=#13])))
 
-(21) Sort [codegen id : 6]
+(22) Sort [codegen id : 7]
 Input [2]: [item_sk#20, rank_col#21]
 Arguments: [rank_col#21 DESC NULLS LAST], false, 0
 
-(22) WindowGroupLimit
+(23) WindowGroupLimit
 Input [2]: [item_sk#20, rank_col#21]
 Arguments: [rank_col#21 DESC NULLS LAST], rank(rank_col#21), 10, Partial
 
-(23) Exchange
+(24) Exchange
 Input [2]: [item_sk#20, rank_col#21]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=3]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=4]
 
-(24) Sort [codegen id : 7]
+(25) Sort [codegen id : 8]
 Input [2]: [item_sk#20, rank_col#21]
 Arguments: [rank_col#21 DESC NULLS LAST], false, 0
 
-(25) WindowGroupLimit
+(26) WindowGroupLimit
 Input [2]: [item_sk#20, rank_col#21]
 Arguments: [rank_col#21 DESC NULLS LAST], rank(rank_col#21), 10, Final
 
-(26) Window
+(27) Window
 Input [2]: [item_sk#20, rank_col#21]
 Arguments: [rank(rank_col#21) windowspecdefinition(rank_col#21 DESC NULLS LAST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rnk#22], [rank_col#21 DESC NULLS LAST]
 
-(27) Filter [codegen id : 8]
+(28) Filter [codegen id : 9]
 Input [3]: [item_sk#20, rank_col#21, rnk#22]
 Condition : ((rnk#22 < 11) AND isnotnull(item_sk#20))
 
-(28) Project [codegen id : 8]
+(29) Project [codegen id : 9]
 Output [2]: [item_sk#20, rnk#22]
 Input [3]: [item_sk#20, rank_col#21, rnk#22]
 
-(29) Sort [codegen id : 8]
+(30) Exchange
+Input [2]: [item_sk#20, rnk#22]
+Arguments: hashpartitioning(rnk#22, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+
+(31) Sort [codegen id : 10]
 Input [2]: [item_sk#20, rnk#22]
 Arguments: [rnk#22 ASC NULLS FIRST], false, 0
 
-(30) SortMergeJoin [codegen id : 11]
+(32) SortMergeJoin [codegen id : 13]
 Left keys [1]: [rnk#14]
 Right keys [1]: [rnk#22]
 Join type: Inner
 Join condition: None
 
-(31) Project [codegen id : 11]
+(33) Project [codegen id : 13]
 Output [3]: [item_sk#10, rnk#14, item_sk#20]
 Input [4]: [item_sk#10, rnk#14, item_sk#20, rnk#22]
 
-(32) Scan parquet spark_catalog.default.item
+(34) Scan parquet spark_catalog.default.item
 Output [2]: [i_item_sk#23, i_product_name#24]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_product_name:string>
 
-(33) ColumnarToRow [codegen id : 9]
+(35) ColumnarToRow [codegen id : 11]
 Input [2]: [i_item_sk#23, i_product_name#24]
 
-(34) Filter [codegen id : 9]
+(36) Filter [codegen id : 11]
 Input [2]: [i_item_sk#23, i_product_name#24]
 Condition : isnotnull(i_item_sk#23)
 
-(35) BroadcastExchange
+(37) BroadcastExchange
 Input [2]: [i_item_sk#23, i_product_name#24]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=4]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=6]
 
-(36) BroadcastHashJoin [codegen id : 11]
+(38) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [item_sk#10]
 Right keys [1]: [i_item_sk#23]
 Join type: Inner
 Join condition: None
 
-(37) Project [codegen id : 11]
+(39) Project [codegen id : 13]
 Output [3]: [rnk#14, item_sk#20, i_product_name#24]
 Input [5]: [item_sk#10, rnk#14, item_sk#20, i_item_sk#23, i_product_name#24]
 
-(38) ReusedExchange [Reuses operator id: 35]
+(40) ReusedExchange [Reuses operator id: 37]
 Output [2]: [i_item_sk#25, i_product_name#26]
 
-(39) BroadcastHashJoin [codegen id : 11]
+(41) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [item_sk#20]
 Right keys [1]: [i_item_sk#25]
 Join type: Inner
 Join condition: None
 
-(40) Project [codegen id : 11]
+(42) Project [codegen id : 13]
 Output [3]: [rnk#14, i_product_name#24 AS best_performing#27, i_product_name#26 AS worst_performing#28]
 Input [5]: [rnk#14, item_sk#20, i_product_name#24, i_item_sk#25, i_product_name#26]
 
-(41) TakeOrderedAndProject
+(43) TakeOrderedAndProject
 Input [3]: [rnk#14, best_performing#27, worst_performing#28]
 Arguments: 100, [rnk#14 ASC NULLS FIRST], [rnk#14, best_performing#27, worst_performing#28]
 
 ===== Subqueries =====
 
 Subquery:1 Hosting operator id = 8 Hosting Expression = Subquery scalar-subquery#12, [id=#13]
-* HashAggregate (48)
-+- Exchange (47)
-   +- * HashAggregate (46)
-      +- * Project (45)
-         +- * Filter (44)
-            +- * ColumnarToRow (43)
-               +- Scan parquet spark_catalog.default.store_sales (42)
+* HashAggregate (50)
++- Exchange (49)
+   +- * HashAggregate (48)
+      +- * Project (47)
+         +- * Filter (46)
+            +- * ColumnarToRow (45)
+               +- Scan parquet spark_catalog.default.store_sales (44)
 
 
-(42) Scan parquet spark_catalog.default.store_sales
+(44) Scan parquet spark_catalog.default.store_sales
 Output [4]: [ss_addr_sk#29, ss_store_sk#30, ss_net_profit#31, ss_sold_date_sk#32]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store_sales]
 PushedFilters: [IsNotNull(ss_store_sk), EqualTo(ss_store_sk,4), IsNull(ss_addr_sk)]
 ReadSchema: struct<ss_addr_sk:int,ss_store_sk:int,ss_net_profit:decimal(7,2)>
 
-(43) ColumnarToRow [codegen id : 1]
+(45) ColumnarToRow [codegen id : 1]
 Input [4]: [ss_addr_sk#29, ss_store_sk#30, ss_net_profit#31, ss_sold_date_sk#32]
 
-(44) Filter [codegen id : 1]
+(46) Filter [codegen id : 1]
 Input [4]: [ss_addr_sk#29, ss_store_sk#30, ss_net_profit#31, ss_sold_date_sk#32]
 Condition : ((isnotnull(ss_store_sk#30) AND (ss_store_sk#30 = 4)) AND isnull(ss_addr_sk#29))
 
-(45) Project [codegen id : 1]
+(47) Project [codegen id : 1]
 Output [2]: [ss_store_sk#30, ss_net_profit#31]
 Input [4]: [ss_addr_sk#29, ss_store_sk#30, ss_net_profit#31, ss_sold_date_sk#32]
 
-(46) HashAggregate [codegen id : 1]
+(48) HashAggregate [codegen id : 1]
 Input [2]: [ss_store_sk#30, ss_net_profit#31]
 Keys [1]: [ss_store_sk#30]
 Functions [1]: [partial_avg(UnscaledValue(ss_net_profit#31))]
 Aggregate Attributes [2]: [sum#33, count#34]
 Results [3]: [ss_store_sk#30, sum#35, count#36]
 
-(47) Exchange
+(49) Exchange
 Input [3]: [ss_store_sk#30, sum#35, count#36]
-Arguments: hashpartitioning(ss_store_sk#30, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+Arguments: hashpartitioning(ss_store_sk#30, 5), ENSURE_REQUIREMENTS, [plan_id=7]
 
-(48) HashAggregate [codegen id : 2]
+(50) HashAggregate [codegen id : 2]
 Input [3]: [ss_store_sk#30, sum#35, count#36]
 Keys [1]: [ss_store_sk#30]
 Functions [1]: [avg(UnscaledValue(ss_net_profit#31))]
 Aggregate Attributes [1]: [avg(UnscaledValue(ss_net_profit#31))#37]
 Results [1]: [cast((avg(UnscaledValue(ss_net_profit#31))#37 / 100.0) as decimal(11,6)) AS rank_col#38]
 
-Subquery:2 Hosting operator id = 20 Hosting Expression = ReusedSubquery Subquery scalar-subquery#12, [id=#13]
+Subquery:2 Hosting operator id = 21 Hosting Expression = ReusedSubquery Subquery scalar-subquery#12, [id=#13]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q44/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q44/simplified.txt
@@ -1,5 +1,5 @@
 TakeOrderedAndProject [rnk,best_performing,worst_performing]
-  WholeStageCodegen (11)
+  WholeStageCodegen (13)
     Project [rnk,i_product_name,i_product_name]
       BroadcastHashJoin [item_sk,i_item_sk]
         Project [rnk,item_sk,i_product_name]
@@ -7,69 +7,75 @@ TakeOrderedAndProject [rnk,best_performing,worst_performing]
             Project [item_sk,rnk,item_sk]
               SortMergeJoin [rnk,rnk]
                 InputAdapter
-                  WholeStageCodegen (4)
+                  WholeStageCodegen (5)
                     Sort [rnk]
-                      Project [item_sk,rnk]
-                        Filter [rnk,item_sk]
-                          InputAdapter
-                            Window [rank_col]
-                              WindowGroupLimit [rank_col]
-                                WholeStageCodegen (3)
-                                  Sort [rank_col]
-                                    InputAdapter
-                                      Exchange #1
-                                        WindowGroupLimit [rank_col]
-                                          WholeStageCodegen (2)
-                                            Sort [rank_col]
-                                              Filter [rank_col]
-                                                Subquery #1
-                                                  WholeStageCodegen (2)
-                                                    HashAggregate [ss_store_sk,sum,count] [avg(UnscaledValue(ss_net_profit)),rank_col,sum,count]
-                                                      InputAdapter
-                                                        Exchange [ss_store_sk] #3
-                                                          WholeStageCodegen (1)
-                                                            HashAggregate [ss_store_sk,ss_net_profit] [sum,count,sum,count]
-                                                              Project [ss_store_sk,ss_net_profit]
-                                                                Filter [ss_store_sk,ss_addr_sk]
-                                                                  ColumnarToRow
-                                                                    InputAdapter
-                                                                      Scan parquet spark_catalog.default.store_sales [ss_addr_sk,ss_store_sk,ss_net_profit,ss_sold_date_sk]
-                                                HashAggregate [ss_item_sk,sum,count] [avg(UnscaledValue(ss_net_profit)),item_sk,rank_col,sum,count]
-                                                  InputAdapter
-                                                    Exchange [ss_item_sk] #2
-                                                      WholeStageCodegen (1)
-                                                        HashAggregate [ss_item_sk,ss_net_profit] [sum,count,sum,count]
-                                                          Project [ss_item_sk,ss_net_profit]
-                                                            Filter [ss_store_sk]
-                                                              ColumnarToRow
-                                                                InputAdapter
-                                                                  Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_store_sk,ss_net_profit,ss_sold_date_sk]
+                      InputAdapter
+                        Exchange [rnk] #1
+                          WholeStageCodegen (4)
+                            Project [item_sk,rnk]
+                              Filter [rnk,item_sk]
+                                InputAdapter
+                                  Window [rank_col]
+                                    WindowGroupLimit [rank_col]
+                                      WholeStageCodegen (3)
+                                        Sort [rank_col]
+                                          InputAdapter
+                                            Exchange #2
+                                              WindowGroupLimit [rank_col]
+                                                WholeStageCodegen (2)
+                                                  Sort [rank_col]
+                                                    Filter [rank_col]
+                                                      Subquery #1
+                                                        WholeStageCodegen (2)
+                                                          HashAggregate [ss_store_sk,sum,count] [avg(UnscaledValue(ss_net_profit)),rank_col,sum,count]
+                                                            InputAdapter
+                                                              Exchange [ss_store_sk] #4
+                                                                WholeStageCodegen (1)
+                                                                  HashAggregate [ss_store_sk,ss_net_profit] [sum,count,sum,count]
+                                                                    Project [ss_store_sk,ss_net_profit]
+                                                                      Filter [ss_store_sk,ss_addr_sk]
+                                                                        ColumnarToRow
+                                                                          InputAdapter
+                                                                            Scan parquet spark_catalog.default.store_sales [ss_addr_sk,ss_store_sk,ss_net_profit,ss_sold_date_sk]
+                                                      HashAggregate [ss_item_sk,sum,count] [avg(UnscaledValue(ss_net_profit)),item_sk,rank_col,sum,count]
+                                                        InputAdapter
+                                                          Exchange [ss_item_sk] #3
+                                                            WholeStageCodegen (1)
+                                                              HashAggregate [ss_item_sk,ss_net_profit] [sum,count,sum,count]
+                                                                Project [ss_item_sk,ss_net_profit]
+                                                                  Filter [ss_store_sk]
+                                                                    ColumnarToRow
+                                                                      InputAdapter
+                                                                        Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_store_sk,ss_net_profit,ss_sold_date_sk]
                 InputAdapter
-                  WholeStageCodegen (8)
+                  WholeStageCodegen (10)
                     Sort [rnk]
-                      Project [item_sk,rnk]
-                        Filter [rnk,item_sk]
-                          InputAdapter
-                            Window [rank_col]
-                              WindowGroupLimit [rank_col]
-                                WholeStageCodegen (7)
-                                  Sort [rank_col]
-                                    InputAdapter
-                                      Exchange #4
-                                        WindowGroupLimit [rank_col]
-                                          WholeStageCodegen (6)
-                                            Sort [rank_col]
-                                              Filter [rank_col]
-                                                ReusedSubquery [rank_col] #1
-                                                HashAggregate [ss_item_sk,sum,count] [avg(UnscaledValue(ss_net_profit)),item_sk,rank_col,sum,count]
-                                                  InputAdapter
-                                                    ReusedExchange [ss_item_sk,sum,count] #2
+                      InputAdapter
+                        Exchange [rnk] #5
+                          WholeStageCodegen (9)
+                            Project [item_sk,rnk]
+                              Filter [rnk,item_sk]
+                                InputAdapter
+                                  Window [rank_col]
+                                    WindowGroupLimit [rank_col]
+                                      WholeStageCodegen (8)
+                                        Sort [rank_col]
+                                          InputAdapter
+                                            Exchange #6
+                                              WindowGroupLimit [rank_col]
+                                                WholeStageCodegen (7)
+                                                  Sort [rank_col]
+                                                    Filter [rank_col]
+                                                      ReusedSubquery [rank_col] #1
+                                                      HashAggregate [ss_item_sk,sum,count] [avg(UnscaledValue(ss_net_profit)),item_sk,rank_col,sum,count]
+                                                        InputAdapter
+                                                          ReusedExchange [ss_item_sk,sum,count] #3
             InputAdapter
-              BroadcastExchange #5
-                WholeStageCodegen (9)
+              BroadcastExchange #7
+                WholeStageCodegen (11)
                   Filter [i_item_sk]
                     ColumnarToRow
                       InputAdapter
                         Scan parquet spark_catalog.default.item [i_item_sk,i_product_name]
         InputAdapter
-          ReusedExchange [i_item_sk,i_product_name] #5
+          ReusedExchange [i_item_sk,i_product_name] #7

--- a/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CachedTableSuite.scala
@@ -522,146 +522,152 @@ class CachedTableSuite extends QueryTest with SQLTestUtils
   }
 
   test("A cached table preserves the partitioning and ordering of its cached SparkPlan") {
-    val table3x = testData.union(testData).union(testData)
-    table3x.createOrReplaceTempView("testData3x")
+    // Set MAX_SINGLE_PARTITION_BYTES to Long.MaxValue to avoid inserting Exchange node
+    withSQLConf(SQLConf.MAX_SINGLE_PARTITION_BYTES.key -> Long.MaxValue.toString) {
+      val table3x = testData.union(testData).union(testData)
+      table3x.createOrReplaceTempView("testData3x")
 
-    sql("SELECT key, value FROM testData3x ORDER BY key").createOrReplaceTempView("orderedTable")
-    spark.catalog.cacheTable("orderedTable")
-    assertCached(spark.table("orderedTable"))
-    // Should not have an exchange as the query is already sorted on the group by key.
-    verifyNumExchanges(sql("SELECT key, count(*) FROM orderedTable GROUP BY key"), 0)
-    checkAnswer(
-      sql("SELECT key, count(*) FROM orderedTable GROUP BY key ORDER BY key"),
-      sql("SELECT key, count(*) FROM testData3x GROUP BY key ORDER BY key").collect())
-    uncacheTable("orderedTable")
-    spark.catalog.dropTempView("orderedTable")
+      sql("SELECT key, value FROM testData3x ORDER BY key").createOrReplaceTempView("orderedTable")
+      spark.catalog.cacheTable("orderedTable")
+      assertCached(spark.table("orderedTable"))
+      // Should not have an exchange as the query is already sorted on the group by key.
+      verifyNumExchanges(sql("SELECT key, count(*) FROM orderedTable GROUP BY key"), 0)
+      checkAnswer(
+        sql("SELECT key, count(*) FROM orderedTable GROUP BY key ORDER BY key"),
+        sql("SELECT key, count(*) FROM testData3x GROUP BY key ORDER BY key").collect())
+      uncacheTable("orderedTable")
+      spark.catalog.dropTempView("orderedTable")
 
-    // Set up two tables distributed in the same way. Try this with the data distributed into
-    // different number of partitions.
-    for (numPartitions <- 1 until 10 by 4) {
+      // Set up two tables distributed in the same way. Try this with the data distributed into
+      // different number of partitions.
+      for (numPartitions <- 1 until 10 by 4) {
+        withTempView("t1", "t2") {
+          testData.repartition(numPartitions, $"key").createOrReplaceTempView("t1")
+          testData2.repartition(numPartitions, $"a").createOrReplaceTempView("t2")
+          spark.catalog.cacheTable("t1")
+          spark.catalog.cacheTable("t2")
+
+          // Joining them should result in no exchanges.
+          verifyNumExchanges(sql("SELECT * FROM t1 t1 JOIN t2 t2 ON t1.key = t2.a"), 0)
+          checkAnswer(sql("SELECT * FROM t1 t1 JOIN t2 t2 ON t1.key = t2.a"),
+            sql("SELECT * FROM testData t1 JOIN testData2 t2 ON t1.key = t2.a"))
+
+          // Grouping on the partition key should result in no exchanges
+          verifyNumExchanges(sql("SELECT count(*) FROM t1 GROUP BY key"), 0)
+          checkAnswer(sql("SELECT count(*) FROM t1 GROUP BY key"),
+            sql("SELECT count(*) FROM testData GROUP BY key"))
+
+          uncacheTable("t1")
+          uncacheTable("t2")
+        }
+      }
+
+      // Distribute the tables into non-matching number of partitions. Need to shuffle one side.
       withTempView("t1", "t2") {
-        testData.repartition(numPartitions, $"key").createOrReplaceTempView("t1")
-        testData2.repartition(numPartitions, $"a").createOrReplaceTempView("t2")
+        testData.repartition(6, $"key").createOrReplaceTempView("t1")
+        testData2.repartition(3, $"a").createOrReplaceTempView("t2")
         spark.catalog.cacheTable("t1")
         spark.catalog.cacheTable("t2")
 
-        // Joining them should result in no exchanges.
-        verifyNumExchanges(sql("SELECT * FROM t1 t1 JOIN t2 t2 ON t1.key = t2.a"), 0)
-        checkAnswer(sql("SELECT * FROM t1 t1 JOIN t2 t2 ON t1.key = t2.a"),
-          sql("SELECT * FROM testData t1 JOIN testData2 t2 ON t1.key = t2.a"))
-
-        // Grouping on the partition key should result in no exchanges
-        verifyNumExchanges(sql("SELECT count(*) FROM t1 GROUP BY key"), 0)
-        checkAnswer(sql("SELECT count(*) FROM t1 GROUP BY key"),
-          sql("SELECT count(*) FROM testData GROUP BY key"))
-
+        val query = sql("SELECT key, value, a, b FROM t1 t1 JOIN t2 t2 ON t1.key = t2.a")
+        verifyNumExchanges(query, 1)
+        assert(
+          stripAQEPlan(query.queryExecution.executedPlan).outputPartitioning.numPartitions === 6)
+        checkAnswer(
+          query,
+          testData.join(testData2, $"key" === $"a").select($"key", $"value", $"a", $"b"))
         uncacheTable("t1")
         uncacheTable("t2")
       }
-    }
 
-    // Distribute the tables into non-matching number of partitions. Need to shuffle one side.
-    withTempView("t1", "t2") {
-      testData.repartition(6, $"key").createOrReplaceTempView("t1")
-      testData2.repartition(3, $"a").createOrReplaceTempView("t2")
-      spark.catalog.cacheTable("t1")
-      spark.catalog.cacheTable("t2")
+      // One side of join is not partitioned in the desired way. Need to shuffle one side.
+      withTempView("t1", "t2") {
+        testData.repartition(6, $"value").createOrReplaceTempView("t1")
+        testData2.repartition(6, $"a").createOrReplaceTempView("t2")
+        spark.catalog.cacheTable("t1")
+        spark.catalog.cacheTable("t2")
 
-      val query = sql("SELECT key, value, a, b FROM t1 t1 JOIN t2 t2 ON t1.key = t2.a")
-      verifyNumExchanges(query, 1)
-      assert(stripAQEPlan(query.queryExecution.executedPlan).outputPartitioning.numPartitions === 6)
-      checkAnswer(
-        query,
-        testData.join(testData2, $"key" === $"a").select($"key", $"value", $"a", $"b"))
-      uncacheTable("t1")
-      uncacheTable("t2")
-    }
+        val query = sql("SELECT key, value, a, b FROM t1 t1 JOIN t2 t2 ON t1.key = t2.a")
+        verifyNumExchanges(query, 1)
+        assert(
+          stripAQEPlan(query.queryExecution.executedPlan).outputPartitioning.numPartitions === 6)
+        checkAnswer(
+          query,
+          testData.join(testData2, $"key" === $"a").select($"key", $"value", $"a", $"b"))
+        uncacheTable("t1")
+        uncacheTable("t2")
+      }
 
-    // One side of join is not partitioned in the desired way. Need to shuffle one side.
-    withTempView("t1", "t2") {
-      testData.repartition(6, $"value").createOrReplaceTempView("t1")
-      testData2.repartition(6, $"a").createOrReplaceTempView("t2")
-      spark.catalog.cacheTable("t1")
-      spark.catalog.cacheTable("t2")
+      withTempView("t1", "t2") {
+        testData.repartition(6, $"value").createOrReplaceTempView("t1")
+        testData2.repartition(12, $"a").createOrReplaceTempView("t2")
+        spark.catalog.cacheTable("t1")
+        spark.catalog.cacheTable("t2")
 
-      val query = sql("SELECT key, value, a, b FROM t1 t1 JOIN t2 t2 ON t1.key = t2.a")
-      verifyNumExchanges(query, 1)
-      assert(stripAQEPlan(query.queryExecution.executedPlan).outputPartitioning.numPartitions === 6)
-      checkAnswer(
-        query,
-        testData.join(testData2, $"key" === $"a").select($"key", $"value", $"a", $"b"))
-      uncacheTable("t1")
-      uncacheTable("t2")
-    }
+        val query = sql("SELECT key, value, a, b FROM t1 t1 JOIN t2 t2 ON t1.key = t2.a")
+        verifyNumExchanges(query, 1)
+        assert(
+          stripAQEPlan(query.queryExecution.executedPlan).outputPartitioning.numPartitions === 12)
+        checkAnswer(
+          query,
+          testData.join(testData2, $"key" === $"a").select($"key", $"value", $"a", $"b"))
+        uncacheTable("t1")
+        uncacheTable("t2")
+      }
 
-    withTempView("t1", "t2") {
-      testData.repartition(6, $"value").createOrReplaceTempView("t1")
-      testData2.repartition(12, $"a").createOrReplaceTempView("t2")
-      spark.catalog.cacheTable("t1")
-      spark.catalog.cacheTable("t2")
+      // One side of join is not partitioned in the desired way. We'll only shuffle this side.
+      withTempView("t1", "t2") {
+        testData.repartition(6, $"value").createOrReplaceTempView("t1")
+        testData2.repartition(3, $"a").createOrReplaceTempView("t2")
+        spark.catalog.cacheTable("t1")
+        spark.catalog.cacheTable("t2")
 
-      val query = sql("SELECT key, value, a, b FROM t1 t1 JOIN t2 t2 ON t1.key = t2.a")
-      verifyNumExchanges(query, 1)
-      assert(stripAQEPlan(query.queryExecution.executedPlan).
-        outputPartitioning.numPartitions === 12)
-      checkAnswer(
-        query,
-        testData.join(testData2, $"key" === $"a").select($"key", $"value", $"a", $"b"))
-      uncacheTable("t1")
-      uncacheTable("t2")
-    }
+        val query = sql("SELECT key, value, a, b FROM t1 t1 JOIN t2 t2 ON t1.key = t2.a")
+        verifyNumExchanges(query, 1)
+        checkAnswer(
+          query,
+          testData.join(testData2, $"key" === $"a").select($"key", $"value", $"a", $"b"))
+        uncacheTable("t1")
+        uncacheTable("t2")
+      }
 
-    // One side of join is not partitioned in the desired way. We'll only shuffle this side.
-    withTempView("t1", "t2") {
-      testData.repartition(6, $"value").createOrReplaceTempView("t1")
-      testData2.repartition(3, $"a").createOrReplaceTempView("t2")
-      spark.catalog.cacheTable("t1")
-      spark.catalog.cacheTable("t2")
+      // repartition's column ordering is different from group by column ordering.
+      // But they use the same set of columns.
+      withTempView("t1") {
+        testData.repartition(6, $"value", $"key").createOrReplaceTempView("t1")
+        spark.catalog.cacheTable("t1")
 
-      val query = sql("SELECT key, value, a, b FROM t1 t1 JOIN t2 t2 ON t1.key = t2.a")
-      verifyNumExchanges(query, 1)
-      checkAnswer(
-        query,
-        testData.join(testData2, $"key" === $"a").select($"key", $"value", $"a", $"b"))
-      uncacheTable("t1")
-      uncacheTable("t2")
-    }
+        val query = sql("SELECT value, key from t1 group by key, value")
+        verifyNumExchanges(query, 0)
+        checkAnswer(
+          query,
+          testData.distinct().select($"value", $"key"))
+        uncacheTable("t1")
+      }
 
-    // repartition's column ordering is different from group by column ordering.
-    // But they use the same set of columns.
-    withTempView("t1") {
-      testData.repartition(6, $"value", $"key").createOrReplaceTempView("t1")
-      spark.catalog.cacheTable("t1")
+      // repartition's column ordering is different from join condition's column ordering.
+      // We will still shuffle because hashcodes of a row depend on the column ordering.
+      // If we do not shuffle, we may actually partition two tables in totally two different way.
+      // See PartitioningSuite for more details.
+      withTempView("t1", "t2") {
+        val df1 = testData
+        df1.repartition(6, $"value", $"key").createOrReplaceTempView("t1")
+        val df2 = testData2.select($"a", $"b".cast("string"))
+        df2.repartition(6, $"a", $"b").createOrReplaceTempView("t2")
+        spark.catalog.cacheTable("t1")
+        spark.catalog.cacheTable("t2")
 
-      val query = sql("SELECT value, key from t1 group by key, value")
-      verifyNumExchanges(query, 0)
-      checkAnswer(
-        query,
-        testData.distinct().select($"value", $"key"))
-      uncacheTable("t1")
-    }
-
-    // repartition's column ordering is different from join condition's column ordering.
-    // We will still shuffle because hashcodes of a row depend on the column ordering.
-    // If we do not shuffle, we may actually partition two tables in totally two different way.
-    // See PartitioningSuite for more details.
-    withTempView("t1", "t2") {
-      val df1 = testData
-      df1.repartition(6, $"value", $"key").createOrReplaceTempView("t1")
-      val df2 = testData2.select($"a", $"b".cast("string"))
-      df2.repartition(6, $"a", $"b").createOrReplaceTempView("t2")
-      spark.catalog.cacheTable("t1")
-      spark.catalog.cacheTable("t2")
-
-      val query =
-        sql("SELECT key, value, a, b FROM t1 t1 JOIN t2 t2 ON t1.key = t2.a and t1.value = t2.b")
-      verifyNumExchanges(query, 1)
-      assert(stripAQEPlan(query.queryExecution.executedPlan).outputPartitioning.numPartitions === 6)
-      checkAnswer(
-        query,
-        df1.join(df2, $"key" === $"a" && $"value" === $"b").select($"key", $"value", $"a", $"b"))
-      uncacheTable("t1")
-      uncacheTable("t2")
+        val query =
+          sql("SELECT key, value, a, b FROM t1 t1 JOIN t2 t2 ON t1.key = t2.a and t1.value = t2.b")
+        verifyNumExchanges(query, 1)
+        assert(
+          stripAQEPlan(query.queryExecution.executedPlan).outputPartitioning.numPartitions === 6)
+        checkAnswer(
+          query,
+          df1.join(df2, $"key" === $"a" && $"value" === $"b").select($"key", $"value", $"a", $"b"))
+        uncacheTable("t1")
+        uncacheTable("t2")
+      }
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Change default value of `spark.sql.maxSinglePartitionBytes` from `Long.maxValue` to `128m`

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
`spark.sql.maxSinglePartitionBytes` was introduced in SPARK-41986(https://github.com/apache/spark/pull/39512), and the default value was set to `Long. MaxValue` for the safety.

Recently, we hit the same issue described in the SPARK-41986, and setting it to `128m`(the original proposed default value) works fine in our internal cluster.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, the migration guide was updated correspondingly.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Pass GA.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.