### PR TITLE
[SPARK-43943][FOLLOWUP] Correct a function alias

### DIFF
--- a/python/pyspark/sql/connect/functions.py
+++ b/python/pyspark/sql/connect/functions.py
@@ -824,7 +824,7 @@ def signum(col: "ColumnOrName") -> Column:
 signum.__doc__ = pysparkfuncs.signum.__doc__
 
 
-sigh = signum
+sign = signum
 
 
 def sin(col: "ColumnOrName") -> Column:


### PR DESCRIPTION
### What changes were proposed in this pull request?
Correct a function alias


### Why are the changes needed?
it should be `sign`


### Does this PR introduce _any_ user-facing change?
actually no, since `pyspark.sql.connect.function` shares the same namespace with `pyspark.sql.function`

also manually check (before this PR)
```
Welcome to
      ____              __
     / __/__  ___ _____/ /__
    _\ \/ _ \/ _ `/ __/  '_/
   /__ / .__/\_,_/_/ /_/\_\   version 4.0.0.dev0
      /_/

Using Python version 3.10.11 (main, May 17 2023 14:30:36)
Client connected to the Spark Connect server at localhost
SparkSession available as 'spark'.

In [1]: from pyspark.sql import functions as sf

In [2]: sf.sign
Out[2]: <function pyspark.sql.functions.signum(col: 'ColumnOrName') -> pyspark.sql.column.Column>

In [3]: sf.sigh
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[3], line 1
----> 1 sf.sigh

AttributeError: module 'pyspark.sql.functions' has no attribute 'sigh'
```


### How was this patch tested?
CI


### Was this patch authored or co-authored using generative AI tooling?
NO