### PR TITLE
[SPARK-44939][R] Support Java 21 in SparkR SystemRequirements

### DIFF
--- a/R/pkg/DESCRIPTION
+++ b/R/pkg/DESCRIPTION
@@ -10,7 +10,7 @@ Authors@R:
 License: Apache License (== 2.0)
 URL: https://www.apache.org https://spark.apache.org
 BugReports: https://spark.apache.org/contributing.html
-SystemRequirements: Java (>= 8, < 18)
+SystemRequirements: Java (>= 8, < 22)
 Depends:
     R (>= 3.5),
     methods


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update `SystemRequirements` to support Java 21 in SparkR.

### Why are the changes needed?

To support Java 21 officially in SparkR. We've been running SparkR CI on master branch.
- https://github.com/apache/spark/actions/runs/5946839640/job/16128043220

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

On Java 21, do the following.
```
$ build/sbt test:package -Psparkr -Phive

$ R/install-dev.sh; R/run-tests.sh
...
Status: 2 NOTEs
See
  ‘/Users/dongjoon/APACHE/spark-merge/R/SparkR.Rcheck/00check.log’
for details.


+ popd
Tests passed.
```

### Was this patch authored or co-authored using generative AI tooling?

No.