### PR TITLE
[SPARK-44302][BUILD] Reenable PySpark test on the daily test of Java 21 after the new arrow version release

### DIFF
--- a/.github/workflows/build_java21.yml
+++ b/.github/workflows/build_java21.yml
@@ -42,7 +42,7 @@ jobs:
       jobs: >-
         {
           "build": "true",
-          "pyspark": "false",
+          "pyspark": "true",
           "sparkr": "true",
           "tpcds-1g": "true",
           "docker-integration-tests": "true"


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to re-enable PySpark in Java 21.
This depends on https://github.com/apache/spark/pull/42181 .

### Why are the changes needed?
To have Java 21 test coverage.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA.

### Was this patch authored or co-authored using generative AI tooling?
No.
