### PR TITLE
[SPARK-44820][DOCS] Switch languages consistently across docs for all code snippets

### DIFF
--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -65,11 +65,20 @@ function codeTabs() {
 
       tabBar.append(
         '<li class="nav-item"><button class="' +
-        active + 'nav-link tab_' + lang + '" data-bs-target="#' + id +
-        '" data-bs-toggle="tab">' + buttonLabel + '</button></li>'
+        active + 'nav-link tab_' + lang + '" data-bs-target="#' +
+        id + '" data-tab-lang="tab_' + lang + '" data-bs-toggle="tab">' +
+        buttonLabel + '</button></li>'
       );
     });
     counter++;
+  });
+  $("ul.nav-tabs button").click(function (e) {
+    // Toggling a tab should switch all tabs corresponding to the same language
+    // while retaining the scroll position
+    e.preventDefault();
+    var scrollOffset = $(this).offset().top - $(document).scrollTop();
+    $("." + $(this).attr('data-tab-lang')).tab('show');
+    $(document).scrollTop($(this).offset().top - scrollOffset);
   });
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to fix bug for `Switch languages consistently across docs for all code snippets`.

### Why are the changes needed?
When a user chooses a different language for a code snippet, all code snippets on that page should switch to the chosen language. This was the behavior for, for example, Spark 2.0 doc: https://spark.apache.org/docs/2.0.0/structured-streaming-programming-guide.html
But it was broken for later docs, for example the Spark 3.4.1 doc: https://spark.apache.org/docs/latest/quick-start.html
We should fix this behavior change and possibly add test cases to prevent future regressions.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Manually test:
```
cd docs
SKIP_API=1 bundle exec jekyll serve --watch
```

### Was this patch authored or co-authored using generative AI tooling?
No.