### PR TITLE
[SPARK-44958][PYTHON][CONNECT][TESTS] Add a test to validate the parity of functions

### DIFF
--- a/python/pyspark/sql/connect/functions.py
+++ b/python/pyspark/sql/connect/functions.py
@@ -744,6 +744,9 @@ def pow(col1: Union["ColumnOrName", float], col2: Union["ColumnOrName", float]) 
 pow.__doc__ = pysparkfuncs.pow.__doc__
 
 
+power = pow
+
+
 def radians(col: "ColumnOrName") -> Column:
     return _invoke_function_over_columns("radians", col)
 

--- a/python/pyspark/sql/tests/connect/test_connect_function.py
+++ b/python/pyspark/sql/tests/connect/test_connect_function.py
@@ -2380,7 +2380,9 @@ class SparkConnectFunctionTests(ReusedConnectTestCase, PandasOnSparkTestUtils, S
         }
 
         self.assertEqual(
-            sf_fn - cf_fn, sf_excluded_fn, "Missing functions in Spark Connect not as expected"
+            sf_fn - cf_fn,
+            sf_excluded_fn,
+            "Missing functions in Spark Connect not as expected",
         )
 
         # Functions in Spark Connect we do not expect to be available in vanilla PySpark
@@ -2389,7 +2391,9 @@ class SparkConnectFunctionTests(ReusedConnectTestCase, PandasOnSparkTestUtils, S
         }
 
         self.assertEqual(
-            cf_fn - sf_fn, cf_excluded_fn, "Missing functions in vanilla PySpark not as expected"
+            cf_fn - sf_fn,
+            cf_excluded_fn,
+            "Missing functions in vanilla PySpark not as expected",
         )
 
 

--- a/python/pyspark/sql/tests/connect/test_connect_function.py
+++ b/python/pyspark/sql/tests/connect/test_connect_function.py
@@ -16,6 +16,7 @@
 #
 import os
 import unittest
+from inspect import getmembers, isfunction
 
 from pyspark.errors import PySparkTypeError, PySparkValueError
 from pyspark.sql import SparkSession as PySparkSession
@@ -2362,6 +2363,34 @@ class SparkConnectFunctionTests(ReusedConnectTestCase, PandasOnSparkTestUtils, S
 
     def test_pandas_udf_import(self):
         self.assert_eq(getattr(CF, "pandas_udf"), getattr(SF, "pandas_udf"))
+
+    def test_function_parity(self):
+        # This test compares the available list of functions in pyspark.sql.functions with those
+        # available in the Spark Connect Python Client in pyspark.sql.connect.functions
+
+        sf_fn = {name for (name, value) in getmembers(SF, isfunction) if name[0] != "_"}
+
+        cf_fn = {name for (name, value) in getmembers(CF, isfunction) if name[0] != "_"}
+
+        # Functions in vanilla PySpark we do not expect to be available in Spark Connect
+        sf_excluded_fn = {
+            "get_active_spark_context",  # internal helper function
+            "try_remote_functions",  # internal helper function
+            "to_str",  # internal helper function
+        }
+
+        self.assertEqual(
+            sf_fn - cf_fn, sf_excluded_fn, "Missing functions in Spark Connect not as expected"
+        )
+
+        # Functions in Spark Connect we do not expect to be available in vanilla PySpark
+        cf_excluded_fn = {
+            "check_dependencies",  # internal helper function
+        }
+
+        self.assertEqual(
+            cf_fn - sf_fn, cf_excluded_fn, "Missing functions in vanilla PySpark not as expected"
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add a test to validate the parity of functions


### Why are the changes needed?
there is [a test](https://github.com/apache/spark/blob/206554f127903f5239b20a7fe1e6e226fcb822ea/python/pyspark/sql/tests/test_functions.py#L37) to compare the functions between PySpark and JVM side, but we don't have one to compare PySpark vs Spark Connect

### Does this PR introduce _any_ user-facing change?
no, test-only


### How was this patch tested?
added UT


### Was this patch authored or co-authored using generative AI tooling?
NO