### PR TITLE
[SPARK-42017][PYTHON][CONNECT][FOLLOWUP] Avoid double validation in `__getattr__ `

### DIFF
--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -54,7 +54,6 @@ from pyspark.sql.dataframe import (
 )
 
 from pyspark.errors import (
-    AnalysisException,
     PySparkTypeError,
     PySparkAttributeError,
     PySparkValueError,
@@ -1583,6 +1582,9 @@ class DataFrame:
         return None
 
     def __getattr__(self, name: str) -> "Column":
+        if self._plan is None:
+            raise SparkConnectException("Cannot analyze on empty plan.")
+
         if name in ["_jseq", "_jdf", "_jmap", "_jcols"]:
             raise PySparkAttributeError(
                 error_class="JVM_ATTRIBUTE_NOT_SUPPORTED", message_parameters={"attr_name": name}
@@ -1600,16 +1602,16 @@ class DataFrame:
                 message_parameters={"feature": f"{name}()"},
             )
 
-        try:
-            # let self[name] validate the column name
-            return self[name]
-        except AnalysisException as e:
-            if "UNRESOLVED_COLUMN" in e.message:
-                raise AttributeError(
-                    "'%s' object has no attribute '%s'" % (self.__class__.__name__, name)
-                )
-            else:
-                raise
+        if name not in self.columns:
+            raise AttributeError(
+                "'%s' object has no attribute '%s'" % (self.__class__.__name__, name)
+            )
+
+        alias = self._get_alias()
+        return _to_col_with_plan_id(
+            col=alias if alias is not None else name,
+            plan_id=self._plan._plan_id,
+        )
 
     __getattr__.__doc__ = PySparkDataFrame.__getattr__.__doc__
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Avoid double validation in `__getattr__ `


### Why are the changes needed?
after https://github.com/apache/spark/pull/42608, `df.col` will validate column name `col` twice:

- `if name not in self.columns` in `__getattr__ `
- `self.select(item).isLocal()` in `self[name]`

each one requires a RPC call, we should skip the second validation

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
CI


### Was this patch authored or co-authored using generative AI tooling?
No
