### PR TITLE
[SPARK-44960][UI] Unescape and consist error summary across UI pages

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/ui/SparkConnectServerPage.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/ui/SparkConnectServerPage.scala
@@ -23,8 +23,6 @@ import javax.servlet.http.HttpServletRequest
 
 import scala.xml.Node
 
-import org.apache.commons.text.StringEscapeUtils
-
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.connect.ui.ToolTips._
 import org.apache.spark.ui._
@@ -330,22 +328,8 @@ private[ui] class SqlStatsPagedTable(
       <td>
         {sqlStatsTableRow.sparkSessionTags.mkString(", ")}
       </td>
-      {errorMessageCell(Option(info.detail))}
+      {UIUtils.errorMessageCell(Option(info.detail).getOrElse(""))}
     </tr>
-  }
-
-  private def errorMessageCell(errorMessageOption: Option[String]): Seq[Node] = {
-    val errorMessage = errorMessageOption.getOrElse("")
-    val isMultiline = errorMessage.indexOf('\n') >= 0
-    val errorSummary = StringEscapeUtils.escapeHtml4(if (isMultiline) {
-      errorMessage.substring(0, errorMessage.indexOf('\n'))
-    } else {
-      errorMessage
-    })
-    val details = detailsUINode(isMultiline, errorMessage)
-    <td>
-      {errorSummary}{details}
-    </td>
   }
 
   private def jobURL(request: HttpServletRequest, jobId: String): String =

--- a/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
@@ -31,7 +31,6 @@ import scala.util.control.NonFatal
 import scala.xml._
 import scala.xml.transform.{RewriteRule, RuleTransformer}
 
-import org.apache.commons.text.StringEscapeUtils
 import org.glassfish.jersey.internal.util.collection.MultivaluedStringMap
 
 import org.apache.spark.internal.Logging
@@ -709,7 +708,7 @@ private[spark] object UIUtils extends Logging {
 
   private final val ERROR_CLASS_REGEX = """\[(?<errorClass>[A-Z][A-Z_.]+[A-Z])]""".r
 
-  private def errorSummary(errorMessage: String): (String, Boolean) = {
+  def errorSummary(errorMessage: String): (String, Boolean) = {
     var isMultiline = true
     val maybeErrorClass =
       ERROR_CLASS_REGEX.findFirstMatchIn(errorMessage).map(_.group("errorClass"))
@@ -724,8 +723,7 @@ private[spark] object UIUtils extends Logging {
       errorMessage
     }
 
-    val errorSummary = StringEscapeUtils.escapeHtml4(errorClassOrBrief)
-    (errorSummary, isMultiline)
+    (errorClassOrBrief, isMultiline)
   }
 
   def errorMessageCell(errorMessage: String): Seq[Node] = {

--- a/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
@@ -708,7 +708,7 @@ private[spark] object UIUtils extends Logging {
 
   private final val ERROR_CLASS_REGEX = """\[(?<errorClass>[A-Z][A-Z_.]+[A-Z])]""".r
 
-  def errorSummary(errorMessage: String): (String, Boolean) = {
+  private[spark] def errorSummary(errorMessage: String): (String, Boolean) = {
     var isMultiline = true
     val maybeErrorClass =
       ERROR_CLASS_REGEX.findFirstMatchIn(errorMessage).map(_.group("errorClass"))

--- a/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
@@ -708,7 +708,7 @@ private[spark] object UIUtils extends Logging {
 
   private final val ERROR_CLASS_REGEX = """\[(?<errorClass>[A-Z][A-Z_.]+[A-Z])]""".r
 
-  private[spark] def errorSummary(errorMessage: String): (String, Boolean) = {
+  def errorSummary(errorMessage: String): (String, Boolean) = {
     var isMultiline = true
     val maybeErrorClass =
       ERROR_CLASS_REGEX.findFirstMatchIn(errorMessage).map(_.group("errorClass"))

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/ui/StreamingQueryPage.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/ui/StreamingQueryPage.scala
@@ -176,6 +176,14 @@ private[ui] class StreamingQueryPagedTable(
       .format(SparkUIUtils.prependBaseUri(request, parent.basePath), parent.prefix,
         streamingQuery.summary.runId)
 
+    def details: Seq[Node] = {
+      if (isActive) {
+        Seq.empty[Node]
+      } else {
+        SparkUIUtils.errorMessageCell(streamingQuery.summary.exception.getOrElse("-"))
+      }
+    }
+
     <tr>
       <td>{UIUtils.getQueryName(streamingQuery)}</td>
       <td>{UIUtils.getQueryStatus(streamingQuery)}</td>
@@ -186,13 +194,7 @@ private[ui] class StreamingQueryPagedTable(
       <td>{withNoProgress(streamingQuery, {"%.2f".format(query.avgInput)}, "NaN")}</td>
       <td>{withNoProgress(streamingQuery, {"%.2f".format(query.avgProcess)}, "NaN")}</td>
       <td>{withNoProgress(streamingQuery, {streamingQuery.lastProgress.batchId}, "NaN")}</td>
-      {
-        if (isActive) {
-          Seq.empty[Node]
-        } else {
-          SparkUIUtils.errorMessageCell(streamingQuery.summary.exception.getOrElse("-"))
-        }
-      }
+      {details}
     </tr>
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/UISeleniumSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/UISeleniumSuite.scala
@@ -17,8 +17,11 @@
 
 package org.apache.spark.sql.execution.ui
 
+import scala.collection.JavaConverters._
 import scala.concurrent.duration.DurationInt
 
+import org.apache.commons.text.StringEscapeUtils.escapeJava
+import org.apache.commons.text.translate.EntityArrays._
 import org.openqa.selenium.htmlunit.HtmlUnitDriver
 import org.scalatest.concurrent.Eventually.eventually
 import org.scalatest.concurrent.Futures.{interval, timeout}
@@ -48,6 +51,13 @@ class UISeleniumSuite extends SparkFunSuite with WebBrowser {
     assert(webUrl.isDefined, "please turn on spark.ui.enabled")
     go to s"${webUrl.get}/SQL"
     findAll(cssSelector("""#failed-table td .stacktrace-details""")).map(_.text).toList
+  }
+
+  private def findErrorSummaryOnSQLUI(): String = {
+    val webUrl = spark.sparkContext.uiWebUrl
+    assert(webUrl.isDefined, "please turn on spark.ui.enabled")
+    go to s"${webUrl.get}/SQL"
+    findAll(cssSelector("""#failed-table td""")).map(_.text).toList.last
   }
 
   private def findExecutionIDOnSQLUI(): Int = {
@@ -101,6 +111,18 @@ class UISeleniumSuite extends SparkFunSuite with WebBrowser {
       assert(planDot.head.startsWith("digraph G {"))
       val planDetails = findAll(cssSelector("""#physical-plan-details""")).map(_.text).toList
       assert(planDetails.head.contains("TABLE_OR_VIEW_NOT_FOUND"))
+    }
+  }
+
+  test("Escape html is not necessary") {
+    spark = creatSparkSessionWithUI
+    val escape = (BASIC_ESCAPE.keySet().asScala.toSeq ++ ISO8859_1_ESCAPE.keySet().asScala ++
+      HTML40_EXTENDED_ESCAPE.keySet().asScala).mkString
+    val errorMsg = escapeJava(escape.mkString)
+    intercept[Exception](spark.sql(s"SELECT raise_error('$errorMsg')").collect())
+    eventually(timeout(10.seconds), interval(100.milliseconds)) {
+      val summary = findErrorSummaryOnSQLUI()
+      assert(!summary.contains("&amp;"))
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/UISeleniumSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/UISeleniumSuite.scala
@@ -114,7 +114,7 @@ class UISeleniumSuite extends SparkFunSuite with WebBrowser {
     }
   }
 
-  test("Escape html is not necessary") {
+  test("SPARK-44960: Escape html is not necessary for Spark UI") {
     spark = creatSparkSessionWithUI
     val escape = (BASIC_ESCAPE.keySet().asScala.toSeq ++ ISO8859_1_ESCAPE.keySet().asScala ++
       HTML40_EXTENDED_ESCAPE.keySet().asScala).mkString

--- a/streaming/src/main/scala/org/apache/spark/streaming/ui/UIUtils.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/ui/UIUtils.scala
@@ -21,8 +21,6 @@ import java.util.concurrent.TimeUnit
 
 import scala.xml.Node
 
-import org.apache.commons.text.StringEscapeUtils
-
 import org.apache.spark.ui.{ UIUtils => SparkUIUtils }
 
 private[streaming] object UIUtils {
@@ -96,14 +94,7 @@ private[streaming] object UIUtils {
       failureReason: String,
       rowspan: Int = 1,
       includeFirstLineInExpandDetails: Boolean = true): Seq[Node] = {
-    val isMultiline = failureReason.indexOf('\n') >= 0
-    // Display the first line by default
-    val failureReasonSummary = StringEscapeUtils.escapeHtml4(
-      if (isMultiline) {
-        failureReason.substring(0, failureReason.indexOf('\n'))
-      } else {
-        failureReason
-      })
+    val (failureReasonSummary, isMultiline) = SparkUIUtils.errorSummary(failureReason)
     val failureDetails =
       if (isMultiline && !includeFirstLineInExpandDetails) {
         // Skip the first line


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->


### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This pull request eliminates the unnecessary use of escape for error summary cells.

Previously, all the error details and some of the error summaries, such as the Task list on the stage page, did not call escapeHtml4. The rest of the error summaries, such as Job list, Stage list, Query list, etc., will do an extra escapeHtml4 that is unnecessary.



### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
UI improvement

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

UI changes

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

#### new tests
#### Local test

##### Before

![image](https://github.com/apache/spark/assets/8326978/f65e0713-087f-47a0-9cc9-321898ec6e6c)

##### After

![image](https://github.com/apache/spark/assets/8326978/e07c06f5-72ab-4465-b950-3e51350a3046)

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
no