### PR TITLE
[SPARK-44962][INFRA] Add Java 21 `Maven` build to `build_and_test.yml`

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -86,7 +86,7 @@ jobs:
           sparkr=`./dev/is-changed.py -m sparkr`
           tpcds=`./dev/is-changed.py -m sql`
           docker=`./dev/is-changed.py -m docker-integration-tests`
-          # 'build', 'scala-213', and 'java-11-17' are always true for now.
+          # 'build', 'scala-213', and 'java-other-versions' are always true for now.
           # It does not save significant time and most of PRs trigger the build.
           precondition="
             {
@@ -96,7 +96,7 @@ jobs:
               \"tpcds-1g\": \"$tpcds\",
               \"docker-integration-tests\": \"$docker\",
               \"scala-213\": \"true\",
-              \"java-11-17\": \"true\",
+              \"java-other-versions\": \"true\",
               \"lint\" : \"true\",
               \"k8s-integration-tests\" : \"true\",
               \"breaking-changes-buf\" : \"true\",
@@ -755,9 +755,9 @@ jobs:
         path: site.tar.bz2
         retention-days: 1
 
-  java-11-17:
+  java-other-versions:
     needs: precondition
-    if: fromJson(needs.precondition.outputs.required).java-11-17 == 'true'
+    if: fromJson(needs.precondition.outputs.required).java-other-versions == 'true'
     name: Java ${{ matrix.java }} build with Maven
     strategy:
       fail-fast: false
@@ -765,6 +765,7 @@ jobs:
         java:
           - 11
           - 17
+          - 21-ea
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout Spark repository


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add **Java 21 Maven** build to `build_and_test.yml` to `master` branch for Apache Spark 4.0.0.
- `java-11-17` is renamed to `java-other-versions`
- New Java version `21-ea` is added.

### Why are the changes needed?

Now, we have a daily **Java 21 SBT-based** GitHub Action job with full test coverage.
- https://github.com/apache/spark/actions/runs/5971697224/job/16201162347

This will do a **Java 21 Maven** build test in advance to prevent any compilation errors and Maven-specific issues.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

The PR builder has `Java 21`.

- https://github.com/dongjoon-hyun/spark/runs/16204552462

![Screenshot 2023-08-25 at 12 17 25 AM](https://github.com/apache/spark/assets/9700541/b2b06f51-26e8-4bcb-8a0a-d9e4bcb1c7a7)

### Was this patch authored or co-authored using generative AI tooling?

No.
