### PR TITLE
[SPARK-44963][PYTHON][ML][TESTS] Make PySpark (pyspark-ml module) tests passing without any optional dependency

### DIFF
--- a/python/pyspark/ml/functions.py
+++ b/python/pyspark/ml/functions.py
@@ -17,8 +17,16 @@
 from __future__ import annotations
 
 import inspect
-import numpy as np
 import uuid
+from typing import Any, Callable, Iterator, List, Mapping, TYPE_CHECKING, Tuple, Union, Optional
+
+import numpy as np
+
+try:
+    import pandas as pd
+except ImportError:
+    pass  # Let it throw a better error message later when the API is invoked.
+
 from pyspark import SparkContext
 from pyspark.sql.functions import pandas_udf
 from pyspark.sql.column import Column, _to_java_column
@@ -35,10 +43,8 @@ from pyspark.sql.types import (
     StructType,
 )
 from pyspark.ml.util import try_remote_functions
-from typing import Any, Callable, Iterator, List, Mapping, TYPE_CHECKING, Tuple, Union, Optional
 
 if TYPE_CHECKING:
-    import pandas as pd
     from pyspark.sql._typing import UserDefinedFunctionLike
 
 supported_scalar_types = (
@@ -160,8 +166,6 @@ def _batched(
     data: Union[pd.Series, pd.DataFrame, Tuple[pd.Series]], batch_size: int
 ) -> Iterator[pd.DataFrame]:
     """Generator that splits a pandas dataframe/series into batches."""
-    import pandas as pd
-
     if isinstance(data, pd.DataFrame):
         df = data
     elif isinstance(data, pd.Series):
@@ -177,8 +181,6 @@ def _batched(
 
 
 def _is_tensor_col(data: Union[pd.Series, pd.DataFrame]) -> bool:
-    import pandas as pd
-
     if isinstance(data, pd.Series):
         return data.dtype == np.object_ and isinstance(data.iloc[0], (np.ndarray, list))
     elif isinstance(data, pd.DataFrame):
@@ -193,8 +195,6 @@ def _is_tensor_col(data: Union[pd.Series, pd.DataFrame]) -> bool:
 
 def _has_tensor_cols(data: Union[pd.Series, pd.DataFrame, Tuple[pd.Series]]) -> bool:
     """Check if input Series/DataFrame/Tuple contains any tensor-valued columns."""
-    import pandas as pd
-
     if isinstance(data, (pd.Series, pd.DataFrame)):
         return _is_tensor_col(data)
     else:  # isinstance(data, Tuple):
@@ -276,8 +276,6 @@ def _validate_and_transform_prediction_result(
 ) -> pd.DataFrame | pd.Series:
     """Validate numpy-based model predictions against the expected pandas_udf return_type and
     transforms the predictions into an equivalent pandas DataFrame or Series."""
-    import pandas as pd
-
     if isinstance(return_type, StructType):
         struct_rtype: StructType = return_type
         fieldNames = struct_rtype.names
@@ -829,7 +827,6 @@ def _test() -> None:
     from pyspark.sql import SparkSession
     import pyspark.ml.functions
     import sys
-    import warnings
 
     from pyspark.sql.pandas.utils import (
         require_minimum_pandas_version,

--- a/python/pyspark/ml/tests/connect/test_connect_classification.py
+++ b/python/pyspark/ml/tests/connect/test_connect_classification.py
@@ -18,7 +18,7 @@
 
 import unittest
 from pyspark.sql import SparkSession
-from pyspark.ml.tests.connect.test_legacy_mode_classification import ClassificationTestsMixin
+from pyspark.testing.connectutils import should_test_connect, connect_requirement_message
 
 have_torch = True
 try:
@@ -26,8 +26,13 @@ try:
 except ImportError:
     have_torch = False
 
+if should_test_connect:
+    from pyspark.ml.tests.connect.test_legacy_mode_classification import ClassificationTestsMixin
 
-@unittest.skipIf(not have_torch, "torch is required")
+
+@unittest.skipIf(
+    not should_test_connect or not have_torch, connect_requirement_message or "torch is required"
+)
 class ClassificationTestsOnConnect(ClassificationTestsMixin, unittest.TestCase):
     def setUp(self) -> None:
         self.spark = (

--- a/python/pyspark/ml/tests/connect/test_connect_evaluation.py
+++ b/python/pyspark/ml/tests/connect/test_connect_evaluation.py
@@ -17,7 +17,7 @@
 
 import unittest
 from pyspark.sql import SparkSession
-from pyspark.ml.tests.connect.test_legacy_mode_evaluation import EvaluationTestsMixin
+from pyspark.testing.connectutils import should_test_connect, connect_requirement_message
 
 have_torcheval = True
 try:
@@ -25,8 +25,14 @@ try:
 except ImportError:
     have_torcheval = False
 
+if should_test_connect:
+    from pyspark.ml.tests.connect.test_legacy_mode_evaluation import EvaluationTestsMixin
 
-@unittest.skipIf(not have_torcheval, "torcheval is required")
+
+@unittest.skipIf(
+    not should_test_connect or not have_torcheval,
+    connect_requirement_message or "torcheval is required",
+)
 class EvaluationTestsOnConnect(EvaluationTestsMixin, unittest.TestCase):
     def setUp(self) -> None:
         self.spark = SparkSession.builder.remote("local[2]").getOrCreate()

--- a/python/pyspark/ml/tests/connect/test_connect_feature.py
+++ b/python/pyspark/ml/tests/connect/test_connect_feature.py
@@ -17,9 +17,13 @@
 
 import unittest
 from pyspark.sql import SparkSession
-from pyspark.ml.tests.connect.test_legacy_mode_feature import FeatureTestsMixin
+from pyspark.testing.connectutils import should_test_connect, connect_requirement_message
+
+if should_test_connect:
+    from pyspark.ml.tests.connect.test_legacy_mode_feature import FeatureTestsMixin
 
 
+@unittest.skipIf(not should_test_connect, connect_requirement_message)
 class FeatureTestsOnConnect(FeatureTestsMixin, unittest.TestCase):
     def setUp(self) -> None:
         self.spark = SparkSession.builder.remote("local[2]").getOrCreate()

--- a/python/pyspark/ml/tests/connect/test_connect_pipeline.py
+++ b/python/pyspark/ml/tests/connect/test_connect_pipeline.py
@@ -18,9 +18,13 @@
 
 import unittest
 from pyspark.sql import SparkSession
-from pyspark.ml.tests.connect.test_legacy_mode_pipeline import PipelineTestsMixin
+from pyspark.testing.connectutils import should_test_connect, connect_requirement_message
+
+if should_test_connect:
+    from pyspark.ml.tests.connect.test_legacy_mode_pipeline import PipelineTestsMixin
 
 
+@unittest.skipIf(not should_test_connect, connect_requirement_message)
 class PipelineTestsOnConnect(PipelineTestsMixin, unittest.TestCase):
     def setUp(self) -> None:
         self.spark = (

--- a/python/pyspark/ml/tests/connect/test_connect_summarizer.py
+++ b/python/pyspark/ml/tests/connect/test_connect_summarizer.py
@@ -17,9 +17,13 @@
 
 import unittest
 from pyspark.sql import SparkSession
-from pyspark.ml.tests.connect.test_legacy_mode_summarizer import SummarizerTestsMixin
+from pyspark.testing.connectutils import should_test_connect, connect_requirement_message
+
+if should_test_connect:
+    from pyspark.ml.tests.connect.test_legacy_mode_summarizer import SummarizerTestsMixin
 
 
+@unittest.skipIf(not should_test_connect, connect_requirement_message)
 class SummarizerTestsOnConnect(SummarizerTestsMixin, unittest.TestCase):
     def setUp(self) -> None:
         self.spark = SparkSession.builder.remote("local[2]").getOrCreate()

--- a/python/pyspark/ml/tests/connect/test_connect_tuning.py
+++ b/python/pyspark/ml/tests/connect/test_connect_tuning.py
@@ -18,9 +18,14 @@
 
 import unittest
 from pyspark.sql import SparkSession
-from pyspark.ml.tests.connect.test_legacy_mode_tuning import CrossValidatorTestsMixin
+
+from pyspark.testing.connectutils import should_test_connect, connect_requirement_message
+
+if should_test_connect:
+    from pyspark.ml.tests.connect.test_legacy_mode_tuning import CrossValidatorTestsMixin
 
 
+@unittest.skipIf(not should_test_connect, connect_requirement_message)
 class CrossValidatorTestsOnConnect(CrossValidatorTestsMixin, unittest.TestCase):
     def setUp(self) -> None:
         self.spark = (

--- a/python/pyspark/ml/tests/connect/test_legacy_mode_classification.py
+++ b/python/pyspark/ml/tests/connect/test_legacy_mode_classification.py
@@ -19,18 +19,20 @@ import os
 import tempfile
 import unittest
 import numpy as np
-from pyspark.ml.connect.classification import (
-    LogisticRegression as LORV2,
-    LogisticRegressionModel as LORV2Model,
-)
 from pyspark.sql import SparkSession
-
+from pyspark.testing.connectutils import should_test_connect, connect_requirement_message
 
 have_torch = True
 try:
     import torch  # noqa: F401
 except ImportError:
     have_torch = False
+
+if should_test_connect:
+    from pyspark.ml.connect.classification import (
+        LogisticRegression as LORV2,
+        LogisticRegressionModel as LORV2Model,
+    )
 
 
 class ClassificationTestsMixin:
@@ -218,6 +220,9 @@ class ClassificationTestsMixin:
             loaded_model.transform(eval_df1.toPandas())
 
 
+@unittest.skipIf(
+    not should_test_connect or not have_torch, connect_requirement_message or "No torch found"
+)
 class ClassificationTests(ClassificationTestsMixin, unittest.TestCase):
     def setUp(self) -> None:
         self.spark = SparkSession.builder.master("local[2]").getOrCreate()

--- a/python/pyspark/ml/tests/connect/test_legacy_mode_evaluation.py
+++ b/python/pyspark/ml/tests/connect/test_legacy_mode_evaluation.py
@@ -19,19 +19,21 @@ import unittest
 import numpy as np
 import tempfile
 
-from pyspark.ml.connect.evaluation import (
-    RegressionEvaluator,
-    BinaryClassificationEvaluator,
-    MulticlassClassificationEvaluator,
-)
 from pyspark.sql import SparkSession
-
+from pyspark.testing.connectutils import should_test_connect, connect_requirement_message
 
 have_torcheval = True
 try:
     import torcheval  # noqa: F401
 except ImportError:
     have_torcheval = False
+
+if should_test_connect:
+    from pyspark.ml.connect.evaluation import (
+        RegressionEvaluator,
+        BinaryClassificationEvaluator,
+        MulticlassClassificationEvaluator,
+    )
 
 
 class EvaluationTestsMixin:
@@ -173,7 +175,10 @@ class EvaluationTestsMixin:
             assert loaded_evaluator.getMetricName() == "accuracy"
 
 
-@unittest.skipIf(not have_torcheval, "torcheval is required")
+@unittest.skipIf(
+    not should_test_connect or not have_torcheval,
+    connect_requirement_message or "torcheval is required",
+)
 class EvaluationTests(EvaluationTestsMixin, unittest.TestCase):
     def setUp(self) -> None:
         self.spark = SparkSession.builder.master("local[2]").getOrCreate()

--- a/python/pyspark/ml/tests/connect/test_legacy_mode_feature.py
+++ b/python/pyspark/ml/tests/connect/test_legacy_mode_feature.py
@@ -22,13 +22,16 @@ import numpy as np
 import tempfile
 import unittest
 
-from pyspark.ml.connect.feature import (
-    MaxAbsScaler,
-    MaxAbsScalerModel,
-    StandardScaler,
-    StandardScalerModel,
-)
 from pyspark.sql import SparkSession
+from pyspark.testing.connectutils import should_test_connect, connect_requirement_message
+
+if should_test_connect:
+    from pyspark.ml.connect.feature import (
+        MaxAbsScaler,
+        MaxAbsScalerModel,
+        StandardScaler,
+        StandardScalerModel,
+    )
 
 
 class FeatureTestsMixin:
@@ -136,6 +139,7 @@ class FeatureTestsMixin:
                 np.testing.assert_allclose(sk_result, expected_result)
 
 
+@unittest.skipIf(not should_test_connect, connect_requirement_message)
 class FeatureTests(FeatureTestsMixin, unittest.TestCase):
     def setUp(self) -> None:
         self.spark = SparkSession.builder.master("local[2]").getOrCreate()

--- a/python/pyspark/ml/tests/connect/test_legacy_mode_pipeline.py
+++ b/python/pyspark/ml/tests/connect/test_legacy_mode_pipeline.py
@@ -19,17 +19,13 @@ import os
 import tempfile
 import unittest
 import numpy as np
-from pyspark.ml.connect.feature import StandardScaler
-from pyspark.ml.connect.classification import LogisticRegression as LORV2
-from pyspark.ml.connect.pipeline import Pipeline
 from pyspark.sql import SparkSession
+from pyspark.testing.connectutils import should_test_connect, connect_requirement_message
 
-
-have_torch = True
-try:
-    import torch  # noqa: F401
-except ImportError:
-    have_torch = False
+if should_test_connect:
+    from pyspark.ml.connect.feature import StandardScaler
+    from pyspark.ml.connect.classification import LogisticRegression as LORV2
+    from pyspark.ml.connect.pipeline import Pipeline
 
 
 class PipelineTestsMixin:
@@ -164,6 +160,7 @@ class PipelineTestsMixin:
         assert lorv2.getOrDefault(lorv2.maxIter) == 200
 
 
+@unittest.skipIf(not should_test_connect, connect_requirement_message)
 class PipelineTests(PipelineTestsMixin, unittest.TestCase):
     def setUp(self) -> None:
         self.spark = SparkSession.builder.master("local[2]").getOrCreate()

--- a/python/pyspark/ml/tests/connect/test_legacy_mode_summarizer.py
+++ b/python/pyspark/ml/tests/connect/test_legacy_mode_summarizer.py
@@ -19,8 +19,11 @@
 import unittest
 import numpy as np
 
-from pyspark.ml.connect.summarizer import summarize_dataframe
 from pyspark.sql import SparkSession
+from pyspark.testing.connectutils import should_test_connect, connect_requirement_message
+
+if should_test_connect:
+    from pyspark.ml.connect.summarizer import summarize_dataframe
 
 
 class SummarizerTestsMixin:
@@ -58,6 +61,7 @@ class SummarizerTestsMixin:
         assert_dict_allclose(result_local, expected_result)
 
 
+@unittest.skipIf(not should_test_connect, connect_requirement_message)
 class SummarizerTests(SummarizerTestsMixin, unittest.TestCase):
     def setUp(self) -> None:
         self.spark = SparkSession.builder.master("local[2]").getOrCreate()

--- a/python/pyspark/ml/tests/connect/test_legacy_mode_tuning.py
+++ b/python/pyspark/ml/tests/connect/test_legacy_mode_tuning.py
@@ -19,26 +19,27 @@
 import tempfile
 import unittest
 import numpy as np
-import pandas as pd
+
 from pyspark.ml.param import Param, Params
-from pyspark.ml.connect import Model, Estimator
-from pyspark.ml.connect.feature import StandardScaler
-from pyspark.ml.connect.classification import LogisticRegression as LORV2
-from pyspark.ml.connect.pipeline import Pipeline
-from pyspark.ml.connect.tuning import CrossValidator, CrossValidatorModel
-from pyspark.ml.connect.evaluation import BinaryClassificationEvaluator, RegressionEvaluator
 from pyspark.ml.tuning import ParamGridBuilder
 from pyspark.sql import SparkSession
 from pyspark.sql.functions import rand
+from pyspark.testing.connectutils import should_test_connect, connect_requirement_message
 
-from sklearn.datasets import load_breast_cancer
-
-
-have_torch = True
+have_sklearn = True
 try:
-    import torch  # noqa: F401
+    from sklearn.datasets import load_breast_cancer  # noqa: F401
 except ImportError:
-    have_torch = False
+    have_sklearn = False
+
+if should_test_connect:
+    import pandas as pd
+    from pyspark.ml.connect import Model, Estimator
+    from pyspark.ml.connect.feature import StandardScaler
+    from pyspark.ml.connect.classification import LogisticRegression as LORV2
+    from pyspark.ml.connect.pipeline import Pipeline
+    from pyspark.ml.connect.tuning import CrossValidator, CrossValidatorModel
+    from pyspark.ml.connect.evaluation import BinaryClassificationEvaluator, RegressionEvaluator
 
 
 class HasInducedError(Params):
@@ -272,6 +273,9 @@ class CrossValidatorTestsMixin:
         cv.fit(train_dataset)
 
 
+@unittest.skipIf(
+    not should_test_connect or not have_sklearn, connect_requirement_message or "No sklearn found"
+)
 class CrossValidatorTests(CrossValidatorTestsMixin, unittest.TestCase):
     def setUp(self) -> None:
         self.spark = SparkSession.builder.master("local[2]").getOrCreate()

--- a/python/pyspark/ml/tests/connect/test_parity_torch_data_loader.py
+++ b/python/pyspark/ml/tests/connect/test_parity_torch_data_loader.py
@@ -18,16 +18,9 @@
 import unittest
 from pyspark.sql import SparkSession
 
-have_torch = True
-try:
-    import torch  # noqa: F401
-except ImportError:
-    have_torch = False
-
 from pyspark.ml.torch.tests.test_data_loader import TorchDistributorDataLoaderUnitTests
 
 
-@unittest.skipIf(not have_torch, "torch is required")
 class TorchDistributorBaselineUnitTestsOnConnect(TorchDistributorDataLoaderUnitTests):
     def setUp(self) -> None:
         self.spark = (

--- a/python/pyspark/ml/tests/connect/test_parity_torch_data_loader.py
+++ b/python/pyspark/ml/tests/connect/test_parity_torch_data_loader.py
@@ -20,7 +20,14 @@ from pyspark.sql import SparkSession
 
 from pyspark.ml.torch.tests.test_data_loader import TorchDistributorDataLoaderUnitTests
 
+have_torch = True
+try:
+    import torch  # noqa: F401
+except ImportError:
+    have_torch = False
 
+
+@unittest.skipIf(not have_torch, "torch is required")
 class TorchDistributorBaselineUnitTestsOnConnect(TorchDistributorDataLoaderUnitTests):
     def setUp(self) -> None:
         self.spark = (

--- a/python/pyspark/ml/tests/connect/test_parity_torch_distributor.py
+++ b/python/pyspark/ml/tests/connect/test_parity_torch_distributor.py
@@ -135,6 +135,7 @@ class TorchDistributorDistributedUnitTestsOnConnect(
         cls.spark.stop()
 
 
+@unittest.skipIf(not have_torch, "torch is required")
 class TorchWrapperUnitTestsOnConnect(TorchWrapperUnitTestsMixin, unittest.TestCase):
     pass
 

--- a/python/pyspark/ml/tests/connect/test_parity_torch_distributor.py
+++ b/python/pyspark/ml/tests/connect/test_parity_torch_distributor.py
@@ -135,7 +135,6 @@ class TorchDistributorDistributedUnitTestsOnConnect(
         cls.spark.stop()
 
 
-@unittest.skipIf(not have_torch, "torch is required")
 class TorchWrapperUnitTestsOnConnect(TorchWrapperUnitTestsMixin, unittest.TestCase):
     pass
 

--- a/python/pyspark/ml/tests/test_functions.py
+++ b/python/pyspark/ml/tests/test_functions.py
@@ -28,9 +28,6 @@ from pyspark.testing.sqlutils import (
     pyarrow_requirement_message,
 )
 
-if have_pandas:
-    import pandas as pd
-
 
 @unittest.skipIf(
     not have_pandas or not have_pyarrow,
@@ -38,6 +35,8 @@ if have_pandas:
 )
 class PredictBatchUDFTests(SparkSessionTestCase):
     def setUp(self):
+        import pandas as pd
+
         super(PredictBatchUDFTests, self).setUp()
         self.data = np.arange(0, 1000, dtype=np.float64).reshape(-1, 4)
 

--- a/python/pyspark/ml/tests/test_functions.py
+++ b/python/pyspark/ml/tests/test_functions.py
@@ -15,15 +15,27 @@
 # limitations under the License.
 #
 import numpy as np
-import pandas as pd
 import unittest
 
 from pyspark.ml.functions import predict_batch_udf
 from pyspark.sql.functions import array, struct, col
 from pyspark.sql.types import ArrayType, DoubleType, IntegerType, StructType, StructField, FloatType
 from pyspark.testing.mlutils import SparkSessionTestCase
+from pyspark.testing.sqlutils import (
+    have_pandas,
+    have_pyarrow,
+    pandas_requirement_message,
+    pyarrow_requirement_message,
+)
+
+if have_pandas:
+    import pandas as pd
 
 
+@unittest.skipIf(
+    not have_pandas or not have_pyarrow,
+    pandas_requirement_message or pyarrow_requirement_message,
+)
 class PredictBatchUDFTests(SparkSessionTestCase):
     def setUp(self):
         super(PredictBatchUDFTests, self).setUp()

--- a/python/pyspark/ml/torch/tests/test_distributor.py
+++ b/python/pyspark/ml/torch/tests/test_distributor.py
@@ -18,7 +18,7 @@
 import contextlib
 import os
 import shutil
-from six import StringIO
+from io import StringIO
 import stat
 import subprocess
 import sys

--- a/python/pyspark/ml/torch/tests/test_log_communication.py
+++ b/python/pyspark/ml/torch/tests/test_log_communication.py
@@ -18,7 +18,7 @@
 from __future__ import absolute_import, division, print_function
 
 import contextlib
-from six import StringIO
+from io import StringIO
 import sys
 import time
 from typing import Any, Callable


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to fix the tests to properly run or skip when there aren't optional dependencies installed.

### Why are the changes needed?

Currently, it fails as below:

```
./python/run-tests --python-executables=python3 --modules=pyspark-ml
...
Starting test(python3): pyspark.ml.tests.test_model_cache (temp output: /Users/hyukjin.kwon/workspace/forked/spark/python/target/f6f88c1e-0cb2-43e6-980e-47f1cdb9b463/python3__pyspark.ml.tests.test_model_cache__zij05l1u.log)
Traceback (most recent call last):
  File "/Users/hyukjin.kwon/miniconda3/envs/vanilla-3.10/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/Users/hyukjin.kwon/miniconda3/envs/vanilla-3.10/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/Users/hyukjin.kwon/workspace/forked/spark/python/pyspark/ml/tests/test_functions.py", line 18, in <module>
    import pandas as pd
ModuleNotFoundError: No module named 'pandas'
```

PySpark tests should pass without optional dependencies.


### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Manually ran as described above.

### Was this patch authored or co-authored using generative AI tooling?

No.