### PR TITLE
[SPARK-44840][SQL][FOLLOWUP] Change the version from 3.5.0 to 3.4.2 for `spark.sql.legacy.negativeIndexInArrayInsert`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4396,7 +4396,7 @@ object SQLConf {
         "for the index -1. For example, `array_insert(['a', 'b'], -1, 'x')` returns " +
         "`['a', 'x', 'b']`. When set to false, the -1 index points out to the last element, " +
         "and the given example produces `['a', 'b', 'x']`.")
-      .version("3.5.0")
+      .version("3.4.2")
       .booleanConf
       .createWithDefault(false)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
After the PR https://github.com/apache/spark/pull/42655, the earliest version when the SQL config `spark.sql.legacy.negativeIndexInArrayInsert` appears is `3.4.2`. This PR update configs version according to the recent changes.

### Why are the changes needed?
To don't confuse users. The doc should contain actual info with the earliest version.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By CI.

### Was this patch authored or co-authored using generative AI tooling?
No.