### PR TITLE
[SPARK-44967][SQL][CONNECT] Unit should be considered first before using Boolean for TreeNodeTag

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -1391,8 +1391,8 @@ class SparkConnectPlanner(val sessionHolder: SessionHolder) extends Logging {
     if (attr.hasPlanId) {
       expr.setTagValue(LogicalPlan.PLAN_ID_TAG, attr.getPlanId)
     }
-    if (attr.hasIsMetadataColumn) {
-      expr.setTagValue(LogicalPlan.IS_METADATA_COL, attr.getIsMetadataColumn)
+    if (attr.hasIsMetadataColumn && attr.getIsMetadataColumn) {
+      expr.setTagValue(LogicalPlan.IS_METADATA_COL, ())
     }
     expr
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ColumnResolutionHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ColumnResolutionHelper.scala
@@ -511,7 +511,7 @@ trait ColumnResolutionHelper extends Logging {
     }
     val plan = planOpt.get
 
-    val isMetadataAccess = u.getTagValue(LogicalPlan.IS_METADATA_COL).contains(true)
+    val isMetadataAccess = u.getTagValue(LogicalPlan.IS_METADATA_COL).isDefined
     try {
       if (!isMetadataAccess) {
         plan.resolve(u.nameParts, conf.resolver)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala
@@ -134,7 +134,7 @@ package object dsl {
         expr
       } else {
         val cast = Cast(expr, to)
-        cast.setTagValue(Cast.USER_SPECIFIED_CAST, true)
+        cast.setTagValue(Cast.USER_SPECIFIED_CAST, ())
         cast
       }
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -181,7 +181,7 @@ object Cast extends QueryErrorsBase {
   /**
    * A tag to decide if a CAST is specified by user.
    */
-  val USER_SPECIFIED_CAST = new TreeNodeTag[Boolean]("user_specified_cast")
+  val USER_SPECIFIED_CAST = new TreeNodeTag[Unit]("user_specified_cast")
 
   /**
    * Returns true iff we can cast `from` type to `to` type.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -2118,12 +2118,12 @@ class AstBuilder extends DataTypeAstBuilder with SQLConfHelper with Logging {
     ctx.name.getType match {
       case SqlBaseParser.CAST =>
         val cast = Cast(expression(ctx.expression), dataType)
-        cast.setTagValue(Cast.USER_SPECIFIED_CAST, true)
+        cast.setTagValue(Cast.USER_SPECIFIED_CAST, ())
         cast
 
       case SqlBaseParser.TRY_CAST =>
         val cast = Cast(expression(ctx.expression), dataType, evalMode = EvalMode.TRY)
-        cast.setTagValue(Cast.USER_SPECIFIED_CAST, true)
+        cast.setTagValue(Cast.USER_SPECIFIED_CAST, ())
         cast
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlan.scala
@@ -196,7 +196,7 @@ object LogicalPlan {
   //    3, resolve this expression with the matching node. If any error occurs, analyzer fallbacks
   //    to the old code path.
   private[spark] val PLAN_ID_TAG = TreeNodeTag[Long]("plan_id")
-  private[spark] val IS_METADATA_COL = TreeNodeTag[Boolean]("is_metadata_col")
+  private[spark] val IS_METADATA_COL = TreeNodeTag[Unit]("is_metadata_col")
 }
 
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -53,7 +53,7 @@ import org.apache.spark.util.collection.BitSet
 private class MutableInt(var i: Int)
 
 // A tag of a `TreeNode`, which defines name and type
-// Note: In general, developers only care about its tagging capabilities,
+// Note: In general, if developers only care about its tagging capabilities,
 // so Unit should be considered first before using Boolean.
 case class TreeNodeTag[T](name: String)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -54,7 +54,7 @@ private class MutableInt(var i: Int)
 
 // A tag of a `TreeNode`, which defines name and type
 // Note: In general, if developers only care about its tagging capabilities,
-// so Unit should be considered first before using Boolean.
+// then Unit should be considered first before using Boolean.
 case class TreeNodeTag[T](name: String)
 
 // A functor that always returns true.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -53,6 +53,8 @@ import org.apache.spark.util.collection.BitSet
 private class MutableInt(var i: Int)
 
 // A tag of a `TreeNode`, which defines name and type
+// Note: In general, developers only care about its tagging capabilities,
+// so Unit should be considered first before using Boolean.
 case class TreeNodeTag[T](name: String)
 
 // A functor that always returns true.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/package.scala
@@ -104,7 +104,7 @@ package object util extends Logging {
       PrettyAttribute(usePrettyExpression(e.child) + "." + e.field.name, e.dataType)
     case r: InheritAnalysisRules =>
       PrettyAttribute(r.makeSQLString(r.parameters.map(toPrettySQL)), r.dataType)
-    case c: Cast if !c.getTagValue(Cast.USER_SPECIFIED_CAST).getOrElse(false) =>
+    case c: Cast if c.getTagValue(Cast.USER_SPECIFIED_CAST).isEmpty =>
       PrettyAttribute(usePrettyExpression(c.child).sql, c.dataType)
     case p: PythonFuncExpression => PrettyPythonUDF(p.name, p.dataType, p.children)
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/Column.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Column.scala
@@ -1171,7 +1171,7 @@ class Column(val expr: Expression) extends Logging {
    */
   def cast(to: DataType): Column = withExpr {
     val cast = Cast(expr, CharVarcharUtils.replaceCharVarcharWithStringForCast(to))
-    cast.setTagValue(Cast.USER_SPECIFIED_CAST, true)
+    cast.setTagValue(Cast.USER_SPECIFIED_CAST, ())
     cast
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileMetadataStructSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileMetadataStructSuite.scala
@@ -1035,10 +1035,10 @@ class FileMetadataStructSuite extends QueryTest with SharedSparkSession {
       spark.range(end = 10).write.format("parquet").save(path.toString)
 
       // Add the tag to the base Dataframe before selecting a metadata column.
-      val customTag = TreeNodeTag[Boolean]("customTag")
+      val customTag = TreeNodeTag[Unit]("customTag")
       val baseDf = spark.read.format("parquet").load(path.toString)
       val tagsPut = baseDf.queryExecution.analyzed.collect {
-        case rel: LogicalRelation => rel.setTagValue(customTag, true)
+        case rel: LogicalRelation => rel.setTagValue(customTag, ())
       }
 
       assert(tagsPut.nonEmpty)
@@ -1047,7 +1047,7 @@ class FileMetadataStructSuite extends QueryTest with SharedSparkSession {
 
       // Expect the tag in the analyzed and optimized plan after querying a metadata column.
       def isTaggedRelation(plan: LogicalPlan): Boolean = plan match {
-        case rel: LogicalRelation => rel.getTagValue(customTag).getOrElse(false)
+        case rel: LogicalRelation => rel.getTagValue(customTag).isDefined
         case _ => false
       }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently, there are a lot of `TreeNodeTag[Boolean]` are defined.
In fact, developers don't require the boolean value boxed into `TreeNodeTag`, just want know it as a flag.


### Why are the changes needed?
Unit should be considered first before using Boolean for TreeNodeTag.


### Does this PR introduce _any_ user-facing change?
'No'.
Just update inner implementation.


### How was this patch tested?
N/A


### Was this patch authored or co-authored using generative AI tooling?
'No'.
