### PR TITLE
[SPARK-44980][PYTHON][CONNECT] Fix inherited namedtuples to work in createDataFrame

### DIFF
--- a/python/pyspark/sql/connect/conversion.py
+++ b/python/pyspark/sql/connect/conversion.py
@@ -117,7 +117,11 @@ class LocalDataToArrowConversion:
                     ), f"{type(value)} {value}"
 
                     _dict = {}
-                    if not isinstance(value, Row) and hasattr(value, "__dict__"):
+                    if (
+                        not isinstance(value, Row)
+                        and not isinstance(value, tuple)  # inherited namedtuple
+                        and hasattr(value, "__dict__")
+                    ):
                         value = value.__dict__
                     if isinstance(value, dict):
                         for i, field in enumerate(field_names):
@@ -274,7 +278,11 @@ class LocalDataToArrowConversion:
         pylist: List[List] = [[] for _ in range(len(column_names))]
 
         for item in data:
-            if not isinstance(item, Row) and hasattr(item, "__dict__"):
+            if (
+                not isinstance(item, Row)
+                and not isinstance(item, tuple)  # inherited namedtuple
+                and hasattr(item, "__dict__")
+            ):
                 item = item.__dict__
             if isinstance(item, dict):
                 for i, col in enumerate(column_names):

--- a/python/pyspark/sql/tests/connect/test_parity_arrow.py
+++ b/python/pyspark/sql/tests/connect/test_parity_arrow.py
@@ -135,6 +135,9 @@ class ArrowParityTests(ArrowTestsMixin, ReusedConnectTestCase, PandasOnSparkTest
     def test_toPandas_udt(self):
         self.check_toPandas_udt(True)
 
+    def test_create_dataframe_namedtuples(self):
+        self.check_create_dataframe_namedtuples(True)
+
 
 if __name__ == "__main__":
     from pyspark.sql.tests.connect.test_parity_arrow import *  # noqa: F401


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes the bug in createDataFrame with Python Spark Connect client. Now it respects inherited namedtuples as below:


```python
from collections import namedtuple
MyTuple = namedtuple("MyTuple", ["zz", "b", "a"])

class MyInheritedTuple(MyTuple):
    pass

df = spark.createDataFrame([MyInheritedTuple(1, 2, 3), MyInheritedTuple(11, 22, 33)])
df.collect()
```

Before:

```
[Row(zz=None, b=None, a=None), Row(zz=None, b=None, a=None)]
```

After:

```
[Row(zz=1, b=2, a=3), Row(zz=11, b=22, a=33)]
```


### Why are the changes needed?

This is already supported without Spark Connect. We should match the behaviour for consistent API support.

### Does this PR introduce _any_ user-facing change?

Yes, as described above. It fixes a bug,

### How was this patch tested?

Manually tested as described above, and unittests were added.

### Was this patch authored or co-authored using generative AI tooling?

No.