### PR TITLE
[SPARK-44984][PYTHON][CONNECT] Remove `_get_alias` from DataFrame

### DIFF
--- a/python/pyspark/sql/connect/plan.py
+++ b/python/pyspark/sql/connect/plan.py
@@ -464,7 +464,6 @@ class Project(LogicalPlan):
     def __init__(self, child: Optional["LogicalPlan"], *columns: "ColumnOrName") -> None:
         super().__init__(child)
         self._columns = list(columns)
-        self.alias: Optional[str] = None
         self._verify_expressions()
 
     def _verify_expressions(self) -> None:


### PR DESCRIPTION
### What changes were proposed in this pull request?
Remove `_get_alias` from DataFrame


### Why are the changes needed?
`_get_alias` was added in the [initial PR](https://github.com/apache/spark/commit/6637bbe2b25ff2877b41a9677ce6d75e6996f968), but seems unneeded

- field `alias` in `plan.Project` is always `None`;
- `_get_alias` takes no parameter, but is used to replace a specify column name, the logic is weird when the column name varies;

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
CI


### Was this patch authored or co-authored using generative AI tooling?
No