### PR TITLE
[SPARK-44986][DOCS] There should be a gap at the bottom of the HTML

### DIFF
--- a/docs/css/custom.css
+++ b/docs/css/custom.css
@@ -9,6 +9,7 @@ body {
   overflow-wrap: anywhere;
   overflow-x: hidden;
   padding-top: 80px;
+  padding-bottom: 20px;
 }
 
 a {

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -470,18 +470,18 @@ Congratulations on running your first Spark application!
 * For an in-depth overview of the API, start with the [RDD programming guide](rdd-programming-guide.html) and the [SQL programming guide](sql-programming-guide.html), or see "Programming Guides" menu for other components.
 * For running applications on a cluster, head to the [deployment overview](cluster-overview.html).
 * Finally, Spark includes several samples in the `examples` directory
-([Scala]({{site.SPARK_GITHUB_URL}}/tree/master/examples/src/main/scala/org/apache/spark/examples),
+([Python]({{site.SPARK_GITHUB_URL}}/tree/master/examples/src/main/python),
+ [Scala]({{site.SPARK_GITHUB_URL}}/tree/master/examples/src/main/scala/org/apache/spark/examples),
  [Java]({{site.SPARK_GITHUB_URL}}/tree/master/examples/src/main/java/org/apache/spark/examples),
- [Python]({{site.SPARK_GITHUB_URL}}/tree/master/examples/src/main/python),
  [R]({{site.SPARK_GITHUB_URL}}/tree/master/examples/src/main/r)).
 You can run them as follows:
 
 {% highlight bash %}
-# For Scala and Java, use run-example:
-./bin/run-example SparkPi
-
 # For Python examples, use spark-submit directly:
 ./bin/spark-submit examples/src/main/python/pi.py
+
+# For Scala and Java, use run-example:
+./bin/run-example SparkPi
 
 # For R examples, use spark-submit directly:
 ./bin/spark-submit examples/src/main/r/dataframe.R

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -470,18 +470,18 @@ Congratulations on running your first Spark application!
 * For an in-depth overview of the API, start with the [RDD programming guide](rdd-programming-guide.html) and the [SQL programming guide](sql-programming-guide.html), or see "Programming Guides" menu for other components.
 * For running applications on a cluster, head to the [deployment overview](cluster-overview.html).
 * Finally, Spark includes several samples in the `examples` directory
-([Python]({{site.SPARK_GITHUB_URL}}/tree/master/examples/src/main/python),
- [Scala]({{site.SPARK_GITHUB_URL}}/tree/master/examples/src/main/scala/org/apache/spark/examples),
+([Scala]({{site.SPARK_GITHUB_URL}}/tree/master/examples/src/main/scala/org/apache/spark/examples),
  [Java]({{site.SPARK_GITHUB_URL}}/tree/master/examples/src/main/java/org/apache/spark/examples),
+ [Python]({{site.SPARK_GITHUB_URL}}/tree/master/examples/src/main/python),
  [R]({{site.SPARK_GITHUB_URL}}/tree/master/examples/src/main/r)).
 You can run them as follows:
 
 {% highlight bash %}
-# For Python examples, use spark-submit directly:
-./bin/spark-submit examples/src/main/python/pi.py
-
 # For Scala and Java, use run-example:
 ./bin/run-example SparkPi
+
+# For Python examples, use spark-submit directly:
+./bin/spark-submit examples/src/main/python/pi.py
 
 # For R examples, use spark-submit directly:
 ./bin/spark-submit examples/src/main/r/dataframe.R


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to add gap at the bottom of the HTML.

### Why are the changes needed?
The old document style has good white space at the bottom, but the latest document has lost this piece, which looks unattractive and borderless.
<img width="918" alt="image" src="https://github.com/apache/spark/assets/15246973/c7d4e1c9-f83a-4a4b-a22f-240f3ea534c9">

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Manual testing.
```
SKIP_API=1 bundle exec jekyll serve --watch
```

### Was this patch authored or co-authored using generative AI tooling?
No.