### PR TITLE
[SPARK-44868][SQL][FOLLOWUP] Invoke the `to_varchar` function in Scala API

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -4431,7 +4431,7 @@ object functions {
    * @group string_funcs
    * @since 3.5.0
    */
-  def to_varchar(e: Column, format: Column): Column = to_char(e, format)
+  def to_varchar(e: Column, format: Column): Column = call_function("to_varchar", e, format)
 
   /**
    * Convert string 'e' to a number based on the string format 'format'.

--- a/sql/core/src/test/scala/org/apache/spark/sql/StringFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/StringFunctionsSuite.scala
@@ -878,7 +878,7 @@ class StringFunctionsSuite extends QueryTest with SharedSparkSession {
         errorClass = "_LEGACY_ERROR_TEMP_1100",
         parameters = Map(
           "argName" -> "format",
-          "funcName" -> "to_char",
+          "funcName" -> funcName,
           "requiredType" -> "string"))
       checkError(
         exception = intercept[AnalysisException] {
@@ -887,7 +887,7 @@ class StringFunctionsSuite extends QueryTest with SharedSparkSession {
         errorClass = "INVALID_PARAMETER_VALUE.BINARY_FORMAT",
         parameters = Map(
           "parameter" -> "`format`",
-          "functionName" -> "`to_char`",
+          "functionName" -> s"`$funcName`",
           "invalidFormat" -> "'invalid_format'"))
       checkError(
         exception = intercept[AnalysisException] {


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to invoke the `to_varchar` function instead of `to_char` in `to_varchar` of Scala/Java API.

### Why are the changes needed?
1. To show correct function name in error messages and in `explain`.
2. To be consistent to other API: PySpark and the previous Spark SQL version 3.5.0.

### Does this PR introduce _any_ user-facing change?
Yes.

### How was this patch tested?
By running the modified test:
```
$ build/sbt "test:testOnly *.StringFunctionsSuite"
```

### Was this patch authored or co-authored using generative AI tooling?
No.