### PR TITLE
[SPARK-44989][INFRA] Add a directional message to promote JIRA_ACCESS_TOKEN

### DIFF
--- a/dev/merge_spark_pr.py
+++ b/dev/merge_spark_pr.py
@@ -538,6 +538,9 @@ def initialize_jira():
             else:
                 raise e
     elif JIRA_USERNAME and JIRA_PASSWORD:
+        print("You can use JIRA_ACCESS_TOKEN instead of JIRA_USERNAME/JIRA_PASSWORD.")
+        print("Visit https://issues.apache.org/jira/secure/ViewProfile.jspa ")
+        print("and click 'Personal Access Tokens' menu to manage your own tokens.")
         asf_jira = jira.client.JIRA(jira_server, basic_auth=(JIRA_USERNAME, JIRA_PASSWORD))
     else:
         print("Neither JIRA_ACCESS_TOKEN nor JIRA_USERNAME/JIRA_PASSWORD are set.")

--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -42,7 +42,7 @@ docutils<0.18.0
 markupsafe==2.0.1
 
 # Development scripts
-jira
+jira==3.5.2
 PyGithub
 
 # pandas API on Spark Code formatter.

--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -42,7 +42,7 @@ docutils<0.18.0
 markupsafe==2.0.1
 
 # Development scripts
-jira==3.5.2
+jira>=3.5.2
 PyGithub
 
 # pandas API on Spark Code formatter.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add a directional message to promote `JIRA_ACCESS_TOKEN` when `JIRA_USERNAME` and `JIRA_PASSWORD` are used.

Also, this PR set the minimum JIRA library version to make it sure that `token_auths` features exist in the installed `jira` library.
```
-jira
+jira>=3.5.2
```

### Why are the changes needed?

Since SPARK-44802, `Token` feature seems to be stable and provides much secure environments to Apache Spark committers by hiding not only `JIRA_PASSWORD`, but also the static `JIRA_USERNAME`.
```
SPARK-44802 Token based ASF JIRA authentication
SPARK-44802 Fix to consider JIRA_ACCESS_TOKEN in precheck conditions
SPARK-44972 Eagerly check if the token is valid to align with the behavior of username/password auth
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No,