### PR TITLE
[SPARK-42304][SQL] Rename `_LEGACY_ERROR_TEMP_2189` to `GET_TABLES_BY_TYPE_UNSUPPORTED_BY_HIVE_VERSION`

### DIFF
--- a/common/utils/src/main/resources/error/error-classes.json
+++ b/common/utils/src/main/resources/error/error-classes.json
@@ -3205,6 +3205,11 @@
     },
     "sqlState" : "0A000"
   },
+  "UNSUPPORTED_FUNCTION_BY_HIVE_VERSION" : {
+    "message" : [
+      "Hive 2.2 and lower versions don't support getTablesByType. Please use Hive 2.3 or higher version."
+    ]
+  },
   "UNSUPPORTED_GENERATOR" : {
     "message" : [
       "The generator is not supported:"
@@ -5642,11 +5647,6 @@
   "_LEGACY_ERROR_TEMP_2187" : {
     "message" : [
       "<message>, db: <dbName>, table: <tableName>."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_2189" : {
-    "message" : [
-      "Hive 2.2 and lower versions don't support getTablesByType. Please use Hive 2.3 or higher version."
     ]
   },
   "_LEGACY_ERROR_TEMP_2190" : {

--- a/common/utils/src/main/resources/error/error-classes.json
+++ b/common/utils/src/main/resources/error/error-classes.json
@@ -921,6 +921,11 @@
       "A column cannot have both a default value and a generation expression but column <colName> has default value: (<defaultValue>) and generation expression: (<genExpr>)."
     ]
   },
+  "GET_TABLES_BY_TYPE_UNSUPPORTED_BY_HIVE_VERSION" : {
+    "message" : [
+      "Hive 2.2 and lower versions don't support getTablesByType. Please use Hive 2.3 or higher version."
+    ]
+  },
   "GRAPHITE_SINK_INVALID_PROTOCOL" : {
     "message" : [
       "Invalid Graphite protocol: <protocol>."
@@ -3204,11 +3209,6 @@
       }
     },
     "sqlState" : "0A000"
-  },
-  "UNSUPPORTED_FUNCTION_BY_HIVE_VERSION" : {
-    "message" : [
-      "Hive 2.2 and lower versions don't support getTablesByType. Please use Hive 2.3 or higher version."
-    ]
   },
   "UNSUPPORTED_GENERATOR" : {
     "message" : [

--- a/docs/sql-error-conditions.md
+++ b/docs/sql-error-conditions.md
@@ -2014,6 +2014,12 @@ The feature is not supported:
 
 For more details see [UNSUPPORTED_FEATURE](sql-error-conditions-unsupported-feature-error-class.html)
 
+### UNSUPPORTED_FUNCTION_BY_HIVE_VERSION
+
+SQLSTATE: none assigned
+
+Hive 2.2 and lower versions don't support getTablesByType. Please use Hive 2.3 or higher version.
+
 ### [UNSUPPORTED_GENERATOR](sql-error-conditions-unsupported-generator-error-class.html)
 
 [SQLSTATE: 0A000](sql-error-conditions-sqlstates.html#class-0A-feature-not-supported)

--- a/docs/sql-error-conditions.md
+++ b/docs/sql-error-conditions.md
@@ -575,6 +575,12 @@ SQLSTATE: none assigned
 
 A column cannot have both a default value and a generation expression but column `<colName>` has default value: (`<defaultValue>`) and generation expression: (`<genExpr>`).
 
+### GET_TABLES_BY_TYPE_UNSUPPORTED_BY_HIVE_VERSION
+
+SQLSTATE: none assigned
+
+Hive 2.2 and lower versions don't support getTablesByType. Please use Hive 2.3 or higher version.
+
 ### GRAPHITE_SINK_INVALID_PROTOCOL
 
 SQLSTATE: none assigned
@@ -2014,12 +2020,6 @@ The feature is not supported:
 
 For more details see [UNSUPPORTED_FEATURE](sql-error-conditions-unsupported-feature-error-class.html)
 
-### UNSUPPORTED_FUNCTION_BY_HIVE_VERSION
-
-SQLSTATE: none assigned
-
-Hive 2.2 and lower versions don't support getTablesByType. Please use Hive 2.3 or higher version.
-
 ### [UNSUPPORTED_GENERATOR](sql-error-conditions-unsupported-generator-error-class.html)
 
 [SQLSTATE: 0A000](sql-error-conditions-sqlstates.html#class-0A-feature-not-supported)
@@ -2180,3 +2180,5 @@ The operation `<operation>` requires a `<requiredType>`. But `<objectName>` is a
 The `<functionName>` requires `<expectedNum>` parameters but the actual number is `<actualNum>`.
 
 For more details see [WRONG_NUM_ARGS](sql-error-conditions-wrong-num-args-error-class.html)
+
+

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -1635,7 +1635,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
 
   def getTablesByTypeUnsupportedByHiveVersionError(): SparkUnsupportedOperationException = {
     new SparkUnsupportedOperationException(
-      errorClass = "UNSUPPORTED_FUNCTION_BY_HIVE_VERSION",
+      errorClass = "GET_TABLES_BY_TYPE_UNSUPPORTED_BY_HIVE_VERSION",
       messageParameters = Map.empty)
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -1635,7 +1635,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
 
   def getTablesByTypeUnsupportedByHiveVersionError(): SparkUnsupportedOperationException = {
     new SparkUnsupportedOperationException(
-      errorClass = "_LEGACY_ERROR_TEMP_2189",
+      errorClass = "UNSUPPORTED_FUNCTION_BY_HIVE_VERSION",
       messageParameters = Map.empty)
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR proposes to assign name to _LEGACY_ERROR_TEMP_2189, "GET_TABLES_BY_TYPE_UNSUPPORTED_BY_HIVE_VERSION".

### Why are the changes needed?
Assign proper name to LEGACY_ERROR_TEMP*

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
./build/sbt "testOnly org.apache.spark.SparkThrowableSuite"

### Was this patch authored or co-authored using generative AI tooling?
No
