### PR TITLE
[SPARK-44995][K8S] Promote `SparkKubernetesClientFactory` to `DeveloperApi`

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/SparkKubernetesClientFactory.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/SparkKubernetesClientFactory.scala
@@ -30,18 +30,28 @@ import okhttp3.Dispatcher
 import okhttp3.OkHttpClient
 
 import org.apache.spark.SparkConf
+import org.apache.spark.annotation.{DeveloperApi, Since, Stable}
 import org.apache.spark.deploy.k8s.Config._
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config.ConfigEntry
 import org.apache.spark.util.ThreadUtils
 
 /**
+ * :: DeveloperApi ::
+ *
  * Spark-opinionated builder for Kubernetes clients. It uses a prefix plus common suffixes to
  * parse configuration keys, similar to the manner in which Spark's SecurityManager parses SSL
  * options for different components.
+ *
+ * This can be used to implement new ExternalClusterManagers.
+ *
+ * @since 4.0.0
  */
-private[spark] object SparkKubernetesClientFactory extends Logging {
+@Stable
+@DeveloperApi
+object SparkKubernetesClientFactory extends Logging {
 
+  @Since("4.0.0")
   def createKubernetesClient(
       master: String,
       namespace: Option[String],


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to promote `SparkKubernetesClientFactory` as **stable** `DeveloperApi` in order to maintain it officially in a backward compatible way at Apache Spark 4.0.0.

### Why are the changes needed?

Like SPARK-35280 and SPARK-37497, `SparkKubernetesClientFactory` is also able to be used to develop new `ExternalClusterManager` for K8s environment.
- https://github.com/apache/spark/pull/32406
- https://github.com/apache/spark/pull/34751

### Does this PR introduce _any_ user-facing change?

No. Previously, it was `private[spark]`.

### How was this patch tested?

Manual review because this is only a visibility change.

### Was this patch authored or co-authored using generative AI tooling?

No.