### PR TITLE
[SPARK-44996][K8S] Use `lazy val` for `DefaultVolcanoClient`

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/VolcanoFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/VolcanoFeatureStep.scala
@@ -46,7 +46,7 @@ private[spark] class VolcanoFeatureStep extends KubernetesDriverCustomFeatureCon
         "for executor.")
       return Seq.empty
     }
-    val client = new DefaultVolcanoClient
+    lazy val client = new DefaultVolcanoClient
     val template = kubernetesConf.getOption(POD_GROUP_TEMPLATE_FILE_KEY)
     val pg = template.map(client.podGroups.load(_).item).getOrElse(new PodGroup())
     var metadata = pg.getMetadata


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to improve `VolcanoFeatureStep` to use lazy creation for `DefaultVolcanoClient`.

### Why are the changes needed?

We can verify this change in the existing test case of `VolcanoFeatureStepSuite`.
Since `VolcanoFeatureStep` creates `DefaultVolcanoClient` always, the unit test suite `VolcanoFeatureStepSuite` behaves like an integration test. In other words, it fails when there is no accessible K8s clusters.
```
$ build/sbt -Pkubernetes -Pvolcano "kubernetes/testOnly *Volcano* -- -z SPARK-36061"
...
[info] VolcanoFeatureStepSuite:
[info] - SPARK-36061: Driver Pod with Volcano PodGroup *** FAILED *** (646 milliseconds)
[info]   org.snakeyaml.engine.v2.exceptions.ScannerException: mapping values are not allowed here
[info]  in reader, line 1, column 94:
[info]      ... well-known/openid-configuration": dial tcp: lookup iam.corp. ...
[info]
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual tests. Disable network and run the following.
```
$ build/sbt -Pkubernetes -Pvolcano "kubernetes/testOnly *Volcano* -- -z SPARK-36061"
```

### Was this patch authored or co-authored using generative AI tooling?

No.
