### PR TITLE
[SPARK-45000][PYTHON][CONNECT] Implement DataFrame.foreach

### DIFF
--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -1521,6 +1521,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
         .. versionadded:: 1.3.0
 
+        .. versionchanged:: 4.0.0
+            Supports Spark Connect.
+
         Parameters
         ----------
         f : function

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -3033,7 +3033,6 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
         df = self.connect.read.table(self.tbl_name)
         for f in (
             "rdd",
-            "foreach",
             "foreachPartition",
             "checkpoint",
             "localCheckpoint",


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR implements `DataFrame.foreach` by using Python UDF in Spark Connect

### Why are the changes needed?

For API parity.

### Does this PR introduce _any_ user-facing change?

Yes, it adds a new API into Python Spark Connect client.

### How was this patch tested?

Manually tested:

```
./bin/pyspark --remote "local"
```

```python
def func(r):
    print(r)

spark.range(10).foreach(func)
```

```
Row(id=0)
Row(id=1)
Row(id=2)
Row(id=3)
Row(id=4)
Row(id=5)
Row(id=6)
Row(id=7)
Row(id=8)
Row(id=9)
```


Doctest will be reused too.

### Was this patch authored or co-authored using generative AI tooling?

No.