### PR TITLE
[SPARK-45001][PYTHON][CONNECT] Implement DataFrame.foreachPartition

### DIFF
--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -46,7 +46,7 @@ from collections.abc import Iterable
 from pyspark import _NoValue
 from pyspark._globals import _NoValueType
 from pyspark.sql.observation import Observation
-from pyspark.sql.types import Row, StructType
+from pyspark.sql.types import Row, StructType, _create_row
 from pyspark.sql.dataframe import (
     DataFrame as PySparkDataFrame,
     DataFrameNaFunctions as PySparkDataFrameNaFunctions,
@@ -63,6 +63,7 @@ from pyspark.errors.exceptions.connect import SparkConnectException
 from pyspark.rdd import PythonEvalType
 from pyspark.storagelevel import StorageLevel
 import pyspark.sql.connect.plan as plan
+from pyspark.sql.connect.conversion import ArrowTableToRowsConversion
 from pyspark.sql.connect.group import GroupedData
 from pyspark.sql.connect.readwriter import DataFrameWriter, DataFrameWriterV2
 from pyspark.sql.connect.streaming.readwriter import DataStreamWriter
@@ -1586,7 +1587,6 @@ class DataFrame:
         elif name in [
             "rdd",
             "toJSON",
-            "foreachPartition",
             "checkpoint",
             "localCheckpoint",
         ]:
@@ -1663,8 +1663,6 @@ class DataFrame:
         schema = schema or from_arrow_schema(table.schema, prefer_timestamp_ntz=True)
 
         assert schema is not None and isinstance(schema, StructType)
-
-        from pyspark.sql.connect.conversion import ArrowTableToRowsConversion
 
         return ArrowTableToRowsConversion.convert(table, schema)
 
@@ -1907,8 +1905,6 @@ class DataFrame:
         return self.storageLevel != StorageLevel.NONE
 
     def toLocalIterator(self, prefetchPartitions: bool = False) -> Iterator[Row]:
-        from pyspark.sql.connect.conversion import ArrowTableToRowsConversion
-
         if self._plan is None:
             raise Exception("Cannot collect on empty plan.")
         if self._session is None:
@@ -2017,6 +2013,32 @@ class DataFrame:
         ).collect()
 
     foreach.__doc__ = PySparkDataFrame.foreach.__doc__
+
+    def foreachPartition(self, f: Callable[[Iterator[Row]], None]) -> None:
+        assert self._plan is not None
+
+        schema = self.schema
+        field_converters = [
+            ArrowTableToRowsConversion._create_converter(f.dataType) for f in schema.fields
+        ]
+
+        def foreach_partition_func(itr: Iterable[pa.RecordBatch]) -> Iterable[pa.RecordBatch]:
+            def flatten() -> Iterator[Row]:
+                for table in itr:
+                    columnar_data = [column.to_pylist() for column in table.columns]
+                    for i in range(0, table.num_rows):
+                        values = [
+                            field_converters[j](columnar_data[j][i])
+                            for j in range(table.num_columns)
+                        ]
+                        yield _create_row(fields=schema.fieldNames(), values=values)
+
+            f(flatten())
+            return iter([])
+
+        self.mapInArrow(foreach_partition_func, schema=StructType()).collect()
+
+    foreachPartition.__doc__ = PySparkDataFrame.foreachPartition.__doc__
 
     @property
     def writeStream(self) -> DataStreamWriter:

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -1548,6 +1548,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
         .. versionadded:: 1.3.0
 
+        .. versionchanged:: 4.0.0
+            Supports Spark Connect.
+
         Parameters
         ----------
         f : function

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -3033,7 +3033,6 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
         df = self.connect.read.table(self.tbl_name)
         for f in (
             "rdd",
-            "foreachPartition",
             "checkpoint",
             "localCheckpoint",
         ):


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR implements `DataFrame.foreachPartition` by using `mapInArrow` in Spark Connect

### Why are the changes needed?

For API parity.

### Does this PR introduce _any_ user-facing change?

Yes, it adds a new API into Python Spark Connect client.

### How was this patch tested?

Manually tested:

```
./bin/pyspark --remote "local"
```

```python
def func(itr):
    for r in itr:
        print(r)


spark.range(10).foreachPartition(func)
```

```
Row(id=0)
Row(id=1)
Row(id=2)
Row(id=3)
Row(id=4)
Row(id=5)
Row(id=6)
Row(id=7)
Row(id=8)
Row(id=9)
```

Doctest will be reused too.

### Was this patch authored or co-authored using generative AI tooling?

No.