### PR TITLE
[SPARK-45006][UI] Use the same date format of other UI date elements for the x-axis of timelines

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/timeline-view.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/timeline-view.js
@@ -17,6 +17,29 @@
 
 /* global $, vis, uiRoot, appBasePath */
 /* eslint-disable no-unused-vars */
+const xAxisFormat = {
+  minorLabels: {
+    millisecond:'SSS',
+    second:     'ss',
+    minute:     'mm',
+    hour:       'HH',
+    weekday:    'DD',
+    day:        'DD',
+    month:      'MM',
+    year:       'YYYY'
+  },
+  majorLabels: {
+    millisecond:'YYYY/MM/DD HH:mm:ss',
+    second:     'YYYY/MM/DD HH:mm',
+    minute:     'YYYY/MM/DD HH',
+    hour:       'YYYY/MM/DD',
+    weekday:    'YYYY/MM',
+    day:        'YYYY/MM',
+    month:      'YYYY',
+    year:       ''
+  }
+}
+
 function drawApplicationTimeline(groupArray, eventObjArray, startTime, offset) {
   var groups = new vis.DataSet(groupArray);
   var items = new vis.DataSet(eventObjArray);
@@ -34,6 +57,7 @@ function drawApplicationTimeline(groupArray, eventObjArray, startTime, offset) {
     moment: function (date) {
       return vis.moment(date).utcOffset(offset);
     },
+    format: xAxisFormat,
     xss: {
       disabled: false,
       filterOptions: {
@@ -126,6 +150,7 @@ function drawJobTimeline(groupArray, eventObjArray, startTime, offset) {
     moment: function (date) {
       return vis.moment(date).utcOffset(offset);
     },
+    format: xAxisFormat,
     xss: {
       disabled: false,
       filterOptions: {
@@ -224,6 +249,7 @@ function drawTaskAssignmentTimeline(groupArray, eventObjArray, minLaunchTime, ma
     moment: function (date) {
       return vis.moment(date).utcOffset(offset);
     },
+    format: xAxisFormat,
     xss: {
       disabled: false,
       filterOptions: {


### PR DESCRIPTION


<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR introduces a custom date format aligned with other UI elements for the x-axis of the timeline graph. For example,

![image](https://github.com/apache/spark/assets/8326978/739cd54e-0fb4-4c73-a7fe-b2f15db386f8)

FYI, https://momentjs.com/docs/#/displaying/format/

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

It can be distracting when the values and axes are not presented in the same format.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

yes

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

##### Regular size

![image](https://github.com/apache/spark/assets/8326978/7cea9dd1-2b2b-4ded-b1b2-f147a04ef12f)

##### zoom in

![image](https://github.com/apache/spark/assets/8326978/cfc62391-67ea-44d3-b98f-f522a7cd9871)

##### zoom out

![image](https://github.com/apache/spark/assets/8326978/96859a44-9d69-4250-9f43-5af4cbad780f)


![image](https://github.com/apache/spark/assets/8326978/8f742acd-d2fe-4615-993e-ed8e2f0c3103)


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

no
