### PR TITLE
Interrupt receiveLoop on MessageLoop shutdown

### DIFF
--- a/core/src/main/scala/org/apache/spark/rpc/netty/MessageLoop.scala
+++ b/core/src/main/scala/org/apache/spark/rpc/netty/MessageLoop.scala
@@ -53,7 +53,7 @@ private sealed abstract class MessageLoop(dispatcher: Dispatcher) extends Loggin
     synchronized {
       if (!stopped) {
         setActive(MessageLoop.PoisonPill)
-        threadpool.shutdown()
+        threadpool.shutdownNow()
         stopped = true
       }
     }


### PR DESCRIPTION
This is spotted when I run the "send-abort" test that it waits a long time before the `RpcEnv` (-> `Dispatcher` -> `MessageLoop`) can properly stop.