### PR TITLE
[SPARK-45007][INFRA] Fix merged pull requests resolution

### DIFF
--- a/dev/merge_spark_pr.py
+++ b/dev/merge_spark_pr.py
@@ -611,9 +611,9 @@ def main():
     pr_repo_desc = "%s/%s" % (user_login, base_ref)
 
     # Merged pull requests don't appear as merged in the GitHub API;
-    # Instead, they're closed by asfgit.
+    # Instead, they're closed by committers.
     merge_commits = [
-        e for e in pr_events if e["actor"]["login"] == "asfgit" and e["event"] == "closed"
+        e for e in pr_events if e["event"] == "closed" and e["commit_id"] is not None
     ]
 
     if merge_commits:

--- a/dev/merge_spark_pr.py
+++ b/dev/merge_spark_pr.py
@@ -612,9 +612,7 @@ def main():
 
     # Merged pull requests don't appear as merged in the GitHub API;
     # Instead, they're closed by committers.
-    merge_commits = [
-        e for e in pr_events if e["event"] == "closed" and e["commit_id"] is not None
-    ]
+    merge_commits = [e for e in pr_events if e["event"] == "closed" and e["commit_id"] is not None]
 
     if merge_commits:
         merge_hash = merge_commits[0]["commit_id"]


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR fixes the resolution for merged pull requests. It appears that the user "asfgit" is no longer closing pull requests, but rather the committers are.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Bugfix, make the merge script re-runnable again if you accidentally abort cherry-pick or change your mind later for backporting.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

maintainer only

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

```
>>> for e in pr_events:
...    print(e["event"], e["commit_id"])
...
labeled None
labeled None
labeled None
review_requested None
review_requested None
head_ref_force_pushed None
head_ref_force_pushed None
head_ref_force_pushed None
head_ref_force_pushed None
closed 76a32d3df0fe8e857221662657936e5ae336d3ee
```

```
./dev/merge_spark_pr.py
git rev-parse --abbrev-ref HEAD
Which pull request would you like to merge? (e.g. 34): 42714
Pull request 42714 has already been merged, assuming you want to backport
['git', 'rev-parse', '--quiet', '--verify', '76a32d3df0fe8e857221662657936e5ae336d3ee^{commit}']
Found commit 76a32d3df0fe8e857221662657936e5ae336d3ee:
.
.
.
Closes #42714 from HyukjinKwon/SPARK-45000.

Authored-by: Hyukjin Kwon <gurwls223@apache.org>
Signed-off-by: Dongjoon Hyun <dhyun@apple.com>
Enter a branch name [branch-3.5]:
```

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
