### PR TITLE
[SPARK-45010][INFRA] Limit GHA job execution time to up to 5 hours in `build_and_test.yml`

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -127,6 +127,7 @@ jobs:
     needs: precondition
     if: fromJson(needs.precondition.outputs.required).build == 'true'
     runs-on: ubuntu-22.04
+    timeout-minutes: 300
     strategy:
       fail-fast: false
       matrix:
@@ -342,6 +343,7 @@ jobs:
     if: (!cancelled()) && fromJson(needs.precondition.outputs.required).pyspark == 'true'
     name: "Build modules: ${{ matrix.modules }}"
     runs-on: ubuntu-22.04
+    timeout-minutes: 300
     container:
       image: ${{ needs.precondition.outputs.image_url }}
     strategy:
@@ -478,6 +480,7 @@ jobs:
     if: (!cancelled()) && fromJson(needs.precondition.outputs.required).sparkr == 'true'
     name: "Build modules: sparkr"
     runs-on: ubuntu-22.04
+    timeout-minutes: 300
     container:
       image: ${{ needs.precondition.outputs.image_url }}
     env:
@@ -586,6 +589,7 @@ jobs:
     if: (!cancelled()) && fromJson(needs.precondition.outputs.required).lint == 'true'
     name: Linters, licenses, dependencies and documentation generation
     runs-on: ubuntu-22.04
+    timeout-minutes: 300
     env:
       LC_ALL: C.UTF-8
       LANG: C.UTF-8
@@ -767,6 +771,7 @@ jobs:
           - 17
           - 21-ea
     runs-on: ubuntu-22.04
+    timeout-minutes: 300
     steps:
     - name: Checkout Spark repository
       uses: actions/checkout@v3
@@ -817,6 +822,7 @@ jobs:
     if: fromJson(needs.precondition.outputs.required).scala-213 == 'true'
     name: Scala 2.13 build with SBT
     runs-on: ubuntu-22.04
+    timeout-minutes: 300
     steps:
     - name: Checkout Spark repository
       uses: actions/checkout@v3
@@ -865,6 +871,7 @@ jobs:
     name: Run TPC-DS queries with SF=1
     # Pin to 'Ubuntu 20.04' due to 'databricks/tpcds-kit' compilation
     runs-on: ubuntu-20.04
+    timeout-minutes: 300
     env:
       SPARK_LOCAL_IP: localhost
     steps:
@@ -963,6 +970,7 @@ jobs:
     if: fromJson(needs.precondition.outputs.required).docker-integration-tests == 'true'
     name: Run Docker integration tests
     runs-on: ubuntu-22.04
+    timeout-minutes: 300
     env:
       HADOOP_PROFILE: ${{ inputs.hadoop }}
       HIVE_PROFILE: hive2.3
@@ -1029,6 +1037,7 @@ jobs:
     if: fromJson(needs.precondition.outputs.required).k8s-integration-tests == 'true'
     name: Run Spark on Kubernetes Integration test
     runs-on: ubuntu-22.04
+    timeout-minutes: 300
     steps:
       - name: Checkout Spark repository
         uses: actions/checkout@v3


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to limit GHA job execution time to up to 5 hours in `build_and_test.yml` in order to avoid idle hung time.
New limit is applied for all jobs except three jobs (`precondition`, `infra-image`, and `breaking-changes-buf`) which didn't get a hung situation before.

### Why are the changes needed?

Currently, the default value (6 hour) is used.

- https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes
  > The maximum number of minutes to let a job run before GitHub automatically cancels it. Default: 360

However, when the jobs hit the limit, it's already a hung job and the pipeline becomes idle for over 5 hours like the following.

- https://github.com/apache/spark/actions/runs/5999379610/job/16269462910 (IDLE for about 5 hours 3 minutes)
```
2023-08-28T12:44:10.9217219Z Starting test(python3.9): pyspark.mllib.tests.test_algorithms (temp output: /__w/spark/spark/python/target/1a1ff656-2923-4d34-b046-1e947ab0f05b/python3.9__pyspark.mllib.tests.test_algorithms__f9df3bwd.log)
2023-08-28T17:47:21.5922036Z ##[error]The operation was canceled.
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No because the successful CIs finished in 4 ~ 5 hours.

### Was this patch authored or co-authored using generative AI tooling?

No.