### PR TITLE
[SPARK-45017][PYTHON] Add `CalendarIntervalType` to PySpark

### DIFF
--- a/python/docs/source/reference/pyspark.sql/data_types.rst
+++ b/python/docs/source/reference/pyspark.sql/data_types.rst
@@ -48,3 +48,4 @@ Data Types
     TimestampNTZType
     DayTimeIntervalType
     YearMonthIntervalType
+    CalendarIntervalType

--- a/python/pyspark/sql/tests/connect/test_parity_types.py
+++ b/python/pyspark/sql/tests/connect/test_parity_types.py
@@ -86,6 +86,10 @@ class TypesParityTests(TypesTestsMixin, ReusedConnectTestCase):
     def test_udt(self):
         super().test_udt()
 
+    @unittest.skip("SPARK-45018: should support CalendarIntervalType")
+    def test_calendar_interval_type(self):
+        super().test_calendar_interval_type()
+
 
 if __name__ == "__main__":
     import unittest

--- a/python/pyspark/sql/tests/test_types.py
+++ b/python/pyspark/sql/tests/test_types.py
@@ -1277,7 +1277,7 @@ class TypesTestsMixin:
     def test_calendar_interval_type_constructor(self):
         self.assertEqual(CalendarIntervalType().simpleString(), "interval")
 
-        with self.assertRaisesRegex(TypeError, "DataTypeSingleton.__call__() takes 1"):
+        with self.assertRaisesRegex(TypeError, "takes 1 positional argument but 2 were given"):
             CalendarIntervalType(3)
 
     def test_calendar_interval_type(self):

--- a/python/pyspark/sql/tests/test_types.py
+++ b/python/pyspark/sql/tests/test_types.py
@@ -36,6 +36,7 @@ from pyspark.sql.types import (
     TimestampType,
     DayTimeIntervalType,
     YearMonthIntervalType,
+    CalendarIntervalType,
     MapType,
     StringType,
     CharType,
@@ -1163,6 +1164,7 @@ class TypesTestsMixin:
             IntegerType(),
             LongType(),
             ShortType(),
+            CalendarIntervalType(),
             ArrayType(StringType()),
             MapType(StringType(), IntegerType()),
             StructField("f1", StringType(), True),
@@ -1271,6 +1273,16 @@ class TypesTestsMixin:
 
         schema3 = self.spark.sql("SELECT INTERVAL '8' MONTH AS interval").schema
         self.assertEqual(schema3.fields[0].dataType, YearMonthIntervalType(1, 1))
+
+    def test_calendar_interval_type_constructor(self):
+        self.assertEqual(CalendarIntervalType().simpleString(), "interval")
+
+        with self.assertRaisesRegex(TypeError, "DataTypeSingleton.__call__() takes 1"):
+            CalendarIntervalType(3)
+
+    def test_calendar_interval_type(self):
+        schema1 = self.spark.sql("SELECT make_interval(100, 11, 1, 1, 12, 30, 01.001001)").schema
+        self.assertEqual(schema1.fields[0].dataType, CalendarIntervalType())
 
 
 class DataTypeTests(unittest.TestCase):

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -77,6 +77,7 @@ __all__ = [
     "LongType",
     "DayTimeIntervalType",
     "YearMonthIntervalType",
+    "CalendarIntervalType",
     "Row",
     "ShortType",
     "ArrayType",
@@ -491,6 +492,20 @@ class YearMonthIntervalType(AnsiIntervalType):
 
     def __repr__(self) -> str:
         return "%s(%d, %d)" % (type(self).__name__, self.startField, self.endField)
+
+
+class CalendarIntervalType(DataType, metaclass=DataTypeSingleton):
+    """The data type representing calendar intervals.
+
+    The calendar interval is stored internally in three components:
+    - an integer value representing the number of `months` in this interval.
+    - an integer value representing the number of `days` in this interval.
+    - a long value representing the number of `microseconds` in this interval.
+    """
+
+    @classmethod
+    def typeName(cls) -> str:
+        return "interval"
 
 
 class ArrayType(DataType):
@@ -1402,6 +1417,8 @@ def _parse_datatype_json_value(json_value: Union[dict, str]) -> DataType:
             if first_field is not None and second_field is None:
                 return YearMonthIntervalType(first_field)
             return YearMonthIntervalType(first_field, second_field)
+        elif json_value == "interval":
+            return CalendarIntervalType()
         elif _LENGTH_CHAR.match(json_value):
             m = _LENGTH_CHAR.match(json_value)
             return CharType(int(m.group(1)))  # type: ignore[union-attr]
@@ -1564,6 +1581,8 @@ def _infer_type(
         return DayTimeIntervalType()
     if dataType is YearMonthIntervalType:
         return YearMonthIntervalType()
+    if dataType is CalendarIntervalType:
+        return CalendarIntervalType()
     elif dataType is not None:
         return dataType()
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add `CalendarIntervalType` to PySpark


### Why are the changes needed?
in scala:
```
scala> spark.sql("SELECT make_interval(100, 11, 1, 1, 12, 30, 01.001001)").schema
res2: org.apache.spark.sql.types.StructType = StructType(StructField(make_interval(100, 11, 1, 1, 12, 30, 1.001001),CalendarIntervalType,true))
```

in python:
```
In [1]: spark.sql("SELECT make_interval(100, 11, 1, 1, 12, 30, 01.001001)").schema

...

AssertionError: Undefined error message parameter for error class: CANNOT_PARSE_DATATYPE. Parameters: {'error': "Undefined error message parameter for error class: CANNOT_PARSE_DATATYPE. Parameters: {'error': 'interval'}"}
```

### Does this PR introduce _any_ user-facing change?
yes

after this PR:
```
In [1]: spark.sql("SELECT make_interval(100, 11, 1, 1, 12, 30, 01.001001)").schema
Out[1]: StructType([StructField('make_interval(100, 11, 1, 1, 12, 30, 1.001001)', CalendarIntervalType(), True)])

```


### How was this patch tested?
added UT

### Was this patch authored or co-authored using generative AI tooling?
NO