### PR TITLE
[SPARK-45021][BUILD] Remove `antlr4-maven-plugin` configuration from `sql/catalyst/pom.xml`

### DIFF
--- a/sql/catalyst/pom.xml
+++ b/sql/catalyst/pom.xml
@@ -155,22 +155,6 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.antlr</groupId>
-        <artifactId>antlr4-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <goals>
-              <goal>antlr4</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <visitor>true</visitor>
-          <sourceDirectory>../catalyst/src/main/antlr4</sourceDirectory>
-          <treatWarningsAsErrors>true</treatWarningsAsErrors>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
         <executions>


### PR DESCRIPTION
### What changes were proposed in this pull request?
SPARK-44475(https://github.com/apache/spark/pull/41928) has already moved the `antlr4-maven-plugin` relevant configuration to `sql/api/pom.xml`, so the configuration in the `catalyst` module is unused now, so this pr remove it from `sql/catalyst/pom.xml`

### Why are the changes needed?
Clean up unused Maven `antlr4-maven-plugin` from catalyst module.




### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass GitHub Actions
- Manual verification

```
build/mvn clean install -DskipTests -pl sql/catalyst -am
```

Before

We can see

```
[INFO] 
[INFO] --- antlr4-maven-plugin:4.9.3:antlr4 (default) @ spark-catalyst_2.12 ---
[INFO] No ANTLR 4 grammars to compile in /Users/yangjie01/SourceCode/git/spark-mine-12/sql/catalyst/src/main/antlr4
[INFO] 
```

After

no relevant messages.


### Was this patch authored or co-authored using generative AI tooling?
No
