### PR TITLE
[SPARK-44750][PYTHON][CONNECT][TESTS][FOLLOW-UP] Avoid creating session twice in `SparkConnectSessionWithOptionsTest` 

### DIFF
--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -3345,7 +3345,7 @@ class SparkConnectSessionTests(ReusedConnectTestCase):
             self.assertIn("Create a new SparkSession is only supported with SparkConnect.", str(e))
 
 
-class SparkConnectSessionWithOptionsTest(ReusedConnectTestCase):
+class SparkConnectSessionWithOptionsTest(unittest.TestCase):
     def setUp(self) -> None:
         self.spark = (
             PySparkSession.builder.config("string", "foo")


### PR DESCRIPTION
### What changes were proposed in this pull request?
Avoid creating session twice in `SparkConnectSessionWithOptionsTest` 


### Why are the changes needed?
the session created in `ReusedConnectTestCase#setUpClass` is not used, so no need to inherit 


### Does this PR introduce _any_ user-facing change?
no, test-only

### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no
