### PR TITLE
[SPARK-45032][CONNECT] Fix compilation warnings related to `Top-level wildcard is not allowed and will error under -Xsource:3`

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/ExecuteHolder.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/ExecuteHolder.scala
@@ -172,7 +172,7 @@ private[connect] class ExecuteHolder(
     }
   }
 
-  def removeGrpcResponseSender[_](sender: ExecuteGrpcResponseSender[_]): Unit = synchronized {
+  def removeGrpcResponseSender(sender: ExecuteGrpcResponseSender[_]): Unit = synchronized {
     // if closed, we are shutting down and interrupting all senders already
     if (closedTime.isEmpty) {
       grpcResponseSenders -=


### PR DESCRIPTION
### What changes were proposed in this pull request?
Build with Scala 2.13, will result in the following compilation warnings:

```
[warn] /Users/yangjie01/SourceCode/git/spark-mine-sbt/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/ExecuteHolder.scala:175:32: [deprecation @  | origin= | version=2.13.7] Top-level wildcard is not allowed and will error under -Xsource:3
[warn]   def removeGrpcResponseSender[_](sender: ExecuteGrpcResponseSender[_]): Unit = synchronized {
[warn]                                ^
```
So this pr fix it.

### Why are the changes needed?
Fix compilation warnings related to `Top-level wildcard is not allowed and will error under -Xsource:3`.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No