### PR TITLE
[SPARK-44667][INFRA][FOLLOWUP] Uninstall `deepspeed` libraries for non-ML jobs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -425,7 +425,7 @@ jobs:
       run: |
         if [[ "$MODULES_TO_TEST" != *"pyspark-ml"* ]] && [[ "$BRANCH" != "branch-3.5" ]]; then
           # uninstall libraries dedicated for ML testing
-          python3.9 -m pip uninstall -y torch torchvision torcheval torchtnt tensorboard mlflow
+          python3.9 -m pip uninstall -y torch torchvision torcheval torchtnt tensorboard mlflow deepspeed
         fi
         if [ -f ./dev/free_disk_space_container ]; then
           ./dev/free_disk_space_container


### PR DESCRIPTION
### What changes were proposed in this pull request?
Uninstall `deepspeed` libraries for non-ML jobs


### Why are the changes needed?
after https://github.com/apache/spark/pull/42334, `deepspeed` was introduced as a dependency, which is not needed for non-ML jobs


### Does this PR introduce _any_ user-facing change?
no, dev-only

### How was this patch tested?
CI


### Was this patch authored or co-authored using generative AI tooling?
NO