### PR TITLE
[SPARK-45051][CONNECT] Use UUIDv7 by default for operation IDs to make operations chronologically sortable

### DIFF
--- a/connector/connect/common/pom.xml
+++ b/connector/connect/common/pom.xml
@@ -44,6 +44,11 @@
             <artifactId>scala-library</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.uuid</groupId>
+            <artifactId>java-uuid-generator</artifactId>
+            <version>${fasterxml.uuid.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
         </dependency>

--- a/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/client/ExecutePlanResponseReattachableIterator.scala
+++ b/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/client/ExecutePlanResponseReattachableIterator.scala
@@ -16,10 +16,9 @@
  */
 package org.apache.spark.sql.connect.client
 
-import java.util.UUID
-
 import scala.util.control.NonFatal
 
+import com.fasterxml.uuid.Generators.timeBasedEpochGenerator
 import io.grpc.{ManagedChannel, StatusRuntimeException}
 import io.grpc.protobuf.StatusProto
 import io.grpc.stub.StreamObserver
@@ -56,11 +55,11 @@ class ExecutePlanResponseReattachableIterator(
   val operationId = if (request.hasOperationId) {
     request.getOperationId
   } else {
-    // Add operation id, if not present.
+    // Add an UUIDv7 operation id, if not present.
     // with operationId set by the client, the client can use it to try to reattach on error
     // even before getting the first response. If the operation in fact didn't even reach the
     // server, that will end with INVALID_HANDLE.OPERATION_NOT_FOUND error.
-    UUID.randomUUID.toString
+    timeBasedEpochGenerator().generate().toString
   }
 
   // Need raw stubs, don't want retry handling or error conversion done by the custom stubs.

--- a/connector/connect/server/pom.xml
+++ b/connector/connect/server/pom.xml
@@ -224,6 +224,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.uuid</groupId>
+      <artifactId>java-uuid-generator</artifactId>
+      <version>${fasterxml.uuid.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.scalacheck</groupId>
       <artifactId>scalacheck_${scala.binary.version}</artifactId>
       <scope>test</scope>

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/ExecuteHolder.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/ExecuteHolder.scala
@@ -17,10 +17,11 @@
 
 package org.apache.spark.sql.connect.service
 
-import java.util.UUID
-
 import scala.collection.JavaConverters._
 import scala.collection.mutable
+
+import com.fasterxml.uuid.Generators.timeBasedEpochGenerator
+import com.fasterxml.uuid.impl.UUIDUtil
 
 import org.apache.spark.{SparkEnv, SparkSQLException}
 import org.apache.spark.connect.proto
@@ -42,15 +43,16 @@ private[connect] class ExecuteHolder(
 
   val operationId = if (request.hasOperationId) {
     try {
-      UUID.fromString(request.getOperationId).toString
+        UUIDUtil.uuid(request.getOperationId).toString
     } catch {
-      case _: IllegalArgumentException =>
+      case _: NumberFormatException =>
         throw new SparkSQLException(
           errorClass = "INVALID_HANDLE.FORMAT",
           messageParameters = Map("handle" -> request.getOperationId))
     }
   } else {
-    UUID.randomUUID().toString
+    // use UUIDv7 as operationId
+    timeBasedEpochGenerator().generate().toString
   }
 
   /**

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/ExecuteHolder.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/ExecuteHolder.scala
@@ -43,7 +43,7 @@ private[connect] class ExecuteHolder(
 
   val operationId = if (request.hasOperationId) {
     try {
-        UUIDUtil.uuid(request.getOperationId).toString
+      UUIDUtil.uuid(request.getOperationId).toString
     } catch {
       case _: NumberFormatException =>
         throw new SparkSQLException(

--- a/dev/create-release/spark-rm/Dockerfile
+++ b/dev/create-release/spark-rm/Dockerfile
@@ -42,7 +42,7 @@ ARG APT_INSTALL="apt-get install --no-install-recommends -y"
 #   We should use the latest Sphinx version once this is fixed.
 # TODO(SPARK-35375): Jinja2 3.0.0+ causes error when building with Sphinx.
 #   See also https://issues.apache.org/jira/browse/SPARK-35375.
-ARG PIP_PKGS="sphinx==3.0.4 mkdocs==1.1.2 numpy==1.20.3 pydata_sphinx_theme==0.8.0 ipython==7.19.0 nbsphinx==0.8.0 numpydoc==1.1.0 jinja2==2.11.3 twine==3.4.1 sphinx-plotly-directive==0.1.3 pandas==1.5.3 pyarrow==3.0.0 plotly==5.4.0 markupsafe==2.0.1 docutils<0.17 grpcio==1.56.0 protobuf==4.21.6 grpcio-status==1.56.0 googleapis-common-protos==1.56.4"
+ARG PIP_PKGS="sphinx==3.0.4 mkdocs==1.1.2 numpy==1.20.3 pydata_sphinx_theme==0.8.0 ipython==7.19.0 nbsphinx==0.8.0 numpydoc==1.1.0 jinja2==2.11.3 twine==3.4.1 sphinx-plotly-directive==0.1.3 pandas==1.5.3 pyarrow==3.0.0 plotly==5.4.0 markupsafe==2.0.1 docutils<0.17 grpcio==1.56.0 protobuf==4.21.6 grpcio-status==1.56.0 googleapis-common-protos==1.56.4 uuid6==2023.5.2"
 ARG GEM_PKGS="bundler:2.3.8"
 
 # Install extra needed repos and refresh.

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -116,7 +116,6 @@ jakarta.xml.bind-api/2.3.2//jakarta.xml.bind-api-2.3.2.jar
 janino/3.1.9//janino-3.1.9.jar
 javassist/3.29.2-GA//javassist-3.29.2-GA.jar
 javax.jdo/3.2.0-m3//javax.jdo-3.2.0-m3.jar
-java-uuid-generator/4.2.0//java-uuid-generator-4.2.0.jar
 javolution/5.5.1//javolution-5.5.1.jar
 jaxb-runtime/2.3.2//jaxb-runtime-2.3.2.jar
 jcl-over-slf4j/2.0.7//jcl-over-slf4j-2.0.7.jar

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -116,6 +116,7 @@ jakarta.xml.bind-api/2.3.2//jakarta.xml.bind-api-2.3.2.jar
 janino/3.1.9//janino-3.1.9.jar
 javassist/3.29.2-GA//javassist-3.29.2-GA.jar
 javax.jdo/3.2.0-m3//javax.jdo-3.2.0-m3.jar
+java-uuid-generator/4.2.0//java-uuid-generator-4.2.0.jar
 javolution/5.5.1//javolution-5.5.1.jar
 jaxb-runtime/2.3.2//jaxb-runtime-2.3.2.jar
 jcl-over-slf4j/2.0.7//jcl-over-slf4j-2.0.7.jar

--- a/dev/infra/Dockerfile
+++ b/dev/infra/Dockerfile
@@ -68,7 +68,7 @@ RUN pypy3 -m pip install numpy 'pandas<=2.0.3' scipy coverage matplotlib
 RUN python3.9 -m pip install numpy pyarrow 'pandas<=2.0.3' scipy unittest-xml-reporting plotly>=4.8 'mlflow>=2.3.1' coverage matplotlib openpyxl 'memory-profiler==0.60.0' 'scikit-learn==1.1.*'
 
 # Add Python deps for Spark Connect.
-RUN python3.9 -m pip install grpcio protobuf googleapis-common-protos grpcio-status
+RUN python3.9 -m pip install grpcio protobuf googleapis-common-protos grpcio-status uuid6==2023.5.2
 
 # Add torch as a testing dependency for TorchDistributor
 RUN python3.9 -m pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu

--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -54,6 +54,7 @@ grpcio>=1.48,<1.57
 grpcio-status>=1.48,<1.57
 protobuf==3.20.3
 googleapis-common-protos==1.56.4
+uuid6==2023.5.2
 
 # Spark Connect python proto generation plugin (optional)
 mypy-protobuf==3.3.0

--- a/pom.xml
+++ b/pom.xml
@@ -186,6 +186,7 @@
     <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
     <fasterxml.jackson.version>2.15.2</fasterxml.jackson.version>
     <fasterxml.jackson.databind.version>2.15.2</fasterxml.jackson.databind.version>
+    <fasterxml.uuid.version>4.2.0</fasterxml.uuid.version>
     <ws.xmlschema.version>2.3.0</ws.xmlschema.version>
     <org.glassfish.jaxb.txw2.version>3.0.2</org.glassfish.jaxb.txw2.version>
     <snappy.version>1.1.10.3</snappy.version>
@@ -961,6 +962,11 @@
         <groupId>io.dropwizard.metrics</groupId>
         <artifactId>metrics-jmx</artifactId>
         <version>${codahale.metrics.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.uuid</groupId>
+        <artifactId>java-uuid-generator</artifactId>
+        <version>${fasterxml.uuid.version}</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>

--- a/python/docs/source/getting_started/install.rst
+++ b/python/docs/source/getting_started/install.rst
@@ -162,6 +162,7 @@ Package                    Supported version Note
 `grpcio`                   >=1.48,<1.57              Required for Spark Connect
 `grpcio-status`            >=1.48,<1.57              Required for Spark Connect
 `googleapis-common-protos` ==1.56.4                  Required for Spark Connect
+`uuid6`                    ==2023.5.2                Required for Spark Connect
 ========================== ========================= ======================================================================================
 
 Note that PySpark requires Java 8 or later with ``JAVA_HOME`` properly set.  

--- a/python/pyspark/sql/connect/client/reattach.py
+++ b/python/pyspark/sql/connect/client/reattach.py
@@ -19,7 +19,7 @@ from pyspark.sql.connect.utils import check_dependencies
 check_dependencies(__name__)
 
 import warnings
-import uuid
+import uuid6
 from collections.abc import Generator
 from typing import Optional, Dict, Any, Iterator, Iterable, Tuple, Callable, cast
 from multiprocessing.pool import ThreadPool
@@ -67,11 +67,11 @@ class ExecutePlanResponseReattachableIterator(Generator):
         if request.operation_id:
             self._operation_id = request.operation_id
         else:
-            # Add operation id, if not present.
+            # Add UUIDv7 operation id, if not present.
             # with operationId set by the client, the client can use it to try to reattach on error
             # even before getting the first response. If the operation in fact didn't even reach the
             # server, that will end with INVALID_HANDLE.OPERATION_NOT_FOUND error.
-            self._operation_id = str(uuid.uuid4())
+            self._operation_id = str(uuid6.uuid7())
 
         self._stub = stub
         request.request_options.append(

--- a/python/setup.py
+++ b/python/setup.py
@@ -326,6 +326,7 @@ try:
                 "grpcio-status>=%s" % _minimum_grpc_version,
                 "googleapis-common-protos>=%s" % _minimum_googleapis_common_protos_version,
                 "numpy>=1.15",
+                "uuid6==2023.5.2",
             ],
         },
         python_requires=">=3.8",


### PR DESCRIPTION
### What changes were proposed in this pull request?
This changes the default operations ID format from UUIDv4 to UUIDv7. This is done on the server and on the client side (both Scala and Python) since both sides can set this ID first.


### Why are the changes needed?
Spark Connect currently uses UUIDv4 for operation IDs. Using UUIDv7 instead allows us to sort operations by ID to receive a chronological order while keeping the collision-free properties we require from this ID.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Existing tests.


### Was this patch authored or co-authored using generative AI tooling?
No.
