### PR TITLE
[SPARK-45055] [SQL] Do not transpose windows if they conflict on ORDER BY / PROJECT clauses

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1310,21 +1310,15 @@ object TransposeWindow extends Rule[LogicalPlan] {
   private def compatibleOrderBy(w1: Window, w2: Window): Boolean = {
     val childWindowExprs = w2.windowExpressions.map(x => x.toAttribute)
     val parentOrder = w1.orderSpec.flatMap(x => x.references)
-    println(s"child window expr ${childWindowExprs}")
-    println(s"parent order ${parentOrder}")
-    println(s"Intersects? ${childWindowExprs.intersect(parentOrder).isEmpty}")
     childWindowExprs.intersect(parentOrder).isEmpty
   }
 
   private def windowsCompatible(w1: Window, w2: Window): Boolean = {
-    println(s"Parent ${w1.references} vs produced ${w1.producedAttributes}")
-    println(s"Child ${w2.windowOutputSet}")
-    println(s"Intersect is empty? ${w1.references.intersect(w2.windowOutputSet).isEmpty}")
     w1.references.intersect(w2.windowOutputSet).isEmpty &&
       w1.expressions.forall(_.deterministic) &&
       w2.expressions.forall(_.deterministic) &&
-      compatiblePartitions(w1.partitionSpec, w2.partitionSpec) // &&
-      // compatibleOrderBy(w1, w2)
+      compatiblePartitions(w1.partitionSpec, w2.partitionSpec) &&
+      compatibleOrderBy(w1, w2)
   }
 
   def apply(plan: LogicalPlan): LogicalPlan = plan.transformUpWithPruning(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1305,11 +1305,22 @@ object TransposeWindow extends Rule[LogicalPlan] {
     }
   }
 
+  // Returns false if the parent 'w1' window function order by any of the window
+  // expressions produced by 'w2'.
+  private def compatibleOrderBy(w1: Window, w2: Window): Boolean = {
+    val childWindowExprs = w2.windowExpressions.map(x => x.toAttribute)
+    val parentOrder = w1.orderSpec.flatMap(x => x.references)
+
+    println(s"PARENT ORDER ${parentOrder}")
+    childWindowExprs.intersect(parentOrder).isEmpty
+  }
+
   private def windowsCompatible(w1: Window, w2: Window): Boolean = {
     w1.references.intersect(w2.windowOutputSet).isEmpty &&
       w1.expressions.forall(_.deterministic) &&
       w2.expressions.forall(_.deterministic) &&
-      compatiblePartitions(w1.partitionSpec, w2.partitionSpec)
+      compatiblePartitions(w1.partitionSpec, w2.partitionSpec) &&
+      compatibleOrderBy(w1, w2)
   }
 
   def apply(plan: LogicalPlan): LogicalPlan = plan.transformUpWithPruning(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1310,8 +1310,6 @@ object TransposeWindow extends Rule[LogicalPlan] {
   private def compatibleOrderBy(w1: Window, w2: Window): Boolean = {
     val childWindowExprs = w2.windowExpressions.map(x => x.toAttribute)
     val parentOrder = w1.orderSpec.flatMap(x => x.references)
-
-    println(s"PARENT ORDER ${parentOrder}")
     childWindowExprs.intersect(parentOrder).isEmpty
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1310,15 +1310,21 @@ object TransposeWindow extends Rule[LogicalPlan] {
   private def compatibleOrderBy(w1: Window, w2: Window): Boolean = {
     val childWindowExprs = w2.windowExpressions.map(x => x.toAttribute)
     val parentOrder = w1.orderSpec.flatMap(x => x.references)
+    println(s"child window expr ${childWindowExprs}")
+    println(s"parent order ${parentOrder}")
+    println(s"Intersects? ${childWindowExprs.intersect(parentOrder).isEmpty}")
     childWindowExprs.intersect(parentOrder).isEmpty
   }
 
   private def windowsCompatible(w1: Window, w2: Window): Boolean = {
+    println(s"Parent ${w1.references} vs produced ${w1.producedAttributes}")
+    println(s"Child ${w2.windowOutputSet}")
+    println(s"Intersect is empty? ${w1.references.intersect(w2.windowOutputSet).isEmpty}")
     w1.references.intersect(w2.windowOutputSet).isEmpty &&
       w1.expressions.forall(_.deterministic) &&
       w2.expressions.forall(_.deterministic) &&
-      compatiblePartitions(w1.partitionSpec, w2.partitionSpec) &&
-      compatibleOrderBy(w1, w2)
+      compatiblePartitions(w1.partitionSpec, w2.partitionSpec) // &&
+      // compatibleOrderBy(w1, w2)
   }
 
   def apply(plan: LogicalPlan): LogicalPlan = plan.transformUpWithPruning(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/TransposeWindowSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/TransposeWindowSuite.scala
@@ -160,4 +160,18 @@ class TransposeWindowSuite extends PlanTest {
     comparePlans(optimized, correctAnswer.analyze)
   }
 
+  test("two windows with overlapping project/order by lists") {
+    // Parent orders by the window expression of the child, no reordering.
+    val sum_a_2 = sum(c).as('sum_a_2)
+    val parentOrderSpec = Seq(d.asc, sum_a_2.toAttribute.asc)
+    val query = testRelation
+      .window(Seq(sum_a_2),
+        partitionSpec4, orderSpec2)
+      .window(Seq(sum(c).as('sum_a_1)), partitionSpec3,
+        parentOrderSpec)
+    val analyzed = query.analyze
+    val optimized = Optimize.execute(analyzed)
+    comparePlans(optimized, analyzed)
+  }
+
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
TransposeWindows rule reorders parent and child window functions. Currently it incorrectly reorders the window functions in cases where the top window function orders by on the result of the bottom window function, e.g. `sum1` in the following example:

`SELECT ROW_NUMBER() OVER (PARTITION BY C ORDER BY sum1) 
FROM (SELECT ROW_NUMBER() OVER (PARTITION BY C) as sum1 FROM T)
`

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
TransposeWindows currently produces invalid query plans for the case described above.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Unit test.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No