### PR TITLE
[SPARK-43241][PS] `MultiIndex.append` not checking names for equality

### DIFF
--- a/python/pyspark/pandas/indexes/base.py
+++ b/python/pyspark/pandas/indexes/base.py
@@ -1917,18 +1917,12 @@ class Index(IndexOpsMixin):
         sdf_other = other._internal.spark_frame.select(other._internal.index_spark_columns)
         sdf_appended = sdf_self.union(sdf_other)
 
-        # names should be kept when MultiIndex, but Index wouldn't keep its name.
-        if isinstance(self, MultiIndex):
-            index_names = self._internal.index_names
-        else:
-            index_names = None
-
         internal = InternalFrame(
             spark_frame=sdf_appended,
             index_spark_columns=[
                 scol_for(sdf_appended, col) for col in self._internal.index_spark_column_names
             ],
-            index_names=index_names,
+            index_names=None,
             index_fields=index_fields,
         )
 

--- a/python/pyspark/pandas/tests/indexes/test_base_slow.py
+++ b/python/pyspark/pandas/tests/indexes/test_base_slow.py
@@ -107,29 +107,9 @@ class IndexesSlowTestsMixin:
         psmidx1 = ps.from_pandas(pmidx1)
         psmidx2 = ps.from_pandas(pmidx2)
 
-        # TODO(SPARK-43241): MultiIndex.append not checking names for equality.
-        # Also refer to https://github.com/pandas-dev/pandas/pull/48288.
-        if LooseVersion(pd.__version__) >= LooseVersion("2.0.0"):
-            self.assert_eq(
-                pmidx1.append(pmidx2), psmidx1.append(psmidx2).rename([None, None, None])
-            )
-        else:
-            self.assert_eq(pmidx1.append(pmidx2), psmidx1.append(psmidx2))
-
-        if LooseVersion(pd.__version__) >= LooseVersion("2.0.0"):
-            self.assert_eq(
-                pmidx2.append(pmidx1), psmidx2.append(psmidx1).rename([None, None, None])
-            )
-        else:
-            self.assert_eq(pmidx2.append(pmidx1), psmidx2.append(psmidx1))
-
-        if LooseVersion(pd.__version__) >= LooseVersion("2.0.0"):
-            self.assert_eq(
-                pmidx1.append(pmidx2).names,
-                psmidx1.append(psmidx2).rename([None, None, None]).names,
-            )
-        else:
-            self.assert_eq(pmidx1.append(pmidx2).names, psmidx1.append(psmidx2).names)
+        self.assert_eq(pmidx1.append(pmidx2), psmidx1.append(psmidx2))
+        self.assert_eq(pmidx2.append(pmidx1), psmidx2.append(psmidx1))
+        self.assert_eq(pmidx1.append(pmidx2).names, psmidx1.append(psmidx2).names)
 
         # Index & MultiIndex is currently not supported
         expected_error_message = r"append\(\) between Index & MultiIndex is currently not supported"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to fix the behavior of `MultiIndex.append` to do not checking names.

### Why are the changes needed?

To match the behavior with pandas according to https://github.com/pandas-dev/pandas/pull/48288

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, the behavior is changed to match with pandas:

**Testing data**
```python
>>> psmidx1
MultiIndex([('a', 'x', 1),
            ('b', 'y', 2),
            ('c', 'z', 3)],
           names=['x', 'y', 'z'])
>>> psmidx2
MultiIndex([('a', 'x', 1),
            ('b', 'y', 2),
            ('c', 'z', 3)],
           names=['p', 'q', 'r'])
```

**Before**
```python
>>> psmidx1.append(psmidx2)
MultiIndex([('a', 'x', 1),
            ('b', 'y', 2),
            ('c', 'z', 3),
            ('a', 'x', 1),
            ('b', 'y', 2),
            ('c', 'z', 3)],
           names=['x', 'y', 'z'])
```

**After**
```python
>>> psmidx1.append(psmidx2)
MultiIndex([('a', 'x', 1),
            ('b', 'y', 2),
            ('c', 'z', 3),
            ('a', 'x', 1),
            ('b', 'y', 2),
            ('c', 'z', 3)],
           )
```

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Fix the existing UTs.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.