### PR TITLE
[SPARK-45066][SQL][PYTHON][CONNECT] Make function `repeat` accept column-type `n`

### DIFF
--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/functions.scala
@@ -4092,6 +4092,14 @@ object functions {
   def repeat(str: Column, n: Int): Column = Column.fn("repeat", str, lit(n))
 
   /**
+   * Repeats a string column n times, and returns it as a new string column.
+   *
+   * @group string_funcs
+   * @since 4.0.0
+   */
+  def repeat(str: Column, n: Column): Column = Column.fn("repeat", str, n)
+
+  /**
    * Trim the spaces from right end for the specified string value.
    *
    * @group string_funcs

--- a/python/pyspark/sql/connect/functions.py
+++ b/python/pyspark/sql/connect/functions.py
@@ -2357,8 +2357,9 @@ def rpad(col: "ColumnOrName", len: int, pad: str) -> Column:
 rpad.__doc__ = pysparkfuncs.rpad.__doc__
 
 
-def repeat(col: "ColumnOrName", n: int) -> Column:
-    return _invoke_function("repeat", _to_col(col), lit(n))
+def repeat(col: "ColumnOrName", n: Union["ColumnOrName", int]) -> Column:
+    n = lit(n) if isinstance(n, int) else n
+    return _invoke_function("repeat", _to_col(col), _to_col(n))
 
 
 repeat.__doc__ = pysparkfuncs.repeat.__doc__

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -4200,6 +4200,16 @@ object functions {
   }
 
   /**
+   * Repeats a string column n times, and returns it as a new string column.
+   *
+   * @group string_funcs
+   * @since 4.0.0
+   */
+  def repeat(str: Column, n: Column): Column = withExpr {
+    StringRepeat(str.expr, n.expr)
+  }
+
+  /**
    * Trim the spaces from right end for the specified string value.
    *
    * @group string_funcs


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make function `repeat` accept column-type `n`


### Why are the changes needed?

1. to follow this guide: https://github.com/apache/spark/blob/5b609598503df603cbddd5e1adf8d2cb28a5f977/sql/core/src/main/scala/org/apache/spark/sql/functions.scala#L60-L62
2. especially, can replace [the internal function](https://github.com/apache/spark/blob/17fac569b4e4b569d41f761db07d7bf112801e0c/python/pyspark/pandas/spark/functions.py#L138-L143) in Pandas API (to make the PR clean, I will replace it in separate PR)


### Does this PR introduce _any_ user-facing change?
yes

### How was this patch tested?
NO


### Was this patch authored or co-authored using generative AI tooling?
NO
