### PR TITLE
[SPARK-45070][SQL][DOCS] Describe the binary and datetime formats of `to_char`/`to_varchar`

### DIFF
--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/functions.scala
@@ -4263,6 +4263,7 @@ object functions {
    */
   def to_binary(e: Column): Column = Column.fn("to_binary", e)
 
+  // scalastyle:off line.size.limit
   /**
    * Convert `e` to a string based on the `format`. Throws an exception if the conversion fails.
    *
@@ -4284,6 +4285,14 @@ object functions {
    *   prints '+' for positive values but 'MI' prints a space.</li> <li>'PR': Only allowed at the
    *   end of the format string; specifies that the result string will be wrapped by angle
    *   brackets if the input value is negative.</li> </ul>
+   *   If `e` is a datetime, `format` shall be a valid datetime pattern, see
+   *   <a href="https://spark.apache.org/docs/latest/sql-ref-datetime-pattern.html">Datetime Patterns</a>.
+   *   If `e` is a binary, it is converted to a string in one of the formats:
+   *   <ul>
+   *     <li>'base64': a base 64 string.</li>
+   *     <li>'hex': a string in the hexadecimal format.</li>
+   *     <li>'utf-8': the input binary is decoded to UTF-8 string.</li>
+   *   </ul>
    *
    * @group string_funcs
    * @since 3.5.0
@@ -4311,11 +4320,20 @@ object functions {
    *   prints '+' for positive values but 'MI' prints a space.</li> <li>'PR': Only allowed at the
    *   end of the format string; specifies that the result string will be wrapped by angle
    *   brackets if the input value is negative.</li> </ul>
+   *   If `e` is a datetime, `format` shall be a valid datetime pattern, see
+   *   <a href="https://spark.apache.org/docs/latest/sql-ref-datetime-pattern.html">Datetime Patterns</a>.
+   *   If `e` is a binary, it is converted to a string in one of the formats:
+   *   <ul>
+   *     <li>'base64': a base 64 string.</li>
+   *     <li>'hex': a string in the hexadecimal format.</li>
+   *     <li>'utf-8': the input binary is decoded to UTF-8 string.</li>
+   *   </ul>
    *
    * @group string_funcs
    * @since 3.5.0
    */
   def to_varchar(e: Column, format: Column): Column = Column.fn("to_varchar", e, format)
+  // scalastyle:on line.size.limit
 
   /**
    * Convert string 'e' to a number based on the string format 'format'. Throws an exception if

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/functions.scala
@@ -4284,15 +4284,12 @@ object functions {
    *   (optional, only allowed once at the beginning or end of the format string). Note that 'S'
    *   prints '+' for positive values but 'MI' prints a space.</li> <li>'PR': Only allowed at the
    *   end of the format string; specifies that the result string will be wrapped by angle
-   *   brackets if the input value is negative.</li> </ul>
-   *   If `e` is a datetime, `format` shall be a valid datetime pattern, see
-   *   <a href="https://spark.apache.org/docs/latest/sql-ref-datetime-pattern.html">Datetime Patterns</a>.
-   *   If `e` is a binary, it is converted to a string in one of the formats:
-   *   <ul>
-   *     <li>'base64': a base 64 string.</li>
-   *     <li>'hex': a string in the hexadecimal format.</li>
-   *     <li>'utf-8': the input binary is decoded to UTF-8 string.</li>
-   *   </ul>
+   *   brackets if the input value is negative.</li> </ul> If `e` is a datetime, `format` shall be
+   *   a valid datetime pattern, see <a
+   *   href="https://spark.apache.org/docs/latest/sql-ref-datetime-pattern.html">Datetime
+   *   Patterns</a>. If `e` is a binary, it is converted to a string in one of the formats: <ul>
+   *   <li>'base64': a base 64 string.</li> <li>'hex': a string in the hexadecimal format.</li>
+   *   <li>'utf-8': the input binary is decoded to UTF-8 string.</li> </ul>
    *
    * @group string_funcs
    * @since 3.5.0
@@ -4321,15 +4318,12 @@ object functions {
    *   (optional, only allowed once at the beginning or end of the format string). Note that 'S'
    *   prints '+' for positive values but 'MI' prints a space.</li> <li>'PR': Only allowed at the
    *   end of the format string; specifies that the result string will be wrapped by angle
-   *   brackets if the input value is negative.</li> </ul>
-   *   If `e` is a datetime, `format` shall be a valid datetime pattern, see
-   *   <a href="https://spark.apache.org/docs/latest/sql-ref-datetime-pattern.html">Datetime Patterns</a>.
-   *   If `e` is a binary, it is converted to a string in one of the formats:
-   *   <ul>
-   *     <li>'base64': a base 64 string.</li>
-   *     <li>'hex': a string in the hexadecimal format.</li>
-   *     <li>'utf-8': the input binary is decoded to UTF-8 string.</li>
-   *   </ul>
+   *   brackets if the input value is negative.</li> </ul> If `e` is a datetime, `format` shall be
+   *   a valid datetime pattern, see <a
+   *   href="https://spark.apache.org/docs/latest/sql-ref-datetime-pattern.html">Datetime
+   *   Patterns</a>. If `e` is a binary, it is converted to a string in one of the formats: <ul>
+   *   <li>'base64': a base 64 string.</li> <li>'hex': a string in the hexadecimal format.</li>
+   *   <li>'utf-8': the input binary is decoded to UTF-8 string.</li> </ul>
    *
    * @group string_funcs
    * @since 3.5.0

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/functions.scala
@@ -4297,8 +4297,10 @@ object functions {
    * @group string_funcs
    * @since 3.5.0
    */
+  // scalastyle:on line.size.limit
   def to_char(e: Column, format: Column): Column = Column.fn("to_char", e, format)
 
+  // scalastyle:off line.size.limit
   /**
    * Convert `e` to a string based on the `format`. Throws an exception if the conversion fails.
    *
@@ -4332,8 +4334,8 @@ object functions {
    * @group string_funcs
    * @since 3.5.0
    */
-  def to_varchar(e: Column, format: Column): Column = Column.fn("to_varchar", e, format)
   // scalastyle:on line.size.limit
+  def to_varchar(e: Column, format: Column): Column = Column.fn("to_varchar", e, format)
 
   /**
    * Convert string 'e' to a number based on the string format 'format'. Throws an exception if

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -10426,9 +10426,9 @@ def to_char(col: "ColumnOrName", format: "ColumnOrName") -> Column:
     If `col` is a datetime, `format` shall be a valid datetime pattern, see
     <a href="https://spark.apache.org/docs/latest/sql-ref-datetime-pattern.html">Patterns</a>.
     If `col` is a binary, it is converted to a string in one of the formats:
-     'base64': a base 64 string.
-     'hex': a string in the hexadecimal format.
-     'utf-8': the input binary is decoded to UTF-8 string.
+    'base64': a base 64 string.
+    'hex': a string in the hexadecimal format.
+    'utf-8': the input binary is decoded to UTF-8 string.
 
     .. versionadded:: 3.5.0
 
@@ -10472,9 +10472,9 @@ def to_varchar(col: "ColumnOrName", format: "ColumnOrName") -> Column:
     If `col` is a datetime, `format` shall be a valid datetime pattern, see
     <a href="https://spark.apache.org/docs/latest/sql-ref-datetime-pattern.html">Patterns</a>.
     If `col` is a binary, it is converted to a string in one of the formats:
-     'base64': a base 64 string.
-     'hex': a string in the hexadecimal format.
-     'utf-8': the input binary is decoded to UTF-8 string.
+    'base64': a base 64 string.
+    'hex': a string in the hexadecimal format.
+    'utf-8': the input binary is decoded to UTF-8 string.
 
     .. versionadded:: 3.5.0
 

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -10423,6 +10423,12 @@ def to_char(col: "ColumnOrName", format: "ColumnOrName") -> Column:
     values but 'MI' prints a space.
     'PR': Only allowed at the end of the format string; specifies that the result string
     will be wrapped by angle brackets if the input value is negative.
+    If `col` is a datetime, `format` shall be a valid datetime pattern, see
+    <a href="https://spark.apache.org/docs/latest/sql-ref-datetime-pattern.html">Patterns</a>.
+    If `col` is a binary, it is converted to a string in one of the formats:
+     'base64': a base 64 string.
+     'hex': a string in the hexadecimal format.
+     'utf-8': the input binary is decoded to UTF-8 string.
 
     .. versionadded:: 3.5.0
 
@@ -10463,6 +10469,12 @@ def to_varchar(col: "ColumnOrName", format: "ColumnOrName") -> Column:
     values but 'MI' prints a space.
     'PR': Only allowed at the end of the format string; specifies that the result string
     will be wrapped by angle brackets if the input value is negative.
+    If `col` is a datetime, `format` shall be a valid datetime pattern, see
+    <a href="https://spark.apache.org/docs/latest/sql-ref-datetime-pattern.html">Patterns</a>.
+    If `col` is a binary, it is converted to a string in one of the formats:
+     'base64': a base 64 string.
+     'hex': a string in the hexadecimal format.
+     'utf-8': the input binary is decoded to UTF-8 string.
 
     .. versionadded:: 3.5.0
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -4399,6 +4399,7 @@ object functions {
     new ToBinary(e.expr)
   }
 
+  // scalastyle:off line.size.limit
   /**
    * Convert `e` to a string based on the `format`.
    * Throws an exception if the conversion fails. The format can consist of the following
@@ -4419,6 +4420,13 @@ object functions {
    *     but 'MI' prints a space.
    *   'PR': Only allowed at the end of the format string; specifies that the result string will be
    *     wrapped by angle brackets if the input value is negative.
+   *
+   *  If `e` is a datetime, `format` shall be a valid datetime pattern, see
+   *  <a href="https://spark.apache.org/docs/latest/sql-ref-datetime-pattern.html">Datetime Patterns</a>.
+   *  If `e` is a binary, it is converted to a string in one of the formats:
+   *     'base64': a base 64 string.
+   *     'hex': a string in the hexadecimal format.
+   *     'utf-8': the input binary is decoded to UTF-8 string.
    *
    * @group string_funcs
    * @since 3.5.0
@@ -4446,10 +4454,18 @@ object functions {
    *   'PR': Only allowed at the end of the format string; specifies that the result string will be
    *     wrapped by angle brackets if the input value is negative.
    *
+   *  If `e` is a datetime, `format` shall be a valid datetime pattern, see
+   *  <a href="https://spark.apache.org/docs/latest/sql-ref-datetime-pattern.html">Datetime Patterns</a>.
+   *  If `e` is a binary, it is converted to a string in one of the formats:
+   *     'base64': a base 64 string.
+   *     'hex': a string in the hexadecimal format.
+   *     'utf-8': the input binary is decoded to UTF-8 string.
+   *
    * @group string_funcs
    * @since 3.5.0
    */
   def to_varchar(e: Column, format: Column): Column = call_function("to_varchar", e, format)
+  // scalastyle:on line.size.limit
 
   /**
    * Convert string 'e' to a number based on the string format 'format'.

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -4431,8 +4431,10 @@ object functions {
    * @group string_funcs
    * @since 3.5.0
    */
+  // scalastyle:on line.size.limit
   def to_char(e: Column, format: Column): Column = call_function("to_char", e, format)
 
+  // scalastyle:off line.size.limit
   /**
    * Convert `e` to a string based on the `format`.
    * Throws an exception if the conversion fails. The format can consist of the following
@@ -4464,8 +4466,8 @@ object functions {
    * @group string_funcs
    * @since 3.5.0
    */
-  def to_varchar(e: Column, format: Column): Column = call_function("to_varchar", e, format)
   // scalastyle:on line.size.limit
+  def to_varchar(e: Column, format: Column): Column = call_function("to_varchar", e, format)
 
   /**
    * Convert string 'e' to a number based on the string format 'format'.


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to document the recent changes related to the `format` of the `to_char`/`to_varchar` functions:
1. binary formats added by https://github.com/apache/spark/pull/42632
2. datetime formats introduced by https://github.com/apache/spark/pull/42534

### Why are the changes needed?
To inform users about recent changes.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By CI.

### Was this patch authored or co-authored using generative AI tooling?
No.