### PR TITLE
[SPARK-45072][CONNECT] Fix outer scopes for ammonite classes

### DIFF
--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/application/ConnectRepl.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/application/ConnectRepl.scala
@@ -22,7 +22,8 @@ import java.util.concurrent.Semaphore
 import scala.util.control.NonFatal
 
 import ammonite.compiler.CodeClassWrapper
-import ammonite.util.Bind
+import ammonite.compiler.iface.CodeWrapper
+import ammonite.util.{Bind, Imports, Name, Util}
 
 import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.sql.SparkSession
@@ -94,8 +95,8 @@ object ConnectRepl {
     val main = ammonite.Main(
       welcomeBanner = Option(splash),
       predefCode = predefCode,
-      replCodeWrapper = CodeClassWrapper,
-      scriptCodeWrapper = CodeClassWrapper,
+      replCodeWrapper = ExtendedCodeClassWrapper,
+      scriptCodeWrapper = ExtendedCodeClassWrapper,
       inputStream = inputStream,
       outputStream = outputStream,
       errorStream = errorStream)
@@ -105,5 +106,24 @@ object ConnectRepl {
     } else {
       main.run(sparkBind)
     }
+  }
+}
+
+/**
+ * [[CodeWrapper]] that makes sure new Helper classes are always registered as an outer scope.
+ */
+@DeveloperApi
+object ExtendedCodeClassWrapper extends CodeWrapper {
+  override def wrapperPath: Seq[Name] = CodeClassWrapper.wrapperPath
+  override def apply(
+      code: String,
+      source: Util.CodeSource,
+      imports: Imports,
+      printCode: String,
+      indexedWrapper: Name,
+      extraCode: String): (String, String, Int) = {
+    val augmentedCode =
+      "org.apache.spark.sql.catalyst.encoders.OuterScopes.addOuterScope(this)\n" + code
+    CodeClassWrapper(augmentedCode, source, imports, printCode, indexedWrapper, extraCode)
   }
 }

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/application/ConnectRepl.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/application/ConnectRepl.scala
@@ -122,8 +122,11 @@ object ExtendedCodeClassWrapper extends CodeWrapper {
       printCode: String,
       indexedWrapper: Name,
       extraCode: String): (String, String, Int) = {
-    val augmentedCode =
-      "org.apache.spark.sql.catalyst.encoders.OuterScopes.addOuterScope(this)\n" + code
-    CodeClassWrapper(augmentedCode, source, imports, printCode, indexedWrapper, extraCode)
+    val (top, bottom, level) =
+      CodeClassWrapper(code, source, imports, printCode, indexedWrapper, extraCode)
+    // Make sure we register the Helper before anything else, so outer scopes work as expected.
+    val augmentedTop = top +
+      "\norg.apache.spark.sql.catalyst.encoders.OuterScopes.addOuterScope(this)\n"
+    (augmentedTop, bottom, level)
   }
 }

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/CheckConnectJvmClientCompatibility.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/CheckConnectJvmClientCompatibility.scala
@@ -359,6 +359,12 @@ object CheckConnectJvmClientCompatibility {
       ProblemFilters.exclude[MissingClassProblem](
         "org.apache.spark.sql.application.ConnectRepl$" // developer API
       ),
+      ProblemFilters.exclude[MissingClassProblem](
+        "org.apache.spark.sql.application.ExtendedCodeClassWrapper" // developer API
+      ),
+      ProblemFilters.exclude[MissingClassProblem](
+        "org.apache.spark.sql.application.ExtendedCodeClassWrapper$" // developer API
+      ),
 
       // SparkSession
       // developer API


### PR DESCRIPTION
### What changes were proposed in this pull request?
Ammonite places all user code inside Helper classes which are nested inside the class it creates for each command. This PR adds a custom code class wrapper for the Ammonite REPL. It makes sure the Helper classes generated by ammonite are always registered as an outer scope immediately. This way we can instantiate classes defined inside the Helper class, even when we execute Spark code as part of the Helper's constructor.

### Why are the changes needed?
When you currently define a class and execute a Spark command using that class inside the same cell/line this will fail with an NullPointerException. The reason for that is that we cannot resolve the outer scope needed to instantiate the class. This PR fixes that issue. The following code will now execute successfully (include the curly braces):
```scala
{
  case class Thing(val value: String)
  val r = (0 to 10).map( value => Thing(value.toString) )
  spark.createDataFrame(r)
}
```

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
I added more tests to the `ReplE2ESuite`.

### Was this patch authored or co-authored using generative AI tooling?
No.