### PR TITLE
[MINOR][PYTHON][TESTS] Add init file to pyspark.ml.tests.connect

### DIFF
--- a/python/pyspark/ml/tests/connect/__init__.py
+++ b/python/pyspark/ml/tests/connect/__init__.py
@@ -1,0 +1,16 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to add `__init__.py` file to `pyspark.ml.tests.connect`

### Why are the changes needed?

To make `pyspark.ml.tests.connect` as a canonical Python package

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

N/A

### Was this patch authored or co-authored using generative AI tooling?
No.
