### PR TITLE
[SPARK-44835][CONNECT] Make INVALID_CURSOR.DISCONNECTED a retriable error

### DIFF
--- a/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/client/GrpcRetryHandler.scala
+++ b/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/client/GrpcRetryHandler.scala
@@ -222,11 +222,10 @@ private[sql] object GrpcRetryHandler extends Logging {
 
         if (List(Status.Code.INTERNAL)
             .contains(statusCode)) {
-          // This error happens if another RPC preempts this RPC, retry.
-          val msg_cursor_disconnected = "INVALID_CURSOR.DISCONNECTED"
-
           val msg: String = e.toString
-          if (List(msg_cursor_disconnected).exists(msg.contains)) {
+
+          // This error happens if another RPC preempts this RPC.
+          if (msg.contains("INVALID_CURSOR.DISCONNECTED")) {
             return true
           }
         }

--- a/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/client/GrpcRetryHandler.scala
+++ b/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/client/GrpcRetryHandler.scala
@@ -221,7 +221,7 @@ private[sql] object GrpcRetryHandler extends Logging {
         val statusCode: Status.Code = e.getStatus.getCode
 
         if (List(Status.Code.INTERNAL)
-          .contains(statusCode)) {
+            .contains(statusCode)) {
           // This error happens if another RPC preempts this RPC, retry.
           val msg_cursor_disconnected = "INVALID_CURSOR.DISCONNECTED"
 

--- a/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/client/GrpcRetryHandler.scala
+++ b/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/client/GrpcRetryHandler.scala
@@ -220,8 +220,7 @@ private[sql] object GrpcRetryHandler extends Logging {
       case e: StatusRuntimeException =>
         val statusCode: Status.Code = e.getStatus.getCode
 
-        if (List(Status.Code.INTERNAL)
-            .contains(statusCode)) {
+        if (statusCode == Status.Code.INTERNAL) {
           val msg: String = e.toString
 
           // This error happens if another RPC preempts this RPC.

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -604,11 +604,10 @@ class SparkConnectClient(object):
             return False
 
         if e.code() in [grpc.StatusCode.INTERNAL]:
-            # This error happens if another RPC preempts this RPC, retry.
-            msg_cursor_disconnected = "INVALID_CURSOR.DISCONNECTED"
-
             msg = str(e)
-            if any(map(lambda x: x in msg, [msg_cursor_disconnected])):
+
+            # This error happens if another RPC preempts this RPC.
+            if "INVALID_CURSOR.DISCONNECTED" in msg:
                 return True
 
         if e.code() == grpc.StatusCode.UNAVAILABLE:

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -603,9 +603,7 @@ class SparkConnectClient(object):
         if not isinstance(e, grpc.RpcError):
             return False
 
-        if e.code() in [
-            grpc.StatusCode.INTERNAL
-        ]:
+        if e.code() in [grpc.StatusCode.INTERNAL]:
             # This error happens if another RPC preempts this RPC, retry.
             msg_cursor_disconnected = "INVALID_CURSOR.DISCONNECTED"
 

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -585,10 +585,38 @@ class SparkConnectClient(object):
 
     @classmethod
     def retry_exception(cls, e: Exception) -> bool:
-        if isinstance(e, grpc.RpcError):
-            return e.code() == grpc.StatusCode.UNAVAILABLE
-        else:
+        """
+        Helper function that is used to identify if an exception thrown by the server
+        can be retried or not.
+
+        Parameters
+        ----------
+        e : Exception
+            The GRPC error as received from the server. Typed as Exception, because other exception
+            thrown during client processing can be passed here as well.
+
+        Returns
+        -------
+        True if the exception can be retried, False otherwise.
+
+        """
+        if not isinstance(e, grpc.RpcError):
             return False
+
+        if e.code() in [
+            grpc.StatusCode.INTERNAL
+        ]:
+            # This error happens if another RPC preempts this RPC, retry.
+            msg_cursor_disconnected = "INVALID_CURSOR.DISCONNECTED"
+
+            msg = str(e)
+            if any(map(lambda x: x in msg, [msg_cursor_disconnected])):
+                return True
+
+        if e.code() == grpc.StatusCode.UNAVAILABLE:
+            return True
+
+        return False
 
     def __init__(
         self,


### PR DESCRIPTION
### What changes were proposed in this pull request?

Make INVALID_CURSOR.DISCONNECTED a retriable error.

### Why are the changes needed?

This error can happen if two RPCs are racing to reattach to the query, and the client is still using the losing one. SPARK-44833 was a bug that exposed such a situation. That was fixed, but to be more robust, we can make this error retryable.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Tests will be added in https://github.com/apache/spark/pull/42560

### Was this patch authored or co-authored using generative AI tooling?

No.