### PR TITLE
[SPARK-45082][DOC] Review and fix issues in API docs for 3.5.0

### DIFF
--- a/common/utils/src/main/scala/org/apache/spark/SparkBuildInfo.scala
+++ b/common/utils/src/main/scala/org/apache/spark/SparkBuildInfo.scala
@@ -18,7 +18,7 @@ package org.apache.spark
 
 import java.util.Properties
 
-object SparkBuildInfo {
+private[spark] object SparkBuildInfo {
 
   val (
     spark_version: String,

--- a/common/utils/src/main/scala/org/apache/spark/util/SparkClassUtils.scala
+++ b/common/utils/src/main/scala/org/apache/spark/util/SparkClassUtils.scala
@@ -20,7 +20,7 @@ import java.util.Random
 
 import scala.util.Try
 
-trait SparkClassUtils {
+private[spark] trait SparkClassUtils {
   val random = new Random()
 
   def getSparkClassLoader: ClassLoader = getClass.getClassLoader
@@ -80,4 +80,4 @@ trait SparkClassUtils {
   }
 }
 
-object SparkClassUtils extends SparkClassUtils
+private[spark] object SparkClassUtils extends SparkClassUtils

--- a/common/utils/src/main/scala/org/apache/spark/util/SparkCollectionUtils.scala
+++ b/common/utils/src/main/scala/org/apache/spark/util/SparkCollectionUtils.scala
@@ -18,7 +18,7 @@ package org.apache.spark.sql.catalyst.util
 
 import scala.collection.immutable
 
-trait SparkCollectionUtils {
+private[spark] trait SparkCollectionUtils {
   /**
    * Same function as `keys.zipWithIndex.toMap`, but has perf gain.
    */
@@ -34,4 +34,4 @@ trait SparkCollectionUtils {
   }
 }
 
-object SparkCollectionUtils extends SparkCollectionUtils
+private[spark] object SparkCollectionUtils extends SparkCollectionUtils

--- a/common/utils/src/main/scala/org/apache/spark/util/SparkErrorUtils.scala
+++ b/common/utils/src/main/scala/org/apache/spark/util/SparkErrorUtils.scala
@@ -90,4 +90,4 @@ private[spark] trait SparkErrorUtils extends Logging {
   }
 }
 
-object SparkErrorUtils extends SparkErrorUtils
+private[spark] object SparkErrorUtils extends SparkErrorUtils

--- a/common/utils/src/main/scala/org/apache/spark/util/SparkSerDeUtils.scala
+++ b/common/utils/src/main/scala/org/apache/spark/util/SparkSerDeUtils.scala
@@ -18,7 +18,7 @@ package org.apache.spark.util
 
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, ObjectOutputStream, ObjectStreamClass}
 
-trait SparkSerDeUtils {
+private[spark] trait SparkSerDeUtils {
   /** Serialize an object using Java serialization */
   def serialize[T](o: T): Array[Byte] = {
     val bos = new ByteArrayOutputStream()
@@ -51,4 +51,4 @@ trait SparkSerDeUtils {
   }
 }
 
-object SparkSerDeUtils extends SparkSerDeUtils
+private[spark] object SparkSerDeUtils extends SparkSerDeUtils

--- a/connector/avro/src/main/java/org/apache/spark/sql/avro/CustomDecimal.scala
+++ b/connector/avro/src/main/java/org/apache/spark/sql/avro/CustomDecimal.scala
@@ -22,14 +22,14 @@ import org.apache.avro.Schema
 
 import org.apache.spark.sql.types.DecimalType
 
-object CustomDecimal {
+private[spark] object CustomDecimal {
   val TYPE_NAME = "custom-decimal"
 }
 
 // A customized logical type, which will be registered to Avro. This logical type is similar to
 // Avro's builtin Decimal type, but is meant to be registered for long type. It indicates that
 // the long type should be converted to Spark's Decimal type, with provided precision and scale.
-private class CustomDecimal(schema: Schema) extends LogicalType(CustomDecimal.TYPE_NAME) {
+private[spark] class CustomDecimal(schema: Schema) extends LogicalType(CustomDecimal.TYPE_NAME) {
   val scale : Int = {
     val obj = schema.getObjectProp("scale")
     obj match {

--- a/core/src/main/scala/org/apache/spark/util/StubClassLoader.scala
+++ b/core/src/main/scala/org/apache/spark/util/StubClassLoader.scala
@@ -28,7 +28,7 @@ import org.apache.spark.internal.Logging
  * whose capturing class contains unknown (and unneeded) classes. The lambda itself does not need
  * the class and therefor is safe to replace by a stub.
  */
-class StubClassLoader(parent: ClassLoader, shouldStub: String => Boolean)
+private[spark] class StubClassLoader(parent: ClassLoader, shouldStub: String => Boolean)
   extends ClassLoader(parent) with Logging {
   override def findClass(name: String): Class[_] = {
     if (!shouldStub(name)) {
@@ -40,7 +40,7 @@ class StubClassLoader(parent: ClassLoader, shouldStub: String => Boolean)
   }
 }
 
-object StubClassLoader {
+private[spark] object StubClassLoader {
   def apply(parent: ClassLoader, binaryName: Seq[String]): StubClassLoader = {
     new StubClassLoader(parent, name => binaryName.exists(p => name.startsWith(p)))
   }

--- a/sql/api/src/main/scala/org/apache/spark/sql/errors/CompilationErrors.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/errors/CompilationErrors.scala
@@ -51,4 +51,4 @@ private[sql] trait CompilationErrors extends DataTypeErrorsBase {
   }
 }
 
-object CompilationErrors extends CompilationErrors
+private[sql] object CompilationErrors extends CompilationErrors

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataTypeExpression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DataTypeExpression.scala
@@ -18,7 +18,7 @@ package org.apache.spark.sql.types
 
 import org.apache.spark.sql.catalyst.expressions.Expression
 
-abstract class DataTypeExpression(val dataType: DataType) {
+private[sql] abstract class DataTypeExpression(val dataType: DataType) {
   /**
    * Enables matching against DataType for expressions:
    * {{{
@@ -29,18 +29,18 @@ abstract class DataTypeExpression(val dataType: DataType) {
   private[sql] def unapply(e: Expression): Boolean = e.dataType == dataType
 }
 
-case object BooleanTypeExpression extends DataTypeExpression(BooleanType)
-case object StringTypeExpression extends DataTypeExpression(StringType)
-case object TimestampTypeExpression extends DataTypeExpression(TimestampType)
-case object DateTypeExpression extends DataTypeExpression(DateType)
-case object ByteTypeExpression extends DataTypeExpression(ByteType)
-case object ShortTypeExpression extends DataTypeExpression(ShortType)
-case object IntegerTypeExpression extends DataTypeExpression(IntegerType)
-case object LongTypeExpression extends DataTypeExpression(LongType)
-case object DoubleTypeExpression extends DataTypeExpression(DoubleType)
-case object FloatTypeExpression extends DataTypeExpression(FloatType)
+private[sql] case object BooleanTypeExpression extends DataTypeExpression(BooleanType)
+private[sql] case object StringTypeExpression extends DataTypeExpression(StringType)
+private[sql] case object TimestampTypeExpression extends DataTypeExpression(TimestampType)
+private[sql] case object DateTypeExpression extends DataTypeExpression(DateType)
+private[sql] case object ByteTypeExpression extends DataTypeExpression(ByteType)
+private[sql] case object ShortTypeExpression extends DataTypeExpression(ShortType)
+private[sql] case object IntegerTypeExpression extends DataTypeExpression(IntegerType)
+private[sql] case object LongTypeExpression extends DataTypeExpression(LongType)
+private[sql] case object DoubleTypeExpression extends DataTypeExpression(DoubleType)
+private[sql] case object FloatTypeExpression extends DataTypeExpression(FloatType)
 
-object NumericTypeExpression {
+private[sql] object NumericTypeExpression {
   /**
    * Enables matching against NumericType for expressions:
    * {{{
@@ -53,7 +53,7 @@ object NumericTypeExpression {
   }
 }
 
-object IntegralTypeExpression {
+private[sql] object IntegralTypeExpression {
   /**
    * Enables matching against IntegralType for expressions:
    * {{{
@@ -66,12 +66,12 @@ object IntegralTypeExpression {
   }
 }
 
-object AnyTimestampTypeExpression {
+private[sql] object AnyTimestampTypeExpression {
   def unapply(e: Expression): Boolean =
     e.dataType.isInstanceOf[TimestampType] || e.dataType.isInstanceOf[TimestampNTZType]
 }
 
-object DecimalExpression {
+private[sql] object DecimalExpression {
   def unapply(e: Expression): Option[(Int, Int)] = e.dataType match {
     case t: DecimalType => Some((t.precision, t.scale))
     case _ => None

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -719,6 +719,6 @@ object JdbcDialects {
 /**
  * NOOP dialect object, always returning the neutral element.
  */
-object NoopDialect extends JdbcDialect {
+private[spark] object NoopDialect extends JdbcDialect {
   override def canHandle(url : String): Boolean = true
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Compare the 3.4 API doc with the 3.5 RC3 cut. Fix the following issues:

- Remove the leaking class/object in API doc

### Why are the changes needed?
Fix the issues in the Spark 3.5.0 release API docs.

### Does this PR introduce _any_ user-facing change?
No, API doc changes only.

### How was this patch tested?
Manually test.

### Was this patch authored or co-authored using generative AI tooling?
no