### PR TITLE
[SPARK-45084][SS] StateOperatorProgress to use accurate effective shuffle partition number

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/ProgressReporter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/ProgressReporter.scala
@@ -33,6 +33,7 @@ import org.apache.spark.sql.connector.catalog.Table
 import org.apache.spark.sql.connector.read.streaming.{MicroBatchStream, ReportsSinkMetrics, ReportsSourceMetrics, SparkDataStream}
 import org.apache.spark.sql.execution.QueryExecution
 import org.apache.spark.sql.execution.datasources.v2.{MicroBatchScanExec, StreamingDataSourceV2Relation, StreamWriterCommitProgress}
+import org.apache.spark.sql.internal.SQLConf.SHUFFLE_PARTITIONS
 import org.apache.spark.sql.streaming._
 import org.apache.spark.sql.streaming.StreamingQueryListener.{QueryIdleEvent, QueryProgressEvent}
 import org.apache.spark.util.Clock
@@ -235,6 +236,8 @@ trait ProgressReporter extends Logging {
 
     val observedMetrics = extractObservedMetrics(hasNewData, lastExecution)
 
+
+
     val newProgress = new StreamingQueryProgress(
       id = id,
       runId = runId,
@@ -264,9 +267,16 @@ trait ProgressReporter extends Logging {
     if (lastExecution == null) return Nil
     // lastExecution could belong to one of the previous triggers if `!hasExecuted`.
     // Walking the plan again should be inexpensive.
+
+    val shufflePartitionValue = sparkSession.conf.getOption(SHUFFLE_PARTITIONS.key).getOrElse("-1")
+    val numShufflePartitions: Long = try {
+      shufflePartitionValue.toLong
+    } catch {
+      case e: NumberFormatException => -1L
+    }
     lastExecution.executedPlan.collect {
       case p if p.isInstanceOf[StateStoreWriter] =>
-        val progress = p.asInstanceOf[StateStoreWriter].getProgress()
+        val progress = p.asInstanceOf[StateStoreWriter].getProgress(numShufflePartitions)
         if (hasExecuted) {
           progress
         } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/ProgressReporter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/ProgressReporter.scala
@@ -236,8 +236,6 @@ trait ProgressReporter extends Logging {
 
     val observedMetrics = extractObservedMetrics(hasNewData, lastExecution)
 
-
-
     val newProgress = new StreamingQueryProgress(
       id = id,
       runId = runId,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/statefulOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/statefulOperators.scala
@@ -143,7 +143,6 @@ trait StateStoreWriter extends StatefulOperator with PythonSQLMetrics { self: Sp
     "allRemovalsTimeMs" -> SQLMetrics.createTimingMetric(sparkContext, "time to remove"),
     "commitTimeMs" -> SQLMetrics.createTimingMetric(sparkContext, "time to commit changes"),
     "stateMemory" -> SQLMetrics.createSizeMetric(sparkContext, "memory used by state"),
-    "numShufflePartitions" -> SQLMetrics.createMetric(sparkContext, "number of shuffle partitions"),
     "numStateStoreInstances" -> SQLMetrics.createMetric(sparkContext,
       "number of state store instances")
   ) ++ stateStoreCustomMetrics ++ pythonMetrics
@@ -152,13 +151,15 @@ trait StateStoreWriter extends StatefulOperator with PythonSQLMetrics { self: Sp
    * Get the progress made by this stateful operator after execution. This should be called in
    * the driver after this SparkPlan has been executed and metrics have been updated.
    */
-  def getProgress(): StateOperatorProgress = {
+  def getProgress(numShufflePartitions: Long): StateOperatorProgress = {
     val customMetrics = (stateStoreCustomMetrics ++ statefulOperatorCustomMetrics)
       .map(entry => entry._1 -> longMetric(entry._1).value)
 
     val javaConvertedCustomMetrics: java.util.HashMap[String, java.lang.Long] =
       new java.util.HashMap(customMetrics.mapValues(long2Long).toMap.asJava)
 
+    // We now don't report number of shuffle partitions inside the state operator. Instead,
+    // it will be filled when the stream query progress is reported
     new StateOperatorProgress(
       operatorName = shortName,
       numRowsTotal = longMetric("numTotalStateRows").value,
@@ -169,7 +170,7 @@ trait StateStoreWriter extends StatefulOperator with PythonSQLMetrics { self: Sp
       commitTimeMs = longMetric("commitTimeMs").value,
       memoryUsedBytes = longMetric("stateMemory").value,
       numRowsDroppedByWatermark = longMetric("numRowsDroppedByWatermark").value,
-      numShufflePartitions = longMetric("numShufflePartitions").value,
+      numShufflePartitions = numShufflePartitions,
       numStateStoreInstances = longMetric("numStateStoreInstances").value,
       javaConvertedCustomMetrics
     )
@@ -183,7 +184,6 @@ trait StateStoreWriter extends StatefulOperator with PythonSQLMetrics { self: Sp
     assert(numStateStoreInstances >= 1, s"invalid number of stores: $numStateStoreInstances")
     // Shuffle partitions capture the number of tasks that have this stateful operator instance.
     // For each task instance this number is incremented by one.
-    longMetric("numShufflePartitions") += 1
     longMetric("numStateStoreInstances") += numStateStoreInstances
   }
 
@@ -870,8 +870,8 @@ case class SessionWindowStateStoreSaveExec(
    * This method should be called in the driver after this SparkPlan has been executed and metrics
    * have been updated.
    */
-  override def getProgress(): StateOperatorProgress = {
-    val stateOpProgress = super.getProgress()
+  override def getProgress(numShufflePartitions: Long): StateOperatorProgress = {
+    val stateOpProgress = super.getProgress(numShufflePartitions)
 
     // This should be safe, since the method is called in the driver after the plan has been
     // executed and metrics have been updated.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/statefulOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/statefulOperators.scala
@@ -151,7 +151,7 @@ trait StateStoreWriter extends StatefulOperator with PythonSQLMetrics { self: Sp
    * Get the progress made by this stateful operator after execution. This should be called in
    * the driver after this SparkPlan has been executed and metrics have been updated.
    */
-  def getProgress(numShufflePartitions: Long): StateOperatorProgress = {
+  def getProgress(): StateOperatorProgress = {
     val customMetrics = (stateStoreCustomMetrics ++ statefulOperatorCustomMetrics)
       .map(entry => entry._1 -> longMetric(entry._1).value)
 
@@ -170,7 +170,7 @@ trait StateStoreWriter extends StatefulOperator with PythonSQLMetrics { self: Sp
       commitTimeMs = longMetric("commitTimeMs").value,
       memoryUsedBytes = longMetric("stateMemory").value,
       numRowsDroppedByWatermark = longMetric("numRowsDroppedByWatermark").value,
-      numShufflePartitions = numShufflePartitions,
+      numShufflePartitions = stateInfo.map(_.numPartitions.toLong).getOrElse(-1L),
       numStateStoreInstances = longMetric("numStateStoreInstances").value,
       javaConvertedCustomMetrics
     )
@@ -870,8 +870,8 @@ case class SessionWindowStateStoreSaveExec(
    * This method should be called in the driver after this SparkPlan has been executed and metrics
    * have been updated.
    */
-  override def getProgress(numShufflePartitions: Long): StateOperatorProgress = {
-    val stateOpProgress = super.getProgress(numShufflePartitions)
+  override def getProgress(): StateOperatorProgress = {
+    val stateOpProgress = super.getProgress()
 
     // This should be safe, since the method is called in the driver after the plan has been
     // executed and metrics have been updated.


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make StateOperatorProgress.numShufflePartitions to use the effective number of shuffle partitions is reported.
This metric StateStoreWriter.numShufflePartitions is dropped at the same time, as it is not a metric anymore.

### Why are the changes needed?
Currently, there is a numShufflePartitions "metric" reported in 
StateOperatorProgress part of the progress report. However, the number is reported by aggregating executors so in the case of task retry or speculative executor, the metric is higher than number of shuffle partitions for the query plan. We change the metric to use the value to use to make it more usable.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
StreamingAggregationSuite contains a unit test that validates the value 

### Was this patch authored or co-authored using generative AI tooling?
No.