### PR TITLE
[SPARK-44833][CONNECT][PYTHON][FOLLOW-UP] Fix the type annotation for iterator at reattach.py

### DIFF
--- a/python/pyspark/sql/connect/client/reattach.py
+++ b/python/pyspark/sql/connect/client/reattach.py
@@ -94,7 +94,7 @@ class ExecutePlanResponseReattachableIterator(Generator):
         # Note: This is not retried, because no error would ever be thrown here, and GRPC will only
         # throw error on first self._has_next().
         self._metadata = metadata
-        self._iterator: Iterator[pb2.ExecutePlanResponse] = iter(
+        self._iterator: Optional[Iterator[pb2.ExecutePlanResponse]] = iter(
             self._stub.ExecutePlan(self._initial_request, metadata=metadata)
         )
 

--- a/python/pyspark/sql/connect/client/reattach.py
+++ b/python/pyspark/sql/connect/client/reattach.py
@@ -133,8 +133,9 @@ class ExecutePlanResponseReattachableIterator(Generator):
                     with attempt:
                         if self._current is None:
                             try:
-                                assert self._iterator is not None
-                                self._current = self._call_iter(lambda: next(self._iterator))
+                                self._current = self._call_iter(
+                                    lambda: next(self._iterator)  # type: ignore[arg-type]
+                                )
                             except StopIteration:
                                 pass
 
@@ -151,8 +152,9 @@ class ExecutePlanResponseReattachableIterator(Generator):
                                 # shouldn't change
                                 assert not self._result_complete
                                 try:
-                                    assert self._iterator is not None
-                                    self._current = self._call_iter(lambda: next(self._iterator))
+                                    self._current = self._call_iter(
+                                        lambda: next(self._iterator)  # type: ignore[arg-type]
+                                    )
                                 except StopIteration:
                                     pass
                                 has_next = self._current is not None

--- a/python/pyspark/sql/connect/client/reattach.py
+++ b/python/pyspark/sql/connect/client/reattach.py
@@ -133,6 +133,7 @@ class ExecutePlanResponseReattachableIterator(Generator):
                     with attempt:
                         if self._current is None:
                             try:
+                                assert self._iterator is not None
                                 self._current = self._call_iter(lambda: next(self._iterator))
                             except StopIteration:
                                 pass
@@ -150,6 +151,7 @@ class ExecutePlanResponseReattachableIterator(Generator):
                                 # shouldn't change
                                 assert not self._result_complete
                                 try:
+                                    assert self._iterator is not None
                                     self._current = self._call_iter(lambda: next(self._iterator))
                                 except StopIteration:
                                     pass


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes the type hint of `self._iterator` at `reattach.py` to be `Optional` because `None` is assigned here.

### Why are the changes needed?

To fix the CI:

```
starting mypy annotations test...
annotations failed mypy checks:
python/pyspark/sql/connect/client/reattach.py:149: error: Incompatible types in assignment (expression has type "None", variable has type "Iterator[ExecutePlanResponse]")  [assignment]
python/pyspark/sql/connect/client/reattach.py:254: error: Incompatible types in assignment (expression has type "None", variable has type "Iterator[ExecutePlanResponse]")  [assignment]
python/pyspark/sql/connect/client/reattach.py:[25](https://github.com/apache/spark/actions/runs/6093065151/job/16532169212#step:19:26)8: error: Incompatible types in assignment (expression has type "None", variable has type "Iterator[ExecutePlanResponse]")  [assignment]
Found 3 errors in 1 file (checked 703 source files)
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manually ran the script of `./dev/lint-python`

### Was this patch authored or co-authored using generative AI tooling?

No
