### PR TITLE
[WIP] enforce Window#windowExpressions to be window expressions only

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -3128,7 +3128,7 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
       // "sum(a) over (...)" and "sum(b) over (...)" out, and assign "_we0" as the alias to
       // "sum(a) over (...)" and "_we1" as the alias to "sum(b) over (...)".
       // Then, the projectList will be [_we0/_we1].
-      val extractedWindowExprBuffer = new ArrayBuffer[NamedExpression]()
+      val extractedWindowExprBuffer = new ArrayBuffer[Alias]()
       val newExpressionsWithWindowFunctions = expressionsWithWindowFunctions.map {
         // We need to use transformDown because we want to trigger
         // "case alias @ Alias(window: WindowExpression, _)" first.
@@ -3148,7 +3148,7 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
 
       // SPARK-32616: Use a linked hash map to maintains the insertion order of the Window
       // operators, so the query with multiple Window operators can have the determined plan.
-      val groupedWindowExpressions = mutable.LinkedHashMap.empty[Spec, ArrayBuffer[NamedExpression]]
+      val groupedWindowExpressions = mutable.LinkedHashMap.empty[Spec, ArrayBuffer[Alias]]
       // Second, we group extractedWindowExprBuffer based on their Partition and Order Specs.
       extractedWindowExprBuffer.foreach { expr =>
         val distinctWindowSpec = expr.collect {
@@ -3168,7 +3168,7 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
           val spec = distinctWindowSpec.head
           val specKey = (spec.partitionSpec, spec.orderSpec, WindowFunctionType.functionType(expr))
           val windowExprs = groupedWindowExpressions
-            .getOrElseUpdate(specKey, new ArrayBuffer[NamedExpression])
+            .getOrElseUpdate(specKey, new ArrayBuffer[Alias])
           windowExprs += expr
         }
       }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/DeduplicateRelations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/DeduplicateRelations.scala
@@ -424,7 +424,8 @@ object DeduplicateRelations extends Rule[LogicalPlan] {
       case oldVersion @ Window(windowExpressions, _, _, child)
           if AttributeSet(windowExpressions.map(_.toAttribute)).intersect(conflictingAttributes)
           .nonEmpty =>
-        val newVersion = oldVersion.copy(windowExpressions = newAliases(windowExpressions))
+        val newVersion = oldVersion.copy(
+          windowExpressions = newAliases(windowExpressions).asInstanceOf[Seq[Alias]])
         newVersion.copyTagsFrom(oldVersion)
         Seq((oldVersion, newVersion))
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala
@@ -151,10 +151,10 @@ package object dsl {
     def asc_nullsLast: SortOrder = SortOrder(expr, Ascending, NullsLast, Seq.empty)
     def desc: SortOrder = SortOrder(expr, Descending)
     def desc_nullsFirst: SortOrder = SortOrder(expr, Descending, NullsFirst, Seq.empty)
-    def as(alias: String): NamedExpression = Alias(expr, alias)()
+    def as(alias: String): Alias = Alias(expr, alias)()
     // TODO: Remove at Spark 4.0.0
     @deprecated("Use as(alias: String)", "3.4.0")
-    def as(alias: Symbol): NamedExpression = Alias(expr, alias.name)()
+    def as(alias: Symbol): Alias = Alias(expr, alias.name)()
   }
 
   trait ExpressionConversions {
@@ -456,7 +456,7 @@ package object dsl {
       }
 
       def window(
-          windowExpressions: Seq[NamedExpression],
+          windowExpressions: Seq[Alias],
           partitionSpec: Seq[Expression],
           orderSpec: Seq[SortOrder]): LogicalPlan =
         Window(windowExpressions, partitionSpec, orderSpec, logicalPlan)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/namedExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/namedExpressions.scala
@@ -183,7 +183,7 @@ case class Alias(child: Expression, name: String)(
       nonInheritableMetadataKeys = nonInheritableMetadataKeys)
   }
 
-  def newInstance(): NamedExpression =
+  def newInstance(): Alias =
     Alias(child, name)(
       qualifier = qualifier,
       explicitMetadata = explicitMetadata,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -1213,10 +1213,12 @@ object Aggregate {
 }
 
 case class Window(
-    windowExpressions: Seq[NamedExpression],
+    windowExpressions: Seq[Alias],
     partitionSpec: Seq[Expression],
     orderSpec: Seq[SortOrder],
     child: LogicalPlan) extends UnaryNode {
+  assert(windowExpressions.forall(_.child.isInstanceOf[WindowExpression]))
+
   override def maxRows: Option[Long] = child.maxRows
   override def output: Seq[Attribute] =
     child.output ++ windowExpressions.map(_.toAttribute)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/DecorrelateInnerQuerySuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/DecorrelateInnerQuerySuite.scala
@@ -582,41 +582,53 @@ class DecorrelateInnerQuerySuite extends PlanTest {
     check(innerPlan, outerPlan, correctAnswer, Seq(a <=> a))
   }
 
+  val winSpec = windowSpec(Nil, Nil, SpecifiedWindowFrame(RowFrame, UnboundedPreceding, CurrentRow))
+  val winExpr1 = windowExpr(count(b), winSpec).as("w1")
+  val winExpr2 = windowExpr(count(c), winSpec).as("w2")
+
   test("window function with correlated equality predicate") {
     val outerPlan = testRelation2
     val innerPlan =
-      Window(Seq(b, c),
-        partitionSpec = Seq(c), orderSpec = b.asc :: Nil,
-        Filter(And(OuterReference(x) === a, b === 3),
-          testRelation))
+      Window(
+        windowExpressions = Seq(winExpr1, winExpr2),
+        partitionSpec = Seq(c),
+        orderSpec = b.asc :: Nil,
+        child = Filter(And(OuterReference(x) === a, b === 3), testRelation)
+      )
     // Both the project list and the partition spec have added the correlated variable.
     val correctAnswer =
-      Window(Seq(b, c, a), partitionSpec = Seq(c, a), orderSpec = b.asc :: Nil,
-        Filter(b === 3,
-          testRelation))
+      Window(
+        windowExpressions = Seq(winExpr1, winExpr2),
+        partitionSpec = Seq(c, a),
+        orderSpec = b.asc :: Nil,
+        child = Filter(b === 3, testRelation)
+      )
     check(innerPlan, outerPlan, correctAnswer, Seq(x === a))
   }
 
   test("window function with correlated non-equality predicate") {
     val outerPlan = testRelation2
     val innerPlan =
-      Window(Seq(b, c),
-        partitionSpec = Seq(c), orderSpec = b.asc :: Nil,
-        Filter(And(OuterReference(x) > a, b === 3),
-          testRelation))
-    // Both the project list and the partition spec have added the correlated variable.
-    // The input to the filter is a domain join that produces 'x' values.
+      Window(
+        windowExpressions = Seq(winExpr1, winExpr2),
+        partitionSpec = Seq(c),
+        orderSpec = b.asc :: Nil,
+        child = Filter(And(OuterReference(x) > a, b === 3), testRelation)
+      )
     val correctAnswer =
-    Window(Seq(b, c, x), partitionSpec = Seq(c, x), orderSpec = b.asc :: Nil,
-      Filter(And(b === 3, x > a),
-        DomainJoin(Seq(x), testRelation)))
+      Window(
+        windowExpressions = Seq(winExpr1, winExpr2),
+        partitionSpec = Seq(c, x),
+        orderSpec = b.asc :: Nil,
+        child = Filter(And(b === 3, x > a), DomainJoin(Seq(x), testRelation))
+      )
     check(innerPlan, outerPlan, correctAnswer, Seq(x <=> x))
   }
 
   test("window function with correlated columns inside") {
     val outerPlan = testRelation2
     val innerPlan =
-      Window(Seq(b, c),
+      Window(Seq(winExpr1, winExpr2),
         partitionSpec = Seq(c, OuterReference(x)), orderSpec = b.asc :: Nil,
         Filter(b === 3,
           testRelation))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RemoveRedundantAliasAndProjectSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RemoveRedundantAliasAndProjectSuite.scala
@@ -113,9 +113,12 @@ class RemoveRedundantAliasAndProjectSuite extends PlanTest {
 
   test("remove redundant alias from window") {
     val relation = LocalRelation($"a".int, $"b".int)
-    val query = relation.window(Seq($"b" as "b"), Seq($"a" as "a"), Seq()).analyze
+    val winSpec = windowSpec($"a" :: Nil, $"a".asc :: Nil, UnspecifiedFrame)
+    val winExpr = windowExpr(count($"b"), winSpec)
+
+    val query = relation.window(Seq(winExpr as "b" as "bb"), Seq($"a" as "a"), Seq()).analyze
     val optimized = Optimize.execute(query)
-    val expected = relation.window(Seq($"b"), Seq($"a"), Seq()).analyze
+    val expected = relation.window(Seq(winExpr as "bb"), Seq($"a"), Seq()).analyze
     comparePlans(optimized, expected)
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
