### PR TITLE
[SPARK-45095][CORE] Support `spark.master.rest.host`

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -155,7 +155,8 @@ private[deploy] class Master(
 
     if (restServerEnabled) {
       val port = conf.get(MASTER_REST_SERVER_PORT)
-      restServer = Some(new StandaloneRestServer(address.host, port, conf, self, masterUrl))
+      val host = conf.get(MASTER_REST_SERVER_HOST).getOrElse(address.host)
+      restServer = Some(new StandaloneRestServer(host, port, conf, self, masterUrl))
     }
     restServerBoundPort = restServer.map(_.start())
 

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1828,6 +1828,11 @@ package object config {
     .booleanConf
     .createWithDefault(false)
 
+  private[spark] val MASTER_REST_SERVER_HOST = ConfigBuilder("spark.master.rest.host")
+    .version("4.0.0")
+    .stringConf
+    .createOptional
+
   private[spark] val MASTER_REST_SERVER_PORT = ConfigBuilder("spark.master.rest.port")
     .version("1.3.0")
     .intConf


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support a new configuration `spark.master.rest.host` to allow REST Server to choose a host to listen.

### Why are the changes needed?

This allows additional controllability on the REST Server.

In addition, in K8s environment, K8s port-forwarding only works with 127.0.0.1.

```
$ kubectl port-forward svc/master 6066
Forwarding from 127.0.0.1:6066 -> 6066
Forwarding from [::1]:6066 -> 6066
```

It's difficult to use `port-forward` because the AS-IS Spark REST Server only listens the podIP and not 127.0.0.1. 

We can use `spark.master.rest.host=0.0.0.0` with this PR.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

It was a little difficult to write a unit test code because it requires two IPs to test in CI.

For manual testing, start the REST API.
```
$ SPARK_NO_DAEMONIZE=1 SPARK_MASTER_OPTS="-Dspark.master.rest.enabled=true -Dspark.master.rest.host=0.0.0.0" sbin/start-master.sh
```

And, connect with both IPs (your public IP and 127.0.0.1) on the machine.
```
$ curl -v http://127.0.0.1:6066/v1/submissions/status/0 
$ curl -v http://a.b.c.d:6066/v1/submissions/status/0 
```

### Was this patch authored or co-authored using generative AI tooling?

No.