### PR TITLE
[KUBERNETES] Add ephemeral storage configs for spark on kubernetes

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -139,6 +139,34 @@ private[spark] object Config extends Logging {
       .version("2.3.0")
       .fallbackConf(CONTAINER_IMAGE)
 
+  val EXECUTOR_REQUEST_EPHEMERAL_STORAGE_GB =
+    ConfigBuilder("spark.kubernetes.executor.ephemeralStorageGB.request")
+      .doc("Ephemeral storage to use for the executors.")
+      .intConf
+      .checkValue(_ >= 0, "Ephemeral storage should be a positive integer")
+      .createWithDefault(0)
+
+  val EXECUTOR_LIMIT_EPHEMERAL_STORAGE_GB =
+    ConfigBuilder("spark.kubernetes.executor.ephemeralStorageGB.limit")
+      .doc("Ephemeral storage to use for the executors.")
+      .intConf
+      .checkValue(_ >= 0, "Ephemeral storage should be a positive integer")
+      .createWithDefault(0)
+
+  val DRIVER_REQUEST_EPHEMERAL_STORAGE_GB =
+    ConfigBuilder("spark.kubernetes.driver.ephemeralStorageGB.request")
+      .doc("Ephemeral storage to use for the driver.")
+      .intConf
+      .checkValue(_ >= 0, "Ephemeral storage should be a positive integer")
+      .createWithDefault(0)
+
+  val DRIVER_LIMIT_EPHEMERAL_STORAGE_GB =
+    ConfigBuilder("spark.kubernetes.driver.ephemeralStorageGB.limit")
+      .doc("Ephemeral storage to use for the driver.")
+      .intConf
+      .checkValue(_ >= 0, "Ephemeral storage should be a positive integer")
+      .createWithDefault(0)
+
   val CONTAINER_IMAGE_PULL_POLICY =
     ConfigBuilder("spark.kubernetes.container.image.pullPolicy")
       .doc("Kubernetes image pull policy. Valid values are Always, Never, and IfNotPresent.")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Add the ephemeral storage configs for spark on kubernetes.  
User can specify these configs to make their program more configurable.  
`--conf spark.kubernetes.driver.ephemeralStorageGB.request xxx
`
`--conf spark.kubernetes.driver.ephemeralStorageGB.limit xxx
`
`--conf spark.kubernetes.executor.ephemeralStorageGB.request xxx
`
`--conf spark.kubernetes.executor.ephemeralStorageGB.limit xxx
`
### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
It can be used in the spark-submit command handily.  
Image that you build a platform to help users to submit their data pipelines with spark, it would be very convenient to have these parameters to support user's different demands.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No. This PR does not introduce any user-facing change. It only introduces more options to users.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
We have applied these change in our internal project and it works well.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.