### PR TITLE
[SPARK-43252][SQL] Replace the error class `_LEGACY_ERROR_TEMP_2016` with an internal error

### DIFF
--- a/common/utils/src/main/resources/error/error-classes.json
+++ b/common/utils/src/main/resources/error/error-classes.json
@@ -4944,11 +4944,6 @@
       "Negative values found in <frequencyExpression>"
     ]
   },
-  "_LEGACY_ERROR_TEMP_2016" : {
-    "message" : [
-      "Can not interpolate <arg> into code block."
-    ]
-  },
   "_LEGACY_ERROR_TEMP_2017" : {
     "message" : [
       "not resolved."

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -410,10 +410,8 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
       s"Cannot generate $codeType code for incomparable type: ${toSQLType(dataType)}.")
   }
 
-  def cannotInterpolateClassIntoCodeBlockError(arg: Any): SparkIllegalArgumentException = {
-    new SparkIllegalArgumentException(
-      errorClass = "_LEGACY_ERROR_TEMP_2016",
-      messageParameters = Map("arg" -> arg.getClass.getName))
+  def cannotInterpolateClassIntoCodeBlockError(arg: Any): Throwable = {
+    SparkException.internalError(s"Can not interpolate ${arg.getClass.getName} into code block.")
   }
 
   def customCollectionClsNotResolvedError(): SparkUnsupportedOperationException = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeBlockSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeBlockSuite.scala
@@ -117,10 +117,13 @@ class CodeBlockSuite extends SparkFunSuite {
 
   test("Throws exception when interpolating unexpected object in code block") {
     val obj = Tuple2(1, 1)
-    val e = intercept[SparkException] {
-      code"$obj"
-    }
-    assert(e.getMessage().contains(s"Can not interpolate ${obj.getClass.getName}"))
+    checkError(
+      exception = intercept[SparkException] {
+        code"$obj"
+      },
+      errorClass = "INTERNAL_ERROR",
+      parameters = Map("message" -> s"Can not interpolate ${obj.getClass.getName} into code block.")
+    )
   }
 
   test("transform expr in code block") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeBlockSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeBlockSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.catalyst.expressions.codegen
 
-import org.apache.spark.SparkFunSuite
+import org.apache.spark.{SparkException, SparkFunSuite}
 import org.apache.spark.sql.catalyst.expressions.codegen.Block._
 import org.apache.spark.sql.types.IntegerType
 
@@ -117,7 +117,7 @@ class CodeBlockSuite extends SparkFunSuite {
 
   test("Throws exception when interpolating unexpected object in code block") {
     val obj = Tuple2(1, 1)
-    val e = intercept[IllegalArgumentException] {
+    val e = intercept[SparkException] {
       code"$obj"
     }
     assert(e.getMessage().contains(s"Can not interpolate ${obj.getClass.getName}"))


### PR DESCRIPTION

### What changes were proposed in this pull request?
Replace the legacy error class `_LEGACY_ERROR_TEMP_2016` with an internal error as it is not triggered by the user space.

### Why are the changes needed?
As the error is not triggered by the user space, the legacy error class can be replaced by an internal error.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Existing test cases.

### Was this patch authored or co-authored using generative AI tooling?
No.
