### PR TITLE
[SPARK-45128][SQL] Support `CalendarIntervalType` in Arrow

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/util/ArrowUtils.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/util/ArrowUtils.scala
@@ -118,6 +118,13 @@ private[sql] object ArrowUtils {
             nullable = false,
             timeZoneId,
             largeVarTypes)).asJava)
+      case CalendarIntervalType =>
+        val structType = StructType(
+          StructField("months", IntegerType, false) ::
+            StructField("days", IntegerType, false) ::
+            StructField("microseconds", LongType, false) ::Nil
+        )
+        toArrowField(name, structType, nullable, timeZoneId, largeVarTypes)
       case udt: UserDefinedType[_] =>
         toArrowField(name, udt.sqlType, nullable, timeZoneId, largeVarTypes)
       case dataType =>

--- a/sql/api/src/main/scala/org/apache/spark/sql/util/ArrowUtils.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/util/ArrowUtils.scala
@@ -59,7 +59,7 @@ private[sql] object ArrowUtils {
     case NullType => ArrowType.Null.INSTANCE
     case _: YearMonthIntervalType => new ArrowType.Interval(IntervalUnit.YEAR_MONTH)
     case _: DayTimeIntervalType => new ArrowType.Duration(TimeUnit.MICROSECOND)
-    case _: CalendarIntervalType => new ArrowType.Interval(IntervalUnit.MONTH_DAY_NANO)
+    case CalendarIntervalType => new ArrowType.Interval(IntervalUnit.MONTH_DAY_NANO)
     case _ =>
       throw ExecutionErrors.unsupportedDataTypeError(dt)
   }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/vectorized/ArrowColumnVector.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/vectorized/ArrowColumnVector.java
@@ -17,7 +17,6 @@
 
 package org.apache.spark.sql.vectorized;
 
-import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.vector.*;
 import org.apache.arrow.vector.complex.*;
 import org.apache.arrow.vector.holders.NullableIntervalMonthDayNanoHolder;

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/vectorized/ArrowColumnVector.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/vectorized/ArrowColumnVector.java
@@ -115,6 +115,12 @@ public class ArrowColumnVector extends ColumnVector {
   }
 
   @Override
+  public CalendarInterval getInterval(int rowId) {
+    if (isNullAt(rowId)) return null;
+    return accessor.getInterval(rowId);
+  }
+
+  @Override
   public byte[] getBinary(int rowId) {
     if (isNullAt(rowId)) return null;
     return accessor.getBinary(rowId);

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/vectorized/ArrowColumnVector.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/vectorized/ArrowColumnVector.java
@@ -622,7 +622,7 @@ public class ArrowColumnVector extends ColumnVector {
     private final IntervalMonthDayNanoVector accessor;
 
     private final NullableIntervalMonthDayNanoHolder result =
-            new NullableIntervalMonthDayNanoHolder();
+      new NullableIntervalMonthDayNanoHolder();
 
     IntervalMonthDayNanoAccessor(IntervalMonthDayNanoVector vector) {
       super(vector);

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/vectorized/ColumnVector.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/vectorized/ColumnVector.java
@@ -289,7 +289,13 @@ public abstract class ColumnVector implements AutoCloseable {
    * is a long type vector, containing all the microsecond values of all the interval values in this
    * vector.
    */
-  public abstract CalendarInterval getInterval(int rowId);
+  public CalendarInterval getInterval(int rowId) {
+    if (isNullAt(rowId)) return null;
+    final int months = getChild(0).getInt(rowId);
+    final int days = getChild(1).getInt(rowId);
+    final long microseconds = getChild(2).getLong(rowId);
+    return new CalendarInterval(months, days, microseconds);
+  }
 
   /**
    * @return child {@link ColumnVector} at the given ordinal.

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/vectorized/ColumnVector.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/vectorized/ColumnVector.java
@@ -289,7 +289,7 @@ public abstract class ColumnVector implements AutoCloseable {
    * is a long type vector, containing all the microsecond values of all the interval values in this
    * vector.
    */
-  public final CalendarInterval getInterval(int rowId) {
+  public CalendarInterval getInterval(int rowId) {
     if (isNullAt(rowId)) return null;
     final int months = getChild(0).getInt(rowId);
     final int days = getChild(1).getInt(rowId);

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/vectorized/ColumnVector.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/vectorized/ColumnVector.java
@@ -289,13 +289,7 @@ public abstract class ColumnVector implements AutoCloseable {
    * is a long type vector, containing all the microsecond values of all the interval values in this
    * vector.
    */
-  public CalendarInterval getInterval(int rowId) {
-    if (isNullAt(rowId)) return null;
-    final int months = getChild(0).getInt(rowId);
-    final int days = getChild(1).getInt(rowId);
-    final long microseconds = getChild(2).getLong(rowId);
-    return new CalendarInterval(months, days, microseconds);
-  }
+  public abstract CalendarInterval getInterval(int rowId);
 
   /**
    * @return child {@link ColumnVector} at the given ordinal.

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/vectorized/ColumnVector.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/vectorized/ColumnVector.java
@@ -288,6 +288,8 @@ public abstract class ColumnVector implements AutoCloseable {
    * containing all the day values of all the interval values in this vector. The third child vector
    * is a long type vector, containing all the microsecond values of all the interval values in this
    * vector.
+   * Note that the ArrowColumnVector leverages its built-in IntervalMonthDayNanoVector instead of
+   * above-mentioned protocol.
    */
   public CalendarInterval getInterval(int rowId) {
     if (isNullAt(rowId)) return null;

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/arrow/ArrowWriter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/arrow/ArrowWriter.scala
@@ -79,6 +79,12 @@ object ArrowWriter {
           createFieldWriter(vector.getChildByOrdinal(ordinal))
         }
         new StructWriter(vector, children.toArray)
+      case (CalendarIntervalType, vector: StructVector) =>
+        assert(vector.size() == 3)
+        val children = (0 until vector.size()).map { ordinal =>
+          createFieldWriter(vector.getChildByOrdinal(ordinal))
+        }
+        new StructWriter(vector, children.toArray)
       case (NullType, vector: NullVector) => new NullWriter(vector)
       case (_: YearMonthIntervalType, vector: IntervalYearVector) => new IntervalYearWriter(vector)
       case (_: DayTimeIntervalType, vector: DurationVector) => new DurationWriter(vector)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/arrow/ArrowWriter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/arrow/ArrowWriter.scala
@@ -82,7 +82,7 @@ object ArrowWriter {
       case (NullType, vector: NullVector) => new NullWriter(vector)
       case (_: YearMonthIntervalType, vector: IntervalYearVector) => new IntervalYearWriter(vector)
       case (_: DayTimeIntervalType, vector: DurationVector) => new DurationWriter(vector)
-      case (_: CalendarIntervalType, vector: IntervalMonthDayNanoVector) =>
+      case (CalendarIntervalType, vector: IntervalMonthDayNanoVector) =>
         new IntervalMonthDayNanoWriter(vector)
       case (dt, _) =>
         throw ExecutionErrors.unsupportedDataTypeError(dt)
@@ -475,6 +475,6 @@ private[arrow] class IntervalMonthDayNanoWriter(val valueVector: IntervalMonthDa
 
   override def setValue(input: SpecializedGetters, ordinal: Int): Unit = {
     val ci = input.getInterval(ordinal)
-    valueVector.setSafe(count, ci.months, ci.days, ci.microseconds * 1000)
+    valueVector.setSafe(count, ci.months, ci.days, Math.multiplyExact(ci.microseconds, 1000L))
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/arrow/ArrowConvertersSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/arrow/ArrowConvertersSuite.scala
@@ -28,7 +28,7 @@ import org.apache.arrow.vector.{VectorLoader, VectorSchemaRoot}
 import org.apache.arrow.vector.ipc.JsonFileReader
 import org.apache.arrow.vector.util.{ByteArrayReadableSeekableByteChannel, Validator}
 
-import org.apache.spark.{SparkException, SparkUnsupportedOperationException, TaskContext}
+import org.apache.spark.TaskContext
 import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.UnsafeProjection
@@ -1265,15 +1265,9 @@ class ArrowConvertersSuite extends SharedSparkSession {
     spark.conf.unset(SQLConf.ARROW_EXECUTION_MAX_RECORDS_PER_BATCH.key)
   }
 
-  testQuietly("interval is unsupported for arrow") {
-    val e = intercept[SparkException] {
-      calendarIntervalData.toDF().toArrowBatchRdd.collect()
-    }
-    checkError(
-      exception = e.getCause.asInstanceOf[SparkUnsupportedOperationException],
-      errorClass = "UNSUPPORTED_DATATYPE",
-      parameters = Map("typeName" -> "\"INTERVAL\"")
-    )
+  test("interval is supported for arrow") {
+    val collected = calendarIntervalData.toDF().toArrowBatchRdd.collect()
+    assert(collected.size == 1)
   }
 
   test("test Arrow Validator") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/arrow/ArrowWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/arrow/ArrowWriterSuite.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.util._
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.vectorized._
-import org.apache.spark.unsafe.types.UTF8String
+import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
 
 class ArrowWriterSuite extends SparkFunSuite {
 
@@ -66,6 +66,7 @@ class ArrowWriterSuite extends SparkFunSuite {
             case TimestampNTZType => reader.getLong(rowId)
             case _: YearMonthIntervalType => reader.getInt(rowId)
             case _: DayTimeIntervalType => reader.getLong(rowId)
+            case CalendarIntervalType => reader.getInterval(rowId)
           }
           assert(value === datum)
       }
@@ -92,6 +93,12 @@ class ArrowWriterSuite extends SparkFunSuite {
       .foreach(check(_, Seq(null, 0, 1, -1, Int.MaxValue, Int.MinValue)))
     DataTypeTestUtils.dayTimeIntervalTypes.foreach(check(_,
       Seq(null, 0L, 1000L, -1000L, (Long.MaxValue - 807L), (Long.MinValue + 808L))))
+    check(CalendarIntervalType,
+      Seq(new CalendarInterval(1, 2, 3),
+        new CalendarInterval(11, 22, 33),
+        new CalendarInterval(-1, -2, -3),
+        new CalendarInterval(-11, -22, -33),
+        null))
   }
 
   test("get multiple") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support CalendarIntervalType in Arrow:
1, map `CalendarIntervalType` to `org.apache.arrow.vector.IntervalMonthDayNanoVector`
2, map `CalendarInterval` to `org.apache.arrow.vector.PeriodDuration`;


### Why are the changes needed?
we should support more datatypes in Arrow, see https://spark.apache.org/docs/latest/api/python/user_guide/sql/arrow_pandas.html#supported-sql-types




### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
updated UTs


### Was this patch authored or co-authored using generative AI tooling?
No