### PR TITLE
[SPARK-45100][SQL] Fix an internal error from `reflect()`on `NULL` class and method

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/CallMethodViaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/CallMethodViaReflection.scala
@@ -85,6 +85,10 @@ case class CallMethodViaReflection(
               "inputExpr" -> toSQLExpr(children.head)
             )
           )
+        case (e, 0) if e.eval() == null =>
+          DataTypeMismatch(
+            errorSubClass = "UNEXPECTED_NULL",
+            messageParameters = Map("exprName" -> toSQLId("class")))
         case (e, 1) if !(e.dataType == StringType && e.foldable) =>
           DataTypeMismatch(
             errorSubClass = "NON_FOLDABLE_INPUT",
@@ -94,6 +98,10 @@ case class CallMethodViaReflection(
               "inputExpr" -> toSQLExpr(children(1))
             )
           )
+        case (e, 1) if e.eval() == null =>
+          DataTypeMismatch(
+            errorSubClass = "UNEXPECTED_NULL",
+            messageParameters = Map("exprName" -> toSQLId("method")))
         case (e, idx) if idx > 1 && !CallMethodViaReflection.typeMapping.contains(e.dataType) =>
           DataTypeMismatch(
             errorSubClass = "UNEXPECTED_INPUT_TYPE",

--- a/sql/core/src/test/scala/org/apache/spark/sql/MiscFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/MiscFunctionsSuite.scala
@@ -233,6 +233,26 @@ class MiscFunctionsSuite extends QueryTest with SharedSparkSession {
       Seq(Row("a5cf6c42-0c85-418f-af6c-3e4e5b1328f2")))
     checkAnswer(df.select(reflect(lit("java.util.UUID"), lit("fromString"), col("a"))),
       Seq(Row("a5cf6c42-0c85-418f-af6c-3e4e5b1328f2")))
+
+    checkError(
+      exception = intercept[AnalysisException] {
+        df.selectExpr("reflect(cast(null as string), 'fromString', a)")
+      },
+      errorClass = "DATATYPE_MISMATCH.UNEXPECTED_NULL",
+      parameters = Map(
+        "exprName" -> "`class`",
+        "sqlExpr" -> "\"reflect(CAST(NULL AS STRING), fromString, a)\""),
+      context = ExpectedContext("", "", 0, 45, "reflect(cast(null as string), 'fromString', a)"))
+    checkError(
+      exception = intercept[AnalysisException] {
+        df.selectExpr("reflect('java.util.UUID', cast(null as string), a)")
+      },
+      errorClass = "DATATYPE_MISMATCH.UNEXPECTED_NULL",
+      parameters = Map(
+        "exprName" -> "`method`",
+        "sqlExpr" -> "\"reflect(java.util.UUID, CAST(NULL AS STRING), a)\""),
+      context = ExpectedContext("", "", 0, 49,
+        "reflect('java.util.UUID', cast(null as string), a)"))
   }
 
   test("java_method") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to check that the `class` and `method` arguments are not a NULL in `CallMethodViaReflection`. And if they are, throw an `AnalysisException` with new error class `DATATYPE_MISMATCH.UNEXPECTED_NULL`.

### Why are the changes needed?
To fix the issue demonstrated by the example:
```sql
$ spark-sql (default)> select reflect('java.util.UUID', CAST(NULL AS STRING));
[INTERNAL_ERROR] The Spark SQL phase analysis failed with an internal error. You hit a bug in Spark or the Spark plugins you use. Please, report this bug to the corresponding communities or vendors, and provide the full stack trace.
``` 

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By running new test:
```
$ build/sbt "test:testOnly *.MiscFunctionsSuite"
```

### Was this patch authored or co-authored using generative AI tooling?
No.