### PR TITLE
[SPARK-45103][BUILD][3.4] Update ORC to 1.8.5

### DIFF
--- a/dev/deps/spark-deps-hadoop-2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2-hive-2.3
@@ -222,9 +222,9 @@ objenesis/3.2//objenesis-3.2.jar
 okhttp/3.12.12//okhttp-3.12.12.jar
 okio/1.15.0//okio-1.15.0.jar
 opencsv/2.3//opencsv-2.3.jar
-orc-core/1.8.4/shaded-protobuf/orc-core-1.8.4-shaded-protobuf.jar
-orc-mapreduce/1.8.4/shaded-protobuf/orc-mapreduce-1.8.4-shaded-protobuf.jar
-orc-shims/1.8.4//orc-shims-1.8.4.jar
+orc-core/1.8.5/shaded-protobuf/orc-core-1.8.5-shaded-protobuf.jar
+orc-mapreduce/1.8.5/shaded-protobuf/orc-mapreduce-1.8.5-shaded-protobuf.jar
+orc-shims/1.8.5//orc-shims-1.8.5.jar
 oro/2.0.8//oro-2.0.8.jar
 osgi-resource-locator/1.0.3//osgi-resource-locator-1.0.3.jar
 paranamer/2.8//paranamer-2.8.jar

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -209,9 +209,9 @@ opencsv/2.3//opencsv-2.3.jar
 opentracing-api/0.33.0//opentracing-api-0.33.0.jar
 opentracing-noop/0.33.0//opentracing-noop-0.33.0.jar
 opentracing-util/0.33.0//opentracing-util-0.33.0.jar
-orc-core/1.8.4/shaded-protobuf/orc-core-1.8.4-shaded-protobuf.jar
-orc-mapreduce/1.8.4/shaded-protobuf/orc-mapreduce-1.8.4-shaded-protobuf.jar
-orc-shims/1.8.4//orc-shims-1.8.4.jar
+orc-core/1.8.5/shaded-protobuf/orc-core-1.8.5-shaded-protobuf.jar
+orc-mapreduce/1.8.5/shaded-protobuf/orc-mapreduce-1.8.5-shaded-protobuf.jar
+orc-shims/1.8.5//orc-shims-1.8.5.jar
 oro/2.0.8//oro-2.0.8.jar
 osgi-resource-locator/1.0.3//osgi-resource-locator-1.0.3.jar
 paranamer/2.8//paranamer-2.8.jar

--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
     <!-- After 10.15.1.3, the minimum required version is JDK9 -->
     <derby.version>10.14.2.0</derby.version>
     <parquet.version>1.12.3</parquet.version>
-    <orc.version>1.8.4</orc.version>
+    <orc.version>1.8.5</orc.version>
     <orc.classifier>shaded-protobuf</orc.classifier>
     <jetty.version>9.4.50.v20221201</jetty.version>
     <jakartaservlet.version>4.0.3</jakartaservlet.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade Apache ORC to 1.8.4 for Apache Spark 3.4.2.

Please note that Apache ORC community maintains
- Apache ORC 1.8.x for Apache Spark 3.4.x
- Apache ORC 1.9.x for Apache Spark 3.5.x
- Apache ORC 2.0.x for Apache Spark 4.0.x

### Why are the changes needed?

To bring the latest bug fixes like [ORC-1482](https://issues.apache.org/jira/browse/ORC-1482).

- https://orc.apache.org/news/2023/09/05/ORC-1.8.5/


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.