### PR TITLE
[MINOR][PYTHON][DOCS] Fix potentially wrong underline length

### DIFF
--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -4626,7 +4626,7 @@ def approx_count_distinct(col: "ColumnOrName", rsd: Optional[float] = None) -> C
         A new Column object representing the approximate unique count.
 
     See Also
-    ----------
+    --------
     :meth:`pyspark.sql.functions.count_distinct`
 
     Examples


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to fix potentially wrong underline length.

### Why are the changes needed?
Fix potentially wrong underline length.
<img width="951" alt="image" src="https://github.com/apache/spark/assets/15246973/8f5e8648-7670-4dce-860b-bd12c52e73f3">

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Manually test.
```
cd python/docs
make clean html
```

### Was this patch authored or co-authored using generative AI tooling?
No.
