### PR TITLE
[SPARK-45105][DOCS] Make hyperlinks in documents clickable

### DIFF
--- a/docs/running-on-mesos.md
+++ b/docs/running-on-mesos.md
@@ -136,7 +136,7 @@ If you want to deploy a Spark Application into a Mesos cluster that is running i
 - `LIBPROCESS_SSL_KEY_FILE=pathToKeyFile.key` path to key
 - `LIBPROCESS_SSL_CERT_FILE=pathToCRTFile.crt` the certificate file to be used
 
-All options can be found at http://mesos.apache.org/documentation/latest/ssl/
+All options can be found at [http://mesos.apache.org/documentation/latest/ssl/](http://mesos.apache.org/documentation/latest/ssl/)
 
 Then submit happens as described in Client mode or Cluster mode below
 
@@ -579,7 +579,7 @@ See the [configuration page](configuration.html) for information on Spark config
     This only affects docker containers, and must be one of "docker"
     or "mesos".  Mesos supports two types of
     containerizers for docker: the "docker" containerizer, and the preferred
-    "mesos" containerizer.  Read more here: http://mesos.apache.org/documentation/latest/container-image/
+    "mesos" containerizer.  Read more <a href="http://mesos.apache.org/documentation/latest/container-image/">here</a>.
   </td>
   <td>2.1.0</td>
 </tr>

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -163,7 +163,7 @@ To use a custom metrics.properties for the application master and executors, upd
     Amount of resource to use for the YARN Application Master in client mode.
     In cluster mode, use <code>spark.yarn.driver.resource.&lt;resource-type&gt;.amount</code> instead.
     Please note that this feature can be used only with YARN 3.0+
-    For reference, see YARN Resource Model documentation: https://hadoop.apache.org/docs/current/hadoop-yarn/hadoop-yarn-site/ResourceModel.html
+    For reference, see <a href="https://hadoop.apache.org/docs/current/hadoop-yarn/hadoop-yarn-site/ResourceModel.html">YARN Resource Model documentation</a>
     <p/>
     Example:
     To request GPU resources from YARN, use: <code>spark.yarn.am.resource.yarn.io/gpu.amount</code>
@@ -185,7 +185,7 @@ To use a custom metrics.properties for the application master and executors, upd
   <td>
     Amount of resource to use for the YARN Application Master in cluster mode.
     Please note that this feature can be used only with YARN 3.0+
-    For reference, see YARN Resource Model documentation: https://hadoop.apache.org/docs/current/hadoop-yarn/hadoop-yarn-site/ResourceModel.html
+    For reference, see <a href="https://hadoop.apache.org/docs/current/hadoop-yarn/hadoop-yarn-site/ResourceModel.html">YARN Resource Model documentation</a>
     <p/>
     Example:
     To request GPU resources from YARN, use: <code>spark.yarn.driver.resource.yarn.io/gpu.amount</code>
@@ -198,7 +198,7 @@ To use a custom metrics.properties for the application master and executors, upd
   <td>
     Amount of resource to use per executor process.
     Please note that this feature can be used only with YARN 3.0+
-    For reference, see YARN Resource Model documentation: https://hadoop.apache.org/docs/current/hadoop-yarn/hadoop-yarn-site/ResourceModel.html
+    For reference, see <a href="https://hadoop.apache.org/docs/current/hadoop-yarn/hadoop-yarn-site/ResourceModel.html">YARN Resource Model documentation</a>
     <p/>
     Example:
     To request GPU resources from YARN, use: <code>spark.yarn.executor.resource.yarn.io/gpu.amount</code>


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to make hyperlinks in documents clickable, include: running-on-mesos.html & running-on-yarn.html

### Why are the changes needed?
Improve the convenience of using Spark documents.

Before:
<img width="1372" alt="image" src="https://github.com/apache/spark/assets/15246973/eea24735-babe-4008-ab96-ec2c29ebafd5">

After:
<img width="571" alt="image" src="https://github.com/apache/spark/assets/15246973/1ff1098b-c412-4f3d-b66c-825046691408">

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Manually test.


### Was this patch authored or co-authored using generative AI tooling?
No.
