### PR TITLE
[SPARK-45106][SQL] `PercentileCont` should check user supplied input

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/percentiles.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/percentiles.scala
@@ -369,9 +369,9 @@ case class PercentileCont(left: Expression, right: Expression, reverse: Boolean 
     s"$prettyName($distinct${right.sql}) WITHIN GROUP (ORDER BY ${left.sql}$direction)"
   }
 
-  /* override def checkInputDataTypes(): TypeCheckResult = {
+  override def checkInputDataTypes(): TypeCheckResult = {
     percentile.checkInputDataTypes()
-  } */
+  }
 
   override protected def withNewChildrenInternal(
       newLeft: Expression, newRight: Expression): PercentileCont =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/percentiles.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/percentiles.scala
@@ -368,6 +368,11 @@ case class PercentileCont(left: Expression, right: Expression, reverse: Boolean 
     val direction = if (reverse) " DESC" else ""
     s"$prettyName($distinct${right.sql}) WITHIN GROUP (ORDER BY ${left.sql}$direction)"
   }
+
+  /* override def checkInputDataTypes(): TypeCheckResult = {
+    percentile.checkInputDataTypes()
+  } */
+
   override protected def withNewChildrenInternal(
       newLeft: Expression, newRight: Expression): PercentileCont =
     this.copy(left = newLeft, right = newRight)

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/percentiles.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/percentiles.sql.out
@@ -869,6 +869,31 @@ Aggregate [percentile_disc(a#x, cast(0.0 as double), false, 0, 0, true) AS p0#x,
 
 
 -- !query
+SELECT
+  percentile_cont(b) WITHIN GROUP (ORDER BY a DESC) as p0
+FROM values (12, 0.25), (13, 0.25), (22, 0.25) as v(a, b)
+-- !query analysis
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "DATATYPE_MISMATCH.NON_FOLDABLE_INPUT",
+  "sqlState" : "42K09",
+  "messageParameters" : {
+    "inputExpr" : "\"b\"",
+    "inputName" : "percentage",
+    "inputType" : "\"DOUBLE\"",
+    "sqlExpr" : "\"percentile_cont(a, b)\""
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 10,
+    "stopIndex" : 58,
+    "fragment" : "percentile_cont(b) WITHIN GROUP (ORDER BY a DESC)"
+  } ]
+}
+
+
+-- !query
 SET spark.sql.legacy.percentileDiscCalculation = false
 -- !query analysis
 SetCommand (spark.sql.legacy.percentileDiscCalculation,Some(false))

--- a/sql/core/src/test/resources/sql-tests/inputs/percentiles.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/percentiles.sql
@@ -374,4 +374,8 @@ SELECT
   percentile_disc(1.0) WITHIN GROUP (ORDER BY a) as p10
 FROM VALUES (0), (1), (2), (3), (4) AS v(a);
 
+SELECT
+  percentile_cont(b) WITHIN GROUP (ORDER BY a DESC) as p0
+FROM values (12, 0.25), (13, 0.25), (22, 0.25) as v(a, b);
+
 SET spark.sql.legacy.percentileDiscCalculation = false;

--- a/sql/core/src/test/resources/sql-tests/results/percentiles.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/percentiles.sql.out
@@ -841,6 +841,33 @@ struct<p0:double,p1:double,p2:double,p3:double,p4:double,p5:double,p6:double,p7:
 
 
 -- !query
+SELECT
+  percentile_cont(b) WITHIN GROUP (ORDER BY a DESC) as p0
+FROM values (12, 0.25), (13, 0.25), (22, 0.25) as v(a, b)
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "DATATYPE_MISMATCH.NON_FOLDABLE_INPUT",
+  "sqlState" : "42K09",
+  "messageParameters" : {
+    "inputExpr" : "\"b\"",
+    "inputName" : "percentage",
+    "inputType" : "\"DOUBLE\"",
+    "sqlExpr" : "\"percentile_cont(a, b)\""
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 10,
+    "stopIndex" : 58,
+    "fragment" : "percentile_cont(b) WITHIN GROUP (ORDER BY a DESC)"
+  } ]
+}
+
+
+-- !query
 SET spark.sql.legacy.percentileDiscCalculation = false
 -- !query schema
 struct<key:string,value:string>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Change `PercentileCont` to explicitly check user-supplied input by calling `checkInputDataTypes` on the replacement.

### Why are the changes needed?

`PercentileCont` does not currently check the user's input. If the runtime replacement (an instance of `Percentile`) rejects the user's input, the runtime replacement ends up unresolved.

For example, this query throws an internal error rather than producing a useful error message:
```
select percentile_cont(b) WITHIN GROUP (ORDER BY a DESC) as x 
from (values (12, 0.25), (13, 0.25), (22, 0.25)) as (a, b);

[INTERNAL_ERROR] Cannot resolve the runtime replaceable expression "percentile_cont(a, b)". The replacement is unresolved: "percentile(a, b, 1)".
org.apache.spark.SparkException: [INTERNAL_ERROR] Cannot resolve the runtime replaceable expression "percentile_cont(a, b)". The replacement is unresolved: "percentile(a, b, 1)".
	at org.apache.spark.SparkException$.internalError(SparkException.scala:92)
	at org.apache.spark.SparkException$.internalError(SparkException.scala:96)
	at org.apache.spark.sql.catalyst.analysis.CheckAnalysis.$anonfun$checkAnalysis0$6(CheckAnalysis.scala:313)
	at org.apache.spark.sql.catalyst.analysis.CheckAnalysis.$anonfun$checkAnalysis0$6$adapted(CheckAnalysis.scala:277)
...
```
With this PR, the above query will produce the following error message:
```
[DATATYPE_MISMATCH.NON_FOLDABLE_INPUT] Cannot resolve "percentile_cont(a, b)" due to data type mismatch: the input percentage should be a foldable "DOUBLE" expression; however, got "b".; line 1 pos 7;
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

New tests.

### Was this patch authored or co-authored using generative AI tooling?

No.
