### PR TITLE
[MINOR][DOCS] Change "filter" to "transform" in `transform` function docstring

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -6267,8 +6267,8 @@ object functions {
    * }}}
    *
    * @param column the input array column
-   * @param f (col, index) => transformed_col, the lambda function to filter the input column
-   *           given the index. Indices start at 0.
+   * @param f (col, index) => transformed_col, the lambda function to transform the input
+   *           column given the index. Indices start at 0.
    *
    * @group collection_funcs
    * @since 3.0.0


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR proposes a simple change in the documentation for the `transform` function in `sql`. I believe where it currently reads "filter" it should read "transform".

### Why are the changes needed?
I believe this change might not be needed per se, but it would be a slight improvement to the current version to avoid the misnomer.

### Does this PR introduce _any_ user-facing change?
Yes, it shows the word "transform' instead of "filter" in the documentation for the `transform` `sql`. function.


### How was this patch tested?
This patch was not tested because it only changes documentation.


### Was this patch authored or co-authored using generative AI tooling?
No