### PR TITLE
[SPARK-45114][PYTHON][DOCS] Adjust the `versionadded` and `versionchanged` information to the parameters

### DIFF
--- a/python/pyspark/sql/catalog.py
+++ b/python/pyspark/sql/catalog.py
@@ -129,8 +129,7 @@ class Catalog:
         pattern : str
             The pattern that the catalog name needs to match.
 
-            .. versionchanged: 3.5.0
-                Added ``pattern`` argument.
+            .. versionadded: 3.5.0
 
         Returns
         -------
@@ -201,8 +200,7 @@ class Catalog:
         pattern : str
             The pattern that the database name needs to match.
 
-            .. versionchanged: 3.5.0
-                Adds ``pattern`` argument.
+            .. versionadded: 3.5.0
 
         Returns
         -------
@@ -325,8 +323,7 @@ class Catalog:
         pattern : str
             The pattern that the database name needs to match.
 
-            .. versionchanged: 3.5.0
-                Adds ``pattern`` argument.
+            .. versionadded: 3.5.0
 
         Returns
         -------
@@ -455,8 +452,7 @@ class Catalog:
         pattern : str
             The pattern that the function name needs to match.
 
-            .. versionchanged: 3.5.0
-                Adds ``pattern`` argument.
+            .. versionadded: 3.5.0
 
         Returns
         -------

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -597,8 +597,7 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         level : int, optional, default None
             How many levels to print for nested schemas.
 
-            .. versionchanged:: 3.5.0
-                Added Level parameter.
+            .. versionadded:: 3.5.0
 
         Examples
         --------
@@ -2864,13 +2863,13 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         .. versionchanged:: 3.4.0
             Supports Spark Connect.
 
-        .. versionchanged:: 4.0.0
-            Supports column ordinal.
-
         Parameters
         ----------
         cols : int, str, list or :class:`Column`, optional
             list of :class:`Column` or column names or column ordinals to sort by.
+
+            .. versionchanged:: 4.0.0
+               Supports column ordinal.
 
         Other Parameters
         ----------------
@@ -2928,13 +2927,13 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         .. versionchanged:: 3.4.0
             Supports Spark Connect.
 
-        .. versionchanged:: 4.0.0
-            Supports column ordinal.
-
         Parameters
         ----------
         cols : int, str, list, or :class:`Column`, optional
              list of :class:`Column` or column names or column ordinals to sort by.
+
+            .. versionchanged:: 4.0.0
+               Supports column ordinal.
 
         Other Parameters
         ----------------
@@ -3826,15 +3825,15 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         .. versionchanged:: 3.4.0
             Supports Spark Connect.
 
-        .. versionchanged:: 4.0.0
-            Supports column ordinal.
-
         Parameters
         ----------
-        cols : list, str or :class:`Column`
+        cols : list, str, int or :class:`Column`
             The columns to group by.
             Each element can be a column name (string) or an expression (:class:`Column`)
             or a column ordinal (int, 1-based) or list of them.
+
+            .. versionchanged:: 4.0.0
+               Supports column ordinal.
 
         Returns
         -------
@@ -3935,15 +3934,15 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         .. versionchanged:: 3.4.0
             Supports Spark Connect.
 
-        .. versionchanged:: 4.0.0
-            Supports column ordinal.
-
         Parameters
         ----------
-        cols : list, str or :class:`Column`
+        cols : list, str, int or :class:`Column`
             The columns to roll-up by.
             Each element should be a column name (string) or an expression (:class:`Column`)
             or a column ordinal (int, 1-based) or list of them.
+
+            .. versionchanged:: 4.0.0
+               Supports column ordinal.
 
         Returns
         -------
@@ -4020,15 +4019,15 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         .. versionchanged:: 3.4.0
             Supports Spark Connect.
 
-        .. versionchanged:: 4.0.0
-            Supports column ordinal.
-
         Parameters
         ----------
-        cols : list, str or :class:`Column`
+        cols : list, str, int or :class:`Column`
             The columns to cube by.
             Each element should be a column name (string) or an expression (:class:`Column`)
             or a column ordinal (int, 1-based) or list of them.
+
+            .. versionchanged:: 4.0.0
+               Supports column ordinal.
 
         Returns
         -------


### PR DESCRIPTION
### What changes were proposed in this pull request?
1, for newly added parameters, using `versionadded` instead of `versionchanged`, to follow pandas 

https://github.com/pandas-dev/pandas/blob/cea0cc0a54725ed234e2f51cc21a1182674a6032/pandas/io/sql.py#L317

2, for newly changed parameters, move `versionchanged` under the corresponding parameter


### Why are the changes needed?
for better doc


### Does this PR introduce _any_ user-facing change?
yes

### How was this patch tested?
CI

### Was this patch authored or co-authored using generative AI tooling?
NO
