### PR TITLE
[SPARK-45121][CONNECT][PS] Support `Series.empty` for Spark Connect.

### DIFF
--- a/python/pyspark/pandas/base.py
+++ b/python/pyspark/pandas/base.py
@@ -505,7 +505,7 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
         >>> ps.DataFrame({}, index=list('abc')).index.empty
         False
         """
-        return self._internal.resolved_copy.spark_frame.rdd.isEmpty()
+        return self._internal.resolved_copy.spark_frame.isEmpty()
 
     @property
     def hasnans(self) -> bool:

--- a/python/pyspark/pandas/tests/series/test_series.py
+++ b/python/pyspark/pandas/tests/series/test_series.py
@@ -113,6 +113,8 @@ class SeriesTestsMixin:
             self.assert_eq(ps.from_pandas(pser_a), pser_a)
             self.assert_eq(ps.from_pandas(pser_b), pser_b)
 
+        self.assertTrue(pser_a.empty)
+
     def test_all_null_series(self):
         pser_a = pd.Series([None, None, None], dtype="float64")
         pser_b = pd.Series([None, None, None], dtype="str")


### PR DESCRIPTION


### What changes were proposed in this pull request?

This PR proposes to support Series.empty for Spark Connect by removing JVM dependency.


### Why are the changes needed?

Increase API coverage for Spark Connect.


### Does this PR introduce _any_ user-facing change?

`Series.empty` is available on Spark Connect.

### How was this patch tested?

Added UT.

### Was this patch authored or co-authored using generative AI tooling?

No.