### PR TITLE
[SPARK-45127][DOCS] Exclude README.md from document build

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -46,3 +46,5 @@ DOCSEARCH_SCRIPT: |
   });
 
 permalink: 404.html
+
+exclude: ['README.md']


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to exclude `README.md` from document build.

### Why are the changes needed?
- Currently, our document `README.html` does not have any CSS style applied to it, as shown below:
   https://spark.apache.org/docs/latest/README.html
   <img width="1432" alt="image" src="https://github.com/apache/spark/assets/15246973/1dfe5f69-30d9-4ce4-8d82-1bba5e721ccd">

   **If we do not intend to display the above page to users, we should remove it during the document build process.**

- As we saw in the project `spark-website`, it has already set the following configuration:
   https://github.com/apache/spark-website/blob/642d1fb834817014e1799e73882d53650c1c1662/_config.yml#L7
    <img width="720" alt="image" src="https://github.com/apache/spark/assets/15246973/421b7be5-4ece-407e-9d49-8e7487b74a47">
   Let's stay consistent.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
- Manually test.
   After this pr, the README.html file will no longer be generated
   ```
    (base) panbingkun:~/Developer/spark/spark-community/docs/_site$ls -al README.html
    ls: README.html: No such file or directory
    ```
- Pass GA.

### Was this patch authored or co-authored using generative AI tooling?
No.
