### PR TITLE
[SPARK-42304][FOLLOWUP][SQL] Add test for `GET_TABLES_BY_TYPE_UNSUPPORTED_BY_HIVE_VERSION`

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -9,7 +9,7 @@ Thanks for sending a pull request!  Here are some tips for you:
   7. If you want to add a new configuration, please read the guideline first for naming configurations in
      'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
   8. If you want to add or modify an error type or message, please read the guideline first in
-     'core/src/main/resources/error/README.md'.
+     'common/utils/src/main/resources/error/README.md'.
 -->
 
 ### What changes were proposed in this pull request?

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -9,7 +9,7 @@ Thanks for sending a pull request!  Here are some tips for you:
   7. If you want to add a new configuration, please read the guideline first for naming configurations in
      'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
   8. If you want to add or modify an error type or message, please read the guideline first in
-     'common/utils/src/main/resources/error/README.md'.
+     'core/src/main/resources/error/README.md'.
 -->
 
 ### What changes were proposed in this pull request?

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HiveShimSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HiveShimSuite.scala
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hive.client
+
+import org.apache.hadoop.hive.conf.HiveConf
+import org.apache.hadoop.hive.metastore.TableType
+import org.apache.hadoop.hive.ql.metadata.{Hive, Table}
+import org.apache.hadoop.hive.ql.session.SessionState
+
+import org.apache.spark.SparkUnsupportedOperationException
+import org.apache.spark.sql.hive.client.HiveClientImpl.getHive
+import org.apache.spark.util.Utils
+
+class HiveShimSuite(version: String) extends HiveVersionSuite(version) {
+
+  private val shim = version match {
+    case "0.12" => new Shim_v0_12()
+    case "0.13" => new Shim_v0_13()
+    case "0.14" => new Shim_v0_14()
+    case "1.0" => new Shim_v1_0()
+    case "1.1" => new Shim_v1_1()
+    case "1.2" => new Shim_v1_2()
+    case "2.0" => new Shim_v2_0()
+    case "2.1" => new Shim_v2_1()
+    case "2.2" => new Shim_v2_2()
+    case "2.3" => new Shim_v2_3()
+    case "3.0" => new Shim_v3_0()
+    case "3.1" => new Shim_v3_1()
+  }
+
+  private def hive: Hive = {
+    val hiveConf = new HiveConf(classOf[SessionState])
+    lazy val warehousePath = Utils.createTempDir()
+
+    hiveConf.set("datanucleus.schema.autoCreateAll", "true")
+    hiveConf.set("hive.metastore.schema.verification", "false")
+    hiveConf.set("hive.metastore.warehouse.dir", warehousePath.toString)
+
+    getHive(hiveConf)
+  }
+
+  test("createTables") {
+    shim.createTable(hive, new Table("default", "table1"), ifNotExists = true)
+  }
+
+  test("getTablesByType") {
+    if (version >= "2.3") {
+      val managed = shim.getTablesByType(hive, "default", "table1", TableType.MANAGED_TABLE)
+      val external = shim.getTablesByType(hive, "default", "table1", TableType.EXTERNAL_TABLE)
+
+      assert(managed === Seq("table1"))
+      assert(external === Seq.empty)
+    } else {
+      val e = intercept[SparkUnsupportedOperationException] {
+        shim.getTablesByType(hive, "default", "table1", TableType.MANAGED_TABLE)
+      }
+      checkError(e, errorClass = "GET_TABLES_BY_TYPE_UNSUPPORTED_BY_HIVE_VERSION")
+    }
+  }
+
+  test("dropTable") {
+    shim.dropTable(hive, "default", "table1")
+  }
+}

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HiveShimSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HiveShimSuite.scala
@@ -29,12 +29,6 @@ import org.apache.spark.util.Utils
 class HiveShimSuite(version: String) extends HiveVersionSuite(version) {
 
   private val shim = version match {
-    case "0.12" => new Shim_v0_12()
-    case "0.13" => new Shim_v0_13()
-    case "0.14" => new Shim_v0_14()
-    case "1.0" => new Shim_v1_0()
-    case "1.1" => new Shim_v1_1()
-    case "1.2" => new Shim_v1_2()
     case "2.0" => new Shim_v2_0()
     case "2.1" => new Shim_v2_1()
     case "2.2" => new Shim_v2_2()
@@ -49,6 +43,7 @@ class HiveShimSuite(version: String) extends HiveVersionSuite(version) {
 
     hiveConf.set("hive.metastore.schema.verification", "false")
     hiveConf.set("hive.metastore.warehouse.dir", warehousePath.toString)
+    hiveConf.set("datanucleus.schema.autoCreateAll", "true")
 
     getHive(hiveConf)
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HiveShimSuites.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HiveShimSuites.scala
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hive.client
+
+import scala.collection.immutable.IndexedSeq
+
+import org.scalatest.Suite
+
+class HiveShimSuites extends Suite with HiveClientVersions {
+  override def nestedSuites: IndexedSeq[Suite] = {
+    versions.map(new HiveShimSuite(_))
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
1) Add test for getTablesByType function to cover error class "UNSUPPORTED_FUNCTION_BY_HIVE_VERSION" added in PR https://github.com/apache/spark/pull/42706

### Why are the changes needed?
Test error class for getTablesByType()


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
./build/sbt "testOnly org.apache.spark.SparkThrowableSuite"
./build/sbt "sql/testOnly org.apache.spark.sql.hive.client.HiveShimSuites"

### Was this patch authored or co-authored using generative AI tooling?
No