### PR TITLE
[MINOR][DOCS] Add errors.rst to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ python/.eggs/
 python/coverage.xml
 python/deps
 python/docs/_site/
+python/docs/source/development/errors.rst
 python/docs/source/reference/**/api/
 python/docs/source/user_guide/pandas_on_spark/supported_pandas_api.rst
 python/test_coverage/coverage_data


### PR DESCRIPTION
### What changes were proposed in this pull request?
After PR [[SPARK-44945][DOCS][PYTHON] Automate PySpark error class documentation](https://github.com/apache/spark/pull/42658), `errors.rst` file will be automatically generated during document build process. 
<img width="535" alt="image" src="https://github.com/apache/spark/assets/15246973/f6048e2e-7fc8-4930-9c11-767ccbfa1c68">
Add the file `python/docs/source/development/errors.rst` to git ignore.

### Why are the changes needed?
- To avoid developers from accidentally adding those files when working on docs.

- According on what we have seen, the files generated ` python/docs/source/user_guide/pandas_on_spark/supported_pandas_api.rst` in the building document have also been added to the `.gitignore` file.
https://github.com/apache/spark/blob/994b6976b2a5a53323a83e70e0c6195cd74292a1/python/docs/source/conf.py#L26-L41
https://github.com/apache/spark/blob/994b6976b2a5a53323a83e70e0c6195cd74292a1/.gitignore#L77

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Manually test.

### Was this patch authored or co-authored using generative AI tooling?
No.
