### PR TITLE
[SPARK-25689][YARN][FOLLOWUP] Add a missing argument usage description for ApplicationMasterArguments

### DIFF
--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMasterArguments.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMasterArguments.scala
@@ -96,7 +96,8 @@ class ApplicationMasterArguments(val args: Array[String]) {
       |  --primary-r-file     A main R file
       |  --arg ARG            Argument to be passed to your application's main class.
       |                       Multiple invocations are possible, each will be passed in order.
-      |  --properties-file FILE Path to a custom Spark properties file.
+      |  --properties-file    FILE Path to a custom Spark properties file.
+      |  --dist-cache-conf    FILE Path to a custom Spark distributed cache info file.
       """.stripMargin)
     // scalastyle:on println
     System.exit(exitCode)


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pull request adds a missing argument usage description for ApplicationMasterArguments.

A followup PR for [SPARK-25689](https://github.com/apache/spark/pull/23338)
https://github.com/apache/spark/pull/23338/files#diff-dbb471beb8bb44a98a65b56f069c5d6abb74141073c97b9f5256c971164aedbdR66

### Why are the changes needed?
PR for SPARK-25689 missed the description for argument "--dist-cache-conf" in ApplicationMasterArguments.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
This commit doesn't need to be tested. It only affects the usage log.


### Was this patch authored or co-authored using generative AI tooling?
No.

