### PR TITLE
[SPARK-45135][PYTHON][TESTS] Make `utils.eventually` a parameterized decorator

### DIFF
--- a/python/pyspark/ml/tests/test_image.py
+++ b/python/pyspark/ml/tests/test_image.py
@@ -19,11 +19,11 @@ import unittest
 from pyspark.ml.image import ImageSchema
 from pyspark.testing.mlutils import SparkSessionTestCase
 from pyspark.sql import Row
-from pyspark.testing.utils import QuietTest, retry
+from pyspark.testing.utils import QuietTest, eventually
 
 
 class ImageFileFormatTest(SparkSessionTestCase):
-    @retry(maxTries=5)
+    @eventually(timeout=60.0, catch_assertions=True)
     def test_read_images(self):
         data_path = "data/mllib/images/origin/kittens"
         df = (

--- a/python/pyspark/ml/tests/test_image.py
+++ b/python/pyspark/ml/tests/test_image.py
@@ -70,12 +70,6 @@ class ImageFileFormatTest(SparkSessionTestCase):
                 lambda: ImageSchema.toImage("a"),
             )
 
-    @retry(maxTries=50)
-    def test_rand(self):
-        import random
-
-        self.assertTrue(random.random() < 0.1)
-
 
 if __name__ == "__main__":
     from pyspark.ml.tests.test_image import *  # noqa: F401

--- a/python/pyspark/ml/tests/test_image.py
+++ b/python/pyspark/ml/tests/test_image.py
@@ -70,6 +70,12 @@ class ImageFileFormatTest(SparkSessionTestCase):
                 lambda: ImageSchema.toImage("a"),
             )
 
+    @retry(maxTries=50)
+    def test_rand(self):
+        import random
+
+        self.assertTrue(random.random() < 0.1)
+
 
 if __name__ == "__main__":
     from pyspark.ml.tests.test_image import *  # noqa: F401

--- a/python/pyspark/ml/tests/test_image.py
+++ b/python/pyspark/ml/tests/test_image.py
@@ -19,10 +19,11 @@ import unittest
 from pyspark.ml.image import ImageSchema
 from pyspark.testing.mlutils import SparkSessionTestCase
 from pyspark.sql import Row
-from pyspark.testing.utils import QuietTest
+from pyspark.testing.utils import QuietTest, retry
 
 
 class ImageFileFormatTest(SparkSessionTestCase):
+    @retry(maxTries=5)
     def test_read_images(self):
         data_path = "data/mllib/images/origin/kittens"
         df = (
@@ -68,6 +69,12 @@ class ImageFileFormatTest(SparkSessionTestCase):
                 "array argument should be numpy.ndarray; however, it got",
                 lambda: ImageSchema.toImage("a"),
             )
+
+    @retry(maxTries=50)
+    def test_rand(self):
+        import random
+
+        self.assertTrue(random.random() < 0.1)
 
 
 if __name__ == "__main__":

--- a/python/pyspark/ml/tests/test_wrapper.py
+++ b/python/pyspark/ml/tests/test_wrapper.py
@@ -63,7 +63,7 @@ class JavaWrapperMemoryTests(SparkSessionTestCase):
             self.assertIn("LinearRegressionTrainingSummary", summary._java_obj.toString())
             return True
 
-        eventually(condition, timeout=10, catch_assertions=True)
+        eventually(timeout=10, catch_assertions=True)(condition)()
 
         try:
             summary.__del__()
@@ -77,7 +77,7 @@ class JavaWrapperMemoryTests(SparkSessionTestCase):
                 summary._java_obj.toString()
             return True
 
-        eventually(condition, timeout=10, catch_assertions=True)
+        eventually(timeout=10, catch_assertions=True)(condition)()
 
 
 class WrapperTests(MLlibTestCase):

--- a/python/pyspark/mllib/tests/test_algorithms.py
+++ b/python/pyspark/mllib/tests/test_algorithms.py
@@ -97,27 +97,28 @@ class ListTests(MLlibTestCase):
             # TODO: Allow small numeric difference.
             self.assertTrue(array_equal(c1, c2))
 
+    @eventually(timeout=60, catch_assertions=True)
     def test_gmm(self):
         from pyspark.mllib.clustering import GaussianMixture
 
-        def condition():
-            data = self.sc.parallelize(
-                [
-                    [1, 2],
-                    [8, 9],
-                    [-4, -3],
-                    [-6, -7],
-                ]
-            )
-            clusters = GaussianMixture.train(
-                data, 2, convergenceTol=0.001, maxIterations=10, seed=1
-            )
-            labels = clusters.predict(data).collect()
-            self.assertEqual(labels[0], labels[1])
-            self.assertEqual(labels[2], labels[3])
-            return True
-
-        eventually(condition, timeout=60, catch_assertions=True)
+        data = self.sc.parallelize(
+            [
+                [1, 2],
+                [8, 9],
+                [-4, -3],
+                [-6, -7],
+            ]
+        )
+        clusters = GaussianMixture.train(
+            data,
+            2,
+            convergenceTol=0.001,
+            maxIterations=10,
+            seed=1,
+        )
+        labels = clusters.predict(data).collect()
+        self.assertEqual(labels[0], labels[1])
+        self.assertEqual(labels[2], labels[3])
 
     def test_gmm_deterministic(self):
         from pyspark.mllib.clustering import GaussianMixture

--- a/python/pyspark/mllib/tests/test_streaming_algorithms.py
+++ b/python/pyspark/mllib/tests/test_streaming_algorithms.py
@@ -73,7 +73,7 @@ class StreamingKMeansTest(MLLibStreamingTestCase):
             self.assertEqual(stkm.latestModel().clusterWeights, [25.0])
             return True
 
-        eventually(condition, catch_assertions=True)
+        eventually(catch_assertions=True)(condition)()
 
         realCenters = array_sum(array(centers), axis=0)
         for i in range(5):
@@ -118,7 +118,7 @@ class StreamingKMeansTest(MLLibStreamingTestCase):
             self.assertEqual(finalModel.clusterWeights, [5.0, 5.0, 5.0, 5.0])
             return True
 
-        eventually(condition, 90, catch_assertions=True)
+        eventually(timeout=90, catch_assertions=True)(condition)()
 
     def test_predictOn_model(self):
         """Test that the model predicts correctly on toy data."""
@@ -147,7 +147,7 @@ class StreamingKMeansTest(MLLibStreamingTestCase):
             self.assertEqual(result, [[0], [1], [2], [3]])
             return True
 
-        eventually(condition, catch_assertions=True)
+        eventually(catch_assertions=True)(condition)()
 
     @unittest.skip("SPARK-10086: Flaky StreamingKMeans test in PySpark")
     def test_trainOn_predictOn(self):
@@ -180,7 +180,7 @@ class StreamingKMeansTest(MLLibStreamingTestCase):
             self.assertEqual(predict_results, [[0, 1, 1], [1, 0, 1]])
             return True
 
-        eventually(condition, catch_assertions=True)
+        eventually(catch_assertions=True)(condition)()
 
 
 class StreamingLogisticRegressionWithSGDTests(MLLibStreamingTestCase):
@@ -223,7 +223,7 @@ class StreamingLogisticRegressionWithSGDTests(MLLibStreamingTestCase):
             self.assertAlmostEqual(rel, 0.1, 1)
             return True
 
-        eventually(condition, timeout=120.0, catch_assertions=True)
+        eventually(timeout=120.0, catch_assertions=True)(condition)()
 
     def test_convergence(self):
         """
@@ -247,7 +247,7 @@ class StreamingLogisticRegressionWithSGDTests(MLLibStreamingTestCase):
             return True
 
         # We want all batches to finish for this test.
-        eventually(condition, 120, catch_assertions=True)
+        eventually(timeout=120, catch_assertions=True)(condition)()
 
         t_models = array(models)
         diff = t_models[1:] - t_models[:-1]
@@ -278,7 +278,7 @@ class StreamingLogisticRegressionWithSGDTests(MLLibStreamingTestCase):
             self.assertEqual(len(true_predicted), len(input_batches))
             return True
 
-        eventually(condition, catch_assertions=True)
+        eventually(catch_assertions=True)(condition)()
 
         # Test that the accuracy error is no more than 0.4 on each batch.
         for batch in true_predicted:
@@ -319,7 +319,7 @@ class StreamingLogisticRegressionWithSGDTests(MLLibStreamingTestCase):
                 return True
             return "Latest errors: " + ", ".join(map(lambda x: str(x), errors))
 
-        eventually(condition, timeout=180.0)
+        eventually(timeout=180.0)(condition)()
 
 
 class StreamingLinearRegressionWithTests(MLLibStreamingTestCase):
@@ -354,7 +354,7 @@ class StreamingLinearRegressionWithTests(MLLibStreamingTestCase):
             self.assertAlmostEqual(slr.latestModel().intercept, 0.0, 1)
             return True
 
-        eventually(condition, catch_assertions=True)
+        eventually(catch_assertions=True)(condition)()
 
     def test_parameter_convergence(self):
         """Test that the model parameters improve with streaming data."""
@@ -380,7 +380,7 @@ class StreamingLinearRegressionWithTests(MLLibStreamingTestCase):
             return True
 
         # We want all batches to finish for this test.
-        eventually(condition, 90, catch_assertions=True)
+        eventually(timeout=90, catch_assertions=True)(condition)()
 
         w = array(model_weights)
         diff = w[1:] - w[:-1]
@@ -412,7 +412,7 @@ class StreamingLinearRegressionWithTests(MLLibStreamingTestCase):
             return True
 
         # We want all batches to finish for this test.
-        eventually(condition, catch_assertions=True)
+        eventually(catch_assertions=True)(condition)()
 
         # Test that mean absolute error on each batch is less than 0.1
         for batch in samples:
@@ -456,7 +456,7 @@ class StreamingLinearRegressionWithTests(MLLibStreamingTestCase):
                 return True
             return "Latest errors: " + ", ".join(map(lambda x: str(x), errors))
 
-        eventually(condition, timeout=180.0)
+        eventually(timeout=180.0)(condition)()
 
 
 if __name__ == "__main__":

--- a/python/pyspark/sql/tests/pandas/test_pandas_grouped_map_with_state.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_grouped_map_with_state.py
@@ -319,7 +319,7 @@ class GroupedApplyInPandasWithStateTestsMixin:
                 return False
 
         try:
-            eventually(assert_test, timeout=120)
+            eventually(timeout=120)(assert_test)()
         finally:
             q.stop()
 

--- a/python/pyspark/testing/utils.py
+++ b/python/pyspark/testing/utils.py
@@ -132,10 +132,7 @@ def retry(maxTries=10, interval=1.0):
                 if lastValue is True:
                     return
 
-                print()
-                print(f"The {numTries}-th attempt failed, due to {str(lastValue)}!")
-                print()
-
+                print(f"\nAttempt #{numTries} failed!\n{lastValue}")
                 sleep(interval)
 
             if isinstance(lastValue, Exception):

--- a/python/pyspark/tests/test_taskcontext.py
+++ b/python/pyspark/tests/test_taskcontext.py
@@ -286,11 +286,12 @@ class TaskContextTestsWithWorkerReuse(unittest.TestCase):
             self.assertTrue(pid in worker_pids)
         return True
 
+    @eventually(catch_assertions=True)
     def test_task_context_correct_with_python_worker_reuse(self):
         # Retrying the check as the PIDs from Python workers might be different even
         # when reusing Python workers is enabled if a Python worker is dead for some reasons
         # (e.g., socket connection failure) and new Python worker is created.
-        eventually(self.check_task_context_correct_with_python_worker_reuse, catch_assertions=True)
+        self.check_task_context_correct_with_python_worker_reuse()
 
     def tearDown(self):
         self.sc.stop()

--- a/python/pyspark/tests/test_util.py
+++ b/python/pyspark/tests/test_util.py
@@ -20,7 +20,7 @@ import unittest
 from py4j.protocol import Py4JJavaError
 
 from pyspark import keyword_only
-from pyspark.testing.utils import PySparkTestCase
+from pyspark.testing.utils import PySparkTestCase, eventually
 from pyspark.find_spark_home import _find_spark_home
 
 
@@ -83,6 +83,27 @@ class UtilTests(PySparkTestCase):
             self.assertEquals(origin, _find_spark_home())
         finally:
             os.environ["SPARK_HOME"] = origin
+
+    @eventually(timeout=180, catch_assertions=True)
+    def test_eventually_decorator(self):
+        import random
+
+        self.assertTrue(random.random() < 0.1)
+
+    def test_eventually_function(self):
+        import random
+
+        def condition():
+            self.assertTrue(random.random() < 0.1)
+
+        eventually(timeout=180, catch_assertions=True)(condition)()
+
+    def test_eventually_lambda(self):
+        import random
+
+        eventually(timeout=180, catch_assertions=True)(
+            lambda: self.assertTrue(random.random() < 0.1)
+        )()
 
 
 if __name__ == "__main__":

--- a/python/pyspark/tests/test_worker.py
+++ b/python/pyspark/tests/test_worker.py
@@ -186,16 +186,13 @@ class WorkerTests(ReusedPySparkTestCase):
 
 
 class WorkerReuseTest(PySparkTestCase):
+    @eventually(catch_assertions=True)
     def test_reuse_worker_of_parallelize_range(self):
-        def check_reuse_worker_of_parallelize_range():
-            rdd = self.sc.parallelize(range(20), 8)
-            previous_pids = rdd.map(lambda x: os.getpid()).collect()
-            current_pids = rdd.map(lambda x: os.getpid()).collect()
-            for pid in current_pids:
-                self.assertTrue(pid in previous_pids)
-            return True
-
-        eventually(check_reuse_worker_of_parallelize_range, catch_assertions=True)
+        rdd = self.sc.parallelize(range(20), 8)
+        previous_pids = rdd.map(lambda x: os.getpid()).collect()
+        current_pids = rdd.map(lambda x: os.getpid()).collect()
+        for pid in current_pids:
+            self.assertTrue(pid in previous_pids)
 
 
 @unittest.skipIf(


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Make utils.eventually a parameterized decorator
- Retry `test_read_images` if it fails

### Why are the changes needed?
previously, we used `utils.eventually` to retry flaky tests, e.g. https://github.com/apache/spark/commit/745ed93fe451b3f9e8148b06356c28b889a4db5a

however, it needs to modify the test body, sometime the change maybe large

To minimize the changes, I'd like to ~~add a decorator for test retry~~ Make utils.eventually a parameterized decorator.



### Does this PR introduce _any_ user-facing change?
no, test-only


### How was this patch tested?
CI

### Was this patch authored or co-authored using generative AI tooling?
no