### PR TITLE
[SPARK-45162][SQL] Support maps and array parameters constructed via `call_function`

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -269,7 +269,7 @@ class SparkConnectPlanner(val sessionHolder: SessionHolder) extends Logging {
     if (!args.isEmpty) {
       NameParameterizedQuery(parsedPlan, args.asScala.mapValues(transformLiteral).toMap)
     } else if (!posArgs.isEmpty) {
-      PosParameterizedQuery(parsedPlan, posArgs.asScala.map(transformLiteral))
+      PosParameterizedQuery(parsedPlan, posArgs.asScala.map(transformLiteral).toSeq)
     } else {
       parsedPlan
     }

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -269,7 +269,7 @@ class SparkConnectPlanner(val sessionHolder: SessionHolder) extends Logging {
     if (!args.isEmpty) {
       NameParameterizedQuery(parsedPlan, args.asScala.mapValues(transformLiteral).toMap)
     } else if (!posArgs.isEmpty) {
-      PosParameterizedQuery(parsedPlan, posArgs.asScala.map(transformLiteral).toArray)
+      PosParameterizedQuery(parsedPlan, posArgs.asScala.map(transformLiteral))
     } else {
       parsedPlan
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -260,7 +260,6 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
       // at the beginning of analysis.
       OptimizeUpdateFields,
       CTESubstitution,
-      BindParameters,
       WindowsSubstitution,
       EliminateUnions,
       SubstituteUnresolvedOrdinals),
@@ -322,6 +321,7 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
       RewriteDeleteFromTable ::
       RewriteUpdateTable ::
       RewriteMergeIntoTable ::
+      BindParameters ::
       typeCoercionRules ++
       Seq(
         ResolveWithCTE,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
@@ -218,9 +218,7 @@ abstract class QueryPlan[PlanType <: QueryPlan[PlanType]]
     def recursiveTransform(arg: Any): AnyRef = arg match {
       case e: Expression => transformExpression(e)
       case Some(value) => Some(recursiveTransform(value))
-      case a: Array[Expression] => a.map(transformExpression)
-      case am: AttributeMap[_] => am
-      case m: Map[_, _] => m.map(kv => recursiveTransform(kv._1) -> recursiveTransform(kv._2))
+      case m: Map[_, _] => m
       case d: DataType => d // Avoid unpacking Structs
       case stream: Stream[_] => stream.map(recursiveTransform).force
       case seq: Iterable[_] => seq.map(recursiveTransform)
@@ -276,9 +274,6 @@ abstract class QueryPlan[PlanType <: QueryPlan[PlanType]]
     productIterator.flatMap {
       case e: Expression => e :: Nil
       case s: Some[_] => seqToExpressions(s.toSeq)
-      case a: Array[Expression] => seqToExpressions(a.toSeq)
-      case _: AttributeMap[_] => Nil
-      case m: Map[_, _] => seqToExpressions(m.keys ++ m.values)
       case seq: Iterable[_] => seqToExpressions(seq)
       case other => Nil
     }.toSeq

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
@@ -219,6 +219,7 @@ abstract class QueryPlan[PlanType <: QueryPlan[PlanType]]
       case e: Expression => transformExpression(e)
       case Some(value) => Some(recursiveTransform(value))
       case a: Array[Expression] => a.map(transformExpression)
+      case am: AttributeMap[_] => am
       case m: Map[_, _] => m.map(kv => recursiveTransform(kv._1) -> recursiveTransform(kv._2))
       case d: DataType => d // Avoid unpacking Structs
       case stream: Stream[_] => stream.map(recursiveTransform).force
@@ -276,6 +277,7 @@ abstract class QueryPlan[PlanType <: QueryPlan[PlanType]]
       case e: Expression => e :: Nil
       case s: Some[_] => seqToExpressions(s.toSeq)
       case a: Array[Expression] => seqToExpressions(a.toSeq)
+      case _: AttributeMap[_] => Nil
       case m: Map[_, _] => seqToExpressions(m.keys ++ m.values)
       case seq: Iterable[_] => seqToExpressions(seq)
       case other => Nil

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
@@ -218,7 +218,8 @@ abstract class QueryPlan[PlanType <: QueryPlan[PlanType]]
     def recursiveTransform(arg: Any): AnyRef = arg match {
       case e: Expression => transformExpression(e)
       case Some(value) => Some(recursiveTransform(value))
-      case m: Map[_, _] => m
+      case a: Array[Expression] => a.map(transformExpression)
+      case m: Map[_, _] => m.map(kv => recursiveTransform(kv._1) -> recursiveTransform(kv._2))
       case d: DataType => d // Avoid unpacking Structs
       case stream: Stream[_] => stream.map(recursiveTransform).force
       case seq: Iterable[_] => seq.map(recursiveTransform)
@@ -274,6 +275,8 @@ abstract class QueryPlan[PlanType <: QueryPlan[PlanType]]
     productIterator.flatMap {
       case e: Expression => e :: Nil
       case s: Some[_] => seqToExpressions(s.toSeq)
+      case a: Array[Expression] => seqToExpressions(a.toSeq)
+      case m: Map[_, _] => seqToExpressions(m.keys ++ m.values)
       case seq: Iterable[_] => seqToExpressions(seq)
       case other => Nil
     }.toSeq

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
@@ -1432,7 +1432,7 @@ class AnalysisSuite extends AnalysisTest with Matchers {
     CTERelationDef.curId.set(0)
     val actual1 = PosParameterizedQuery(
       child = parsePlan("WITH a AS (SELECT 1 c) SELECT * FROM a LIMIT ?"),
-      args = Array(Literal(10))).analyze
+      args = Seq(Literal(10))).analyze
     CTERelationDef.curId.set(0)
     val expected1 = parsePlan("WITH a AS (SELECT 1 c) SELECT * FROM a LIMIT 10").analyze
     comparePlans(actual1, expected1)
@@ -1440,7 +1440,7 @@ class AnalysisSuite extends AnalysisTest with Matchers {
     CTERelationDef.curId.set(0)
     val actual2 = PosParameterizedQuery(
       child = parsePlan("WITH a AS (SELECT 1 c) SELECT c FROM a WHERE c < ?"),
-      args = Array(Literal(20), Literal(10))).analyze
+      args = Seq(Literal(20), Literal(10))).analyze
     CTERelationDef.curId.set(0)
     val expected2 = parsePlan("WITH a AS (SELECT 1 c) SELECT c FROM a WHERE c < 20").analyze
     comparePlans(actual2, expected2)

--- a/sql/core/src/test/scala/org/apache/spark/sql/ParametersSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ParametersSuite.scala
@@ -533,8 +533,7 @@ class ParametersSuite extends QueryTest with SharedSparkSession {
 
   test("SPARK-45033: maps as parameters") {
     def fromArr(keys: Array[_], values: Array[_]): Column = {
-      // map_from_arrays(Column(Literal(keys)), Column(Literal(values)))
-      call_function("map_from_arrays", Column(Literal(keys)), Column(Literal(values)))
+      map_from_arrays(Column(Literal(keys)), Column(Literal(values)))
     }
     def callFromArr(keys: Array[_], values: Array[_]): Column = {
       call_function("map_from_arrays", Column(Literal(keys)), Column(Literal(values)))

--- a/sql/core/src/test/scala/org/apache/spark/sql/ParametersSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ParametersSuite.scala
@@ -21,7 +21,7 @@ import java.time.{Instant, LocalDate, LocalDateTime, ZoneId}
 
 import org.apache.spark.sql.catalyst.expressions.Literal
 import org.apache.spark.sql.catalyst.parser.ParseException
-import org.apache.spark.sql.functions.{array, lit, map, map_from_arrays, map_from_entries, str_to_map, struct}
+import org.apache.spark.sql.functions.{array, call_function, lit, map, map_from_arrays, map_from_entries, str_to_map, struct}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 
@@ -533,19 +533,32 @@ class ParametersSuite extends QueryTest with SharedSparkSession {
 
   test("SPARK-45033: maps as parameters") {
     def fromArr(keys: Array[_], values: Array[_]): Column = {
-      map_from_arrays(Column(Literal(keys)), Column(Literal(values)))
+      // map_from_arrays(Column(Literal(keys)), Column(Literal(values)))
+      call_function("map_from_arrays", Column(Literal(keys)), Column(Literal(values)))
+    }
+    def callFromArr(keys: Array[_], values: Array[_]): Column = {
+      call_function("map_from_arrays", Column(Literal(keys)), Column(Literal(values)))
     }
     def createMap(keys: Array[_], values: Array[_]): Column = {
       val zipped = keys.map(k => Column(Literal(k))).zip(values.map(v => Column(Literal(v))))
       map(zipped.map { case (k, v) => Seq(k, v) }.flatten: _*)
+    }
+    def callMap(keys: Array[_], values: Array[_]): Column = {
+      val zipped = keys.map(k => Column(Literal(k))).zip(values.map(v => Column(Literal(v))))
+      call_function("map", zipped.map { case (k, v) => Seq(k, v) }.flatten: _*)
     }
     def fromEntries(keys: Array[_], values: Array[_]): Column = {
       val structures = keys.zip(values)
         .map { case (k, v) => struct(Column(Literal(k)), Column(Literal(v)))}
       map_from_entries(array(structures: _*))
     }
+    def callFromEntries(keys: Array[_], values: Array[_]): Column = {
+      val structures = keys.zip(values)
+        .map { case (k, v) => struct(Column(Literal(k)), Column(Literal(v)))}
+      call_function("map_from_entries", call_function("array", structures: _*))
+    }
 
-    Seq(fromArr(_, _), createMap(_, _)).foreach { f =>
+    Seq(fromArr(_, _), createMap(_, _), callFromArr(_, _), callMap(_, _)).foreach { f =>
       checkAnswer(
         spark.sql("SELECT map_contains_key(:mapParam, 0)",
           Map("mapParam" -> f(Array.empty[Int], Array.empty[String]))),
@@ -555,7 +568,8 @@ class ParametersSuite extends QueryTest with SharedSparkSession {
           Array(f(Array.empty[String], Array.empty[Double]))),
         Row(false))
     }
-    Seq(fromArr(_, _), createMap(_, _), fromEntries(_, _)).foreach { f =>
+    Seq(fromArr(_, _), createMap(_, _), fromEntries(_, _),
+      callFromArr(_, _), callMap(_, _), callFromEntries(_, _)).foreach { f =>
       checkAnswer(
         spark.sql("SELECT element_at(:mapParam, 'a')",
           Map("mapParam" -> f(Array("a"), Array(0)))),


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to move the `BindParameters` rules from the `Substitution` to the `Resolution` batch, and change types of the `args` parameter of `NameParameterizedQuery` and `PosParameterizedQuery` to an `Iterable` to resolve argument expressions. 

### Why are the changes needed?
After the PR, the parameterized `sql()` allows map/array/struct constructed by functions like `map()`, `array()`, and `struct()`, but the same functions invoked via `call_function` are not supported:
```scala
scala> sql("SELECT element_at(:mapParam, 'a')", Map("mapParam" -> call_function("map", lit("a"), lit(1))))
org.apache.spark.sql.catalyst.ExtendedAnalysisException: [UNBOUND_SQL_PARAMETER] Found the unbound parameter: mapParam. Please, fix `args` and provide a mapping of the parameter to a SQL literal.; line 1 pos 18;
```

### Does this PR introduce _any_ user-facing change?
No, should not since it fixes an issue. Only if user code depends on the error message.

After the changes:
```scala
scala> sql("SELECT element_at(:mapParam, 'a')", Map("mapParam" -> call_function("map", lit("a"), lit(1)))).show(false)
+------------------------+
|element_at(map(a, 1), a)|
+------------------------+
|1                       |
+------------------------+
```

### How was this patch tested?
By running new tests:
```
$ build/sbt "test:testOnly *ParametersSuite"
```

### Was this patch authored or co-authored using generative AI tooling?
No.