### PR TITLE
[SPARK-45138][SS] Define a new error class and apply it when checkpointing state to DFS fails

### DIFF
--- a/common/utils/src/main/resources/error/error-classes.json
+++ b/common/utils/src/main/resources/error/error-classes.json
@@ -314,6 +314,23 @@
       "<details>"
     ]
   },
+  "CANNOT_WRITE_STATE_FILE" : {
+    "message" : [
+      "Error writing state store files for provider <providerClass>."
+    ],
+    "subClass" : {
+      "CANNOT_COMMIT" : {
+        "message" : [
+          "Cannot perform commit during state checkpoint."
+        ]
+      },
+      "CANNOT_DO_MAINTENANCE" : {
+        "message" : [
+          "Cannot do maintenance on state store."
+        ]
+      }
+    }
+  },
   "CAST_INVALID_INPUT" : {
     "message" : [
       "The value <expression> of the type <sourceType> cannot be cast to <targetType> because it is malformed. Correct the value as per the syntax, or change its target type. Use `try_cast` to tolerate malformed input and return NULL instead. If necessary set <ansiConfig> to \"false\" to bypass this error."

--- a/common/utils/src/main/resources/error/error-classes.json
+++ b/common/utils/src/main/resources/error/error-classes.json
@@ -314,7 +314,7 @@
       "<details>"
     ]
   },
-  "CANNOT_WRITE_STATE_FILE" : {
+  "CANNOT_WRITE_STATE_STORE" : {
     "message" : [
       "Error writing state store files for provider <providerClass>."
     ],

--- a/common/utils/src/main/resources/error/error-classes.json
+++ b/common/utils/src/main/resources/error/error-classes.json
@@ -323,11 +323,6 @@
         "message" : [
           "Cannot perform commit during state checkpoint."
         ]
-      },
-      "CANNOT_DO_MAINTENANCE" : {
-        "message" : [
-          "Cannot do maintenance on state store."
-        ]
       }
     }
   },

--- a/docs/sql-error-conditions-cannot-write-state-store-error-class.md
+++ b/docs/sql-error-conditions-cannot-write-state-store-error-class.md
@@ -1,0 +1,32 @@
+---
+layout: global
+title: CANNOT_WRITE_STATE_STORE error class
+displayTitle: CANNOT_WRITE_STATE_STORE error class
+license: |
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+---
+
+SQLSTATE: none assigned
+
+Error writing state store files for provider `<providerClass>`.
+
+This error class has the following derived error classes:
+
+## CANNOT_COMMIT
+
+Cannot perform commit during state checkpoint.
+
+

--- a/docs/sql-error-conditions.md
+++ b/docs/sql-error-conditions.md
@@ -271,6 +271,14 @@ SQLSTATE: none assigned
 Cannot up cast `<expression>` from `<sourceType>` to `<targetType>`.
 `<details>`
 
+### [CANNOT_WRITE_STATE_STORE](sql-error-conditions-cannot-write-state-store-error-class.html)
+
+SQLSTATE: none assigned
+
+Error writing state store files for provider `<providerClass>`.
+
+For more details see [CANNOT_WRITE_STATE_STORE](sql-error-conditions-cannot-write-state-store-error-class.html)
+
 ### CAST_INVALID_INPUT
 
 [SQLSTATE: 22018](sql-error-conditions-sqlstates.html#class-22-data-exception)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -2256,13 +2256,6 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
       cause = f)
   }
 
-  def failedToDoMaintenanceError(providerClass: String, f: Throwable): Throwable = {
-    new SparkException(
-      errorClass = "CANNOT_WRITE_STATE_FILE.CANNOT_DO_MAINTENANCE",
-      messageParameters = Map("providerClass" -> providerClass),
-      cause = f)
-  }
-
   def cannotPurgeAsBreakInternalStateError(): SparkUnsupportedOperationException = {
     new SparkUnsupportedOperationException(
       errorClass = "_LEGACY_ERROR_TEMP_2260",

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -2249,6 +2249,20 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
       cause = f)
   }
 
+  def failedToCommitStateFileError(providerClass: String, f: Throwable): Throwable = {
+    new SparkException(
+      errorClass = "CANNOT_WRITE_STATE_FILE.CANNOT_COMMIT",
+      messageParameters = Map("providerClass" -> providerClass),
+      cause = f)
+  }
+
+  def failedToDoMaintenanceError(providerClass: String, f: Throwable): Throwable = {
+    new SparkException(
+      errorClass = "CANNOT_WRITE_STATE_FILE.CANNOT_DO_MAINTENANCE",
+      messageParameters = Map("providerClass" -> providerClass),
+      cause = f)
+  }
+
   def cannotPurgeAsBreakInternalStateError(): SparkUnsupportedOperationException = {
     new SparkUnsupportedOperationException(
       errorClass = "_LEGACY_ERROR_TEMP_2260",

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -2251,7 +2251,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
 
   def failedToCommitStateFileError(providerClass: String, f: Throwable): Throwable = {
     new SparkException(
-      errorClass = "CANNOT_WRITE_STATE_FILE.CANNOT_COMMIT",
+      errorClass = "CANNOT_WRITE_STATE_STORE.CANNOT_COMMIT",
       messageParameters = Map("providerClass" -> providerClass),
       cause = f)
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
@@ -135,17 +135,15 @@ private[sql] class HDFSBackedStateStoreProvider extends StateStoreProvider with 
 
     /** Commit all the updates that have been made to the store, and return the new version. */
     override def commit(): Long = {
-      verify(state == UPDATING, "Cannot commit after already committed or aborted")
-
       try {
+        verify(state == UPDATING, "Cannot commit after already committed or aborted")
         commitUpdates(newVersion, mapToUpdate, compressedStream)
         state = COMMITTED
         logInfo(s"Committed version $newVersion for $this to file $finalDeltaFile")
         newVersion
       } catch {
-        case NonFatal(e) =>
-          throw new IllegalStateException(
-            s"Error committing version $newVersion into $this", e)
+        case e: Throwable =>
+          throw QueryExecutionErrors.failedToCommitStateFileError("HDFS", e)
       }
     }
 
@@ -263,8 +261,8 @@ private[sql] class HDFSBackedStateStoreProvider extends StateStoreProvider with 
       doSnapshot()
       cleanup()
     } catch {
-      case NonFatal(e) =>
-        logWarning(s"Error performing snapshot and cleaning up $this")
+      case e: Throwable =>
+        throw QueryExecutionErrors.failedToDoMaintenanceError(this.getClass.getSimpleName, e)
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
@@ -143,7 +143,7 @@ private[sql] class HDFSBackedStateStoreProvider extends StateStoreProvider with 
         newVersion
       } catch {
         case e: Throwable =>
-          throw QueryExecutionErrors.failedToCommitStateFileError("HDFS", e)
+          throw QueryExecutionErrors.failedToCommitStateFileError(this.toString(), e)
       }
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
@@ -261,8 +261,8 @@ private[sql] class HDFSBackedStateStoreProvider extends StateStoreProvider with 
       doSnapshot()
       cleanup()
     } catch {
-      case e: Throwable =>
-        throw QueryExecutionErrors.failedToDoMaintenanceError(this.getClass.getSimpleName, e)
+      case NonFatal(e) =>
+        logWarning(s"Error performing snapshot and cleaning up $this")
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
@@ -98,7 +98,7 @@ private[sql] class RocksDBStateStoreProvider
         newVersion
       } catch {
         case e: Throwable =>
-          throw QueryExecutionErrors.failedToCommitStateFileError("RocksDB", e)
+          throw QueryExecutionErrors.failedToCommitStateFileError(this.toString(), e)
       }
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
@@ -220,12 +220,7 @@ private[sql] class RocksDBStateStoreProvider
   }
 
   override def doMaintenance(): Unit = {
-    try {
-      rocksDB.doMaintenance()
-    } catch {
-      case e: Throwable =>
-        throw QueryExecutionErrors.failedToDoMaintenanceError(this.getClass.getSimpleName, e)
-    }
+    rocksDB.doMaintenance()
   }
 
   override def close(): Unit = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
@@ -152,6 +152,10 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
     newStoreProvider(storeId, numColsPrefixKey = 0)
   }
 
+  def newStoreProvider(storeId: StateStoreId, conf: Configuration): RocksDBStateStoreProvider = {
+    newStoreProvider(storeId, numColsPrefixKey = -1, conf = conf)
+  }
+
   override def newStoreProvider(numPrefixCols: Int): RocksDBStateStoreProvider = {
     newStoreProvider(StateStoreId(newDir(), Random.nextInt(), 0), numColsPrefixKey = numPrefixCols)
   }
@@ -159,11 +163,12 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
   def newStoreProvider(
       storeId: StateStoreId,
       numColsPrefixKey: Int,
-      sqlConf: Option[SQLConf] = None): RocksDBStateStoreProvider = {
+      sqlConf: Option[SQLConf] = None,
+      conf: Configuration = new Configuration): RocksDBStateStoreProvider = {
     val provider = new RocksDBStateStoreProvider()
     provider.init(
       storeId, keySchema, valueSchema, numColsPrefixKey = numColsPrefixKey,
-      new StateStoreConf(sqlConf.getOrElse(SQLConf.get)), new Configuration)
+      new StateStoreConf(sqlConf.getOrElse(SQLConf.get)), conf)
     provider
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
@@ -677,7 +677,6 @@ class StateStoreSuite extends StateStoreSuiteBase[HDFSBackedStateStoreProvider]
       // Fail commit for next version and verify that reloading resets the files
       CreateAtomicTestManager.shouldFailInCreateAtomic = true
       put(store, "11", 0, 11)
-      // [NEIL]
       val e = intercept[SparkException] { quietly { store.commit() } }
       assert(e.getCause.isInstanceOf[IOException])
       assert(e.getMessage.contains("Cannot perform commit"))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
@@ -1160,11 +1160,11 @@ abstract class StateStoreSuiteBase[ProviderClass <: StateStoreProvider]
       put(store, "a", 0, 0)
       val e = intercept[SparkException](quietly { store.commit() } )
 
-      assert(e.getErrorClass == "CANNOT_WRITE_STATE_FILE.CANNOT_COMMIT")
+      assert(e.getErrorClass == "CANNOT_WRITE_STATE_STORE.CANNOT_COMMIT")
       if (store.getClass.getName contains ROCKSDB_STATE_STORE) {
-        assert(e.getMessage contains "RocksDB")
+        assert(e.getMessage contains "RocksDBStateStore[id=(op=0,part=0)")
       } else {
-        assert(e.getMessage contains "HDFS")
+        assert(e.getMessage contains "HDFSStateStore[id=(op=0,part=0)")
       }
       assert(e.getMessage contains "Error writing state store files")
       assert(e.getCause.getMessage.contains("Failed to rename"))


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

In this change, we add a new a new error class when checkpointing state to the DFS, for either state store provider, fails during `commit`.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Users might be confused when they see an `IOException`, for example, if a call to `commit` fails. This is a neat and self-explanatory wrapper around such exceptions.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes, the error message when DFS checkpoint fails is now a `SparkException` with error class.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

- Modified existing UTs


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No
