### PR TITLE
[SPARK-45146][DOCS]Update the default value of 'spark.submit.deployMode'

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -394,7 +394,7 @@ of the most common options to set are:
 </tr>
 <tr>
   <td><code>spark.submit.deployMode</code></td>
-  <td>(none)</td>
+  <td>client</td>
   <td>
     The deploy mode of Spark driver program, either "client" or "cluster",
     Which means to launch driver program locally ("client")


### PR DESCRIPTION
**What changes were proposed in this pull request?**
The PR updates the default value of 'spark.submit.deployMode' in configuration.html on the website

**Why are the changes needed?**
The default value of 'spark.submit.deployMode' is 'client', but the website is wrong.

**Does this PR introduce any user-facing change?**
No

**How was this patch tested?**
It doesn't need to.

**Was this patch authored or co-authored using generative AI tooling?**
No