### PR TITLE
[CONNECT][SPARK-45155] Add API Docs for Spark Connect JVM/Scala Client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ dev/pr-deps/
 dist/
 docs/_site/
 docs/api
+docs/connect
 docs/.local_ruby_bundle
 sql/docs
 sql/site

--- a/.gitignore
+++ b/.gitignore
@@ -52,7 +52,6 @@ dev/pr-deps/
 dist/
 docs/_site/
 docs/api
-docs/connect
 docs/.local_ruby_bundle
 sql/docs
 sql/site

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -478,13 +478,7 @@ final class DataFrameWriter[T] private[sql] (ds: Dataset[T]) {
    * }}}
    *
    * Note that writing a XML file from `DataFrame` having a field `ArrayType` with its element as
-   * `ArrayType` would have an additional nested field for the element. For example, the
-   * `DataFrame` having a field below,
-   *
-   * {@code fieldA [[data1], [data2]]}
-   *
-   * would produce a XML file below. { @code <fieldA> <item>data1</item> </fieldA> <fieldA>
-   * <item>data2</item> </fieldA>}
+   * `ArrayType` would have an additional nested field for the element.
    *
    * Namely, roundtrip in writing and reading can end up in different schema structure.
    *

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/DataFrameWriterV2.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/DataFrameWriterV2.scala
@@ -92,12 +92,8 @@ final class DataFrameWriterV2[T] private[sql] (table: String, ds: Dataset[T])
   /**
    * Append the contents of the data frame to the output table.
    *
-   * If the output table does not exist, this operation will fail with
-   * [[org.apache.spark.sql.catalyst.analysis.NoSuchTableException]]. The data frame will be
+   * If the output table does not exist, this operation will fail. The data frame will be
    * validated to ensure it is compatible with the existing table.
-   *
-   * @throws org.apache.spark.sql.catalyst.analysis.NoSuchTableException
-   *   If the table does not exist
    */
   def append(): Unit = {
     executeWriteOperation(proto.WriteOperationV2.Mode.MODE_APPEND)
@@ -107,12 +103,8 @@ final class DataFrameWriterV2[T] private[sql] (table: String, ds: Dataset[T])
    * Overwrite rows matching the given filter condition with the contents of the data frame in the
    * output table.
    *
-   * If the output table does not exist, this operation will fail with
-   * [[org.apache.spark.sql.catalyst.analysis.NoSuchTableException]]. The data frame will be
+   * If the output table does not exist, this operation will fail. The data frame will be
    * validated to ensure it is compatible with the existing table.
-   *
-   * @throws org.apache.spark.sql.catalyst.analysis.NoSuchTableException
-   *   If the table does not exist
    */
   def overwrite(condition: Column): Unit = {
     overwriteCondition = Some(condition.expr)
@@ -126,12 +118,8 @@ final class DataFrameWriterV2[T] private[sql] (table: String, ds: Dataset[T])
    * This operation is equivalent to Hive's `INSERT OVERWRITE ... PARTITION`, which replaces
    * partitions dynamically depending on the contents of the data frame.
    *
-   * If the output table does not exist, this operation will fail with
-   * [[org.apache.spark.sql.catalyst.analysis.NoSuchTableException]]. The data frame will be
+   * If the output table does not exist, this operation will fail. The data frame will be
    * validated to ensure it is compatible with the existing table.
-   *
-   * @throws org.apache.spark.sql.catalyst.analysis.NoSuchTableException
-   *   If the table does not exist
    */
   def overwritePartitions(): Unit = {
     executeWriteOperation(proto.WriteOperationV2.Mode.MODE_OVERWRITE_PARTITIONS)
@@ -225,11 +213,7 @@ trait CreateTableWriter[T] extends WriteConfigMethods[CreateTableWriter[T]] {
    * The new table's schema, partition layout, properties, and other configuration will be based
    * on the configuration set on this writer.
    *
-   * If the output table exists, this operation will fail with
-   * [[org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException]].
-   *
-   * @throws org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException
-   *   If the table already exists
+   * If the output table exists, this operation will fail.
    */
   def create(): Unit
 
@@ -239,11 +223,7 @@ trait CreateTableWriter[T] extends WriteConfigMethods[CreateTableWriter[T]] {
    * The existing table's schema, partition layout, properties, and other configuration will be
    * replaced with the contents of the data frame and the configuration set on this writer.
    *
-   * If the output table does not exist, this operation will fail with
-   * [[org.apache.spark.sql.catalyst.analysis.CannotReplaceMissingTableException]].
-   *
-   * @throws org.apache.spark.sql.catalyst.analysis.CannotReplaceMissingTableException
-   *   If the table does not exist
+   * If the output table does not exist, this operation will fail.
    */
   def replace(): Unit
 

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/KeyValueGroupedDataset.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/KeyValueGroupedDataset.scala
@@ -157,8 +157,6 @@ class KeyValueGroupedDataset[K, V] private[sql] () extends Serializable {
    * sorted according to the given sort expressions. That sorting does not add computational
    * complexity.
    *
-   * @see
-   *   [[org.apache.spark.sql.KeyValueGroupedDataset#flatMapGroups]]
    * @since 3.5.0
    */
   def flatMapSortedGroups[U: Encoder](sortExprs: Column*)(
@@ -186,8 +184,6 @@ class KeyValueGroupedDataset[K, V] private[sql] () extends Serializable {
    * sorted according to the given sort expressions. That sorting does not add computational
    * complexity.
    *
-   * @see
-   *   [[org.apache.spark.sql.KeyValueGroupedDataset#flatMapGroups]]
    * @since 3.5.0
    */
   def flatMapSortedGroups[U](
@@ -427,8 +423,6 @@ class KeyValueGroupedDataset[K, V] private[sql] () extends Serializable {
    * sorted according to the given sort expressions. That sorting does not add computational
    * complexity.
    *
-   * @see
-   *   [[org.apache.spark.sql.KeyValueGroupedDataset#cogroup]]
    * @since 3.5.0
    */
   def cogroupSorted[U, R: Encoder](other: KeyValueGroupedDataset[K, U])(thisSortExprs: Column*)(
@@ -448,8 +442,6 @@ class KeyValueGroupedDataset[K, V] private[sql] () extends Serializable {
    * sorted according to the given sort expressions. That sorting does not add computational
    * complexity.
    *
-   * @see
-   *   [[org.apache.spark.sql.KeyValueGroupedDataset#cogroup]]
    * @since 3.5.0
    */
   def cogroupSorted[U, R](

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -443,8 +443,8 @@ class SparkSession private[sql] (
   // scalastyle:off
   // Disable style checker so "implicits" object can start with lowercase i
   /**
-   * (Scala-specific) Implicit methods available in Scala for converting common names and
-   * [[Symbol]]s into [[Column]]s, and for converting common Scala objects into `DataFrame`s.
+   * (Scala-specific) Implicit methods available in Scala for converting common names and Symbols
+   * into [[Column]]s, and for converting common Scala objects into DataFrame`s.
    *
    * {{{
    *   val sparkSession = SparkSession.builder.getOrCreate()
@@ -595,8 +595,7 @@ class SparkSession private[sql] (
   def addArtifacts(uri: URI*): Unit = client.addArtifacts(uri)
 
   /**
-   * Register a [[ClassFinder]] for dynamically generated classes.
-   *
+   * Register a ClassFinder for dynamically generated classes.
    * @since 3.5.0
    */
   @Experimental
@@ -659,7 +658,7 @@ class SparkSession private[sql] (
 
   /**
    * Close the [[SparkSession]]. This closes the connection, and the allocator. The latter will
-   * throw an exception if there are still open [[SparkResult]]s.
+   * throw an exception if there are still open SparkResults.
    *
    * @since 3.4.0
    */
@@ -793,7 +792,7 @@ object SparkSession extends Logging {
     }
 
     /**
-     * Add an interceptor [[ClientInterceptor]] to be used during channel creation.
+     * Add an interceptor to be used during channel creation.
      *
      * Note that interceptors added last are executed first by gRPC.
      *

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/test/RemoteSparkSession.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/test/RemoteSparkSession.scala
@@ -36,14 +36,7 @@ import org.apache.spark.sql.test.IntegrationTestUtils._
 /**
  * An util class to start a local spark connect server in a different process for local E2E tests.
  * Pre-running the tests, the spark connect artifact needs to be built using e.g. `build/sbt
- * package`. It is designed to start the server once but shared by all tests. It is equivalent to
- * use the following command to start the connect server via command line:
- *
- * {{{
- * bin/spark-shell \
- * --jars `ls connector/connect/server/target/**/spark-connect*SNAPSHOT.jar | paste -sd ',' -` \
- * --conf spark.plugins=org.apache.spark.sql.connect.SparkConnectPlugin
- * }}}
+ * package`. It is designed to start the server once but shared by all tests.
  *
  * Set system property `spark.test.home` or env variable `SPARK_HOME` if the test is not executed
  * from the Spark project top folder. Set system property `spark.debug.sc.jvm.client=true` or
@@ -51,6 +44,11 @@ import org.apache.spark.sql.test.IntegrationTestUtils._
  * console to debug server start stop problems.
  */
 object SparkConnectServerUtils {
+
+  // The equivalent command to start the connect server via command line:
+  // bin/spark-shell \
+  // --jars `ls connector/connect/server/target/**/spark-connect*SNAPSHOT.jar | paste -sd ',' -` \
+  // --conf spark.plugins=org.apache.spark.sql.connect.SparkConnectPlugin
 
   // Server port
   val port: Int =

--- a/docs/_layouts/global.html
+++ b/docs/_layouts/global.html
@@ -73,6 +73,7 @@
                         <div class="dropdown-menu" aria-labelledby="navbarAPIDocs">
                             <a class="dropdown-item" href="api/python/index.html">Python</a>
                             <a class="dropdown-item" href="api/scala/org/apache/spark/index.html">Scala</a>
+                            <a class="dropdown-item" href="connect/api/scala/org/apache/spark/index.html">Scala (Spark Connect)</a>
                             <a class="dropdown-item" href="api/java/index.html">Java</a>
                             <a class="dropdown-item" href="api/R/index.html">R</a>
                             <a class="dropdown-item" href="api/sql/index.html">SQL, Built-in Functions</a>

--- a/docs/_layouts/global.html
+++ b/docs/_layouts/global.html
@@ -73,7 +73,7 @@
                         <div class="dropdown-menu" aria-labelledby="navbarAPIDocs">
                             <a class="dropdown-item" href="api/python/index.html">Python</a>
                             <a class="dropdown-item" href="api/scala/org/apache/spark/index.html">Scala</a>
-                            <a class="dropdown-item" href="connect/api/scala/org/apache/spark/index.html">Scala (Spark Connect)</a>
+                            <a class="dropdown-item" href="api/connect/scala/org/apache/spark/index.html">Scala (Spark Connect)</a>
                             <a class="dropdown-item" href="api/java/index.html">Java</a>
                             <a class="dropdown-item" href="api/R/index.html">R</a>
                             <a class="dropdown-item" href="api/sql/index.html">SQL, Built-in Functions</a>

--- a/docs/_plugins/copy_api_dirs.rb
+++ b/docs/_plugins/copy_api_dirs.rb
@@ -34,45 +34,64 @@ if not (ENV['SKIP_API'] == '1')
 
     puts "Removing old docs"
     puts `rm -rf api`
+    puts 'rm -rf connect'
 
     # Copy over the unified ScalaDoc for all projects to api/scala.
     # This directory will be copied over to _site when `jekyll` command is run.
     source = "../target/scala-2.12/unidoc"
     dest = "api/scala"
 
-    puts "Making directory " + dest
+    sourceConnect = "../connector/connect/client/jvm/target/scala-2.12/unidoc"
+    destConnect = "connect/api/scala"
+    puts "Making directories: " + dest + ", " + destConnect
     mkdir_p dest
+    mkdir_p destConnect
 
     # From the rubydoc: cp_r('src', 'dest') makes src/dest, but this doesn't.
     puts "cp -r " + source + "/. " + dest
     cp_r(source + "/.", dest)
+
+    puts "cp -r " + sourceConnect + "/. " + destConnect
+    cp_r(sourceConnect + "/.", destConnect)
 
     # Append custom JavaScript
     js = File.readlines("./js/api-docs.js")
     js_file = dest + "/lib/template.js"
     File.open(js_file, 'a') { |f| f.write("\n" + js.join()) }
 
+    js_file_connect = destConnect + "/lib/template.js"
+    File.open(js_file_connect, 'a') { |f| f.write("\n" + js.join()) }
+
     # Append custom CSS
     css = File.readlines("./css/api-docs.css")
     css_file = dest + "/lib/template.css"
     File.open(css_file, 'a') { |f| f.write("\n" + css.join()) }
 
+    css_file_connect = destConnect + "/lib/template.css"
+    File.open(css_file_connect, 'a') { |f| f.write("\n" + css.join()) }
+
     # Copy over the unified JavaDoc for all projects to api/java.
     source = "../target/javaunidoc"
     dest = "api/java"
+    sourceConnect = "../connector/connect/client/jvm/target/javaunidoc"
+    destConnect = "connect/api/java"
 
-    puts "Making directory " + dest
+    puts "Making directories: " + dest + ", " + destConnect
     mkdir_p dest
+    mkdir_p destConnect
 
     puts "cp -r " + source + "/. " + dest
     cp_r(source + "/.", dest)
+
+    puts "cp -r " + sourceConnect + "/. " + destConnect
+    cp_r(sourceConnect + "/.", destConnect)
 
     # Begin updating JavaDoc files for badge post-processing
     puts "Updating JavaDoc files for badge post-processing"
     js_script_start = '<script defer="defer" type="text/javascript" src="'
     js_script_end = '.js"></script>'
 
-    javadoc_files = Dir["./" + dest + "/**/*.html"]
+    javadoc_files = Dir["./" + dest + "/**/*.html", "./" + destConnect + "/**/*.html"]
     javadoc_files.each do |javadoc_file|
       # Determine file depths to reference js files
       slash_count = javadoc_file.count "/"
@@ -102,14 +121,27 @@ if not (ENV['SKIP_API'] == '1')
     mkdir_p("./api/java/lib")
     cp(jquery_src_file, jquery_dest_file)
 
+    jquery_src_file = "./connect/api/scala/lib/jquery.min.js"
+    jquery_dest_file = "./connect/api/java/lib/jquery.min.js"
+    mkdir_p("./connect/api/java/lib")
+    cp(jquery_src_file, jquery_dest_file)
+
     puts "Copying api_javadocs.js to Java API for page post-processing of badges"
     api_javadocs_src_file = "./js/api-javadocs.js"
     api_javadocs_dest_file = "./api/java/lib/api-javadocs.js"
     cp(api_javadocs_src_file, api_javadocs_dest_file)
 
+    api_javadocs_src_file = "./js/api-javadocs.js"
+    api_javadocs_dest_file = "./connect/api/java/lib/api-javadocs.js"
+    cp(api_javadocs_src_file, api_javadocs_dest_file)
+
     puts "Appending content of api-javadocs.css to JavaDoc stylesheet.css for badge styles"
     css = File.readlines("./css/api-javadocs.css")
     css_file = dest + "/stylesheet.css"
+    File.open(css_file, 'a') { |f| f.write("\n" + css.join()) }
+
+    css = File.readlines("./css/api-javadocs.css")
+    css_file = destConnect + "/stylesheet.css"
     File.open(css_file, 'a') { |f| f.write("\n" + css.join()) }
   end
 

--- a/docs/_plugins/copy_api_dirs.rb
+++ b/docs/_plugins/copy_api_dirs.rb
@@ -27,14 +27,13 @@ if not (ENV['SKIP_API'] == '1')
     cd("..")
 
     puts "Running 'build/sbt -Pkinesis-asl clean compile unidoc' from " + pwd + "; this may take a few minutes..."
-    system("build/sbt -Pkinesis-asl clean compile unidoc") || raise("Unidoc generation failed")
+    system("build/sbt -Pkinesis-asl compile unidoc") || raise("Unidoc generation failed")
 
     puts "Moving back into docs dir."
     cd("docs")
 
     puts "Removing old docs"
     puts `rm -rf api`
-    puts 'rm -rf connect'
 
     # Copy over the unified ScalaDoc for all projects to api/scala.
     # This directory will be copied over to _site when `jekyll` command is run.
@@ -42,7 +41,7 @@ if not (ENV['SKIP_API'] == '1')
     dest = "api/scala"
 
     sourceConnect = "../connector/connect/client/jvm/target/scala-2.12/unidoc"
-    destConnect = "connect/api/scala"
+    destConnect = "api/connect/scala"
     puts "Making directories: " + dest + ", " + destConnect
     mkdir_p dest
     mkdir_p destConnect
@@ -74,7 +73,7 @@ if not (ENV['SKIP_API'] == '1')
     source = "../target/javaunidoc"
     dest = "api/java"
     sourceConnect = "../connector/connect/client/jvm/target/javaunidoc"
-    destConnect = "connect/api/java"
+    destConnect = "api/connect/java"
 
     puts "Making directories: " + dest + ", " + destConnect
     mkdir_p dest
@@ -121,9 +120,9 @@ if not (ENV['SKIP_API'] == '1')
     mkdir_p("./api/java/lib")
     cp(jquery_src_file, jquery_dest_file)
 
-    jquery_src_file = "./connect/api/scala/lib/jquery.min.js"
-    jquery_dest_file = "./connect/api/java/lib/jquery.min.js"
-    mkdir_p("./connect/api/java/lib")
+    jquery_src_file = "./api/connect/scala/lib/jquery.min.js"
+    jquery_dest_file = "./api/connect/java/lib/jquery.min.js"
+    mkdir_p("./api/connect/java/lib")
     cp(jquery_src_file, jquery_dest_file)
 
     puts "Copying api_javadocs.js to Java API for page post-processing of badges"
@@ -132,7 +131,7 @@ if not (ENV['SKIP_API'] == '1')
     cp(api_javadocs_src_file, api_javadocs_dest_file)
 
     api_javadocs_src_file = "./js/api-javadocs.js"
-    api_javadocs_dest_file = "./connect/api/java/lib/api-javadocs.js"
+    api_javadocs_dest_file = "./api/connect/java/lib/api-javadocs.js"
     cp(api_javadocs_src_file, api_javadocs_dest_file)
 
     puts "Appending content of api-javadocs.css to JavaDoc stylesheet.css for badge styles"

--- a/docs/index.md
+++ b/docs/index.md
@@ -122,6 +122,7 @@ options for deployment:
 
 * [Spark Python API (Sphinx)](api/python/index.html)
 * [Spark Scala API (Scaladoc)](api/scala/org/apache/spark/index.html)
+* [Spark Connect Scala Client API (Scaladoc)](connect/api/scala/org/apache/spark/index.html)
 * [Spark Java API (Javadoc)](api/java/index.html)
 * [Spark R API (Roxygen2)](api/R/index.html)
 * [Spark SQL, Built-in Functions (MkDocs)](api/sql/index.html)

--- a/docs/index.md
+++ b/docs/index.md
@@ -122,7 +122,7 @@ options for deployment:
 
 * [Spark Python API (Sphinx)](api/python/index.html)
 * [Spark Scala API (Scaladoc)](api/scala/org/apache/spark/index.html)
-* [Spark Connect Scala Client API (Scaladoc)](connect/api/scala/org/apache/spark/index.html)
+* [Spark Connect Scala Client API (Scaladoc)](api/connect/scala/org/apache/spark/index.html)
 * [Spark Java API (Javadoc)](api/java/index.html)
 * [Spark R API (Roxygen2)](api/R/index.html)
 * [Spark SQL, Built-in Functions (MkDocs)](api/sql/index.html)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

- Enables Scala and Java Unidoc generation for the `connectClient` project
- Generates docs and moves them to the `docs/api/connect` folder
- References API docs in the main index page and the global floating header.

Documentation of some methods in the connect directory had to be modified to remove references to avoid javadoc generation failures.
 
### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Increasing scope of documentation for the Spark Connect JVM/Scala Client project.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes.

A new row in the dropdown list:
<img width="210" alt="Screenshot 2023-09-13 at 18 32 24" src="https://github.com/apache/spark/assets/21010250/a9a1ac5c-ee7a-4d46-ac4c-fa362b9c5d60">

Sample page from the Spark Connect docs:
<img width="1222" alt="Screenshot 2023-09-13 at 18 33 34" src="https://github.com/apache/spark/assets/21010250/cb812c12-e533-4b98-88c8-1514e190fe8d">

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Existing tests + manual doc generation.
### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.