### PR TITLE
[SPARK-45081][SQL][3.4] Encoders.bean does no longer work with read-only properties

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
@@ -345,7 +345,9 @@ object ScalaReflection extends ScalaReflection {
         CreateExternalRow(convertedFields, enc.schema))
 
     case JavaBeanEncoder(tag, fields) =>
-      val setters = fields.map { f =>
+      val setters = fields
+        .filter(_.writeMethod.isDefined)
+        .map { f =>
         val newTypePath = walkedTypePath.recordField(
           f.enc.clsTag.runtimeClass.getName,
           f.name)

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDatasetSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDatasetSuite.java
@@ -1711,6 +1711,23 @@ public class JavaDatasetSuite implements Serializable {
     Assert.assertEquals(1, df.collectAsList().size());
   }
 
+  public static class ReadOnlyPropertyBean implements Serializable {
+      public boolean isEmpty() {
+        return true;
+      }
+  }
+
+  @Test
+  public void testReadOnlyPropertyBean() {
+    ReadOnlyPropertyBean bean = new ReadOnlyPropertyBean();
+    List<ReadOnlyPropertyBean> data = Arrays.asList(bean);
+    Dataset<ReadOnlyPropertyBean> df = spark.createDataset(data,
+            Encoders.bean(ReadOnlyPropertyBean.class));
+    Assert.assertEquals(1, df.schema().length());
+    Assert.assertEquals(1, df.collectAsList().size());
+
+  }
+
   public class CircularReference1Bean implements Serializable {
     private CircularReference2Bean child;
 

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDatasetSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDatasetSuite.java
@@ -1712,9 +1712,9 @@ public class JavaDatasetSuite implements Serializable {
   }
 
   public static class ReadOnlyPropertyBean implements Serializable {
-      public boolean isEmpty() {
-        return true;
-      }
+    public boolean isEmpty() {
+      return true;
+    }
   }
 
   @Test
@@ -1725,7 +1725,6 @@ public class JavaDatasetSuite implements Serializable {
             Encoders.bean(ReadOnlyPropertyBean.class));
     Assert.assertEquals(1, df.schema().length());
     Assert.assertEquals(1, df.collectAsList().size());
-
   }
 
   public class CircularReference1Bean implements Serializable {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR re-enables Encoders.bean to be called against beans having read-only properties, that is properties that have only getters and no setter method. Beans with read only properties are even used in internal tests.
Setter methods of a Java bean encoder are stored within an Option wrapper because they are missing in case of read-only properties. When a java bean has to be initialized, setter methods for the bean properties have to be called: this PR filters out read-only properties from that process.

### Why are the changes needed?
The changes are required to avoid an exception to the thrown by getting the value of a None option object.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
An additional regression test has been added

### Was this patch authored or co-authored using generative AI tooling?
No

@hvanhovell this is 3.4 branch port of [PR-42829](https://github.com/apache/spark/pull/42829)