### PR TITLE
[SPARK-45160][DOCS]Update the default value of 'spark.executor.logs.rolling.strategy'

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -694,13 +694,13 @@ Apart from these, the following properties are also available, and may be useful
 </tr>
 <tr>
   <td><code>spark.executor.logs.rolling.strategy</code></td>
-  <td>""</td>
+  <td>""(disabled)</td>
   <td>
     Set the strategy of rolling of executor logs. By default it is disabled. It can
-    be set to "time" (time-based rolling) or "size" (size-based rolling). For "time",
+    be set to "time" (time-based rolling) or "size" (size-based rolling) or ""(empty string). For "time",
     use <code>spark.executor.logs.rolling.time.interval</code> to set the rolling interval.
     For "size", use <code>spark.executor.logs.rolling.maxSize</code> to set
-    the maximum file size for rolling.
+    the maximum file size for rolling. For "", it is disabled without warning.
   </td>
   <td>1.1.0</td>
 </tr>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -697,10 +697,10 @@ Apart from these, the following properties are also available, and may be useful
   <td>""(disabled)</td>
   <td>
     Set the strategy of rolling of executor logs. By default it is disabled. It can
-    be set to "time" (time-based rolling) or "size" (size-based rolling) or ""(empty string). For "time",
+    be set to "time" (time-based rolling) or "size" (size-based rolling) or "" (disabled). For "time",
     use <code>spark.executor.logs.rolling.time.interval</code> to set the rolling interval.
     For "size", use <code>spark.executor.logs.rolling.maxSize</code> to set
-    the maximum file size for rolling. For "", it is disabled without warning.
+    the maximum file size for rolling.
   </td>
   <td>1.1.0</td>
 </tr>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -694,7 +694,7 @@ Apart from these, the following properties are also available, and may be useful
 </tr>
 <tr>
   <td><code>spark.executor.logs.rolling.strategy</code></td>
-  <td>(none)</td>
+  <td>""</td>
   <td>
     Set the strategy of rolling of executor logs. By default it is disabled. It can
     be set to "time" (time-based rolling) or "size" (size-based rolling). For "time",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -694,7 +694,7 @@ Apart from these, the following properties are also available, and may be useful
 </tr>
 <tr>
   <td><code>spark.executor.logs.rolling.strategy</code></td>
-  <td>""(disabled)</td>
+  <td>"" (disabled)</td>
   <td>
     Set the strategy of rolling of executor logs. By default it is disabled. It can
     be set to "time" (time-based rolling) or "size" (size-based rolling) or "" (disabled). For "time",


### PR DESCRIPTION
What changes were proposed in this pull request?
The PR updates the default value of 'spark.executor.logs.rolling.strategy in configuration.html on the website

Why are the changes needed?
The default value of 'spark.executor.logs.rolling.strategy' is '', but is not (none). The website has Inaccurate description.It can bring ambiguity.

Does this PR introduce any user-facing change?
No

How was this patch tested?
It doesn't need to.

Was this patch authored or co-authored using generative AI tooling?
No