### PR TITLE
[SPARK-45168][PYTHON] Increase Pandas minimum version to 1.4.4

### DIFF
--- a/python/docs/source/getting_started/install.rst
+++ b/python/docs/source/getting_started/install.rst
@@ -156,7 +156,7 @@ Dependencies
 Package                    Supported version Note
 ========================== ========================= ======================================================================================
 `py4j`                     >=0.10.9.7                Required
-`pandas`                   >=1.0.5                   Required for pandas API on Spark and Spark Connect; Optional for Spark SQL
+`pandas`                   >=1.4.4                   Required for pandas API on Spark and Spark Connect; Optional for Spark SQL
 `pyarrow`                  >=4.0.0                   Required for pandas API on Spark and Spark Connect; Optional for Spark SQL
 `numpy`                    >=1.15                    Required for pandas API on Spark and MLLib DataFrame-based API; Optional for Spark SQL
 `grpcio`                   >=1.48,<1.57              Required for Spark Connect

--- a/python/docs/source/user_guide/sql/arrow_pandas.rst
+++ b/python/docs/source/user_guide/sql/arrow_pandas.rst
@@ -414,7 +414,7 @@ working with timestamps in ``pandas_udf``\s to get the best performance, see
 Recommended Pandas and PyArrow Versions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-For usage with pyspark.sql, the minimum supported versions of Pandas is 1.0.5 and PyArrow is 4.0.0.
+For usage with pyspark.sql, the minimum supported versions of Pandas is 1.4.4 and PyArrow is 4.0.0.
 Higher versions may be used, however, compatibility and data correctness can not be guaranteed and should
 be verified by the user.
 

--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -21,7 +21,6 @@ A wrapper for GroupedData to behave like pandas GroupBy.
 from abc import ABCMeta, abstractmethod
 import inspect
 from collections import defaultdict, namedtuple
-from distutils.version import LooseVersion
 from functools import partial
 from itertools import product
 from typing import (
@@ -46,12 +45,7 @@ import warnings
 import pandas as pd
 from pandas.api.types import is_number, is_hashable, is_list_like  # type: ignore[attr-defined]
 
-if LooseVersion(pd.__version__) >= LooseVersion("1.3.0"):
-    from pandas.core.common import _builtin_table  # type: ignore[attr-defined]
-else:
-    from pandas.core.base import SelectionMixin
-
-    _builtin_table = SelectionMixin._builtin_table  # type: ignore[attr-defined]
+from pandas.core.common import _builtin_table  # type: ignore[attr-defined]
 
 from pyspark.sql import Column, DataFrame as SparkDataFrame, Window, functions as F
 from pyspark.sql.types import (
@@ -2700,7 +2694,7 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
             else window.orderBy(F.col(NATURAL_ORDER_COLUMN_NAME).desc())
         )
 
-        if n >= 0 or LooseVersion(pd.__version__) < LooseVersion("1.4.0"):
+        if n >= 0:
             tmp_row_num_col = verify_temp_column_name(sdf, "__row_number__")
             sdf = (
                 sdf.withColumn(tmp_row_num_col, F.row_number().over(ordered_window))

--- a/python/pyspark/pandas/resample.py
+++ b/python/pyspark/pandas/resample.py
@@ -19,7 +19,6 @@
 A wrapper for ResampledData to behave like pandas Resampler.
 """
 from abc import ABCMeta, abstractmethod
-from distutils.version import LooseVersion
 from functools import partial
 from typing import (
     Any,
@@ -33,13 +32,7 @@ import numpy as np
 
 import pandas as pd
 from pandas.tseries.frequencies import to_offset
-
-if LooseVersion(pd.__version__) >= LooseVersion("1.3.0"):
-    from pandas.core.common import _builtin_table  # type: ignore[attr-defined]
-else:
-    from pandas.core.base import SelectionMixin
-
-    _builtin_table = SelectionMixin._builtin_table  # type: ignore[attr-defined]
+from pandas.core.common import _builtin_table  # type: ignore[attr-defined]
 
 from pyspark.sql import Column, functions as F
 from pyspark.sql.types import (

--- a/python/pyspark/pandas/resample.py
+++ b/python/pyspark/pandas/resample.py
@@ -32,7 +32,6 @@ import numpy as np
 
 import pandas as pd
 from pandas.tseries.frequencies import to_offset
-from pandas.core.common import _builtin_table  # type: ignore[attr-defined]
 
 from pyspark.sql import Column, functions as F
 from pyspark.sql.types import (

--- a/python/pyspark/pandas/tests/computation/test_binary_ops.py
+++ b/python/pyspark/pandas/tests/computation/test_binary_ops.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from distutils.version import LooseVersion
+
 import unittest
 
 import numpy as np
@@ -193,13 +193,7 @@ class FrameBinaryOpsMixin:
         psdf = ps.from_pandas(pdf)
         psdf1, psdf2 = psdf["X"], psdf["Y"]
 
-        if LooseVersion(pd.__version__) >= LooseVersion("1.2.0"):
-            self.assert_eq(pdf1.combine_first(pdf2), psdf1.combine_first(psdf2))
-        else:
-            # pandas < 1.2.0 returns unexpected dtypes,
-            # please refer to https://github.com/pandas-dev/pandas/issues/28481 for details
-            expected_pdf = pd.DataFrame({"A": [None, 0], "B": [4.0, 1.0], "C": [3, 3]})
-            self.assert_eq(expected_pdf, psdf1.combine_first(psdf2))
+        self.assert_eq(pdf1.combine_first(pdf2), psdf1.combine_first(psdf2))
 
     def test_dot(self):
         psdf = self.psdf

--- a/python/pyspark/pandas/tests/computation/test_combine.py
+++ b/python/pyspark/pandas/tests/computation/test_combine.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from distutils.version import LooseVersion
 import unittest
 
 import numpy as np
@@ -556,9 +555,7 @@ class FrameCombineMixin:
         left_pdf.update(right_pdf)
         left_psdf.update(right_psdf)
         self.assert_eq(left_pdf.sort_values(by=["A", "B"]), left_psdf.sort_values(by=["A", "B"]))
-        # Skip due to pandas bug: https://github.com/pandas-dev/pandas/issues/47188
-        if not (LooseVersion("1.4.0") <= LooseVersion(pd.__version__) <= LooseVersion("1.4.2")):
-            self.assert_eq(psser.sort_index(), pser.sort_index())
+        self.assert_eq(psser.sort_index(), pser.sort_index())
 
         left_psdf, left_pdf, right_psdf, right_pdf = get_data()
         left_pdf.update(right_pdf, overwrite=False)

--- a/python/pyspark/pandas/tests/computation/test_describe.py
+++ b/python/pyspark/pandas/tests/computation/test_describe.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from distutils.version import LooseVersion
+
 import unittest
 
 import numpy as np
@@ -74,38 +74,10 @@ class FrameDescribeMixin:
             }
         )
         pdf = psdf._to_pandas()
-        if LooseVersion(pd.__version__) >= LooseVersion("1.1.0"):
-            self.assert_eq(
-                psdf.describe().loc[["count", "mean", "min", "max"]],
-                pdf.describe().astype(str).loc[["count", "mean", "min", "max"]],
-            )
-        else:
-            self.assert_eq(
-                psdf.describe(),
-                ps.DataFrame(
-                    {
-                        "A": [
-                            "4",
-                            "2021-07-16 18:00:00",
-                            "2020-10-20 00:00:00",
-                            "2020-10-20 00:00:00",
-                            "2021-06-02 00:00:00",
-                            "2021-06-02 00:00:00",
-                            "2022-07-11 00:00:00",
-                        ],
-                        "B": [
-                            "4",
-                            "2024-08-02 18:00:00",
-                            "2021-11-20 00:00:00",
-                            "2021-11-20 00:00:00",
-                            "2023-06-02 00:00:00",
-                            "2026-07-11 00:00:00",
-                            "2026-07-11 00:00:00",
-                        ],
-                    },
-                    index=["count", "mean", "min", "25%", "50%", "75%", "max"],
-                ),
-            )
+        self.assert_eq(
+            psdf.describe().loc[["count", "mean", "min", "max"]],
+            pdf.describe().astype(str).loc[["count", "mean", "min", "max"]],
+        )
 
         # String & timestamp columns
         psdf = ps.DataFrame(
@@ -120,41 +92,16 @@ class FrameDescribeMixin:
             }
         )
         pdf = psdf._to_pandas()
-        if LooseVersion(pd.__version__) >= LooseVersion("1.1.0"):
-            self.assert_eq(
-                psdf.describe().loc[["count", "mean", "min", "max"]],
-                pdf.describe().astype(str).loc[["count", "mean", "min", "max"]],
-            )
-            psdf.A += psdf.A
-            pdf.A += pdf.A
-            self.assert_eq(
-                psdf.describe().loc[["count", "mean", "min", "max"]],
-                pdf.describe().astype(str).loc[["count", "mean", "min", "max"]],
-            )
-        else:
-            expected_result = ps.DataFrame(
-                {
-                    "B": [
-                        "4",
-                        "2024-08-02 18:00:00",
-                        "2021-11-20 00:00:00",
-                        "2021-11-20 00:00:00",
-                        "2023-06-02 00:00:00",
-                        "2026-07-11 00:00:00",
-                        "2026-07-11 00:00:00",
-                    ]
-                },
-                index=["count", "mean", "min", "25%", "50%", "75%", "max"],
-            )
-            self.assert_eq(
-                psdf.describe(),
-                expected_result,
-            )
-            psdf.A += psdf.A
-            self.assert_eq(
-                psdf.describe(),
-                expected_result,
-            )
+        self.assert_eq(
+            psdf.describe().loc[["count", "mean", "min", "max"]],
+            pdf.describe().astype(str).loc[["count", "mean", "min", "max"]],
+        )
+        psdf.A += psdf.A
+        pdf.A += pdf.A
+        self.assert_eq(
+            psdf.describe().loc[["count", "mean", "min", "max"]],
+            pdf.describe().astype(str).loc[["count", "mean", "min", "max"]],
+        )
 
         # Numeric & timestamp columns
         psdf = ps.DataFrame(
@@ -169,61 +116,20 @@ class FrameDescribeMixin:
             }
         )
         pdf = psdf._to_pandas()
-        if LooseVersion(pd.__version__) >= LooseVersion("1.1.0"):
-            pandas_result = pdf.describe()
-            pandas_result.B = pandas_result.B.astype(str)
-            self.assert_eq(
-                psdf.describe().loc[["count", "mean", "min", "max"]],
-                pandas_result.loc[["count", "mean", "min", "max"]],
-            )
-            psdf.A += psdf.A
-            pdf.A += pdf.A
-            pandas_result = pdf.describe()
-            pandas_result.B = pandas_result.B.astype(str)
-            self.assert_eq(
-                psdf.describe().loc[["count", "mean", "min", "max"]],
-                pandas_result.loc[["count", "mean", "min", "max"]],
-            )
-        else:
-            self.assert_eq(
-                psdf.describe(),
-                ps.DataFrame(
-                    {
-                        "A": [4, 2, 1, 1, 2, 2, 3, 0.816497],
-                        "B": [
-                            "4",
-                            "2024-08-02 18:00:00",
-                            "2021-11-20 00:00:00",
-                            "2021-11-20 00:00:00",
-                            "2023-06-02 00:00:00",
-                            "2026-07-11 00:00:00",
-                            "2026-07-11 00:00:00",
-                            "None",
-                        ],
-                    },
-                    index=["count", "mean", "min", "25%", "50%", "75%", "max", "std"],
-                ),
-            )
-            psdf.A += psdf.A
-            self.assert_eq(
-                psdf.describe(),
-                ps.DataFrame(
-                    {
-                        "A": [4, 4, 2, 2, 4, 4, 6, 1.632993],
-                        "B": [
-                            "4",
-                            "2024-08-02 18:00:00",
-                            "2021-11-20 00:00:00",
-                            "2021-11-20 00:00:00",
-                            "2023-06-02 00:00:00",
-                            "2026-07-11 00:00:00",
-                            "2026-07-11 00:00:00",
-                            "None",
-                        ],
-                    },
-                    index=["count", "mean", "min", "25%", "50%", "75%", "max", "std"],
-                ),
-            )
+        pandas_result = pdf.describe()
+        pandas_result.B = pandas_result.B.astype(str)
+        self.assert_eq(
+            psdf.describe().loc[["count", "mean", "min", "max"]],
+            pandas_result.loc[["count", "mean", "min", "max"]],
+        )
+        psdf.A += psdf.A
+        pdf.A += pdf.A
+        pandas_result = pdf.describe()
+        pandas_result.B = pandas_result.B.astype(str)
+        self.assert_eq(
+            psdf.describe().loc[["count", "mean", "min", "max"]],
+            pandas_result.loc[["count", "mean", "min", "max"]],
+        )
 
         # Include None column
         psdf = ps.DataFrame(
@@ -234,33 +140,12 @@ class FrameDescribeMixin:
             }
         )
         pdf = psdf._to_pandas()
-        if LooseVersion(pd.__version__) >= LooseVersion("1.1.0"):
-            pandas_result = pdf.describe()
-            pandas_result.b = pandas_result.b.astype(str)
-            self.assert_eq(
-                psdf.describe().loc[["count", "mean", "min", "max"]],
-                pandas_result.loc[["count", "mean", "min", "max"]],
-            )
-        else:
-            self.assert_eq(
-                psdf.describe(),
-                ps.DataFrame(
-                    {
-                        "a": [3.0, 2.0, 1.0, 1.0, 2.0, 3.0, 3.0, 1.0],
-                        "b": [
-                            "3",
-                            "1970-01-01 00:00:00.000001",
-                            "1970-01-01 00:00:00.000001",
-                            "1970-01-01 00:00:00.000001",
-                            "1970-01-01 00:00:00.000001",
-                            "1970-01-01 00:00:00.000001",
-                            "1970-01-01 00:00:00.000001",
-                            "None",
-                        ],
-                    },
-                    index=["count", "mean", "min", "25%", "50%", "75%", "max", "std"],
-                ),
-            )
+        pandas_result = pdf.describe()
+        pandas_result.b = pandas_result.b.astype(str)
+        self.assert_eq(
+            psdf.describe().loc[["count", "mean", "min", "max"]],
+            pandas_result.loc[["count", "mean", "min", "max"]],
+        )
 
         msg = r"Percentiles should all be in the interval \[0, 1\]"
         with self.assertRaisesRegex(ValueError, msg):
@@ -306,81 +191,23 @@ class FrameDescribeMixin:
         pdf = psdf._to_pandas()
         # For timestamp type, we should convert NaT to None in pandas result
         # since pandas API on Spark doesn't support the NaT for object type.
-        if LooseVersion(pd.__version__) >= LooseVersion("1.1.0"):
-            pdf_result = pdf[pdf.a != pdf.a].describe()
-            self.assert_eq(
-                psdf[psdf.a != psdf.a].describe(),
-                pdf_result.where(pdf_result.notnull(), None).astype(str),
-            )
-        else:
-            self.assert_eq(
-                psdf[psdf.a != psdf.a].describe(),
-                ps.DataFrame(
-                    {
-                        "a": [
-                            "0",
-                            "None",
-                            "None",
-                            "None",
-                            "None",
-                            "None",
-                            "None",
-                        ],
-                        "b": [
-                            "0",
-                            "None",
-                            "None",
-                            "None",
-                            "None",
-                            "None",
-                            "None",
-                        ],
-                    },
-                    index=["count", "mean", "min", "25%", "50%", "75%", "max"],
-                ),
-            )
+        pdf_result = pdf[pdf.a != pdf.a].describe()
+        self.assert_eq(
+            psdf[psdf.a != psdf.a].describe(),
+            pdf_result.where(pdf_result.notnull(), None).astype(str),
+        )
 
         # Explicit empty DataFrame numeric & timestamp
         psdf = ps.DataFrame(
             {"a": [1, 2, 3], "b": [pd.Timestamp(1), pd.Timestamp(1), pd.Timestamp(1)]}
         )
         pdf = psdf._to_pandas()
-        if LooseVersion(pd.__version__) >= LooseVersion("1.1.0"):
-            pdf_result = pdf[pdf.a != pdf.a].describe()
-            pdf_result.b = pdf_result.b.where(pdf_result.b.notnull(), None).astype(str)
-            self.assert_eq(
-                psdf[psdf.a != psdf.a].describe(),
-                pdf_result,
-            )
-        else:
-            self.assert_eq(
-                psdf[psdf.a != psdf.a].describe(),
-                ps.DataFrame(
-                    {
-                        "a": [
-                            0,
-                            None,
-                            None,
-                            None,
-                            None,
-                            None,
-                            None,
-                            None,
-                        ],
-                        "b": [
-                            "0",
-                            "None",
-                            "None",
-                            "None",
-                            "None",
-                            "None",
-                            "None",
-                            "None",
-                        ],
-                    },
-                    index=["count", "mean", "min", "25%", "50%", "75%", "max", "std"],
-                ),
-            )
+        pdf_result = pdf[pdf.a != pdf.a].describe()
+        pdf_result.b = pdf_result.b.where(pdf_result.b.notnull(), None).astype(str)
+        self.assert_eq(
+            psdf[psdf.a != psdf.a].describe(),
+            pdf_result,
+        )
 
         # Explicit empty DataFrame numeric & string
         psdf = ps.DataFrame({"a": [1, 2, 3], "b": ["a", "b", "c"]})
@@ -395,30 +222,11 @@ class FrameDescribeMixin:
             {"a": ["a", "b", "c"], "b": [pd.Timestamp(1), pd.Timestamp(1), pd.Timestamp(1)]}
         )
         pdf = psdf._to_pandas()
-        if LooseVersion(pd.__version__) >= LooseVersion("1.1.0"):
-            pdf_result = pdf[pdf.a != pdf.a].describe()
-            self.assert_eq(
-                psdf[psdf.a != psdf.a].describe(),
-                pdf_result.where(pdf_result.notnull(), None).astype(str),
-            )
-        else:
-            self.assert_eq(
-                psdf[psdf.a != psdf.a].describe(),
-                ps.DataFrame(
-                    {
-                        "b": [
-                            "0",
-                            "None",
-                            "None",
-                            "None",
-                            "None",
-                            "None",
-                            "None",
-                        ],
-                    },
-                    index=["count", "mean", "min", "25%", "50%", "75%", "max"],
-                ),
-            )
+        pdf_result = pdf[pdf.a != pdf.a].describe()
+        self.assert_eq(
+            psdf[psdf.a != psdf.a].describe(),
+            pdf_result.where(pdf_result.notnull(), None).astype(str),
+        )
 
 
 class FrameDescribeTests(FrameDescribeMixin, ComparisonTestBase, SQLTestUtils):

--- a/python/pyspark/pandas/tests/computation/test_eval.py
+++ b/python/pyspark/pandas/tests/computation/test_eval.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from distutils.version import LooseVersion
+
 import unittest
 
 import numpy as np
@@ -60,9 +60,7 @@ class FrameEvalMixin:
         pdf.eval("A = B + C", inplace=True)
         psdf.eval("A = B + C", inplace=True)
         self.assert_eq(pdf, psdf)
-        # Skip due to pandas bug: https://github.com/pandas-dev/pandas/issues/47449
-        if not (LooseVersion("1.4.0") <= LooseVersion(pd.__version__) <= LooseVersion("1.4.3")):
-            self.assert_eq(pser, psser)
+        self.assert_eq(pser, psser)
 
         # doesn't support for multi-index columns
         columns = pd.MultiIndex.from_tuples([("x", "a"), ("y", "b"), ("z", "c")])

--- a/python/pyspark/pandas/tests/computation/test_missing_data.py
+++ b/python/pyspark/pandas/tests/computation/test_missing_data.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from distutils.version import LooseVersion
+
 import unittest
 
 import numpy as np
@@ -53,28 +53,12 @@ class FrameMissingDataMixin:
         )
         psdf = ps.from_pandas(pdf)
 
-        if LooseVersion(pd.__version__) >= LooseVersion("1.1"):
-            self.assert_eq(pdf.backfill(), psdf.backfill())
+        self.assert_eq(pdf.backfill(), psdf.backfill())
 
-            # Test `inplace=True`
-            pdf.backfill(inplace=True)
-            psdf.backfill(inplace=True)
-            self.assert_eq(pdf, psdf)
-        else:
-            expected = ps.DataFrame(
-                {
-                    "A": [3.0, 3.0, None, None],
-                    "B": [2.0, 4.0, 3.0, 3.0],
-                    "C": [1.0, 1.0, 1.0, 1.0],
-                    "D": [0, 1, 5, 4],
-                },
-                columns=["A", "B", "C", "D"],
-            )
-            self.assert_eq(expected, psdf.backfill())
-
-            # Test `inplace=True`
-            psdf.backfill(inplace=True)
-            self.assert_eq(expected, psdf)
+        # Test `inplace=True`
+        pdf.backfill(inplace=True)
+        psdf.backfill(inplace=True)
+        self.assert_eq(pdf, psdf)
 
     def _test_dropna(self, pdf, axis):
         psdf = ps.from_pandas(pdf)
@@ -235,9 +219,7 @@ class FrameMissingDataMixin:
         pdf.fillna({"x": -1, "y": -2, "z": -5}, inplace=True)
         psdf.fillna({"x": -1, "y": -2, "z": -5}, inplace=True)
         self.assert_eq(psdf, pdf)
-        # Skip due to pandas bug: https://github.com/pandas-dev/pandas/issues/47188
-        if not (LooseVersion("1.4.0") <= LooseVersion(pd.__version__) <= LooseVersion("1.4.2")):
-            self.assert_eq(psser, pser)
+        self.assert_eq(psser, pser)
 
         pser = pdf.z
         psser = psdf.z
@@ -287,15 +269,13 @@ class FrameMissingDataMixin:
         self.assert_eq(pdf.fillna(method="bfill"), psdf.fillna(method="bfill"))
         self.assert_eq(pdf.fillna(method="bfill", limit=2), psdf.fillna(method="bfill", limit=2))
 
-        # See also: https://github.com/pandas-dev/pandas/issues/47649
-        if LooseVersion("1.4.3") != LooseVersion(pd.__version__):
-            self.assert_eq(psdf.fillna({"x": -1}), pdf.fillna({"x": -1}))
-            self.assert_eq(
-                psdf.fillna({"x": -1, ("x", "b"): -2}), pdf.fillna({"x": -1, ("x", "b"): -2})
-            )
-            self.assert_eq(
-                psdf.fillna({("x", "b"): -2, "x": -1}), pdf.fillna({("x", "b"): -2, "x": -1})
-            )
+        self.assert_eq(psdf.fillna({"x": -1}), pdf.fillna({"x": -1}))
+        self.assert_eq(
+            psdf.fillna({"x": -1, ("x", "b"): -2}), pdf.fillna({"x": -1, ("x", "b"): -2})
+        )
+        self.assert_eq(
+            psdf.fillna({("x", "b"): -2, "x": -1}), pdf.fillna({("x", "b"): -2, "x": -1})
+        )
 
         # check multi index
         pdf = pdf.set_index([("x", "a"), ("x", "b")])
@@ -480,28 +460,12 @@ class FrameMissingDataMixin:
         )
         psdf = ps.from_pandas(pdf)
 
-        if LooseVersion(pd.__version__) >= LooseVersion("1.1"):
-            self.assert_eq(pdf.pad(), psdf.pad())
+        self.assert_eq(pdf.pad(), psdf.pad())
 
-            # Test `inplace=True`
-            pdf.pad(inplace=True)
-            psdf.pad(inplace=True)
-            self.assert_eq(pdf, psdf)
-        else:
-            expected = ps.DataFrame(
-                {
-                    "A": [None, 3, 3, 3],
-                    "B": [2.0, 4.0, 4.0, 3.0],
-                    "C": [None, None, None, 1],
-                    "D": [0, 1, 5, 4],
-                },
-                columns=["A", "B", "C", "D"],
-            )
-            self.assert_eq(expected, psdf.pad())
-
-            # Test `inplace=True`
-            psdf.pad(inplace=True)
-            self.assert_eq(expected, psdf)
+        # Test `inplace=True`
+        pdf.pad(inplace=True)
+        psdf.pad(inplace=True)
+        self.assert_eq(pdf, psdf)
 
 
 class FrameMissingDataTests(FrameMissingDataMixin, ComparisonTestBase, SQLTestUtils):

--- a/python/pyspark/pandas/tests/connect/data_type_ops/testing_utils.py
+++ b/python/pyspark/pandas/tests/connect/data_type_ops/testing_utils.py
@@ -17,13 +17,11 @@
 
 import datetime
 import decimal
-from distutils.version import LooseVersion
 
 import numpy as np
 import pandas as pd
 
 import pyspark.pandas as ps
-from pyspark.pandas.typedef import extension_dtypes
 
 from pyspark.pandas.typedef.typehints import (
     extension_dtypes_available,
@@ -50,20 +48,13 @@ class OpsTestBase:
         sers = [pd.Series([1, 2, 3], dtype=dtype) for dtype in dtypes]
         sers.append(pd.Series([decimal.Decimal(1), decimal.Decimal(2), decimal.Decimal(3)]))
         sers.append(pd.Series([1, 2, np.nan], dtype=float))
-        # Skip decimal_nan test before v1.3.0, it not supported by pandas on spark yet.
-        if LooseVersion(pd.__version__) >= LooseVersion("1.3.0"):
-            sers.append(
-                pd.Series([decimal.Decimal(1), decimal.Decimal(2), decimal.Decimal(np.nan)])
-            )
+        sers.append(pd.Series([decimal.Decimal(1), decimal.Decimal(2), decimal.Decimal(np.nan)]))
         pdf = pd.concat(sers, axis=1)
-        if LooseVersion(pd.__version__) >= LooseVersion("1.3.0"):
-            pdf.columns = [dtype.__name__ for dtype in dtypes] + [
-                "decimal",
-                "float_nan",
-                "decimal_nan",
-            ]
-        else:
-            pdf.columns = [dtype.__name__ for dtype in dtypes] + ["decimal", "float_nan"]
+        pdf.columns = [dtype.__name__ for dtype in dtypes] + [
+            "decimal",
+            "float_nan",
+            "decimal_nan",
+        ]
         return pdf
 
     @property
@@ -218,9 +209,4 @@ class OpsTestBase:
         This utility is to adjust an issue for comparing numeric ExtensionDtypes in specific
         pandas versions. Please refer to https://github.com/pandas-dev/pandas/issues/39410.
         """
-        if LooseVersion("1.1") <= LooseVersion(pd.__version__) < LooseVersion("1.2.2"):
-            self.assert_eq(left, right, check_exact=False)
-            self.assertTrue(isinstance(left.dtype, extension_dtypes))
-            self.assertTrue(isinstance(right.dtype, extension_dtypes))
-        else:
-            self.assert_eq(left, right)
+        self.assert_eq(left, right)

--- a/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
@@ -17,7 +17,6 @@
 
 import datetime
 import unittest
-from distutils.version import LooseVersion
 
 import pandas as pd
 import numpy as np
@@ -751,9 +750,7 @@ class BooleanExtensionOpsTest(OpsTestBase):
                 # A pandas boolean extension series cannot be casted to fractional extension dtypes
                 self.assert_eq([1.0, 0.0, np.nan], psser.astype(dtype).tolist())
             elif dtype in self.string_extension_dtype:
-                if LooseVersion(pd.__version__) >= LooseVersion("1.1.0"):
-                    # Limit pandas version due to https://github.com/pandas-dev/pandas/issues/31204
-                    self.check_extension(pser.astype(dtype), psser.astype(dtype))
+                self.check_extension(pser.astype(dtype), psser.astype(dtype))
             else:
                 self.check_extension(pser.astype(dtype), psser.astype(dtype))
 

--- a/python/pyspark/pandas/tests/data_type_ops/test_categorical_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_categorical_ops.py
@@ -15,8 +15,6 @@
 # limitations under the License.
 #
 
-from distutils.version import LooseVersion
-
 import pandas as pd
 import numpy as np
 from pandas.api.types import CategoricalDtype
@@ -187,11 +185,7 @@ class CategoricalOpsTestsMixin:
         self.assert_eq(pser.astype("category"), psser.astype("category"))
 
         cat_type = CategoricalDtype(categories=[3, 1, 2])
-        # CategoricalDtype is not updated if the dtype is same from pandas 1.3.
-        if LooseVersion(pd.__version__) >= LooseVersion("1.3"):
-            self.assert_eq(pser.astype(cat_type), psser.astype(cat_type))
-        else:
-            self.assert_eq(psser.astype(cat_type), pser)
+        self.assert_eq(pser.astype(cat_type), psser.astype(cat_type))
 
         # Empty
         pser = pd.Series([], dtype="category")

--- a/python/pyspark/pandas/tests/data_type_ops/test_num_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_num_ops.py
@@ -162,6 +162,8 @@ class NumOpsTestsMixin:
             ValueError, "Cannot convert"
         ):
             psser.astype(int)
+        with ps.option_context("compute.eager_check", False):
+            psser.astype(int)
 
     def test_neg(self):
         pdf, psdf = self.pdf, self.psdf
@@ -259,7 +261,9 @@ class IntegralExtensionOpsTest(OpsTestBase):
     def test_astype(self):
         for pser, psser in self.intergral_extension_pser_psser_pairs:
             for dtype in self.extension_dtypes:
-                if dtype not in self.string_extension_dtype:
+                if dtype in self.string_extension_dtype:
+                    self.check_extension(pser.astype(dtype), psser.astype(dtype))
+                else:
                     self.check_extension(pser.astype(dtype), psser.astype(dtype))
         for pser, psser in self.intergral_extension_pser_psser_pairs:
             self.assert_eq(pser.astype(float), psser.astype(float))

--- a/python/pyspark/pandas/tests/data_type_ops/testing_utils.py
+++ b/python/pyspark/pandas/tests/data_type_ops/testing_utils.py
@@ -17,7 +17,6 @@
 
 import datetime
 import decimal
-from distutils.version import LooseVersion
 
 import numpy as np
 import pandas as pd
@@ -52,20 +51,13 @@ class OpsTestBase(ComparisonTestBase):
         sers = [pd.Series([1, 2, 3], dtype=dtype) for dtype in dtypes]
         sers.append(pd.Series([decimal.Decimal(1), decimal.Decimal(2), decimal.Decimal(3)]))
         sers.append(pd.Series([1, 2, np.nan], dtype=float))
-        # Skip decimal_nan test before v1.3.0, it not supported by pandas on spark yet.
-        if LooseVersion(pd.__version__) >= LooseVersion("1.3.0"):
-            sers.append(
-                pd.Series([decimal.Decimal(1), decimal.Decimal(2), decimal.Decimal(np.nan)])
-            )
+        sers.append(pd.Series([decimal.Decimal(1), decimal.Decimal(2), decimal.Decimal(np.nan)]))
         pdf = pd.concat(sers, axis=1)
-        if LooseVersion(pd.__version__) >= LooseVersion("1.3.0"):
-            pdf.columns = [dtype.__name__ for dtype in dtypes] + [
-                "decimal",
-                "float_nan",
-                "decimal_nan",
-            ]
-        else:
-            pdf.columns = [dtype.__name__ for dtype in dtypes] + ["decimal", "float_nan"]
+        pdf.columns = [dtype.__name__ for dtype in dtypes] + [
+            "decimal",
+            "float_nan",
+            "decimal_nan",
+        ]
         return pdf
 
     @property
@@ -220,9 +212,4 @@ class OpsTestBase(ComparisonTestBase):
         This utility is to adjust an issue for comparing numeric ExtensionDtypes in specific
         pandas versions. Please refer to https://github.com/pandas-dev/pandas/issues/39410.
         """
-        if LooseVersion("1.1") <= LooseVersion(pd.__version__) < LooseVersion("1.2.2"):
-            self.assert_eq(left, right, check_exact=False)
-            self.assertTrue(isinstance(left.dtype, extension_dtypes))
-            self.assertTrue(isinstance(right.dtype, extension_dtypes))
-        else:
-            self.assert_eq(left, right)
+        self.assert_eq(left, right)

--- a/python/pyspark/pandas/tests/frame/test_attrs.py
+++ b/python/pyspark/pandas/tests/frame/test_attrs.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 #
 from datetime import datetime
-from distutils.version import LooseVersion
 import unittest
 
 import numpy as np
@@ -124,39 +123,20 @@ class FrameAttrsMixin:
         pmidx = pd.MultiIndex.from_arrays(arrays, names=("number", "color"))
         psmidx = ps.from_pandas(pmidx)
 
-        if LooseVersion(pd.__version__) >= LooseVersion("1.3"):
-            self.assert_eq(psmidx.dtypes, pmidx.dtypes)
-        else:
-            expected = pd.Series([np.dtype("int64"), np.dtype("O")], index=["number", "color"])
-            self.assert_eq(psmidx.dtypes, expected)
+        self.assert_eq(psmidx.dtypes, pmidx.dtypes)
 
         # multiple labels
         pmidx = pd.MultiIndex.from_arrays(arrays, names=[("zero", "first"), ("one", "second")])
         psmidx = ps.from_pandas(pmidx)
 
-        if LooseVersion(pd.__version__) >= LooseVersion("1.3"):
-            if LooseVersion(pd.__version__) not in (LooseVersion("1.4.1"), LooseVersion("1.4.2")):
-                self.assert_eq(psmidx.dtypes, pmidx.dtypes)
-        else:
-            expected = pd.Series(
-                [np.dtype("int64"), np.dtype("O")],
-                index=pd.Index([("zero", "first"), ("one", "second")]),
-            )
-            self.assert_eq(psmidx.dtypes, expected)
+        self.assert_eq(psmidx.dtypes, pmidx.dtypes)
 
     def test_multi_index_dtypes_not_unique_name(self):
         # Regression test for https://github.com/pandas-dev/pandas/issues/45174
         pmidx = pd.MultiIndex.from_arrays([[1], [2]], names=[1, 1])
         psmidx = ps.from_pandas(pmidx)
 
-        if LooseVersion(pd.__version__) < LooseVersion("1.4"):
-            expected = pd.Series(
-                [np.dtype("int64"), np.dtype("int64")],
-                index=[1, 1],
-            )
-            self.assert_eq(psmidx.dtypes, expected)
-        else:
-            self.assert_eq(psmidx.dtypes, pmidx.dtypes)
+        self.assert_eq(psmidx.dtypes, pmidx.dtypes)
 
     def test_dtype(self):
         pdf = pd.DataFrame(
@@ -201,14 +181,7 @@ class FrameAttrsMixin:
         psdf["a"] = psdf["a"] + 10
 
         self.assert_eq(psdf, pdf)
-        # SPARK-38946: Since Spark 3.4, df.__setitem__ generate a new dataframe to follow
-        # pandas 1.4 behaviors
-        if LooseVersion(pd.__version__) >= LooseVersion("1.4.0"):
-            self.assert_eq(psser, pser)
-        else:
-            # Follow pandas latest behavior
-            with self.assertRaisesRegex(AssertionError, "Series are different"):
-                self.assert_eq(psser, pser)
+        self.assert_eq(psser, pser)
 
     def test_dataframe_multiindex_columns(self):
         pdf = pd.DataFrame(

--- a/python/pyspark/pandas/tests/frame/test_constructor.py
+++ b/python/pyspark/pandas/tests/frame/test_constructor.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 #
 from datetime import datetime, timedelta
-from distutils.version import LooseVersion
 import unittest
 
 import numpy as np
@@ -490,14 +489,6 @@ class FrameConstructorMixin:
             # test ps.DataFrame with pd.MultiIndex
             ps.DataFrame(data=psdf, index=pdf.index)
 
-    def _check_extension(self, psdf, pdf):
-        if LooseVersion("1.1") <= LooseVersion(pd.__version__) < LooseVersion("1.2.2"):
-            self.assert_eq(psdf, pdf, check_exact=False)
-            for dtype in psdf.dtypes:
-                self.assertTrue(isinstance(dtype, extension_dtypes))
-        else:
-            self.assert_eq(psdf, pdf)
-
     @unittest.skipIf(not extension_dtypes_available, "pandas extension dtypes are not available")
     def test_extension_dtypes(self):
         pdf = pd.DataFrame(
@@ -510,8 +501,8 @@ class FrameConstructorMixin:
         )
         psdf = ps.from_pandas(pdf)
 
-        self._check_extension(psdf, pdf)
-        self._check_extension(psdf + psdf, pdf + pdf)
+        self.assert_eq(psdf, pdf)
+        self.assert_eq(psdf + psdf, pdf + pdf)
 
     @unittest.skipIf(not extension_dtypes_available, "pandas extension dtypes are not available")
     def test_astype_extension_dtypes(self):
@@ -527,7 +518,7 @@ class FrameConstructorMixin:
 
         astype = {"a": "Int8", "b": "Int16", "c": "Int32", "d": "Int64"}
 
-        self._check_extension(psdf.astype(astype), pdf.astype(astype))
+        self.assert_eq(psdf.astype(astype), pdf.astype(astype))
 
     @unittest.skipIf(
         not extension_object_dtypes_available, "pandas extension object dtypes are not available"
@@ -541,7 +532,7 @@ class FrameConstructorMixin:
         )
         psdf = ps.from_pandas(pdf)
 
-        self._check_extension(psdf, pdf)
+        self.assert_eq(psdf, pdf)
 
     @unittest.skipIf(
         not extension_object_dtypes_available, "pandas extension object dtypes are not available"
@@ -552,7 +543,7 @@ class FrameConstructorMixin:
 
         astype = {"a": "string", "b": "boolean"}
 
-        self._check_extension(psdf.astype(astype), pdf.astype(astype))
+        self.assert_eq(psdf.astype(astype), pdf.astype(astype))
 
     @unittest.skipIf(
         not extension_float_dtypes_available, "pandas extension float dtypes are not available"
@@ -566,9 +557,9 @@ class FrameConstructorMixin:
         )
         psdf = ps.from_pandas(pdf)
 
-        self._check_extension(psdf, pdf)
-        self._check_extension(psdf + 1, pdf + 1)
-        self._check_extension(psdf + psdf, pdf + pdf)
+        self.assert_eq(psdf, pdf)
+        self.assert_eq(psdf + 1, pdf + 1)
+        self.assert_eq(psdf + psdf, pdf + pdf)
 
     @unittest.skipIf(
         not extension_float_dtypes_available, "pandas extension float dtypes are not available"
@@ -579,7 +570,7 @@ class FrameConstructorMixin:
 
         astype = {"a": "Float32", "b": "Float64"}
 
-        self._check_extension(psdf.astype(astype), pdf.astype(astype))
+        self.assert_eq(psdf.astype(astype), pdf.astype(astype))
 
 
 class FrameConstructorTests(FrameConstructorMixin, ComparisonTestBase, SQLTestUtils):

--- a/python/pyspark/pandas/tests/frame/test_reindexing.py
+++ b/python/pyspark/pandas/tests/frame/test_reindexing.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from distutils.version import LooseVersion
 import unittest
 
 import numpy as np
@@ -822,31 +821,9 @@ class FrameReindexingMixin:
         )
         psdf = ps.from_pandas(pdf)
 
-        if LooseVersion(pd.__version__) >= LooseVersion("1.2"):
-            self.assert_eq(psdf.isin([4, 3, 1, 1, None]), pdf.isin([4, 3, 1, 1, None]))
-        else:
-            expected = pd.DataFrame(
-                {
-                    "a": [True, False, True, True, False, False],
-                    "b": [True, False, False, True, False, True],
-                    "c": [False, False, False, True, False, True],
-                }
-            )
-            self.assert_eq(psdf.isin([4, 3, 1, 1, None]), expected)
+        self.assert_eq(psdf.isin([4, 3, 1, 1, None]), pdf.isin([4, 3, 1, 1, None]))
 
-        if LooseVersion(pd.__version__) >= LooseVersion("1.2"):
-            self.assert_eq(
-                psdf.isin({"b": [4, 3, 1, 1, None]}), pdf.isin({"b": [4, 3, 1, 1, None]})
-            )
-        else:
-            expected = pd.DataFrame(
-                {
-                    "a": [False, False, False, False, False, False],
-                    "b": [True, False, False, True, False, True],
-                    "c": [False, False, False, False, False, False],
-                }
-            )
-            self.assert_eq(psdf.isin({"b": [4, 3, 1, 1, None]}), expected)
+        self.assert_eq(psdf.isin({"b": [4, 3, 1, 1, None]}), pdf.isin({"b": [4, 3, 1, 1, None]}))
 
     def test_sample(self):
         psdf = ps.DataFrame({"A": [0, 2, 4]}, index=["x", "y", "z"])

--- a/python/pyspark/pandas/tests/frame/test_reshaping.py
+++ b/python/pyspark/pandas/tests/frame/test_reshaping.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from distutils.version import LooseVersion
+
 import unittest
 
 import numpy as np
@@ -212,12 +212,8 @@ class FrameReshapingMixin:
             index=np.random.rand(7),
         )
         psdf = ps.from_pandas(pdf)
-        # see also: https://github.com/pandas-dev/pandas/issues/46589
-        if not (LooseVersion("1.4.0") <= LooseVersion(pd.__version__) <= LooseVersion("1.4.2")):
-            self.assert_eq(psdf.nlargest(5, columns="a"), pdf.nlargest(5, columns="a"))
-            self.assert_eq(
-                psdf.nlargest(5, columns=["a", "b"]), pdf.nlargest(5, columns=["a", "b"])
-            )
+        self.assert_eq(psdf.nlargest(5, columns="a"), pdf.nlargest(5, columns="a"))
+        self.assert_eq(psdf.nlargest(5, columns=["a", "b"]), pdf.nlargest(5, columns=["a", "b"]))
         self.assert_eq(psdf.nlargest(5, columns=["c"]), pdf.nlargest(5, columns=["c"]))
         self.assert_eq(
             psdf.nlargest(5, columns=["c"], keep="first"),
@@ -241,11 +237,10 @@ class FrameReshapingMixin:
         )
         psdf = ps.from_pandas(pdf)
         # see also: https://github.com/pandas-dev/pandas/issues/46589
-        if not (LooseVersion("1.4.0") <= LooseVersion(pd.__version__) <= LooseVersion("1.4.2")):
-            self.assert_eq(psdf.nsmallest(n=5, columns="a"), pdf.nsmallest(5, columns="a"))
-            self.assert_eq(
-                psdf.nsmallest(n=5, columns=["a", "b"]), pdf.nsmallest(5, columns=["a", "b"])
-            )
+        self.assert_eq(psdf.nsmallest(n=5, columns="a"), pdf.nsmallest(5, columns="a"))
+        self.assert_eq(
+            psdf.nsmallest(n=5, columns=["a", "b"]), pdf.nsmallest(5, columns=["a", "b"])
+        )
         self.assert_eq(psdf.nsmallest(n=5, columns=["c"]), pdf.nsmallest(5, columns=["c"]))
         self.assert_eq(
             psdf.nsmallest(n=5, columns=["c"], keep="first"),

--- a/python/pyspark/pandas/tests/frame/test_reshaping.py
+++ b/python/pyspark/pandas/tests/frame/test_reshaping.py
@@ -236,7 +236,6 @@ class FrameReshapingMixin:
             index=np.random.rand(7),
         )
         psdf = ps.from_pandas(pdf)
-        # see also: https://github.com/pandas-dev/pandas/issues/46589
         self.assert_eq(psdf.nsmallest(n=5, columns="a"), pdf.nsmallest(5, columns="a"))
         self.assert_eq(
             psdf.nsmallest(n=5, columns=["a", "b"]), pdf.nsmallest(5, columns=["a", "b"])

--- a/python/pyspark/pandas/tests/frame/test_truncate.py
+++ b/python/pyspark/pandas/tests/frame/test_truncate.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from distutils.version import LooseVersion
 import unittest
 
 import numpy as np
@@ -64,17 +63,8 @@ class FrameTruncateMixin:
         self.assert_eq(psdf1.truncate(after=400), pdf1.truncate(after=400))
         self.assert_eq(psdf1.truncate(copy=False), pdf1.truncate(copy=False))
         self.assert_eq(psdf1.truncate(-20, 400, copy=False), pdf1.truncate(-20, 400, copy=False))
-        # The bug for these tests has been fixed in pandas 1.1.0.
-        if LooseVersion(pd.__version__) >= LooseVersion("1.1.0"):
-            self.assert_eq(psdf2.truncate(0, 550), pdf2.truncate(0, 550))
-            self.assert_eq(psdf2.truncate(0, 550, copy=False), pdf2.truncate(0, 550, copy=False))
-        else:
-            expected_psdf = ps.DataFrame(
-                {"A": ["b", "c", "d"], "B": ["i", "j", "k"], "C": ["p", "q", "r"]},
-                index=[550, 400, 0],
-            )
-            self.assert_eq(psdf2.truncate(0, 550), expected_psdf)
-            self.assert_eq(psdf2.truncate(0, 550, copy=False), expected_psdf)
+        self.assert_eq(psdf2.truncate(0, 550), pdf2.truncate(0, 550))
+        self.assert_eq(psdf2.truncate(0, 550, copy=False), pdf2.truncate(0, 550, copy=False))
 
         # axis = 1
         self.assert_eq(psdf1.truncate(axis=1), pdf1.truncate(axis=1))
@@ -99,14 +89,8 @@ class FrameTruncateMixin:
         self.assert_eq(psdf1.truncate(after=400), pdf1.truncate(after=400))
         self.assert_eq(psdf1.truncate(copy=False), pdf1.truncate(copy=False))
         self.assert_eq(psdf1.truncate(-20, 400, copy=False), pdf1.truncate(-20, 400, copy=False))
-        # The bug for these tests has been fixed in pandas 1.1.0.
-        if LooseVersion(pd.__version__) >= LooseVersion("1.1.0"):
-            self.assert_eq(psdf2.truncate(0, 550), pdf2.truncate(0, 550))
-            self.assert_eq(psdf2.truncate(0, 550, copy=False), pdf2.truncate(0, 550, copy=False))
-        else:
-            expected_psdf.columns = columns
-            self.assert_eq(psdf2.truncate(0, 550), expected_psdf)
-            self.assert_eq(psdf2.truncate(0, 550, copy=False), expected_psdf)
+        self.assert_eq(psdf2.truncate(0, 550), pdf2.truncate(0, 550))
+        self.assert_eq(psdf2.truncate(0, 550, copy=False), pdf2.truncate(0, 550, copy=False))
         # axis = 1
         self.assert_eq(psdf1.truncate(axis=1), pdf1.truncate(axis=1))
         self.assert_eq(psdf1.truncate(before="B", axis=1), pdf1.truncate(before="B", axis=1))

--- a/python/pyspark/pandas/tests/groupby/test_groupby.py
+++ b/python/pyspark/pandas/tests/groupby/test_groupby.py
@@ -17,7 +17,6 @@
 
 import unittest
 import inspect
-from distutils.version import LooseVersion
 
 import numpy as np
 import pandas as pd
@@ -686,21 +685,13 @@ class GroupByTestsMixin:
             psdf.groupby("a").agg({"b": "nunique"}).sort_index(),
             pdf.groupby("a").agg({"b": "nunique"}).sort_index(),
         )
-        if LooseVersion(pd.__version__) < LooseVersion("1.1.0"):
-            expected = ps.DataFrame({"b": [2, 2]}, index=pd.Index([0, 1], name="a"))
-            self.assert_eq(psdf.groupby("a").nunique().sort_index(), expected)
-            self.assert_eq(
-                psdf.groupby("a").nunique(dropna=False).sort_index(),
-                expected,
-            )
-        else:
-            self.assert_eq(
-                psdf.groupby("a").nunique().sort_index(), pdf.groupby("a").nunique().sort_index()
-            )
-            self.assert_eq(
-                psdf.groupby("a").nunique(dropna=False).sort_index(),
-                pdf.groupby("a").nunique(dropna=False).sort_index(),
-            )
+        self.assert_eq(
+            psdf.groupby("a").nunique().sort_index(), pdf.groupby("a").nunique().sort_index()
+        )
+        self.assert_eq(
+            psdf.groupby("a").nunique(dropna=False).sort_index(),
+            pdf.groupby("a").nunique(dropna=False).sort_index(),
+        )
         self.assert_eq(
             psdf.groupby("a")["b"].nunique().sort_index(),
             pdf.groupby("a")["b"].nunique().sort_index(),
@@ -722,25 +713,14 @@ class GroupByTestsMixin:
         pdf.columns = columns
         psdf.columns = columns
 
-        if LooseVersion(pd.__version__) < LooseVersion("1.1.0"):
-            expected = ps.DataFrame({("y", "b"): [2, 2]}, index=pd.Index([0, 1], name=("x", "a")))
-            self.assert_eq(
-                psdf.groupby(("x", "a")).nunique().sort_index(),
-                expected,
-            )
-            self.assert_eq(
-                psdf.groupby(("x", "a")).nunique(dropna=False).sort_index(),
-                expected,
-            )
-        else:
-            self.assert_eq(
-                psdf.groupby(("x", "a")).nunique().sort_index(),
-                pdf.groupby(("x", "a")).nunique().sort_index(),
-            )
-            self.assert_eq(
-                psdf.groupby(("x", "a")).nunique(dropna=False).sort_index(),
-                pdf.groupby(("x", "a")).nunique(dropna=False).sort_index(),
-            )
+        self.assert_eq(
+            psdf.groupby(("x", "a")).nunique().sort_index(),
+            pdf.groupby(("x", "a")).nunique().sort_index(),
+        )
+        self.assert_eq(
+            psdf.groupby(("x", "a")).nunique(dropna=False).sort_index(),
+            pdf.groupby(("x", "a")).nunique(dropna=False).sort_index(),
+        )
 
     def test_unique(self):
         for pdf in [

--- a/python/pyspark/pandas/tests/groupby/test_index.py
+++ b/python/pyspark/pandas/tests/groupby/test_index.py
@@ -84,16 +84,10 @@ class GroupbyIndexMixin:
 
         self.assert_eq(psdf.groupby((10, "a"))[(20, "c")].sum().sort_index(), expected)
 
-        if LooseVersion(pd.__version__) != LooseVersion("1.1.3") and LooseVersion(
-            pd.__version__
-        ) != LooseVersion("1.1.4"):
-            self.assert_eq(
-                psdf[(20, "c")].groupby(psdf[(10, "a")]).sum().sort_index(),
-                pdf[(20, "c")].groupby(pdf[(10, "a")]).sum().sort_index(),
-            )
-        else:
-            # Due to pandas bugs resolved in 1.0.4, re-introduced in 1.1.3 and resolved in 1.1.5
-            self.assert_eq(psdf[(20, "c")].groupby(psdf[(10, "a")]).sum().sort_index(), expected)
+        self.assert_eq(
+            psdf[(20, "c")].groupby(psdf[(10, "a")]).sum().sort_index(),
+            pdf[(20, "c")].groupby(pdf[(10, "a")]).sum().sort_index(),
+        )
 
     def test_idxmax(self):
         pdf = pd.DataFrame(

--- a/python/pyspark/pandas/tests/indexes/test_base.py
+++ b/python/pyspark/pandas/tests/indexes/test_base.py
@@ -1859,17 +1859,8 @@ class IndexesTestsMixin:
 
         pidx = pd.Index([10, 20, 15, 30, 45, None], name="x")
         psidx = ps.Index(pidx)
-        if LooseVersion(pd.__version__) >= LooseVersion("1.3"):
-            self.assert_eq(psidx.astype(bool), pidx.astype(bool))
-            self.assert_eq(psidx.astype(str), pidx.astype(str))
-        else:
-            self.assert_eq(
-                psidx.astype(bool), ps.Index([True, True, True, True, True, True], name="x")
-            )
-            self.assert_eq(
-                psidx.astype(str),
-                ps.Index(["10.0", "20.0", "15.0", "30.0", "45.0", "nan"], name="x"),
-            )
+        self.assert_eq(psidx.astype(bool), pidx.astype(bool))
+        self.assert_eq(psidx.astype(str), pidx.astype(str))
 
         pidx = pd.Index(["hi", "hi ", " ", " \t", "", None], name="x")
         psidx = ps.Index(pidx)

--- a/python/pyspark/pandas/tests/indexes/test_category.py
+++ b/python/pyspark/pandas/tests/indexes/test_category.py
@@ -178,17 +178,10 @@ class CategoricalIndexTestsMixin:
 
         self.assert_eq(pscidx.astype("category"), pcidx.astype("category"))
 
-        # CategoricalDtype is not updated if the dtype is same from pandas 1.3.
-        if LooseVersion(pd.__version__) >= LooseVersion("1.3"):
-            self.assert_eq(
-                pscidx.astype(CategoricalDtype(["b", "c", "a"])),
-                pcidx.astype(CategoricalDtype(["b", "c", "a"])),
-            )
-        else:
-            self.assert_eq(
-                pscidx.astype(CategoricalDtype(["b", "c", "a"])),
-                pcidx,
-            )
+        self.assert_eq(
+            pscidx.astype(CategoricalDtype(["b", "c", "a"])),
+            pcidx.astype(CategoricalDtype(["b", "c", "a"])),
+        )
 
         self.assert_eq(pscidx.astype(str), pcidx.astype(str))
 
@@ -265,25 +258,13 @@ class CategoricalIndexTestsMixin:
         psidx2 = ps.from_pandas(pidx2)
         psidx3 = ps.from_pandas(pidx3)
 
-        if LooseVersion(pd.__version__) >= LooseVersion("1.2"):
-            self.assert_eq(
-                psidx1.intersection(psidx2).sort_values(), pidx1.intersection(pidx2).sort_values()
-            )
-            self.assert_eq(
-                psidx1.intersection(psidx3.astype("category")).sort_values(),
-                pidx1.intersection(pidx3.astype("category")).sort_values(),
-            )
-        else:
-            self.assert_eq(
-                psidx1.intersection(psidx2).sort_values(),
-                pidx1.intersection(pidx2).set_categories(pidx1.categories).sort_values(),
-            )
-            self.assert_eq(
-                psidx1.intersection(psidx3.astype("category")).sort_values(),
-                pidx1.intersection(pidx3.astype("category"))
-                .set_categories(pidx1.categories)
-                .sort_values(),
-            )
+        self.assert_eq(
+            psidx1.intersection(psidx2).sort_values(), pidx1.intersection(pidx2).sort_values()
+        )
+        self.assert_eq(
+            psidx1.intersection(psidx3.astype("category")).sort_values(),
+            pidx1.intersection(pidx3.astype("category")).sort_values(),
+        )
 
         # TODO: intersection non-categorical or categorical with a different category
         self.assertRaises(NotImplementedError, lambda: psidx1.intersection(psidx3))

--- a/python/pyspark/pandas/tests/indexes/test_datetime.py
+++ b/python/pyspark/pandas/tests/indexes/test_datetime.py
@@ -16,7 +16,6 @@
 #
 
 import datetime
-import unittest
 
 from distutils.version import LooseVersion
 
@@ -96,9 +95,8 @@ class DatetimeIndexTestsMixin:
             self.assert_eq(psidx.is_year_end, pd.Index(pidx.is_year_end))
             self.assert_eq(psidx.is_leap_year, pd.Index(pidx.is_leap_year))
 
-            if LooseVersion(pd.__version__) >= LooseVersion("1.2.0"):
-                self.assert_eq(psidx.day_of_year, pidx.day_of_year)
-                self.assert_eq(psidx.day_of_week, pidx.day_of_week)
+            self.assert_eq(psidx.day_of_year, pidx.day_of_year)
+            self.assert_eq(psidx.day_of_week, pidx.day_of_week)
 
         if LooseVersion(pd.__version__) >= LooseVersion("2.0.0"):
             # TODO(SPARK-42617): Support isocalendar.week and replace it.

--- a/python/pyspark/pandas/tests/io/test_io.py
+++ b/python/pyspark/pandas/tests/io/test_io.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from distutils.version import LooseVersion
 import unittest
 from io import StringIO
 
@@ -93,33 +92,6 @@ class FrameIOMixin:
         pdf = pd.DataFrame.from_dict(data, orient="index", columns=["A", "B", "C", "D"])
         psdf = ps.DataFrame.from_dict(data, orient="index", columns=["A", "B", "C", "D"])
         self.assert_eq(pdf, psdf)
-
-    @unittest.skipIf(
-        LooseVersion(pd.__version__) < LooseVersion("1.3.0"),
-        "pandas support `Styler.to_latex` since 1.3.0",
-    )
-    def test_style(self):
-        # Currently, the `style` function returns a pandas object `Styler` as it is,
-        # processing only the number of rows declared in `compute.max_rows`.
-        # So it's a bit vague to test, but we are doing minimal tests instead of not testing at all.
-        pdf = pd.DataFrame(np.random.randn(10, 4), columns=["A", "B", "C", "D"])
-        psdf = ps.from_pandas(pdf)
-
-        def style_negative(v, props=""):
-            return props if v < 0 else None
-
-        def check_style():
-            # If the value is negative, the text color will be displayed as red.
-            pdf_style = pdf.style.applymap(style_negative, props="color:red;")
-            psdf_style = psdf.style.applymap(style_negative, props="color:red;")
-
-            # Test whether the same shape as pandas table is created including the color.
-            self.assert_eq(pdf_style.to_latex(), psdf_style.to_latex())
-
-        check_style()
-
-        with ps.option_context("compute.max_rows", None):
-            check_style()
 
     def test_info(self):
         pdf, psdf = self.df_pair

--- a/python/pyspark/pandas/tests/io/test_io.py
+++ b/python/pyspark/pandas/tests/io/test_io.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
 import unittest
 from io import StringIO
 
@@ -92,6 +93,29 @@ class FrameIOMixin:
         pdf = pd.DataFrame.from_dict(data, orient="index", columns=["A", "B", "C", "D"])
         psdf = ps.DataFrame.from_dict(data, orient="index", columns=["A", "B", "C", "D"])
         self.assert_eq(pdf, psdf)
+
+    def test_style(self):
+        # Currently, the `style` function returns a pandas object `Styler` as it is,
+        # processing only the number of rows declared in `compute.max_rows`.
+        # So it's a bit vague to test, but we are doing minimal tests instead of not testing at all.
+        pdf = pd.DataFrame(np.random.randn(10, 4), columns=["A", "B", "C", "D"])
+        psdf = ps.from_pandas(pdf)
+
+        def style_negative(v, props=""):
+            return props if v < 0 else None
+
+        def check_style():
+            # If the value is negative, the text color will be displayed as red.
+            pdf_style = pdf.style.applymap(style_negative, props="color:red;")
+            psdf_style = psdf.style.applymap(style_negative, props="color:red;")
+
+            # Test whether the same shape as pandas table is created including the color.
+            self.assert_eq(pdf_style.to_latex(), psdf_style.to_latex())
+
+        check_style()
+
+        with ps.option_context("compute.max_rows", None):
+            check_style()
 
     def test_info(self):
         pdf, psdf = self.df_pair

--- a/python/pyspark/pandas/tests/series/test_as_type.py
+++ b/python/pyspark/pandas/tests/series/test_as_type.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 #
 import unittest
-from distutils.version import LooseVersion
 
 import numpy as np
 import pandas as pd
@@ -61,11 +60,7 @@ class SeriesAsTypeMixin:
         psser = ps.Series(pser)
 
         self.assert_eq(psser.astype(bool), pser.astype(bool))
-        if LooseVersion("1.1.1") <= LooseVersion(pd.__version__) < LooseVersion("1.1.4"):
-            # a pandas bug: https://github.com/databricks/koalas/pull/1818#issuecomment-703961980
-            self.assert_eq(psser.astype(str).tolist(), ["hi", "hi ", " ", " \t", "", "None"])
-        else:
-            self.assert_eq(psser.astype(str), pser.astype(str))
+        self.assert_eq(psser.astype(str), pser.astype(str))
         self.assert_eq(psser.str.strip().astype(bool), pser.str.strip().astype(bool))
 
         if extension_object_dtypes_available:
@@ -85,19 +80,8 @@ class SeriesAsTypeMixin:
 
             self._check_extension(psser.astype("boolean"), pser.astype("boolean"))
             self._check_extension(psser.astype(BooleanDtype()), pser.astype(BooleanDtype()))
-
-            if LooseVersion(pd.__version__) >= LooseVersion("1.1"):
-                self._check_extension(psser.astype("string"), pser.astype("string"))
-                self._check_extension(psser.astype(StringDtype()), pser.astype(StringDtype()))
-            else:
-                self._check_extension(
-                    psser.astype("string"),
-                    pd.Series(["True", "False", None], name="x", dtype="string"),
-                )
-                self._check_extension(
-                    psser.astype(StringDtype()),
-                    pd.Series(["True", "False", None], name="x", dtype=StringDtype()),
-                )
+            self._check_extension(psser.astype("string"), pser.astype("string"))
+            self._check_extension(psser.astype(StringDtype()), pser.astype(StringDtype()))
 
         pser = pd.Series(["2020-10-27 00:00:01", None], name="x")
         psser = ps.Series(pser)
@@ -170,18 +154,8 @@ class SeriesAsTypeMixin:
         if extension_object_dtypes_available:
             from pandas import StringDtype
 
-            if LooseVersion(pd.__version__) >= LooseVersion("1.1"):
-                self._check_extension(psser.astype("string"), pser.astype("string"))
-                self._check_extension(psser.astype(StringDtype()), pser.astype(StringDtype()))
-            else:
-                self._check_extension(
-                    psser.astype("string"),
-                    pd.Series(["10", "20", "15", "30", "45"], name="x", dtype="string"),
-                )
-                self._check_extension(
-                    psser.astype(StringDtype()),
-                    pd.Series(["10", "20", "15", "30", "45"], name="x", dtype=StringDtype()),
-                )
+            self._check_extension(psser.astype("string"), pser.astype("string"))
+            self._check_extension(psser.astype(StringDtype()), pser.astype(StringDtype()))
 
         if extension_float_dtypes_available:
             from pandas import Float32Dtype, Float64Dtype
@@ -192,11 +166,7 @@ class SeriesAsTypeMixin:
             self._check_extension(psser.astype(Float64Dtype()), pser.astype(Float64Dtype()))
 
     def _check_extension(self, psser, pser):
-        if LooseVersion("1.1") <= LooseVersion(pd.__version__) < LooseVersion("1.2.2"):
-            self.assert_eq(psser, pser, check_exact=False)
-            self.assertTrue(isinstance(psser.dtype, extension_dtypes))
-        else:
-            self.assert_eq(psser, pser)
+        self.assert_eq(psser, pser)
 
 
 class SeriesAsTypeTests(SeriesAsTypeMixin, ComparisonTestBase, SQLTestUtils):

--- a/python/pyspark/pandas/tests/series/test_compute.py
+++ b/python/pyspark/pandas/tests/series/test_compute.py
@@ -114,16 +114,18 @@ class SeriesComputeMixin:
         self.assert_eq(str_psser.clip(1, 3), str_psser)
 
     def test_compare(self):
-        psser = ps.Series([1, 2])
+        pser = pd.Series([1, 2])
+        psser = ps.from_pandas(pser)
+
         res_psdf = psser.compare(psser)
         self.assertTrue(res_psdf.empty)
         self.assert_eq(res_psdf.columns, pd.Index(["self", "other"]))
-        expected = ps.DataFrame([[1, 2], [2, 3]], columns=["self", "other"])
-        self.assert_eq(expected, psser.compare(psser + 1).sort_index())
 
-        psser = ps.Series([1, 2], index=["x", "y"])
-        expected = ps.DataFrame([[1, 2], [2, 3]], index=["x", "y"], columns=["self", "other"])
-        self.assert_eq(expected, psser.compare(psser + 1).sort_index())
+        self.assert_eq(pser.compare(pser + 1).sort_index(), psser.compare(psser + 1).sort_index())
+
+        pser = pd.Series([1, 2], index=["x", "y"])
+        psser = ps.from_pandas(pser)
+        self.assert_eq(pser.compare(pser + 1).sort_index(), psser.compare(psser + 1).sort_index())
 
     def test_concat(self):
         pser1 = pd.Series([1, 2, 3], name="0")

--- a/python/pyspark/pandas/tests/series/test_compute.py
+++ b/python/pyspark/pandas/tests/series/test_compute.py
@@ -114,34 +114,16 @@ class SeriesComputeMixin:
         self.assert_eq(str_psser.clip(1, 3), str_psser)
 
     def test_compare(self):
-        if LooseVersion(pd.__version__) >= LooseVersion("1.1"):
-            pser = pd.Series([1, 2])
-            psser = ps.from_pandas(pser)
+        psser = ps.Series([1, 2])
+        res_psdf = psser.compare(psser)
+        self.assertTrue(res_psdf.empty)
+        self.assert_eq(res_psdf.columns, pd.Index(["self", "other"]))
+        expected = ps.DataFrame([[1, 2], [2, 3]], columns=["self", "other"])
+        self.assert_eq(expected, psser.compare(psser + 1).sort_index())
 
-            res_psdf = psser.compare(psser)
-            self.assertTrue(res_psdf.empty)
-            self.assert_eq(res_psdf.columns, pd.Index(["self", "other"]))
-
-            self.assert_eq(
-                pser.compare(pser + 1).sort_index(), psser.compare(psser + 1).sort_index()
-            )
-
-            pser = pd.Series([1, 2], index=["x", "y"])
-            psser = ps.from_pandas(pser)
-            self.assert_eq(
-                pser.compare(pser + 1).sort_index(), psser.compare(psser + 1).sort_index()
-            )
-        else:
-            psser = ps.Series([1, 2])
-            res_psdf = psser.compare(psser)
-            self.assertTrue(res_psdf.empty)
-            self.assert_eq(res_psdf.columns, pd.Index(["self", "other"]))
-            expected = ps.DataFrame([[1, 2], [2, 3]], columns=["self", "other"])
-            self.assert_eq(expected, psser.compare(psser + 1).sort_index())
-
-            psser = ps.Series([1, 2], index=["x", "y"])
-            expected = ps.DataFrame([[1, 2], [2, 3]], index=["x", "y"], columns=["self", "other"])
-            self.assert_eq(expected, psser.compare(psser + 1).sort_index())
+        psser = ps.Series([1, 2], index=["x", "y"])
+        expected = ps.DataFrame([[1, 2], [2, 3]], index=["x", "y"], columns=["self", "other"])
+        self.assert_eq(expected, psser.compare(psser + 1).sort_index())
 
     def test_concat(self):
         pser1 = pd.Series([1, 2, 3], name="0")
@@ -292,27 +274,11 @@ class SeriesComputeMixin:
         pser = pd.Series(["a", "b", "c", "a"], dtype="category")
         psser = ps.from_pandas(pser)
 
-        if LooseVersion(pd.__version__) >= LooseVersion("1.3.0"):
-            self.assert_eq(psser.pop(0), pser.pop(0))
-            self.assert_eq(psser, pser)
+        self.assert_eq(psser.pop(0), pser.pop(0))
+        self.assert_eq(psser, pser)
 
-            self.assert_eq(psser.pop(3), pser.pop(3))
-            self.assert_eq(psser, pser)
-        else:
-            # Before pandas 1.3.0, `pop` modifies the dtype of categorical series wrongly.
-            self.assert_eq(psser.pop(0), "a")
-            self.assert_eq(
-                psser,
-                pd.Series(
-                    pd.Categorical(["b", "c", "a"], categories=["a", "b", "c"]), index=[1, 2, 3]
-                ),
-            )
-
-            self.assert_eq(psser.pop(3), "a")
-            self.assert_eq(
-                psser,
-                pd.Series(pd.Categorical(["b", "c"], categories=["a", "b", "c"]), index=[1, 2]),
-            )
+        self.assert_eq(psser.pop(3), pser.pop(3))
+        self.assert_eq(psser, pser)
 
     def test_duplicates(self):
         psers = {
@@ -343,14 +309,8 @@ class SeriesComputeMixin:
         self.assert_eq(psser1.truncate(after=5), pser1.truncate(after=5))
         self.assert_eq(psser1.truncate(copy=False), pser1.truncate(copy=False))
         self.assert_eq(psser1.truncate(2, 5, copy=False), pser1.truncate(2, 5, copy=False))
-        # The bug for these tests has been fixed in pandas 1.1.0.
-        if LooseVersion(pd.__version__) >= LooseVersion("1.1.0"):
-            self.assert_eq(psser2.truncate(4, 6), pser2.truncate(4, 6))
-            self.assert_eq(psser2.truncate(4, 6, copy=False), pser2.truncate(4, 6, copy=False))
-        else:
-            expected_psser = ps.Series([20, 30, 40], index=[6, 5, 4])
-            self.assert_eq(psser2.truncate(4, 6), expected_psser)
-            self.assert_eq(psser2.truncate(4, 6, copy=False), expected_psser)
+        self.assert_eq(psser2.truncate(4, 6), pser2.truncate(4, 6))
+        self.assert_eq(psser2.truncate(4, 6, copy=False), pser2.truncate(4, 6, copy=False))
 
         psser = ps.Series([10, 20, 30, 40, 50, 60, 70], index=[1, 2, 3, 4, 3, 2, 1])
         msg = "truncate requires a sorted index"
@@ -482,9 +442,6 @@ class SeriesComputeMixin:
         #
         # Deals with na_sentinel
         #
-        # pandas >= 1.1.2 support na_sentinel=None
-        #
-        pd_below_1_1_2 = LooseVersion(pd.__version__) < LooseVersion("1.1.2")
 
         pser = pd.Series(["a", "b", "a", np.nan, None])
         psser = ps.from_pandas(pser)
@@ -499,19 +456,18 @@ class SeriesComputeMixin:
         self.assert_eq(pcodes.tolist(), kcodes.to_list())
         self.assert_eq(puniques, kuniques)
 
-        if not pd_below_1_1_2:
-            pcodes, puniques = pser.factorize(sort=True, use_na_sentinel=None)
-            kcodes, kuniques = psser.factorize(use_na_sentinel=None)
-            self.assert_eq(pcodes.tolist(), kcodes.to_list())
-            # puniques is Index(['a', 'b', nan], dtype='object')
-            self.assert_eq(ps.Index(["a", "b", None]), kuniques)
+        pcodes, puniques = pser.factorize(sort=True, use_na_sentinel=None)
+        kcodes, kuniques = psser.factorize(use_na_sentinel=None)
+        self.assert_eq(pcodes.tolist(), kcodes.to_list())
+        # puniques is Index(['a', 'b', nan], dtype='object')
+        self.assert_eq(ps.Index(["a", "b", None]), kuniques)
 
-            psser = ps.Series([1, 2, np.nan, 4, 5])  # Arrow takes np.nan as null
-            psser.loc[3] = np.nan  # Spark takes np.nan as NaN
-            kcodes, kuniques = psser.factorize(use_na_sentinel=None)
-            pcodes, puniques = psser._to_pandas().factorize(sort=True, use_na_sentinel=None)
-            self.assert_eq(pcodes.tolist(), kcodes.to_list())
-            self.assert_eq(puniques, kuniques)
+        psser = ps.Series([1, 2, np.nan, 4, 5])  # Arrow takes np.nan as null
+        psser.loc[3] = np.nan  # Spark takes np.nan as NaN
+        kcodes, kuniques = psser.factorize(use_na_sentinel=None)
+        pcodes, puniques = psser._to_pandas().factorize(sort=True, use_na_sentinel=None)
+        self.assert_eq(pcodes.tolist(), kcodes.to_list())
+        self.assert_eq(puniques, kuniques)
 
     def test_explode(self):
         pser = pd.Series([[1, 2, 3], [], None, [3, 4]])

--- a/python/pyspark/pandas/tests/series/test_missing_data.py
+++ b/python/pyspark/pandas/tests/series/test_missing_data.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 #
 import unittest
-from distutils.version import LooseVersion
 
 import numpy as np
 import pandas as pd
@@ -211,42 +210,26 @@ class SeriesMissingDataMixin:
         psdf = ps.from_pandas(pdf)
         pser, psser = pdf.x, psdf.x
 
-        if LooseVersion(pd.__version__) >= LooseVersion("1.1"):
-            self.assert_eq(pser.pad(), psser.pad())
+        self.assert_eq(pser.pad(), psser.pad())
 
-            # Test `inplace=True`
-            pser.pad(inplace=True)
-            psser.pad(inplace=True)
-            self.assert_eq(pser, psser)
-            self.assert_eq(pdf, psdf)
-        else:
-            expected = ps.Series([np.nan, 2, 3, 4, 4, 6], name="x")
-            self.assert_eq(expected, psser.pad())
-
-            # Test `inplace=True`
-            psser.pad(inplace=True)
-            self.assert_eq(expected, psser)
+        # Test `inplace=True`
+        pser.pad(inplace=True)
+        psser.pad(inplace=True)
+        self.assert_eq(pser, psser)
+        self.assert_eq(pdf, psdf)
 
     def test_backfill(self):
         pdf = pd.DataFrame({"x": [np.nan, 2, 3, 4, np.nan, 6]})
         psdf = ps.from_pandas(pdf)
         pser, psser = pdf.x, psdf.x
 
-        if LooseVersion(pd.__version__) >= LooseVersion("1.1"):
-            self.assert_eq(pser.backfill(), psser.backfill())
+        self.assert_eq(pser.backfill(), psser.backfill())
 
-            # Test `inplace=True`
-            pser.backfill(inplace=True)
-            psser.backfill(inplace=True)
-            self.assert_eq(pser, psser)
-            self.assert_eq(pdf, psdf)
-        else:
-            expected = ps.Series([2.0, 2.0, 3.0, 4.0, 6.0, 6.0], name="x")
-            self.assert_eq(expected, psser.backfill())
-
-            # Test `inplace=True`
-            psser.backfill(inplace=True)
-            self.assert_eq(expected, psser)
+        # Test `inplace=True`
+        pser.backfill(inplace=True)
+        psser.backfill(inplace=True)
+        self.assert_eq(pser, psser)
+        self.assert_eq(pdf, psdf)
 
 
 class SeriesMissingDataTests(SeriesMissingDataMixin, ComparisonTestBase, SQLTestUtils):

--- a/python/pyspark/pandas/tests/series/test_series.py
+++ b/python/pyspark/pandas/tests/series/test_series.py
@@ -17,7 +17,6 @@
 
 import unittest
 from collections import defaultdict
-from distutils.version import LooseVersion
 import inspect
 
 from datetime import datetime, timedelta
@@ -94,11 +93,7 @@ class SeriesTestsMixin:
         self.assertEqual(s.__repr__(), s.rename("a").__repr__())
 
     def _check_extension(self, psser, pser):
-        if LooseVersion("1.1") <= LooseVersion(pd.__version__) < LooseVersion("1.2.2"):
-            self.assert_eq(psser, pser, check_exact=False)
-            self.assertTrue(isinstance(psser.dtype, extension_dtypes))
-        else:
-            self.assert_eq(psser, pser)
+        self.assert_eq(psser, pser)
 
     def test_empty_series(self):
         pser_a = pd.Series([], dtype="i1")
@@ -337,13 +332,7 @@ class SeriesTestsMixin:
         pser = pd.Series([None, 5, None, 3, 2, 1, None, 0, 0], name="a")
         psser = ps.from_pandas(pser)
 
-        if LooseVersion(pd.__version__) >= LooseVersion("1.2"):
-            self.assert_eq(psser.isin([1, 5, 0, None]), pser.isin([1, 5, 0, None]))
-        else:
-            expected = pd.Series(
-                [False, True, False, False, False, True, False, True, True], name="a"
-            )
-            self.assert_eq(psser.isin([1, 5, 0, None]), expected)
+        self.assert_eq(psser.isin([1, 5, 0, None]), pser.isin([1, 5, 0, None]))
 
     def test_notnull(self):
         pser = pd.Series([1, 2, 3, 4, np.nan, 6], name="x")
@@ -763,21 +752,13 @@ class SeriesTestsMixin:
 
         # other = list
         other = [np.nan, 1, 3, 4, np.nan, 6]
-        if LooseVersion(pd.__version__) >= LooseVersion("1.2"):
-            self.assert_eq(pser.eq(other), psser.eq(other).sort_index())
-            self.assert_eq(pser == other, (psser == other).sort_index())
-        else:
-            self.assert_eq(pser.eq(other).rename("x"), psser.eq(other).sort_index())
-            self.assert_eq((pser == other).rename("x"), (psser == other).sort_index())
+        self.assert_eq(pser.eq(other), psser.eq(other).sort_index())
+        self.assert_eq(pser == other, (psser == other).sort_index())
 
         # other = tuple
         other = (np.nan, 1, 3, 4, np.nan, 6)
-        if LooseVersion(pd.__version__) >= LooseVersion("1.2"):
-            self.assert_eq(pser.eq(other), psser.eq(other).sort_index())
-            self.assert_eq(pser == other, (psser == other).sort_index())
-        else:
-            self.assert_eq(pser.eq(other).rename("x"), psser.eq(other).sort_index())
-            self.assert_eq((pser == other).rename("x"), (psser == other).sort_index())
+        self.assert_eq(pser.eq(other), psser.eq(other).sort_index())
+        self.assert_eq(pser == other, (psser == other).sort_index())
 
         # other = list with the different length
         other = [np.nan, 1, 3, 4, np.nan]

--- a/python/pyspark/pandas/tests/series/test_stat.py
+++ b/python/pyspark/pandas/tests/series/test_stat.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 #
 import unittest
-from distutils.version import LooseVersion
 
 import numpy as np
 import pandas as pd
@@ -474,12 +473,7 @@ class SeriesStatMixin:
 
         pser.name = "x"
         psser = ps.from_pandas(pser)
-        if LooseVersion(pd.__version__) < LooseVersion("1.4"):
-            # Due to pandas bug: https://github.com/pandas-dev/pandas/issues/46737
-            psser.name = None
-            self.assert_eq(psser.mode(), pser.mode())
-        else:
-            self.assert_eq(psser.mode(), pser.mode())
+        self.assert_eq(psser.mode(), pser.mode())
         self.assert_eq(
             psser.mode(dropna=False).sort_values().reset_index(drop=True),
             pser.mode(dropna=False).sort_values().reset_index(drop=True),

--- a/python/pyspark/pandas/tests/test_categorical.py
+++ b/python/pyspark/pandas/tests/test_categorical.py
@@ -15,9 +15,6 @@
 # limitations under the License.
 #
 
-import unittest
-from distutils.version import LooseVersion
-
 import numpy as np
 import pandas as pd
 from pandas.api.types import CategoricalDtype
@@ -184,17 +181,10 @@ class CategoricalTestsMixin:
 
         self.assert_eq(pscser.astype("category"), pcser.astype("category"))
 
-        # CategoricalDtype is not updated if the dtype is same from pandas 1.3.
-        if LooseVersion(pd.__version__) >= LooseVersion("1.3"):
-            self.assert_eq(
-                pscser.astype(CategoricalDtype(["b", "c", "a"])),
-                pcser.astype(CategoricalDtype(["b", "c", "a"])),
-            )
-        else:
-            self.assert_eq(
-                pscser.astype(CategoricalDtype(["b", "c", "a"])),
-                pcser,
-            )
+        self.assert_eq(
+            pscser.astype(CategoricalDtype(["b", "c", "a"])),
+            pcser.astype(CategoricalDtype(["b", "c", "a"])),
+        )
 
         self.assert_eq(pscser.astype(str), pcser.astype(str))
 
@@ -385,28 +375,15 @@ class CategoricalTestsMixin:
         )
 
         dtype = CategoricalDtype(categories=["a", "b", "c", "d"])
-
-        # The behavior for CategoricalDtype is changed from pandas 1.3
-        if LooseVersion(pd.__version__) >= LooseVersion("1.3"):
-            ret_dtype = pdf.b.dtype
-        else:
-            ret_dtype = dtype
+        ret_dtype = pdf.b.dtype
 
         def astype(x) -> ps.Series[ret_dtype]:
             return x.astype(dtype)
 
-        if LooseVersion(pd.__version__) >= LooseVersion("1.2"):
-            self.assert_eq(
-                psdf.groupby("a").transform(astype).sort_values("b").reset_index(drop=True),
-                pdf.groupby("a").transform(astype).sort_values("b").reset_index(drop=True),
-            )
-        else:
-            expected = pdf.groupby("a").transform(astype)
-            expected["b"] = dtype.categories.take(expected["b"].cat.codes).astype(dtype)
-            self.assert_eq(
-                psdf.groupby("a").transform(astype).sort_values("b").reset_index(drop=True),
-                expected.sort_values("b").reset_index(drop=True),
-            )
+        self.assert_eq(
+            psdf.groupby("a").transform(astype).sort_values("b").reset_index(drop=True),
+            pdf.groupby("a").transform(astype).sort_values("b").reset_index(drop=True),
+        )
 
     def test_frame_apply_batch(self):
         pdf, psdf = self.df_pair

--- a/python/pyspark/pandas/tests/test_expanding.py
+++ b/python/pyspark/pandas/tests/test_expanding.py
@@ -15,8 +15,6 @@
 # limitations under the License.
 #
 
-from distutils.version import LooseVersion
-
 import numpy as np
 import pandas as pd
 
@@ -133,33 +131,18 @@ class ExpandingTestsMixin:
         pdf = pd.DataFrame({"a": [1.0, 2.0, 3.0, 2.0], "b": [4.0, 2.0, 3.0, 1.0]})
         psdf = ps.from_pandas(pdf)
 
-        # The behavior of GroupBy.expanding is changed from pandas 1.3.
-        if LooseVersion(pd.__version__) >= LooseVersion("1.3"):
-            self.assert_eq(
-                ps_func(psdf.groupby(psdf.a).expanding(2)).sort_index(),
-                pd_func(pdf.groupby(pdf.a).expanding(2)).sort_index(),
-            )
-            self.assert_eq(
-                ps_func(psdf.groupby(psdf.a).expanding(2)).sum(),
-                pd_func(pdf.groupby(pdf.a).expanding(2)).sum(),
-            )
-            self.assert_eq(
-                ps_func(psdf.groupby(psdf.a + 1).expanding(2)).sort_index(),
-                pd_func(pdf.groupby(pdf.a + 1).expanding(2)).sort_index(),
-            )
-        else:
-            self.assert_eq(
-                ps_func(psdf.groupby(psdf.a).expanding(2)).sort_index(),
-                pd_func(pdf.groupby(pdf.a).expanding(2)).drop("a", axis=1).sort_index(),
-            )
-            self.assert_eq(
-                ps_func(psdf.groupby(psdf.a).expanding(2)).sum(),
-                pd_func(pdf.groupby(pdf.a).expanding(2)).sum().drop("a"),
-            )
-            self.assert_eq(
-                ps_func(psdf.groupby(psdf.a + 1).expanding(2)).sort_index(),
-                pd_func(pdf.groupby(pdf.a + 1).expanding(2)).drop("a", axis=1).sort_index(),
-            )
+        self.assert_eq(
+            ps_func(psdf.groupby(psdf.a).expanding(2)).sort_index(),
+            pd_func(pdf.groupby(pdf.a).expanding(2)).sort_index(),
+        )
+        self.assert_eq(
+            ps_func(psdf.groupby(psdf.a).expanding(2)).sum(),
+            pd_func(pdf.groupby(pdf.a).expanding(2)).sum(),
+        )
+        self.assert_eq(
+            ps_func(psdf.groupby(psdf.a + 1).expanding(2)).sort_index(),
+            pd_func(pdf.groupby(pdf.a + 1).expanding(2)).sort_index(),
+        )
 
         self.assert_eq(
             ps_func(psdf.b.groupby(psdf.a).expanding(2)).sort_index(),
@@ -179,29 +162,15 @@ class ExpandingTestsMixin:
         pdf.columns = columns
         psdf.columns = columns
 
-        # The behavior of GroupBy.expanding is changed from pandas 1.3.
-        if LooseVersion(pd.__version__) >= LooseVersion("1.3"):
-            self.assert_eq(
-                ps_func(psdf.groupby(("a", "x")).expanding(2)).sort_index(),
-                pd_func(pdf.groupby(("a", "x")).expanding(2)).sort_index(),
-            )
+        self.assert_eq(
+            ps_func(psdf.groupby(("a", "x")).expanding(2)).sort_index(),
+            pd_func(pdf.groupby(("a", "x")).expanding(2)).sort_index(),
+        )
 
-            self.assert_eq(
-                ps_func(psdf.groupby([("a", "x"), ("a", "y")]).expanding(2)).sort_index(),
-                pd_func(pdf.groupby([("a", "x"), ("a", "y")]).expanding(2)).sort_index(),
-            )
-        else:
-            self.assert_eq(
-                ps_func(psdf.groupby(("a", "x")).expanding(2)).sort_index(),
-                pd_func(pdf.groupby(("a", "x")).expanding(2)).drop(("a", "x"), axis=1).sort_index(),
-            )
-
-            self.assert_eq(
-                ps_func(psdf.groupby([("a", "x"), ("a", "y")]).expanding(2)).sort_index(),
-                pd_func(pdf.groupby([("a", "x"), ("a", "y")]).expanding(2))
-                .drop([("a", "x"), ("a", "y")], axis=1)
-                .sort_index(),
-            )
+        self.assert_eq(
+            ps_func(psdf.groupby([("a", "x"), ("a", "y")]).expanding(2)).sort_index(),
+            pd_func(pdf.groupby([("a", "x"), ("a", "y")]).expanding(2)).sort_index(),
+        )
 
     def test_groupby_expanding_count(self):
         self._test_groupby_expanding_func("count")

--- a/python/pyspark/pandas/tests/test_indexing.py
+++ b/python/pyspark/pandas/tests/test_indexing.py
@@ -228,7 +228,6 @@ class IndexingTest(ComparisonTestBase):
         self.assert_eq(psdf.at[9, 1], pdf.at[9, 1])
 
     def test_at_multiindex(self):
-        pdf = self.pdf.set_index("b", append=True)
         psdf = self.psdf.set_index("b", append=True)
 
         self.assert_eq(psdf.at[(3, 6), "a"], 3)

--- a/python/pyspark/pandas/tests/test_indexing.py
+++ b/python/pyspark/pandas/tests/test_indexing.py
@@ -16,7 +16,6 @@
 #
 
 import datetime
-from distutils.version import LooseVersion
 import unittest
 
 import numpy as np
@@ -232,17 +231,10 @@ class IndexingTest(ComparisonTestBase):
         pdf = self.pdf.set_index("b", append=True)
         psdf = self.psdf.set_index("b", append=True)
 
-        # TODO: seems like a pandas' bug in pandas>=1.1.0
-        if LooseVersion(pd.__version__) < LooseVersion("1.1.0"):
-            self.assert_eq(psdf.at[(3, 6), "a"], pdf.at[(3, 6), "a"])
-            self.assert_eq(psdf.at[(3,), "a"], pdf.at[(3,), "a"])
-            self.assert_eq(list(psdf.at[(9, 0), "a"]), list(pdf.at[(9, 0), "a"]))
-            self.assert_eq(list(psdf.at[(9,), "a"]), list(pdf.at[(9,), "a"]))
-        else:
-            self.assert_eq(psdf.at[(3, 6), "a"], 3)
-            self.assert_eq(psdf.at[(3,), "a"], np.array([3]))
-            self.assert_eq(list(psdf.at[(9, 0), "a"]), [7, 8, 9])
-            self.assert_eq(list(psdf.at[(9,), "a"]), [7, 8, 9])
+        self.assert_eq(psdf.at[(3, 6), "a"], 3)
+        self.assert_eq(psdf.at[(3,), "a"], np.array([3]))
+        self.assert_eq(list(psdf.at[(9, 0), "a"]), [7, 8, 9])
+        self.assert_eq(list(psdf.at[(9,), "a"]), [7, 8, 9])
 
         with self.assertRaises(ValueError):
             psdf.at[3, "a"]

--- a/python/pyspark/pandas/tests/test_namespace.py
+++ b/python/pyspark/pandas/tests/test_namespace.py
@@ -15,10 +15,8 @@
 # limitations under the License.
 #
 
-from distutils.version import LooseVersion
 import itertools
 import inspect
-import unittest
 
 import pandas as pd
 import numpy as np
@@ -320,9 +318,7 @@ class NamespaceTestsMixin:
 
         ignore_indexes = [True, False]
         joins = ["inner", "outer"]
-        sorts = [True]
-        if LooseVersion(pd.__version__) >= LooseVersion("1.4"):
-            sorts += [False]
+        sorts = [True, False]
         objs = [
             ([psdf, psdf.reset_index()], [pdf, pdf.reset_index()]),
             ([psdf.reset_index(), psdf], [pdf.reset_index(), pdf]),
@@ -356,21 +352,19 @@ class NamespaceTestsMixin:
             ([psdf["C"], psdf["A"]], [pdf["C"], pdf["A"]]),
         ]
 
-        # See also https://github.com/pandas-dev/pandas/issues/47127
-        if LooseVersion(pd.__version__) >= LooseVersion("1.4.3"):
-            series_objs = [
-                # more than two Series
-                ([psdf, psdf["C"], psdf["A"]], [pdf, pdf["C"], pdf["A"]]),
-                # only one Series
-                ([psdf, psdf["C"]], [pdf, pdf["C"]]),
-                ([psdf["C"], psdf], [pdf["C"], pdf]),
-            ]
-            for psdfs, pdfs in series_objs:
-                for ignore_index, join, sort in itertools.product(ignore_indexes, joins, sorts):
-                    self.assert_eq(
-                        ps.concat(psdfs, ignore_index=ignore_index, join=join, sort=sort),
-                        pd.concat(pdfs, ignore_index=ignore_index, join=join, sort=sort),
-                    )
+        series_objs = [
+            # more than two Series
+            ([psdf, psdf["C"], psdf["A"]], [pdf, pdf["C"], pdf["A"]]),
+            # only one Series
+            ([psdf, psdf["C"]], [pdf, pdf["C"]]),
+            ([psdf["C"], psdf], [pdf["C"], pdf]),
+        ]
+        for psdfs, pdfs in series_objs:
+            for ignore_index, join, sort in itertools.product(ignore_indexes, joins, sorts):
+                self.assert_eq(
+                    ps.concat(psdfs, ignore_index=ignore_index, join=join, sort=sort),
+                    pd.concat(pdfs, ignore_index=ignore_index, join=join, sort=sort),
+                )
 
         for ignore_index, join, sort in itertools.product(ignore_indexes, joins, sorts):
             for i, (psdfs, pdfs) in enumerate(objs):
@@ -409,11 +403,10 @@ class NamespaceTestsMixin:
             ([psdf3, psdf3[[("Y", "C"), ("X", "A")]]], [pdf3, pdf3[[("Y", "C"), ("X", "A")]]]),
         ]
 
-        if LooseVersion(pd.__version__) >= LooseVersion("1.4"):
-            objs += [
-                ([psdf3.reset_index(), psdf3], [pdf3.reset_index(), pdf3]),
-                ([psdf3[[("Y", "C"), ("X", "A")]], psdf3], [pdf3[[("Y", "C"), ("X", "A")]], pdf3]),
-            ]
+        objs += [
+            ([psdf3.reset_index(), psdf3], [pdf3.reset_index(), pdf3]),
+            ([psdf3[[("Y", "C"), ("X", "A")]], psdf3], [pdf3[[("Y", "C"), ("X", "A")]], pdf3]),
+        ]
 
         for ignore_index, sort in itertools.product(ignore_indexes, sorts):
             for i, (psdfs, pdfs) in enumerate(objs):

--- a/python/pyspark/pandas/tests/test_ops_on_diff_frames.py
+++ b/python/pyspark/pandas/tests/test_ops_on_diff_frames.py
@@ -201,32 +201,22 @@ class OpsOnDiffFramesEnabledTestsMixin:
         psdf1 = ps.from_pandas(pdf1)
         psdf2 = ps.from_pandas(pdf2)
 
-        def assert_eq(actual, expected):
-            if LooseVersion("1.1") <= LooseVersion(pd.__version__) < LooseVersion("1.2.2"):
-                self.assert_eq(actual, expected, check_exact=not check_extension)
-                if check_extension:
-                    if isinstance(actual, DataFrame):
-                        for dtype in actual.dtypes:
-                            self.assertTrue(isinstance(dtype, extension_dtypes))
-                    else:
-                        self.assertTrue(isinstance(actual.dtype, extension_dtypes))
-            else:
-                self.assert_eq(actual, expected)
-
         # Series
-        assert_eq((psdf1.a - psdf2.b).sort_index(), (pdf1.a - pdf2.b).sort_index())
+        self.assert_eq((psdf1.a - psdf2.b).sort_index(), (pdf1.a - pdf2.b).sort_index())
 
-        assert_eq((psdf1.a * psdf2.a).sort_index(), (pdf1.a * pdf2.a).sort_index())
+        self.assert_eq((psdf1.a * psdf2.a).sort_index(), (pdf1.a * pdf2.a).sort_index())
 
         if check_extension and not extension_float_dtypes_available:
             self.assert_eq(
                 (psdf1["a"] / psdf2["a"]).sort_index(), (pdf1["a"] / pdf2["a"]).sort_index()
             )
         else:
-            assert_eq((psdf1["a"] / psdf2["a"]).sort_index(), (pdf1["a"] / pdf2["a"]).sort_index())
+            self.assert_eq(
+                (psdf1["a"] / psdf2["a"]).sort_index(), (pdf1["a"] / pdf2["a"]).sort_index()
+            )
 
         # DataFrame
-        assert_eq((psdf1 + psdf2).sort_index(), (pdf1 + pdf2).sort_index())
+        self.assert_eq((psdf1 + psdf2).sort_index(), (pdf1 + pdf2).sort_index())
 
         # Multi-index columns
         columns = pd.MultiIndex.from_tuples([("x", "a"), ("x", "b")])
@@ -236,47 +226,39 @@ class OpsOnDiffFramesEnabledTestsMixin:
         pdf2.columns = columns
 
         # Series
-        assert_eq(
+        self.assert_eq(
             (psdf1[("x", "a")] - psdf2[("x", "b")]).sort_index(),
             (pdf1[("x", "a")] - pdf2[("x", "b")]).sort_index(),
         )
 
-        assert_eq(
+        self.assert_eq(
             (psdf1[("x", "a")] - psdf2["x"]["b"]).sort_index(),
             (pdf1[("x", "a")] - pdf2["x"]["b"]).sort_index(),
         )
 
-        assert_eq(
+        self.assert_eq(
             (psdf1["x"]["a"] - psdf2[("x", "b")]).sort_index(),
             (pdf1["x"]["a"] - pdf2[("x", "b")]).sort_index(),
         )
 
         # DataFrame
-        assert_eq((psdf1 + psdf2).sort_index(), (pdf1 + pdf2).sort_index())
+        self.assert_eq((psdf1 + psdf2).sort_index(), (pdf1 + pdf2).sort_index())
 
     def _test_arithmetic_series(self, pser1, pser2, *, check_extension):
         psser1 = ps.from_pandas(pser1)
         psser2 = ps.from_pandas(pser2)
 
-        def assert_eq(actual, expected):
-            if LooseVersion("1.1") <= LooseVersion(pd.__version__) < LooseVersion("1.2.2"):
-                self.assert_eq(actual, expected, check_exact=not check_extension)
-                if check_extension:
-                    self.assertTrue(isinstance(actual.dtype, extension_dtypes))
-            else:
-                self.assert_eq(actual, expected)
-
         # MultiIndex Series
-        assert_eq((psser1 + psser2).sort_index(), (pser1 + pser2).sort_index())
+        self.assert_eq((psser1 + psser2).sort_index(), (pser1 + pser2).sort_index())
 
-        assert_eq((psser1 - psser2).sort_index(), (pser1 - pser2).sort_index())
+        self.assert_eq((psser1 - psser2).sort_index(), (pser1 - pser2).sort_index())
 
-        assert_eq((psser1 * psser2).sort_index(), (pser1 * pser2).sort_index())
+        self.assert_eq((psser1 * psser2).sort_index(), (pser1 * pser2).sort_index())
 
         if check_extension and not extension_float_dtypes_available:
             self.assert_eq((psser1 / psser2).sort_index(), (pser1 / pser2).sort_index())
         else:
-            assert_eq((psser1 / psser2).sort_index(), (pser1 / pser2).sort_index())
+            self.assert_eq((psser1 / psser2).sort_index(), (pser1 / pser2).sort_index())
 
     def test_arithmetic_chain(self):
         self._test_arithmetic_chain_frame(self.pdf1, self.pdf2, self.pdf3, check_extension=False)
@@ -321,29 +303,12 @@ class OpsOnDiffFramesEnabledTestsMixin:
         psdf2 = ps.from_pandas(pdf2)
         psdf3 = ps.from_pandas(pdf3)
 
-        common_columns = set(psdf1.columns).intersection(psdf2.columns).intersection(psdf3.columns)
-
-        def assert_eq(actual, expected):
-            if LooseVersion("1.1") <= LooseVersion(pd.__version__) < LooseVersion("1.2.2"):
-                self.assert_eq(actual, expected, check_exact=not check_extension)
-                if check_extension:
-                    if isinstance(actual, DataFrame):
-                        for column, dtype in zip(actual.columns, actual.dtypes):
-                            if column in common_columns:
-                                self.assertTrue(isinstance(dtype, extension_dtypes))
-                            else:
-                                self.assertFalse(isinstance(dtype, extension_dtypes))
-                    else:
-                        self.assertTrue(isinstance(actual.dtype, extension_dtypes))
-            else:
-                self.assert_eq(actual, expected)
-
         # Series
-        assert_eq(
+        self.assert_eq(
             (psdf1.a - psdf2.b - psdf3.c).sort_index(), (pdf1.a - pdf2.b - pdf3.c).sort_index()
         )
 
-        assert_eq(
+        self.assert_eq(
             (psdf1.a * (psdf2.a * psdf3.c)).sort_index(), (pdf1.a * (pdf2.a * pdf3.c)).sort_index()
         )
 
@@ -353,18 +318,13 @@ class OpsOnDiffFramesEnabledTestsMixin:
                 (pdf1["a"] / pdf2["a"] / pdf3["c"]).sort_index(),
             )
         else:
-            assert_eq(
+            self.assert_eq(
                 (psdf1["a"] / psdf2["a"] / psdf3["c"]).sort_index(),
                 (pdf1["a"] / pdf2["a"] / pdf3["c"]).sort_index(),
             )
 
         # DataFrame
-        if check_extension and LooseVersion(pd.__version__) < LooseVersion("1.1"):
-            self.assert_eq(
-                (psdf1 + psdf2 - psdf3).sort_index(), (pdf1 + pdf2 - pdf3).sort_index(), almost=True
-            )
-        else:
-            assert_eq((psdf1 + psdf2 - psdf3).sort_index(), (pdf1 + pdf2 - pdf3).sort_index())
+        self.assert_eq((psdf1 + psdf2 - psdf3).sort_index(), (pdf1 + pdf2 - pdf3).sort_index())
 
         # Multi-index columns
         columns = pd.MultiIndex.from_tuples([("x", "a"), ("x", "b")])
@@ -376,53 +336,46 @@ class OpsOnDiffFramesEnabledTestsMixin:
         psdf3.columns = columns
         pdf3.columns = columns
 
-        common_columns = set(psdf1.columns).intersection(psdf2.columns).intersection(psdf3.columns)
-
         # Series
-        assert_eq(
+        self.assert_eq(
             (psdf1[("x", "a")] - psdf2[("x", "b")] - psdf3[("y", "c")]).sort_index(),
             (pdf1[("x", "a")] - pdf2[("x", "b")] - pdf3[("y", "c")]).sort_index(),
         )
 
-        assert_eq(
+        self.assert_eq(
             (psdf1[("x", "a")] * (psdf2[("x", "b")] * psdf3[("y", "c")])).sort_index(),
             (pdf1[("x", "a")] * (pdf2[("x", "b")] * pdf3[("y", "c")])).sort_index(),
         )
 
         # DataFrame
-        if check_extension and LooseVersion(pd.__version__) < LooseVersion("1.1"):
-            self.assert_eq(
-                (psdf1 + psdf2 - psdf3).sort_index(), (pdf1 + pdf2 - pdf3).sort_index(), almost=True
-            )
-        else:
-            assert_eq((psdf1 + psdf2 - psdf3).sort_index(), (pdf1 + pdf2 - pdf3).sort_index())
+        self.assert_eq((psdf1 + psdf2 - psdf3).sort_index(), (pdf1 + pdf2 - pdf3).sort_index())
 
     def _test_arithmetic_chain_series(self, pser1, pser2, pser3, *, check_extension):
         psser1 = ps.from_pandas(pser1)
         psser2 = ps.from_pandas(pser2)
         psser3 = ps.from_pandas(pser3)
 
-        def assert_eq(actual, expected):
-            if LooseVersion("1.1") <= LooseVersion(pd.__version__) < LooseVersion("1.2.2"):
-                self.assert_eq(actual, expected, check_exact=not check_extension)
-                if check_extension:
-                    self.assertTrue(isinstance(actual.dtype, extension_dtypes))
-            else:
-                self.assert_eq(actual, expected)
-
         # MultiIndex Series
-        assert_eq((psser1 + psser2 - psser3).sort_index(), (pser1 + pser2 - pser3).sort_index())
+        self.assert_eq(
+            (psser1 + psser2 - psser3).sort_index(), (pser1 + pser2 - pser3).sort_index()
+        )
 
-        assert_eq((psser1 * psser2 * psser3).sort_index(), (pser1 * pser2 * pser3).sort_index())
+        self.assert_eq(
+            (psser1 * psser2 * psser3).sort_index(), (pser1 * pser2 * pser3).sort_index()
+        )
 
         if check_extension and not extension_float_dtypes_available:
             self.assert_eq(
                 (psser1 - psser2 / psser3).sort_index(), (pser1 - pser2 / pser3).sort_index()
             )
         else:
-            assert_eq((psser1 - psser2 / psser3).sort_index(), (pser1 - pser2 / pser3).sort_index())
+            self.assert_eq(
+                (psser1 - psser2 / psser3).sort_index(), (pser1 - pser2 / pser3).sort_index()
+            )
 
-        assert_eq((psser1 + psser2 * psser3).sort_index(), (pser1 + pser2 * pser3).sort_index())
+        self.assert_eq(
+            (psser1 + psser2 * psser3).sort_index(), (pser1 + pser2 * pser3).sort_index()
+        )
 
     def test_mod(self):
         pser = pd.Series([100, None, -300, None, 500, -700])
@@ -509,13 +462,6 @@ class OpsOnDiffFramesEnabledTestsMixin:
         not extension_object_dtypes_available, "pandas extension object dtypes are not available"
     )
     def test_bitwise_extension_dtype(self):
-        def assert_eq(actual, expected):
-            if LooseVersion("1.1") <= LooseVersion(pd.__version__) < LooseVersion("1.2.2"):
-                self.assert_eq(actual, expected, check_exact=False)
-                self.assertTrue(isinstance(actual.dtype, extension_dtypes))
-            else:
-                self.assert_eq(actual, expected)
-
         pser1 = pd.Series(
             [True, False, True, False, np.nan, np.nan, True, False, np.nan], dtype="boolean"
         )
@@ -525,8 +471,8 @@ class OpsOnDiffFramesEnabledTestsMixin:
         psser1 = ps.from_pandas(pser1)
         psser2 = ps.from_pandas(pser2)
 
-        assert_eq((psser1 | psser2).sort_index(), pser1 | pser2)
-        assert_eq((psser1 & psser2).sort_index(), pser1 & pser2)
+        self.assert_eq((psser1 | psser2).sort_index(), pser1 | pser2)
+        self.assert_eq((psser1 & psser2).sort_index(), pser1 & pser2)
 
         pser1 = pd.Series([True, False, np.nan], index=list("ABC"), dtype="boolean")
         pser2 = pd.Series([False, True, np.nan], index=list("DEF"), dtype="boolean")
@@ -536,11 +482,11 @@ class OpsOnDiffFramesEnabledTestsMixin:
         # a pandas bug?
         # assert_eq((psser1 | psser2).sort_index(), pser1 | pser2)
         # assert_eq((psser1 & psser2).sort_index(), pser1 & pser2)
-        assert_eq(
+        self.assert_eq(
             (psser1 | psser2).sort_index(),
             pd.Series([True, None, None, None, True, None], index=list("ABCDEF"), dtype="boolean"),
         )
-        assert_eq(
+        self.assert_eq(
             (psser1 & psser2).sort_index(),
             pd.Series(
                 [None, False, None, False, None, None], index=list("ABCDEF"), dtype="boolean"
@@ -660,29 +606,14 @@ class OpsOnDiffFramesEnabledTestsMixin:
         pdf2 = pd.DataFrame({"C": [3, 3], "B": [1, 1]})
         psdf2 = ps.from_pandas(pdf2)
 
-        if LooseVersion(pd.__version__) >= LooseVersion("1.2.0"):
-            self.assert_eq(pdf1.combine_first(pdf2), psdf1.combine_first(psdf2).sort_index())
-        else:
-            # pandas < 1.2.0 returns unexpected dtypes,
-            # please refer to https://github.com/pandas-dev/pandas/issues/28481 for details
-            expected_pdf = pd.DataFrame({"A": [None, 0], "B": [4.0, 1.0], "C": [3, 3]})
-            self.assert_eq(expected_pdf, psdf1.combine_first(psdf2).sort_index())
+        self.assert_eq(pdf1.combine_first(pdf2), psdf1.combine_first(psdf2).sort_index())
 
         pdf1.columns = pd.MultiIndex.from_tuples([("A", "willow"), ("B", "pine")])
         psdf1 = ps.from_pandas(pdf1)
         pdf2.columns = pd.MultiIndex.from_tuples([("C", "oak"), ("B", "pine")])
         psdf2 = ps.from_pandas(pdf2)
 
-        if LooseVersion(pd.__version__) >= LooseVersion("1.2.0"):
-            self.assert_eq(pdf1.combine_first(pdf2), psdf1.combine_first(psdf2).sort_index())
-        else:
-            # pandas < 1.2.0 returns unexpected dtypes,
-            # please refer to https://github.com/pandas-dev/pandas/issues/28481 for details
-            expected_pdf = pd.DataFrame({"A": [None, 0], "B": [4.0, 1.0], "C": [3, 3]})
-            expected_pdf.columns = pd.MultiIndex.from_tuples(
-                [("A", "willow"), ("B", "pine"), ("C", "oak")]
-            )
-            self.assert_eq(expected_pdf, psdf1.combine_first(psdf2).sort_index())
+        self.assert_eq(pdf1.combine_first(pdf2), psdf1.combine_first(psdf2).sort_index())
 
     def test_insert(self):
         #
@@ -727,152 +658,60 @@ class OpsOnDiffFramesEnabledTestsMixin:
         self.assert_eq(psdf.sort_index(), pdf.sort_index())
 
     def test_compare(self):
-        if LooseVersion(pd.__version__) >= LooseVersion("1.1"):
-            pser1 = pd.Series(["b", "c", np.nan, "g", np.nan])
-            pser2 = pd.Series(["a", "c", np.nan, np.nan, "h"])
-            psser1 = ps.from_pandas(pser1)
-            psser2 = ps.from_pandas(pser2)
-            self.assert_eq(
-                pser1.compare(pser2).sort_index(),
-                psser1.compare(psser2).sort_index(),
-            )
+        pser1 = pd.Series(["b", "c", np.nan, "g", np.nan])
+        pser2 = pd.Series(["a", "c", np.nan, np.nan, "h"])
+        psser1 = ps.from_pandas(pser1)
+        psser2 = ps.from_pandas(pser2)
+        self.assert_eq(
+            pser1.compare(pser2).sort_index(),
+            psser1.compare(psser2).sort_index(),
+        )
 
-            # `keep_shape=True`
-            self.assert_eq(
-                pser1.compare(pser2, keep_shape=True).sort_index(),
-                psser1.compare(psser2, keep_shape=True).sort_index(),
-            )
-            # `keep_equal=True`
-            self.assert_eq(
-                pser1.compare(pser2, keep_equal=True).sort_index(),
-                psser1.compare(psser2, keep_equal=True).sort_index(),
-            )
-            # `keep_shape=True` and `keep_equal=True`
-            self.assert_eq(
-                pser1.compare(pser2, keep_shape=True, keep_equal=True).sort_index(),
-                psser1.compare(psser2, keep_shape=True, keep_equal=True).sort_index(),
-            )
+        # `keep_shape=True`
+        self.assert_eq(
+            pser1.compare(pser2, keep_shape=True).sort_index(),
+            psser1.compare(psser2, keep_shape=True).sort_index(),
+        )
+        # `keep_equal=True`
+        self.assert_eq(
+            pser1.compare(pser2, keep_equal=True).sort_index(),
+            psser1.compare(psser2, keep_equal=True).sort_index(),
+        )
+        # `keep_shape=True` and `keep_equal=True`
+        self.assert_eq(
+            pser1.compare(pser2, keep_shape=True, keep_equal=True).sort_index(),
+            psser1.compare(psser2, keep_shape=True, keep_equal=True).sort_index(),
+        )
 
-            # MultiIndex
-            pser1.index = pd.MultiIndex.from_tuples(
-                [("a", "x"), ("b", "y"), ("c", "z"), ("x", "k"), ("q", "l")]
-            )
-            pser2.index = pd.MultiIndex.from_tuples(
-                [("a", "x"), ("b", "y"), ("c", "z"), ("x", "k"), ("q", "l")]
-            )
-            psser1 = ps.from_pandas(pser1)
-            psser2 = ps.from_pandas(pser2)
-            self.assert_eq(
-                pser1.compare(pser2).sort_index(),
-                psser1.compare(psser2).sort_index(),
-            )
+        # MultiIndex
+        pser1.index = pd.MultiIndex.from_tuples(
+            [("a", "x"), ("b", "y"), ("c", "z"), ("x", "k"), ("q", "l")]
+        )
+        pser2.index = pd.MultiIndex.from_tuples(
+            [("a", "x"), ("b", "y"), ("c", "z"), ("x", "k"), ("q", "l")]
+        )
+        psser1 = ps.from_pandas(pser1)
+        psser2 = ps.from_pandas(pser2)
+        self.assert_eq(
+            pser1.compare(pser2).sort_index(),
+            psser1.compare(psser2).sort_index(),
+        )
 
-            # `keep_shape=True` with MultiIndex
-            self.assert_eq(
-                pser1.compare(pser2, keep_shape=True).sort_index(),
-                psser1.compare(psser2, keep_shape=True).sort_index(),
-            )
-            # `keep_equal=True` with MultiIndex
-            self.assert_eq(
-                pser1.compare(pser2, keep_equal=True).sort_index(),
-                psser1.compare(psser2, keep_equal=True).sort_index(),
-            )
-            # `keep_shape=True` and `keep_equal=True` with MultiIndex
-            self.assert_eq(
-                pser1.compare(pser2, keep_shape=True, keep_equal=True).sort_index(),
-                psser1.compare(psser2, keep_shape=True, keep_equal=True).sort_index(),
-            )
-        else:
-            psser1 = ps.Series(["b", "c", np.nan, "g", np.nan])
-            psser2 = ps.Series(["a", "c", np.nan, np.nan, "h"])
-            expected = ps.DataFrame(
-                [["b", "a"], ["g", None], [None, "h"]], index=[0, 3, 4], columns=["self", "other"]
-            )
-            self.assert_eq(expected, psser1.compare(psser2).sort_index())
-
-            # `keep_shape=True`
-            expected = ps.DataFrame(
-                [["b", "a"], [None, None], [None, None], ["g", None], [None, "h"]],
-                index=[0, 1, 2, 3, 4],
-                columns=["self", "other"],
-            )
-            self.assert_eq(
-                expected,
-                psser1.compare(psser2, keep_shape=True).sort_index(),
-            )
-            # `keep_equal=True`
-            expected = ps.DataFrame(
-                [["b", "a"], ["g", None], [None, "h"]], index=[0, 3, 4], columns=["self", "other"]
-            )
-            self.assert_eq(
-                expected,
-                psser1.compare(psser2, keep_equal=True).sort_index(),
-            )
-            # `keep_shape=True` and `keep_equal=True`
-            expected = ps.DataFrame(
-                [["b", "a"], ["c", "c"], [None, None], ["g", None], [None, "h"]],
-                index=[0, 1, 2, 3, 4],
-                columns=["self", "other"],
-            )
-            self.assert_eq(
-                expected,
-                psser1.compare(psser2, keep_shape=True, keep_equal=True).sort_index(),
-            )
-
-            # MultiIndex
-            psser1 = ps.Series(
-                ["b", "c", np.nan, "g", np.nan],
-                index=pd.MultiIndex.from_tuples(
-                    [("a", "x"), ("b", "y"), ("c", "z"), ("x", "k"), ("q", "l")]
-                ),
-            )
-            psser2 = ps.Series(
-                ["a", "c", np.nan, np.nan, "h"],
-                index=pd.MultiIndex.from_tuples(
-                    [("a", "x"), ("b", "y"), ("c", "z"), ("x", "k"), ("q", "l")]
-                ),
-            )
-            expected = ps.DataFrame(
-                [["b", "a"], [None, "h"], ["g", None]],
-                index=pd.MultiIndex.from_tuples([("a", "x"), ("q", "l"), ("x", "k")]),
-                columns=["self", "other"],
-            )
-            self.assert_eq(expected, psser1.compare(psser2).sort_index())
-
-            # `keep_shape=True`
-            expected = ps.DataFrame(
-                [["b", "a"], [None, None], [None, None], [None, "h"], ["g", None]],
-                index=pd.MultiIndex.from_tuples(
-                    [("a", "x"), ("b", "y"), ("c", "z"), ("q", "l"), ("x", "k")]
-                ),
-                columns=["self", "other"],
-            )
-            self.assert_eq(
-                expected,
-                psser1.compare(psser2, keep_shape=True).sort_index(),
-            )
-            # `keep_equal=True`
-            expected = ps.DataFrame(
-                [["b", "a"], [None, "h"], ["g", None]],
-                index=pd.MultiIndex.from_tuples([("a", "x"), ("q", "l"), ("x", "k")]),
-                columns=["self", "other"],
-            )
-            self.assert_eq(
-                expected,
-                psser1.compare(psser2, keep_equal=True).sort_index(),
-            )
-            # `keep_shape=True` and `keep_equal=True`
-            expected = ps.DataFrame(
-                [["b", "a"], ["c", "c"], [None, None], [None, "h"], ["g", None]],
-                index=pd.MultiIndex.from_tuples(
-                    [("a", "x"), ("b", "y"), ("c", "z"), ("q", "l"), ("x", "k")]
-                ),
-                columns=["self", "other"],
-            )
-            self.assert_eq(
-                expected,
-                psser1.compare(psser2, keep_shape=True, keep_equal=True).sort_index(),
-            )
+        # `keep_shape=True` with MultiIndex
+        self.assert_eq(
+            pser1.compare(pser2, keep_shape=True).sort_index(),
+            psser1.compare(psser2, keep_shape=True).sort_index(),
+        )
+        # `keep_equal=True` with MultiIndex
+        self.assert_eq(
+            pser1.compare(pser2, keep_equal=True).sort_index(),
+            psser1.compare(psser2, keep_equal=True).sort_index(),
+        )
+        # `keep_shape=True` and `keep_equal=True` with MultiIndex
+        self.assert_eq(
+            pser1.compare(pser2, keep_shape=True, keep_equal=True).sort_index(),
+            psser1.compare(psser2, keep_shape=True, keep_equal=True).sort_index(),
+        )
 
         # Different Index
         with self.assertRaisesRegex(

--- a/python/pyspark/pandas/tests/test_ops_on_diff_frames_groupby_expanding.py
+++ b/python/pyspark/pandas/tests/test_ops_on_diff_frames_groupby_expanding.py
@@ -15,8 +15,6 @@
 # limitations under the License.
 #
 
-from distutils.version import LooseVersion
-
 import pandas as pd
 
 from pyspark import pandas as ps
@@ -51,17 +49,10 @@ class OpsOnDiffFramesGroupByExpandingTestsMixin:
         psdf = ps.from_pandas(pdf)
         kkey = ps.from_pandas(pkey)
 
-        # The behavior of GroupBy.expanding is changed from pandas 1.3.
-        if LooseVersion(pd.__version__) >= LooseVersion("1.3"):
-            self.assert_eq(
-                getattr(psdf.groupby(kkey).expanding(2), f)().sort_index(),
-                getattr(pdf.groupby(pkey).expanding(2), f)().sort_index(),
-            )
-        else:
-            self.assert_eq(
-                getattr(psdf.groupby(kkey).expanding(2), f)().sort_index(),
-                getattr(pdf.groupby(pkey).expanding(2), f)().drop("a", axis=1).sort_index(),
-            )
+        self.assert_eq(
+            getattr(psdf.groupby(kkey).expanding(2), f)().sort_index(),
+            getattr(pdf.groupby(pkey).expanding(2), f)().sort_index(),
+        )
 
         self.assert_eq(
             getattr(psdf.groupby(kkey)["b"].expanding(2), f)().sort_index(),

--- a/python/pyspark/pandas/tests/test_ops_on_diff_frames_groupby_rolling.py
+++ b/python/pyspark/pandas/tests/test_ops_on_diff_frames_groupby_rolling.py
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import unittest
-from distutils.version import LooseVersion
 
 import pandas as pd
 
@@ -51,17 +49,10 @@ class OpsOnDiffFramesGroupByRollingTestsMixin:
         psdf = ps.from_pandas(pdf)
         kkey = ps.from_pandas(pkey)
 
-        # The behavior of GroupBy.rolling is changed from pandas 1.3.
-        if LooseVersion(pd.__version__) >= LooseVersion("1.3"):
-            self.assert_eq(
-                getattr(psdf.groupby(kkey).rolling(2), f)().sort_index(),
-                getattr(pdf.groupby(pkey).rolling(2), f)().sort_index(),
-            )
-        else:
-            self.assert_eq(
-                getattr(psdf.groupby(kkey).rolling(2), f)().sort_index(),
-                getattr(pdf.groupby(pkey).rolling(2), f)().drop("a", axis=1).sort_index(),
-            )
+        self.assert_eq(
+            getattr(psdf.groupby(kkey).rolling(2), f)().sort_index(),
+            getattr(pdf.groupby(pkey).rolling(2), f)().sort_index(),
+        )
 
         self.assert_eq(
             getattr(psdf.groupby(kkey)["b"].rolling(2), f)().sort_index(),

--- a/python/pyspark/pandas/tests/test_reshape.py
+++ b/python/pyspark/pandas/tests/test_reshape.py
@@ -17,7 +17,6 @@
 
 import datetime
 from decimal import Decimal
-from distutils.version import LooseVersion
 
 import numpy as np
 import pandas as pd
@@ -312,32 +311,16 @@ class ReshapeTestsMixin:
                 .reset_index(drop=True)
             ),
         )
-        if LooseVersion(pd.__version__) >= LooseVersion("1.3"):
-            self.assert_eq(
-                pd.merge_asof(
-                    pdf_left.set_index("a"), pdf_right, left_index=True, right_on="a"
-                ).sort_index(),
-                ps.merge_asof(
-                    psdf_left.set_index("a"), psdf_right, left_index=True, right_on="a"
-                ).sort_index(),
-            )
-        else:
-            expected = pd.DataFrame(
-                {
-                    "b_x": ["x", "y", "z"],
-                    "left_val": ["a", "b", "c"],
-                    "a": [1, 3, 7],
-                    "b_y": ["v", "x", "z"],
-                    "right_val": [1, 3, 7],
-                },
-                index=pd.Index([1, 5, 10], name="a"),
-            )
-            self.assert_eq(
-                expected,
-                ps.merge_asof(
-                    psdf_left.set_index("a"), psdf_right, left_index=True, right_on="a"
-                ).sort_index(),
-            )
+
+        self.assert_eq(
+            pd.merge_asof(
+                pdf_left.set_index("a"), pdf_right, left_index=True, right_on="a"
+            ).sort_index(),
+            ps.merge_asof(
+                psdf_left.set_index("a"), psdf_right, left_index=True, right_on="a"
+            ).sort_index(),
+        )
+
         self.assert_eq(
             pd.merge_asof(
                 pdf_left, pdf_right.set_index("a"), left_on="a", right_index=True

--- a/python/pyspark/sql/pandas/utils.py
+++ b/python/pyspark/sql/pandas/utils.py
@@ -19,7 +19,7 @@
 def require_minimum_pandas_version() -> None:
     """Raise ImportError if minimum version of Pandas is not installed"""
     # TODO(HyukjinKwon): Relocate and deduplicate the version specification.
-    minimum_pandas_version = "1.0.5"
+    minimum_pandas_version = "1.4.4"
 
     from distutils.version import LooseVersion
 

--- a/python/pyspark/testing/pandasutils.py
+++ b/python/pyspark/testing/pandasutils.py
@@ -20,9 +20,8 @@ import shutil
 import tempfile
 import warnings
 from contextlib import contextmanager
-from distutils.version import LooseVersion
 import decimal
-from typing import Any, Union, TYPE_CHECKING
+from typing import Any, Union
 
 import pyspark.pandas as ps
 from pyspark.pandas.frame import DataFrame
@@ -77,18 +76,7 @@ def _assert_pandas_equal(
 
     if isinstance(left, pd.DataFrame) and isinstance(right, pd.DataFrame):
         try:
-            if LooseVersion(pd.__version__) >= LooseVersion("1.1"):
-                kwargs = dict(check_freq=False)
-            else:
-                kwargs = dict()
-
-            if LooseVersion(pd.__version__) < LooseVersion("1.1.1"):
-                # Due to https://github.com/pandas-dev/pandas/issues/35446
-                checkExact = (
-                    checkExact
-                    and all([is_numeric_dtype(dtype) for dtype in left.dtypes])
-                    and all([is_numeric_dtype(dtype) for dtype in right.dtypes])
-                )
+            kwargs = dict(check_freq=False)
 
             assert_frame_equal(
                 left,
@@ -110,15 +98,7 @@ def _assert_pandas_equal(
             )
     elif isinstance(left, pd.Series) and isinstance(right, pd.Series):
         try:
-            if LooseVersion(pd.__version__) >= LooseVersion("1.1"):
-                kwargs = dict(check_freq=False)
-            else:
-                kwargs = dict()
-            if LooseVersion(pd.__version__) < LooseVersion("1.1.1"):
-                # Due to https://github.com/pandas-dev/pandas/issues/35446
-                checkExact = (
-                    checkExact and is_numeric_dtype(left.dtype) and is_numeric_dtype(right.dtype)
-                )
+            kwargs = dict(check_freq=False)
             assert_series_equal(
                 left,
                 right,
@@ -138,11 +118,6 @@ def _assert_pandas_equal(
             )
     elif isinstance(left, pd.Index) and isinstance(right, pd.Index):
         try:
-            if LooseVersion(pd.__version__) < LooseVersion("1.1.1"):
-                # Due to https://github.com/pandas-dev/pandas/issues/35446
-                checkExact = (
-                    checkExact and is_numeric_dtype(left.dtype) and is_numeric_dtype(right.dtype)
-                )
             assert_index_equal(left, right, check_exact=checkExact)
         except AssertionError:
             raise PySparkAssertionError(

--- a/python/setup.py
+++ b/python/setup.py
@@ -130,7 +130,7 @@ if in_spark:
 # For Arrow, you should also check ./pom.xml and ensure there are no breaking changes in the
 # binary format protocol with the Java version, see ARROW_HOME/format/* for specifications.
 # Also don't forget to update python/docs/source/getting_started/install.rst.
-_minimum_pandas_version = "1.0.5"
+_minimum_pandas_version = "1.4.4"
 _minimum_pyarrow_version = "4.0.0"
 _minimum_grpc_version = "1.56.0"
 _minimum_googleapis_common_protos_version = "1.56.4"


### PR DESCRIPTION
### What changes were proposed in this pull request?
Increate Pandas minimum version to 1.4.4


### Why are the changes needed?


pandas 1.0.5 was released 3 year ago, and the latest version is 2.1.0.

[1.4.4](https://pandas.pydata.org/docs/whatsnew/v1.4.4.html#) was released at August 31, 2022, and it is the last maintenance release in 1.4.


1.4.4 should be a fine choice.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
