### PR TITLE
[SPARK-45172][BUILD] Upgrade `commons-compress` to 1.24.0

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -40,7 +40,7 @@ commons-codec/1.16.0//commons-codec-1.16.0.jar
 commons-collections/3.2.2//commons-collections-3.2.2.jar
 commons-collections4/4.4//commons-collections4-4.4.jar
 commons-compiler/3.1.9//commons-compiler-3.1.9.jar
-commons-compress/1.23.0//commons-compress-1.23.0.jar
+commons-compress/1.24.0//commons-compress-1.24.0.jar
 commons-crypto/1.1.0//commons-crypto-1.1.0.jar
 commons-dbcp/1.4//commons-dbcp-1.4.jar
 commons-io/2.13.0//commons-io-2.13.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -191,7 +191,7 @@
     <snappy.version>1.1.10.3</snappy.version>
     <netlib.ludovic.dev.version>3.0.3</netlib.ludovic.dev.version>
     <commons-codec.version>1.16.0</commons-codec.version>
-    <commons-compress.version>1.23.0</commons-compress.version>
+    <commons-compress.version>1.24.0</commons-compress.version>
     <commons-io.version>2.13.0</commons-io.version>
     <!-- org.apache.commons/commons-lang/-->
     <commons-lang2.version>2.6</commons-lang2.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to uppgrade commons-compress.version from 1.23.0 to 1.24.0.

### Why are the changes needed?

There are a bit of micro optimizations, better error messages, etc.

See https://github.com/apache/commons-compress/compare/rel/commons-compress-1.23.0%E2%80%A6rel/commons-compress-1.24.0

### Does this PR introduce _any_ user-facing change?

Virtually, no.

### How was this patch tested?

CI in this PR.

### Was this patch authored or co-authored using generative AI tooling?

No.
