### PR TITLE
[SPARK-45174][CORE] Support `spark.deploy.maxDrivers`

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/Deploy.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/Deploy.scala
@@ -76,10 +76,10 @@ private[spark] object Deploy {
     .createWithDefault(Int.MaxValue)
 
   val MAX_DRIVERS = ConfigBuilder("spark.deploy.maxDrivers")
-    .doc("The maximum number of drivers.")
+    .doc("The maximum number of running drivers.")
     .version("4.0.0")
     .intConf
-    .checkValue(_ > 0, "The maximum number of drivers should be positive.")
+    .checkValue(_ > 0, "The maximum number of running drivers should be positive.")
     .createWithDefault(Int.MaxValue)
 
 }

--- a/core/src/main/scala/org/apache/spark/internal/config/Deploy.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/Deploy.scala
@@ -75,5 +75,11 @@ private[spark] object Deploy {
     .intConf
     .createWithDefault(Int.MaxValue)
 
+  val MAX_DRIVERS = ConfigBuilder("spark.deploy.maxDrivers")
+    .doc("The maximum number of drivers.")
+    .version("4.0.0")
+    .intConf
+    .checkValue(_ > 0, "The maximum number of drivers should be positive.")
+    .createWithDefault(Int.MaxValue)
 
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support a new configuration, `spark.deploy.maxDrivers`, like the existing `spark.mesos.maxDrivers`.

### Why are the changes needed?

To limit the maximum number of running drivers.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs with the newly added test case.

### Was this patch authored or co-authored using generative AI tooling?

No.