### PR TITLE
[SPARK-45167][CONNECT][PYTHON][FOLLOW-UP] Use lighter threading Rlock, and use the existing eventually util function

### DIFF
--- a/python/pyspark/sql/connect/client/reattach.py
+++ b/python/pyspark/sql/connect/client/reattach.py
@@ -18,12 +18,11 @@ from pyspark.sql.connect.utils import check_dependencies
 
 check_dependencies(__name__)
 
+from threading import RLock
 import warnings
 import uuid
 from collections.abc import Generator
 from typing import Optional, Dict, Any, Iterator, Iterable, Tuple, Callable, cast, Type, ClassVar
-from multiprocessing import RLock
-from multiprocessing.synchronize import RLock as RLockBase
 from multiprocessing.pool import ThreadPool
 import os
 
@@ -56,7 +55,7 @@ class ExecutePlanResponseReattachableIterator(Generator):
     """
 
     # Lock to manage the pool
-    _lock: ClassVar[RLockBase] = RLock()
+    _lock: ClassVar[RLock] = RLock()
     _release_thread_pool: Optional[ThreadPool] = ThreadPool(os.cpu_count() if os.cpu_count() else 8)
 
     @classmethod


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/42929 that:
- Use lighter threading `Rlock` instead of multithreading `Rlock`. Multiprocessing does not work with PySpark due to the ser/de problem for socket connections, and many others.
- Use the existing eventually util function `pyspark.testing.eventually` instead of `assertEventually` to deduplicate code.

### Why are the changes needed?

Mainly for code clean-up.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests should pass them.

### Was this patch authored or co-authored using generative AI tooling?

No.