### PR TITLE
[SPARK-43979][SQL][FOLLOWUP] Handle non alias-only project case

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -1134,7 +1134,7 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
   def simplifyPlanForCollectedMetrics(plan: LogicalPlan): LogicalPlan = {
     plan.resolveOperators {
       case p: Project if p.projectList.size == p.child.output.size =>
-        var assignExprIdOnly = p.projectList.zipWithIndex.forall {
+        val assignExprIdOnly = p.projectList.zipWithIndex.forall {
           case (Alias(attr: AttributeReference, _), index) =>
             // The input plan of this method is already canonicalized. The attribute id becomes the
             // ordinal of this attribute in the child outputs. So an alias-only Project means the

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -1131,15 +1131,17 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
    * remove extra project which only re-assign expr ids from the plan so that we can identify exact
    * duplicates metric definition.
    */
-  private def simplifyPlanForCollectedMetrics(plan: LogicalPlan): LogicalPlan = {
+  def simplifyPlanForCollectedMetrics(plan: LogicalPlan): LogicalPlan = {
     plan.resolveOperators {
       case p: Project if p.projectList.size == p.child.output.size =>
-        val assignExprIdOnly = p.projectList.zipWithIndex.forall {
+        var assignExprIdOnly = p.projectList.zipWithIndex.forall {
           case (Alias(attr: AttributeReference, _), index) =>
             // The input plan of this method is already canonicalized. The attribute id becomes the
             // ordinal of this attribute in the child outputs. So an alias-only Project means the
             // the id of the aliased attribute is the same as its index in the project list.
             attr.exprId.id == index
+          case (left: AttributeReference, index) =>
+            left.exprId.id == index
           case _ => false
         }
         if (assignExprIdOnly) {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
@@ -1677,18 +1677,16 @@ class AnalysisSuite extends AnalysisTest with Matchers {
   }
 
   test("simplifyPlanForCollectedMetrics should handle non alias-only project case") {
-    val alias1 = Alias(testRelation2.output(0), "a")()
-    val alias2 = Alias(testRelation2.output(2), "c")()
     val inner = Project(
       Seq(
-        alias1,
+        Alias(testRelation2.output(0), "a")(),
         testRelation2.output(1),
-        alias2,
+        Alias(testRelation2.output(2), "c")(),
         testRelation2.output(3),
-        testRelation2.output(4),
+        testRelation2.output(4)
       ),
       testRelation2)
-    val actual_plan = getAnalyzer.simplifyPlanForCollectedMetrics(inner.canonicalized)
-    assert(actual_plan == testRelation2.canonicalized)
+    val actualPlan = getAnalyzer.simplifyPlanForCollectedMetrics(inner.canonicalized)
+    assert(actualPlan == testRelation2.canonicalized)
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
@@ -1675,4 +1675,20 @@ class AnalysisSuite extends AnalysisTest with Matchers {
       checkAnalysis(ident2.select($"a"), testRelation.select($"a").analyze)
     }
   }
+
+  test("simplifyPlanForCollectedMetrics should handle non alias-only project case") {
+    val alias1 = Alias(testRelation2.output(0), "a")()
+    val alias2 = Alias(testRelation2.output(2), "c")()
+    val inner = Project(
+      Seq(
+        alias1,
+        testRelation2.output(1),
+        alias2,
+        testRelation2.output(3),
+        testRelation2.output(4),
+      ),
+      testRelation2)
+    val actual_plan = getAnalyzer.simplifyPlanForCollectedMetrics(inner.canonicalized)
+    assert(actual_plan == testRelation2.canonicalized)
+  }
 }


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
`simplifyPlanForCollectedMetrics ` still could need to handle non alias-only project case where the project contains a mixed of aliases and attributes. In such case `simplifyPlanForCollectedMetrics` should also drop the extra project for the plan check when it contains CollectedMetrics.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Improve `simplifyPlanForCollectedMetrics` so it handles more plan pattern.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
NO

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
UT

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
NO