### PR TITLE
[SPARK-44788][PYTHON][DOCS][FOLLOW-UP] Add from_xml and schema_of_xml into PySpark documentation

### DIFF
--- a/python/docs/source/reference/pyspark.sql/functions.rst
+++ b/python/docs/source/reference/pyspark.sql/functions.rst
@@ -264,6 +264,8 @@ Collection Functions
     str_to_map
     to_csv
     try_element_at
+    from_xml
+    schema_of_xml
 
 
 Partition Transformation Functions


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds `from_xml` and `schema_of_xml` into PySpark documentation

### Why are the changes needed?

For users to know how to use them.

### Does this PR introduce _any_ user-facing change?

Yes, It adds both `from_xml` and `schema_of_xml` into Python documentation

### How was this patch tested?

Manually tested.

### Was this patch authored or co-authored using generative AI tooling?

No.