### PR TITLE
[SPARK-45056][CONNECT][TESTS][FOLLOWUP] Change the tests related to Python in `SparkConnectSessionHodlerSuite` to assume shouldTestPandasUDFs

### DIFF
--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectSessionHodlerSuite.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectSessionHodlerSuite.scala
@@ -170,7 +170,7 @@ class SparkConnectSessionHolderSuite extends SharedSparkSession {
 
   test("python foreachBatch process: process terminates after query is stopped") {
     // scalastyle:off assume
-    assume(IntegratedUDFTestUtils.shouldTestPythonUDFs)
+    assume(IntegratedUDFTestUtils.shouldTestPandasUDFs)
     // scalastyle:on assume
 
     val sessionHolder = SessionHolder.forTesting(spark)
@@ -237,7 +237,7 @@ class SparkConnectSessionHolderSuite extends SharedSparkSession {
 
   test("python listener process: process terminates after listener is removed") {
     // scalastyle:off assume
-    assume(IntegratedUDFTestUtils.shouldTestPythonUDFs)
+    assume(IntegratedUDFTestUtils.shouldTestPandasUDFs)
     // scalastyle:on assume
 
     val sessionHolder = SessionHolder.forTesting(spark)


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr changes the assume condition of two Python related test cases in the 'SparkConnectSessionHodgerSuite' from `assume(IntegratedUDFTestUtils.shouldTestPythonUDFs)` to `assume(IntegratedUDFTestUtils.shouldTestPandasUDFs)`. These two test cases are: 
- `python foreachBatch process: process terminates after query is stopped`
- `python listener process: process terminates after listener is removed`


### Why are the changes needed?
Maven daily test failed due to not installing Pandas:

```
Traceback (most recent call last):
  File "/home/runner/work/spark/spark/python/pyspark/sql/pandas/utils.py", line 27, in require_minimum_pandas_version
    import pandas
ModuleNotFoundError: No module named 'pandas'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/runner/work/spark/spark/python/pyspark/sql/connect/streaming/worker/foreach_batch_worker.py", line 86, in <module>
    main(sock_file, sock_file)
  File "/home/runner/work/spark/spark/python/pyspark/sql/connect/streaming/worker/foreach_batch_worker.py", line 51, in main
    spark_connect_session = SparkSession.builder.remote(connect_url).getOrCreate()
  File "/home/runner/work/spark/spark/python/pyspark/sql/session.py", line 464, in getOrCreate
    from pyspark.sql.connect.session import SparkSession as RemoteSparkSession
  File "/home/runner/work/spark/spark/python/pyspark/sql/connect/session.py", line 19, in <module>
    check_dependencies(__name__)
  File "/home/runner/work/spark/spark/python/pyspark/sql/connect/utils.py", line 33, in check_dependencies
    require_minimum_pandas_version()
  File "/home/runner/work/spark/spark/python/pyspark/sql/pandas/utils.py", line 34, in require_minimum_pandas_version
    raise ImportError(
ImportError: Pandas >= 1.4.4 must be installed; however, it was not found.
- python foreachBatch process: process terminates after query is stopped *** FAILED ***
  java.io.EOFException:
  at java.io.DataInputStream.readInt(DataInputStream.java:392)
  at org.apache.spark.api.python.StreamingPythonRunner.init(StreamingPythonRunner.scala:101)
  at org.apache.spark.sql.connect.planner.StreamingForeachBatchHelper$.pythonForeachBatchWrapper(StreamingForeachBatchHelper.scala:112)
  at org.apache.spark.sql.connect.service.SparkConnectSessionHolderSuite.$anonfun$new$7(SparkConnectSessionHodlerSuite.scala:182)
  at org.scalatest.enablers.Timed$$anon$1.timeoutAfter(Timed.scala:127)
  at org.scalatest.concurrent.TimeLimits$.failAfterImpl(TimeLimits.scala:282)
  at org.scalatest.concurrent.TimeLimits.failAfter(TimeLimits.scala:231)
  at org.scalatest.concurrent.TimeLimits.failAfter$(TimeLimits.scala:230)
  at org.apache.spark.SparkFunSuite.failAfter(SparkFunSuite.scala:69)
  at org.apache.spark.SparkFunSuite.$anonfun$test$2(SparkFunSuite.scala:155)
  ...
Streaming query listener worker is starting with url sc://localhost:15002/;user_id=testUser and sessionId ccb42571-f971-4fdb-a7f8-091b04bff4a7.
Traceback (most recent call last):
  File "/home/runner/work/spark/spark/python/pyspark/sql/pandas/utils.py", line 27, in require_minimum_pandas_version
    import pandas
ModuleNotFoundError: No module named 'pandas'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/runner/work/spark/spark/python/pyspark/sql/connect/streaming/worker/listener_worker.py", line 99, in <module>
    main(sock_file, sock_file)
  File "/home/runner/work/spark/spark/python/pyspark/sql/connect/streaming/worker/listener_worker.py", line 59, in main
    spark_connect_session = SparkSession.builder.remote(connect_url).getOrCreate()
  File "/home/runner/work/spark/spark/python/pyspark/sql/session.py", line 464, in getOrCreate
    from pyspark.sql.connect.session import SparkSession as RemoteSparkSession
  File "/home/runner/work/spark/spark/python/pyspark/sql/connect/session.py", line 19, in <module>
    check_dependencies(__name__)
  File "/home/runner/work/spark/spark/python/pyspark/sql/connect/utils.py", line 33, in check_dependencies
    require_minimum_pandas_version()
  File "/home/runner/work/spark/spark/python/pyspark/sql/pandas/utils.py", line 34, in require_minimum_pandas_version
    raise ImportError(
ImportError: Pandas >= 1.4.4 must be installed; however, it was not found.
- python listener process: process terminates after listener is removed *** FAILED ***
  java.io.EOFException:
  at java.io.DataInputStream.readInt(DataInputStream.java:392)
  at org.apache.spark.api.python.StreamingPythonRunner.init(StreamingPythonRunner.scala:101)
  at org.apache.spark.sql.connect.planner.PythonStreamingQueryListener.<init>(StreamingQueryListenerHelper.scala:41)
  at org.apache.spark.sql.connect.service.SparkConnectSessionHolderSuite.$anonfun$new$12(SparkConnectSessionHodlerSuite.scala:251)
  at org.scalatest.enablers.Timed$$anon$1.timeoutAfter(Timed.scala:127)
  at org.scalatest.concurrent.TimeLimits$.failAfterImpl(TimeLimits.scala:282)
  at org.scalatest.concurrent.TimeLimits.failAfter(TimeLimits.scala:231)
  at org.scalatest.concurrent.TimeLimits.failAfter$(TimeLimits.scala:230)
  at org.apache.spark.SparkFunSuite.failAfter(SparkFunSuite.scala:69)
  at org.apache.spark.SparkFunSuite.$anonfun$test$2(SparkFunSuite.scala:155)
  ...
```
 
### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Monitor Maven daily test .


### Was this patch authored or co-authored using generative AI tooling?
No
