### PR TITLE
[SPARK-44788][PYTHON][DOCS][FOLLOW-UP] Move `from_xml`/`schema_of_xml` to `Xml Functions`

### DIFF
--- a/python/docs/source/reference/pyspark.sql/functions.rst
+++ b/python/docs/source/reference/pyspark.sql/functions.rst
@@ -264,8 +264,6 @@ Collection Functions
     str_to_map
     to_csv
     try_element_at
-    from_xml
-    schema_of_xml
 
 
 Partition Transformation Functions
@@ -531,6 +529,8 @@ Xml Functions
 .. autosummary::
     :toctree: api/
 
+    from_xml
+    schema_of_xml
     xpath
     xpath_boolean
     xpath_double


### PR DESCRIPTION
### What changes were proposed in this pull request?
Move `from_xml`/`schema_of_xml` to `Xml Functions`

### Why are the changes needed?
there is a dedicated function group for xml functions


### Does this PR introduce _any_ user-facing change?
yes


### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no
