### PR TITLE
[SPARK-45199][SQL] Release cast from attribute in filter to support predicate push down

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -92,6 +92,7 @@ abstract class Optimizer(catalogManager: CatalogManager)
         EliminateOffsets,
         EliminateLimits,
         CombineUnions,
+        SimplifyCasts,
         // Constant folding and strength reduction
         OptimizeRepartition,
         TransposeWindow,
@@ -115,7 +116,6 @@ abstract class Optimizer(catalogManager: CatalogManager)
         SimplifyBinaryComparison,
         ReplaceNullWithFalseInPredicate,
         PruneFilters,
-        SimplifyCasts,
         SimplifyCaseConversionExpressions,
         RewriteCorrelatedScalarSubquery,
         RewriteLateralSubquery,


### PR DESCRIPTION
### What changes were proposed in this pull request?
When a `cast clause` was used in a column in a filter, it will not be able to push down. We can remove the cast from attribute side to support predicate push down if the cast not change the precision or range.


### Why are the changes needed?
To use more predicate push down in query. For example:
```sql
-- dt is string type
explain select * from wechar_tbl where cast(dt as date) = date_sub(current_date(), 1);
```
- Before this patch
```bash
== Physical Plan ==
*(1) ColumnarToRow
+- FileScan parquet default.wechar_tbl[id#5,name#6,dt#7] Batched: true, DataFilters: [], Format: Parquet, Location: InMemoryFileIndex(0 paths)[], PartitionFilters: [isnotnull(dt#7), (cast(dt#7 as date) = 2023-09-17)], PushedFilters: [], ReadSchema: struct<id:int,name:string>
```
**(cast(dt#7 as date) = 2023-09-17) can not be push down in partition filter**
- After this patch
```bash
== Physical Plan ==
*(1) ColumnarToRow
+- FileScan parquet default.wechar_tbl[id#62,name#63,dt#64] Batched: true, DataFilters: [], Format: Parquet, Location: InMemoryFileIndex[], PartitionFilters: [isnotnull(dt#64), (dt#64 = 2023-09-17)], PushedFilters: [], ReadSchema: struct<id:int,name:string>
```
**(dt#64 = 2023-09-17) can be push down in partition filter**

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Add unit test.


### Was this patch authored or co-authored using generative AI tooling?
No.
