### PR TITLE
[SPARK-45204][CONNECT] Extend CommandPlugins to be trackable

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/plugin/CommandPluginWithQueryPlanningTracker.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/plugin/CommandPluginWithQueryPlanningTracker.scala
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connect.plugin
+
+import com.google.protobuf
+
+import org.apache.spark.sql.catalyst.QueryPlanningTracker
+import org.apache.spark.sql.connect.planner.SparkConnectPlanner
+
+/**
+ * Behavior trait for supporting a trackable extension mechanisms for the Spark Connect planner.
+ *
+ * Classes implementing the trait must be trivially constructable and should not rely on internal
+ * state. Every registered extension will be passed the Any instance. If the plugin supports
+ * handling this type it is responsible of constructing the logical expression from this object
+ * and if necessary traverse it's children.
+ */
+trait CommandPluginWithQueryPlanningTracker extends CommandPlugin {
+  def process(
+      command: protobuf.Any,
+      planner: SparkConnectPlanner,
+      tracker: QueryPlanningTracker): Option[Unit]
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
Adding a `CommandPluginWithQueryPlanningTracker` interface which extends the already existing `CommandPlugin` interface with a `process()` method that one can pass a `QueryPlanningTracker` to.

### Why are the changes needed?
There is currently no way to track queries executed by a `CommandPlugin`.


### Does this PR introduce _any_ user-facing change?
Users now can also write trackable plugins by implementing the `CommandPluginWithQueryPlanningTracker`. Since this extends the `CommandPlugin` interface such plugins are also backward-compatible to older versions of spark only knowing the `CommandPlugin` interface.


### How was this patch tested?
Test added.


### Was this patch authored or co-authored using generative AI tooling?
No
