### PR TITLE
[SPARK-45207][SQL][CONNECT] Implement Error Enrichment for Scala Client

### DIFF
--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/streaming/ClientStreamingQuerySuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/streaming/ClientStreamingQuerySuite.scala
@@ -200,10 +200,12 @@ class ClientStreamingQuerySuite extends QueryTest with SQLHelper with Logging {
       query.awaitTermination()
     }
 
+    assert(exception.getCause.isInstanceOf[SparkException])
+    assert(exception.getCause.getCause.isInstanceOf[SparkException])
+    assert(exception.getCause.getCause.getCause.isInstanceOf[SparkException])
     assert(
       exception.getCause.getCause.getCause.getMessage
-        .contains("Exception received from Spark Connect on server java.lang.RuntimeException: " +
-          "Number 2 encountered!"))
+        .contains("java.lang.RuntimeException: Number 2 encountered!"))
   }
 
   test("foreach Row") {

--- a/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/client/CustomSparkConnectBlockingStub.scala
+++ b/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/client/CustomSparkConnectBlockingStub.scala
@@ -34,10 +34,14 @@ private[connect] class CustomSparkConnectBlockingStub(
   private val grpcExceptionConverter = new GrpcExceptionConverter(stub)
 
   def executePlan(request: ExecutePlanRequest): CloseableIterator[ExecutePlanResponse] = {
-    grpcExceptionConverter.convert(request.getSessionId, request.getUserContext) {
+    grpcExceptionConverter.convert(
+      request.getSessionId,
+      request.getUserContext,
+      request.getClientType) {
       grpcExceptionConverter.convertIterator[ExecutePlanResponse](
         request.getSessionId,
         request.getUserContext,
+        request.getClientType,
         retryHandler.RetryIterator[ExecutePlanRequest, ExecutePlanResponse](
           request,
           r => CloseableIterator(stub.executePlan(r).asScala)))
@@ -46,17 +50,24 @@ private[connect] class CustomSparkConnectBlockingStub(
 
   def executePlanReattachable(
       request: ExecutePlanRequest): CloseableIterator[ExecutePlanResponse] = {
-    grpcExceptionConverter.convert(request.getSessionId, request.getUserContext) {
+    grpcExceptionConverter.convert(
+      request.getSessionId,
+      request.getUserContext,
+      request.getClientType) {
       grpcExceptionConverter.convertIterator[ExecutePlanResponse](
         request.getSessionId,
         request.getUserContext,
+        request.getClientType,
         // Don't use retryHandler - own retry handling is inside.
         new ExecutePlanResponseReattachableIterator(request, channel, retryPolicy))
     }
   }
 
   def analyzePlan(request: AnalyzePlanRequest): AnalyzePlanResponse = {
-    grpcExceptionConverter.convert(request.getSessionId, request.getUserContext) {
+    grpcExceptionConverter.convert(
+      request.getSessionId,
+      request.getUserContext,
+      request.getClientType) {
       retryHandler.retry {
         stub.analyzePlan(request)
       }
@@ -64,7 +75,10 @@ private[connect] class CustomSparkConnectBlockingStub(
   }
 
   def config(request: ConfigRequest): ConfigResponse = {
-    grpcExceptionConverter.convert(request.getSessionId, request.getUserContext) {
+    grpcExceptionConverter.convert(
+      request.getSessionId,
+      request.getUserContext,
+      request.getClientType) {
       retryHandler.retry {
         stub.config(request)
       }
@@ -72,7 +86,10 @@ private[connect] class CustomSparkConnectBlockingStub(
   }
 
   def interrupt(request: InterruptRequest): InterruptResponse = {
-    grpcExceptionConverter.convert(request.getSessionId, request.getUserContext) {
+    grpcExceptionConverter.convert(
+      request.getSessionId,
+      request.getUserContext,
+      request.getClientType) {
       retryHandler.retry {
         stub.interrupt(request)
       }
@@ -80,7 +97,10 @@ private[connect] class CustomSparkConnectBlockingStub(
   }
 
   def artifactStatus(request: ArtifactStatusesRequest): ArtifactStatusesResponse = {
-    grpcExceptionConverter.convert(request.getSessionId, request.getUserContext) {
+    grpcExceptionConverter.convert(
+      request.getSessionId,
+      request.getUserContext,
+      request.getClientType) {
       retryHandler.retry {
         stub.artifactStatus(request)
       }

--- a/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/client/CustomSparkConnectBlockingStub.scala
+++ b/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/client/CustomSparkConnectBlockingStub.scala
@@ -30,7 +30,7 @@ private[connect] class CustomSparkConnectBlockingStub(
 
   private val retryHandler = new GrpcRetryHandler(retryPolicy)
 
-  // Constructing GrpcExceptionConverter with a GRPC stub for fetching error details from server.
+  // GrpcExceptionConverter with a GRPC stub for fetching error details from server.
   private val grpcExceptionConverter = new GrpcExceptionConverter(stub)
 
   def executePlan(request: ExecutePlanRequest): CloseableIterator[ExecutePlanResponse] = {

--- a/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/client/GrpcExceptionConverter.scala
+++ b/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/client/GrpcExceptionConverter.scala
@@ -24,48 +24,134 @@ import scala.reflect.ClassTag
 import com.google.rpc.ErrorInfo
 import io.grpc.StatusRuntimeException
 import io.grpc.protobuf.StatusProto
+import org.json4s.DefaultFormats
+import org.json4s.jackson.JsonMethods
 
 import org.apache.spark.{SparkArithmeticException, SparkArrayIndexOutOfBoundsException, SparkDateTimeException, SparkException, SparkIllegalArgumentException, SparkNumberFormatException, SparkRuntimeException, SparkUnsupportedOperationException, SparkUpgradeException}
+import org.apache.spark.connect.proto.{FetchErrorDetailsRequest, FetchErrorDetailsResponse, UserContext}
+import org.apache.spark.connect.proto.SparkConnectServiceGrpc.SparkConnectServiceBlockingStub
+import org.apache.spark.internal.Logging
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.analysis.{NamespaceAlreadyExistsException, NoSuchDatabaseException, NoSuchTableException, TableAlreadyExistsException, TempTableAlreadyExistsException}
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.catalyst.trees.Origin
-import org.apache.spark.util.JsonUtils
 
-private[client] object GrpcExceptionConverter extends JsonUtils {
-  def convert[T](f: => T): T = {
+/**
+ * GrpcExceptionConverter handles the conversion of StatusRuntimeExceptions into Spark exceptions.
+ * It does so by utilizing the ErrorInfo defined in error_details.proto and making an additional
+ * FetchErrorDetails RPC call to retrieve the full error message and optionally the server-side
+ * stacktrace.
+ *
+ * If the FetchErrorDetails RPC call succeeds, the exceptions will be constructed based on the
+ * response. If the RPC call fails, the exception will be constructed based on the ErrorInfo. If
+ * the ErrorInfo is missing, the exception will be constructed based on the StatusRuntimeException
+ * itself.
+ */
+private[client] class GrpcExceptionConverter(grpcStub: SparkConnectServiceBlockingStub)
+    extends Logging {
+  import GrpcExceptionConverter._
+
+  def convert[T](sessionId: String, userContext: UserContext)(f: => T): T = {
     try {
       f
     } catch {
       case e: StatusRuntimeException =>
-        throw toThrowable(e)
+        throw toThrowable(e, sessionId, userContext)
     }
   }
 
-  def convertIterator[T](iter: CloseableIterator[T]): CloseableIterator[T] = {
+  def convertIterator[T](
+      sessionId: String,
+      userContext: UserContext,
+      iter: CloseableIterator[T]): CloseableIterator[T] = {
     new WrappedCloseableIterator[T] {
 
       override def innerIterator: Iterator[T] = iter
 
       override def hasNext: Boolean = {
-        convert {
+        convert(sessionId, userContext) {
           iter.hasNext
         }
       }
 
       override def next(): T = {
-        convert {
+        convert(sessionId, userContext) {
           iter.next()
         }
       }
 
       override def close(): Unit = {
-        convert {
+        convert(sessionId, userContext) {
           iter.close()
         }
       }
     }
   }
+
+  /**
+   * fetchEnrichedError fetches enriched errors with full exception message and optionally
+   * stacktrace by issuing an additional RPC call to fetch error details. The RPC call is
+   * best-effort at-most-once.
+   */
+  private def fetchEnrichedError(
+      info: ErrorInfo,
+      sessionId: String,
+      userContext: UserContext): Option[Throwable] = {
+    val errorId = info.getMetadataOrDefault("errorId", null)
+    if (errorId == null) {
+      logWarning("Unable to fetch enriched error since errorId is missing")
+      return None
+    }
+
+    try {
+      val errorDetailsResponse = grpcStub.fetchErrorDetails(
+        FetchErrorDetailsRequest
+          .newBuilder()
+          .setSessionId(sessionId)
+          .setErrorId(errorId)
+          .setUserContext(UserContext.newBuilder().setUserId(userContext.getUserId).build())
+          .build())
+
+      if (!errorDetailsResponse.hasRootErrorIdx) {
+        logWarning("Unable to fetch enriched error since error is not found")
+        return None
+      }
+
+      Some(
+        errorsToThrowable(
+          errorDetailsResponse.getRootErrorIdx,
+          errorDetailsResponse.getErrorsList.asScala))
+    } catch {
+      case e: StatusRuntimeException =>
+        logWarning("Unable to fetch enriched error", e)
+        None
+    }
+  }
+
+  private def toThrowable(
+      ex: StatusRuntimeException,
+      sessionId: String,
+      userContext: UserContext): Throwable = {
+    val status = StatusProto.fromThrowable(ex)
+
+    val errorInfoOpt = status.getDetailsList.asScala
+      .find(_.is(classOf[ErrorInfo]))
+      .map(_.unpack(classOf[ErrorInfo]))
+
+    if (errorInfoOpt.isDefined) {
+      val enrichedErrorOpt = fetchEnrichedError(errorInfoOpt.get, sessionId, userContext)
+      if (enrichedErrorOpt.isDefined) {
+        return enrichedErrorOpt.get
+      }
+
+      return errorInfoToThrowable(errorInfoOpt.get, StatusProto.fromThrowable(ex).getMessage)
+    }
+
+    new SparkException(ex.toString, ex.getCause)
+  }
+}
+
+private object GrpcExceptionConverter {
 
   private def errorConstructor[T <: Throwable: ClassTag](
       throwableCtr: (String, Option[Throwable]) => T)
@@ -93,33 +179,65 @@ private[client] object GrpcExceptionConverter extends JsonUtils {
       new SparkArrayIndexOutOfBoundsException(message)),
     errorConstructor[DateTimeException]((message, _) => new SparkDateTimeException(message)),
     errorConstructor((message, cause) => new SparkRuntimeException(message, cause)),
-    errorConstructor((message, cause) => new SparkUpgradeException(message, cause)))
+    errorConstructor((message, cause) => new SparkUpgradeException(message, cause)),
+    errorConstructor((message, cause) => new SparkException(message, cause.orNull)))
 
-  private def errorInfoToThrowable(info: ErrorInfo, message: String): Option[Throwable] = {
-    val classes =
-      mapper.readValue(info.getMetadataOrDefault("classes", "[]"), classOf[Array[String]])
+  /**
+   * errorsToThrowable reconstructs the exception based on a list of protobuf messages
+   * FetchErrorDetailsResponse.Error with un-truncated error messages and server-side stacktrace
+   * (if set).
+   */
+  private def errorsToThrowable(
+      errorIdx: Int,
+      errors: Seq[FetchErrorDetailsResponse.Error]): Throwable = {
 
-    classes
-      .find(errorFactory.contains)
-      .map { cls =>
-        val constructor = errorFactory.get(cls).get
-        constructor(message, None)
-      }
-  }
+    val error = errors(errorIdx)
 
-  private def toThrowable(ex: StatusRuntimeException): Throwable = {
-    val status = StatusProto.fromThrowable(ex)
+    val classHierarchy = error.getErrorTypeHierarchyList.asScala
 
-    val fallbackEx = new SparkException(ex.toString, ex.getCause)
+    val constructor =
+      classHierarchy
+        .flatMap(errorFactory.get)
+        .headOption
+        .getOrElse((message: String, cause: Option[Throwable]) =>
+          new SparkException(
+            s"Exception received from Spark Connect on server ${classHierarchy.head}: ${message}",
+            cause.orNull))
 
-    val errorInfoOpt = status.getDetailsList.asScala
-      .find(_.is(classOf[ErrorInfo]))
+    val causeOpt =
+      if (error.hasCauseIdx) Some(errorsToThrowable(error.getCauseIdx, errors)) else None
 
-    if (errorInfoOpt.isEmpty) {
-      return fallbackEx
+    val exception = constructor(error.getMessage, causeOpt)
+
+    if (!error.getStackTraceList.isEmpty) {
+      exception.setStackTrace(error.getStackTraceList.asScala.toArray.map { stackTraceElement =>
+        new StackTraceElement(
+          stackTraceElement.getDeclaringClass,
+          stackTraceElement.getMethodName,
+          stackTraceElement.getFileName,
+          stackTraceElement.getLineNumber)
+      })
     }
 
-    errorInfoToThrowable(errorInfoOpt.get.unpack(classOf[ErrorInfo]), status.getMessage)
-      .getOrElse(fallbackEx)
+    exception
+  }
+
+  /**
+   * errorInfoToThrowable reconstructs the exception based on the error classes hierarchy and the
+   * truncated error message.
+   */
+  private def errorInfoToThrowable(info: ErrorInfo, message: String): Throwable = {
+    implicit val formats = DefaultFormats
+    val classes =
+      JsonMethods.parse(info.getMetadataOrDefault("classes", "[]")).extract[Array[String]]
+
+    errorsToThrowable(
+      0,
+      Seq(
+        FetchErrorDetailsResponse.Error
+          .newBuilder()
+          .setMessage(message)
+          .addAllErrorTypeHierarchy(classes.toIterable.asJava)
+          .build()))
   }
 }

--- a/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/client/GrpcExceptionConverter.scala
+++ b/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/client/GrpcExceptionConverter.scala
@@ -119,7 +119,7 @@ private[client] class GrpcExceptionConverter(grpcStub: SparkConnectServiceBlocki
       Some(
         errorsToThrowable(
           errorDetailsResponse.getRootErrorIdx,
-          errorDetailsResponse.getErrorsList.asScala))
+          errorDetailsResponse.getErrorsList.asScala.toSeq))
     } catch {
       case e: StatusRuntimeException =>
         logWarning("Unable to fetch enriched error", e)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2893,7 +2893,8 @@ object SQLConf {
         "level settings.")
       .version("3.0.0")
       .booleanConf
-      .createWithDefault(false)
+      // show full stacktrace in tests but hide in production by default.
+      .createWithDefault(Utils.isTesting)
 
   val ARROW_SPARKR_EXECUTION_ENABLED =
     buildConf("spark.sql.execution.arrow.sparkr.enabled")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2893,8 +2893,7 @@ object SQLConf {
         "level settings.")
       .version("3.0.0")
       .booleanConf
-      // show full stacktrace in tests but hide in production by default.
-      .createWithDefault(Utils.isTesting)
+      .createWithDefault(false)
 
   val ARROW_SPARKR_EXECUTION_ENABLED =
     buildConf("spark.sql.execution.arrow.sparkr.enabled")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
-  Implemented the reconstruction of the complete exception (un-truncated error messages, cause exceptions, server-side stacktrace) based on the responses of FetchErrorDetails RPC.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
- Cause exceptions play an important role in the current control flow, such as in StreamingQueryException. They are also valuable for debugging.
- Un-truncated error message is useful for debugging
- Providing server-side stack traces aids in effectively diagnosing server-related issues.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
- `build/sbt "connect-client-jvm/testOnly *ClientE2ETestSuite"`
- `build/sbt "connect-client-jvm/testOnly *ClientStreamingQuerySuite"`

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No