### PR TITLE
[SPARK-45210][DOCS][3.4] Switch languages consistently across docs for all code snippets (Spark 3.4 and below)

### DIFF
--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -63,7 +63,7 @@ function codeTabs() {
     // while retaining the scroll position
     e.preventDefault();
     var scrollOffset = $(this).offset().top - $(document).scrollTop();
-    $("." + $(this).attr('class')).tab('show');
+    $("." + $(this).attr('class').split(" ").join(".")).tab('show');
     $(document).scrollTop($(this).offset().top - scrollOffset);
   });
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to recover the availity of switching languages consistently across docs for all code snippets in Spark 3.4 and below by using the proper class selector in the JQuery. Previously the selector was a string `.nav-link tab_python` which did not comply multiple class selection: https://www.w3.org/TR/CSS21/selector.html#class-html. I assume it worked as a legacy behaviour somewhere. Now it uses the standard way `.nav-link.tab_python`.

Note that https://github.com/apache/spark/pull/42657 works because there's only single class assigned (after we refactored the site at https://github.com/apache/spark/pull/40269)

### Why are the changes needed?

This is a regression in our documentation site.

### Does this PR introduce _any_ user-facing change?

Yes, once you click the language tab, it will apply to the examples in the whole page.

### How was this patch tested?

Manually tested after building the site.

![Screenshot 2023-09-19 at 12 08 17 PM](https://github.com/apache/spark/assets/6477701/09d0c117-9774-4404-8e2e-d454b7f700a3)

### Was this patch authored or co-authored using generative AI tooling?

No.