### PR TITLE
[SPARK-43453][PS] Ignore the `names` of `MultiIndex` when `axis=1` for `concat`

### DIFF
--- a/python/pyspark/pandas/namespace.py
+++ b/python/pyspark/pandas/namespace.py
@@ -2564,6 +2564,10 @@ def concat(
         if sort:
             concat_psdf = concat_psdf.sort_index()
 
+        columns = concat_psdf.columns
+        if isinstance(columns, pd.MultiIndex):
+            concat_psdf = concat_psdf.rename_axis([None] * columns.nlevels, axis="columns")
+
         return concat_psdf
 
     # Series, Series ...

--- a/python/pyspark/pandas/tests/test_ops_on_diff_frames.py
+++ b/python/pyspark/pandas/tests/test_ops_on_diff_frames.py
@@ -493,11 +493,6 @@ class OpsOnDiffFramesEnabledTestsMixin:
             ),
         )
 
-    @unittest.skipIf(
-        LooseVersion(pd.__version__) >= LooseVersion("2.0.0"),
-        "TODO(SPARK-43453): Enable OpsOnDiffFramesEnabledTests.test_concat_column_axis "
-        "for pandas 2.0.0.",
-    )
     def test_concat_column_axis(self):
         pdf1 = pd.DataFrame({"A": [0, 2, 4], "B": [1, 3, 5]}, index=[1, 2, 3])
         pdf1.columns.names = ["AB"]


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to update the behavior of `ps.concat` to follow the Pandas behavior, and enable corresponding tests.


### Why are the changes needed?

To follow the latest Pandas.


### Does this PR introduce _any_ user-facing change?

For the `MultiIndex` columns:
```python
>>> psdf3
X   X
AB  A  B
1   0  1
2   2  3
3   4  5
>>> psdf4
Y   X
CD  C  D
1   1  4
3   2  5
5   3  6
```
The behavior of `ps.concat` with `axis=1` is changed:

**Before**
```python
>>> ps.concat([psdf3, psdf4], axis=1)
X     X
AB    A    B    C    D
1   0.0  1.0  1.0  4.0
2   2.0  3.0  NaN  NaN
3   4.0  5.0  2.0  5.0
5   NaN  NaN  3.0  6.0
```

**After (Ignore the names of MultiIndex columns to follow the latest Pandas)**
```python
>>> ps.concat([psdf3, psdf4], axis=1)
     X
     A    B    C    D
1  0.0  1.0  1.0  4.0
2  2.0  3.0  NaN  NaN
3  4.0  5.0  2.0  5.0
5  NaN  NaN  3.0  6.0
```


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Enabling the existing tests.


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.