### PR TITLE
[SPARK-45217][CORE] Support change log level of specific package or class

### DIFF
--- a/R/pkg/R/context.R
+++ b/R/pkg/R/context.R
@@ -443,6 +443,23 @@ setLogLevel <- function(level) {
   invisible(callJMethod(sc, "setLogLevel", level))
 }
 
+#' Set new log level of of specific package or class name.
+#'
+#' Set new log level: "ALL", "DEBUG", "ERROR", "FATAL", "INFO", "OFF", "TRACE", "WARN"
+#'
+#' @rdname setLogLevel
+#' @param loggerName specific java package or class name
+#' @param level New log level
+#' @examples
+#'\dontrun{
+#' setLogLevel("org.apache.spark", "ERROR")
+#'}
+#' @note setLogLevel since 4.0.0
+setLogLevel <- function(loggerName, level) {
+  sc <- getSparkContext()
+  invisible(callJMethod(sc, "setLogLevel", loggerName, level))
+}
+
 #' Set checkpoint directory
 #'
 #' Set the directory under which SparkDataFrame are going to be checkpointed. The directory must be

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -40,6 +40,7 @@ import org.apache.hadoop.io.{ArrayWritable, BooleanWritable, BytesWritable, Doub
 import org.apache.hadoop.mapred.{FileInputFormat, InputFormat, JobConf, SequenceFileInputFormat, TextInputFormat}
 import org.apache.hadoop.mapreduce.{InputFormat => NewInputFormat, Job => NewHadoopJob}
 import org.apache.hadoop.mapreduce.lib.input.{FileInputFormat => NewFileInputFormat}
+import org.apache.logging.log4j.Level
 
 import org.apache.spark.annotation.{DeveloperApi, Experimental}
 import org.apache.spark.broadcast.Broadcast
@@ -399,6 +400,25 @@ class SparkContext(config: SparkConf) extends Logging {
     if (conf.get(EXECUTOR_ALLOW_SYNC_LOG_LEVEL) && _schedulerBackend != null) {
       _schedulerBackend.updateExecutorsLogLevel(upperCased)
     }
+  }
+
+  /** Change logLevel of specific package or class name.
+   *  This overrides any user-defined log settings.
+   *
+   * @param loggerName package or class name such as "org.apache.spark" or
+   *                   "org.apache.spark.SparkContext"
+   * @param logLevel The desired log level as a string.
+   *                 Valid log levels include: ALL, DEBUG, ERROR, FATAL, INFO, OFF, TRACE, WARN
+   *
+   * @since 4.0.0
+   */
+  def setLogLevel(loggerName: String, logLevel: String): Unit = {
+    // let's allow lowercase or mixed case too
+    val upperCased = logLevel.toUpperCase(Locale.ROOT)
+    require(SparkContext.VALID_LOG_LEVELS.contains(upperCased),
+      s"Supplied level $logLevel did not match one of:" +
+        s" ${SparkContext.VALID_LOG_LEVELS.mkString(",")}")
+    Utils.setLogLevel(loggerName, Level.toLevel(upperCased))
   }
 
   try {

--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -707,6 +707,20 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties {
     }
   }
 
+  test("log4j log level change with name") {
+    val loggerName = "org.apache.spark"
+    assert(Utils.getLoggerLevel(loggerName).isEmpty)
+    Utils.setLogLevel(loggerName, Level.ALL)
+    assert(Utils.getLoggerLevel(loggerName).get == Level.ALL)
+    assert(log.isInfoEnabled())
+    Utils.setLogLevel(loggerName, Level.ERROR)
+    assert(Utils.getLoggerLevel(loggerName).get == Level.ERROR)
+    assert(!log.isInfoEnabled())
+    assert(log.isErrorEnabled())
+    Utils.removeLogger(loggerName)
+    assert(Utils.getLoggerLevel(loggerName).isEmpty)
+  }
+
   test("deleteRecursively") {
     val tempDir1 = Utils.createTempDir()
     assert(tempDir1.exists())

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -534,6 +534,27 @@ class SparkContext:
         """
         self._jsc.setLogLevel(logLevel)
 
+    def setLogLevel(self, logName: str, logLevel: str) -> None:
+        """
+        Control our logLevel of specific package or class name.
+        This overrides any user-defined log settings.
+        Valid log levels include: ALL, DEBUG, ERROR, FATAL, INFO, OFF, TRACE, WARN
+
+        .. versionadded:: 4.0.0
+
+        Parameters
+        ----------
+        logName : str
+            specific java package or class name
+        logLevel : str
+            The desired log level as a string.
+
+        Examples
+        --------
+        >>> sc.setLogLevel("org.apache.spark", "WARN")  # doctest :+SKIP
+        """
+        self._jsc.setLogLevel(logName, logLevel)
+
     @classmethod
     def setSystemProperty(cls, key: str, value: str) -> None:
         """


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add `SparkContext.setLogLevel(loggerName: String, logLevel: String)` to support change log level of specific package or class, it has below use cases:

1. Change log level in runtime without restart spark driver or executor. One example is spark-shell.
2. Save the effort to changing the log4j.properties on all host machines or passing long parameter in spark-submit to override log4j.properties.

### Why are the changes needed?
Currently, only support change log level of root logger, we may want to change log level of specific package or class

### Does this PR introduce _any_ user-facing change?
Yes, added below method in `SparkContext`
```
def setLogLevel(loggerName: String, logLevel: String): Unit
```

### How was this patch tested?
Added test in `UtilsSuite`

### Was this patch authored or co-authored using generative AI tooling?
No
