### PR TITLE
[SPARK-43498][PS][TESTS] Enable `StatsTests.test_axis_on_dataframe` for pandas 2.0.0.

### DIFF
--- a/python/pyspark/pandas/tests/test_stats.py
+++ b/python/pyspark/pandas/tests/test_stats.py
@@ -582,9 +582,6 @@ class StatsTestsMixin:
 
 
 class StatsTests(StatsTestsMixin, PandasOnSparkTestCase, SQLTestUtils):
-    def test_axis_on_dataframe(self):
-        super().test_axis_on_dataframe()
-
     pass
 
 

--- a/python/pyspark/pandas/tests/test_stats.py
+++ b/python/pyspark/pandas/tests/test_stats.py
@@ -176,6 +176,7 @@ class StatsTestsMixin:
                 },
                 index=range(10, 15001, 10),
             )
+            # TODO(SPARK-45228): Update `test_axis_on_dataframe` when Pandas regression is fixed
             # There is a regression in Pandas 2.1.0,
             # so we should manually cast to float until the regression is fixed.
             # See https://github.com/pandas-dev/pandas/issues/55194.

--- a/python/pyspark/pandas/tests/test_stats.py
+++ b/python/pyspark/pandas/tests/test_stats.py
@@ -160,10 +160,6 @@ class StatsTestsMixin:
         ):
             psdf.D.abs()
 
-    @unittest.skipIf(
-        LooseVersion(pd.__version__) >= LooseVersion("2.0.0"),
-        "TODO(SPARK-43498): Enable SeriesTests.test_axis_on_dataframe for pandas 2.0.0.",
-    )
     def test_axis_on_dataframe(self):
         # The number of each count is intentionally big
         # because when data is small, it executes a shortcut.
@@ -180,6 +176,10 @@ class StatsTestsMixin:
                 },
                 index=range(10, 15001, 10),
             )
+            # There is a regression in Pandas 2.1.0,
+            # so we should manually cast to float until the regression is fixed.
+            # See https://github.com/pandas-dev/pandas/issues/55194.
+            pdf = pdf.astype(float)
             psdf = ps.from_pandas(pdf)
             self.assert_eq(psdf.count(axis=1), pdf.count(axis=1))
             self.assert_eq(psdf.var(axis=1), pdf.var(axis=1))
@@ -582,6 +582,9 @@ class StatsTestsMixin:
 
 
 class StatsTests(StatsTestsMixin, PandasOnSparkTestCase, SQLTestUtils):
+    def test_axis_on_dataframe(self):
+        super().test_axis_on_dataframe()
+
     pass
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to enable `StatsTests.test_axis_on_dataframe` for pandas 2.0.0.

### Why are the changes needed?

Increase the test coverage.

### Does this PR introduce _any_ user-facing change?

No, it's test-only

### How was this patch tested?

Updated the existing UT.

### Was this patch authored or co-authored using generative AI tooling?

No.