### PR TITLE
[SPARK-45134][SHUFFLE] Avoid repeated fallback when failed to fetch remote push-merged block meta

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/PushBasedFetchHelper.scala
+++ b/core/src/main/scala/org/apache/spark/storage/PushBasedFetchHelper.scala
@@ -60,9 +60,11 @@ private class PushBasedFetchHelper(
   private[this] val chunksMetaMap = new mutable.HashMap[ShuffleBlockChunkId, RoaringBitmap]()
 
   /**
-   * A map for storing inflight MergedBlockMeta.
+   * A set for storing inflight MergedBlockMeta. it is used to guarantee that we fallback
+   * at most once for those failed push-merged block requests.
    */
   private[this] val inflightMergedBlocks = new mutable.HashSet[ShuffleMergedBlockId]()
+
   /**
    * Returns true if the address is for a push-merged block.
    */

--- a/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
@@ -1215,6 +1215,8 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
         Future {
           metaListener.onFailure(shuffleId, shuffleMergeId, reduceId,
             new RuntimeException("forced error"))
+          metaListener.onFailure(shuffleId, shuffleMergeId, reduceId,
+            new RuntimeException("forced error"))
         }
       })
     val taskContext = TaskContext.empty()


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently, `TransportClient.sendMergedBlockMetaReq` cannot guarantee that the  `onFailure` callback will be executed only once when the connection is disconnected. 
By adding inflightMergedBlocks checks, we can avoid executing repeated fallbacks and data duplication.

### Why are the changes needed?

In the `TransportClient.sendMergedBlockMetaReq` method,  the client lets `responseHandler` maintain  the callback for this request, In addition, it also adds a specified listener to the `channelFuture` of `writeAndFlush`. If the sending fails, the `onFailure` callback will be executed.
When a shuffle client fetch push-merged block meta, if the channel happens to be closed at the same time, the two code paths will trigger two `onFailure` callbacks, one from the response handler and the other from the listener of channelFuture.  Two fallback will eventually cause the original block to be obtained twice.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
UT

### Was this patch authored or co-authored using generative AI tooling?
No
