### PR TITLE
[SPARK-TODO][CORE][SQL] Eliminate intermediate staging directory for dynamic partition overwrite commits

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelationCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelationCommand.scala
@@ -165,15 +165,6 @@ case class InsertIntoHadoopFsRelationCommand(
         }
       }
 
-      // For dynamic partition overwrite, FileOutputCommitter's output path is staging path, files
-      // will be renamed from staging path to final output path during commit job
-      val committerOutputPath = if (dynamicPartitionOverwrite) {
-        FileCommitProtocol.getStagingDir(outputPath.toString, jobId)
-          .makeQualified(fs.getUri, fs.getWorkingDirectory)
-      } else {
-        qualifiedOutputPath
-      }
-
       val updatedPartitionPaths =
         FileFormatWriter.write(
           sparkSession = sparkSession,
@@ -181,7 +172,7 @@ case class InsertIntoHadoopFsRelationCommand(
           fileFormat = fileFormat,
           committer = committer,
           outputSpec = FileFormatWriter.OutputSpec(
-            committerOutputPath.toString, customPartitionLocations, outputColumns),
+            qualifiedOutputPath.toString, customPartitionLocations, outputColumns),
           hadoopConf = hadoopConf,
           partitionColumns = partitionColumns,
           bucketSpec = bucketSpec,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Before this change, dynamic partition output files went through the following stages.

1. Each task writes the files under a task specific directory. Each partition gets its own subdirectory. For example,  `finalLoc/.spark-staging-b8b7d3c4-6a75-4d17-8f60-e5ee13ebdfe2/_temporary/0/task_202309201700352612844563734165633_0000_m_000000`.
2. In the commit phase, the task files are merged into an intermediate staging directory. For example,  `finalLoc/.spark-staging-b8b7d3c4-6a75-4d17-8f60-e5ee13ebdfe2`.
3. For the updated partitions, the previous partition directories in the final output location are deleted. `partitions` file operations. This iterates over each partition directory. For example, `finalLoc/partition=a`.
4. After the commit phase, each partition directory is moved from the staging to the final directory. `partitions` file operations. For example, `finalLoc/.spark-staging-b8b7d3c4-6a75-4d17-8f60-e5ee13ebdfe2/partition=a` to `finalLoc/partition=a`.

The only reason step 2 is needed is to make sure the new partition and old partition files are not mixed together. If the previous partitions are deleted before the commit then the intermediate staging directory is not required. The new dynamic partitions procedure is.

1. Each task writes the files under a task specific directory. Each partition gets its own subdirectory. 
2. For the updated partitions, the previous partition directories in the final output location are deleted. 
3. In the commit phase, the task files are merged into the final directory. 

This saves `count(partitions)` file operations.

### Why are the changes needed?
This is a performance optimization to minimize the number of file operations for dynamic partitions. This will decrease the commit phase time reduce the load on storage bottlenecks (e.g. HDFS namenodes).


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Ran all unit tests


### Was this patch authored or co-authored using generative AI tooling?
No
