### PR TITLE
[SPARK-45229][CORE][UI] Show the number of drivers waiting in SUBMITTED status in MasterPage

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/master/ui/MasterPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/ui/MasterPage.scala
@@ -147,7 +147,8 @@ private[ui] class MasterPage(parent: MasterWebUI) extends WebUIPage("") {
                 {state.activeApps.length} <a href="#running-app">Running</a>,
                 {state.completedApps.length} <a href="#completed-app">Completed</a> </li>
               <li><strong>Drivers:</strong>
-                {state.activeDrivers.length} Running,
+                {state.activeDrivers.length} Running
+                ({state.activeDrivers.count(_.state == DriverState.SUBMITTED)} Waiting),
                 {state.completedDrivers.length} Completed </li>
               <li><strong>Status:</strong> {state.status}</li>
             </ul>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to show the number of drivers waiting in `SUBMITTED` status in MasterPage. Note that this UI improvement is valid even when we don't use `spark.deploy.maxDrivers` because the submitted drivers are in `SUBMITTED` status until it gets allocated in all Spark versions.

**BEFORE**:
```
Drivers: 3 Running, 13 Completed
```

**AFTER**:
```
Drivers: 3 Running (1 Waiting), 13 Completed
```


### Why are the changes needed?

![Screenshot 2023-09-19 at 9 53 39 PM](https://github.com/apache/spark/assets/9700541/56356d3e-e9d2-4a6a-a7ea-532856034717)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual check.

### Was this patch authored or co-authored using generative AI tooling?

No.