### PR TITLE
[SPARK-45232][SQL][DOCS] Add missing function groups to SQL references

### DIFF
--- a/docs/sql-ref-functions-builtin.md
+++ b/docs/sql-ref-functions-builtin.md
@@ -48,6 +48,16 @@ license: |
 {% endfor %}
 
 {% for static_file in site.static_files %}
+{% if static_file.name == 'generated-collection-funcs-table.html' %}
+### Collection Functions
+{% include_relative generated-collection-funcs-table.html %}
+#### Examples
+{% include_relative generated-collection-funcs-examples.html %}
+{% break %}
+{% endif %}
+{% endfor %}
+
+{% for static_file in site.static_files %}
     {% if static_file.name == 'generated-map-funcs-table.html' %}
 ### Map Functions
 {% include_relative generated-map-funcs-table.html %}
@@ -63,16 +73,6 @@ license: |
 {% include_relative generated-datetime-funcs-table.html %}
 #### Examples
 {% include_relative generated-datetime-funcs-examples.html %}
-        {% break %}
-    {% endif %}
-{% endfor %}
-
-{% for static_file in site.static_files %}
-    {% if static_file.name == 'generated-json-funcs-table.html' %}
-### JSON Functions
-{% include_relative generated-json-funcs-table.html %}
-#### Examples
-{% include_relative generated-json-funcs-examples.html %}
         {% break %}
     {% endif %}
 {% endfor %}
@@ -108,6 +108,66 @@ license: |
 {% endfor %}
 
 {% for static_file in site.static_files %}
+{% if static_file.name == 'generated-hash-funcs-table.html' %}
+### Hash Functions
+{% include_relative generated-hash-funcs-table.html %}
+#### Examples
+{% include_relative generated-hash-funcs-examples.html %}
+{% break %}
+{% endif %}
+{% endfor %}
+
+{% for static_file in site.static_files %}
+{% if static_file.name == 'generated-lambda-funcs-table.html' %}
+### Lambda Functions
+{% include_relative generated-lambda-funcs-table.html %}
+#### Examples
+{% include_relative generated-lambda-funcs-examples.html %}
+{% break %}
+{% endif %}
+{% endfor %}
+
+{% for static_file in site.static_files %}
+{% if static_file.name == 'generated-csv-funcs-table.html' %}
+### CSV Functions
+{% include_relative generated-csv-funcs-table.html %}
+#### Examples
+{% include_relative generated-csv-funcs-examples.html %}
+{% break %}
+{% endif %}
+{% endfor %}
+
+{% for static_file in site.static_files %}
+{% if static_file.name == 'generated-json-funcs-table.html' %}
+### JSON Functions
+{% include_relative generated-json-funcs-table.html %}
+#### Examples
+{% include_relative generated-json-funcs-examples.html %}
+{% break %}
+{% endif %}
+{% endfor %}
+
+{% for static_file in site.static_files %}
+{% if static_file.name == 'generated-xml-funcs-table.html' %}
+### XML Functions
+{% include_relative generated-xml-funcs-table.html %}
+#### Examples
+{% include_relative generated-xml-funcs-examples.html %}
+{% break %}
+{% endif %}
+{% endfor %}
+
+{% for static_file in site.static_files %}
+{% if static_file.name == 'generated-url-funcs-table.html' %}
+### URL Functions
+{% include_relative generated-url-funcs-table.html %}
+#### Examples
+{% include_relative generated-url-funcs-examples.html %}
+{% break %}
+{% endif %}
+{% endfor %}
+
+{% for static_file in site.static_files %}
     {% if static_file.name == 'generated-bitwise-funcs-table.html' %}
 ### Bitwise Functions
 {% include_relative generated-bitwise-funcs-table.html %}
@@ -138,16 +198,6 @@ license: |
 {% endfor %}
 
 {% for static_file in site.static_files %}
-    {% if static_file.name == 'generated-csv-funcs-table.html' %}
-### Csv Functions
-{% include_relative generated-csv-funcs-table.html %}
-#### Examples
-{% include_relative generated-csv-funcs-examples.html %}
-        {% break %}
-    {% endif %}
-{% endfor %}
-
-{% for static_file in site.static_files %}
     {% if static_file.name == 'generated-misc-funcs-table.html' %}
 ### Misc Functions
 {% include_relative generated-misc-funcs-table.html %}
@@ -165,4 +215,14 @@ license: |
 {% include_relative generated-generator-funcs-examples.html %}
         {% break %}
     {% endif %}
+{% endfor %}
+
+{% for static_file in site.static_files %}
+{% if static_file.name == 'generated-table-funcs-table.html' %}
+### Table Functions
+{% include_relative generated-table-funcs-table.html %}
+#### Examples
+{% include_relative generated-table-funcs-examples.html %}
+{% break %}
+{% endif %}
 {% endfor %}

--- a/docs/sql-ref-functions-builtin.md
+++ b/docs/sql-ref-functions-builtin.md
@@ -58,6 +58,16 @@ license: |
 {% endfor %}
 
 {% for static_file in site.static_files %}
+{% if static_file.name == 'generated-struct-funcs-table.html' %}
+### STRUCT Functions
+{% include_relative generated-struct-funcs-table.html %}
+#### Examples
+{% include_relative generated-struct-funcs-examples.html %}
+{% break %}
+{% endif %}
+{% endfor %}
+
+{% for static_file in site.static_files %}
     {% if static_file.name == 'generated-map-funcs-table.html' %}
 ### Map Functions
 {% include_relative generated-map-funcs-table.html %}

--- a/docs/sql-ref-functions-builtin.md
+++ b/docs/sql-ref-functions-builtin.md
@@ -58,6 +58,16 @@ license: |
 {% endfor %}
 
 {% for static_file in site.static_files %}
+{% if static_file.name == 'generated-lambda-funcs-table.html' %}
+### Advanced Collection Functions
+{% include_relative generated-lambda-funcs-table.html %}
+#### Examples
+{% include_relative generated-lambda-funcs-examples.html %}
+{% break %}
+{% endif %}
+{% endfor %}
+
+{% for static_file in site.static_files %}
 {% if static_file.name == 'generated-struct-funcs-table.html' %}
 ### STRUCT Functions
 {% include_relative generated-struct-funcs-table.html %}
@@ -123,16 +133,6 @@ license: |
 {% include_relative generated-hash-funcs-table.html %}
 #### Examples
 {% include_relative generated-hash-funcs-examples.html %}
-{% break %}
-{% endif %}
-{% endfor %}
-
-{% for static_file in site.static_files %}
-{% if static_file.name == 'generated-lambda-funcs-table.html' %}
-### Lambda Functions
-{% include_relative generated-lambda-funcs-table.html %}
-#### Examples
-{% include_relative generated-lambda-funcs-examples.html %}
 {% break %}
 {% endif %}
 {% endfor %}

--- a/docs/sql-ref-functions-builtin.md
+++ b/docs/sql-ref-functions-builtin.md
@@ -58,16 +58,6 @@ license: |
 {% endfor %}
 
 {% for static_file in site.static_files %}
-{% if static_file.name == 'generated-lambda-funcs-table.html' %}
-### Advanced Collection Functions
-{% include_relative generated-lambda-funcs-table.html %}
-#### Examples
-{% include_relative generated-lambda-funcs-examples.html %}
-{% break %}
-{% endif %}
-{% endfor %}
-
-{% for static_file in site.static_files %}
 {% if static_file.name == 'generated-struct-funcs-table.html' %}
 ### STRUCT Functions
 {% include_relative generated-struct-funcs-table.html %}

--- a/docs/sql-ref-functions-builtin.md
+++ b/docs/sql-ref-functions-builtin.md
@@ -216,13 +216,3 @@ license: |
         {% break %}
     {% endif %}
 {% endfor %}
-
-{% for static_file in site.static_files %}
-{% if static_file.name == 'generated-table-funcs-table.html' %}
-### Table Functions
-{% include_relative generated-table-funcs-table.html %}
-#### Examples
-{% include_relative generated-table-funcs-examples.html %}
-{% break %}
-{% endif %}
-{% endfor %}

--- a/docs/sql-ref-functions.md
+++ b/docs/sql-ref-functions.md
@@ -30,7 +30,6 @@ This subsection presents the usages and descriptions of these functions.
 #### Scalar Functions
  * [Array Functions](sql-ref-functions-builtin.html#array-functions)
  * [Collection Functions](sql-ref-functions-builtin.html#collection-functions)
- * [Advanced Collection Functions](sql-ref-functions-builtin.html#advanced-collection-functions)
  * [Struct Functions](sql-ref-functions-builtin.html#struct-functions)
  * [Map Functions](sql-ref-functions-builtin.html#map-functions)
  * [Date and Timestamp Functions](sql-ref-functions-builtin.html#date-and-timestamp-functions)

--- a/docs/sql-ref-functions.md
+++ b/docs/sql-ref-functions.md
@@ -30,6 +30,7 @@ This subsection presents the usages and descriptions of these functions.
 #### Scalar Functions
  * [Array Functions](sql-ref-functions-builtin.html#array-functions)
  * [Collection Functions](sql-ref-functions-builtin.html#collection-functions)
+ * [Struct Functions](sql-ref-functions-builtin.html#struct-functions)
  * [Map Functions](sql-ref-functions-builtin.html#map-functions)
  * [Date and Timestamp Functions](sql-ref-functions-builtin.html#date-and-timestamp-functions)
  * [Mathematical Functions](sql-ref-functions-builtin.html#mathematical-functions)

--- a/docs/sql-ref-functions.md
+++ b/docs/sql-ref-functions.md
@@ -30,6 +30,7 @@ This subsection presents the usages and descriptions of these functions.
 #### Scalar Functions
  * [Array Functions](sql-ref-functions-builtin.html#array-functions)
  * [Collection Functions](sql-ref-functions-builtin.html#collection-functions)
+ * [Advanced Collection Functions](sql-ref-functions-builtin.html#advanced-collection-functions)
  * [Struct Functions](sql-ref-functions-builtin.html#struct-functions)
  * [Map Functions](sql-ref-functions-builtin.html#map-functions)
  * [Date and Timestamp Functions](sql-ref-functions-builtin.html#date-and-timestamp-functions)
@@ -40,7 +41,6 @@ This subsection presents the usages and descriptions of these functions.
  * [Conditional Functions](sql-ref-functions-builtin.html#conditional-functions)
  * [Predicate Functions](sql-ref-functions-builtin.html#predicate-functions)
  * [Hash Functions](sql-ref-functions-builtin.html#hash-functions)
- * [Lambda Functions](sql-ref-functions-builtin.html#lambda-functions)
  * [CSV Functions](sql-ref-functions-builtin.html#csv-functions)
  * [JSON Functions](sql-ref-functions-builtin.html#json-functions)
  * [XML Functions](sql-ref-functions-builtin.html#xml-functions)

--- a/docs/sql-ref-functions.md
+++ b/docs/sql-ref-functions.md
@@ -53,9 +53,6 @@ This subsection presents the usages and descriptions of these functions.
 #### Generator Functions
 * [Generator Functions](sql-ref-functions-builtin.html#generator-functions)
 
-#### Table Functions
-* [Table Functions](sql-ref-functions-builtin.html#table-functions)
-
 ### UDFs (User-Defined Functions)
 
 User-Defined Functions (UDFs) are a feature of Spark SQL that allows users to define their own functions when the system's built-in functions are not enough to perform the desired task. To use UDFs in Spark SQL, users must first define the function, then register the function with Spark, and finally call the registered function. The User-Defined Functions can act on a single row or act on multiple rows at once. Spark SQL also supports integration of existing Hive implementations of UDFs, UDAFs and UDTFs.

--- a/docs/sql-ref-functions.md
+++ b/docs/sql-ref-functions.md
@@ -29,16 +29,21 @@ This subsection presents the usages and descriptions of these functions.
 
 #### Scalar Functions
  * [Array Functions](sql-ref-functions-builtin.html#array-functions)
+ * [Collection Functions](sql-ref-functions-builtin.html#collection-functions)
  * [Map Functions](sql-ref-functions-builtin.html#map-functions)
  * [Date and Timestamp Functions](sql-ref-functions-builtin.html#date-and-timestamp-functions)
- * [JSON Functions](sql-ref-functions-builtin.html#json-functions)
  * [Mathematical Functions](sql-ref-functions-builtin.html#mathematical-functions)
  * [String Functions](sql-ref-functions-builtin.html#string-functions)
  * [Bitwise Functions](sql-ref-functions-builtin.html#bitwise-functions)
  * [Conversion Functions](sql-ref-functions-builtin.html#conversion-functions)
  * [Conditional Functions](sql-ref-functions-builtin.html#conditional-functions)
  * [Predicate Functions](sql-ref-functions-builtin.html#predicate-functions)
- * [Csv Functions](sql-ref-functions-builtin.html#csv-functions)
+ * [Hash Functions](sql-ref-functions-builtin.html#hash-functions)
+ * [Lambda Functions](sql-ref-functions-builtin.html#lambda-functions)
+ * [CSV Functions](sql-ref-functions-builtin.html#csv-functions)
+ * [JSON Functions](sql-ref-functions-builtin.html#json-functions)
+ * [XML Functions](sql-ref-functions-builtin.html#xml-functions)
+ * [URL Functions](sql-ref-functions-builtin.html#url-functions)
  * [Misc Functions](sql-ref-functions-builtin.html#misc-functions)
 
 #### Aggregate-like Functions
@@ -47,6 +52,9 @@ This subsection presents the usages and descriptions of these functions.
 
 #### Generator Functions
 * [Generator Functions](sql-ref-functions-builtin.html#generator-functions)
+
+#### Table Functions
+* [Table Functions](sql-ref-functions-builtin.html#table-functions)
 
 ### UDFs (User-Defined Functions)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/api/python/PythonSQLUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/api/python/PythonSQLUtils.scala
@@ -29,7 +29,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.security.SocketAuthServer
 import org.apache.spark.sql.{Column, DataFrame, Row, SparkSession}
 import org.apache.spark.sql.catalyst.{CatalystTypeConverters, InternalRow}
-import org.apache.spark.sql.catalyst.analysis.{FunctionRegistry, TableFunctionRegistry}
+import org.apache.spark.sql.catalyst.analysis.FunctionRegistry
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate._
@@ -69,12 +69,6 @@ private[sql] object PythonSQLUtils extends Logging {
   // This is needed when generating SQL documentation for built-in functions.
   def listBuiltinFunctionInfos(): Array[ExpressionInfo] = {
     FunctionRegistry.functionSet.flatMap(f => FunctionRegistry.builtin.lookupFunction(f)).toArray
-  }
-
-  // This is needed when generating SQL documentation for built-in table functions.
-  def listBuiltinTableFunctionInfos(): Array[ExpressionInfo] = {
-    TableFunctionRegistry.functionSet.flatMap(f =>
-      TableFunctionRegistry.builtin.lookupFunction(f)).toArray
   }
 
   private def listAllSQLConfigs(): Seq[(String, String, String, String)] = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/api/python/PythonSQLUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/api/python/PythonSQLUtils.scala
@@ -29,7 +29,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.security.SocketAuthServer
 import org.apache.spark.sql.{Column, DataFrame, Row, SparkSession}
 import org.apache.spark.sql.catalyst.{CatalystTypeConverters, InternalRow}
-import org.apache.spark.sql.catalyst.analysis.FunctionRegistry
+import org.apache.spark.sql.catalyst.analysis.{FunctionRegistry, TableFunctionRegistry}
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate._
@@ -69,6 +69,12 @@ private[sql] object PythonSQLUtils extends Logging {
   // This is needed when generating SQL documentation for built-in functions.
   def listBuiltinFunctionInfos(): Array[ExpressionInfo] = {
     FunctionRegistry.functionSet.flatMap(f => FunctionRegistry.builtin.lookupFunction(f)).toArray
+  }
+
+  // This is needed when generating SQL documentation for built-in table functions.
+  def listBuiltinTableFunctionInfos(): Array[ExpressionInfo] = {
+    TableFunctionRegistry.functionSet.flatMap(f =>
+      TableFunctionRegistry.builtin.lookupFunction(f)).toArray
   }
 
   private def listAllSQLConfigs(): Seq[(String, String, String, String)] = {

--- a/sql/gen-sql-functions-docs.py
+++ b/sql/gen-sql-functions-docs.py
@@ -35,7 +35,7 @@ groups = {
     "predicate_funcs", "string_funcs", "misc_funcs",
     "bitwise_funcs", "conversion_funcs", "csv_funcs",
     "xml_funcs", "lambda_funcs", "collection_funcs",
-    "url_funcs", "hash_funcs", "table_funcs",
+    "url_funcs", "hash_funcs",
 }
 
 
@@ -45,14 +45,7 @@ def _list_grouped_function_infos(jvm):
     Sorts wrapped expression infos in each group by name and returns them.
     """
 
-    py_sql_utils = jvm.org.apache.spark.sql.api.python.PythonSQLUtils
-
-    jinfos = []
-    for jinfo in py_sql_utils.listBuiltinFunctionInfos():
-        jinfos.append(jinfo)
-    for jinfo in py_sql_utils.listBuiltinTableFunctionInfos():
-        jinfos.append(jinfo)
-
+    jinfos = jvm.org.apache.spark.sql.api.python.PythonSQLUtils.listBuiltinFunctionInfos()
     infos = []
 
     for jinfo in filter(lambda x: x.getGroup() in groups, jinfos):

--- a/sql/gen-sql-functions-docs.py
+++ b/sql/gen-sql-functions-docs.py
@@ -45,7 +45,9 @@ def _list_grouped_function_infos(jvm):
     Sorts wrapped expression infos in each group by name and returns them.
     """
 
-    jinfos = jvm.org.apache.spark.sql.api.python.PythonSQLUtils.listBuiltinFunctionInfos()
+    py_sql_utils = jvm.org.apache.spark.sql.api.python.PythonSQLUtils
+
+    jinfos = py_sql_utils.listBuiltinFunctionInfos() + py_sql_utils.listBuiltinTableFunctionInfos()
     infos = []
 
     for jinfo in filter(lambda x: x.getGroup() in groups, jinfos):

--- a/sql/gen-sql-functions-docs.py
+++ b/sql/gen-sql-functions-docs.py
@@ -34,6 +34,8 @@ groups = {
     "math_funcs", "conditional_funcs", "generator_funcs",
     "predicate_funcs", "string_funcs", "misc_funcs",
     "bitwise_funcs", "conversion_funcs", "csv_funcs",
+    "xml_funcs", "lambda_funcs", "collection_funcs",
+    "url_funcs", "hash_funcs", "table_funcs",
 }
 
 

--- a/sql/gen-sql-functions-docs.py
+++ b/sql/gen-sql-functions-docs.py
@@ -35,7 +35,7 @@ groups = {
     "predicate_funcs", "string_funcs", "misc_funcs",
     "bitwise_funcs", "conversion_funcs", "csv_funcs",
     "xml_funcs", "lambda_funcs", "collection_funcs",
-    "url_funcs", "hash_funcs",
+    "url_funcs", "hash_funcs", "struct_funcs",
 }
 
 

--- a/sql/gen-sql-functions-docs.py
+++ b/sql/gen-sql-functions-docs.py
@@ -47,7 +47,12 @@ def _list_grouped_function_infos(jvm):
 
     py_sql_utils = jvm.org.apache.spark.sql.api.python.PythonSQLUtils
 
-    jinfos = py_sql_utils.listBuiltinFunctionInfos() + py_sql_utils.listBuiltinTableFunctionInfos()
+    jinfos = []
+    for jinfo in py_sql_utils.listBuiltinFunctionInfos():
+        jinfos.append(jinfo)
+    for jinfo in py_sql_utils.listBuiltinTableFunctionInfos():
+        jinfos.append(jinfo)
+
     infos = []
 
     for jinfo in filter(lambda x: x.getGroup() in groups, jinfos):

--- a/sql/gen-sql-functions-docs.py
+++ b/sql/gen-sql-functions-docs.py
@@ -52,13 +52,19 @@ def _list_grouped_function_infos(jvm):
         name = jinfo.getName()
         if (name == "raise_error"):
             continue
+
+        # SPARK-45232: convert lambda_funcs to collection_funcs in doc generation
+        group = jinfo.getGroup()
+        if group == "lambda_funcs":
+            group = "collection_funcs"
+
         usage = jinfo.getUsage()
         usage = usage.replace("_FUNC_", name) if usage is not None else usage
         infos.append(ExpressionInfo(
             name=name,
             usage=usage,
             examples=jinfo.getExamples().replace("_FUNC_", name),
-            group=jinfo.getGroup()))
+            group=group))
 
     # Groups expression info by each group value
     grouped_infos = itertools.groupby(sorted(infos, key=lambda x: x.group), key=lambda x: x.group)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add missing function groups to SQL references:
- xml_funcs
- lambda_funcs
- collection_funcs
- url_funcs
- hash_funcs
- struct_funcs

Note that this PR doesn't fix `table_funcs`:
1, `gen-sql-functions-docs.py` doesn't work properly with `TableFunctionRegistry`, I took a cursory look but fail to fix it;
2, table functions except `range` (e.g. `explode`) were already contained in `Generator Functions`, not sure we need to show them twice.


### Why are the changes needed?
when referring to the SQL references, I find many functions are missing https://spark.apache.org/docs/latest/sql-ref-functions.html.





### Does this PR introduce _any_ user-facing change?
yes


### How was this patch tested?
manually check


### Was this patch authored or co-authored using generative AI tooling?
no
