### PR TITLE
[MINOR][DOCS][CONNECT] Update notes about supported modules in PySpark API reference

### DIFF
--- a/python/docs/source/reference/index.rst
+++ b/python/docs/source/reference/index.rst
@@ -22,7 +22,9 @@ API Reference
 
 This page lists an overview of all public PySpark modules, classes, functions and methods.
 
-Pandas API on Spark follows the API specifications of latest pandas release.
+.. note::
+   Spark SQL, Pandas API on Spark, Structured Streaming, and MLlib (DataFrame-based) support
+   Spark Connect.
 
 .. toctree::
    :maxdepth: 2

--- a/python/docs/source/reference/pyspark.pandas/index.rst
+++ b/python/docs/source/reference/pyspark.pandas/index.rst
@@ -22,6 +22,9 @@ Pandas API on Spark
 
 This page gives an overview of all public pandas API on Spark.
 
+.. note::
+   pandas API on Spark follows the API specifications of latest pandas release.
+
 .. toctree::
    :maxdepth: 2
 

--- a/python/docs/source/reference/pyspark.sql/functions.rst
+++ b/python/docs/source/reference/pyspark.sql/functions.rst
@@ -22,7 +22,9 @@ Functions
 .. currentmodule:: pyspark.sql.functions
 
 A collections of builtin functions available for DataFrame operations.
-From Apache Spark 3.5.0, all functions support Spark Connect.
+
+.. note::
+   From Apache Spark 3.5.0, all functions support Spark Connect.
 
 Normal Functions
 ----------------


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to add a couple of notes about which modules are supported by Spark Connect.

### Why are the changes needed?

In order for users to explicitly know which ones are supported in PySpark with Spark Connect.

### Does this PR introduce _any_ user-facing change?

Yes, this exposes some notes for PySpark API with Spark Connect.

### How was this patch tested?

Manually built the site, and checked.

![Screenshot 2023-09-20 at 6 05 54 PM](https://github.com/apache/spark/assets/6477701/64355af1-f8b2-46bf-8b2a-3ea519995272)

![Screenshot 2023-09-20 at 6 05 28 PM](https://github.com/apache/spark/assets/6477701/c6f2af70-ec6a-4644-a848-30eedd4f56cf)

![Screenshot 2023-09-20 at 6 05 32 PM](https://github.com/apache/spark/assets/6477701/b701f5c0-477d-4f7c-9c02-96c307bf14e2)


### Was this patch authored or co-authored using generative AI tooling?

No.
