### PR TITLE
[SPARK-45235][CONNECT][PYTHON] Support map and array parameters by `sql()`

### DIFF
--- a/python/pyspark/sql/connect/plan.py
+++ b/python/pyspark/sql/connect/plan.py
@@ -1049,7 +1049,7 @@ class SQL(LogicalPlan):
         self._query = query
         self._args = args
 
-    def to_expr(self, session: "SparkConnectClient", v: Any) -> proto.Expression:
+    def __to_expr(self, session: "SparkConnectClient", v: Any) -> proto.Expression:
         if isinstance(v, Column):
             return v.to_plan(session)
         else:
@@ -1062,10 +1062,10 @@ class SQL(LogicalPlan):
         if self._args is not None and len(self._args) > 0:
             if isinstance(self._args, Dict):
                 for k, v in self._args.items():
-                    plan.sql.named_arguments[k].CopyFrom(self.to_expr(session, v))
+                    plan.sql.named_arguments[k].CopyFrom(self.__to_expr(session, v))
             else:
                 for v in self._args:
-                    plan.sql.pos_arguments.append(self.to_expr(session, v))
+                    plan.sql.pos_arguments.append(self.__to_expr(session, v))
 
         return plan
 
@@ -1075,10 +1075,10 @@ class SQL(LogicalPlan):
         if self._args is not None and len(self._args) > 0:
             if isinstance(self._args, Dict):
                 for k, v in self._args.items():
-                    cmd.sql_command.named_arguments[k].CopyFrom(self.to_expr(session, v))
+                    cmd.sql_command.named_arguments[k].CopyFrom(self.__to_expr(session, v))
             else:
                 for v in self._args:
-                    cmd.sql_command.pos_arguments.append(self.to_expr(session, v))
+                    cmd.sql_command.pos_arguments.append(self.__to_expr(session, v))
 
         return cmd
 

--- a/python/pyspark/sql/connect/plan.py
+++ b/python/pyspark/sql/connect/plan.py
@@ -1049,6 +1049,12 @@ class SQL(LogicalPlan):
         self._query = query
         self._args = args
 
+    def to_expr(self, session: "SparkConnectClient", v: Any) -> proto.Expression:
+        if isinstance(v, Column):
+            return v.to_plan(session)
+        else:
+            return LiteralExpression._from_value(v).to_plan(session)
+
     def plan(self, session: "SparkConnectClient") -> proto.Relation:
         plan = self._create_proto_relation()
         plan.sql.query = self._query
@@ -1056,14 +1062,10 @@ class SQL(LogicalPlan):
         if self._args is not None and len(self._args) > 0:
             if isinstance(self._args, Dict):
                 for k, v in self._args.items():
-                    plan.sql.args[k].CopyFrom(
-                        LiteralExpression._from_value(v).to_plan(session).literal
-                    )
+                    plan.sql.named_arguments[k].CopyFrom(self.to_expr(session, v))
             else:
                 for v in self._args:
-                    plan.sql.pos_args.append(
-                        LiteralExpression._from_value(v).to_plan(session).literal
-                    )
+                    plan.sql.pos_arguments.append(self.to_expr(session, v))
 
         return plan
 
@@ -1073,14 +1075,10 @@ class SQL(LogicalPlan):
         if self._args is not None and len(self._args) > 0:
             if isinstance(self._args, Dict):
                 for k, v in self._args.items():
-                    cmd.sql_command.args[k].CopyFrom(
-                        LiteralExpression._from_value(v).to_plan(session).literal
-                    )
+                    cmd.sql_command.named_arguments[k].CopyFrom(self.to_expr(session, v))
             else:
                 for v in self._args:
-                    cmd.sql_command.pos_args.append(
-                        LiteralExpression._from_value(v).to_plan(session).literal
-                    )
+                    cmd.sql_command.pos_arguments.append(self.to_expr(session, v))
 
         return cmd
 

--- a/python/pyspark/sql/connect/plan.py
+++ b/python/pyspark/sql/connect/plan.py
@@ -1049,7 +1049,7 @@ class SQL(LogicalPlan):
         self._query = query
         self._args = args
 
-    def __to_expr(self, session: "SparkConnectClient", v: Any) -> proto.Expression:
+    def _to_expr(self, session: "SparkConnectClient", v: Any) -> proto.Expression:
         if isinstance(v, Column):
             return v.to_plan(session)
         else:
@@ -1062,10 +1062,10 @@ class SQL(LogicalPlan):
         if self._args is not None and len(self._args) > 0:
             if isinstance(self._args, Dict):
                 for k, v in self._args.items():
-                    plan.sql.named_arguments[k].CopyFrom(self.__to_expr(session, v))
+                    plan.sql.named_arguments[k].CopyFrom(self._to_expr(session, v))
             else:
                 for v in self._args:
-                    plan.sql.pos_arguments.append(self.__to_expr(session, v))
+                    plan.sql.pos_arguments.append(self._to_expr(session, v))
 
         return plan
 
@@ -1075,10 +1075,10 @@ class SQL(LogicalPlan):
         if self._args is not None and len(self._args) > 0:
             if isinstance(self._args, Dict):
                 for k, v in self._args.items():
-                    cmd.sql_command.named_arguments[k].CopyFrom(self.__to_expr(session, v))
+                    cmd.sql_command.named_arguments[k].CopyFrom(self._to_expr(session, v))
             else:
                 for v in self._args:
-                    cmd.sql_command.pos_arguments.append(self.__to_expr(session, v))
+                    cmd.sql_command.pos_arguments.append(self._to_expr(session, v))
 
         return cmd
 

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -557,7 +557,7 @@ class SparkSession:
         if "sql_command_result" in properties:
             return DataFrame.withPlan(CachedRelation(properties["sql_command_result"]), self)
         else:
-            return DataFrame.withPlan(SQL(sqlQuery, args), self)
+            return DataFrame.withPlan(cmd, self)
 
     sql.__doc__ = PySparkSession.sql.__doc__
 

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -1237,8 +1237,16 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
         self.assertEqual(1, len(pdf.index))
 
     def test_sql_with_named_args(self):
-        df = self.connect.sql("SELECT * FROM range(10) WHERE id > :minId", args={"minId": 7})
-        df2 = self.spark.sql("SELECT * FROM range(10) WHERE id > :minId", args={"minId": 7})
+        from pyspark.sql.functions import create_map, lit
+        from pyspark.sql.connect.functions import lit as clit
+        from pyspark.sql.connect.functions import create_map as ccreate_map
+
+        df = self.connect.sql(
+            "SELECT *, element_at(:m, 'a') FROM range(10) WHERE id > :minId",
+            args={"minId": 7, "m": ccreate_map(clit('a'), clit(1))})
+        df2 = self.spark.sql(
+            "SELECT *, element_at(:m, 'a') FROM range(10) WHERE id > :minId",
+            args={"minId": 7, "m": create_map(lit('a'), lit(1))})
         self.assert_eq(df.toPandas(), df2.toPandas())
 
     def test_sql_with_pos_args(self):

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -1257,11 +1257,11 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
         from pyspark.sql.connect.functions import array as carray
 
         df = self.connect.sql(
-            "SELECT *, element_at(?, 1) FROM range(10) WHERE id > ?",
-            args=[carray(clit(1)), 7])
+            "SELECT *, element_at(?, 1) FROM range(10) WHERE id > ?", args=[carray(clit(1)), 7]
+        )
         df2 = self.spark.sql(
-            "SELECT *, element_at(?, 1) FROM range(10) WHERE id > ?",
-            args=[array(lit(1)), 7])
+            "SELECT *, element_at(?, 1) FROM range(10) WHERE id > ?", args=[array(lit(1)), 7]
+        )
         self.assert_eq(df.toPandas(), df2.toPandas())
 
     def test_head(self):

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -1243,10 +1243,12 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
 
         df = self.connect.sql(
             "SELECT *, element_at(:m, 'a') FROM range(10) WHERE id > :minId",
-            args={"minId": 7, "m": ccreate_map(clit('a'), clit(1))})
+            args={"minId": 7, "m": ccreate_map(clit("a"), clit(1))},
+        )
         df2 = self.spark.sql(
             "SELECT *, element_at(:m, 'a') FROM range(10) WHERE id > :minId",
-            args={"minId": 7, "m": create_map(lit('a'), lit(1))})
+            args={"minId": 7, "m": create_map(lit("a"), lit(1))},
+        )
         self.assert_eq(df.toPandas(), df2.toPandas())
 
     def test_sql_with_pos_args(self):

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -1252,8 +1252,16 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
         self.assert_eq(df.toPandas(), df2.toPandas())
 
     def test_sql_with_pos_args(self):
-        df = self.connect.sql("SELECT * FROM range(10) WHERE id > ?", args=[7])
-        df2 = self.spark.sql("SELECT * FROM range(10) WHERE id > ?", args=[7])
+        from pyspark.sql.functions import array, lit
+        from pyspark.sql.connect.functions import lit as clit
+        from pyspark.sql.connect.functions import array as carray
+
+        df = self.connect.sql(
+            "SELECT *, element_at(?, 1) FROM range(10) WHERE id > ?",
+            args=[carray(clit(1)), 7])
+        df2 = self.spark.sql(
+            "SELECT *, element_at(?, 1) FROM range(10) WHERE id > ?",
+            args=[array(lit(1)), 7])
         self.assert_eq(df.toPandas(), df2.toPandas())
 
     def test_head(self):

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -1241,14 +1241,9 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
         from pyspark.sql.connect.functions import lit as clit
         from pyspark.sql.connect.functions import create_map as ccreate_map
 
-        df = self.connect.sql(
-            "SELECT *, element_at(:m, 'a') FROM range(10) WHERE id > :minId",
-            args={"minId": 7, "m": ccreate_map(clit("a"), clit(1))},
-        )
-        df2 = self.spark.sql(
-            "SELECT *, element_at(:m, 'a') FROM range(10) WHERE id > :minId",
-            args={"minId": 7, "m": create_map(lit("a"), lit(1))},
-        )
+        sqlText = "SELECT *, element_at(:m, 'a') FROM range(10) WHERE id > :minId"
+        df = self.connect.sql(sqlText, args={"minId": 7, "m": ccreate_map(clit("a"), clit(1))})
+        df2 = self.spark.sql(sqlText, args={"minId": 7, "m": create_map(lit("a"), lit(1))})
         self.assert_eq(df.toPandas(), df2.toPandas())
 
     def test_sql_with_pos_args(self):
@@ -1256,12 +1251,9 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
         from pyspark.sql.connect.functions import lit as clit
         from pyspark.sql.connect.functions import array as carray
 
-        df = self.connect.sql(
-            "SELECT *, element_at(?, 1) FROM range(10) WHERE id > ?", args=[carray(clit(1)), 7]
-        )
-        df2 = self.spark.sql(
-            "SELECT *, element_at(?, 1) FROM range(10) WHERE id > ?", args=[array(lit(1)), 7]
-        )
+        sqlText = "SELECT *, element_at(?, 1) FROM range(10) WHERE id > ?"
+        df = self.connect.sql(sqlText, args=[carray(clit(1)), 7])
+        df2 = self.spark.sql(sqlText, args=[array(lit(1)), 7])
         self.assert_eq(df.toPandas(), df2.toPandas())
 
     def test_head(self):

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -1237,23 +1237,17 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
         self.assertEqual(1, len(pdf.index))
 
     def test_sql_with_named_args(self):
-        from pyspark.sql.functions import create_map, lit
-        from pyspark.sql.connect.functions import lit as clit
-        from pyspark.sql.connect.functions import create_map as ccreate_map
-
         sqlText = "SELECT *, element_at(:m, 'a') FROM range(10) WHERE id > :minId"
-        df = self.connect.sql(sqlText, args={"minId": 7, "m": ccreate_map(clit("a"), clit(1))})
-        df2 = self.spark.sql(sqlText, args={"minId": 7, "m": create_map(lit("a"), lit(1))})
+        df = self.connect.sql(
+            sqlText, args={"minId": 7, "m": CF.create_map(CF.lit("a"), CF.lit(1))}
+        )
+        df2 = self.spark.sql(sqlText, args={"minId": 7, "m": SF.create_map(SF.lit("a"), SF.lit(1))})
         self.assert_eq(df.toPandas(), df2.toPandas())
 
     def test_sql_with_pos_args(self):
-        from pyspark.sql.functions import array, lit
-        from pyspark.sql.connect.functions import lit as clit
-        from pyspark.sql.connect.functions import array as carray
-
         sqlText = "SELECT *, element_at(?, 1) FROM range(10) WHERE id > ?"
-        df = self.connect.sql(sqlText, args=[carray(clit(1)), 7])
-        df2 = self.spark.sql(sqlText, args=[array(lit(1)), 7])
+        df = self.connect.sql(sqlText, args=[CF.array(CF.lit(1)), 7])
+        df2 = self.spark.sql(sqlText, args=[SF.array(SF.lit(1)), 7])
         self.assert_eq(df.toPandas(), df2.toPandas())
 
     def test_head(self):


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to change the Python connect client to support `Column` as a parameter of `sql()`.

### Why are the changes needed?
To achieve feature parity w/ regular PySpark which supports map and arrays as parameters of `sql()`, see https://github.com/apache/spark/pull/42996.

### Does this PR introduce _any_ user-facing change?
No. It fixes a bug.

### How was this patch tested?
By running the modified tests:
```
$ python/run-tests --parallelism=1 --testnames 'pyspark.sql.tests.connect.test_connect_basic SparkConnectBasicTests.test_sql_with_named_args'
$ python/run-tests --parallelism=1 --testnames 'pyspark.sql.tests.connect.test_connect_basic SparkConnectBasicTests.test_sql_with_pos_args'
```

### Was this patch authored or co-authored using generative AI tooling?
No.