### PR TITLE
[SPARK-45237][DOCS] Change the default value of `spark.history.store.hybridStore.diskBackend` in `monitoring.md` to `ROCKSDB`

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -414,7 +414,7 @@ Security options for the Spark History Server are covered more detail in the
   </tr>
   <tr>
     <td>spark.history.store.hybridStore.diskBackend</td>
-    <td>LEVELDB</td>
+    <td>ROCKSDB</td>
     <td>
       Specifies a disk-based store used in hybrid store; LEVELDB or ROCKSDB.
     </td>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr change the default value of `spark.history.store.hybridStore.diskBackend` in `monitoring.md` to `ROCKSDB`


### Why are the changes needed?
SPARK-42277 change to use `RocksDB` for `spark.history.store.hybridStore.diskBackend` by default, but in `monitoring.md`, the default value is still set as `LEVELDB`.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No
