### PR TITLE
[SPARK-45241][INFRA] Use Zulu JDK in `build_and_test` and `build_java21` GitHub Action and Java 21

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -780,7 +780,7 @@ jobs:
         java:
           - 11
           - 17
-          - 21-ea
+          - 21
     runs-on: ubuntu-22.04
     timeout-minutes: 300
     steps:
@@ -817,7 +817,7 @@ jobs:
     - name: Install Java ${{ matrix.java }}
       uses: actions/setup-java@v3
       with:
-        distribution: temurin
+        distribution: zulu
         java-version: ${{ matrix.java }}
     - name: Build with Maven
       run: |

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -249,7 +249,7 @@ jobs:
     - name: Install Java ${{ matrix.java }}
       uses: actions/setup-java@v3
       with:
-        distribution: temurin
+        distribution: zulu
         java-version: ${{ matrix.java }}
     - name: Install Python 3.8
       uses: actions/setup-python@v4
@@ -435,7 +435,7 @@ jobs:
     - name: Install Java ${{ matrix.java }}
       uses: actions/setup-java@v3
       with:
-        distribution: temurin
+        distribution: zulu
         java-version: ${{ matrix.java }}
     - name: List Python packages (Python 3.9, PyPy3)
       run: |
@@ -539,7 +539,7 @@ jobs:
     - name: Install Java ${{ inputs.java }}
       uses: actions/setup-java@v3
       with:
-        distribution: temurin
+        distribution: zulu
         java-version: ${{ inputs.java }}
     - name: Run tests
       env: ${{ fromJSON(inputs.envs) }}
@@ -653,7 +653,7 @@ jobs:
     - name: Install Java 8
       uses: actions/setup-java@v3
       with:
-        distribution: temurin
+        distribution: zulu
         java-version: 8
     - name: License test
       run: ./dev/check-license
@@ -868,7 +868,7 @@ jobs:
     - name: Install Java 8
       uses: actions/setup-java@v3
       with:
-        distribution: temurin
+        distribution: zulu
         java-version: 8
     - name: Build with SBT
       run: |
@@ -919,7 +919,7 @@ jobs:
     - name: Install Java 8
       uses: actions/setup-java@v3
       with:
-        distribution: temurin
+        distribution: zulu
         java-version: 8
     - name: Cache TPC-DS generated data
       id: cache-tpcds-sf-1
@@ -1025,7 +1025,7 @@ jobs:
     - name: Install Java 8
       uses: actions/setup-java@v3
       with:
-        distribution: temurin
+        distribution: zulu
         java-version: 8
     - name: Run tests
       run: |
@@ -1084,7 +1084,7 @@ jobs:
       - name: Install Java ${{ inputs.java }}
         uses: actions/setup-java@v3
         with:
-          distribution: temurin
+          distribution: zulu
           java-version: ${{ inputs.java }}
       - name: start minikube
         run: |

--- a/.github/workflows/build_java21.yml
+++ b/.github/workflows/build_java21.yml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-name: "Build (master, Scala 2.12, Hadoop 3, JDK 21-ea)"
+name: "Build (master, Scala 2.12, Hadoop 3, JDK 21)"
 
 on:
   schedule:
@@ -31,7 +31,7 @@ jobs:
     uses: ./.github/workflows/build_and_test.yml
     if: github.repository == 'apache/spark'
     with:
-      java: 21-ea
+      java: 21
       branch: master
       hadoop: hadoop3
       envs: >-


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use Java 21 instead of Java 21-EA. To do that, this PR switched JDK distribution from `Temurin` to `Zulu` in `build_and_test` and `build_java21` GitHub Action pipelines.

![Screenshot 2023-09-20 at 9 30 02 AM](https://github.com/apache/spark/assets/9700541/da5f687e-147a-42e3-8d8f-63dc3e3a117c)

![Screenshot 2023-09-20 at 9 31 26 AM](https://github.com/apache/spark/assets/9700541/b85ec14d-d4c9-4238-943f-099dfc1f481a)


### Why are the changes needed?

To use Java 21. Currently, Temurin JDK doesn't have Java 21 release yet.

### Does this PR introduce _any_ user-facing change?

No. This is a testing infra PR.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.