### PR TITLE
[SPARK-45246][BUILD][PS] Encourage using latest `jinja2` other than documentation build

### DIFF
--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -11,6 +11,7 @@ mlflow>=2.3.1
 scikit-learn
 matplotlib
 memory-profiler==0.60.0
+jinja2
 
 # PySpark test dependencies
 unittest-xml-reporting
@@ -34,7 +35,9 @@ pydata_sphinx_theme
 ipython
 nbsphinx
 numpydoc
-jinja2<3.0.0
+# Commented this because we need the latest version of jinja2 for Pandas API on Spark.
+# Please manually install jinja2<3.0.0 when building the documentation.
+# jinja2<3.0.0
 sphinx<3.1.0
 sphinx-plotly-directive
 docutils<0.18.0

--- a/python/docs/source/conf.py
+++ b/python/docs/source/conf.py
@@ -16,6 +16,11 @@ import sys
 import os
 import shutil
 import errno
+import jinja2
+from distutils.version import LooseVersion
+
+if LooseVersion(jinja2.__version__) >= LooseVersion("3.0.0"):
+    raise RuntimeError("Please install jinja2<3.0.0 for building PySpark documentation.")
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to update the `jinja2` version from `dev/requirements.txt` to the latest version for PySpark.


### Why are the changes needed?

Currently, `jinja2<3.0.0` is installed when running `pip install -r dev/requirements.txt`, but it's not working for some functionality for Pandas API on Spark from 4.0.0 release.

Because Pandas requires the latest version of `jinja2` for their LaTex render engine, so Pandas API on Spark also requires the same version since we're leverage the Pandas internally.

<img width="728" alt="Screenshot 2023-09-21 at 2 06 23 PM" src="https://github.com/apache/spark/assets/44108233/1f0bbb15-829c-473b-bb47-e602fa6cb04d">

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
The existing CI should pass.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.