### PR TITLE
[SPARK-45248][CORE][DOCS] Support for set the timeout for spark ui server

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/UI.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/UI.scala
@@ -136,6 +136,12 @@ private[spark] object UI {
     .bytesConf(ByteUnit.BYTE)
     .createWithDefaultString("8k")
 
+  val UI_CONNECTOR_IDLETIMEOUT = ConfigBuilder("spark.ui.server.connectorIdleTimeout")
+    .doc("Value for ui server connectorIdleTimeout.")
+    .version("3.5.0")
+    .intConf
+    .createWithDefault(8000)
+
   val UI_TIMELINE_ENABLED = ConfigBuilder("spark.ui.timelineEnabled")
     .doc("Whether to display event timeline data on UI pages.")
     .version("3.4.0")

--- a/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
@@ -296,6 +296,9 @@ private[spark] object JettyUtils extends Logging {
         connector.setPort(port)
         connector.setHost(hostName)
         connector.setReuseAddress(!Utils.isWindows)
+        val idleTimeout = conf.get(UI_CONNECTOR_IDLETIMEOUT)
+        logDebug(s"Using idleTimeout: $idleTimeout")
+        connector.setIdleTimeout(idleTimeout)
 
         // Currently we only use "SelectChannelConnector"
         // Limit the max acceptor number to 8 so that we don't waste a lot of threads

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1631,6 +1631,14 @@ Apart from these, the following properties are also available, and may be useful
   <td>2.2.3</td>
 </tr>
 <tr>
+  <td><code>spark.ui.server.connectorIdleTimeout</code></td>
+  <td>8000</td>
+  <td>
+     Timeout in milliseconds for the spark ui server
+  </td>
+  <td>3.5.0</td>
+</tr>
+<tr>
   <td><code>spark.ui.timelineEnabled</code></td>
   <td>true</td>
   <td>


### PR DESCRIPTION
**What changes were proposed in this pull request?**
The PR supports to set the timeout for spark ui server.

**Why are the changes needed?**
It can avoid slow HTTP Denial of Service Attack because the jetty server's timeout is 300000 for deafult.

**Does this PR introduce any user-facing change?**
No

**How was this patch tested?**
Manual review

**Was this patch authored or co-authored using generative AI tooling?**
No