### PR TITLE
[SPARK-45213][SQL] Assign name to the error _LEGACY_ERROR_TEMP_2151

### DIFF
--- a/common/utils/src/main/resources/error/error-classes.json
+++ b/common/utils/src/main/resources/error/error-classes.json
@@ -921,6 +921,12 @@
       }
     }
   },
+  "EXPRESSION_DECODING_FAILED" : {
+    "message" : [
+      "Error while decoding: <e>",
+      "<expressions>."
+    ]
+  },
   "EXPRESSION_TYPE_IS_NOT_ORDERABLE" : {
     "message" : [
       "Column expression <expr> cannot be sorted because its type <exprType> is not orderable."
@@ -5517,12 +5523,6 @@
   "_LEGACY_ERROR_TEMP_2150" : {
     "message" : [
       "Due to Scala's limited support of tuple, tuple with more than 22 elements are not supported."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_2151" : {
-    "message" : [
-      "Error while decoding: <e>",
-      "<expressions>."
     ]
   },
   "_LEGACY_ERROR_TEMP_2152" : {

--- a/common/utils/src/main/resources/error/error-classes.json
+++ b/common/utils/src/main/resources/error/error-classes.json
@@ -923,8 +923,7 @@
   },
   "EXPRESSION_DECODING_FAILED" : {
     "message" : [
-      "Error while decoding: <e>",
-      "<expressions>."
+      "Error while decoding: <expressions>."
     ]
   },
   "EXPRESSION_TYPE_IS_NOT_ORDERABLE" : {

--- a/common/utils/src/main/resources/error/error-classes.json
+++ b/common/utils/src/main/resources/error/error-classes.json
@@ -923,7 +923,7 @@
   },
   "EXPRESSION_DECODING_FAILED" : {
     "message" : [
-      "Error while decoding: <expressions>."
+      "Failed to decode a row to a value of the expressions: <expressions>."
     ]
   },
   "EXPRESSION_TYPE_IS_NOT_ORDERABLE" : {

--- a/docs/sql-error-conditions.md
+++ b/docs/sql-error-conditions.md
@@ -555,7 +555,7 @@ For more details see [EXPECT_VIEW_NOT_TABLE](sql-error-conditions-expect-view-no
 
 SQLSTATE: none assigned
 
-Error while decoding: `<expressions>`.
+Failed to decode a row to a value of the expressions: `<expressions>`.
 
 ### EXPRESSION_TYPE_IS_NOT_ORDERABLE
 

--- a/docs/sql-error-conditions.md
+++ b/docs/sql-error-conditions.md
@@ -551,6 +551,13 @@ The table `<tableName>` does not support `<operation>`.
 
 For more details see [EXPECT_VIEW_NOT_TABLE](sql-error-conditions-expect-view-not-table-error-class.html)
 
+### EXPRESSION_DECODING_FAILED
+
+SQLSTATE: none assigned
+
+Error while decoding: `<e>`
+`<expressions>`.
+
 ### EXPRESSION_TYPE_IS_NOT_ORDERABLE
 
 SQLSTATE: none assigned

--- a/docs/sql-error-conditions.md
+++ b/docs/sql-error-conditions.md
@@ -555,8 +555,7 @@ For more details see [EXPECT_VIEW_NOT_TABLE](sql-error-conditions-expect-view-no
 
 SQLSTATE: none assigned
 
-Error while decoding: `<e>`
-`<expressions>`.
+Error while decoding: `<expressions>`.
 
 ### EXPRESSION_TYPE_IS_NOT_ORDERABLE
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -1344,7 +1344,6 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
     new SparkRuntimeException(
       errorClass = "EXPRESSION_DECODING_FAILED",
       messageParameters = Map(
-        "e" -> e.toString(),
         "expressions" -> expressions.map(
           _.simpleString(SQLConf.get.maxToStringFields)).mkString("\n")),
       cause = e)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -1342,7 +1342,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
 
   def expressionDecodingError(e: Exception, expressions: Seq[Expression]): SparkRuntimeException = {
     new SparkRuntimeException(
-      errorClass = "_LEGACY_ERROR_TEMP_2151",
+      errorClass = "EXPRESSION_DECODING_FAILED",
       messageParameters = Map(
         "e" -> e.toString(),
         "expressions" -> expressions.map(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/EncoderResolutionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/EncoderResolutionSuite.scala
@@ -172,7 +172,7 @@ class EncoderResolutionSuite extends PlanTest {
     val e = intercept[RuntimeException] {
       fromRow(InternalRow(new GenericArrayData(Array(1, null))))
     }
-    assert(e.getMessage.contains("Null value appeared in non-nullable field"))
+    assert(e.getCause.getMessage.contains("Null value appeared in non-nullable field"))
   }
 
   test("the real number of fields doesn't match encoder schema: tuple encoder") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -2594,7 +2594,6 @@ class DatasetSuite extends QueryTest
         exception = exception,
         errorClass = "EXPRESSION_DECODING_FAILED",
         parameters = Map(
-          "e" -> exception.getCause.toString(),
           "expressions" -> expressions.map(
             _.simpleString(SQLConf.get.maxToStringFields)).mkString("\n"))
       )

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -2592,7 +2592,7 @@ class DatasetSuite extends QueryTest
       // Expression decoding error
       checkError(
         exception = exception,
-        errorClass = "_LEGACY_ERROR_TEMP_2151",
+        errorClass = "EXPRESSION_DECODING_FAILED",
         parameters = Map(
           "e" -> exception.getCause.toString(),
           "expressions" -> expressions.map(

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -1220,7 +1220,7 @@ class DatasetSuite extends QueryTest
 
     val message = intercept[RuntimeException] {
       buildDataset(Row(Row("hello", null))).collect()
-    }.getMessage
+    }.getCause.getMessage
 
     assert(message.contains("Null value appeared in non-nullable field"))
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Assign the name `EXPRESSION_DECODING_FAILED` to the legacy error class `_LEGACY_ERROR_TEMP_2151`.


### Why are the changes needed?
To assign proper name as a part of activity in SPARK-37935.


### Does this PR introduce _any_ user-facing change?
Yes, the error message will include the error class name

### How was this patch tested?
An existing unit test to produce the error from user code.


### Was this patch authored or co-authored using generative AI tooling?
No.
