### PR TITLE
[SPARK-45253][SQL][DOCS] Correct the group of `ShiftLeft` and `ArraySize`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -159,7 +159,7 @@ object Size {
        4
   """,
   since = "3.3.0",
-  group = "collection_funcs")
+  group = "array_funcs")
 case class ArraySize(child: Expression)
   extends RuntimeReplaceable with ImplicitCastInputTypes with UnaryLike[Expression] {
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/mathExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/mathExpressions.scala
@@ -1271,7 +1271,7 @@ case class Pow(left: Expression, right: Expression)
        4
   """,
   since = "1.5.0",
-  group = "math_funcs")
+  group = "bitwise_funcs")
 case class ShiftLeft(left: Expression, right: Expression)
   extends BinaryExpression with ImplicitCastInputTypes with NullIntolerant {
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Correct the group of `ShiftLeft` and `ArraySize`


### Why are the changes needed?

`ShiftLeft` should be in the same group of `ShiftRight` and `ShiftRightUnsigned`;

`ArraySize` should be in the same group of `ArrayMax`, `ArrayCompact`, etc.


### Does this PR introduce _any_ user-facing change?
yes

the two functions will be shown in correct category in https://spark.apache.org/docs/latest/sql-ref-functions.html


### How was this patch tested?
manually check


### Was this patch authored or co-authored using generative AI tooling?
no