### PR TITLE
[SPARK-45256][SQL] DurationWriter fails when writing more values than initial capacity 

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/arrow/ArrowWriter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/arrow/ArrowWriter.scala
@@ -463,7 +463,7 @@ private[arrow] class DurationWriter(val valueVector: DurationVector)
   }
 
   override def setValue(input: SpecializedGetters, ordinal: Int): Unit = {
-    valueVector.set(count, input.getLong(ordinal))
+    valueVector.setSafe(count, input.getLong(ordinal))
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/arrow/ArrowWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/arrow/ArrowWriterSuite.scala
@@ -147,6 +147,7 @@ class ArrowWriterSuite extends SparkFunSuite {
     check(TimestampType, (0 until 10).map(_ * 4.32e10.toLong), "America/Los_Angeles")
     check(TimestampNTZType, (0 until 10).map(_ * 4.32e10.toLong))
     DataTypeTestUtils.yearMonthIntervalTypes.foreach(check(_, (0 until 14)))
+    DataTypeTestUtils.dayTimeIntervalTypes.foreach(check(_, (-10 until 10).map(_ * 1000.toLong)))
   }
 
   test("write multiple, over initial capacity") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/arrow/ArrowWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/arrow/ArrowWriterSuite.scala
@@ -147,6 +147,74 @@ class ArrowWriterSuite extends SparkFunSuite {
     check(TimestampType, (0 until 10).map(_ * 4.32e10.toLong), "America/Los_Angeles")
     check(TimestampNTZType, (0 until 10).map(_ * 4.32e10.toLong))
     DataTypeTestUtils.yearMonthIntervalTypes.foreach(check(_, (0 until 14)))
+  }
+
+  test("write multiple, over initial capacity") {
+    def createArrowWriter(
+        schema: StructType,
+        timeZoneId: String): (ArrowWriter, Int) = {
+      val arrowSchema =
+        ArrowUtils.toArrowSchema(schema, timeZoneId, errorOnDuplicatedFieldNames = true)
+      val root = VectorSchemaRoot.create(arrowSchema, ArrowUtils.rootAllocator)
+      val vector = root.getFieldVectors.get(0)
+      vector.allocateNew()
+      val cap = vector.getValueCapacity
+      val writer = new ArrowWriter(root, Array(ArrowWriter.createFieldWriter(vector)))
+      (writer, cap)
+    }
+    def check(dt: DataType, data: Seq[Any], timeZoneId: String = null): Unit = {
+      val dataType = dt match {
+        case _: DayTimeIntervalType => DayTimeIntervalType()
+        case _: YearMonthIntervalType => YearMonthIntervalType()
+        case tpe => tpe
+      }
+      val schema = new StructType().add("value", dataType, nullable = false)
+      val (writer, initialCapacity) = createArrowWriter(schema, timeZoneId)
+
+      assert(writer.schema === schema)
+
+      // Write more values than the initial capacity of the vector
+      val iterations = (initialCapacity / data.length) + 1
+      (0 until iterations).foreach { _ =>
+        data.foreach { datum =>
+          writer.write(InternalRow(datum))
+        }
+      }
+      writer.finish()
+
+      val reader = new ArrowColumnVector(writer.root.getFieldVectors.get(0))
+      (0 until iterations)
+        .map(i => i * data.size)
+        .foreach { offset =>
+        val values = dt match {
+          case BooleanType => reader.getBooleans(offset, data.size)
+          case ByteType => reader.getBytes(offset, data.size)
+          case ShortType => reader.getShorts(offset, data.size)
+          case IntegerType => reader.getInts(offset, data.size)
+          case LongType => reader.getLongs(offset, data.size)
+          case FloatType => reader.getFloats(offset, data.size)
+          case DoubleType => reader.getDoubles(offset, data.size)
+          case DateType => reader.getInts(offset, data.size)
+          case TimestampType => reader.getLongs(offset, data.size)
+          case TimestampNTZType => reader.getLongs(offset, data.size)
+          case _: YearMonthIntervalType => reader.getInts(offset, data.size)
+          case _: DayTimeIntervalType => reader.getLongs(offset, data.size)
+        }
+        assert(values === data)
+      }
+      writer.root.close()
+    }
+    check(BooleanType, Seq(true, false))
+    check(ByteType, (0 until 10).map(_.toByte))
+    check(ShortType, (0 until 10).map(_.toShort))
+    check(IntegerType, (0 until 10))
+    check(LongType, (0 until 10).map(_.toLong))
+    check(FloatType, (0 until 10).map(_.toFloat))
+    check(DoubleType, (0 until 10).map(_.toDouble))
+    check(DateType, (0 until 10))
+    check(TimestampType, (0 until 10).map(_ * 4.32e10.toLong), "America/Los_Angeles")
+    check(TimestampNTZType, (0 until 10).map(_ * 4.32e10.toLong))
+    DataTypeTestUtils.yearMonthIntervalTypes.foreach(check(_, (0 until 14)))
     DataTypeTestUtils.dayTimeIntervalTypes.foreach(check(_, (-10 until 10).map(_ * 1000.toLong)))
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/arrow/ArrowWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/arrow/ArrowWriterSuite.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.execution.arrow
 
+import org.apache.arrow.vector.VectorSchemaRoot
+
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.util._

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/arrow/ArrowWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/arrow/ArrowWriterSuite.scala
@@ -21,6 +21,7 @@ import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.util._
 import org.apache.spark.sql.types._
+import org.apache.spark.sql.util.ArrowUtils
 import org.apache.spark.sql.vectorized._
 import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
The DurationWriter fails if more values are written than the initial capacity of the DurationVector (4032). Fix by using `setSafe` instead of `set` method.

### Why are the changes needed?
Bug fix


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Added unit test for checking all types when writing more values than initial capacity.


### Was this patch authored or co-authored using generative AI tooling?
No
