### PR TITLE
[SPARK-45261][CORE][FOLLOWUP] Avoid `transform` of conf value

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -465,7 +465,7 @@ class SparkContext(config: SparkConf) extends Logging {
 
     _eventLogCodec = {
       val compress = _conf.get(EVENT_LOG_COMPRESS) &&
-          !_conf.get(EVENT_LOG_COMPRESSION_CODEC).equals("none")
+          !_conf.get(EVENT_LOG_COMPRESSION_CODEC).equalsIgnoreCase("none")
       if (compress && isEventLogEnabled) {
         Some(_conf.get(EVENT_LOG_COMPRESSION_CODEC)).map(CompressionCodec.getShortName)
       } else {

--- a/core/src/main/scala/org/apache/spark/deploy/history/EventLogFileWriters.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/EventLogFileWriters.scala
@@ -55,7 +55,7 @@ abstract class EventLogFileWriter(
     hadoopConf: Configuration) extends Logging {
 
   protected val shouldCompress = sparkConf.get(EVENT_LOG_COMPRESS) &&
-      !sparkConf.get(EVENT_LOG_COMPRESSION_CODEC).equals("none")
+      !sparkConf.get(EVENT_LOG_COMPRESSION_CODEC).equalsIgnoreCase("none")
   protected val shouldOverwrite = sparkConf.get(EVENT_LOG_OVERWRITE)
   protected val outputBufferSize = sparkConf.get(EVENT_LOG_OUTPUT_BUFFER_SIZE).toInt
   protected val fileSystem = Utils.getHadoopFileSystem(logBaseDir, hadoopConf)

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1907,7 +1907,6 @@ package object config {
         "the codec.")
       .version("3.0.0")
       .stringConf
-      .transform(_.toLowerCase(Locale.ROOT))
       .createWithDefault("zstd")
 
   private[spark] val BUFFER_SIZE =


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up of #43038 to preserve the config value.

### Why are the changes needed?

`spark.eventLog.compression.codec` allows fully-quilified class names which are case-sensitive.

### Does this PR introduce _any_ user-facing change?

To preserve the existing behavior.

### How was this patch tested?

Pass the CIs. Currently, `ReplayListenerSuite` is broken.
```
[info] ReplayListenerSuite:
[info] - Simple replay (25 milliseconds)
[info] - Replay compressed inprogress log file succeeding on partial read (35 milliseconds)
[info] - Replay incompatible event log (19 milliseconds)
[info] - End-to-end replay (11 seconds, 58 milliseconds)
[info] - End-to-end replay with compression *** FAILED *** (29 milliseconds)
[info]   org.apache.spark.SparkIllegalArgumentException: [CODEC_SHORT_NAME_NOT_FOUND] Cannot find a short name for the codec org.apache.spark.io.lz4compressioncodec.
```

### Was this patch authored or co-authored using generative AI tooling?

No.
