### PR TITLE
[SPARK-45269][K8S] Use Java 21-jre in K8s Dockerfile

### DIFF
--- a/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile
+++ b/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile
@@ -14,9 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ARG java_image_tag=17-jre
+ARG java_image_tag=21-jre
 
-FROM eclipse-temurin:${java_image_tag}
+FROM azul/zulu-openjdk:${java_image_tag}
 
 ARG spark_uid=185
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `Java 21` JRE in K8s Dockerfile. This PR uses Zulu OpenJDK 21 because Eclipse Temurin doesn't have Java 21.

### Why are the changes needed?

- Enable Java 21 test coverage in the K8s integration tests to make it sure all K8s-related library works in Java 21.
- Recommend K8s users to use Java 21 when they build images from Apache Spark 4.0.0 binary distribution

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.