### PR TITLE
[SPARK-45280][INFRA] Change Maven daily test use Java 17 for testing

### DIFF
--- a/.github/workflows/build_maven.yml
+++ b/.github/workflows/build_maven.yml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-name: "Build using Maven (master, Scala 2.13, Hadoop 3, JDK 8)"
+name: "Build using Maven (master, Scala 2.13, Hadoop 3, JDK 17)"
 
 on:
   schedule:

--- a/.github/workflows/maven_test.yml
+++ b/.github/workflows/maven_test.yml
@@ -25,7 +25,7 @@ on:
       java:
         required: false
         type: string
-        default: 8
+        default: 17
       branch:
         description: Branch to run the build against
         required: false


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims change Maven daily test use Java 17 for testing.

### Why are the changes needed?
https://github.com/apache/spark/pull/43005 drop support for Java 8 and Java 11, so  Maven daily test should also test with Java 17 as default.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Monitor Maven daily test GA task


### Was this patch authored or co-authored using generative AI tooling?
No
