### PR TITLE
[SPARK-45281][CORE][TESTS] Update BenchmarkBase to use Java 17 as the base version

### DIFF
--- a/core/src/test/scala/org/apache/spark/benchmark/BenchmarkBase.scala
+++ b/core/src/test/scala/org/apache/spark/benchmark/BenchmarkBase.scala
@@ -51,7 +51,7 @@ abstract class BenchmarkBase {
     val regenerateBenchmarkFiles: Boolean = System.getenv("SPARK_GENERATE_BENCHMARK_FILES") == "1"
     if (regenerateBenchmarkFiles) {
       val version = System.getProperty("java.version").split("\\D+")(0).toInt
-      val jdkString = if (version > 8) s"-jdk$version" else ""
+      val jdkString = if (version > 17) s"-jdk$version" else ""
       val resultFileName =
         s"${this.getClass.getSimpleName.replace("$", "")}$jdkString$suffix-results.txt"
       val prefix = Benchmarks.currentProjectRoot.map(_ + "/").getOrElse("")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update `BenchmarkBase` to use `Java 17` as the base version.

### Why are the changes needed?

Previously, `KryoBenchmark-results.txt` is generated by Java 8. After this PR, it will be the result of Java 17.
```
$ ls -al core/benchmarks/KryoBenchmark*
-rw-r--r--  1 dongjoon  staff  2831 Sep 20 08:47 core/benchmarks/KryoBenchmark-jdk11-results.txt
-rw-r--r--  1 dongjoon  staff  2831 Sep 22 05:53 core/benchmarks/KryoBenchmark-jdk17-results.txt
-rw-r--r--  1 dongjoon  staff  2830 Sep 20 08:47 core/benchmarks/KryoBenchmark-results.txt
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual run the following.
```
$ SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "core/Test/runMain org.apache.spark.serializer.KryoBenchmark"

$ java -version
openjdk version "17.0.8" 2023-07-18 LTS

$ git status
...
	modified:   core/benchmarks/KryoBenchmark-results.txt
```

### Was this patch authored or co-authored using generative AI tooling?

No.