### PR TITLE
[SPARK-45284][R] Update SparkR minimum SystemRequirements to Java 17

### DIFF
--- a/R/pkg/DESCRIPTION
+++ b/R/pkg/DESCRIPTION
@@ -10,7 +10,7 @@ Authors@R:
 License: Apache License (== 2.0)
 URL: https://www.apache.org https://spark.apache.org
 BugReports: https://spark.apache.org/contributing.html
-SystemRequirements: Java (>= 8, < 22)
+SystemRequirements: Java (>= 17, < 22)
 Depends:
     R (>= 3.5),
     methods


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update SparkR's minimum SystemRequirements from Java 8 to Java 17 for Apache Spark 4.0.0.

### Why are the changes needed?

- Apache Spark 4 drops Java 8 and 11 support via SPARK-44112.
- This will make it sure that the users have Java 17+ environment by preventing running on wrong Java versions as much as possible.

### Does this PR introduce _any_ user-facing change?

Yes, but this is an expected behavior change.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.