### PR TITLE
[SQL] Throw an error for correlated exists/IN subqueries with LIMIT clauses

### DIFF
--- a/sql/core/src/test/resources/sql-tests/analyzer-results/subquery/exists-subquery/exists-orderby-limit.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/subquery/exists-subquery/exists-orderby-limit.sql.out
@@ -109,6 +109,72 @@ Sort [hiredate#x ASC NULLS FIRST], true
 
 
 -- !query
+SELECT *
+FROM   emp
+WHERE  EXISTS (SELECT dept.dept_id
+               FROM   dept
+               WHERE  emp.dept_id = dept.dept_id
+               ORDER  BY state
+               LIMIT 1)
+ORDER  BY hiredate
+-- !query analysis
+Sort [hiredate#x ASC NULLS FIRST], true
++- Project [id#x, emp_name#x, hiredate#x, salary#x, dept_id#x]
+   +- Filter exists#x [dept_id#x]
+      :  +- GlobalLimit 1
+      :     +- LocalLimit 1
+      :        +- Project [dept_id#x]
+      :           +- Sort [state#x ASC NULLS FIRST], true
+      :              +- Project [dept_id#x, state#x]
+      :                 +- Filter (outer(dept_id#x) = dept_id#x)
+      :                    +- SubqueryAlias dept
+      :                       +- View (`DEPT`, [dept_id#x,dept_name#x,state#x])
+      :                          +- Project [cast(dept_id#x as int) AS dept_id#x, cast(dept_name#x as string) AS dept_name#x, cast(state#x as string) AS state#x]
+      :                             +- Project [dept_id#x, dept_name#x, state#x]
+      :                                +- SubqueryAlias DEPT
+      :                                   +- LocalRelation [dept_id#x, dept_name#x, state#x]
+      +- SubqueryAlias emp
+         +- View (`EMP`, [id#x,emp_name#x,hiredate#x,salary#x,dept_id#x])
+            +- Project [cast(id#x as int) AS id#x, cast(emp_name#x as string) AS emp_name#x, cast(hiredate#x as date) AS hiredate#x, cast(salary#x as double) AS salary#x, cast(dept_id#x as int) AS dept_id#x]
+               +- Project [id#x, emp_name#x, hiredate#x, salary#x, dept_id#x]
+                  +- SubqueryAlias EMP
+                     +- LocalRelation [id#x, emp_name#x, hiredate#x, salary#x, dept_id#x]
+
+
+-- !query
+SELECT *
+FROM   emp
+WHERE  EXISTS (SELECT dept.dept_id
+               FROM   dept
+               WHERE  emp.dept_id = dept.dept_id
+               ORDER  BY state
+               LIMIT 0)
+ORDER  BY hiredate
+-- !query analysis
+Sort [hiredate#x ASC NULLS FIRST], true
++- Project [id#x, emp_name#x, hiredate#x, salary#x, dept_id#x]
+   +- Filter exists#x [dept_id#x]
+      :  +- GlobalLimit 0
+      :     +- LocalLimit 0
+      :        +- Project [dept_id#x]
+      :           +- Sort [state#x ASC NULLS FIRST], true
+      :              +- Project [dept_id#x, state#x]
+      :                 +- Filter (outer(dept_id#x) = dept_id#x)
+      :                    +- SubqueryAlias dept
+      :                       +- View (`DEPT`, [dept_id#x,dept_name#x,state#x])
+      :                          +- Project [cast(dept_id#x as int) AS dept_id#x, cast(dept_name#x as string) AS dept_name#x, cast(state#x as string) AS state#x]
+      :                             +- Project [dept_id#x, dept_name#x, state#x]
+      :                                +- SubqueryAlias DEPT
+      :                                   +- LocalRelation [dept_id#x, dept_name#x, state#x]
+      +- SubqueryAlias emp
+         +- View (`EMP`, [id#x,emp_name#x,hiredate#x,salary#x,dept_id#x])
+            +- Project [cast(id#x as int) AS id#x, cast(emp_name#x as string) AS emp_name#x, cast(hiredate#x as date) AS hiredate#x, cast(salary#x as double) AS salary#x, cast(dept_id#x as int) AS dept_id#x]
+               +- Project [id#x, emp_name#x, hiredate#x, salary#x, dept_id#x]
+                  +- SubqueryAlias EMP
+                     +- LocalRelation [id#x, emp_name#x, hiredate#x, salary#x, dept_id#x]
+
+
+-- !query
 SELECT id, 
        hiredate 
 FROM   emp 
@@ -170,6 +236,72 @@ Sort [hiredate#x ASC NULLS FIRST], true
 
 
 -- !query
+SELECT *
+FROM   emp
+WHERE  NOT EXISTS (SELECT dept.dept_id
+                   FROM   dept
+                   WHERE  emp.dept_id = dept.dept_id
+                   ORDER  BY state
+                   LIMIT 1)
+ORDER  BY hiredate
+-- !query analysis
+Sort [hiredate#x ASC NULLS FIRST], true
++- Project [id#x, emp_name#x, hiredate#x, salary#x, dept_id#x]
+   +- Filter NOT exists#x [dept_id#x]
+      :  +- GlobalLimit 1
+      :     +- LocalLimit 1
+      :        +- Project [dept_id#x]
+      :           +- Sort [state#x ASC NULLS FIRST], true
+      :              +- Project [dept_id#x, state#x]
+      :                 +- Filter (outer(dept_id#x) = dept_id#x)
+      :                    +- SubqueryAlias dept
+      :                       +- View (`DEPT`, [dept_id#x,dept_name#x,state#x])
+      :                          +- Project [cast(dept_id#x as int) AS dept_id#x, cast(dept_name#x as string) AS dept_name#x, cast(state#x as string) AS state#x]
+      :                             +- Project [dept_id#x, dept_name#x, state#x]
+      :                                +- SubqueryAlias DEPT
+      :                                   +- LocalRelation [dept_id#x, dept_name#x, state#x]
+      +- SubqueryAlias emp
+         +- View (`EMP`, [id#x,emp_name#x,hiredate#x,salary#x,dept_id#x])
+            +- Project [cast(id#x as int) AS id#x, cast(emp_name#x as string) AS emp_name#x, cast(hiredate#x as date) AS hiredate#x, cast(salary#x as double) AS salary#x, cast(dept_id#x as int) AS dept_id#x]
+               +- Project [id#x, emp_name#x, hiredate#x, salary#x, dept_id#x]
+                  +- SubqueryAlias EMP
+                     +- LocalRelation [id#x, emp_name#x, hiredate#x, salary#x, dept_id#x]
+
+
+-- !query
+SELECT *
+FROM   emp
+WHERE  NOT EXISTS (SELECT dept.dept_id
+                   FROM   dept
+                   WHERE  emp.dept_id = dept.dept_id
+                   ORDER  BY state
+                   LIMIT 0)
+ORDER  BY hiredate
+-- !query analysis
+Sort [hiredate#x ASC NULLS FIRST], true
++- Project [id#x, emp_name#x, hiredate#x, salary#x, dept_id#x]
+   +- Filter NOT exists#x [dept_id#x]
+      :  +- GlobalLimit 0
+      :     +- LocalLimit 0
+      :        +- Project [dept_id#x]
+      :           +- Sort [state#x ASC NULLS FIRST], true
+      :              +- Project [dept_id#x, state#x]
+      :                 +- Filter (outer(dept_id#x) = dept_id#x)
+      :                    +- SubqueryAlias dept
+      :                       +- View (`DEPT`, [dept_id#x,dept_name#x,state#x])
+      :                          +- Project [cast(dept_id#x as int) AS dept_id#x, cast(dept_name#x as string) AS dept_name#x, cast(state#x as string) AS state#x]
+      :                             +- Project [dept_id#x, dept_name#x, state#x]
+      :                                +- SubqueryAlias DEPT
+      :                                   +- LocalRelation [dept_id#x, dept_name#x, state#x]
+      +- SubqueryAlias emp
+         +- View (`EMP`, [id#x,emp_name#x,hiredate#x,salary#x,dept_id#x])
+            +- Project [cast(id#x as int) AS id#x, cast(emp_name#x as string) AS emp_name#x, cast(hiredate#x as date) AS hiredate#x, cast(salary#x as double) AS salary#x, cast(dept_id#x as int) AS dept_id#x]
+               +- Project [id#x, emp_name#x, hiredate#x, salary#x, dept_id#x]
+                  +- SubqueryAlias EMP
+                     +- LocalRelation [id#x, emp_name#x, hiredate#x, salary#x, dept_id#x]
+
+
+-- !query
 SELECT emp_name 
 FROM   emp 
 WHERE  NOT EXISTS (SELECT max(dept.dept_id) a 
@@ -196,6 +328,34 @@ Project [emp_name#x]
             +- Project [id#x, emp_name#x, hiredate#x, salary#x, dept_id#x]
                +- SubqueryAlias EMP
                   +- LocalRelation [id#x, emp_name#x, hiredate#x, salary#x, dept_id#x]
+
+
+-- !query
+SELECT emp_name
+FROM   emp
+WHERE  NOT EXISTS (SELECT max(dept.dept_id) a
+                   FROM   dept
+                   WHERE  dept.dept_id = emp.dept_id
+                   GROUP  BY state
+                   ORDER  BY state
+                   LIMIT 2
+                   OFFSET 1)
+-- !query analysis
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "UNSUPPORTED_SUBQUERY_EXPRESSION_CATEGORY.ACCESSING_OUTER_QUERY_COLUMN_IS_NOT_ALLOWED",
+  "sqlState" : "0A000",
+  "messageParameters" : {
+    "treeNode" : "Filter (dept_id#x = outer(dept_id#x))\n+- SubqueryAlias dept\n   +- View (`DEPT`, [dept_id#x,dept_name#x,state#x])\n      +- Project [cast(dept_id#x as int) AS dept_id#x, cast(dept_name#x as string) AS dept_name#x, cast(state#x as string) AS state#x]\n         +- Project [dept_id#x, dept_name#x, state#x]\n            +- SubqueryAlias DEPT\n               +- LocalRelation [dept_id#x, dept_name#x, state#x]\n"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 47,
+    "stopIndex" : 191,
+    "fragment" : "SELECT max(dept.dept_id) a\n                   FROM   dept\n                   WHERE  dept.dept_id = emp.dept_id\n                   GROUP  BY state"
+  } ]
+}
 
 
 -- !query
@@ -256,6 +416,34 @@ Project [id#x, emp_name#x, hiredate#x, salary#x, dept_id#x]
 
 
 -- !query
+SELECT *
+FROM   emp
+WHERE  EXISTS (SELECT dept.dept_name
+               FROM   dept
+               WHERE  dept.dept_id > emp.dept_id
+               LIMIT  1)
+-- !query analysis
+Project [id#x, emp_name#x, hiredate#x, salary#x, dept_id#x]
++- Filter exists#x [dept_id#x]
+   :  +- GlobalLimit 1
+   :     +- LocalLimit 1
+   :        +- Project [dept_name#x]
+   :           +- Filter (dept_id#x > outer(dept_id#x))
+   :              +- SubqueryAlias dept
+   :                 +- View (`DEPT`, [dept_id#x,dept_name#x,state#x])
+   :                    +- Project [cast(dept_id#x as int) AS dept_id#x, cast(dept_name#x as string) AS dept_name#x, cast(state#x as string) AS state#x]
+   :                       +- Project [dept_id#x, dept_name#x, state#x]
+   :                          +- SubqueryAlias DEPT
+   :                             +- LocalRelation [dept_id#x, dept_name#x, state#x]
+   +- SubqueryAlias emp
+      +- View (`EMP`, [id#x,emp_name#x,hiredate#x,salary#x,dept_id#x])
+         +- Project [cast(id#x as int) AS id#x, cast(emp_name#x as string) AS emp_name#x, cast(hiredate#x as date) AS hiredate#x, cast(salary#x as double) AS salary#x, cast(dept_id#x as int) AS dept_id#x]
+            +- Project [id#x, emp_name#x, hiredate#x, salary#x, dept_id#x]
+               +- SubqueryAlias EMP
+                  +- LocalRelation [id#x, emp_name#x, hiredate#x, salary#x, dept_id#x]
+
+
+-- !query
 SELECT * 
 FROM   emp 
 WHERE  EXISTS (SELECT max(dept.dept_id) 
@@ -280,6 +468,32 @@ Project [id#x, emp_name#x, hiredate#x, salary#x, dept_id#x]
             +- Project [id#x, emp_name#x, hiredate#x, salary#x, dept_id#x]
                +- SubqueryAlias EMP
                   +- LocalRelation [id#x, emp_name#x, hiredate#x, salary#x, dept_id#x]
+
+
+-- !query
+SELECT *
+FROM   emp
+WHERE  EXISTS (SELECT max(dept.dept_id)
+               FROM   dept
+               WHERE  dept.dept_id <> emp.dept_id
+               GROUP  BY state
+               LIMIT  1)
+-- !query analysis
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "UNSUPPORTED_SUBQUERY_EXPRESSION_CATEGORY.CORRELATED_COLUMN_IS_NOT_ALLOWED_IN_PREDICATE",
+  "sqlState" : "0A000",
+  "messageParameters" : {
+    "treeNode" : "NOT (dept_id#x = outer(dept_id#x))\nFilter NOT (dept_id#x = outer(dept_id#x))\n+- SubqueryAlias dept\n   +- View (`DEPT`, [dept_id#x,dept_name#x,state#x])\n      +- Project [cast(dept_id#x as int) AS dept_id#x, cast(dept_name#x as string) AS dept_name#x, cast(state#x as string) AS state#x]\n         +- Project [dept_id#x, dept_name#x, state#x]\n            +- SubqueryAlias DEPT\n               +- LocalRelation [dept_id#x, dept_name#x, state#x]\n"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 36,
+    "stopIndex" : 167,
+    "fragment" : "SELECT max(dept.dept_id)\n               FROM   dept\n               WHERE  dept.dept_id <> emp.dept_id\n               GROUP  BY state"
+  } ]
+}
 
 
 -- !query
@@ -367,6 +581,32 @@ Project [id#x, emp_name#x, hiredate#x, salary#x, dept_id#x]
             +- Project [id#x, emp_name#x, hiredate#x, salary#x, dept_id#x]
                +- SubqueryAlias EMP
                   +- LocalRelation [id#x, emp_name#x, hiredate#x, salary#x, dept_id#x]
+
+
+-- !query
+SELECT *
+FROM   emp
+WHERE  EXISTS (SELECT dept.dept_name
+               FROM   dept
+               WHERE  dept.dept_id <> emp.dept_id
+               LIMIT  1
+               OFFSET 2)
+-- !query analysis
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "UNSUPPORTED_SUBQUERY_EXPRESSION_CATEGORY.ACCESSING_OUTER_QUERY_COLUMN_IS_NOT_ALLOWED",
+  "sqlState" : "0A000",
+  "messageParameters" : {
+    "treeNode" : "Filter NOT (dept_id#x = outer(dept_id#x))\n+- SubqueryAlias dept\n   +- View (`DEPT`, [dept_id#x,dept_name#x,state#x])\n      +- Project [cast(dept_id#x as int) AS dept_id#x, cast(dept_name#x as string) AS dept_name#x, cast(state#x as string) AS state#x]\n         +- Project [dept_id#x, dept_name#x, state#x]\n            +- SubqueryAlias DEPT\n               +- LocalRelation [dept_id#x, dept_name#x, state#x]\n"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 36,
+    "stopIndex" : 133,
+    "fragment" : "SELECT dept.dept_name\n               FROM   dept\n               WHERE  dept.dept_id <> emp.dept_id"
+  } ]
+}
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/subquery/in-subquery/in-limit.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/subquery/in-subquery/in-limit.sql.out
@@ -137,6 +137,37 @@ GlobalLimit 2
 -- !query
 SELECT *
 FROM   t1
+WHERE  t1a IN (SELECT t2a
+               FROM   t2
+               WHERE  t1d = t2d
+               LIMIT 10)
+LIMIT  2
+-- !query analysis
+GlobalLimit 2
++- LocalLimit 2
+   +- Project [t1a#x, t1b#x, t1c#x, t1d#xL, t1e#x, t1f#x, t1g#x, t1h#x, t1i#x]
+      +- Filter t1a#x IN (list#x [t1d#xL])
+         :  +- GlobalLimit 10
+         :     +- LocalLimit 10
+         :        +- Project [t2a#x]
+         :           +- Filter (outer(t1d#xL) = t2d#xL)
+         :              +- SubqueryAlias t2
+         :                 +- View (`t2`, [t2a#x,t2b#x,t2c#x,t2d#xL,t2e#x,t2f#x,t2g#x,t2h#x,t2i#x])
+         :                    +- Project [cast(t2a#x as string) AS t2a#x, cast(t2b#x as smallint) AS t2b#x, cast(t2c#x as int) AS t2c#x, cast(t2d#xL as bigint) AS t2d#xL, cast(t2e#x as float) AS t2e#x, cast(t2f#x as double) AS t2f#x, cast(t2g#x as decimal(4,0)) AS t2g#x, cast(t2h#x as timestamp) AS t2h#x, cast(t2i#x as date) AS t2i#x]
+         :                       +- Project [t2a#x, t2b#x, t2c#x, t2d#xL, t2e#x, t2f#x, t2g#x, t2h#x, t2i#x]
+         :                          +- SubqueryAlias t2
+         :                             +- LocalRelation [t2a#x, t2b#x, t2c#x, t2d#xL, t2e#x, t2f#x, t2g#x, t2h#x, t2i#x]
+         +- SubqueryAlias t1
+            +- View (`t1`, [t1a#x,t1b#x,t1c#x,t1d#xL,t1e#x,t1f#x,t1g#x,t1h#x,t1i#x])
+               +- Project [cast(t1a#x as string) AS t1a#x, cast(t1b#x as smallint) AS t1b#x, cast(t1c#x as int) AS t1c#x, cast(t1d#xL as bigint) AS t1d#xL, cast(t1e#x as float) AS t1e#x, cast(t1f#x as double) AS t1f#x, cast(t1g#x as decimal(4,0)) AS t1g#x, cast(t1h#x as timestamp) AS t1h#x, cast(t1i#x as date) AS t1i#x]
+                  +- Project [t1a#x, t1b#x, t1c#x, t1d#xL, t1e#x, t1f#x, t1g#x, t1h#x, t1i#x]
+                     +- SubqueryAlias t1
+                        +- LocalRelation [t1a#x, t1b#x, t1c#x, t1d#xL, t1e#x, t1f#x, t1g#x, t1h#x, t1i#x]
+
+
+-- !query
+SELECT *
+FROM   t1
 WHERE  t1c IN (SELECT t2c
                FROM   t2
                WHERE  t2b >= 8

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/subquery/in-subquery/in-limit.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/subquery/in-subquery/in-limit.sql.out
@@ -201,18 +201,18 @@ SELECT *
 FROM   t1
 WHERE  t1c IN (SELECT t2c
                FROM   t2
-               WHERE  t2b <= t2d
+               WHERE  t2b <= t1d
                LIMIT  2)
 LIMIT 4
 -- !query analysis
 GlobalLimit 4
 +- LocalLimit 4
    +- Project [t1a#x, t1b#x, t1c#x, t1d#xL, t1e#x, t1f#x, t1g#x, t1h#x, t1i#x]
-      +- Filter t1c#x IN (list#x [])
+      +- Filter t1c#x IN (list#x [t1d#xL])
          :  +- GlobalLimit 2
          :     +- LocalLimit 2
          :        +- Project [t2c#x]
-         :           +- Filter (cast(t2b#x as bigint) <= t2d#xL)
+         :           +- Filter (cast(t2b#x as bigint) <= outer(t1d#xL))
          :              +- SubqueryAlias t2
          :                 +- View (`t2`, [t2a#x,t2b#x,t2c#x,t2d#xL,t2e#x,t2f#x,t2g#x,t2h#x,t2i#x])
          :                    +- Project [cast(t2a#x as string) AS t2a#x, cast(t2b#x as smallint) AS t2b#x, cast(t2c#x as int) AS t2c#x, cast(t2d#xL as bigint) AS t2d#xL, cast(t2e#x as float) AS t2e#x, cast(t2f#x as double) AS t2f#x, cast(t2g#x as decimal(4,0)) AS t2g#x, cast(t2h#x as timestamp) AS t2h#x, cast(t2i#x as date) AS t2i#x]
@@ -269,7 +269,7 @@ SELECT Count(DISTINCT( t1a )),
 FROM   t1
 WHERE  t1d IN (SELECT t2d
                FROM   t2
-               WHERE t2b <= t2d
+               WHERE t2b <= t1d
                ORDER  BY t2c, t2d
                LIMIT 2)
 GROUP  BY t1b
@@ -280,13 +280,13 @@ GlobalLimit 1
 +- LocalLimit 1
    +- Sort [t1b#x DESC NULLS FIRST], true
       +- Aggregate [t1b#x], [count(distinct t1a#x) AS count(DISTINCT t1a)#xL, t1b#x]
-         +- Filter t1d#xL IN (list#x [])
+         +- Filter t1d#xL IN (list#x [t1d#xL])
             :  +- GlobalLimit 2
             :     +- LocalLimit 2
             :        +- Project [t2d#xL]
             :           +- Sort [t2c#x ASC NULLS FIRST, t2d#xL ASC NULLS FIRST], true
             :              +- Project [t2d#xL, t2c#x]
-            :                 +- Filter (cast(t2b#x as bigint) <= t2d#xL)
+            :                 +- Filter (cast(t2b#x as bigint) <= outer(t1d#xL))
             :                    +- SubqueryAlias t2
             :                       +- View (`t2`, [t2a#x,t2b#x,t2c#x,t2d#xL,t2e#x,t2f#x,t2g#x,t2h#x,t2i#x])
             :                          +- Project [cast(t2a#x as string) AS t2a#x, cast(t2b#x as smallint) AS t2b#x, cast(t2c#x as int) AS t2c#x, cast(t2d#xL as bigint) AS t2d#xL, cast(t2e#x as float) AS t2e#x, cast(t2f#x as double) AS t2f#x, cast(t2g#x as decimal(4,0)) AS t2g#x, cast(t2h#x as timestamp) AS t2h#x, cast(t2i#x as date) AS t2i#x]
@@ -334,15 +334,15 @@ SELECT *
 FROM   t1
 WHERE  t1b NOT IN (SELECT t2b
                    FROM   t2
-                   WHERE  t2b <= t2d
+                   WHERE  t2b <= t1d
                    LIMIT  2)
 -- !query analysis
 Project [t1a#x, t1b#x, t1c#x, t1d#xL, t1e#x, t1f#x, t1g#x, t1h#x, t1i#x]
-+- Filter NOT t1b#x IN (list#x [])
++- Filter NOT t1b#x IN (list#x [t1d#xL])
    :  +- GlobalLimit 2
    :     +- LocalLimit 2
    :        +- Project [t2b#x]
-   :           +- Filter (cast(t2b#x as bigint) <= t2d#xL)
+   :           +- Filter (cast(t2b#x as bigint) <= outer(t1d#xL))
    :              +- SubqueryAlias t2
    :                 +- View (`t2`, [t2a#x,t2b#x,t2c#x,t2d#xL,t2e#x,t2f#x,t2g#x,t2h#x,t2i#x])
    :                    +- Project [cast(t2a#x as string) AS t2a#x, cast(t2b#x as smallint) AS t2b#x, cast(t2c#x as int) AS t2c#x, cast(t2d#xL as bigint) AS t2d#xL, cast(t2e#x as float) AS t2e#x, cast(t2f#x as double) AS t2f#x, cast(t2g#x as decimal(4,0)) AS t2g#x, cast(t2h#x as timestamp) AS t2h#x, cast(t2i#x as date) AS t2i#x]

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/subquery/in-subquery/in-limit.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/subquery/in-subquery/in-limit.sql.out
@@ -197,6 +197,37 @@ GlobalLimit 4
 
 
 -- !query
+SELECT *
+FROM   t1
+WHERE  t1c IN (SELECT t2c
+               FROM   t2
+               WHERE  t2b <= t2d
+               LIMIT  2)
+LIMIT 4
+-- !query analysis
+GlobalLimit 4
++- LocalLimit 4
+   +- Project [t1a#x, t1b#x, t1c#x, t1d#xL, t1e#x, t1f#x, t1g#x, t1h#x, t1i#x]
+      +- Filter t1c#x IN (list#x [])
+         :  +- GlobalLimit 2
+         :     +- LocalLimit 2
+         :        +- Project [t2c#x]
+         :           +- Filter (cast(t2b#x as bigint) <= t2d#xL)
+         :              +- SubqueryAlias t2
+         :                 +- View (`t2`, [t2a#x,t2b#x,t2c#x,t2d#xL,t2e#x,t2f#x,t2g#x,t2h#x,t2i#x])
+         :                    +- Project [cast(t2a#x as string) AS t2a#x, cast(t2b#x as smallint) AS t2b#x, cast(t2c#x as int) AS t2c#x, cast(t2d#xL as bigint) AS t2d#xL, cast(t2e#x as float) AS t2e#x, cast(t2f#x as double) AS t2f#x, cast(t2g#x as decimal(4,0)) AS t2g#x, cast(t2h#x as timestamp) AS t2h#x, cast(t2i#x as date) AS t2i#x]
+         :                       +- Project [t2a#x, t2b#x, t2c#x, t2d#xL, t2e#x, t2f#x, t2g#x, t2h#x, t2i#x]
+         :                          +- SubqueryAlias t2
+         :                             +- LocalRelation [t2a#x, t2b#x, t2c#x, t2d#xL, t2e#x, t2f#x, t2g#x, t2h#x, t2i#x]
+         +- SubqueryAlias t1
+            +- View (`t1`, [t1a#x,t1b#x,t1c#x,t1d#xL,t1e#x,t1f#x,t1g#x,t1h#x,t1i#x])
+               +- Project [cast(t1a#x as string) AS t1a#x, cast(t1b#x as smallint) AS t1b#x, cast(t1c#x as int) AS t1c#x, cast(t1d#xL as bigint) AS t1d#xL, cast(t1e#x as float) AS t1e#x, cast(t1f#x as double) AS t1f#x, cast(t1g#x as decimal(4,0)) AS t1g#x, cast(t1h#x as timestamp) AS t1h#x, cast(t1i#x as date) AS t1i#x]
+                  +- Project [t1a#x, t1b#x, t1c#x, t1d#xL, t1e#x, t1f#x, t1g#x, t1h#x, t1i#x]
+                     +- SubqueryAlias t1
+                        +- LocalRelation [t1a#x, t1b#x, t1c#x, t1d#xL, t1e#x, t1f#x, t1g#x, t1h#x, t1i#x]
+
+
+-- !query
 SELECT Count(DISTINCT( t1a )),
        t1b
 FROM   t1
@@ -233,6 +264,44 @@ GlobalLimit 1
 
 
 -- !query
+SELECT Count(DISTINCT( t1a )),
+       t1b
+FROM   t1
+WHERE  t1d IN (SELECT t2d
+               FROM   t2
+               WHERE t2b <= t2d
+               ORDER  BY t2c, t2d
+               LIMIT 2)
+GROUP  BY t1b
+ORDER  BY t1b DESC NULLS FIRST
+LIMIT  1
+-- !query analysis
+GlobalLimit 1
++- LocalLimit 1
+   +- Sort [t1b#x DESC NULLS FIRST], true
+      +- Aggregate [t1b#x], [count(distinct t1a#x) AS count(DISTINCT t1a)#xL, t1b#x]
+         +- Filter t1d#xL IN (list#x [])
+            :  +- GlobalLimit 2
+            :     +- LocalLimit 2
+            :        +- Project [t2d#xL]
+            :           +- Sort [t2c#x ASC NULLS FIRST, t2d#xL ASC NULLS FIRST], true
+            :              +- Project [t2d#xL, t2c#x]
+            :                 +- Filter (cast(t2b#x as bigint) <= t2d#xL)
+            :                    +- SubqueryAlias t2
+            :                       +- View (`t2`, [t2a#x,t2b#x,t2c#x,t2d#xL,t2e#x,t2f#x,t2g#x,t2h#x,t2i#x])
+            :                          +- Project [cast(t2a#x as string) AS t2a#x, cast(t2b#x as smallint) AS t2b#x, cast(t2c#x as int) AS t2c#x, cast(t2d#xL as bigint) AS t2d#xL, cast(t2e#x as float) AS t2e#x, cast(t2f#x as double) AS t2f#x, cast(t2g#x as decimal(4,0)) AS t2g#x, cast(t2h#x as timestamp) AS t2h#x, cast(t2i#x as date) AS t2i#x]
+            :                             +- Project [t2a#x, t2b#x, t2c#x, t2d#xL, t2e#x, t2f#x, t2g#x, t2h#x, t2i#x]
+            :                                +- SubqueryAlias t2
+            :                                   +- LocalRelation [t2a#x, t2b#x, t2c#x, t2d#xL, t2e#x, t2f#x, t2g#x, t2h#x, t2i#x]
+            +- SubqueryAlias t1
+               +- View (`t1`, [t1a#x,t1b#x,t1c#x,t1d#xL,t1e#x,t1f#x,t1g#x,t1h#x,t1i#x])
+                  +- Project [cast(t1a#x as string) AS t1a#x, cast(t1b#x as smallint) AS t1b#x, cast(t1c#x as int) AS t1c#x, cast(t1d#xL as bigint) AS t1d#xL, cast(t1e#x as float) AS t1e#x, cast(t1f#x as double) AS t1f#x, cast(t1g#x as decimal(4,0)) AS t1g#x, cast(t1h#x as timestamp) AS t1h#x, cast(t1i#x as date) AS t1i#x]
+                     +- Project [t1a#x, t1b#x, t1c#x, t1d#xL, t1e#x, t1f#x, t1g#x, t1h#x, t1i#x]
+                        +- SubqueryAlias t1
+                           +- LocalRelation [t1a#x, t1b#x, t1c#x, t1d#xL, t1e#x, t1f#x, t1g#x, t1h#x, t1i#x]
+
+
+-- !query
 SELECT *
 FROM   t1
 WHERE  t1b NOT IN (SELECT t2b
@@ -246,6 +315,34 @@ Project [t1a#x, t1b#x, t1c#x, t1d#xL, t1e#x, t1f#x, t1g#x, t1h#x, t1i#x]
    :     +- LocalLimit 2
    :        +- Project [t2b#x]
    :           +- Filter (cast(t2b#x as int) > 6)
+   :              +- SubqueryAlias t2
+   :                 +- View (`t2`, [t2a#x,t2b#x,t2c#x,t2d#xL,t2e#x,t2f#x,t2g#x,t2h#x,t2i#x])
+   :                    +- Project [cast(t2a#x as string) AS t2a#x, cast(t2b#x as smallint) AS t2b#x, cast(t2c#x as int) AS t2c#x, cast(t2d#xL as bigint) AS t2d#xL, cast(t2e#x as float) AS t2e#x, cast(t2f#x as double) AS t2f#x, cast(t2g#x as decimal(4,0)) AS t2g#x, cast(t2h#x as timestamp) AS t2h#x, cast(t2i#x as date) AS t2i#x]
+   :                       +- Project [t2a#x, t2b#x, t2c#x, t2d#xL, t2e#x, t2f#x, t2g#x, t2h#x, t2i#x]
+   :                          +- SubqueryAlias t2
+   :                             +- LocalRelation [t2a#x, t2b#x, t2c#x, t2d#xL, t2e#x, t2f#x, t2g#x, t2h#x, t2i#x]
+   +- SubqueryAlias t1
+      +- View (`t1`, [t1a#x,t1b#x,t1c#x,t1d#xL,t1e#x,t1f#x,t1g#x,t1h#x,t1i#x])
+         +- Project [cast(t1a#x as string) AS t1a#x, cast(t1b#x as smallint) AS t1b#x, cast(t1c#x as int) AS t1c#x, cast(t1d#xL as bigint) AS t1d#xL, cast(t1e#x as float) AS t1e#x, cast(t1f#x as double) AS t1f#x, cast(t1g#x as decimal(4,0)) AS t1g#x, cast(t1h#x as timestamp) AS t1h#x, cast(t1i#x as date) AS t1i#x]
+            +- Project [t1a#x, t1b#x, t1c#x, t1d#xL, t1e#x, t1f#x, t1g#x, t1h#x, t1i#x]
+               +- SubqueryAlias t1
+                  +- LocalRelation [t1a#x, t1b#x, t1c#x, t1d#xL, t1e#x, t1f#x, t1g#x, t1h#x, t1i#x]
+
+
+-- !query
+SELECT *
+FROM   t1
+WHERE  t1b NOT IN (SELECT t2b
+                   FROM   t2
+                   WHERE  t2b <= t2d
+                   LIMIT  2)
+-- !query analysis
+Project [t1a#x, t1b#x, t1c#x, t1d#xL, t1e#x, t1f#x, t1g#x, t1h#x, t1i#x]
++- Filter NOT t1b#x IN (list#x [])
+   :  +- GlobalLimit 2
+   :     +- LocalLimit 2
+   :        +- Project [t2b#x]
+   :           +- Filter (cast(t2b#x as bigint) <= t2d#xL)
    :              +- SubqueryAlias t2
    :                 +- View (`t2`, [t2a#x,t2b#x,t2c#x,t2d#xL,t2e#x,t2f#x,t2g#x,t2h#x,t2i#x])
    :                    +- Project [cast(t2a#x as string) AS t2a#x, cast(t2b#x as smallint) AS t2b#x, cast(t2c#x as int) AS t2c#x, cast(t2d#xL as bigint) AS t2d#xL, cast(t2e#x as float) AS t2e#x, cast(t2f#x as double) AS t2f#x, cast(t2g#x as decimal(4,0)) AS t2g#x, cast(t2h#x as timestamp) AS t2h#x, cast(t2i#x as date) AS t2i#x]
@@ -318,6 +415,41 @@ GlobalLimit 2
             :                 +- Project [t2a#x, t2b#x, t2c#x, t2d#xL, t2e#x, t2f#x, t2g#x, t2h#x, t2i#x]
             :                    +- SubqueryAlias t2
             :                       +- LocalRelation [t2a#x, t2b#x, t2c#x, t2d#xL, t2e#x, t2f#x, t2g#x, t2h#x, t2i#x]
+            +- SubqueryAlias t1
+               +- View (`t1`, [t1a#x,t1b#x,t1c#x,t1d#xL,t1e#x,t1f#x,t1g#x,t1h#x,t1i#x])
+                  +- Project [cast(t1a#x as string) AS t1a#x, cast(t1b#x as smallint) AS t1b#x, cast(t1c#x as int) AS t1c#x, cast(t1d#xL as bigint) AS t1d#xL, cast(t1e#x as float) AS t1e#x, cast(t1f#x as double) AS t1f#x, cast(t1g#x as decimal(4,0)) AS t1g#x, cast(t1h#x as timestamp) AS t1h#x, cast(t1i#x as date) AS t1i#x]
+                     +- Project [t1a#x, t1b#x, t1c#x, t1d#xL, t1e#x, t1f#x, t1g#x, t1h#x, t1i#x]
+                        +- SubqueryAlias t1
+                           +- LocalRelation [t1a#x, t1b#x, t1c#x, t1d#xL, t1e#x, t1f#x, t1g#x, t1h#x, t1i#x]
+
+
+-- !query
+SELECT *
+FROM   t1
+WHERE  t1a IN (SELECT t2a
+               FROM   t2
+               WHERE  t1d > t2d
+               ORDER BY t2a DESC
+               LIMIT 3)
+LIMIT  2
+OFFSET 2
+-- !query analysis
+GlobalLimit 2
++- LocalLimit 2
+   +- Offset 2
+      +- Project [t1a#x, t1b#x, t1c#x, t1d#xL, t1e#x, t1f#x, t1g#x, t1h#x, t1i#x]
+         +- Filter t1a#x IN (list#x [t1d#xL])
+            :  +- GlobalLimit 3
+            :     +- LocalLimit 3
+            :        +- Sort [t2a#x DESC NULLS LAST], true
+            :           +- Project [t2a#x]
+            :              +- Filter (outer(t1d#xL) > t2d#xL)
+            :                 +- SubqueryAlias t2
+            :                    +- View (`t2`, [t2a#x,t2b#x,t2c#x,t2d#xL,t2e#x,t2f#x,t2g#x,t2h#x,t2i#x])
+            :                       +- Project [cast(t2a#x as string) AS t2a#x, cast(t2b#x as smallint) AS t2b#x, cast(t2c#x as int) AS t2c#x, cast(t2d#xL as bigint) AS t2d#xL, cast(t2e#x as float) AS t2e#x, cast(t2f#x as double) AS t2f#x, cast(t2g#x as decimal(4,0)) AS t2g#x, cast(t2h#x as timestamp) AS t2h#x, cast(t2i#x as date) AS t2i#x]
+            :                          +- Project [t2a#x, t2b#x, t2c#x, t2d#xL, t2e#x, t2f#x, t2g#x, t2h#x, t2i#x]
+            :                             +- SubqueryAlias t2
+            :                                +- LocalRelation [t2a#x, t2b#x, t2c#x, t2d#xL, t2e#x, t2f#x, t2g#x, t2h#x, t2i#x]
             +- SubqueryAlias t1
                +- View (`t1`, [t1a#x,t1b#x,t1c#x,t1d#xL,t1e#x,t1f#x,t1g#x,t1h#x,t1i#x])
                   +- Project [cast(t1a#x as string) AS t1a#x, cast(t1b#x as smallint) AS t1b#x, cast(t1c#x as int) AS t1c#x, cast(t1d#xL as bigint) AS t1d#xL, cast(t1e#x as float) AS t1e#x, cast(t1f#x as double) AS t1f#x, cast(t1g#x as decimal(4,0)) AS t1g#x, cast(t1h#x as timestamp) AS t1h#x, cast(t1i#x as date) AS t1i#x]
@@ -430,6 +562,32 @@ Project [t1a#x, t1b#x, t1c#x, t1d#xL, t1e#x, t1f#x, t1g#x, t1h#x, t1i#x]
 
 
 -- !query
+SELECT *
+FROM   t1
+WHERE  t1b NOT IN (SELECT t2b
+                   FROM   t2
+                   WHERE  t2b = t1b
+                   LIMIT  2
+                   OFFSET 2)
+-- !query analysis
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "UNSUPPORTED_SUBQUERY_EXPRESSION_CATEGORY.ACCESSING_OUTER_QUERY_COLUMN_IS_NOT_ALLOWED",
+  "sqlState" : "0A000",
+  "messageParameters" : {
+    "treeNode" : "Filter (t2b#x = outer(t1b#x))\n+- SubqueryAlias t2\n   +- View (`t2`, [t2a#x,t2b#x,t2c#x,t2d#xL,t2e#x,t2f#x,t2g#x,t2h#x,t2i#x])\n      +- Project [cast(t2a#x as string) AS t2a#x, cast(t2b#x as smallint) AS t2b#x, cast(t2c#x as int) AS t2c#x, cast(t2d#xL as bigint) AS t2d#xL, cast(t2e#x as float) AS t2e#x, cast(t2f#x as double) AS t2f#x, cast(t2g#x as decimal(4,0)) AS t2g#x, cast(t2h#x as timestamp) AS t2h#x, cast(t2i#x as date) AS t2i#x]\n         +- Project [t2a#x, t2b#x, t2c#x, t2d#xL, t2e#x, t2f#x, t2g#x, t2h#x, t2i#x]\n            +- SubqueryAlias t2\n               +- LocalRelation [t2a#x, t2b#x, t2c#x, t2d#xL, t2e#x, t2f#x, t2g#x, t2h#x, t2i#x]\n"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 39,
+    "stopIndex" : 113,
+    "fragment" : "SELECT t2b\n                   FROM   t2\n                   WHERE  t2b = t1b"
+  } ]
+}
+
+
+-- !query
 SELECT Count(DISTINCT( t1a )),
        t1b
 FROM   t1
@@ -470,6 +628,38 @@ GlobalLimit 1
 
 
 -- !query
+SELECT Count(DISTINCT( t1a )),
+       t1b
+FROM   t1
+WHERE  t1d NOT IN (SELECT t2d
+                   FROM   t2
+                   WHERE t2b > t1b
+                   ORDER  BY t2b DESC nulls first, t2d
+                   LIMIT 1
+                   OFFSET 1)
+GROUP  BY t1b
+ORDER BY t1b NULLS last
+LIMIT  1
+OFFSET 1
+-- !query analysis
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "UNSUPPORTED_SUBQUERY_EXPRESSION_CATEGORY.ACCESSING_OUTER_QUERY_COLUMN_IS_NOT_ALLOWED",
+  "sqlState" : "0A000",
+  "messageParameters" : {
+    "treeNode" : "Filter (t2b#x > outer(t1b#x))\n+- SubqueryAlias t2\n   +- View (`t2`, [t2a#x,t2b#x,t2c#x,t2d#xL,t2e#x,t2f#x,t2g#x,t2h#x,t2i#x])\n      +- Project [cast(t2a#x as string) AS t2a#x, cast(t2b#x as smallint) AS t2b#x, cast(t2c#x as int) AS t2c#x, cast(t2d#xL as bigint) AS t2d#xL, cast(t2e#x as float) AS t2e#x, cast(t2f#x as double) AS t2f#x, cast(t2g#x as decimal(4,0)) AS t2g#x, cast(t2h#x as timestamp) AS t2h#x, cast(t2i#x as date) AS t2i#x]\n         +- Project [t2a#x, t2b#x, t2c#x, t2d#xL, t2e#x, t2f#x, t2g#x, t2h#x, t2i#x]\n            +- SubqueryAlias t2\n               +- LocalRelation [t2a#x, t2b#x, t2c#x, t2d#xL, t2e#x, t2f#x, t2g#x, t2h#x, t2i#x]\n"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 72,
+    "stopIndex" : 145,
+    "fragment" : "SELECT t2d\n                   FROM   t2\n                   WHERE t2b > t1b"
+  } ]
+}
+
+
+-- !query
 SELECT *
 FROM   t1
 WHERE  t1a IN (SELECT t2a
@@ -499,6 +689,33 @@ Offset 2
 -- !query
 SELECT *
 FROM   t1
+WHERE  t1a IN (SELECT t2a
+               FROM   t2
+               WHERE  t1d = t2d
+               ORDER BY t2a
+               OFFSET 2)
+OFFSET 2
+-- !query analysis
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "UNSUPPORTED_SUBQUERY_EXPRESSION_CATEGORY.ACCESSING_OUTER_QUERY_COLUMN_IS_NOT_ALLOWED",
+  "sqlState" : "0A000",
+  "messageParameters" : {
+    "treeNode" : "Filter (outer(t1d#xL) = t2d#xL)\n+- SubqueryAlias t2\n   +- View (`t2`, [t2a#x,t2b#x,t2c#x,t2d#xL,t2e#x,t2f#x,t2g#x,t2h#x,t2i#x])\n      +- Project [cast(t2a#x as string) AS t2a#x, cast(t2b#x as smallint) AS t2b#x, cast(t2c#x as int) AS t2c#x, cast(t2d#xL as bigint) AS t2d#xL, cast(t2e#x as float) AS t2e#x, cast(t2f#x as double) AS t2f#x, cast(t2g#x as decimal(4,0)) AS t2g#x, cast(t2h#x as timestamp) AS t2h#x, cast(t2i#x as date) AS t2i#x]\n         +- Project [t2a#x, t2b#x, t2c#x, t2d#xL, t2e#x, t2f#x, t2g#x, t2h#x, t2i#x]\n            +- SubqueryAlias t2\n               +- LocalRelation [t2a#x, t2b#x, t2c#x, t2d#xL, t2e#x, t2f#x, t2g#x, t2h#x, t2i#x]\n"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 35,
+    "stopIndex" : 101,
+    "fragment" : "SELECT t2a\n               FROM   t2\n               WHERE  t1d = t2d"
+  } ]
+}
+
+
+-- !query
+SELECT *
+FROM   t1
 WHERE  t1c IN (SELECT t2c
                FROM   t2
                WHERE  t2b >= 8
@@ -523,6 +740,33 @@ Offset 4
                +- Project [t1a#x, t1b#x, t1c#x, t1d#xL, t1e#x, t1f#x, t1g#x, t1h#x, t1i#x]
                   +- SubqueryAlias t1
                      +- LocalRelation [t1a#x, t1b#x, t1c#x, t1d#xL, t1e#x, t1f#x, t1g#x, t1h#x, t1i#x]
+
+
+-- !query
+SELECT *
+FROM   t1
+WHERE  t1c IN (SELECT t2c
+               FROM   t2
+               WHERE  t2b < t1b
+               ORDER BY t2c
+               OFFSET 2)
+OFFSET 1
+-- !query analysis
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "UNSUPPORTED_SUBQUERY_EXPRESSION_CATEGORY.ACCESSING_OUTER_QUERY_COLUMN_IS_NOT_ALLOWED",
+  "sqlState" : "0A000",
+  "messageParameters" : {
+    "treeNode" : "Filter (t2b#x < outer(t1b#x))\n+- SubqueryAlias t2\n   +- View (`t2`, [t2a#x,t2b#x,t2c#x,t2d#xL,t2e#x,t2f#x,t2g#x,t2h#x,t2i#x])\n      +- Project [cast(t2a#x as string) AS t2a#x, cast(t2b#x as smallint) AS t2b#x, cast(t2c#x as int) AS t2c#x, cast(t2d#xL as bigint) AS t2d#xL, cast(t2e#x as float) AS t2e#x, cast(t2f#x as double) AS t2f#x, cast(t2g#x as decimal(4,0)) AS t2g#x, cast(t2h#x as timestamp) AS t2h#x, cast(t2i#x as date) AS t2i#x]\n         +- Project [t2a#x, t2b#x, t2c#x, t2d#xL, t2e#x, t2f#x, t2g#x, t2h#x, t2i#x]\n            +- SubqueryAlias t2\n               +- LocalRelation [t2a#x, t2b#x, t2c#x, t2d#xL, t2e#x, t2f#x, t2g#x, t2h#x, t2i#x]\n"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 35,
+    "stopIndex" : 101,
+    "fragment" : "SELECT t2c\n               FROM   t2\n               WHERE  t2b < t1b"
+  } ]
+}
 
 
 -- !query
@@ -584,6 +828,31 @@ Project [t1a#x, t1b#x, t1c#x, t1d#xL, t1e#x, t1f#x, t1g#x, t1h#x, t1i#x]
             +- Project [t1a#x, t1b#x, t1c#x, t1d#xL, t1e#x, t1f#x, t1g#x, t1h#x, t1i#x]
                +- SubqueryAlias t1
                   +- LocalRelation [t1a#x, t1b#x, t1c#x, t1d#xL, t1e#x, t1f#x, t1g#x, t1h#x, t1i#x]
+
+
+-- !query
+SELECT count(*)
+FROM   t1
+WHERE  t1b NOT IN (SELECT t2b
+                   FROM   t2
+                   WHERE  t2b < t1b
+                   OFFSET 2)
+-- !query analysis
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "UNSUPPORTED_SUBQUERY_EXPRESSION_CATEGORY.ACCESSING_OUTER_QUERY_COLUMN_IS_NOT_ALLOWED",
+  "sqlState" : "0A000",
+  "messageParameters" : {
+    "treeNode" : "Filter (t2b#x < outer(t1b#x))\n+- SubqueryAlias t2\n   +- View (`t2`, [t2a#x,t2b#x,t2c#x,t2d#xL,t2e#x,t2f#x,t2g#x,t2h#x,t2i#x])\n      +- Project [cast(t2a#x as string) AS t2a#x, cast(t2b#x as smallint) AS t2b#x, cast(t2c#x as int) AS t2c#x, cast(t2d#xL as bigint) AS t2d#xL, cast(t2e#x as float) AS t2e#x, cast(t2f#x as double) AS t2f#x, cast(t2g#x as decimal(4,0)) AS t2g#x, cast(t2h#x as timestamp) AS t2h#x, cast(t2i#x as date) AS t2i#x]\n         +- Project [t2a#x, t2b#x, t2c#x, t2d#xL, t2e#x, t2f#x, t2g#x, t2h#x, t2i#x]\n            +- SubqueryAlias t2\n               +- LocalRelation [t2a#x, t2b#x, t2c#x, t2d#xL, t2e#x, t2f#x, t2g#x, t2h#x, t2i#x]\n"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 46,
+    "stopIndex" : 120,
+    "fragment" : "SELECT t2b\n                   FROM   t2\n                   WHERE  t2b < t1b"
+  } ]
+}
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/inputs/subquery/exists-subquery/exists-orderby-limit.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/subquery/exists-subquery/exists-orderby-limit.sql
@@ -47,6 +47,24 @@ WHERE  EXISTS (SELECT dept.dept_id
                ORDER  BY state) 
 ORDER  BY hiredate; 
 
+SELECT *
+FROM   emp
+WHERE  EXISTS (SELECT dept.dept_id
+               FROM   dept
+               WHERE  emp.dept_id = dept.dept_id
+               ORDER  BY state
+               LIMIT 1)
+ORDER  BY hiredate;
+
+SELECT *
+FROM   emp
+WHERE  EXISTS (SELECT dept.dept_id
+               FROM   dept
+               WHERE  emp.dept_id = dept.dept_id
+               ORDER  BY state
+               LIMIT 0)
+ORDER  BY hiredate;
+
 -- TC.01.02
 SELECT id, 
        hiredate 
@@ -67,6 +85,24 @@ WHERE  NOT EXISTS (SELECT dept.dept_id
                    ORDER  BY state) 
 ORDER  BY hiredate; 
 
+SELECT *
+FROM   emp
+WHERE  NOT EXISTS (SELECT dept.dept_id
+                   FROM   dept
+                   WHERE  emp.dept_id = dept.dept_id
+                   ORDER  BY state
+                   LIMIT 1)
+ORDER  BY hiredate;
+
+SELECT *
+FROM   emp
+WHERE  NOT EXISTS (SELECT dept.dept_id
+                   FROM   dept
+                   WHERE  emp.dept_id = dept.dept_id
+                   ORDER  BY state
+                   LIMIT 0)
+ORDER  BY hiredate;
+
 -- group by + order by with not exists
 -- TC.01.04
 SELECT emp_name 
@@ -76,6 +112,17 @@ WHERE  NOT EXISTS (SELECT max(dept.dept_id) a
                    WHERE  dept.dept_id = emp.dept_id 
                    GROUP  BY state 
                    ORDER  BY state);
+
+SELECT emp_name
+FROM   emp
+WHERE  NOT EXISTS (SELECT max(dept.dept_id) a
+                   FROM   dept
+                   WHERE  dept.dept_id = emp.dept_id
+                   GROUP  BY state
+                   ORDER  BY state
+                   LIMIT 2
+                   OFFSET 1);
+
 -- TC.01.05
 SELECT count(*) 
 FROM   emp 
@@ -94,6 +141,13 @@ WHERE  EXISTS (SELECT dept.dept_name
                WHERE  dept.dept_id > 10 
                LIMIT  1); 
 
+SELECT *
+FROM   emp
+WHERE  EXISTS (SELECT dept.dept_name
+               FROM   dept
+               WHERE  dept.dept_id > emp.dept_id
+               LIMIT  1);
+
 -- limit in the exists subquery block with aggregate.
 -- TC.02.02
 SELECT * 
@@ -102,6 +156,14 @@ WHERE  EXISTS (SELECT max(dept.dept_id)
                FROM   dept 
                GROUP  BY state 
                LIMIT  1); 
+
+SELECT *
+FROM   emp
+WHERE  EXISTS (SELECT max(dept.dept_id)
+               FROM   dept
+               WHERE  dept.dept_id <> emp.dept_id
+               GROUP  BY state
+               LIMIT  1);
 
 -- limit in the not exists subquery block.
 -- TC.02.03
@@ -129,6 +191,14 @@ FROM   emp
 WHERE  EXISTS (SELECT dept.dept_name
                FROM   dept
                WHERE  dept.dept_id > 10
+               LIMIT  1
+               OFFSET 2);
+
+SELECT *
+FROM   emp
+WHERE  EXISTS (SELECT dept.dept_name
+               FROM   dept
+               WHERE  dept.dept_id <> emp.dept_id
                LIMIT  1
                OFFSET 2);
 

--- a/sql/core/src/test/resources/sql-tests/inputs/subquery/in-subquery/in-limit.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/subquery/in-subquery/in-limit.sql
@@ -85,7 +85,7 @@ SELECT *
 FROM   t1
 WHERE  t1c IN (SELECT t2c
                FROM   t2
-               WHERE  t2b <= t2d
+               WHERE  t2b <= t1d
                LIMIT  2)
 LIMIT 4;
 
@@ -107,7 +107,7 @@ SELECT Count(DISTINCT( t1a )),
 FROM   t1
 WHERE  t1d IN (SELECT t2d
                FROM   t2
-               WHERE t2b <= t2d
+               WHERE t2b <= t1d
                ORDER  BY t2c, t2d
                LIMIT 2)
 GROUP  BY t1b
@@ -127,7 +127,7 @@ SELECT *
 FROM   t1
 WHERE  t1b NOT IN (SELECT t2b
                    FROM   t2
-                   WHERE  t2b <= t2d
+                   WHERE  t2b <= t1d
                    LIMIT  2);
 
 -- TC 01.05

--- a/sql/core/src/test/resources/sql-tests/inputs/subquery/in-subquery/in-limit.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/subquery/in-subquery/in-limit.sql
@@ -60,6 +60,17 @@ WHERE  t1a IN (SELECT t2a
                WHERE  t1d = t2d)
 LIMIT  2;
 
+-- correlated IN subquery
+-- LIMIT on both parent and subquery sides
+SELECT *
+FROM   t1
+WHERE  t1a IN (SELECT t2a
+               FROM   t2
+               WHERE  t1d = t2d
+               LIMIT 10)
+LIMIT  2;
+
+
 -- TC 01.02
 SELECT *
 FROM   t1
@@ -68,6 +79,16 @@ WHERE  t1c IN (SELECT t2c
                WHERE  t2b >= 8
                LIMIT  2)
 LIMIT 4;
+
+
+SELECT *
+FROM   t1
+WHERE  t1c IN (SELECT t2c
+               FROM   t2
+               WHERE  t2b <= t2d
+               LIMIT  2)
+LIMIT 4;
+
 
 -- TC 01.03
 SELECT Count(DISTINCT( t1a )),
@@ -81,6 +102,18 @@ GROUP  BY t1b
 ORDER  BY t1b DESC NULLS FIRST
 LIMIT  1;
 
+SELECT Count(DISTINCT( t1a )),
+       t1b
+FROM   t1
+WHERE  t1d IN (SELECT t2d
+               FROM   t2
+               WHERE t2b <= t2d
+               ORDER  BY t2c, t2d
+               LIMIT 2)
+GROUP  BY t1b
+ORDER  BY t1b DESC NULLS FIRST
+LIMIT  1;
+
 -- LIMIT with NOT IN
 -- TC 01.04
 SELECT *
@@ -88,6 +121,13 @@ FROM   t1
 WHERE  t1b NOT IN (SELECT t2b
                    FROM   t2
                    WHERE  t2b > 6
+                   LIMIT  2);
+
+SELECT *
+FROM   t1
+WHERE  t1b NOT IN (SELECT t2b
+                   FROM   t2
+                   WHERE  t2b <= t2d
                    LIMIT  2);
 
 -- TC 01.05
@@ -109,6 +149,16 @@ FROM   t1
 WHERE  t1a IN (SELECT t2a
                FROM   t2
                WHERE  t1d = t2d)
+LIMIT  2
+OFFSET 2;
+
+SELECT *
+FROM   t1
+WHERE  t1a IN (SELECT t2a
+               FROM   t2
+               WHERE  t1d > t2d
+               ORDER BY t2a DESC
+               LIMIT 3)
 LIMIT  2
 OFFSET 2;
 
@@ -146,12 +196,35 @@ WHERE  t1b NOT IN (SELECT t2b
                    LIMIT  2
                    OFFSET 2);
 
+-- LIMIT with NOT IN and correlations
+SELECT *
+FROM   t1
+WHERE  t1b NOT IN (SELECT t2b
+                   FROM   t2
+                   WHERE  t2b = t1b
+                   LIMIT  2
+                   OFFSET 2);
+
 -- TC 02.05
 SELECT Count(DISTINCT( t1a )),
        t1b
 FROM   t1
 WHERE  t1d NOT IN (SELECT t2d
                    FROM   t2
+                   ORDER  BY t2b DESC nulls first, t2d
+                   LIMIT 1
+                   OFFSET 1)
+GROUP  BY t1b
+ORDER BY t1b NULLS last
+LIMIT  1
+OFFSET 1;
+
+SELECT Count(DISTINCT( t1a )),
+       t1b
+FROM   t1
+WHERE  t1d NOT IN (SELECT t2d
+                   FROM   t2
+                   WHERE t2b > t1b
                    ORDER  BY t2b DESC nulls first, t2d
                    LIMIT 1
                    OFFSET 1)
@@ -169,6 +242,16 @@ WHERE  t1a IN (SELECT t2a
                WHERE  t1d = t2d)
 OFFSET 2;
 
+-- OFFSET in correlated subquery
+SELECT *
+FROM   t1
+WHERE  t1a IN (SELECT t2a
+               FROM   t2
+               WHERE  t1d = t2d
+               ORDER BY t2a
+               OFFSET 2)
+OFFSET 2;
+
 -- TC 03.02
 SELECT *
 FROM   t1
@@ -177,6 +260,15 @@ WHERE  t1c IN (SELECT t2c
                WHERE  t2b >= 8
                OFFSET 2)
 OFFSET 4;
+
+SELECT *
+FROM   t1
+WHERE  t1c IN (SELECT t2c
+               FROM   t2
+               WHERE  t2b < t1b
+               ORDER BY t2c
+               OFFSET 2)
+OFFSET 1;
 
 -- TC 03.03
 SELECT Count(DISTINCT( t1a )),
@@ -197,6 +289,14 @@ FROM   t1
 WHERE  t1b NOT IN (SELECT t2b
                    FROM   t2
                    WHERE  t2b > 6
+                   OFFSET 2);
+
+-- OFFSET with NOT IN correlated
+SELECT count(*)
+FROM   t1
+WHERE  t1b NOT IN (SELECT t2b
+                   FROM   t2
+                   WHERE  t2b < t1b
                    OFFSET 2);
 
 -- TC 03.05

--- a/sql/core/src/test/resources/sql-tests/results/subquery/exists-subquery/exists-orderby-limit.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/subquery/exists-subquery/exists-orderby-limit.sql.out
@@ -69,6 +69,38 @@ struct<id:int,emp_name:string,hiredate:date,salary:double,dept_id:int>
 
 
 -- !query
+SELECT *
+FROM   emp
+WHERE  EXISTS (SELECT dept.dept_id
+               FROM   dept
+               WHERE  emp.dept_id = dept.dept_id
+               ORDER  BY state
+               LIMIT 1)
+ORDER  BY hiredate
+-- !query schema
+struct<id:int,emp_name:string,hiredate:date,salary:double,dept_id:int>
+-- !query output
+200	emp 2	2003-01-01	200.0	10
+100	emp 1	2005-01-01	100.0	10
+100	emp 1	2005-01-01	100.0	10
+
+
+-- !query
+SELECT *
+FROM   emp
+WHERE  EXISTS (SELECT dept.dept_id
+               FROM   dept
+               WHERE  emp.dept_id = dept.dept_id
+               ORDER  BY state
+               LIMIT 0)
+ORDER  BY hiredate
+-- !query schema
+struct<id:int,emp_name:string,hiredate:date,salary:double,dept_id:int>
+-- !query output
+
+
+
+-- !query
 SELECT id, 
        hiredate 
 FROM   emp 
@@ -105,6 +137,49 @@ struct<id:int,emp_name:string,hiredate:date,salary:double,dept_id:int>
 
 
 -- !query
+SELECT *
+FROM   emp
+WHERE  NOT EXISTS (SELECT dept.dept_id
+                   FROM   dept
+                   WHERE  emp.dept_id = dept.dept_id
+                   ORDER  BY state
+                   LIMIT 1)
+ORDER  BY hiredate
+-- !query schema
+struct<id:int,emp_name:string,hiredate:date,salary:double,dept_id:int>
+-- !query output
+500	emp 5	2001-01-01	400.0	NULL
+600	emp 6 - no dept	2001-01-01	400.0	100
+300	emp 3	2002-01-01	300.0	20
+400	emp 4	2005-01-01	400.0	30
+700	emp 7	2010-01-01	400.0	100
+800	emp 8	2016-01-01	150.0	70
+
+
+-- !query
+SELECT *
+FROM   emp
+WHERE  NOT EXISTS (SELECT dept.dept_id
+                   FROM   dept
+                   WHERE  emp.dept_id = dept.dept_id
+                   ORDER  BY state
+                   LIMIT 0)
+ORDER  BY hiredate
+-- !query schema
+struct<id:int,emp_name:string,hiredate:date,salary:double,dept_id:int>
+-- !query output
+500	emp 5	2001-01-01	400.0	NULL
+600	emp 6 - no dept	2001-01-01	400.0	100
+300	emp 3	2002-01-01	300.0	20
+200	emp 2	2003-01-01	200.0	10
+100	emp 1	2005-01-01	100.0	10
+100	emp 1	2005-01-01	100.0	10
+400	emp 4	2005-01-01	400.0	30
+700	emp 7	2010-01-01	400.0	100
+800	emp 8	2016-01-01	150.0	70
+
+
+-- !query
 SELECT emp_name 
 FROM   emp 
 WHERE  NOT EXISTS (SELECT max(dept.dept_id) a 
@@ -118,6 +193,36 @@ struct<emp_name:string>
 emp 5
 emp 6 - no dept
 emp 7
+
+
+-- !query
+SELECT emp_name
+FROM   emp
+WHERE  NOT EXISTS (SELECT max(dept.dept_id) a
+                   FROM   dept
+                   WHERE  dept.dept_id = emp.dept_id
+                   GROUP  BY state
+                   ORDER  BY state
+                   LIMIT 2
+                   OFFSET 1)
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "UNSUPPORTED_SUBQUERY_EXPRESSION_CATEGORY.ACCESSING_OUTER_QUERY_COLUMN_IS_NOT_ALLOWED",
+  "sqlState" : "0A000",
+  "messageParameters" : {
+    "treeNode" : "Filter (dept_id#x = outer(dept_id#x))\n+- SubqueryAlias dept\n   +- View (`DEPT`, [dept_id#x,dept_name#x,state#x])\n      +- Project [cast(dept_id#x as int) AS dept_id#x, cast(dept_name#x as string) AS dept_name#x, cast(state#x as string) AS state#x]\n         +- Project [dept_id#x, dept_name#x, state#x]\n            +- SubqueryAlias DEPT\n               +- LocalRelation [dept_id#x, dept_name#x, state#x]\n"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 47,
+    "stopIndex" : 191,
+    "fragment" : "SELECT max(dept.dept_id) a\n                   FROM   dept\n                   WHERE  dept.dept_id = emp.dept_id\n                   GROUP  BY state"
+  } ]
+}
 
 
 -- !query
@@ -156,6 +261,19 @@ struct<id:int,emp_name:string,hiredate:date,salary:double,dept_id:int>
 
 
 -- !query
+SELECT *
+FROM   emp
+WHERE  EXISTS (SELECT dept.dept_name
+               FROM   dept
+               WHERE  dept.dept_id > emp.dept_id
+               LIMIT  1)
+-- !query schema
+struct<id:int,emp_name:string,hiredate:date,salary:double,dept_id:int>
+-- !query output
+
+
+
+-- !query
 SELECT * 
 FROM   emp 
 WHERE  EXISTS (SELECT max(dept.dept_id) 
@@ -174,6 +292,34 @@ struct<id:int,emp_name:string,hiredate:date,salary:double,dept_id:int>
 600	emp 6 - no dept	2001-01-01	400.0	100
 700	emp 7	2010-01-01	400.0	100
 800	emp 8	2016-01-01	150.0	70
+
+
+-- !query
+SELECT *
+FROM   emp
+WHERE  EXISTS (SELECT max(dept.dept_id)
+               FROM   dept
+               WHERE  dept.dept_id <> emp.dept_id
+               GROUP  BY state
+               LIMIT  1)
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "UNSUPPORTED_SUBQUERY_EXPRESSION_CATEGORY.CORRELATED_COLUMN_IS_NOT_ALLOWED_IN_PREDICATE",
+  "sqlState" : "0A000",
+  "messageParameters" : {
+    "treeNode" : "NOT (dept_id#x = outer(dept_id#x))\nFilter NOT (dept_id#x = outer(dept_id#x))\n+- SubqueryAlias dept\n   +- View (`DEPT`, [dept_id#x,dept_name#x,state#x])\n      +- Project [cast(dept_id#x as int) AS dept_id#x, cast(dept_name#x as string) AS dept_name#x, cast(state#x as string) AS state#x]\n         +- Project [dept_id#x, dept_name#x, state#x]\n            +- SubqueryAlias DEPT\n               +- LocalRelation [dept_id#x, dept_name#x, state#x]\n"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 36,
+    "stopIndex" : 167,
+    "fragment" : "SELECT max(dept.dept_id)\n               FROM   dept\n               WHERE  dept.dept_id <> emp.dept_id\n               GROUP  BY state"
+  } ]
+}
 
 
 -- !query
@@ -239,6 +385,34 @@ struct<id:int,emp_name:string,hiredate:date,salary:double,dept_id:int>
 600	emp 6 - no dept	2001-01-01	400.0	100
 700	emp 7	2010-01-01	400.0	100
 800	emp 8	2016-01-01	150.0	70
+
+
+-- !query
+SELECT *
+FROM   emp
+WHERE  EXISTS (SELECT dept.dept_name
+               FROM   dept
+               WHERE  dept.dept_id <> emp.dept_id
+               LIMIT  1
+               OFFSET 2)
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "UNSUPPORTED_SUBQUERY_EXPRESSION_CATEGORY.ACCESSING_OUTER_QUERY_COLUMN_IS_NOT_ALLOWED",
+  "sqlState" : "0A000",
+  "messageParameters" : {
+    "treeNode" : "Filter NOT (dept_id#x = outer(dept_id#x))\n+- SubqueryAlias dept\n   +- View (`DEPT`, [dept_id#x,dept_name#x,state#x])\n      +- Project [cast(dept_id#x as int) AS dept_id#x, cast(dept_name#x as string) AS dept_name#x, cast(state#x as string) AS state#x]\n         +- Project [dept_id#x, dept_name#x, state#x]\n            +- SubqueryAlias DEPT\n               +- LocalRelation [dept_id#x, dept_name#x, state#x]\n"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 36,
+    "stopIndex" : 133,
+    "fragment" : "SELECT dept.dept_name\n               FROM   dept\n               WHERE  dept.dept_id <> emp.dept_id"
+  } ]
+}
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/subquery/exists-subquery/exists-orderby-limit.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/subquery/exists-subquery/exists-orderby-limit.sql.out
@@ -78,11 +78,23 @@ WHERE  EXISTS (SELECT dept.dept_id
                LIMIT 1)
 ORDER  BY hiredate
 -- !query schema
-struct<id:int,emp_name:string,hiredate:date,salary:double,dept_id:int>
+struct<>
 -- !query output
-200	emp 2	2003-01-01	200.0	10
-100	emp 1	2005-01-01	100.0	10
-100	emp 1	2005-01-01	100.0	10
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "UNSUPPORTED_SUBQUERY_EXPRESSION_CATEGORY.ACCESSING_OUTER_QUERY_COLUMN_IS_NOT_ALLOWED",
+  "sqlState" : "0A000",
+  "messageParameters" : {
+    "treeNode" : "GlobalLimit 1\n+- LocalLimit 1\n   +- Project [dept_id#x]\n      +- Sort [state#x ASC NULLS FIRST], true\n         +- Project [dept_id#x, state#x]\n            +- Project [cast(dept_id#x as int) AS dept_id#x, cast(dept_name#x as string) AS dept_name#x, cast(state#x as string) AS state#x]\n               +- Project [dept_id#x, dept_name#x, state#x]\n                  +- LocalRelation [dept_id#x, dept_name#x, state#x]\n"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 147,
+    "stopIndex" : 184,
+    "fragment" : "ORDER  BY state\n               LIMIT 1"
+  } ]
+}
 
 
 -- !query
@@ -95,9 +107,23 @@ WHERE  EXISTS (SELECT dept.dept_id
                LIMIT 0)
 ORDER  BY hiredate
 -- !query schema
-struct<id:int,emp_name:string,hiredate:date,salary:double,dept_id:int>
+struct<>
 -- !query output
-
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "UNSUPPORTED_SUBQUERY_EXPRESSION_CATEGORY.ACCESSING_OUTER_QUERY_COLUMN_IS_NOT_ALLOWED",
+  "sqlState" : "0A000",
+  "messageParameters" : {
+    "treeNode" : "GlobalLimit 0\n+- LocalLimit 0\n   +- Project [dept_id#x]\n      +- Sort [state#x ASC NULLS FIRST], true\n         +- Project [dept_id#x, state#x]\n            +- Project [cast(dept_id#x as int) AS dept_id#x, cast(dept_name#x as string) AS dept_name#x, cast(state#x as string) AS state#x]\n               +- Project [dept_id#x, dept_name#x, state#x]\n                  +- LocalRelation [dept_id#x, dept_name#x, state#x]\n"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 147,
+    "stopIndex" : 184,
+    "fragment" : "ORDER  BY state\n               LIMIT 0"
+  } ]
+}
 
 
 -- !query
@@ -146,14 +172,23 @@ WHERE  NOT EXISTS (SELECT dept.dept_id
                    LIMIT 1)
 ORDER  BY hiredate
 -- !query schema
-struct<id:int,emp_name:string,hiredate:date,salary:double,dept_id:int>
+struct<>
 -- !query output
-500	emp 5	2001-01-01	400.0	NULL
-600	emp 6 - no dept	2001-01-01	400.0	100
-300	emp 3	2002-01-01	300.0	20
-400	emp 4	2005-01-01	400.0	30
-700	emp 7	2010-01-01	400.0	100
-800	emp 8	2016-01-01	150.0	70
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "UNSUPPORTED_SUBQUERY_EXPRESSION_CATEGORY.ACCESSING_OUTER_QUERY_COLUMN_IS_NOT_ALLOWED",
+  "sqlState" : "0A000",
+  "messageParameters" : {
+    "treeNode" : "GlobalLimit 1\n+- LocalLimit 1\n   +- Project [dept_id#x]\n      +- Sort [state#x ASC NULLS FIRST], true\n         +- Project [dept_id#x, state#x]\n            +- Project [cast(dept_id#x as int) AS dept_id#x, cast(dept_name#x as string) AS dept_name#x, cast(state#x as string) AS state#x]\n               +- Project [dept_id#x, dept_name#x, state#x]\n                  +- LocalRelation [dept_id#x, dept_name#x, state#x]\n"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 163,
+    "stopIndex" : 204,
+    "fragment" : "ORDER  BY state\n                   LIMIT 1"
+  } ]
+}
 
 
 -- !query
@@ -166,17 +201,23 @@ WHERE  NOT EXISTS (SELECT dept.dept_id
                    LIMIT 0)
 ORDER  BY hiredate
 -- !query schema
-struct<id:int,emp_name:string,hiredate:date,salary:double,dept_id:int>
+struct<>
 -- !query output
-500	emp 5	2001-01-01	400.0	NULL
-600	emp 6 - no dept	2001-01-01	400.0	100
-300	emp 3	2002-01-01	300.0	20
-200	emp 2	2003-01-01	200.0	10
-100	emp 1	2005-01-01	100.0	10
-100	emp 1	2005-01-01	100.0	10
-400	emp 4	2005-01-01	400.0	30
-700	emp 7	2010-01-01	400.0	100
-800	emp 8	2016-01-01	150.0	70
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "UNSUPPORTED_SUBQUERY_EXPRESSION_CATEGORY.ACCESSING_OUTER_QUERY_COLUMN_IS_NOT_ALLOWED",
+  "sqlState" : "0A000",
+  "messageParameters" : {
+    "treeNode" : "GlobalLimit 0\n+- LocalLimit 0\n   +- Project [dept_id#x]\n      +- Sort [state#x ASC NULLS FIRST], true\n         +- Project [dept_id#x, state#x]\n            +- Project [cast(dept_id#x as int) AS dept_id#x, cast(dept_name#x as string) AS dept_name#x, cast(state#x as string) AS state#x]\n               +- Project [dept_id#x, dept_name#x, state#x]\n                  +- LocalRelation [dept_id#x, dept_name#x, state#x]\n"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 163,
+    "stopIndex" : 204,
+    "fragment" : "ORDER  BY state\n                   LIMIT 0"
+  } ]
+}
 
 
 -- !query
@@ -268,9 +309,23 @@ WHERE  EXISTS (SELECT dept.dept_name
                WHERE  dept.dept_id > emp.dept_id
                LIMIT  1)
 -- !query schema
-struct<id:int,emp_name:string,hiredate:date,salary:double,dept_id:int>
+struct<>
 -- !query output
-
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "UNSUPPORTED_SUBQUERY_EXPRESSION_CATEGORY.ACCESSING_OUTER_QUERY_COLUMN_IS_NOT_ALLOWED",
+  "sqlState" : "0A000",
+  "messageParameters" : {
+    "treeNode" : "GlobalLimit 1\n+- LocalLimit 1\n   +- Project [dept_name#x, dept_id#x]\n      +- Project [cast(dept_id#x as int) AS dept_id#x, cast(dept_name#x as string) AS dept_name#x, cast(state#x as string) AS state#x]\n         +- Project [dept_id#x, dept_name#x, state#x]\n            +- LocalRelation [dept_id#x, dept_name#x, state#x]\n"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 149,
+    "stopIndex" : 156,
+    "fragment" : "LIMIT  1"
+  } ]
+}
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/subquery/in-subquery/in-limit.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/subquery/in-subquery/in-limit.sql.out
@@ -86,10 +86,23 @@ WHERE  t1a IN (SELECT t2a
                LIMIT 10)
 LIMIT  2
 -- !query schema
-struct<t1a:string,t1b:smallint,t1c:int,t1d:bigint,t1e:float,t1f:double,t1g:decimal(4,0),t1h:timestamp,t1i:date>
+struct<>
 -- !query output
-val1b	8	16	19	17.0	25.0	2600	2014-05-04 01:01:00	2014-05-04
-val1c	8	16	19	17.0	25.0	2600	2014-05-04 01:02:00.001	2014-05-05
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "UNSUPPORTED_SUBQUERY_EXPRESSION_CATEGORY.ACCESSING_OUTER_QUERY_COLUMN_IS_NOT_ALLOWED",
+  "sqlState" : "0A000",
+  "messageParameters" : {
+    "treeNode" : "GlobalLimit 10\n+- LocalLimit 10\n   +- Project [t2a#x, t2d#xL]\n      +- Project [cast(t2a#x as string) AS t2a#x, cast(t2b#x as smallint) AS t2b#x, cast(t2c#x as int) AS t2c#x, cast(t2d#xL as bigint) AS t2d#xL, cast(t2e#x as float) AS t2e#x, cast(t2f#x as double) AS t2f#x, cast(t2g#x as decimal(4,0)) AS t2g#x, cast(t2h#x as timestamp) AS t2h#x, cast(t2i#x as date) AS t2i#x]\n         +- Project [t2a#x, t2b#x, t2c#x, t2d#xL, t2e#x, t2f#x, t2g#x, t2h#x, t2i#x]\n            +- LocalRelation [t2a#x, t2b#x, t2c#x, t2d#xL, t2e#x, t2f#x, t2g#x, t2h#x, t2i#x]\n"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 118,
+    "stopIndex" : 125,
+    "fragment" : "LIMIT 10"
+  } ]
+}
 
 
 -- !query
@@ -110,11 +123,44 @@ val1c	8	16	19	17.0	25.0	2600	2014-05-04 01:02:00.001	2014-05-05
 
 
 -- !query
+SELECT *
+FROM   t1
+WHERE  t1c IN (SELECT t2c
+               FROM   t2
+               WHERE  t2b <= t2d
+               LIMIT  2)
+LIMIT 4
+-- !query schema
+struct<t1a:string,t1b:smallint,t1c:int,t1d:bigint,t1e:float,t1f:double,t1g:decimal(4,0),t1h:timestamp,t1i:date>
+-- !query output
+val1a	16	12	10	15.0	20.0	2000	2014-07-04 01:01:00	2014-07-04
+val1a	16	12	21	15.0	20.0	2000	2014-06-04 01:02:00.001	2014-06-04
+
+
+-- !query
 SELECT Count(DISTINCT( t1a )),
        t1b
 FROM   t1
 WHERE  t1d IN (SELECT t2d
                FROM   t2
+               ORDER  BY t2c, t2d
+               LIMIT 2)
+GROUP  BY t1b
+ORDER  BY t1b DESC NULLS FIRST
+LIMIT  1
+-- !query schema
+struct<count(DISTINCT t1a):bigint,t1b:smallint>
+-- !query output
+1	NULL
+
+
+-- !query
+SELECT Count(DISTINCT( t1a )),
+       t1b
+FROM   t1
+WHERE  t1d IN (SELECT t2d
+               FROM   t2
+               WHERE t2b <= t2d
                ORDER  BY t2c, t2d
                LIMIT 2)
 GROUP  BY t1b
@@ -140,6 +186,22 @@ val1a	16	12	10	15.0	20.0	2000	2014-07-04 01:01:00	2014-07-04
 val1a	16	12	21	15.0	20.0	2000	2014-06-04 01:02:00.001	2014-06-04
 val1a	6	8	10	15.0	20.0	2000	2014-04-04 01:00:00	2014-04-04
 val1a	6	8	10	15.0	20.0	2000	2014-04-04 01:02:00.001	2014-04-04
+
+
+-- !query
+SELECT *
+FROM   t1
+WHERE  t1b NOT IN (SELECT t2b
+                   FROM   t2
+                   WHERE  t2b <= t2d
+                   LIMIT  2)
+-- !query schema
+struct<t1a:string,t1b:smallint,t1c:int,t1d:bigint,t1e:float,t1f:double,t1g:decimal(4,0),t1h:timestamp,t1i:date>
+-- !query output
+val1a	16	12	10	15.0	20.0	2000	2014-07-04 01:01:00	2014-07-04
+val1a	16	12	21	15.0	20.0	2000	2014-06-04 01:02:00.001	2014-06-04
+val1b	8	16	19	17.0	25.0	2600	2014-05-04 01:01:00	2014-05-04
+val1c	8	16	19	17.0	25.0	2600	2014-05-04 01:02:00.001	2014-05-05
 
 
 -- !query
@@ -172,6 +234,36 @@ struct<t1a:string,t1b:smallint,t1c:int,t1d:bigint,t1e:float,t1f:double,t1g:decim
 -- !query output
 val1e	10	NULL	19	17.0	25.0	2600	2014-05-04 01:01:00	2014-05-04
 val1e	10	NULL	19	17.0	25.0	2600	2014-09-04 01:02:00.001	2014-09-04
+
+
+-- !query
+SELECT *
+FROM   t1
+WHERE  t1a IN (SELECT t2a
+               FROM   t2
+               WHERE  t1d > t2d
+               ORDER BY t2a DESC
+               LIMIT 3)
+LIMIT  2
+OFFSET 2
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "UNSUPPORTED_SUBQUERY_EXPRESSION_CATEGORY.ACCESSING_OUTER_QUERY_COLUMN_IS_NOT_ALLOWED",
+  "sqlState" : "0A000",
+  "messageParameters" : {
+    "treeNode" : "GlobalLimit 3\n+- LocalLimit 3\n   +- Sort [t2a#x DESC NULLS LAST], true\n      +- Project [t2a#x, t2d#xL]\n         +- Project [cast(t2a#x as string) AS t2a#x, cast(t2b#x as smallint) AS t2b#x, cast(t2c#x as int) AS t2c#x, cast(t2d#xL as bigint) AS t2d#xL, cast(t2e#x as float) AS t2e#x, cast(t2f#x as double) AS t2f#x, cast(t2g#x as decimal(4,0)) AS t2g#x, cast(t2h#x as timestamp) AS t2h#x, cast(t2i#x as date) AS t2i#x]\n            +- Project [t2a#x, t2b#x, t2c#x, t2d#xL, t2e#x, t2f#x, t2g#x, t2h#x, t2i#x]\n               +- LocalRelation [t2a#x, t2b#x, t2c#x, t2d#xL, t2e#x, t2f#x, t2g#x, t2h#x, t2i#x]\n"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 118,
+    "stopIndex" : 157,
+    "fragment" : "ORDER BY t2a DESC\n               LIMIT 3"
+  } ]
+}
 
 
 -- !query
@@ -231,6 +323,34 @@ val1e	10	NULL	25	17.0	25.0	2600	2014-08-04 01:01:00	2014-08-04
 
 
 -- !query
+SELECT *
+FROM   t1
+WHERE  t1b NOT IN (SELECT t2b
+                   FROM   t2
+                   WHERE  t2b = t1b
+                   LIMIT  2
+                   OFFSET 2)
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "UNSUPPORTED_SUBQUERY_EXPRESSION_CATEGORY.ACCESSING_OUTER_QUERY_COLUMN_IS_NOT_ALLOWED",
+  "sqlState" : "0A000",
+  "messageParameters" : {
+    "treeNode" : "Filter (t2b#x = outer(t1b#x))\n+- SubqueryAlias t2\n   +- View (`t2`, [t2a#x,t2b#x,t2c#x,t2d#xL,t2e#x,t2f#x,t2g#x,t2h#x,t2i#x])\n      +- Project [cast(t2a#x as string) AS t2a#x, cast(t2b#x as smallint) AS t2b#x, cast(t2c#x as int) AS t2c#x, cast(t2d#xL as bigint) AS t2d#xL, cast(t2e#x as float) AS t2e#x, cast(t2f#x as double) AS t2f#x, cast(t2g#x as decimal(4,0)) AS t2g#x, cast(t2h#x as timestamp) AS t2h#x, cast(t2i#x as date) AS t2i#x]\n         +- Project [t2a#x, t2b#x, t2c#x, t2d#xL, t2e#x, t2f#x, t2g#x, t2h#x, t2i#x]\n            +- SubqueryAlias t2\n               +- LocalRelation [t2a#x, t2b#x, t2c#x, t2d#xL, t2e#x, t2f#x, t2g#x, t2h#x, t2i#x]\n"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 39,
+    "stopIndex" : 113,
+    "fragment" : "SELECT t2b\n                   FROM   t2\n                   WHERE  t2b = t1b"
+  } ]
+}
+
+
+-- !query
 SELECT Count(DISTINCT( t1a )),
        t1b
 FROM   t1
@@ -250,6 +370,40 @@ struct<count(DISTINCT t1a):bigint,t1b:smallint>
 
 
 -- !query
+SELECT Count(DISTINCT( t1a )),
+       t1b
+FROM   t1
+WHERE  t1d NOT IN (SELECT t2d
+                   FROM   t2
+                   WHERE t2b > t1b
+                   ORDER  BY t2b DESC nulls first, t2d
+                   LIMIT 1
+                   OFFSET 1)
+GROUP  BY t1b
+ORDER BY t1b NULLS last
+LIMIT  1
+OFFSET 1
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "UNSUPPORTED_SUBQUERY_EXPRESSION_CATEGORY.ACCESSING_OUTER_QUERY_COLUMN_IS_NOT_ALLOWED",
+  "sqlState" : "0A000",
+  "messageParameters" : {
+    "treeNode" : "Filter (t2b#x > outer(t1b#x))\n+- SubqueryAlias t2\n   +- View (`t2`, [t2a#x,t2b#x,t2c#x,t2d#xL,t2e#x,t2f#x,t2g#x,t2h#x,t2i#x])\n      +- Project [cast(t2a#x as string) AS t2a#x, cast(t2b#x as smallint) AS t2b#x, cast(t2c#x as int) AS t2c#x, cast(t2d#xL as bigint) AS t2d#xL, cast(t2e#x as float) AS t2e#x, cast(t2f#x as double) AS t2f#x, cast(t2g#x as decimal(4,0)) AS t2g#x, cast(t2h#x as timestamp) AS t2h#x, cast(t2i#x as date) AS t2i#x]\n         +- Project [t2a#x, t2b#x, t2c#x, t2d#xL, t2e#x, t2f#x, t2g#x, t2h#x, t2i#x]\n            +- SubqueryAlias t2\n               +- LocalRelation [t2a#x, t2b#x, t2c#x, t2d#xL, t2e#x, t2f#x, t2g#x, t2h#x, t2i#x]\n"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 72,
+    "stopIndex" : 145,
+    "fragment" : "SELECT t2d\n                   FROM   t2\n                   WHERE t2b > t1b"
+  } ]
+}
+
+
+-- !query
 SELECT *
 FROM   t1
 WHERE  t1a IN (SELECT t2a
@@ -266,6 +420,35 @@ val1e	10	NULL	19	17.0	25.0	2600	2014-09-04 01:02:00.001	2014-09-04
 -- !query
 SELECT *
 FROM   t1
+WHERE  t1a IN (SELECT t2a
+               FROM   t2
+               WHERE  t1d = t2d
+               ORDER BY t2a
+               OFFSET 2)
+OFFSET 2
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "UNSUPPORTED_SUBQUERY_EXPRESSION_CATEGORY.ACCESSING_OUTER_QUERY_COLUMN_IS_NOT_ALLOWED",
+  "sqlState" : "0A000",
+  "messageParameters" : {
+    "treeNode" : "Filter (outer(t1d#xL) = t2d#xL)\n+- SubqueryAlias t2\n   +- View (`t2`, [t2a#x,t2b#x,t2c#x,t2d#xL,t2e#x,t2f#x,t2g#x,t2h#x,t2i#x])\n      +- Project [cast(t2a#x as string) AS t2a#x, cast(t2b#x as smallint) AS t2b#x, cast(t2c#x as int) AS t2c#x, cast(t2d#xL as bigint) AS t2d#xL, cast(t2e#x as float) AS t2e#x, cast(t2f#x as double) AS t2f#x, cast(t2g#x as decimal(4,0)) AS t2g#x, cast(t2h#x as timestamp) AS t2h#x, cast(t2i#x as date) AS t2i#x]\n         +- Project [t2a#x, t2b#x, t2c#x, t2d#xL, t2e#x, t2f#x, t2g#x, t2h#x, t2i#x]\n            +- SubqueryAlias t2\n               +- LocalRelation [t2a#x, t2b#x, t2c#x, t2d#xL, t2e#x, t2f#x, t2g#x, t2h#x, t2i#x]\n"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 35,
+    "stopIndex" : 101,
+    "fragment" : "SELECT t2a\n               FROM   t2\n               WHERE  t1d = t2d"
+  } ]
+}
+
+
+-- !query
+SELECT *
+FROM   t1
 WHERE  t1c IN (SELECT t2c
                FROM   t2
                WHERE  t2b >= 8
@@ -276,6 +459,35 @@ struct<t1a:string,t1b:smallint,t1c:int,t1d:bigint,t1e:float,t1f:double,t1g:decim
 -- !query output
 val1d	NULL	16	19	17.0	25.0	2600	2014-07-04 01:02:00.001	NULL
 val1d	NULL	16	22	17.0	25.0	2600	2014-06-04 01:01:00	NULL
+
+
+-- !query
+SELECT *
+FROM   t1
+WHERE  t1c IN (SELECT t2c
+               FROM   t2
+               WHERE  t2b < t1b
+               ORDER BY t2c
+               OFFSET 2)
+OFFSET 1
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "UNSUPPORTED_SUBQUERY_EXPRESSION_CATEGORY.ACCESSING_OUTER_QUERY_COLUMN_IS_NOT_ALLOWED",
+  "sqlState" : "0A000",
+  "messageParameters" : {
+    "treeNode" : "Filter (t2b#x < outer(t1b#x))\n+- SubqueryAlias t2\n   +- View (`t2`, [t2a#x,t2b#x,t2c#x,t2d#xL,t2e#x,t2f#x,t2g#x,t2h#x,t2i#x])\n      +- Project [cast(t2a#x as string) AS t2a#x, cast(t2b#x as smallint) AS t2b#x, cast(t2c#x as int) AS t2c#x, cast(t2d#xL as bigint) AS t2d#xL, cast(t2e#x as float) AS t2e#x, cast(t2f#x as double) AS t2f#x, cast(t2g#x as decimal(4,0)) AS t2g#x, cast(t2h#x as timestamp) AS t2h#x, cast(t2i#x as date) AS t2i#x]\n         +- Project [t2a#x, t2b#x, t2c#x, t2d#xL, t2e#x, t2f#x, t2g#x, t2h#x, t2i#x]\n            +- SubqueryAlias t2\n               +- LocalRelation [t2a#x, t2b#x, t2c#x, t2d#xL, t2e#x, t2f#x, t2g#x, t2h#x, t2i#x]\n"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 35,
+    "stopIndex" : 101,
+    "fragment" : "SELECT t2c\n               FROM   t2\n               WHERE  t2b < t1b"
+  } ]
+}
 
 
 -- !query
@@ -310,6 +522,33 @@ val1a	16	12	10	15.0	20.0	2000	2014-07-04 01:01:00	2014-07-04
 val1a	16	12	21	15.0	20.0	2000	2014-06-04 01:02:00.001	2014-06-04
 val1a	6	8	10	15.0	20.0	2000	2014-04-04 01:00:00	2014-04-04
 val1a	6	8	10	15.0	20.0	2000	2014-04-04 01:02:00.001	2014-04-04
+
+
+-- !query
+SELECT count(*)
+FROM   t1
+WHERE  t1b NOT IN (SELECT t2b
+                   FROM   t2
+                   WHERE  t2b < t1b
+                   OFFSET 2)
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.catalyst.ExtendedAnalysisException
+{
+  "errorClass" : "UNSUPPORTED_SUBQUERY_EXPRESSION_CATEGORY.ACCESSING_OUTER_QUERY_COLUMN_IS_NOT_ALLOWED",
+  "sqlState" : "0A000",
+  "messageParameters" : {
+    "treeNode" : "Filter (t2b#x < outer(t1b#x))\n+- SubqueryAlias t2\n   +- View (`t2`, [t2a#x,t2b#x,t2c#x,t2d#xL,t2e#x,t2f#x,t2g#x,t2h#x,t2i#x])\n      +- Project [cast(t2a#x as string) AS t2a#x, cast(t2b#x as smallint) AS t2b#x, cast(t2c#x as int) AS t2c#x, cast(t2d#xL as bigint) AS t2d#xL, cast(t2e#x as float) AS t2e#x, cast(t2f#x as double) AS t2f#x, cast(t2g#x as decimal(4,0)) AS t2g#x, cast(t2h#x as timestamp) AS t2h#x, cast(t2i#x as date) AS t2i#x]\n         +- Project [t2a#x, t2b#x, t2c#x, t2d#xL, t2e#x, t2f#x, t2g#x, t2h#x, t2i#x]\n            +- SubqueryAlias t2\n               +- LocalRelation [t2a#x, t2b#x, t2c#x, t2d#xL, t2e#x, t2f#x, t2g#x, t2h#x, t2i#x]\n"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 46,
+    "stopIndex" : 120,
+    "fragment" : "SELECT t2b\n                   FROM   t2\n                   WHERE  t2b < t1b"
+  } ]
+}
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/subquery/in-subquery/in-limit.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/subquery/in-subquery/in-limit.sql.out
@@ -80,6 +80,21 @@ val1c	8	16	19	17.0	25.0	2600	2014-05-04 01:02:00.001	2014-05-05
 -- !query
 SELECT *
 FROM   t1
+WHERE  t1a IN (SELECT t2a
+               FROM   t2
+               WHERE  t1d = t2d
+               LIMIT 10)
+LIMIT  2
+-- !query schema
+struct<t1a:string,t1b:smallint,t1c:int,t1d:bigint,t1e:float,t1f:double,t1g:decimal(4,0),t1h:timestamp,t1i:date>
+-- !query output
+val1b	8	16	19	17.0	25.0	2600	2014-05-04 01:01:00	2014-05-04
+val1c	8	16	19	17.0	25.0	2600	2014-05-04 01:02:00.001	2014-05-05
+
+
+-- !query
+SELECT *
+FROM   t1
 WHERE  t1c IN (SELECT t2c
                FROM   t2
                WHERE  t2b >= 8

--- a/sql/core/src/test/resources/sql-tests/results/subquery/in-subquery/in-limit.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/subquery/in-subquery/in-limit.sql.out
@@ -127,14 +127,27 @@ SELECT *
 FROM   t1
 WHERE  t1c IN (SELECT t2c
                FROM   t2
-               WHERE  t2b <= t2d
+               WHERE  t2b <= t1d
                LIMIT  2)
 LIMIT 4
 -- !query schema
-struct<t1a:string,t1b:smallint,t1c:int,t1d:bigint,t1e:float,t1f:double,t1g:decimal(4,0),t1h:timestamp,t1i:date>
+struct<>
 -- !query output
-val1a	16	12	10	15.0	20.0	2000	2014-07-04 01:01:00	2014-07-04
-val1a	16	12	21	15.0	20.0	2000	2014-06-04 01:02:00.001	2014-06-04
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "UNSUPPORTED_SUBQUERY_EXPRESSION_CATEGORY.ACCESSING_OUTER_QUERY_COLUMN_IS_NOT_ALLOWED",
+  "sqlState" : "0A000",
+  "messageParameters" : {
+    "treeNode" : "GlobalLimit 2\n+- LocalLimit 2\n   +- Project [t2c#x, t2b#x]\n      +- Project [cast(t2a#x as string) AS t2a#x, cast(t2b#x as smallint) AS t2b#x, cast(t2c#x as int) AS t2c#x, cast(t2d#xL as bigint) AS t2d#xL, cast(t2e#x as float) AS t2e#x, cast(t2f#x as double) AS t2f#x, cast(t2g#x as decimal(4,0)) AS t2g#x, cast(t2h#x as timestamp) AS t2h#x, cast(t2i#x as date) AS t2i#x]\n         +- Project [t2a#x, t2b#x, t2c#x, t2d#xL, t2e#x, t2f#x, t2g#x, t2h#x, t2i#x]\n            +- LocalRelation [t2a#x, t2b#x, t2c#x, t2d#xL, t2e#x, t2f#x, t2g#x, t2h#x, t2i#x]\n"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 119,
+    "stopIndex" : 126,
+    "fragment" : "LIMIT  2"
+  } ]
+}
 
 
 -- !query
@@ -160,16 +173,30 @@ SELECT Count(DISTINCT( t1a )),
 FROM   t1
 WHERE  t1d IN (SELECT t2d
                FROM   t2
-               WHERE t2b <= t2d
+               WHERE t2b <= t1d
                ORDER  BY t2c, t2d
                LIMIT 2)
 GROUP  BY t1b
 ORDER  BY t1b DESC NULLS FIRST
 LIMIT  1
 -- !query schema
-struct<count(DISTINCT t1a):bigint,t1b:smallint>
+struct<>
 -- !query output
-1	NULL
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "UNSUPPORTED_SUBQUERY_EXPRESSION_CATEGORY.ACCESSING_OUTER_QUERY_COLUMN_IS_NOT_ALLOWED",
+  "sqlState" : "0A000",
+  "messageParameters" : {
+    "treeNode" : "GlobalLimit 2\n+- LocalLimit 2\n   +- Project [t2d#xL, t2b#x]\n      +- Sort [t2c#x ASC NULLS FIRST, t2d#xL ASC NULLS FIRST], true\n         +- Project [t2d#xL, t2c#x, t2b#x]\n            +- Project [cast(t2a#x as string) AS t2a#x, cast(t2b#x as smallint) AS t2b#x, cast(t2c#x as int) AS t2c#x, cast(t2d#xL as bigint) AS t2d#xL, cast(t2e#x as float) AS t2e#x, cast(t2f#x as double) AS t2f#x, cast(t2g#x as decimal(4,0)) AS t2g#x, cast(t2h#x as timestamp) AS t2h#x, cast(t2i#x as date) AS t2i#x]\n               +- Project [t2a#x, t2b#x, t2c#x, t2d#xL, t2e#x, t2f#x, t2g#x, t2h#x, t2i#x]\n                  +- LocalRelation [t2a#x, t2b#x, t2c#x, t2d#xL, t2e#x, t2f#x, t2g#x, t2h#x, t2i#x]\n"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 151,
+    "stopIndex" : 191,
+    "fragment" : "ORDER  BY t2c, t2d\n               LIMIT 2"
+  } ]
+}
 
 
 -- !query
@@ -193,15 +220,26 @@ SELECT *
 FROM   t1
 WHERE  t1b NOT IN (SELECT t2b
                    FROM   t2
-                   WHERE  t2b <= t2d
+                   WHERE  t2b <= t1d
                    LIMIT  2)
 -- !query schema
-struct<t1a:string,t1b:smallint,t1c:int,t1d:bigint,t1e:float,t1f:double,t1g:decimal(4,0),t1h:timestamp,t1i:date>
+struct<>
 -- !query output
-val1a	16	12	10	15.0	20.0	2000	2014-07-04 01:01:00	2014-07-04
-val1a	16	12	21	15.0	20.0	2000	2014-06-04 01:02:00.001	2014-06-04
-val1b	8	16	19	17.0	25.0	2600	2014-05-04 01:01:00	2014-05-04
-val1c	8	16	19	17.0	25.0	2600	2014-05-04 01:02:00.001	2014-05-05
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "UNSUPPORTED_SUBQUERY_EXPRESSION_CATEGORY.ACCESSING_OUTER_QUERY_COLUMN_IS_NOT_ALLOWED",
+  "sqlState" : "0A000",
+  "messageParameters" : {
+    "treeNode" : "GlobalLimit 2\n+- LocalLimit 2\n   +- Project [t2b#x]\n      +- Project [cast(t2a#x as string) AS t2a#x, cast(t2b#x as smallint) AS t2b#x, cast(t2c#x as int) AS t2c#x, cast(t2d#xL as bigint) AS t2d#xL, cast(t2e#x as float) AS t2e#x, cast(t2f#x as double) AS t2f#x, cast(t2g#x as decimal(4,0)) AS t2g#x, cast(t2h#x as timestamp) AS t2h#x, cast(t2i#x as date) AS t2i#x]\n         +- Project [t2a#x, t2b#x, t2c#x, t2d#xL, t2e#x, t2f#x, t2g#x, t2h#x, t2i#x]\n            +- LocalRelation [t2a#x, t2b#x, t2c#x, t2d#xL, t2e#x, t2f#x, t2g#x, t2h#x, t2i#x]\n"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 135,
+    "stopIndex" : 142,
+    "fragment" : "LIMIT  2"
+  } ]
+}
 
 
 -- !query


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Support for LIMIT in correlated lateral and scalar subqueries was added in https://github.com/apache/spark/pull/42705. However, that PR also extended Analyzer support for limit/order by in EXISTS/IN subqueries, for which we don't have good planning support yet. 
This PR introduces checks that ensure correlated IN/EXISTS subqueries do not have LIMIT clauses.
We do not add a new type of QueryCompilationError, as we plan to fully support such subqueries in the next couple of months, so for now we re-use the same analysis error as used to be issued before https://github.com/apache/spark/pull/42705.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
See above.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Unit tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No