### PR TITLE
[SPARK-45285][CORE][TESTS] Remove deprecated `Runtime.getRuntime.exec(String)` API usage

### DIFF
--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -990,13 +990,13 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties {
       }
 
       def pidExists(pid: Int): Boolean = {
-        val p = Runtime.getRuntime.exec(s"kill -0 $pid")
+        val p = Runtime.getRuntime.exec(Array("kill", "-0", s"$pid"))
         p.waitFor()
         p.exitValue() == 0
       }
 
       def signal(pid: Int, s: String): Unit = {
-        val p = Runtime.getRuntime.exec(s"kill -$s $pid")
+        val p = Runtime.getRuntime.exec(Array("kill", s"-$s", s"$pid"))
         p.waitFor()
       }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove the deprecated `Runtime.exec` methods with a single string command line.

### Why are the changes needed?

This is deprecated from Java 18.
- https://bugs.openjdk.org/browse/JDK-8276408 (Deprecate Runtime.exec methods with a single string command line argument)

Apache Spark has only two lines in a single test case of `core` module. `yarn` module already using the recommended one.

```
$ git grep getRuntime | grep exec | grep -v Statistics
core/src/test/scala/org/apache/spark/util/UtilsSuite.scala:        val p = Runtime.getRuntime.exec(Array(s"kill -0 $pid"))
core/src/test/scala/org/apache/spark/util/UtilsSuite.scala:        val p = Runtime.getRuntime.exec(Array(s"kill -$s $pid"))
resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtilSuite.scala:      val exitCode = Runtime.getRuntime().exec(Array("bash", "--version")).waitFor()
resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtilSuite.scala:      val proc = Runtime.getRuntime().exec(Array(scriptFile.getAbsolutePath()))
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

```
$ build/sbt "core/testOnly *.UtilsSuite -- -z process"
...
[info] UtilsSuite:
[info] - Kill process (5 seconds, 194 milliseconds)
```

Manually check the compilation log.

### Was this patch authored or co-authored using generative AI tooling?

No.