### PR TITLE
[SPARK-45290][INFRA][Launcher]Fix The return status is incorrect in standalone mode. The status of endevent is correct

### DIFF
--- a/launcher/src/main/java/org/apache/spark/launcher/AbstractAppHandle.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/AbstractAppHandle.java
@@ -75,7 +75,7 @@ abstract class AbstractAppHandle implements SparkAppHandle {
       try {
         connection.close();
       } catch (IOException ioe) {
-        // no-op.
+        LOG.log(Level.INFO, "disconnect close // no-op..", ioe);
       }
     }
     dispose();
@@ -109,7 +109,7 @@ abstract class AbstractAppHandle implements SparkAppHandle {
         try {
           connection.waitForClose();
         } catch (IOException ioe) {
-          // no-op.
+          LOG.log(Level.INFO, "disconnect waitForClose // no-op..", ioe);
         }
       }
       server.unregister(this);
@@ -118,6 +118,7 @@ abstract class AbstractAppHandle implements SparkAppHandle {
       setState(State.LOST, false);
       this.disposed = true;
     }
+    endEvent();
   }
 
   void setState(SparkAppHandle.State s) {
@@ -159,6 +160,14 @@ abstract class AbstractAppHandle implements SparkAppHandle {
         } else {
           l.stateChanged(this);
         }
+      }
+    }
+  }
+
+  private void endEvent() {
+    if (listeners != null) {
+      for (Listener l : listeners) {
+        l.taskEnd(this);
       }
     }
   }

--- a/launcher/src/main/java/org/apache/spark/launcher/SparkAppHandle.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkAppHandle.java
@@ -131,6 +131,16 @@ public interface SparkAppHandle {
      */
     void infoChanged(SparkAppHandle handle);
 
+    /**
+     * task end event.
+     */
+    /**
+     * Callback for end handle.
+     *
+     * @param handle The updated handle.
+     */
+    void taskEnd(SparkAppHandle handle);
+
   }
 
 }

--- a/launcher/src/test/java/org/apache/spark/launcher/LauncherServerSuite.java
+++ b/launcher/src/test/java/org/apache/spark/launcher/LauncherServerSuite.java
@@ -73,6 +73,11 @@ public class LauncherServerSuite extends BaseSuite {
         public void infoChanged(SparkAppHandle handle) {
           semaphore.release();
         }
+
+        @Override
+        public void taskEnd(SparkAppHandle handle) {
+          semaphore.release();
+        }
       });
 
       client = new TestClient(s);
@@ -137,6 +142,11 @@ public class LauncherServerSuite extends BaseSuite {
           semaphore.release();
         }
         public void infoChanged(SparkAppHandle handle) {
+          semaphore.release();
+        }
+
+        @Override
+        public void taskEnd(SparkAppHandle handle) {
           semaphore.release();
         }
       });


### PR DESCRIPTION
Fix The return status is incorrect in standalone mode. The status of endevent is correct
### What changes were proposed in this pull request?
This pr aims fix the return status is incorrect in standalone mode. 

### Why are the changes needed?
The return status is incorrect in standalone mode. The status of endevent is correct

### Does this PR introduce _any_ user-facing change?
No

### Was this patch authored or co-authored using generative AI tooling?
No

Closes https://issues.apache.org/jira/browse/SPARK-45290 from changhu/SPARK-45290.
