### PR TITLE
[SPARK-44170][BUILD][TESTS] Migrate Junit 4 to Junit 5 

### DIFF
--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/ArrayWrappersSuite.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/ArrayWrappersSuite.java
@@ -17,8 +17,8 @@
 
 package org.apache.spark.util.kvstore;
 
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ArrayWrappersSuite {
 

--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/DBIteratorSuite.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/DBIteratorSuite.java
@@ -28,13 +28,13 @@ import java.util.Random;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public abstract class DBIteratorSuite {
 
@@ -79,25 +79,25 @@ public abstract class DBIteratorSuite {
 
   /**
    * Implementations should override this method; it is called only once, before all tests are
-   * run. Any state can be safely stored in static variables and cleaned up in a @AfterClass
+   * run. Any state can be safely stored in static variables and cleaned up in a @AfterAll
    * handler.
    */
   protected abstract KVStore createStore() throws Exception;
 
-  @BeforeClass
+  @BeforeAll
   public static void setupClass() {
     long seed = RND.nextLong();
     LOG.info("Random seed: {}", seed);
     RND.setSeed(seed);
   }
 
-  @AfterClass
-  public static void cleanupData() throws Exception {
+  @AfterAll
+  public static void cleanupData() {
     allEntries = null;
     db = null;
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     if (db != null) {
       return;
@@ -485,8 +485,8 @@ public abstract class DBIteratorSuite {
       message = "stray";
     }
 
-    assertEquals(String.format("Found %s elements: %s", message, Arrays.asList(remaining)),
-      expectedCount, actualCount);
+    assertEquals(expectedCount, actualCount,
+      String.format("Found %s elements: %s", message, Arrays.asList(remaining)));
   }
 
   private KVStoreView<CustomType1> view() throws Exception {

--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/InMemoryStoreSuite.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/InMemoryStoreSuite.java
@@ -20,8 +20,8 @@ package org.apache.spark.util.kvstore;
 import java.util.NoSuchElementException;
 
 import com.google.common.collect.ImmutableSet;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class InMemoryStoreSuite {
 

--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBBenchmark.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBBenchmark.java
@@ -29,13 +29,13 @@ import com.codahale.metrics.Slf4jReporter;
 import com.codahale.metrics.Snapshot;
 import com.codahale.metrics.Timer;
 import org.apache.commons.io.FileUtils;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * A set of small benchmarks for the LevelDB implementation.
@@ -48,7 +48,7 @@ import static org.junit.Assert.*;
  * - iterate over natural index, ascending and descending
  * - iterate over ref index, ascending and descending
  */
-@Ignore
+@Disabled
 public class LevelDBBenchmark {
 
   private static final int COUNT = 1024;
@@ -60,7 +60,7 @@ public class LevelDBBenchmark {
   private LevelDB db;
   private File dbpath;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     dbpath = File.createTempFile("test.", ".ldb");
     dbpath.delete();
@@ -69,7 +69,7 @@ public class LevelDBBenchmark {
     }
   }
 
-  @After
+  @AfterEach
   public void cleanup() throws Exception {
     if (db != null) {
       try(Timer.Context ctx = dbClose.time()) {
@@ -81,7 +81,7 @@ public class LevelDBBenchmark {
     }
   }
 
-  @AfterClass
+  @AfterAll
   public static void report() {
     if (metrics.getTimers().isEmpty()) {
       return;
@@ -260,7 +260,7 @@ public class LevelDBBenchmark {
   }
 
   private Timer newTimer(String name) {
-    assertNull("Timer already exists: " + name, metrics.getTimers().get(name));
+    assertNull(metrics.getTimers().get(name), "Timer already exists: " + name);
     return metrics.timer(name);
   }
 

--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBIteratorSuite.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBIteratorSuite.java
@@ -21,15 +21,15 @@ import java.io.File;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.SystemUtils;
-import org.junit.AfterClass;
-import static org.junit.Assume.assumeFalse;
+import org.junit.jupiter.api.AfterAll;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 public class LevelDBIteratorSuite extends DBIteratorSuite {
 
   private static File dbpath;
   private static LevelDB db;
 
-  @AfterClass
+  @AfterAll
   public static void cleanup() throws Exception {
     if (db != null) {
       db.close();

--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBSuite.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBSuite.java
@@ -30,18 +30,18 @@ import com.google.common.collect.ImmutableSet;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.iq80.leveldb.DBIterator;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import static org.junit.Assert.*;
-import static org.junit.Assume.assumeFalse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 public class LevelDBSuite {
 
   private LevelDB db;
   private File dbpath;
 
-  @After
+  @AfterEach
   public void cleanup() throws Exception {
     if (db != null) {
       db.close();
@@ -51,7 +51,7 @@ public class LevelDBSuite {
     }
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     assumeFalse(SystemUtils.IS_OS_MAC_OSX && SystemUtils.OS_ARCH.equals("aarch64"));
     dbpath = File.createTempFile("test.", ".ldb");

--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBTypeInfoSuite.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBTypeInfoSuite.java
@@ -19,8 +19,8 @@ package org.apache.spark.util.kvstore;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class LevelDBTypeInfoSuite {
 
@@ -154,7 +154,7 @@ public class LevelDBTypeInfoSuite {
   }
 
   private void assertBefore(String str1, String str2) {
-    assertTrue(String.format("%s < %s failed", str1, str2), str1.compareTo(str2) < 0);
+    assertTrue(str1.compareTo(str2) < 0, String.format("%s < %s failed", str1, str2));
   }
 
   private void assertSame(byte[] key1, byte[] key2) {

--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/RocksDBBenchmark.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/RocksDBBenchmark.java
@@ -29,13 +29,13 @@ import com.codahale.metrics.Slf4jReporter;
 import com.codahale.metrics.Snapshot;
 import com.codahale.metrics.Timer;
 import org.apache.commons.io.FileUtils;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * A set of small benchmarks for the RocksDB implementation.
@@ -48,7 +48,7 @@ import static org.junit.Assert.*;
  * - iterate over natural index, ascending and descending
  * - iterate over ref index, ascending and descending
  */
-@Ignore
+@Disabled
 public class RocksDBBenchmark {
 
   private static final int COUNT = 1024;
@@ -60,7 +60,7 @@ public class RocksDBBenchmark {
   private RocksDB db;
   private File dbpath;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     dbpath = File.createTempFile("test.", ".rdb");
     dbpath.delete();
@@ -69,7 +69,7 @@ public class RocksDBBenchmark {
     }
   }
 
-  @After
+  @AfterEach
   public void cleanup() throws Exception {
     if (db != null) {
       try(Timer.Context ctx = dbClose.time()) {
@@ -81,7 +81,7 @@ public class RocksDBBenchmark {
     }
   }
 
-  @AfterClass
+  @AfterAll
   public static void report() {
     if (metrics.getTimers().isEmpty()) {
       return;
@@ -259,7 +259,7 @@ public class RocksDBBenchmark {
   }
 
   private Timer newTimer(String name) {
-    assertNull("Timer already exists: " + name, metrics.getTimers().get(name));
+    assertNull(metrics.getTimers().get(name), "Timer already exists: " + name);
     return metrics.timer(name);
   }
 

--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/RocksDBIteratorSuite.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/RocksDBIteratorSuite.java
@@ -20,14 +20,14 @@ package org.apache.spark.util.kvstore;
 import java.io.File;
 
 import org.apache.commons.io.FileUtils;
-import org.junit.AfterClass;
+import org.junit.jupiter.api.AfterAll;
 
 public class RocksDBIteratorSuite extends DBIteratorSuite {
 
   private static File dbpath;
   private static RocksDB db;
 
-  @AfterClass
+  @AfterAll
   public static void cleanup() throws Exception {
     if (db != null) {
       db.close();

--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/RocksDBSuite.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/RocksDBSuite.java
@@ -28,19 +28,19 @@ import java.util.stream.StreamSupport;
 
 import com.google.common.collect.ImmutableSet;
 import org.apache.commons.io.FileUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.rocksdb.RocksIterator;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class RocksDBSuite {
 
   private RocksDB db;
   private File dbpath;
 
-  @After
+  @AfterEach
   public void cleanup() throws Exception {
     if (db != null) {
       db.close();
@@ -50,7 +50,7 @@ public class RocksDBSuite {
     }
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     dbpath = File.createTempFile("test.", ".rdb");
     dbpath.delete();

--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/RocksDBTypeInfoSuite.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/RocksDBTypeInfoSuite.java
@@ -19,8 +19,8 @@ package org.apache.spark.util.kvstore;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class RocksDBTypeInfoSuite {
 
@@ -154,7 +154,7 @@ public class RocksDBTypeInfoSuite {
   }
 
   private void assertBefore(String str1, String str2) {
-    assertTrue(String.format("%s < %s failed", str1, str2), str1.compareTo(str2) < 0);
+    assertTrue(str1.compareTo(str2) < 0, String.format("%s < %s failed", str1, str2));
   }
 
   private void assertSame(byte[] key1, byte[] key2) {

--- a/common/network-common/src/test/java/org/apache/spark/network/ChunkFetchIntegrationSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/ChunkFetchIntegrationSuite.java
@@ -32,11 +32,11 @@ import java.util.concurrent.TimeUnit;
 
 import com.google.common.collect.Sets;
 import com.google.common.io.Closeables;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.apache.spark.network.buffer.FileSegmentManagedBuffer;
 import org.apache.spark.network.buffer.ManagedBuffer;
@@ -65,7 +65,7 @@ public class ChunkFetchIntegrationSuite {
   static ManagedBuffer bufferChunk;
   static ManagedBuffer fileChunk;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception {
     int bufSize = 100000;
     final ByteBuffer buf = ByteBuffer.allocate(bufSize);
@@ -123,7 +123,7 @@ public class ChunkFetchIntegrationSuite {
     clientFactory = context.createClientFactory();
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() {
     bufferChunk.release();
     server.close();

--- a/common/network-common/src/test/java/org/apache/spark/network/ChunkFetchRequestHandlerSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/ChunkFetchRequestHandlerSuite.java
@@ -22,8 +22,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import io.netty.channel.Channel;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import static org.mockito.Mockito.*;
 
@@ -72,16 +72,16 @@ public class ChunkFetchRequestHandlerSuite {
 
     RequestMessage request0 = new ChunkFetchRequest(new StreamChunkId(streamId, 0));
     requestHandler.channelRead(context, request0);
-    Assert.assertEquals(1, responseAndPromisePairs.size());
-    Assert.assertTrue(responseAndPromisePairs.get(0).getLeft() instanceof ChunkFetchSuccess);
-    Assert.assertEquals(managedBuffers.get(0),
+    Assertions.assertEquals(1, responseAndPromisePairs.size());
+    Assertions.assertTrue(responseAndPromisePairs.get(0).getLeft() instanceof ChunkFetchSuccess);
+    Assertions.assertEquals(managedBuffers.get(0),
       ((ChunkFetchSuccess) (responseAndPromisePairs.get(0).getLeft())).body());
 
     RequestMessage request1 = new ChunkFetchRequest(new StreamChunkId(streamId, 1));
     requestHandler.channelRead(context, request1);
-    Assert.assertEquals(2, responseAndPromisePairs.size());
-    Assert.assertTrue(responseAndPromisePairs.get(1).getLeft() instanceof ChunkFetchSuccess);
-    Assert.assertEquals(managedBuffers.get(1),
+    Assertions.assertEquals(2, responseAndPromisePairs.size());
+    Assertions.assertTrue(responseAndPromisePairs.get(1).getLeft() instanceof ChunkFetchSuccess);
+    Assertions.assertEquals(managedBuffers.get(1),
       ((ChunkFetchSuccess) (responseAndPromisePairs.get(1).getLeft())).body());
 
     // Finish flushing the response for request0.
@@ -89,23 +89,23 @@ public class ChunkFetchRequestHandlerSuite {
 
     RequestMessage request2 = new ChunkFetchRequest(new StreamChunkId(streamId, 2));
     requestHandler.channelRead(context, request2);
-    Assert.assertEquals(3, responseAndPromisePairs.size());
-    Assert.assertTrue(responseAndPromisePairs.get(2).getLeft() instanceof ChunkFetchFailure);
+    Assertions.assertEquals(3, responseAndPromisePairs.size());
+    Assertions.assertTrue(responseAndPromisePairs.get(2).getLeft() instanceof ChunkFetchFailure);
     ChunkFetchFailure chunkFetchFailure =
         ((ChunkFetchFailure) (responseAndPromisePairs.get(2).getLeft()));
-    Assert.assertEquals("java.lang.IllegalStateException: Chunk was not found",
+    Assertions.assertEquals("java.lang.IllegalStateException: Chunk was not found",
         chunkFetchFailure.errorString.split("\\r?\\n")[0]);
 
     RequestMessage request3 = new ChunkFetchRequest(new StreamChunkId(streamId, 3));
     requestHandler.channelRead(context, request3);
-    Assert.assertEquals(4, responseAndPromisePairs.size());
-    Assert.assertTrue(responseAndPromisePairs.get(3).getLeft() instanceof ChunkFetchSuccess);
-    Assert.assertEquals(managedBuffers.get(3),
+    Assertions.assertEquals(4, responseAndPromisePairs.size());
+    Assertions.assertTrue(responseAndPromisePairs.get(3).getLeft() instanceof ChunkFetchSuccess);
+    Assertions.assertEquals(managedBuffers.get(3),
       ((ChunkFetchSuccess) (responseAndPromisePairs.get(3).getLeft())).body());
 
     RequestMessage request4 = new ChunkFetchRequest(new StreamChunkId(streamId, 4));
     requestHandler.channelRead(context, request4);
     verify(channel, times(1)).close();
-    Assert.assertEquals(4, responseAndPromisePairs.size());
+    Assertions.assertEquals(4, responseAndPromisePairs.size());
   }
 }

--- a/common/network-common/src/test/java/org/apache/spark/network/ProtocolSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/ProtocolSuite.java
@@ -25,9 +25,9 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.FileRegion;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.MessageToMessageEncoder;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.spark.network.protocol.ChunkFetchFailure;
 import org.apache.spark.network.protocol.ChunkFetchRequest;

--- a/common/network-common/src/test/java/org/apache/spark/network/RequestTimeoutIntegrationSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/RequestTimeoutIntegrationSuite.java
@@ -29,8 +29,8 @@ import org.apache.spark.network.server.StreamManager;
 import org.apache.spark.network.server.TransportServer;
 import org.apache.spark.network.util.MapConfigProvider;
 import org.apache.spark.network.util.TransportConf;
-import org.junit.*;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -58,7 +58,7 @@ public class RequestTimeoutIntegrationSuite {
   // A large timeout that "shouldn't happen", for the sake of faulty tests not hanging forever.
   private static final int FOREVER = 60 * 1000;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     Map<String, String> configMap = new HashMap<>();
     configMap.put("spark.shuffle.io.connectionTimeout", "10s");
@@ -72,7 +72,7 @@ public class RequestTimeoutIntegrationSuite {
     };
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     if (server != null) {
       server.close();

--- a/common/network-common/src/test/java/org/apache/spark/network/RpcIntegrationSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/RpcIntegrationSuite.java
@@ -28,11 +28,11 @@ import com.google.common.collect.Sets;
 import com.google.common.io.Files;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.apache.spark.network.buffer.ManagedBuffer;
 import org.apache.spark.network.buffer.NioManagedBuffer;
@@ -54,7 +54,7 @@ public class RpcIntegrationSuite {
   static ConcurrentHashMap<String, VerifyingStreamCallback> streamCallbacks =
       new ConcurrentHashMap<>();
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception {
     conf = new TransportConf("shuffle", MapConfigProvider.EMPTY);
     testData = new StreamTestHelper();
@@ -160,7 +160,7 @@ public class RpcIntegrationSuite {
     }
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() {
     server.close();
     clientFactory.close();
@@ -325,7 +325,7 @@ public class RpcIntegrationSuite {
   public void sendRpcWithStreamOneAtATime() throws Exception {
     for (String stream : StreamTestHelper.STREAMS) {
       RpcResult res = sendRpcWithStream(stream);
-      assertTrue("there were error messages!" + res.errorMessages, res.errorMessages.isEmpty());
+      assertTrue(res.errorMessages.isEmpty(), "there were error messages!" + res.errorMessages);
       assertEquals(Sets.newHashSet(stream), res.successMessages);
     }
   }
@@ -362,21 +362,21 @@ public class RpcIntegrationSuite {
   }
 
   private void assertErrorsContain(Set<String> errors, Set<String> contains) {
-    assertEquals("Expected " + contains.size() + " errors, got " + errors.size() + "errors: " +
-        errors, contains.size(), errors.size());
+    assertEquals(contains.size(), errors.size(),
+      "Expected " + contains.size() + " errors, got " + errors.size() + "errors: " + errors);
 
     Pair<Set<String>, Set<String>> r = checkErrorsContain(errors, contains);
-    assertTrue("Could not find error containing " + r.getRight() + "; errors: " + errors,
-        r.getRight().isEmpty());
+    assertTrue(r.getRight().isEmpty(),
+      "Could not find error containing " + r.getRight() + "; errors: " + errors);
 
     assertTrue(r.getLeft().isEmpty());
   }
 
   private void assertErrorAndClosed(RpcResult result, String expectedError) {
-    assertTrue("unexpected success: " + result.successMessages, result.successMessages.isEmpty());
+    assertTrue(result.successMessages.isEmpty(), "unexpected success: " + result.successMessages);
     Set<String> errors = result.errorMessages;
-    assertEquals("Expected 2 errors, got " + errors.size() + "errors: " +
-        errors, 2, errors.size());
+    assertEquals(2, errors.size(),
+      "Expected 2 errors, got " + errors.size() + "errors: " + errors);
 
     // We expect 1 additional error due to closed connection and here are possible keywords in the
     // error message.
@@ -392,15 +392,15 @@ public class RpcIntegrationSuite {
 
     Pair<Set<String>, Set<String>> r = checkErrorsContain(errors, containsAndClosed);
 
-    assertTrue("Got a non-empty set " + r.getLeft(), r.getLeft().isEmpty());
+    assertTrue(r.getLeft().isEmpty(), "Got a non-empty set " + r.getLeft());
 
     Set<String> errorsNotFound = r.getRight();
     assertEquals(
-        "The size of " + errorsNotFound + " was not " + (possibleClosedErrors.size() - 1),
         possibleClosedErrors.size() - 1,
-        errorsNotFound.size());
+        errorsNotFound.size(),
+        "The size of " + errorsNotFound + " was not " + (possibleClosedErrors.size() - 1));
     for (String err: errorsNotFound) {
-      assertTrue("Found a wrong error " + err, containsAndClosed.contains(err));
+      assertTrue(containsAndClosed.contains(err), "Found a wrong error " + err);
     }
   }
 
@@ -446,7 +446,7 @@ public class RpcIntegrationSuite {
 
     void verify() throws IOException {
       if (streamId.equals("file")) {
-        assertTrue("File stream did not match.", Files.equal(testData.testFile, outFile));
+        assertTrue(Files.equal(testData.testFile, outFile), "File stream did not match.");
       } else {
         byte[] result = ((ByteArrayOutputStream)out).toByteArray();
         ByteBuffer srcBuffer = testData.srcBuffer(streamId);
@@ -457,7 +457,7 @@ public class RpcIntegrationSuite {
         byte[] expected = new byte[base.remaining()];
         base.get(expected);
         assertEquals(expected.length, result.length);
-        assertArrayEquals("buffers don't match", expected, result);
+        assertArrayEquals(expected, result, "buffers don't match");
       }
     }
 

--- a/common/network-common/src/test/java/org/apache/spark/network/StreamSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/StreamSuite.java
@@ -30,10 +30,10 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import com.google.common.io.Files;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.apache.spark.network.buffer.ManagedBuffer;
 import org.apache.spark.network.client.RpcResponseCallback;
@@ -63,7 +63,7 @@ public class StreamSuite {
     return buf;
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception {
     testData = new StreamTestHelper();
 
@@ -98,7 +98,7 @@ public class StreamSuite {
     clientFactory = context.createClientFactory();
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() {
     server.close();
     clientFactory.close();
@@ -154,7 +154,7 @@ public class StreamSuite {
       }
 
       executor.shutdown();
-      assertTrue("Timed out waiting for tasks.", executor.awaitTermination(30, TimeUnit.SECONDS));
+      assertTrue(executor.awaitTermination(30, TimeUnit.SECONDS), "Timed out waiting for tasks.");
       for (StreamTask task : tasks) {
         task.check();
       }
@@ -213,7 +213,7 @@ public class StreamSuite {
         callback.waitForCompletion(timeoutMs);
 
         if (srcBuffer == null) {
-          assertTrue("File stream did not match.", Files.equal(testData.testFile, outFile));
+          assertTrue(Files.equal(testData.testFile, outFile), "File stream did not match.");
         } else {
           ByteBuffer base;
           synchronized (srcBuffer) {
@@ -223,7 +223,7 @@ public class StreamSuite {
           byte[] expected = new byte[base.remaining()];
           base.get(expected);
           assertEquals(expected.length, result.length);
-          assertArrayEquals("buffers don't match", expected, result);
+          assertArrayEquals(expected, result, "buffers don't match");
         }
       } catch (Throwable t) {
         error = t;
@@ -297,7 +297,7 @@ public class StreamSuite {
           now = System.currentTimeMillis();
         }
       }
-      assertTrue("Timed out waiting for stream.", completed);
+      assertTrue(completed, "Timed out waiting for stream.");
       assertNull(error);
     }
   }

--- a/common/network-common/src/test/java/org/apache/spark/network/TransportRequestHandlerSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/TransportRequestHandlerSuite.java
@@ -22,10 +22,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 import io.netty.channel.Channel;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
@@ -66,7 +66,7 @@ public class TransportRequestHandlerSuite {
     managedBuffers.add(new TestManagedBuffer(40));
     long streamId = streamManager.registerStream("test-app", managedBuffers.iterator(), channel);
 
-    Assert.assertEquals(1, streamManager.numStreamStates());
+    Assertions.assertEquals(1, streamManager.numStreamStates());
 
     TransportClient reverseClient = mock(TransportClient.class);
     TransportRequestHandler requestHandler = new TransportRequestHandler(channel, reverseClient,
@@ -74,16 +74,16 @@ public class TransportRequestHandlerSuite {
 
     RequestMessage request0 = new StreamRequest(String.format("%d_%d", streamId, 0));
     requestHandler.handle(request0);
-    Assert.assertEquals(1, responseAndPromisePairs.size());
-    Assert.assertTrue(responseAndPromisePairs.get(0).getLeft() instanceof StreamResponse);
-    Assert.assertEquals(managedBuffers.get(0),
+    Assertions.assertEquals(1, responseAndPromisePairs.size());
+    Assertions.assertTrue(responseAndPromisePairs.get(0).getLeft() instanceof StreamResponse);
+    Assertions.assertEquals(managedBuffers.get(0),
       ((StreamResponse) (responseAndPromisePairs.get(0).getLeft())).body());
 
     RequestMessage request1 = new StreamRequest(String.format("%d_%d", streamId, 1));
     requestHandler.handle(request1);
-    Assert.assertEquals(2, responseAndPromisePairs.size());
-    Assert.assertTrue(responseAndPromisePairs.get(1).getLeft() instanceof StreamResponse);
-    Assert.assertEquals(managedBuffers.get(1),
+    Assertions.assertEquals(2, responseAndPromisePairs.size());
+    Assertions.assertTrue(responseAndPromisePairs.get(1).getLeft() instanceof StreamResponse);
+    Assertions.assertEquals(managedBuffers.get(1),
       ((StreamResponse) (responseAndPromisePairs.get(1).getLeft())).body());
 
     // Finish flushing the response for request0.
@@ -91,16 +91,16 @@ public class TransportRequestHandlerSuite {
 
     StreamRequest request2 = new StreamRequest(String.format("%d_%d", streamId, 2));
     requestHandler.handle(request2);
-    Assert.assertEquals(3, responseAndPromisePairs.size());
-    Assert.assertTrue(responseAndPromisePairs.get(2).getLeft() instanceof StreamFailure);
-    Assert.assertEquals(String.format("Stream '%s' was not found.", request2.streamId),
+    Assertions.assertEquals(3, responseAndPromisePairs.size());
+    Assertions.assertTrue(responseAndPromisePairs.get(2).getLeft() instanceof StreamFailure);
+    Assertions.assertEquals(String.format("Stream '%s' was not found.", request2.streamId),
         ((StreamFailure) (responseAndPromisePairs.get(2).getLeft())).error);
 
     RequestMessage request3 = new StreamRequest(String.format("%d_%d", streamId, 3));
     requestHandler.handle(request3);
-    Assert.assertEquals(4, responseAndPromisePairs.size());
-    Assert.assertTrue(responseAndPromisePairs.get(3).getLeft() instanceof StreamResponse);
-    Assert.assertEquals(managedBuffers.get(3),
+    Assertions.assertEquals(4, responseAndPromisePairs.size());
+    Assertions.assertTrue(responseAndPromisePairs.get(3).getLeft() instanceof StreamResponse);
+    Assertions.assertEquals(managedBuffers.get(3),
       ((StreamResponse) (responseAndPromisePairs.get(3).getLeft())).body());
 
     // Request4 will trigger the close of channel, because the number of max chunks being
@@ -108,10 +108,10 @@ public class TransportRequestHandlerSuite {
     RequestMessage request4 = new StreamRequest(String.format("%d_%d", streamId, 4));
     requestHandler.handle(request4);
     verify(channel, times(1)).close();
-    Assert.assertEquals(4, responseAndPromisePairs.size());
+    Assertions.assertEquals(4, responseAndPromisePairs.size());
 
     streamManager.connectionTerminated(channel);
-    Assert.assertEquals(0, streamManager.numStreamStates());
+    Assertions.assertEquals(0, streamManager.numStreamStates());
   }
 
   @Test

--- a/common/network-common/src/test/java/org/apache/spark/network/TransportResponseHandlerSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/TransportResponseHandlerSuite.java
@@ -22,10 +22,10 @@ import java.nio.ByteBuffer;
 
 import io.netty.channel.Channel;
 import io.netty.channel.local.LocalChannel;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
 
 import org.apache.spark.network.buffer.NioManagedBuffer;

--- a/common/network-common/src/test/java/org/apache/spark/network/client/TransportClientFactorySuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/client/TransportClientFactorySuite.java
@@ -26,10 +26,10 @@ import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.network.TestUtils;
 import org.apache.spark.network.TransportContext;
@@ -41,7 +41,7 @@ import org.apache.spark.network.util.MapConfigProvider;
 import org.apache.spark.network.util.JavaUtils;
 import org.apache.spark.network.util.TransportConf;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TransportClientFactorySuite {
   private TransportConf conf;
@@ -49,7 +49,7 @@ public class TransportClientFactorySuite {
   private TransportServer server1;
   private TransportServer server2;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     conf = new TransportConf("shuffle", MapConfigProvider.EMPTY);
     RpcHandler rpcHandler = new NoOpRpcHandler();
@@ -58,7 +58,7 @@ public class TransportClientFactorySuite {
     server2 = context.createServer();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     JavaUtils.closeQuietly(server1);
     JavaUtils.closeQuietly(server2);
@@ -114,8 +114,8 @@ public class TransportClientFactorySuite {
         attempt.join();
       }
 
-      Assert.assertEquals(0, failed.get());
-      Assert.assertTrue(clients.size() <= maxConnections);
+      Assertions.assertEquals(0, failed.get());
+      Assertions.assertTrue(clients.size() <= maxConnections);
 
       for (TransportClient client : clients) {
         client.close();
@@ -220,7 +220,7 @@ public class TransportClientFactorySuite {
   public void closeFactoryBeforeCreateClient() {
     TransportClientFactory factory = context.createClientFactory();
     factory.close();
-    Assert.assertThrows(IOException.class,
+    Assertions.assertThrows(IOException.class,
       () -> factory.createClient(TestUtils.getLocalHost(), server1.getPort()));
   }
 
@@ -230,10 +230,11 @@ public class TransportClientFactorySuite {
     TransportServer server = context.createServer();
     int unreachablePort = server.getPort();
     server.close();
-    Assert.assertThrows(IOException.class,
+    Assertions.assertThrows(IOException.class,
       () -> factory.createClient(TestUtils.getLocalHost(), unreachablePort, true));
-    Assert.assertThrows("fail this connection directly", IOException.class,
-      () -> factory.createClient(TestUtils.getLocalHost(), unreachablePort, true));
+    Assertions.assertThrows(IOException.class,
+      () -> factory.createClient(TestUtils.getLocalHost(), unreachablePort, true),
+      "fail this connection directly");
   }
 
   @Test
@@ -257,7 +258,7 @@ public class TransportClientFactorySuite {
       TransportServer server = ctx.createServer();
       int unreachablePort = server.getPort();
       JavaUtils.closeQuietly(server);
-      IOException exception = Assert.assertThrows(IOException.class,
+      IOException exception = Assertions.assertThrows(IOException.class,
           () -> factory.createClient(TestUtils.getLocalHost(), unreachablePort, true));
       assertNotEquals(exception.getCause(), null);
     }

--- a/common/network-common/src/test/java/org/apache/spark/network/crypto/AuthEngineSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/crypto/AuthEngineSuite.java
@@ -29,9 +29,9 @@ import io.netty.channel.FileRegion;
 import org.apache.spark.network.util.ByteArrayWritableChannel;
 import org.apache.spark.network.util.MapConfigProvider;
 import org.apache.spark.network.util.TransportConf;
-import static org.junit.Assert.*;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import static org.mockito.Mockito.*;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -54,7 +54,7 @@ public class AuthEngineSuite {
   private static final String outputIv = "a72709baf00785cad6329ce09f631f71";
   private static TransportConf conf;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() {
     conf = new TransportConf("rpc", MapConfigProvider.EMPTY);
   }

--- a/common/network-common/src/test/java/org/apache/spark/network/crypto/AuthIntegrationSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/crypto/AuthIntegrationSuite.java
@@ -24,9 +24,9 @@ import java.util.Map;
 
 import com.google.common.collect.ImmutableMap;
 import io.netty.channel.Channel;
-import org.junit.After;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import org.apache.spark.network.TestUtils;
@@ -48,7 +48,7 @@ public class AuthIntegrationSuite {
 
   private AuthTestCtx ctx;
 
-  @After
+  @AfterEach
   public void cleanUp() throws Exception {
     if (ctx != null) {
       ctx.close();
@@ -142,7 +142,7 @@ public class AuthIntegrationSuite {
     Exception e = assertThrows(Exception.class,
       () -> ctx.client.sendRpcSync(JavaUtils.stringToBytes("Ping"), 5000));
     assertTrue(ctx.authRpcHandler.isAuthenticated());
-    assertTrue(e.getMessage() + " is not an expected error", e.getMessage().contains("DDDDD"));
+    assertTrue(e.getMessage().contains("DDDDD"), e.getMessage() + " is not an expected error");
     // Verify we receive the complete error message
     int messageStart = e.getMessage().indexOf("DDDDD");
     int messageEnd = e.getMessage().lastIndexOf("DDDDD") + 5;

--- a/common/network-common/src/test/java/org/apache/spark/network/crypto/AuthMessagesSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/crypto/AuthMessagesSuite.java
@@ -21,9 +21,9 @@ import java.util.Arrays;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertArrayEquals;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import org.junit.jupiter.api.Test;
 
 public class AuthMessagesSuite {
 

--- a/common/network-common/src/test/java/org/apache/spark/network/crypto/TransportCipherSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/crypto/TransportCipherSuite.java
@@ -28,11 +28,11 @@ import org.apache.commons.crypto.stream.CryptoInputStream;
 import org.apache.commons.crypto.stream.CryptoOutputStream;
 import org.apache.spark.network.util.MapConfigProvider;
 import org.apache.spark.network.util.TransportConf;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;

--- a/common/network-common/src/test/java/org/apache/spark/network/protocol/EncodersSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/protocol/EncodersSuite.java
@@ -19,10 +19,10 @@ package org.apache.spark.network.protocol;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.roaringbitmap.RoaringBitmap;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests for {@link Encoders}.
@@ -39,12 +39,13 @@ public class EncodersSuite {
     assertEquals(bitmap, decodedBitmap);
   }
 
-  @Test (expected = java.nio.BufferOverflowException.class)
+  @Test
   public void testRoaringBitmapEncodeShouldFailWhenBufferIsSmall() {
     RoaringBitmap bitmap = new RoaringBitmap();
     bitmap.add(1, 2, 3);
     ByteBuf buf = Unpooled.buffer(4);
-    Encoders.Bitmaps.encode(buf, bitmap);
+    assertThrows(java.nio.BufferOverflowException.class,
+      () -> Encoders.Bitmaps.encode(buf, bitmap));
   }
 
   @Test

--- a/common/network-common/src/test/java/org/apache/spark/network/protocol/MergedBlockMetaSuccessSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/protocol/MergedBlockMetaSuccessSuite.java
@@ -28,8 +28,8 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.roaringbitmap.RoaringBitmap;
 
 import static org.mockito.Mockito.*;
@@ -70,7 +70,7 @@ public class MergedBlockMetaSuccessSuite {
     when(context.alloc()).thenReturn(ByteBufAllocator.DEFAULT);
 
     MessageEncoder.INSTANCE.encode(context, expectedMeta, out);
-    Assert.assertEquals(1, out.size());
+    Assertions.assertEquals(1, out.size());
     MessageWithHeader msgWithHeader = (MessageWithHeader) out.remove(0);
 
     ByteArrayWritableChannel writableChannel =
@@ -81,20 +81,20 @@ public class MergedBlockMetaSuccessSuite {
     ByteBuf messageBuf = Unpooled.wrappedBuffer(writableChannel.getData());
     messageBuf.readLong(); // frame length
     MessageDecoder.INSTANCE.decode(mock(ChannelHandlerContext.class), messageBuf, out);
-    Assert.assertEquals(1, out.size());
+    Assertions.assertEquals(1, out.size());
     MergedBlockMetaSuccess decoded = (MergedBlockMetaSuccess) out.get(0);
-    Assert.assertEquals("merged block", expectedMeta.requestId, decoded.requestId);
-    Assert.assertEquals("num chunks", expectedMeta.getNumChunks(), decoded.getNumChunks());
+    Assertions.assertEquals(expectedMeta.requestId, decoded.requestId, "merged block");
+    Assertions.assertEquals(expectedMeta.getNumChunks(), decoded.getNumChunks(), "num chunks");
 
     ByteBuf responseBuf = Unpooled.wrappedBuffer(decoded.body().nioByteBuffer());
     RoaringBitmap[] responseBitmaps = new RoaringBitmap[expectedMeta.getNumChunks()];
     for (int i = 0; i < expectedMeta.getNumChunks(); i++) {
       responseBitmaps[i] = Encoders.Bitmaps.decode(responseBuf);
     }
-    Assert.assertEquals(
-      "num of roaring bitmaps", expectedMeta.getNumChunks(), responseBitmaps.length);
+    Assertions.assertEquals(
+      expectedMeta.getNumChunks(), responseBitmaps.length, "num of roaring bitmaps");
     for (int i = 0; i < expectedMeta.getNumChunks(); i++) {
-      Assert.assertEquals("chunk bitmap " + i, expectedChunks[i], responseBitmaps[i]);
+      Assertions.assertEquals(expectedChunks[i], responseBitmaps[i], "chunk bitmap " + i);
     }
     Files.delete(chunkMetaFile.toPath());
   }

--- a/common/network-common/src/test/java/org/apache/spark/network/protocol/MessageWithHeaderSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/protocol/MessageWithHeaderSuite.java
@@ -25,10 +25,10 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.Unpooled;
 import org.apache.spark.network.util.AbstractFileRegion;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.apache.spark.network.TestManagedBuffer;
 import org.apache.spark.network.buffer.ManagedBuffer;
@@ -133,7 +133,7 @@ public class MessageWithHeaderSuite {
       msg.transferTo(channel, msg.transferred());
       writes++;
     }
-    assertTrue("Not enough writes!", minExpectedWrites <= writes);
+    assertTrue(minExpectedWrites <= writes, "Not enough writes!");
     return Unpooled.wrappedBuffer(channel.getData());
   }
 

--- a/common/network-common/src/test/java/org/apache/spark/network/sasl/SparkSaslSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/sasl/SparkSaslSuite.java
@@ -17,7 +17,7 @@
 
 package org.apache.spark.network.sasl;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import java.io.File;
@@ -44,7 +44,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
 import io.netty.channel.ChannelPromise;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.network.TestUtils;
 import org.apache.spark.network.TransportContext;
@@ -206,7 +206,7 @@ public class SparkSaslSuite {
 
       channel.reset();
       count = emsg.transferTo(channel, emsg.transferred());
-      assertTrue("Unexpected count: " + count, count > 1 && count < data.length);
+      assertTrue(count > 1 && count < data.length, "Unexpected count: " + count);
       assertEquals(data.length, emsg.transferred());
     } finally {
       msg.release();

--- a/common/network-common/src/test/java/org/apache/spark/network/server/OneForOneStreamManagerSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/server/OneForOneStreamManagerSuite.java
@@ -22,9 +22,9 @@ import java.util.Iterator;
 import java.util.List;
 
 import io.netty.channel.Channel;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import org.apache.spark.network.TestManagedBuffer;
@@ -34,7 +34,7 @@ public class OneForOneStreamManagerSuite {
 
   List<ManagedBuffer> managedBuffersToRelease = new ArrayList<>();
 
-  @After
+  @AfterEach
   public void tearDown() {
     managedBuffersToRelease.forEach(managedBuffer -> managedBuffer.release());
     managedBuffersToRelease.clear();
@@ -66,10 +66,10 @@ public class OneForOneStreamManagerSuite {
 
     Channel dummyChannel = Mockito.mock(Channel.class, Mockito.RETURNS_SMART_NULLS);
     long streamId = manager.registerStream("appId", buffers.iterator(), dummyChannel);
-    Assert.assertEquals(1, manager.numStreamStates());
-    Assert.assertNotNull(getChunk(manager, streamId, 0));
-    Assert.assertNull(getChunk(manager, streamId, 1));
-    Assert.assertNotNull(getChunk(manager, streamId, 2));
+    Assertions.assertEquals(1, manager.numStreamStates());
+    Assertions.assertNotNull(getChunk(manager, streamId, 0));
+    Assertions.assertNull(getChunk(manager, streamId, 1));
+    Assertions.assertNotNull(getChunk(manager, streamId, 2));
     manager.connectionTerminated(dummyChannel);
 
     // loaded buffers are not released yet as in production a ManagedBuffer returned by getChunk()
@@ -90,12 +90,12 @@ public class OneForOneStreamManagerSuite {
 
     Channel dummyChannel = Mockito.mock(Channel.class, Mockito.RETURNS_SMART_NULLS);
     manager.registerStream("appId", buffers.iterator(), dummyChannel);
-    Assert.assertEquals(1, manager.numStreamStates());
+    Assertions.assertEquals(1, manager.numStreamStates());
     manager.connectionTerminated(dummyChannel);
 
     Mockito.verify(buffer1, Mockito.times(1)).release();
     Mockito.verify(buffer2, Mockito.times(1)).release();
-    Assert.assertEquals(0, manager.numStreamStates());
+    Assertions.assertEquals(0, manager.numStreamStates());
   }
 
   @SuppressWarnings("unchecked")
@@ -117,15 +117,16 @@ public class OneForOneStreamManagerSuite {
     manager.registerStream("appId", buffers, dummyChannel);
     manager.registerStream("appId", buffers2, dummyChannel);
 
-    Assert.assertEquals(2, manager.numStreamStates());
+    Assertions.assertEquals(2, manager.numStreamStates());
 
-    Assert.assertThrows(RuntimeException.class, () -> manager.connectionTerminated(dummyChannel));
+    Assertions.assertThrows(RuntimeException.class,
+      () -> manager.connectionTerminated(dummyChannel));
     Mockito.verify(buffers, Mockito.times(1)).hasNext();
     Mockito.verify(buffers, Mockito.times(1)).next();
     Mockito.verify(buffers2, Mockito.times(2)).hasNext();
     Mockito.verify(buffers2, Mockito.times(2)).next();
     Mockito.verify(mockManagedBuffer, Mockito.times(1)).release();
-    Assert.assertEquals(0, manager.numStreamStates());
+    Assertions.assertEquals(0, manager.numStreamStates());
   }
 
   @SuppressWarnings("unchecked")
@@ -147,7 +148,7 @@ public class OneForOneStreamManagerSuite {
     manager.registerStream("appId", buffers1, dummyChannel, false);
     // should NOT Release
     manager.registerStream("appId", buffers2, dummyChannel, true);
-    Assert.assertEquals(2, manager.numStreamStates());
+    Assertions.assertEquals(2, manager.numStreamStates());
 
     // connectionTerminated
     manager.connectionTerminated(dummyChannel);
@@ -159,6 +160,6 @@ public class OneForOneStreamManagerSuite {
     Mockito.verify(buffers2, Mockito.times(0)).next();
     // only buffers1 has been released
     Mockito.verify(mockManagedBuffer, Mockito.times(1)).release();
-    Assert.assertEquals(0, manager.numStreamStates());
+    Assertions.assertEquals(0, manager.numStreamStates());
   }
 }

--- a/common/network-common/src/test/java/org/apache/spark/network/util/CryptoUtilsSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/util/CryptoUtilsSuite.java
@@ -21,8 +21,8 @@ import java.util.Map;
 import java.util.Properties;
 
 import com.google.common.collect.ImmutableMap;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class CryptoUtilsSuite {
 

--- a/common/network-common/src/test/java/org/apache/spark/network/util/JavaUtilsSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/util/JavaUtilsSuite.java
@@ -19,9 +19,9 @@ package org.apache.spark.network.util;
 import java.io.File;
 import java.io.IOException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class JavaUtilsSuite {
 

--- a/common/network-common/src/test/java/org/apache/spark/network/util/NettyMemoryMetricsSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/util/NettyMemoryMetricsSuite.java
@@ -27,9 +27,9 @@ import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.MetricSet;
 import org.apache.spark.network.TestUtils;
 import org.apache.spark.network.client.TransportClient;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.network.TransportContext;
 import org.apache.spark.network.client.TransportClientFactory;
@@ -54,7 +54,7 @@ public class NettyMemoryMetricsSuite {
     clientFactory = context.createClientFactory();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     if (clientFactory != null) {
       JavaUtils.closeQuietly(clientFactory);
@@ -76,50 +76,50 @@ public class NettyMemoryMetricsSuite {
     setUp(false);
 
     MetricSet serverMetrics = server.getAllMetrics();
-    Assert.assertNotNull(serverMetrics);
-    Assert.assertNotNull(serverMetrics.getMetrics());
-    Assert.assertNotEquals(serverMetrics.getMetrics().size(), 0);
+    Assertions.assertNotNull(serverMetrics);
+    Assertions.assertNotNull(serverMetrics.getMetrics());
+    Assertions.assertNotEquals(serverMetrics.getMetrics().size(), 0);
 
     Map<String, Metric> serverMetricMap = serverMetrics.getMetrics();
     serverMetricMap.forEach((name, metric) ->
-      Assert.assertTrue(name.startsWith("shuffle-server"))
+      Assertions.assertTrue(name.startsWith("shuffle-server"))
     );
 
     MetricSet clientMetrics = clientFactory.getAllMetrics();
-    Assert.assertNotNull(clientMetrics);
-    Assert.assertNotNull(clientMetrics.getMetrics());
-    Assert.assertNotEquals(clientMetrics.getMetrics().size(), 0);
+    Assertions.assertNotNull(clientMetrics);
+    Assertions.assertNotNull(clientMetrics.getMetrics());
+    Assertions.assertNotEquals(clientMetrics.getMetrics().size(), 0);
 
     Map<String, Metric> clientMetricMap = clientMetrics.getMetrics();
     clientMetricMap.forEach((name, metrics) ->
-      Assert.assertTrue(name.startsWith("shuffle-client"))
+      Assertions.assertTrue(name.startsWith("shuffle-client"))
     );
 
     // Make sure general metrics existed.
     String heapMemoryMetric = "usedHeapMemory";
     String directMemoryMetric = "usedDirectMemory";
-    Assert.assertNotNull(serverMetricMap.get(
+    Assertions.assertNotNull(serverMetricMap.get(
       MetricRegistry.name("shuffle-server", heapMemoryMetric)));
-    Assert.assertNotNull(serverMetricMap.get(
+    Assertions.assertNotNull(serverMetricMap.get(
       MetricRegistry.name("shuffle-server", directMemoryMetric)));
 
-    Assert.assertNotNull(clientMetricMap.get(
+    Assertions.assertNotNull(clientMetricMap.get(
       MetricRegistry.name("shuffle-client", heapMemoryMetric)));
-    Assert.assertNotNull(clientMetricMap.get(
+    Assertions.assertNotNull(clientMetricMap.get(
       MetricRegistry.name("shuffle-client", directMemoryMetric)));
 
     try (TransportClient client =
         clientFactory.createClient(TestUtils.getLocalHost(), server.getPort())) {
-      Assert.assertTrue(client.isActive());
+      Assertions.assertTrue(client.isActive());
 
-      Assert.assertTrue(((Gauge<Long>)serverMetricMap.get(
+      Assertions.assertTrue(((Gauge<Long>)serverMetricMap.get(
         MetricRegistry.name("shuffle-server", heapMemoryMetric))).getValue() >= 0L);
-      Assert.assertTrue(((Gauge<Long>)serverMetricMap.get(
+      Assertions.assertTrue(((Gauge<Long>)serverMetricMap.get(
         MetricRegistry.name("shuffle-server", directMemoryMetric))).getValue() >= 0L);
 
-      Assert.assertTrue(((Gauge<Long>)clientMetricMap.get(
+      Assertions.assertTrue(((Gauge<Long>)clientMetricMap.get(
         MetricRegistry.name("shuffle-client", heapMemoryMetric))).getValue() >= 0L);
-      Assert.assertTrue(((Gauge<Long>)clientMetricMap.get(
+      Assertions.assertTrue(((Gauge<Long>)clientMetricMap.get(
         MetricRegistry.name("shuffle-client", directMemoryMetric))).getValue() >= 0L);
 
     }
@@ -133,18 +133,18 @@ public class NettyMemoryMetricsSuite {
     // Make sure additional metrics are added.
     Map<String, Metric> serverMetricMap = server.getAllMetrics().getMetrics();
     serverMetricMap.forEach((name, metric) -> {
-      Assert.assertTrue(name.startsWith("shuffle-server"));
+      Assertions.assertTrue(name.startsWith("shuffle-server"));
       String metricName = name.substring(name.lastIndexOf(".") + 1);
-      Assert.assertTrue(metricName.equals("usedDirectMemory")
+      Assertions.assertTrue(metricName.equals("usedDirectMemory")
         || metricName.equals("usedHeapMemory")
         || NettyMemoryMetrics.VERBOSE_METRICS.contains(metricName));
     });
 
     Map<String, Metric> clientMetricMap = clientFactory.getAllMetrics().getMetrics();
     clientMetricMap.forEach((name, metric) -> {
-      Assert.assertTrue(name.startsWith("shuffle-client"));
+      Assertions.assertTrue(name.startsWith("shuffle-client"));
       String metricName = name.substring(name.lastIndexOf(".") + 1);
-      Assert.assertTrue(metricName.equals("usedDirectMemory")
+      Assertions.assertTrue(metricName.equals("usedDirectMemory")
         || metricName.equals("usedHeapMemory")
         || NettyMemoryMetrics.VERBOSE_METRICS.contains(metricName));
     });
@@ -152,13 +152,13 @@ public class NettyMemoryMetricsSuite {
     TransportClient client = null;
     try {
       client = clientFactory.createClient(TestUtils.getLocalHost(), server.getPort());
-      Assert.assertTrue(client.isActive());
+      Assertions.assertTrue(client.isActive());
 
       String activeBytesMetric = "numActiveBytes";
-      Assert.assertTrue(((Gauge<Long>) serverMetricMap.get(MetricRegistry.name("shuffle-server",
+      Assertions.assertTrue(((Gauge<Long>) serverMetricMap.get(MetricRegistry.name("shuffle-server",
         "directArena0", activeBytesMetric))).getValue() >= 0L);
 
-      Assert.assertTrue(((Gauge<Long>) clientMetricMap.get(MetricRegistry.name("shuffle-client",
+      Assertions.assertTrue(((Gauge<Long>) clientMetricMap.get(MetricRegistry.name("shuffle-client",
         "directArena0", activeBytesMetric))).getValue() >= 0L);
     } finally {
       if (client != null) {

--- a/common/network-common/src/test/java/org/apache/spark/network/util/TimerWithCustomUnitSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/util/TimerWithCustomUnitSuite.java
@@ -24,10 +24,10 @@ import java.util.concurrent.TimeUnit;
 import com.codahale.metrics.Clock;
 import com.codahale.metrics.Snapshot;
 import com.codahale.metrics.Timer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /** Tests for {@link TimerWithCustomTimeUnit} */
 public class TimerWithCustomUnitSuite {

--- a/common/network-common/src/test/java/org/apache/spark/network/util/TransportFrameDecoderSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/util/TransportFrameDecoderSuite.java
@@ -25,12 +25,12 @@ import java.util.concurrent.atomic.AtomicInteger;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
-import org.junit.AfterClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 public class TransportFrameDecoderSuite {
@@ -38,7 +38,7 @@ public class TransportFrameDecoderSuite {
   private static final Logger logger = LoggerFactory.getLogger(TransportFrameDecoderSuite.class);
   private static Random RND = new Random();
 
-  @AfterClass
+  @AfterAll
   public static void cleanup() {
     RND = null;
   }
@@ -246,7 +246,7 @@ public class TransportFrameDecoderSuite {
       ByteBuf data) throws Exception {
     try {
       decoder.channelInactive(ctx);
-      assertTrue("There shouldn't be dangling references to the data.", data.release());
+      assertTrue(data.release(), "There shouldn't be dangling references to the data.");
     } finally {
       release(data);
     }

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/sasl/SaslIntegrationSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/sasl/SaslIntegrationSuite.java
@@ -22,12 +22,12 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import org.apache.spark.network.TestUtils;
@@ -57,7 +57,7 @@ public class SaslIntegrationSuite {
 
   TransportClientFactory clientFactory;
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeAll() throws IOException {
     conf = new TransportConf("shuffle", MapConfigProvider.EMPTY);
     context = new TransportContext(conf, new TestRpcHandler());
@@ -75,13 +75,13 @@ public class SaslIntegrationSuite {
   }
 
 
-  @AfterClass
+  @AfterAll
   public static void afterAll() {
     server.close();
     context.close();
   }
 
-  @After
+  @AfterEach
   public void afterEach() {
     if (clientFactory != null) {
       clientFactory.close();
@@ -111,7 +111,7 @@ public class SaslIntegrationSuite {
     // Bootstrap should fail on startup.
     Exception e = assertThrows(Exception.class,
       () -> clientFactory.createClient(TestUtils.getLocalHost(), server.getPort()));
-    assertTrue(e.getMessage(), e.getMessage().contains("Mismatched response"));
+    assertTrue(e.getMessage().contains("Mismatched response"), e.getMessage());
   }
 
   @Test
@@ -121,12 +121,12 @@ public class SaslIntegrationSuite {
     TransportClient client = clientFactory.createClient(TestUtils.getLocalHost(), server.getPort());
     Exception e1 = assertThrows(Exception.class,
       () -> client.sendRpcSync(ByteBuffer.allocate(13), TIMEOUT_MS));
-    assertTrue(e1.getMessage(), e1.getMessage().contains("Expected SaslMessage"));
+    assertTrue(e1.getMessage().contains("Expected SaslMessage"), e1.getMessage());
 
     // Guessing the right tag byte doesn't magically get you in...
     Exception e2 = assertThrows(Exception.class,
       () -> client.sendRpcSync(ByteBuffer.wrap(new byte[] { (byte) 0xEA }), TIMEOUT_MS));
-    assertTrue(e2.getMessage(), e2.getMessage().contains("java.lang.IndexOutOfBoundsException"));
+    assertTrue(e2.getMessage().contains("java.lang.IndexOutOfBoundsException"), e2.getMessage());
   }
 
   @Test
@@ -138,7 +138,7 @@ public class SaslIntegrationSuite {
       try (TransportServer server = context.createServer()) {
         Exception e = assertThrows(Exception.class,
           () -> clientFactory.createClient(TestUtils.getLocalHost(), server.getPort()));
-        assertTrue(e.getMessage(), e.getMessage().contains("Digest-challenge format violation"));
+        assertTrue(e.getMessage().contains("Digest-challenge format violation"), e.getMessage());
       }
     }
   }

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/sasl/ShuffleSecretManagerSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/sasl/ShuffleSecretManagerSuite.java
@@ -19,8 +19,8 @@ package org.apache.spark.network.sasl;
 
 import java.nio.ByteBuffer;
 
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ShuffleSecretManagerSuite {
   static String app1 = "app1";

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/AppIsolationSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/AppIsolationSuite.java
@@ -26,10 +26,10 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import org.apache.spark.network.TestUtils;
@@ -64,7 +64,7 @@ public class AppIsolationSuite {
   private static SecretKeyHolder secretKeyHolder;
   private static TransportConf conf;
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeAll() {
     Map<String, String> confMap = new HashMap<>();
     confMap.put("spark.network.crypto.enabled", "true");
@@ -177,8 +177,8 @@ public class AppIsolationSuite {
   }
 
   private static void checkSecurityException(Throwable t) {
-    assertNotNull("No exception was caught.", t);
-    assertTrue("Expected SecurityException.",
-      t.getMessage().contains(SecurityException.class.getName()));
+    assertNotNull(t,"No exception was caught.");
+    assertTrue(t.getMessage().contains(SecurityException.class.getName()),
+      "Expected SecurityException.");
   }
 }

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/BlockTransferMessagesSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/BlockTransferMessagesSuite.java
@@ -17,9 +17,9 @@
 
 package org.apache.spark.network.shuffle;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/CleanupNonShuffleServiceServedFilesSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/CleanupNonShuffleServiceServedFilesSuite.java
@@ -30,10 +30,10 @@ import java.util.stream.Stream;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.spark.network.util.MapConfigProvider;
 import org.apache.spark.network.util.TransportConf;
@@ -196,7 +196,7 @@ public class CleanupNonShuffleServiceServedFilesSuite {
 
   private static void assertStillThere(TestShuffleDataContext dataContext) {
     for (String localDir : dataContext.localDirs) {
-      assertTrue(localDir + " was cleaned up prematurely", new File(localDir).exists());
+      assertTrue(new File(localDir).exists(), localDir + " was cleaned up prematurely");
     }
   }
 

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ErrorHandlerSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ErrorHandlerSuite.java
@@ -19,12 +19,12 @@ package org.apache.spark.network.shuffle;
 
 import java.net.ConnectException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.network.server.BlockPushNonFatalFailure;
 import org.apache.spark.network.server.BlockPushNonFatalFailure.ReturnCode;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test suite for {@link ErrorHandler}

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalBlockHandlerSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalBlockHandlerSuite.java
@@ -28,12 +28,13 @@ import com.codahale.metrics.Meter;
 import com.codahale.metrics.Metric;
 import com.codahale.metrics.Timer;
 import com.google.common.io.ByteStreams;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.roaringbitmap.RoaringBitmap;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import org.apache.spark.network.buffer.ManagedBuffer;
@@ -72,7 +73,7 @@ public class ExternalBlockHandlerSuite {
     new NioManagedBuffer(ByteBuffer.wrap(new byte[7]))
   };
 
-  @Before
+  @BeforeEach
   public void beforeEach() {
     streamManager = mock(OneForOneStreamManager.class);
     blockResolver = mock(ExternalShuffleBlockResolver.class);
@@ -393,9 +394,9 @@ public class ExternalBlockHandlerSuite {
         ArgumentCaptor.forClass(ManagedBuffer.class);
       verify(callback, times(1)).onSuccess(numChunksResponse.capture(),
         chunkBitmapResponse.capture());
-      assertEquals("num chunks in merged block " + reduceId, expectedCount[reduceId],
-        numChunksResponse.getValue().intValue());
-      assertNotNull("chunks bitmap buffer " + reduceId, chunkBitmapResponse.getValue());
+      assertEquals(expectedCount[reduceId], numChunksResponse.getValue(),
+        "num chunks in merged block " + reduceId);
+      assertNotNull(chunkBitmapResponse.getValue(), "chunks bitmap buffer " + reduceId);
     }
   }
 

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalShuffleBlockResolverSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalShuffleBlockResolverSuite.java
@@ -28,11 +28,11 @@ import org.apache.spark.network.shuffle.protocol.ExecutorShuffleInfo;
 import org.apache.spark.network.util.MapConfigProvider;
 import org.apache.spark.network.util.TransportConf;
 import org.apache.spark.network.shuffle.ExternalShuffleBlockResolver.AppExecId;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ExternalShuffleBlockResolverSuite {
   private static final String sortBlock0 = "Hello!";
@@ -44,7 +44,7 @@ public class ExternalShuffleBlockResolverSuite {
   private static final TransportConf conf =
       new TransportConf("shuffle", MapConfigProvider.EMPTY);
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeAll() throws IOException {
     dataContext = new TestShuffleDataContext(2, 5);
 
@@ -55,7 +55,7 @@ public class ExternalShuffleBlockResolverSuite {
         sortBlock1.getBytes(StandardCharsets.UTF_8)});
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterAll() {
     dataContext.cleanup();
   }
@@ -66,7 +66,7 @@ public class ExternalShuffleBlockResolverSuite {
     // Unregistered executor
     RuntimeException e = assertThrows(RuntimeException.class,
       () -> resolver.getBlockData("app0", "exec1", 1, 1, 0));
-    assertTrue("Bad error message: " + e, e.getMessage().contains("not registered"));
+    assertTrue(e.getMessage().contains("not registered"), "Bad error message: " + e);
 
     // Nonexistent shuffle block
     resolver.registerExecutor("app0", "exec3",

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalShuffleCleanupSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalShuffleCleanupSuite.java
@@ -24,9 +24,9 @@ import java.util.Random;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.junit.Test;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.spark.network.util.MapConfigProvider;
 import org.apache.spark.network.util.TransportConf;
@@ -124,13 +124,13 @@ public class ExternalShuffleCleanupSuite {
 
   private static void assertStillThere(TestShuffleDataContext dataContext) {
     for (String localDir : dataContext.localDirs) {
-      assertTrue(localDir + " was cleaned up prematurely", new File(localDir).exists());
+      assertTrue(new File(localDir).exists(), localDir + " was cleaned up prematurely");
     }
   }
 
   private static void assertCleanedUp(TestShuffleDataContext dataContext) {
     for (String localDir : dataContext.localDirs) {
-      assertFalse(localDir + " wasn't cleaned up", new File(localDir).exists());
+      assertFalse(new File(localDir).exists(), localDir + " wasn't cleaned up");
     }
   }
 

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalShuffleIntegrationSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalShuffleIntegrationSuite.java
@@ -36,12 +36,12 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 import org.apache.spark.network.buffer.FileSegmentManagedBuffer;
 import org.apache.spark.network.server.OneForOneStreamManager;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.apache.spark.network.TestUtils;
 import org.apache.spark.network.TransportContext;
@@ -86,7 +86,7 @@ public class ExternalShuffleIntegrationSuite {
     new byte[54321],
   };
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeAll() throws IOException {
     Random rand = new Random();
 
@@ -133,14 +133,14 @@ public class ExternalShuffleIntegrationSuite {
     server = transportContext.createServer();
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterAll() {
     dataContext0.cleanup();
     server.close();
     transportContext.close();
   }
 
-  @After
+  @AfterEach
   public void afterEach() {
     handler.applicationRemoved(APP_ID, false /* cleanupLocalDirs */);
   }

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalShuffleSecuritySuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalShuffleSecuritySuite.java
@@ -21,11 +21,11 @@ import java.io.IOException;
 import java.util.Arrays;
 
 import com.google.common.collect.ImmutableMap;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.apache.spark.network.TestUtils;
 import org.apache.spark.network.TransportContext;
@@ -43,7 +43,7 @@ public class ExternalShuffleSecuritySuite {
   TransportServer server;
   TransportContext transportContext;
 
-  @Before
+  @BeforeEach
   public void beforeEach() throws IOException {
     transportContext = new TransportContext(conf, new ExternalBlockHandler(conf, null));
     TransportServerBootstrap bootstrap = new SaslServerBootstrap(conf,
@@ -51,7 +51,7 @@ public class ExternalShuffleSecuritySuite {
     this.server = transportContext.createServer(Arrays.asList(bootstrap));
   }
 
-  @After
+  @AfterEach
   public void afterEach() {
     if (server != null) {
       server.close();
@@ -72,14 +72,14 @@ public class ExternalShuffleSecuritySuite {
   public void testBadAppId() {
     Exception e = assertThrows(Exception.class,
       () -> validate("wrong-app-id", "secret", false));
-    assertTrue(e.getMessage(), e.getMessage().contains("Wrong appId!"));
+    assertTrue(e.getMessage().contains("Wrong appId!"), e.getMessage());
   }
 
   @Test
   public void testBadSecret() {
     Exception e = assertThrows(Exception.class,
       () -> validate("my-app-id", "bad-secret", false));
-    assertTrue(e.getMessage(), e.getMessage().contains("Mismatched response"));
+    assertTrue(e.getMessage().contains("Mismatched response"), e.getMessage());
   }
 
   @Test

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/OneForOneBlockFetcherSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/OneForOneBlockFetcherSuite.java
@@ -25,9 +25,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import com.google.common.collect.Maps;
 import io.netty.buffer.Unpooled;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/OneForOneBlockPusherSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/OneForOneBlockPusherSuite.java
@@ -25,9 +25,9 @@ import java.util.Map;
 
 import com.google.common.collect.Maps;
 import io.netty.buffer.Unpooled;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.AdditionalMatchers.*;
 import static org.mockito.Mockito.*;
 

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/RetryingBlockTransferorSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/RetryingBlockTransferorSuite.java
@@ -30,13 +30,12 @@ import java.util.concurrent.TimeoutException;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
-
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.stubbing.Answer;
 import org.mockito.stubbing.Stubber;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import org.apache.spark.network.buffer.ManagedBuffer;
@@ -60,7 +59,7 @@ public class RetryingBlockTransferorSuite {
 
   private static final int MAX_RETRIES = 2;
 
-  @Before
+  @BeforeEach
   public void initMap() {
     configMap = new HashMap<String, String>() {{
       put("spark.shuffle.io.maxRetries", Integer.toString(MAX_RETRIES));

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ShuffleIndexInformationSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ShuffleIndexInformationSuite.java
@@ -17,15 +17,15 @@
 
 package org.apache.spark.network.shuffle;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
 import java.nio.charset.StandardCharsets;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ShuffleIndexInformationSuite {
   private static final String sortBlock0 = "tiny block";
@@ -34,7 +34,7 @@ public class ShuffleIndexInformationSuite {
   private static TestShuffleDataContext dataContext;
   private static String blockId;
 
-  @BeforeClass
+  @BeforeAll
   public static void before() throws IOException {
     dataContext = new TestShuffleDataContext(2, 5);
 
@@ -45,7 +45,7 @@ public class ShuffleIndexInformationSuite {
         sortBlock1.getBytes(StandardCharsets.UTF_8)});
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterAll() {
     dataContext.cleanup();
   }

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ShuffleTransportContextSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ShuffleTransportContextSuite.java
@@ -31,9 +31,9 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.channel.socket.SocketChannel;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -55,7 +55,7 @@ public class ShuffleTransportContextSuite {
 
   private ExternalBlockHandler blockHandler;
 
-  @Before
+  @BeforeEach
   public void before() throws IOException {
     blockHandler = mock(ExternalBlockHandler.class);
   }
@@ -96,9 +96,9 @@ public class ShuffleTransportContextSuite {
       ctx.initializePipeline(channel, rpcHandler);
       String handlerName = ShuffleTransportContext.FinalizedHandler.HANDLER_NAME;
       if (enabled) {
-        Assert.assertNotNull(channel.pipeline().get(handlerName));
+        Assertions.assertNotNull(channel.pipeline().get(handlerName));
       } else {
-        Assert.assertNull(channel.pipeline().get(handlerName));
+        Assertions.assertNull(channel.pipeline().get(handlerName));
       }
     }
   }
@@ -115,9 +115,9 @@ public class ShuffleTransportContextSuite {
     List<Object> out = Lists.newArrayList();
     decoder.decode(mock(ChannelHandlerContext.class), messageBuf, out);
 
-    Assert.assertEquals(1, out.size());
-    Assert.assertTrue(out.get(0) instanceof ShuffleTransportContext.RpcRequestInternal);
-    Assert.assertEquals(BlockTransferMessage.Type.FINALIZE_SHUFFLE_MERGE,
+    Assertions.assertEquals(1, out.size());
+    Assertions.assertTrue(out.get(0) instanceof ShuffleTransportContext.RpcRequestInternal);
+    Assertions.assertEquals(BlockTransferMessage.Type.FINALIZE_SHUFFLE_MERGE,
         ((ShuffleTransportContext.RpcRequestInternal) out.get(0)).messageType);
   }
 
@@ -133,8 +133,8 @@ public class ShuffleTransportContextSuite {
     List<Object> out = Lists.newArrayList();
     decoder.decode(mock(ChannelHandlerContext.class), messageBuf, out);
 
-    Assert.assertEquals(1, out.size());
-    Assert.assertTrue(out.get(0) instanceof RpcRequest);
-    Assert.assertEquals(rpcRequest.requestId, ((RpcRequest) out.get(0)).requestId);
+    Assertions.assertEquals(1, out.size());
+    Assertions.assertTrue(out.get(0) instanceof RpcRequest);
+    Assertions.assertEquals(rpcRequest.requestId, ((RpcRequest) out.get(0)).requestId);
   }
 }

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/TestShuffleDataContext.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/TestShuffleDataContext.java
@@ -27,7 +27,7 @@ import com.google.common.io.Closeables;
 
 import org.apache.spark.network.shuffle.protocol.ExecutorShuffleInfo;
 import org.apache.spark.network.util.JavaUtils;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -125,7 +125,7 @@ public class TestShuffleDataContext {
   private void insertFile(String filename, byte[] block) throws IOException {
     OutputStream dataStream = null;
     File file = new File(ExecutorDiskUtils.getFilePath(localDirs, subDirsPerLocalDir, filename));
-    Assert.assertFalse("this test file has been already generated", file.exists());
+    Assertions.assertFalse(file.exists(), "this test file has been already generated");
     try {
       dataStream = new FileOutputStream(
         new File(ExecutorDiskUtils.getFilePath(localDirs, subDirsPerLocalDir, filename)));

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/protocol/FetchShuffleBlockChunksSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/protocol/FetchShuffleBlockChunksSuite.java
@@ -19,10 +19,10 @@ package org.apache.spark.network.shuffle.protocol;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class FetchShuffleBlockChunksSuite {
 
@@ -30,9 +30,9 @@ public class FetchShuffleBlockChunksSuite {
   public void testFetchShuffleBlockChunksEncodeDecode() {
     FetchShuffleBlockChunks shuffleBlockChunks =
       new FetchShuffleBlockChunks("app0", "exec1", 0, 0, new int[] {0}, new int[][] {{0, 1}});
-    Assert.assertEquals(2, shuffleBlockChunks.getNumBlocks());
+    Assertions.assertEquals(2, shuffleBlockChunks.getNumBlocks());
     int len = shuffleBlockChunks.encodedLength();
-    Assert.assertEquals(49, len);
+    Assertions.assertEquals(49, len);
     ByteBuf buf = Unpooled.buffer(len);
     shuffleBlockChunks.encode(buf);
 

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/protocol/FetchShuffleBlocksSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/protocol/FetchShuffleBlocksSuite.java
@@ -19,10 +19,10 @@ package org.apache.spark.network.shuffle.protocol;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class FetchShuffleBlocksSuite {
 
@@ -30,9 +30,9 @@ public class FetchShuffleBlocksSuite {
   public void testFetchShuffleBlockEncodeDecode() {
     FetchShuffleBlocks fetchShuffleBlocks =
       new FetchShuffleBlocks("app0", "exec1", 0, new long[] {0}, new int[][] {{0, 1}}, false);
-    Assert.assertEquals(2, fetchShuffleBlocks.getNumBlocks());
+    Assertions.assertEquals(2, fetchShuffleBlocks.getNumBlocks());
     int len = fetchShuffleBlocks.encodedLength();
-    Assert.assertEquals(50, len);
+    Assertions.assertEquals(50, len);
     ByteBuf buf = Unpooled.buffer(len);
     fetchShuffleBlocks.encode(buf);
 

--- a/common/unsafe/src/test/java/org/apache/spark/unsafe/PlatformUtilSuite.java
+++ b/common/unsafe/src/test/java/org/apache/spark/unsafe/PlatformUtilSuite.java
@@ -21,8 +21,8 @@ import org.apache.spark.unsafe.memory.HeapMemoryAllocator;
 import org.apache.spark.unsafe.memory.MemoryAllocator;
 import org.apache.spark.unsafe.memory.MemoryBlock;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class PlatformUtilSuite {
 
@@ -36,7 +36,7 @@ public class PlatformUtilSuite {
 
     Platform.copyMemory(data, Platform.BYTE_ARRAY_OFFSET, data, Platform.BYTE_ARRAY_OFFSET, size);
     for (int i = 0; i < data.length; ++i) {
-      Assert.assertEquals((byte)i, data[i]);
+      Assertions.assertEquals((byte)i, data[i]);
     }
 
     Platform.copyMemory(
@@ -46,7 +46,7 @@ public class PlatformUtilSuite {
         Platform.BYTE_ARRAY_OFFSET,
         size);
     for (int i = 0; i < size; ++i) {
-      Assert.assertEquals((byte)(i + 1), data[i]);
+      Assertions.assertEquals((byte)(i + 1), data[i]);
     }
 
     for (int i = 0; i < data.length; ++i) {
@@ -59,7 +59,7 @@ public class PlatformUtilSuite {
         Platform.BYTE_ARRAY_OFFSET + 1,
         size);
     for (int i = 0; i < size; ++i) {
-      Assert.assertEquals((byte)i, data[i + 1]);
+      Assertions.assertEquals((byte)i, data[i + 1]);
     }
   }
 
@@ -70,50 +70,50 @@ public class PlatformUtilSuite {
     MemoryAllocator.HEAP.free(block1);
     MemoryBlock block2 = MemoryAllocator.HEAP.allocate(1024 * 1024);
     Object baseObject2 = block2.getBaseObject();
-    Assert.assertSame(baseObject1, baseObject2);
+    Assertions.assertSame(baseObject1, baseObject2);
     MemoryAllocator.HEAP.free(block2);
   }
 
   @Test
   public void freeingOnHeapMemoryBlockResetsBaseObjectAndOffset() {
     MemoryBlock block = MemoryAllocator.HEAP.allocate(1024);
-    Assert.assertNotNull(block.getBaseObject());
+    Assertions.assertNotNull(block.getBaseObject());
     MemoryAllocator.HEAP.free(block);
-    Assert.assertNull(block.getBaseObject());
-    Assert.assertEquals(0, block.getBaseOffset());
-    Assert.assertEquals(MemoryBlock.FREED_IN_ALLOCATOR_PAGE_NUMBER, block.pageNumber);
+    Assertions.assertNull(block.getBaseObject());
+    Assertions.assertEquals(0, block.getBaseOffset());
+    Assertions.assertEquals(MemoryBlock.FREED_IN_ALLOCATOR_PAGE_NUMBER, block.pageNumber);
   }
 
   @Test
   public void freeingOffHeapMemoryBlockResetsOffset() {
     MemoryBlock block = MemoryAllocator.UNSAFE.allocate(1024);
-    Assert.assertNull(block.getBaseObject());
-    Assert.assertNotEquals(0, block.getBaseOffset());
+    Assertions.assertNull(block.getBaseObject());
+    Assertions.assertNotEquals(0, block.getBaseOffset());
     MemoryAllocator.UNSAFE.free(block);
-    Assert.assertNull(block.getBaseObject());
-    Assert.assertEquals(0, block.getBaseOffset());
-    Assert.assertEquals(MemoryBlock.FREED_IN_ALLOCATOR_PAGE_NUMBER, block.pageNumber);
+    Assertions.assertNull(block.getBaseObject());
+    Assertions.assertEquals(0, block.getBaseOffset());
+    Assertions.assertEquals(MemoryBlock.FREED_IN_ALLOCATOR_PAGE_NUMBER, block.pageNumber);
   }
 
   @Test
   public void onHeapMemoryAllocatorThrowsAssertionErrorOnDoubleFree() {
     MemoryBlock block = MemoryAllocator.HEAP.allocate(1024);
     MemoryAllocator.HEAP.free(block);
-    Assert.assertThrows(AssertionError.class, () -> MemoryAllocator.HEAP.free(block));
+    Assertions.assertThrows(AssertionError.class, () -> MemoryAllocator.HEAP.free(block));
   }
 
   @Test
   public void offHeapMemoryAllocatorThrowsAssertionErrorOnDoubleFree() {
     MemoryBlock block = MemoryAllocator.UNSAFE.allocate(1024);
     MemoryAllocator.UNSAFE.free(block);
-    Assert.assertThrows(AssertionError.class, () -> MemoryAllocator.UNSAFE.free(block));
+    Assertions.assertThrows(AssertionError.class, () -> MemoryAllocator.UNSAFE.free(block));
   }
 
   @Test
   public void memoryDebugFillEnabledInTest() {
-    Assert.assertTrue(MemoryAllocator.MEMORY_DEBUG_FILL_ENABLED);
+    Assertions.assertTrue(MemoryAllocator.MEMORY_DEBUG_FILL_ENABLED);
     MemoryBlock onheap = MemoryAllocator.HEAP.allocate(1);
-    Assert.assertEquals(
+    Assertions.assertEquals(
       MemoryAllocator.MEMORY_DEBUG_FILL_CLEAN_VALUE,
       Platform.getByte(onheap.getBaseObject(), onheap.getBaseOffset()));
 
@@ -121,16 +121,16 @@ public class PlatformUtilSuite {
     Object onheap1BaseObject = onheap1.getBaseObject();
     long onheap1BaseOffset = onheap1.getBaseOffset();
     MemoryAllocator.HEAP.free(onheap1);
-    Assert.assertEquals(
+    Assertions.assertEquals(
       MemoryAllocator.MEMORY_DEBUG_FILL_FREED_VALUE,
       Platform.getByte(onheap1BaseObject, onheap1BaseOffset));
     MemoryBlock onheap2 = MemoryAllocator.HEAP.allocate(1024 * 1024);
-    Assert.assertEquals(
+    Assertions.assertEquals(
       MemoryAllocator.MEMORY_DEBUG_FILL_CLEAN_VALUE,
       Platform.getByte(onheap2.getBaseObject(), onheap2.getBaseOffset()));
 
     MemoryBlock offheap = MemoryAllocator.UNSAFE.allocate(1);
-    Assert.assertEquals(
+    Assertions.assertEquals(
       MemoryAllocator.MEMORY_DEBUG_FILL_CLEAN_VALUE,
       Platform.getByte(offheap.getBaseObject(), offheap.getBaseOffset()));
     MemoryAllocator.UNSAFE.free(offheap);
@@ -145,16 +145,16 @@ public class PlatformUtilSuite {
     Object obj1 = onheap1.getBaseObject();
     heapMem.free(onheap1);
     MemoryBlock onheap2 = heapMem.allocate(514);
-    Assert.assertNotEquals(obj1, onheap2.getBaseObject());
+    Assertions.assertNotEquals(obj1, onheap2.getBaseObject());
 
     // The size is greater than `HeapMemoryAllocator.POOLING_THRESHOLD_BYTES`,
     // reuse the previous memory which has released.
     MemoryBlock onheap3 = heapMem.allocate(1024 * 1024 + 1);
-    Assert.assertEquals(1024 * 1024 + 1, onheap3.size());
+    Assertions.assertEquals(1024 * 1024 + 1, onheap3.size());
     Object obj3 = onheap3.getBaseObject();
     heapMem.free(onheap3);
     MemoryBlock onheap4 = heapMem.allocate(1024 * 1024 + 7);
-    Assert.assertEquals(1024 * 1024 + 7, onheap4.size());
-    Assert.assertEquals(obj3, onheap4.getBaseObject());
+    Assertions.assertEquals(1024 * 1024 + 7, onheap4.size());
+    Assertions.assertEquals(obj3, onheap4.getBaseObject());
   }
 }

--- a/common/unsafe/src/test/java/org/apache/spark/unsafe/array/ByteArraySuite.java
+++ b/common/unsafe/src/test/java/org/apache/spark/unsafe/array/ByteArraySuite.java
@@ -19,8 +19,8 @@ package org.apache.spark.unsafe.array;
 
 import org.apache.spark.unsafe.Platform;
 import org.apache.spark.unsafe.types.ByteArray;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class ByteArraySuite {
   private long getPrefixByByte(byte[] bytes) {
@@ -45,7 +45,7 @@ public class ByteArraySuite {
 
       long result = ByteArray.getPrefix(bytes);
       long expected = getPrefixByByte(bytes);
-      Assert.assertEquals(result, expected);
+      Assertions.assertEquals(result, expected);
     }
   }
 
@@ -53,18 +53,18 @@ public class ByteArraySuite {
   public void testCompareBinary() {
     byte[] x1 = new byte[0];
     byte[] y1 = new byte[]{(byte) 1, (byte) 2, (byte) 3};
-    Assert.assertTrue(ByteArray.compareBinary(x1, y1) < 0);
+    Assertions.assertTrue(ByteArray.compareBinary(x1, y1) < 0);
 
     byte[] x2 = new byte[]{(byte) 200, (byte) 100};
     byte[] y2 = new byte[]{(byte) 100, (byte) 100};
-    Assert.assertTrue(ByteArray.compareBinary(x2, y2) > 0);
+    Assertions.assertTrue(ByteArray.compareBinary(x2, y2) > 0);
 
     byte[] x3 = new byte[]{(byte) 100, (byte) 200, (byte) 12};
     byte[] y3 = new byte[]{(byte) 100, (byte) 200};
-    Assert.assertTrue(ByteArray.compareBinary(x3, y3) > 0);
+    Assertions.assertTrue(ByteArray.compareBinary(x3, y3) > 0);
 
     byte[] x4 = new byte[]{(byte) 100, (byte) 200};
     byte[] y4 = new byte[]{(byte) 100, (byte) 200};
-    Assert.assertEquals(0, ByteArray.compareBinary(x4, y4));
+    Assertions.assertEquals(0, ByteArray.compareBinary(x4, y4));
   }
 }

--- a/common/unsafe/src/test/java/org/apache/spark/unsafe/array/LongArraySuite.java
+++ b/common/unsafe/src/test/java/org/apache/spark/unsafe/array/LongArraySuite.java
@@ -17,8 +17,8 @@
 
 package org.apache.spark.unsafe.array;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.unsafe.memory.MemoryBlock;
 
@@ -31,12 +31,12 @@ public class LongArraySuite {
     arr.set(0, 1L);
     arr.set(1, 2L);
     arr.set(1, 3L);
-    Assert.assertEquals(2, arr.size());
-    Assert.assertEquals(1L, arr.get(0));
-    Assert.assertEquals(3L, arr.get(1));
+    Assertions.assertEquals(2, arr.size());
+    Assertions.assertEquals(1L, arr.get(0));
+    Assertions.assertEquals(3L, arr.get(1));
 
     arr.zeroOut();
-    Assert.assertEquals(0L, arr.get(0));
-    Assert.assertEquals(0L, arr.get(1));
+    Assertions.assertEquals(0L, arr.get(0));
+    Assertions.assertEquals(0L, arr.get(1));
   }
 }

--- a/common/unsafe/src/test/java/org/apache/spark/unsafe/hash/Murmur3_x86_32Suite.java
+++ b/common/unsafe/src/test/java/org/apache/spark/unsafe/hash/Murmur3_x86_32Suite.java
@@ -25,8 +25,8 @@ import java.util.Set;
 import scala.util.hashing.MurmurHash3$;
 
 import org.apache.spark.unsafe.Platform;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test file based on Guava's Murmur3Hash32Test.
@@ -37,36 +37,36 @@ public class Murmur3_x86_32Suite {
 
   @Test
   public void testKnownIntegerInputs() {
-    Assert.assertEquals(593689054, hasher.hashInt(0));
-    Assert.assertEquals(-189366624, hasher.hashInt(-42));
-    Assert.assertEquals(-1134849565, hasher.hashInt(42));
-    Assert.assertEquals(-1718298732, hasher.hashInt(Integer.MIN_VALUE));
-    Assert.assertEquals(-1653689534, hasher.hashInt(Integer.MAX_VALUE));
+    Assertions.assertEquals(593689054, hasher.hashInt(0));
+    Assertions.assertEquals(-189366624, hasher.hashInt(-42));
+    Assertions.assertEquals(-1134849565, hasher.hashInt(42));
+    Assertions.assertEquals(-1718298732, hasher.hashInt(Integer.MIN_VALUE));
+    Assertions.assertEquals(-1653689534, hasher.hashInt(Integer.MAX_VALUE));
   }
 
   @Test
   public void testKnownLongInputs() {
-    Assert.assertEquals(1669671676, hasher.hashLong(0L));
-    Assert.assertEquals(-846261623, hasher.hashLong(-42L));
-    Assert.assertEquals(1871679806, hasher.hashLong(42L));
-    Assert.assertEquals(1366273829, hasher.hashLong(Long.MIN_VALUE));
-    Assert.assertEquals(-2106506049, hasher.hashLong(Long.MAX_VALUE));
+    Assertions.assertEquals(1669671676, hasher.hashLong(0L));
+    Assertions.assertEquals(-846261623, hasher.hashLong(-42L));
+    Assertions.assertEquals(1871679806, hasher.hashLong(42L));
+    Assertions.assertEquals(1366273829, hasher.hashLong(Long.MIN_VALUE));
+    Assertions.assertEquals(-2106506049, hasher.hashLong(Long.MAX_VALUE));
   }
 
   // SPARK-23381 Check whether the hash of the byte array is the same as another implementations
   @Test
   public void testKnownBytesInputs() {
     byte[] test = "test".getBytes(StandardCharsets.UTF_8);
-    Assert.assertEquals(MurmurHash3$.MODULE$.bytesHash(test, 0),
+    Assertions.assertEquals(MurmurHash3$.MODULE$.bytesHash(test, 0),
       Murmur3_x86_32.hashUnsafeBytes2(test, Platform.BYTE_ARRAY_OFFSET, test.length, 0));
     byte[] test1 = "test1".getBytes(StandardCharsets.UTF_8);
-    Assert.assertEquals(MurmurHash3$.MODULE$.bytesHash(test1, 0),
+    Assertions.assertEquals(MurmurHash3$.MODULE$.bytesHash(test1, 0),
       Murmur3_x86_32.hashUnsafeBytes2(test1, Platform.BYTE_ARRAY_OFFSET, test1.length, 0));
     byte[] te = "te".getBytes(StandardCharsets.UTF_8);
-    Assert.assertEquals(MurmurHash3$.MODULE$.bytesHash(te, 0),
+    Assertions.assertEquals(MurmurHash3$.MODULE$.bytesHash(te, 0),
       Murmur3_x86_32.hashUnsafeBytes2(te, Platform.BYTE_ARRAY_OFFSET, te.length, 0));
     byte[] tes = "tes".getBytes(StandardCharsets.UTF_8);
-    Assert.assertEquals(MurmurHash3$.MODULE$.bytesHash(tes, 0),
+    Assertions.assertEquals(MurmurHash3$.MODULE$.bytesHash(tes, 0),
       Murmur3_x86_32.hashUnsafeBytes2(tes, Platform.BYTE_ARRAY_OFFSET, tes.length, 0));
   }
 
@@ -80,14 +80,14 @@ public class Murmur3_x86_32Suite {
     for (int i = 0; i < size; i++) {
       int vint = rand.nextInt();
       long lint = rand.nextLong();
-      Assert.assertEquals(hasher.hashInt(vint), hasher.hashInt(vint));
-      Assert.assertEquals(hasher.hashLong(lint), hasher.hashLong(lint));
+      Assertions.assertEquals(hasher.hashInt(vint), hasher.hashInt(vint));
+      Assertions.assertEquals(hasher.hashLong(lint), hasher.hashLong(lint));
 
       hashcodes.add(hasher.hashLong(lint));
     }
 
     // A very loose bound.
-    Assert.assertTrue(hashcodes.size() > size * 0.95);
+    Assertions.assertTrue(hashcodes.size() > size * 0.95);
   }
 
   @Test
@@ -102,7 +102,7 @@ public class Murmur3_x86_32Suite {
       byte[] bytes = new byte[byteArrSize];
       rand.nextBytes(bytes);
 
-      Assert.assertEquals(
+      Assertions.assertEquals(
         hasher.hashUnsafeWords(bytes, Platform.BYTE_ARRAY_OFFSET, byteArrSize),
         hasher.hashUnsafeWords(bytes, Platform.BYTE_ARRAY_OFFSET, byteArrSize));
 
@@ -111,7 +111,7 @@ public class Murmur3_x86_32Suite {
     }
 
     // A very loose bound.
-    Assert.assertTrue(hashcodes.size() > size * 0.95);
+    Assertions.assertTrue(hashcodes.size() > size * 0.95);
   }
 
   @Test
@@ -125,7 +125,7 @@ public class Murmur3_x86_32Suite {
       byte[] paddedBytes = new byte[byteArrSize];
       System.arraycopy(strBytes, 0, paddedBytes, 0, strBytes.length);
 
-      Assert.assertEquals(
+      Assertions.assertEquals(
         hasher.hashUnsafeWords(paddedBytes, Platform.BYTE_ARRAY_OFFSET, byteArrSize),
         hasher.hashUnsafeWords(paddedBytes, Platform.BYTE_ARRAY_OFFSET, byteArrSize));
 
@@ -134,6 +134,6 @@ public class Murmur3_x86_32Suite {
     }
 
     // A very loose bound.
-    Assert.assertTrue(hashcodes.size() > size * 0.95);
+    Assertions.assertTrue(hashcodes.size() > size * 0.95);
   }
 }

--- a/common/unsafe/src/test/java/org/apache/spark/unsafe/types/CalendarIntervalSuite.java
+++ b/common/unsafe/src/test/java/org/apache/spark/unsafe/types/CalendarIntervalSuite.java
@@ -17,12 +17,12 @@
 
 package org.apache.spark.unsafe.types;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.time.Period;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.apache.spark.sql.catalyst.util.DateTimeConstants.*;
 
 public class CalendarIntervalSuite {

--- a/common/unsafe/src/test/java/org/apache/spark/unsafe/types/UTF8StringSuite.java
+++ b/common/unsafe/src/test/java/org/apache/spark/unsafe/types/UTF8StringSuite.java
@@ -26,9 +26,9 @@ import java.util.*;
 
 import com.google.common.collect.ImmutableMap;
 import org.apache.spark.unsafe.Platform;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import static org.apache.spark.unsafe.Platform.BYTE_ARRAY_OFFSET;
 import static org.apache.spark.unsafe.types.UTF8String.*;
@@ -682,7 +682,7 @@ public class UTF8StringSuite {
   }
 
   @Test
-  public void testToShort() throws IOException {
+  public void testToShort() {
     Map<String, Short> inputToExpectedOutput = new HashMap<>();
     inputToExpectedOutput.put("1", (short) 1);
     inputToExpectedOutput.put("+1", (short) 1);
@@ -700,7 +700,7 @@ public class UTF8StringSuite {
 
     IntWrapper wrapper = new IntWrapper();
     for (Map.Entry<String, Short> entry : inputToExpectedOutput.entrySet()) {
-      assertTrue(entry.getKey(), UTF8String.fromString(entry.getKey()).toShort(wrapper));
+      assertTrue(UTF8String.fromString(entry.getKey()).toShort(wrapper), entry.getKey());
       assertEquals((short) entry.getValue(), wrapper.value);
     }
 
@@ -708,12 +708,12 @@ public class UTF8StringSuite {
       Arrays.asList("", "  ", "null", "NULL", "\n", "~1212121", "3276700");
 
     for (String negativeInput : negativeInputs) {
-      assertFalse(negativeInput, UTF8String.fromString(negativeInput).toShort(wrapper));
+      assertFalse(UTF8String.fromString(negativeInput).toShort(wrapper), negativeInput);
     }
   }
 
   @Test
-  public void testToByte() throws IOException {
+  public void testToByte() {
     Map<String, Byte> inputToExpectedOutput = new HashMap<>();
     inputToExpectedOutput.put("1", (byte) 1);
     inputToExpectedOutput.put("+1",(byte)  1);
@@ -731,7 +731,7 @@ public class UTF8StringSuite {
 
     IntWrapper intWrapper = new IntWrapper();
     for (Map.Entry<String, Byte> entry : inputToExpectedOutput.entrySet()) {
-      assertTrue(entry.getKey(), UTF8String.fromString(entry.getKey()).toByte(intWrapper));
+      assertTrue(UTF8String.fromString(entry.getKey()).toByte(intWrapper), entry.getKey());
       assertEquals((byte) entry.getValue(), intWrapper.value);
     }
 
@@ -739,12 +739,12 @@ public class UTF8StringSuite {
       Arrays.asList("", "  ", "null", "NULL", "\n", "~1212121", "12345678901234567890");
 
     for (String negativeInput : negativeInputs) {
-      assertFalse(negativeInput, UTF8String.fromString(negativeInput).toByte(intWrapper));
+      assertFalse(UTF8String.fromString(negativeInput).toByte(intWrapper), negativeInput);
     }
   }
 
   @Test
-  public void testToInt() throws IOException {
+  public void testToInt() {
     Map<String, Integer> inputToExpectedOutput = new HashMap<>();
     inputToExpectedOutput.put("1", 1);
     inputToExpectedOutput.put("+1", 1);
@@ -762,7 +762,7 @@ public class UTF8StringSuite {
 
     IntWrapper intWrapper = new IntWrapper();
     for (Map.Entry<String, Integer> entry : inputToExpectedOutput.entrySet()) {
-      assertTrue(entry.getKey(), UTF8String.fromString(entry.getKey()).toInt(intWrapper));
+      assertTrue(UTF8String.fromString(entry.getKey()).toInt(intWrapper), entry.getKey());
       assertEquals((int) entry.getValue(), intWrapper.value);
     }
 
@@ -770,12 +770,12 @@ public class UTF8StringSuite {
       Arrays.asList("", "  ", "null", "NULL", "\n", "~1212121", "12345678901234567890");
 
     for (String negativeInput : negativeInputs) {
-      assertFalse(negativeInput, UTF8String.fromString(negativeInput).toInt(intWrapper));
+      assertFalse(UTF8String.fromString(negativeInput).toInt(intWrapper), negativeInput);
     }
   }
 
   @Test
-  public void testToLong() throws IOException {
+  public void testToLong() {
     Map<String, Long> inputToExpectedOutput = new HashMap<>();
     inputToExpectedOutput.put("1", 1L);
     inputToExpectedOutput.put("+1", 1L);
@@ -793,7 +793,7 @@ public class UTF8StringSuite {
 
     LongWrapper wrapper = new LongWrapper();
     for (Map.Entry<String, Long> entry : inputToExpectedOutput.entrySet()) {
-      assertTrue(entry.getKey(), UTF8String.fromString(entry.getKey()).toLong(wrapper));
+      assertTrue(UTF8String.fromString(entry.getKey()).toLong(wrapper), entry.getKey());
       assertEquals((long) entry.getValue(), wrapper.value);
     }
 
@@ -801,7 +801,7 @@ public class UTF8StringSuite {
         "1234567890123456789012345678901234");
 
     for (String negativeInput : negativeInputs) {
-      assertFalse(negativeInput, UTF8String.fromString(negativeInput).toLong(wrapper));
+      assertFalse(UTF8String.fromString(negativeInput).toLong(wrapper), negativeInput);
     }
   }
 

--- a/connector/avro/src/test/java/org/apache/spark/sql/avro/JavaAvroFunctionsSuite.java
+++ b/connector/avro/src/test/java/org/apache/spark/sql/avro/JavaAvroFunctionsSuite.java
@@ -17,9 +17,9 @@
 
 package org.apache.spark.sql.avro;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.QueryTest$;
@@ -33,12 +33,12 @@ import static org.apache.spark.sql.avro.functions.from_avro;
 public class JavaAvroFunctionsSuite {
   private transient TestSparkSession spark;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     spark = new TestSparkSession();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     spark.stop();
   }

--- a/connector/connect/client/jvm/src/test/java/org/apache/spark/sql/JavaEncoderSuite.java
+++ b/connector/connect/client/jvm/src/test/java/org/apache/spark/sql/JavaEncoderSuite.java
@@ -21,8 +21,8 @@ import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.*;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import static org.apache.spark.sql.Encoders.*;
 import static org.apache.spark.sql.functions.*;
@@ -37,12 +37,12 @@ import org.apache.spark.sql.types.StructType;
 public class JavaEncoderSuite implements Serializable {
   private static SparkSession spark;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() {
     spark = SparkConnectServerUtils.createSparkSession();
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() {
     spark.stop();
     spark = null;
@@ -104,6 +104,6 @@ public class JavaEncoderSuite implements Serializable {
             Encoders.row(schema))
         .filter(col("a").geq(1));
     final List<Row> expected = Arrays.asList(create(1, "s1"), create(2, "s2"));
-    Assert.assertEquals(expected, df.collectAsList());
+    Assertions.assertEquals(expected, df.collectAsList());
   }
 }

--- a/connector/kafka-0-10-sql/pom.xml
+++ b/connector/kafka-0-10-sql/pom.xml
@@ -157,7 +157,7 @@
     </dependency>
     <dependency>
       <groupId>org.jmock</groupId>
-      <artifactId>jmock-junit4</artifactId>
+      <artifactId>jmock-junit5</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/connector/kafka-0-10/pom.xml
+++ b/connector/kafka-0-10/pom.xml
@@ -123,7 +123,7 @@
     </dependency>
     <dependency>
       <groupId>org.jmock</groupId>
-      <artifactId>jmock-junit4</artifactId>
+      <artifactId>jmock-junit5</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/connector/kafka-0-10/src/test/java/org/apache/spark/streaming/kafka010/JavaConsumerStrategySuite.java
+++ b/connector/kafka-0-10/src/test/java/org/apache/spark/streaming/kafka010/JavaConsumerStrategySuite.java
@@ -25,8 +25,8 @@ import scala.collection.JavaConverters;
 
 import org.apache.kafka.common.TopicPartition;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class JavaConsumerStrategySuite implements Serializable {
 
@@ -62,7 +62,7 @@ public class JavaConsumerStrategySuite implements Serializable {
     final ConsumerStrategy<String, String> sub4 =
       ConsumerStrategies.Subscribe(topics, kafkaParams);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
       sub1.executorKafkaParams().get("bootstrap.servers"),
       sub3.executorKafkaParams().get("bootstrap.servers"));
 
@@ -75,7 +75,7 @@ public class JavaConsumerStrategySuite implements Serializable {
     final ConsumerStrategy<String, String> psub4 =
       ConsumerStrategies.SubscribePattern(pat, kafkaParams);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
       psub1.executorKafkaParams().get("bootstrap.servers"),
       psub3.executorKafkaParams().get("bootstrap.servers"));
 
@@ -88,7 +88,7 @@ public class JavaConsumerStrategySuite implements Serializable {
     final ConsumerStrategy<String, String> asn4 =
       ConsumerStrategies.Assign(parts, kafkaParams);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
       asn1.executorKafkaParams().get("bootstrap.servers"),
       asn3.executorKafkaParams().get("bootstrap.servers"));
   }

--- a/connector/kafka-0-10/src/test/java/org/apache/spark/streaming/kafka010/JavaDirectKafkaStreamSuite.java
+++ b/connector/kafka-0-10/src/test/java/org/apache/spark/streaming/kafka010/JavaDirectKafkaStreamSuite.java
@@ -24,10 +24,10 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaRDD;
@@ -42,7 +42,7 @@ public class JavaDirectKafkaStreamSuite implements Serializable {
   private transient JavaStreamingContext ssc = null;
   private transient KafkaTestUtils kafkaTestUtils = null;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     kafkaTestUtils = new KafkaTestUtils();
     kafkaTestUtils.setup();
@@ -51,7 +51,7 @@ public class JavaDirectKafkaStreamSuite implements Serializable {
     ssc = new JavaStreamingContext(sparkConf, Durations.milliseconds(200));
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     if (ssc != null) {
       ssc.stop();
@@ -100,7 +100,7 @@ public class JavaDirectKafkaStreamSuite implements Serializable {
         JavaRDD<ConsumerRecord<String, String>>>) rdd -> {
         OffsetRange[] offsets = ((HasOffsetRanges) rdd.rdd()).offsetRanges();
         offsetRanges.set(offsets);
-        Assert.assertEquals(topic1, offsets[0].topic());
+        Assertions.assertEquals(topic1, offsets[0].topic());
         return rdd;
       }
     ).map(
@@ -123,7 +123,7 @@ public class JavaDirectKafkaStreamSuite implements Serializable {
         JavaRDD<ConsumerRecord<String, String>>>) rdd -> {
         OffsetRange[] offsets = ((HasOffsetRanges) rdd.rdd()).offsetRanges();
         offsetRanges.set(offsets);
-        Assert.assertEquals(topic2, offsets[0].topic());
+        Assertions.assertEquals(topic2, offsets[0].topic());
         return rdd;
       }
     ).map(
@@ -142,7 +142,7 @@ public class JavaDirectKafkaStreamSuite implements Serializable {
       matches = sent.size() == result.size();
       Thread.sleep(50);
     }
-    Assert.assertEquals(sent, result);
+    Assertions.assertEquals(sent, result);
     ssc.stop();
   }
 

--- a/connector/kafka-0-10/src/test/java/org/apache/spark/streaming/kafka010/JavaKafkaRDDSuite.java
+++ b/connector/kafka-0-10/src/test/java/org/apache/spark/streaming/kafka010/JavaKafkaRDDSuite.java
@@ -25,10 +25,10 @@ import java.util.Random;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaRDD;
@@ -39,7 +39,7 @@ public class JavaKafkaRDDSuite implements Serializable {
   private transient JavaSparkContext sc = null;
   private transient KafkaTestUtils kafkaTestUtils = null;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     kafkaTestUtils = new KafkaTestUtils();
     kafkaTestUtils.setup();
@@ -48,7 +48,7 @@ public class JavaKafkaRDDSuite implements Serializable {
     sc = new JavaSparkContext(sparkConf);
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     if (sc != null) {
       sc.stop();
@@ -108,8 +108,8 @@ public class JavaKafkaRDDSuite implements Serializable {
     // just making sure the java user APIs work; the scala tests handle logic corner cases
     long count1 = rdd1.count();
     long count2 = rdd2.count();
-    Assert.assertTrue(count1 > 0);
-    Assert.assertEquals(count1, count2);
+    Assertions.assertTrue(count1 > 0);
+    Assertions.assertEquals(count1, count2);
   }
 
   private  String[] createTopicAndSendData(String topic) {

--- a/connector/kafka-0-10/src/test/java/org/apache/spark/streaming/kafka010/JavaLocationStrategySuite.java
+++ b/connector/kafka-0-10/src/test/java/org/apache/spark/streaming/kafka010/JavaLocationStrategySuite.java
@@ -24,8 +24,8 @@ import scala.collection.JavaConverters;
 
 import org.apache.kafka.common.TopicPartition;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class JavaLocationStrategySuite implements Serializable {
 
@@ -43,17 +43,17 @@ public class JavaLocationStrategySuite implements Serializable {
     // make sure constructors can be called from java
     final LocationStrategy c1 = LocationStrategies.PreferConsistent();
     final LocationStrategy c2 = LocationStrategies.PreferConsistent();
-    Assert.assertSame(c1, c2);
+    Assertions.assertSame(c1, c2);
 
     final LocationStrategy c3 = LocationStrategies.PreferBrokers();
     final LocationStrategy c4 = LocationStrategies.PreferBrokers();
-    Assert.assertSame(c3, c4);
+    Assertions.assertSame(c3, c4);
 
-    Assert.assertNotSame(c1, c3);
+    Assertions.assertNotSame(c1, c3);
 
     final LocationStrategy c5 = LocationStrategies.PreferFixed(hosts);
     final LocationStrategy c6 = LocationStrategies.PreferFixed(sHosts);
-    Assert.assertEquals(c5, c6);
+    Assertions.assertEquals(c5, c6);
   }
 
 }

--- a/connector/kinesis-asl/src/test/java/org/apache/spark/streaming/kinesis/JavaKinesisInputDStreamBuilderSuite.java
+++ b/connector/kinesis-asl/src/test/java/org/apache/spark/streaming/kinesis/JavaKinesisInputDStreamBuilderSuite.java
@@ -18,8 +18,8 @@
 package org.apache.spark.streaming.kinesis;
 
 import com.amazonaws.services.kinesis.clientlibrary.lib.worker.InitialPositionInStream;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.streaming.kinesis.KinesisInitialPositions.TrimHorizon;
 import org.apache.spark.storage.StorageLevel;
@@ -51,14 +51,14 @@ public class JavaKinesisInputDStreamBuilderSuite extends LocalJavaStreamingConte
       .checkpointInterval(checkpointInterval)
       .storageLevel(storageLevel)
       .build();
-    Assert.assertEquals(streamName, kinesisDStream.streamName());
-    Assert.assertEquals(endpointUrl, kinesisDStream.endpointUrl());
-    Assert.assertEquals(region, kinesisDStream.regionName());
-    Assert.assertEquals(initialPosition.getPosition(),
+    Assertions.assertEquals(streamName, kinesisDStream.streamName());
+    Assertions.assertEquals(endpointUrl, kinesisDStream.endpointUrl());
+    Assertions.assertEquals(region, kinesisDStream.regionName());
+    Assertions.assertEquals(initialPosition.getPosition(),
         kinesisDStream.initialPosition().getPosition());
-    Assert.assertEquals(appName, kinesisDStream.checkpointAppName());
-    Assert.assertEquals(checkpointInterval, kinesisDStream.checkpointInterval());
-    Assert.assertEquals(storageLevel, kinesisDStream._storageLevel());
+    Assertions.assertEquals(appName, kinesisDStream.checkpointAppName());
+    Assertions.assertEquals(checkpointInterval, kinesisDStream.checkpointInterval());
+    Assertions.assertEquals(storageLevel, kinesisDStream._storageLevel());
     ssc.stop();
   }
 
@@ -86,14 +86,14 @@ public class JavaKinesisInputDStreamBuilderSuite extends LocalJavaStreamingConte
       .checkpointInterval(checkpointInterval)
       .storageLevel(storageLevel)
       .build();
-    Assert.assertEquals(streamName, kinesisDStream.streamName());
-    Assert.assertEquals(endpointUrl, kinesisDStream.endpointUrl());
-    Assert.assertEquals(region, kinesisDStream.regionName());
-    Assert.assertEquals(InitialPositionInStream.LATEST,
+    Assertions.assertEquals(streamName, kinesisDStream.streamName());
+    Assertions.assertEquals(endpointUrl, kinesisDStream.endpointUrl());
+    Assertions.assertEquals(region, kinesisDStream.regionName());
+    Assertions.assertEquals(InitialPositionInStream.LATEST,
         kinesisDStream.initialPosition().getPosition());
-    Assert.assertEquals(appName, kinesisDStream.checkpointAppName());
-    Assert.assertEquals(checkpointInterval, kinesisDStream.checkpointInterval());
-    Assert.assertEquals(storageLevel, kinesisDStream._storageLevel());
+    Assertions.assertEquals(appName, kinesisDStream.checkpointAppName());
+    Assertions.assertEquals(checkpointInterval, kinesisDStream.checkpointInterval());
+    Assertions.assertEquals(storageLevel, kinesisDStream._storageLevel());
     ssc.stop();
   }
 }

--- a/core/src/test/java/org/apache/spark/JavaJdbcRDDSuite.java
+++ b/core/src/test/java/org/apache/spark/JavaJdbcRDDSuite.java
@@ -27,16 +27,16 @@ import java.util.UUID;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.rdd.JdbcRDD;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class JavaJdbcRDDSuite implements Serializable {
   private String dbName = "db_" + UUID.randomUUID().toString().replace('-', '_');
   private transient JavaSparkContext sc;
 
-  @Before
+  @BeforeEach
   public void setUp() throws ClassNotFoundException, SQLException {
     sc = new JavaSparkContext("local", "JavaAPISuite");
 
@@ -66,7 +66,7 @@ public class JavaJdbcRDDSuite implements Serializable {
     }
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws SQLException {
     try {
       DriverManager.getConnection("jdbc:derby:target/" + dbName + ";shutdown=true");
@@ -92,7 +92,7 @@ public class JavaJdbcRDDSuite implements Serializable {
       r -> r.getInt(1)
     ).cache();
 
-    Assert.assertEquals(100, rdd.count());
-    Assert.assertEquals(Integer.valueOf(10100), rdd.reduce((i1, i2) -> i1 + i2));
+    Assertions.assertEquals(100, rdd.count());
+    Assertions.assertEquals(Integer.valueOf(10100), rdd.reduce((i1, i2) -> i1 + i2));
   }
 }

--- a/core/src/test/java/org/apache/spark/api/java/OptionalSuite.java
+++ b/core/src/test/java/org/apache/spark/api/java/OptionalSuite.java
@@ -17,8 +17,8 @@
 
 package org.apache.spark.api.java;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests {@link Optional}.
@@ -27,71 +27,71 @@ public class OptionalSuite {
 
   @Test
   public void testEmpty() {
-    Assert.assertFalse(Optional.empty().isPresent());
-    Assert.assertNull(Optional.empty().orNull());
-    Assert.assertEquals("foo", Optional.empty().or("foo"));
-    Assert.assertEquals("foo", Optional.empty().orElse("foo"));
+    Assertions.assertFalse(Optional.empty().isPresent());
+    Assertions.assertNull(Optional.empty().orNull());
+    Assertions.assertEquals("foo", Optional.empty().or("foo"));
+    Assertions.assertEquals("foo", Optional.empty().orElse("foo"));
   }
 
   @Test
   public void testEmptyGet() {
-    Assert.assertThrows(NullPointerException.class,
+    Assertions.assertThrows(NullPointerException.class,
       () -> Optional.empty().get());
   }
 
   @Test
   public void testAbsent() {
-    Assert.assertFalse(Optional.absent().isPresent());
-    Assert.assertNull(Optional.absent().orNull());
-    Assert.assertEquals("foo", Optional.absent().or("foo"));
-    Assert.assertEquals("foo", Optional.absent().orElse("foo"));
+    Assertions.assertFalse(Optional.absent().isPresent());
+    Assertions.assertNull(Optional.absent().orNull());
+    Assertions.assertEquals("foo", Optional.absent().or("foo"));
+    Assertions.assertEquals("foo", Optional.absent().orElse("foo"));
   }
 
   @Test
   public void testAbsentGet() {
-    Assert.assertThrows(NullPointerException.class,
+    Assertions.assertThrows(NullPointerException.class,
       () -> Optional.absent().get());
   }
 
   @Test
   public void testOf() {
-    Assert.assertTrue(Optional.of(1).isPresent());
-    Assert.assertNotNull(Optional.of(1).orNull());
-    Assert.assertEquals(Integer.valueOf(1), Optional.of(1).get());
-    Assert.assertEquals(Integer.valueOf(1), Optional.of(1).or(2));
-    Assert.assertEquals(Integer.valueOf(1), Optional.of(1).orElse(2));
+    Assertions.assertTrue(Optional.of(1).isPresent());
+    Assertions.assertNotNull(Optional.of(1).orNull());
+    Assertions.assertEquals(Integer.valueOf(1), Optional.of(1).get());
+    Assertions.assertEquals(Integer.valueOf(1), Optional.of(1).or(2));
+    Assertions.assertEquals(Integer.valueOf(1), Optional.of(1).orElse(2));
   }
 
   @Test
   public void testOfWithNull() {
-    Assert.assertThrows(NullPointerException.class,
+    Assertions.assertThrows(NullPointerException.class,
       () -> Optional.of(null));
   }
 
   @Test
   public void testOfNullable() {
-    Assert.assertTrue(Optional.ofNullable(1).isPresent());
-    Assert.assertNotNull(Optional.ofNullable(1).orNull());
-    Assert.assertEquals(Integer.valueOf(1), Optional.ofNullable(1).get());
-    Assert.assertEquals(Integer.valueOf(1), Optional.ofNullable(1).or(2));
-    Assert.assertEquals(Integer.valueOf(1), Optional.ofNullable(1).orElse(2));
-    Assert.assertFalse(Optional.ofNullable(null).isPresent());
-    Assert.assertNull(Optional.ofNullable(null).orNull());
-    Assert.assertEquals(Integer.valueOf(2), Optional.<Integer>ofNullable(null).or(2));
-    Assert.assertEquals(Integer.valueOf(2), Optional.<Integer>ofNullable(null).orElse(2));
+    Assertions.assertTrue(Optional.ofNullable(1).isPresent());
+    Assertions.assertNotNull(Optional.ofNullable(1).orNull());
+    Assertions.assertEquals(Integer.valueOf(1), Optional.ofNullable(1).get());
+    Assertions.assertEquals(Integer.valueOf(1), Optional.ofNullable(1).or(2));
+    Assertions.assertEquals(Integer.valueOf(1), Optional.ofNullable(1).orElse(2));
+    Assertions.assertFalse(Optional.ofNullable(null).isPresent());
+    Assertions.assertNull(Optional.ofNullable(null).orNull());
+    Assertions.assertEquals(Integer.valueOf(2), Optional.<Integer>ofNullable(null).or(2));
+    Assertions.assertEquals(Integer.valueOf(2), Optional.<Integer>ofNullable(null).orElse(2));
   }
 
   @Test
   public void testFromNullable() {
-    Assert.assertTrue(Optional.fromNullable(1).isPresent());
-    Assert.assertNotNull(Optional.fromNullable(1).orNull());
-    Assert.assertEquals(Integer.valueOf(1), Optional.fromNullable(1).get());
-    Assert.assertEquals(Integer.valueOf(1), Optional.fromNullable(1).or(2));
-    Assert.assertEquals(Integer.valueOf(1), Optional.fromNullable(1).orElse(2));
-    Assert.assertFalse(Optional.fromNullable(null).isPresent());
-    Assert.assertNull(Optional.fromNullable(null).orNull());
-    Assert.assertEquals(Integer.valueOf(2), Optional.<Integer>fromNullable(null).or(2));
-    Assert.assertEquals(Integer.valueOf(2), Optional.<Integer>fromNullable(null).orElse(2));
+    Assertions.assertTrue(Optional.fromNullable(1).isPresent());
+    Assertions.assertNotNull(Optional.fromNullable(1).orNull());
+    Assertions.assertEquals(Integer.valueOf(1), Optional.fromNullable(1).get());
+    Assertions.assertEquals(Integer.valueOf(1), Optional.fromNullable(1).or(2));
+    Assertions.assertEquals(Integer.valueOf(1), Optional.fromNullable(1).orElse(2));
+    Assertions.assertFalse(Optional.fromNullable(null).isPresent());
+    Assertions.assertNull(Optional.fromNullable(null).orNull());
+    Assertions.assertEquals(Integer.valueOf(2), Optional.<Integer>fromNullable(null).or(2));
+    Assertions.assertEquals(Integer.valueOf(2), Optional.<Integer>fromNullable(null).orElse(2));
   }
 
 }

--- a/core/src/test/java/org/apache/spark/io/GenericFileInputStreamSuite.java
+++ b/core/src/test/java/org/apache/spark/io/GenericFileInputStreamSuite.java
@@ -17,16 +17,16 @@
 package org.apache.spark.io;
 
 import org.apache.commons.io.FileUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.concurrent.ThreadLocalRandom;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests functionality of {@link NioBufferedFileInputStream}
@@ -40,14 +40,14 @@ public abstract class GenericFileInputStreamSuite {
 
   protected InputStream[] inputStreams;
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException {
     ThreadLocalRandom.current().nextBytes(randomBytes);
     inputFile = File.createTempFile("temp-file", ".tmp");
     FileUtils.writeByteArrayToFile(inputFile, randomBytes);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws IOException {
     inputFile.delete();
 

--- a/core/src/test/java/org/apache/spark/io/NioBufferedInputStreamSuite.java
+++ b/core/src/test/java/org/apache/spark/io/NioBufferedInputStreamSuite.java
@@ -16,7 +16,7 @@
  */
 package org.apache.spark.io;
 
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.io.InputStream;
 import java.io.IOException;
@@ -26,7 +26,7 @@ import java.io.IOException;
  */
 public class NioBufferedInputStreamSuite extends GenericFileInputStreamSuite {
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException {
     super.setUp();
     inputStreams = new InputStream[] {

--- a/core/src/test/java/org/apache/spark/io/ReadAheadInputStreamSuite.java
+++ b/core/src/test/java/org/apache/spark/io/ReadAheadInputStreamSuite.java
@@ -16,7 +16,7 @@
  */
 package org.apache.spark.io;
 
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -26,7 +26,7 @@ import java.io.InputStream;
  */
 public class ReadAheadInputStreamSuite extends GenericFileInputStreamSuite {
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException {
     super.setUp();
     inputStreams = new InputStream[] {

--- a/core/src/test/java/org/apache/spark/launcher/SparkLauncherSuite.java
+++ b/core/src/test/java/org/apache/spark/launcher/SparkLauncherSuite.java
@@ -25,9 +25,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
-import org.junit.Test;
-import static org.junit.Assert.*;
-import static org.junit.Assume.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
 import static org.mockito.Mockito.*;
 
 import org.apache.spark.SparkContext;
@@ -280,9 +280,8 @@ public class SparkLauncherSuite extends BaseSuite {
     // Here DAGScheduler is stopped, while SparkContext.clearActiveContext may not be called yet.
     // Wait for a reasonable amount of time to avoid creating two active SparkContext in JVM.
     // See SPARK-23019 and SparkContext.stop() for details.
-    eventually(Duration.ofSeconds(5), Duration.ofMillis(10), () -> {
-      assertTrue("SparkContext is still alive.", SparkContext$.MODULE$.getActive().isEmpty());
-    });
+    eventually(Duration.ofSeconds(5), Duration.ofMillis(10), () ->
+      assertTrue(SparkContext$.MODULE$.getActive().isEmpty(), "SparkContext is still alive."));
   }
 
   public static class SparkLauncherTestApp {

--- a/core/src/test/java/org/apache/spark/memory/TaskMemoryManagerSuite.java
+++ b/core/src/test/java/org/apache/spark/memory/TaskMemoryManagerSuite.java
@@ -17,8 +17,8 @@
 
 package org.apache.spark.memory;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.SparkConf;
 import org.apache.spark.unsafe.memory.MemoryAllocator;
@@ -38,8 +38,8 @@ public class TaskMemoryManagerSuite {
       0);
     final MemoryConsumer c = new TestMemoryConsumer(manager);
     manager.allocatePage(4096, c);  // leak memory
-    Assert.assertEquals(4096, manager.getMemoryConsumptionForThisTask());
-    Assert.assertEquals(4096, manager.cleanUpAllAllocatedMemory());
+    Assertions.assertEquals(4096, manager.getMemoryConsumptionForThisTask());
+    Assertions.assertEquals(4096, manager.cleanUpAllAllocatedMemory());
   }
 
   @Test
@@ -54,8 +54,8 @@ public class TaskMemoryManagerSuite {
     // encode. This test exercises that corner-case:
     final long offset = ((1L << TaskMemoryManager.OFFSET_BITS) + 10);
     final long encodedAddress = manager.encodePageNumberAndOffset(dataPage, offset);
-    Assert.assertEquals(null, manager.getPage(encodedAddress));
-    Assert.assertEquals(offset, manager.getOffsetInPage(encodedAddress));
+    Assertions.assertNull(manager.getPage(encodedAddress));
+    Assertions.assertEquals(offset, manager.getOffsetInPage(encodedAddress));
     manager.freePage(dataPage, c);
   }
 
@@ -67,8 +67,8 @@ public class TaskMemoryManagerSuite {
     final MemoryConsumer c = new TestMemoryConsumer(manager, MemoryMode.ON_HEAP);
     final MemoryBlock dataPage = manager.allocatePage(256, c);
     final long encodedAddress = manager.encodePageNumberAndOffset(dataPage, 64);
-    Assert.assertEquals(dataPage.getBaseObject(), manager.getPage(encodedAddress));
-    Assert.assertEquals(64, manager.getOffsetInPage(encodedAddress));
+    Assertions.assertEquals(dataPage.getBaseObject(), manager.getPage(encodedAddress));
+    Assertions.assertEquals(64, manager.getOffsetInPage(encodedAddress));
   }
 
   @Test
@@ -79,7 +79,7 @@ public class TaskMemoryManagerSuite {
     final MemoryConsumer c = new TestMemoryConsumer(manager, MemoryMode.ON_HEAP);
     final MemoryBlock dataPage = manager.allocatePage(256, c);
     c.freePage(dataPage);
-    Assert.assertEquals(MemoryBlock.FREED_IN_ALLOCATOR_PAGE_NUMBER, dataPage.pageNumber);
+    Assertions.assertEquals(MemoryBlock.FREED_IN_ALLOCATOR_PAGE_NUMBER, dataPage.pageNumber);
   }
 
   @Test
@@ -89,7 +89,7 @@ public class TaskMemoryManagerSuite {
         new SparkConf().set(package$.MODULE$.MEMORY_OFFHEAP_ENABLED(), false)), 0);
     final MemoryConsumer c = new TestMemoryConsumer(manager, MemoryMode.ON_HEAP);
     final MemoryBlock dataPage = manager.allocatePage(256, c);
-    Assert.assertThrows(AssertionError.class, () -> MemoryAllocator.HEAP.free(dataPage));
+    Assertions.assertThrows(AssertionError.class, () -> MemoryAllocator.HEAP.free(dataPage));
   }
 
   @Test
@@ -99,7 +99,7 @@ public class TaskMemoryManagerSuite {
         new SparkConf().set(package$.MODULE$.MEMORY_OFFHEAP_ENABLED(), false)), 0);
     final MemoryConsumer c = new TestMemoryConsumer(manager, MemoryMode.ON_HEAP);
     final MemoryBlock dataPage = MemoryAllocator.HEAP.allocate(256);
-    Assert.assertThrows(AssertionError.class, () -> manager.freePage(dataPage, c));
+    Assertions.assertThrows(AssertionError.class, () -> manager.freePage(dataPage, c));
   }
 
   @Test
@@ -111,37 +111,37 @@ public class TaskMemoryManagerSuite {
     TestMemoryConsumer c1 = new TestMemoryConsumer(manager);
     TestMemoryConsumer c2 = new TestMemoryConsumer(manager);
     c1.use(100);
-    Assert.assertEquals(100, c1.getUsed());
+    Assertions.assertEquals(100, c1.getUsed());
     c2.use(100);
-    Assert.assertEquals(100, c2.getUsed());
-    Assert.assertEquals(0, c1.getUsed());  // spilled
+    Assertions.assertEquals(100, c2.getUsed());
+    Assertions.assertEquals(0, c1.getUsed());  // spilled
     c1.use(100);
-    Assert.assertEquals(100, c1.getUsed());
-    Assert.assertEquals(0, c2.getUsed());  // spilled
+    Assertions.assertEquals(100, c1.getUsed());
+    Assertions.assertEquals(0, c2.getUsed());  // spilled
 
     c1.use(50);
-    Assert.assertEquals(50, c1.getUsed());  // spilled
-    Assert.assertEquals(0, c2.getUsed());
+    Assertions.assertEquals(50, c1.getUsed());  // spilled
+    Assertions.assertEquals(0, c2.getUsed());
     c2.use(50);
-    Assert.assertEquals(50, c1.getUsed());
-    Assert.assertEquals(50, c2.getUsed());
+    Assertions.assertEquals(50, c1.getUsed());
+    Assertions.assertEquals(50, c2.getUsed());
 
     c1.use(100);
-    Assert.assertEquals(100, c1.getUsed());
-    Assert.assertEquals(0, c2.getUsed());  // spilled
+    Assertions.assertEquals(100, c1.getUsed());
+    Assertions.assertEquals(0, c2.getUsed());  // spilled
 
     c1.free(20);
-    Assert.assertEquals(80, c1.getUsed());
+    Assertions.assertEquals(80, c1.getUsed());
     c2.use(10);
-    Assert.assertEquals(80, c1.getUsed());
-    Assert.assertEquals(10, c2.getUsed());
+    Assertions.assertEquals(80, c1.getUsed());
+    Assertions.assertEquals(10, c2.getUsed());
     c2.use(100);
-    Assert.assertEquals(100, c2.getUsed());
-    Assert.assertEquals(0, c1.getUsed());  // spilled
+    Assertions.assertEquals(100, c2.getUsed());
+    Assertions.assertEquals(0, c1.getUsed());  // spilled
 
     c1.free(0);
     c2.free(100);
-    Assert.assertEquals(0, manager.cleanUpAllAllocatedMemory());
+    Assertions.assertEquals(0, manager.cleanUpAllAllocatedMemory());
   }
 
   @Test
@@ -155,28 +155,29 @@ public class TaskMemoryManagerSuite {
     TestMemoryConsumer c3 = new TestMemoryConsumer(manager);
 
     c1.use(20);
-    Assert.assertEquals(20, c1.getUsed());
+    Assertions.assertEquals(20, c1.getUsed());
     c2.use(80);
-    Assert.assertEquals(80, c2.getUsed());
+    Assertions.assertEquals(80, c2.getUsed());
     c3.use(80);
-    Assert.assertEquals(20, c1.getUsed());  // c1: not spilled
-    Assert.assertEquals(0, c2.getUsed());   // c2: spilled as it has required size of memory
-    Assert.assertEquals(80, c3.getUsed());
+    Assertions.assertEquals(20, c1.getUsed());  // c1: not spilled
+    Assertions.assertEquals(0, c2.getUsed());   // c2: spilled as it has required size of memory
+    Assertions.assertEquals(80, c3.getUsed());
 
     c2.use(80);
-    Assert.assertEquals(20, c1.getUsed());  // c1: not spilled
-    Assert.assertEquals(0, c3.getUsed());   // c3: spilled as it has required size of memory
-    Assert.assertEquals(80, c2.getUsed());
+    Assertions.assertEquals(20, c1.getUsed());  // c1: not spilled
+    Assertions.assertEquals(0, c3.getUsed());   // c3: spilled as it has required size of memory
+    Assertions.assertEquals(80, c2.getUsed());
 
     c3.use(10);
-    Assert.assertEquals(0, c1.getUsed());   // c1: spilled as it has required size of memory
-    Assert.assertEquals(80, c2.getUsed());  // c2: not spilled as spilling c1 already satisfies c3
-    Assert.assertEquals(10, c3.getUsed());
+    Assertions.assertEquals(0, c1.getUsed());   // c1: spilled as it has required size of memory
+    Assertions
+      .assertEquals(80, c2.getUsed());  // c2: not spilled as spilling c1 already satisfies c3
+    Assertions.assertEquals(10, c3.getUsed());
 
     c1.free(0);
     c2.free(80);
     c3.free(10);
-    Assert.assertEquals(0, manager.cleanUpAllAllocatedMemory());
+    Assertions.assertEquals(0, manager.cleanUpAllAllocatedMemory());
   }
 
 
@@ -197,17 +198,17 @@ public class TaskMemoryManagerSuite {
     c2.use(40);
     c3.use(10);
     c1.use(50);
-    Assert.assertEquals(100, c1.getUsed());
-    Assert.assertEquals(0, c2.getUsed());
-    Assert.assertEquals(0, c3.getUsed());
+    Assertions.assertEquals(100, c1.getUsed());
+    Assertions.assertEquals(0, c2.getUsed());
+    Assertions.assertEquals(0, c3.getUsed());
     // Force a self-spill.
     c1.use(50);
-    Assert.assertEquals(50, c1.getUsed());
+    Assertions.assertEquals(50, c1.getUsed());
     // Force a self-spill after c2 is spilled.
     c2.use(10);
     c1.use(60);
-    Assert.assertEquals(60, c1.getUsed());
-    Assert.assertEquals(0, c2.getUsed());
+    Assertions.assertEquals(60, c1.getUsed());
+    Assertions.assertEquals(0, c2.getUsed());
 
     c1.free(c1.getUsed());
 
@@ -216,9 +217,9 @@ public class TaskMemoryManagerSuite {
     c2.use(40);
     c3.use(10);
     c3.use(50);
-    Assert.assertEquals(0, c1.getUsed());
-    Assert.assertEquals(40, c2.getUsed());
-    Assert.assertEquals(60, c3.getUsed());
+    Assertions.assertEquals(0, c1.getUsed());
+    Assertions.assertEquals(40, c2.getUsed());
+    Assertions.assertEquals(60, c3.getUsed());
   }
 
   @Test
@@ -238,24 +239,24 @@ public class TaskMemoryManagerSuite {
     c2.use(40);
     c3.use(10);
     c4.use(5);
-    Assert.assertEquals(50, c1.getUsed());
-    Assert.assertEquals(40, c2.getUsed());
-    Assert.assertEquals(0, c3.getUsed());
-    Assert.assertEquals(5, c4.getUsed());
+    Assertions.assertEquals(50, c1.getUsed());
+    Assertions.assertEquals(40, c2.getUsed());
+    Assertions.assertEquals(0, c3.getUsed());
+    Assertions.assertEquals(5, c4.getUsed());
 
     // Allocate 45. 5 is unused and 40 will come from c2.
     c3.use(45);
-    Assert.assertEquals(50, c1.getUsed());
-    Assert.assertEquals(0, c2.getUsed());
-    Assert.assertEquals(45, c3.getUsed());
-    Assert.assertEquals(5, c4.getUsed());
+    Assertions.assertEquals(50, c1.getUsed());
+    Assertions.assertEquals(0, c2.getUsed());
+    Assertions.assertEquals(45, c3.getUsed());
+    Assertions.assertEquals(5, c4.getUsed());
 
     // Allocate 51. 50 is taken from c1, then c4 is the best fit to get 1 more byte.
     c2.use(51);
-    Assert.assertEquals(0, c1.getUsed());
-    Assert.assertEquals(51, c2.getUsed());
-    Assert.assertEquals(45, c3.getUsed());
-    Assert.assertEquals(0, c4.getUsed());
+    Assertions.assertEquals(0, c1.getUsed());
+    Assertions.assertEquals(51, c2.getUsed());
+    Assertions.assertEquals(45, c3.getUsed());
+    Assertions.assertEquals(0, c4.getUsed());
   }
 
   @Test
@@ -267,14 +268,14 @@ public class TaskMemoryManagerSuite {
     TestMemoryConsumer c1 = new TestMemoryConsumer(manager, MemoryMode.ON_HEAP);
     TestMemoryConsumer c2 = new TestMemoryConsumer(manager, MemoryMode.OFF_HEAP);
     c1.use(80);
-    Assert.assertEquals(80, c1.getUsed());
+    Assertions.assertEquals(80, c1.getUsed());
     c2.use(80);
-    Assert.assertEquals(20, c2.getUsed());  // not enough memory
-    Assert.assertEquals(80, c1.getUsed());  // not spilled
+    Assertions.assertEquals(20, c2.getUsed());  // not enough memory
+    Assertions.assertEquals(80, c1.getUsed());  // not spilled
 
     c2.use(10);
-    Assert.assertEquals(10, c2.getUsed());  // spilled
-    Assert.assertEquals(80, c1.getUsed());  // not spilled
+    Assertions.assertEquals(10, c2.getUsed());  // spilled
+    Assertions.assertEquals(80, c1.getUsed());  // not spilled
   }
 
   @Test
@@ -285,7 +286,7 @@ public class TaskMemoryManagerSuite {
       .set("spark.unsafe.offHeap", "true")
       .set(package$.MODULE$.MEMORY_OFFHEAP_SIZE(), 1000L);
     final TaskMemoryManager manager = new TaskMemoryManager(new TestMemoryManager(conf), 0);
-    Assert.assertSame(MemoryMode.OFF_HEAP, manager.tungstenMemoryMode);
+    Assertions.assertSame(MemoryMode.OFF_HEAP, manager.tungstenMemoryMode);
   }
 
 }

--- a/core/src/test/java/org/apache/spark/resource/JavaResourceProfileSuite.java
+++ b/core/src/test/java/org/apache/spark/resource/JavaResourceProfileSuite.java
@@ -19,8 +19,8 @@ package org.apache.spark.resource;
 
 import java.util.Map;
 
-import static org.junit.Assert.*;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 // Test the ResourceProfile and Request api's from Java
 public class JavaResourceProfileSuite {

--- a/core/src/test/java/org/apache/spark/shuffle/sort/PackedRecordPointerSuite.java
+++ b/core/src/test/java/org/apache/spark/shuffle/sort/PackedRecordPointerSuite.java
@@ -19,7 +19,7 @@ package org.apache.spark.shuffle.sort;
 
 import java.io.IOException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.SparkConf;
 import org.apache.spark.internal.config.package$;
@@ -28,9 +28,9 @@ import org.apache.spark.unsafe.memory.MemoryBlock;
 
 import static org.apache.spark.shuffle.sort.PackedRecordPointer.MAXIMUM_PAGE_SIZE_BYTES;
 import static org.apache.spark.shuffle.sort.PackedRecordPointer.MAXIMUM_PARTITION_ID;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class PackedRecordPointerSuite {
 

--- a/core/src/test/java/org/apache/spark/shuffle/sort/ShuffleInMemorySorterSuite.java
+++ b/core/src/test/java/org/apache/spark/shuffle/sort/ShuffleInMemorySorterSuite.java
@@ -21,8 +21,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Random;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.HashPartitioner;
 import org.apache.spark.SparkConf;
@@ -54,11 +54,11 @@ public class ShuffleInMemorySorterSuite {
     final ShuffleInMemorySorter sorter = new ShuffleInMemorySorter(
       consumer, 100, shouldUseRadixSort());
     final ShuffleInMemorySorter.ShuffleSorterIterator iter = sorter.getSortedIterator();
-    Assert.assertFalse(iter.hasNext());
+    Assertions.assertFalse(iter.hasNext());
   }
 
   @Test
-  public void testBasicSorting() throws Exception {
+  public void testBasicSorting() {
     final String[] dataToSort = new String[] {
       "Boba",
       "Pearls",
@@ -102,12 +102,12 @@ public class ShuffleInMemorySorterSuite {
     int prevPartitionId = -1;
     Arrays.sort(dataToSort);
     for (int i = 0; i < dataToSort.length; i++) {
-      Assert.assertTrue(iter.hasNext());
+      Assertions.assertTrue(iter.hasNext());
       iter.loadNext();
       final int partitionId = iter.packedRecordPointer.getPartitionId();
-      Assert.assertTrue(partitionId >= 0 && partitionId <= 3);
-      Assert.assertTrue("Partition id " + partitionId + " should be >= prev id " + prevPartitionId,
-        partitionId >= prevPartitionId);
+      Assertions.assertTrue(partitionId >= 0 && partitionId <= 3);
+      Assertions.assertTrue(partitionId >= prevPartitionId,
+        "Partition id " + partitionId + " should be >= prev id " + prevPartitionId);
       final long recordAddress = iter.packedRecordPointer.getRecordPointer();
       final int recordLength = Platform.getInt(
         memoryManager.getPage(recordAddress), memoryManager.getOffsetInPage(recordAddress));
@@ -115,13 +115,13 @@ public class ShuffleInMemorySorterSuite {
         memoryManager.getPage(recordAddress),
         memoryManager.getOffsetInPage(recordAddress) + 4, // skip over record length
         recordLength);
-      Assert.assertTrue(Arrays.binarySearch(dataToSort, str) != -1);
+      Assertions.assertTrue(Arrays.binarySearch(dataToSort, str) != -1);
     }
-    Assert.assertFalse(iter.hasNext());
+    Assertions.assertFalse(iter.hasNext());
   }
 
   @Test
-  public void testSortingManyNumbers() throws Exception {
+  public void testSortingManyNumbers() {
     ShuffleInMemorySorter sorter = new ShuffleInMemorySorter(consumer, 4, shouldUseRadixSort());
     int[] numbersToSort = new int[128000];
     Random random = new Random(16);
@@ -141,6 +141,6 @@ public class ShuffleInMemorySorterSuite {
       sorterResult[j] = iter.packedRecordPointer.getPartitionId();
       j += 1;
     }
-    Assert.assertArrayEquals(numbersToSort, sorterResult);
+    Assertions.assertArrayEquals(numbersToSort, sorterResult);
   }
 }

--- a/core/src/test/java/org/apache/spark/shuffle/sort/UnsafeShuffleWriterSuite.java
+++ b/core/src/test/java/org/apache/spark/shuffle/sort/UnsafeShuffleWriterSuite.java
@@ -30,9 +30,9 @@ import scala.*;
 import scala.collection.Iterator;
 
 import com.google.common.collect.HashMultiset;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -54,7 +54,7 @@ import org.apache.spark.shuffle.sort.io.LocalDiskShuffleExecutorComponents;
 import org.apache.spark.storage.*;
 import org.apache.spark.util.Utils;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Answers.RETURNS_SMART_NULLS;
 import static org.mockito.Mockito.*;
 
@@ -80,7 +80,7 @@ public class UnsafeShuffleWriterSuite implements ShuffleChecksumTestHelper {
   @Mock(answer = RETURNS_SMART_NULLS) TaskContext taskContext;
   @Mock(answer = RETURNS_SMART_NULLS) ShuffleDependency<Object, Object, Object> shuffleDep;
 
-  @After
+  @AfterEach
   public void tearDown() {
     Utils.deleteRecursively(tempDir);
     final long leakedMemory = taskMemoryManager.cleanUpAllAllocatedMemory();
@@ -89,7 +89,7 @@ public class UnsafeShuffleWriterSuite implements ShuffleChecksumTestHelper {
     }
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     MockitoAnnotations.openMocks(this).close();
     tempDir = Utils.createTempDir(null, "test");
@@ -198,8 +198,8 @@ public class UnsafeShuffleWriterSuite implements ShuffleChecksumTestHelper {
 
   private void assertSpillFilesWereCleanedUp() {
     for (File spillFile : spillFilesCreated) {
-      assertFalse("Spill file " + spillFile.getPath() + " was not cleaned up",
-        spillFile.exists());
+      assertFalse(spillFile.exists(),
+        "Spill file " + spillFile.getPath() + " was not cleaned up");
     }
   }
 
@@ -236,7 +236,7 @@ public class UnsafeShuffleWriterSuite implements ShuffleChecksumTestHelper {
   }
 
   @Test
-  public void doNotNeedToCallWriteBeforeUnsuccessfulStop() throws IOException, SparkException {
+  public void doNotNeedToCallWriteBeforeUnsuccessfulStop() throws SparkException {
     createWriter(false).stop(false);
   }
 

--- a/core/src/test/java/org/apache/spark/util/SerializableConfigurationSuite.java
+++ b/core/src/test/java/org/apache/spark/util/SerializableConfigurationSuite.java
@@ -19,25 +19,25 @@ package org.apache.spark.util;
 import java.util.Arrays;
 
 import org.apache.hadoop.conf.Configuration;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 
 public class SerializableConfigurationSuite {
   private transient JavaSparkContext sc;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     sc = new JavaSparkContext("local", "SerializableConfigurationSuite");
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     sc.stop();
     sc = null;

--- a/core/src/test/java/org/apache/spark/util/collection/unsafe/sort/UnsafeExternalSorterSuite.java
+++ b/core/src/test/java/org/apache/spark/util/collection/unsafe/sort/UnsafeExternalSorterSuite.java
@@ -25,9 +25,9 @@ import java.util.UUID;
 
 import scala.Tuple2$;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -45,7 +45,7 @@ import org.apache.spark.storage.*;
 import org.apache.spark.unsafe.Platform;
 import org.apache.spark.util.Utils;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Answers.RETURNS_SMART_NULLS;
 import static org.mockito.Mockito.*;
 
@@ -90,7 +90,7 @@ public class UnsafeExternalSorterSuite {
   private final int spillThreshold =
     (int) conf.get(package$.MODULE$.SHUFFLE_SPILL_NUM_ELEMENTS_FORCE_SPILL_THRESHOLD());
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     MockitoAnnotations.openMocks(this).close();
     tempDir = Utils.createTempDir(System.getProperty("java.io.tmpdir"), "unsafe-test");
@@ -124,7 +124,7 @@ public class UnsafeExternalSorterSuite {
       });
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     try {
       assertEquals(0L, taskMemoryManager.cleanUpAllAllocatedMemory());
@@ -136,8 +136,8 @@ public class UnsafeExternalSorterSuite {
 
   private void assertSpillFilesWereCleanedUp() {
     for (File spillFile : spillFilesCreated) {
-      assertFalse("Spill file " + spillFile.getPath() + " was not cleaned up",
-        spillFile.exists());
+      assertFalse(spillFile.exists(),
+        "Spill file " + spillFile.getPath() + " was not cleaned up");
     }
   }
 

--- a/core/src/test/java/org/apache/spark/util/collection/unsafe/sort/UnsafeInMemorySorterSuite.java
+++ b/core/src/test/java/org/apache/spark/util/collection/unsafe/sort/UnsafeInMemorySorterSuite.java
@@ -21,8 +21,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 import org.apache.spark.unsafe.array.LongArray;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.HashPartitioner;
 import org.apache.spark.SparkConf;
@@ -33,8 +33,8 @@ import org.apache.spark.unsafe.Platform;
 import org.apache.spark.unsafe.memory.MemoryBlock;
 import org.apache.spark.internal.config.package$;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 public class UnsafeInMemorySorterSuite {
@@ -60,7 +60,7 @@ public class UnsafeInMemorySorterSuite {
       100,
       shouldUseRadixSort());
     final UnsafeSorterIterator iter = sorter.getSortedIterator();
-    Assert.assertFalse(iter.hasNext());
+    Assertions.assertFalse(iter.hasNext());
   }
 
   @Test
@@ -175,7 +175,7 @@ public class UnsafeInMemorySorterSuite {
     testMemoryManager.markconsequentOOM(Integer.MAX_VALUE);
     sorter.freeMemory();
     testMemoryManager.resetConsequentOOM();
-    Assert.assertFalse(sorter.hasSpaceForAnotherRecord());
+    Assertions.assertFalse(sorter.hasSpaceForAnotherRecord());
 
     // Get the sorter in an usable state again by allocating a new pointer array.
     LongArray array = consumer.allocateArray(1000);
@@ -186,7 +186,7 @@ public class UnsafeInMemorySorterSuite {
     sorter.freeMemory();
     sorter.freeMemory();
     testMemoryManager.resetConsequentOOM();
-    Assert.assertFalse(sorter.hasSpaceForAnotherRecord());
+    Assertions.assertFalse(sorter.hasSpaceForAnotherRecord());
 
     assertEquals(0L, memoryManager.cleanUpAllAllocatedMemory());
   }

--- a/core/src/test/java/test/org/apache/spark/Java8RDDAPISuite.java
+++ b/core/src/test/java/test/org/apache/spark/Java8RDDAPISuite.java
@@ -28,10 +28,10 @@ import com.google.common.collect.Iterables;
 import org.apache.hadoop.io.IntWritable;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapred.SequenceFileOutputFormat;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.api.java.JavaDoubleRDD;
 import org.apache.spark.api.java.JavaPairRDD;
@@ -49,12 +49,12 @@ public class Java8RDDAPISuite implements Serializable {
   private static int foreachCalls = 0;
   private transient JavaSparkContext sc;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     sc = new JavaSparkContext("local", "JavaAPISuite");
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     sc.stop();
     sc = null;
@@ -65,7 +65,7 @@ public class Java8RDDAPISuite implements Serializable {
     foreachCalls = 0;
     JavaRDD<String> rdd = sc.parallelize(Arrays.asList("Hello", "World"));
     rdd.foreach(s -> foreachCalls++);
-    Assert.assertEquals(2, foreachCalls);
+    Assertions.assertEquals(2, foreachCalls);
   }
 
   @Test
@@ -73,7 +73,7 @@ public class Java8RDDAPISuite implements Serializable {
     foreachCalls = 0;
     JavaRDD<String> rdd = sc.parallelize(Arrays.asList("Hello", "World"));
     rdd.foreach(x -> foreachCalls++);
-    Assert.assertEquals(2, foreachCalls);
+    Assertions.assertEquals(2, foreachCalls);
   }
 
   @Test
@@ -81,14 +81,14 @@ public class Java8RDDAPISuite implements Serializable {
     JavaRDD<Integer> rdd = sc.parallelize(Arrays.asList(1, 1, 2, 3, 5, 8, 13));
     Function<Integer, Boolean> isOdd = x -> x % 2 == 0;
     JavaPairRDD<Boolean, Iterable<Integer>> oddsAndEvens = rdd.groupBy(isOdd);
-    Assert.assertEquals(2, oddsAndEvens.count());
-    Assert.assertEquals(2, Iterables.size(oddsAndEvens.lookup(true).get(0)));  // Evens
-    Assert.assertEquals(5, Iterables.size(oddsAndEvens.lookup(false).get(0))); // Odds
+    Assertions.assertEquals(2, oddsAndEvens.count());
+    Assertions.assertEquals(2, Iterables.size(oddsAndEvens.lookup(true).get(0)));  // Evens
+    Assertions.assertEquals(5, Iterables.size(oddsAndEvens.lookup(false).get(0))); // Odds
 
     oddsAndEvens = rdd.groupBy(isOdd, 1);
-    Assert.assertEquals(2, oddsAndEvens.count());
-    Assert.assertEquals(2, Iterables.size(oddsAndEvens.lookup(true).get(0)));  // Evens
-    Assert.assertEquals(5, Iterables.size(oddsAndEvens.lookup(false).get(0))); // Odds
+    Assertions.assertEquals(2, oddsAndEvens.count());
+    Assertions.assertEquals(2, Iterables.size(oddsAndEvens.lookup(true).get(0)));  // Evens
+    Assertions.assertEquals(5, Iterables.size(oddsAndEvens.lookup(false).get(0))); // Odds
   }
 
   @Test
@@ -107,10 +107,10 @@ public class Java8RDDAPISuite implements Serializable {
     ));
     List<Tuple2<Integer, Tuple2<Integer, Optional<Character>>>> joined =
       rdd1.leftOuterJoin(rdd2).collect();
-    Assert.assertEquals(5, joined.size());
+    Assertions.assertEquals(5, joined.size());
     Tuple2<Integer, Tuple2<Integer, Optional<Character>>> firstUnmatched =
       rdd1.leftOuterJoin(rdd2).filter(tup -> !tup._2()._2().isPresent()).first();
-    Assert.assertEquals(3, firstUnmatched._1().intValue());
+    Assertions.assertEquals(3, firstUnmatched._1().intValue());
   }
 
   @Test
@@ -119,10 +119,10 @@ public class Java8RDDAPISuite implements Serializable {
     Function2<Integer, Integer, Integer> add = (a, b) -> a + b;
 
     int sum = rdd.fold(0, add);
-    Assert.assertEquals(33, sum);
+    Assertions.assertEquals(33, sum);
 
     sum = rdd.reduce(add);
-    Assert.assertEquals(33, sum);
+    Assertions.assertEquals(33, sum);
   }
 
   @Test
@@ -136,9 +136,9 @@ public class Java8RDDAPISuite implements Serializable {
     );
     JavaPairRDD<Integer, Integer> rdd = sc.parallelizePairs(pairs);
     JavaPairRDD<Integer, Integer> sums = rdd.foldByKey(0, (a, b) -> a + b);
-    Assert.assertEquals(1, sums.lookup(1).get(0).intValue());
-    Assert.assertEquals(2, sums.lookup(2).get(0).intValue());
-    Assert.assertEquals(3, sums.lookup(3).get(0).intValue());
+    Assertions.assertEquals(1, sums.lookup(1).get(0).intValue());
+    Assertions.assertEquals(2, sums.lookup(2).get(0).intValue());
+    Assertions.assertEquals(3, sums.lookup(3).get(0).intValue());
   }
 
   @Test
@@ -152,19 +152,19 @@ public class Java8RDDAPISuite implements Serializable {
     );
     JavaPairRDD<Integer, Integer> rdd = sc.parallelizePairs(pairs);
     JavaPairRDD<Integer, Integer> counts = rdd.reduceByKey((a, b) -> a + b);
-    Assert.assertEquals(1, counts.lookup(1).get(0).intValue());
-    Assert.assertEquals(2, counts.lookup(2).get(0).intValue());
-    Assert.assertEquals(3, counts.lookup(3).get(0).intValue());
+    Assertions.assertEquals(1, counts.lookup(1).get(0).intValue());
+    Assertions.assertEquals(2, counts.lookup(2).get(0).intValue());
+    Assertions.assertEquals(3, counts.lookup(3).get(0).intValue());
 
     Map<Integer, Integer> localCounts = counts.collectAsMap();
-    Assert.assertEquals(1, localCounts.get(1).intValue());
-    Assert.assertEquals(2, localCounts.get(2).intValue());
-    Assert.assertEquals(3, localCounts.get(3).intValue());
+    Assertions.assertEquals(1, localCounts.get(1).intValue());
+    Assertions.assertEquals(2, localCounts.get(2).intValue());
+    Assertions.assertEquals(3, localCounts.get(3).intValue());
 
     localCounts = rdd.reduceByKeyLocally((a, b) -> a + b);
-    Assert.assertEquals(1, localCounts.get(1).intValue());
-    Assert.assertEquals(2, localCounts.get(2).intValue());
-    Assert.assertEquals(3, localCounts.get(3).intValue());
+    Assertions.assertEquals(1, localCounts.get(1).intValue());
+    Assertions.assertEquals(2, localCounts.get(2).intValue());
+    Assertions.assertEquals(3, localCounts.get(3).intValue());
   }
 
   @Test
@@ -185,8 +185,8 @@ public class Java8RDDAPISuite implements Serializable {
       "The quick brown fox jumps over the lazy dog."));
     JavaRDD<String> words = rdd.flatMap(x -> Arrays.asList(x.split(" ")).iterator());
 
-    Assert.assertEquals("Hello", words.first());
-    Assert.assertEquals(11, words.count());
+    Assertions.assertEquals("Hello", words.first());
+    Assertions.assertEquals(11, words.count());
 
     JavaPairRDD<String, String> pairs = rdd.flatMapToPair(s -> {
       List<Tuple2<String, String>> pairs2 = new LinkedList<>();
@@ -196,8 +196,8 @@ public class Java8RDDAPISuite implements Serializable {
       return pairs2.iterator();
     });
 
-    Assert.assertEquals(new Tuple2<>("Hello", "Hello"), pairs.first());
-    Assert.assertEquals(11, pairs.count());
+    Assertions.assertEquals(new Tuple2<>("Hello", "Hello"), pairs.first());
+    Assertions.assertEquals(11, pairs.count());
 
     JavaDoubleRDD doubles = rdd.flatMapToDouble(s -> {
       List<Double> lengths = new LinkedList<>();
@@ -207,8 +207,8 @@ public class Java8RDDAPISuite implements Serializable {
       return lengths.iterator();
     });
 
-    Assert.assertEquals(5.0, doubles.first(), 0.01);
-    Assert.assertEquals(11, pairs.count());
+    Assertions.assertEquals(5.0, doubles.first(), 0.01);
+    Assertions.assertEquals(11, pairs.count());
   }
 
   @Test
@@ -240,7 +240,7 @@ public class Java8RDDAPISuite implements Serializable {
       return Collections.singletonList(sum).iterator();
     });
 
-    Assert.assertEquals("[3, 7]", partitionSums.collect().toString());
+    Assertions.assertEquals("[3, 7]", partitionSums.collect().toString());
   }
 
   @Test
@@ -261,7 +261,7 @@ public class Java8RDDAPISuite implements Serializable {
     // Try reading the output back as an object file
     JavaPairRDD<Integer, String> readRDD = sc.sequenceFile(outputDir, IntWritable.class, Text.class)
       .mapToPair(pair -> new Tuple2<>(pair._1().get(), pair._2().toString()));
-    Assert.assertEquals(pairs, readRDD.collect());
+    Assertions.assertEquals(pairs, readRDD.collect());
     Utils.deleteRecursively(tempDir);
   }
 
@@ -292,15 +292,15 @@ public class Java8RDDAPISuite implements Serializable {
         return Arrays.asList(sizeI, sizeS).iterator();
       };
     JavaRDD<Integer> sizes = rdd1.zipPartitions(rdd2, sizesFn);
-    Assert.assertEquals("[3, 2, 3, 2]", sizes.collect().toString());
+    Assertions.assertEquals("[3, 2, 3, 2]", sizes.collect().toString());
   }
 
   @Test
   public void keyBy() {
     JavaRDD<Integer> rdd = sc.parallelize(Arrays.asList(1, 2));
     List<Tuple2<String, Integer>> s = rdd.keyBy(Object::toString).collect();
-    Assert.assertEquals(new Tuple2<>("1", 1), s.get(0));
-    Assert.assertEquals(new Tuple2<>("2", 2), s.get(1));
+    Assertions.assertEquals(new Tuple2<>("1", 1), s.get(0));
+    Assertions.assertEquals(new Tuple2<>("2", 2), s.get(1));
   }
 
   @Test
@@ -310,7 +310,7 @@ public class Java8RDDAPISuite implements Serializable {
       rdd1.mapToPair(i -> new Tuple2<>(i, i % 2));
     JavaPairRDD<Integer, Integer> rdd3 =
       rdd2.mapToPair(in -> new Tuple2<>(in._2(), in._1()));
-    Assert.assertEquals(Arrays.asList(
+    Assertions.assertEquals(Arrays.asList(
       new Tuple2<>(1, 1),
       new Tuple2<>(0, 2),
       new Tuple2<>(1, 3),
@@ -324,19 +324,19 @@ public class Java8RDDAPISuite implements Serializable {
     JavaPairRDD<Integer, Integer> rdd2 =
       rdd1.mapToPair(i -> new Tuple2<>(i, i % 2));
     List<Integer>[] parts = rdd1.collectPartitions(new int[]{0});
-    Assert.assertEquals(Arrays.asList(1, 2), parts[0]);
+    Assertions.assertEquals(Arrays.asList(1, 2), parts[0]);
 
     parts = rdd1.collectPartitions(new int[]{1, 2});
-    Assert.assertEquals(Arrays.asList(3, 4), parts[0]);
-    Assert.assertEquals(Arrays.asList(5, 6, 7), parts[1]);
+    Assertions.assertEquals(Arrays.asList(3, 4), parts[0]);
+    Assertions.assertEquals(Arrays.asList(5, 6, 7), parts[1]);
 
-    Assert.assertEquals(Arrays.asList(new Tuple2<>(1, 1), new Tuple2<>(2, 0)),
+    Assertions.assertEquals(Arrays.asList(new Tuple2<>(1, 1), new Tuple2<>(2, 0)),
       rdd2.collectPartitions(new int[]{0})[0]);
 
     List<Tuple2<Integer, Integer>>[] parts2 = rdd2.collectPartitions(new int[]{1, 2});
-    Assert.assertEquals(Arrays.asList(new Tuple2<>(3, 1), new Tuple2<>(4, 0)), parts2[0]);
-    Assert.assertEquals(Arrays.asList(new Tuple2<>(5, 1), new Tuple2<>(6, 0), new Tuple2<>(7, 1)),
-      parts2[1]);
+    Assertions.assertEquals(Arrays.asList(new Tuple2<>(3, 1), new Tuple2<>(4, 0)), parts2[0]);
+    Assertions.assertEquals(
+      Arrays.asList(new Tuple2<>(5, 1), new Tuple2<>(6, 0), new Tuple2<>(7, 1)), parts2[1]);
   }
 
   @Test

--- a/core/src/test/java/test/org/apache/spark/JavaAPISuite.java
+++ b/core/src/test/java/test/org/apache/spark/JavaAPISuite.java
@@ -57,10 +57,10 @@ import org.apache.hadoop.io.compress.DefaultCodec;
 import org.apache.hadoop.mapred.SequenceFileInputFormat;
 import org.apache.hadoop.mapred.SequenceFileOutputFormat;
 import org.apache.hadoop.mapreduce.Job;
-import org.junit.After;
-import static org.junit.Assert.*;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.api.java.JavaDoubleRDD;
 import org.apache.spark.api.java.JavaFutureAction;
@@ -90,14 +90,14 @@ public class JavaAPISuite implements Serializable {
   private transient JavaSparkContext sc;
   private transient File tempDir;
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException {
     sc = new JavaSparkContext("local", "JavaAPISuite");
     tempDir = Utils.createTempDir();
     tempDir.deleteOnExit();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     sc.stop();
     sc = null;
@@ -187,9 +187,9 @@ public class JavaAPISuite implements Serializable {
     long s0 = splits[0].count();
     long s1 = splits[1].count();
     long s2 = splits[2].count();
-    assertTrue(s0 + " not within expected range", s0 > 150 && s0 < 250);
-    assertTrue(s1 + " not within expected range", s1 > 250 && s1 < 350);
-    assertTrue(s2 + " not within expected range", s2 > 430 && s2 < 570);
+    assertTrue(s0 > 150 && s0 < 250, s0 + " not within expected range");
+    assertTrue(s1 > 250 && s1 < 350, s1 + " not within expected range");
+    assertTrue(s2 > 430 && s2 < 570, s2 + " not within expected range");
   }
 
   @Test
@@ -281,7 +281,7 @@ public class JavaAPISuite implements Serializable {
   @Test
   public void emptyRDD() {
     JavaRDD<String> rdd = sc.emptyRDD();
-    assertEquals("Empty RDD shouldn't have any values", 0, rdd.count());
+    assertEquals(0, rdd.count(), "Empty RDD shouldn't have any values");
   }
 
   @Test

--- a/core/src/test/java/test/org/apache/spark/JavaSparkContextSuite.java
+++ b/core/src/test/java/test/org/apache/spark/JavaSparkContextSuite.java
@@ -24,7 +24,7 @@ import scala.collection.immutable.List$;
 import scala.collection.immutable.Map;
 import scala.collection.immutable.Map$;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.api.java.*;
 import org.apache.spark.*;

--- a/launcher/src/test/java/org/apache/spark/launcher/BaseSuite.java
+++ b/launcher/src/test/java/org/apache/spark/launcher/BaseSuite.java
@@ -19,9 +19,9 @@ package org.apache.spark.launcher;
 
 import java.time.Duration;
 
-import org.junit.After;
+import org.junit.jupiter.api.AfterEach;
 import org.slf4j.bridge.SLF4JBridgeHandler;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Handles configuring the JUL -> SLF4J bridge, and provides some utility methods for tests.
@@ -33,7 +33,7 @@ class BaseSuite {
     SLF4JBridgeHandler.install();
   }
 
-  @After
+  @AfterEach
   public void postChecks() {
     LauncherServer server = LauncherServer.getServer();
     if (server != null) {
@@ -50,7 +50,7 @@ class BaseSuite {
   protected void waitFor(final SparkAppHandle handle) throws Exception {
     try {
       eventually(Duration.ofSeconds(10), Duration.ofMillis(10), () -> {
-        assertTrue("Handle is not in final state.", handle.getState().isFinal());
+        assertTrue(handle.getState().isFinal(), "Handle is not in final state.");
       });
     } finally {
       if (!handle.getState().isFinal()) {
@@ -62,7 +62,7 @@ class BaseSuite {
     // have been performed.
     AbstractAppHandle ahandle = (AbstractAppHandle) handle;
     eventually(Duration.ofSeconds(10), Duration.ofMillis(10), () -> {
-      assertTrue("Handle is still not marked as disposed.", ahandle.isDisposed());
+      assertTrue(ahandle.isDisposed(), "Handle is still not marked as disposed.");
     });
   }
 
@@ -71,7 +71,7 @@ class BaseSuite {
    * elapses.
    */
   protected void eventually(Duration timeout, Duration period, Runnable check) throws Exception {
-    assertTrue("Timeout needs to be larger than period.", timeout.compareTo(period) > 0);
+    assertTrue(timeout.compareTo(period) > 0, "Timeout needs to be larger than period.");
     long deadline = System.nanoTime() + timeout.toNanos();
     int count = 0;
     while (true) {

--- a/launcher/src/test/java/org/apache/spark/launcher/ChildProcAppHandleSuite.java
+++ b/launcher/src/test/java/org/apache/spark/launcher/ChildProcAppHandleSuite.java
@@ -34,12 +34,12 @@ import org.apache.logging.log4j.core.Filter;
 import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.appender.AbstractAppender;
 import org.apache.logging.log4j.core.LogEvent;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import static org.junit.Assert.*;
-import static org.junit.Assume.*;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
 
 import static org.apache.spark.launcher.CommandBuilderUtils.*;
 
@@ -56,7 +56,7 @@ public class ChildProcAppHandleSuite extends BaseSuite {
 
   private static File TEST_SCRIPT_PATH;
 
-  @AfterClass
+  @AfterAll
   public static void cleanupClass() throws Exception {
     if (TEST_SCRIPT_PATH != null) {
       TEST_SCRIPT_PATH.delete();
@@ -64,7 +64,7 @@ public class ChildProcAppHandleSuite extends BaseSuite {
     }
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setupClass() throws Exception {
     TEST_SCRIPT_PATH = File.createTempFile("output-redir-test", ".sh");
     Files.setPosixFilePermissions(TEST_SCRIPT_PATH.toPath(),
@@ -72,7 +72,7 @@ public class ChildProcAppHandleSuite extends BaseSuite {
     Files.write(TEST_SCRIPT_PATH.toPath(), TEST_SCRIPT);
   }
 
-  @Before
+  @BeforeEach
   public void cleanupLog() {
     MESSAGES.clear();
   }

--- a/launcher/src/test/java/org/apache/spark/launcher/CommandBuilderUtilsSuite.java
+++ b/launcher/src/test/java/org/apache/spark/launcher/CommandBuilderUtilsSuite.java
@@ -21,8 +21,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 import static org.apache.spark.launcher.CommandBuilderUtils.*;
 
@@ -100,8 +100,8 @@ public class CommandBuilderUtilsSuite {
   }
 
   private static void testOpt(String opts, List<String> expected) {
-    assertEquals(String.format("test string failed to parse: [[ %s ]]", opts),
-        expected, parseOptionString(opts));
+    assertEquals(expected, parseOptionString(opts),
+      String.format("test string failed to parse: [[ %s ]]", opts));
   }
 
   private static void testInvalidOpt(String opts) {

--- a/launcher/src/test/java/org/apache/spark/launcher/InProcessLauncherSuite.java
+++ b/launcher/src/test/java/org/apache/spark/launcher/InProcessLauncherSuite.java
@@ -23,9 +23,9 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.Before;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class InProcessLauncherSuite extends BaseSuite {
 
@@ -38,7 +38,7 @@ public class InProcessLauncherSuite extends BaseSuite {
 
   private static Throwable lastError;
 
-  @Before
+  @BeforeEach
   public void testSetup() {
     lastError = null;
   }

--- a/launcher/src/test/java/org/apache/spark/launcher/LauncherServerSuite.java
+++ b/launcher/src/test/java/org/apache/spark/launcher/LauncherServerSuite.java
@@ -32,8 +32,8 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 import static org.apache.spark.launcher.LauncherProtocol.*;
 

--- a/launcher/src/test/java/org/apache/spark/launcher/SparkClassCommandBuilderSuite.java
+++ b/launcher/src/test/java/org/apache/spark/launcher/SparkClassCommandBuilderSuite.java
@@ -21,9 +21,9 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class SparkClassCommandBuilderSuite extends BaseSuite {
 

--- a/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitCommandBuilderSuite.java
+++ b/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitCommandBuilderSuite.java
@@ -26,22 +26,22 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class SparkSubmitCommandBuilderSuite extends BaseSuite {
 
   private static File dummyPropsFile;
   private static SparkSubmitOptionParser parser;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception {
     dummyPropsFile = File.createTempFile("spark", "properties");
     parser = new SparkSubmitOptionParser();
   }
 
-  @AfterClass
+  @AfterAll
   public static void cleanUp() throws Exception {
     dummyPropsFile.delete();
   }
@@ -63,13 +63,13 @@ public class SparkSubmitCommandBuilderSuite extends BaseSuite {
     List<String> helpArgs = Arrays.asList(parser.HELP);
     Map<String, String> env = new HashMap<>();
     List<String> cmd = buildCommand(helpArgs, env);
-    assertTrue("--help should be contained in the final cmd.", cmd.contains(parser.HELP));
+    assertTrue(cmd.contains(parser.HELP), "--help should be contained in the final cmd.");
 
     List<String> sparkEmptyArgs = Collections.emptyList();
     cmd = buildCommand(sparkEmptyArgs, env);
     assertTrue(
-      "org.apache.spark.deploy.SparkSubmit should be contained in the final cmd of empty input.",
-      cmd.contains("org.apache.spark.deploy.SparkSubmit"));
+      cmd.contains("org.apache.spark.deploy.SparkSubmit"),
+      "org.apache.spark.deploy.SparkSubmit should be contained in the final cmd of empty input.");
   }
 
   @Test
@@ -133,9 +133,10 @@ public class SparkSubmitCommandBuilderSuite extends BaseSuite {
     assertTrue(findInStringList(env.get(CommandBuilderUtils.getLibPathEnvName()),
         File.pathSeparator, "/driverLibPath"));
     assertTrue(findInStringList(findArgValue(cmd, "-cp"), File.pathSeparator, "/driverCp"));
-    assertTrue("Driver -Xmx should be configured.", cmd.contains("-Xmx42g"));
-    assertTrue("Command should contain user-defined conf.",
-      Collections.indexOfSubList(cmd, Arrays.asList(parser.CONF, "spark.randomOption=foo")) > 0);
+    assertTrue(cmd.contains("-Xmx42g"), "Driver -Xmx should be configured.");
+    assertTrue(
+      Collections.indexOfSubList(cmd, Arrays.asList(parser.CONF, "spark.randomOption=foo")) > 0,
+      "Command should contain user-defined conf.");
   }
 
   @Test
@@ -238,14 +239,14 @@ public class SparkSubmitCommandBuilderSuite extends BaseSuite {
   }
 
   @Test
-  public void testExamplesRunnerWithMasterNoMainClass() throws Exception {
+  public void testExamplesRunnerWithMasterNoMainClass() {
     List<String> sparkSubmitArgs = Arrays.asList(
       SparkSubmitCommandBuilder.RUN_EXAMPLE,
       parser.MASTER + "=foo"
     );
     Map<String, String> env = new HashMap<>();
-    Assert.assertThrows("Missing example class name.", IllegalArgumentException.class,
-      () -> buildCommand(sparkSubmitArgs, env));
+    assertThrows(IllegalArgumentException.class,
+      () -> buildCommand(sparkSubmitArgs, env), "Missing example class name.");
   }
 
   @Test
@@ -267,7 +268,7 @@ public class SparkSubmitCommandBuilderSuite extends BaseSuite {
   }
 
   @Test
-  public void testExamplesRunnerPrimaryResource() throws Exception {
+  public void testExamplesRunnerPrimaryResource() {
     List<String> sparkSubmitArgs = Arrays.asList(
             SparkSubmitCommandBuilder.RUN_EXAMPLE,
             parser.MASTER + "=foo",
@@ -294,12 +295,12 @@ public class SparkSubmitCommandBuilderSuite extends BaseSuite {
   public void testIsClientMode() {
     // Default master is "local[*]"
     SparkSubmitCommandBuilder builder = newCommandBuilder(Collections.emptyList());
-    assertTrue("By default application run in local mode",
-      builder.isClientMode(Collections.emptyMap()));
+    assertTrue(builder.isClientMode(Collections.emptyMap()),
+      "By default application run in local mode");
     // --master yarn or it can be any RM
     List<String> sparkSubmitArgs = Arrays.asList(parser.MASTER, "yarn");
     builder = newCommandBuilder(sparkSubmitArgs);
-    assertTrue("By default deploy mode is client", builder.isClientMode(Collections.emptyMap()));
+    assertTrue(builder.isClientMode(Collections.emptyMap()), "By default deploy mode is client");
     // --master yarn and set spark.submit.deployMode to client
     Map<String, String> userProps = new HashMap<>();
     userProps.put("spark.submit.deployMode", "client");
@@ -346,10 +347,10 @@ public class SparkSubmitCommandBuilderSuite extends BaseSuite {
     // Checks below are different for driver and non-driver mode.
 
     if (isDriver) {
-      assertTrue("Driver -Xmx should be configured.", cmd.contains("-Xmx1g"));
-      assertTrue("Driver default options should be configured.",
-        cmd.contains(DRIVER_DEFAULT_PARAM));
-      assertTrue("Driver extra options should be configured.", cmd.contains(DRIVER_EXTRA_PARAM));
+      assertTrue(cmd.contains("-Xmx1g"), "Driver -Xmx should be configured.");
+      assertTrue(cmd.contains(DRIVER_DEFAULT_PARAM),
+        "Driver default options should be configured.");
+      assertTrue(cmd.contains(DRIVER_EXTRA_PARAM), "Driver extra options should be configured.");
     } else {
       boolean found = false;
       for (String arg : cmd) {
@@ -358,27 +359,27 @@ public class SparkSubmitCommandBuilderSuite extends BaseSuite {
           break;
         }
       }
-      assertFalse("Memory arguments should not be set.", found);
-      assertFalse("Driver default options should not be configured.",
-        cmd.contains(DRIVER_DEFAULT_PARAM));
-      assertFalse("Driver extra options should not be configured.",
-        cmd.contains(DRIVER_EXTRA_PARAM));
+      assertFalse(found, "Memory arguments should not be set.");
+      assertFalse(cmd.contains(DRIVER_DEFAULT_PARAM),
+        "Driver default options should not be configured.");
+      assertFalse(cmd.contains(DRIVER_EXTRA_PARAM),
+        "Driver extra options should not be configured.");
     }
 
     String[] cp = findArgValue(cmd, "-cp").split(Pattern.quote(File.pathSeparator));
     if (isDriver) {
-      assertTrue("Driver classpath should contain provided entry.", contains("/driver", cp));
+      assertTrue(contains("/driver", cp), "Driver classpath should contain provided entry.");
     } else {
-      assertFalse("Driver classpath should not be in command.", contains("/driver", cp));
+      assertFalse(contains("/driver", cp), "Driver classpath should not be in command.");
     }
 
     String libPath = env.get(CommandBuilderUtils.getLibPathEnvName());
     if (isDriver) {
-      assertNotNull("Native library path should be set.", libPath);
-      assertTrue("Native library path should contain provided entry.",
-        contains("/native", libPath.split(Pattern.quote(File.pathSeparator))));
+      assertNotNull(libPath, "Native library path should be set.");
+      assertTrue(contains("/native", libPath.split(Pattern.quote(File.pathSeparator))),
+        "Native library path should contain provided entry.");
     } else {
-      assertNull("Native library should not be set.", libPath);
+      assertNull(libPath, "Native library should not be set.");
     }
 
     // Checks below are the same for both driver and non-driver mode.
@@ -400,7 +401,7 @@ public class SparkSubmitCommandBuilderSuite extends BaseSuite {
         break;
       }
     }
-    assertTrue("App resource and args should be added to command.", appArgsOk);
+    assertTrue(appArgsOk, "App resource and args should be added to command.");
 
     Map<String, String> conf = parseConf(cmd, parser);
     assertEquals("foo", conf.get("spark.foo"));
@@ -462,8 +463,7 @@ public class SparkSubmitCommandBuilderSuite extends BaseSuite {
     }
     Map<String, String> env = new HashMap<>();
     List<String> cmd = buildCommand(args, env);
-    assertTrue(opt + " should be contained in the final cmd.",
-      cmd.contains(opt));
+    assertTrue(cmd.contains(opt), opt + " should be contained in the final cmd.");
   }
 
 }

--- a/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitOptionParserSuite.java
+++ b/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitOptionParserSuite.java
@@ -21,16 +21,17 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
-import static org.junit.Assert.assertThrows;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.*;
 
 public class SparkSubmitOptionParserSuite extends BaseSuite {
 
   private SparkSubmitOptionParser parser;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     parser = spy(new DummyParser());
   }

--- a/mllib/src/test/java/org/apache/spark/SharedSparkSession.java
+++ b/mllib/src/test/java/org/apache/spark/SharedSparkSession.java
@@ -20,8 +20,8 @@ package org.apache.spark;
 import java.io.IOException;
 import java.io.Serializable;
 
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.sql.SparkSession;
@@ -31,7 +31,7 @@ public abstract class SharedSparkSession implements Serializable {
   protected transient SparkSession spark;
   protected transient JavaSparkContext jsc;
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException {
     spark = SparkSession.builder()
       .master("local[2]")
@@ -40,7 +40,7 @@ public abstract class SharedSparkSession implements Serializable {
     jsc = new JavaSparkContext(spark.sparkContext());
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     try {
       spark.stop();

--- a/mllib/src/test/java/org/apache/spark/ml/JavaPipelineSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/JavaPipelineSuite.java
@@ -19,7 +19,8 @@ package org.apache.spark.ml;
 
 import java.io.IOException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.SharedSparkSession;
 import org.apache.spark.api.java.JavaRDD;
@@ -38,6 +39,7 @@ public class JavaPipelineSuite extends SharedSparkSession {
   private transient Dataset<Row> dataset;
 
   @Override
+  @BeforeEach
   public void setUp() throws IOException {
     super.setUp();
     JavaRDD<LabeledPoint> points =

--- a/mllib/src/test/java/org/apache/spark/ml/attribute/JavaAttributeGroupSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/attribute/JavaAttributeGroupSuite.java
@@ -17,8 +17,8 @@
 
 package org.apache.spark.ml.attribute;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class JavaAttributeGroupSuite {
 
@@ -35,11 +35,11 @@ public class JavaAttributeGroupSuite {
       NumericAttribute.defaultAttr()
     };
     AttributeGroup group = new AttributeGroup("user", attrs);
-    Assert.assertEquals(8, group.size());
-    Assert.assertEquals("user", group.name());
-    Assert.assertEquals(NumericAttribute.defaultAttr().withIndex(0), group.getAttr(0));
-    Assert.assertEquals(3, group.indexOf("age"));
-    Assert.assertFalse(group.hasAttr("abc"));
-    Assert.assertEquals(group, AttributeGroup.fromStructField(group.toStructField()));
+    Assertions.assertEquals(8, group.size());
+    Assertions.assertEquals("user", group.name());
+    Assertions.assertEquals(NumericAttribute.defaultAttr().withIndex(0), group.getAttr(0));
+    Assertions.assertEquals(3, group.indexOf("age"));
+    Assertions.assertFalse(group.hasAttr("abc"));
+    Assertions.assertEquals(group, AttributeGroup.fromStructField(group.toStructField()));
   }
 }

--- a/mllib/src/test/java/org/apache/spark/ml/attribute/JavaAttributeSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/attribute/JavaAttributeSuite.java
@@ -17,8 +17,8 @@
 
 package org.apache.spark.ml.attribute;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class JavaAttributeSuite {
 
@@ -27,29 +27,29 @@ public class JavaAttributeSuite {
     AttributeType numericType = AttributeType.Numeric();
     AttributeType nominalType = AttributeType.Nominal();
     AttributeType binaryType = AttributeType.Binary();
-    Assert.assertEquals(numericType, NumericAttribute.defaultAttr().attrType());
-    Assert.assertEquals(nominalType, NominalAttribute.defaultAttr().attrType());
-    Assert.assertEquals(binaryType, BinaryAttribute.defaultAttr().attrType());
+    Assertions.assertEquals(numericType, NumericAttribute.defaultAttr().attrType());
+    Assertions.assertEquals(nominalType, NominalAttribute.defaultAttr().attrType());
+    Assertions.assertEquals(binaryType, BinaryAttribute.defaultAttr().attrType());
   }
 
   @Test
   public void testNumericAttribute() {
     NumericAttribute attr = NumericAttribute.defaultAttr()
       .withName("age").withIndex(0).withMin(0.0).withMax(1.0).withStd(0.5).withSparsity(0.4);
-    Assert.assertEquals(attr.withoutIndex(), Attribute.fromStructField(attr.toStructField()));
+    Assertions.assertEquals(attr.withoutIndex(), Attribute.fromStructField(attr.toStructField()));
   }
 
   @Test
   public void testNominalAttribute() {
     NominalAttribute attr = NominalAttribute.defaultAttr()
       .withName("size").withIndex(1).withValues("small", "medium", "large");
-    Assert.assertEquals(attr.withoutIndex(), Attribute.fromStructField(attr.toStructField()));
+    Assertions.assertEquals(attr.withoutIndex(), Attribute.fromStructField(attr.toStructField()));
   }
 
   @Test
   public void testBinaryAttribute() {
     BinaryAttribute attr = BinaryAttribute.defaultAttr()
       .withName("clicked").withIndex(2).withValues("no", "yes");
-    Assert.assertEquals(attr.withoutIndex(), Attribute.fromStructField(attr.toStructField()));
+    Assertions.assertEquals(attr.withoutIndex(), Attribute.fromStructField(attr.toStructField()));
   }
 }

--- a/mllib/src/test/java/org/apache/spark/ml/classification/JavaDecisionTreeClassifierSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/classification/JavaDecisionTreeClassifierSuite.java
@@ -20,7 +20,7 @@ package org.apache.spark.ml.classification;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.SharedSparkSession;
 import org.apache.spark.api.java.JavaRDD;

--- a/mllib/src/test/java/org/apache/spark/ml/classification/JavaGBTClassifierSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/classification/JavaGBTClassifierSuite.java
@@ -20,7 +20,7 @@ package org.apache.spark.ml.classification;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.SharedSparkSession;
 import org.apache.spark.api.java.JavaRDD;

--- a/mllib/src/test/java/org/apache/spark/ml/classification/JavaLogisticRegressionSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/classification/JavaLogisticRegressionSuite.java
@@ -20,8 +20,9 @@ package org.apache.spark.ml.classification;
 import java.io.IOException;
 import java.util.List;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.SharedSparkSession;
 import org.apache.spark.api.java.JavaRDD;
@@ -39,6 +40,7 @@ public class JavaLogisticRegressionSuite extends SharedSparkSession {
   private double eps = 1e-5;
 
   @Override
+  @BeforeEach
   public void setUp() throws IOException {
     super.setUp();
     List<LabeledPoint> points = generateLogisticInputAsList(1.0, 1.0, 100, 42);
@@ -50,16 +52,16 @@ public class JavaLogisticRegressionSuite extends SharedSparkSession {
   @Test
   public void logisticRegressionDefaultParams() {
     LogisticRegression lr = new LogisticRegression();
-    Assert.assertEquals("label", lr.getLabelCol());
+    Assertions.assertEquals("label", lr.getLabelCol());
     LogisticRegressionModel model = lr.fit(dataset);
     model.transform(dataset).createOrReplaceTempView("prediction");
     Dataset<Row> predictions = spark.sql("SELECT label, probability, prediction FROM prediction");
     predictions.collectAsList();
     // Check defaults
-    Assert.assertEquals(0.5, model.getThreshold(), eps);
-    Assert.assertEquals("features", model.getFeaturesCol());
-    Assert.assertEquals("prediction", model.getPredictionCol());
-    Assert.assertEquals("probability", model.getProbabilityCol());
+    Assertions.assertEquals(0.5, model.getThreshold(), eps);
+    Assertions.assertEquals("features", model.getFeaturesCol());
+    Assertions.assertEquals("prediction", model.getPredictionCol());
+    Assertions.assertEquals("probability", model.getProbabilityCol());
   }
 
   @Test
@@ -72,19 +74,19 @@ public class JavaLogisticRegressionSuite extends SharedSparkSession {
       .setProbabilityCol("myProbability");
     LogisticRegressionModel model = lr.fit(dataset);
     LogisticRegression parent = (LogisticRegression) model.parent();
-    Assert.assertEquals(10, parent.getMaxIter());
-    Assert.assertEquals(1.0, parent.getRegParam(), eps);
-    Assert.assertEquals(0.4, parent.getThresholds()[0], eps);
-    Assert.assertEquals(0.6, parent.getThresholds()[1], eps);
-    Assert.assertEquals(0.6, parent.getThreshold(), eps);
-    Assert.assertEquals(0.6, model.getThreshold(), eps);
+    Assertions.assertEquals(10, parent.getMaxIter());
+    Assertions.assertEquals(1.0, parent.getRegParam(), eps);
+    Assertions.assertEquals(0.4, parent.getThresholds()[0], eps);
+    Assertions.assertEquals(0.6, parent.getThresholds()[1], eps);
+    Assertions.assertEquals(0.6, parent.getThreshold(), eps);
+    Assertions.assertEquals(0.6, model.getThreshold(), eps);
 
     // Modify model params, and check that the params worked.
     model.setThreshold(1.0);
     model.transform(dataset).createOrReplaceTempView("predAllZero");
     Dataset<Row> predAllZero = spark.sql("SELECT prediction, myProbability FROM predAllZero");
     for (Row r : predAllZero.collectAsList()) {
-      Assert.assertEquals(0.0, r.getDouble(0), eps);
+      Assertions.assertEquals(0.0, r.getDouble(0), eps);
     }
     // Call transform with params, and check that the params worked.
     model.transform(dataset, model.threshold().w(0.0), model.probabilityCol().w("myProb"))
@@ -94,35 +96,35 @@ public class JavaLogisticRegressionSuite extends SharedSparkSession {
     for (Row r : predNotAllZero.collectAsList()) {
       if (r.getDouble(0) != 0.0) foundNonZero = true;
     }
-    Assert.assertTrue(foundNonZero);
+    Assertions.assertTrue(foundNonZero);
 
     // Call fit() with new params, and check as many params as we can.
     LogisticRegressionModel model2 = lr.fit(dataset, lr.maxIter().w(5), lr.regParam().w(0.1),
       lr.threshold().w(0.4), lr.probabilityCol().w("theProb"));
     LogisticRegression parent2 = (LogisticRegression) model2.parent();
-    Assert.assertEquals(5, parent2.getMaxIter());
-    Assert.assertEquals(0.1, parent2.getRegParam(), eps);
-    Assert.assertEquals(0.4, parent2.getThreshold(), eps);
-    Assert.assertEquals(0.4, model2.getThreshold(), eps);
-    Assert.assertEquals("theProb", model2.getProbabilityCol());
+    Assertions.assertEquals(5, parent2.getMaxIter());
+    Assertions.assertEquals(0.1, parent2.getRegParam(), eps);
+    Assertions.assertEquals(0.4, parent2.getThreshold(), eps);
+    Assertions.assertEquals(0.4, model2.getThreshold(), eps);
+    Assertions.assertEquals("theProb", model2.getProbabilityCol());
   }
 
   @Test
   public void logisticRegressionPredictorClassifierMethods() {
     LogisticRegression lr = new LogisticRegression();
     LogisticRegressionModel model = lr.fit(dataset);
-    Assert.assertEquals(2, model.numClasses());
+    Assertions.assertEquals(2, model.numClasses());
 
     model.transform(dataset).createOrReplaceTempView("transformed");
     Dataset<Row> trans1 = spark.sql("SELECT rawPrediction, probability FROM transformed");
     for (Row row : trans1.collectAsList()) {
       Vector raw = (Vector) row.get(0);
       Vector prob = (Vector) row.get(1);
-      Assert.assertEquals(2, raw.size());
-      Assert.assertEquals(2, prob.size());
+      Assertions.assertEquals(2, raw.size());
+      Assertions.assertEquals(2, prob.size());
       double probFromRaw1 = 1.0 / (1.0 + Math.exp(-raw.apply(1)));
-      Assert.assertEquals(0, Math.abs(prob.apply(1) - probFromRaw1), eps);
-      Assert.assertEquals(0, Math.abs(prob.apply(0) - (1.0 - probFromRaw1)), eps);
+      Assertions.assertEquals(0, Math.abs(prob.apply(1) - probFromRaw1), eps);
+      Assertions.assertEquals(0, Math.abs(prob.apply(0) - (1.0 - probFromRaw1)), eps);
     }
 
     Dataset<Row> trans2 = spark.sql("SELECT prediction, probability FROM transformed");
@@ -131,7 +133,7 @@ public class JavaLogisticRegressionSuite extends SharedSparkSession {
       Vector prob = (Vector) row.get(1);
       double probOfPred = prob.apply((int) pred);
       for (int i = 0; i < prob.size(); ++i) {
-        Assert.assertTrue(probOfPred >= prob.apply(i));
+        Assertions.assertTrue(probOfPred >= prob.apply(i));
       }
     }
   }
@@ -142,6 +144,6 @@ public class JavaLogisticRegressionSuite extends SharedSparkSession {
     LogisticRegressionModel model = lr.fit(dataset);
 
     LogisticRegressionTrainingSummary summary = model.summary();
-    Assert.assertEquals(summary.totalIterations(), summary.objectiveHistory().length - 1);
+    Assertions.assertEquals(summary.totalIterations(), summary.objectiveHistory().length - 1);
   }
 }

--- a/mllib/src/test/java/org/apache/spark/ml/classification/JavaMultilayerPerceptronClassifierSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/classification/JavaMultilayerPerceptronClassifierSuite.java
@@ -20,8 +20,8 @@ package org.apache.spark.ml.classification;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.SharedSparkSession;
 import org.apache.spark.ml.feature.LabeledPoint;
@@ -50,7 +50,7 @@ public class JavaMultilayerPerceptronClassifierSuite extends SharedSparkSession 
     Dataset<Row> result = model.transform(dataFrame);
     List<Row> predictionAndLabels = result.select("prediction", "label").collectAsList();
     for (Row r : predictionAndLabels) {
-      Assert.assertEquals((int) r.getDouble(0), (int) r.getDouble(1));
+      Assertions.assertEquals((int) r.getDouble(0), (int) r.getDouble(1));
     }
   }
 }

--- a/mllib/src/test/java/org/apache/spark/ml/classification/JavaNaiveBayesSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/classification/JavaNaiveBayesSuite.java
@@ -20,8 +20,8 @@ package org.apache.spark.ml.classification;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.spark.SharedSparkSession;
 import org.apache.spark.ml.linalg.VectorUDT;

--- a/mllib/src/test/java/org/apache/spark/ml/classification/JavaOneVsRestSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/classification/JavaOneVsRestSuite.java
@@ -22,8 +22,9 @@ import java.util.List;
 
 import scala.collection.JavaConverters;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.SharedSparkSession;
 import org.apache.spark.api.java.JavaRDD;
@@ -38,6 +39,7 @@ public class JavaOneVsRestSuite extends SharedSparkSession {
   private transient JavaRDD<LabeledPoint> datasetRDD;
 
   @Override
+  @BeforeEach
   public void setUp() throws IOException {
     super.setUp();
     int nPoints = 3;
@@ -62,12 +64,12 @@ public class JavaOneVsRestSuite extends SharedSparkSession {
   public void oneVsRestDefaultParams() {
     OneVsRest ova = new OneVsRest();
     ova.setClassifier(new LogisticRegression());
-    Assert.assertEquals("label", ova.getLabelCol());
-    Assert.assertEquals("prediction", ova.getPredictionCol());
+    Assertions.assertEquals("label", ova.getLabelCol());
+    Assertions.assertEquals("prediction", ova.getPredictionCol());
     OneVsRestModel ovaModel = ova.fit(dataset);
     Dataset<Row> predictions = ovaModel.transform(dataset).select("label", "prediction");
     predictions.collectAsList();
-    Assert.assertEquals("label", ovaModel.getLabelCol());
-    Assert.assertEquals("prediction", ovaModel.getPredictionCol());
+    Assertions.assertEquals("label", ovaModel.getLabelCol());
+    Assertions.assertEquals("prediction", ovaModel.getPredictionCol());
   }
 }

--- a/mllib/src/test/java/org/apache/spark/ml/classification/JavaRandomForestClassifierSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/classification/JavaRandomForestClassifierSuite.java
@@ -20,8 +20,8 @@ package org.apache.spark.ml.classification;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.SharedSparkSession;
 import org.apache.spark.api.java.JavaRDD;
@@ -73,7 +73,7 @@ public class JavaRandomForestClassifierSuite extends SharedSparkSession {
     }
     String[] invalidStrategies = {"-.1", "-.10", "-0.10", ".0", "0.0", "1.1", "0"};
     for (String strategy : invalidStrategies) {
-      Assert.assertThrows(IllegalArgumentException.class,
+      Assertions.assertThrows(IllegalArgumentException.class,
         () -> rf.setFeatureSubsetStrategy(strategy));
     }
 

--- a/mllib/src/test/java/org/apache/spark/ml/clustering/JavaKMeansSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/clustering/JavaKMeansSuite.java
@@ -21,9 +21,10 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.spark.SharedSparkSession;
 import org.apache.spark.ml.linalg.Vector;
@@ -36,6 +37,7 @@ public class JavaKMeansSuite extends SharedSparkSession {
   private transient Dataset<Row> dataset;
 
   @Override
+  @BeforeEach
   public void setUp() throws IOException {
     super.setUp();
     dataset = KMeansSuite.generateKMeansData(spark, 50, 3, k);

--- a/mllib/src/test/java/org/apache/spark/ml/feature/JavaBucketizerSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/feature/JavaBucketizerSuite.java
@@ -20,8 +20,8 @@ package org.apache.spark.ml.feature;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.SharedSparkSession;
 import org.apache.spark.sql.Dataset;
@@ -58,7 +58,7 @@ public class JavaBucketizerSuite extends SharedSparkSession {
 
     for (Row r : result) {
       double index = r.getDouble(0);
-      Assert.assertTrue((index >= 0) && (index <= 1));
+      Assertions.assertTrue((index >= 0) && (index <= 1));
     }
   }
 
@@ -90,10 +90,10 @@ public class JavaBucketizerSuite extends SharedSparkSession {
 
     for (Row r : result) {
       double index1 = r.getDouble(0);
-      Assert.assertTrue((index1 >= 0) && (index1 <= 1));
+      Assertions.assertTrue((index1 >= 0) && (index1 <= 1));
 
       double index2 = r.getDouble(1);
-      Assert.assertTrue((index2 >= 0) && (index2 <= 2));
+      Assertions.assertTrue((index2 >= 0) && (index2 <= 2));
     }
   }
 }

--- a/mllib/src/test/java/org/apache/spark/ml/feature/JavaDCTSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/feature/JavaDCTSuite.java
@@ -22,8 +22,8 @@ import java.util.List;
 
 import org.jtransforms.dct.DoubleDCT_1D;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.SharedSparkSession;
 import org.apache.spark.ml.linalg.Vector;
@@ -57,6 +57,6 @@ public class JavaDCTSuite extends SharedSparkSession {
     List<Row> result = dct.transform(dataset).select("resultVec").collectAsList();
     Vector resultVec = result.get(0).getAs("resultVec");
 
-    Assert.assertArrayEquals(expectedResult, resultVec.toArray(), 1e-6);
+    Assertions.assertArrayEquals(expectedResult, resultVec.toArray(), 1e-6);
   }
 }

--- a/mllib/src/test/java/org/apache/spark/ml/feature/JavaHashingTFSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/feature/JavaHashingTFSuite.java
@@ -20,8 +20,8 @@ package org.apache.spark.ml.feature;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.SharedSparkSession;
 import org.apache.spark.ml.linalg.Vector;
@@ -64,7 +64,7 @@ public class JavaHashingTFSuite extends SharedSparkSession {
     Dataset<Row> rescaledData = idfModel.transform(featurizedData);
     for (Row r : rescaledData.select("features", "label").takeAsList(3)) {
       Vector features = r.getAs(0);
-      Assert.assertEquals(numFeatures, features.size());
+      Assertions.assertEquals(numFeatures, features.size());
     }
   }
 }

--- a/mllib/src/test/java/org/apache/spark/ml/feature/JavaNormalizerSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/feature/JavaNormalizerSuite.java
@@ -19,7 +19,7 @@ package org.apache.spark.ml.feature;
 
 import java.util.Arrays;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.SharedSparkSession;
 import org.apache.spark.api.java.JavaRDD;

--- a/mllib/src/test/java/org/apache/spark/ml/feature/JavaPCASuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/feature/JavaPCASuite.java
@@ -21,8 +21,8 @@ import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.SharedSparkSession;
 import org.apache.spark.api.java.JavaRDD;
@@ -94,7 +94,7 @@ public class JavaPCASuite extends SharedSparkSession {
       Vector calculatedVector = (Vector) r.get(0);
       Vector expectedVector = (Vector) r.get(1);
       for (int i = 0; i < calculatedVector.size(); i++) {
-        Assert.assertEquals(calculatedVector.apply(i), expectedVector.apply(i), 1.0e-8);
+        Assertions.assertEquals(calculatedVector.apply(i), expectedVector.apply(i), 1.0e-8);
       }
     }
   }

--- a/mllib/src/test/java/org/apache/spark/ml/feature/JavaPolynomialExpansionSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/feature/JavaPolynomialExpansionSuite.java
@@ -20,8 +20,8 @@ package org.apache.spark.ml.feature;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.SharedSparkSession;
 import org.apache.spark.ml.linalg.Vector;
@@ -69,7 +69,7 @@ public class JavaPolynomialExpansionSuite extends SharedSparkSession {
     for (Row r : pairs) {
       double[] polyFeatures = ((Vector) r.get(0)).toArray();
       double[] expected = ((Vector) r.get(1)).toArray();
-      Assert.assertArrayEquals(polyFeatures, expected, 1e-1);
+      Assertions.assertArrayEquals(polyFeatures, expected, 1e-1);
     }
   }
 }

--- a/mllib/src/test/java/org/apache/spark/ml/feature/JavaStandardScalerSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/feature/JavaStandardScalerSuite.java
@@ -20,7 +20,7 @@ package org.apache.spark.ml.feature;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.SharedSparkSession;
 import org.apache.spark.ml.linalg.Vectors;

--- a/mllib/src/test/java/org/apache/spark/ml/feature/JavaStopWordsRemoverSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/feature/JavaStopWordsRemoverSuite.java
@@ -20,7 +20,7 @@ package org.apache.spark.ml.feature;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.SharedSparkSession;
 import org.apache.spark.sql.Dataset;

--- a/mllib/src/test/java/org/apache/spark/ml/feature/JavaStringIndexerSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/feature/JavaStringIndexerSuite.java
@@ -22,8 +22,8 @@ import java.util.List;
 
 import static org.apache.spark.sql.types.DataTypes.*;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.SharedSparkSession;
 import org.apache.spark.sql.Dataset;
@@ -49,7 +49,7 @@ public class JavaStringIndexerSuite extends SharedSparkSession {
       .setOutputCol("labelIndex");
     Dataset<Row> output = indexer.fit(dataset).transform(dataset);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
       Arrays.asList(cr(0, 0.0), cr(1, 2.0), cr(2, 1.0), cr(3, 0.0), cr(4, 0.0), cr(5, 1.0)),
       output.orderBy("id").select("id", "labelIndex").collectAsList());
   }

--- a/mllib/src/test/java/org/apache/spark/ml/feature/JavaTokenizerSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/feature/JavaTokenizerSuite.java
@@ -20,8 +20,8 @@ package org.apache.spark.ml.feature;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.SharedSparkSession;
 import org.apache.spark.api.java.JavaRDD;
@@ -52,7 +52,7 @@ public class JavaTokenizerSuite extends SharedSparkSession {
       .collectAsList();
 
     for (Row r : pairs) {
-      Assert.assertEquals(r.get(0), r.get(1));
+      Assertions.assertEquals(r.get(0), r.get(1));
     }
   }
 }

--- a/mllib/src/test/java/org/apache/spark/ml/feature/JavaVectorAssemblerSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/feature/JavaVectorAssemblerSuite.java
@@ -21,8 +21,8 @@ import java.util.Arrays;
 
 import static org.apache.spark.sql.types.DataTypes.*;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.SharedSparkSession;
 import org.apache.spark.ml.linalg.Vector;
@@ -54,7 +54,7 @@ public class JavaVectorAssemblerSuite extends SharedSparkSession {
       .setInputCols(new String[]{"x", "y", "z", "n"})
       .setOutputCol("features");
     Dataset<Row> output = assembler.transform(dataset);
-    Assert.assertEquals(
+    Assertions.assertEquals(
       Vectors.sparse(6, new int[]{1, 2, 4, 5}, new double[]{1.0, 2.0, 3.0, 10.0}),
       output.select("features").first().<Vector>getAs(0));
   }

--- a/mllib/src/test/java/org/apache/spark/ml/feature/JavaVectorIndexerSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/feature/JavaVectorIndexerSuite.java
@@ -21,8 +21,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.SharedSparkSession;
 import org.apache.spark.ml.feature.VectorIndexerSuite.FeatureData;
@@ -47,9 +47,9 @@ public class JavaVectorIndexerSuite extends SharedSparkSession {
       .setOutputCol("indexed")
       .setMaxCategories(2);
     VectorIndexerModel model = indexer.fit(data);
-    Assert.assertEquals(2, model.numFeatures());
+    Assertions.assertEquals(2, model.numFeatures());
     Map<Integer, Map<Double, Integer>> categoryMaps = model.javaCategoryMaps();
-    Assert.assertEquals(1, categoryMaps.size());
+    Assertions.assertEquals(1, categoryMaps.size());
     Dataset<Row> indexedData = model.transform(data);
   }
 }

--- a/mllib/src/test/java/org/apache/spark/ml/feature/JavaVectorSlicerSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/feature/JavaVectorSlicerSuite.java
@@ -20,8 +20,8 @@ package org.apache.spark.ml.feature;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.SharedSparkSession;
 import org.apache.spark.ml.attribute.Attribute;
@@ -63,7 +63,7 @@ public class JavaVectorSlicerSuite extends SharedSparkSession {
 
     for (Row r : output.select("userFeatures", "features").takeAsList(2)) {
       Vector features = r.getAs(1);
-      Assert.assertEquals(2, features.size());
+      Assertions.assertEquals(2, features.size());
     }
   }
 }

--- a/mllib/src/test/java/org/apache/spark/ml/feature/JavaWord2VecSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/feature/JavaWord2VecSuite.java
@@ -19,8 +19,8 @@ package org.apache.spark.ml.feature;
 
 import java.util.Arrays;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.SharedSparkSession;
 import org.apache.spark.ml.linalg.Vector;
@@ -53,7 +53,7 @@ public class JavaWord2VecSuite extends SharedSparkSession {
 
     for (Row r : result.select("result").collectAsList()) {
       double[] polyFeatures = ((Vector) r.get(0)).toArray();
-      Assert.assertEquals(3, polyFeatures.length);
+      Assertions.assertEquals(3, polyFeatures.length);
     }
   }
 }

--- a/mllib/src/test/java/org/apache/spark/ml/linalg/JavaSQLDataTypesSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/linalg/JavaSQLDataTypesSuite.java
@@ -17,15 +17,15 @@
 
 package org.apache.spark.ml.linalg;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.spark.ml.linalg.SQLDataTypes.*;
 
 public class JavaSQLDataTypesSuite {
   @Test
   public void testSQLDataTypes() {
-    Assert.assertEquals(new VectorUDT(), VectorType());
-    Assert.assertEquals(new MatrixUDT(), MatrixType());
+    Assertions.assertEquals(new VectorUDT(), VectorType());
+    Assertions.assertEquals(new MatrixUDT(), MatrixType());
   }
 }

--- a/mllib/src/test/java/org/apache/spark/ml/param/JavaParamsSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/param/JavaParamsSuite.java
@@ -19,8 +19,8 @@ package org.apache.spark.ml.param;
 
 import java.util.Arrays;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test Param and related classes in Java
@@ -30,11 +30,11 @@ public class JavaParamsSuite {
   @Test
   public void testParams() {
     JavaTestParams testParams = new JavaTestParams();
-    Assert.assertEquals(1, testParams.getMyIntParam());
+    Assertions.assertEquals(1, testParams.getMyIntParam());
     testParams.setMyIntParam(2).setMyDoubleParam(0.4).setMyStringParam("a");
-    Assert.assertEquals(0.4, testParams.getMyDoubleParam(), 0.0);
-    Assert.assertEquals("a", testParams.getMyStringParam());
-    Assert.assertArrayEquals(testParams.getMyDoubleArrayParam(), new double[]{1.0, 2.0}, 0.0);
+    Assertions.assertEquals(0.4, testParams.getMyDoubleParam(), 0.0);
+    Assertions.assertEquals("a", testParams.getMyStringParam());
+    Assertions.assertArrayEquals(testParams.getMyDoubleArrayParam(), new double[]{1.0, 2.0}, 0.0);
   }
 
   @Test

--- a/mllib/src/test/java/org/apache/spark/ml/regression/JavaDecisionTreeRegressorSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/regression/JavaDecisionTreeRegressorSuite.java
@@ -20,7 +20,7 @@ package org.apache.spark.ml.regression;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.SharedSparkSession;
 import org.apache.spark.api.java.JavaRDD;

--- a/mllib/src/test/java/org/apache/spark/ml/regression/JavaGBTRegressorSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/regression/JavaGBTRegressorSuite.java
@@ -20,7 +20,7 @@ package org.apache.spark.ml.regression;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.SharedSparkSession;
 import org.apache.spark.api.java.JavaRDD;

--- a/mllib/src/test/java/org/apache/spark/ml/regression/JavaLinearRegressionSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/regression/JavaLinearRegressionSuite.java
@@ -20,8 +20,9 @@ package org.apache.spark.ml.regression;
 import java.io.IOException;
 import java.util.List;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.spark.SharedSparkSession;
 import org.apache.spark.api.java.JavaRDD;
@@ -35,6 +36,7 @@ public class JavaLinearRegressionSuite extends SharedSparkSession {
   private transient JavaRDD<LabeledPoint> datasetRDD;
 
   @Override
+  @BeforeEach
   public void setUp() throws IOException {
     super.setUp();
     List<LabeledPoint> points = generateLogisticInputAsList(1.0, 1.0, 100, 42);

--- a/mllib/src/test/java/org/apache/spark/ml/regression/JavaRandomForestRegressorSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/regression/JavaRandomForestRegressorSuite.java
@@ -20,8 +20,8 @@ package org.apache.spark.ml.regression;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.SharedSparkSession;
 import org.apache.spark.api.java.JavaRDD;
@@ -75,7 +75,7 @@ public class JavaRandomForestRegressorSuite extends SharedSparkSession {
     }
     String[] invalidStrategies = {"-.1", "-.10", "-0.10", ".0", "0.0", "1.1", "0"};
     for (String strategy : invalidStrategies) {
-      Assert.assertThrows(IllegalArgumentException.class,
+      Assertions.assertThrows(IllegalArgumentException.class,
         () -> rf.setFeatureSubsetStrategy(strategy));
     }
 

--- a/mllib/src/test/java/org/apache/spark/ml/source/libsvm/JavaLibSVMRelationSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/source/libsvm/JavaLibSVMRelationSuite.java
@@ -23,8 +23,9 @@ import java.nio.charset.StandardCharsets;
 
 import com.google.common.io.Files;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.SharedSparkSession;
 import org.apache.spark.ml.linalg.DenseVector;
@@ -43,6 +44,7 @@ public class JavaLibSVMRelationSuite extends SharedSparkSession {
   private String path;
 
   @Override
+  @BeforeEach
   public void setUp() throws IOException {
     super.setUp();
     tempDir = Utils.createTempDir(System.getProperty("java.io.tmpdir"), "datasource");
@@ -62,11 +64,11 @@ public class JavaLibSVMRelationSuite extends SharedSparkSession {
   public void verifyLibSVMDF() {
     Dataset<Row> dataset = spark.read().format("libsvm").option("vectorType", "dense")
       .load(path);
-    Assert.assertEquals("label", dataset.columns()[0]);
-    Assert.assertEquals("features", dataset.columns()[1]);
+    Assertions.assertEquals("label", dataset.columns()[0]);
+    Assertions.assertEquals("features", dataset.columns()[1]);
     Row r = dataset.first();
-    Assert.assertEquals(1.0, r.getDouble(0), 1e-15);
+    Assertions.assertEquals(1.0, r.getDouble(0), 1e-15);
     DenseVector v = r.getAs(1);
-    Assert.assertEquals(Vectors.dense(1.0, 0.0, 2.0, 0.0, 3.0, 0.0), v);
+    Assertions.assertEquals(Vectors.dense(1.0, 0.0, 2.0, 0.0, 3.0, 0.0), v);
   }
 }

--- a/mllib/src/test/java/org/apache/spark/ml/stat/JavaKolmogorovSmirnovTestSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/stat/JavaKolmogorovSmirnovTestSuite.java
@@ -23,8 +23,9 @@ import java.util.List;
 
 import org.apache.commons.math3.distribution.NormalDistribution;
 import org.apache.spark.sql.Encoders;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.SharedSparkSession;
 import org.apache.spark.api.java.function.Function;
@@ -37,6 +38,7 @@ public class JavaKolmogorovSmirnovTestSuite extends SharedSparkSession {
   private transient Dataset<Row> dataset;
 
   @Override
+  @BeforeEach
   public void setUp() throws IOException {
     super.setUp();
     List<java.lang.Double> points = Arrays.asList(0.1, 1.1, 10.1, -1.1);
@@ -61,7 +63,7 @@ public class JavaKolmogorovSmirnovTestSuite extends SharedSparkSession {
       .test(dataset, "sample", stdNormalCDF).head();
     double pValue1 = results.getDouble(0);
     // Cannot reject null hypothesis
-    Assert.assertTrue(pValue1 > pThreshold);
+    Assertions.assertTrue(pValue1 > pThreshold);
   }
 
   @Test
@@ -73,6 +75,6 @@ public class JavaKolmogorovSmirnovTestSuite extends SharedSparkSession {
             .test(dataset, "sample", "norm", 0.0, 1.0).head();
     double pValue1 = results.getDouble(0);
     // Cannot reject null hypothesis
-    Assert.assertTrue(pValue1 > pThreshold);
+    Assertions.assertTrue(pValue1 > pThreshold);
   }
 }

--- a/mllib/src/test/java/org/apache/spark/ml/stat/JavaSummarizerSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/stat/JavaSummarizerSuite.java
@@ -21,9 +21,10 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertArrayEquals;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 import org.apache.spark.SharedSparkSession;
 import org.apache.spark.sql.Row;
@@ -38,6 +39,7 @@ public class JavaSummarizerSuite extends SharedSparkSession {
   private transient Dataset<Row> dataset;
 
   @Override
+  @BeforeEach
   public void setUp() throws IOException {
     super.setUp();
     List<LabeledPoint> points = new ArrayList<>();

--- a/mllib/src/test/java/org/apache/spark/ml/tuning/JavaCrossValidatorSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/tuning/JavaCrossValidatorSuite.java
@@ -20,8 +20,9 @@ package org.apache.spark.ml.tuning;
 import java.io.IOException;
 import java.util.List;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.SharedSparkSession;
 import org.apache.spark.ml.classification.LogisticRegression;
@@ -38,6 +39,7 @@ public class JavaCrossValidatorSuite extends SharedSparkSession {
   private transient Dataset<Row> dataset;
 
   @Override
+  @BeforeEach
   public void setUp() throws IOException {
     super.setUp();
     List<LabeledPoint> points = generateLogisticInputAsList(1.0, 1.0, 100, 42);
@@ -59,7 +61,7 @@ public class JavaCrossValidatorSuite extends SharedSparkSession {
       .setNumFolds(3);
     CrossValidatorModel cvModel = cv.fit(dataset);
     LogisticRegression parent = (LogisticRegression) cvModel.bestModel().parent();
-    Assert.assertEquals(0.001, parent.getRegParam(), 0.0);
-    Assert.assertEquals(10, parent.getMaxIter());
+    Assertions.assertEquals(0.001, parent.getRegParam(), 0.0);
+    Assertions.assertEquals(10, parent.getMaxIter());
   }
 }

--- a/mllib/src/test/java/org/apache/spark/ml/util/JavaDefaultReadWriteSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/util/JavaDefaultReadWriteSuite.java
@@ -20,8 +20,10 @@ package org.apache.spark.ml.util;
 import java.io.File;
 import java.io.IOException;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.SharedSparkSession;
 import org.apache.spark.util.Utils;
@@ -30,6 +32,7 @@ public class JavaDefaultReadWriteSuite extends SharedSparkSession {
   File tempDir = null;
 
   @Override
+  @BeforeEach
   public void setUp() throws IOException {
     super.setUp();
     tempDir = Utils.createTempDir(
@@ -37,6 +40,7 @@ public class JavaDefaultReadWriteSuite extends SharedSparkSession {
   }
 
   @Override
+  @AfterEach
   public void tearDown() {
     super.tearDown();
     Utils.deleteRecursively(tempDir);
@@ -49,11 +53,11 @@ public class JavaDefaultReadWriteSuite extends SharedSparkSession {
     instance.set(instance.intParam(), 2);
     String outputPath = new File(tempDir, uid).getPath();
     instance.save(outputPath);
-    Assert.assertThrows(IOException.class, () -> instance.save(outputPath));
+    Assertions.assertThrows(IOException.class, () -> instance.save(outputPath));
     instance.write().session(spark).overwrite().save(outputPath);
     MyParams newInstance = MyParams.load(outputPath);
-    Assert.assertEquals("UID should match.", instance.uid(), newInstance.uid());
-    Assert.assertEquals("Params should be preserved.",
-      2, newInstance.getOrDefault(newInstance.intParam()));
+    Assertions.assertEquals(instance.uid(), newInstance.uid(), "UID should match.");
+    Assertions.assertEquals(2, newInstance.getOrDefault(newInstance.intParam()),
+      "Params should be preserved.");
   }
 }

--- a/mllib/src/test/java/org/apache/spark/mllib/classification/JavaLogisticRegressionSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/classification/JavaLogisticRegressionSuite.java
@@ -19,8 +19,8 @@ package org.apache.spark.mllib.classification;
 
 import java.util.List;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.SharedSparkSession;
 import org.apache.spark.api.java.JavaRDD;
@@ -55,7 +55,7 @@ public class JavaLogisticRegressionSuite extends SharedSparkSession {
     LogisticRegressionModel model = lrImpl.run(testRDD.rdd());
 
     int numAccurate = validatePrediction(validationData, model);
-    Assert.assertTrue(numAccurate > nPoints * 4.0 / 5.0);
+    Assertions.assertTrue(numAccurate > nPoints * 4.0 / 5.0);
   }
 
   @Test
@@ -73,6 +73,6 @@ public class JavaLogisticRegressionSuite extends SharedSparkSession {
         .run(testRDD.rdd());
 
     int numAccurate = validatePrediction(validationData, model);
-    Assert.assertTrue(numAccurate > nPoints * 4.0 / 5.0);
+    Assertions.assertTrue(numAccurate > nPoints * 4.0 / 5.0);
   }
 }

--- a/mllib/src/test/java/org/apache/spark/mllib/classification/JavaNaiveBayesSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/classification/JavaNaiveBayesSuite.java
@@ -20,8 +20,8 @@ package org.apache.spark.mllib.classification;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.SharedSparkSession;
 import org.apache.spark.api.java.JavaRDD;
@@ -59,7 +59,7 @@ public class JavaNaiveBayesSuite extends SharedSparkSession {
     NaiveBayesModel model = nb.run(testRDD.rdd());
 
     int numAccurate = validatePrediction(POINTS, model);
-    Assert.assertEquals(POINTS.size(), numAccurate);
+    Assertions.assertEquals(POINTS.size(), numAccurate);
   }
 
   @Test
@@ -68,11 +68,11 @@ public class JavaNaiveBayesSuite extends SharedSparkSession {
 
     NaiveBayesModel model1 = NaiveBayes.train(testRDD.rdd());
     int numAccurate1 = validatePrediction(POINTS, model1);
-    Assert.assertEquals(POINTS.size(), numAccurate1);
+    Assertions.assertEquals(POINTS.size(), numAccurate1);
 
     NaiveBayesModel model2 = NaiveBayes.train(testRDD.rdd(), 0.5);
     int numAccurate2 = validatePrediction(POINTS, model2);
-    Assert.assertEquals(POINTS.size(), numAccurate2);
+    Assertions.assertEquals(POINTS.size(), numAccurate2);
   }
 
   @Test

--- a/mllib/src/test/java/org/apache/spark/mllib/classification/JavaSVMSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/classification/JavaSVMSuite.java
@@ -19,8 +19,8 @@ package org.apache.spark.mllib.classification;
 
 import java.util.List;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.SharedSparkSession;
 import org.apache.spark.api.java.JavaRDD;
@@ -58,7 +58,7 @@ public class JavaSVMSuite extends SharedSparkSession {
     SVMModel model = svmSGDImpl.run(testRDD.rdd());
 
     int numAccurate = validatePrediction(validationData, model);
-    Assert.assertTrue(numAccurate > nPoints * 4.0 / 5.0);
+    Assertions.assertTrue(numAccurate > nPoints * 4.0 / 5.0);
   }
 
   @Test
@@ -75,6 +75,6 @@ public class JavaSVMSuite extends SharedSparkSession {
     SVMModel model = SVMWithSGD.train(testRDD.rdd(), 100, 1.0, 1.0, 1.0);
 
     int numAccurate = validatePrediction(validationData, model);
-    Assert.assertTrue(numAccurate > nPoints * 4.0 / 5.0);
+    Assertions.assertTrue(numAccurate > nPoints * 4.0 / 5.0);
   }
 }

--- a/mllib/src/test/java/org/apache/spark/mllib/classification/JavaStreamingLogisticRegressionSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/classification/JavaStreamingLogisticRegressionSuite.java
@@ -22,9 +22,9 @@ import java.util.List;
 
 import scala.Tuple2;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.SparkConf;
 import org.apache.spark.mllib.linalg.Vector;
@@ -40,7 +40,7 @@ public class JavaStreamingLogisticRegressionSuite {
 
   protected transient JavaStreamingContext ssc;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     SparkConf conf = new SparkConf()
       .setMaster("local[2]")
@@ -50,7 +50,7 @@ public class JavaStreamingLogisticRegressionSuite {
     ssc.checkpoint("checkpoint");
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     ssc.stop();
     ssc = null;

--- a/mllib/src/test/java/org/apache/spark/mllib/clustering/JavaBisectingKMeansSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/clustering/JavaBisectingKMeansSuite.java
@@ -19,8 +19,8 @@ package org.apache.spark.mllib.clustering;
 
 import java.util.Arrays;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.SharedSparkSession;
 import org.apache.spark.api.java.JavaRDD;
@@ -42,16 +42,16 @@ public class JavaBisectingKMeansSuite extends SharedSparkSession {
       .setMaxIterations(2)
       .setSeed(1L);
     BisectingKMeansModel model = bkm.run(points);
-    Assert.assertEquals(3, model.k());
-    Assert.assertArrayEquals(new double[]{3.0, 0.0}, model.root().center().toArray(), 1e-12);
+    Assertions.assertEquals(3, model.k());
+    Assertions.assertArrayEquals(new double[]{3.0, 0.0}, model.root().center().toArray(), 1e-12);
     for (ClusteringTreeNode child : model.root().children()) {
       double[] center = child.center().toArray();
       if (center[0] > 2) {
-        Assert.assertEquals(2, child.size());
-        Assert.assertArrayEquals(new double[]{4.0, 0.0}, center, 1e-12);
+        Assertions.assertEquals(2, child.size());
+        Assertions.assertArrayEquals(new double[]{4.0, 0.0}, center, 1e-12);
       } else {
-        Assert.assertEquals(1, child.size());
-        Assert.assertArrayEquals(new double[]{1.0, 0.0}, center, 1e-12);
+        Assertions.assertEquals(1, child.size());
+        Assertions.assertArrayEquals(new double[]{1.0, 0.0}, center, 1e-12);
       }
     }
   }

--- a/mllib/src/test/java/org/apache/spark/mllib/clustering/JavaGaussianMixtureSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/clustering/JavaGaussianMixtureSuite.java
@@ -20,9 +20,9 @@ package org.apache.spark.mllib.clustering;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.SharedSparkSession;
 import org.apache.spark.api.java.JavaRDD;

--- a/mllib/src/test/java/org/apache/spark/mllib/clustering/JavaKMeansSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/clustering/JavaKMeansSuite.java
@@ -20,9 +20,9 @@ package org.apache.spark.mllib.clustering;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.SharedSparkSession;
 import org.apache.spark.api.java.JavaRDD;

--- a/mllib/src/test/java/org/apache/spark/mllib/clustering/JavaLDASuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/clustering/JavaLDASuite.java
@@ -22,11 +22,12 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.junit.jupiter.api.BeforeEach;
 import scala.Tuple2;
 import scala.Tuple3;
 
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.apache.spark.SharedSparkSession;
 import org.apache.spark.api.java.JavaPairRDD;
@@ -36,7 +37,9 @@ import org.apache.spark.mllib.linalg.Vector;
 import org.apache.spark.mllib.linalg.Vectors;
 
 public class JavaLDASuite extends SharedSparkSession {
+
   @Override
+  @BeforeEach
   public void setUp() throws IOException {
     super.setUp();
     List<Tuple2<Long, Vector>> tinyCorpus = new ArrayList<>();

--- a/mllib/src/test/java/org/apache/spark/mllib/clustering/JavaStreamingKMeansSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/clustering/JavaStreamingKMeansSuite.java
@@ -22,9 +22,9 @@ import java.util.List;
 
 import scala.Tuple2;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.SparkConf;
 import org.apache.spark.mllib.linalg.Vector;
@@ -39,7 +39,7 @@ public class JavaStreamingKMeansSuite {
 
   protected transient JavaStreamingContext ssc;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     SparkConf conf = new SparkConf()
       .setMaster("local[2]")
@@ -49,7 +49,7 @@ public class JavaStreamingKMeansSuite {
     ssc.checkpoint("checkpoint");
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     ssc.stop();
     ssc = null;

--- a/mllib/src/test/java/org/apache/spark/mllib/evaluation/JavaRankingMetricsSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/evaluation/JavaRankingMetricsSuite.java
@@ -26,8 +26,9 @@ import scala.Tuple3;
 import scala.Tuple2$;
 import scala.Tuple3$;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.SharedSparkSession;
 import org.apache.spark.api.java.JavaRDD;
@@ -38,6 +39,7 @@ public class JavaRankingMetricsSuite extends SharedSparkSession {
     predictionLabelsAndRelevance;
 
   @Override
+  @BeforeEach
   public void setUp() throws IOException {
     super.setUp();
     predictionAndLabels = jsc.parallelize(Arrays.asList(
@@ -68,14 +70,14 @@ public class JavaRankingMetricsSuite extends SharedSparkSession {
   @Test
   public void rankingMetrics() {
     RankingMetrics<?> metrics = RankingMetrics.of(predictionAndLabels);
-    Assert.assertEquals(0.355026, metrics.meanAveragePrecision(), 1e-5);
-    Assert.assertEquals(0.75 / 3.0, metrics.precisionAt(4), 1e-5);
+    Assertions.assertEquals(0.355026, metrics.meanAveragePrecision(), 1e-5);
+    Assertions.assertEquals(0.75 / 3.0, metrics.precisionAt(4), 1e-5);
   }
 
   @Test
   public void rankingMetricsWithRelevance() {
     RankingMetrics<?> metrics = RankingMetrics.of(predictionLabelsAndRelevance);
-    Assert.assertEquals(0.355026, metrics.meanAveragePrecision(), 1e-5);
-    Assert.assertEquals(0.511959, metrics.ndcgAt(3), 1e-5);
+    Assertions.assertEquals(0.355026, metrics.meanAveragePrecision(), 1e-5);
+    Assertions.assertEquals(0.511959, metrics.ndcgAt(3), 1e-5);
   }
 }

--- a/mllib/src/test/java/org/apache/spark/mllib/feature/JavaTfIdfSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/feature/JavaTfIdfSuite.java
@@ -20,8 +20,8 @@ package org.apache.spark.mllib.feature;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.SharedSparkSession;
 import org.apache.spark.api.java.JavaRDD;
@@ -44,7 +44,7 @@ public class JavaTfIdfSuite extends SharedSparkSession {
     List<Vector> localTfIdfs = tfIdfs.collect();
     int indexOfThis = tf.indexOf("this");
     for (Vector v : localTfIdfs) {
-      Assert.assertEquals(0.0, v.apply(indexOfThis), 1e-15);
+      Assertions.assertEquals(0.0, v.apply(indexOfThis), 1e-15);
     }
   }
 
@@ -63,7 +63,7 @@ public class JavaTfIdfSuite extends SharedSparkSession {
     List<Vector> localTfIdfs = tfIdfs.collect();
     int indexOfThis = tf.indexOf("this");
     for (Vector v : localTfIdfs) {
-      Assert.assertEquals(0.0, v.apply(indexOfThis), 1e-15);
+      Assertions.assertEquals(0.0, v.apply(indexOfThis), 1e-15);
     }
   }
 

--- a/mllib/src/test/java/org/apache/spark/mllib/feature/JavaWord2VecSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/feature/JavaWord2VecSuite.java
@@ -24,8 +24,8 @@ import com.google.common.base.Strings;
 
 import scala.Tuple2;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.SharedSparkSession;
 import org.apache.spark.api.java.JavaRDD;
@@ -44,8 +44,8 @@ public class JavaWord2VecSuite extends SharedSparkSession {
       .setSeed(42L);
     Word2VecModel model = word2vec.fit(doc);
     Tuple2<String, Object>[] syms = model.findSynonyms("a", 2);
-    Assert.assertEquals(2, syms.length);
-    Assert.assertEquals("b", syms[0]._1());
-    Assert.assertEquals("c", syms[1]._1());
+    Assertions.assertEquals(2, syms.length);
+    Assertions.assertEquals("b", syms[0]._1());
+    Assertions.assertEquals("c", syms[1]._1());
   }
 }

--- a/mllib/src/test/java/org/apache/spark/mllib/fpm/JavaAssociationRulesSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/fpm/JavaAssociationRulesSuite.java
@@ -18,7 +18,7 @@ package org.apache.spark.mllib.fpm;
 
 import java.util.Arrays;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.SharedSparkSession;
 import org.apache.spark.api.java.JavaRDD;

--- a/mllib/src/test/java/org/apache/spark/mllib/fpm/JavaFPGrowthSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/fpm/JavaFPGrowthSuite.java
@@ -21,9 +21,9 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.SharedSparkSession;
 import org.apache.spark.api.java.JavaRDD;

--- a/mllib/src/test/java/org/apache/spark/mllib/fpm/JavaPrefixSpanSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/fpm/JavaPrefixSpanSuite.java
@@ -21,8 +21,8 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.SharedSparkSession;
 import org.apache.spark.api.java.JavaRDD;
@@ -45,7 +45,7 @@ public class JavaPrefixSpanSuite extends SharedSparkSession {
     PrefixSpanModel<Integer> model = prefixSpan.run(sequences);
     JavaRDD<FreqSequence<Integer>> freqSeqs = model.freqSequences().toJavaRDD();
     List<FreqSequence<Integer>> localFreqSeqs = freqSeqs.collect();
-    Assert.assertEquals(5, localFreqSeqs.size());
+    Assertions.assertEquals(5, localFreqSeqs.size());
     // Check that each frequent sequence could be materialized.
     for (PrefixSpan.FreqSequence<Integer> freqSeq : localFreqSeqs) {
       List<List<Integer>> seq = freqSeq.javaSequence();
@@ -77,7 +77,7 @@ public class JavaPrefixSpanSuite extends SharedSparkSession {
           (PrefixSpanModel<Integer>) PrefixSpanModel.load(spark.sparkContext(), outputPath);
       JavaRDD<FreqSequence<Integer>> freqSeqs = newModel.freqSequences().toJavaRDD();
       List<FreqSequence<Integer>> localFreqSeqs = freqSeqs.collect();
-      Assert.assertEquals(5, localFreqSeqs.size());
+      Assertions.assertEquals(5, localFreqSeqs.size());
       // Check that each frequent sequence could be materialized.
       for (PrefixSpan.FreqSequence<Integer> freqSeq : localFreqSeqs) {
         List<List<Integer>> seq = freqSeq.javaSequence();

--- a/mllib/src/test/java/org/apache/spark/mllib/linalg/JavaMatricesSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/linalg/JavaMatricesSuite.java
@@ -19,10 +19,10 @@ package org.apache.spark.mllib.linalg;
 
 import java.util.Random;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class JavaMatricesSuite {
 

--- a/mllib/src/test/java/org/apache/spark/mllib/linalg/JavaVectorsSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/linalg/JavaVectorsSuite.java
@@ -19,11 +19,11 @@ package org.apache.spark.mllib.linalg;
 
 import java.util.Arrays;
 
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 import scala.Tuple2;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class JavaVectorsSuite {
 

--- a/mllib/src/test/java/org/apache/spark/mllib/linalg/distributed/JavaRowMatrixSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/linalg/distributed/JavaRowMatrixSuite.java
@@ -19,7 +19,7 @@ package org.apache.spark.mllib.linalg.distributed;
 
 import java.util.Arrays;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.SharedSparkSession;
 import org.apache.spark.api.java.JavaRDD;

--- a/mllib/src/test/java/org/apache/spark/mllib/random/JavaRandomRDDsSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/random/JavaRandomRDDsSuite.java
@@ -20,8 +20,8 @@ package org.apache.spark.mllib.random;
 import java.io.Serializable;
 import java.util.Arrays;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.SharedSparkSession;
 import org.apache.spark.api.java.JavaDoubleRDD;
@@ -40,7 +40,7 @@ public class JavaRandomRDDsSuite extends SharedSparkSession {
     JavaDoubleRDD rdd2 = uniformJavaRDD(jsc, m, p);
     JavaDoubleRDD rdd3 = uniformJavaRDD(jsc, m, p, seed);
     for (JavaDoubleRDD rdd : Arrays.asList(rdd1, rdd2, rdd3)) {
-      Assert.assertEquals(m, rdd.count());
+      Assertions.assertEquals(m, rdd.count());
     }
   }
 
@@ -53,7 +53,7 @@ public class JavaRandomRDDsSuite extends SharedSparkSession {
     JavaDoubleRDD rdd2 = normalJavaRDD(jsc, m, p);
     JavaDoubleRDD rdd3 = normalJavaRDD(jsc, m, p, seed);
     for (JavaDoubleRDD rdd : Arrays.asList(rdd1, rdd2, rdd3)) {
-      Assert.assertEquals(m, rdd.count());
+      Assertions.assertEquals(m, rdd.count());
     }
   }
 
@@ -68,7 +68,7 @@ public class JavaRandomRDDsSuite extends SharedSparkSession {
     JavaDoubleRDD rdd2 = logNormalJavaRDD(jsc, mean, std, m, p);
     JavaDoubleRDD rdd3 = logNormalJavaRDD(jsc, mean, std, m, p, seed);
     for (JavaDoubleRDD rdd : Arrays.asList(rdd1, rdd2, rdd3)) {
-      Assert.assertEquals(m, rdd.count());
+      Assertions.assertEquals(m, rdd.count());
     }
   }
 
@@ -82,7 +82,7 @@ public class JavaRandomRDDsSuite extends SharedSparkSession {
     JavaDoubleRDD rdd2 = poissonJavaRDD(jsc, mean, m, p);
     JavaDoubleRDD rdd3 = poissonJavaRDD(jsc, mean, m, p, seed);
     for (JavaDoubleRDD rdd : Arrays.asList(rdd1, rdd2, rdd3)) {
-      Assert.assertEquals(m, rdd.count());
+      Assertions.assertEquals(m, rdd.count());
     }
   }
 
@@ -96,7 +96,7 @@ public class JavaRandomRDDsSuite extends SharedSparkSession {
     JavaDoubleRDD rdd2 = exponentialJavaRDD(jsc, mean, m, p);
     JavaDoubleRDD rdd3 = exponentialJavaRDD(jsc, mean, m, p, seed);
     for (JavaDoubleRDD rdd : Arrays.asList(rdd1, rdd2, rdd3)) {
-      Assert.assertEquals(m, rdd.count());
+      Assertions.assertEquals(m, rdd.count());
     }
   }
 
@@ -111,7 +111,7 @@ public class JavaRandomRDDsSuite extends SharedSparkSession {
     JavaDoubleRDD rdd2 = gammaJavaRDD(jsc, shape, jscale, m, p);
     JavaDoubleRDD rdd3 = gammaJavaRDD(jsc, shape, jscale, m, p, seed);
     for (JavaDoubleRDD rdd : Arrays.asList(rdd1, rdd2, rdd3)) {
-      Assert.assertEquals(m, rdd.count());
+      Assertions.assertEquals(m, rdd.count());
     }
   }
 
@@ -126,8 +126,8 @@ public class JavaRandomRDDsSuite extends SharedSparkSession {
     JavaRDD<Vector> rdd2 = uniformJavaVectorRDD(jsc, m, n, p);
     JavaRDD<Vector> rdd3 = uniformJavaVectorRDD(jsc, m, n, p, seed);
     for (JavaRDD<Vector> rdd : Arrays.asList(rdd1, rdd2, rdd3)) {
-      Assert.assertEquals(m, rdd.count());
-      Assert.assertEquals(n, rdd.first().size());
+      Assertions.assertEquals(m, rdd.count());
+      Assertions.assertEquals(n, rdd.first().size());
     }
   }
 
@@ -141,8 +141,8 @@ public class JavaRandomRDDsSuite extends SharedSparkSession {
     JavaRDD<Vector> rdd2 = normalJavaVectorRDD(jsc, m, n, p);
     JavaRDD<Vector> rdd3 = normalJavaVectorRDD(jsc, m, n, p, seed);
     for (JavaRDD<Vector> rdd : Arrays.asList(rdd1, rdd2, rdd3)) {
-      Assert.assertEquals(m, rdd.count());
-      Assert.assertEquals(n, rdd.first().size());
+      Assertions.assertEquals(m, rdd.count());
+      Assertions.assertEquals(n, rdd.first().size());
     }
   }
 
@@ -158,8 +158,8 @@ public class JavaRandomRDDsSuite extends SharedSparkSession {
     JavaRDD<Vector> rdd2 = logNormalJavaVectorRDD(jsc, mean, std, m, n, p);
     JavaRDD<Vector> rdd3 = logNormalJavaVectorRDD(jsc, mean, std, m, n, p, seed);
     for (JavaRDD<Vector> rdd : Arrays.asList(rdd1, rdd2, rdd3)) {
-      Assert.assertEquals(m, rdd.count());
-      Assert.assertEquals(n, rdd.first().size());
+      Assertions.assertEquals(m, rdd.count());
+      Assertions.assertEquals(n, rdd.first().size());
     }
   }
 
@@ -174,8 +174,8 @@ public class JavaRandomRDDsSuite extends SharedSparkSession {
     JavaRDD<Vector> rdd2 = poissonJavaVectorRDD(jsc, mean, m, n, p);
     JavaRDD<Vector> rdd3 = poissonJavaVectorRDD(jsc, mean, m, n, p, seed);
     for (JavaRDD<Vector> rdd : Arrays.asList(rdd1, rdd2, rdd3)) {
-      Assert.assertEquals(m, rdd.count());
-      Assert.assertEquals(n, rdd.first().size());
+      Assertions.assertEquals(m, rdd.count());
+      Assertions.assertEquals(n, rdd.first().size());
     }
   }
 
@@ -190,8 +190,8 @@ public class JavaRandomRDDsSuite extends SharedSparkSession {
     JavaRDD<Vector> rdd2 = exponentialJavaVectorRDD(jsc, mean, m, n, p);
     JavaRDD<Vector> rdd3 = exponentialJavaVectorRDD(jsc, mean, m, n, p, seed);
     for (JavaRDD<Vector> rdd : Arrays.asList(rdd1, rdd2, rdd3)) {
-      Assert.assertEquals(m, rdd.count());
-      Assert.assertEquals(n, rdd.first().size());
+      Assertions.assertEquals(m, rdd.count());
+      Assertions.assertEquals(n, rdd.first().size());
     }
   }
 
@@ -207,8 +207,8 @@ public class JavaRandomRDDsSuite extends SharedSparkSession {
     JavaRDD<Vector> rdd2 = gammaJavaVectorRDD(jsc, shape, jscale, m, n, p);
     JavaRDD<Vector> rdd3 = gammaJavaVectorRDD(jsc, shape, jscale, m, n, p, seed);
     for (JavaRDD<Vector> rdd : Arrays.asList(rdd1, rdd2, rdd3)) {
-      Assert.assertEquals(m, rdd.count());
-      Assert.assertEquals(n, rdd.first().size());
+      Assertions.assertEquals(m, rdd.count());
+      Assertions.assertEquals(n, rdd.first().size());
     }
   }
 
@@ -222,8 +222,8 @@ public class JavaRandomRDDsSuite extends SharedSparkSession {
     JavaRDD<String> rdd2 = randomJavaRDD(jsc, gen, size, numPartitions);
     JavaRDD<String> rdd3 = randomJavaRDD(jsc, gen, size, numPartitions, seed);
     for (JavaRDD<String> rdd : Arrays.asList(rdd1, rdd2, rdd3)) {
-      Assert.assertEquals(size, rdd.count());
-      Assert.assertEquals(2, rdd.first().length());
+      Assertions.assertEquals(size, rdd.count());
+      Assertions.assertEquals(2, rdd.first().length());
     }
   }
 
@@ -238,8 +238,8 @@ public class JavaRandomRDDsSuite extends SharedSparkSession {
     JavaRDD<Vector> rdd2 = randomJavaVectorRDD(jsc, generator, m, n, p);
     JavaRDD<Vector> rdd3 = randomJavaVectorRDD(jsc, generator, m, n, p, seed);
     for (JavaRDD<Vector> rdd : Arrays.asList(rdd1, rdd2, rdd3)) {
-      Assert.assertEquals(m, rdd.count());
-      Assert.assertEquals(n, rdd.first().size());
+      Assertions.assertEquals(m, rdd.count());
+      Assertions.assertEquals(n, rdd.first().size());
     }
   }
 }

--- a/mllib/src/test/java/org/apache/spark/mllib/recommendation/JavaALSSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/recommendation/JavaALSSuite.java
@@ -23,8 +23,8 @@ import java.util.List;
 import scala.Tuple2;
 import scala.Tuple3;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.SharedSparkSession;
 import org.apache.spark.api.java.JavaPairRDD;
@@ -48,13 +48,14 @@ public class JavaALSSuite extends SharedSparkSession {
     }
     JavaPairRDD<Integer, Integer> usersProducts = jsc.parallelizePairs(localUsersProducts);
     List<Rating> predictedRatings = model.predict(usersProducts).collect();
-    Assert.assertEquals(users * products, predictedRatings.size());
+    Assertions.assertEquals(users * products, predictedRatings.size());
     if (!implicitPrefs) {
       for (Rating r : predictedRatings) {
         double prediction = r.rating();
         double correct = trueRatings[r.product() * users + r.user()];
-        Assert.assertTrue(String.format("Prediction=%2.4f not below match threshold of %2.2f",
-          prediction, matchThreshold), Math.abs(prediction - correct) < matchThreshold);
+        Assertions.assertTrue(Math.abs(prediction - correct) < matchThreshold,
+          String.format("Prediction=%2.4f not below match threshold of %2.2f",
+            prediction, matchThreshold));
       }
     } else {
       // For implicit prefs we use the confidence-weighted RMSE to test
@@ -71,8 +72,9 @@ public class JavaALSSuite extends SharedSparkSession {
         denom += confidence;
       }
       double rmse = Math.sqrt(sqErr / denom);
-      Assert.assertTrue(String.format("Confidence-weighted RMSE=%2.4f above threshold of %2.2f",
-        rmse, matchThreshold), rmse < matchThreshold);
+      Assertions.assertTrue(rmse < matchThreshold,
+        String.format("Confidence-weighted RMSE=%2.4f above threshold of %2.2f",
+          rmse, matchThreshold));
     }
   }
 
@@ -176,11 +178,11 @@ public class JavaALSSuite extends SharedSparkSession {
   }
 
   private static void validateRecommendations(Rating[] recommendations, int howMany) {
-    Assert.assertEquals(howMany, recommendations.length);
+    Assertions.assertEquals(howMany, recommendations.length);
     for (int i = 1; i < recommendations.length; i++) {
-      Assert.assertTrue(recommendations[i - 1].rating() >= recommendations[i].rating());
+      Assertions.assertTrue(recommendations[i - 1].rating() >= recommendations[i].rating());
     }
-    Assert.assertTrue(recommendations[0].rating() > 0.7);
+    Assertions.assertTrue(recommendations[0].rating() > 0.7);
   }
 
 }

--- a/mllib/src/test/java/org/apache/spark/mllib/regression/JavaIsotonicRegressionSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/regression/JavaIsotonicRegressionSuite.java
@@ -23,8 +23,8 @@ import java.util.List;
 
 import scala.Tuple3;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.SharedSparkSession;
 import org.apache.spark.api.java.JavaDoubleRDD;
@@ -54,7 +54,7 @@ public class JavaIsotonicRegressionSuite extends SharedSparkSession {
     IsotonicRegressionModel model =
       runIsotonicRegression(new double[]{1, 2, 3, 3, 1, 6, 7, 8, 11, 9, 10, 12});
 
-    Assert.assertArrayEquals(
+    Assertions.assertArrayEquals(
       new double[]{1, 2, 7.0 / 3, 7.0 / 3, 6, 7, 8, 10, 10, 12}, model.predictions(), 1.0e-14);
   }
 
@@ -66,10 +66,10 @@ public class JavaIsotonicRegressionSuite extends SharedSparkSession {
     JavaDoubleRDD testRDD = jsc.parallelizeDoubles(Arrays.asList(0.0, 1.0, 9.5, 12.0, 13.0));
     List<Double> predictions = model.predict(testRDD).collect();
 
-    Assert.assertEquals(1.0, predictions.get(0).doubleValue(), 1.0e-14);
-    Assert.assertEquals(1.0, predictions.get(1).doubleValue(), 1.0e-14);
-    Assert.assertEquals(10.0, predictions.get(2).doubleValue(), 1.0e-14);
-    Assert.assertEquals(12.0, predictions.get(3).doubleValue(), 1.0e-14);
-    Assert.assertEquals(12.0, predictions.get(4).doubleValue(), 1.0e-14);
+    Assertions.assertEquals(1.0, predictions.get(0).doubleValue(), 1.0e-14);
+    Assertions.assertEquals(1.0, predictions.get(1).doubleValue(), 1.0e-14);
+    Assertions.assertEquals(10.0, predictions.get(2).doubleValue(), 1.0e-14);
+    Assertions.assertEquals(12.0, predictions.get(3).doubleValue(), 1.0e-14);
+    Assertions.assertEquals(12.0, predictions.get(4).doubleValue(), 1.0e-14);
   }
 }

--- a/mllib/src/test/java/org/apache/spark/mllib/regression/JavaLassoSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/regression/JavaLassoSuite.java
@@ -19,8 +19,8 @@ package org.apache.spark.mllib.regression;
 
 import java.util.List;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.SharedSparkSession;
 import org.apache.spark.api.java.JavaRDD;
@@ -55,7 +55,7 @@ public class JavaLassoSuite extends SharedSparkSession {
     LassoModel model = lassoSGDImpl.run(testRDD.rdd());
 
     int numAccurate = validatePrediction(validationData, model);
-    Assert.assertTrue(numAccurate > nPoints * 4.0 / 5.0);
+    Assertions.assertTrue(numAccurate > nPoints * 4.0 / 5.0);
   }
 
   @Test
@@ -72,7 +72,7 @@ public class JavaLassoSuite extends SharedSparkSession {
     LassoModel model = new LassoWithSGD(1.0, 100, 0.01, 1.0).run(testRDD.rdd());
 
     int numAccurate = validatePrediction(validationData, model);
-    Assert.assertTrue(numAccurate > nPoints * 4.0 / 5.0);
+    Assertions.assertTrue(numAccurate > nPoints * 4.0 / 5.0);
   }
 
 }

--- a/mllib/src/test/java/org/apache/spark/mllib/regression/JavaLinearRegressionSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/regression/JavaLinearRegressionSuite.java
@@ -19,8 +19,8 @@ package org.apache.spark.mllib.regression;
 
 import java.util.List;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.SharedSparkSession;
 import org.apache.spark.api.java.JavaRDD;
@@ -58,7 +58,7 @@ public class JavaLinearRegressionSuite extends SharedSparkSession {
     LinearRegressionModel model = linSGDImpl.run(testRDD.rdd());
 
     int numAccurate = validatePrediction(validationData, model);
-    Assert.assertTrue(numAccurate > nPoints * 4.0 / 5.0);
+    Assertions.assertTrue(numAccurate > nPoints * 4.0 / 5.0);
   }
 
   @Test
@@ -76,7 +76,7 @@ public class JavaLinearRegressionSuite extends SharedSparkSession {
         .run(testRDD.rdd());
 
     int numAccurate = validatePrediction(validationData, model);
-    Assert.assertTrue(numAccurate > nPoints * 4.0 / 5.0);
+    Assertions.assertTrue(numAccurate > nPoints * 4.0 / 5.0);
   }
 
   @Test

--- a/mllib/src/test/java/org/apache/spark/mllib/regression/JavaRidgeRegressionSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/regression/JavaRidgeRegressionSuite.java
@@ -21,8 +21,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.SharedSparkSession;
 import org.apache.spark.api.java.JavaRDD;
@@ -68,7 +68,7 @@ public class JavaRidgeRegressionSuite extends SharedSparkSession {
     model = ridgeSGDImpl.run(testRDD.rdd());
     double regularizedErr = predictionError(validationData, model);
 
-    Assert.assertTrue(regularizedErr < unRegularizedErr);
+    Assertions.assertTrue(regularizedErr < unRegularizedErr);
   }
 
   @Test
@@ -89,6 +89,6 @@ public class JavaRidgeRegressionSuite extends SharedSparkSession {
         .run(testRDD.rdd());
     double regularizedErr = predictionError(validationData, model);
 
-    Assert.assertTrue(regularizedErr < unRegularizedErr);
+    Assertions.assertTrue(regularizedErr < unRegularizedErr);
   }
 }

--- a/mllib/src/test/java/org/apache/spark/mllib/regression/JavaStreamingLinearRegressionSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/regression/JavaStreamingLinearRegressionSuite.java
@@ -22,9 +22,9 @@ import java.util.List;
 
 import scala.Tuple2;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.SparkConf;
 import org.apache.spark.mllib.linalg.Vector;
@@ -39,7 +39,7 @@ public class JavaStreamingLinearRegressionSuite {
 
   protected transient JavaStreamingContext ssc;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     SparkConf conf = new SparkConf()
       .setMaster("local[2]")
@@ -49,7 +49,7 @@ public class JavaStreamingLinearRegressionSuite {
     ssc.checkpoint("checkpoint");
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     ssc.stop();
     ssc = null;

--- a/mllib/src/test/java/org/apache/spark/mllib/stat/JavaStatisticsSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/stat/JavaStatisticsSuite.java
@@ -20,10 +20,10 @@ package org.apache.spark.mllib.stat;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaDoubleRDD;
@@ -46,7 +46,7 @@ public class JavaStatisticsSuite {
   private transient JavaSparkContext jsc;
   private transient JavaStreamingContext ssc;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     SparkConf conf = new SparkConf()
       .set("spark.streaming.clock", "org.apache.spark.util.ManualClock");
@@ -60,7 +60,7 @@ public class JavaStatisticsSuite {
     ssc.checkpoint("checkpoint");
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     spark.stop();
     ssc.stop();

--- a/mllib/src/test/java/org/apache/spark/mllib/tree/JavaDecisionTreeSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/tree/JavaDecisionTreeSuite.java
@@ -20,8 +20,8 @@ package org.apache.spark.mllib.tree;
 import java.util.HashMap;
 import java.util.List;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.SharedSparkSession;
 import org.apache.spark.api.java.JavaRDD;
@@ -62,7 +62,7 @@ public class JavaDecisionTreeSuite extends SharedSparkSession {
     DecisionTreeModel model = learner.run(rdd.rdd());
 
     int numCorrect = validatePrediction(arr, model);
-    Assert.assertEquals(numCorrect, rdd.count());
+    Assertions.assertEquals(numCorrect, rdd.count());
   }
 
   @Test
@@ -84,7 +84,7 @@ public class JavaDecisionTreeSuite extends SharedSparkSession {
     JavaRDD<Double> predictions = model.predict(rdd.map(LabeledPoint::features));
 
     int numCorrect = validatePrediction(arr, model);
-    Assert.assertEquals(numCorrect, rdd.count());
+    Assertions.assertEquals(numCorrect, rdd.count());
   }
 
 }

--- a/mllib/src/test/java/org/apache/spark/mllib/util/JavaMLUtilsSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/util/JavaMLUtilsSuite.java
@@ -20,8 +20,8 @@ package org.apache.spark.mllib.util;
 import java.util.Arrays;
 import java.util.Collections;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.SharedSparkSession;
 import org.apache.spark.mllib.linalg.*;
@@ -44,11 +44,11 @@ public class JavaMLUtilsSuite extends SharedSparkSession {
     ).select("label", "features");
     Dataset<Row> newDataset1 = MLUtils.convertVectorColumnsToML(dataset);
     Row new1 = newDataset1.first();
-    Assert.assertEquals(RowFactory.create(1.0, x.asML()), new1);
+    Assertions.assertEquals(RowFactory.create(1.0, x.asML()), new1);
     Row new2 = MLUtils.convertVectorColumnsToML(dataset, "features").first();
-    Assert.assertEquals(new1, new2);
+    Assertions.assertEquals(new1, new2);
     Row old1 = MLUtils.convertVectorColumnsFromML(newDataset1).first();
-    Assert.assertEquals(RowFactory.create(1.0, x), old1);
+    Assertions.assertEquals(RowFactory.create(1.0, x), old1);
   }
 
   @Test
@@ -65,10 +65,10 @@ public class JavaMLUtilsSuite extends SharedSparkSession {
 
     Dataset<Row> newDataset1 = MLUtils.convertMatrixColumnsToML(dataset);
     Row new1 = newDataset1.first();
-    Assert.assertEquals(RowFactory.create(1.0, x.asML()), new1);
+    Assertions.assertEquals(RowFactory.create(1.0, x.asML()), new1);
     Row new2 = MLUtils.convertMatrixColumnsToML(dataset, "features").first();
-    Assert.assertEquals(new1, new2);
+    Assertions.assertEquals(new1, new2);
     Row old1 = MLUtils.convertMatrixColumnsFromML(newDataset1).first();
-    Assert.assertEquals(RowFactory.create(1.0, x), old1);
+    Assertions.assertEquals(RowFactory.create(1.0, x), old1);
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -417,13 +417,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.sbt</groupId>
-      <artifactId>junit-interface</artifactId>
+      <groupId>net.aichler</groupId>
+      <artifactId>jupiter-interface</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -1182,7 +1182,7 @@
       </dependency>
       <dependency>
         <groupId>org.jmock</groupId>
-        <artifactId>jmock-junit4</artifactId>
+        <artifactId>jmock-junit5</artifactId>
         <scope>test</scope>
         <version>2.12.0</version>
       </dependency>
@@ -1193,15 +1193,15 @@
         <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>4.13.2</version>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter</artifactId>
+        <version>5.9.3</version>
         <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>com.github.sbt</groupId>
-        <artifactId>junit-interface</artifactId>
-        <version>0.13.3</version>
+        <groupId>net.aichler</groupId>
+        <artifactId>jupiter-interface</artifactId>
+        <version>0.11.1</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -1435,6 +1435,10 @@
           <exclusion>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-reload4j</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
           </exclusion>
         </exclusions>
       </dependency>

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -1650,7 +1650,7 @@ object TestSettings {
     (Test / testOptions) += Tests.Argument(TestFrameworks.ScalaTest, "-W", "120", "300"),
     (Test / testOptions) += Tests.Argument(TestFrameworks.JUnit, "-v", "-a"),
     // Enable Junit testing.
-    libraryDependencies += "com.github.sbt" % "junit-interface" % "0.13.3" % "test",
+    libraryDependencies += "net.aichler" % "jupiter-interface" % "0.11.1" % "test",
     // `parallelExecutionInTest` controls whether test suites belonging to the same SBT project
     // can run in parallel with one another. It does NOT control whether tests execute in parallel
     // within the same JVM (which is controlled by `testForkedParallel`) or whether test cases

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -45,4 +45,6 @@ addSbtPlugin("com.simplytyped" % "sbt-antlr4" % "0.8.3")
 
 addSbtPlugin("com.github.sbt" % "sbt-pom-reader" % "2.4.0")
 
+addSbtPlugin("net.aichler" % "sbt-jupiter-interface" % "0.11.1")
+
 addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.6")

--- a/resource-managers/kubernetes/core/pom.xml
+++ b/resource-managers/kubernetes/core/pom.xml
@@ -121,9 +121,20 @@
       <scope>test</scope>
     </dependency>
 
+
     <dependency>
       <groupId>org.jmock</groupId>
-      <artifactId>jmock-junit4</artifactId>
+      <artifactId>jmock-junit5</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.junit.jupiter</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.junit.platform</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
       <scope>test</scope>
     </dependency>
 

--- a/sql/catalyst/src/test/java/org/apache/spark/sql/catalyst/expressions/HiveHasherSuite.java
+++ b/sql/catalyst/src/test/java/org/apache/spark/sql/catalyst/expressions/HiveHasherSuite.java
@@ -19,8 +19,8 @@ package org.apache.spark.sql.catalyst.expressions;
 
 import org.apache.spark.unsafe.Platform;
 import org.apache.spark.unsafe.types.UTF8String;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
@@ -33,17 +33,17 @@ public class HiveHasherSuite {
   public void testKnownIntegerInputs() {
     int[] inputs = {0, Integer.MIN_VALUE, Integer.MAX_VALUE, 593689054, -189366624};
     for (int input : inputs) {
-      Assert.assertEquals(input, HiveHasher.hashInt(input));
+      Assertions.assertEquals(input, HiveHasher.hashInt(input));
     }
   }
 
   @Test
   public void testKnownLongInputs() {
-    Assert.assertEquals(0, HiveHasher.hashLong(0L));
-    Assert.assertEquals(41, HiveHasher.hashLong(-42L));
-    Assert.assertEquals(42, HiveHasher.hashLong(42L));
-    Assert.assertEquals(-2147483648, HiveHasher.hashLong(Long.MIN_VALUE));
-    Assert.assertEquals(-2147483648, HiveHasher.hashLong(Long.MAX_VALUE));
+    Assertions.assertEquals(0, HiveHasher.hashLong(0L));
+    Assertions.assertEquals(41, HiveHasher.hashLong(-42L));
+    Assertions.assertEquals(42, HiveHasher.hashLong(42L));
+    Assertions.assertEquals(-2147483648, HiveHasher.hashLong(Long.MIN_VALUE));
+    Assertions.assertEquals(-2147483648, HiveHasher.hashLong(Long.MAX_VALUE));
   }
 
   @Test
@@ -54,7 +54,7 @@ public class HiveHasherSuite {
     for (int i = 0; i < inputs.length; i++) {
       UTF8String s = UTF8String.fromString("val_" + inputs[i]);
       int hash = HiveHasher.hashUnsafeBytes(s.getBaseObject(), s.getBaseOffset(), s.numBytes());
-      Assert.assertEquals(expected[i], ((31 * inputs[i]) + hash));
+      Assertions.assertEquals(expected[i], ((31 * inputs[i]) + hash));
     }
   }
 
@@ -68,14 +68,14 @@ public class HiveHasherSuite {
     for (int i = 0; i < size; i++) {
       int vint = rand.nextInt();
       long lint = rand.nextLong();
-      Assert.assertEquals(HiveHasher.hashInt(vint), HiveHasher.hashInt(vint));
-      Assert.assertEquals(HiveHasher.hashLong(lint), HiveHasher.hashLong(lint));
+      Assertions.assertEquals(HiveHasher.hashInt(vint), HiveHasher.hashInt(vint));
+      Assertions.assertEquals(HiveHasher.hashLong(lint), HiveHasher.hashLong(lint));
 
       hashcodes.add(HiveHasher.hashLong(lint));
     }
 
     // A very loose bound.
-    Assert.assertTrue(hashcodes.size() > size * 0.95);
+    Assertions.assertTrue(hashcodes.size() > size * 0.95);
   }
 
   @Test
@@ -90,7 +90,7 @@ public class HiveHasherSuite {
       byte[] bytes = new byte[byteArrSize];
       rand.nextBytes(bytes);
 
-      Assert.assertEquals(
+      Assertions.assertEquals(
           HiveHasher.hashUnsafeBytes(bytes, Platform.BYTE_ARRAY_OFFSET, byteArrSize),
           HiveHasher.hashUnsafeBytes(bytes, Platform.BYTE_ARRAY_OFFSET, byteArrSize));
 
@@ -99,7 +99,7 @@ public class HiveHasherSuite {
     }
 
     // A very loose bound.
-    Assert.assertTrue(hashcodes.size() > size * 0.95);
+    Assertions.assertTrue(hashcodes.size() > size * 0.95);
   }
 
   @Test
@@ -113,7 +113,7 @@ public class HiveHasherSuite {
       byte[] paddedBytes = new byte[byteArrSize];
       System.arraycopy(strBytes, 0, paddedBytes, 0, strBytes.length);
 
-      Assert.assertEquals(
+      Assertions.assertEquals(
           HiveHasher.hashUnsafeBytes(paddedBytes, Platform.BYTE_ARRAY_OFFSET, byteArrSize),
           HiveHasher.hashUnsafeBytes(paddedBytes, Platform.BYTE_ARRAY_OFFSET, byteArrSize));
 
@@ -122,6 +122,6 @@ public class HiveHasherSuite {
     }
 
     // A very loose bound.
-    Assert.assertTrue(hashcodes.size() > size * 0.95);
+    Assertions.assertTrue(hashcodes.size() > size * 0.95);
   }
 }

--- a/sql/catalyst/src/test/java/org/apache/spark/sql/catalyst/expressions/RowBasedKeyValueBatchSuite.java
+++ b/sql/catalyst/src/test/java/org/apache/spark/sql/catalyst/expressions/RowBasedKeyValueBatchSuite.java
@@ -17,10 +17,10 @@
 
 package org.apache.spark.sql.catalyst.expressions;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.SparkConf;
 import org.apache.spark.memory.TaskMemoryManager;
@@ -48,7 +48,7 @@ public class RowBasedKeyValueBatchSuite {
   private int DEFAULT_CAPACITY = 1 << 16;
 
   private String getRandomString(int length) {
-    Assert.assertTrue(length >= 0);
+    Assertions.assertTrue(length >= 0);
     final byte[] bytes = new byte[length];
     rand.nextBytes(bytes);
     return new String(bytes);
@@ -102,7 +102,7 @@ public class RowBasedKeyValueBatchSuite {
     return (row.getLong(0) == v1) && (row.getLong(1) == v2);
   }
 
-  @Before
+  @BeforeEach
   public void setup() {
     memoryManager = new TestMemoryManager(new SparkConf()
             .set(package$.MODULE$.MEMORY_OFFHEAP_ENABLED(), false)
@@ -111,13 +111,13 @@ public class RowBasedKeyValueBatchSuite {
     taskMemoryManager = new TaskMemoryManager(memoryManager, 0);
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     if (taskMemoryManager != null) {
-      Assert.assertEquals(0L, taskMemoryManager.cleanUpAllAllocatedMemory());
+      Assertions.assertEquals(0L, taskMemoryManager.cleanUpAllAllocatedMemory());
       long leakedMemory = taskMemoryManager.getMemoryConsumptionForThisTask();
       taskMemoryManager = null;
-      Assert.assertEquals(0L, leakedMemory);
+      Assertions.assertEquals(0L, leakedMemory);
     }
   }
 
@@ -126,12 +126,12 @@ public class RowBasedKeyValueBatchSuite {
   public void emptyBatch() throws Exception {
     try (RowBasedKeyValueBatch batch = RowBasedKeyValueBatch.allocate(keySchema,
         valueSchema, taskMemoryManager, DEFAULT_CAPACITY)) {
-      Assert.assertEquals(0, batch.numRows());
-      Assert.assertThrows(AssertionError.class, () -> batch.getKeyRow(-1));
-      Assert.assertThrows(AssertionError.class, () -> batch.getValueRow(-1));
-      Assert.assertThrows(AssertionError.class, () -> batch.getKeyRow(0));
-      Assert.assertThrows(AssertionError.class, () -> batch.getValueRow(0));
-      Assert.assertFalse(batch.rowIterator().next());
+      Assertions.assertEquals(0, batch.numRows());
+      Assertions.assertThrows(AssertionError.class, () -> batch.getKeyRow(-1));
+      Assertions.assertThrows(AssertionError.class, () -> batch.getValueRow(-1));
+      Assertions.assertThrows(AssertionError.class, () -> batch.getKeyRow(0));
+      Assertions.assertThrows(AssertionError.class, () -> batch.getValueRow(0));
+      Assertions.assertFalse(batch.rowIterator().next());
     }
   }
 
@@ -141,8 +141,8 @@ public class RowBasedKeyValueBatchSuite {
         valueSchema, taskMemoryManager, DEFAULT_CAPACITY);
          RowBasedKeyValueBatch batch2 = RowBasedKeyValueBatch.allocate(fixedKeySchema,
         valueSchema, taskMemoryManager, DEFAULT_CAPACITY)) {
-      Assert.assertEquals(VariableLengthRowBasedKeyValueBatch.class, batch1.getClass());
-      Assert.assertEquals(FixedLengthRowBasedKeyValueBatch.class, batch2.getClass());
+      Assertions.assertEquals(VariableLengthRowBasedKeyValueBatch.class, batch1.getClass());
+      Assertions.assertEquals(FixedLengthRowBasedKeyValueBatch.class, batch2.getClass());
     }
   }
 
@@ -151,23 +151,23 @@ public class RowBasedKeyValueBatchSuite {
     try (RowBasedKeyValueBatch batch = RowBasedKeyValueBatch.allocate(keySchema,
         valueSchema, taskMemoryManager, DEFAULT_CAPACITY)) {
       UnsafeRow ret1 = appendRow(batch, makeKeyRow(1, "A"), makeValueRow(1, 1));
-      Assert.assertTrue(checkValue(ret1, 1, 1));
+      Assertions.assertTrue(checkValue(ret1, 1, 1));
       UnsafeRow ret2 = appendRow(batch, makeKeyRow(2, "B"), makeValueRow(2, 2));
-      Assert.assertTrue(checkValue(ret2, 2, 2));
+      Assertions.assertTrue(checkValue(ret2, 2, 2));
       UnsafeRow ret3 = appendRow(batch, makeKeyRow(3, "C"), makeValueRow(3, 3));
-      Assert.assertTrue(checkValue(ret3, 3, 3));
-      Assert.assertEquals(3, batch.numRows());
+      Assertions.assertTrue(checkValue(ret3, 3, 3));
+      Assertions.assertEquals(3, batch.numRows());
       UnsafeRow retrievedKey1 = batch.getKeyRow(0);
-      Assert.assertTrue(checkKey(retrievedKey1, 1, "A"));
+      Assertions.assertTrue(checkKey(retrievedKey1, 1, "A"));
       UnsafeRow retrievedKey2 = batch.getKeyRow(1);
-      Assert.assertTrue(checkKey(retrievedKey2, 2, "B"));
+      Assertions.assertTrue(checkKey(retrievedKey2, 2, "B"));
       UnsafeRow retrievedValue1 = batch.getValueRow(1);
-      Assert.assertTrue(checkValue(retrievedValue1, 2, 2));
+      Assertions.assertTrue(checkValue(retrievedValue1, 2, 2));
       UnsafeRow retrievedValue2 = batch.getValueRow(2);
-      Assert.assertTrue(checkValue(retrievedValue2, 3, 3));
+      Assertions.assertTrue(checkValue(retrievedValue2, 3, 3));
 
-      Assert.assertThrows(AssertionError.class, () -> batch.getKeyRow(3));
-      Assert.assertThrows(AssertionError.class, () -> batch.getValueRow(3));
+      Assertions.assertThrows(AssertionError.class, () -> batch.getKeyRow(3));
+      Assertions.assertThrows(AssertionError.class, () -> batch.getValueRow(3));
     }
   }
 
@@ -176,11 +176,11 @@ public class RowBasedKeyValueBatchSuite {
     try (RowBasedKeyValueBatch batch = RowBasedKeyValueBatch.allocate(keySchema,
         valueSchema, taskMemoryManager, DEFAULT_CAPACITY)) {
       appendRow(batch, makeKeyRow(1, "A"), makeValueRow(1, 1));
-      Assert.assertEquals(1, batch.numRows());
+      Assertions.assertEquals(1, batch.numRows());
       UnsafeRow retrievedValue = batch.getValueRow(0);
       updateValueRow(retrievedValue, 2, 2);
       UnsafeRow retrievedValue2 = batch.getValueRow(0);
-      Assert.assertTrue(checkValue(retrievedValue2, 2, 2));
+      Assertions.assertTrue(checkValue(retrievedValue2, 2, 2));
     }
   }
 
@@ -192,25 +192,25 @@ public class RowBasedKeyValueBatchSuite {
       appendRow(batch, makeKeyRow(1, "A"), makeValueRow(1, 1));
       appendRow(batch, makeKeyRow(2, "B"), makeValueRow(2, 2));
       appendRow(batch, makeKeyRow(3, "C"), makeValueRow(3, 3));
-      Assert.assertEquals(3, batch.numRows());
+      Assertions.assertEquals(3, batch.numRows());
       org.apache.spark.unsafe.KVIterator<UnsafeRow, UnsafeRow> iterator
               = batch.rowIterator();
-      Assert.assertTrue(iterator.next());
+      Assertions.assertTrue(iterator.next());
       UnsafeRow key1 = iterator.getKey();
       UnsafeRow value1 = iterator.getValue();
-      Assert.assertTrue(checkKey(key1, 1, "A"));
-      Assert.assertTrue(checkValue(value1, 1, 1));
-      Assert.assertTrue(iterator.next());
+      Assertions.assertTrue(checkKey(key1, 1, "A"));
+      Assertions.assertTrue(checkValue(value1, 1, 1));
+      Assertions.assertTrue(iterator.next());
       UnsafeRow key2 = iterator.getKey();
       UnsafeRow value2 = iterator.getValue();
-      Assert.assertTrue(checkKey(key2, 2, "B"));
-      Assert.assertTrue(checkValue(value2, 2, 2));
-      Assert.assertTrue(iterator.next());
+      Assertions.assertTrue(checkKey(key2, 2, "B"));
+      Assertions.assertTrue(checkValue(value2, 2, 2));
+      Assertions.assertTrue(iterator.next());
       UnsafeRow key3 = iterator.getKey();
       UnsafeRow value3 = iterator.getValue();
-      Assert.assertTrue(checkKey(key3, 3, "C"));
-      Assert.assertTrue(checkValue(value3, 3, 3));
-      Assert.assertFalse(iterator.next());
+      Assertions.assertTrue(checkKey(key3, 3, "C"));
+      Assertions.assertTrue(checkValue(value3, 3, 3));
+      Assertions.assertFalse(iterator.next());
     }
   }
 
@@ -222,32 +222,32 @@ public class RowBasedKeyValueBatchSuite {
       appendRow(batch, makeKeyRow(22, 22), makeValueRow(2, 2));
       appendRow(batch, makeKeyRow(33, 33), makeValueRow(3, 3));
       UnsafeRow retrievedKey1 = batch.getKeyRow(0);
-      Assert.assertTrue(checkKey(retrievedKey1, 11, 11));
+      Assertions.assertTrue(checkKey(retrievedKey1, 11, 11));
       UnsafeRow retrievedKey2 = batch.getKeyRow(1);
-      Assert.assertTrue(checkKey(retrievedKey2, 22, 22));
+      Assertions.assertTrue(checkKey(retrievedKey2, 22, 22));
       UnsafeRow retrievedValue1 = batch.getValueRow(1);
-      Assert.assertTrue(checkValue(retrievedValue1, 2, 2));
+      Assertions.assertTrue(checkValue(retrievedValue1, 2, 2));
       UnsafeRow retrievedValue2 = batch.getValueRow(2);
-      Assert.assertTrue(checkValue(retrievedValue2, 3, 3));
-      Assert.assertEquals(3, batch.numRows());
+      Assertions.assertTrue(checkValue(retrievedValue2, 3, 3));
+      Assertions.assertEquals(3, batch.numRows());
       org.apache.spark.unsafe.KVIterator<UnsafeRow, UnsafeRow> iterator
               = batch.rowIterator();
-      Assert.assertTrue(iterator.next());
+      Assertions.assertTrue(iterator.next());
       UnsafeRow key1 = iterator.getKey();
       UnsafeRow value1 = iterator.getValue();
-      Assert.assertTrue(checkKey(key1, 11, 11));
-      Assert.assertTrue(checkValue(value1, 1, 1));
-      Assert.assertTrue(iterator.next());
+      Assertions.assertTrue(checkKey(key1, 11, 11));
+      Assertions.assertTrue(checkValue(value1, 1, 1));
+      Assertions.assertTrue(iterator.next());
       UnsafeRow key2 = iterator.getKey();
       UnsafeRow value2 = iterator.getValue();
-      Assert.assertTrue(checkKey(key2, 22, 22));
-      Assert.assertTrue(checkValue(value2, 2, 2));
-      Assert.assertTrue(iterator.next());
+      Assertions.assertTrue(checkKey(key2, 22, 22));
+      Assertions.assertTrue(checkValue(value2, 2, 2));
+      Assertions.assertTrue(iterator.next());
       UnsafeRow key3 = iterator.getKey();
       UnsafeRow value3 = iterator.getValue();
-      Assert.assertTrue(checkKey(key3, 33, 33));
-      Assert.assertTrue(checkValue(value3, 3, 3));
-      Assert.assertFalse(iterator.next());
+      Assertions.assertTrue(checkKey(key3, 33, 33));
+      Assertions.assertTrue(checkValue(value3, 3, 3));
+      Assertions.assertFalse(iterator.next());
     }
   }
 
@@ -261,18 +261,18 @@ public class RowBasedKeyValueBatchSuite {
         appendRow(batch, key, value);
       }
       UnsafeRow ret = appendRow(batch, key, value);
-      Assert.assertEquals(10, batch.numRows());
-      Assert.assertNull(ret);
+      Assertions.assertEquals(10, batch.numRows());
+      Assertions.assertNull(ret);
       org.apache.spark.unsafe.KVIterator<UnsafeRow, UnsafeRow> iterator
               = batch.rowIterator();
       for (int i = 0; i < 10; i++) {
-        Assert.assertTrue(iterator.next());
+        Assertions.assertTrue(iterator.next());
         UnsafeRow key1 = iterator.getKey();
         UnsafeRow value1 = iterator.getValue();
-        Assert.assertTrue(checkKey(key1, 1, "A"));
-        Assert.assertTrue(checkValue(value1, 1, 1));
+        Assertions.assertTrue(checkKey(key1, 1, "A"));
+        Assertions.assertTrue(checkValue(value1, 1, 1));
       }
-      Assert.assertFalse(iterator.next());
+      Assertions.assertFalse(iterator.next());
     }
   }
 
@@ -293,18 +293,18 @@ public class RowBasedKeyValueBatchSuite {
         numRows++;
       }
       UnsafeRow ret = appendRow(batch, key, value);
-      Assert.assertEquals(numRows, batch.numRows());
-      Assert.assertNull(ret);
+      Assertions.assertEquals(numRows, batch.numRows());
+      Assertions.assertNull(ret);
       org.apache.spark.unsafe.KVIterator<UnsafeRow, UnsafeRow> iterator
               = batch.rowIterator();
       for (int i = 0; i < numRows; i++) {
-        Assert.assertTrue(iterator.next());
+        Assertions.assertTrue(iterator.next());
         UnsafeRow key1 = iterator.getKey();
         UnsafeRow value1 = iterator.getValue();
-        Assert.assertTrue(checkKey(key1, 1, "A"));
-        Assert.assertTrue(checkValue(value1, 1, 1));
+        Assertions.assertTrue(checkKey(key1, 1, "A"));
+        Assertions.assertTrue(checkValue(value1, 1, 1));
       }
-      Assert.assertFalse(iterator.next());
+      Assertions.assertFalse(iterator.next());
     }
   }
 
@@ -316,8 +316,8 @@ public class RowBasedKeyValueBatchSuite {
       UnsafeRow key = makeKeyRow(1, "A");
       UnsafeRow value = makeValueRow(11, 11);
       UnsafeRow ret = appendRow(batch, key, value);
-      Assert.assertNull(ret);
-      Assert.assertFalse(batch.rowIterator().next());
+      Assertions.assertNull(ret);
+      Assertions.assertFalse(batch.rowIterator().next());
     }
   }
 
@@ -347,11 +347,11 @@ public class RowBasedKeyValueBatchSuite {
         int rowId = rand.nextInt(numEntry);
         if (rand.nextBoolean()) {
           UnsafeRow key = batch.getKeyRow(rowId);
-          Assert.assertTrue(checkKey(key, expectedK1[rowId], expectedK2[rowId]));
+          Assertions.assertTrue(checkKey(key, expectedK1[rowId], expectedK2[rowId]));
         }
         if (rand.nextBoolean()) {
           UnsafeRow value = batch.getValueRow(rowId);
-          Assert.assertTrue(checkValue(value, expectedV1[rowId], expectedV2[rowId]));
+          Assertions.assertTrue(checkValue(value, expectedV1[rowId], expectedV2[rowId]));
         }
       }
     }

--- a/sql/catalyst/src/test/java/org/apache/spark/sql/catalyst/expressions/XXH64Suite.java
+++ b/sql/catalyst/src/test/java/org/apache/spark/sql/catalyst/expressions/XXH64Suite.java
@@ -23,8 +23,8 @@ import java.util.Random;
 import java.util.Set;
 
 import org.apache.spark.unsafe.Platform;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test the XXH64 function.
@@ -52,81 +52,81 @@ public class XXH64Suite {
 
   @Test
   public void testKnownIntegerInputs() {
-    Assert.assertEquals(0x9256E58AA397AEF1L, hasher.hashInt(TEST_INT));
-    Assert.assertEquals(0x9D5FFDFB928AB4BL, XXH64.hashInt(TEST_INT, PRIME));
+    Assertions.assertEquals(0x9256E58AA397AEF1L, hasher.hashInt(TEST_INT));
+    Assertions.assertEquals(0x9D5FFDFB928AB4BL, XXH64.hashInt(TEST_INT, PRIME));
   }
 
   @Test
   public void testKnownLongInputs() {
-    Assert.assertEquals(0xF74CB1451B32B8CFL, hasher.hashLong(TEST_LONG));
-    Assert.assertEquals(0x9C44B77FBCC302C5L, XXH64.hashLong(TEST_LONG, PRIME));
+    Assertions.assertEquals(0xF74CB1451B32B8CFL, hasher.hashLong(TEST_LONG));
+    Assertions.assertEquals(0x9C44B77FBCC302C5L, XXH64.hashLong(TEST_LONG, PRIME));
   }
 
   @Test
   public void testKnownByteArrayInputs() {
-    Assert.assertEquals(0xEF46DB3751D8E999L,
+    Assertions.assertEquals(0xEF46DB3751D8E999L,
             hasher.hashUnsafeBytes(BUFFER, Platform.BYTE_ARRAY_OFFSET, 0));
-    Assert.assertEquals(0xAC75FDA2929B17EFL,
+    Assertions.assertEquals(0xAC75FDA2929B17EFL,
             XXH64.hashUnsafeBytes(BUFFER, Platform.BYTE_ARRAY_OFFSET, 0, PRIME));
-    Assert.assertEquals(0x4FCE394CC88952D8L,
+    Assertions.assertEquals(0x4FCE394CC88952D8L,
             hasher.hashUnsafeBytes(BUFFER, Platform.BYTE_ARRAY_OFFSET, 1));
-    Assert.assertEquals(0x739840CB819FA723L,
+    Assertions.assertEquals(0x739840CB819FA723L,
             XXH64.hashUnsafeBytes(BUFFER, Platform.BYTE_ARRAY_OFFSET, 1, PRIME));
-    Assert.assertEquals(0x9256E58AA397AEF1L,
+    Assertions.assertEquals(0x9256E58AA397AEF1L,
             hasher.hashUnsafeBytes(BUFFER, Platform.BYTE_ARRAY_OFFSET, 4));
-    Assert.assertEquals(0x9D5FFDFB928AB4BL,
+    Assertions.assertEquals(0x9D5FFDFB928AB4BL,
             XXH64.hashUnsafeBytes(BUFFER, Platform.BYTE_ARRAY_OFFSET, 4, PRIME));
-    Assert.assertEquals(0xF74CB1451B32B8CFL,
+    Assertions.assertEquals(0xF74CB1451B32B8CFL,
             hasher.hashUnsafeBytes(BUFFER, Platform.BYTE_ARRAY_OFFSET, 8));
-    Assert.assertEquals(0x9C44B77FBCC302C5L,
+    Assertions.assertEquals(0x9C44B77FBCC302C5L,
             XXH64.hashUnsafeBytes(BUFFER, Platform.BYTE_ARRAY_OFFSET, 8, PRIME));
-    Assert.assertEquals(0xCFFA8DB881BC3A3DL,
+    Assertions.assertEquals(0xCFFA8DB881BC3A3DL,
             hasher.hashUnsafeBytes(BUFFER, Platform.BYTE_ARRAY_OFFSET, 14));
-    Assert.assertEquals(0x5B9611585EFCC9CBL,
+    Assertions.assertEquals(0x5B9611585EFCC9CBL,
             XXH64.hashUnsafeBytes(BUFFER, Platform.BYTE_ARRAY_OFFSET, 14, PRIME));
-    Assert.assertEquals(0x0EAB543384F878ADL,
+    Assertions.assertEquals(0x0EAB543384F878ADL,
             hasher.hashUnsafeBytes(BUFFER, Platform.BYTE_ARRAY_OFFSET, SIZE));
-    Assert.assertEquals(0xCAA65939306F1E21L,
+    Assertions.assertEquals(0xCAA65939306F1E21L,
             XXH64.hashUnsafeBytes(BUFFER, Platform.BYTE_ARRAY_OFFSET, SIZE, PRIME));
   }
 
   @Test
   public void testKnownWordArrayInputs() {
-    Assert.assertEquals(0XEF46DB3751D8E999L,
+    Assertions.assertEquals(0XEF46DB3751D8E999L,
             hasher.hashUnsafeWords(BUFFER, Platform.BYTE_ARRAY_OFFSET, 0));
-    Assert.assertEquals(0XAC75FDA2929B17EFL,
+    Assertions.assertEquals(0XAC75FDA2929B17EFL,
             XXH64.hashUnsafeWords(BUFFER, Platform.BYTE_ARRAY_OFFSET, 0, PRIME));
-    Assert.assertEquals(0XF74CB1451B32B8CFL,
+    Assertions.assertEquals(0XF74CB1451B32B8CFL,
             hasher.hashUnsafeWords(BUFFER, Platform.BYTE_ARRAY_OFFSET, 8));
-    Assert.assertEquals(0X9C44B77FBCC302C5L,
+    Assertions.assertEquals(0X9C44B77FBCC302C5L,
             XXH64.hashUnsafeWords(BUFFER, Platform.BYTE_ARRAY_OFFSET, 8, PRIME));
-    Assert.assertEquals(0X169173A697113B29L,
+    Assertions.assertEquals(0X169173A697113B29L,
             hasher.hashUnsafeWords(BUFFER, Platform.BYTE_ARRAY_OFFSET, 16));
-    Assert.assertEquals(0XA0B652822C1538F6L,
+    Assertions.assertEquals(0XA0B652822C1538F6L,
             XXH64.hashUnsafeWords(BUFFER, Platform.BYTE_ARRAY_OFFSET, 16, PRIME));
-    Assert.assertEquals(0XCEF5D1497F99F246L,
+    Assertions.assertEquals(0XCEF5D1497F99F246L,
             hasher.hashUnsafeWords(BUFFER, Platform.BYTE_ARRAY_OFFSET, 24));
-    Assert.assertEquals(0X1FA29EA08AA60D77L,
+    Assertions.assertEquals(0X1FA29EA08AA60D77L,
             XXH64.hashUnsafeWords(BUFFER, Platform.BYTE_ARRAY_OFFSET, 24, PRIME));
-    Assert.assertEquals(0XAF5753D39159EDEEL,
+    Assertions.assertEquals(0XAF5753D39159EDEEL,
             hasher.hashUnsafeWords(BUFFER, Platform.BYTE_ARRAY_OFFSET, 32));
-    Assert.assertEquals(0XDCAB9233B8CA7B0FL,
+    Assertions.assertEquals(0XDCAB9233B8CA7B0FL,
             XXH64.hashUnsafeWords(BUFFER, Platform.BYTE_ARRAY_OFFSET, 32, PRIME));
-    Assert.assertEquals(0XBAB04D3F1769013L,
+    Assertions.assertEquals(0XBAB04D3F1769013L,
             hasher.hashUnsafeWords(BUFFER, Platform.BYTE_ARRAY_OFFSET, 40));
-    Assert.assertEquals(0X21273A6B8D344CF0L,
+    Assertions.assertEquals(0X21273A6B8D344CF0L,
             XXH64.hashUnsafeWords(BUFFER, Platform.BYTE_ARRAY_OFFSET, 40, PRIME));
-    Assert.assertEquals(0XB3571A0E02A3F4E1L,
+    Assertions.assertEquals(0XB3571A0E02A3F4E1L,
             hasher.hashUnsafeWords(BUFFER, Platform.BYTE_ARRAY_OFFSET, 48));
-    Assert.assertEquals(0X867479AC0EF16154L,
+    Assertions.assertEquals(0X867479AC0EF16154L,
             XXH64.hashUnsafeWords(BUFFER, Platform.BYTE_ARRAY_OFFSET, 48, PRIME));
-    Assert.assertEquals(0XA3D5C82BD2EE104AL,
+    Assertions.assertEquals(0XA3D5C82BD2EE104AL,
             hasher.hashUnsafeWords(BUFFER, Platform.BYTE_ARRAY_OFFSET, 56));
-    Assert.assertEquals(0X55EF042CF82C04D7L,
+    Assertions.assertEquals(0X55EF042CF82C04D7L,
             XXH64.hashUnsafeWords(BUFFER, Platform.BYTE_ARRAY_OFFSET, 56, PRIME));
-    Assert.assertEquals(0X18F5388F1D2BA08CL,
+    Assertions.assertEquals(0X18F5388F1D2BA08CL,
             hasher.hashUnsafeWords(BUFFER, Platform.BYTE_ARRAY_OFFSET, 64));
-    Assert.assertEquals(0X479E7103CF9AA020L,
+    Assertions.assertEquals(0X479E7103CF9AA020L,
             XXH64.hashUnsafeWords(BUFFER, Platform.BYTE_ARRAY_OFFSET, 64, PRIME));
   }
 
@@ -140,14 +140,14 @@ public class XXH64Suite {
     for (int i = 0; i < size; i++) {
       int vint = rand.nextInt();
       long lint = rand.nextLong();
-      Assert.assertEquals(hasher.hashInt(vint), hasher.hashInt(vint));
-      Assert.assertEquals(hasher.hashLong(lint), hasher.hashLong(lint));
+      Assertions.assertEquals(hasher.hashInt(vint), hasher.hashInt(vint));
+      Assertions.assertEquals(hasher.hashLong(lint), hasher.hashLong(lint));
 
       hashcodes.add(hasher.hashLong(lint));
     }
 
     // A very loose bound.
-    Assert.assertTrue(hashcodes.size() > size * 0.95d);
+    Assertions.assertTrue(hashcodes.size() > size * 0.95d);
   }
 
   @Test
@@ -162,7 +162,7 @@ public class XXH64Suite {
       byte[] bytes = new byte[byteArrSize];
       rand.nextBytes(bytes);
 
-      Assert.assertEquals(
+      Assertions.assertEquals(
               hasher.hashUnsafeWords(bytes, Platform.BYTE_ARRAY_OFFSET, byteArrSize),
               hasher.hashUnsafeWords(bytes, Platform.BYTE_ARRAY_OFFSET, byteArrSize));
 
@@ -171,7 +171,7 @@ public class XXH64Suite {
     }
 
     // A very loose bound.
-    Assert.assertTrue(hashcodes.size() > size * 0.95d);
+    Assertions.assertTrue(hashcodes.size() > size * 0.95d);
   }
 
   @Test
@@ -185,7 +185,7 @@ public class XXH64Suite {
       byte[] paddedBytes = new byte[byteArrSize];
       System.arraycopy(strBytes, 0, paddedBytes, 0, strBytes.length);
 
-      Assert.assertEquals(
+      Assertions.assertEquals(
               hasher.hashUnsafeWords(paddedBytes, Platform.BYTE_ARRAY_OFFSET, byteArrSize),
               hasher.hashUnsafeWords(paddedBytes, Platform.BYTE_ARRAY_OFFSET, byteArrSize));
 
@@ -194,6 +194,6 @@ public class XXH64Suite {
     }
 
     // A very loose bound.
-    Assert.assertTrue(hashcodes.size() > size * 0.95d);
+    Assertions.assertTrue(hashcodes.size() > size * 0.95d);
   }
 }

--- a/sql/catalyst/src/test/java/org/apache/spark/sql/connector/catalog/CatalogLoadingSuite.java
+++ b/sql/catalyst/src/test/java/org/apache/spark/sql/connector/catalog/CatalogLoadingSuite.java
@@ -17,14 +17,13 @@
 
 package org.apache.spark.sql.connector.catalog;
 
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
 import org.apache.spark.SparkException;
 import org.apache.spark.sql.internal.SQLConf;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 import org.apache.spark.util.Utils;
-
-import org.junit.Assert;
-import org.junit.Test;
-
 public class CatalogLoadingSuite {
   @Test
   public void testLoad() throws SparkException {
@@ -32,13 +31,14 @@ public class CatalogLoadingSuite {
     conf.setConfString("spark.sql.catalog.test-name", TestCatalogPlugin.class.getCanonicalName());
 
     CatalogPlugin plugin = Catalogs.load("test-name", conf);
-    Assert.assertNotNull("Should instantiate a non-null plugin", plugin);
-    Assert.assertEquals("Plugin should have correct implementation",
-        TestCatalogPlugin.class, plugin.getClass());
+    Assertions.assertNotNull(plugin, "Should instantiate a non-null plugin");
+    Assertions.assertEquals(TestCatalogPlugin.class, plugin.getClass(),
+      "Plugin should have correct implementation");
 
     TestCatalogPlugin testPlugin = (TestCatalogPlugin) plugin;
-    Assert.assertEquals("Options should contain no keys", 0, testPlugin.options.size());
-    Assert.assertEquals("Catalog should have correct name", "test-name", testPlugin.name());
+    Assertions.assertEquals(0, testPlugin.options.size(),
+      "Options should contain no keys");
+    Assertions.assertEquals("test-name", testPlugin.name(), "Catalog should have correct name");
   }
 
   @Test
@@ -46,10 +46,10 @@ public class CatalogLoadingSuite {
     SQLConf conf = new SQLConf();
     conf.setConfString("spark.sql.catalog.test.name", TestCatalogPlugin.class.getCanonicalName());
 
-    SparkException exc = Assert.assertThrows(SparkException.class,
-            () -> Catalogs.load("test.name", conf));
-    Assert.assertTrue("Catalog name should not contain '.'", exc.getMessage().contains(
-            "Invalid catalog name: test.name"));
+    SparkException exc = Assertions.assertThrows(SparkException.class,
+      () -> Catalogs.load("test.name", conf));
+    Assertions.assertTrue(exc.getMessage().contains("Invalid catalog name: test.name"),
+      "Catalog name should not contain '.'");
   }
 
   @Test
@@ -60,31 +60,31 @@ public class CatalogLoadingSuite {
     conf.setConfString("spark.sql.catalog.test-name.kEy", "valUE");
 
     CatalogPlugin plugin = Catalogs.load("test-name", conf);
-    Assert.assertNotNull("Should instantiate a non-null plugin", plugin);
-    Assert.assertEquals("Plugin should have correct implementation",
-        TestCatalogPlugin.class, plugin.getClass());
+    Assertions.assertNotNull(plugin,"Should instantiate a non-null plugin");
+    Assertions.assertEquals(TestCatalogPlugin.class, plugin.getClass(),
+      "Plugin should have correct implementation");
 
     TestCatalogPlugin testPlugin = (TestCatalogPlugin) plugin;
 
-    Assert.assertEquals("Options should contain only two keys", 2, testPlugin.options.size());
-    Assert.assertEquals("Options should contain correct value for name (not overwritten)",
-        "not-catalog-name", testPlugin.options.get("name"));
-    Assert.assertEquals("Options should contain correct value for key",
-        "valUE", testPlugin.options.get("key"));
+    Assertions.assertEquals(2, testPlugin.options.size(), "Options should contain only two keys");
+    Assertions.assertEquals("not-catalog-name", testPlugin.options.get("name"),
+      "Options should contain correct value for name (not overwritten)");
+    Assertions.assertEquals("valUE", testPlugin.options.get("key"),
+      "Options should contain correct value for key");
   }
 
   @Test
   public void testLoadWithoutConfig() {
     SQLConf conf = new SQLConf();
 
-    SparkException exc = Assert.assertThrows(CatalogNotFoundException.class,
+    SparkException exc = Assertions.assertThrows(CatalogNotFoundException.class,
         () -> Catalogs.load("missing", conf));
 
-    Assert.assertTrue("Should complain that implementation is not configured",
-        exc.getMessage()
-            .contains("plugin class not found: spark.sql.catalog.missing is not defined"));
-    Assert.assertTrue("Should identify the catalog by name",
-        exc.getMessage().contains("missing"));
+    Assertions.assertTrue(
+      exc.getMessage().contains("plugin class not found: spark.sql.catalog.missing is not defined"),
+      "Should complain that implementation is not configured");
+    Assertions.assertTrue(exc.getMessage().contains("missing"),
+      "Should identify the catalog by name");
   }
 
   @Test
@@ -92,15 +92,15 @@ public class CatalogLoadingSuite {
     SQLConf conf = new SQLConf();
     conf.setConfString("spark.sql.catalog.missing", "com.example.NoSuchCatalogPlugin");
 
-    SparkException exc =
-      Assert.assertThrows(SparkException.class, () -> Catalogs.load("missing", conf));
+    SparkException exc = Assertions.assertThrows(SparkException.class,
+      () -> Catalogs.load("missing", conf));
 
-    Assert.assertTrue("Should complain that the class is not found",
-        exc.getMessage().contains("Cannot find catalog plugin class"));
-    Assert.assertTrue("Should identify the catalog by name",
-        exc.getMessage().contains("missing"));
-    Assert.assertTrue("Should identify the missing class",
-        exc.getMessage().contains("com.example.NoSuchCatalogPlugin"));
+    Assertions.assertTrue(exc.getMessage().contains("Cannot find catalog plugin class"),
+      "Should complain that the class is not found");
+    Assertions.assertTrue(exc.getMessage().contains("missing"),
+      "Should identify the catalog by name");
+    Assertions.assertTrue(exc.getMessage().contains("com.example.NoSuchCatalogPlugin"),
+      "Should identify the missing class");
   }
 
   @Test
@@ -110,10 +110,10 @@ public class CatalogLoadingSuite {
     conf.setConfString("spark.sql.catalog.missing", catalogClass);
 
     SparkException exc =
-        Assert.assertThrows(SparkException.class, () -> Catalogs.load("missing", conf));
+      Assertions.assertThrows(SparkException.class, () -> Catalogs.load("missing", conf));
 
-    Assert.assertTrue(exc.getCause() instanceof ClassNotFoundException);
-    Assert.assertTrue(exc.getCause().getMessage().contains(catalogClass + "Dep"));
+    Assertions.assertTrue(exc.getCause() instanceof ClassNotFoundException);
+    Assertions.assertTrue(exc.getCause().getMessage().contains(catalogClass + "Dep"));
   }
 
   @Test
@@ -122,15 +122,15 @@ public class CatalogLoadingSuite {
     String invalidClassName = InvalidCatalogPlugin.class.getCanonicalName();
     conf.setConfString("spark.sql.catalog.invalid", invalidClassName);
 
-    SparkException exc =
-      Assert.assertThrows(SparkException.class, () -> Catalogs.load("invalid", conf));
+    SparkException exc = Assertions.assertThrows(SparkException.class,
+      () -> Catalogs.load("invalid", conf));
 
-    Assert.assertTrue("Should complain that class does not implement CatalogPlugin",
-        exc.getMessage().contains("does not implement CatalogPlugin"));
-    Assert.assertTrue("Should identify the catalog by name",
-        exc.getMessage().contains("invalid"));
-    Assert.assertTrue("Should identify the class",
-        exc.getMessage().contains(invalidClassName));
+    Assertions.assertTrue(exc.getMessage().contains("does not implement CatalogPlugin"),
+      "Should complain that class does not implement CatalogPlugin");
+    Assertions.assertTrue(exc.getMessage().contains("invalid"),
+      "Should identify the catalog by name");
+    Assertions.assertTrue(exc.getMessage().contains(invalidClassName),
+      "Should identify the class");
   }
 
   @Test
@@ -139,13 +139,14 @@ public class CatalogLoadingSuite {
     String invalidClassName = ConstructorFailureCatalogPlugin.class.getCanonicalName();
     conf.setConfString("spark.sql.catalog.invalid", invalidClassName);
 
-    SparkException exc =
-      Assert.assertThrows(SparkException.class, () -> Catalogs.load("invalid", conf));
+    SparkException exc = Assertions.assertThrows(SparkException.class,
+      () -> Catalogs.load("invalid", conf));
 
-    Assert.assertTrue("Should identify the constructor error",
-        exc.getMessage().contains("Failed during instantiating constructor for catalog"));
-    Assert.assertTrue("Should have expected error message",
-        exc.getCause().getMessage().contains("Expected failure"));
+    Assertions.assertTrue(
+      exc.getMessage().contains("Failed during instantiating constructor for catalog"),
+      "Should identify the constructor error");
+    Assertions.assertTrue(exc.getCause().getMessage().contains("Expected failure"),
+      "Should have expected error message");
   }
 
   @Test
@@ -154,15 +155,16 @@ public class CatalogLoadingSuite {
     String invalidClassName = AccessErrorCatalogPlugin.class.getCanonicalName();
     conf.setConfString("spark.sql.catalog.invalid", invalidClassName);
 
-    SparkException exc =
-      Assert.assertThrows(SparkException.class, () -> Catalogs.load("invalid", conf));
+    SparkException exc = Assertions.assertThrows(SparkException.class,
+      () -> Catalogs.load("invalid", conf));
 
-    Assert.assertTrue("Should complain that no public constructor is provided",
-        exc.getMessage().contains("Failed to call public no-arg constructor for catalog"));
-    Assert.assertTrue("Should identify the catalog by name",
-        exc.getMessage().contains("invalid"));
-    Assert.assertTrue("Should identify the class",
-        exc.getMessage().contains(invalidClassName));
+    Assertions.assertTrue(
+      exc.getMessage().contains("Failed to call public no-arg constructor for catalog"),
+      "Should complain that no public constructor is provided");
+    Assertions.assertTrue(exc.getMessage().contains("invalid"),
+      "Should identify the catalog by name");
+    Assertions.assertTrue(exc.getMessage().contains(invalidClassName),
+      "Should identify the class");
   }
 }
 

--- a/sql/catalyst/src/test/java/org/apache/spark/sql/streaming/JavaGroupStateTimeoutSuite.java
+++ b/sql/catalyst/src/test/java/org/apache/spark/sql/streaming/JavaGroupStateTimeoutSuite.java
@@ -17,8 +17,8 @@
 
 package org.apache.spark.sql.streaming;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.sql.catalyst.plans.logical.EventTimeTimeout$;
 import org.apache.spark.sql.catalyst.plans.logical.NoTimeout$;
@@ -28,8 +28,9 @@ public class JavaGroupStateTimeoutSuite {
 
   @Test
   public void testTimeouts() {
-    Assert.assertSame(GroupStateTimeout.ProcessingTimeTimeout(), ProcessingTimeTimeout$.MODULE$);
-    Assert.assertSame(GroupStateTimeout.EventTimeTimeout(), EventTimeTimeout$.MODULE$);
-    Assert.assertSame(GroupStateTimeout.NoTimeout(), NoTimeout$.MODULE$);
+    Assertions
+      .assertSame(GroupStateTimeout.ProcessingTimeTimeout(), ProcessingTimeTimeout$.MODULE$);
+    Assertions.assertSame(GroupStateTimeout.EventTimeTimeout(), EventTimeTimeout$.MODULE$);
+    Assertions.assertSame(GroupStateTimeout.NoTimeout(), NoTimeout$.MODULE$);
   }
 }

--- a/sql/catalyst/src/test/java/org/apache/spark/sql/streaming/JavaOutputModeSuite.java
+++ b/sql/catalyst/src/test/java/org/apache/spark/sql/streaming/JavaOutputModeSuite.java
@@ -19,16 +19,16 @@ package org.apache.spark.sql.streaming;
 
 import java.util.Locale;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class JavaOutputModeSuite {
 
   @Test
   public void testOutputModes() {
     OutputMode o1 = OutputMode.Append();
-    Assert.assertTrue(o1.toString().toLowerCase(Locale.ROOT).contains("append"));
+    Assertions.assertTrue(o1.toString().toLowerCase(Locale.ROOT).contains("append"));
     OutputMode o2 = OutputMode.Complete();
-    Assert.assertTrue(o2.toString().toLowerCase(Locale.ROOT).contains("complete"));
+    Assertions.assertTrue(o2.toString().toLowerCase(Locale.ROOT).contains("complete"));
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/TestGroupState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/TestGroupState.scala
@@ -97,7 +97,7 @@ import org.apache.spark.sql.execution.streaming.GroupStateImpl._
  *   Integer[] values = ...;
  *
  *   // Asserts the prevState is in init state without updates.
- *   Assert.assertFalse(prevState.isUpdated());
+ *   Assertions.assertFalse(prevState.isUpdated());
  *
  *   // Calls the state transition function with the test previous state
  *   // with desired configs.
@@ -105,8 +105,8 @@ import org.apache.spark.sql.execution.streaming.GroupStateImpl._
  *
  *   // Asserts the test GroupState object has been updated but not removed
  *   // after calling the state transition function
- *   Assert.assertTrue(prevState.isUpdated());
- *   Assert.assertFalse(prevState.isRemoved());
+ *   Assertions.assertTrue(prevState.isUpdated());
+ *   Assertions.assertFalse(prevState.isRemoved());
  * }
  * }}}
  *

--- a/sql/core/src/test/java/test/org/apache/spark/sql/Java8DatasetAggregatorSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/Java8DatasetAggregatorSuite.java
@@ -19,8 +19,8 @@ package test.org.apache.spark.sql;
 
 import java.util.Arrays;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import scala.Tuple2;
 
 import org.apache.spark.sql.Dataset;
@@ -36,7 +36,7 @@ public class Java8DatasetAggregatorSuite extends JavaDatasetAggregatorSuiteBase 
     KeyValueGroupedDataset<String, Tuple2<String, Integer>> grouped = generateGroupedDataset();
     Dataset<Tuple2<String, Double>> aggregated = grouped.agg(
       org.apache.spark.sql.expressions.javalang.typed.avg(v -> (double)(v._2() * 2)));
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Arrays.asList(new Tuple2<>("a", 3.0), new Tuple2<>("b", 6.0)),
         aggregated.collectAsList());
   }
@@ -47,7 +47,7 @@ public class Java8DatasetAggregatorSuite extends JavaDatasetAggregatorSuiteBase 
     KeyValueGroupedDataset<String, Tuple2<String, Integer>> grouped = generateGroupedDataset();
     Dataset<Tuple2<String, Long>> aggregated = grouped.agg(
       org.apache.spark.sql.expressions.javalang.typed.count(v -> v));
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Arrays.asList(new Tuple2<>("a", 2L), new Tuple2<>("b", 1L)),
         aggregated.collectAsList());
   }
@@ -58,7 +58,7 @@ public class Java8DatasetAggregatorSuite extends JavaDatasetAggregatorSuiteBase 
     KeyValueGroupedDataset<String, Tuple2<String, Integer>> grouped = generateGroupedDataset();
     Dataset<Tuple2<String, Double>> aggregated = grouped.agg(
       org.apache.spark.sql.expressions.javalang.typed.sum(v -> (double)v._2()));
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Arrays.asList(new Tuple2<>("a", 3.0), new Tuple2<>("b", 3.0)),
         aggregated.collectAsList());
   }
@@ -69,7 +69,7 @@ public class Java8DatasetAggregatorSuite extends JavaDatasetAggregatorSuiteBase 
     KeyValueGroupedDataset<String, Tuple2<String, Integer>> grouped = generateGroupedDataset();
     Dataset<Tuple2<String, Long>> aggregated = grouped.agg(
       org.apache.spark.sql.expressions.javalang.typed.sumLong(v -> (long)v._2()));
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Arrays.asList(new Tuple2<>("a", 3L), new Tuple2<>("b", 3L)),
         aggregated.collectAsList());
   }

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaApplySchemaSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaApplySchemaSuite.java
@@ -23,10 +23,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
@@ -46,7 +46,7 @@ public class JavaApplySchemaSuite implements Serializable {
   private transient SparkSession spark;
   private transient JavaSparkContext jsc;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     spark = SparkSession.builder()
       .master("local[*]")
@@ -55,7 +55,7 @@ public class JavaApplySchemaSuite implements Serializable {
     jsc = new JavaSparkContext(spark.sparkContext());
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     spark.stop();
     spark = null;
@@ -110,7 +110,7 @@ public class JavaApplySchemaSuite implements Serializable {
     expected.add(RowFactory.create("Michael", 29));
     expected.add(RowFactory.create("Yin", 28));
 
-    Assert.assertEquals(expected, actual);
+    Assertions.assertEquals(expected, actual);
   }
 
   @Test
@@ -142,7 +142,7 @@ public class JavaApplySchemaSuite implements Serializable {
     expected.add("Michael_29");
     expected.add("Yin_28");
 
-    Assert.assertEquals(expected, actual);
+    Assertions.assertEquals(expected, actual);
   }
 
   @Test
@@ -186,16 +186,16 @@ public class JavaApplySchemaSuite implements Serializable {
 
     Dataset<Row> df1 = spark.read().json(jsonDS);
     StructType actualSchema1 = df1.schema();
-    Assert.assertEquals(expectedSchema, actualSchema1);
+    Assertions.assertEquals(expectedSchema, actualSchema1);
     df1.createOrReplaceTempView("jsonTable1");
     List<Row> actual1 = spark.sql("select * from jsonTable1").collectAsList();
-    Assert.assertEquals(expectedResult, actual1);
+    Assertions.assertEquals(expectedResult, actual1);
 
     Dataset<Row> df2 = spark.read().schema(expectedSchema).json(jsonDS);
     StructType actualSchema2 = df2.schema();
-    Assert.assertEquals(expectedSchema, actualSchema2);
+    Assertions.assertEquals(expectedSchema, actualSchema2);
     df2.createOrReplaceTempView("jsonTable2");
     List<Row> actual2 = spark.sql("select * from jsonTable2").collectAsList();
-    Assert.assertEquals(expectedResult, actual2);
+    Assertions.assertEquals(expectedResult, actual2);
   }
 }

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaBeanDeserializationSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaBeanDeserializationSuite.java
@@ -26,10 +26,10 @@ import java.util.*;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
+import org.junit.jupiter.api.*;
+
 import org.apache.spark.api.java.function.MapFunction;
 import org.apache.spark.api.java.function.ReduceFunction;
-import org.junit.*;
-
 import org.apache.spark.sql.*;
 import org.apache.spark.sql.catalyst.expressions.GenericRow;
 import org.apache.spark.sql.catalyst.util.DateTimeUtils;
@@ -45,12 +45,12 @@ public class JavaBeanDeserializationSuite implements Serializable {
 
   private TestSparkSession spark;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     spark = new TestSparkSession();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     spark.stop();
     spark = null;
@@ -86,7 +86,7 @@ public class JavaBeanDeserializationSuite implements Serializable {
       .as(encoder);
 
     List<ArrayRecord> records = dataset.collectAsList();
-    Assert.assertEquals(ARRAY_RECORDS, records);
+    Assertions.assertEquals(ARRAY_RECORDS, records);
   }
 
   private static final List<MapRecord> MAP_RECORDS = new ArrayList<>();
@@ -129,7 +129,7 @@ public class JavaBeanDeserializationSuite implements Serializable {
 
     List<MapRecord> records = dataset.collectAsList();
 
-    Assert.assertEquals(MAP_RECORDS, records);
+    Assertions.assertEquals(MAP_RECORDS, records);
   }
 
   @Test
@@ -167,7 +167,7 @@ public class JavaBeanDeserializationSuite implements Serializable {
 
     List<RecordSpark22000> records = dataset.collectAsList();
 
-    Assert.assertEquals(expectedRecords, records);
+    Assertions.assertEquals(expectedRecords, records);
   }
 
   @Test
@@ -186,9 +186,9 @@ public class JavaBeanDeserializationSuite implements Serializable {
 
     Dataset<Row> dataFrame = spark.createDataFrame(inputRows, schema);
 
-    AnalysisException e = Assert.assertThrows(AnalysisException.class,
+    AnalysisException e = Assertions.assertThrows(AnalysisException.class,
       () -> dataFrame.as(encoder).collect());
-    Assert.assertTrue(e.getMessage().contains("Cannot up cast "));
+    Assertions.assertTrue(e.getMessage().contains("Cannot up cast "));
   }
 
   private static Row createRecordSpark22000Row(Long index) {
@@ -550,7 +550,7 @@ public class JavaBeanDeserializationSuite implements Serializable {
 
       List<LocalDateInstantRecord> records = dataset.collectAsList();
 
-      Assert.assertEquals(expectedRecords, records);
+      Assertions.assertEquals(expectedRecords, records);
     } finally {
         spark.conf().set(SQLConf.DATETIME_JAVA8API_ENABLED().key(), originConf);
     }
@@ -580,7 +580,7 @@ public class JavaBeanDeserializationSuite implements Serializable {
     ReduceFunction<Item> rf = new ReduceFunction<Item>() {
       @Override
       public Item call(Item item1, Item item2) throws Exception {
-        Assert.assertNotSame(item1, item2);
+        Assertions.assertNotSame(item1, item2);
         return item1.addValue(item2.getV());
       }
     };
@@ -596,7 +596,7 @@ public class JavaBeanDeserializationSuite implements Serializable {
 
     List<Tuple2<String, Item>> result = finalDs.collectAsList();
 
-    Assert.assertEquals(expectedRecords, result);
+    Assertions.assertEquals(expectedRecords, result);
   }
 
   public static class Item implements Serializable {

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaColumnExpressionSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaColumnExpressionSuite.java
@@ -21,10 +21,10 @@ import java.util.*;
 
 import com.google.common.collect.Maps;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.api.java.function.FilterFunction;
 import org.apache.spark.sql.AnalysisException;
@@ -40,12 +40,12 @@ import static org.apache.spark.sql.types.DataTypes.*;
 public class JavaColumnExpressionSuite {
   private transient TestSparkSession spark;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     spark = new TestSparkSession();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     spark.stop();
     spark = null;
@@ -62,13 +62,13 @@ public class JavaColumnExpressionSuite {
       createStructField("b", StringType, false)));
     Dataset<Row> df = spark.createDataFrame(rows, schema);
     // Test with different types of collections
-    Assert.assertArrayEquals(
+    Assertions.assertArrayEquals(
       (Row[]) df.filter(df.col("a").isInCollection(Arrays.asList(1, 2))).collect(),
       (Row[]) df.filter((FilterFunction<Row>) r -> r.getInt(0) == 1 || r.getInt(0) == 2).collect());
-    Assert.assertArrayEquals(
+    Assertions.assertArrayEquals(
       (Row[]) df.filter(df.col("a").isInCollection(new HashSet<>(Arrays.asList(1, 2)))).collect(),
       (Row[]) df.filter((FilterFunction<Row>) r -> r.getInt(0) == 1 || r.getInt(0) == 2).collect());
-    Assert.assertArrayEquals(
+    Assertions.assertArrayEquals(
       (Row[]) df.filter(df.col("a").isInCollection(new ArrayList<>(Arrays.asList(3, 1)))).collect(),
       (Row[]) df.filter((FilterFunction<Row>) r -> r.getInt(0) == 3 || r.getInt(0) == 1).collect());
   }
@@ -83,13 +83,13 @@ public class JavaColumnExpressionSuite {
       createStructField("a", IntegerType, false),
       createStructField("b", createArrayType(IntegerType, false), false)));
     Dataset<Row> df = spark.createDataFrame(rows, schema);
-    AnalysisException e = Assert.assertThrows(AnalysisException.class,
+    AnalysisException e = Assertions.assertThrows(AnalysisException.class,
       () -> df.filter(df.col("a").isInCollection(Arrays.asList(new Column("b")))));
-    Assert.assertTrue(e.getErrorClass().equals("DATATYPE_MISMATCH.DATA_DIFF_TYPES"));
+    Assertions.assertTrue(e.getErrorClass().equals("DATATYPE_MISMATCH.DATA_DIFF_TYPES"));
     Map<String, String> messageParameters = new HashMap<>();
     messageParameters.put("functionName", "`in`");
     messageParameters.put("dataType", "[\"INT\", \"ARRAY<INT>\"]");
     messageParameters.put("sqlExpr", "\"(a IN (b))\"");
-    Assert.assertTrue(Maps.difference(e.getMessageParameters(), messageParameters).areEqual());
+    Assertions.assertTrue(Maps.difference(e.getMessageParameters(), messageParameters).areEqual());
   }
 }

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDataFrameReaderWriterSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDataFrameReaderWriterSuite.java
@@ -25,9 +25,9 @@ import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.test.TestSparkSession;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.util.Utils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class JavaDataFrameReaderWriterSuite {
   private SparkSession spark = new TestSparkSession();
@@ -35,7 +35,7 @@ public class JavaDataFrameReaderWriterSuite {
   private transient String input;
   private transient String output;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     input = Utils.createTempDir(System.getProperty("java.io.tmpdir"), "input").toString();
     File f = Utils.createTempDir(System.getProperty("java.io.tmpdir"), "output");
@@ -43,7 +43,7 @@ public class JavaDataFrameReaderWriterSuite {
     output = f.toString();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     spark.stop();
     spark = null;

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDataFrameSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDataFrameSuite.java
@@ -29,7 +29,7 @@ import scala.collection.Seq;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.primitives.Ints;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
@@ -49,7 +49,7 @@ public class JavaDataFrameSuite {
   private transient TestSparkSession spark;
   private transient JavaSparkContext jsc;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     // Trigger static initializer of TestData
     spark = new TestSparkSession();
@@ -57,7 +57,7 @@ public class JavaDataFrameSuite {
     spark.loadTestData();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     spark.stop();
     spark = null;
@@ -66,14 +66,14 @@ public class JavaDataFrameSuite {
   @Test
   public void testExecution() {
     Dataset<Row> df = spark.table("testData").filter("key = 1");
-    Assert.assertEquals(1, df.select("key").collectAsList().get(0).get(0));
+    Assertions.assertEquals(1, df.select("key").collectAsList().get(0).get(0));
   }
 
   @Test
   public void testCollectAndTake() {
     Dataset<Row> df = spark.table("testData").filter("key = 1 or key = 2 or key = 3");
-    Assert.assertEquals(3, df.select("key").collectAsList().size());
-    Assert.assertEquals(2, df.select("key").takeAsList(2).size());
+    Assertions.assertEquals(3, df.select("key").collectAsList().size());
+    Assertions.assertEquals(2, df.select("key").takeAsList(2).size());
   }
 
   /**
@@ -121,7 +121,7 @@ public class JavaDataFrameSuite {
     df2.select(col("*"), randn(5L));
   }
 
-  @Ignore
+  @Disabled
   public void testShow() {
     // This test case is intended ignored, but to make sure it compiles correctly
     Dataset<Row> df = spark.table("testData");
@@ -175,52 +175,52 @@ public class JavaDataFrameSuite {
 
   void validateDataFrameWithBeans(Bean bean, Dataset<Row> df) {
     StructType schema = df.schema();
-    Assert.assertEquals(new StructField("a", DoubleType$.MODULE$, false, Metadata.empty()),
+    Assertions.assertEquals(new StructField("a", DoubleType$.MODULE$, false, Metadata.empty()),
       schema.apply("a"));
-    Assert.assertEquals(
+    Assertions.assertEquals(
       new StructField("b", new ArrayType(IntegerType$.MODULE$, true), true, Metadata.empty()),
       schema.apply("b"));
     ArrayType valueType = new ArrayType(DataTypes.IntegerType, false);
     MapType mapType = new MapType(DataTypes.StringType, valueType, true);
-    Assert.assertEquals(
+    Assertions.assertEquals(
       new StructField("c", mapType, true, Metadata.empty()),
       schema.apply("c"));
-    Assert.assertEquals(
+    Assertions.assertEquals(
       new StructField("d", new ArrayType(DataTypes.StringType, true), true, Metadata.empty()),
       schema.apply("d"));
-    Assert.assertEquals(new StructField("e", DataTypes.createDecimalType(38,0), true,
+    Assertions.assertEquals(new StructField("e", DataTypes.createDecimalType(38,0), true,
       Metadata.empty()), schema.apply("e"));
     StructType nestedBeanType =
       DataTypes.createStructType(Collections.singletonList(new StructField(
         "a", IntegerType$.MODULE$, false, Metadata.empty())));
-    Assert.assertEquals(new StructField("f", nestedBeanType, true, Metadata.empty()),
+    Assertions.assertEquals(new StructField("f", nestedBeanType, true, Metadata.empty()),
       schema.apply("f"));
-    Assert.assertEquals(new StructField("g", nestedBeanType, true, Metadata.empty()),
+    Assertions.assertEquals(new StructField("g", nestedBeanType, true, Metadata.empty()),
       schema.apply("g"));
     Row first = df.select("a", "b", "c", "d", "e", "f", "g").first();
-    Assert.assertEquals(bean.getA(), first.getDouble(0), 0.0);
+    Assertions.assertEquals(bean.getA(), first.getDouble(0), 0.0);
     // Now Java lists and maps are converted to Scala Seq's and Map's. Once we get a Seq below,
     // verify that it has the expected length, and contains expected elements.
     Seq<Integer> result = first.getAs(1);
-    Assert.assertEquals(bean.getB().length, result.length());
+    Assertions.assertEquals(bean.getB().length, result.length());
     for (int i = 0; i < result.length(); i++) {
-      Assert.assertEquals(bean.getB()[i], result.apply(i));
+      Assertions.assertEquals(bean.getB()[i], result.apply(i));
     }
     @SuppressWarnings("unchecked")
     Seq<Integer> outputBuffer = (Seq<Integer>) first.getJavaMap(2).get("hello");
-    Assert.assertArrayEquals(
+    Assertions.assertArrayEquals(
       bean.getC().get("hello"),
       Ints.toArray(JavaConverters.seqAsJavaListConverter(outputBuffer).asJava()));
     Seq<String> d = first.getAs(3);
-    Assert.assertEquals(bean.getD().size(), d.length());
+    Assertions.assertEquals(bean.getD().size(), d.length());
     for (int i = 0; i < d.length(); i++) {
-      Assert.assertEquals(bean.getD().get(i), d.apply(i));
+      Assertions.assertEquals(bean.getD().get(i), d.apply(i));
     }
     // Java.math.BigInteger is equivalent to Spark Decimal(38,0)
-    Assert.assertEquals(new BigDecimal(bean.getE()), first.getDecimal(4));
+    Assertions.assertEquals(new BigDecimal(bean.getE()), first.getDecimal(4));
     Row nested = first.getStruct(5);
-    Assert.assertEquals(bean.getF().getA(), nested.getInt(0));
-    Assert.assertTrue(first.isNullAt(6));
+    Assertions.assertEquals(bean.getF().getA(), nested.getInt(0));
+    Assertions.assertTrue(first.isNullAt(6));
   }
 
   @Test
@@ -245,7 +245,7 @@ public class JavaDataFrameSuite {
     List<Row> rows = Arrays.asList(RowFactory.create(0));
     Dataset<Row> df = spark.createDataFrame(rows, schema);
     List<Row> result = df.collectAsList();
-    Assert.assertEquals(1, result.size());
+    Assertions.assertEquals(1, result.size());
   }
 
   @Test
@@ -253,12 +253,12 @@ public class JavaDataFrameSuite {
     List<StructField> fields1 = new ArrayList<>();
     fields1.add(new StructField("id", DataTypes.StringType, true, Metadata.empty()));
     StructType schema1 = StructType$.MODULE$.apply(fields1);
-    Assert.assertEquals(0, schema1.fieldIndex("id"));
+    Assertions.assertEquals(0, schema1.fieldIndex("id"));
 
     List<StructField> fields2 =
         Arrays.asList(new StructField("id", DataTypes.StringType, true, Metadata.empty()));
     StructType schema2 = StructType$.MODULE$.apply(fields2);
-    Assert.assertEquals(0, schema2.fieldIndex("id"));
+    Assertions.assertEquals(0, schema2.fieldIndex("id"));
   }
 
   private static final Comparator<Row> crosstabRowComparator = (row1, row2) -> {
@@ -272,16 +272,16 @@ public class JavaDataFrameSuite {
     Dataset<Row> df = spark.table("testData2");
     Dataset<Row> crosstab = df.stat().crosstab("a", "b");
     String[] columnNames = crosstab.schema().fieldNames();
-    Assert.assertEquals("a_b", columnNames[0]);
-    Assert.assertEquals("1", columnNames[1]);
-    Assert.assertEquals("2", columnNames[2]);
+    Assertions.assertEquals("a_b", columnNames[0]);
+    Assertions.assertEquals("1", columnNames[1]);
+    Assertions.assertEquals("2", columnNames[2]);
     List<Row> rows = crosstab.collectAsList();
     rows.sort(crosstabRowComparator);
     Integer count = 1;
     for (Row row : rows) {
-      Assert.assertEquals(row.get(0).toString(), count.toString());
-      Assert.assertEquals(1L, row.getLong(1));
-      Assert.assertEquals(1L, row.getLong(2));
+      Assertions.assertEquals(row.get(0).toString(), count.toString());
+      Assertions.assertEquals(1L, row.getLong(1));
+      Assertions.assertEquals(1L, row.getLong(2));
       count++;
     }
   }
@@ -291,21 +291,21 @@ public class JavaDataFrameSuite {
     Dataset<Row> df = spark.table("testData2");
     String[] cols = {"a"};
     Dataset<Row> results = df.stat().freqItems(cols, 0.2);
-    Assert.assertTrue(results.collectAsList().get(0).getSeq(0).contains(1));
+    Assertions.assertTrue(results.collectAsList().get(0).getSeq(0).contains(1));
   }
 
   @Test
   public void testCorrelation() {
     Dataset<Row> df = spark.table("testData2");
     Double pearsonCorr = df.stat().corr("a", "b", "pearson");
-    Assert.assertTrue(Math.abs(pearsonCorr) < 1.0e-6);
+    Assertions.assertTrue(Math.abs(pearsonCorr) < 1.0e-6);
   }
 
   @Test
   public void testCovariance() {
     Dataset<Row> df = spark.table("testData2");
     Double result = df.stat().cov("a", "b");
-    Assert.assertTrue(Math.abs(result) < 1.0e-6);
+    Assertions.assertTrue(Math.abs(result) < 1.0e-6);
   }
 
   @Test
@@ -313,10 +313,10 @@ public class JavaDataFrameSuite {
     Dataset<Row> df = spark.range(0, 100, 1, 2).select(col("id").mod(3).as("key"));
     Dataset<Row> sampled = df.stat().sampleBy("key", ImmutableMap.of(0, 0.1, 1, 0.2), 0L);
     List<Row> actual = sampled.groupBy("key").count().orderBy("key").collectAsList();
-    Assert.assertEquals(0, actual.get(0).getLong(0));
-    Assert.assertTrue(0 <= actual.get(0).getLong(1) && actual.get(0).getLong(1) <= 8);
-    Assert.assertEquals(1, actual.get(1).getLong(0));
-    Assert.assertTrue(2 <= actual.get(1).getLong(1) && actual.get(1).getLong(1) <= 13);
+    Assertions.assertEquals(0, actual.get(0).getLong(0));
+    Assertions.assertTrue(0 <= actual.get(0).getLong(1) && actual.get(0).getLong(1) <= 8);
+    Assertions.assertEquals(1, actual.get(1).getLong(0));
+    Assertions.assertTrue(2 <= actual.get(1).getLong(1) && actual.get(1).getLong(1) <= 13);
   }
 
   @Test
@@ -329,9 +329,9 @@ public class JavaDataFrameSuite {
     StructType expected = df.withColumn("a1", col("a")).withColumn("b1", col("b")).schema();
     StructType actual = df.withColumns(colMaps).schema();
     // Validate geting same result with withColumn loop call
-    Assert.assertEquals(expected, actual);
+    Assertions.assertEquals(expected, actual);
     // Validate the col names
-    Assert.assertArrayEquals(actual.fieldNames(), new String[] {"a", "b", "a1", "b1"});
+    Assertions.assertArrayEquals(actual.fieldNames(), new String[] {"a", "b", "a1", "b1"});
   }
 
   @Test
@@ -339,10 +339,10 @@ public class JavaDataFrameSuite {
     Dataset<Row> df = spark.range(0, 100, 1, 2).select(col("id").mod(3).as("key"));
     Dataset<Row> sampled = df.stat().sampleBy(col("key"), ImmutableMap.of(0, 0.1, 1, 0.2), 0L);
     List<Row> actual = sampled.groupBy("key").count().orderBy("key").collectAsList();
-    Assert.assertEquals(0, actual.get(0).getLong(0));
-    Assert.assertTrue(0 <= actual.get(0).getLong(1) && actual.get(0).getLong(1) <= 8);
-    Assert.assertEquals(1, actual.get(1).getLong(0));
-    Assert.assertTrue(2 <= actual.get(1).getLong(1) && actual.get(1).getLong(1) <= 13);
+    Assertions.assertEquals(0, actual.get(0).getLong(0));
+    Assertions.assertTrue(0 <= actual.get(0).getLong(1) && actual.get(0).getLong(1) <= 8);
+    Assertions.assertEquals(1, actual.get(1).getLong(0));
+    Assertions.assertTrue(2 <= actual.get(1).getLong(1) && actual.get(1).getLong(1) <= 13);
   }
 
   @Test
@@ -352,13 +352,13 @@ public class JavaDataFrameSuite {
       .pivot("course", Arrays.asList("dotNET", "Java"))
       .agg(sum("earnings")).orderBy("year").collectAsList();
 
-    Assert.assertEquals(2012, actual.get(0).getInt(0));
-    Assert.assertEquals(15000.0, actual.get(0).getDouble(1), 0.01);
-    Assert.assertEquals(20000.0, actual.get(0).getDouble(2), 0.01);
+    Assertions.assertEquals(2012, actual.get(0).getInt(0));
+    Assertions.assertEquals(15000.0, actual.get(0).getDouble(1), 0.01);
+    Assertions.assertEquals(20000.0, actual.get(0).getDouble(2), 0.01);
 
-    Assert.assertEquals(2013, actual.get(1).getInt(0));
-    Assert.assertEquals(48000.0, actual.get(1).getDouble(1), 0.01);
-    Assert.assertEquals(30000.0, actual.get(1).getDouble(2), 0.01);
+    Assertions.assertEquals(2013, actual.get(1).getInt(0));
+    Assertions.assertEquals(48000.0, actual.get(1).getDouble(1), 0.01);
+    Assertions.assertEquals(30000.0, actual.get(1).getDouble(2), 0.01);
   }
 
   @Test
@@ -368,13 +368,13 @@ public class JavaDataFrameSuite {
       .pivot(col("course"), Arrays.asList(lit("dotNET"), lit("Java")))
       .agg(sum("earnings")).orderBy("year").collectAsList();
 
-    Assert.assertEquals(2012, actual.get(0).getInt(0));
-    Assert.assertEquals(15000.0, actual.get(0).getDouble(1), 0.01);
-    Assert.assertEquals(20000.0, actual.get(0).getDouble(2), 0.01);
+    Assertions.assertEquals(2012, actual.get(0).getInt(0));
+    Assertions.assertEquals(15000.0, actual.get(0).getDouble(1), 0.01);
+    Assertions.assertEquals(20000.0, actual.get(0).getDouble(2), 0.01);
 
-    Assert.assertEquals(2013, actual.get(1).getInt(0));
-    Assert.assertEquals(48000.0, actual.get(1).getDouble(1), 0.01);
-    Assert.assertEquals(30000.0, actual.get(1).getDouble(2), 0.01);
+    Assertions.assertEquals(2013, actual.get(1).getInt(0));
+    Assertions.assertEquals(48000.0, actual.get(1).getDouble(1), 0.01);
+    Assertions.assertEquals(30000.0, actual.get(1).getDouble(2), 0.01);
   }
 
   private String getResource(String resource) {
@@ -397,23 +397,23 @@ public class JavaDataFrameSuite {
   @Test
   public void testGenericLoad() {
     Dataset<Row> df1 = spark.read().format("text").load(getResource("test-data/text-suite.txt"));
-    Assert.assertEquals(4L, df1.count());
+    Assertions.assertEquals(4L, df1.count());
 
     Dataset<Row> df2 = spark.read().format("text").load(
       getResource("test-data/text-suite.txt"),
       getResource("test-data/text-suite2.txt"));
-    Assert.assertEquals(5L, df2.count());
+    Assertions.assertEquals(5L, df2.count());
   }
 
   @Test
   public void testTextLoad() {
     Dataset<String> ds1 = spark.read().textFile(getResource("test-data/text-suite.txt"));
-    Assert.assertEquals(4L, ds1.count());
+    Assertions.assertEquals(4L, ds1.count());
 
     Dataset<String> ds2 = spark.read().textFile(
       getResource("test-data/text-suite.txt"),
       getResource("test-data/text-suite2.txt"));
-    Assert.assertEquals(5L, ds2.count());
+    Assertions.assertEquals(5L, ds2.count());
   }
 
   @Test
@@ -421,24 +421,24 @@ public class JavaDataFrameSuite {
     Dataset<Long> df = spark.range(1000);
 
     CountMinSketch sketch1 = df.stat().countMinSketch("id", 10, 20, 42);
-    Assert.assertEquals(1000, sketch1.totalCount());
-    Assert.assertEquals(10, sketch1.depth());
-    Assert.assertEquals(20, sketch1.width());
+    Assertions.assertEquals(1000, sketch1.totalCount());
+    Assertions.assertEquals(10, sketch1.depth());
+    Assertions.assertEquals(20, sketch1.width());
 
     CountMinSketch sketch2 = df.stat().countMinSketch(col("id"), 10, 20, 42);
-    Assert.assertEquals(1000, sketch2.totalCount());
-    Assert.assertEquals(10, sketch2.depth());
-    Assert.assertEquals(20, sketch2.width());
+    Assertions.assertEquals(1000, sketch2.totalCount());
+    Assertions.assertEquals(10, sketch2.depth());
+    Assertions.assertEquals(20, sketch2.width());
 
     CountMinSketch sketch3 = df.stat().countMinSketch("id", 0.001, 0.99, 42);
-    Assert.assertEquals(1000, sketch3.totalCount());
-    Assert.assertEquals(0.001, sketch3.relativeError(), 1.0e-4);
-    Assert.assertEquals(0.99, sketch3.confidence(), 5.0e-3);
+    Assertions.assertEquals(1000, sketch3.totalCount());
+    Assertions.assertEquals(0.001, sketch3.relativeError(), 1.0e-4);
+    Assertions.assertEquals(0.99, sketch3.confidence(), 5.0e-3);
 
     CountMinSketch sketch4 = df.stat().countMinSketch(col("id"), 0.001, 0.99, 42);
-    Assert.assertEquals(1000, sketch4.totalCount());
-    Assert.assertEquals(0.001, sketch4.relativeError(), 1.0e-4);
-    Assert.assertEquals(0.99, sketch4.confidence(), 5.0e-3);
+    Assertions.assertEquals(1000, sketch4.totalCount());
+    Assertions.assertEquals(0.001, sketch4.relativeError(), 1.0e-4);
+    Assertions.assertEquals(0.99, sketch4.confidence(), 5.0e-3);
   }
 
   @Test
@@ -446,27 +446,27 @@ public class JavaDataFrameSuite {
     Dataset<Long> df = spark.range(1000);
 
     BloomFilter filter1 = df.stat().bloomFilter("id", 1000, 0.03);
-    Assert.assertTrue(filter1.expectedFpp() - 0.03 < 1e-3);
+    Assertions.assertTrue(filter1.expectedFpp() - 0.03 < 1e-3);
     for (int i = 0; i < 1000; i++) {
-      Assert.assertTrue(filter1.mightContain(i));
+      Assertions.assertTrue(filter1.mightContain(i));
     }
 
     BloomFilter filter2 = df.stat().bloomFilter(col("id").multiply(3), 1000, 0.03);
-    Assert.assertTrue(filter2.expectedFpp() - 0.03 < 1e-3);
+    Assertions.assertTrue(filter2.expectedFpp() - 0.03 < 1e-3);
     for (int i = 0; i < 1000; i++) {
-      Assert.assertTrue(filter2.mightContain(i * 3));
+      Assertions.assertTrue(filter2.mightContain(i * 3));
     }
 
     BloomFilter filter3 = df.stat().bloomFilter("id", 1000, 64 * 5);
-    Assert.assertEquals(64 * 5, filter3.bitSize());
+    Assertions.assertEquals(64 * 5, filter3.bitSize());
     for (int i = 0; i < 1000; i++) {
-      Assert.assertTrue(filter3.mightContain(i));
+      Assertions.assertTrue(filter3.mightContain(i));
     }
 
     BloomFilter filter4 = df.stat().bloomFilter(col("id").multiply(3), 1000, 64 * 5);
-    Assert.assertEquals(64 * 5, filter4.bitSize());
+    Assertions.assertEquals(64 * 5, filter4.bitSize());
     for (int i = 0; i < 1000; i++) {
-      Assert.assertTrue(filter4.mightContain(i * 3));
+      Assertions.assertTrue(filter4.mightContain(i * 3));
     }
   }
 
@@ -483,8 +483,8 @@ public class JavaDataFrameSuite {
     BeanWithoutGetter bean = new BeanWithoutGetter();
     List<BeanWithoutGetter> data = Arrays.asList(bean);
     Dataset<Row> df = spark.createDataFrame(data, BeanWithoutGetter.class);
-    Assert.assertEquals(0, df.schema().length());
-    Assert.assertEquals(1, df.collectAsList().size());
+    Assertions.assertEquals(0, df.schema().length());
+    Assertions.assertEquals(1, df.collectAsList().size());
   }
 
   @SuppressWarnings("deprecation")
@@ -493,8 +493,8 @@ public class JavaDataFrameSuite {
     // This is a test for the deprecated API in SPARK-15615.
     JavaRDD<String> rdd = jsc.parallelize(Arrays.asList("{\"a\": 2}"));
     Dataset<Row> df = spark.read().json(rdd);
-    Assert.assertEquals(1L, df.count());
-    Assert.assertEquals(2L, df.collectAsList().get(0).getLong(0));
+    Assertions.assertEquals(1L, df.count());
+    Assertions.assertEquals(2L, df.collectAsList().get(0).getLong(0));
   }
 
   public class CircularReference1Bean implements Serializable {
@@ -526,7 +526,7 @@ public class JavaDataFrameSuite {
   @Test
   public void testCircularReferenceBean() {
     CircularReference1Bean bean = new CircularReference1Bean();
-    Assert.assertThrows(UnsupportedOperationException.class,
+    Assertions.assertThrows(UnsupportedOperationException.class,
       () -> spark.createDataFrame(Arrays.asList(bean), CircularReference1Bean.class));
   }
 
@@ -538,6 +538,6 @@ public class JavaDataFrameSuite {
       .toArray(String[]::new);
     String[] expected = spark.table("testData").collectAsList().stream()
       .map(row -> row.get(0).toString() + row.getString(1)).toArray(String[]::new);
-    Assert.assertArrayEquals(expected, result);
+    Assertions.assertArrayEquals(expected, result);
   }
 }

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDataFrameWriterV2Suite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDataFrameWriterV2Suite.java
@@ -26,9 +26,9 @@ import org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException;
 import org.apache.spark.sql.connector.catalog.InMemoryTableCatalog;
 import org.apache.spark.sql.test.TestSparkSession;
 import org.apache.spark.sql.types.StructType;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.spark.sql.functions.*;
 
@@ -40,14 +40,14 @@ public class JavaDataFrameWriterV2Suite {
     return spark.read().schema(schema).text();
   }
 
-  @Before
+  @BeforeEach
   public void createTestTable() {
     this.spark = new TestSparkSession();
     spark.conf().set("spark.sql.catalog.testcat", InMemoryTableCatalog.class.getName());
     spark.sql("CREATE TABLE testcat.t (s string) USING foo");
   }
 
-  @After
+  @AfterEach
   public void dropTestTable() {
     spark.sql("DROP TABLE testcat.t");
     spark.stop();

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDatasetAggregatorSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDatasetAggregatorSuite.java
@@ -21,8 +21,8 @@ import java.util.Arrays;
 
 import scala.Tuple2;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Encoder;
@@ -39,13 +39,13 @@ public class JavaDatasetAggregatorSuite extends JavaDatasetAggregatorSuiteBase {
     KeyValueGroupedDataset<String, Tuple2<String, Integer>> grouped = generateGroupedDataset();
 
     Dataset<Tuple2<String, Integer>> aggregated = grouped.agg(new IntSumOf().toColumn());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Arrays.asList(new Tuple2<>("a", 3), new Tuple2<>("b", 3)),
         aggregated.collectAsList());
 
     Dataset<Tuple2<String, Integer>> aggregated2 = grouped.agg(new IntSumOf().toColumn())
       .as(Encoders.tuple(Encoders.STRING(), Encoders.INT()));
-    Assert.assertEquals(
+    Assertions.assertEquals(
       Arrays.asList(
         new Tuple2<>("a", 3),
         new Tuple2<>("b", 3)),
@@ -90,7 +90,7 @@ public class JavaDatasetAggregatorSuite extends JavaDatasetAggregatorSuiteBase {
     KeyValueGroupedDataset<String, Tuple2<String, Integer>> grouped = generateGroupedDataset();
     Dataset<Tuple2<String, Double>> aggregated = grouped.agg(
       org.apache.spark.sql.expressions.javalang.typed.avg(value -> value._2() * 2.0));
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Arrays.asList(new Tuple2<>("a", 3.0), new Tuple2<>("b", 6.0)),
         aggregated.collectAsList());
   }
@@ -101,7 +101,7 @@ public class JavaDatasetAggregatorSuite extends JavaDatasetAggregatorSuiteBase {
     KeyValueGroupedDataset<String, Tuple2<String, Integer>> grouped = generateGroupedDataset();
     Dataset<Tuple2<String, Long>> aggregated = grouped.agg(
       org.apache.spark.sql.expressions.javalang.typed.count(value -> value));
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Arrays.asList(new Tuple2<>("a", 2L), new Tuple2<>("b", 1L)),
         aggregated.collectAsList());
   }
@@ -112,7 +112,7 @@ public class JavaDatasetAggregatorSuite extends JavaDatasetAggregatorSuiteBase {
     KeyValueGroupedDataset<String, Tuple2<String, Integer>> grouped = generateGroupedDataset();
     Dataset<Tuple2<String, Double>> aggregated = grouped.agg(
       org.apache.spark.sql.expressions.javalang.typed.sum(value -> (double) value._2()));
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Arrays.asList(new Tuple2<>("a", 3.0), new Tuple2<>("b", 3.0)),
         aggregated.collectAsList());
   }
@@ -123,7 +123,7 @@ public class JavaDatasetAggregatorSuite extends JavaDatasetAggregatorSuiteBase {
     KeyValueGroupedDataset<String, Tuple2<String, Integer>> grouped = generateGroupedDataset();
     Dataset<Tuple2<String, Long>> aggregated = grouped.agg(
       org.apache.spark.sql.expressions.javalang.typed.sumLong(value -> (long) value._2()));
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Arrays.asList(new Tuple2<>("a", 3L), new Tuple2<>("b", 3L)),
         aggregated.collectAsList());
   }

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDatasetAggregatorSuiteBase.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDatasetAggregatorSuiteBase.java
@@ -23,8 +23,8 @@ import java.util.List;
 
 import scala.Tuple2;
 
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 import org.apache.spark.api.java.function.MapFunction;
 import org.apache.spark.sql.Dataset;
@@ -39,14 +39,14 @@ import org.apache.spark.sql.test.TestSparkSession;
 public class JavaDatasetAggregatorSuiteBase implements Serializable {
   private transient TestSparkSession spark;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     // Trigger static initializer of TestData
     spark = new TestSparkSession();
     spark.loadTestData();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     spark.stop();
     spark = null;

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDatasetSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDatasetSuite.java
@@ -36,7 +36,10 @@ import scala.Tuple5;
 
 import com.google.common.base.Objects;
 import org.apache.spark.sql.streaming.TestGroupState;
-import org.junit.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaSparkContext;
@@ -56,7 +59,7 @@ public class JavaDatasetSuite implements Serializable {
   private transient TestSparkSession spark;
   private transient JavaSparkContext jsc;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     // Trigger static initializer of TestData
     spark = new TestSparkSession();
@@ -64,7 +67,7 @@ public class JavaDatasetSuite implements Serializable {
     spark.loadTestData();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     spark.stop();
     spark = null;
@@ -79,7 +82,7 @@ public class JavaDatasetSuite implements Serializable {
     List<String> data = Arrays.asList("hello", "world");
     Dataset<String> ds = spark.createDataset(data, Encoders.STRING());
     List<String> collected = ds.collectAsList();
-    Assert.assertEquals(Arrays.asList("hello", "world"), collected);
+    Assertions.assertEquals(Arrays.asList("hello", "world"), collected);
   }
 
   @Test
@@ -87,7 +90,7 @@ public class JavaDatasetSuite implements Serializable {
     List<String> data = Arrays.asList("hello", "world");
     Dataset<String> ds = spark.createDataset(data, Encoders.STRING());
     List<String> collected = ds.takeAsList(1);
-    Assert.assertEquals(Arrays.asList("hello"), collected);
+    Assertions.assertEquals(Arrays.asList("hello"), collected);
   }
 
   @Test
@@ -95,9 +98,9 @@ public class JavaDatasetSuite implements Serializable {
     List<String> data = Arrays.asList("hello", "world");
     Dataset<String> ds = spark.createDataset(data, Encoders.STRING());
     Iterator<String> iter = ds.toLocalIterator();
-    Assert.assertEquals("hello", iter.next());
-    Assert.assertEquals("world", iter.next());
-    Assert.assertFalse(iter.hasNext());
+    Assertions.assertEquals("hello", iter.next());
+    Assertions.assertEquals("world", iter.next());
+    Assertions.assertFalse(iter.hasNext());
   }
 
   // SPARK-15632: typed filter should preserve the underlying logical schema
@@ -105,22 +108,22 @@ public class JavaDatasetSuite implements Serializable {
   public void testTypedFilterPreservingSchema() {
     Dataset<Long> ds = spark.range(10);
     Dataset<Long> ds2 = ds.filter((FilterFunction<Long>) value -> value > 3);
-    Assert.assertEquals(ds.schema(), ds2.schema());
+    Assertions.assertEquals(ds.schema(), ds2.schema());
   }
 
   @Test
   public void testCommonOperation() {
     List<String> data = Arrays.asList("hello", "world");
     Dataset<String> ds = spark.createDataset(data, Encoders.STRING());
-    Assert.assertEquals("hello", ds.first());
+    Assertions.assertEquals("hello", ds.first());
 
     Dataset<String> filtered = ds.filter((FilterFunction<String>) v -> v.startsWith("h"));
-    Assert.assertEquals(Arrays.asList("hello"), filtered.collectAsList());
+    Assertions.assertEquals(Arrays.asList("hello"), filtered.collectAsList());
 
 
     Dataset<Integer> mapped =
       ds.map((MapFunction<String, Integer>) String::length, Encoders.INT());
-    Assert.assertEquals(Arrays.asList(5, 5), mapped.collectAsList());
+    Assertions.assertEquals(Arrays.asList(5, 5), mapped.collectAsList());
 
     Dataset<String> parMapped = ds.mapPartitions((MapPartitionsFunction<String, String>) it -> {
       List<String> ls = new LinkedList<>();
@@ -129,7 +132,7 @@ public class JavaDatasetSuite implements Serializable {
       }
       return ls.iterator();
     }, Encoders.STRING());
-    Assert.assertEquals(Arrays.asList("HELLO", "WORLD"), parMapped.collectAsList());
+    Assertions.assertEquals(Arrays.asList("HELLO", "WORLD"), parMapped.collectAsList());
 
     Dataset<String> flatMapped = ds.flatMap((FlatMapFunction<String, String>) s -> {
       List<String> ls = new LinkedList<>();
@@ -138,7 +141,7 @@ public class JavaDatasetSuite implements Serializable {
       }
       return ls.iterator();
     }, Encoders.STRING());
-    Assert.assertEquals(
+    Assertions.assertEquals(
       Arrays.asList("h", "e", "l", "l", "o", "w", "o", "r", "l", "d"),
       flatMapped.collectAsList());
   }
@@ -150,7 +153,7 @@ public class JavaDatasetSuite implements Serializable {
     Dataset<String> ds = spark.createDataset(data, Encoders.STRING());
 
     ds.foreach((ForeachFunction<String>) s -> accum.add(1));
-    Assert.assertEquals(3, accum.value().intValue());
+    Assertions.assertEquals(3, accum.value().intValue());
   }
 
   @Test
@@ -159,7 +162,7 @@ public class JavaDatasetSuite implements Serializable {
     Dataset<Integer> ds = spark.createDataset(data, Encoders.INT());
 
     int reduced = ds.reduce((ReduceFunction<Integer>) (v1, v2) -> v1 + v2);
-    Assert.assertEquals(6, reduced);
+    Assertions.assertEquals(6, reduced);
   }
 
   @Test
@@ -197,7 +200,7 @@ public class JavaDatasetSuite implements Serializable {
       GroupStateTimeout.NoTimeout(),
       kvInitStateMappedDS);
 
-    Assert.assertEquals(asSet("1a", "2", "3foobar"), toSet(flatMapped2.collectAsList()));
+    Assertions.assertEquals(asSet("1a", "2", "3foobar"), toSet(flatMapped2.collectAsList()));
     Dataset<String> mapped2 = grouped.mapGroupsWithState(
       (MapGroupsWithStateFunction<Integer, String, Long, String>) (key, values, s) -> {
         StringBuilder sb = new StringBuilder(key.toString());
@@ -210,35 +213,29 @@ public class JavaDatasetSuite implements Serializable {
       Encoders.STRING(),
       GroupStateTimeout.NoTimeout(),
       kvInitStateMappedDS);
-    Assert.assertEquals(asSet("1a", "2", "3foobar"), toSet(mapped2.collectAsList()));
+    Assertions.assertEquals(asSet("1a", "2", "3foobar"), toSet(mapped2.collectAsList()));
   }
 
   @Test
   public void testIllegalTestGroupStateCreations() {
     // SPARK-35800: test code throws upon illegal TestGroupState create() calls
-    Assert.assertThrows(
-      "eventTimeWatermarkMs must be 0 or positive if present",
+    Assertions.assertThrows(
       IllegalArgumentException.class,
-      () -> {
-        TestGroupState.create(
-          Optional.of(5), GroupStateTimeout.EventTimeTimeout(), 0L, Optional.of(-1000L), false);
-      });
+      () -> TestGroupState.create(
+        Optional.of(5), GroupStateTimeout.EventTimeTimeout(), 0L, Optional.of(-1000L), false),
+      "eventTimeWatermarkMs must be 0 or positive if present");
 
-    Assert.assertThrows(
-      "batchProcessingTimeMs must be 0 or positive",
+    Assertions.assertThrows(
       IllegalArgumentException.class,
-      () -> {
-        TestGroupState.create(
-          Optional.of(5), GroupStateTimeout.EventTimeTimeout(), -100L, Optional.of(1000L), false);
-      });
+      () -> TestGroupState.create(
+        Optional.of(5), GroupStateTimeout.EventTimeTimeout(), -100L, Optional.of(1000L), false),
+      "batchProcessingTimeMs must be 0 or positive");
 
-    Assert.assertThrows(
-      "hasTimedOut is true however there's no timeout configured",
+    Assertions.assertThrows(
       UnsupportedOperationException.class,
-      () -> {
-        TestGroupState.create(
-          Optional.of(5), GroupStateTimeout.NoTimeout(), 100L, Optional.empty(), true);
-      });
+      () -> TestGroupState.create(
+        Optional.of(5), GroupStateTimeout.NoTimeout(), 100L, Optional.empty(), true),
+      "hasTimedOut is true however there's no timeout configured");
   }
 
   @Test
@@ -270,37 +267,37 @@ public class JavaDatasetSuite implements Serializable {
     TestGroupState<Integer> prevState = TestGroupState.create(
       Optional.empty(), GroupStateTimeout.EventTimeTimeout(), 0L, Optional.of(1000L), false);
 
-    Assert.assertFalse(prevState.isUpdated());
-    Assert.assertFalse(prevState.isRemoved());
-    Assert.assertFalse(prevState.exists());
-    Assert.assertEquals(Optional.empty(), prevState.getTimeoutTimestampMs());
+    Assertions.assertFalse(prevState.isUpdated());
+    Assertions.assertFalse(prevState.isRemoved());
+    Assertions.assertFalse(prevState.exists());
+    Assertions.assertEquals(Optional.empty(), prevState.getTimeoutTimestampMs());
 
     Integer[] values = {1, 3, 5};
     mappingFunction.call(1, Arrays.asList(values).iterator(), prevState);
 
-    Assert.assertTrue(prevState.isUpdated());
-    Assert.assertFalse(prevState.isRemoved());
-    Assert.assertTrue(prevState.exists());
-    Assert.assertEquals(Integer.valueOf(9), prevState.get());
-    Assert.assertEquals(0L, prevState.getCurrentProcessingTimeMs());
-    Assert.assertEquals(1000L, prevState.getCurrentWatermarkMs());
-    Assert.assertEquals(Optional.of(1500L), prevState.getTimeoutTimestampMs());
+    Assertions.assertTrue(prevState.isUpdated());
+    Assertions.assertFalse(prevState.isRemoved());
+    Assertions.assertTrue(prevState.exists());
+    Assertions.assertEquals(Integer.valueOf(9), prevState.get());
+    Assertions.assertEquals(0L, prevState.getCurrentProcessingTimeMs());
+    Assertions.assertEquals(1000L, prevState.getCurrentWatermarkMs());
+    Assertions.assertEquals(Optional.of(1500L), prevState.getTimeoutTimestampMs());
 
     mappingFunction.call(1, Arrays.asList(values).iterator(), prevState);
 
-    Assert.assertTrue(prevState.isUpdated());
-    Assert.assertFalse(prevState.isRemoved());
-    Assert.assertTrue(prevState.exists());
-    Assert.assertEquals(Integer.valueOf(18), prevState.get());
+    Assertions.assertTrue(prevState.isUpdated());
+    Assertions.assertFalse(prevState.isRemoved());
+    Assertions.assertTrue(prevState.exists());
+    Assertions.assertEquals(Integer.valueOf(18), prevState.get());
 
     prevState = TestGroupState.create(
       Optional.of(9), GroupStateTimeout.EventTimeTimeout(), 0L, Optional.of(1000L), true);
 
     mappingFunction.call(1, Arrays.asList(values).iterator(), prevState);
 
-    Assert.assertFalse(prevState.isUpdated());
-    Assert.assertTrue(prevState.isRemoved());
-    Assert.assertFalse(prevState.exists());
+    Assertions.assertFalse(prevState.isUpdated());
+    Assertions.assertTrue(prevState.isRemoved());
+    Assertions.assertFalse(prevState.exists());
   }
 
   @Test
@@ -319,7 +316,7 @@ public class JavaDatasetSuite implements Serializable {
         return sb.toString();
       }, Encoders.STRING());
 
-    Assert.assertEquals(asSet("1a", "3foobar"), toSet(mapped.collectAsList()));
+    Assertions.assertEquals(asSet("1a", "3foobar"), toSet(mapped.collectAsList()));
 
     Dataset<String> flatMapped = grouped.flatMapGroups(
         (FlatMapGroupsFunction<Integer, String, String>) (key, values) -> {
@@ -331,7 +328,7 @@ public class JavaDatasetSuite implements Serializable {
         },
         Encoders.STRING());
 
-    Assert.assertEquals(asSet("1a", "3foobar"), toSet(flatMapped.collectAsList()));
+    Assertions.assertEquals(asSet("1a", "3foobar"), toSet(flatMapped.collectAsList()));
     Dataset<String> flatMapSorted = grouped.flatMapSortedGroups(
         new Column[] { ds.col("value") },
         (FlatMapGroupsFunction<Integer, String, String>) (key, values) -> {
@@ -343,7 +340,7 @@ public class JavaDatasetSuite implements Serializable {
         },
         Encoders.STRING());
 
-    Assert.assertEquals(asSet("1a", "3barfoo"), toSet(flatMapSorted.collectAsList()));
+    Assertions.assertEquals(asSet("1a", "3barfoo"), toSet(flatMapSorted.collectAsList()));
 
     Dataset<String> mapped2 = grouped.mapGroupsWithState(
         (MapGroupsWithStateFunction<Integer, String, Long, String>) (key, values, s) -> {
@@ -356,7 +353,7 @@ public class JavaDatasetSuite implements Serializable {
         Encoders.LONG(),
         Encoders.STRING());
 
-    Assert.assertEquals(asSet("1a", "3foobar"), toSet(mapped2.collectAsList()));
+    Assertions.assertEquals(asSet("1a", "3foobar"), toSet(mapped2.collectAsList()));
 
     Dataset<String> flatMapped2 = grouped.flatMapGroupsWithState(
         (FlatMapGroupsWithStateFunction<Integer, String, Long, String>) (key, values, s) -> {
@@ -371,12 +368,12 @@ public class JavaDatasetSuite implements Serializable {
         Encoders.STRING(),
         GroupStateTimeout.NoTimeout());
 
-    Assert.assertEquals(asSet("1a", "3foobar"), toSet(flatMapped2.collectAsList()));
+    Assertions.assertEquals(asSet("1a", "3foobar"), toSet(flatMapped2.collectAsList()));
 
     Dataset<Tuple2<Integer, String>> reduced =
       grouped.reduceGroups((ReduceFunction<String>) (v1, v2) -> v1 + v2);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
       asSet(tuple2(1, "a"), tuple2(3, "foobar")),
       toSet(reduced.collectAsList()));
 
@@ -401,7 +398,7 @@ public class JavaDatasetSuite implements Serializable {
       },
       Encoders.STRING());
 
-    Assert.assertEquals(asSet("1a#2", "3foobar#67", "5#10"), toSet(cogrouped.collectAsList()));
+    Assertions.assertEquals(asSet("1a#2", "3foobar#67", "5#10"), toSet(cogrouped.collectAsList()));
 
     Dataset<String> cogroupSorted = grouped.cogroupSorted(
       grouped2,
@@ -420,7 +417,8 @@ public class JavaDatasetSuite implements Serializable {
       },
       Encoders.STRING());
 
-    Assert.assertEquals(asSet("1a#2", "3barfoo#76", "5#10"), toSet(cogroupSorted.collectAsList()));
+    Assertions.assertEquals(
+      asSet("1a#2", "3barfoo#76", "5#10"),toSet(cogroupSorted.collectAsList()));
   }
 
   @Test
@@ -451,7 +449,7 @@ public class JavaDatasetSuite implements Serializable {
       namedMetrics = namedObservation.getAsJava();
       unnamedMetrics = unnamedObservation.getAsJava();
     } catch (InterruptedException e) {
-      Assert.fail();
+      Assertions.fail();
     }
     Map<String, Object> expectedNamedMetrics = new HashMap<String, Object>() {{
       put("min_val", 0L);
@@ -459,22 +457,22 @@ public class JavaDatasetSuite implements Serializable {
       put("sum_val", 4950L);
       put("num_even", 50L);
     }};
-    Assert.assertEquals(expectedNamedMetrics, namedMetrics);
+    Assertions.assertEquals(expectedNamedMetrics, namedMetrics);
 
     Map<String, Object> expectedUnnamedMetrics = new HashMap<String, Object>() {{
       put("avg_val", 49);
     }};
-    Assert.assertEquals(expectedUnnamedMetrics, unnamedMetrics);
+    Assertions.assertEquals(expectedUnnamedMetrics, unnamedMetrics);
 
     // we can get the result multiple times
     try {
       namedMetrics = namedObservation.getAsJava();
       unnamedMetrics = unnamedObservation.getAsJava();
     } catch (InterruptedException e) {
-      Assert.fail();
+      Assertions.fail();
     }
-    Assert.assertEquals(expectedNamedMetrics, namedMetrics);
-    Assert.assertEquals(expectedUnnamedMetrics, unnamedMetrics);
+    Assertions.assertEquals(expectedNamedMetrics, namedMetrics);
+    Assertions.assertEquals(expectedUnnamedMetrics, unnamedMetrics);
   }
 
   @Test
@@ -486,7 +484,7 @@ public class JavaDatasetSuite implements Serializable {
       expr("value + 1"),
       col("value").cast("string")).as(Encoders.tuple(Encoders.INT(), Encoders.STRING()));
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
       Arrays.asList(tuple2(3, "2"), tuple2(7, "6")),
       selected.collectAsList());
   }
@@ -496,21 +494,21 @@ public class JavaDatasetSuite implements Serializable {
     List<String> data = Arrays.asList("abc", "abc", "xyz");
     Dataset<String> ds = spark.createDataset(data, Encoders.STRING());
 
-    Assert.assertEquals(asSet("abc", "xyz"), toSet(ds.distinct().collectAsList()));
+    Assertions.assertEquals(asSet("abc", "xyz"), toSet(ds.distinct().collectAsList()));
 
     List<String> data2 = Arrays.asList("xyz", "foo", "foo");
     Dataset<String> ds2 = spark.createDataset(data2, Encoders.STRING());
 
     Dataset<String> intersected = ds.intersect(ds2);
-    Assert.assertEquals(Arrays.asList("xyz"), intersected.collectAsList());
+    Assertions.assertEquals(Arrays.asList("xyz"), intersected.collectAsList());
 
     Dataset<String> unioned = ds.union(ds2).union(ds);
-    Assert.assertEquals(
+    Assertions.assertEquals(
       Arrays.asList("abc", "abc", "xyz", "xyz", "foo", "foo", "abc", "abc", "xyz"),
       unioned.collectAsList());
 
     Dataset<String> subtracted = ds.except(ds2);
-    Assert.assertEquals(Arrays.asList("abc"), subtracted.collectAsList());
+    Assertions.assertEquals(Arrays.asList("abc"), subtracted.collectAsList());
   }
 
   private static <T> Set<T> toSet(List<T> records) {
@@ -532,7 +530,7 @@ public class JavaDatasetSuite implements Serializable {
 
     Dataset<Tuple2<Integer, Integer>> joined =
       ds.joinWith(ds2, col("a.value").equalTo(col("b.value")));
-    Assert.assertEquals(
+    Assertions.assertEquals(
       Arrays.asList(tuple2(2, 2), tuple2(3, 3)),
       joined.collectAsList());
   }
@@ -556,7 +554,7 @@ public class JavaDatasetSuite implements Serializable {
   private void assertEqualsUnorderly(
       List<Tuple2<String, Integer>> expected,
       List<Tuple2<String, Integer>> actual) {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         expected.stream().sorted(comparatorStringAndIntTuple).collect(Collectors.toList()),
         actual.stream().sorted(comparatorStringAndIntTuple).collect(Collectors.toList())
     );
@@ -612,21 +610,21 @@ public class JavaDatasetSuite implements Serializable {
     Encoder<Tuple2<Integer, String>> encoder2 = Encoders.tuple(Encoders.INT(), Encoders.STRING());
     List<Tuple2<Integer, String>> data2 = Arrays.asList(tuple2(1, "a"), tuple2(2, "b"));
     Dataset<Tuple2<Integer, String>> ds2 = spark.createDataset(data2, encoder2);
-    Assert.assertEquals(data2, ds2.collectAsList());
+    Assertions.assertEquals(data2, ds2.collectAsList());
 
     Encoder<Tuple3<Integer, Long, String>> encoder3 =
       Encoders.tuple(Encoders.INT(), Encoders.LONG(), Encoders.STRING());
     List<Tuple3<Integer, Long, String>> data3 =
       Arrays.asList(new Tuple3<>(1, 2L, "a"));
     Dataset<Tuple3<Integer, Long, String>> ds3 = spark.createDataset(data3, encoder3);
-    Assert.assertEquals(data3, ds3.collectAsList());
+    Assertions.assertEquals(data3, ds3.collectAsList());
 
     Encoder<Tuple4<Integer, String, Long, String>> encoder4 =
       Encoders.tuple(Encoders.INT(), Encoders.STRING(), Encoders.LONG(), Encoders.STRING());
     List<Tuple4<Integer, String, Long, String>> data4 =
       Arrays.asList(new Tuple4<>(1, "b", 2L, "a"));
     Dataset<Tuple4<Integer, String, Long, String>> ds4 = spark.createDataset(data4, encoder4);
-    Assert.assertEquals(data4, ds4.collectAsList());
+    Assertions.assertEquals(data4, ds4.collectAsList());
 
     Encoder<Tuple5<Integer, String, Long, String, Boolean>> encoder5 =
       Encoders.tuple(Encoders.INT(), Encoders.STRING(), Encoders.LONG(), Encoders.STRING(),
@@ -635,7 +633,7 @@ public class JavaDatasetSuite implements Serializable {
       Arrays.asList(new Tuple5<>(1, "b", 2L, "a", true));
     Dataset<Tuple5<Integer, String, Long, String, Boolean>> ds5 =
       spark.createDataset(data5, encoder5);
-    Assert.assertEquals(data5, ds5.collectAsList());
+    Assertions.assertEquals(data5, ds5.collectAsList());
   }
 
   @Test
@@ -650,8 +648,8 @@ public class JavaDatasetSuite implements Serializable {
     Dataset<Row> ds2 = spark.createDataset(JavaPairRDD.toRDD(pairRDD), encoder)
       .toDF("value1", "value2");
 
-    Assert.assertEquals(ds1.schema(), ds2.schema());
-    Assert.assertEquals(ds1.select(expr("value2._1")).collectAsList(),
+    Assertions.assertEquals(ds1.schema(), ds2.schema());
+    Assertions.assertEquals(ds1.select(expr("value2._1")).collectAsList(),
       ds2.select(expr("value2._1")).collectAsList());
   }
 
@@ -663,7 +661,7 @@ public class JavaDatasetSuite implements Serializable {
     List<Tuple2<Tuple2<Integer, String>, String>> data =
       Arrays.asList(tuple2(tuple2(1, "a"), "a"), tuple2(tuple2(2, "b"), "b"));
     Dataset<Tuple2<Tuple2<Integer, String>, String>> ds = spark.createDataset(data, encoder);
-    Assert.assertEquals(data, ds.collectAsList());
+    Assertions.assertEquals(data, ds.collectAsList());
 
     // test (int, (string, string, long))
     Encoder<Tuple2<Integer, Tuple3<String, String, Long>>> encoder2 =
@@ -673,7 +671,7 @@ public class JavaDatasetSuite implements Serializable {
       Arrays.asList(tuple2(1, new Tuple3<>("a", "b", 3L)));
     Dataset<Tuple2<Integer, Tuple3<String, String, Long>>> ds2 =
       spark.createDataset(data2, encoder2);
-    Assert.assertEquals(data2, ds2.collectAsList());
+    Assertions.assertEquals(data2, ds2.collectAsList());
 
     // test (int, ((string, long), string))
     Encoder<Tuple2<Integer, Tuple2<Tuple2<String, Long>, String>>> encoder3 =
@@ -683,7 +681,7 @@ public class JavaDatasetSuite implements Serializable {
       Arrays.asList(tuple2(1, tuple2(tuple2("a", 2L), "b")));
     Dataset<Tuple2<Integer, Tuple2<Tuple2<String, Long>, String>>> ds3 =
       spark.createDataset(data3, encoder3);
-    Assert.assertEquals(data3, ds3.collectAsList());
+    Assertions.assertEquals(data3, ds3.collectAsList());
   }
 
   @Test
@@ -697,7 +695,7 @@ public class JavaDatasetSuite implements Serializable {
           Date.valueOf("1970-01-01"), new Timestamp(System.currentTimeMillis()), Float.MAX_VALUE));
     Dataset<Tuple5<Double, BigDecimal, Date, Timestamp, Float>> ds =
       spark.createDataset(data, encoder);
-    Assert.assertEquals(data, ds.collectAsList());
+    Assertions.assertEquals(data, ds.collectAsList());
   }
 
   @Test
@@ -707,7 +705,7 @@ public class JavaDatasetSuite implements Serializable {
     List<Tuple2<LocalDate, Instant>> data =
       Arrays.asList(new Tuple2<>(LocalDate.ofEpochDay(0), Instant.ofEpochSecond(0)));
     Dataset<Tuple2<LocalDate, Instant>> ds = spark.createDataset(data, encoder);
-    Assert.assertEquals(data, ds.collectAsList());
+    Assertions.assertEquals(data, ds.collectAsList());
   }
 
   @Test
@@ -715,7 +713,7 @@ public class JavaDatasetSuite implements Serializable {
     Encoder<LocalDateTime> encoder = Encoders.LOCALDATETIME();
     List<LocalDateTime> data = Arrays.asList(LocalDateTime.of(1, 1, 1, 1, 1));
     Dataset<LocalDateTime> ds = spark.createDataset(data, encoder);
-    Assert.assertEquals(data, ds.collectAsList());
+    Assertions.assertEquals(data, ds.collectAsList());
   }
 
   @Test
@@ -723,7 +721,7 @@ public class JavaDatasetSuite implements Serializable {
     Encoder<Duration> encoder = Encoders.DURATION();
     List<Duration> data = Arrays.asList(Duration.ofDays(0));
     Dataset<Duration> ds = spark.createDataset(data, encoder);
-    Assert.assertEquals(data, ds.collectAsList());
+    Assertions.assertEquals(data, ds.collectAsList());
   }
 
   @Test
@@ -731,7 +729,7 @@ public class JavaDatasetSuite implements Serializable {
     Encoder<Period> encoder = Encoders.PERIOD();
     List<Period> data = Arrays.asList(Period.ofYears(10));
     Dataset<Period> ds = spark.createDataset(data, encoder);
-    Assert.assertEquals(data, ds.collectAsList());
+    Assertions.assertEquals(data, ds.collectAsList());
   }
 
   public static class KryoSerializable {
@@ -782,7 +780,7 @@ public class JavaDatasetSuite implements Serializable {
     List<KryoSerializable> data = Arrays.asList(
       new KryoSerializable("hello"), new KryoSerializable("world"));
     Dataset<KryoSerializable> ds = spark.createDataset(data, encoder);
-    Assert.assertEquals(data, ds.collectAsList());
+    Assertions.assertEquals(data, ds.collectAsList());
   }
 
   @Test
@@ -791,7 +789,7 @@ public class JavaDatasetSuite implements Serializable {
     List<JavaSerializable> data = Arrays.asList(
       new JavaSerializable("hello"), new JavaSerializable("world"));
     Dataset<JavaSerializable> ds = spark.createDataset(data, encoder);
-    Assert.assertEquals(data, ds.collectAsList());
+    Assertions.assertEquals(data, ds.collectAsList());
   }
 
   @Test
@@ -801,7 +799,7 @@ public class JavaDatasetSuite implements Serializable {
     double[] arraySplit = {1, 2, 3};
 
     List<Dataset<String>> randomSplit =  ds.randomSplitAsList(arraySplit, 1);
-    Assert.assertEquals("wrong number of splits", randomSplit.size(), 3);
+    Assertions.assertEquals(randomSplit.size(), 3, "wrong number of splits");
   }
 
   /**
@@ -812,13 +810,13 @@ public class JavaDatasetSuite implements Serializable {
 
   @Test
   public void testJavaEncoderErrorMessageForPrivateClass() {
-    Assert.assertThrows(UnsupportedOperationException.class,
+    Assertions.assertThrows(UnsupportedOperationException.class,
       () -> Encoders.javaSerialization(PrivateClassTest.class));
   }
 
   @Test
   public void testKryoEncoderErrorMessageForPrivateClass() {
-    Assert.assertThrows(UnsupportedOperationException.class,
+    Assertions.assertThrows(UnsupportedOperationException.class,
       () -> Encoders.kryo(PrivateClassTest.class));
   }
 
@@ -1034,14 +1032,14 @@ public class JavaDatasetSuite implements Serializable {
 
     List<SimpleJavaBean> data = Arrays.asList(obj1, obj2);
     Dataset<SimpleJavaBean> ds = spark.createDataset(data, Encoders.bean(SimpleJavaBean.class));
-    Assert.assertEquals(data, ds.collectAsList());
+    Assertions.assertEquals(data, ds.collectAsList());
 
     NestedJavaBean obj3 = new NestedJavaBean();
     obj3.setA(obj1);
 
     List<NestedJavaBean> data2 = Arrays.asList(obj3);
     Dataset<NestedJavaBean> ds2 = spark.createDataset(data2, Encoders.bean(NestedJavaBean.class));
-    Assert.assertEquals(data2, ds2.collectAsList());
+    Assertions.assertEquals(data2, ds2.collectAsList());
 
     Row row1 = new GenericRow(new Object[]{
       true,
@@ -1072,7 +1070,7 @@ public class JavaDatasetSuite implements Serializable {
       .add("h",createMapType(createArrayType(LongType), createMapType(StringType, StringType)));
     Dataset<SimpleJavaBean> ds3 = spark.createDataFrame(Arrays.asList(row1, row2), schema)
       .as(Encoders.bean(SimpleJavaBean.class));
-    Assert.assertEquals(data, ds3.collectAsList());
+    Assertions.assertEquals(data, ds3.collectAsList());
   }
 
   @Test
@@ -1244,7 +1242,7 @@ public class JavaDatasetSuite implements Serializable {
       NestedSmallBean nestedSmallBean = new NestedSmallBean();
       nestedSmallBean.setF(smallBean);
 
-      Assert.assertEquals(Collections.singletonList(nestedSmallBean), ds.collectAsList());
+      Assertions.assertEquals(Collections.singletonList(nestedSmallBean), ds.collectAsList());
     }
 
     // Shouldn't throw runtime exception when parent object (`ClassData`) is null
@@ -1255,7 +1253,7 @@ public class JavaDatasetSuite implements Serializable {
       Dataset<NestedSmallBean> ds = df.as(Encoders.bean(NestedSmallBean.class));
 
       NestedSmallBean nestedSmallBean = new NestedSmallBean();
-      Assert.assertEquals(Collections.singletonList(nestedSmallBean), ds.collectAsList());
+      Assertions.assertEquals(Collections.singletonList(nestedSmallBean), ds.collectAsList());
     }
 
     {
@@ -1268,8 +1266,8 @@ public class JavaDatasetSuite implements Serializable {
       Dataset<Row> df = spark.createDataFrame(Collections.singletonList(row), schema);
       Dataset<NestedSmallBean> ds = df.as(Encoders.bean(NestedSmallBean.class));
 
-      Assert.assertThrows("Null value appeared in non-nullable field", RuntimeException.class,
-        ds::collect);
+      Assertions.assertThrows(RuntimeException.class, ds::collect,
+        "Null value appeared in non-nullable field");
     }
   }
 
@@ -1769,7 +1767,7 @@ public class JavaDatasetSuite implements Serializable {
             new BeanWithEnum(MyEnum.B, "flower boulevard"));
     Encoder<BeanWithEnum> encoder = Encoders.bean(BeanWithEnum.class);
     Dataset<BeanWithEnum> ds = spark.createDataset(data, encoder);
-    Assert.assertEquals(data, ds.collectAsList());
+    Assertions.assertEquals(data, ds.collectAsList());
   }
 
   public static class EmptyBean implements Serializable {}
@@ -1779,8 +1777,8 @@ public class JavaDatasetSuite implements Serializable {
     EmptyBean bean = new EmptyBean();
     List<EmptyBean> data = Arrays.asList(bean);
     Dataset<EmptyBean> df = spark.createDataset(data, Encoders.bean(EmptyBean.class));
-    Assert.assertEquals(0, df.schema().length());
-    Assert.assertEquals(1, df.collectAsList().size());
+    Assertions.assertEquals(0, df.schema().length());
+    Assertions.assertEquals(1, df.collectAsList().size());
   }
 
   public static class ReadOnlyPropertyBean implements Serializable {
@@ -1795,8 +1793,8 @@ public class JavaDatasetSuite implements Serializable {
     List<ReadOnlyPropertyBean> data = Arrays.asList(bean);
     Dataset<ReadOnlyPropertyBean> df = spark.createDataset(data,
             Encoders.bean(ReadOnlyPropertyBean.class));
-    Assert.assertEquals(1, df.schema().length());
-    Assert.assertEquals(1, df.collectAsList().size());
+    Assertions.assertEquals(1, df.schema().length());
+    Assertions.assertEquals(1, df.collectAsList().size());
 
   }
 
@@ -1872,21 +1870,21 @@ public class JavaDatasetSuite implements Serializable {
   @Test
   public void testCircularReferenceBean1() {
     CircularReference1Bean bean = new CircularReference1Bean();
-    Assert.assertThrows(UnsupportedOperationException.class,
+    Assertions.assertThrows(UnsupportedOperationException.class,
       () -> spark.createDataset(Arrays.asList(bean), Encoders.bean(CircularReference1Bean.class)));
   }
 
   @Test
   public void testCircularReferenceBean2() {
     CircularReference3Bean bean = new CircularReference3Bean();
-    Assert.assertThrows(UnsupportedOperationException.class,
+    Assertions.assertThrows(UnsupportedOperationException.class,
       () -> spark.createDataset(Arrays.asList(bean), Encoders.bean(CircularReference3Bean.class)));
   }
 
   @Test
   public void testCircularReferenceBean3() {
     CircularReference4Bean bean = new CircularReference4Bean();
-    Assert.assertThrows(UnsupportedOperationException.class,
+    Assertions.assertThrows(UnsupportedOperationException.class,
       () -> spark.createDataset(Arrays.asList(bean), Encoders.bean(CircularReference4Bean.class)));
   }
 
@@ -1894,7 +1892,7 @@ public class JavaDatasetSuite implements Serializable {
   public void testNullInTopLevelBean() {
     NestedSmallBean bean = new NestedSmallBean();
     // We cannot set null in top-level bean
-    Assert.assertThrows(RuntimeException.class,
+    Assertions.assertThrows(RuntimeException.class,
       () -> spark.createDataset(Arrays.asList(bean, null), Encoders.bean(NestedSmallBean.class)));
   }
 
@@ -1904,10 +1902,10 @@ public class JavaDatasetSuite implements Serializable {
     Encoder<NestedSmallBean> encoder = Encoders.bean(NestedSmallBean.class);
     List<NestedSmallBean> beans = Arrays.asList(bean);
     Dataset<NestedSmallBean> ds1 = spark.createDataset(beans, encoder);
-    Assert.assertEquals(beans, ds1.collectAsList());
+    Assertions.assertEquals(beans, ds1.collectAsList());
     Dataset<NestedSmallBean> ds2 =
       ds1.map((MapFunction<NestedSmallBean, NestedSmallBean>) b -> b, encoder);
-    Assert.assertEquals(beans, ds2.collectAsList());
+    Assertions.assertEquals(beans, ds2.collectAsList());
   }
 
   @Test
@@ -1924,15 +1922,15 @@ public class JavaDatasetSuite implements Serializable {
     Dataset<NestedSmallBeanWithNonNullField> ds1 = spark.createDataset(beans1, encoder1);
 
     StructType schema = ds1.schema();
-    Assert.assertFalse(schema.apply("nonNull_f").nullable());
-    Assert.assertTrue(schema.apply("nullable_f").nullable());
-    Assert.assertFalse(schema.apply("childMap").nullable());
+    Assertions.assertFalse(schema.apply("nonNull_f").nullable());
+    Assertions.assertTrue(schema.apply("nullable_f").nullable());
+    Assertions.assertFalse(schema.apply("childMap").nullable());
 
-    Assert.assertEquals(beans1, ds1.collectAsList());
+    Assertions.assertEquals(beans1, ds1.collectAsList());
     Dataset<NestedSmallBeanWithNonNullField> ds2 = ds1.map(
       (MapFunction<NestedSmallBeanWithNonNullField, NestedSmallBeanWithNonNullField>) b -> b,
       encoder1);
-    Assert.assertEquals(beans1, ds2.collectAsList());
+    Assertions.assertEquals(beans1, ds2.collectAsList());
 
     // Nonnull nested fields
     NestedSmallBean2 bean2 = new NestedSmallBean2();
@@ -1946,16 +1944,16 @@ public class JavaDatasetSuite implements Serializable {
     StructType nestedSchema = (StructType) ds3.schema()
       .fields()[ds3.schema().fieldIndex("f")]
       .dataType();
-    Assert.assertFalse(nestedSchema.apply("nonNull_f").nullable());
-    Assert.assertTrue(nestedSchema.apply("nullable_f").nullable());
-    Assert.assertFalse(nestedSchema.apply("childMap").nullable());
+    Assertions.assertFalse(nestedSchema.apply("nonNull_f").nullable());
+    Assertions.assertTrue(nestedSchema.apply("nullable_f").nullable());
+    Assertions.assertFalse(nestedSchema.apply("childMap").nullable());
 
-    Assert.assertEquals(beans2, ds3.collectAsList());
+    Assertions.assertEquals(beans2, ds3.collectAsList());
 
     Dataset<NestedSmallBean2> ds4 = ds3.map(
       (MapFunction<NestedSmallBean2, NestedSmallBean2>) b -> b,
       encoder2);
-    Assert.assertEquals(beans2, ds4.collectAsList());
+    Assertions.assertEquals(beans2, ds4.collectAsList());
   }
 
   @Test
@@ -1971,7 +1969,7 @@ public class JavaDatasetSuite implements Serializable {
     List<SpecificListsBean> beans = Collections.singletonList(bean);
     Dataset<SpecificListsBean> dataset =
       spark.createDataset(beans, Encoders.bean(SpecificListsBean.class));
-    Assert.assertEquals(beans, dataset.collectAsList());
+    Assertions.assertEquals(beans, dataset.collectAsList());
   }
 
   @Test
@@ -1989,7 +1987,7 @@ public class JavaDatasetSuite implements Serializable {
             Encoders.row(schema))
         .filter(col("a").geq(1));
     final List<Row> expected = Arrays.asList(create(1, "s1"), create(2, "s2"));
-    Assert.assertEquals(expected, df.collectAsList());
+    Assertions.assertEquals(expected, df.collectAsList());
   }
 
   public static class SpecificListsBean implements Serializable {

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaHigherOrderFunctionsSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaHigherOrderFunctionsSuite.java
@@ -24,10 +24,10 @@ import static java.util.stream.Collectors.toList;
 
 import static scala.collection.JavaConverters.mapAsScalaMap;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
@@ -44,19 +44,19 @@ public class JavaHigherOrderFunctionsSuite {
 
     private void checkAnswer(Dataset<Row> actualDS, List<Row> expected) throws Exception {
         List<Row> actual = actualDS.collectAsList();
-        Assert.assertEquals(expected.size(), actual.size());
+        Assertions.assertEquals(expected.size(), actual.size());
         for (int i = 0; i < expected.size(); i++) {
             Row expectedRow = expected.get(i);
             Row actualRow = actual.get(i);
-            Assert.assertEquals(expectedRow.size(), actualRow.size());
+            Assertions.assertEquals(expectedRow.size(), actualRow.size());
             for (int j = 0; j < expectedRow.size(); j++) {
                 Object expectedValue = expectedRow.get(j);
                 Object actualValue = actualRow.get(j);
                 if (expectedValue != null && expectedValue.getClass().isArray()) {
                     actualValue = actualValue.getClass().getMethod("array").invoke(actualValue);
-                    Assert.assertArrayEquals((Object[]) expectedValue, (Object[]) actualValue);
+                    Assertions.assertArrayEquals((Object[]) expectedValue, (Object[]) actualValue);
                 } else {
-                    Assert.assertEquals(expectedValue, actualValue);
+                    Assertions.assertEquals(expectedValue, actualValue);
                 }
             }
         }
@@ -99,14 +99,14 @@ public class JavaHigherOrderFunctionsSuite {
         mapDf = spark.createDataFrame(data, schema);
     }
 
-    @Before
+    @BeforeEach
     public void setUp() {
         spark = new TestSparkSession();
         setUpArrDf();
         setUpMapDf();
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         spark.stop();
         spark = null;

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaRowSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaRowSuite.java
@@ -26,9 +26,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.RowFactory;
@@ -47,7 +47,7 @@ public class JavaRowSuite {
   private Date dateValue;
   private Timestamp timestampValue;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     byteValue = (byte)127;
     shortValue = (short)32767;
@@ -88,44 +88,44 @@ public class JavaRowSuite {
       null                       // null
     );
 
-    Assert.assertEquals(byteValue, simpleRow.getByte(0));
-    Assert.assertEquals(byteValue, simpleRow.get(0));
-    Assert.assertEquals(byteValue, simpleRow.getByte(1));
-    Assert.assertEquals(byteValue, simpleRow.get(1));
-    Assert.assertEquals(shortValue, simpleRow.getShort(2));
-    Assert.assertEquals(shortValue, simpleRow.get(2));
-    Assert.assertEquals(shortValue, simpleRow.getShort(3));
-    Assert.assertEquals(shortValue, simpleRow.get(3));
-    Assert.assertEquals(intValue, simpleRow.getInt(4));
-    Assert.assertEquals(intValue, simpleRow.get(4));
-    Assert.assertEquals(intValue, simpleRow.getInt(5));
-    Assert.assertEquals(intValue, simpleRow.get(5));
-    Assert.assertEquals(longValue, simpleRow.getLong(6));
-    Assert.assertEquals(longValue, simpleRow.get(6));
-    Assert.assertEquals(longValue, simpleRow.getLong(7));
-    Assert.assertEquals(longValue, simpleRow.get(7));
+    Assertions.assertEquals(byteValue, simpleRow.getByte(0));
+    Assertions.assertEquals(byteValue, simpleRow.get(0));
+    Assertions.assertEquals(byteValue, simpleRow.getByte(1));
+    Assertions.assertEquals(byteValue, simpleRow.get(1));
+    Assertions.assertEquals(shortValue, simpleRow.getShort(2));
+    Assertions.assertEquals(shortValue, simpleRow.get(2));
+    Assertions.assertEquals(shortValue, simpleRow.getShort(3));
+    Assertions.assertEquals(shortValue, simpleRow.get(3));
+    Assertions.assertEquals(intValue, simpleRow.getInt(4));
+    Assertions.assertEquals(intValue, simpleRow.get(4));
+    Assertions.assertEquals(intValue, simpleRow.getInt(5));
+    Assertions.assertEquals(intValue, simpleRow.get(5));
+    Assertions.assertEquals(longValue, simpleRow.getLong(6));
+    Assertions.assertEquals(longValue, simpleRow.get(6));
+    Assertions.assertEquals(longValue, simpleRow.getLong(7));
+    Assertions.assertEquals(longValue, simpleRow.get(7));
     // When we create the row, we do not do any conversion
     // for a float/double value, so we just set the delta to 0.
-    Assert.assertEquals(floatValue, simpleRow.getFloat(8), 0);
-    Assert.assertEquals(floatValue, simpleRow.get(8));
-    Assert.assertEquals(floatValue, simpleRow.getFloat(9), 0);
-    Assert.assertEquals(floatValue, simpleRow.get(9));
-    Assert.assertEquals(doubleValue, simpleRow.getDouble(10), 0);
-    Assert.assertEquals(doubleValue, simpleRow.get(10));
-    Assert.assertEquals(doubleValue, simpleRow.getDouble(11), 0);
-    Assert.assertEquals(doubleValue, simpleRow.get(11));
-    Assert.assertEquals(decimalValue, simpleRow.get(12));
-    Assert.assertEquals(booleanValue, simpleRow.getBoolean(13));
-    Assert.assertEquals(booleanValue, simpleRow.get(13));
-    Assert.assertEquals(booleanValue, simpleRow.getBoolean(14));
-    Assert.assertEquals(booleanValue, simpleRow.get(14));
-    Assert.assertEquals(stringValue, simpleRow.getString(15));
-    Assert.assertEquals(stringValue, simpleRow.get(15));
-    Assert.assertEquals(binaryValue, simpleRow.get(16));
-    Assert.assertEquals(dateValue, simpleRow.get(17));
-    Assert.assertEquals(timestampValue, simpleRow.get(18));
-    Assert.assertTrue(simpleRow.isNullAt(19));
-    Assert.assertNull(simpleRow.get(19));
+    Assertions.assertEquals(floatValue, simpleRow.getFloat(8), 0);
+    Assertions.assertEquals(floatValue, simpleRow.get(8));
+    Assertions.assertEquals(floatValue, simpleRow.getFloat(9), 0);
+    Assertions.assertEquals(floatValue, simpleRow.get(9));
+    Assertions.assertEquals(doubleValue, simpleRow.getDouble(10), 0);
+    Assertions.assertEquals(doubleValue, simpleRow.get(10));
+    Assertions.assertEquals(doubleValue, simpleRow.getDouble(11), 0);
+    Assertions.assertEquals(doubleValue, simpleRow.get(11));
+    Assertions.assertEquals(decimalValue, simpleRow.get(12));
+    Assertions.assertEquals(booleanValue, simpleRow.getBoolean(13));
+    Assertions.assertEquals(booleanValue, simpleRow.get(13));
+    Assertions.assertEquals(booleanValue, simpleRow.getBoolean(14));
+    Assertions.assertEquals(booleanValue, simpleRow.get(14));
+    Assertions.assertEquals(stringValue, simpleRow.getString(15));
+    Assertions.assertEquals(stringValue, simpleRow.get(15));
+    Assertions.assertEquals(binaryValue, simpleRow.get(16));
+    Assertions.assertEquals(dateValue, simpleRow.get(17));
+    Assertions.assertEquals(timestampValue, simpleRow.get(18));
+    Assertions.assertTrue(simpleRow.isNullAt(19));
+    Assertions.assertNull(simpleRow.get(19));
   }
 
   @Test
@@ -161,19 +161,19 @@ public class JavaRowSuite {
       arrayOfRows,
       complexMap,
       null);
-    Assert.assertEquals(simpleStringArray, complexStruct.get(0));
-    Assert.assertEquals(simpleMap, complexStruct.get(1));
-    Assert.assertEquals(simpleStruct, complexStruct.get(2));
-    Assert.assertEquals(arrayOfMaps, complexStruct.get(3));
-    Assert.assertEquals(arrayOfRows, complexStruct.get(4));
-    Assert.assertEquals(complexMap, complexStruct.get(5));
-    Assert.assertNull(complexStruct.get(6));
+    Assertions.assertEquals(simpleStringArray, complexStruct.get(0));
+    Assertions.assertEquals(simpleMap, complexStruct.get(1));
+    Assertions.assertEquals(simpleStruct, complexStruct.get(2));
+    Assertions.assertEquals(arrayOfMaps, complexStruct.get(3));
+    Assertions.assertEquals(arrayOfRows, complexStruct.get(4));
+    Assertions.assertEquals(complexMap, complexStruct.get(5));
+    Assertions.assertNull(complexStruct.get(6));
 
     // A very complex row
     Row complexRow = RowFactory.create(arrayOfMaps, arrayOfRows, complexMap, complexStruct);
-    Assert.assertEquals(arrayOfMaps, complexRow.get(0));
-    Assert.assertEquals(arrayOfRows, complexRow.get(1));
-    Assert.assertEquals(complexMap, complexRow.get(2));
-    Assert.assertEquals(complexStruct, complexRow.get(3));
+    Assertions.assertEquals(arrayOfMaps, complexRow.get(0));
+    Assertions.assertEquals(arrayOfRows, complexRow.get(1));
+    Assertions.assertEquals(complexMap, complexRow.get(2));
+    Assertions.assertEquals(complexStruct, complexRow.get(3));
   }
 }

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaSaveLoadSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaSaveLoadSuite.java
@@ -24,9 +24,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.sql.*;
 import org.apache.spark.sql.types.DataTypes;
@@ -45,7 +45,7 @@ public class JavaSaveLoadSuite {
     QueryTest$.MODULE$.checkAnswer(actual, expected);
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException {
     spark = SparkSession.builder()
       .master("local[*]")
@@ -67,7 +67,7 @@ public class JavaSaveLoadSuite {
     df.createOrReplaceTempView("jsonTable");
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     spark.stop();
     spark = null;

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaSparkSessionSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaSparkSessionSuite.java
@@ -17,20 +17,21 @@
 
 package test.org.apache.spark.sql;
 
-import org.apache.spark.sql.*;
-import org.apache.spark.sql.test.TestSparkSession;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Test;
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import org.apache.spark.sql.*;
+import org.apache.spark.sql.test.TestSparkSession;
+
 public class JavaSparkSessionSuite {
   private SparkSession spark;
 
-  @After
+  @AfterEach
   public void tearDown() {
     spark.stop();
     spark = null;
@@ -53,7 +54,7 @@ public class JavaSparkSessionSuite {
       .getOrCreate();
 
     for (Map.Entry<String, Object> e : map.entrySet()) {
-      Assert.assertEquals(spark.conf().get(e.getKey()), e.getValue().toString());
+      Assertions.assertEquals(spark.conf().get(e.getKey()), e.getValue().toString());
     }
   }
 
@@ -63,23 +64,23 @@ public class JavaSparkSessionSuite {
 
     int[] emptyArgs = {};
     List<Row> collected1 = spark.sql("select 'abc'", emptyArgs).collectAsList();
-    Assert.assertEquals("abc", collected1.get(0).getString(0));
+    Assertions.assertEquals("abc", collected1.get(0).getString(0));
 
     Object[] singleArg = new String[] { "abc" };
     List<Row> collected2 = spark.sql("select ?", singleArg).collectAsList();
-    Assert.assertEquals("abc", collected2.get(0).getString(0));
+    Assertions.assertEquals("abc", collected2.get(0).getString(0));
 
     int[] args = new int[] { 1, 2, 3 };
     List<Row> collected3 = spark.sql("select ?, ?, ?", args).collectAsList();
     Row r0 = collected3.get(0);
-    Assert.assertEquals(1, r0.getInt(0));
-    Assert.assertEquals(2, r0.getInt(1));
-    Assert.assertEquals(3, r0.getInt(2));
+    Assertions.assertEquals(1, r0.getInt(0));
+    Assertions.assertEquals(2, r0.getInt(1));
+    Assertions.assertEquals(3, r0.getInt(2));
 
     Object[] mixedArgs = new Object[] { 1, "abc" };
     List<Row> collected4 = spark.sql("select ?, ?", mixedArgs).collectAsList();
     Row r1 = collected4.get(0);
-    Assert.assertEquals(1, r1.getInt(0));
-    Assert.assertEquals("abc", r1.getString(1));
+    Assertions.assertEquals(1, r1.getInt(0));
+    Assertions.assertEquals("abc", r1.getString(1));
   }
 }

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaUDAFSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaUDAFSuite.java
@@ -19,17 +19,17 @@ package test.org.apache.spark.sql;
 
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 
 public class JavaUDAFSuite {
 
   private transient SparkSession spark;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     spark = SparkSession.builder()
         .master("local[*]")
@@ -37,7 +37,7 @@ public class JavaUDAFSuite {
         .getOrCreate();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     spark.stop();
     spark = null;
@@ -48,7 +48,7 @@ public class JavaUDAFSuite {
     spark.range(1, 10).toDF("value").createOrReplaceTempView("df");
     spark.udf().registerJavaUDAF("myDoubleAvg", MyDoubleAvg.class.getName());
     Row result = spark.sql("SELECT myDoubleAvg(value) as my_avg from df").head();
-    Assert.assertEquals(105.0, result.getDouble(0), 1.0e-6);
+    Assertions.assertEquals(105.0, result.getDouble(0), 1.0e-6);
   }
 
 }

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaUDFSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaUDFSuite.java
@@ -24,10 +24,10 @@ import java.util.List;
 import org.apache.spark.sql.catalyst.FunctionIdentifier;
 import org.apache.spark.sql.catalyst.expressions.ExpressionInfo;
 import org.apache.spark.sql.internal.SQLConf;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.sql.AnalysisException;
 import org.apache.spark.sql.Row;
@@ -41,7 +41,7 @@ import org.apache.spark.sql.types.DataTypes;
 public class JavaUDFSuite implements Serializable {
   private transient SparkSession spark;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     spark = SparkSession.builder()
       .master("local[*]")
@@ -49,7 +49,7 @@ public class JavaUDFSuite implements Serializable {
       .getOrCreate();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     spark.stop();
     spark = null;
@@ -60,7 +60,7 @@ public class JavaUDFSuite implements Serializable {
     spark.udf().register("stringLengthTest", (String str) -> str.length(), DataTypes.IntegerType);
 
     Row result = spark.sql("SELECT stringLengthTest('test')").head();
-    Assert.assertEquals(4, result.getInt(0));
+    Assertions.assertEquals(4, result.getInt(0));
   }
 
   @Test
@@ -69,7 +69,7 @@ public class JavaUDFSuite implements Serializable {
         (String str1, String str2) -> str1.length() + str2.length(), DataTypes.IntegerType);
 
     Row result = spark.sql("SELECT stringLengthTest('test', 'test2')").head();
-    Assert.assertEquals(9, result.getInt(0));
+    Assertions.assertEquals(9, result.getInt(0));
   }
 
   public static class StringLengthTest implements UDF2<String, String, Integer> {
@@ -84,12 +84,12 @@ public class JavaUDFSuite implements Serializable {
     spark.udf().registerJava("stringLengthTest", StringLengthTest.class.getName(),
         DataTypes.IntegerType);
     Row result = spark.sql("SELECT stringLengthTest('test', 'test2')").head();
-    Assert.assertEquals(9, result.getInt(0));
+    Assertions.assertEquals(9, result.getInt(0));
 
     // returnType is not provided
     spark.udf().registerJava("stringLengthTest2", StringLengthTest.class.getName(), null);
     result = spark.sql("SELECT stringLengthTest('test', 'test2')").head();
-    Assert.assertEquals(9, result.getInt(0));
+    Assertions.assertEquals(9, result.getInt(0));
   }
 
   @Test
@@ -99,18 +99,18 @@ public class JavaUDFSuite implements Serializable {
     spark.range(10).toDF("x").createOrReplaceTempView("tmp");
     // This tests when Java UDFs are required to be the semantically same (See SPARK-9435).
     List<Row> results = spark.sql("SELECT inc(x) FROM tmp GROUP BY inc(x)").collectAsList();
-    Assert.assertEquals(10, results.size());
+    Assertions.assertEquals(10, results.size());
     long sum = 0;
     for (Row result : results) {
       sum += result.getLong(0);
     }
-    Assert.assertEquals(55, sum);
+    Assertions.assertEquals(55, sum);
   }
 
   @Test
   public void udf5Test() {
     spark.udf().register("inc", (Long i) -> i + 1, DataTypes.LongType);
-    Assert.assertThrows(AnalysisException.class,
+    Assertions.assertThrows(AnalysisException.class,
       () -> spark.sql("SELECT inc(1, 5)").collectAsList());
   }
 
@@ -118,7 +118,7 @@ public class JavaUDFSuite implements Serializable {
   public void udf6Test() {
     spark.udf().register("returnOne", () -> 1, DataTypes.IntegerType);
     Row result = spark.sql("SELECT returnOne()").head();
-    Assert.assertEquals(1, result.getInt(0));
+    Assertions.assertEquals(1, result.getInt(0));
   }
 
   @Test
@@ -130,7 +130,7 @@ public class JavaUDFSuite implements Serializable {
           "plusDay",
           (java.time.LocalDate ld) -> ld.plusDays(1), DataTypes.DateType);
       Row result = spark.sql("SELECT plusDay(DATE '2019-02-26')").head();
-      Assert.assertEquals(LocalDate.parse("2019-02-27"), result.get(0));
+      Assertions.assertEquals(LocalDate.parse("2019-02-27"), result.get(0));
     } finally {
       spark.conf().set(SQLConf.DATETIME_JAVA8API_ENABLED().key(), originConf);
     }
@@ -141,6 +141,6 @@ public class JavaUDFSuite implements Serializable {
     spark.udf().register("stringLengthTest", (String str) -> str.length(), DataTypes.IntegerType);
     ExpressionInfo info = spark.sessionState().catalog().lookupFunctionInfo(
             FunctionIdentifier.apply("stringLengthTest"));
-    Assert.assertEquals("java_udf", info.getSource());
+    Assertions.assertEquals("java_udf", info.getSource());
   }
 }

--- a/sql/core/src/test/java/test/org/apache/spark/sql/execution/datasources/xml/JavaXmlSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/execution/datasources/xml/JavaXmlSuite.java
@@ -23,10 +23,10 @@ import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
 
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
@@ -55,7 +55,7 @@ public final class JavaXmlSuite {
         }
     }
 
-    @Before
+    @BeforeEach
     public void setUp() throws IOException {
         setEnv("SPARK_LOCAL_IP", "127.0.0.1");
         spark = SparkSession.builder()
@@ -68,7 +68,7 @@ public final class JavaXmlSuite {
         tempDir.toFile().deleteOnExit();
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         spark.stop();
         spark = null;
@@ -85,7 +85,7 @@ public final class JavaXmlSuite {
         Dataset<Row> df = spark.read().options(options).format("xml").load(booksFile);
         String prefix = XmlOptions.DEFAULT_ATTRIBUTE_PREFIX();
         long result = df.select(prefix + "id").count();
-        Assert.assertEquals(result, numBooks);
+        Assertions.assertEquals(result, numBooks);
     }
 
     @Test
@@ -94,7 +94,7 @@ public final class JavaXmlSuite {
         options.put("rowTag", booksFileTag);
         Dataset<Row> df = spark.read().options(options).format("xml").load(booksFile);
         long result = df.select("description").count();
-        Assert.assertEquals(result, numBooks);
+        Assertions.assertEquals(result, numBooks);
     }
 
     @Test
@@ -108,7 +108,7 @@ public final class JavaXmlSuite {
 
         Dataset<Row> newDf = spark.read().format("xml").load(booksPath.toString());
         long result = newDf.select("price").count();
-        Assert.assertEquals(result, numBooks);
+        Assertions.assertEquals(result, numBooks);
     }
 
 }

--- a/sql/core/src/test/java/test/org/apache/spark/sql/execution/sort/RecordBinaryComparatorSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/execution/sort/RecordBinaryComparatorSuite.java
@@ -32,10 +32,10 @@ import org.apache.spark.unsafe.memory.MemoryBlock;
 import org.apache.spark.unsafe.types.UTF8String;
 import org.apache.spark.util.collection.unsafe.sort.*;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteOrder;
 
@@ -57,7 +57,7 @@ public class RecordBinaryComparatorSuite {
   private LongArray array;
   private int pos;
 
-  @Before
+  @BeforeEach
   public void beforeEach() {
     // Only compare between two input rows.
     array = consumer.allocateArray(2);
@@ -67,7 +67,7 @@ public class RecordBinaryComparatorSuite {
     pageCursor = dataPage.getBaseOffset();
   }
 
-  @After
+  @AfterEach
   public void afterEach() {
     consumer.freePage(dataPage);
     dataPage = null;
@@ -84,14 +84,14 @@ public class RecordBinaryComparatorSuite {
     int recordLength = row.getSizeInBytes();
 
     Object baseObject = dataPage.getBaseObject();
-    Assert.assertTrue(pageCursor + recordLength <= dataPage.getBaseOffset() + dataPage.size());
+    Assertions.assertTrue(pageCursor + recordLength <= dataPage.getBaseOffset() + dataPage.size());
     long recordAddress = memoryManager.encodePageNumberAndOffset(dataPage, pageCursor);
     UnsafeAlignedOffset.putSize(baseObject, pageCursor, recordLength);
     pageCursor += uaoSize;
     Platform.copyMemory(recordBase, recordOffset, baseObject, pageCursor, recordLength);
     pageCursor += recordLength;
 
-    Assert.assertTrue(pos < 2);
+    Assertions.assertTrue(pos < 2);
     array.set(pos, recordAddress);
     pos++;
   }
@@ -144,8 +144,8 @@ public class RecordBinaryComparatorSuite {
     insertRow(row1);
     insertRow(row2);
 
-    Assert.assertEquals(0, compare(0, 0));
-    Assert.assertTrue(compare(0, 1) < 0);
+    Assertions.assertEquals(0, compare(0, 0));
+    Assertions.assertTrue(compare(0, 1) < 0);
   }
 
   @Test
@@ -169,8 +169,8 @@ public class RecordBinaryComparatorSuite {
     insertRow(row1);
     insertRow(row2);
 
-    Assert.assertEquals(0, compare(0, 0));
-    Assert.assertTrue(compare(0, 1) < 0);
+    Assertions.assertEquals(0, compare(0, 0));
+    Assertions.assertTrue(compare(0, 1) < 0);
   }
 
   @Test
@@ -196,8 +196,8 @@ public class RecordBinaryComparatorSuite {
     insertRow(row1);
     insertRow(row2);
 
-    Assert.assertEquals(0, compare(0, 0));
-    Assert.assertTrue(compare(0, 1) > 0);
+    Assertions.assertEquals(0, compare(0, 0));
+    Assertions.assertTrue(compare(0, 1) > 0);
   }
 
   @Test
@@ -229,8 +229,8 @@ public class RecordBinaryComparatorSuite {
     insertRow(row1);
     insertRow(row2);
 
-    Assert.assertEquals(0, compare(0, 0));
-    Assert.assertTrue(compare(0, 1) > 0);
+    Assertions.assertEquals(0, compare(0, 0));
+    Assertions.assertTrue(compare(0, 1) > 0);
   }
 
   @Test
@@ -255,8 +255,8 @@ public class RecordBinaryComparatorSuite {
     insertRow(row1);
     insertRow(row2);
 
-    Assert.assertEquals(0, compare(0, 0));
-    Assert.assertTrue(compare(0, 1) > 0);
+    Assertions.assertEquals(0, compare(0, 0));
+    Assertions.assertTrue(compare(0, 1) > 0);
   }
 
   @Test
@@ -293,7 +293,7 @@ public class RecordBinaryComparatorSuite {
     insertRow(row1);
     insertRow(row2);
 
-    Assert.assertTrue(compare(0, 1) < 0);
+    Assertions.assertTrue(compare(0, 1) < 0);
   }
 
   @Test
@@ -330,7 +330,7 @@ public class RecordBinaryComparatorSuite {
     insertRow(row1);
     insertRow(row2);
 
-    Assert.assertTrue(compare(0, 1) > 0);
+    Assertions.assertTrue(compare(0, 1) > 0);
   }
 
   @Test
@@ -356,7 +356,7 @@ public class RecordBinaryComparatorSuite {
     insertRow(row1);
     insertRow(row2);
 
-    Assert.assertTrue(compare(0, 1) < 0);
+    Assertions.assertTrue(compare(0, 1) < 0);
   }
 
   @Test
@@ -378,7 +378,7 @@ public class RecordBinaryComparatorSuite {
     // both left and right offset is not aligned, it will start with byte-by-byte comparison
     int result2 = binaryComparator.compare(arr3, arrayOffset, 8, arr4, arrayOffset, 8);
 
-    Assert.assertEquals(result1, result2);
+    Assertions.assertEquals(result1, result2);
   }
 
   @Test
@@ -400,6 +400,6 @@ public class RecordBinaryComparatorSuite {
     // so it will start with byte-by-byte comparison
     int result2 = binaryComparator.compare(arr3, arrayOffset, 8, arr4, arrayOffset, 8);
 
-    Assert.assertEquals(result1, result2);
+    Assertions.assertEquals(result1, result2);
   }
 }

--- a/sql/core/src/test/java/test/org/apache/spark/sql/streaming/JavaDataStreamReaderWriterSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/streaming/JavaDataStreamReaderWriterSuite.java
@@ -20,9 +20,9 @@ package test.org.apache.spark.sql.streaming;
 import java.io.File;
 import java.util.concurrent.TimeoutException;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.api.java.function.VoidFunction2;
 import org.apache.spark.sql.Dataset;
@@ -36,13 +36,13 @@ public class JavaDataStreamReaderWriterSuite {
   private SparkSession spark;
   private String input;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     spark = new TestSparkSession();
     input = Utils.createTempDir(System.getProperty("java.io.tmpdir"), "input").toString();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     try {
       Utils.deleteRecursively(new File(input));

--- a/sql/hive/src/test/java/org/apache/spark/sql/hive/JavaDataFrameSuite.java
+++ b/sql/hive/src/test/java/org/apache/spark/sql/hive/JavaDataFrameSuite.java
@@ -21,9 +21,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.sql.*;
 import org.apache.spark.sql.expressions.Window;
@@ -41,7 +41,7 @@ public class JavaDataFrameSuite {
     QueryTest$.MODULE$.checkAnswer(actual, expected);
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException {
     hc = TestHive$.MODULE$;
     List<String> jsonObjects = new ArrayList<>(10);
@@ -52,7 +52,7 @@ public class JavaDataFrameSuite {
     df.createOrReplaceTempView("window_table");
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws IOException {
     // Clean up tables.
     if (hc != null) {

--- a/sql/hive/src/test/java/org/apache/spark/sql/hive/JavaMetastoreDataSourcesSuite.java
+++ b/sql/hive/src/test/java/org/apache/spark/sql/hive/JavaMetastoreDataSourcesSuite.java
@@ -26,9 +26,9 @@ import java.util.Map;
 
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.sql.Dataset;
@@ -50,7 +50,7 @@ public class JavaMetastoreDataSourcesSuite {
   FileSystem fs;
   Dataset<Row> df;
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException {
     sqlContext = TestHive$.MODULE$;
     sc = new JavaSparkContext(sqlContext.sparkContext());
@@ -74,7 +74,7 @@ public class JavaMetastoreDataSourcesSuite {
     df.createOrReplaceTempView("jsonTable");
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws IOException {
     // Clean up tables.
     if (sqlContext != null) {

--- a/streaming/src/test/java/org/apache/spark/streaming/JavaDurationSuite.java
+++ b/streaming/src/test/java/org/apache/spark/streaming/JavaDurationSuite.java
@@ -18,8 +18,8 @@
 
 package org.apache.spark.streaming;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class JavaDurationSuite {
 
@@ -28,57 +28,57 @@ public class JavaDurationSuite {
 
   @Test
   public void testLess() {
-    Assert.assertTrue(new Duration(999).less(new Duration(1000)));
+    Assertions.assertTrue(new Duration(999).less(new Duration(1000)));
   }
 
   @Test
   public void testLessEq() {
-    Assert.assertTrue(new Duration(1000).lessEq(new Duration(1000)));
+    Assertions.assertTrue(new Duration(1000).lessEq(new Duration(1000)));
   }
 
   @Test
   public void testGreater() {
-    Assert.assertTrue(new Duration(1000).greater(new Duration(999)));
+    Assertions.assertTrue(new Duration(1000).greater(new Duration(999)));
   }
 
   @Test
   public void testGreaterEq() {
-    Assert.assertTrue(new Duration(1000).greaterEq(new Duration(1000)));
+    Assertions.assertTrue(new Duration(1000).greaterEq(new Duration(1000)));
   }
 
   @Test
   public void testPlus() {
-    Assert.assertEquals(new Duration(1100), new Duration(1000).plus(new Duration(100)));
+    Assertions.assertEquals(new Duration(1100), new Duration(1000).plus(new Duration(100)));
   }
 
   @Test
   public void testMinus() {
-    Assert.assertEquals(new Duration(900), new Duration(1000).minus(new Duration(100)));
+    Assertions.assertEquals(new Duration(900), new Duration(1000).minus(new Duration(100)));
   }
 
   @Test
   public void testTimes() {
-    Assert.assertEquals(new Duration(200), new Duration(100).times(2));
+    Assertions.assertEquals(new Duration(200), new Duration(100).times(2));
   }
 
   @Test
   public void testDiv() {
-    Assert.assertEquals(200.0, new Duration(1000).div(new Duration(5)), 1.0e-12);
+    Assertions.assertEquals(200.0, new Duration(1000).div(new Duration(5)), 1.0e-12);
   }
 
   @Test
   public void testMilliseconds() {
-    Assert.assertEquals(new Duration(100), Durations.milliseconds(100));
+    Assertions.assertEquals(new Duration(100), Durations.milliseconds(100));
   }
 
   @Test
   public void testSeconds() {
-    Assert.assertEquals(new Duration(30 * 1000), Durations.seconds(30));
+    Assertions.assertEquals(new Duration(30 * 1000), Durations.seconds(30));
   }
 
   @Test
   public void testMinutes() {
-    Assert.assertEquals(new Duration(2 * 60 * 1000), Durations.minutes(2));
+    Assertions.assertEquals(new Duration(2 * 60 * 1000), Durations.minutes(2));
   }
 
 }

--- a/streaming/src/test/java/org/apache/spark/streaming/JavaMapWithStateSuite.java
+++ b/streaming/src/test/java/org/apache/spark/streaming/JavaMapWithStateSuite.java
@@ -29,8 +29,8 @@ import scala.Tuple2;
 import com.google.common.collect.Sets;
 import org.apache.spark.streaming.api.java.JavaDStream;
 import org.apache.spark.util.ManualClock;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.HashPartitioner;
 import org.apache.spark.api.java.JavaPairRDD;
@@ -161,7 +161,7 @@ public class JavaMapWithStateSuite extends LocalJavaStreamingContext implements 
         .advance(ssc.ssc().progressListener().batchDuration() * numBatches + 1);
     batchCounter.waitUntilBatchesCompleted(numBatches, 10000);
 
-    Assert.assertEquals(expectedOutputs, collectedOutputs);
-    Assert.assertEquals(expectedStateSnapshots, collectedStateSnapshots);
+    Assertions.assertEquals(expectedOutputs, collectedOutputs);
+    Assertions.assertEquals(expectedStateSnapshots, collectedStateSnapshots);
   }
 }

--- a/streaming/src/test/java/org/apache/spark/streaming/JavaReceiverAPISuite.java
+++ b/streaming/src/test/java/org/apache/spark/streaming/JavaReceiverAPISuite.java
@@ -24,10 +24,10 @@ import org.apache.spark.streaming.api.java.JavaReceiverInputDStream;
 import org.apache.spark.streaming.api.java.JavaStreamingContext;
 
 import com.google.common.io.Closeables;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.storage.StorageLevel;
 import org.apache.spark.streaming.receiver.Receiver;
@@ -44,12 +44,12 @@ import java.util.concurrent.atomic.AtomicLong;
 
 public class JavaReceiverAPISuite implements Serializable {
 
-  @Before
+  @BeforeEach
   public void setUp() {
     System.clearProperty("spark.streaming.clock");
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     System.clearProperty("spark.streaming.clock");
   }
@@ -84,7 +84,7 @@ public class JavaReceiverAPISuite implements Serializable {
         Thread.sleep(100);
       }
       ssc.stop();
-      Assert.assertTrue(dataCounter.get() > 0);
+      Assertions.assertTrue(dataCounter.get() > 0);
     } finally {
       server.stop();
     }

--- a/streaming/src/test/java/org/apache/spark/streaming/JavaTimeSuite.java
+++ b/streaming/src/test/java/org/apache/spark/streaming/JavaTimeSuite.java
@@ -17,8 +17,8 @@
 
 package org.apache.spark.streaming;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class JavaTimeSuite {
 
@@ -27,37 +27,37 @@ public class JavaTimeSuite {
 
   @Test
   public void testLess() {
-    Assert.assertTrue(new Time(999).less(new Time(1000)));
+    Assertions.assertTrue(new Time(999).less(new Time(1000)));
   }
 
   @Test
   public void testLessEq() {
-    Assert.assertTrue(new Time(1000).lessEq(new Time(1000)));
+    Assertions.assertTrue(new Time(1000).lessEq(new Time(1000)));
   }
 
   @Test
   public void testGreater() {
-    Assert.assertTrue(new Time(1000).greater(new Time(999)));
+    Assertions.assertTrue(new Time(1000).greater(new Time(999)));
   }
 
   @Test
   public void testGreaterEq() {
-    Assert.assertTrue(new Time(1000).greaterEq(new Time(1000)));
+    Assertions.assertTrue(new Time(1000).greaterEq(new Time(1000)));
   }
 
   @Test
   public void testPlus() {
-    Assert.assertEquals(new Time(1100), new Time(1000).plus(new Duration(100)));
+    Assertions.assertEquals(new Time(1100), new Time(1000).plus(new Duration(100)));
   }
 
   @Test
   public void testMinusTime() {
-    Assert.assertEquals(new Duration(900), new Time(1000).minus(new Time(100)));
+    Assertions.assertEquals(new Duration(900), new Time(1000).minus(new Time(100)));
   }
 
   @Test
   public void testMinusDuration() {
-    Assert.assertEquals(new Time(900), new Time(1000).minus(new Duration(100)));
+    Assertions.assertEquals(new Time(900), new Time(1000).minus(new Duration(100)));
   }
 
 }

--- a/streaming/src/test/java/org/apache/spark/streaming/JavaWriteAheadLogSuite.java
+++ b/streaming/src/test/java/org/apache/spark/streaming/JavaWriteAheadLogSuite.java
@@ -30,8 +30,8 @@ import org.apache.spark.streaming.util.WriteAheadLog;
 import org.apache.spark.streaming.util.WriteAheadLogRecordHandle;
 import org.apache.spark.streaming.util.WriteAheadLogUtils;
 
-import org.junit.Test;
-import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
 
 public class JavaWriteAheadLogSuite extends WriteAheadLog {
 
@@ -107,8 +107,8 @@ public class JavaWriteAheadLogSuite extends WriteAheadLog {
 
     String data1 = "data1";
     WriteAheadLogRecordHandle handle = wal.write(JavaUtils.stringToBytes(data1), 1234);
-    Assert.assertTrue(handle instanceof JavaWriteAheadLogSuiteHandle);
-    Assert.assertEquals(data1, JavaUtils.bytesToString(wal.read(handle)));
+    Assertions.assertTrue(handle instanceof JavaWriteAheadLogSuiteHandle);
+    Assertions.assertEquals(data1, JavaUtils.bytesToString(wal.read(handle)));
 
     wal.write(JavaUtils.stringToBytes("data2"), 1235);
     wal.write(JavaUtils.stringToBytes("data3"), 1236);
@@ -120,6 +120,6 @@ public class JavaWriteAheadLogSuite extends WriteAheadLog {
     while (dataIterator.hasNext()) {
       readData.add(JavaUtils.bytesToString(dataIterator.next()));
     }
-    Assert.assertEquals(Arrays.asList("data3", "data4"), readData);
+    Assertions.assertEquals(Arrays.asList("data3", "data4"), readData);
   }
 }

--- a/streaming/src/test/java/org/apache/spark/streaming/LocalJavaStreamingContext.java
+++ b/streaming/src/test/java/org/apache/spark/streaming/LocalJavaStreamingContext.java
@@ -19,14 +19,14 @@ package org.apache.spark.streaming;
 
 import org.apache.spark.SparkConf;
 import org.apache.spark.streaming.api.java.JavaStreamingContext;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 public abstract class LocalJavaStreamingContext {
 
     protected transient JavaStreamingContext ssc;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         SparkConf conf = new SparkConf()
             .setMaster("local[2]")
@@ -36,7 +36,7 @@ public abstract class LocalJavaStreamingContext {
         ssc.checkpoint("checkpoint");
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         ssc.stop();
         ssc = null;

--- a/streaming/src/test/java/test/org/apache/spark/streaming/Java8APISuite.java
+++ b/streaming/src/test/java/test/org/apache/spark/streaming/Java8APISuite.java
@@ -32,8 +32,8 @@ import org.apache.spark.streaming.Time;
 import scala.Tuple2;
 
 import com.google.common.collect.Sets;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.spark.HashPartitioner;
 import org.apache.spark.api.java.Optional;
@@ -108,7 +108,7 @@ public class Java8APISuite extends LocalJavaStreamingContext implements Serializ
     JavaTestUtils.attachTestOutputStream(mapped);
     List<List<String>> result = JavaTestUtils.runStreams(ssc, 2, 2);
 
-    Assert.assertEquals(expected, result);
+    Assertions.assertEquals(expected, result);
   }
 
   @Test
@@ -128,7 +128,7 @@ public class Java8APISuite extends LocalJavaStreamingContext implements Serializ
     JavaTestUtils.attachTestOutputStream(reduced);
     List<List<Integer>> result = JavaTestUtils.runStreams(ssc, 3, 3);
 
-    Assert.assertEquals(expected, result);
+    Assertions.assertEquals(expected, result);
   }
 
   @Test
@@ -150,7 +150,7 @@ public class Java8APISuite extends LocalJavaStreamingContext implements Serializ
     JavaTestUtils.attachTestOutputStream(reducedWindowed);
     List<List<Integer>> result = JavaTestUtils.runStreams(ssc, 4, 4);
 
-    Assert.assertEquals(expected, result);
+    Assertions.assertEquals(expected, result);
   }
 
   @Test
@@ -247,7 +247,7 @@ public class Java8APISuite extends LocalJavaStreamingContext implements Serializ
       unorderedResult.add(Sets.newHashSet(res));
     }
 
-    Assert.assertEquals(expected, unorderedResult);
+    Assertions.assertEquals(expected, unorderedResult);
   }
 
 
@@ -322,7 +322,7 @@ public class Java8APISuite extends LocalJavaStreamingContext implements Serializ
     // This is just to test whether this transform to JavaStream compiles
     JavaDStream<Long> transformed1 = ssc.transform(
       listOfDStreams1, (List<JavaRDD<?>> listOfRDDs, Time time) -> {
-      Assert.assertEquals(2, listOfRDDs.size());
+      Assertions.assertEquals(2, listOfRDDs.size());
       return null;
     });
 
@@ -331,7 +331,7 @@ public class Java8APISuite extends LocalJavaStreamingContext implements Serializ
 
     JavaPairDStream<Integer, Tuple2<Integer, String>> transformed2 = ssc.transformToPair(
       listOfDStreams2, (List<JavaRDD<?>> listOfRDDs, Time time) -> {
-      Assert.assertEquals(3, listOfRDDs.size());
+      Assertions.assertEquals(3, listOfRDDs.size());
       JavaRDD<Integer> rdd1 = (JavaRDD<Integer>) listOfRDDs.get(0);
       JavaRDD<Integer> rdd2 = (JavaRDD<Integer>) listOfRDDs.get(1);
       JavaRDD<Tuple2<Integer, String>> rdd3 = (JavaRDD<Tuple2<Integer, String>>) listOfRDDs.get(2);
@@ -343,7 +343,7 @@ public class Java8APISuite extends LocalJavaStreamingContext implements Serializ
     JavaTestUtils.attachTestOutputStream(transformed2);
     List<List<Tuple2<Integer, Tuple2<Integer, String>>>> result =
       JavaTestUtils.runStreams(ssc, 2, 2);
-    Assert.assertEquals(expected, result);
+    Assertions.assertEquals(expected, result);
   }
 
   @Test
@@ -413,7 +413,7 @@ public class Java8APISuite extends LocalJavaStreamingContext implements Serializ
     JavaTestUtils.attachTestOutputStream(flatMapped);
     List<List<Tuple2<Integer, String>>> result = JavaTestUtils.runStreams(ssc, 3, 3);
 
-    Assert.assertEquals(expected, result);
+    Assertions.assertEquals(expected, result);
   }
 
   /*
@@ -429,7 +429,7 @@ public class Java8APISuite extends LocalJavaStreamingContext implements Serializ
         Collections.sort(sortedList);
         sortedActual.add(sortedList);
     });
-    Assert.assertEquals(expected, sortedActual);
+    Assertions.assertEquals(expected, sortedActual);
   }
 
   @Test
@@ -449,7 +449,7 @@ public class Java8APISuite extends LocalJavaStreamingContext implements Serializ
     JavaTestUtils.attachTestOutputStream(filtered);
     List<List<Tuple2<String, Integer>>> result = JavaTestUtils.runStreams(ssc, 2, 2);
 
-    Assert.assertEquals(expected, result);
+    Assertions.assertEquals(expected, result);
   }
 
   List<List<Tuple2<String, String>>> stringStringKVStream = Arrays.asList(
@@ -497,7 +497,7 @@ public class Java8APISuite extends LocalJavaStreamingContext implements Serializ
     JavaTestUtils.attachTestOutputStream(reversed);
     List<List<Tuple2<Integer, String>>> result = JavaTestUtils.runStreams(ssc, 2, 2);
 
-    Assert.assertEquals(expected, result);
+    Assertions.assertEquals(expected, result);
   }
 
   @Test
@@ -531,7 +531,7 @@ public class Java8APISuite extends LocalJavaStreamingContext implements Serializ
     JavaTestUtils.attachTestOutputStream(reversed);
     List<List<Tuple2<Integer, String>>> result = JavaTestUtils.runStreams(ssc, 2, 2);
 
-    Assert.assertEquals(expected, result);
+    Assertions.assertEquals(expected, result);
   }
 
   @Test
@@ -549,7 +549,7 @@ public class Java8APISuite extends LocalJavaStreamingContext implements Serializ
     JavaTestUtils.attachTestOutputStream(reversed);
     List<List<Integer>> result = JavaTestUtils.runStreams(ssc, 2, 2);
 
-    Assert.assertEquals(expected, result);
+    Assertions.assertEquals(expected, result);
   }
 
   @Test
@@ -588,7 +588,7 @@ public class Java8APISuite extends LocalJavaStreamingContext implements Serializ
     JavaTestUtils.attachTestOutputStream(flatMapped);
     List<List<Tuple2<Integer, String>>> result = JavaTestUtils.runStreams(ssc, 2, 2);
 
-    Assert.assertEquals(expected, result);
+    Assertions.assertEquals(expected, result);
   }
 
   @Test
@@ -612,7 +612,7 @@ public class Java8APISuite extends LocalJavaStreamingContext implements Serializ
     JavaTestUtils.attachTestOutputStream(reduced);
     List<List<Tuple2<String, Integer>>> result = JavaTestUtils.runStreams(ssc, 2, 2);
 
-    Assert.assertEquals(expected, result);
+    Assertions.assertEquals(expected, result);
   }
 
   @Test
@@ -637,7 +637,7 @@ public class Java8APISuite extends LocalJavaStreamingContext implements Serializ
     JavaTestUtils.attachTestOutputStream(combined);
     List<List<Tuple2<String, Integer>>> result = JavaTestUtils.runStreams(ssc, 2, 2);
 
-    Assert.assertEquals(expected, result);
+    Assertions.assertEquals(expected, result);
   }
 
   @Test
@@ -661,7 +661,7 @@ public class Java8APISuite extends LocalJavaStreamingContext implements Serializ
     JavaTestUtils.attachTestOutputStream(reduceWindowed);
     List<List<Tuple2<String, Integer>>> result = JavaTestUtils.runStreams(ssc, 3, 3);
 
-    Assert.assertEquals(expected, result);
+    Assertions.assertEquals(expected, result);
   }
 
   @Test
@@ -694,7 +694,7 @@ public class Java8APISuite extends LocalJavaStreamingContext implements Serializ
     JavaTestUtils.attachTestOutputStream(updated);
     List<List<Tuple2<String, Integer>>> result = JavaTestUtils.runStreams(ssc, 3, 3);
 
-    Assert.assertEquals(expected, result);
+    Assertions.assertEquals(expected, result);
   }
 
   @Test
@@ -719,7 +719,7 @@ public class Java8APISuite extends LocalJavaStreamingContext implements Serializ
     JavaTestUtils.attachTestOutputStream(reduceWindowed);
     List<List<Tuple2<String, Integer>>> result = JavaTestUtils.runStreams(ssc, 3, 3);
 
-    Assert.assertEquals(expected, result);
+    Assertions.assertEquals(expected, result);
   }
 
   @Test
@@ -757,7 +757,7 @@ public class Java8APISuite extends LocalJavaStreamingContext implements Serializ
     JavaTestUtils.attachTestOutputStream(sorted);
     List<List<Tuple2<Integer, Integer>>> result = JavaTestUtils.runStreams(ssc, 2, 2);
 
-    Assert.assertEquals(expected, result);
+    Assertions.assertEquals(expected, result);
   }
 
   @Test
@@ -785,7 +785,7 @@ public class Java8APISuite extends LocalJavaStreamingContext implements Serializ
     JavaTestUtils.attachTestOutputStream(firstParts);
     List<List<Integer>> result = JavaTestUtils.runStreams(ssc, 2, 2);
 
-    Assert.assertEquals(expected, result);
+    Assertions.assertEquals(expected, result);
   }
 
   @Test
@@ -811,7 +811,7 @@ public class Java8APISuite extends LocalJavaStreamingContext implements Serializ
     JavaTestUtils.attachTestOutputStream(mapped);
     List<List<Tuple2<String, String>>> result = JavaTestUtils.runStreams(ssc, 2, 2);
 
-    Assert.assertEquals(expected, result);
+    Assertions.assertEquals(expected, result);
   }
 
   @Test
@@ -844,7 +844,7 @@ public class Java8APISuite extends LocalJavaStreamingContext implements Serializ
       pairStream.flatMapValues(in -> Arrays.asList(in + "1", in + "2").iterator());
     JavaTestUtils.attachTestOutputStream(flatMapped);
     List<List<Tuple2<String, String>>> result = JavaTestUtils.runStreams(ssc, 2, 2);
-    Assert.assertEquals(expected, result);
+    Assertions.assertEquals(expected, result);
   }
 
   /**

--- a/streaming/src/test/java/test/org/apache/spark/streaming/JavaAPISuite.java
+++ b/streaming/src/test/java/test/org/apache/spark/streaming/JavaAPISuite.java
@@ -36,8 +36,8 @@ import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapreduce.lib.input.TextInputFormat;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import com.google.common.io.Files;
 import com.google.common.collect.Sets;
@@ -61,9 +61,9 @@ public class JavaAPISuite extends LocalJavaStreamingContext implements Serializa
 
   public static void equalIterator(Iterator<?> a, Iterator<?> b) {
     while (a.hasNext() && b.hasNext()) {
-      Assert.assertEquals(a.next(), b.next());
+      Assertions.assertEquals(a.next(), b.next());
     }
-    Assert.assertEquals(a.hasNext(), b.hasNext());
+    Assertions.assertEquals(a.hasNext(), b.hasNext());
   }
 
   public static void equalIterable(Iterable<?> a, Iterable<?> b) {
@@ -72,20 +72,20 @@ public class JavaAPISuite extends LocalJavaStreamingContext implements Serializa
 
   @Test
   public void testInitialization() {
-    Assert.assertNotNull(ssc.sparkContext());
+    Assertions.assertNotNull(ssc.sparkContext());
   }
 
   @Test
   public void testContextState() {
     List<List<Integer>> inputData = Arrays.asList(Arrays.asList(1, 2, 3, 4));
-    Assert.assertEquals(StreamingContextState.INITIALIZED, ssc.getState());
+    Assertions.assertEquals(StreamingContextState.INITIALIZED, ssc.getState());
     JavaDStream<Integer> stream = JavaTestUtils.attachTestInputStream(ssc, inputData, 1);
     JavaTestUtils.attachTestOutputStream(stream);
-    Assert.assertEquals(StreamingContextState.INITIALIZED, ssc.getState());
+    Assertions.assertEquals(StreamingContextState.INITIALIZED, ssc.getState());
     ssc.start();
-    Assert.assertEquals(StreamingContextState.ACTIVE, ssc.getState());
+    Assertions.assertEquals(StreamingContextState.ACTIVE, ssc.getState());
     ssc.stop();
-    Assert.assertEquals(StreamingContextState.STOPPED, ssc.getState());
+    Assertions.assertEquals(StreamingContextState.STOPPED, ssc.getState());
   }
 
   @Test
@@ -199,10 +199,10 @@ public class JavaAPISuite extends LocalJavaStreamingContext implements Serializa
         stream.repartition(4);
     JavaTestUtils.attachTestOutputStream(repartitioned);
     List<List<List<Integer>>> result = JavaTestUtils.runStreamsWithPartitions(ssc, 2, 2);
-    Assert.assertEquals(2, result.size());
+    Assertions.assertEquals(2, result.size());
     for (List<List<Integer>> rdd : result) {
-      Assert.assertEquals(4, rdd.size());
-      Assert.assertEquals(
+      Assertions.assertEquals(4, rdd.size());
+      Assertions.assertEquals(
         10, rdd.get(0).size() + rdd.get(1).size() + rdd.get(2).size() + rdd.get(3).size());
     }
   }
@@ -218,10 +218,10 @@ public class JavaAPISuite extends LocalJavaStreamingContext implements Serializa
         stream.repartition(2);
     JavaTestUtils.attachTestOutputStream(repartitioned);
     List<List<List<Integer>>> result = JavaTestUtils.runStreamsWithPartitions(ssc, 2, 2);
-    Assert.assertEquals(2, result.size());
+    Assertions.assertEquals(2, result.size());
     for (List<List<Integer>> rdd : result) {
-      Assert.assertEquals(2, rdd.size());
-      Assert.assertEquals(10, rdd.get(0).size() + rdd.get(1).size());
+      Assertions.assertEquals(2, rdd.size());
+      Assertions.assertEquals(10, rdd.get(0).size() + rdd.get(1).size());
     }
   }
 
@@ -240,7 +240,7 @@ public class JavaAPISuite extends LocalJavaStreamingContext implements Serializa
     JavaTestUtils.attachTestOutputStream(glommed);
     List<List<List<String>>> result = JavaTestUtils.runStreams(ssc, 2, 2);
 
-    Assert.assertEquals(expected, result);
+    Assertions.assertEquals(expected, result);
   }
 
   @Test
@@ -264,7 +264,7 @@ public class JavaAPISuite extends LocalJavaStreamingContext implements Serializa
     JavaTestUtils.attachTestOutputStream(mapped);
     List<List<String>> result = JavaTestUtils.runStreams(ssc, 2, 2);
 
-    Assert.assertEquals(expected, result);
+    Assertions.assertEquals(expected, result);
   }
 
   private static class IntegerSum implements Function2<Integer, Integer, Integer> {
@@ -298,7 +298,7 @@ public class JavaAPISuite extends LocalJavaStreamingContext implements Serializa
     JavaTestUtils.attachTestOutputStream(reduced);
     List<List<Integer>> result = JavaTestUtils.runStreams(ssc, 3, 3);
 
-    Assert.assertEquals(expected, result);
+    Assertions.assertEquals(expected, result);
   }
 
   @Test
@@ -337,7 +337,7 @@ public class JavaAPISuite extends LocalJavaStreamingContext implements Serializa
     JavaTestUtils.attachTestOutputStream(reducedWindowed);
     List<List<Integer>> result = JavaTestUtils.runStreams(ssc, 4, 4);
 
-    Assert.assertEquals(expected, result);
+    Assertions.assertEquals(expected, result);
   }
 
   @Test
@@ -368,7 +368,7 @@ public class JavaAPISuite extends LocalJavaStreamingContext implements Serializa
     JavaDStream<Integer> stream = ssc.queueStream(rdds);
     JavaTestUtils.attachTestOutputStream(stream);
     List<List<Integer>> result = JavaTestUtils.runStreams(ssc, 3, 3);
-    Assert.assertEquals(expected, result);
+    Assertions.assertEquals(expected, result);
   }
 
   @Test
@@ -474,7 +474,7 @@ public class JavaAPISuite extends LocalJavaStreamingContext implements Serializa
       unorderedResult.add(Sets.newHashSet(res));
     }
 
-    Assert.assertEquals(expected, unorderedResult);
+    Assertions.assertEquals(expected, unorderedResult);
   }
 
 
@@ -547,7 +547,7 @@ public class JavaAPISuite extends LocalJavaStreamingContext implements Serializa
     ssc.transform(
       listOfDStreams1,
       (listOfRDDs, time) -> {
-        Assert.assertEquals(2, listOfRDDs.size());
+        Assertions.assertEquals(2, listOfRDDs.size());
         return null;
       }
     );
@@ -558,7 +558,7 @@ public class JavaAPISuite extends LocalJavaStreamingContext implements Serializa
     JavaPairDStream<Integer, Tuple2<Integer, String>> transformed2 = ssc.transformToPair(
       listOfDStreams2,
       (listOfRDDs, time) -> {
-        Assert.assertEquals(3, listOfRDDs.size());
+        Assertions.assertEquals(3, listOfRDDs.size());
         JavaRDD<Integer> rdd1 = (JavaRDD<Integer>)listOfRDDs.get(0);
         JavaRDD<Integer> rdd2 = (JavaRDD<Integer>)listOfRDDs.get(1);
         JavaRDD<Tuple2<Integer, String>> rdd3 =
@@ -572,7 +572,7 @@ public class JavaAPISuite extends LocalJavaStreamingContext implements Serializa
     JavaTestUtils.attachTestOutputStream(transformed2);
     List<List<Tuple2<Integer, Tuple2<Integer, String>>>> result =
       JavaTestUtils.runStreams(ssc, 2, 2);
-    Assert.assertEquals(expected, result);
+    Assertions.assertEquals(expected, result);
   }
 
   @Test
@@ -617,8 +617,8 @@ public class JavaAPISuite extends LocalJavaStreamingContext implements Serializa
 
     JavaTestUtils.runStreams(ssc, 2, 2);
 
-    Assert.assertEquals(2, accumRdd.value().intValue());
-    Assert.assertEquals(6, accumEle.value().intValue());
+    Assertions.assertEquals(2, accumRdd.value().intValue());
+    Assertions.assertEquals(6, accumEle.value().intValue());
   }
 
   @Test
@@ -666,7 +666,7 @@ public class JavaAPISuite extends LocalJavaStreamingContext implements Serializa
     JavaTestUtils.attachTestOutputStream(flatMapped);
     List<List<Tuple2<Integer, String>>> result = JavaTestUtils.runStreams(ssc, 3, 3);
 
-    Assert.assertEquals(expected, result);
+    Assertions.assertEquals(expected, result);
   }
 
   @Test
@@ -710,7 +710,7 @@ public class JavaAPISuite extends LocalJavaStreamingContext implements Serializa
     for (List<T> list: actual) {
       actualSets.add(Collections.unmodifiableSet(new HashSet<>(list)));
     }
-    Assert.assertEquals(expectedSets, actualSets);
+    Assertions.assertEquals(expectedSets, actualSets);
   }
 
 
@@ -733,7 +733,7 @@ public class JavaAPISuite extends LocalJavaStreamingContext implements Serializa
     JavaTestUtils.attachTestOutputStream(filtered);
     List<List<Tuple2<String, Integer>>> result = JavaTestUtils.runStreams(ssc, 2, 2);
 
-    Assert.assertEquals(expected, result);
+    Assertions.assertEquals(expected, result);
   }
 
   private final List<List<Tuple2<String, String>>> stringStringKVStream = Arrays.asList(
@@ -782,7 +782,7 @@ public class JavaAPISuite extends LocalJavaStreamingContext implements Serializa
     JavaTestUtils.attachTestOutputStream(reversed);
     List<List<Tuple2<Integer, String>>> result = JavaTestUtils.runStreams(ssc, 2, 2);
 
-    Assert.assertEquals(expected, result);
+    Assertions.assertEquals(expected, result);
   }
 
   @Test
@@ -816,7 +816,7 @@ public class JavaAPISuite extends LocalJavaStreamingContext implements Serializa
     JavaTestUtils.attachTestOutputStream(reversed);
     List<List<Tuple2<Integer, String>>> result = JavaTestUtils.runStreams(ssc, 2, 2);
 
-    Assert.assertEquals(expected, result);
+    Assertions.assertEquals(expected, result);
   }
 
   @Test
@@ -835,7 +835,7 @@ public class JavaAPISuite extends LocalJavaStreamingContext implements Serializa
     JavaTestUtils.attachTestOutputStream(reversed);
     List<List<Integer>> result = JavaTestUtils.runStreams(ssc, 2, 2);
 
-    Assert.assertEquals(expected, result);
+    Assertions.assertEquals(expected, result);
   }
 
   @Test
@@ -873,7 +873,7 @@ public class JavaAPISuite extends LocalJavaStreamingContext implements Serializa
     JavaTestUtils.attachTestOutputStream(flatMapped);
     List<List<Tuple2<Integer, String>>> result = JavaTestUtils.runStreams(ssc, 2, 2);
 
-    Assert.assertEquals(expected, result);
+    Assertions.assertEquals(expected, result);
   }
 
   @Test
@@ -896,7 +896,7 @@ public class JavaAPISuite extends LocalJavaStreamingContext implements Serializa
     JavaTestUtils.attachTestOutputStream(grouped);
     List<List<Tuple2<String, Iterable<String>>>> result = JavaTestUtils.runStreams(ssc, 2, 2);
 
-    Assert.assertEquals(expected.size(), result.size());
+    Assertions.assertEquals(expected.size(), result.size());
     Iterator<List<Tuple2<String, Iterable<String>>>> resultItr = result.iterator();
     Iterator<List<Tuple2<String, List<String>>>> expectedItr = expected.iterator();
     while (resultItr.hasNext() && expectedItr.hasNext()) {
@@ -905,10 +905,10 @@ public class JavaAPISuite extends LocalJavaStreamingContext implements Serializa
       while (resultElements.hasNext() && expectedElements.hasNext()) {
         Tuple2<String, Iterable<String>> resultElement = resultElements.next();
         Tuple2<String, List<String>> expectedElement = expectedElements.next();
-        Assert.assertEquals(expectedElement._1(), resultElement._1());
+        Assertions.assertEquals(expectedElement._1(), resultElement._1());
         equalIterable(expectedElement._2(), resultElement._2());
       }
-      Assert.assertEquals(resultElements.hasNext(), expectedElements.hasNext());
+      Assertions.assertEquals(resultElements.hasNext(), expectedElements.hasNext());
     }
   }
 
@@ -933,7 +933,7 @@ public class JavaAPISuite extends LocalJavaStreamingContext implements Serializa
     JavaTestUtils.attachTestOutputStream(reduced);
     List<List<Tuple2<String, Integer>>> result = JavaTestUtils.runStreams(ssc, 2, 2);
 
-    Assert.assertEquals(expected, result);
+    Assertions.assertEquals(expected, result);
   }
 
   @Test
@@ -958,7 +958,7 @@ public class JavaAPISuite extends LocalJavaStreamingContext implements Serializa
     JavaTestUtils.attachTestOutputStream(combined);
     List<List<Tuple2<String, Integer>>> result = JavaTestUtils.runStreams(ssc, 2, 2);
 
-    Assert.assertEquals(expected, result);
+    Assertions.assertEquals(expected, result);
   }
 
   @Test
@@ -983,7 +983,7 @@ public class JavaAPISuite extends LocalJavaStreamingContext implements Serializa
     JavaTestUtils.attachTestOutputStream(counted);
     List<List<Tuple2<String, Long>>> result = JavaTestUtils.runStreams(ssc, 3, 3);
 
-    Assert.assertEquals(expected, result);
+    Assertions.assertEquals(expected, result);
   }
 
   @Test
@@ -1014,9 +1014,9 @@ public class JavaAPISuite extends LocalJavaStreamingContext implements Serializa
     JavaTestUtils.attachTestOutputStream(groupWindowed);
     List<List<Tuple2<String, List<Integer>>>> result = JavaTestUtils.runStreams(ssc, 3, 3);
 
-    Assert.assertEquals(expected.size(), result.size());
+    Assertions.assertEquals(expected.size(), result.size());
     for (int i = 0; i < result.size(); i++) {
-      Assert.assertEquals(convert(expected.get(i)), convert(result.get(i)));
+      Assertions.assertEquals(convert(expected.get(i)), convert(result.get(i)));
     }
   }
 
@@ -1054,7 +1054,7 @@ public class JavaAPISuite extends LocalJavaStreamingContext implements Serializa
     JavaTestUtils.attachTestOutputStream(reduceWindowed);
     List<List<Tuple2<String, Integer>>> result = JavaTestUtils.runStreams(ssc, 3, 3);
 
-    Assert.assertEquals(expected, result);
+    Assertions.assertEquals(expected, result);
   }
 
   @Test
@@ -1086,7 +1086,7 @@ public class JavaAPISuite extends LocalJavaStreamingContext implements Serializa
     JavaTestUtils.attachTestOutputStream(updated);
     List<List<Tuple2<String, Integer>>> result = JavaTestUtils.runStreams(ssc, 3, 3);
 
-    Assert.assertEquals(expected, result);
+    Assertions.assertEquals(expected, result);
   }
 
   @Test
@@ -1150,7 +1150,7 @@ public class JavaAPISuite extends LocalJavaStreamingContext implements Serializa
     JavaTestUtils.attachTestOutputStream(reduceWindowed);
     List<List<Tuple2<String, Integer>>> result = JavaTestUtils.runStreams(ssc, 3, 3);
 
-    Assert.assertEquals(expected, result);
+    Assertions.assertEquals(expected, result);
   }
 
   @SuppressWarnings("unchecked")
@@ -1184,7 +1184,7 @@ public class JavaAPISuite extends LocalJavaStreamingContext implements Serializa
       unorderedResult.add(Sets.newHashSet(res));
     }
 
-    Assert.assertEquals(expected, unorderedResult);
+    Assertions.assertEquals(expected, unorderedResult);
   }
 
   @Test
@@ -1222,7 +1222,7 @@ public class JavaAPISuite extends LocalJavaStreamingContext implements Serializa
     JavaTestUtils.attachTestOutputStream(sorted);
     List<List<Tuple2<Integer, Integer>>> result = JavaTestUtils.runStreams(ssc, 2, 2);
 
-    Assert.assertEquals(expected, result);
+    Assertions.assertEquals(expected, result);
   }
 
   @Test
@@ -1252,7 +1252,7 @@ public class JavaAPISuite extends LocalJavaStreamingContext implements Serializa
     JavaTestUtils.attachTestOutputStream(firstParts);
     List<List<Integer>> result = JavaTestUtils.runStreams(ssc, 2, 2);
 
-    Assert.assertEquals(expected, result);
+    Assertions.assertEquals(expected, result);
   }
 
   @Test
@@ -1279,7 +1279,7 @@ public class JavaAPISuite extends LocalJavaStreamingContext implements Serializa
     JavaTestUtils.attachTestOutputStream(mapped);
     List<List<Tuple2<String, String>>> result = JavaTestUtils.runStreams(ssc, 2, 2);
 
-    Assert.assertEquals(expected, result);
+    Assertions.assertEquals(expected, result);
   }
 
   @Test
@@ -1319,7 +1319,7 @@ public class JavaAPISuite extends LocalJavaStreamingContext implements Serializa
     JavaTestUtils.attachTestOutputStream(flatMapped);
     List<List<Tuple2<String, String>>> result = JavaTestUtils.runStreams(ssc, 2, 2);
 
-    Assert.assertEquals(expected, result);
+    Assertions.assertEquals(expected, result);
   }
 
   @Test
@@ -1364,7 +1364,7 @@ public class JavaAPISuite extends LocalJavaStreamingContext implements Serializa
     List<List<Tuple2<String, Tuple2<Iterable<String>, Iterable<String>>>>> result =
         JavaTestUtils.runStreams(ssc, 2, 2);
 
-    Assert.assertEquals(expected.size(), result.size());
+    Assertions.assertEquals(expected.size(), result.size());
     Iterator<List<Tuple2<String, Tuple2<Iterable<String>, Iterable<String>>>>> resultItr =
         result.iterator();
     Iterator<List<Tuple2<String, Tuple2<List<String>, List<String>>>>> expectedItr =
@@ -1379,11 +1379,11 @@ public class JavaAPISuite extends LocalJavaStreamingContext implements Serializa
             resultElements.next();
         Tuple2<String, Tuple2<List<String>, List<String>>> expectedElement =
             expectedElements.next();
-        Assert.assertEquals(expectedElement._1(), resultElement._1());
+        Assertions.assertEquals(expectedElement._1(), resultElement._1());
         equalIterable(expectedElement._2()._1(), resultElement._2()._1());
         equalIterable(expectedElement._2()._2(), resultElement._2()._2());
       }
-      Assert.assertEquals(resultElements.hasNext(), expectedElements.hasNext());
+      Assertions.assertEquals(resultElements.hasNext(), expectedElements.hasNext());
     }
   }
 
@@ -1427,7 +1427,7 @@ public class JavaAPISuite extends LocalJavaStreamingContext implements Serializa
     JavaTestUtils.attachTestOutputStream(joined);
     List<List<Tuple2<String, Tuple2<String, String>>>> result = JavaTestUtils.runStreams(ssc, 2, 2);
 
-    Assert.assertEquals(expected, result);
+    Assertions.assertEquals(expected, result);
   }
 
   @Test
@@ -1459,7 +1459,7 @@ public class JavaAPISuite extends LocalJavaStreamingContext implements Serializa
     JavaTestUtils.attachTestOutputStream(counted);
     List<List<Long>> result = JavaTestUtils.runStreams(ssc, 2, 2);
 
-    Assert.assertEquals(expected, result);
+    Assertions.assertEquals(expected, result);
   }
 
   @Test
@@ -1522,26 +1522,26 @@ public class JavaAPISuite extends LocalJavaStreamingContext implements Serializa
 
     newContextCreated.set(false);
     ssc = JavaStreamingContext.getOrCreate(emptyDir.getAbsolutePath(), creatingFunc);
-    Assert.assertTrue("new context not created", newContextCreated.get());
+    Assertions.assertTrue(newContextCreated.get(), "new context not created");
     ssc.stop();
 
     newContextCreated.set(false);
     ssc = JavaStreamingContext.getOrCreate(corruptedCheckpointDir, creatingFunc,
         new Configuration(), true);
-    Assert.assertTrue("new context not created", newContextCreated.get());
+    Assertions.assertTrue(newContextCreated.get(), "new context not created");
     ssc.stop();
 
     newContextCreated.set(false);
     ssc = JavaStreamingContext.getOrCreate(checkpointDir, creatingFunc,
         new Configuration());
-    Assert.assertTrue("old context not recovered", !newContextCreated.get());
+    Assertions.assertTrue(!newContextCreated.get(), "old context not recovered");
     ssc.stop();
 
     newContextCreated.set(false);
     JavaSparkContext sc = new JavaSparkContext(conf);
     ssc = JavaStreamingContext.getOrCreate(checkpointDir, creatingFunc,
         new Configuration());
-    Assert.assertTrue("old context not recovered", !newContextCreated.get());
+    Assertions.assertTrue(!newContextCreated.get(), "old context not recovered");
     ssc.stop();
   }
 
@@ -1642,8 +1642,8 @@ public class JavaAPISuite extends LocalJavaStreamingContext implements Serializa
   private static List<List<String>> fileTestPrepare(File testDir) throws IOException {
     File existingFile = new File(testDir, "0");
     Files.write("0\n", existingFile, StandardCharsets.UTF_8);
-    Assert.assertTrue(existingFile.setLastModified(1000));
-    Assert.assertEquals(1000, existingFile.lastModified());
+    Assertions.assertTrue(existingFile.setLastModified(1000));
+    Assertions.assertEquals(1000, existingFile.lastModified());
     return Arrays.asList(Arrays.asList("0"));
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to migrate Junit 4 to Junit 5 jupiter api, the main changes are as follows:

1. Change JUnit 4 related test dependencies to JUnit 5 to ensure Maven and SBT can run JUnit test normally: `junit` -> `junit-jupiter`, `com.github.sbt:junit-interface` -> `net.aichler:jupiter-interface`, `jmock-junit4` -> `jmock-junit5` and add `sbt-jupiter-interface` plugin to plugins.sbt
2. API migration：
2.1 Annotations reside in the `org.junit.jupiter.api` package
2.2 `@Before` and `@After` no longer exist, use `@BeforeEach` and `@AfterEach` instead
2.3 `@BeforeClass` and `@AfterClass` no longer exist, use `@BeforeAll` and `@AfterAll` instead
2.4 `@Ignore` no longer exists, use `@Disabled` instead
2.5 `Assertions` reside in `org.junit.jupiter.api.Assertions` and the assertion api with error message has a little changes there are a few api changes, for example: `assertEquals("my message", 1, 2)` -> `assertEquals(1, 2, "my message")`
2.6 Assumptions reside in `org.junit.jupiter.api.Assumptions`

### Why are the changes needed?
JUnit5 is a powerful and flexible update to the JUnit framework, and it provides a variety of improvements and new features to organize and describe test cases, as well as help in understanding test results：

1. JUnit 5 leverages features from Java 8 or later, such as lambda functions, making tests more powerful and easier to maintain, but Junit 4 still a Java 7 compatible version
2. JUnit 5 has added some useful new features for describing, organizing, and executing tests. For examples: [Parameterized Tests](https://junit.org/junit5/docs/current/user-guide/#writing-tests-parameterized-tests) and [Conditional Test Execution](https://junit.org/junit5/docs/current/user-guide/#extensions-conditions) may make our test code look simpler, [Parallel Execution](https://junit.org/junit5/docs/current/user-guide/#writing-tests-parallel-execution) may make our test faster

More importantly, Junit4 is currently an inactive project, which has not released a new version for more than two years.


More importantly, Junit4 is currently an inactive project, which has not released a new version for more than two years


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions

### Was this patch authored or co-authored using generative AI tooling?
No