### PR TITLE
[SPARK-45294][PYTHON][DOCS] Use JDK 17 in Binder integration for PySpark live notebooks

### DIFF
--- a/binder/apt.txt
+++ b/binder/apt.txt
@@ -1,2 +1,2 @@
-openjdk-8-jre
+openjdk-17-jre
 git


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR upgrades the JRE from 8 to 17 in Binder live notebooks.

### Why are the changes needed?

To use the properly supported JRE version in the live notebook.

### Does this PR introduce _any_ user-facing change?

Virtually no.

### How was this patch tested?

https://mybinder.org/v2/gh/HyukjinKwon/spark/SPARK-45294?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart_df.ipynb

https://mybinder.org/v2/gh/HyukjinKwon/spark/SPARK-45294?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart_connect.ipynb

https://mybinder.org/v2/gh/HyukjinKwon/spark/SPARK-45294?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart_ps.ipynb

### Was this patch authored or co-authored using generative AI tooling?

No.
