### PR TITLE
[SPARK-45296][INFRA][BUILD] Comment out unused JDK 11 related in dev/run-tests.py

### DIFF
--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -361,12 +361,13 @@ def run_scala_tests(build_tool, extra_profiles, test_modules, excluded_tags, inc
     if excluded_tags:
         test_profiles += ["-Dtest.exclude.tags=" + ",".join(excluded_tags)]
 
-    # set up java11 env if this is a pull request build with 'test-java11' in the title
-    if "ghprbPullTitle" in os.environ:
-        if "test-java11" in os.environ["ghprbPullTitle"].lower():
-            os.environ["JAVA_HOME"] = "/usr/java/jdk-11.0.1"
-            os.environ["PATH"] = "%s/bin:%s" % (os.environ["JAVA_HOME"], os.environ["PATH"])
-            test_profiles += ["-Djava.version=11"]
+    # SPARK-45296: legacy code for Jenkins. If we move to Jenkins, we should
+    # revive this logic with a different combination of JDK.
+    # if "ghprbPullTitle" in os.environ:
+    #     if "test-java11" in os.environ["ghprbPullTitle"].lower():
+    #         os.environ["JAVA_HOME"] = "/usr/java/jdk-11.0.1"
+    #         os.environ["PATH"] = "%s/bin:%s" % (os.environ["JAVA_HOME"], os.environ["PATH"])
+    #         test_profiles += ["-Djava.version=11"]
 
     if build_tool == "maven":
         run_scala_tests_maven(test_profiles)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to comment unused JDK 11 related in `dev/run-tests.py`.

### Why are the changes needed?

For readability, and commenting out unused code. I added some explanation inlined.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

No.

### Was this patch authored or co-authored using generative AI tooling?

No.