### PR TITLE
[SPARK-45297][SQL] Remove workaround for dateformatter added in SPARK-31827

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeFormatterHelper.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeFormatterHelper.scala
@@ -262,15 +262,6 @@ private object DateTimeFormatterHelper {
     toFormatter(builder, TimestampFormatter.defaultLocale)
   }
 
-  private final val bugInStandAloneForm = {
-    // Java 8 has a bug for stand-alone form. See https://bugs.openjdk.java.net/browse/JDK-8114833
-    // Note: we only check the US locale so that it's a static check. It can produce false-negative
-    // as some locales are not affected by the bug. Since `L`/`q` is rarely used, we choose to not
-    // complicate the check here.
-    // TODO: remove it when we drop Java 8 support.
-    val formatter = DateTimeFormatter.ofPattern("LLL qqq", Locale.US)
-    formatter.format(LocalDate.of(2000, 1, 1)) == "1 1"
-  }
   // SPARK-31892: The week-based date fields are rarely used and really confusing for parsing values
   // to datetime, especially when they are mixed with other non-week-based ones;
   // SPARK-31879: It's also difficult for us to restore the behavior of week-based date fields
@@ -327,12 +318,6 @@ private object DateTimeFormatterHelper {
           }
           for (style <- unsupportedPatternLengths if patternPart.contains(style)) {
             throw new IllegalArgumentException(s"Too many pattern letters: ${style.head}")
-          }
-          if (bugInStandAloneForm && (patternPart.contains("LLL") || patternPart.contains("qqq"))) {
-            throw new IllegalArgumentException("Java 8 has a bug to support stand-alone " +
-              "form (3 or more 'L' or 'q' in the pattern string). Please use 'M' or 'Q' instead, " +
-              "or upgrade your Java version. For more details, please read " +
-              "https://bugs.openjdk.java.net/browse/JDK-8114833")
           }
           // In DateTimeFormatter, 'u' supports negative years. We substitute 'y' to 'u' here for
           // keeping the support in Spark 3.0. If parse failed in Spark 3.0, fall back to 'y'.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR removes the legacy workaround for JDK 8 added at SPARK-31827

### Why are the changes needed?

To remove legacy workaround. We dropped JDK 8 at SPARK-44112

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing unittest/docs added in SPARK-31827

### Was this patch authored or co-authored using generative AI tooling?

No.
