### PR TITLE
[SPARK-45298][SQL][TESTS] Remove the workaround for JDK-8228469 in SPARK-31959 test

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/RebaseDateTimeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/RebaseDateTimeSuite.scala
@@ -417,22 +417,12 @@ class RebaseDateTimeSuite extends SparkFunSuite with Matchers with SQLHelper {
     // clocks were moved backward to become Sunday, 18 November, 1945 01:00:00 AM.
     // In this way, the overlap happened w/o Daylight Saving Time.
     val hkZid = getZoneId("Asia/Hong_Kong")
-    var expected = "1945-11-18 01:30:00.0"
-    var ldt = LocalDateTime.of(1945, 11, 18, 1, 30, 0)
-    var earlierMicros = instantToMicros(ldt.atZone(hkZid).withEarlierOffsetAtOverlap().toInstant)
-    var laterMicros = instantToMicros(ldt.atZone(hkZid).withLaterOffsetAtOverlap().toInstant)
-    var overlapInterval = MICROS_PER_HOUR
-    if (earlierMicros + overlapInterval != laterMicros) {
-      // Old JDK might have an outdated time zone database.
-      // See https://bugs.openjdk.java.net/browse/JDK-8228469: "Hong Kong ... Its 1945 transition
-      // from JST to HKT was on 11-18 at 02:00, not 09-15 at 00:00"
-      expected = "1945-09-14 23:30:00.0"
-      ldt = LocalDateTime.of(1945, 9, 14, 23, 30, 0)
-      earlierMicros = instantToMicros(ldt.atZone(hkZid).withEarlierOffsetAtOverlap().toInstant)
-      laterMicros = instantToMicros(ldt.atZone(hkZid).withLaterOffsetAtOverlap().toInstant)
-      // If time zone db doesn't have overlapping at all, set the overlap interval to zero.
-      overlapInterval = laterMicros - earlierMicros
-    }
+    val expected = "1945-11-18 01:30:00.0"
+    val ldt = LocalDateTime.of(1945, 11, 18, 1, 30, 0)
+    val earlierMicros = instantToMicros(ldt.atZone(hkZid).withEarlierOffsetAtOverlap().toInstant)
+    val laterMicros = instantToMicros(ldt.atZone(hkZid).withLaterOffsetAtOverlap().toInstant)
+    val overlapInterval = MICROS_PER_HOUR
+    assert(earlierMicros + overlapInterval == laterMicros)
     val hkTz = TimeZone.getTimeZone(hkZid)
     val rebasedEarlierMicros = rebaseGregorianToJulianMicros(hkTz, earlierMicros)
     val rebasedLaterMicros = rebaseGregorianToJulianMicros(hkTz, laterMicros)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR removes the legacy workaround for old JDK added at SPARK-31959

### Why are the changes needed?

To remove legacy workaround. We dropped JDK 8/11 at SPARK-44112

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing unittest/docs added in SPARK-31959

### Was this patch authored or co-authored using generative AI tooling?

No.
