### PR TITLE
[SPARK-45299][TESTS] Remove JDK 8 workaround in UtilsSuite

### DIFF
--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -1033,8 +1033,7 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties {
       file.getAbsoluteFile.setExecutable(true)
 
       val process = new ProcessBuilder(file.getAbsolutePath).start()
-      val pid = getPid(process)
-      assert(pidExists(pid))
+      process.toHandle.pid()
       try {
         signal(pid, "SIGSTOP")
         val startNs = System.nanoTime()

--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -32,7 +32,7 @@ import scala.util.Random
 
 import com.google.common.io.Files
 import org.apache.commons.io.IOUtils
-import org.apache.commons.lang3.{JavaVersion, SystemUtils}
+import org.apache.commons.lang3.SystemUtils
 import org.apache.commons.math3.stat.inference.ChiSquareTest
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
@@ -983,13 +983,13 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties {
     // Verify that we can terminate a process even if it is in a bad state. This is only run
     // on UNIX since it does some OS specific things to verify the correct behavior.
     if (SystemUtils.IS_OS_UNIX) {
-      def pidExists(pid: Int): Boolean = {
+      def pidExists(pid: Long): Boolean = {
         val p = Runtime.getRuntime.exec(Array("kill", "-0", s"$pid"))
         p.waitFor()
         p.exitValue() == 0
       }
 
-      def signal(pid: Int, s: String): Unit = {
+      def signal(pid: Long, s: String): Unit = {
         val p = Runtime.getRuntime.exec(Array("kill", s"-$s", s"$pid"))
         p.waitFor()
       }

--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -983,12 +983,6 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties {
     // Verify that we can terminate a process even if it is in a bad state. This is only run
     // on UNIX since it does some OS specific things to verify the correct behavior.
     if (SystemUtils.IS_OS_UNIX) {
-      def getPid(p: Process): Int = {
-        val f = p.getClass().getDeclaredField("pid")
-        f.setAccessible(true)
-        f.get(p).asInstanceOf[Int]
-      }
-
       def pidExists(pid: Int): Boolean = {
         val p = Runtime.getRuntime.exec(Array("kill", "-0", s"$pid"))
         p.waitFor()
@@ -1004,7 +998,7 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties {
       // less time and the process is no longer there.
       val startTimeNs = System.nanoTime()
       val process = new ProcessBuilder("sleep", "10").start()
-      val pid = getPid(process)
+      val pid = process.toHandle.pid()
       try {
         assert(pidExists(pid))
         val terminated = Utils.terminateProcess(process, 5000)

--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -997,7 +997,7 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties {
       // Start up a process that runs 'sleep 10'. Terminate the process and assert it takes
       // less time and the process is no longer there.
       val startTimeNs = System.nanoTime()
-      val process = new ProcessBuilder("sleep", "10").start()
+      var process = new ProcessBuilder("sleep", "10").start()
       var pid = process.toHandle.pid()
       try {
         assert(pidExists(pid))
@@ -1026,7 +1026,7 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties {
       Files.write(cmd.getBytes(UTF_8), file)
       file.getAbsoluteFile.setExecutable(true)
 
-      val process = new ProcessBuilder(file.getAbsolutePath).start()
+      process = new ProcessBuilder(file.getAbsolutePath).start()
       pid = process.toHandle.pid()
       try {
         signal(pid, "SIGSTOP")

--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -998,7 +998,7 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties {
       // less time and the process is no longer there.
       val startTimeNs = System.nanoTime()
       val process = new ProcessBuilder("sleep", "10").start()
-      val pid = process.toHandle.pid()
+      var pid = process.toHandle.pid()
       try {
         assert(pidExists(pid))
         val terminated = Utils.terminateProcess(process, 5000)
@@ -1027,7 +1027,7 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties {
       file.getAbsoluteFile.setExecutable(true)
 
       val process = new ProcessBuilder(file.getAbsolutePath).start()
-      process.toHandle.pid()
+      pid = process.toHandle.pid()
       try {
         signal(pid, "SIGSTOP")
         val startNs = System.nanoTime()


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR removes the legacy workaround for JDK 7 and below at SPARK-12486. The main code was cleaned up at SPARK-16182 but the test code was not cleaned up.

### Why are the changes needed?

To remove legacy workaround.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Fixed unittests.

### Was this patch authored or co-authored using generative AI tooling?

No.
