### PR TITLE
[SPARK-45301][BUILD] Remove org.scala-lang scala-library added for JDK 11 workaround

### DIFF
--- a/common/network-common/pom.xml
+++ b/common/network-common/pom.xml
@@ -35,12 +35,6 @@
   </properties>
 
   <dependencies>
-    <!-- SPARK-28932 This is required in JDK11 -->
-    <dependency>
-      <groupId>org.scala-lang</groupId>
-      <artifactId>scala-library</artifactId>
-    </dependency>
-
     <!-- Core dependencies -->
     <!-- Netty Begin -->
     <dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR removes the legacy workaround for JDK 11 added at SPARK-28932

### Why are the changes needed?

To remove legacy workaround. With JDK 17, now it seems working.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

As described in https://github.com/apache/spark/pull/25800

```bash
./build/mvn clean install -pl common/network-common -DskipTests
```

```
...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  48.139 s
[INFO] Finished at: 2023-09-25T12:27:43+09:00
[INFO] ------------------------------------------------------------------------
```

### Was this patch authored or co-authored using generative AI tooling?

No.
