### PR TITLE
[SPARK-45303][CORE] Remove JDK 8/11 workaround in KryoSerializerBenchmark

### DIFF
--- a/core/src/test/scala/org/apache/spark/benchmark/BenchmarkBase.scala
+++ b/core/src/test/scala/org/apache/spark/benchmark/BenchmarkBase.scala
@@ -23,7 +23,7 @@ import org.apache.spark.internal.config.Tests.IS_TESTING
 
 /**
  * A base class for generate benchmark results to a file.
- * For JDK9+, JDK major version number is added to the file names to distinguish the results.
+ * For JDK 21+, JDK major version number is added to the file names to distinguish the results.
  */
 abstract class BenchmarkBase {
   var output: Option[OutputStream] = None

--- a/core/src/test/scala/org/apache/spark/serializer/KryoSerializerBenchmark.scala
+++ b/core/src/test/scala/org/apache/spark/serializer/KryoSerializerBenchmark.scala
@@ -28,7 +28,6 @@ import org.apache.spark.benchmark.{Benchmark, BenchmarkBase}
 import org.apache.spark.internal.config._
 import org.apache.spark.internal.config.Kryo._
 import org.apache.spark.internal.config.Tests.IS_TESTING
-import org.apache.spark.launcher.SparkLauncher.EXECUTOR_EXTRA_JAVA_OPTIONS
 import org.apache.spark.serializer.KryoTest._
 import org.apache.spark.util.ThreadUtils
 
@@ -76,9 +75,6 @@ object KryoSerializerBenchmark extends BenchmarkBase {
 
   def createSparkContext(usePool: Boolean): SparkContext = {
     val conf = new SparkConf()
-    // SPARK-29282 This is for consistency between JDK8 and JDK11.
-    conf.set(EXECUTOR_EXTRA_JAVA_OPTIONS,
-      "-XX:+UseParallelGC -XX:-UseDynamicNumberOfGCThreads")
     conf.set(SERIALIZER, "org.apache.spark.serializer.KryoSerializer")
     conf.set(KRYO_USER_REGISTRATORS, Seq(classOf[MyRegistrator].getName))
     conf.set(KRYO_USE_POOL, usePool)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR removes the legacy workaround for JDK 8/11 in SPARK-29282.
They were already removed in SPARK-37293. This is the leftover.

### Why are the changes needed?

For consistency.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Fixed unittests.

### Was this patch authored or co-authored using generative AI tooling?

No.
