### PR TITLE
[SPARK-37508][SQL] Add Unicode[encode/decode]() function

### DIFF
--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/functions.scala
@@ -8350,3 +8350,21 @@ object functions {
   }
 
 }
+
+/**
+ * Decodes a Unicode encoding format to str
+ * scheme.
+ *
+ * @group string_funcs
+ * @since 3.5.0
+ */
+def unicode_decode(str: Column): Column = Column.fn("unicode_decode", str)
+/**
+ * Translates a string into Unicode encoding format.
+ * scheme.
+ *
+ * @group string_funcs
+ * @since 3.5.0
+ */
+def unicode_encode(str: Column): Column = Column.fn("unicode_encode", str)
+

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/PlanGenerationTestSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/PlanGenerationTestSuite.scala
@@ -3292,4 +3292,14 @@ class PlanGenerationTestSuite
   test("to_protobuf messageClassName descFilePath") {
     binary.select(pbFn.to_protobuf(fn.col("bytes"), "StorageLevel", testDescFilePath))
   }
+
+
+  functionTest("unicode_decode") {
+    fn.unicode_decode(fn.col("g"))
+  }
+
+  functionTest("unicode_encode") {
+    fn.unicode_encode(fn.col("g"))
+  }
+
 }

--- a/python/docs/source/reference/pyspark.sql/functions.rst
+++ b/python/docs/source/reference/pyspark.sql/functions.rst
@@ -450,6 +450,8 @@ String Functions
     upper
     url_decode
     url_encode
+    unicode_encode
+    unicode_decode
 
 
 Bitwise Functions

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -591,11 +591,15 @@ object FunctionRegistry {
     expression[RegExpCount]("regexp_count"),
     expression[RegExpSubStr]("regexp_substr"),
     expression[RegExpInStr]("regexp_instr"),
+    // Unicode functions
+    expression[UnicodeEncode]("unicode_encode"),
+    expression[UnicodeDecode]("unicode_decode"),
 
     // url functions
     expression[UrlEncode]("url_encode"),
     expression[UrlDecode]("url_decode"),
     expression[ParseUrl]("parse_url"),
+
 
     // datetime functions
     expression[AddMonths]("add_months"),
@@ -835,6 +839,8 @@ object FunctionRegistry {
     // Xml
     expression[XmlToStructs]("from_xml"),
     expression[SchemaOfXml]("schema_of_xml")
+
+
   )
 
   val builtin: SimpleFunctionRegistry = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/UnicodeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/UnicodeExpressions.scala
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.expressions
+import java.util.regex.{Matcher, Pattern}
+
+import org.apache.spark.sql.catalyst.expressions.objects.StaticInvoke
+import org.apache.spark.sql.catalyst.trees.UnaryLike
+import org.apache.spark.sql.types.{AbstractDataType, StringType}
+import org.apache.spark.unsafe.types.UTF8String
+
+
+// scalastyle:off line.size.limit
+@ExpressionDescription(
+  usage =
+    """
+    _FUNC_(str) - Translates a string into Unicode encoding. The Unicode Standard is a text encoding standard maintained by the Unicode Consortium designed to support the use of text written in all of the world's major writing systems.
+  """,
+  arguments =
+    """
+    Arguments:
+      str - a string expression to be translated
+  """,
+  examples =
+    """
+    Examples:
+      > SELECT _FUNC_('apache');
+       \u0061\u0070\u0061\u0063\u0068\u0065
+  """,
+  since = "3.5.0",
+  group = "string_funcs")
+// scalastyle:on line.size.limit
+case class UnicodeEncode(child: Expression)
+  extends RuntimeReplaceable with UnaryLike[Expression] with ImplicitCastInputTypes {
+
+  override def replacement: Expression =
+    StaticInvoke(
+      UnicodeCodec.getClass,
+      StringType,
+      "encode",
+      Seq(child, Literal("UTF-8")),
+      Seq(StringType, StringType))
+
+  override protected def withNewChildInternal(newChild: Expression): Expression = {
+    copy(child = newChild)
+  }
+
+  override def inputTypes: Seq[AbstractDataType] = Seq(StringType)
+
+  override def prettyName: String = "unicode_encode"
+}
+
+// scalastyle:off line.size.limit
+@ExpressionDescription(
+  usage =
+    """
+    _FUNC_(str) - Decodes a `str` in Unicode encoding format.  The Unicode Standard is a text encoding standard maintained by the Unicode Consortium designed to support the use of text written in all of the world's major writing systems.
+  """,
+  arguments =
+    """
+    Arguments:
+      * str - a string expression to decode
+  """,
+  examples =
+    """
+    Examples:
+      > SELECT _FUNC_('\u0061\u0070\u0061\u0063\u0068\u0065');
+       apache
+  """,
+  since = "3.5.0",
+  group = "string_funcs")
+// scalastyle:on line.size.limit
+case class UnicodeDecode(child: Expression)
+  extends RuntimeReplaceable with UnaryLike[Expression] with ImplicitCastInputTypes {
+
+  override def replacement: Expression =
+    StaticInvoke(
+      UnicodeCodec.getClass,
+      StringType,
+      "decode",
+      Seq(child, Literal("UTF-8")),
+      Seq(StringType, StringType))
+
+  override protected def withNewChildInternal(newChild: Expression): Expression = {
+    copy(child = newChild)
+  }
+
+  override def inputTypes: Seq[AbstractDataType] = Seq(StringType)
+
+  override def prettyName: String = "unicode_decode"
+}
+
+object UnicodeCodec {
+  def encode(str: String): UTF8String = {
+    val utfBytes = str.toCharArray()
+    val unicodeBytes: StringBuilder = new StringBuilder();
+    for (utfByte <- utfBytes) {
+      var hexB = Integer.toHexString(utfByte);
+      if (hexB.length() <= 2) {
+        hexB = "00" + hexB;
+      }
+      unicodeBytes.append("\\u").append(hexB);
+    }
+    UTF8String.fromString(unicodeBytes.toString())
+
+  }
+
+  def decode(str: String): String = {
+    val pattern: Pattern = Pattern.compile("(\\\\u(\\w{4}))");
+    val matcher: Matcher = pattern.matcher(str);
+    var ch: Char = 0
+    var src: String = str
+    while (matcher.find()) {
+      ch = Integer.parseInt(matcher.group(2), 16).toChar
+      src = str.replace(matcher.group(1), ch + "");
+    }
+    str;
+  }
+
+}
+

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -8582,4 +8582,24 @@ object functions {
   def unwrap_udt(column: Column): Column = withExpr {
     UnwrapUDT(column.expr)
   }
+
+  /**
+   * Decodes a `str` in Unicode encoding format.
+   *
+   * @group string_funcs
+   * @since 3.5.0
+   */
+  def unicode_decode(str: Column): Column = withExpr {
+    UnicodeDecode(str.expr)
+  }
+
+  /**
+   * Translates a string into Unicode encoding.
+   *
+   * @group string_funcs
+   * @since 3.5.0
+   */
+  def unicode_encode(str: Column): Column = withExpr {
+    UnicodeEncode(str.expr)
+  }
 }

--- a/sql/core/src/test/resources/sql-tests/inputs/Unicode-functions.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/Unicode-functions.sql
@@ -1,0 +1,7 @@
+-- unicode_encode function
+select unicode_encode('https://spark.apache.org');
+select unicode_encode(null);
+
+-- unicode_decode function
+select unicode_decode('\u0061\u0070\u0061\u0063\u0068\u0065');
+select unicode_decode(null);

--- a/sql/core/src/test/scala/org/apache/spark/sql/StringFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/StringFunctionsSuite.scala
@@ -1225,4 +1225,24 @@ class StringFunctionsSuite extends QueryTest with SharedSparkSession {
       )
     )
   }
+
+  test("unicode_decode") {
+    val df = Seq("\u0061\u0070\u0061\u0063\u0068\u0065").toDF("a")
+    checkAnswer(
+      df.selectExpr("unicode_decode(a)"),
+      Row("apache"))
+    checkAnswer(
+      df.select(unicode_decode(col("a"))),
+      Row("apache"))
+  }
+
+  test("unicode_encode") {
+    val df = Seq("apache").toDF("a")
+    checkAnswer(
+      df.selectExpr("unicode_encode(a)"),
+      Row("\u0061\u0070\u0061\u0063\u0068\u0065"))
+    checkAnswer(
+      df.select(unicode_encode(col("a"))),
+      Row("\u0061\u0070\u0061\u0063\u0068\u0065"))
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently,  Spark don't support unicode encode/decode as built-in functions, the usermight use reflect instead , 
It's a bit of poor efficiency ,And often these functions are useful.

### Why are the changes needed?
unicode encode/decode functions are useful in SQL statistics


### Does this PR introduce _any_ user-facing change?
yes, add new function as built-in function


### How was this patch tested?
add new tests yet 


### Was this patch authored or co-authored using generative AI tooling?
No
