### PR TITLE
[SPARK-45304][BUILD] Remove test classloader workaround for SBT build

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -365,10 +365,6 @@ object SparkBuild extends PomBuild {
     // to be enabled in specific ones that have previous artifacts
     MimaKeys.mimaFailOnNoPrevious := false,
 
-    // To prevent intermittent compilation failures, see also SPARK-33297
-    // Apparently we can remove this when we use JDK 11.
-    Test / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.Flat,
-
     // Setting version for the protobuf compiler. This has to be propagated to every sub-project
     // even if the project is not using it.
     PB.protocVersion := protoVersion,


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to remove the workaround for JDK 8 in SBT build, see https://github.com/apache/spark/pull/30198

### Why are the changes needed?

We don't need this with JDK 11+ anymore, see https://github.com/apache/spark/pull/30198.

### Does this PR introduce _any_ user-facing change?

No, dev-only.


### How was this patch tested?

CI


### Was this patch authored or co-authored using generative AI tooling?

No.
