### PR TITLE
[MINOR][SQL][DOCS] Remove JDK 8 related information in the comemnts for aes_encrypt and aes_decrypt

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
@@ -304,8 +304,6 @@ case class CurrentUser() extends LeafExpression with Unevaluable {
 
 /**
  * A function that encrypts input using AES. Key lengths of 128, 192 or 256 bits can be used.
- * For versions prior to JDK 8u161, 192 and 256 bits keys can be used
- * if Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files are installed.
  * If either argument is NULL or the key length is not one of the permitted values,
  * the return value is NULL.
  */
@@ -388,8 +386,6 @@ case class AesEncrypt(
 
 /**
  * A function that decrypts input using AES. Key lengths of 128, 192 or 256 bits can be used.
- * For versions prior to JDK 8u161, 192 and 256 bits keys can be used
- * if Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files are installed.
  * If either argument is NULL or the key length is not one of the permitted values,
  * the return value is NULL.
  */


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to fix the comments in both `aes_encrypt` and `aes_decrypt`. Did a quick check for Scala/Python/R API, and seems like this is the only place to fix.

### Why are the changes needed?

We dropped JDK 8 at SPARK-44112

### Does this PR introduce _any_ user-facing change?

No, it's Scaladoc, and the doc is not user-facing.

### How was this patch tested?

Build in this CI should check them.

### Was this patch authored or co-authored using generative AI tooling?

No.
