### PR TITLE
[SPARK-45305][SQL][TESTS] Remove JDK 8 workaround added TreeNodeSuite

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/trees/TreeNodeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/trees/TreeNodeSuite.scala
@@ -871,28 +871,6 @@ class TreeNodeSuite extends SparkFunSuite with SQLHelper {
     }
   }
 
-  test("SPARK-32999: TreeNode.nodeName should not throw malformed class name error") {
-    val testTriggersExpectedError = try {
-      classOf[MalformedClassObject.MalformedNameExpression].getSimpleName
-      false
-    } catch {
-      case ex: java.lang.InternalError if ex.getMessage.contains("Malformed class name") =>
-        true
-      case ex: Throwable => throw ex
-    }
-    // This test case only applies on older JDK versions (e.g. JDK8u), and doesn't trigger the
-    // issue on newer JDK versions (e.g. JDK11u).
-    assume(testTriggersExpectedError, "the test case didn't trigger malformed class name error")
-
-    val expr = MalformedClassObject.MalformedNameExpression(Literal(1))
-    try {
-      expr.nodeName
-    } catch {
-      case ex: java.lang.InternalError if ex.getMessage.contains("Malformed class name") =>
-        fail("TreeNode.nodeName should not throw malformed class name error")
-    }
-  }
-
   test("SPARK-37800: TreeNode.argString incorrectly formats arguments of type Set[_]") {
     case class Node(set: Set[String], nested: Seq[Set[Int]]) extends LeafNode {
       val output: Seq[Attribute] = Nil

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/trees/TreeNodeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/trees/TreeNodeSuite.scala
@@ -864,13 +864,6 @@ class TreeNodeSuite extends SparkFunSuite with SQLHelper {
     assert(getStateful(withNestedStatefulBefore) ne getStateful(withNestedStatefulAfter))
   }
 
-  object MalformedClassObject extends Serializable {
-    case class MalformedNameExpression(child: Expression) extends TaggingExpression {
-      override protected def withNewChildInternal(newChild: Expression): Expression =
-        copy(child = newChild)
-    }
-  }
-
   test("SPARK-37800: TreeNode.argString incorrectly formats arguments of type Set[_]") {
     case class Node(set: Set[String], nested: Seq[Set[Int]]) extends LeafNode {
       val output: Seq[Attribute] = Nil


### PR DESCRIPTION
### What changes were proposed in this pull request?

In theory, we don't need https://github.com/apache/spark/pull/29875 anymore because we dropped JDK 8 (according to the PR description in https://github.com/apache/spark/pull/29875) but `Utils.getSimpleClass` handles malformed class names in any event, so should be safe to keep them.

### Why are the changes needed?

To remove test that does not run. We dropped JDK 11/8 at SPARK-44112

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

CI in this PR should test them out.

### Was this patch authored or co-authored using generative AI tooling?

No.
