### PR TITLE
[SPARK-45307][INFRA] Use Zulu JDK in `benchmark` GitHub Action and Java 21

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -107,7 +107,7 @@ jobs:
         if: steps.cache-tpcds-sf-1.outputs.cache-hit != 'true'
         uses: actions/setup-java@v3
         with:
-          distribution: temurin
+          distribution: zulu
           java-version: ${{ github.event.inputs.jdk }}
       - name: Generate TPC-DS (SF=1) table data
         if: steps.cache-tpcds-sf-1.outputs.cache-hit != 'true'
@@ -159,7 +159,7 @@ jobs:
     - name: Install Java ${{ github.event.inputs.jdk }}
       uses: actions/setup-java@v3
       with:
-        distribution: temurin
+        distribution: zulu
         java-version: ${{ github.event.inputs.jdk }}
     - name: Cache TPC-DS generated data
       if: contains(github.event.inputs.class, 'TPCDSQueryBenchmark') || contains(github.event.inputs.class, '*')


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to use Zulu JDK in benchmark GitHub Action and Java 21.

### Why are the changes needed?
When I was preparing to obtain the results of `org.apache.spark.MapStatusesConvertBenchmark` benchmark running on JDK21 in GA, the following error occurred, 
https://github.com/panbingkun/spark/actions/runs/6293925655/job/17085885694
<img width="1020" alt="image" src="https://github.com/apache/spark/assets/15246973/36e293e0-cae8-4764-a93a-93a139b6eaaa">


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Manually test.
https://github.com/panbingkun/spark/actions/runs/6295588793

### Was this patch authored or co-authored using generative AI tooling?
No.
