### PR TITLE
[SPARK-45320][SQL][TESTS] Update benchmark result for `InMemoryColumnarBenchmark`

### DIFF
--- a/sql/core/benchmarks/InMemoryColumnarBenchmark-jdk21-results.txt
+++ b/sql/core/benchmarks/InMemoryColumnarBenchmark-jdk21-results.txt
@@ -2,11 +2,11 @@
 Int In-memory with 1000000 rows
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.8+7-LTS on Linux 5.15.0-1046-azure
-Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+OpenJDK 64-Bit Server VM 21+35 on Linux 5.15.0-1046-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Int In-Memory scan:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------
-columnar deserialization + columnar-to-row            274            437         146          3.7         273.8       1.0X
-row-based deserialization                             263            308          39          3.8         263.2       1.0X
+columnar deserialization + columnar-to-row            336            413          67          3.0         336.2       1.0X
+row-based deserialization                             215            285          61          4.7         214.7       1.6X
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims update `InMemoryColumnarBenchmark` benchmark result for Java 17 and add benchmark result for Java 21


### Why are the changes needed?
Track the performance of Java 17/21 through micro-benchmark testing.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No
