### PR TITLE
[SPARK-45322][CORE] Use ProcessHandle to get pid directly

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -2149,8 +2149,7 @@ private[spark] object Utils
 
   /** Return a heap dump. Used to capture dumps for the web UI */
   def getHeapHistogram(): Array[String] = {
-    // From Java 9+, we can use 'ProcessHandle.current().pid()'
-    val pid = getProcessName().split("@").head
+    val pid = String.valueOf(ProcessHandle.current().pid())
     val jmap = System.getProperty("java.home") + "/bin/jmap"
     val builder = new ProcessBuilder(jmap, "-histo:live", pid)
     val p = builder.start()


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `ProcessHandle` to get the current pid directly.

https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/ProcessHandle.html

### Why are the changes needed?

Previously, we extract the pid from the process names.

https://github.com/apache/spark/blob/0edeb605f2f6e462036905816d26ca141a378c0c/core/src/main/scala/org/apache/spark/util/Utils.scala#L2153

https://github.com/apache/spark/blob/0edeb605f2f6e462036905816d26ca141a378c0c/core/src/main/scala/org/apache/spark/util/Utils.scala#L2660-L2666


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs and do the manual test.

This is the only place.
```
$ git grep getProcessName
core/src/main/scala/org/apache/spark/util/Utils.scala:    val pid = getProcessName().split("@").head
core/src/main/scala/org/apache/spark/util/Utils.scala:  def getProcessName(): String = {
core/src/main/scala/org/apache/spark/util/Utils.scala:    log.info(s"Started daemon with process name: ${Utils.getProcessName()}")
```

### Was this patch authored or co-authored using generative AI tooling?

No.