### PR TITLE
[SPARK-45310][CORE] Report shuffle block status should respect shuffle service during decommission migration

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/Tests.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/Tests.scala
@@ -83,4 +83,13 @@ private[spark] object Tests {
       .booleanConf
       .createWithDefault(false)
 
+  val TEST_SKIP_ESS_REGISTER = ConfigBuilder("spark.testing.skipESSRegister")
+    .version("4.0.0")
+    .doc("None of Spark testing modes (local, local-cluster) enables shuffle service. So it is " +
+      s"hard to test ${SHUFFLE_SERVICE_ENABLED.key} when you only want to test this flag but " +
+      s"without the real server. This config provides a way to allow tests run with " +
+      s"${SHUFFLE_SERVICE_ENABLED.key} enabled without registration failures.")
+    .booleanConf
+    .createWithDefault(false)
+
 }

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -43,7 +43,7 @@ import org.apache.spark.errors.SparkCoreErrors
 import org.apache.spark.executor.DataReadMethod
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config
-import org.apache.spark.internal.config.{Network, RDD_CACHE_VISIBILITY_TRACKING_ENABLED}
+import org.apache.spark.internal.config.{Network, RDD_CACHE_VISIBILITY_TRACKING_ENABLED, Tests}
 import org.apache.spark.memory.{MemoryManager, MemoryMode}
 import org.apache.spark.metrics.source.Source
 import org.apache.spark.network._
@@ -527,9 +527,7 @@ private[spark] class BlockManager(
       logInfo(s"external shuffle service port = $externalShuffleServicePort")
       shuffleServerId = BlockManagerId(executorId, blockTransferService.hostName,
         externalShuffleServicePort)
-      // Do not try to register with the external shuffle server under testing since none of
-      // test modes (local, local-cluster) enables shuffle service.
-      if (!isDriver && !Utils.isTesting) {
+      if (!isDriver && !(Utils.isTesting && conf.get(Tests.TEST_SKIP_ESS_REGISTER))) {
         registerWithExternalShuffleServer()
       }
     }

--- a/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
@@ -311,7 +311,7 @@ class BlockManagerSuite extends SparkFunSuite with Matchers with PrivateMethodTe
   }
 
   Seq(true, false).foreach { shuffleServiceEnabled =>
-    test(s"SPARK-45310: report shuffle block status should respect " +
+    test("SPARK-45310: report shuffle block status should respect " +
       s"external shuffle service (enabled=$shuffleServiceEnabled)") {
       val conf = new SparkConf().set(config.SHUFFLE_SERVICE_ENABLED, shuffleServiceEnabled)
       val bm = makeBlockManager(1000, "executor", testConf = Some(conf))

--- a/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
@@ -313,7 +313,9 @@ class BlockManagerSuite extends SparkFunSuite with Matchers with PrivateMethodTe
   Seq(true, false).foreach { shuffleServiceEnabled =>
     test("SPARK-45310: report shuffle block status should respect " +
       s"external shuffle service (enabled=$shuffleServiceEnabled)") {
-      val conf = new SparkConf().set(config.SHUFFLE_SERVICE_ENABLED, shuffleServiceEnabled)
+      val conf = new SparkConf()
+        .set(config.SHUFFLE_SERVICE_ENABLED, shuffleServiceEnabled)
+        .set(config.Tests.TEST_SKIP_ESS_REGISTER, true)
       val bm = makeBlockManager(1000, "executor", testConf = Some(conf))
       val blockManagerId = bm.blockManagerId
       val shuffleServiceId = bm.shuffleServerId

--- a/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
@@ -133,12 +133,12 @@ class BlockManagerSuite extends SparkFunSuite with Matchers with PrivateMethodTe
     val bmSecurityMgr = new SecurityManager(bmConf, encryptionKey)
     val serializerManager = new SerializerManager(serializer, bmConf, encryptionKey)
     val transfer = transferService.getOrElse(new NettyBlockTransferService(
-      conf, securityMgr, serializerManager, "localhost", "localhost", 0, 1))
+      bmConf, securityMgr, serializerManager, "localhost", "localhost", 0, 1))
     val memManager = UnifiedMemoryManager(bmConf, numCores = 1)
-    val externalShuffleClient = if (conf.get(config.SHUFFLE_SERVICE_ENABLED)) {
-      val transConf = SparkTransportConf.fromSparkConf(conf, "shuffle", 0)
+    val externalShuffleClient = if (bmConf.get(config.SHUFFLE_SERVICE_ENABLED)) {
+      val transConf = SparkTransportConf.fromSparkConf(bmConf, "shuffle", 0)
       Some(new ExternalBlockStoreClient(transConf, bmSecurityMgr,
-        bmSecurityMgr.isAuthenticationEnabled(), conf.get(config.SHUFFLE_REGISTRATION_TIMEOUT)))
+        bmSecurityMgr.isAuthenticationEnabled(), bmConf.get(config.SHUFFLE_REGISTRATION_TIMEOUT)))
     } else {
       None
     }
@@ -308,6 +308,35 @@ class BlockManagerSuite extends SparkFunSuite with Matchers with PrivateMethodTe
     // locations to BlockManagerMaster)
     master.updateBlockInfo(bm1Id, RDDBlockId(0, 0), StorageLevel.MEMORY_ONLY, 100, 0)
     master.updateBlockInfo(bm2Id, RDDBlockId(0, 1), StorageLevel.MEMORY_ONLY, 100, 0)
+  }
+
+  Seq(true, false).foreach { shuffleServiceEnabled =>
+    test(s"SPARK-45310: report shuffle block status should respect " +
+      s"external shuffle service (enabled=$shuffleServiceEnabled)") {
+      val conf = new SparkConf().set(config.SHUFFLE_SERVICE_ENABLED, shuffleServiceEnabled)
+      val bm = makeBlockManager(1000, "executor", testConf = Some(conf))
+      val blockManagerId = bm.blockManagerId
+      val shuffleServiceId = bm.shuffleServerId
+      bm.reportBlockStatus(BlockId("rdd_0_0"), BlockStatus.empty)
+      eventually(timeout(5.seconds)) {
+        // For non-shuffle blocks, it should just report block manager id.
+        verify(master, times(1))
+          .updateBlockInfo(mc.eq(blockManagerId), mc.any(), mc.any(), mc.any(), mc.any())
+      }
+      bm.reportBlockStatus(BlockId("shuffle_0_0_0.index"), BlockStatus.empty)
+      bm.reportBlockStatus(BlockId("shuffle_0_0_0.data"), BlockStatus.empty)
+      eventually(timeout(5.seconds)) {
+        // For shuffle blocks, it should report shuffle service id (if enabled)
+        // instead of block manager id.
+        val (expectedBMId, expectedTimes) = if (shuffleServiceEnabled) {
+          (shuffleServiceId, 2)
+        } else {
+          (blockManagerId, 3)
+        }
+        verify(master, times(expectedTimes))
+          .updateBlockInfo(mc.eq(expectedBMId), mc.any(), mc.any(), mc.any(), mc.any())
+      }
+    }
   }
 
   test("SPARK-36036: make sure temporary download files are deleted") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Currently, when migrating a shuffle block during decommission, its location type would be changed from shuffle service (if enabled) to the executor. This is of course not the expected behavior. We should still use the external shuffle service to fetch the migrated shuffle blocks. This PR fixes this issue by respecting the shuffle service when reporting the shuffle blocks.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Bug fix/improvment.

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?

Unit test.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.
