### PR TITLE
[SPARK-45335][SQL][DOCS] Correct the group of `ElementAt` and `TryElementAt`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -2333,7 +2333,7 @@ case class Get(
        b
   """,
   since = "2.4.0",
-  group = "map_funcs")
+  group = "collection_funcs")
 case class ElementAt(
     left: Expression,
     right: Expression,
@@ -2557,7 +2557,7 @@ case class ElementAt(
        b
   """,
   since = "3.3.0",
-  group = "map_funcs")
+  group = "collection_funcs")
 case class TryElementAt(left: Expression, right: Expression, replacement: Expression)
   extends RuntimeReplaceable with InheritAnalysisRules {
   def this(left: Expression, right: Expression) =


### PR DESCRIPTION
### What changes were proposed in this pull request?
Correct the group of `ElementAt` and `TryElementAt`, they both support array and map input, so should be in `collection functions`.

Existing category strategy seems like this: if a function support more than one types, it should be in `collection functions`:

- `Size` supports both array and map, it is in `collection functions`;
- `Reverse` supports both array and string, it is in `collection functions`;

So far, I didn't find other places with incorrect groups.

### Why are the changes needed?
for docs


### Does this PR introduce _any_ user-facing change?
yes, they will be in `collection functions` in SQL references


### How was this patch tested?
CI

### Was this patch authored or co-authored using generative AI tooling?
No