### PR TITLE
[SPARK-45337][CORE] Refactor `AbstractCommandBuilder#getScalaVersion` to remove the check for Scala 2.12

### DIFF
--- a/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
@@ -230,17 +230,11 @@ abstract class AbstractCommandBuilder {
       return scala;
     }
     String sparkHome = getSparkHome();
-    File scala212 = new File(sparkHome, "launcher/target/scala-2.12");
     File scala213 = new File(sparkHome, "launcher/target/scala-2.13");
-    checkState(!scala212.isDirectory() || !scala213.isDirectory(),
+    checkState(!scala213.isDirectory(),
       "Presence of build for multiple Scala versions detected.\n" +
       "Either clean one of them or set SPARK_SCALA_VERSION in your environment.");
-    if (scala213.isDirectory()) {
-      return "2.13";
-    } else {
-      checkState(scala212.isDirectory(), "Cannot find any build directories.");
-      return "2.12";
-    }
+    return "2.13";
   }
 
   String getSparkHome() {

--- a/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
@@ -231,10 +231,20 @@ abstract class AbstractCommandBuilder {
     }
     String sparkHome = getSparkHome();
     File scala213 = new File(sparkHome, "launcher/target/scala-2.13");
-    checkState(!scala213.isDirectory(),
-      "Presence of build for multiple Scala versions detected.\n" +
-      "Either clean one of them or set SPARK_SCALA_VERSION in your environment.");
+    checkState(scala213.isDirectory(), "Cannot find any build directories.");
     return "2.13";
+    // String sparkHome = getSparkHome();
+    // File scala212 = new File(sparkHome, "launcher/target/scala-2.12");
+    // File scala213 = new File(sparkHome, "launcher/target/scala-2.13");
+    // checkState(!scala212.isDirectory() || !scala213.isDirectory(),
+    //  "Presence of build for multiple Scala versions detected.\n" +
+    //  "Either clean one of them or set SPARK_SCALA_VERSION in your environment.");
+    // if (scala213.isDirectory()) {
+    //  return "2.13";
+    // } else {
+    //  checkState(scala212.isDirectory(), "Cannot find any build directories.");
+    //  return "2.12";
+    // }
   }
 
   String getSparkHome() {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr refactors `AbstractCommandBuilder#getScalaVersion` function as follows:
1. comment out the code for multiple Scala versions support , making it easier to reintroduce when Scala 3 is supported.
2. Change to directly return `"2.13"` when `scala213.isDirectory()` is true

### Why are the changes needed?
Remove Scala 2.12 check


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
- Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No