### PR TITLE
[SPARK-45339][PYTHON][CONNECT] Pyspark should log errors it retries

### DIFF
--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -1565,9 +1565,12 @@ class RetryState:
         self._count += 1
 
     def throw(self) -> None:
+        raise self.exception()
+
+    def exception(self) -> BaseException:
         if self._exception is None:
             raise RuntimeError("No exception is set")
-        raise self._exception
+        return self._exception
 
     def set_done(self) -> None:
         self._done = True
@@ -1676,7 +1679,9 @@ class Retrying:
                 if backoff >= self._min_jitter_threshold:
                     backoff += random.uniform(0, self._jitter)
 
-                logger.debug(f"Retrying call after {backoff} ms sleep")
+                logger.debug(
+                    f"Will retry call after {backoff} ms sleep (error: {retry_state.exception()})"
+                )
                 self._sleep(backoff / 1000.0)
             yield AttemptManager(self._can_retry, retry_state)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

In the retry mechanism, log errors which were supressed and retried.

### Why are the changes needed?

Is needed to debug problems our users are facing (requested by @grundprinzip).

### Does this PR introduce _any_ user-facing change?
Errors are logged


### How was this patch tested?

By hand

### Was this patch authored or co-authored using generative AI tooling?

No