### PR TITLE
[SPARK-43850][BUILD][GRAPHX] Remove the import for `scala.language.higherKinds` and delete the corresponding suppression rule

### DIFF
--- a/graphx/src/main/scala/org/apache/spark/graphx/impl/VertexPartitionBase.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/impl/VertexPartitionBase.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.graphx.impl
 
-import scala.language.higherKinds
 import scala.reflect.ClassTag
 
 import org.apache.spark.graphx._

--- a/graphx/src/main/scala/org/apache/spark/graphx/impl/VertexPartitionBaseOps.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/impl/VertexPartitionBaseOps.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.graphx.impl
 
-import scala.language.higherKinds
 import scala.language.implicitConversions
 import scala.reflect.ClassTag
 

--- a/pom.xml
+++ b/pom.xml
@@ -2971,12 +2971,6 @@
               <arg>-Wconf:cat=unchecked&amp;msg=eliminated by erasure:s</arg>
               <arg>-Wconf:msg=^(?=.*?a value of type)(?=.*?cannot also be).+$:s</arg>
               <!--
-                TODO(SPARK-43850): Remove the following suppression rules and remove `import scala.language.higherKinds`
-                from the corresponding files when Scala 2.12 is no longer supported.
-              -->
-              <arg>-Wconf:cat=unused-imports&amp;src=org\/apache\/spark\/graphx\/impl\/VertexPartitionBase.scala:s</arg>
-              <arg>-Wconf:cat=unused-imports&amp;src=org\/apache\/spark\/graphx\/impl\/VertexPartitionBaseOps.scala:s</arg>
-              <!--
                 SPARK-40497 Upgrade Scala to 2.13.11 and suppress `Implicit definition should have explicit type`
               -->
               <arg>-Wconf:msg=Implicit definition should have explicit type:s</arg>

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -258,10 +258,6 @@ object SparkBuild extends PomBuild {
         "-Wconf:cat=unchecked&msg=outer reference:s",
         "-Wconf:cat=unchecked&msg=eliminated by erasure:s",
         "-Wconf:msg=^(?=.*?a value of type)(?=.*?cannot also be).+$:s",
-        // TODO(SPARK-43850): Remove the following suppression rules and remove `import scala.language.higherKinds`
-        // from the corresponding files when Scala 2.12 is no longer supported.
-        "-Wconf:cat=unused-imports&src=org\\/apache\\/spark\\/graphx\\/impl\\/VertexPartitionBase.scala:s",
-        "-Wconf:cat=unused-imports&src=org\\/apache\\/spark\\/graphx\\/impl\\/VertexPartitionBaseOps.scala:s",
         // SPARK-40497 Upgrade Scala to 2.13.11 and suppress `Implicit definition should have explicit type`
         "-Wconf:msg=Implicit definition should have explicit type:s"
       )


### PR DESCRIPTION
### What changes were proposed in this pull request?
`scala.language.higherKinds` is deprecated and no longer needs to be imported explicitly in Scala 2.13, so this PR removes the imports for scala.language.higherKinds and the corresponding compiler suppression rules.

### Why are the changes needed?
In SPARK-43849(https://github.com/apache/spark/pull/41356), I added compiler suppression rules to allow `unused imports` checks to work with both Scala 2.12 and Scala 2.13. As there is no longer a need to support Scala 2.12, we can now clean them up.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No