### PR TITLE
[SPARK-45350][CORE] Rename the imported `java.lang.Boolean` to JBoolean

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/rest/SubmitRestProtocolResponse.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/rest/SubmitRestProtocolResponse.scala
@@ -17,14 +17,14 @@
 
 package org.apache.spark.deploy.rest
 
-import java.lang.Boolean
+import java.lang.{Boolean => JBoolean}
 
 /**
  * An abstract response sent from the server in the REST application submission protocol.
  */
 private[rest] abstract class SubmitRestProtocolResponse extends SubmitRestProtocolMessage {
   var serverSparkVersion: String = null
-  var success: Boolean = null
+  var success: JBoolean = null
   var unknownFields: Array[String] = null
   protected override def doValidate(): Unit = {
     super.doValidate()

--- a/core/src/test/scala/org/apache/spark/deploy/rest/SubmitRestProtocolSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/rest/SubmitRestProtocolSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.deploy.rest
 
-import java.lang.Boolean
+import java.lang.{Boolean => JBoolean}
 
 import scala.util.Properties.versionNumberString
 
@@ -347,7 +347,7 @@ class SubmitRestProtocolSuite extends SparkFunSuite {
 
 private class DummyResponse extends SubmitRestProtocolResponse
 private class DummyRequest extends SubmitRestProtocolRequest {
-  var active: Boolean = null
+  var active: JBoolean = null
   var age: Integer = null
   var name: String = null
   protected override def doValidate(): Unit = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr change `import java.lang.Boolean` in Scala file to `import java.lang.{Boolean => JBoolean}`.

### Why are the changes needed?
Follow the existing import practices in Spark.



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No