### PR TITLE
[MINOR][PYTHON][CONNECT] Check `self._session` before call `self._session.client`

### DIFF
--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -1730,9 +1730,9 @@ class DataFrame:
     @property
     def schema(self) -> StructType:
         if self._plan is not None:
-            query = self._plan.to_proto(self._session.client)
             if self._session is None:
                 raise Exception("Cannot analyze without SparkSession.")
+            query = self._plan.to_proto(self._session.client)
             return self._session.client.schema(query)
         else:
             raise Exception("Empty plan.")
@@ -1860,9 +1860,9 @@ class DataFrame:
             explain_mode = cast(str, extended)
 
         if self._plan is not None:
-            query = self._plan.to_proto(self._session.client)
             if self._session is None:
                 raise Exception("Cannot analyze without SparkSession.")
+            query = self._plan.to_proto(self._session.client)
             return self._session.client.explain_string(query, explain_mode)
         else:
             return ""


### PR DESCRIPTION
### What changes were proposed in this pull request?
In `DataFrame.{schema, explain}`, check `self._session` before call `self._session.client`

I don't find other similar places

### Why are the changes needed?
we should check `self._session` before call `self._session.client`

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
ci

### Was this patch authored or co-authored using generative AI tooling?
no