### PR TITLE
[SPARK-45354][SQL] Resolve functions bottom-up

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -2207,7 +2207,7 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
         Project(aliases, u.child)
 
       case q: LogicalPlan =>
-        q.transformExpressionsWithPruning(
+        q.transformExpressionsUpWithPruning(
           _.containsAnyPattern(UNRESOLVED_FUNCTION, GENERATOR),
           ruleId) {
           case u @ UnresolvedFunction(nameParts, arguments, _, _, _)

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/udf/udf-udaf.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/udf/udf-udaf.sql.out
@@ -72,9 +72,9 @@ org.apache.spark.sql.AnalysisException
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",
-    "startIndex" : 95,
-    "stopIndex" : 117,
-    "fragment" : "default.udaf1(int_col1)"
+    "startIndex" : 8,
+    "stopIndex" : 35,
+    "fragment" : "default.udaf1(udf(int_col1))"
   } ]
 }
 

--- a/sql/core/src/test/resources/sql-tests/results/udf/udf-udaf.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udf/udf-udaf.sql.out
@@ -73,9 +73,9 @@ org.apache.spark.sql.AnalysisException
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",
-    "startIndex" : 95,
-    "stopIndex" : 117,
-    "fragment" : "default.udaf1(int_col1)"
+    "startIndex" : 8,
+    "stopIndex" : 35,
+    "fragment" : "default.udaf1(udf(int_col1))"
   } ]
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR proposes bottum-up resolution in `ResolveFunctions`, which is much faster (requires less number of resolution rounds) if we have deeply nested `UnresolvedFunctions`. These structures are more likely to occur after https://github.com/apache/spark/pull/42864.

### Why are the changes needed?
Performance optimization.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Existing UTs.

### Was this patch authored or co-authored using generative AI tooling?
No.
