### PR TITLE
[SPARK-45362][PYTHON] Project out PARTITION BY expressions before Python UDTF 'eval' method consumes them

### DIFF
--- a/python/pyspark/sql/tests/test_udtf.py
+++ b/python/pyspark/sql/tests/test_udtf.py
@@ -2009,7 +2009,7 @@ class BaseUDTFTestsMixin:
                 self._partition_col = None
 
             def eval(self, row: Row):
-                # Make sure that the PARTITION BY and ORDER BY expressions were projected out.
+                # Make sure that the PARTITION BY expressions were projected out.
                 assert(len(row.asDict().items()) == 2)
                 self._sum += row["input"]
                 if self._partition_col is not None and self._partition_col != row["partition_col"]:

--- a/python/pyspark/sql/tests/test_udtf.py
+++ b/python/pyspark/sql/tests/test_udtf.py
@@ -2009,6 +2009,8 @@ class BaseUDTFTestsMixin:
                 self._partition_col = None
 
             def eval(self, row: Row):
+                # Make sure that the PARTITION BY and ORDER BY expressions were projected out.
+                assert(len(row.asDict().items()) == 2)
                 self._sum += row["input"]
                 if self._partition_col is not None and self._partition_col != row["partition_col"]:
                     # Make sure that all values of the partitioning column are the same
@@ -2092,6 +2094,8 @@ class BaseUDTFTestsMixin:
                 self._partition_col = None
 
             def eval(self, row: Row, partition_col: str):
+                # Make sure that the PARTITION BY and ORDER BY expressions were projected out.
+                assert(len(row.asDict().items()) == 2)
                 # Make sure that all values of the partitioning column are the same
                 # for each row consumed by this method for this instance of the class.
                 if self._partition_col is not None and self._partition_col != row[partition_col]:
@@ -2247,6 +2251,8 @@ class BaseUDTFTestsMixin:
                 )
 
             def eval(self, row: Row):
+                # Make sure that the PARTITION BY and ORDER BY expressions were projected out.
+                assert(len(row.asDict().items()) == 2)
                 # Make sure that all values of the partitioning column are the same
                 # for each row consumed by this method for this instance of the class.
                 if self._partition_col is not None and self._partition_col != row["partition_col"]:

--- a/python/pyspark/sql/tests/test_udtf.py
+++ b/python/pyspark/sql/tests/test_udtf.py
@@ -2010,7 +2010,9 @@ class BaseUDTFTestsMixin:
 
             def eval(self, row: Row):
                 # Make sure that the PARTITION BY expressions were projected out.
-                assert(len(row.asDict().items()) == 2)
+                assert len(row.asDict().items()) == 2
+                assert "partition_col" in row
+                assert "input" in row
                 self._sum += row["input"]
                 if self._partition_col is not None and self._partition_col != row["partition_col"]:
                     # Make sure that all values of the partitioning column are the same
@@ -2095,7 +2097,9 @@ class BaseUDTFTestsMixin:
 
             def eval(self, row: Row, partition_col: str):
                 # Make sure that the PARTITION BY and ORDER BY expressions were projected out.
-                assert(len(row.asDict().items()) == 2)
+                assert len(row.asDict().items()) == 2
+                assert "partition_col" in row
+                assert "input" in row
                 # Make sure that all values of the partitioning column are the same
                 # for each row consumed by this method for this instance of the class.
                 if self._partition_col is not None and self._partition_col != row[partition_col]:
@@ -2252,7 +2256,9 @@ class BaseUDTFTestsMixin:
 
             def eval(self, row: Row):
                 # Make sure that the PARTITION BY and ORDER BY expressions were projected out.
-                assert(len(row.asDict().items()) == 2)
+                assert len(row.asDict().items()) == 2
+                assert "partition_col" in row
+                assert "input" in row
                 # Make sure that all values of the partitioning column are the same
                 # for each row consumed by this method for this instance of the class.
                 if self._partition_col is not None and self._partition_col != row["partition_col"]:

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -738,8 +738,7 @@ def read_udtf(pickleSer, infile, eval_type):
                 # Filter the arguments to exclude projected PARTITION BY values added by Catalyst.
                 filtered_args = [self._remove_partition_by_exprs(arg) for arg in args]
                 filtered_kwargs = {
-                    key: self._remove_partition_by_exprs(value)
-                    for (key, value) in kwargs.items()
+                    key: self._remove_partition_by_exprs(value) for (key, value) in kwargs.items()
                 }
                 result = self._udtf.eval(*filtered_args, **filtered_kwargs)
                 if result is not None:

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -737,12 +737,10 @@ def read_udtf(pickleSer, infile, eval_type):
             if self._udtf.eval is not None:
                 # Filter the arguments to exclude projected PARTITION BY values added by Catalyst.
                 filtered_args = [self._remove_partition_by_exprs(arg) for arg in args]
-                filtered_kwargs = dict(
-                    [
-                        (key, self._remove_partition_by_exprs(value))
-                        for (key, value) in kwargs.items()
-                    ]
-                )
+                filtered_kwargs = {
+                    key: self._remove_partition_by_exprs(value)
+                    for (key, value) in kwargs.items()
+                }
                 result = self._udtf.eval(*filtered_args, **filtered_kwargs)
                 if result is not None:
                     for row in result:
@@ -771,10 +769,10 @@ def read_udtf(pickleSer, infile, eval_type):
             return [x for x in inputs if type(x) is Row][0]
 
         def _remove_partition_by_exprs(self, arg: Any) -> Any:
-            if type(arg) is Row:
+            if isinstance(arg, Row):
                 new_row_keys = []
                 new_row_values = []
-                for i, (key, value) in enumerate(arg.asDict().items()):
+                for i, (key, value) in enumerate(zip(arg.__fields__, arg)):
                     if i not in self._partition_child_indexes:
                         new_row_keys.append(key)
                         new_row_values.append(value)

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -50,8 +50,15 @@ from pyspark.sql.pandas.serializers import (
     ArrowStreamUDFSerializer,
     ApplyInPandasWithStateSerializer,
 )
-from pyspark.sql.pandas.types import _create_row, to_arrow_type
-from pyspark.sql.types import BinaryType, Row, StringType, StructType, _parse_datatype_json_string
+from pyspark.sql.pandas.types import to_arrow_type
+from pyspark.sql.types import (
+    BinaryType,
+    Row,
+    StringType,
+    StructType,
+    _create_row,
+    _parse_datatype_json_string,
+)
 from pyspark.util import fail_on_stopiteration, handle_worker_exception
 from pyspark import shuffle
 from pyspark.errors import PySparkRuntimeError, PySparkTypeError

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -737,9 +737,12 @@ def read_udtf(pickleSer, infile, eval_type):
             if self._udtf.eval is not None:
                 # Filter the arguments to exclude projected PARTITION BY values added by Catalyst.
                 filtered_args = [self._remove_partition_by_exprs(arg) for arg in args]
-                filtered_kwargs = dict([
-                    (key, self._remove_partition_by_exprs(value))
-                    for (key, value) in kwargs.items()])
+                filtered_kwargs = dict(
+                    [
+                        (key, self._remove_partition_by_exprs(value))
+                        for (key, value) in kwargs.items()
+                    ]
+                )
                 result = self._udtf.eval(*filtered_args, **filtered_kwargs)
                 if result is not None:
                     for row in result:
@@ -771,7 +774,7 @@ def read_udtf(pickleSer, infile, eval_type):
             if type(arg) is Row:
                 new_row_keys = []
                 new_row_values = []
-                for (i, (key, value)) in enumerate(arg.asDict().items()):
+                for i, (key, value) in enumerate(arg.asDict().items()):
                     if i not in self._partition_child_indexes:
                         new_row_keys.append(key)
                         new_row_values.append(value)

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -50,7 +50,7 @@ from pyspark.sql.pandas.serializers import (
     ArrowStreamUDFSerializer,
     ApplyInPandasWithStateSerializer,
 )
-from pyspark.sql.pandas.types import to_arrow_type
+from pyspark.sql.pandas.types import _create_row, to_arrow_type
 from pyspark.sql.types import BinaryType, Row, StringType, StructType, _parse_datatype_json_string
 from pyspark.util import fail_on_stopiteration, handle_worker_exception
 from pyspark import shuffle
@@ -776,7 +776,7 @@ def read_udtf(pickleSer, infile, eval_type):
                     if i not in self._partition_child_indexes:
                         new_row_keys.append(key)
                         new_row_values.append(value)
-                return Row(*new_row_keys)(*new_row_values)
+                return _create_row(new_row_keys, new_row_values)
             else:
                 return arg
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR projects out PARTITION BY expressions before Python UDTF 'eval' method consumes them.

Before this PR, if a query included this `PARTITION BY` clause:

```
SELECT * FROM udtf((SELECT a, b FROM TABLE t) PARTITION BY (c, d))
```

Then the `eval` method received four columns in each row: `a, b, c, d`.

After this PR, the `eval` method only receives two columns: `a, b`, as expected.

### Why are the changes needed?

This makes the Python UDTF `TABLE` columns consistently match what the `eval` method receives, as expected.

### Does this PR introduce _any_ user-facing change?

Yes, see above.

### How was this patch tested?

This PR adds new unit tests.

### Was this patch authored or co-authored using generative AI tooling?

No