### PR TITLE
[SPARK-45365][INFRA] Allow `branch-3.4` daily test to use the new test group tags

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -180,10 +180,10 @@ jobs:
             java: ${{ inputs.java }}
             hadoop: ${{ inputs.hadoop }}
             hive: hive2.3
-            # Using a tag that will not appear in sql module for placeholder, branch-3.3 and branch-3.4 will not run any UTs.
+            # Using a tag that will not appear in sql module for placeholder, branch-3.3 will not run any UTs.
             included-tags: >-
               ${{
-                ((inputs.branch == 'branch-3.3' || inputs.branch == 'branch-3.4') && 'org.apache.spark.tags.SlowHiveTest')
+                (inputs.branch == 'branch-3.3' && 'org.apache.spark.tags.SlowHiveTest')
                 || 'org.apache.spark.tags.SlowSQLTest'
               }}
             comment: "- slow tests"
@@ -193,7 +193,7 @@ jobs:
             hive: hive2.3
             excluded-tags: >-
               ${{
-                ((inputs.branch == 'branch-3.3' || inputs.branch == 'branch-3.4') && 'org.apache.spark.tags.ExtendedSQLTest')
+                (inputs.branch == 'branch-3.3' && 'org.apache.spark.tags.ExtendedSQLTest')
                 || 'org.apache.spark.tags.ExtendedSQLTest,org.apache.spark.tags.SlowSQLTest'
               }}
             comment: "- other tests"


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to allow branch-3.4 daily test to use the new test group tags.

### Why are the changes needed?
Already backport SPARK-44034 to branch-3.4, new test tags can be used to reduce the average time consumption of daily tests.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Should monitor GA.


### Was this patch authored or co-authored using generative AI tooling?
No