### PR TITLE
[SPARK-45377][CORE] Handle InputStream in NettyLogger

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/util/NettyLogger.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/NettyLogger.java
@@ -25,6 +25,9 @@ import io.netty.handler.logging.LogLevel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import java.io.InputStream;
+
 public class NettyLogger {
   private static final Logger logger = LoggerFactory.getLogger(NettyLogger.class);
 
@@ -42,6 +45,14 @@ public class NettyLogger {
       } else if (arg instanceof ByteBufHolder) {
         return format(ctx, eventName) + " " +
           ((ByteBufHolder) arg).content().readableBytes() + "B";
+      } else if (arg instanceof InputStream) {
+        int available = 0;
+        try {
+          available = ((InputStream) arg).available();
+        } catch (IOException ex) {
+          // Swallow
+        }
+        return format(ctx, eventName) + " " + available + "B";
       } else {
         return super.format(ctx, eventName, arg);
       }

--- a/common/network-common/src/main/java/org/apache/spark/network/util/NettyLogger.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/NettyLogger.java
@@ -17,6 +17,9 @@
 
 package org.apache.spark.network.util;
 
+import java.io.IOException;
+import java.io.InputStream;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufHolder;
 import io.netty.channel.ChannelHandlerContext;
@@ -24,9 +27,6 @@ import io.netty.handler.logging.LoggingHandler;
 import io.netty.handler.logging.LogLevel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.io.InputStream;
 
 public class NettyLogger {
   private static final Logger logger = LoggerFactory.getLogger(NettyLogger.class);
@@ -50,9 +50,10 @@ public class NettyLogger {
         try {
           available = ((InputStream) arg).available();
         } catch (IOException ex) {
-          // Swallow
+          // Swallow, but return -1 to indicate an error happened
+          available = -1;
         }
-        return format(ctx, eventName) + " " + available + "B";
+        return format(ctx, eventName, arg) + " " + available + "B";
       } else {
         return super.format(ctx, eventName, arg);
       }

--- a/common/network-common/src/main/java/org/apache/spark/network/util/NettyLogger.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/NettyLogger.java
@@ -46,12 +46,11 @@ public class NettyLogger {
         return format(ctx, eventName) + " " +
           ((ByteBufHolder) arg).content().readableBytes() + "B";
       } else if (arg instanceof InputStream) {
-        int available = 0;
+        int available = -1;
         try {
           available = ((InputStream) arg).available();
         } catch (IOException ex) {
           // Swallow, but return -1 to indicate an error happened
-          available = -1;
         }
         return format(ctx, eventName, arg) + " " + available + "B";
       } else {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Handle `InputStream`s in the `NettyLogger` so we can print out how many available bytes there are.

### Why are the changes needed?

As part of the SSL support we are going to transfer `InputStream`s via Netty, and this functionality makes it easy to see the size of the streams in the log at a glance.


### Does this PR introduce _any_ user-facing change?

No


### How was this patch tested?

CI. Tested as part of the changes in https://github.com/apache/spark/pull/42685 which this is split out of, I observed the logs there.


### Was this patch authored or co-authored using generative AI tooling?

No
