### PR TITLE
[SPARK-45372][CORE] Handle ClassNotFoundException when load extension

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -2840,6 +2840,10 @@ private[spark] object Utils
 
             case cause => throw cause
           }
+
+        case e: ClassNotFoundException =>
+          logError(s"Extension $name class not found.")
+          None
       }
     }
   }

--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -1290,6 +1290,12 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties {
     }
   }
 
+  test("load extensions when ClassNotFound") {
+    val conf = new SparkConf(false)
+    val instances = Utils.loadExtensions(classOf[Object], Seq("NotExistedClass"), conf)
+    assert(instances.size === 0)
+  }
+
   test("check Kubernetes master URL") {
     val k8sMasterURLHttps = Utils.checkAndGetK8sMasterUrl("k8s://https://host:port")
     assert(k8sMasterURLHttps === "k8s://https://host:port")


### PR DESCRIPTION
### What changes were proposed in this pull request?
Skip extension load when `ClassNotFoundException` encountered and log error

### Why are the changes needed?
When load extension with ClassNotFoundException, SparkContext failed to initialize. Better behavior is skip this extension and log error without failing SparkContext initialization.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Added UT in `UtilsSuite.scala`

### Was this patch authored or co-authored using generative AI tooling?
No
