### PR TITLE
[SPARK-45385][SQL] Deprecate `spark.sql.parser.escapedStringLiterals`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4514,7 +4514,9 @@ object SQLConf {
       DeprecatedConfig(LEGACY_REPLACE_DATABRICKS_SPARK_AVRO_ENABLED.key, "3.2",
         """Use `.format("avro")` in `DataFrameWriter` or `DataFrameReader` instead."""),
       DeprecatedConfig(COALESCE_PARTITIONS_MIN_PARTITION_NUM.key, "3.2",
-        s"Use '${COALESCE_PARTITIONS_MIN_PARTITION_SIZE.key}' instead.")
+        s"Use '${COALESCE_PARTITIONS_MIN_PARTITION_SIZE.key}' instead."),
+      DeprecatedConfig(ESCAPED_STRING_LITERALS.key, "4.0",
+        "Use raw string literals with the `r` prefix instead. ")
     )
 
     Map(configs.map { cfg => cfg.key -> cfg } : _*)


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to deprecate the SQL config `spark.sql.parser.escapedStringLiterals`, and put to the list of deprecated configs: `SQLConf.deprecatedSQLConfigs`. Also I modified a test to check that the recommendation in the deprecation comment works actually.

### Why are the changes needed?
The config allows to switch to legacy behaviour of Spark 1.6 which is pretty old and not maintained anymore. Deprecation and removing of the config in the future versions should improve code maintenance. Also there is an alternative approach by using RAW string literals in which Spark doesn't especially handle escaped character sequences.

Also removing of the SQL config in the future should simplify functions/expressions description like `LIKE`, [link](https://spark.apache.org/docs/latest/api/sql/#like).

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By running the modified test suite:
```
$ build/sbt "test:testOnly *DatasetSuite"
```

### Was this patch authored or co-authored using generative AI tooling?
No.