### PR TITLE
[SPARK-45388][SQL] Eliminate unnecessary reflection invocation in Hive shim classes

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -1661,7 +1661,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
       messageParameters = Map.empty)
   }
 
-  def getPartitionMetadataByFilterError(e: InvocationTargetException): SparkRuntimeException = {
+  def getPartitionMetadataByFilterError(e: Exception): SparkRuntimeException = {
     new SparkRuntimeException(
       errorClass = "_LEGACY_ERROR_TEMP_2193",
       messageParameters = Map(

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
@@ -18,8 +18,8 @@
 package org.apache.spark.sql.hive.client
 
 import java.lang.{Boolean => JBoolean, Integer => JInteger, Long => JLong}
-import java.lang.reflect.{InvocationTargetException, Method, Modifier}
-import java.util.{ArrayList => JArrayList, List => JList, Locale, Map => JMap, Set => JSet}
+import java.lang.reflect.{InvocationTargetException, Method}
+import java.util.{ArrayList => JArrayList, List => JList, Locale, Map => JMap}
 import java.util.concurrent.TimeUnit
 
 import scala.jdk.CollectionConverters._
@@ -27,8 +27,7 @@ import scala.util.control.NonFatal
 
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.hive.conf.HiveConf
-import org.apache.hadoop.hive.metastore.IMetaStoreClient
-import org.apache.hadoop.hive.metastore.TableType
+import org.apache.hadoop.hive.metastore.{IMetaStoreClient, PartitionDropOptions, TableType}
 import org.apache.hadoop.hive.metastore.api.{Database, EnvironmentContext, Function => HiveFunction, FunctionType, Index, MetaException, PrincipalType, ResourceType, ResourceUri}
 import org.apache.hadoop.hive.ql.Driver
 import org.apache.hadoop.hive.ql.io.AcidUtils
@@ -51,7 +50,6 @@ import org.apache.spark.sql.execution.datasources.PartitioningUtils
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{AtomicType, DateType, IntegralType, IntegralTypeExpression, StringType}
 import org.apache.spark.unsafe.types.UTF8String
-import org.apache.spark.util.Utils
 
 /**
  * A shim that defines the interface between [[HiveClientImpl]] and the underlying Hive library used
@@ -233,13 +231,6 @@ private[client] sealed abstract class Shim {
 
   def setDatabaseOwnerName(db: Database, owner: String): Unit
 
-  protected def findStaticMethod(klass: Class[_], name: String, args: Class[_]*): Method = {
-    val method = findMethod(klass, name, args: _*)
-    require(Modifier.isStatic(method.getModifiers),
-      s"Method $name of class $klass is not static.")
-    method
-  }
-
   def getMSC(hive: Hive): IMetaStoreClient
 
   def getIndexes(hive: Hive, dbName: String, tableName: String, max: Short): Seq[Index]
@@ -266,56 +257,8 @@ private[client] class Shim_v2_0 extends Shim with Logging {
   // txnId can be 0 unless isAcid == true
   protected lazy val txnIdInLoadDynamicPartitions: JLong = 0L
 
-  protected lazy val getMSCMethod = {
-    // Since getMSC() in Hive 0.12 is private, findMethod() could not work here
-    val msc = classOf[Hive].getDeclaredMethod("getMSC")
-    msc.setAccessible(true)
-    msc
-  }
+  override def getMSC(hive: Hive): IMetaStoreClient = hive.getMSC
 
-  override def getMSC(hive: Hive): IMetaStoreClient = {
-    getMSCMethod.invoke(hive).asInstanceOf[IMetaStoreClient]
-  }
-
-  private lazy val setCurrentSessionStateMethod =
-    findStaticMethod(
-      classOf[SessionState],
-      "setCurrentSessionState",
-      classOf[SessionState])
-  private lazy val getDataLocationMethod = findMethod(classOf[Table], "getDataLocation")
-  private lazy val setDataLocationMethod =
-    findMethod(
-      classOf[Table],
-      "setDataLocation",
-      classOf[Path])
-  private lazy val getAllPartitionsMethod =
-    findMethod(
-      classOf[Hive],
-      "getAllPartitionsOf",
-      classOf[Table])
-  private lazy val getPartitionsByFilterMethod =
-    findMethod(
-      classOf[Hive],
-      "getPartitionsByFilter",
-      classOf[Table],
-      classOf[String])
-  private lazy val getCommandProcessorMethod =
-    findStaticMethod(
-      classOf[CommandProcessorFactory],
-      "get",
-      classOf[Array[String]],
-      classOf[HiveConf])
-  private lazy val getDriverResultsMethod =
-    findMethod(
-      classOf[Driver],
-      "getResults",
-      classOf[JList[Object]])
-  private lazy val getTimeVarMethod =
-    findMethod(
-      classOf[HiveConf],
-      "getTimeVar",
-      classOf[HiveConf.ConfVars],
-      classOf[TimeUnit])
   private lazy val loadPartitionMethod =
     findMethod(
       classOf[Hive],
@@ -350,24 +293,6 @@ private[client] class Shim_v2_0 extends Shim with Logging {
       JBoolean.TYPE,
       JBoolean.TYPE,
       JLong.TYPE)
-  private lazy val dropIndexMethod =
-    findMethod(
-      classOf[Hive],
-      "dropIndex",
-      classOf[String],
-      classOf[String],
-      classOf[String],
-      JBoolean.TYPE,
-      JBoolean.TYPE)
-  private lazy val dropTableMethod =
-    findMethod(
-      classOf[Hive],
-      "dropTable",
-      classOf[String],
-      classOf[String],
-      JBoolean.TYPE,
-      JBoolean.TYPE,
-      JBoolean.TYPE)
   private lazy val alterTableMethod =
     findMethod(
       classOf[Hive],
@@ -380,36 +305,15 @@ private[client] class Shim_v2_0 extends Shim with Logging {
       "alterPartitions",
       classOf[String],
       classOf[JList[Partition]])
-  private lazy val dropOptionsClass =
-    Utils.classForName("org.apache.hadoop.hive.metastore.PartitionDropOptions")
-  private lazy val dropOptionsDeleteData = dropOptionsClass.getField("deleteData")
-  private lazy val dropOptionsPurge = dropOptionsClass.getField("purgeData")
-  private lazy val dropPartitionMethod =
-    findMethod(
-      classOf[Hive],
-      "dropPartition",
-      classOf[String],
-      classOf[String],
-      classOf[JList[String]],
-      dropOptionsClass)
-  private lazy val getDatabaseOwnerNameMethod =
-    findMethod(
-      classOf[Database],
-      "getOwnerName")
-  private lazy val setDatabaseOwnerNameMethod =
-    findMethod(
-      classOf[Database],
-      "setOwnerName",
-      classOf[String])
 
   override def setCurrentSessionState(state: SessionState): Unit =
-    setCurrentSessionStateMethod.invoke(null, state)
+    SessionState.setCurrentSessionState(state)
 
   override def getDataLocation(table: Table): Option[String] =
-    Option(getDataLocationMethod.invoke(table)).map(_.toString())
+    Option(table.getDataLocation).map(_.toString())
 
   override def setDataLocation(table: Table, loc: String): Unit =
-    setDataLocationMethod.invoke(table, new Path(loc))
+    table.setDataLocation(new Path(loc))
 
   override def createPartitions(
       hive: Hive,
@@ -431,7 +335,7 @@ private[client] class Shim_v2_0 extends Shim with Logging {
 
   override def getAllPartitions(hive: Hive, table: Table): Seq[Partition] = {
     recordHiveCall()
-    getAllPartitionsMethod.invoke(hive, table).asInstanceOf[JSet[Partition]].asScala.toSeq
+    hive.getAllPartitionsOf(table).asScala.toSeq
   }
 
   override def getPartitionsByFilter(
@@ -461,8 +365,7 @@ private[client] class Shim_v2_0 extends Shim with Logging {
           // occurs and the config`spark.sql.hive.metastorePartitionPruningFallbackOnException` is
           // enabled.
           recordHiveCall()
-          getPartitionsByFilterMethod.invoke(hive, table, filter)
-            .asInstanceOf[JArrayList[Partition]]
+          hive.getPartitionsByFilter(table, filter)
         } catch {
           case ex: InvocationTargetException if ex.getCause.isInstanceOf[MetaException] &&
             shouldFallback =>
@@ -507,7 +410,7 @@ private[client] class Shim_v2_0 extends Shim with Logging {
       predicates.isEmpty ||
       predicates.exists(hasTimeZoneAwareExpression)) {
       recordHiveCall()
-      getAllPartitionsMethod.invoke(hive, table).asInstanceOf[JSet[Partition]]
+      hive.getAllPartitionsOf(table)
     } else {
       try {
         val partitionSchema = CharVarcharUtils.replaceCharVarcharWithStringInSchema(
@@ -540,29 +443,25 @@ private[client] class Shim_v2_0 extends Shim with Logging {
           logWarning("Caught Hive MetaException attempting to get partition metadata by " +
             "filter from client side. Falling back to fetching all partition metadata", ex)
           recordHiveCall()
-          getAllPartitionsMethod.invoke(hive, table).asInstanceOf[JSet[Partition]]
+          hive.getAllPartitionsOf(table)
       }
     }
   }
 
   override def getCommandProcessor(token: String, conf: HiveConf): CommandProcessor =
-    getCommandProcessorMethod.invoke(null, Array(token), conf).asInstanceOf[CommandProcessor]
+    CommandProcessorFactory.get(Array(token), conf)
 
   override def getDriverResults(driver: Driver): Seq[String] = {
     val res = new JArrayList[Object]()
-    getDriverResultsMethod.invoke(driver, res)
+    driver.getResults(res)
     res.asScala.map {
       case s: String => s
       case a: Array[Object] => a(0).asInstanceOf[String]
     }.toSeq
   }
 
-  override def getMetastoreClientConnectRetryDelayMillis(conf: HiveConf): Long = {
-    getTimeVarMethod.invoke(
-      conf,
-      HiveConf.ConfVars.METASTORE_CLIENT_CONNECT_RETRY_DELAY,
-      TimeUnit.MILLISECONDS).asInstanceOf[Long]
-  }
+  override def getMetastoreClientConnectRetryDelayMillis(conf: HiveConf): Long =
+    conf.getTimeVar(HiveConf.ConfVars.METASTORE_CLIENT_CONNECT_RETRY_DELAY, TimeUnit.MILLISECONDS)
 
   override def getTablesByType(
       hive: Hive,
@@ -613,8 +512,7 @@ private[client] class Shim_v2_0 extends Shim with Logging {
 
   override def dropIndex(hive: Hive, dbName: String, tableName: String, indexName: String): Unit = {
     recordHiveCall()
-    dropIndexMethod.invoke(hive, dbName, tableName, indexName, throwExceptionInDropIndex,
-      deleteDataInDropIndex)
+    hive.dropIndex(dbName, tableName, indexName, throwExceptionInDropIndex, deleteDataInDropIndex)
   }
 
   override def dropTable(
@@ -625,8 +523,7 @@ private[client] class Shim_v2_0 extends Shim with Logging {
       ignoreIfNotExists: Boolean,
       purge: Boolean): Unit = {
     recordHiveCall()
-    dropTableMethod.invoke(hive, dbName, tableName, deleteData: JBoolean,
-      ignoreIfNotExists: JBoolean, purge: JBoolean)
+    hive.dropTable(dbName, tableName, deleteData, ignoreIfNotExists, purge)
   }
 
   override def alterTable(hive: Hive, tableName: String, table: Table): Unit = {
@@ -646,11 +543,11 @@ private[client] class Shim_v2_0 extends Shim with Logging {
       part: JList[String],
       deleteData: Boolean,
       purge: Boolean): Unit = {
-    val dropOptions = dropOptionsClass.getConstructor().newInstance().asInstanceOf[Object]
-    dropOptionsDeleteData.setBoolean(dropOptions, deleteData)
-    dropOptionsPurge.setBoolean(dropOptions, purge)
+    val dropOptions = new PartitionDropOptions
+    dropOptions.deleteData(deleteData)
+    dropOptions.purgeData(purge)
     recordHiveCall()
-    dropPartitionMethod.invoke(hive, dbName, tableName, part, dropOptions)
+    hive.dropPartition(dbName, tableName, part, dropOptions)
   }
 
   private def toHiveFunction(f: CatalogFunction, db: String): HiveFunction = {
@@ -969,11 +866,11 @@ private[client] class Shim_v2_0 extends Shim with Logging {
   }
 
   override def getDatabaseOwnerName(db: Database): String = {
-    Option(getDatabaseOwnerNameMethod.invoke(db)).map(_.asInstanceOf[String]).getOrElse("")
+    Option(db.getOwnerName).getOrElse("")
   }
 
   override def setDatabaseOwnerName(db: Database, owner: String): Unit = {
-    setDatabaseOwnerNameMethod.invoke(db, owner)
+    db.setOwnerName(owner)
   }
 
   override def createDatabase(hive: Hive, db: Database, ignoreIfExists: Boolean): Unit = {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
@@ -367,8 +367,7 @@ private[client] class Shim_v2_0 extends Shim with Logging {
           recordHiveCall()
           hive.getPartitionsByFilter(table, filter)
         } catch {
-          case ex: InvocationTargetException if ex.getCause.isInstanceOf[MetaException] &&
-            shouldFallback =>
+          case ex: MetaException if shouldFallback =>
             logWarning("Caught Hive MetaException attempting to get partition metadata by " +
               "filter from Hive. Falling back to fetching all partition metadata, which will " +
               "degrade performance. Modifying your Hive metastore configuration to set " +
@@ -381,7 +380,7 @@ private[client] class Shim_v2_0 extends Shim with Logging {
               " to false and let the query fail instead.", ex)
             // HiveShim clients are expected to handle a superset of the requested partitions
             prunePartitionsFastFallback(hive, table, catalogTable, predicates)
-          case ex: InvocationTargetException if ex.getCause.isInstanceOf[MetaException] =>
+          case ex: MetaException =>
             throw QueryExecutionErrors.getPartitionMetadataByFilterError(ex)
         }
       }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Replace unnecessary reflection invocation with direct method invocation in Hive shim classes.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This is the next step of SPARK-45358, after dropping support for Hive prior to 2.0.0, some reflection invocations become unnecessary, we can replace those reflection invocations with direct method invocations to gain compiling-time checks.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Pass GA.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.