### PR TITLE
[SPARK-45390][PYTHON] Remove `distutils` usage

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -221,6 +221,7 @@ connector/spark-ganglia-lgpl/src/main/java/com/codahale/metrics/ganglia/GangliaR
 Python Software Foundation License
 ----------------------------------
 
+python/pyspark/loose_version.py
 python/docs/source/_static/copybutton.js
 
 BSD 3-Clause

--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -421,6 +421,12 @@ This section summarizes those components and their licenses. See licenses-binary
 for text of these licenses.
 
 
+Python Software Foundation License
+----------------------------------
+
+python/pyspark/loose_version.py
+
+
 BSD 2-Clause
 ------------
 

--- a/dev/.rat-excludes
+++ b/dev/.rat-excludes
@@ -142,3 +142,4 @@ empty.proto
 LimitedInputStream.java
 TimSort.java
 xml-resources/*
+loose_version.py

--- a/python/pyspark/__init__.py
+++ b/python/pyspark/__init__.py
@@ -51,10 +51,6 @@ import types
 from typing import cast, Any, Callable, Optional, TypeVar, Union
 from warnings import filterwarnings
 
-filterwarnings(
-    "ignore", message="distutils Version classes are deprecated. Use packaging.version instead."
-)
-
 from pyspark.conf import SparkConf
 from pyspark.rdd import RDD, RDDBarrier
 from pyspark.files import SparkFiles

--- a/python/pyspark/__init__.py
+++ b/python/pyspark/__init__.py
@@ -49,7 +49,6 @@ Public classes:
 from functools import wraps
 import types
 from typing import cast, Any, Callable, Optional, TypeVar, Union
-from warnings import filterwarnings
 
 from pyspark.conf import SparkConf
 from pyspark.rdd import RDD, RDDBarrier

--- a/python/pyspark/loose_version.py
+++ b/python/pyspark/loose_version.py
@@ -1,14 +1,20 @@
+# Licensed under the PYTHON SOFTWARE FOUNDATION LICENSE VERSION 2
+# https://github.com/python/cpython/blob/3.11/LICENSE
+# File originates from the cpython source
+# https://github.com/python/cpython/blob/3.11/Lib/distutils/version.py
+
 import re
+from typing import Optional
 
 
 class LooseVersion:
     component_re = re.compile(r"(\d+ | [a-z]+ | \.)", re.VERBOSE)
 
-    def __init__(self, vstring=None):
+    def __init__(self, vstring: Optional[str]) -> None:
         if vstring:
             self.parse(vstring)
 
-    def parse(self, vstring):
+    def parse(self, vstring: str) -> None:
         self.vstring = vstring
         components = [x for x in self.component_re.split(vstring) if x and x != "."]
         for i, obj in enumerate(components):
@@ -19,43 +25,43 @@ class LooseVersion:
 
         self.version = components
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.vstring
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "LooseVersion ('%s')" % str(self)
 
-    def __eq__(self, other):
+    def __eq__(self, other):  # type: ignore[no-untyped-def]
         c = self._cmp(other)
         if c is NotImplemented:
             return c
         return c == 0
 
-    def __lt__(self, other):
+    def __lt__(self, other):  # type: ignore[no-untyped-def]
         c = self._cmp(other)
         if c is NotImplemented:
             return c
         return c < 0
 
-    def __le__(self, other):
+    def __le__(self, other):  # type: ignore[no-untyped-def]
         c = self._cmp(other)
         if c is NotImplemented:
             return c
         return c <= 0
 
-    def __gt__(self, other):
+    def __gt__(self, other):  # type: ignore[no-untyped-def]
         c = self._cmp(other)
         if c is NotImplemented:
             return c
         return c > 0
 
-    def __ge__(self, other):
+    def __ge__(self, other):  # type: ignore[no-untyped-def]
         c = self._cmp(other)
         if c is NotImplemented:
             return c
         return c >= 0
 
-    def _cmp(self, other):
+    def _cmp(self, other):  # type: ignore[no-untyped-def]
         if isinstance(other, str):
             other = LooseVersion(other)
         elif not isinstance(other, LooseVersion):

--- a/python/pyspark/loose_version.py
+++ b/python/pyspark/loose_version.py
@@ -1,0 +1,78 @@
+import re
+
+class LooseVersion:
+
+    component_re = re.compile(r'(\d+ | [a-z]+ | \.)', re.VERBOSE)
+
+    def __init__ (self, vstring=None):
+        if vstring:
+            self.parse(vstring)
+
+
+    def parse (self, vstring):
+        # I've given up on thinking I can reconstruct the version string
+        # from the parsed tuple -- so I just store the string here for
+        # use by __str__
+        self.vstring = vstring
+        components = [x for x in self.component_re.split(vstring)
+                              if x and x != '.']
+        for i, obj in enumerate(components):
+            try:
+                components[i] = int(obj)
+            except ValueError:
+                pass
+
+        self.version = components
+
+
+    def __str__ (self):
+        return self.vstring
+
+
+    def __repr__ (self):
+        return "LooseVersion ('%s')" % str(self)
+
+
+    def __eq__(self, other):
+        c = self._cmp(other)
+        if c is NotImplemented:
+            return c
+        return c == 0
+
+    def __lt__(self, other):
+        c = self._cmp(other)
+        if c is NotImplemented:
+            return c
+        return c < 0
+
+    def __le__(self, other):
+        c = self._cmp(other)
+        if c is NotImplemented:
+            return c
+        return c <= 0
+
+    def __gt__(self, other):
+        c = self._cmp(other)
+        if c is NotImplemented:
+            return c
+        return c > 0
+
+    def __ge__(self, other):
+        c = self._cmp(other)
+        if c is NotImplemented:
+            return c
+        return c >= 0
+
+    def _cmp (self, other):
+        if isinstance(other, str):
+            other = LooseVersion(other)
+        elif not isinstance(other, LooseVersion):
+            return NotImplemented
+
+        if self.version == other.version:
+            return 0
+        if self.version < other.version:
+            return -1
+        if self.version > other.version:
+            return 1
+

--- a/python/pyspark/loose_version.py
+++ b/python/pyspark/loose_version.py
@@ -1,21 +1,16 @@
 import re
 
+
 class LooseVersion:
+    component_re = re.compile(r"(\d+ | [a-z]+ | \.)", re.VERBOSE)
 
-    component_re = re.compile(r'(\d+ | [a-z]+ | \.)', re.VERBOSE)
-
-    def __init__ (self, vstring=None):
+    def __init__(self, vstring=None):
         if vstring:
             self.parse(vstring)
 
-
-    def parse (self, vstring):
-        # I've given up on thinking I can reconstruct the version string
-        # from the parsed tuple -- so I just store the string here for
-        # use by __str__
+    def parse(self, vstring):
         self.vstring = vstring
-        components = [x for x in self.component_re.split(vstring)
-                              if x and x != '.']
+        components = [x for x in self.component_re.split(vstring) if x and x != "."]
         for i, obj in enumerate(components):
             try:
                 components[i] = int(obj)
@@ -24,14 +19,11 @@ class LooseVersion:
 
         self.version = components
 
-
-    def __str__ (self):
+    def __str__(self):
         return self.vstring
 
-
-    def __repr__ (self):
+    def __repr__(self):
         return "LooseVersion ('%s')" % str(self)
-
 
     def __eq__(self, other):
         c = self._cmp(other)
@@ -63,7 +55,7 @@ class LooseVersion:
             return c
         return c >= 0
 
-    def _cmp (self, other):
+    def _cmp(self, other):
         if isinstance(other, str):
             other = LooseVersion(other)
         elif not isinstance(other, LooseVersion):
@@ -75,4 +67,3 @@ class LooseVersion:
             return -1
         if self.version > other.version:
             return 1
-

--- a/python/pyspark/pandas/plot/matplotlib.py
+++ b/python/pyspark/pandas/plot/matplotlib.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-from distutils.version import LooseVersion
+from pyspark.loose_version import LooseVersion
 
 import matplotlib as mat
 import numpy as np

--- a/python/pyspark/pandas/supported_api_gen.py
+++ b/python/pyspark/pandas/supported_api_gen.py
@@ -19,7 +19,7 @@
 Generate 'Supported pandas APIs' documentation file
 """
 import warnings
-from distutils.version import LooseVersion
+from pyspark.loose_version import LooseVersion
 from enum import Enum, unique
 from inspect import getmembers, isclass, isfunction, signature
 from typing import Any, Callable, Dict, List, NamedTuple, Set, TextIO, Tuple

--- a/python/pyspark/pandas/tests/computation/test_any_all.py
+++ b/python/pyspark/pandas/tests/computation/test_any_all.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from distutils.version import LooseVersion
 import unittest
 
 import numpy as np

--- a/python/pyspark/pandas/tests/computation/test_corrwith.py
+++ b/python/pyspark/pandas/tests/computation/test_corrwith.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from distutils.version import LooseVersion
 import unittest
 
 

--- a/python/pyspark/pandas/tests/computation/test_cov.py
+++ b/python/pyspark/pandas/tests/computation/test_cov.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from distutils.version import LooseVersion
 import unittest
 import decimal
 

--- a/python/pyspark/pandas/tests/data_type_ops/test_date_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_date_ops.py
@@ -17,7 +17,6 @@
 
 import datetime
 import unittest
-from distutils.version import LooseVersion
 
 import pandas as pd
 from pandas.api.types import CategoricalDtype

--- a/python/pyspark/pandas/tests/diff_frames_ops/test_cov_corrwith.py
+++ b/python/pyspark/pandas/tests/diff_frames_ops/test_cov_corrwith.py
@@ -14,12 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from distutils.version import LooseVersion
 
 import pandas as pd
 import numpy as np
 
 from pyspark import pandas as ps
+from pyspark.loose_version import LooseVersion
 from pyspark.pandas.config import set_option, reset_option
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils

--- a/python/pyspark/pandas/tests/groupby/test_aggregate.py
+++ b/python/pyspark/pandas/tests/groupby/test_aggregate.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 #
 import unittest
-from distutils.version import LooseVersion
 
 import pandas as pd
 

--- a/python/pyspark/pandas/tests/groupby/test_apply_func.py
+++ b/python/pyspark/pandas/tests/groupby/test_apply_func.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from distutils.version import LooseVersion
 import unittest
 
 import numpy as np

--- a/python/pyspark/pandas/tests/groupby/test_head_tail.py
+++ b/python/pyspark/pandas/tests/groupby/test_head_tail.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from distutils.version import LooseVersion
 import unittest
 
 import numpy as np

--- a/python/pyspark/pandas/tests/groupby/test_index.py
+++ b/python/pyspark/pandas/tests/groupby/test_index.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from distutils.version import LooseVersion
 import unittest
 
 import pandas as pd

--- a/python/pyspark/pandas/tests/groupby/test_split_apply.py
+++ b/python/pyspark/pandas/tests/groupby/test_split_apply.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from distutils.version import LooseVersion
 import unittest
 
 import pandas as pd

--- a/python/pyspark/pandas/tests/groupby/test_stat.py
+++ b/python/pyspark/pandas/tests/groupby/test_stat.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from distutils.version import LooseVersion
 import unittest
 
 import numpy as np

--- a/python/pyspark/pandas/tests/indexes/test_base.py
+++ b/python/pyspark/pandas/tests/indexes/test_base.py
@@ -17,13 +17,13 @@
 
 import inspect
 import unittest
-from distutils.version import LooseVersion
 from datetime import datetime, timedelta
 
 import numpy as np
 import pandas as pd
 
 import pyspark.pandas as ps
+from pyspark.loose_version import LooseVersion
 from pyspark.pandas.exceptions import PandasNotImplementedError
 from pyspark.pandas.missing.indexes import (
     MissingPandasLikeDatetimeIndex,

--- a/python/pyspark/pandas/tests/indexes/test_category.py
+++ b/python/pyspark/pandas/tests/indexes/test_category.py
@@ -16,12 +16,12 @@
 #
 
 import unittest
-from distutils.version import LooseVersion
 
 import pandas as pd
 from pandas.api.types import CategoricalDtype
 
 import pyspark.pandas as ps
+from pyspark.loose_version import LooseVersion
 from pyspark.testing.pandasutils import PandasOnSparkTestCase, TestUtils
 
 

--- a/python/pyspark/pandas/tests/indexes/test_datetime.py
+++ b/python/pyspark/pandas/tests/indexes/test_datetime.py
@@ -17,8 +17,6 @@
 
 import datetime
 
-from distutils.version import LooseVersion
-
 import numpy as np
 import pandas as pd
 

--- a/python/pyspark/pandas/tests/indexes/test_indexing.py
+++ b/python/pyspark/pandas/tests/indexes/test_indexing.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 #
 import unittest
-from distutils.version import LooseVersion
 
 import numpy as np
 import pandas as pd

--- a/python/pyspark/pandas/tests/indexes/test_reindex.py
+++ b/python/pyspark/pandas/tests/indexes/test_reindex.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 #
 import unittest
-from distutils.version import LooseVersion
 
 import numpy as np
 import pandas as pd

--- a/python/pyspark/pandas/tests/indexes/test_timedelta.py
+++ b/python/pyspark/pandas/tests/indexes/test_timedelta.py
@@ -17,7 +17,6 @@
 
 import unittest
 from datetime import timedelta
-from distutils.version import LooseVersion
 
 import pandas as pd
 

--- a/python/pyspark/pandas/tests/series/test_compute.py
+++ b/python/pyspark/pandas/tests/series/test_compute.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 #
 import unittest
-from distutils.version import LooseVersion
 from itertools import product
 
 import numpy as np

--- a/python/pyspark/pandas/tests/test_csv.py
+++ b/python/pyspark/pandas/tests/test_csv.py
@@ -20,7 +20,6 @@ import shutil
 import tempfile
 import unittest
 from contextlib import contextmanager
-from distutils.version import LooseVersion
 
 import pandas as pd
 import numpy as np

--- a/python/pyspark/pandas/tests/test_dataframe_conversion.py
+++ b/python/pyspark/pandas/tests/test_dataframe_conversion.py
@@ -21,7 +21,6 @@ import string
 import tempfile
 import unittest
 import sys
-from distutils.version import LooseVersion
 
 import numpy as np
 import pandas as pd

--- a/python/pyspark/pandas/tests/test_dataframe_spark_io.py
+++ b/python/pyspark/pandas/tests/test_dataframe_spark_io.py
@@ -18,12 +18,12 @@
 import unittest
 import glob
 import os
-from distutils.version import LooseVersion
 
 import numpy as np
 import pandas as pd
 
 from pyspark import pandas as ps
+from pyspark.loose_version import LooseVersion
 from pyspark.testing.pandasutils import PandasOnSparkTestCase, TestUtils
 
 

--- a/python/pyspark/pandas/tests/test_ops_on_diff_frames.py
+++ b/python/pyspark/pandas/tests/test_ops_on_diff_frames.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 #
 
-from distutils.version import LooseVersion
 from itertools import product
 import unittest
 

--- a/python/pyspark/pandas/tests/test_ops_on_diff_frames_groupby.py
+++ b/python/pyspark/pandas/tests/test_ops_on_diff_frames_groupby.py
@@ -16,7 +16,6 @@
 #
 
 import unittest
-from distutils.version import LooseVersion
 
 import pandas as pd
 

--- a/python/pyspark/pandas/tests/test_rolling.py
+++ b/python/pyspark/pandas/tests/test_rolling.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 #
 import unittest
-from distutils.version import LooseVersion
 
 import numpy as np
 import pandas as pd

--- a/python/pyspark/pandas/tests/test_series_conversion.py
+++ b/python/pyspark/pandas/tests/test_series_conversion.py
@@ -17,7 +17,6 @@
 
 import unittest
 import sys
-from distutils.version import LooseVersion
 
 import pandas as pd
 

--- a/python/pyspark/pandas/tests/test_series_datetime.py
+++ b/python/pyspark/pandas/tests/test_series_datetime.py
@@ -17,7 +17,6 @@
 
 import datetime
 import unittest
-from distutils.version import LooseVersion
 
 import numpy as np
 import pandas as pd

--- a/python/pyspark/pandas/tests/test_series_string.py
+++ b/python/pyspark/pandas/tests/test_series_string.py
@@ -19,7 +19,6 @@ import pandas as pd
 import numpy as np
 import re
 import unittest
-from distutils.version import LooseVersion
 
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase

--- a/python/pyspark/pandas/tests/test_stats.py
+++ b/python/pyspark/pandas/tests/test_stats.py
@@ -16,7 +16,6 @@
 #
 
 import unittest
-from distutils.version import LooseVersion
 import numpy as np
 import pandas as pd
 

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -19,6 +19,7 @@ __all__ = [
     "SparkConnectClient",
 ]
 
+from pyspark.loose_version import LooseVersion
 from pyspark.sql.connect.utils import check_dependencies
 
 check_dependencies(__name__)
@@ -31,7 +32,6 @@ import time
 import urllib.parse
 import uuid
 import sys
-from distutils.version import LooseVersion
 from types import TracebackType
 from typing import (
     Iterable,

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -22,7 +22,6 @@ import threading
 import os
 import warnings
 from collections.abc import Sized
-from distutils.version import LooseVersion
 from functools import reduce
 from threading import RLock
 from typing import (
@@ -50,6 +49,7 @@ from pandas.api.types import (  # type: ignore[attr-defined]
 import urllib
 
 from pyspark import SparkContext, SparkConf, __version__
+from pyspark.loose_version import LooseVersion
 from pyspark.sql.connect.client import SparkConnectClient, ChannelBuilder
 from pyspark.sql.connect.conf import RuntimeConf
 from pyspark.sql.connect.dataframe import DataFrame

--- a/python/pyspark/sql/connect/utils.py
+++ b/python/pyspark/sql/connect/utils.py
@@ -16,6 +16,7 @@
 #
 import sys
 
+from pyspark.loose_version import LooseVersion
 from pyspark.sql.pandas.utils import require_minimum_pandas_version, require_minimum_pyarrow_version
 
 
@@ -38,8 +39,6 @@ def check_dependencies(mod_name: str) -> None:
 def require_minimum_grpc_version() -> None:
     """Raise ImportError if minimum version of grpc is not installed"""
     minimum_grpc_version = "1.48.1"
-
-    from distutils.version import LooseVersion
 
     try:
         import grpc

--- a/python/pyspark/sql/pandas/conversion.py
+++ b/python/pyspark/sql/pandas/conversion.py
@@ -26,9 +26,9 @@ from typing import (
     TYPE_CHECKING,
 )
 from warnings import warn
-from distutils.version import LooseVersion
 
 from pyspark.errors.exceptions.captured import unwrap_spark_exception
+from pyspark.loose_version import LooseVersion
 from pyspark.rdd import _load_from_socket
 from pyspark.sql.pandas.serializers import ArrowCollectSerializer
 from pyspark.sql.pandas.types import _dedup_names

--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -20,6 +20,7 @@ Serializers for PyArrow and pandas conversions. See `pyspark.serializers` for mo
 """
 
 from pyspark.errors import PySparkRuntimeError, PySparkTypeError, PySparkValueError
+from pyspark.loose_version import LooseVersion
 from pyspark.serializers import Serializer, read_int, write_int, UTF8Deserializer, CPickleSerializer
 from pyspark.sql.pandas.types import (
     from_arrow_type,
@@ -188,7 +189,6 @@ class ArrowStreamPandasSerializer(ArrowStreamSerializer):
         pandas_options = {"date_as_object": True}
 
         import pyarrow as pa
-        from distutils.version import LooseVersion
 
         if LooseVersion(pa.__version__) >= LooseVersion("13.0.0"):
             # A legacy option to coerce date32, date64, duration, and timestamp

--- a/python/pyspark/sql/pandas/utils.py
+++ b/python/pyspark/sql/pandas/utils.py
@@ -17,6 +17,7 @@
 
 from pyspark.loose_version import LooseVersion
 
+
 def require_minimum_pandas_version() -> None:
     """Raise ImportError if minimum version of Pandas is not installed"""
     # TODO(HyukjinKwon): Relocate and deduplicate the version specification.

--- a/python/pyspark/sql/pandas/utils.py
+++ b/python/pyspark/sql/pandas/utils.py
@@ -15,13 +15,12 @@
 # limitations under the License.
 #
 
+from pyspark.loose_version import LooseVersion
 
 def require_minimum_pandas_version() -> None:
     """Raise ImportError if minimum version of Pandas is not installed"""
     # TODO(HyukjinKwon): Relocate and deduplicate the version specification.
     minimum_pandas_version = "1.4.4"
-
-    from distutils.version import LooseVersion
 
     try:
         import pandas
@@ -46,7 +45,6 @@ def require_minimum_pyarrow_version() -> None:
     # TODO(HyukjinKwon): Relocate and deduplicate the version specification.
     minimum_pyarrow_version = "4.0.0"
 
-    from distutils.version import LooseVersion
     import os
 
     try:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove `distutils` usage from Spark codebase.

**BEFORE**
```
$ git grep distutils | wc -l
      38
```

**AFTER**
```
$ git grep distutils | wc -l
       0
```

### Why are the changes needed?

Currently, Apache Spark ignores the warnings but the module itself is removed at Python 3.12 via [PEP-632](https://peps.python.org/pep-0632) in favor of `packaging` package.

https://github.com/apache/spark/blob/58c24a5719b8717ea37347c668c9df8a3714ae3c/python/pyspark/__init__.py#L54-L56

 Initially, #43184 proposed to follow Python community guideline via using `packaging` package, but, this PR is embedding `LooseVersion` Python class to avoid adding a new package requirement.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.