### PR TITLE
[SPARK-45385][SQL][TESTS][FOLLOWUP] Improve the test case for deprecate `spark.sql.parser.escapedStringLiterals`

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -1872,6 +1872,9 @@ class DatasetSuite extends QueryTest
   }
 
   test("SPARK-20399: do not unescaped regex pattern when ESCAPED_STRING_LITERALS is enabled") {
+    val data = Seq("\u0020\u0021\u0023", "abc")
+    val df = data.toDF()
+
     Seq(
       true ->
         ("value rlike '^\\x20[\\x20-\\x23]+$'", "value rlike '^\\\\x20[\\\\x20-\\\\x23]+$'"),
@@ -1879,8 +1882,6 @@ class DatasetSuite extends QueryTest
         ("value rlike r'^\\x20[\\x20-\\x23]+$'", "value rlike r'^\\\\x20[\\\\x20-\\\\x23]+$'")
     ).foreach { case (escaped, (filter1, filter3)) =>
       withSQLConf(SQLConf.ESCAPED_STRING_LITERALS.key -> escaped.toString) {
-        val data = Seq("\u0020\u0021\u0023", "abc")
-        val df = data.toDF()
         val rlike1 = df.filter(filter1)
         val rlike2 = df.filter($"value".rlike("^\\x20[\\x20-\\x23]+$"))
         val rlike3 = df.filter(filter3)

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -1872,8 +1872,7 @@ class DatasetSuite extends QueryTest
   }
 
   test("SPARK-20399: do not unescaped regex pattern when ESCAPED_STRING_LITERALS is enabled") {
-    val data = Seq("\u0020\u0021\u0023", "abc")
-    val df = data.toDF()
+    val df = Seq("\u0020\u0021\u0023", "abc").toDF()
 
     Seq(
       true ->


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR follows up https://github.com/apache/spark/pull/43187 and improve the test case.


### Why are the changes needed?
Avoid create data set duplicately of the test case.


### Does this PR introduce _any_ user-facing change?
'No'.
Just update the test cases.


### How was this patch tested?
Test cases updated.


### Was this patch authored or co-authored using generative AI tooling?
'No'.
