### PR TITLE
[SPARK-45399][SQL] XML: Add XML Options using newOption

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/StaxXmlParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/StaxXmlParser.scala
@@ -35,7 +35,6 @@ import org.apache.spark.sql.catalyst.util.{ArrayBasedMapData, BadRecordException
 import org.apache.spark.sql.catalyst.xml.StaxXmlParser.convertStream
 import org.apache.spark.sql.catalyst.xml.TypeCast._
 import org.apache.spark.sql.errors.QueryExecutionErrors
-import org.apache.spark.sql.internal.{LegacyBehaviorPolicy, SQLConf}
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
@@ -46,24 +45,6 @@ class StaxXmlParser(
     filters: Seq[Filter] = Seq.empty) extends Logging {
 
   private val factory = options.buildXmlFactory()
-
-  // Flags to signal if we need to fall back to the backward compatible behavior of parsing
-  // dates and timestamps.
-  // For more information, see comments for "enableDateTimeParsingFallback" option in XmlOptions.
-  private val enableParsingFallbackForTimestampType =
-  options.enableDateTimeParsingFallback
-    .orElse(SQLConf.get.jsonEnableDateTimeParsingFallback)
-    .getOrElse {
-      SQLConf.get.legacyTimeParserPolicy == LegacyBehaviorPolicy.LEGACY ||
-        options.timestampFormatInRead.isEmpty
-    }
-  private val enableParsingFallbackForDateType =
-    options.enableDateTimeParsingFallback
-      .orElse(SQLConf.get.jsonEnableDateTimeParsingFallback)
-      .getOrElse {
-        SQLConf.get.legacyTimeParserPolicy == LegacyBehaviorPolicy.LEGACY ||
-          options.dateFormatInRead.isEmpty
-      }
 
   /**
    * Parses a single XML string and turns it into either one resulting row or no row (if the

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/XmlSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/XmlSuite.scala
@@ -332,7 +332,7 @@ class XmlSuite extends QueryTest with SharedSparkSession {
     val cars = spark.read.xml(getTestResourcePath(resDir + "cars.xml"))
     cars.write
       .mode(SaveMode.Overwrite)
-      .options(Map("codec" -> classOf[GzipCodec].getName))
+      .options(Map("compression" -> classOf[GzipCodec].getName))
       .xml(copyFilePath.toString)
     // Check that the part file has a .gz extension
     assert(Files.list(copyFilePath).iterator().asScala


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add XML Options using `DataSourceOptions::newOption`

Also, removed legacy date and timestamp support as these are not applicable to newly introduced XML data source.

### Why are the changes needed?
Consistency with other formats like json and csv.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
XML unit tests and github action

### Was this patch authored or co-authored using generative AI tooling?
No