### PR TITLE
[SPARK-45406][PYTHON][CONNECT] Delete `schema` from DataFrame constructor

### DIFF
--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -103,10 +103,8 @@ class DataFrame:
     def __init__(
         self,
         session: "SparkSession",
-        schema: Optional[StructType] = None,
     ):
         """Creates a new data frame"""
-        self._schema = schema
         self._plan: Optional[plan.LogicalPlan] = None
         self._session: "SparkSession" = session
         # Check whether _repr_html is supported or not, we use it to avoid calling RPC twice


### PR DESCRIPTION
### What changes were proposed in this pull request?
Delete `schema` from DataFrame constructor


### Why are the changes needed?
this `schema` field was originally designed to cache the schema, however, it is never used and we won't cache schema anymore


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
CI


### Was this patch authored or co-authored using generative AI tooling?
No
