### PR TITLE
[SPARK-45407][INFRA] Skip Unidoc in SparkR GitHub Action Job

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -482,6 +482,7 @@ jobs:
       HIVE_PROFILE: hive2.3
       GITHUB_PREV_SHA: ${{ github.event.before }}
       SPARK_LOCAL_IP: localhost
+      SKIP_UNIDOC: true
       SKIP_MIMA: true
       SKIP_PACKAGING: true
     steps:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to skip `Building Unidoc API Documentation` step in `SparkR` GitHub Action job.
```
========================================================================
Building Unidoc API Documentation
========================================================================
```

### Why are the changes needed?

Since `lint` GitHub Action job already does the same thing, we can skip in `SparkR` job.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual check the log of GitHub Action job in this PR.

### Was this patch authored or co-authored using generative AI tooling?

No.