### PR TITLE
[SPARK-45396][PYTHON] Add doc entry for `pyspark.ml.connect` module, and adds `Evaluator` to `__all__` at `ml.connect` 

### DIFF
--- a/python/docs/source/reference/index.rst
+++ b/python/docs/source/reference/index.rst
@@ -33,6 +33,7 @@ This page lists an overview of all public PySpark modules, classes, functions an
    pyspark.pandas/index
    pyspark.ss/index
    pyspark.ml
+   pyspark.ml.connect
    pyspark.streaming
    pyspark.mllib
    pyspark

--- a/python/docs/source/reference/pyspark.ml.connect.rst
+++ b/python/docs/source/reference/pyspark.ml.connect.rst
@@ -1,0 +1,120 @@
+..  Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+..    http://www.apache.org/licenses/LICENSE-2.0
+
+..  Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+
+MLlib for Spark Connect
+=======================
+
+Pipeline APIs
+-------------
+
+.. currentmodule:: pyspark.ml.connect
+
+.. autosummary::
+    :template: autosummary/class_with_docs.rst
+    :toctree: api/
+
+    Transformer
+    Estimator
+    Model
+    Evaluator
+    Pipeline
+    PipelineModel
+
+
+Feature
+-------
+
+.. currentmodule:: pyspark.ml.connect.feature
+
+.. autosummary::
+    :template: autosummary/class_with_docs.rst
+    :toctree: api/
+
+    MaxAbsScaler
+    MaxAbsScalerModel
+    StandardScaler
+    StandardScalerModel
+
+
+Classification
+--------------
+
+.. currentmodule:: pyspark.ml.connect.classification
+
+.. autosummary::
+    :template: autosummary/class_with_docs.rst
+    :toctree: api/
+
+    LogisticRegression
+    LogisticRegressionModel
+
+
+
+Functions
+---------
+
+.. currentmodule:: pyspark.ml.connect.functions
+
+.. autosummary::
+    :toctree: api/
+
+    array_to_vector
+    vector_to_array
+
+
+Tuning
+------
+
+.. currentmodule:: pyspark.ml.connect.tuning
+
+.. autosummary::
+    :template: autosummary/class_with_docs.rst
+    :toctree: api/
+
+    CrossValidator
+    CrossValidatorModel
+
+
+Evaluation
+----------
+
+.. currentmodule:: pyspark.ml.connect.evaluation
+
+.. autosummary::
+    :template: autosummary/class_with_docs.rst
+    :toctree: api/
+
+    RegressionEvaluator
+    BinaryClassificationEvaluator
+    MulticlassClassificationEvaluator
+
+
+Utilities
+---------
+
+.. currentmodule:: pyspark.ml.connect.io_utils
+
+.. autosummary::
+    :template: autosummary/class_with_docs.rst
+    :toctree: api/
+
+    ParamsReadWrite
+    CoreModelReadWrite
+    MetaAlgorithmReadWrite
+
+

--- a/python/docs/source/reference/pyspark.ml.connect.rst
+++ b/python/docs/source/reference/pyspark.ml.connect.rst
@@ -16,8 +16,12 @@
     under the License.
 
 
-MLlib for Spark Connect
-=======================
+MLlib (DataFrame-based) for Spark Connect
+=========================================
+
+.. warning::
+    The namespace for this package can change in the future Spark version.
+
 
 Pipeline APIs
 -------------
@@ -62,7 +66,6 @@ Classification
 
     LogisticRegression
     LogisticRegressionModel
-
 
 
 Functions
@@ -116,5 +119,4 @@ Utilities
     ParamsReadWrite
     CoreModelReadWrite
     MetaAlgorithmReadWrite
-
 

--- a/python/pyspark/ml/connect/__init__.py
+++ b/python/pyspark/ml/connect/__init__.py
@@ -31,13 +31,14 @@ from pyspark.ml.connect import (
     evaluation,
     tuning,
 )
+from pyspark.ml.connect.evaluation import Evaluator
 
 from pyspark.ml.connect.pipeline import Pipeline, PipelineModel
 
 __all__ = [
     "Estimator",
     "Transformer",
-    "Estimator",
+    "Evaluator",
     "Model",
     "feature",
     "evaluation",


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR documents MLlib's Spark Connect support at API reference.

This PR also piggies back a fix in `__all__` at `python/pyspark/ml/connect/__init__.py` so `from pyspark.sql.commect import Evaluator` works.

### Why are the changes needed?

With this this, user cannot see `pyspark.ml.connect` Python APIs on doc website.

### Does this PR introduce _any_ user-facing change?

Yes it adds the new page into your facing documentation ([PySpark API reference](https://spark.apache.org/docs/latest/api/python/reference/index.html)).


### How was this patch tested?

Manually tested via:

```bash
cd python/docs
make clean html
```

### Was this patch authored or co-authored using generative AI tooling?
No.
