### PR TITLE
[SPARK-43656][CONNECT][PS][TESTS] Enable numpy compat tests for Spark Connect

### DIFF
--- a/python/pyspark/pandas/tests/connect/test_parity_numpy_compat.py
+++ b/python/pyspark/pandas/tests/connect/test_parity_numpy_compat.py
@@ -35,18 +35,6 @@ class NumPyCompatParityTests(NumPyCompatTestsMixin, PandasOnSparkTestUtils, Reus
     def psdf(self):
         return ps.from_pandas(self.pdf)
 
-    @unittest.skip(
-        "TODO(SPARK-43656): Fix pyspark.sql.column._to_java_column to accept Connect Column."
-    )
-    def test_np_spark_compat_frame(self):
-        super().test_np_spark_compat_frame()
-
-    @unittest.skip(
-        "TODO(SPARK-43656): Fix pyspark.sql.column._to_java_column to accept Connect Column."
-    )
-    def test_np_spark_compat_series(self):
-        super().test_np_spark_compat_series()
-
 
 if __name__ == "__main__":
     from pyspark.pandas.tests.connect.test_parity_numpy_compat import *  # noqa: F401

--- a/python/pyspark/pandas/tests/test_numpy_compat.py
+++ b/python/pyspark/pandas/tests/test_numpy_compat.py
@@ -20,7 +20,6 @@ import pandas as pd
 
 from pyspark import pandas as ps
 from pyspark.pandas import set_option, reset_option
-from pyspark.pandas.numpy_compat import unary_np_spark_mappings, binary_np_spark_mappings
 from pyspark.testing.pandasutils import ComparisonTestBase
 from pyspark.testing.sqlutils import SQLTestUtils
 
@@ -86,6 +85,8 @@ class NumPyCompatTestsMixin:
             np.left_shift(psdf1, psdf2)
 
     def test_np_spark_compat_series(self):
+        from pyspark.pandas.numpy_compat import unary_np_spark_mappings, binary_np_spark_mappings
+
         # Use randomly generated dataFrame
         pdf = pd.DataFrame(
             np.random.randint(-100, 100, size=(np.random.randint(100), 2)), columns=["a", "b"]
@@ -134,6 +135,8 @@ class NumPyCompatTestsMixin:
             reset_option("compute.ops_on_diff_frames")
 
     def test_np_spark_compat_frame(self):
+        from pyspark.pandas.numpy_compat import unary_np_spark_mappings, binary_np_spark_mappings
+
         # Use randomly generated dataFrame
         pdf = pd.DataFrame(
             np.random.randint(-100, 100, size=(np.random.randint(100), 2)), columns=["a", "b"]


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to enable `test_np_spark_compat_frame` and `test_np_spark_compat_series` for Spark Connect.


### Why are the changes needed?

To increase test coverage


### Does this PR introduce _any_ user-facing change?

No, it's test-only.

### How was this patch tested?

The existing tests should pass.

### Was this patch authored or co-authored using generative AI tooling?

No.