### PR TITLE
[SPARK-45394][PYTHON][CONNECT] Add retries for artifact API. Improve error handling (follow-up to [SPARK-45093]).

### DIFF
--- a/python/pyspark/sql/connect/client/artifact.py
+++ b/python/pyspark/sql/connect/client/artifact.py
@@ -253,7 +253,7 @@ class ArtifactManager:
             *(self._parse_artifacts(p, pyfile=pyfile, archive=archive, file=file) for p in path)
         )
 
-        def generator():
+        def generator() -> Iterator[proto.AddArtifactsRequest]:
             try:
                 yield from self._add_artifacts(artifacts)
             except Exception as e:

--- a/python/pyspark/sql/connect/client/artifact.py
+++ b/python/pyspark/sql/connect/client/artifact.py
@@ -73,6 +73,13 @@ class LocalFile(LocalData):
         self._size: int
         self._stream: int
 
+        # Check that the file can be read
+        # so that incorrect references can be discovered during Artifact creation,
+        # and not at the point of consumption.
+
+        with self.stream():
+            pass
+
     @cached_property
     def size(self) -> int:
         return os.path.getsize(self.path)
@@ -280,6 +287,7 @@ class ArtifactManager:
         requests: Iterator[proto.AddArtifactsRequest] = self._create_requests(
             *path, pyfile=pyfile, archive=archive, file=file
         )
+
         self._request_add_artifacts(requests)
 
     def _add_forward_to_fs_artifacts(self, local_path: str, dest_path: str) -> None:

--- a/python/pyspark/sql/connect/client/artifact.py
+++ b/python/pyspark/sql/connect/client/artifact.py
@@ -250,10 +250,7 @@ class ArtifactManager:
         # And not during grpc consuming iterator, allowing for much better error reporting.
 
         artifacts: Iterator[Artifact] = chain(
-            *(
-                self._parse_artifacts(p, pyfile=pyfile, archive=archive, file=file)
-                for p in path
-            )
+            *(self._parse_artifacts(p, pyfile=pyfile, archive=archive, file=file) for p in path)
         )
 
         def generator():

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -1549,9 +1549,7 @@ class SparkConnectClient(object):
     def copy_from_local_to_fs(self, local_path: str, dest_path: str) -> None:
         for attempt in self._retrying():
             with attempt:
-                self._artifact_manager._add_forward_to_fs_artifacts(
-                    local_path, dest_path
-                )
+                self._artifact_manager._add_forward_to_fs_artifacts(local_path, dest_path)
 
     def cache_artifact(self, blob: bytes) -> str:
         return self._artifact_manager.cache_artifact(blob)

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -1552,7 +1552,9 @@ class SparkConnectClient(object):
                 self._artifact_manager._add_forward_to_fs_artifacts(local_path, dest_path)
 
     def cache_artifact(self, blob: bytes) -> str:
-        return self._artifact_manager.cache_artifact(blob)
+        for attempt in self._retrying():
+            with attempt:
+                return self._artifact_manager.cache_artifact(blob)
 
 
 class RetryState:

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -1538,11 +1538,20 @@ class SparkConnectClient(object):
         else:
             raise SparkConnectGrpcException(str(rpc_error)) from None
 
-    def add_artifacts(self, *path: str, pyfile: bool, archive: bool, file: bool) -> None:
-        self._artifact_manager.add_artifacts(*path, pyfile=pyfile, archive=archive, file=file)
+    def add_artifacts(self, *paths: str, pyfile: bool, archive: bool, file: bool) -> None:
+        for path in paths:
+            for attempt in self._retrying():
+                with attempt:
+                    self._artifact_manager.add_artifacts(
+                        path, pyfile=pyfile, archive=archive, file=file
+                    )
 
     def copy_from_local_to_fs(self, local_path: str, dest_path: str) -> None:
-        self._artifact_manager._add_forward_to_fs_artifacts(local_path, dest_path)
+        for attempt in self._retrying():
+            with attempt:
+                self._artifact_manager._add_forward_to_fs_artifacts(
+                    local_path, dest_path
+                )
 
     def cache_artifact(self, blob: bytes) -> str:
         return self._artifact_manager.cache_artifact(blob)

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -1555,6 +1555,7 @@ class SparkConnectClient(object):
         for attempt in self._retrying():
             with attempt:
                 return self._artifact_manager.cache_artifact(blob)
+        raise SparkConnectException("Invalid state during retry exception handling.")
 
 
 class RetryState:

--- a/python/pyspark/sql/tests/connect/client/test_artifact.py
+++ b/python/pyspark/sql/tests/connect/client/test_artifact.py
@@ -388,6 +388,11 @@ class ArtifactTests(ReusedConnectTestCase, ArtifactTestsMixin):
         self.assertEqual(actualHash, expected_hash)
         self.assertEqual(self.artifact_manager.is_cached_artifact(expected_hash), True)
 
+    def test_add_not_existing_artifact(self):
+        with tempfile.TemporaryDirectory() as d:
+            with self.assertRaises(FileNotFoundError):
+                self.artifact_manager.add_artifacts(os.path.join(d, "not_existing"), file=True)
+
 
 class LocalClusterArtifactTests(ReusedConnectTestCase, ArtifactTestsMixin):
     @classmethod

--- a/python/pyspark/sql/tests/connect/client/test_artifact.py
+++ b/python/pyspark/sql/tests/connect/client/test_artifact.py
@@ -391,7 +391,9 @@ class ArtifactTests(ReusedConnectTestCase, ArtifactTestsMixin):
     def test_add_not_existing_artifact(self):
         with tempfile.TemporaryDirectory() as d:
             with self.assertRaises(FileNotFoundError):
-                self.artifact_manager.add_artifacts(os.path.join(d, "not_existing"), file=True)
+                self.artifact_manager.add_artifacts(
+                    os.path.join(d, "not_existing"), file=True, pyfile=False, archive=False
+                )
 
 
 class LocalClusterArtifactTests(ReusedConnectTestCase, ArtifactTestsMixin):


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Add retries to `add_artifact` api in client

2. Slightly change control flow within `artifact.py` so that client-side errors (e.g. FileNotFound) are properly thrown. (Previously we attempted to add logs in https://github.com/apache/spark/pull/42949, but that was imperfect solution, this should be much better).

3. Accept proper ownership over files in LocalData, and close those descriptors.

### Why are the changes needed?

Improves user experience

### Does this PR introduce _any_ user-facing change?

Improve error handling, adds retries.

### How was this patch tested?

Added test coverage for add_artifact when there is no artifact.


### Was this patch authored or co-authored using generative AI tooling?

NO