### PR TITLE
[SPARK-45413][CORE] Add warning for prepare drop LevelDB support

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/util/DBProvider.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/DBProvider.java
@@ -58,7 +58,9 @@ public class DBProvider {
     public static DB initDB(DBBackend dbBackend, File file) throws IOException {
       if (file != null) {
         switch (dbBackend) {
-          case LEVELDB: return new LevelDB(LevelDBProvider.initLevelDB(file));
+          case LEVELDB:
+            logger.warn("The LEVELDB are deprecated. Please use ROCKSDB instead.");
+            return new LevelDB(LevelDBProvider.initLevelDB(file));
           case ROCKSDB: return new RocksDB(RocksDBProvider.initRocksDB(file));
           default:
             throw new IllegalArgumentException("Unsupported DBBackend: " + dbBackend);

--- a/common/network-common/src/main/java/org/apache/spark/network/util/DBProvider.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/DBProvider.java
@@ -28,7 +28,11 @@ import org.apache.spark.network.shuffledb.LevelDB;
 import org.apache.spark.network.shuffledb.RocksDB;
 import org.apache.spark.network.shuffledb.StoreVersion;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class DBProvider {
+  private static final Logger logger = LoggerFactory.getLogger(DBProvider.class);
     public static DB initDB(
         DBBackend dbBackend,
         File dbFile,
@@ -38,6 +42,7 @@ public class DBProvider {
         switch (dbBackend) {
           case LEVELDB:
             org.iq80.leveldb.DB levelDB = LevelDBProvider.initLevelDB(dbFile, version, mapper);
+            logger.warn("The LEVELDB are deprecated. Please use ROCKSDB instead.");
             return levelDB != null ? new LevelDB(levelDB) : null;
           case ROCKSDB:
             org.rocksdb.RocksDB rocksDB = RocksDBProvider.initRockDB(dbFile, version, mapper);

--- a/common/network-common/src/main/java/org/apache/spark/network/util/DBProvider.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/DBProvider.java
@@ -21,15 +21,14 @@ import java.io.IOException;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.apache.spark.network.shuffledb.DB;
 import org.apache.spark.network.shuffledb.DBBackend;
 import org.apache.spark.network.shuffledb.LevelDB;
 import org.apache.spark.network.shuffledb.RocksDB;
 import org.apache.spark.network.shuffledb.StoreVersion;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class DBProvider {
   private static final Logger logger = LoggerFactory.getLogger(DBProvider.class);
@@ -42,7 +41,7 @@ public class DBProvider {
         switch (dbBackend) {
           case LEVELDB:
             org.iq80.leveldb.DB levelDB = LevelDBProvider.initLevelDB(dbFile, version, mapper);
-            logger.warn("The LEVELDB are deprecated. Please use ROCKSDB instead.");
+            logger.warn("The LEVELDB is deprecated. Please use ROCKSDB instead.");
             return levelDB != null ? new LevelDB(levelDB) : null;
           case ROCKSDB:
             org.rocksdb.RocksDB rocksDB = RocksDBProvider.initRockDB(dbFile, version, mapper);
@@ -59,7 +58,7 @@ public class DBProvider {
       if (file != null) {
         switch (dbBackend) {
           case LEVELDB:
-            logger.warn("The LEVELDB are deprecated. Please use ROCKSDB instead.");
+            logger.warn("The LEVELDB is deprecated. Please use ROCKSDB instead.");
             return new LevelDB(LevelDBProvider.initLevelDB(file));
           case ROCKSDB: return new RocksDB(RocksDBProvider.initRocksDB(file));
           default:

--- a/core/src/main/scala/org/apache/spark/internal/config/History.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/History.scala
@@ -243,7 +243,7 @@ private[spark] object History {
   }
 
   val HYBRID_STORE_DISK_BACKEND = ConfigBuilder("spark.history.store.hybridStore.diskBackend")
-    .doc("Specifies a disk-based store used in hybrid store; LEVELDB or ROCKSDB.")
+    .doc("Specifies a disk-based store used in hybrid store; ROCKSDB or LEVELDB (deprecated).")
     .version("3.3.0")
     .stringConf
     .transform(_.toUpperCase(Locale.ROOT))

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -725,7 +725,7 @@ package object config {
   private[spark] val SHUFFLE_SERVICE_DB_BACKEND =
     ConfigBuilder(Constants.SHUFFLE_SERVICE_DB_BACKEND)
       .doc("Specifies a disk-based store used in shuffle service local db. " +
-        "LEVELDB or ROCKSDB.")
+        "ROCKSDB or LEVELDB (deprecated).")
       .version("3.4.0")
       .stringConf
       .transform(_.toUpperCase(Locale.ROOT))

--- a/core/src/main/scala/org/apache/spark/status/KVUtils.scala
+++ b/core/src/main/scala/org/apache/spark/status/KVUtils.scala
@@ -95,7 +95,9 @@ private[spark] object KVUtils extends Logging {
 
     val kvSerializer = serializer(conf, live)
     val db = backend(conf, live) match {
-      case LEVELDB => new LevelDB(path, kvSerializer)
+      case LEVELDB =>
+        logWarning("The LEVELDB are deprecated. Please use ROCKSDB instead.")
+        new LevelDB(path, kvSerializer)
       case ROCKSDB => new RocksDB(path, kvSerializer)
     }
     val dbMeta = db.getMetadata(classTag[M].runtimeClass)

--- a/core/src/main/scala/org/apache/spark/status/KVUtils.scala
+++ b/core/src/main/scala/org/apache/spark/status/KVUtils.scala
@@ -96,7 +96,7 @@ private[spark] object KVUtils extends Logging {
     val kvSerializer = serializer(conf, live)
     val db = backend(conf, live) match {
       case LEVELDB =>
-        logWarning("The LEVELDB are deprecated. Please use ROCKSDB instead.")
+        logWarning("The LEVELDB is deprecated. Please use ROCKSDB instead.")
         new LevelDB(path, kvSerializer)
       case ROCKSDB => new RocksDB(path, kvSerializer)
     }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1282,7 +1282,7 @@ Apart from these, the following properties are also available, and may be useful
   <td><code>spark.shuffle.service.db.backend</code></td>
   <td>ROCKSDB</td>
   <td>
-    Specifies a disk-based store used in shuffle service local db. Setting as LEVELDB or ROCKSDB.
+    Specifies a disk-based store used in shuffle service local db. Setting as ROCKSDB or LEVELDB (deprecated).
   </td>
   <td>3.4.0</td>
 </tr>

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -416,7 +416,7 @@ Security options for the Spark History Server are covered more detail in the
     <td>spark.history.store.hybridStore.diskBackend</td>
     <td>ROCKSDB</td>
     <td>
-      Specifies a disk-based store used in hybrid store; LEVELDB or ROCKSDB.
+      Specifies a disk-based store used in hybrid store; ROCKSDB or LEVELDB (deprecated).
     </td>
     <td>3.3.0</td>
   </tr>

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -917,8 +917,8 @@ The following extra configuration options are available when the shuffle service
   <td>ROCKSDB</td>
   <td>
     When work-preserving restart is enabled in YARN, this is used to specify the disk-base store used
-    in shuffle service state store, supports `LEVELDB` and `ROCKSDB` with `ROCKSDB` as default value.
-    The original data store in `LevelDB/RocksDB` will not be automatically converted to another kind
+    in shuffle service state store, supports `ROCKSDB` and `LEVELDB` (deprecated) with `ROCKSDB` as default value.
+    The original data store in `RocksDB/LevelDB` will not be automatically converted to another kind
     of storage now. The original data store will be retained and the new type data store will be
     created when switching storage types.
   </td>

--- a/docs/spark-standalone.md
+++ b/docs/spark-standalone.md
@@ -335,8 +335,8 @@ SPARK_WORKER_OPTS supports the following system properties:
   <td>ROCKSDB</td>
   <td>
     When <code>spark.shuffle.service.db.enabled</code> is true, user can use this to specify the kind of disk-based
-    store used in shuffle service state store. This supports `LEVELDB` and `ROCKSDB` now and `ROCKSDB` as default value.
-    The original data store in `LevelDB/RocksDB` will not be automatically convert to another kind of storage now.
+    store used in shuffle service state store. This supports `ROCKSDB` and `LEVELDB` (deprecated) now and `ROCKSDB` as default value.
+    The original data store in `RocksDB/LevelDB` will not be automatically convert to another kind of storage now.
   </td>
   <td>3.4.0</td>
 </tr>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
This PR add warning deprecated message for use LEVELDB in `spark.history.store.hybridStore.diskBackend` or `spark.shuffle.service.db.backend`.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
Add warning for LEVELDB users in Spark, so we can remove it safety in the future.
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
NO
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
exist test.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
No
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
