### PR TITLE
[SPARK-45268][PYTHON][DOCS][FOLLOWUP] Correct the group of `equal_null`

### DIFF
--- a/python/docs/source/reference/pyspark.sql/functions.rst
+++ b/python/docs/source/reference/pyspark.sql/functions.rst
@@ -58,6 +58,7 @@ Predicate Functions
 .. autosummary::
     :toctree: api/
 
+    equal_null
     ilike
     isnan
     isnotnull
@@ -582,7 +583,6 @@ Misc Functions
     current_database
     current_schema
     current_user
-    equal_null
     hll_sketch_estimate
     hll_union
     input_file_block_length


### PR DESCRIPTION
### What changes were proposed in this pull request?
the group of `equal_null` should be `Predicate Functions` after https://github.com/apache/spark/commit/6e6ee613a0d36c56d2e522510897818ba1754d56

### Why are the changes needed?
to be consistent with SQL side


### Does this PR introduce _any_ user-facing change?
yes


### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no
