### PR TITLE
[SPARK-45167][CONNECT][PYTHON][FOLLOW-UP][3.5] Use lighter threading Rlock

### DIFF
--- a/python/pyspark/sql/connect/client/reattach.py
+++ b/python/pyspark/sql/connect/client/reattach.py
@@ -18,12 +18,11 @@ from pyspark.sql.connect.utils import check_dependencies
 
 check_dependencies(__name__)
 
+from threading import RLock
 import warnings
 import uuid
 from collections.abc import Generator
 from typing import Optional, Dict, Any, Iterator, Iterable, Tuple, Callable, cast, Type, ClassVar
-from multiprocessing import RLock
-from multiprocessing.synchronize import RLock as RLockBase
 from multiprocessing.pool import ThreadPool
 import os
 
@@ -56,7 +55,7 @@ class ExecutePlanResponseReattachableIterator(Generator):
     """
 
     # Lock to manage the pool
-    _lock: ClassVar[RLockBase] = RLock()
+    _lock: ClassVar[RLock] = RLock()
     _release_thread_pool: Optional[ThreadPool] = ThreadPool(os.cpu_count() if os.cpu_count() else 8)
 
     @classmethod


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR reverts the revert: https://github.com/apache/spark/commit/522af69713502d33d34b330bce6166e3d15dba8a. It only partially ports the real change within main code. It excludes the testing side which depends on https://github.com/apache/spark/commit/9798244ca647ec68d36f4b9b21356a6de5f73f77 that does not exist in `branch-3.5`.

### Why are the changes needed?

Mainly for code clean-up.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests should cover this.

### Was this patch authored or co-authored using generative AI tooling?

No.
