### PR TITLE
[SPARK-45417][PYTHON] Make InheritableThread inherit the active session

### DIFF
--- a/python/pyspark/tests/test_pin_thread.py
+++ b/python/pyspark/tests/test_pin_thread.py
@@ -14,12 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import contextlib
 import os
 import time
 import threading
 import unittest
 
-from pyspark import SparkContext, SparkConf, InheritableThread
+from pyspark import SparkContext, SparkConf, InheritableThread, inheritable_thread_target
+from pyspark.sql import SparkSession
 
 
 class PinThreadTests(unittest.TestCase):
@@ -179,6 +181,69 @@ class PinThreadTests(unittest.TestCase):
 
         self.assertEqual(self.sc.getLocalProperty("b"), None)
         self.assertEqual(expected, ["hi", "hello"])
+
+    @contextlib.contextmanager
+    def ensure_active_spark_session(self):
+        jvm = self.sc._jvm
+        old_active_spark_session = SparkSession.getActiveSession()
+        if old_active_spark_session is None:
+            old_default_spark_session = jvm.SparkSession.getDefaultSession()
+            try:
+                spark = SparkSession.builder.getOrCreate()
+                jvm.SparkSession.setActiveSession(spark._jsparkSession)
+                self.assertEqual(SparkSession.getActiveSession(), spark)
+                yield spark
+            finally:
+                jvm.SparkSession.setActiveSession(None)
+                self.assertEqual(SparkSession.getActiveSession(), None)
+                if old_default_spark_session.isDefined():
+                    jvm.SparkSession.setDefaultSession(old_default_spark_session.get())
+                else:
+                    jvm.SparkSession.setDefaultSession(None)
+        else:
+            yield old_active_session
+
+    def _test_inheritable_active_session(self, make_thread):
+        with self.ensure_active_spark_session() as spark:
+            active_session_in_thread = []
+
+            def get_active_session_in_thread():
+                active_session_in_thread.append(SparkSession.getActiveSession())
+
+            t = make_thread(get_active_session_in_thread)
+            t.start()
+            t.join()
+
+            self.assertEqual(active_session_in_thread, [spark])
+
+    def test_inheritable_thread_active_session(self):
+        self._test_inheritable_active_session(lambda target: InheritableThread(target=target))
+
+    def test_inheritable_thread_target_active_session(self):
+        self._test_inheritable_active_session(
+            lambda target: threading.Thread(target=inheritable_thread_target(target)))
+
+    def _test_inheritable_active_session_negative(self, make_thread):
+        self.assertEqual(SparkSession.getActiveSession(), None)
+
+        active_session_in_thread = []
+
+        def get_active_session_in_thread():
+            active_session_in_thread.append(SparkSession.getActiveSession())
+
+        t = make_thread(get_active_session_in_thread)
+        t.start()
+        t.join()
+
+        self.assertEqual(active_session_in_thread, [None])
+
+    def test_inheritable_thread_active_session_negative(self):
+        self._test_inheritable_active_session_negative(
+            lambda target: InheritableThread(target=target))
+
+    def test_inheritable_thread_target_active_session_negative(self):
+        self._test_inheritable_active_session_negative(
+            lambda target: InheritableThread(target=target))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make `InheritableThread` and `inheritable_thread_target` inherit the active session.

### Why are the changes needed?
Sometimes the active session can be null in Python threads, even with `InheritableThread` or `inheritable_thread_target`.

Example:

```python
# repro.py
# run as: bin/spark-submit repro.py
from multiprocessing.pool import ThreadPool
from pyspark import inheritable_thread_target
from pyspark.sql import SparkSession

spark = SparkSession.builder.appName("Test").getOrCreate()
spark.sparkContext.setLogLevel("ERROR")

def f(i, spark):
    print(f"{i} spark = {spark}")
    print(f"{i} active session = {SparkSession.getActiveSession()}")
    print(f"{i} local property foo = {spark.sparkContext.getLocalProperty('foo')}")
    spark = SparkSession.builder.appName("Test").getOrCreate()
    print(f"{i} spark = {spark}")
    print(f"{i} active session = {SparkSession.getActiveSession()}")

pool = ThreadPool(4)
spark.sparkContext.setLocalProperty("foo", "bar")
pool.starmap(inheritable_thread_target(f), [(i, spark) for i in range(4)])
```

### Does this PR introduce _any_ user-facing change?
Yes. When using `InheritableThread` or `inheritable_thread_target`, the active session will be copied from the parent thread.

### How was this patch tested?
`python/run-tests --testnames pyspark.tests.test_pin_thread`

### Was this patch authored or co-authored using generative AI tooling?
No
