### PR TITLE
[SPARK-45401][PYTHON] Add a new method `cleanup` in the UDTF interface

### DIFF
--- a/python/docs/source/user_guide/sql/python_udtf.rst
+++ b/python/docs/source/user_guide/sql/python_udtf.rst
@@ -108,15 +108,18 @@ To implement a Python UDTF, you first need to define a class implementing the me
 
         def terminate(self) -> Iterator[Any]:
             """
-            Called when the UDTF has processed all input rows.
+            Called when the UDTF has successfully processed all input rows.
 
             This method is optional to implement and is useful for performing any
-            cleanup or finalization operations after the UDTF has finished processing
+            finalization operations after the UDTF has finished processing
             all rows. It can also be used to yield additional rows if needed.
             Table functions that consume all rows in the entire input partition
             and then compute and return the entire output table can do so from
             this method as well (please be mindful of memory usage when doing
             this).
+
+            If any exceptions occur during input row processing, this method
+            won't be called.
 
             Yields
             ------
@@ -128,6 +131,21 @@ To implement a Python UDTF, you first need to define a class implementing the me
             --------
             >>> def terminate(self) -> Iterator[Any]:
             >>>     yield "done", None
+            """
+            ...
+
+        def cleanup(self) -> None:
+            """
+            Invoked after the UDTF completes processing input rows.
+
+            This method is optional to implement and is useful for final cleanup
+            regardless of whether the UDTF processed all input rows successfully
+            or was aborted due to exceptions.
+
+            Examples
+            --------
+            >>> def cleanup(self) -> None:
+            >>>     self.conn.close()
             """
             ...
 

--- a/python/pyspark/sql/tests/test_udtf.py
+++ b/python/pyspark/sql/tests/test_udtf.py
@@ -409,6 +409,7 @@ class BaseUDTFTestsMixin:
     def test_udtf_cleanup(self):
         with tempfile.TemporaryDirectory() as d:
             path = os.path.join(d, "file.txt")
+
             @udtf(returnType="x: int")
             class TestUDTF:
                 def __init__(self):

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -757,6 +757,10 @@ def read_udtf(pickleSer, infile, eval_type):
                 return self._udtf.terminate()
             return iter(())
 
+        def cleanup(self) -> None:
+            if self._udtf.cleanup is not None:
+                self._udtf.cleanup()
+
         def _check_partition_boundaries(self, arguments: list) -> bool:
             result = False
             if len(self._prev_arguments) > 0:
@@ -894,15 +898,19 @@ def read_udtf(pickleSer, infile, eval_type):
         else:
             terminate = None
 
+        cleanup = getattr(udtf, "cleanup") if hasattr(udtf, "cleanup") else None
+
         def mapper(_, it):
             try:
                 for a in it:
                     # The eval function yields an iterator. Each element produced by this
                     # iterator is a tuple in the form of (pandas.DataFrame, arrow_return_type).
                     yield from eval(*[a[o] for o in args_kwargs_offsets])
-            finally:
                 if terminate is not None:
                     yield from terminate()
+            finally:
+                if cleanup is not None:
+                    cleanup()
 
         return mapper, None, ser, ser
 
@@ -977,14 +985,18 @@ def read_udtf(pickleSer, infile, eval_type):
         else:
             terminate = None
 
+        cleanup = getattr(udtf, "cleanup") if hasattr(udtf, "cleanup") else None
+
         # Return an iterator of iterators.
         def mapper(_, it):
             try:
                 for a in it:
                     yield eval(*[a[o] for o in args_kwargs_offsets])
-            finally:
                 if terminate is not None:
                     yield terminate()
+            finally:
+                if cleanup is not None:
+                    cleanup()
 
         return mapper, None, ser, ser
 

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -758,7 +758,7 @@ def read_udtf(pickleSer, infile, eval_type):
             return iter(())
 
         def cleanup(self) -> None:
-            if self._udtf.cleanup is not None:
+            if hasattr(self._udtf, "cleanup"):
                 self._udtf.cleanup()
 
         def _check_partition_boundaries(self, arguments: list) -> bool:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR adds a new API `cleanup` to the current Python UDTF interface.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Currently, the `terminate` method of a UDTF is always executed, regardless of whether the `eval` method calls are successful. This is problematic as users might have certain logic in `terminate` that can only be executed once all `eval` calls succeed.

But what if users wish to perform cleanup actions during UDTF execution, such as closing connections? One option is for users to embed a try...except logic within the eval call:

```
def eval(self, row: Any):
  try:
    run_code()
  except Exception:
    clean_up()
```

However, running this try-except block for every eval call can be expensive, potentially affecting the performance of UDTFs.

To tackle this, we can introduce a new method in the UDTF interface that will be called regardless of the outcome. Now the logic would look like:

```
try:
  for row in rows:
    eval(row)
  terminate()
finally:
  cleanup()
```

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Unit test

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No