### PR TITLE
[SPARK-45420][SQL][PYTHON][CONNECT] Add DataType.fromDDL into PySpark

### DIFF
--- a/python/pyspark/sql/tests/test_types.py
+++ b/python/pyspark/sql/tests/test_types.py
@@ -28,6 +28,7 @@ from pyspark.sql import Row
 from pyspark.sql import functions as F
 from pyspark.errors import AnalysisException, PySparkTypeError, PySparkValueError
 from pyspark.sql.types import (
+    DataType,
     ByteType,
     ShortType,
     IntegerType,
@@ -1287,6 +1288,17 @@ class TypesTestsMixin:
     def test_calendar_interval_type_with_sf(self):
         schema1 = self.spark.range(1).select(F.make_interval(F.lit(1))).schema
         self.assertEqual(schema1.fields[0].dataType, CalendarIntervalType())
+
+    def test_from_ddl(self):
+        self.assertEqual(DataType.fromDDL("long"), LongType())
+        self.assertEqual(
+            DataType.fromDDL("a: int, b: string"),
+            StructType([StructField("a", IntegerType()), StructField("b", StringType())]),
+        )
+        self.assertEqual(
+            DataType.fromDDL("a int, b string"),
+            StructType([StructField("a", IntegerType()), StructField("b", StringType())]),
+        )
 
 
 class DataTypeTests(unittest.TestCase):


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR implements `DataType.fromDDL` as the parity to Scala API:

https://github.com/apache/spark/blob/350b8d8388c9ad15303d39f22b249b8c73785695/sql/api/src/main/scala/org/apache/spark/sql/types/DataType.scala#L121-L126

One difference is that Python API also supports the legacy format inside `struct<...>`, e.g., `a: int, b: int`.

### Why are the changes needed?

In order for the end users to parse the DDL formatted type easily.

### Does this PR introduce _any_ user-facing change?

Yes, this PR adds a new user-facing API: `DataType.fromDDL`.

### How was this patch tested?

Unittests were added, and manually tested them too.

### Was this patch authored or co-authored using generative AI tooling?

No.