### PR TITLE
[SPARK-45423][SQL] Lower `ParquetWriteSupport` log level to debug

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetWriteSupport.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetWriteSupport.scala
@@ -132,7 +132,7 @@ class ParquetWriteSupport extends WriteSupport[InternalRow] with Logging {
       }
     }
 
-    logInfo(
+    logDebug(
       s"""Initialized Parquet WriteSupport with Catalyst schema:
          |${schema.prettyJson}
          |and corresponding Parquet message type:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to lower `ParquetWriteSupport` log level from INFO to DEBUG

### Why are the changes needed?

 Currently, `ParquetWriteSupport` is too verbose at INFO level because it dumps the Parquet file schema per file. Since this is the only log in `ParquetWriteSupport`,  the users can see this via a proper `log4j2.properties` setting when they want to debug jobs.
 ```
23/10/05 16:29:43 INFO ParquetOutputFormat: ParquetRecordWriter [block size: 134217728b, row group padding size: 8388608b, validating: false]
23/10/05 16:29:43 INFO ParquetWriteSupport: Initialized Parquet WriteSupport with Catalyst schema:
{
  "type" : "struct",
  "fields" : [ {
    "name" : "id",
    "type" : "long",
    "nullable" : false,
    "metadata" : { }
  } ]
}
and corresponding Parquet message type:
message spark_schema {
  required int64 id;
}

       
23/10/05 16:29:43 INFO MagicCommitTracker: ...
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual tests.

### Was this patch authored or co-authored using generative AI tooling?

No.