### PR TITLE
[SPARK-45417][PYTHON] Make InheritableThread inherit the active session

### DIFF
--- a/python/pyspark/tests/test_pin_thread.py
+++ b/python/pyspark/tests/test_pin_thread.py
@@ -220,7 +220,8 @@ class PinThreadTests(unittest.TestCase):
 
     def test_inheritable_thread_target_active_session(self):
         self._test_inheritable_active_session(
-            lambda target: threading.Thread(target=inheritable_thread_target(target)))
+            lambda target: threading.Thread(target=inheritable_thread_target(target))
+        )
 
     def _test_inheritable_active_session_negative(self, make_thread):
         self.assertEqual(SparkSession.getActiveSession(), None)
@@ -238,11 +239,13 @@ class PinThreadTests(unittest.TestCase):
 
     def test_inheritable_thread_active_session_negative(self):
         self._test_inheritable_active_session_negative(
-            lambda target: InheritableThread(target=target))
+            lambda target: InheritableThread(target=target)
+        )
 
     def test_inheritable_thread_target_active_session_negative(self):
         self._test_inheritable_active_session_negative(
-            lambda target: InheritableThread(target=target))
+            lambda target: InheritableThread(target=target)
+        )
 
 
 if __name__ == "__main__":

--- a/python/pyspark/tests/test_pin_thread.py
+++ b/python/pyspark/tests/test_pin_thread.py
@@ -200,7 +200,7 @@ class PinThreadTests(unittest.TestCase):
                 else:
                     jvm.SparkSession.setDefaultSession(None)
         else:
-            yield old_active_session
+            yield old_active_spark_session
 
     def _test_inheritable_active_session(self, make_thread):
         with self.ensure_active_spark_session() as spark:

--- a/python/pyspark/util.py
+++ b/python/pyspark/util.py
@@ -369,7 +369,7 @@ def inheritable_thread_target(f: Optional[Union[Callable, "SparkSession"]] = Non
         # copies when the function is wrapped.
         assert SparkContext._active_spark_context is not None
         properties = SparkContext._active_spark_context._jsc.sc().getLocalProperties().clone()
-        session = SparkSession.getActiveSession()
+        active_spark_session = SparkSession.getActiveSession()
         assert callable(f)
 
         @functools.wraps(f)
@@ -377,8 +377,10 @@ def inheritable_thread_target(f: Optional[Union[Callable, "SparkSession"]] = Non
             # Set local properties in child thread.
             assert SparkContext._active_spark_context is not None
             SparkContext._active_spark_context._jsc.sc().setLocalProperties(properties)
-            if session is not None:
-                session._jsparkSession.setActiveSession(session._jsparkSession)
+            if active_spark_session is not None:
+                active_spark_session._jsparkSession.setActiveSession(
+                    active_spark_session._jsparkSession
+                )
             return f(*args, **kwargs)  # type: ignore[misc, operator]
 
         return wrapped

--- a/python/pyspark/util.py
+++ b/python/pyspark/util.py
@@ -460,7 +460,6 @@ class InheritableThread(threading.Thread):
         else:
             # Non Spark Connect
             from pyspark import SparkContext
-            from pyspark.sql import SparkSession
 
             if isinstance(SparkContext._gateway, ClientServer):
                 # Here's when the pinned-thread mode (PYSPARK_PIN_THREAD) is on.


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make `InheritableThread` and `inheritable_thread_target` inherit the active session.

### Why are the changes needed?
Sometimes the active session can be null in Python threads, even with `InheritableThread` or `inheritable_thread_target`.

Example:

```python
# repro.py
# run as: bin/spark-submit repro.py
from multiprocessing.pool import ThreadPool
from pyspark import inheritable_thread_target
from pyspark.sql import SparkSession

spark = SparkSession.builder.appName("Test").getOrCreate()
spark.sparkContext.setLogLevel("ERROR")

def f(i, spark):
    print(f"{i} spark = {spark}")
    print(f"{i} active session = {SparkSession.getActiveSession()}")
    print(f"{i} local property foo = {spark.sparkContext.getLocalProperty('foo')}")
    spark = SparkSession.builder.appName("Test").getOrCreate()
    print(f"{i} spark = {spark}")
    print(f"{i} active session = {SparkSession.getActiveSession()}")

pool = ThreadPool(4)
spark.sparkContext.setLocalProperty("foo", "bar")
pool.starmap(inheritable_thread_target(f), [(i, spark) for i in range(4)])
```

### Does this PR introduce _any_ user-facing change?
Yes. When using `InheritableThread` or `inheritable_thread_target`, the active session will be copied from the parent thread.

### How was this patch tested?
`python/run-tests --testnames pyspark.tests.test_pin_thread`

### Was this patch authored or co-authored using generative AI tooling?
No
