### PR TITLE
[SPARK-45425][SQL] Mapped TINYINT to ShortType for MsSqlServerDialect

### DIFF
--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MsSqlServerIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MsSqlServerIntegrationSuite.scala
@@ -197,7 +197,11 @@ class MsSqlServerIntegrationSuite extends DockerJDBCIntegrationSuite {
         assert(types(10).equals("class java.math.BigDecimal"))
         assert(types(11).equals("class java.math.BigDecimal"))
         assert(row.getBoolean(0) == false)
-        assert(row.getInt(1) == 255)
+        if (flag) {
+          assert(row.getInt(1) == 255)
+        } else {
+          assert(row.getShort(1) == 255)
+        }
         if (flag) {
           assert(row.getInt(2) == 32767)
         } else {

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MsSqlServerIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MsSqlServerIntegrationSuite.scala
@@ -172,7 +172,11 @@ class MsSqlServerIntegrationSuite extends DockerJDBCIntegrationSuite {
         val types = row.toSeq.map(x => x.getClass.toString)
         assert(types.length == 12)
         assert(types(0).equals("class java.lang.Boolean"))
-        assert(types(1).equals("class java.lang.Short"))
+        if (flag) {
+          assert(types(1).equals("class java.lang.Integer"))
+        } else {
+          assert(types(1).equals("class java.lang.Short"))
+        }
         if (flag) {
           assert(types(2).equals("class java.lang.Integer"))
         } else {

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MsSqlServerIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MsSqlServerIntegrationSuite.scala
@@ -172,7 +172,7 @@ class MsSqlServerIntegrationSuite extends DockerJDBCIntegrationSuite {
         val types = row.toSeq.map(x => x.getClass.toString)
         assert(types.length == 12)
         assert(types(0).equals("class java.lang.Boolean"))
-        assert(types(1).equals("class java.lang.Integer"))
+        assert(types(1).equals("class java.lang.Short"))
         if (flag) {
           assert(types(2).equals("class java.lang.Integer"))
         } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MsSqlServerDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MsSqlServerDialect.scala
@@ -109,6 +109,8 @@ private object MsSqlServerDialect extends JdbcDialect {
         None
       } else {
         sqlType match {
+          // Data range of TINYINT is 0-255 so it needs to be stored in ShortType.
+          // Reference doc: https://learn.microsoft.com/en-us/sql/t-sql/data-types
           case java.sql.Types.SMALLINT | java.sql.Types.TINYINT => Some(ShortType)
           case java.sql.Types.REAL => Some(FloatType)
           case SpecificTypes.GEOMETRY | SpecificTypes.GEOGRAPHY => Some(BinaryType)

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MsSqlServerDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MsSqlServerDialect.scala
@@ -109,7 +109,7 @@ private object MsSqlServerDialect extends JdbcDialect {
         None
       } else {
         sqlType match {
-          case java.sql.Types.SMALLINT => Some(ShortType)
+          case java.sql.Types.SMALLINT | java.sql.Types.TINYINT => Some(ShortType)
           case java.sql.Types.REAL => Some(FloatType)
           case SpecificTypes.GEOMETRY | SpecificTypes.GEOGRAPHY => Some(BinaryType)
           case _ => None


### PR DESCRIPTION
### What changes were proposed in this pull request?
Mapped TINYINT to `ShortType` for MsSqlServerDialect. For TINYINT of sql server, its range is `0-255`

### Why are the changes needed?
TINYINT of SQL server is not correctly mapped to spark types when using JDBC connector. For now, it is mapped to the `IntegerType`, which is not accurate. It should be mapped to `ShortType`.

### Does this PR introduce _any_ user-facing change?
Yes, after the change, `TINYINT` of SQL server will be mapped to `ShortType`


### How was this patch tested?
UT


### Was this patch authored or co-authored using generative AI tooling?
No
