### PR TITLE
[MINOR][SQL] Remove Scalac 2.12-specific code in `InMemoryFileIndex`

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InMemoryFileIndex.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InMemoryFileIndex.scala
@@ -126,7 +126,6 @@ class InMemoryFileIndex(
         case None =>
           pathsToFetch += path
       }
-      () // for some reasons scalac 2.12 needs this; return type doesn't matter
     }
     val filter = FileInputFormat.getInputPathFilter(new JobConf(hadoopConf, this.getClass))
     val discovered = InMemoryFileIndex.bulkListLeafFiles(


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove `scalac 2.12`-specific code from InMemoryFileIndex class.

### Why are the changes needed?

Like the comment mentioned, we don't need this because `master` branch is using Scala 2.13 only.
https://github.com/apache/spark/blob/c0d9ca3be14cb0ec8d8f9920d3ecc4aac3cf5adc/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InMemoryFileIndex.scala#L129

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.