### PR TITLE
should use current plan's output in ScanOperation

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
@@ -143,16 +143,16 @@ object ScanOperation extends OperationHelper {
     // bottom-most Filter, or more following deterministic Filters if the bottom-most Filter is
     // also deterministic.
     if (filters.isEmpty) {
-      Some((fields.getOrElse(child.output), Nil, Nil, child))
+      Some((fields.getOrElse(plan.output), Nil, Nil, child))
     } else if (filters.head.deterministic) {
       val filtersCanPushDown = filters.takeWhile(_.deterministic)
         .flatMap(splitConjunctivePredicates)
       val filtersStayUp = filters.dropWhile(_.deterministic)
-      Some((fields.getOrElse(child.output), filtersStayUp, filtersCanPushDown, child))
+      Some((fields.getOrElse(plan.output), filtersStayUp, filtersCanPushDown, child))
     } else {
       val filtersCanPushDown = splitConjunctivePredicates(filters.head)
       val filtersStayUp = filters.drop(1)
-      Some((fields.getOrElse(child.output), filtersStayUp, filtersCanPushDown, child))
+      Some((fields.getOrElse(plan.output), filtersStayUp, filtersCanPushDown, child))
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
For following plan
```
Filter isnotnull(part_key)
  Relation ...
```
The output used by project list is child instead of current plan in FileSourceStrategy. Technically, this strategy should not change original plan's output, so current plan's output should be used.


### Why are the changes needed?
improvement

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
UT


### Was this patch authored or co-authored using generative AI tooling?
No
