### PR TITLE
[SPARK-45444][BUILD] Upgrade `commons-io` to 2.14.0

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -43,7 +43,7 @@ commons-compiler/3.1.9//commons-compiler-3.1.9.jar
 commons-compress/1.24.0//commons-compress-1.24.0.jar
 commons-crypto/1.1.0//commons-crypto-1.1.0.jar
 commons-dbcp/1.4//commons-dbcp-1.4.jar
-commons-io/2.13.0//commons-io-2.13.0.jar
+commons-io/2.14.0//commons-io-2.14.0.jar
 commons-lang/2.6//commons-lang-2.6.jar
 commons-lang3/3.13.0//commons-lang3-3.13.0.jar
 commons-logging/1.1.3//commons-logging-1.1.3.jar

--- a/pom.xml
+++ b/pom.xml
@@ -192,7 +192,7 @@
     <netlib.ludovic.dev.version>3.0.3</netlib.ludovic.dev.version>
     <commons-codec.version>1.16.0</commons-codec.version>
     <commons-compress.version>1.24.0</commons-compress.version>
-    <commons-io.version>2.13.0</commons-io.version>
+    <commons-io.version>2.14.0</commons-io.version>
     <!-- org.apache.commons/commons-lang/-->
     <commons-lang2.version>2.6</commons-lang2.version>
     <!-- org.apache.commons/commons-lang3/-->


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade `commons-io` to 1.24.0.

### Why are the changes needed?
The new version bring some bug fixes, eg:
- IO-799: ReaderInputStream.read() throws an exception instead of returning -1 when called again after returning -1.
- MagicNumberFileFilter.accept(Path, BasicFileAttributes) doesn't set its byteOffset before reading.

It depends on `commons-lang3` version `3.13.0`, which is consistent with Spark.

Full release notes: https://commons.apache.org/proper/commons-io/changes-report.html#a2.14.0

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
