### PR TITLE
[SPARK-45448][PYTHON] Fix imports according to PEP8: pyspark.testing, pyspark.mllib, pyspark.resource and pyspark.streaming

### DIFF
--- a/python/pyspark/mllib/_typing.pyi
+++ b/python/pyspark/mllib/_typing.pyi
@@ -19,10 +19,10 @@
 from typing import List, Tuple, TypeVar, Union
 
 from typing_extensions import Literal
-
-from pyspark.mllib.linalg import Vector
 from numpy import ndarray  # noqa: F401
 from py4j.java_gateway import JavaObject
+
+from pyspark.mllib.linalg import Vector
 
 VectorLike = Union[ndarray, Vector, List[float], Tuple[float, ...]]
 C = TypeVar("C", bound=type)

--- a/python/pyspark/mllib/evaluation.py
+++ b/python/pyspark/mllib/evaluation.py
@@ -16,7 +16,6 @@
 #
 
 from typing import Generic, List, Optional, Tuple, TypeVar, Union
-
 import sys
 
 from pyspark import since

--- a/python/pyspark/mllib/feature.py
+++ b/python/pyspark/mllib/feature.py
@@ -29,7 +29,6 @@ from pyspark.rdd import RDD
 from pyspark.mllib.common import callMLlibFunc, JavaModelWrapper
 from pyspark.mllib.linalg import Vectors, _convert_to_vector
 from pyspark.mllib.util import JavaLoader, JavaSaveable
-
 from pyspark.context import SparkContext
 from pyspark.mllib.linalg import Vector
 from pyspark.mllib.regression import LabeledPoint

--- a/python/pyspark/mllib/linalg/__init__.py
+++ b/python/pyspark/mllib/linalg/__init__.py
@@ -26,22 +26,6 @@ SciPy is available in their environment.
 import sys
 import array
 import struct
-
-import numpy as np
-
-from pyspark import since
-from pyspark.ml import linalg as newlinalg
-from pyspark.sql.types import (
-    UserDefinedType,
-    StructField,
-    StructType,
-    ArrayType,
-    DoubleType,
-    IntegerType,
-    ByteType,
-    BooleanType,
-)
-
 from typing import (
     Any,
     Callable,
@@ -58,6 +42,21 @@ from typing import (
     TypeVar,
     TYPE_CHECKING,
     Union,
+)
+
+import numpy as np
+
+from pyspark import since
+from pyspark.ml import linalg as newlinalg
+from pyspark.sql.types import (
+    UserDefinedType,
+    StructField,
+    StructType,
+    ArrayType,
+    DoubleType,
+    IntegerType,
+    ByteType,
+    BooleanType,
 )
 
 if TYPE_CHECKING:

--- a/python/pyspark/mllib/util.py
+++ b/python/pyspark/mllib/util.py
@@ -17,6 +17,7 @@
 
 import sys
 from functools import reduce
+
 import numpy as np
 
 from pyspark import SparkContext, since

--- a/python/pyspark/resource/profile.py
+++ b/python/pyspark/resource/profile.py
@@ -16,6 +16,7 @@
 #
 
 from typing import overload, Dict, Union, Optional
+
 from py4j.java_gateway import JavaObject
 
 from pyspark.resource.requests import (

--- a/python/pyspark/streaming/dstream.py
+++ b/python/pyspark/streaming/dstream.py
@@ -36,12 +36,12 @@ from typing import (
 )
 
 from py4j.protocol import Py4JJavaError
+from py4j.java_gateway import JavaObject
 
 from pyspark.storagelevel import StorageLevel
 from pyspark.streaming.util import rddToFileName, TransformFunction
 from pyspark.rdd import portable_hash, RDD
 from pyspark.resultiterable import ResultIterable
-from py4j.java_gateway import JavaObject
 
 if TYPE_CHECKING:
     from pyspark.serializers import Serializer

--- a/python/pyspark/testing/connectutils.py
+++ b/python/pyspark/testing/connectutils.py
@@ -23,17 +23,6 @@ import functools
 import unittest
 import uuid
 
-from pyspark import Row, SparkConf
-from pyspark.testing.utils import PySparkErrorTestUtils
-from pyspark.testing.sqlutils import (
-    have_pandas,
-    pandas_requirement_message,
-    pyarrow_requirement_message,
-    SQLTestUtils,
-)
-from pyspark.sql.session import SparkSession as PySparkSession
-
-
 grpc_requirement_message = None
 try:
     import grpc
@@ -55,6 +44,16 @@ try:
 except ImportError as e:
     googleapis_common_protos_requirement_message = str(e)
 have_googleapis_common_protos = googleapis_common_protos_requirement_message is None
+
+from pyspark import Row, SparkConf
+from pyspark.testing.utils import PySparkErrorTestUtils
+from pyspark.testing.sqlutils import (
+    have_pandas,
+    pandas_requirement_message,
+    pyarrow_requirement_message,
+    SQLTestUtils,
+)
+from pyspark.sql.session import SparkSession as PySparkSession
 
 
 connect_requirement_message = (

--- a/python/pyspark/testing/pandasutils.py
+++ b/python/pyspark/testing/pandasutils.py
@@ -23,14 +23,6 @@ from contextlib import contextmanager
 import decimal
 from typing import Any, Union
 
-import pyspark.pandas as ps
-from pyspark.pandas.frame import DataFrame
-from pyspark.pandas.indexes import Index
-from pyspark.pandas.series import Series
-from pyspark.pandas.utils import SPARK_CONF_ARROW_ENABLED
-from pyspark.testing.sqlutils import ReusedSQLTestCase
-from pyspark.errors import PySparkAssertionError
-
 tabulate_requirement_message = None
 try:
     from tabulate import tabulate
@@ -62,6 +54,15 @@ try:
     import pandas as pd
 except ImportError:
     pass
+
+import pyspark.pandas as ps
+from pyspark.pandas.frame import DataFrame
+from pyspark.pandas.indexes import Index
+from pyspark.pandas.series import Series
+from pyspark.pandas.utils import SPARK_CONF_ARROW_ENABLED
+from pyspark.testing.sqlutils import ReusedSQLTestCase
+from pyspark.errors import PySparkAssertionError
+
 
 __all__ = ["assertPandasOnSparkEqual"]
 

--- a/python/pyspark/testing/sqlutils.py
+++ b/python/pyspark/testing/sqlutils.py
@@ -22,11 +22,6 @@ import shutil
 import tempfile
 from contextlib import contextmanager
 
-from pyspark.sql import SparkSession
-from pyspark.sql.types import ArrayType, DoubleType, UserDefinedType, Row
-from pyspark.testing.utils import ReusedPySparkTestCase, PySparkErrorTestUtils
-
-
 pandas_requirement_message = None
 try:
     from pyspark.sql.pandas.utils import require_minimum_pandas_version
@@ -52,6 +47,11 @@ try:
     require_test_compiled()
 except Exception as e:
     test_not_compiled_message = str(e)
+
+from pyspark.sql import SparkSession
+from pyspark.sql.types import ArrayType, DoubleType, UserDefinedType, Row
+from pyspark.testing.utils import ReusedPySparkTestCase, PySparkErrorTestUtils
+
 
 have_pandas = pandas_requirement_message is None
 have_pyarrow = pyarrow_requirement_message is None

--- a/python/pyspark/testing/utils.py
+++ b/python/pyspark/testing/utils.py
@@ -34,13 +34,6 @@ from typing import (
 )
 from itertools import zip_longest
 
-from pyspark import SparkContext, SparkConf
-from pyspark.errors import PySparkAssertionError, PySparkException
-from pyspark.find_spark_home import _find_spark_home
-from pyspark.sql.dataframe import DataFrame
-from pyspark.sql import Row
-from pyspark.sql.types import StructType, AtomicType, StructField
-
 have_scipy = False
 have_numpy = False
 try:
@@ -57,6 +50,14 @@ try:
 except ImportError:
     # No NumPy, but that's okay, we'll skip those tests
     pass
+
+from pyspark import SparkContext, SparkConf
+from pyspark.errors import PySparkAssertionError, PySparkException
+from pyspark.find_spark_home import _find_spark_home
+from pyspark.sql.dataframe import DataFrame
+from pyspark.sql import Row
+from pyspark.sql.types import StructType, AtomicType, StructField
+
 
 __all__ = ["assertDataFrameEqual", "assertSchemaEqual"]
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to fix imports according to PEP8 in `pyspark.testing`, `pyspark.mllib`, `pyspark.resource` and `pyspark.streaming`, see https://peps.python.org/pep-0008/#imports.

### Why are the changes needed?

I have not been fixing them as they are too minor. However, this practice is being propagated across the whole PySpark packages, and I think we should fix them all so other users do not follow the non-standard practice.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing linters and tests should cover.

### Was this patch authored or co-authored using generative AI tooling?

No.
