### PR TITLE
[SPARK-45450][PYTHON] Fix imports according to PEP8: pyspark.pandas and pyspark (core)

### DIFF
--- a/python/pyspark/conf.py
+++ b/python/pyspark/conf.py
@@ -21,6 +21,7 @@ import sys
 from typing import Dict, List, Optional, Tuple, cast, overload
 
 from py4j.java_gateway import JVMView, JavaObject
+
 from pyspark.errors import PySparkRuntimeError
 
 

--- a/python/pyspark/errors_doc_gen.py
+++ b/python/pyspark/errors_doc_gen.py
@@ -1,4 +1,5 @@
 import re
+
 from pyspark.errors.error_classes import ERROR_CLASSES_MAP
 
 

--- a/python/pyspark/java_gateway.py
+++ b/python/pyspark/java_gateway.py
@@ -28,6 +28,7 @@ from subprocess import Popen, PIPE
 
 from py4j.java_gateway import java_import, JavaGateway, JavaObject, GatewayParameters
 from py4j.clientserver import ClientServer, JavaParameters, PythonParameters
+
 from pyspark.find_spark_home import _find_spark_home
 from pyspark.serializers import read_int, write_with_length, UTF8Deserializer
 from pyspark.errors import PySparkRuntimeError

--- a/python/pyspark/join.py
+++ b/python/pyspark/join.py
@@ -31,8 +31,9 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
-from pyspark.resultiterable import ResultIterable
 from functools import reduce
+
+from pyspark.resultiterable import ResultIterable
 
 
 def _do_python_join(rdd, other, numPartitions, dispatch):

--- a/python/pyspark/pandas/accessors.py
+++ b/python/pyspark/pandas/accessors.py
@@ -27,7 +27,6 @@ import pandas as pd
 from pyspark.sql import functions as F
 from pyspark.sql.functions import pandas_udf
 from pyspark.sql.types import DataType, LongType, StructField, StructType
-
 from pyspark.pandas._typing import DataFrameOrSeries, Name
 from pyspark.pandas.internal import (
     InternalField,

--- a/python/pyspark/pandas/base.py
+++ b/python/pyspark/pandas/base.py
@@ -27,9 +27,9 @@ from typing import Any, Callable, Optional, Sequence, Tuple, Union, cast, TYPE_C
 import numpy as np
 import pandas as pd
 from pandas.api.types import is_list_like, CategoricalDtype  # type: ignore[attr-defined]
+
 from pyspark.sql import functions as F, Column, Window
 from pyspark.sql.types import LongType, BooleanType, NumericType
-
 from pyspark import pandas as ps  # For running doctests and reference resolution in PyCharm.
 from pyspark.pandas._typing import Axis, Dtype, IndexOpsLike, Label, SeriesOrIndex
 from pyspark.pandas.config import get_option, option_context

--- a/python/pyspark/pandas/config.py
+++ b/python/pyspark/pandas/config.py
@@ -23,7 +23,6 @@ import json
 from typing import Any, Callable, Dict, Iterator, List, Tuple, Union
 
 from pyspark._globals import _NoValue, _NoValueType
-
 from pyspark.pandas.utils import default_session
 
 

--- a/python/pyspark/pandas/correlation.py
+++ b/python/pyspark/pandas/correlation.py
@@ -19,7 +19,6 @@ from typing import List
 
 from pyspark.sql import DataFrame as SparkDataFrame, functions as F
 from pyspark.sql.window import Window
-
 from pyspark.pandas.utils import verify_temp_column_name
 
 

--- a/python/pyspark/pandas/data_type_ops/date_ops.py
+++ b/python/pyspark/pandas/data_type_ops/date_ops.py
@@ -26,7 +26,6 @@ from pandas.api.types import CategoricalDtype
 from pyspark.sql import functions as F
 from pyspark.sql.types import BooleanType, DateType, StringType
 from pyspark.sql.utils import get_column_class
-
 from pyspark.pandas._typing import Dtype, IndexOpsLike, SeriesOrIndex
 from pyspark.pandas.base import column_op, IndexOpsMixin
 from pyspark.pandas.data_type_ops.base import (

--- a/python/pyspark/pandas/data_type_ops/datetime_ops.py
+++ b/python/pyspark/pandas/data_type_ops/datetime_ops.py
@@ -34,7 +34,6 @@ from pyspark.sql.types import (
     NumericType,
 )
 from pyspark.sql.utils import pyspark_column_op
-
 from pyspark.pandas._typing import Dtype, IndexOpsLike, SeriesOrIndex
 from pyspark.pandas.base import IndexOpsMixin
 from pyspark.pandas.data_type_ops.base import (

--- a/python/pyspark/pandas/data_type_ops/string_ops.py
+++ b/python/pyspark/pandas/data_type_ops/string_ops.py
@@ -23,7 +23,6 @@ from pandas.api.types import CategoricalDtype
 from pyspark.sql import functions as F
 from pyspark.sql.types import IntegralType, StringType
 from pyspark.sql.utils import pyspark_column_op
-
 from pyspark.pandas._typing import Dtype, IndexOpsLike, SeriesOrIndex
 from pyspark.pandas.base import column_op, IndexOpsMixin
 from pyspark.pandas.data_type_ops.base import (

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -59,14 +59,14 @@ from pandas.api.types import (  # type: ignore[attr-defined]
 )
 from pandas.tseries.frequencies import DateOffset, to_offset
 
-from pyspark.errors import PySparkValueError
-
 if TYPE_CHECKING:
     from pandas.io.formats.style import Styler
 
 from pandas.core.dtypes.common import infer_dtype_from_object
 from pandas.core.accessor import CachedAccessor
 from pandas.core.dtypes.inference import is_sequence
+
+from pyspark.errors import PySparkValueError
 from pyspark import StorageLevel
 from pyspark.sql import Column as PySparkColumn, DataFrame as PySparkDataFrame, functions as F
 from pyspark.sql.functions import pandas_udf
@@ -86,7 +86,6 @@ from pyspark.sql.types import (
     NullType,
 )
 from pyspark.sql.window import Window
-
 from pyspark import pandas as ps  # For running doctests and reference resolution in PyCharm.
 from pyspark.pandas._typing import (
     Axis,
@@ -150,8 +149,6 @@ from pyspark.pandas.typedef.typehints import (
     create_tuple_for_frame_type,
 )
 from pyspark.pandas.plot import PandasOnSparkPlotAccessor
-
-# For supporting Spark Connect
 from pyspark.sql.utils import get_column_class, get_dataframe_class
 
 if TYPE_CHECKING:

--- a/python/pyspark/pandas/generic.py
+++ b/python/pyspark/pandas/generic.py
@@ -48,7 +48,6 @@ from pyspark.sql.types import (
     LongType,
     NumericType,
 )
-
 from pyspark import pandas as ps  # For running doctests and reference resolution in PyCharm.
 from pyspark.pandas._typing import (
     Axis,

--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -44,7 +44,6 @@ import warnings
 
 import pandas as pd
 from pandas.api.types import is_number, is_hashable, is_list_like  # type: ignore[attr-defined]
-
 from pandas.core.common import _builtin_table  # type: ignore[attr-defined]
 
 from pyspark.sql import Column, DataFrame as SparkDataFrame, Window, functions as F
@@ -57,7 +56,6 @@ from pyspark.sql.types import (
     StructType,
     StringType,
 )
-
 from pyspark import pandas as ps  # For running doctests and reference resolution in PyCharm.
 from pyspark.pandas._typing import Axis, FrameLike, Label, Name
 from pyspark.pandas.typedef import infer_return_type, DataFrameType, ScalarType, SeriesType

--- a/python/pyspark/pandas/indexes/base.py
+++ b/python/pyspark/pandas/indexes/base.py
@@ -53,7 +53,6 @@ from pyspark.sql.types import (
     TimestampType,
     TimestampNTZType,
 )
-
 from pyspark import pandas as ps  # For running doctests and reference resolution in PyCharm.
 from pyspark.pandas._typing import Dtype, Label, Name, Scalar
 from pyspark.pandas.config import get_option, option_context

--- a/python/pyspark/pandas/indexes/multi.py
+++ b/python/pyspark/pandas/indexes/multi.py
@@ -24,8 +24,6 @@ from pandas.api.types import is_hashable, is_list_like  # type: ignore[attr-defi
 from pyspark.sql import functions as F, Column as PySparkColumn, Window
 from pyspark.sql.types import DataType
 from pyspark.sql.utils import get_column_class
-
-# For running doctests and reference resolution in PyCharm.
 from pyspark import pandas as ps
 from pyspark.pandas._typing import Label, Name, Scalar
 from pyspark.pandas.exceptions import PandasNotImplementedError

--- a/python/pyspark/pandas/indexing.py
+++ b/python/pyspark/pandas/indexing.py
@@ -25,11 +25,11 @@ from typing import Any, Optional, List, Tuple, TYPE_CHECKING, Union, cast, Sized
 
 import pandas as pd
 from pandas.api.types import is_list_like  # type: ignore[attr-defined]
+import numpy as np
+
 from pyspark.sql import functions as F, Column as PySparkColumn
 from pyspark.sql.types import BooleanType, LongType, DataType
 from pyspark.errors import AnalysisException
-import numpy as np
-
 from pyspark import pandas as ps  # noqa: F401
 from pyspark.pandas._typing import Label, Name, Scalar
 from pyspark.pandas.internal import (
@@ -50,8 +50,6 @@ from pyspark.pandas.utils import (
     spark_column_equals,
     verify_temp_column_name,
 )
-
-# For Supporting Spark Connect
 from pyspark.sql.utils import get_column_class
 
 if TYPE_CHECKING:

--- a/python/pyspark/pandas/internal.py
+++ b/python/pyspark/pandas/internal.py
@@ -24,6 +24,7 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple, Union, TYPE_CHECK
 import numpy as np
 import pandas as pd
 from pandas.api.types import CategoricalDtype  # noqa: F401
+
 from pyspark._globals import _NoValue, _NoValueType
 from pyspark.sql import (
     functions as F,
@@ -40,17 +41,9 @@ from pyspark.sql.types import (  # noqa: F401
     StringType,
 )
 from pyspark.sql.utils import is_timestamp_ntz_preferred
-
-# For supporting Spark Connect
 from pyspark.sql.utils import is_remote, get_column_class, get_dataframe_class
-
-# For running doctests and reference resolution in PyCharm.
 from pyspark import pandas as ps
 from pyspark.pandas._typing import Label
-
-if TYPE_CHECKING:
-    # This is required in old Python 3.5 to prevent circular reference.
-    from pyspark.pandas.series import Series
 from pyspark.pandas.spark.utils import as_nullable_spark_type, force_decimal_precision_scale
 from pyspark.pandas.data_type_ops.base import DataTypeOps
 from pyspark.pandas.typedef import (
@@ -70,7 +63,6 @@ from pyspark.pandas.utils import (
     scol_for,
     spark_column_equals,
 )
-
 
 # A function to turn given numbers to Spark columns that represent pandas-on-Spark index.
 SPARK_INDEX_NAME_FORMAT = "__index_level_{}__".format

--- a/python/pyspark/pandas/internal.py
+++ b/python/pyspark/pandas/internal.py
@@ -64,6 +64,9 @@ from pyspark.pandas.utils import (
     spark_column_equals,
 )
 
+if TYPE_CHECKING:
+    from pyspark.pandas.series import Series
+
 # A function to turn given numbers to Spark columns that represent pandas-on-Spark index.
 SPARK_INDEX_NAME_FORMAT = "__index_level_{}__".format
 SPARK_DEFAULT_INDEX_NAME = SPARK_INDEX_NAME_FORMAT(0)

--- a/python/pyspark/pandas/mlflow.py
+++ b/python/pyspark/pandas/mlflow.py
@@ -19,12 +19,12 @@
 MLflow-related functions to load models and apply them to pandas-on-Spark dataframes.
 """
 from typing import List, Union
-
-from pyspark.sql.types import DataType
-import pandas as pd
-import numpy as np
 from typing import Any
 
+import pandas as pd
+import numpy as np
+
+from pyspark.sql.types import DataType
 from pyspark.pandas._typing import Label, Dtype
 from pyspark.pandas.utils import lazy_property, default_session
 from pyspark.pandas.frame import DataFrame

--- a/python/pyspark/pandas/namespace.py
+++ b/python/pyspark/pandas/namespace.py
@@ -48,6 +48,7 @@ from pandas.api.types import (  # type: ignore[attr-defined]
 from pandas.tseries.offsets import DateOffset
 import pyarrow as pa
 import pyarrow.parquet as pq
+
 from pyspark.sql import functions as F, Column as PySparkColumn
 from pyspark.sql.functions import pandas_udf
 from pyspark.sql.types import (
@@ -67,7 +68,6 @@ from pyspark.sql.types import (
     DataType,
 )
 from pyspark.sql.dataframe import DataFrame as PySparkDataFrame
-
 from pyspark import pandas as ps
 from pyspark.pandas._typing import Axis, Dtype, Label, Name
 from pyspark.pandas.base import IndexOpsMixin

--- a/python/pyspark/pandas/numpy_compat.py
+++ b/python/pyspark/pandas/numpy_compat.py
@@ -17,10 +17,10 @@
 from typing import Any, Callable, no_type_check
 
 import numpy as np
+
 from pyspark.sql import functions as F
 from pyspark.sql.pandas.functions import pandas_udf
 from pyspark.sql.types import DoubleType, LongType, BooleanType
-
 from pyspark.pandas.base import IndexOpsMixin
 
 

--- a/python/pyspark/pandas/plot/core.py
+++ b/python/pyspark/pandas/plot/core.py
@@ -19,12 +19,12 @@ import importlib
 
 import pandas as pd
 import numpy as np
-from pyspark.ml.feature import Bucketizer
-from pyspark.mllib.stat import KernelDensity
-from pyspark.sql import functions as F
 from pandas.core.base import PandasObject
 from pandas.core.dtypes.inference import is_integer
 
+from pyspark.ml.feature import Bucketizer
+from pyspark.mllib.stat import KernelDensity
+from pyspark.sql import functions as F
 from pyspark.pandas.missing import unsupported_function
 from pyspark.pandas.config import get_option
 from pyspark.pandas.utils import name_like_string

--- a/python/pyspark/pandas/plot/matplotlib.py
+++ b/python/pyspark/pandas/plot/matplotlib.py
@@ -22,7 +22,6 @@ import numpy as np
 from matplotlib.axes._base import _process_plot_format  # type: ignore[attr-defined]
 from pandas.core.dtypes.inference import is_list_like
 from pandas.io.formats.printing import pprint_thing
-
 from pandas.plotting._matplotlib import (  # type: ignore[attr-defined]
     BarPlot as PandasBarPlot,
     BoxPlot as PandasBoxPlot,

--- a/python/pyspark/pandas/resample.py
+++ b/python/pyspark/pandas/resample.py
@@ -29,7 +29,6 @@ from typing import (
 )
 
 import numpy as np
-
 import pandas as pd
 from pandas.tseries.frequencies import to_offset
 
@@ -40,7 +39,6 @@ from pyspark.sql.types import (
     TimestampNTZType,
     DataType,
 )
-
 from pyspark import pandas as ps  # For running doctests and reference resolution in PyCharm.
 from pyspark.pandas._typing import FrameLike
 from pyspark.pandas.frame import DataFrame

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -53,6 +53,7 @@ from pandas.api.types import (  # type: ignore[attr-defined]
     CategoricalDtype,
 )
 from pandas.tseries.frequencies import DateOffset
+
 from pyspark.sql import functions as F, Column as PySparkColumn, DataFrame as SparkDataFrame
 from pyspark.sql.types import (
     ArrayType,
@@ -71,7 +72,6 @@ from pyspark.sql.types import (
 )
 from pyspark.sql.window import Window
 from pyspark.sql.utils import get_column_class, get_window_class
-
 from pyspark import pandas as ps  # For running doctests and reference resolution in PyCharm.
 from pyspark.pandas._typing import Axis, Dtype, Label, Name, Scalar, T
 from pyspark.pandas.accessors import PandasOnSparkSeriesMethods

--- a/python/pyspark/pandas/spark/accessors.py
+++ b/python/pyspark/pandas/spark/accessors.py
@@ -25,11 +25,8 @@ from typing import TYPE_CHECKING, Callable, Generic, List, Optional, Union
 from pyspark import StorageLevel
 from pyspark.sql import Column as PySparkColumn, DataFrame as PySparkDataFrame
 from pyspark.sql.types import DataType, StructType
-
 from pyspark.pandas._typing import IndexOpsLike
 from pyspark.pandas.internal import InternalField
-
-# For Supporting Spark Connect
 from pyspark.sql.utils import get_column_class, get_dataframe_class
 
 if TYPE_CHECKING:

--- a/python/pyspark/pandas/spark/functions.py
+++ b/python/pyspark/pandas/spark/functions.py
@@ -19,8 +19,6 @@ Additional Spark functions used in pandas-on-Spark.
 """
 from pyspark import SparkContext
 from pyspark.sql.column import Column
-
-# For supporting Spark Connect
 from pyspark.sql.utils import is_remote
 
 

--- a/python/pyspark/pandas/sql_processor.py
+++ b/python/pyspark/pandas/sql_processor.py
@@ -18,10 +18,10 @@
 import _string  # type: ignore[import]
 from typing import Any, Dict, Optional, Union, List
 import inspect
+
 import pandas as pd
 
 from pyspark.sql import SparkSession, DataFrame as SDataFrame
-
 from pyspark import pandas as ps  # For running doctests and reference resolution in PyCharm.
 from pyspark.pandas.utils import default_session
 from pyspark.pandas.frame import DataFrame

--- a/python/pyspark/pandas/strings.py
+++ b/python/pyspark/pandas/strings.py
@@ -30,12 +30,11 @@ from typing import (
 )
 
 import numpy as np
-
 import pandas as pd
+
 from pyspark.sql.types import StringType, BinaryType, ArrayType, LongType, MapType
 from pyspark.sql import functions as F
 from pyspark.sql.functions import pandas_udf
-
 import pyspark.pandas as ps
 
 

--- a/python/pyspark/pandas/supported_api_gen.py
+++ b/python/pyspark/pandas/supported_api_gen.py
@@ -19,7 +19,6 @@
 Generate 'Supported pandas APIs' documentation file
 """
 import warnings
-from pyspark.loose_version import LooseVersion
 from enum import Enum, unique
 from inspect import getmembers, isclass, isfunction, signature
 from typing import Any, Callable, Dict, List, NamedTuple, Set, TextIO, Tuple
@@ -27,11 +26,12 @@ from typing import Any, Callable, Dict, List, NamedTuple, Set, TextIO, Tuple
 import pyspark.pandas as ps
 import pyspark.pandas.groupby as psg
 import pyspark.pandas.window as psw
-from pyspark.pandas.exceptions import PandasNotImplementedError
-
 import pandas as pd
 import pandas.core.groupby as pdg
 import pandas.core.window as pdw
+
+from pyspark.loose_version import LooseVersion
+from pyspark.pandas.exceptions import PandasNotImplementedError
 
 MAX_MISSING_PARAMS_SIZE = 5
 COMMON_PARAMETER_SET = {

--- a/python/pyspark/pandas/tests/computation/test_corrwith.py
+++ b/python/pyspark/pandas/tests/computation/test_corrwith.py
@@ -16,7 +16,6 @@
 #
 import unittest
 
-
 import numpy as np
 import pandas as pd
 

--- a/python/pyspark/pandas/tests/computation/test_cov.py
+++ b/python/pyspark/pandas/tests/computation/test_cov.py
@@ -17,7 +17,6 @@
 import unittest
 import decimal
 
-
 import numpy as np
 import pandas as pd
 

--- a/python/pyspark/pandas/tests/connect/data_type_ops/testing_utils.py
+++ b/python/pyspark/pandas/tests/connect/data_type_ops/testing_utils.py
@@ -22,7 +22,6 @@ import numpy as np
 import pandas as pd
 
 import pyspark.pandas as ps
-
 from pyspark.pandas.typedef.typehints import (
     extension_dtypes_available,
     extension_float_dtypes_available,

--- a/python/pyspark/pandas/tests/connect/test_parity_extension.py
+++ b/python/pyspark/pandas/tests/connect/test_parity_extension.py
@@ -18,6 +18,7 @@ import unittest
 
 import pandas as pd
 import numpy as np
+
 from pyspark import pandas as ps
 from pyspark.pandas.tests.test_extension import ExtensionTestsMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase

--- a/python/pyspark/pandas/tests/connect/test_parity_indexing.py
+++ b/python/pyspark/pandas/tests/connect/test_parity_indexing.py
@@ -17,6 +17,7 @@
 import unittest
 
 import pandas as pd
+
 from pyspark import pandas as ps
 from pyspark.pandas.tests.test_indexing import BasicIndexingTestsMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase

--- a/python/pyspark/pandas/tests/connect/test_parity_numpy_compat.py
+++ b/python/pyspark/pandas/tests/connect/test_parity_numpy_compat.py
@@ -17,6 +17,7 @@
 import unittest
 
 import pandas as pd
+
 from pyspark import pandas as ps
 from pyspark.pandas.tests.test_numpy_compat import NumPyCompatTestsMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase

--- a/python/pyspark/pandas/tests/data_type_ops/testing_utils.py
+++ b/python/pyspark/pandas/tests/data_type_ops/testing_utils.py
@@ -23,13 +23,11 @@ import pandas as pd
 
 import pyspark.pandas as ps
 from pyspark.pandas.typedef import extension_dtypes
-
 from pyspark.pandas.typedef.typehints import (
     extension_dtypes_available,
     extension_float_dtypes_available,
     extension_object_dtypes_available,
 )
-
 from pyspark.testing.pandasutils import ComparisonTestBase
 
 if extension_dtypes_available:

--- a/python/pyspark/pandas/tests/frame/test_reshaping.py
+++ b/python/pyspark/pandas/tests/frame/test_reshaping.py
@@ -22,7 +22,6 @@ import pandas as pd
 
 from pyspark import pandas as ps
 from pyspark.pandas.config import option_context
-
 from pyspark.testing.pandasutils import ComparisonTestBase
 from pyspark.testing.sqlutils import SQLTestUtils
 

--- a/python/pyspark/pandas/tests/frame/test_spark.py
+++ b/python/pyspark/pandas/tests/frame/test_spark.py
@@ -21,10 +21,10 @@ from io import StringIO
 
 import numpy as np
 import pandas as pd
+
 from pyspark import StorageLevel
 from pyspark.ml.linalg import SparseVector
 from pyspark.sql.types import StructType
-
 from pyspark import pandas as ps
 from pyspark.pandas.frame import CachedDataFrame
 from pyspark.pandas.exceptions import PandasNotImplementedError

--- a/python/pyspark/pandas/tests/series/test_series.py
+++ b/python/pyspark/pandas/tests/series/test_series.py
@@ -18,7 +18,6 @@
 import unittest
 from collections import defaultdict
 import inspect
-
 from datetime import datetime, timedelta
 
 import numpy as np

--- a/python/pyspark/pandas/tests/series/test_stat.py
+++ b/python/pyspark/pandas/tests/series/test_stat.py
@@ -15,10 +15,10 @@
 # limitations under the License.
 #
 import unittest
+from decimal import Decimal
 
 import numpy as np
 import pandas as pd
-from decimal import Decimal
 
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import ComparisonTestBase

--- a/python/pyspark/pandas/tests/test_indexops_spark.py
+++ b/python/pyspark/pandas/tests/test_indexops_spark.py
@@ -16,9 +16,9 @@
 #
 
 import pandas as pd
+
 from pyspark.errors import AnalysisException
 from pyspark.sql import functions as F
-
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils

--- a/python/pyspark/pandas/tests/test_stats.py
+++ b/python/pyspark/pandas/tests/test_stats.py
@@ -16,6 +16,7 @@
 #
 
 import unittest
+
 import numpy as np
 import pandas as pd
 

--- a/python/pyspark/pandas/utils.py
+++ b/python/pyspark/pandas/utils.py
@@ -37,14 +37,13 @@ from typing import (
 )
 import warnings
 
+import pandas as pd
+from pandas.api.types import is_list_like  # type: ignore[attr-defined]
+
 from pyspark.sql import functions as F, Column, DataFrame as PySparkDataFrame, SparkSession
 from pyspark.sql.types import DoubleType
 from pyspark.sql.utils import is_remote, get_dataframe_class
 from pyspark.errors import PySparkTypeError
-import pandas as pd
-from pandas.api.types import is_list_like  # type: ignore[attr-defined]
-
-# For running doctests and reference resolution in PyCharm.
 from pyspark import pandas as ps  # noqa: F401
 from pyspark.pandas._typing import (
     Axis,

--- a/python/pyspark/pandas/window.py
+++ b/python/pyspark/pandas/window.py
@@ -30,8 +30,6 @@ from pyspark.pandas.missing.window import (
     MissingPandasLikeExponentialMoving,
     MissingPandasLikeExponentialMovingGroupby,
 )
-
-# For running doctests and reference resolution in PyCharm.
 from pyspark import pandas as ps  # noqa: F401
 from pyspark.pandas._typing import FrameLike
 from pyspark.pandas.groupby import GroupBy, DataFrameGroupBy

--- a/python/pyspark/profiler.py
+++ b/python/pyspark/profiler.py
@@ -27,7 +27,6 @@ from typing import (
     Union,
     cast,
 )
-
 import cProfile
 import inspect
 import pstats

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -94,6 +94,9 @@ if TYPE_CHECKING:
     import socket
     import io
 
+    from py4j.java_gateway import JavaObject
+    from py4j.java_collections import JavaArray
+
     from pyspark._typing import NonUDFType
     from pyspark._typing import S, NumberOrArray
     from pyspark.context import SparkContext
@@ -118,9 +121,6 @@ if TYPE_CHECKING:
         SQLBatchedUDFType,
         SQLTableUDFType,
     )
-
-    from py4j.java_gateway import JavaObject
-    from py4j.java_collections import JavaArray
 
 T = TypeVar("T")
 T_co = TypeVar("T_co", covariant=True)

--- a/python/pyspark/shuffle.py
+++ b/python/pyspark/shuffle.py
@@ -24,8 +24,8 @@ import itertools
 import operator
 import random
 import sys
-
 import heapq
+
 from pyspark.serializers import (
     BatchedSerializer,
     CPickleSerializer,

--- a/python/pyspark/tests/test_statcounter.py
+++ b/python/pyspark/tests/test_statcounter.py
@@ -14,9 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import math
+
 from pyspark.statcounter import StatCounter
 from pyspark.testing.utils import ReusedPySparkTestCase
-import math
 
 
 class StatCounterTests(ReusedPySparkTestCase):

--- a/python/pyspark/util.py
+++ b/python/pyspark/util.py
@@ -28,9 +28,9 @@ import typing
 from types import TracebackType
 from typing import Any, Callable, IO, Iterator, List, Optional, TextIO, Tuple, Union
 
-from pyspark.errors import PySparkRuntimeError
-
 from py4j.clientserver import ClientServer
+
+from pyspark.errors import PySparkRuntimeError
 
 __all__: List[str] = []
 

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -24,7 +24,6 @@ import time
 from inspect import getfullargspec
 import json
 from typing import Any, Callable, Iterable, Iterator
-
 import faulthandler
 
 from pyspark.accumulators import _accumulatorRegistry


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to fix imports according to PEP8 in `pyspark.pandas` and `pyspark.*` (core), see https://peps.python.org/pep-0008/#imports.

### Why are the changes needed?

I have not been fixing them as they are too minor. However, this practice is being propagated across the whole PySpark packages, and I think we should fix them all so other users do not follow the non-standard practice.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing linters and tests should cover.

### Was this patch authored or co-authored using generative AI tooling?

No.
