### PR TITLE
[SPARK-45449][SQL] Cache Invalidation Issue with JDBC Table

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
@@ -46,14 +46,6 @@ class JDBCOptions(
       JDBCOptions.JDBC_TABLE_NAME -> table)))
   }
 
-  override def hashCode: Int = this.parameters.hashCode()
-
-  override def equals(other: Any): Boolean = other match {
-    case otherOption: JDBCOptions =>
-      otherOption.parameters.equals(this.parameters)
-    case _ => false
-  }
-
   /**
    * Returns a property with all options.
    */
@@ -247,6 +239,14 @@ class JDBCOptions(
       .get(JDBC_PREFER_TIMESTAMP_NTZ)
       .map(_.toBoolean)
       .getOrElse(SQLConf.get.timestampType == TimestampNTZType)
+
+  override def hashCode: Int = this.parameters.hashCode()
+
+  override def equals(other: Any): Boolean = other match {
+    case otherOption: JDBCOptions =>
+      otherOption.parameters.equals(this.parameters)
+    case _ => false
+  }
 }
 
 class JdbcOptionsInWrite(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
@@ -46,6 +46,15 @@ class JDBCOptions(
       JDBCOptions.JDBC_TABLE_NAME -> table)))
   }
 
+  override def hashCode: Int = this.parameters.hashCode()
+
+  /** Returns true if the members of this AttributeSet and other are the same. */
+  override def equals(other: Any): Boolean = other match {
+    case otherOption: JDBCOptions =>
+      otherOption.parameters.equals(this.parameters)
+    case _ => false
+  }
+
   /**
    * Returns a property with all options.
    */

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
@@ -48,7 +48,6 @@ class JDBCOptions(
 
   override def hashCode: Int = this.parameters.hashCode()
 
-  /** Returns true if the members of this AttributeSet and other are the same. */
   override def equals(other: Any): Boolean = other match {
     case otherOption: JDBCOptions =>
       otherOption.parameters.equals(this.parameters)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalogSuite.scala
@@ -525,7 +525,6 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
       sql("CACHE TABLE t1 SELECT id, name FROM h2.test.cache_t")
       val plan = sql("select * from t1").queryExecution.sparkPlan
       assert(plan.isInstanceOf[InMemoryTableScanExec])
-      sql("UNCACHE TABLE IF EXISTS t1")
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalogSuite.scala
@@ -521,7 +521,6 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
           |name TEXT(32) NOT NULL)""".stripMargin).executeUpdate()
     }
     val ss = spark.cloneSession()
-    // the upper bound exceeds the maximum value of long
     ss.sql("insert overwrite h2.test.cache_t select 1 as id, 'a' as name")
 
     sql("cache table ct1 select id, name from h2.test.cache_t")


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add an equals method to `JDBCOptions` that considers two instances equal if their `JDBCOptions.parameters` are the same.

### Why are the changes needed?
We have identified a cache invalidation issue when caching JDBC tables in Spark SQL. The cached table is unexpectedly invalidated when queried, leading to a re-read from the JDBC table instead of retrieving data from the cache.
Example SQL:

```
CACHE TABLE cache_t SELECT * FROM mysql.test.test1;
SELECT * FROM cache_t;
```
Expected Behavior:
The expectation is that querying the cached table (cache_t) should retrieve the result from the cache without re-evaluating the execution plan.

Actual Behavior:
However, the cache is invalidated, and the content is re-read from the JDBC table.

Root Cause:
The issue lies in the `CacheData` class, where the comparison involves `JDBCTable`. The `JDBCTable` is a case class:

`case class JDBCTable(ident: Identifier, schema: StructType, jdbcOptions: JDBCOptions)`
The comparison of non-case class components, such as `jdbcOptions`, involves pointer comparison. This leads to unnecessary cache invalidation.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Add uts


### Was this patch authored or co-authored using generative AI tooling?
No
