### PR TITLE
[SPARK-45457][DOCS] Surface sc.setLocalProperty() value=NULL param meaning

### DIFF
--- a/R/pkg/R/sparkR.R
+++ b/R/pkg/R/sparkR.R
@@ -662,6 +662,7 @@ setJobDescription <- function(value) {
 
 #' Set a local property that affects jobs submitted from this thread, such as the
 #' Spark fair scheduler pool.
+#' To remove/unset property simply set `value` to NULL e.g. setLocalProperty("key", NULL)
 #'
 #' @param key The key for a local property.
 #' @param value The value for a local property.

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -794,6 +794,8 @@ class SparkContext(config: SparkConf) extends Logging {
    * may have unexpected consequences when working with thread pools. The standard java
    * implementation of thread pools have worker threads spawn other worker threads.
    * As a result, local properties may propagate unpredictably.
+   *
+   * To remove/unset property simply set `value` to null e.g. sc.setLocalProperty("key", null)
    */
   def setLocalProperty(key: String, value: String): Unit = {
     if (value == null) {

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -2349,7 +2349,7 @@ class SparkContext:
         key : str
             The key of the local property to set.
         value : str
-            The value of the local property to set. If set to `null` then the
+            The value of the local property to set. If set to `None` then the
             property will be removed
 
         See Also

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -2340,7 +2340,7 @@ class SparkContext:
         Set a local property that affects jobs submitted from this thread, such as the
         Spark fair scheduler pool.
 
-        To remove/unset property simply set `value` to null e.g. sc.setLocalProperty("key", null)
+        To remove/unset property simply set `value` to None e.g. sc.setLocalProperty("key", None)
 
         .. versionadded:: 1.0.0
 

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -2340,6 +2340,8 @@ class SparkContext:
         Set a local property that affects jobs submitted from this thread, such as the
         Spark fair scheduler pool.
 
+        To remove/unset property simply set `value` to null e.g. sc.setLocalProperty("key", null)
+
         .. versionadded:: 1.0.0
 
         Parameters
@@ -2347,7 +2349,8 @@ class SparkContext:
         key : str
             The key of the local property to set.
         value : str
-            The value of the local property to set.
+            The value of the local property to set. If set to `null` then the
+            property will be removed
 
         See Also
         --------


### PR DESCRIPTION
### What changes were proposed in this pull request?

sc.setLocalProperty() has special meaning/feature for `null` value as a parameter and when supplied then removes the property associated with the key parameter. It's only mentioned in the [Fair Scheduler section of the documentation](https://spark.apache.org/docs/latest/job-scheduling.html#fair-scheduler-pools) although it is not limited to scheduler pool config and has got more general use cases.

So, it would be nice to document that on the APIs as well for users' benefit.

### Why are the changes needed?

API documentation


### Does this PR introduce _any_ user-facing change?
Yes

### How was this patch tested?
Local lint


### Was this patch authored or co-authored using generative AI tooling?
No
