### PR TITLE
[SPARK-45459][SQL][TESTS][DOCS] Remove the last 2 extra spaces in the automatically generated `sql-error-conditions.md` file

### DIFF
--- a/common/utils/src/main/resources/error/error-classes.json
+++ b/common/utils/src/main/resources/error/error-classes.json
@@ -92,6 +92,11 @@
     ],
     "sqlState" : "22003"
   },
+  "BIT_POSITION_OUT_OF_RANGE" : {
+    "message" : [
+      "The bit position <pos> must in [0, <upper>)."
+    ]
+  },
   "CALL_ON_STREAMING_DATASET_UNSUPPORTED" : {
     "message" : [
       "The method <methodName> can not be called on streaming Dataset/DataFrame."
@@ -1026,11 +1031,6 @@
       "GROUP BY <index> refers to an expression <aggExpr> that contains an aggregate function. Aggregate functions are not allowed in GROUP BY."
     ],
     "sqlState" : "42903"
-  },
-  "BIT_POSITION_OUT_OF_RANGE" : {
-    "message" : [
-      "The bit position <pos> must in [0, <upper>)."
-    ]
   },
   "GROUP_BY_POS_OUT_OF_RANGE" : {
     "message" : [

--- a/common/utils/src/main/resources/error/error-classes.json
+++ b/common/utils/src/main/resources/error/error-classes.json
@@ -1027,6 +1027,11 @@
     ],
     "sqlState" : "42903"
   },
+  "BIT_POSITION_OUT_OF_RANGE" : {
+    "message" : [
+      "The bit position <pos> must in [0, <upper>)."
+    ]
+  },
   "GROUP_BY_POS_OUT_OF_RANGE" : {
     "message" : [
       "GROUP BY position <index> is not in select list (valid range is [1, <size>])."

--- a/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
@@ -267,8 +267,7 @@ class SparkThrowableSuite extends SparkFunSuite {
          |
          |Also see [SQLSTATE Codes](sql-error-conditions-sqlstates.html).
          |
-         |$sqlErrorParentDocContent
-         |""".stripMargin
+         |$sqlErrorParentDocContent""".stripMargin
 
     errors.filter(_._2.subClass.isDefined).foreach(error => {
       val name = error._1
@@ -330,7 +329,7 @@ class SparkThrowableSuite extends SparkFunSuite {
         }
         FileUtils.writeStringToFile(
           parentDocPath.toFile,
-          sqlErrorParentDoc + lineSeparator,
+          sqlErrorParentDoc,
           StandardCharsets.UTF_8)
       }
     } else {

--- a/docs/sql-error-conditions.md
+++ b/docs/sql-error-conditions.md
@@ -111,6 +111,12 @@ Unable to find batch `<batchMetadataFile>`.
 
 `<value1>` `<symbol>` `<value2>` caused overflow.
 
+### BIT_POSITION_OUT_OF_RANGE
+
+SQLSTATE: none assigned
+
+The bit position `<pos>` must in [0, `<upper>`).
+
 ### CALL_ON_STREAMING_DATASET_UNSUPPORTED
 
 SQLSTATE: none assigned

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/bitwiseExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/bitwiseExpressions.scala
@@ -19,8 +19,8 @@ package org.apache.spark.sql.catalyst.expressions
 
 import org.apache.spark.sql.catalyst.analysis.FunctionRegistry
 import org.apache.spark.sql.catalyst.expressions.codegen._
+import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.types._
-
 
 /**
  * A function that calculates bitwise and(&) of two numbers.
@@ -247,10 +247,8 @@ case class BitwiseCount(child: Expression)
 
 object BitwiseGetUtil {
   def checkPosition(pos: Int, size: Int): Unit = {
-    if (pos < 0) {
-      throw new IllegalArgumentException(s"Invalid bit position: $pos is less than zero")
-    } else if (size <= pos) {
-      throw new IllegalArgumentException(s"Invalid bit position: $pos exceeds the bit upper limit")
+    if (pos < 0 || pos >= size) {
+      throw QueryExecutionErrors.bitPositionRangeError(pos, size)
     }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -2775,4 +2775,12 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
       }
     }
   }
+
+  def bitPositionRangeError(pos: Int, size: Int): Throwable = {
+    new SparkIllegalArgumentException(
+      errorClass = "BIT_POSITION_OUT_OF_RANGE",
+      messageParameters = Map(
+        "pos" -> pos.toString,
+        "upper" -> size.toString))
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
@@ -24,7 +24,7 @@ import java.sql.{Date, Timestamp}
 
 import scala.util.Random
 
-import org.apache.spark.{SPARK_DOC_ROOT, SparkException, SparkRuntimeException}
+import org.apache.spark.{SPARK_DOC_ROOT, SparkException, SparkIllegalArgumentException, SparkRuntimeException}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.{FunctionRegistry, UnresolvedAttribute}
 import org.apache.spark.sql.catalyst.expressions.{Alias, ArraysZip, AttributeReference, Expression, NamedExpression, UnaryExpression}
@@ -279,6 +279,22 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       testData2.select(bit_get($"a", lit(0)), bit_get($"a", lit(1)), bit_get($"a", lit(2))),
       testData2.selectExpr("bit_get(a, 0)", "bit_get(a, 1)", "bit_get(a, 2)"))
+
+    checkError(
+      exception = intercept[SparkIllegalArgumentException] {
+        sql("select bit_get(11, -1)").collect()
+      },
+      errorClass = "BIT_POSITION_OUT_OF_RANGE",
+      parameters = Map("pos" -> "-1", "upper" -> "32")
+    )
+
+    checkError(
+      exception = intercept[SparkIllegalArgumentException] {
+        sql("select bit_get(11, 32)").collect()
+      },
+      errorClass = "BIT_POSITION_OUT_OF_RANGE",
+      parameters = Map("pos" -> "32", "upper" -> "32")
+    )
   }
 
   test("getbit") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to remove the last 2 extra spaces in the automatically generated `sql-error-conditions.md` file.

### Why are the changes needed?
When I am work on another PR, I use the following command:
```
SPARK_GENERATE_GOLDEN_FILES=1 build/sbt \
        "core/testOnly *SparkThrowableSuite -- -t \"Error classes match with document\""
```
I found that in the automatically generated `sql-error-conditions.md` file, there are 2 extra spaces added at the end,
Obviously, this is not what we expected, otherwise we would need to manually remove it, which is not in line with automation.
The git clearly tells us this difference, as follows:



### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
- Pass GA.
- Manually test.

### Was this patch authored or co-authored using generative AI tooling?
No.