### PR TITLE
[SPARK-45460][SQL] Replace `scala.collection.convert.ImplicitConversions` to `scala.jdk.CollectionConverters`

### DIFF
--- a/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/common/DataTypeProtoConverter.scala
+++ b/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/common/DataTypeProtoConverter.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.connect.common
 
-import scala.collection.convert.ImplicitConversions._
+import scala.jdk.CollectionConverters._
 
 import org.apache.spark.connect.proto
 import org.apache.spark.sql.types._
@@ -98,7 +98,7 @@ object DataTypeProtoConverter {
   }
 
   private def toCatalystStructType(t: proto.DataType.Struct): StructType = {
-    val fields = t.getFieldsList.toSeq.map { protoField =>
+    val fields = t.getFieldsList.asScala.toSeq.map { protoField =>
       val metadata = if (protoField.hasMetadata) {
         Metadata.fromJson(protoField.getMetadata)
       } else {
@@ -253,7 +253,7 @@ object DataTypeProtoConverter {
           .setStruct(
             proto.DataType.Struct
               .newBuilder()
-              .addAllFields(protoFields)
+              .addAllFields(protoFields.asJava)
               .build())
           .build()
 

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectServer.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectServer.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.connect.service
 
 import java.net.InetSocketAddress
 
-import scala.collection.convert.ImplicitConversions._
+import scala.jdk.CollectionConverters._
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
@@ -35,7 +35,7 @@ object SparkConnectServer extends Logging {
     try {
       try {
         SparkConnectService.start(session.sparkContext)
-        SparkConnectService.server.getListenSockets.foreach { sa =>
+        SparkConnectService.server.getListenSockets.asScala.foreach { sa =>
           val isa = sa.asInstanceOf[InetSocketAddress]
           logInfo(
             s"Spark Connect server started at: " +

--- a/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
@@ -22,7 +22,7 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.util.Locale
 
-import scala.collection.convert.ImplicitConversions._
+import scala.jdk.CollectionConverters._
 import scala.util.Properties.lineSeparator
 import scala.util.matching.Regex
 
@@ -229,7 +229,7 @@ class SparkThrowableSuite extends SparkFunSuite {
       }).toSet
 
       val docsDir = getWorkspaceFilePath("docs")
-      val orphans = FileUtils.listFiles(docsDir.toFile, Array("md"), false).filter { f =>
+      val orphans = FileUtils.listFiles(docsDir.toFile, Array("md"), false).asScala.filter { f =>
         (f.getName.startsWith("sql-error-conditions-") && f.getName.endsWith("-error-class.md")) &&
           !subErrorFileNames.contains(f.getName)
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to replace `scala.collection.convert.ImplicitConversions` to `scala.jdk.CollectionConverters`.

### Why are the changes needed?
Since scala 2.13.0,  `scala.collection.convert.ImplicitConversions` mark as deprecated. So this PR change all `scala.collection.convert.ImplicitConversions` to `scala.jdk.CollectionConverters`.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA.

### Was this patch authored or co-authored using generative AI tooling?
No.