### PR TITLE
[MINOR][DOCS] Update `CTAS` with `LOCATION` behavior with Spark 3.2+

### DIFF
--- a/docs/sql-ref-syntax-ddl-create-table-datasource.md
+++ b/docs/sql-ref-syntax-ddl-create-table-datasource.md
@@ -104,9 +104,9 @@ In general CREATE TABLE is creating a "pointer", and you need to make sure it po
 existing. An exception is file source such as parquet, json. If you don't specify the LOCATION,
 Spark will create a default table location for you.
 
-For CREATE TABLE AS SELECT with LOCATION, Spark throws analysis exceptions if the given location exists.
-If `spark.sql.legacy.allowNonEmptyLocationInCTAS` is set to true, Spark overwrites the underlying
-data source with the data of the
+For CREATE TABLE AS SELECT with LOCATION, Spark throws analysis exceptions if the given location
+exists as a non-empty directory. If `spark.sql.legacy.allowNonEmptyLocationInCTAS` is set to true,
+Spark overwrites the underlying data source with the data of the
 input query, to make sure the table gets created contains exactly the same data as the input query.
 
 ### Examples

--- a/docs/sql-ref-syntax-ddl-create-table-datasource.md
+++ b/docs/sql-ref-syntax-ddl-create-table-datasource.md
@@ -104,7 +104,9 @@ In general CREATE TABLE is creating a "pointer", and you need to make sure it po
 existing. An exception is file source such as parquet, json. If you don't specify the LOCATION,
 Spark will create a default table location for you.
 
-For CREATE TABLE AS SELECT, Spark will overwrite the underlying data source with the data of the
+For CREATE TABLE AS SELECT with LOCATION, Spark throws analysis exceptions if the given location exists.
+If `spark.sql.legacy.allowNonEmptyLocationInCTAS` is set to true, Spark overwrites the underlying
+data source with the data of the
 input query, to make sure the table gets created contains exactly the same data as the input query.
 
 ### Examples


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update `CTAS` with `LOCATION` behavior according to Spark 3.2+.

### Why are the changes needed?

SPARK-28551 changed the behavior at Apache Spark 3.2.0.

https://github.com/apache/spark/blob/24b82dfd6cfb9a658af615446be5423695830dd9/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala#L2306-L2313

### Does this PR introduce _any_ user-facing change?

No. This is a documentation fix.

### How was this patch tested?

N/A

### Was this patch authored or co-authored using generative AI tooling?

No.