### PR TITLE
[SPARK-45462][CORE][WEBUI] Show `Duration` in `ApplicationPage`

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/master/ui/ApplicationPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/ui/ApplicationPage.scala
@@ -90,6 +90,7 @@ private[ui] class ApplicationPage(parent: MasterWebUI) extends WebUIPage("app") 
               {formatResourceRequirements(app.desc.resourceReqsPerExecutor)}
             </li>
             <li><strong>Submit Date:</strong> {UIUtils.formatDate(app.submitDate)}</li>
+            <li><strong>Duration:</strong> {UIUtils.formatDuration(app.duration)}</li>
             <li><strong>State:</strong> {app.state}</li>
             {
               if (!app.isFinished) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to show `Duration` information in `ApplicationPage`.

### Why are the changes needed?

`Duration` is already exposed in `MasterPage` as `Duration` column in the list.

![Screenshot 2023-10-08 at 4 58 03 AM](https://github.com/apache/spark/assets/9700541/587bfba8-9ffb-4d83-8b4a-7c580c644cb4)

When we visit the Application detail page, we had better show it consistently. Otherwise, we need to go back to the list and search the app id. In the following images, `Duration` is added after `Submit Date` row.

- **Live App**
![Screenshot 2023-10-08 at 4 53 52 AM](https://github.com/apache/spark/assets/9700541/9b7bdd24-f9d4-4eab-b3a1-b36cc3e29600)

- **Completed App**
![Screenshot 2023-10-08 at 4 56 57 AM](https://github.com/apache/spark/assets/9700541/54897ba3-5fee-4df2-9486-9e62eb20e7ed)

### Does this PR introduce _any_ user-facing change?

No. This is a new addition to the UI.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.