### PR TITLE
[SPARK-45463][CORE][SHUFFLE] Support reliable store with specified executorId

### DIFF
--- a/core/src/main/java/org/apache/spark/shuffle/api/ShuffleDriverComponents.java
+++ b/core/src/main/java/org/apache/spark/shuffle/api/ShuffleDriverComponents.java
@@ -68,7 +68,7 @@ public interface ShuffleDriverComponents {
    * persisting it in a remote shuffle service.
    *
    * Note: This method is for compatibility with older implementations,
-   * the newer implementation should just directly return true or false
+   * the newer implementation should not use this method.
    */
   default boolean supportsReliableStorage() {
     return false;
@@ -76,9 +76,9 @@ public interface ShuffleDriverComponents {
 
   /**
    * Does this executor support reliable storage for all shuffle data.
-   * @param execId The executor id for which the check is being performed.
+   * @param execId The executor id, null for validation use only.
    */
   default boolean supportsReliableStorage(String execId) {
-    return true;
+    return supportsReliableStorage();
   }
 }

--- a/core/src/main/java/org/apache/spark/shuffle/api/ShuffleDriverComponents.java
+++ b/core/src/main/java/org/apache/spark/shuffle/api/ShuffleDriverComponents.java
@@ -63,11 +63,20 @@ public interface ShuffleDriverComponents {
   default void removeShuffle(int shuffleId, boolean blocking) {}
 
   /**
+   * This method is only used for validation
+   */
+  default boolean supportsReliableStorage() {
+    return false;
+  }
+
+  /**
    * Does this shuffle component support reliable storage - external to the lifecycle of the
    * executor host ? For example, writing shuffle data to a distributed filesystem or
    * persisting it in a remote shuffle service.
+   * @param execId The executor id
+   * @return Does this executor support reliable storage
    */
-  default boolean supportsReliableStorage() {
+  default boolean supportsReliableStorage(String execId) {
     return false;
   }
 }

--- a/core/src/main/java/org/apache/spark/shuffle/api/ShuffleDriverComponents.java
+++ b/core/src/main/java/org/apache/spark/shuffle/api/ShuffleDriverComponents.java
@@ -63,20 +63,20 @@ public interface ShuffleDriverComponents {
   default void removeShuffle(int shuffleId, boolean blocking) {}
 
   /**
-   * This method is for compatibility with older implementations
-   * the implementation should just directly return true
-   * when use distributed filesystem or in a disaggregated shuffle cluster
+   * Does this shuffle component support reliable storage - external to the lifecycle of the
+   * executor host ? For example, writing shuffle data to a distributed filesystem or
+   * persisting it in a remote shuffle service.
+   *
+   * Note: This method is for compatibility with older implementations,
+   * the newer implementation should just directly return true or false
    */
   default boolean supportsReliableStorage() {
     return false;
   }
 
   /**
-   * Does this shuffle component support reliable storage - external to the lifecycle of the
-   * executor host ? For example, writing shuffle data to a distributed filesystem or
-   * persisting it in a remote shuffle service.
-   * @param execId The executor id
-   * @return Does this executor support reliable storage for all shuffle data
+   * Does this executor support reliable storage for all shuffle data.
+   * @param execId The executor id for which the check is being performed.
    */
   default boolean supportsReliableStorage(String execId) {
     return true;

--- a/core/src/main/java/org/apache/spark/shuffle/api/ShuffleDriverComponents.java
+++ b/core/src/main/java/org/apache/spark/shuffle/api/ShuffleDriverComponents.java
@@ -63,7 +63,9 @@ public interface ShuffleDriverComponents {
   default void removeShuffle(int shuffleId, boolean blocking) {}
 
   /**
-   * This method is only used for validation
+   * This method is for compatibility with older implementations
+   * the implementation should just directly return true
+   * when use distributed filesystem or in a disaggregated shuffle cluster
    */
   default boolean supportsReliableStorage() {
     return false;
@@ -74,9 +76,9 @@ public interface ShuffleDriverComponents {
    * executor host ? For example, writing shuffle data to a distributed filesystem or
    * persisting it in a remote shuffle service.
    * @param execId The executor id
-   * @return Does this executor support reliable storage
+   * @return Does this executor support reliable storage for all shuffle data
    */
   default boolean supportsReliableStorage(String execId) {
-    return false;
+    return true;
   }
 }

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -661,7 +661,7 @@ class SparkContext(config: SparkConf) extends Logging {
             Some(new ExecutorAllocationManager(
               schedulerBackend.asInstanceOf[ExecutorAllocationClient], listenerBus, _conf,
               cleaner = cleaner, resourceProfileManager = resourceProfileManager,
-              reliableShuffleStorage = _shuffleDriverComponents.supportsReliableStorage()))
+              reliableShuffleStorage = _shuffleDriverComponents.supportsReliableStorage(null)))
           case _ =>
             None
         }

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -2580,7 +2580,8 @@ private[spark] class DAGScheduler(
     // if the cluster manager explicitly tells us that the entire worker was lost, then
     // we know to unregister shuffle output.  (Note that "worker" specifically refers to the process
     // from a Standalone cluster, where the shuffle service lives in the Worker.)
-    val fileLost = !sc.shuffleDriverComponents.supportsReliableStorage(execId) &&
+    val fileLost = !(sc.shuffleDriverComponents.supportsReliableStorage() &&
+      sc.shuffleDriverComponents.supportsReliableStorage(execId)) &&
       (workerHost.isDefined || !env.blockManager.externalShuffleServiceEnabled)
     removeExecutorAndUnregisterOutputs(
       execId = execId,

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -2580,8 +2580,7 @@ private[spark] class DAGScheduler(
     // if the cluster manager explicitly tells us that the entire worker was lost, then
     // we know to unregister shuffle output.  (Note that "worker" specifically refers to the process
     // from a Standalone cluster, where the shuffle service lives in the Worker.)
-    val fileLost = !(sc.shuffleDriverComponents.supportsReliableStorage() &&
-      sc.shuffleDriverComponents.supportsReliableStorage(execId)) &&
+    val fileLost = !sc.shuffleDriverComponents.supportsReliableStorage(execId) &&
       (workerHost.isDefined || !env.blockManager.externalShuffleServiceEnabled)
     removeExecutorAndUnregisterOutputs(
       execId = execId,

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -2580,7 +2580,7 @@ private[spark] class DAGScheduler(
     // if the cluster manager explicitly tells us that the entire worker was lost, then
     // we know to unregister shuffle output.  (Note that "worker" specifically refers to the process
     // from a Standalone cluster, where the shuffle service lives in the Worker.)
-    val fileLost = !sc.shuffleDriverComponents.supportsReliableStorage() &&
+    val fileLost = !sc.shuffleDriverComponents.supportsReliableStorage(execId) &&
       (workerHost.isDefined || !env.blockManager.externalShuffleServiceEnabled)
     removeExecutorAndUnregisterOutputs(
       execId = execId,

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -1046,7 +1046,8 @@ private[spark] class TaskSetManager(
     // can destroy the whole host). The reason is the next stage wouldn't be able to fetch the
     // data from this dead executor so we would need to rerun these tasks on other executors.
     val maybeShuffleMapOutputLoss = isShuffleMapTasks &&
-      !sched.sc.shuffleDriverComponents.supportsReliableStorage(execId) &&
+      !(sched.sc.shuffleDriverComponents.supportsReliableStorage() &&
+        sched.sc.shuffleDriverComponents.supportsReliableStorage(execId)) &&
       (reason.isInstanceOf[ExecutorDecommission] || !env.blockManager.externalShuffleServiceEnabled)
     if (maybeShuffleMapOutputLoss && !isZombie) {
       for ((tid, info) <- taskInfos if info.executorId == execId) {

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -1046,7 +1046,7 @@ private[spark] class TaskSetManager(
     // can destroy the whole host). The reason is the next stage wouldn't be able to fetch the
     // data from this dead executor so we would need to rerun these tasks on other executors.
     val maybeShuffleMapOutputLoss = isShuffleMapTasks &&
-      !sched.sc.shuffleDriverComponents.supportsReliableStorage() &&
+      !sched.sc.shuffleDriverComponents.supportsReliableStorage(execId) &&
       (reason.isInstanceOf[ExecutorDecommission] || !env.blockManager.externalShuffleServiceEnabled)
     if (maybeShuffleMapOutputLoss && !isZombie) {
       for ((tid, info) <- taskInfos if info.executorId == execId) {

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -1046,8 +1046,7 @@ private[spark] class TaskSetManager(
     // can destroy the whole host). The reason is the next stage wouldn't be able to fetch the
     // data from this dead executor so we would need to rerun these tasks on other executors.
     val maybeShuffleMapOutputLoss = isShuffleMapTasks &&
-      !(sched.sc.shuffleDriverComponents.supportsReliableStorage() &&
-        sched.sc.shuffleDriverComponents.supportsReliableStorage(execId)) &&
+      !sched.sc.shuffleDriverComponents.supportsReliableStorage(execId) &&
       (reason.isInstanceOf[ExecutorDecommission] || !env.blockManager.externalShuffleServiceEnabled)
     if (maybeShuffleMapOutputLoss && !isZombie) {
       for ((tid, info) <- taskInfos if info.executorId == execId) {

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -996,7 +996,6 @@ class DAGSchedulerSuite extends SparkFunSuite with TempLocalSparkContext with Ti
 
     conf.set(config.SHUFFLE_IO_PLUGIN_CLASS.key,
       classOf[TestShuffleDataIOWithMockedComponents].getName)
-    when(sc.shuffleDriverComponents.supportsReliableStorage()).thenReturn(true)
     when(sc.shuffleDriverComponents.supportsReliableStorage(any())).thenReturn(true)
 
     val event = ExecutorProcessLost("", Some("hostA"))

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -997,6 +997,7 @@ class DAGSchedulerSuite extends SparkFunSuite with TempLocalSparkContext with Ti
     conf.set(config.SHUFFLE_IO_PLUGIN_CLASS.key,
       classOf[TestShuffleDataIOWithMockedComponents].getName)
     when(sc.shuffleDriverComponents.supportsReliableStorage()).thenReturn(true)
+    when(sc.shuffleDriverComponents.supportsReliableStorage(any())).thenReturn(true)
 
     val event = ExecutorProcessLost("", Some("hostA"))
     val shuffleMapRdd = new MyRDD(sc, 2, Nil)


### PR DESCRIPTION
### What changes were proposed in this pull request?
According to weather the map data shuffled by the lost executor are all reliable stored, `ShuffleDriverComponent` can support reliable store with specified executorId

### Why are the changes needed?
Downstream projects may have different shuffle strategy(which cause by cluster loads or columnar support) for different stages, for example Apache Uniffle with Gluten or Apache Celeborn. In this situation, some shuffle stages are local shuffle data, some shuffle stages are remote shuffle data which are reliable stored. once a executor is lost, we need use the executorId to decide weather the shuffle data produced by the executor is reliable stored.

### Does this PR introduce _any_ user-facing change?
Enhances the `ShuffleDriverComponents` API, but defaults to current behavior.

### How was this patch tested?
Unit tests

### Was this patch authored or co-authored using generative AI tooling?
No
