### PR TITLE
[SPARK-44729][PYTHON][DOCS][3.4] Add canonical links to the PySpark docs page

### DIFF
--- a/python/docs/source/conf.py
+++ b/python/docs/source/conf.py
@@ -259,6 +259,8 @@ html_use_index = False
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'pysparkdoc'
 
+# The base URL which points to the root of the HTML documentation.
+html_baseurl = 'https://spark.apache.org/docs/latest/api/python'
 
 # -- Options for LaTeX output ---------------------------------------------
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to add canonical links to the PySpark docs page, backport this to branch 3.4.
Master branch pr: https://github.com/apache/spark/pull/42425.


### Why are the changes needed?
Backport this to branch 3.4.

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
- Pass GA.
- Manually test.

### Was this patch authored or co-authored using generative AI tooling?
No.
