### PR TITLE
[SPARK-45466][ML] `VectorAssembler` should validate the vector elements

### DIFF
--- a/mllib/src/test/scala/org/apache/spark/ml/feature/VectorAssemblerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/VectorAssemblerSuite.scala
@@ -184,6 +184,38 @@ class VectorAssemblerSuite
     intercept[SparkException](assemble(Array(2), keepInvalid = false)(null))
   }
 
+  test("assemble should keep Vector's NaN when keepInvalid is true") {
+    import org.apache.spark.ml.feature.VectorAssembler.assemble
+    assert(assemble(Array(3), keepInvalid = true)(
+      Vectors.dense(1.0, 2.0, Double.NaN)
+    ) === Vectors.dense(1.0, 2.0, Double.NaN))
+    assert(assemble(Array(3), keepInvalid = true)(
+      Vectors.sparse(3, Array(0, 2), Array(1.0, Double.NaN))
+    ) === Vectors.dense(1.0, 0.0, Double.NaN))
+    assert(assemble(Array(3, 1), keepInvalid = true)(
+      Vectors.dense(1.0, 2.0, Double.NaN), null
+    ) === Vectors.dense(1.0, 2.0, Double.NaN, Double.NaN))
+    assert(assemble(Array(3, 1), keepInvalid = true)(
+      Vectors.sparse(3, Array(0, 2), Array(1.0, Double.NaN)), null
+    ) === Vectors.dense(1.0, 0.0, Double.NaN, Double.NaN))
+  }
+
+  test("assemble should throw errors when Vector has NaN and keepInvalid is false") {
+    import org.apache.spark.ml.feature.VectorAssembler.assemble
+    intercept[SparkException](assemble(Array(3), keepInvalid = false)(
+      Vectors.dense(1.0, 2.0, Double.NaN)
+    ))
+    intercept[SparkException](assemble(Array(3), keepInvalid = false)(
+      Vectors.sparse(3, Array(0, 2), Array(1.0, Double.NaN))
+    ))
+    intercept[SparkException](assemble(Array(3, 1), keepInvalid = false)(
+      Vectors.dense(1.0, 2.0, Double.NaN), null
+    ))
+    intercept[SparkException](assemble(Array(3, 1), keepInvalid = false)(
+      Vectors.sparse(3, Array(0, 2), Array(1.0, Double.NaN)), null
+    ))
+  }
+
   test("get lengths functions") {
     import org.apache.spark.ml.feature.VectorAssembler._
     val df = dfWithNullsAndNaNs


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make `VectorAssembler` validate the vector values


### Why are the changes needed?
`VectorAssembler` should validate the vector values


### Does this PR introduce _any_ user-facing change?
yes, in `error` mode, if a vector contains `NaN`, it fails

before this PR:
```
In [15]: from pyspark.ml.linalg import Vectors

In [16]: from pyspark.ml.feature import VectorAssembler

In [17]: df = spark.createDataFrame([(1.0, Vectors.dense(float('nan'))), (0.0, Vectors.sparse(1, [], []))], ["label", "features
    ...: "])

In [18]: vecAssembler = VectorAssembler(outputCol="new_features")

In [19]: vecAssembler.setInputCols(["label", "features"])
Out[19]: VectorAssembler_a3896f503d95

In [20]: vecAssembler.transform(df).show()
+-----+---------+------------+
|label| features|new_features|
+-----+---------+------------+
|  1.0|    [NaN]|   [1.0,NaN]|
|  0.0|(1,[],[])|   (2,[],[])|
+-----+---------+------------+
```

after this PR:
```
In [6]: vecAssembler.transform(df).show()
23/10/10 10:53:20 ERROR Executor: Exception in task 0.0 in stage 5.0 (TID 17)
org.apache.spark.SparkException: [FAILED_EXECUTE_UDF] Failed to execute user defined function (`VectorAssembler$$Lambda$2749/0x0000007001e3fb20`: (struct<label:double,features:struct<type:tinyint,size:int,indices:array<int>,values:array<double>>>) => struct<type:tinyint,size:int,indices:array<int>,values:array<double>>).
	at org.apache.spark.sql.errors.QueryExecutionErrors$.failedExecuteUserDefinedFunctionError(QueryExecutionErrors.scala:194)
    ...
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: org.apache.spark.SparkException: Encountered NaN while assembling a row with handleInvalid = "error". Consider
removing NaNs from dataset or using handleInvalid = "keep" or "skip".

```

### How was this patch tested?
added UTs


### Was this patch authored or co-authored using generative AI tooling?
no