### PR TITLE
[SPARK-45464][CORE] Fix network-yarn distribution build

### DIFF
--- a/common/network-yarn/pom.xml
+++ b/common/network-yarn/pom.xml
@@ -174,7 +174,18 @@
             <configuration>
                 <target>
                     <echo message="Shade netty native libraries to ${spark.shade.native.packageName}" />
-                    <unzip src="${shuffle.jar}" dest="${project.build.directory}/exploded/" />
+                    <!-- 
+                      We have a LICENSE file with apache licenses and license directory for netty-tcnative licenses. This breaks
+                      packaging on OSX where filesystems are case insensitive. So, create the directory, which results
+                      in the LICENSE file not being written, letting the netty licenses be copied over.
+                      LICENSE.txt also contains the apache license so this should be OK 
+                    -->
+                    <mkdir dir="${project.build.directory}/exploded/META-INF/LICENSE" />
+                    <unzip src="${shuffle.jar}" dest="${project.build.directory}/exploded/">
+                      <patternset>
+                          <exclude name="META-INF/LICENSE"/>
+                      </patternset>
+                    </unzip>
                     <move file="${project.build.directory}/exploded/META-INF/native/libnetty_transport_native_epoll_x86_64.so"
                           tofile="${project.build.directory}/exploded/META-INF/native/lib${spark.shade.native.packageName}_netty_transport_native_epoll_x86_64.so" />
                     <move file="${project.build.directory}/exploded/META-INF/native/libnetty_transport_native_kqueue_x86_64.jnilib"

--- a/common/network-yarn/pom.xml
+++ b/common/network-yarn/pom.xml
@@ -110,6 +110,7 @@
                 <exclude>META-INF/*.SF</exclude>
                 <exclude>META-INF/*.DSA</exclude>
                 <exclude>META-INF/*.RSA</exclude>
+                <exclude>META-INF/license/*</exclude>
               </excludes>
             </filter>
           </filters>
@@ -174,18 +175,7 @@
             <configuration>
                 <target>
                     <echo message="Shade netty native libraries to ${spark.shade.native.packageName}" />
-                    <!-- 
-                      We have a LICENSE file with apache licenses and license directory for netty-tcnative licenses. This breaks
-                      packaging on OSX where filesystems are case insensitive. So, create the directory, which results
-                      in the LICENSE file not being written, letting the netty licenses be copied over.
-                      LICENSE.txt also contains the apache license so this should be OK 
-                    -->
-                    <mkdir dir="${project.build.directory}/exploded/META-INF/LICENSE" />
-                    <unzip src="${shuffle.jar}" dest="${project.build.directory}/exploded/">
-                      <patternset>
-                          <exclude name="META-INF/LICENSE"/>
-                      </patternset>
-                    </unzip>
+                    <unzip src="${shuffle.jar}" dest="${project.build.directory}/exploded/" />
                     <move file="${project.build.directory}/exploded/META-INF/native/libnetty_transport_native_epoll_x86_64.so"
                           tofile="${project.build.directory}/exploded/META-INF/native/lib${spark.shade.native.packageName}_netty_transport_native_epoll_x86_64.so" />
                     <move file="${project.build.directory}/exploded/META-INF/native/libnetty_transport_native_kqueue_x86_64.jnilib"
@@ -194,6 +184,14 @@
                           tofile="${project.build.directory}/exploded/META-INF/native/lib${spark.shade.native.packageName}_netty_transport_native_epoll_aarch_64.so" />
                     <move file="${project.build.directory}/exploded/META-INF/native/libnetty_transport_native_kqueue_aarch_64.jnilib"
                           tofile="${project.build.directory}/exploded/META-INF/native/lib${spark.shade.native.packageName}_netty_transport_native_kqueue_aarch_64.jnilib" />
+                    <move file="${project.build.directory}/exploded/META-INF/native/libnetty_tcnative_linux_x86_64.so"
+                          tofile="${project.build.directory}/exploded/META-INF/native/lib${spark.shade.native.packageName}_netty_tcnative_linux_x86_64.so" />
+                    <move file="${project.build.directory}/exploded/META-INF/native/libnetty_tcnative_linux_aarch_64.so"
+                          tofile="${project.build.directory}/exploded/META-INF/native/lib${spark.shade.native.packageName}_netty_tcnative_linux_aarch_64.so" />
+                    <move file="${project.build.directory}/exploded/META-INF/native/libnetty_tcnative_osx_x86_64.jnilib"
+                          tofile="${project.build.directory}/exploded/META-INF/native/lib${spark.shade.native.packageName}_netty_tcnative_osx_x86_64.jnilib" />
+                    <move file="${project.build.directory}/exploded/META-INF/native/libnetty_tcnative_osx_aarch_64.jnilib"
+                          tofile="${project.build.directory}/exploded/META-INF/native/lib${spark.shade.native.packageName}_netty_tcnative_osx_aarch_64.jnilib" />
                     <jar destfile="${shuffle.jar}" basedir="${project.build.directory}/exploded" />
                 </target>
             </configuration>

--- a/common/network-yarn/pom.xml
+++ b/common/network-yarn/pom.xml
@@ -110,7 +110,7 @@
                 <exclude>META-INF/*.SF</exclude>
                 <exclude>META-INF/*.DSA</exclude>
                 <exclude>META-INF/*.RSA</exclude>
-                <exclude>META-INF/license/*</exclude>
+                <exclude>META-INF/LICENSE</exclude>
               </excludes>
             </filter>
           </filters>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Exclude an apache license in the packaged jar to fix the build for network-yarn. Also shade the native libraries so they can be used.

### Why are the changes needed?

Making a distribution build using the following command currently fails after https://github.com/apache/spark/pull/43164:

```
./dev/make-distribution.sh --tgz  -Phive -Phive-thriftserver -Pyarn
```

Failures look like 

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-antrun-plugin:3.1.0:run (unpack) on project spark-network-yarn_2.13: An Ant BuildException has occured: Error while expanding /Users/hasnain.lakhani/spark/common/network-yarn/target/scala-2.13/spark-4.0.0-SNAPSHOT-yarn-shuffle.jar
[ERROR] java.nio.file.FileSystemException: /Users/hasnain.lakhani/spark/common/network-yarn/target/exploded/META-INF/license/LICENSE.aix-netbsd.txt: Not a directory
[ERROR] around Ant part ...<unzip src="/Users/hasnain.lakhani/spark/common/network-yarn/target/scala-2.13/spark-4.0.0-SNAPSHOT-yarn-shuffle.jar" dest="/Users/hasnain.lakhani/spark/common/network-yarn/target/exploded/" />... @ 5:198 in /Users/hasnain.lakhani/spark/common/network-yarn/target/antrun/build-main.xml
[ERROR] -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.apache.maven.plugins:maven-antrun-plugin:3.1.0:run (unpack) on project spark-network-yarn_2.13: An Ant BuildException has occured: Error while expanding /Users/hasnain.lakhani/spark/common/network-yarn/target/scala-2.13/spark-4.0.0-SNAPSHOT-yarn-shuffle.jar
java.nio.file.FileSystemException: /Users/hasnain.lakhani/spark/common/network-yarn/target/exploded/META-INF/license/LICENSE.aix-netbsd.txt: Not a directory
around Ant part ...<unzip src="/Users/hasnain.lakhani/spark/common/network-yarn/target/scala-2.13/spark-4.0.0-SNAPSHOT-yarn-shuffle.jar" dest="/Users/hasnain.lakhani/spark/common/network-yarn/target/exploded/" />... @ 5:198 in /Users/hasnain.lakhani/spark/common/network-yarn/target/antrun/build-main.xml
```

After much trial and error (I added a debugging section for the next person who runs into this) I realized the problem is that inside the jar, the META-inf folder looks like this:

```
META-INF/LICENSE
META-INF/LICENSE.txt
META-INF/license/
META-INF/license/LICENSE.aix-netbsd.txt
META-INF/license/LICENSE.boringssl.txt
META-INF/license/LICENSE.mvn-wrapper.txt
META-INF/license/LICENSE.tomcat-native.txt
```

Since the filesystem on macosx is case insensitive, this causes issues. Unzipping this fails, as we unzip the file first, then do not create the directory, and fail to unzip the files after that.

This PR proposes to fix it by removing the `LICENSE` file, as suggested, by adding it to the exclusion list, so the folder gets copied. The contents are the same as `LICENSE.txt` (which is also just the apache2 license) so this should be fine. We also shade and copy over the new native libraries similar to the existing ones.

### Does this PR introduce _any_ user-facing change?

No


### How was this patch tested?

CI

I reran 

```
./dev/make-distribution.sh --tgz  -Phive -Phive-thriftserver -Pyarn
```

and it succeeded

### Was this patch authored or co-authored using generative AI tooling?

No

### Appendix: debugging

I was able to debug the contents of the jar using `jar tf $jar` and print out the files using `unzip -q -c $jar $path`.

To make iterations go faster I went to `/Users/hasnain.lakhani/spark/common/network-yarn/target/antrun` and edited the ant file by hand then ran `ant -f build-main.xml`