### PR TITLE
[SPARK-45470][SQL] Avoid paste string value of hive orc compression kind

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/CompressionCodecSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/CompressionCodecSuite.scala
@@ -23,6 +23,7 @@ import java.util.Locale
 import scala.jdk.CollectionConverters._
 
 import org.apache.hadoop.fs.Path
+import org.apache.hadoop.hive.ql.io.orc.CompressionKind
 import org.apache.orc.OrcConf.COMPRESS
 import org.apache.parquet.hadoop.ParquetOutputFormat
 import org.scalatest.BeforeAndAfterAll
@@ -256,7 +257,7 @@ class CompressionCodecSuite extends TestHiveSingleton with ParquetTest with Befo
     val uncompressedSize = getUncompressedDataSizeByFormat(format, isPartitioned, usingCTAS)
     compressionCodec match {
       case "UNCOMPRESSED" if format == "parquet" => tableSize == uncompressedSize
-      case "NONE" if format == "orc" => tableSize == uncompressedSize
+      case CompressionKind.NONE.name if format == "orc" => tableSize == uncompressedSize
       case _ => tableSize != uncompressedSize
     }
   }
@@ -291,8 +292,10 @@ class CompressionCodecSuite extends TestHiveSingleton with ParquetTest with Befo
       tableCompressCodecs = List("UNCOMPRESSED", "SNAPPY", "GZIP"),
       sessionCompressCodecs = List("SNAPPY", "GZIP", "SNAPPY"))
     checkForTableWithCompressProp("orc",
-      tableCompressCodecs = List("NONE", "SNAPPY", "ZLIB"),
-      sessionCompressCodecs = List("SNAPPY", "ZLIB", "SNAPPY"))
+      tableCompressCodecs =
+        List(CompressionKind.NONE.name, CompressionKind.SNAPPY.name, CompressionKind.ZLIB.name),
+      sessionCompressCodecs =
+        List(CompressionKind.SNAPPY.name, CompressionKind.ZLIB.name, CompressionKind.SNAPPY.name))
   }
 
   test("table-level compression is not set but session-level compressions is set ") {
@@ -301,7 +304,8 @@ class CompressionCodecSuite extends TestHiveSingleton with ParquetTest with Befo
       sessionCompressCodecs = List("UNCOMPRESSED", "SNAPPY", "GZIP"))
     checkForTableWithCompressProp("orc",
       tableCompressCodecs = List.empty,
-      sessionCompressCodecs = List("NONE", "SNAPPY", "ZLIB"))
+      sessionCompressCodecs =
+        List(CompressionKind.NONE.name, CompressionKind.SNAPPY.name, CompressionKind.ZLIB.name))
   }
 
   def checkTableWriteWithCompressionCodecs(format: String, compressCodecs: List[String]): Unit = {
@@ -336,6 +340,8 @@ class CompressionCodecSuite extends TestHiveSingleton with ParquetTest with Befo
 
   test("test table containing mixed compression codec") {
     checkTableWriteWithCompressionCodecs("parquet", List("UNCOMPRESSED", "SNAPPY", "GZIP"))
-    checkTableWriteWithCompressionCodecs("orc", List("NONE", "SNAPPY", "ZLIB"))
+    checkTableWriteWithCompressionCodecs(
+      "orc",
+      List(CompressionKind.NONE.name, CompressionKind.SNAPPY.name, CompressionKind.ZLIB.name))
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/CompressionCodecSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/CompressionCodecSuite.scala
@@ -257,7 +257,7 @@ class CompressionCodecSuite extends TestHiveSingleton with ParquetTest with Befo
     val uncompressedSize = getUncompressedDataSizeByFormat(format, isPartitioned, usingCTAS)
     compressionCodec match {
       case "UNCOMPRESSED" if format == "parquet" => tableSize == uncompressedSize
-      case CompressionKind.NONE.name if format == "orc" => tableSize == uncompressedSize
+      case "NONE" if format == "orc" => tableSize == uncompressedSize
       case _ => tableSize != uncompressedSize
     }
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/OrcHadoopFsRelationSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/OrcHadoopFsRelationSuite.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.hive.orc
 import java.io.File
 
 import org.apache.hadoop.fs.Path
+import org.apache.hadoop.hive.ql.io.orc.CompressionKind
 
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.catalog.CatalogUtils
@@ -87,7 +88,7 @@ class OrcHadoopFsRelationSuite extends HadoopFsRelationTest {
       val path = s"${dir.getCanonicalPath}/table1"
       val df = (1 to 5).map(i => (i, (i % 2).toString)).toDF("a", "b")
       df.write
-        .option("compression", "ZlIb")
+        .option("compression", CompressionKind.ZLIB.name())
         .orc(path)
 
       // Check if this is compressed as ZLIB.
@@ -98,7 +99,7 @@ class OrcHadoopFsRelationSuite extends HadoopFsRelationTest {
       val orcFilePath = maybeOrcFile.get.toPath.toString
       val expectedCompressionKind =
         OrcFileOperator.getFileReader(orcFilePath).get.getCompression
-      assert("ZLIB" === expectedCompressionKind.name())
+      assert(CompressionKind.ZLIB.name() === expectedCompressionKind.name())
 
       val copyDf = spark
         .read
@@ -113,7 +114,7 @@ class OrcHadoopFsRelationSuite extends HadoopFsRelationTest {
         .orc(file.getCanonicalPath)
       val expectedCompressionKind =
         OrcFileOperator.getFileReader(file.getCanonicalPath).get.getCompression
-      assert("SNAPPY" === expectedCompressionKind.name())
+      assert(CompressionKind.SNAPPY.name() === expectedCompressionKind.name())
     }
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/OrcHadoopFsRelationSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/OrcHadoopFsRelationSuite.scala
@@ -88,7 +88,7 @@ class OrcHadoopFsRelationSuite extends HadoopFsRelationTest {
       val path = s"${dir.getCanonicalPath}/table1"
       val df = (1 to 5).map(i => (i, (i % 2).toString)).toDF("a", "b")
       df.write
-        .option("compression", CompressionKind.ZLIB.name())
+        .option("compression", "ZlIb")
         .orc(path)
 
       // Check if this is compressed as ZLIB.

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/OrcReadBenchmark.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/OrcReadBenchmark.scala
@@ -21,6 +21,8 @@ import java.io.File
 
 import scala.util.Random
 
+import org.apache.hadoop.hive.ql.io.orc.CompressionKind
+
 import org.apache.spark.SparkConf
 import org.apache.spark.benchmark.Benchmark
 import org.apache.spark.sql.{DataFrame, SparkSession}
@@ -46,7 +48,7 @@ object OrcReadBenchmark extends SqlBasedBenchmark {
 
   override def getSparkSession: SparkSession = {
     val conf = new SparkConf()
-    conf.set("orc.compression", "snappy")
+    conf.set("orc.compression", CompressionKind.SNAPPY.name())
 
     val sparkSession = SparkSession.builder()
       .master("local[1]")


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently, Hive supports ORC format with some compression codec( Please refer [ql/src/java/org/apache/hadoop/hive/ql/io/orc/CompressionKind.java](https://github.com/apache/hive/blob/master/ql/src/java/org/apache/hadoop/hive/ql/io/orc/CompressionKind.java)).

Spark pasted many string literal of these compression codec. It is easy to make mistakes and reduce development efficiency.


### Why are the changes needed?
Avoid paste string value of hive orc compression kind


### Does this PR introduce _any_ user-facing change?
'No'.
Just update inner implementation.


### How was this patch tested?
Exists test cases.


### Was this patch authored or co-authored using generative AI tooling?
'No'.
