### PR TITLE
[SPARK-45468][UI] More transparent proxy handling for HTTP redirects

### DIFF
--- a/core/src/main/scala/org/apache/spark/TestUtils.scala
+++ b/core/src/main/scala/org/apache/spark/TestUtils.scala
@@ -345,11 +345,13 @@ private[spark] object TestUtils {
   def withHttpConnection[T](
       url: URL,
       method: String = "GET",
-      headers: Seq[(String, String)] = Nil)
+      headers: Seq[(String, String)] = Nil,
+      followRedirect: Boolean = true)
       (fn: HttpURLConnection => T): T = {
     val connection = url.openConnection().asInstanceOf[HttpURLConnection]
     connection.setRequestMethod(method)
     headers.foreach { case (k, v) => connection.setRequestProperty(k, v) }
+    connection.setInstanceFollowRedirects(followRedirect)
 
     connection match {
       // Disable cert and host name validation for HTTPS tests.

--- a/core/src/main/scala/org/apache/spark/internal/config/UI.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/UI.scala
@@ -206,15 +206,6 @@ private[spark] object UI {
     .stringConf
     .createWithDefault("org.apache.spark.security.ShellBasedGroupsMappingProvider")
 
-  val REDIRECT_WITHOUT_HOST = ConfigBuilder("spark.ui.redirectWithoutHost")
-    .doc("Use path without host for HTTP redirects so that proxies become transparent in the " +
-      "same way as other hyperlinks. When a proxy prefix exists, X-Forwarded-Context HTTP header " +
-      "or spark.ui.proxyBase system property still needs to be set. This option does not take " +
-      "effect if spark.ui.proxyRedirectUri is set.")
-    .version("4.0.0")
-    .booleanConf
-    .createWithDefault(false)
-
   val PROXY_REDIRECT_URI = ConfigBuilder("spark.ui.proxyRedirectUri")
     .doc("Proxy address to use when responding with HTTP redirects.")
     .version("3.0.0")

--- a/core/src/main/scala/org/apache/spark/internal/config/UI.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/UI.scala
@@ -206,6 +206,15 @@ private[spark] object UI {
     .stringConf
     .createWithDefault("org.apache.spark.security.ShellBasedGroupsMappingProvider")
 
+  val REDIRECT_WITHOUT_HOST = ConfigBuilder("spark.ui.redirectWithoutHost")
+    .doc("Use path without host for HTTP redirects so that proxies become transparent in the " +
+      "same way as other hyperlinks. When a proxy prefix exists, X-Forwarded-Context HTTP header " +
+      "or spark.ui.proxyBase system property still needs to be set. This option does not take " +
+      "effect if spark.ui.proxyRedirectUri is set.")
+    .version("4.0.0")
+    .booleanConf
+    .createWithDefault(false)
+
   val PROXY_REDIRECT_URI = ConfigBuilder("spark.ui.proxyRedirectUri")
     .doc("Proxy address to use when responding with HTTP redirects.")
     .version("3.0.0")

--- a/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
@@ -420,11 +420,10 @@ private[spark] object JettyUtils extends Logging {
       headerValue: String,
       clientRequest: HttpServletRequest,
       targetUri: URI): String = {
-    val toReplace = targetUri.getScheme() + "://" + targetUri.getAuthority()
-    if (headerValue.startsWith(toReplace)) {
+    val uri = targetUri.resolve(headerValue)
+    if (uri.getScheme == targetUri.getScheme && uri.getAuthority == targetUri.getAuthority) {
       val id = clientRequest.getPathInfo.substring("/proxy/".length).takeWhile(_ != '/')
-      val headerPath = headerValue.substring(toReplace.length)
-
+      val headerPath = uri.getPath
       s"${clientRequest.getScheme}://${clientRequest.getHeader("host")}/proxy/$id$headerPath"
     } else {
       null

--- a/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
@@ -314,9 +314,7 @@ private[spark] object JettyUtils extends Logging {
       val requestHeaderSize = conf.get(UI_REQUEST_HEADER_SIZE).toInt
       logDebug(s"Using requestHeaderSize: $requestHeaderSize")
       httpConfig.setRequestHeaderSize(requestHeaderSize)
-      if (conf.get(REDIRECT_WITHOUT_HOST)) {
-        httpConfig.setRelativeRedirectAllowed(true)
-      }
+      httpConfig.setRelativeRedirectAllowed(true)
 
       // If SSL is configured, create the secure connector first.
       val securePort = sslOptions.createJettySslContextFactory().map { factory =>

--- a/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
@@ -655,11 +655,11 @@ abstract class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with
       assert(code === 302, s"Unexpected status code $code for $url")
       attemptId match {
         case None =>
-          assert(location.stripSuffix("/") === lastAttemptUrl.toString)
+          assert(location.stripSuffix("/") === lastAttemptUrl.getPath)
         case _ =>
-          assert(location.stripSuffix("/") === url.toString)
+          assert(location.stripSuffix("/") === url.getPath)
       }
-      HistoryServerSuite.getUrl(new URL(location))
+      HistoryServerSuite.getUrl(new URL(s"http://$localhost:$port$location"))
     }
   }
 
@@ -706,7 +706,7 @@ abstract class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with
     conn.setInstanceFollowRedirects(false)
     conn.connect()
     assert(conn.getResponseCode === 302)
-    assert(conn.getHeaderField("Location") === s"http://$localhost:$port/")
+    assert(conn.getHeaderField("Location") === s"/")
   }
 }
 

--- a/core/src/test/scala/org/apache/spark/ui/UISuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/UISuite.scala
@@ -387,6 +387,117 @@ class UISuite extends SparkFunSuite {
     }
   }
 
+  test("SPARK-45468 redirect without proxyRedirectUri preserves uiRoot") {
+    val (conf, securityMgr, sslOptions) = sslDisabledConf()
+
+    val serverInfo = JettyUtils.startJettyServer("0.0.0.0", 0, sslOptions, conf)
+    try {
+      val serverAddr = s"http://$localhost:${serverInfo.boundPort}"
+
+      val redirect = JettyUtils.createRedirectHandler("/src", "/dst")
+      serverInfo.addHandler(redirect, securityMgr)
+
+      // Test with a URL handled by the added redirect handler, and also including a path prefix.
+      val headers = Seq("X-Forwarded-Context" -> "/prefix")
+      TestUtils.withHttpConnection(
+          new URL(s"$serverAddr/src/"),
+          headers = headers,
+          followRedirect = false) { conn =>
+        assert(conn.getResponseCode() === HttpServletResponse.SC_FOUND)
+        val location = Option(conn.getHeaderFields().get("Location"))
+          .map(_.get(0)).orNull
+        assert(location === s"$serverAddr/prefix/dst")
+      }
+
+      // Not really used by Spark, but test with a relative redirect.
+      val relative = JettyUtils.createRedirectHandler("/rel", "root")
+      serverInfo.addHandler(relative, securityMgr)
+      TestUtils.withHttpConnection(new URL(s"$serverAddr/rel/"), followRedirect = false) { conn =>
+        assert(conn.getResponseCode() === HttpServletResponse.SC_FOUND)
+        val location = Option(conn.getHeaderFields().get("Location"))
+          .map(_.get(0)).orNull
+        assert(location === s"$serverAddr/rel/root")
+      }
+    } finally {
+      stopServer(serverInfo)
+    }
+  }
+
+  test("SPARK-45468 redirect without host") {
+    val (conf, securityMgr, sslOptions) = sslDisabledConf()
+    conf.set(UI.REDIRECT_WITHOUT_HOST, true)
+
+    val serverInfo = JettyUtils.startJettyServer("0.0.0.0", 0, sslOptions, conf)
+    try {
+      val serverAddr = s"http://$localhost:${serverInfo.boundPort}"
+
+      val redirect = JettyUtils.createRedirectHandler("/src", "/dst")
+      serverInfo.addHandler(redirect, securityMgr)
+
+      // Test with a URL handled by the added redirect handler, and also including a path prefix.
+      val headers = Seq("X-Forwarded-Context" -> "/prefix")
+      TestUtils.withHttpConnection(
+          new URL(s"$serverAddr/src/"),
+          headers = headers,
+          followRedirect = false) { conn =>
+        assert(conn.getResponseCode() === HttpServletResponse.SC_FOUND)
+        val location = Option(conn.getHeaderFields().get("Location"))
+          .map(_.get(0)).orNull
+        assert(location === "/prefix/dst")
+      }
+
+      // Not really used by Spark, but test with a relative redirect.
+      val relative = JettyUtils.createRedirectHandler("/rel", "root")
+      serverInfo.addHandler(relative, securityMgr)
+      TestUtils.withHttpConnection(new URL(s"$serverAddr/rel/"), followRedirect = false) { conn =>
+        assert(conn.getResponseCode() === HttpServletResponse.SC_FOUND)
+        val location = Option(conn.getHeaderFields().get("Location"))
+          .map(_.get(0)).orNull
+        assert(location === "/rel/root")
+      }
+    } finally {
+      stopServer(serverInfo)
+    }
+  }
+
+  test("SPARK-45468 redirect without host is disabled if proxyRedirectUri is set") {
+    val proxyRoot = "https://proxy.example.com:443/prefix"
+    val (conf, securityMgr, sslOptions) = sslDisabledConf()
+    conf.set(UI.PROXY_REDIRECT_URI, proxyRoot)
+    conf.set(UI.REDIRECT_WITHOUT_HOST, true)
+
+    val serverInfo = JettyUtils.startJettyServer("0.0.0.0", 0, sslOptions, conf)
+    try {
+      val serverAddr = s"http://$localhost:${serverInfo.boundPort}"
+
+      val redirect = JettyUtils.createRedirectHandler("/src", "/dst")
+      serverInfo.addHandler(redirect, securityMgr)
+
+      // Test with a URL handled by the added redirect handler, and also including a path prefix.
+      val headers = Seq("X-Forwarded-Context" -> "/prefix")
+      TestUtils.withHttpConnection(
+          new URL(s"$serverAddr/src/"),
+          headers = headers) { conn =>
+        assert(conn.getResponseCode() === HttpServletResponse.SC_FOUND)
+        val location = Option(conn.getHeaderFields().get("Location"))
+          .map(_.get(0)).orNull
+        assert(location === s"$proxyRoot/prefix/dst")
+      }
+
+      // Not really used by Spark, but test with a relative redirect.
+      val relative = JettyUtils.createRedirectHandler("/rel", "root")
+      serverInfo.addHandler(relative, securityMgr)
+      TestUtils.withHttpConnection(new URL(s"$serverAddr/rel/")) { conn =>
+        assert(conn.getResponseCode() === HttpServletResponse.SC_FOUND)
+        val location = Option(conn.getHeaderFields().get("Location"))
+          .map(_.get(0)).orNull
+        assert(location === s"$proxyRoot/rel/root")
+      }
+    } finally {
+      stopServer(serverInfo)
+    }
+  }
+
   test("SPARK-34449: Jetty 9.4.35.v20201120 and later no longer return status code 302 " +
        " and handle internally when request URL ends with a context path without trailing '/'") {
     val proxyRoot = "https://proxy.example.com:443/prefix"


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR aims to make HTTP redirects behavior in Web UI similar to other hyperlinks in the UI by using a path without host for Location header so that reverse proxies can be handled transparently in the same as other hyperlinks.

#### Example
Let's say proxy reverse URL is `https://example.org/sparkui/...` forwarding to `http://drv.svc/...` and `spark.ui.proxyRoot` is configured to be `/sparkui`.

##### Existing behavior (without `spark.ui.proxyRedirectUri`)
job/stage kill links, for example, redirect to `http://drv.svc/jobs/` that likely results in 404.
(other hyperlinks point to paths with prefix, e.g., `/sparkui/executors` that works fine)

##### After the change
The kill links redirect to `/sparkui/jobs/` that correctly opens jobs tab of the proxy host.
This behavior is also consistent with other hyperlinks.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Currently, proxies can be made transparent for hyperlinks in Spark web UIs with `spark.ui.proxyRoot` or `X-Forwarded-Context` header. However, HTTP redirects (such as job/stage kill) currently requires explicit `spark.ui.proxyRedirectUri` for handling proxy. This is not ideal as proxy hostname may not be known at the time of configuring Spark apps.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

HTTP redirect paths will be without scheme and hosts. This is transparent to users as long as their HTTP client/browser conforms to [RFC 7231](https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.2) from 2014. When users set `spark.ui.proxyRedirectUri`, the existing behavior of redirecting with explicit proxy host and scheme is not affected by this change.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added unit-tests. Also confirmed that Spark UI redirects work fine behind an Envoy proxy with prefix without setting `spark.ui.proxyRedirectUri` in a k8s cluster.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No

