### PR TITLE
[SPARK-45477][INFRA] Use `matrix.java/inputs.java` to replace the hardcoded Java version in `test results/unit tests log` naming

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -460,13 +460,13 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v3
       with:
-        name: test-results-${{ matrix.modules }}--8-${{ inputs.hadoop }}-hive2.3
+        name: test-results-${{ matrix.modules }}--${{ matrix.java }}-${{ inputs.hadoop }}-hive2.3
         path: "**/target/test-reports/*.xml"
     - name: Upload unit tests log files
       if: ${{ !success() }}
       uses: actions/upload-artifact@v3
       with:
-        name: unit-tests-log-${{ matrix.modules }}--8-${{ inputs.hadoop }}-hive2.3
+        name: unit-tests-log-${{ matrix.modules }}--${{ matrix.java }}-${{ inputs.hadoop }}-hive2.3
         path: "**/target/unit-tests.log"
 
   sparkr:
@@ -545,7 +545,7 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v3
       with:
-        name: test-results-sparkr--8-${{ inputs.hadoop }}-hive2.3
+        name: test-results-sparkr--${{ inputs.java }}-${{ inputs.hadoop }}-hive2.3
         path: "**/target/test-reports/*.xml"
 
   breaking-changes-buf:
@@ -911,13 +911,13 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v3
       with:
-        name: test-results-tpcds--8-${{ inputs.hadoop }}-hive2.3
+        name: test-results-tpcds--${{ inputs.java }}-${{ inputs.hadoop }}-hive2.3
         path: "**/target/test-reports/*.xml"
     - name: Upload unit tests log files
       if: ${{ !success() }}
       uses: actions/upload-artifact@v3
       with:
-        name: unit-tests-log-tpcds--8-${{ inputs.hadoop }}-hive2.3
+        name: unit-tests-log-tpcds--${{ inputs.java }}-${{ inputs.hadoop }}-hive2.3
         path: "**/target/unit-tests.log"
 
   docker-integration-tests:
@@ -978,13 +978,13 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v3
       with:
-        name: test-results-docker-integration--8-${{ inputs.hadoop }}-hive2.3
+        name: test-results-docker-integration--${{ inputs.java }}-${{ inputs.hadoop }}-hive2.3
         path: "**/target/test-reports/*.xml"
     - name: Upload unit tests log files
       if: ${{ !success() }}
       uses: actions/upload-artifact@v3
       with:
-        name: unit-tests-log-docker-integration--8-${{ inputs.hadoop }}-hive2.3
+        name: unit-tests-log-docker-integration--${{ inputs.java }}-${{ inputs.hadoop }}-hive2.3
         path: "**/target/unit-tests.log"
 
   k8s-integration-tests:


### PR DESCRIPTION
### What changes were proposed in this pull request?
There are some places in `build_and_test.yml` where the Java version part is hardcoded to 8 when naming `test results/unit tests log`, this pr changes them to use `matrix.java/inputs.java`.

### Why are the changes needed?
The actual Java version should be used to name the `test results/unit tests log`.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Monitor GA, check if the `test results/unit tests log` has used the actual Java version for naming.


### Was this patch authored or co-authored using generative AI tooling?
No