### PR TITLE
[SPARK-45479][INFRA] Uses the default Python versions in the scheduled builds in other branches

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -448,7 +448,12 @@ jobs:
           export SKIP_PACKAGING=false
           echo "Python Packaging Tests Enabled!"
         fi
-        ./dev/run-tests --parallelism 1 --modules "$MODULES_TO_TEST" --python-executables "$PYTHON_TO_TEST"
+        if [ ! -z "$PYTHON_TO_TEST" ]; then
+          ./dev/run-tests --parallelism 1 --modules "$MODULES_TO_TEST" --python-executables "$PYTHON_TO_TEST"
+        else
+          # For branch-3.5 and below, it uses the default Python versions.
+          ./dev/run-tests --parallelism 1 --modules "$MODULES_TO_TEST"
+        fi
     - name: Upload coverage to Codecov
       if: fromJSON(inputs.envs).PYSPARK_CODECOV == 'true'
       uses: codecov/codecov-action@v2

--- a/.github/workflows/build_branch33.yml
+++ b/.github/workflows/build_branch33.yml
@@ -36,7 +36,8 @@ jobs:
       hadoop: hadoop3
       envs: >-
         {
-          "SCALA_PROFILE": "scala2.13"
+          "SCALA_PROFILE": "scala2.13",
+          "PYTHON_TO_TEST": ""
         }
       jobs: >-
         {

--- a/.github/workflows/build_branch34.yml
+++ b/.github/workflows/build_branch34.yml
@@ -36,7 +36,8 @@ jobs:
       hadoop: hadoop3
       envs: >-
         {
-          "SCALA_PROFILE": "scala2.13"
+          "SCALA_PROFILE": "scala2.13",
+          "PYTHON_TO_TEST": ""
         }
       jobs: >-
         {

--- a/.github/workflows/build_branch35.yml
+++ b/.github/workflows/build_branch35.yml
@@ -36,7 +36,8 @@ jobs:
       hadoop: hadoop3
       envs: >-
         {
-          "SCALA_PROFILE": "scala2.13"
+          "SCALA_PROFILE": "scala2.13",
+          "PYTHON_TO_TEST": ""
         }
       jobs: >-
         {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR explicitly sets `PYTHON_TO_TEST` to an empty string for other branches so they use their default Python versions.
https://github.com/apache/spark/pull/43209 added a new option to the testing script but that option does not exist in other branches so it fails.

### Why are the changes needed?

To recover the build (see https://github.com/apache/spark/actions/workflows/build_branch33.yml, https://github.com/apache/spark/actions/workflows/build_branch34.yml and https://github.com/apache/spark/actions/workflows/build_branch35.yml)

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

After merging this, I will monitor the build. I locally tested the changes too.

### Was this patch authored or co-authored using generative AI tooling?

No.