### PR TITLE
[SPARK-45496][CORE][DSTREAM] Fix the compilation warning related to `other-pure-statement`

### DIFF
--- a/core/src/test/scala/org/apache/spark/scheduler/OutputCommitCoordinatorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/OutputCommitCoordinatorSuite.scala
@@ -161,7 +161,7 @@ class OutputCommitCoordinatorSuite extends SparkFunSuite with BeforeAndAfter {
     def resultHandler(x: Int, y: Unit): Unit = {}
     val futureAction: SimpleFutureAction[Unit] = sc.submitJob[Int, Unit, Unit](rdd,
       OutputCommitFunctions(tempDir.getAbsolutePath).commitSuccessfully,
-      0 until rdd.partitions.size, resultHandler, () => ())
+      0 until rdd.partitions.size, resultHandler, ())
     // It's an error if the job completes successfully even though no committer was authorized,
     // so throw an exception if the job was allowed to complete.
     intercept[TimeoutException] {

--- a/pom.xml
+++ b/pom.xml
@@ -2970,9 +2970,6 @@
               <arg>-Wconf:cat=scaladoc:wv</arg>
               <arg>-Wconf:cat=lint-multiarg-infix:wv</arg>
               <arg>-Wconf:cat=other-nullary-override:wv</arg>
-              <arg>-Wconf:cat=other-match-analysis&amp;site=org.apache.spark.sql.catalyst.catalog.SessionCatalog.lookupFunction.catalogFunction:wv</arg>
-              <arg>-Wconf:cat=other-pure-statement&amp;site=org.apache.spark.streaming.util.FileBasedWriteAheadLog.readAll.readFile:wv</arg>
-              <arg>-Wconf:cat=other-pure-statement&amp;site=org.apache.spark.scheduler.OutputCommitCoordinatorSuite:wv</arg>
               <!--
                 SPARK-33775 Suppress compilation warnings that contain the following contents.
                 TODO(SPARK-33805): Undo the corresponding deprecated usage suppression rule after fixed.

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -234,10 +234,6 @@ object SparkBuild extends PomBuild {
         "-Wunused:imports",
         "-Wconf:cat=lint-multiarg-infix:wv",
         "-Wconf:cat=other-nullary-override:wv",
-        "-Wconf:cat=other-match-analysis&site=org.apache.spark.sql.catalyst.catalog.SessionCatalog.lookupFunction.catalogFunction:wv",
-        "-Wconf:cat=other-pure-statement&site=org.apache.spark.streaming.util.FileBasedWriteAheadLog.readAll.readFile:wv",
-        "-Wconf:cat=other-pure-statement&site=org.apache.spark.scheduler.OutputCommitCoordinatorSuite:wv",
-        "-Wconf:cat=other-pure-statement&site=org.apache.spark.sql.streaming.sources.StreamingDataSourceV2Suite.testPositiveCase.\\$anonfun:wv",
         // SPARK-33775 Suppress compilation warnings that contain the following contents.
         // TODO(SPARK-33805): Undo the corresponding deprecated usage suppression rule after
         //  fixed.

--- a/streaming/src/main/scala/org/apache/spark/streaming/util/FileBasedWriteAheadLog.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/util/FileBasedWriteAheadLog.scala
@@ -139,7 +139,7 @@ private[streaming] class FileBasedWriteAheadLog(
     def readFile(file: String): Iterator[ByteBuffer] = {
       logDebug(s"Creating log reader with $file")
       val reader = new FileBasedWriteAheadLogReader(file, hadoopConf)
-      CompletionIterator[ByteBuffer, Iterator[ByteBuffer]](reader, () => reader.close())
+      CompletionIterator[ByteBuffer, Iterator[ByteBuffer]](reader, reader.close())
     }
     if (!closeFileAfterWrite) {
       logFilesToRead.iterator.flatMap(readFile).asJava


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR fixes two compilation warnings related to `other-pure-statement` 

```
[error] /Users/yangjie01/SourceCode/git/spark-mine-sbt/core/src/test/scala/org/apache/spark/scheduler/OutputCommitCoordinatorSuite.scala:164:54: a pure expression does nothing in statement position
[error] Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=other-pure-statement, site=org.apache.spark.scheduler.OutputCommitCoordinatorSuite
[error]       0 until rdd.partitions.size, resultHandler, () => ())

[error] /Users/yangjie01/SourceCode/git/spark-mine-sbt/streaming/src/main/scala/org/apache/spark/streaming/util/FileBasedWriteAheadLog.scala:142:71: a pure expression does nothing in statement position
[error] Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=other-pure-statement, site=org.apache.spark.streaming.util.FileBasedWriteAheadLog.readAll.readFile
[error]       CompletionIterator[ByteBuffer, Iterator[ByteBuffer]](reader, () => reader.close())
```

and removes the corresponding suppression rules from the compilation options

```
"-Wconf:cat=other-pure-statement&site=org.apache.spark.streaming.util.FileBasedWriteAheadLog.readAll.readFile:wv",
"-Wconf:cat=other-pure-statement&site=org.apache.spark.scheduler.OutputCommitCoordinatorSuite:wv",
```

On the other hand, the code corresponding to the following two suppression rules no longer exists, so the corresponding suppression rules were also cleaned up in this pr.

```
"-Wconf:cat=other-match-analysis&site=org.apache.spark.sql.catalyst.catalog.SessionCatalog.lookupFunction.catalogFunction:wv",
"-Wconf:cat=other-pure-statement&site=org.apache.spark.sql.streaming.sources.StreamingDataSourceV2Suite.testPositiveCase.\\$anonfun:wv",
```

### Why are the changes needed?
Code clean up.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No
