### PR TITLE
[SPARK-45488][SQL] XML: Add support for value in 'rowTag' element

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/StaxXmlParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/StaxXmlParser.scala
@@ -122,7 +122,12 @@ class StaxXmlParser(
       }
       val parser = StaxXmlParserUtils.filteredReader(xml)
       val rootAttributes = StaxXmlParserUtils.gatherRootAttributes(parser)
-      Some(convertObject(parser, schema, options, rootAttributes))
+      // A structure object is an attribute-only element
+      // if it only consists of attributes and valueTags.
+      val isRootAttributesOnly = schema.fields.forall { f =>
+        f.name == options.valueTag || f.name.startsWith(options.attributePrefix)
+      }
+      Some(convertObject(parser, schema, options, rootAttributes, isRootAttributesOnly))
     } catch {
       case e: SparkUpgradeException => throw e
       case e@(_: RuntimeException | _: XMLStreamException | _: MalformedInputException
@@ -324,7 +329,8 @@ class StaxXmlParser(
       parser: XMLEventReader,
       schema: StructType,
       options: XmlOptions,
-      rootAttributes: Array[Attribute] = Array.empty): InternalRow = {
+      rootAttributes: Array[Attribute] = Array.empty,
+      isRootAttributesOnly: Boolean = false): InternalRow = {
     val row = new Array[Any](schema.length)
     val nameToIndex = schema.map(_.name).zipWithIndex.toMap
     // If there are attributes, then we process them first.
@@ -389,6 +395,13 @@ class StaxXmlParser(
           case NonFatal(e) =>
             badRecordException = badRecordException.orElse(Some(e))
         }
+
+        case c: Characters if !c.isWhiteSpace && isRootAttributesOnly =>
+          nameToIndex.get(options.valueTag) match {
+            case Some(index) =>
+              row(index) = convertTo(c.getData, schema(index).dataType, options)
+            case None => // do nothing
+          }
 
         case _: EndElement =>
           shouldStop = StaxXmlParserUtils.checkEndElement(parser)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/XmlInferSchema.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/XmlInferSchema.scala
@@ -230,13 +230,13 @@ private[sql] object XmlInferSchema {
         case _ => // do nothing
       }
     }
-     // A structure object is an attribute-only element
-     // if it only consists of attributes and valueTags.
+    // A structure object is an attribute-only element
+    // if it only consists of attributes and valueTags.
     // If not, we will remove the valueTag field from the schema
     val attributesOnly = nameToDataType.forall {
-       case (fieldName, dataTypes) =>
-         dataTypes.length == 1 &&
-           (fieldName == options.valueTag || fieldName.startsWith(options.attributePrefix))
+      case (fieldName, dataTypes) =>
+        dataTypes.length == 1 &&
+        (fieldName == options.valueTag || fieldName.startsWith(options.attributePrefix))
     }
     if (!attributesOnly) {
       nameToDataType -= options.valueTag

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/XmlInferSchema.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/XmlInferSchema.scala
@@ -219,11 +219,27 @@ private[sql] object XmlInferSchema {
           dataTypes += inferredType
           nameToDataType += (field -> dataTypes)
 
+        case c: Characters if !c.isWhiteSpace =>
+          // This can be an attribute-only object
+          val valueTagType = inferFrom(c.getData, options)
+          nameToDataType += options.valueTag -> ArrayBuffer(valueTagType)
+
         case _: EndElement =>
           shouldStop = StaxXmlParserUtils.checkEndElement(parser)
 
         case _ => // do nothing
       }
+    }
+     // A structure object is an attribute-only element
+     // if it only consists of attributes and valueTags.
+    // If not, we will remove the valueTag field from the schema
+    val attributesOnly = nameToDataType.forall {
+       case (fieldName, dataTypes) =>
+         dataTypes.length == 1 &&
+           (fieldName == options.valueTag || fieldName.startsWith(options.attributePrefix))
+    }
+    if (!attributesOnly) {
+      nameToDataType -= options.valueTag
     }
     // We need to manually merges the fields having the sames so that
     // This can be inferred as ArrayType.

--- a/sql/core/src/test/resources/test-data/xml-resources/root-level-value-none.xml
+++ b/sql/core/src/test/resources/test-data/xml-resources/root-level-value-none.xml
@@ -2,8 +2,7 @@
 <ROWSET>
     <ROW>value1</ROW>
     <ROW attr="attr1">value2</ROW>
-    <ROW>
-        value3
-        <!-- this is a comment-->
-    </ROW>
+    <ROW>4<tag>5</tag></ROW>
+    <ROW><tag>6</tag>7</ROW>
+    <ROW attr="8"></ROW>
 </ROWSET>

--- a/sql/core/src/test/resources/test-data/xml-resources/root-level-value.xml
+++ b/sql/core/src/test/resources/test-data/xml-resources/root-level-value.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<ROWSET>
+    <ROW>value1</ROW>
+    <ROW attr="attr1">value2</ROW>
+    <ROW>
+        value3
+        <!-- this is a comment-->
+    </ROW>
+</ROWSET>

--- a/sql/core/src/test/resources/test-data/xml-resources/root-level-value.xml
+++ b/sql/core/src/test/resources/test-data/xml-resources/root-level-value.xml
@@ -6,4 +6,7 @@
         value3
         <!-- this is a comment-->
     </ROW>
+    <ROW>4<tag>5</tag></ROW>
+    <ROW><tag>6</tag>7</ROW>
+    <ROW attr="8"></ROW>
 </ROWSET>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/XmlSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/XmlSuite.scala
@@ -1667,7 +1667,7 @@ class XmlSuite extends QueryTest with SharedSparkSession {
     }
   }
 
-  test("root-level value tag for attributes-only object - from xml") {
+  test("SPARK-45488: root-level value tag for attributes-only object - from xml") {
     val xmlData =
       """
          |<ROW attr="attr1">123456</ROW>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/XmlSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/XmlSuite.scala
@@ -1645,4 +1645,43 @@ class XmlSuite extends QueryTest with SharedSparkSession {
       .xml(getTestResourcePath(resDir + "fias_house.xml"))
     assert(df.collect().length === 37)
   }
+
+  test("root-level value tag for attributes-only object") {
+
+    val schema = buildSchema(field("_attr"), field("_VALUE"))
+    val results = Seq(
+      // user specified schema
+      spark.read
+        .schema(schema)
+        .xml(getTestResourcePath(resDir + "root-level-value.xml")).collect(),
+      // schema inference
+      spark.read
+        .xml(getTestResourcePath(resDir + "root-level-value.xml")).collect())
+    results.foreach { result =>
+      assert(result.length === 3)
+      assert(result(0).getAs[String]("_VALUE") == "value1")
+      assert(result(1).getAs[String]("_attr") == "attr1"
+        && result(1).getAs[String]("_VALUE") == "value2")
+      // comments aren't included in valueTag
+      assert(result(2).getAs[String]("_VALUE") == "\n        value3\n        ")
+    }
+  }
+
+  test("root-level value tag for attributes-only object - from xml") {
+    val xmlData =
+      s"""
+         |<ROW attr="attr1">123456</ROW>
+         |""".stripMargin
+    val df = Seq((1, xmlData)).toDF("number", "payload")
+    val xmlSchema = schema_of_xml(xmlData)
+    val schema = buildSchema(
+      field("_VALUE", LongType),
+      field("_attr"))
+    val expectedSchema = df.schema.add("decoded", schema)
+    val result = df.withColumn("decoded",
+      from_xml(df.col("payload"), xmlSchema, Map[String, String]().asJava))
+    assert(expectedSchema == result.schema)
+    assert(result.select("decoded._VALUE").head().getLong(0) === 123456L)
+    assert(result.select("decoded._attr").head().getString(0) === "attr1")
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/XmlSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/XmlSuite.scala
@@ -1646,7 +1646,7 @@ class XmlSuite extends QueryTest with SharedSparkSession {
     assert(df.collect().length === 37)
   }
 
-  test("root-level value tag for attributes-only object") {
+  test("SPARK-45488: root-level value tag for attributes-only object") {
 
     val schema = buildSchema(field("_attr"), field("_VALUE"))
     val results = Seq(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/XmlSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/XmlSuite.scala
@@ -1647,7 +1647,6 @@ class XmlSuite extends QueryTest with SharedSparkSession {
   }
 
   test("SPARK-45488: root-level value tag for attributes-only object") {
-
     val schema = buildSchema(field("_attr"), field("_VALUE"))
     val results = Seq(
       // user specified schema
@@ -1668,10 +1667,7 @@ class XmlSuite extends QueryTest with SharedSparkSession {
   }
 
   test("SPARK-45488: root-level value tag for attributes-only object - from xml") {
-    val xmlData =
-      """
-         |<ROW attr="attr1">123456</ROW>
-         |""".stripMargin
+    val xmlData = """<ROW attr="attr1">123456</ROW>"""
     val df = Seq((1, xmlData)).toDF("number", "payload")
     val xmlSchema = schema_of_xml(xmlData)
     val schema = buildSchema(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/XmlSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/XmlSuite.scala
@@ -1669,7 +1669,7 @@ class XmlSuite extends QueryTest with SharedSparkSession {
 
   test("root-level value tag for attributes-only object - from xml") {
     val xmlData =
-      s"""
+      """
          |<ROW attr="attr1">123456</ROW>
          |""".stripMargin
     val df = Seq((1, xmlData)).toDF("number", "payload")


### PR DESCRIPTION
### What changes were proposed in this pull request?

The following XML with rowTag 'book' will yield a schema with just "_id" column and not the value:
 
```
 <p><book id="1">Great Book</book> </p>   
```

Let's parse value as well. The scope of this PR is to keep the rowTag's behavior of `valueTag` consistent with the inner objects.


### Why are the changes needed?


The semantics for attributes and `valueTag` should be consistent

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?


Unit test

### Was this patch authored or co-authored using generative AI tooling?

No