### PR TITLE
[SPARK-45499][CORE][TESTS] Replace `Reference#isEnqueued` with `Reference#refersTo(null)`

### DIFF
--- a/core/src/test/scala/org/apache/spark/util/CompletionIteratorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/CompletionIteratorSuite.scala
@@ -57,13 +57,13 @@ class CompletionIteratorSuite extends SparkFunSuite {
     sub = null
     iter.toArray
 
-    for (_ <- 1 to 100 if !ref.isEnqueued) {
+    for (_ <- 1 to 100 if !ref.refersTo(null)) {
       System.gc()
-      if (!ref.isEnqueued) {
+      if (!ref.refersTo(null)) {
         Thread.sleep(10)
       }
     }
-    assert(ref.isEnqueued)
+    assert(ref.refersTo(null))
     assert(refQueue.poll() === ref)
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr just replace `Reference#isEnqueued` with `Reference#refersTo` in `CompletionIteratorSuite`, the solution refer to

https://github.com/openjdk/jdk/blob/dfacda488bfbe2e11e8d607a6d08527710286982/src/java.base/share/classes/java/lang/ref/Reference.java#L436-L454

```
     * @deprecated
     * This method was originally specified to test if a reference object has
     * been cleared and enqueued but was never implemented to do this test.
     * This method could be misused due to the inherent race condition
     * or without an associated {@code ReferenceQueue}.
     * An application relying on this method to release critical resources
     * could cause serious performance issue.
     * An application should use {@link ReferenceQueue} to reliably determine
     * what reference objects that have been enqueued or
     * {@link #refersTo(Object) refersTo(null)} to determine if this reference
     * object has been cleared.
     *
     * @return   {@code true} if and only if this reference object is
     *           in its associated queue (if any).
     */
    @Deprecated(since="16")
    public boolean isEnqueued() {
        return (this.queue == ReferenceQueue.ENQUEUED);
    }
```

### Why are the changes needed?
Clean up deprecated api usage.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No