### PR TITLE
[SPARK-45532][DOCS] Restore codetabs for the Protobuf Data Source Guide

### DIFF
--- a/docs/sql-data-sources-protobuf.md
+++ b/docs/sql-data-sources-protobuf.md
@@ -18,6 +18,9 @@ license: |
   limitations under the License.
 ---
 
+* This will become a table of contents (this text will be scraped).
+{:toc}
+
 Since Spark 3.4.0 release, [Spark SQL](https://spark.apache.org/docs/latest/sql-programming-guide.html) provides built-in support for reading and writing protobuf data.
 
 ## Deploying
@@ -46,18 +49,20 @@ Kafka key-value record will be augmented with some metadata, such as the ingesti
 
 Spark SQL schema is generated based on the protobuf descriptor file or protobuf class passed to `from_protobuf` and `to_protobuf`. The specified protobuf class or protobuf descriptor file must match the data, otherwise, the behavior is undefined: it may fail or return arbitrary results.
 
-### Python
-```python
+<div class="codetabs">
+
+<div data-lang="python" markdown="1">
+{% highlight python %}
 from pyspark.sql.protobuf.functions import from_protobuf, to_protobuf
 
-# `from_protobuf` and `to_protobuf` provides two schema choices. Via Protobuf descriptor file,
-# or via shaded Java class.
+# `from_protobuf` and `to_protobuf` provides two schema choices. First, via the protobuf descriptor
+# file, and then via the protobuf message class name.
 # give input .proto protobuf schema
 # syntax  = "proto3"
 # message AppEvent {
-#  string name = 1;
-#  int64 id = 2;
-#  string context = 3;
+#    string name = 1;
+#    int64 id = 2;
+#    string context = 3;
 # }
 
 df = spark\
@@ -102,14 +107,16 @@ query = output\
 .option("kafka.bootstrap.servers", "host1:port1,host2:port2")\
 .option("topic", "topic2")\
 .start()
-```
 
-### Scala
-```scala
+{% endhighlight %}
+</div>
+
+<div data-lang="scala" markdown="1">
+{% highlight scala %}
 import org.apache.spark.sql.protobuf.functions._
 
-// `from_protobuf` and `to_protobuf` provides two schema choices. Via Protobuf descriptor file,
-// or via shaded Java class.
+// `from_protobuf` and `to_protobuf` provides two schema choices. First, via the protobuf descriptor
+// file, and then via the protobuf message class name.
 // give input .proto protobuf schema
 // syntax  = "proto3"
 // message AppEvent {
@@ -165,21 +172,23 @@ val query = output
 .option("kafka.bootstrap.servers", "host1:port1,host2:port2")
 .option("topic", "topic2")
 .start()
-```
 
-### Java
-```java
+{% endhighlight %}
+</div>
+
+<div data-lang="java" markdown="1">
+{% highlight java %}
 import static org.apache.spark.sql.functions.col;
 import static org.apache.spark.sql.protobuf.functions.*;
 
-// `from_protobuf` and `to_protobuf` provides two schema choices. Via Protobuf descriptor file,
-// or via shaded Java class.
+// `from_protobuf` and `to_protobuf` provides two schema choices. First, via the protobuf descriptor
+// file, and then via the protobuf message class name.
 // give input .proto protobuf schema
 // syntax  = "proto3"
 // message AppEvent {
-//  string name = 1;
-//  int64 id = 2;
-//  string context = 3;
+//    string name = 1;
+//    int64 id = 2;
+//    string context = 3;
 // }
 
 Dataset<Row> df = spark
@@ -226,14 +235,18 @@ StreamingQuery query = output
 .option("kafka.bootstrap.servers", "host1:port1,host2:port2")
 .option("topic", "topic2")
 .start();
-```
+
+{% endhighlight %}
+</div>
+
+</div>
 
 ## Supported types for Protobuf -> Spark SQL conversion
 Currently Spark supports reading [protobuf scalar types](https://developers.google.com/protocol-buffers/docs/proto3#scalar), [enum types](https://developers.google.com/protocol-buffers/docs/proto3#enum), [nested type](https://developers.google.com/protocol-buffers/docs/proto3#nested), and [maps type](https://developers.google.com/protocol-buffers/docs/proto3#maps) under messages of Protobuf.
 In addition to the these types, `spark-protobuf` also introduces support for Protobuf `OneOf` fields. which allows you to handle messages that can have multiple possible sets of fields, but only one set can be present at a time. This is useful for situations where the data you are working with is not always in the same format, and you need to be able to handle messages with different sets of fields without encountering errors.
 
-<table class="table">
-  <tr><th><b>Protobuf type</b></th><th><b>Spark SQL type</b></th></tr>
+<table class="table table-striped">
+  <thead><tr><th><b>Protobuf type</b></th><th><b>Spark SQL type</b></th></tr></thead>
   <tr>
     <td>boolean</td>
     <td>BooleanType</td>
@@ -282,16 +295,12 @@ In addition to the these types, `spark-protobuf` also introduces support for Pro
     <td>OneOf</td>
     <td>Struct</td>
   </tr>
-  <tr>
-    <td>Any</td>
-    <td>StructType</td>
-  </tr>
 </table>
 
 It also supports reading the following Protobuf types [Timestamp](https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#timestamp) and [Duration](https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#duration)
 
-<table class="table">
-  <tr><th><b>Protobuf logical type</b></th><th><b>Protobuf schema</b></th><th><b>Spark SQL type</b></th></tr>
+<table class="table table-striped">
+  <thead><tr><th><b>Protobuf logical type</b></th><th><b>Protobuf schema</b></th><th><b>Spark SQL type</b></th></tr></thead>
   <tr>
     <td>duration</td>
     <td>MessageType{seconds: Long, nanos: Int}</td>
@@ -307,8 +316,8 @@ It also supports reading the following Protobuf types [Timestamp](https://develo
 ## Supported types for Spark SQL -> Protobuf conversion
 Spark supports the writing of all Spark SQL types into Protobuf. For most types, the mapping from Spark types to Protobuf types is straightforward (e.g. IntegerType gets converted to int);
 
-<table class="table">
-  <tr><th><b>Spark SQL type</b></th><th><b>Protobuf type</b></th></tr>
+<table class="table table-striped">
+  <thead><tr><th><b>Spark SQL type</b></th><th><b>Protobuf type</b></th></tr></thead>
   <tr>
     <td>BooleanType</td>
     <td>boolean</td>
@@ -357,13 +366,14 @@ Spark supports the writing of all Spark SQL types into Protobuf. For most types,
 
 ## Handling circular references protobuf fields
 One common issue that can arise when working with Protobuf data is the presence of circular references. In Protobuf, a circular reference occurs when a field refers back to itself or to another field that refers back to the original field. This can cause issues when parsing the data, as it can result in infinite loops or other unexpected behavior.
-To address this issue, the latest version of spark-protobuf introduces a new feature: the ability to check for circular references through field types. This allows users use the `recursive.fields.max.depth` option to specify the maximum number of levels of recursion to allow when parsing the schema. By default, `spark-protobuf` will not permit recursive fields by setting `recursive.fields.max.depth` to -1. However, you can set this option to 0 to 10 if needed. 
+To address this issue, the latest version of spark-protobuf introduces a new feature: the ability to check for circular references through field types. This allows users use the `recursive.fields.max.depth` option to specify the maximum number of levels of recursion to allow when parsing the schema. By default, `spark-protobuf` will not permit recursive fields by setting `recursive.fields.max.depth` to -1. However, you can set this option to 0 to 10 if needed.
 
 Setting `recursive.fields.max.depth` to 0 drops all recursive fields, setting it to 1 allows it to be recursed once, and setting it to 2 allows it to be recursed twice. A `recursive.fields.max.depth` value greater than 10 is not allowed, as it can lead to performance issues and even stack overflows.
 
 SQL Schema for the below protobuf message will vary based on the value of `recursive.fields.max.depth`.
 
-```proto
+<div data-lang="scala" markdown="1">
+{% highlight scala %}
 syntax  = "proto3"
 message Person {
   string name = 1;
@@ -376,4 +386,6 @@ message Person {
 0: struct<name: string, bff: null>
 1: struct<name string, bff: <name: string, bff: null>>
 2: struct<name string, bff: <name: string, bff: struct<name: string, bff: null>>> ...
-```
+
+{% endhighlight %}
+</div>

--- a/docs/sql-data-sources-protobuf.md
+++ b/docs/sql-data-sources-protobuf.md
@@ -21,7 +21,7 @@ license: |
 * This will become a table of contents (this text will be scraped).
 {:toc}
 
-Since Spark 3.4.0 release, [Spark SQL](https://spark.apache.org/docs/latest/sql-programming-guide.html) provides built-in support for reading and writing protobuf data.
+Since Spark 3.4.0 release, [Spark SQL](sql-programming-guide.html) provides built-in support for reading and writing protobuf data.
 
 ## Deploying
 The `spark-protobuf` module is external and not included in `spark-submit` or `spark-shell` by default.
@@ -52,44 +52,50 @@ Spark SQL schema is generated based on the protobuf descriptor file or protobuf 
 <div class="codetabs">
 
 <div data-lang="python" markdown="1">
+
+<div class="d-none">
+This div is only used to make markdown editor/viewer happy and does not display on web
+
+```python
+</div>
+
 {% highlight python %}
+
 from pyspark.sql.protobuf.functions import from_protobuf, to_protobuf
 
-# `from_protobuf` and `to_protobuf` provides two schema choices. First, via the protobuf descriptor
-# file, and then via the protobuf message class name.
+# from_protobuf and to_protobuf provide two schema choices. Via Protobuf descriptor file,
+# or via shaded Java class.
 # give input .proto protobuf schema
-# syntax  = "proto3"
+# syntax = "proto3"
 # message AppEvent {
-#    string name = 1;
-#    int64 id = 2;
-#    string context = 3;
+#   string name = 1;
+#   int64 id = 2;
+#   string context = 3;
 # }
-
-df = spark\
-.readStream\
-.format("kafka")\
-.option("kafka.bootstrap.servers", "host1:port1,host2:port2")\
-.option("subscribe", "topic1")\
-.load()
+df = spark
+  .readStream
+  .format("kafka")\
+  .option("kafka.bootstrap.servers", "host1:port1,host2:port2")
+  .option("subscribe", "topic1")
+  .load()
 
 # 1. Decode the Protobuf data of schema `AppEvent` into a struct;
 # 2. Filter by column `name`;
 # 3. Encode the column `event` in Protobuf format.
 # The Protobuf protoc command can be used to generate a protobuf descriptor file for give .proto file.
-output = df\
-.select(from_protobuf("value", "AppEvent", descriptorFilePath).alias("event"))\
-.where('event.name == "alice"')\
-.select(to_protobuf("event", "AppEvent", descriptorFilePath).alias("event"))
+output = df
+  .select(from_protobuf("value", "AppEvent", descriptorFilePath).alias("event"))
+  .where('event.name == "alice"')
+  .select(to_protobuf("event", "AppEvent", descriptorFilePath).alias("event"))
 
 # Alternatively, you can decode and encode the SQL columns into protobuf format using protobuf
 # class name. The specified Protobuf class must match the data, otherwise the behavior is undefined:
 # it may fail or return arbitrary result. To avoid conflicts, the jar file containing the
 # 'com.google.protobuf.*' classes should be shaded. An example of shading can be found at
 # https://github.com/rangadi/shaded-protobuf-classes.
-
-output = df\
-.select(from_protobuf("value", "org.sparkproject.spark_protobuf.protobuf.AppEvent").alias("event"))\
-.where('event.name == "alice"')
+output = df
+  .select(from_protobuf("value", "org.sparkproject.spark_protobuf.protobuf.AppEvent").alias("event"))
+  .where('event.name == "alice"')
 
 output.printSchema()
 # root
@@ -99,54 +105,66 @@ output.printSchema()
 #  |   |-- context: string (nullable = true)
 
 output = output
-.select(to_protobuf("event", "org.sparkproject.spark_protobuf.protobuf.AppEvent").alias("event"))
+  .select(to_protobuf("event", "org.sparkproject.spark_protobuf.protobuf.AppEvent").alias("event"))
 
-query = output\
-.writeStream\
-.format("kafka")\
-.option("kafka.bootstrap.servers", "host1:port1,host2:port2")\
-.option("topic", "topic2")\
-.start()
+query = output
+  .writeStream
+  .format("kafka")
+  .option("kafka.bootstrap.servers", "host1:port1,host2:port2")\
+  .option("topic", "topic2")
+  .start()
 
 {% endhighlight %}
+
+<div class="d-none">
+```
+</div>
+
 </div>
 
 <div data-lang="scala" markdown="1">
+
+<div class="d-none">
+This div is only used to make markdown editor/viewer happy and does not display on web
+
+```scala
+</div>
+
 {% highlight scala %}
 import org.apache.spark.sql.protobuf.functions._
 
-// `from_protobuf` and `to_protobuf` provides two schema choices. First, via the protobuf descriptor
-// file, and then via the protobuf message class name.
+// `from_protobuf` and `to_protobuf` provides two schema choices. Via the protobuf descriptor file,
+// or via shaded Java class.
 // give input .proto protobuf schema
-// syntax  = "proto3"
+// syntax = "proto3"
 // message AppEvent {
-//    string name = 1;
-//    int64 id = 2;
-//    string context = 3;
+//   string name = 1;
+//   int64 id = 2;
+//   string context = 3;
 // }
 
 val df = spark
-.readStream
-.format("kafka")
-.option("kafka.bootstrap.servers", "host1:port1,host2:port2")
-.option("subscribe", "topic1")
-.load()
+  .readStream
+  .format("kafka")
+  .option("kafka.bootstrap.servers", "host1:port1,host2:port2")
+  .option("subscribe", "topic1")
+  .load()
 
 // 1. Decode the Protobuf data of schema `AppEvent` into a struct;
 // 2. Filter by column `name`;
 // 3. Encode the column `event` in Protobuf format.
 // The Protobuf protoc command can be used to generate a protobuf descriptor file for give .proto file.
 val output = df
-.select(from_protobuf($"value", "AppEvent", descriptorFilePath) as $"event")
-.where("event.name == \"alice\"")
-.select(to_protobuf($"user", "AppEvent", descriptorFilePath) as $"event")
+  .select(from_protobuf($"value", "AppEvent", descriptorFilePath) as $"event")
+  .where("event.name == \"alice\"")
+  .select(to_protobuf($"user", "AppEvent", descriptorFilePath) as $"event")
 
 val query = output
-.writeStream
-.format("kafka")
-.option("kafka.bootstrap.servers", "host1:port1,host2:port2")
-.option("topic", "topic2")
-.start()
+  .writeStream
+  .format("kafka")
+  .option("kafka.bootstrap.servers", "host1:port1,host2:port2")
+  .option("topic", "topic2")
+  .start()
 
 // Alternatively, you can decode and encode the SQL columns into protobuf format using protobuf
 // class name. The specified Protobuf class must match the data, otherwise the behavior is undefined:
@@ -154,8 +172,8 @@ val query = output
 // 'com.google.protobuf.*' classes should be shaded. An example of shading can be found at
 // https://github.com/rangadi/shaded-protobuf-classes.
 var output = df
-.select(from_protobuf($"value", "org.example.protos..AppEvent") as $"event")
-.where("event.name == \"alice\"")
+  .select(from_protobuf($"value", "org.example.protos..AppEvent") as $"event")
+  .where("event.name == \"alice\"")
 
 output.printSchema()
 // root
@@ -167,45 +185,56 @@ output.printSchema()
 output = output.select(to_protobuf($"event", "org.sparkproject.spark_protobuf.protobuf.AppEvent") as $"event")
 
 val query = output
-.writeStream
-.format("kafka")
-.option("kafka.bootstrap.servers", "host1:port1,host2:port2")
-.option("topic", "topic2")
-.start()
+  .writeStream
+  .format("kafka")
+  .option("kafka.bootstrap.servers", "host1:port1,host2:port2")
+  .option("topic", "topic2")
+  .start()
 
 {% endhighlight %}
+
+<div class="d-none">
+```
+</div>
 </div>
 
 <div data-lang="java" markdown="1">
+
+<div class="d-none">
+This div is only used to make markdown editor/viewer happy and does not display on web
+
+```java
+</div>
+
 {% highlight java %}
 import static org.apache.spark.sql.functions.col;
 import static org.apache.spark.sql.protobuf.functions.*;
 
-// `from_protobuf` and `to_protobuf` provides two schema choices. First, via the protobuf descriptor
-// file, and then via the protobuf message class name.
+// `from_protobuf` and `to_protobuf` provides two schema choices. Via the protobuf descriptor file,
+// or via shaded Java class.
 // give input .proto protobuf schema
-// syntax  = "proto3"
+// syntax = "proto3"
 // message AppEvent {
-//    string name = 1;
-//    int64 id = 2;
-//    string context = 3;
+//   string name = 1;
+//   int64 id = 2;
+//   string context = 3;
 // }
 
 Dataset<Row> df = spark
-.readStream()
-.format("kafka")
-.option("kafka.bootstrap.servers", "host1:port1,host2:port2")
-.option("subscribe", "topic1")
-.load();
+  .readStream()
+  .format("kafka")
+  .option("kafka.bootstrap.servers", "host1:port1,host2:port2")
+  .option("subscribe", "topic1")
+  .load();
 
 // 1. Decode the Protobuf data of schema `AppEvent` into a struct;
 // 2. Filter by column `name`;
 // 3. Encode the column `event` in Protobuf format.
 // The Protobuf protoc command can be used to generate a protobuf descriptor file for give .proto file.
 Dataset<Row> output = df
-.select(from_protobuf(col("value"), "AppEvent", descriptorFilePath).as("event"))
-.where("event.name == \"alice\"")
-.select(to_protobuf(col("event"), "AppEvent", descriptorFilePath).as("event"));
+  .select(from_protobuf(col("value"), "AppEvent", descriptorFilePath).as("event"))
+  .where("event.name == \"alice\"")
+  .select(to_protobuf(col("event"), "AppEvent", descriptorFilePath).as("event"));
 
 // Alternatively, you can decode and encode the SQL columns into protobuf format using protobuf
 // class name. The specified Protobuf class must match the data, otherwise the behavior is undefined:
@@ -213,10 +242,10 @@ Dataset<Row> output = df
 // 'com.google.protobuf.*' classes should be shaded. An example of shading can be found at
 // https://github.com/rangadi/shaded-protobuf-classes.
 Dataset<Row> output = df
-.select(
-  from_protobuf(col("value"),
-  "org.sparkproject.spark_protobuf.protobuf.AppEvent").as("event"))
-.where("event.name == \"alice\"")
+  .select(
+    from_protobuf(col("value"),
+    "org.sparkproject.spark_protobuf.protobuf.AppEvent").as("event"))
+  .where("event.name == \"alice\"")
 
 output.printSchema()
 // root
@@ -230,18 +259,23 @@ output = output.select(
   "org.sparkproject.spark_protobuf.protobuf.AppEvent").as("event"));
 
 StreamingQuery query = output
-.writeStream()
-.format("kafka")
-.option("kafka.bootstrap.servers", "host1:port1,host2:port2")
-.option("topic", "topic2")
-.start();
+  .writeStream()
+  .format("kafka")
+  .option("kafka.bootstrap.servers", "host1:port1,host2:port2")
+  .option("topic", "topic2")
+  .start();
 
 {% endhighlight %}
+
+<div class="d-none">
+```
+</div>
 </div>
 
 </div>
 
 ## Supported types for Protobuf -> Spark SQL conversion
+
 Currently Spark supports reading [protobuf scalar types](https://developers.google.com/protocol-buffers/docs/proto3#scalar), [enum types](https://developers.google.com/protocol-buffers/docs/proto3#enum), [nested type](https://developers.google.com/protocol-buffers/docs/proto3#nested), and [maps type](https://developers.google.com/protocol-buffers/docs/proto3#maps) under messages of Protobuf.
 In addition to the these types, `spark-protobuf` also introduces support for Protobuf `OneOf` fields. which allows you to handle messages that can have multiple possible sets of fields, but only one set can be present at a time. This is useful for situations where the data you are working with is not always in the same format, and you need to be able to handle messages with different sets of fields without encountering errors.
 
@@ -314,6 +348,7 @@ It also supports reading the following Protobuf types [Timestamp](https://develo
 </table>
 
 ## Supported types for Spark SQL -> Protobuf conversion
+
 Spark supports the writing of all Spark SQL types into Protobuf. For most types, the mapping from Spark types to Protobuf types is straightforward (e.g. IntegerType gets converted to int);
 
 <table class="table table-striped">
@@ -365,6 +400,7 @@ Spark supports the writing of all Spark SQL types into Protobuf. For most types,
 </table>
 
 ## Handling circular references protobuf fields
+
 One common issue that can arise when working with Protobuf data is the presence of circular references. In Protobuf, a circular reference occurs when a field refers back to itself or to another field that refers back to the original field. This can cause issues when parsing the data, as it can result in infinite loops or other unexpected behavior.
 To address this issue, the latest version of spark-protobuf introduces a new feature: the ability to check for circular references through field types. This allows users use the `recursive.fields.max.depth` option to specify the maximum number of levels of recursion to allow when parsing the schema. By default, `spark-protobuf` will not permit recursive fields by setting `recursive.fields.max.depth` to -1. However, you can set this option to 0 to 10 if needed.
 
@@ -372,9 +408,15 @@ Setting `recursive.fields.max.depth` to 0 drops all recursive fields, setting it
 
 SQL Schema for the below protobuf message will vary based on the value of `recursive.fields.max.depth`.
 
-<div data-lang="scala" markdown="1">
-{% highlight scala %}
-syntax  = "proto3"
+<div data-lang="proto" markdown="1">
+<div class="d-none">
+This div is only used to make markdown editor/viewer happy and does not display on web
+
+```protobuf
+</div>
+
+{% highlight protobuf %}
+syntax = "proto3"
 message Person {
   string name = 1;
   Person bff = 2
@@ -388,4 +430,7 @@ message Person {
 2: struct<name string, bff: <name: string, bff: struct<name: string, bff: null>>> ...
 
 {% endhighlight %}
+<div class="d-none">
+```
+</div>
 </div>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR restores the [Protobuf Data Source Guide](https://spark.apache.org/docs/latest/sql-data-sources-protobuf.html#python)'s code tabs which https://github.com/apache/spark/pull/40614 removed for markdown syntax fixes

In this PR, we introduce a hidden div to hold the code-block marker of markdown, then make both the liquid and markdown happy.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

improve doc readability and consistency.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

yes, doc change

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

#### Doc build

![image](https://github.com/apache/spark/assets/8326978/8aefeee0-92b2-4048-a3f6-108e4c3f309d)


#### markdown editor and view

![image](https://github.com/apache/spark/assets/8326978/283b0820-390a-4540-8713-647c40f956ac)


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

no