### PR TITLE
[SPARK-45529][SS][TESTS] Decrease flakiness by ignore zero offset(wip)

### DIFF
--- a/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceOffset.scala
+++ b/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceOffset.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.execution.streaming.{Offset, SerializedOffset}
 private[kafka010]
 case class KafkaSourceOffset(partitionToOffsets: Map[TopicPartition, Long]) extends Offset {
 
-  override val json = JsonUtils.partitionOffsets(partitionToOffsets)
+  override val json = JsonUtils.partitionOffsets(partitionToOffsets.filter(_._2 > 0))
 }
 
 private[kafka010]


### PR DESCRIPTION
### What changes were proposed in this pull request?
Improve the infamous `KafkaSourceStressSuite`, I find there are more than one reason for this problem, the most frequently failure path is: [XXX, Add partition, CheckAnswer], I guess we are not granted to get offsets from empty partitions when fetching data in `MicroBatchExecution`.

 I run the test locally  more than 10 times and they are all successful after made this change, I even increased iterations from 50 to 100 and it only failed once in more than 10 times.

### Why are the changes needed?
To make test less flaky, at least 90% more reliable the before. however, it's still possible to fail since I find some other reason


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Github CI


### Was this patch authored or co-authored using generative AI tooling?
No
