### PR TITLE
[SPARK-45536][BUILD] Lower the default `-Xmx` of `build/mvn` to 3g

### DIFF
--- a/build/mvn
+++ b/build/mvn
@@ -36,7 +36,7 @@ _DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # Preserve the calling directory
 _CALLING_DIR="$(pwd)"
 # Options used during compilation
-_COMPILE_JVM_OPTS="-Xss128m -Xmx4g -XX:ReservedCodeCacheSize=128m"
+_COMPILE_JVM_OPTS="-Xss128m -Xmx3g -XX:ReservedCodeCacheSize=128m"
 
 # Installs any application tarball given a URL, the expected tarball name,
 # and, optionally, a checkable binary path to determine if the binary has


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr lower the default `-Xmx` of `build/mvn` from 4g to 3g to reduce the peak memory usage of Maven compilation.


### Why are the changes needed?
This can potentially fix the snapshot build being failed: https://github.com/apache/spark/actions/runs/6502277099



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?

- Manual check.

run 
```
build/mvn clean install -DskipTests -Pyarn -Pkubernetes -Pvolcano -Phive -Phive-thriftserver -Pspark-ganglia-lgpl -Phadoop-cloud
```

**Before**

Peak memory usage is at 6.1GB.

**After**

Peak memory usage is at 5GB, but the compilation time has increased by 10%.

### Was this patch authored or co-authored using generative AI tooling?
No
