### PR TITLE
[SPARK-45535][BUILD] Do not compile tests for snapshots and release build

### DIFF
--- a/dev/create-release/release-build.sh
+++ b/dev/create-release/release-build.sh
@@ -432,14 +432,14 @@ if [[ "$1" == "publish-snapshot" ]]; then
   echo "</server></servers></settings>" >> $tmp_settings
 
   if [[ $PUBLISH_SCALA_2_12 = 1 ]]; then
-    $MVN --settings $tmp_settings -DskipTests $SCALA_2_12_PROFILES $PUBLISH_PROFILES clean deploy
+    $MVN --settings $tmp_settings -Dmaven.test.skip=true $SCALA_2_12_PROFILES $PUBLISH_PROFILES clean deploy
   fi
 
   if [[ $PUBLISH_SCALA_2_13 = 1 ]]; then
     if [[ $SPARK_VERSION < "4.0" ]]; then
       ./dev/change-scala-version.sh 2.13
     fi
-    $MVN --settings $tmp_settings -DskipTests $SCALA_2_13_PROFILES $PUBLISH_PROFILES clean deploy
+    $MVN --settings $tmp_settings -Dmaven.test.skip=true $SCALA_2_13_PROFILES $PUBLISH_PROFILES clean deploy
   fi
 
   rm $tmp_settings
@@ -473,13 +473,13 @@ if [[ "$1" == "publish-release" ]]; then
     if [[ $SPARK_VERSION < "4.0" ]]; then
       ./dev/change-scala-version.sh 2.13
     fi
-    $MVN -Dmaven.repo.local=$tmp_repo -DskipTests \
+    $MVN -Dmaven.repo.local=$tmp_repo -Dmaven.test.skip=true \
       $SCALA_2_13_PROFILES $PUBLISH_PROFILES clean install
   fi
 
   if [[ $PUBLISH_SCALA_2_12 = 1 ]]; then
     ./dev/change-scala-version.sh 2.12
-    $MVN -Dmaven.repo.local=$tmp_repo -DskipTests \
+    $MVN -Dmaven.repo.local=$tmp_repo -Dmaven.test.skip=true \
       $SCALA_2_12_PROFILES $PUBLISH_PROFILES clean install
   fi
 

--- a/dev/make-distribution.sh
+++ b/dev/make-distribution.sh
@@ -167,7 +167,7 @@ export MAVEN_OPTS="${MAVEN_OPTS:--Xss128m -Xmx4g -XX:ReservedCodeCacheSize=128m}
 # Normal quoting tricks don't work.
 # See: http://mywiki.wooledge.org/BashFAQ/050
 BUILD_COMMAND=("$MVN" clean package \
-    -DskipTests \
+    -Dmaven.test.skip=true \
     -Dmaven.javadoc.skip=true \
     -Dmaven.scaladoc.skip=true \
     -Dmaven.source.skip \

--- a/python/setup.py
+++ b/python/setup.py
@@ -55,7 +55,7 @@ If you are installing pyspark from spark source, you must first build Spark and
 run sdist.
 
     To build Spark with maven you can run:
-      ./build/mvn -DskipTests clean package
+      ./build/mvn -Dmaven.test.skip=true clean package
     Building the source dist is done in the Python directory:
       cd python
       python setup.py sdist


### PR DESCRIPTION
### What changes were proposed in this pull request?

- `-DskipTests` compiles the tests, but skips running them
- `-Dmaven.test.skip=true` skips compiling the tests and does not run them

This PR switches from the former to the latter when we build the release because we do not need test classes.
Other places, we still need to better compile test classes because several tests in PySpark or SparkR need them, e.g., `org.apache.spark.sql.TestQueryExecutionListener` at `pyspark/sql/tests/test_dataframe.py` .

### Why are the changes needed?

- To remove unnecessary overhead for compiling tests.
- This can potentially fix the snapshot build being failed: https://github.com/apache/spark/actions/runs/6502277099

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Manually tested.

### Was this patch authored or co-authored using generative AI tooling?

No.
