### PR TITLE
[SPARK-45537][CORE]Fix the issue where the last task may get stuck in a multi-profile

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -629,7 +629,8 @@ private[spark] class TaskSchedulerImpl(
         if (!launchedAnyTask) {
 
           val hostToExecutorsForTaskSet = hostToExecutors.map { case (host, execsOnHost) =>
-            (host, execsOnHost.filter(taskSet.taskSet.resourceProfileId == executorIdToResourceProfileId(_)))
+            (host, execsOnHost.filter(taskSet.taskSet.resourceProfileId ==
+              executorIdToResourceProfileId(_)))
           }
 
           taskSet.getCompletelyExcludedTaskIfAny(hostToExecutorsForTaskSet).foreach { taskIndex =>
@@ -649,7 +650,8 @@ private[spark] class TaskSchedulerImpl(
               // notify ExecutorAllocationManager to allocate more executors to schedule the
               // unschedulable tasks else we will abort immediately.
               executorIdToRunningTaskIds
-                .filter(x => taskSet.taskSet.resourceProfileId == executorIdToResourceProfileId(x._1))
+                .filter(x => taskSet.taskSet.resourceProfileId ==
+                  executorIdToResourceProfileId(x._1))
                 .find(x => !isExecutorBusy(x._1)) match {
                 case Some ((executorId, _)) =>
                   if (!unschedulableTaskSetToExpiryTime.contains(taskSet)) {

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
@@ -2269,9 +2269,8 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext
     }
   }
 
-  test("test") {
+  test("SPARK-45537: Fix the issue where the last task may get stuck in a multi-profile") {
     val taskCpus = 1
-    val taskGpus = 1
     val executorCpus = 1
 
     val taskScheduler = setupSchedulerWithMockTaskSetExcludelist(

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
@@ -2301,9 +2301,6 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext
     when(tsm.taskSetExcludelistHelperOpt.get.isExecutorExcludedForTask(
       "executor0", failedTask.index)).thenReturn(true)
 
-    // make an offer on the excluded executor.  We won't schedule anything, and set the abort
-    // timer to expire if no new executors could be acquired. We kill the existing idle excluded
-    // executor and try to acquire a new one.
     assert(taskScheduler.resourceOffers(IndexedSeq(
       WorkerOffer("executor0", "host0", 1, resourceProfileId = profileId),
       WorkerOffer("executor1", "host0", 1, resourceProfileId =

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
@@ -2302,8 +2302,8 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext
 
     assert(taskScheduler.resourceOffers(IndexedSeq(
       WorkerOffer("executor0", "host0", 1, resourceProfileId = profileId),
-      WorkerOffer("executor1", "host0", 1, resourceProfileId =
-        ResourceProfile.DEFAULT_RESOURCE_PROFILE_ID),
+      WorkerOffer("executor1", "host0", 1,
+        resourceProfileId = ResourceProfile.DEFAULT_RESOURCE_PROFILE_ID)
     )).flatten.size === 0)
     assert(taskScheduler.unschedulableTaskSetToExpiryTime.contains(tsm))
     assert(!tsm.isZombie)


### PR DESCRIPTION


### What changes were proposed in this pull request?
After the task set fails to find schedulable tasks, before checking if there are tasks that cannot be scheduled on any executor, filter out the executors corresponding to the profileId of that task set.


### Why are the changes needed?

In scenarios involving multiple resource profiles (e.g., prof1 and prof2), when a taskset (prof1) has only one remaining task (task0) awaiting scheduling, and there are executors (executor0 with prof0 and executor1 with prof1), if executor1 fails to run task0, executor1 gets blacklisted for task0. Consequently, task0 becomes unschedulable, leading to a blockage in the task scheduling process.

**Example Code:**

```
val rprof = new ResourceProfileBuilder()
val ereqs = new ExecutorResourceRequests()
ereqs.memory("4g")
ereqs.memoryOverhead("2g").offHeapMemory("1g")
val resourceProfile = rprof.require(ereqs).build()
val rdd = sc.parallelize(1 to 10, 1).withResources(resourceProfile)
rdd.map(num => {
  if (TaskContext.get().attemptNumber() == 0) {
    throw new RuntimeException("First attempt encounters an error")
  } else {
    num / 2
  }
}).collect()
```


**Reason:**
The issue arises when the taskSet becomes unschedulable. The logic attempts to find a task that cannot be scheduled on any executor across all profiles. However, when determining whether an executor can schedule the task, there is no distinction made based on the resource profile. This leads to an incorrect assumption that executor0 (prof0) can schedule the task, which is not the case.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Add Uts


### Was this patch authored or co-authored using generative AI tooling?
No
