### PR TITLE
[SPARK-45538][PYTHON][CONNECT]pyspark connect overwrite_partitions bug

### DIFF
--- a/python/pyspark/sql/connect/plan.py
+++ b/python/pyspark/sql/connect/plan.py
@@ -1743,7 +1743,7 @@ class WriteOperationV2(LogicalPlan):
                 plan.write_operation_v2.mode = proto.WriteOperationV2.Mode.MODE_CREATE
             elif wm == "overwrite":
                 plan.write_operation_v2.mode = proto.WriteOperationV2.Mode.MODE_OVERWRITE
-            elif wm == "overwrite_partition":
+            elif wm == "overwrite_partitions":
                 plan.write_operation_v2.mode = proto.WriteOperationV2.Mode.MODE_OVERWRITE_PARTITIONS
             elif wm == "append":
                 plan.write_operation_v2.mode = proto.WriteOperationV2.Mode.MODE_APPEND


### PR DESCRIPTION


### What changes were proposed in this pull request?

Fix a bug in pyspark connect.

DataFrameWriterV2.overwritePartitions set mode as overwrite_partitions [pyspark/sql/connect/readwriter.py, line 825], but WirteOperationV2 take it as overwrite_partition [pyspark/sql/connect/plan.py, line 1660]


### Why are the changes needed?

make dataframe.writeTo(table).overwritePartitions() work


### Does this PR introduce _any_ user-facing change?

No


### How was this patch tested?

No test. This bug is very obvious.


### Was this patch authored or co-authored using generative AI tooling?

No
