### PR TITLE
[SPARK-44733][PYTHON][DOCS] Add Python to Spark type conversion page to PySpark docs.

### DIFF
--- a/docs/sql-ref-datatypes.md
+++ b/docs/sql-ref-datatypes.md
@@ -119,10 +119,10 @@ from pyspark.sql.types import *
 
 |Data type|Value type in Python|API to access or create a data type|
 |---------|--------------------|-----------------------------------|
-|**ByteType**|int or long<br/>**Note:** Numbers will be converted to 1-byte signed integer numbers at runtime. Please make sure that numbers are within the range of -128 to 127.|ByteType()|
-|**ShortType**|int or long<br/>**Note:** Numbers will be converted to 2-byte signed integer numbers at runtime. Please make sure that numbers are within the range of -32768 to 32767.|ShortType()|
-|**IntegerType**|int or long|IntegerType()|
-|**LongType**|long<br/>**Note:** Numbers will be converted to 8-byte signed integer numbers at runtime. Please make sure that numbers are within the range of -9223372036854775808 to 9223372036854775807. Otherwise, please convert data to decimal.Decimal and use DecimalType.|LongType()|
+|**ByteType**|int<br/>**Note:** Numbers will be converted to 1-byte signed integer numbers at runtime. Please make sure that numbers are within the range of -128 to 127.|ByteType()|
+|**ShortType**|int<br/>**Note:** Numbers will be converted to 2-byte signed integer numbers at runtime. Please make sure that numbers are within the range of -32768 to 32767.|ShortType()|
+|**IntegerType**|int|IntegerType()|
+|**LongType**|int<br/>**Note:** Numbers will be converted to 8-byte signed integer numbers at runtime. Please make sure that numbers are within the range of -9223372036854775808 to 9223372036854775807. Otherwise, please convert data to decimal.Decimal and use DecimalType.|LongType()|
 |**FloatType**|float<br/>**Note:** Numbers will be converted to 4-byte single-precision floating point numbers at runtime.|FloatType()|
 |**DoubleType**|float|DoubleType()|
 |**DecimalType**|decimal.Decimal|DecimalType()|

--- a/python/docs/source/user_guide/sql/index.rst
+++ b/python/docs/source/user_guide/sql/index.rst
@@ -25,4 +25,5 @@ Spark SQL
 
    arrow_pandas
    python_udtf
+   type_conversions
 

--- a/python/docs/source/user_guide/sql/type_conversions.rst
+++ b/python/docs/source/user_guide/sql/type_conversions.rst
@@ -28,6 +28,41 @@ You can access them by doing:
 
     from pyspark.sql.types import *
 
+The conversion between native types and Spark SQL types is especially important to consider when writing Python UDFs.
+
+.. code-block:: python
+
+    from pyspark.sql.types import (
+        StructType,
+        StructField,
+        IntegerType,
+        StringType,
+        FloatType,
+    )
+    from pyspark.sql.functions import udf, col
+
+    df = spark.createDataFrame(
+        [[1]], schema=StructType([StructField("int", IntegerType())])
+    )
+
+    @udf(returnType=StringType())
+    def to_string(value):
+        # Must cast return value to str to convert to StringType.
+        return str(value)
+
+
+    @udf(returnType=FloatType())
+    def to_float(value):
+        # Must cast return value to float to convert to FloatType.
+        return float(value)
+
+
+    df.withColumn("cast_int", to_float(col("int"))).withColumn(
+        "cast_str", to_string(col("int"))
+    ).show()
+
+All conversions can be found below:
+
 .. list-table::
     :header-rows: 1
 
@@ -96,3 +131,5 @@ You can access them by doing:
       - The value type in Python of the data type of this field. For example, Int for a StructField with the data type IntegerType.
       - StructField(*name*, *dataType*, [*nullable*])
           .. note:: The default value of *nullable* is True.
+
+.. TODO: Add explanation and table for type conversions (SPARK-44734).

--- a/python/docs/source/user_guide/sql/type_conversions.rst
+++ b/python/docs/source/user_guide/sql/type_conversions.rst
@@ -19,7 +19,7 @@
 Python to Spark Type Conversions
 ================================
 
-.. TODO: Add additional information on conversions when Arrow is enabled..
+.. TODO: Add additional information on conversions when Arrow is enabled.
 .. TODO: Add in-depth explanation and table for type conversions (SPARK-44734).
 
 .. currentmodule:: pyspark.sql.types
@@ -64,6 +64,77 @@ are listed below:
     * - spark.sql.timestampType
       - If set to `TIMESTAMP_NTZ`, the default timestamp type is ``TimestampNTZType``. Otherwise, the default timestamp type is TimestampType.
       - ""
+
+All Conversions
+---------------
+.. list-table::
+    :header-rows: 1
+
+    * - Data type
+      - Value type in Python
+      - API to access or create a data type
+    * - **ByteType**
+      - int
+          .. note:: Numbers will be converted to 1-byte signed integer numbers at runtime. Please make sure that numbers are within the range of -128 to 127.
+      - ByteType()
+    * - **ShortType**
+      - int
+          .. note:: Numbers will be converted to 2-byte signed integer numbers at runtime. Please make sure that numbers are within the range of -32768 to 32767.
+      - ShortType()
+    * - **IntegerType**
+      - int
+      - IntegerType()
+    * - **LongType**
+      - int
+          .. note:: Numbers will be converted to 8-byte signed integer numbers at runtime. Please make sure that numbers are within the range of -9223372036854775808 to 9223372036854775807. Otherwise, please convert data to decimal.Decimal and use DecimalType.
+      - LongType()
+    * - **FloatType**
+      - float
+          .. note:: Numbers will be converted to 4-byte single-precision floating point numbers at runtime.
+      - FloatType()
+    * - **DoubleType**
+      - float
+      - DoubleType()
+    * - **DecimalType**
+      - decimal.Decimal
+      - DecimalType()|
+    * - **StringType**
+      - string
+      - StringType()
+    * - **BinaryType**
+      - bytearray
+      - BinaryType()
+    * - **BooleanType**
+      - bool
+      - BooleanType()
+    * - **TimestampType**
+      - datetime.datetime
+      - TimestampType()
+    * - **TimestampNTZType**
+      - datetime.datetime
+      - TimestampNTZType()
+    * - **DateType**
+      - datetime.date
+      - DateType()
+    * - **DayTimeIntervalType**
+      - datetime.timedelta
+      - DayTimeIntervalType()
+    * - **ArrayType**
+      - list, tuple, or array
+      - ArrayType(*elementType*, [*containsNull*])
+          .. note:: The default value of *containsNull* is True.
+    * - **MapType**
+      - dict
+      - MapType(*keyType*, *valueType*, [*valueContainsNull]*)
+          .. note:: The default value of *valueContainsNull* is True.
+    * - **StructType**
+      - list or tuple
+      - StructType(*fields*)
+          .. note:: *fields* is a Seq of StructFields. Also, two fields with the same name are not allowed.
+    * - **StructField**
+      - The value type in Python of the data type of this field. For example, Int for a StructField with the data type IntegerType.
+      - StructField(*name*, *dataType*, [*nullable*])
+          .. note:: The default value of *nullable* is True.
 
 Conversions in Practice - UDFs
 ------------------------------
@@ -175,75 +246,3 @@ Nested data types will convert to ``StructType``, ``MapType``, and ``ArrayType``
   #  |    |-- Math: struct (nullable = true)
   #  |    |    |-- H1: double (nullable = true)
   #  |    |    |-- H2: double (nullable = true)
-
-All Conversions
----------------
-
-.. list-table::
-    :header-rows: 1
-
-    * - Data type
-      - Value type in Python
-      - API to access or create a data type
-    * - **ByteType**
-      - int
-          .. note:: Numbers will be converted to 1-byte signed integer numbers at runtime. Please make sure that numbers are within the range of -128 to 127.
-      - ByteType()
-    * - **ShortType**
-      - int
-          .. note:: Numbers will be converted to 2-byte signed integer numbers at runtime. Please make sure that numbers are within the range of -32768 to 32767.
-      - ShortType()
-    * - **IntegerType**
-      - int
-      - IntegerType()
-    * - **LongType**
-      - int
-          .. note:: Numbers will be converted to 8-byte signed integer numbers at runtime. Please make sure that numbers are within the range of -9223372036854775808 to 9223372036854775807. Otherwise, please convert data to decimal.Decimal and use DecimalType.
-      - LongType()
-    * - **FloatType**
-      - float
-          .. note:: Numbers will be converted to 4-byte single-precision floating point numbers at runtime.
-      - FloatType()
-    * - **DoubleType**
-      - float
-      - DoubleType()
-    * - **DecimalType**
-      - decimal.Decimal
-      - DecimalType()|
-    * - **StringType**
-      - string
-      - StringType()
-    * - **BinaryType**
-      - bytearray
-      - BinaryType()
-    * - **BooleanType**
-      - bool
-      - BooleanType()
-    * - **TimestampType**
-      - datetime.datetime
-      - TimestampType()
-    * - **TimestampNTZType**
-      - datetime.datetime
-      - TimestampNTZType()
-    * - **DateType**
-      - datetime.date
-      - DateType()
-    * - **DayTimeIntervalType**
-      - datetime.timedelta
-      - DayTimeIntervalType()
-    * - **ArrayType**
-      - list, tuple, or array
-      - ArrayType(*elementType*, [*containsNull*])
-          .. note:: The default value of *containsNull* is True.
-    * - **MapType**
-      - dict
-      - MapType(*keyType*, *valueType*, [*valueContainsNull]*)
-          .. note:: The default value of *valueContainsNull* is True.
-    * - **StructType**
-      - list or tuple
-      - StructType(*fields*)
-          .. note:: *fields* is a Seq of StructFields. Also, two fields with the same name are not allowed.
-    * - **StructField**
-      - The value type in Python of the data type of this field. For example, Int for a StructField with the data type IntegerType.
-      - StructField(*name*, *dataType*, [*nullable*])
-          .. note:: The default value of *nullable* is True.

--- a/python/docs/source/user_guide/sql/type_conversions.rst
+++ b/python/docs/source/user_guide/sql/type_conversions.rst
@@ -15,9 +15,9 @@
     specific language governing permissions and limitations
     under the License.
 
-=======================
+================================
 Python to Spark Type Conversions
-=======================
+================================
 
 .. currentmodule:: pyspark.sql.types
 
@@ -35,27 +35,23 @@ You can access them by doing:
       - Value type in Python
       - API to access or create a data type
     * - **ByteType**
-      - | int or long
-        |
-        | **Note:** Numbers will be converted to 1-byte signed integer numbers at runtime. Please make sure that numbers are within the range of -128 to 127.
+      - int
+          .. note:: Numbers will be converted to 1-byte signed integer numbers at runtime. Please make sure that numbers are within the range of -128 to 127.
       - ByteType()
     * - **ShortType**
-      - | int or long
-        |
-        | **Note:** Numbers will be converted to 2-byte signed integer numbers at runtime. Please make sure that numbers are within the range of -32768 to 32767.
+      - int
+          .. note:: Numbers will be converted to 2-byte signed integer numbers at runtime. Please make sure that numbers are within the range of -32768 to 32767.
       - ShortType()
     * - **IntegerType**
-      - int or long
+      - int
       - IntegerType()
     * - **LongType**
-      - | long
-        |
-        | **Note:** Numbers will be converted to 8-byte signed integer numbers at runtime. Please make sure that numbers are within the range of -9223372036854775808 to 9223372036854775807. Otherwise, please convert data to decimal.Decimal and use DecimalType.
+      - int
+          .. note:: Numbers will be converted to 8-byte signed integer numbers at runtime. Please make sure that numbers are within the range of -9223372036854775808 to 9223372036854775807. Otherwise, please convert data to decimal.Decimal and use DecimalType.
       - LongType()
     * - **FloatType**
-      - | float
-        |
-        | **Note:** Numbers will be converted to 4-byte single-precision floating point numbers at runtime.
+      - float
+          .. note:: Numbers will be converted to 4-byte single-precision floating point numbers at runtime.
       - FloatType()
     * - **DoubleType**
       - float
@@ -86,21 +82,17 @@ You can access them by doing:
       - DayTimeIntervalType()
     * - **ArrayType**
       - list, tuple, or array
-      - | ArrayType(*elementType*, [*containsNull*])
-        |
-        | **Note:** The default value of *containsNull* is True.
+      - ArrayType(*elementType*, [*containsNull*])
+          .. note:: The default value of *containsNull* is True.
     * - **MapType**
       - dict
-      - | MapType(*keyType*, *valueType*, [*valueContainsNull]*)
-        |
-        | **Note:** The default value of *valueContainsNull* is True.
+      - MapType(*keyType*, *valueType*, [*valueContainsNull]*)
+          .. note:: The default value of *valueContainsNull* is True.
     * - **StructType**
       - list or tuple
-      - | StructType(*fields*)
-        |
-        | **Note:** *fields* is a Seq of StructFields. Also, two fields with the same name are not allowed.
+      - StructType(*fields*)
+          .. note:: *fields* is a Seq of StructFields. Also, two fields with the same name are not allowed.
     * - **StructField**
-      - | The value type in Python of the data type of this field. For example, Int for a StructField with the data type IntegerType.
-      - | StructField(*name*, *dataType*, [*nullable*])
-        |
-        | **Note:** The default value of *nullable* is True.
+      - The value type in Python of the data type of this field. For example, Int for a StructField with the data type IntegerType.
+      - StructField(*name*, *dataType*, [*nullable*])
+          .. note:: The default value of *nullable* is True.

--- a/python/docs/source/user_guide/sql/type_conversions.rst
+++ b/python/docs/source/user_guide/sql/type_conversions.rst
@@ -1,0 +1,106 @@
+..  Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+..    http://www.apache.org/licenses/LICENSE-2.0
+
+..  Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+=======================
+Python to Spark Type Conversions
+=======================
+
+.. currentmodule:: pyspark.sql.types
+
+All data types of Spark SQL are located in the package of `pyspark.sql.types`.
+You can access them by doing:
+
+.. code-block:: python
+
+    from pyspark.sql.types import *
+
+.. list-table::
+    :header-rows: 1
+
+    * - Data type
+      - Value type in Python
+      - API to access or create a data type
+    * - **ByteType**
+      - | int or long
+        |
+        | **Note:** Numbers will be converted to 1-byte signed integer numbers at runtime. Please make sure that numbers are within the range of -128 to 127.
+      - ByteType()
+    * - **ShortType**
+      - | int or long
+        |
+        | **Note:** Numbers will be converted to 2-byte signed integer numbers at runtime. Please make sure that numbers are within the range of -32768 to 32767.
+      - ShortType()
+    * - **IntegerType**
+      - int or long
+      - IntegerType()
+    * - **LongType**
+      - | long
+        |
+        | **Note:** Numbers will be converted to 8-byte signed integer numbers at runtime. Please make sure that numbers are within the range of -9223372036854775808 to 9223372036854775807. Otherwise, please convert data to decimal.Decimal and use DecimalType.
+      - LongType()
+    * - **FloatType**
+      - | float
+        |
+        | **Note:** Numbers will be converted to 4-byte single-precision floating point numbers at runtime.
+      - FloatType()
+    * - **DoubleType**
+      - float
+      - DoubleType()
+    * - **DecimalType**
+      - decimal.Decimal 
+      - DecimalType()|
+    * - **StringType**
+      - string
+      - StringType()
+    * - **BinaryType**
+      - bytearray
+      - BinaryType()
+    * - **BooleanType**
+      - bool
+      - BooleanType()
+    * - **TimestampType**
+      - datetime.datetime
+      - TimestampType()
+    * - **TimestampNTZType**
+      - datetime.datetime
+      - TimestampNTZType()
+    * - **DateType**
+      - datetime.date
+      - DateType()
+    * - **DayTimeIntervalType**
+      - datetime.timedelta
+      - DayTimeIntervalType()
+    * - **ArrayType**
+      - list, tuple, or array
+      - | ArrayType(*elementType*, [*containsNull*])
+        |
+        | **Note:** The default value of *containsNull* is True.
+    * - **MapType**
+      - dict
+      - | MapType(*keyType*, *valueType*, [*valueContainsNull]*)
+        |
+        | **Note:** The default value of *valueContainsNull* is True.
+    * - **StructType**
+      - list or tuple
+      - | StructType(*fields*)
+        |
+        | **Note:** *fields* is a Seq of StructFields. Also, two fields with the same name are not allowed.
+    * - **StructField**
+      - | The value type in Python of the data type of this field. For example, Int for a StructField with the data type IntegerType.
+      - | StructField(*name*, *dataType*, [*nullable*])
+        |
+        | **Note:** The default value of *nullable* is True.


### PR DESCRIPTION
@allisonwang-db

### What changes were proposed in this pull request?
Add documentation page showing Python to Spark type mappings for PySpark.


### Why are the changes needed?
Surface this information to users navigating the PySpark docs per https://issues.apache.org/jira/browse/SPARK-44733.


### Does this PR introduce _any_ user-facing change?
Yes, adds new page to PySpark docs.


### How was this patch tested?
Build HTML docs file using Sphinx, inspect visually.


### Was this patch authored or co-authored using generative AI tooling?
No.

![full](https://github.com/apache/spark/assets/15946757/fde09420-5dc1-461c-9dc8-5e3c830740bd)