### PR TITLE
[SPARK-45534][CORE] Use java.lang.ref.Cleaner instead of finalize for RemoteBlockPushResolver

### DIFF
--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
@@ -1871,34 +1871,6 @@ public class RemoteBlockPushResolver implements MergedShuffleFileManager {
       metaFile.getChannel().truncate(metaFile.getPos());
     }
 
-    private static void closeAllFiles(
-        FileChannel dataChannel,
-        MergeShuffleFile indexFile,
-        MergeShuffleFile metaFile,
-        AppAttemptShuffleMergeId appAttemptShuffleMergeId,
-        int reduceId) {
-      try {
-        if (dataChannel.isOpen()) {
-          dataChannel.close();
-        }
-      } catch (IOException ioe) {
-        logger.warn("Error closing data channel for {} reduceId {}",
-            appAttemptShuffleMergeId, reduceId);
-      }
-      try {
-        metaFile.close();
-      } catch (IOException ioe) {
-        logger.warn("Error closing meta file for {} reduceId {}",
-            appAttemptShuffleMergeId, reduceId);
-        }
-      try {
-        indexFile.close();
-      } catch (IOException ioe) {
-        logger.warn("Error closing index file for {} reduceId {}",
-            appAttemptShuffleMergeId, reduceId);
-      }
-    }
-
     private void deleteAllFiles() {
       try {
         dataFile.delete();
@@ -1963,9 +1935,37 @@ public class RemoteBlockPushResolver implements MergedShuffleFileManager {
 
       @Override
       public void run() {
-        AppShufflePartitionInfo.closeAllFiles(dataChannel,
+        closeAllFiles(dataChannel,
             indexFile, metaFile, appAttemptShuffleMergeId, reduceId);
       }
+
+      private void closeAllFiles(
+        FileChannel dataChannel,
+        MergeShuffleFile indexFile,
+        MergeShuffleFile metaFile,
+        AppAttemptShuffleMergeId appAttemptShuffleMergeId,
+        int reduceId) {
+      try {
+        if (dataChannel.isOpen()) {
+          dataChannel.close();
+        }
+      } catch (IOException ioe) {
+        logger.warn("Error closing data channel for {} reduceId {}",
+            appAttemptShuffleMergeId, reduceId);
+      }
+      try {
+        metaFile.close();
+      } catch (IOException ioe) {
+        logger.warn("Error closing meta file for {} reduceId {}",
+            appAttemptShuffleMergeId, reduceId);
+        }
+      try {
+        indexFile.close();
+      } catch (IOException ioe) {
+        logger.warn("Error closing index file for {} reduceId {}",
+            appAttemptShuffleMergeId, reduceId);
+      }
+    }
     }
   }
 

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
@@ -540,7 +540,7 @@ public class RemoteBlockPushResolver implements MergedShuffleFileManager {
     partitions
       .forEach((partitionId, partitionInfo) -> {
         synchronized (partitionInfo) {
-          AppShufflePartitionInfo.closeAllFilesAndDeleteIfNeeded(false, partitionInfo.dataFile,
+          AppShufflePartitionInfo.closeAllFilesAndDeleteIfNeeded(true, partitionInfo.dataFile,
               partitionInfo.getDataChannel(), partitionInfo.getIndexFile(), partitionInfo.getMetaFile(),
               partitionInfo.getAppAttemptShuffleMergeId(), partitionInfo.getReduceId());
         }

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
@@ -1879,19 +1879,19 @@ public class RemoteBlockPushResolver implements MergedShuffleFileManager {
         }
       } catch (Exception exception) {
         logger.warn("Error deleting data file for {} reduceId {}",
-            appAttemptShuffleMergeId, reduceId);
+          appAttemptShuffleMergeId, reduceId);
       }
       try {
         metaFile.delete();
       } catch (IOException ioe) {
         logger.warn("Error deleting meta file for {} reduceId {}",
-            appAttemptShuffleMergeId, reduceId);
+          appAttemptShuffleMergeId, reduceId);
       }
       try {
         indexFile.delete();
       } catch (IOException ioe) {
         logger.warn("Error deleting index file for {} reduceId {}",
-            appAttemptShuffleMergeId, reduceId);
+          appAttemptShuffleMergeId, reduceId);
       }
     }
 
@@ -1954,19 +1954,19 @@ public class RemoteBlockPushResolver implements MergedShuffleFileManager {
           }
         } catch (IOException ioe) {
           logger.warn("Error closing data channel for {} reduceId {}",
-              appAttemptShuffleMergeId, reduceId);
+            appAttemptShuffleMergeId, reduceId);
         }
         try {
           metaFile.close();
         } catch (IOException ioe) {
           logger.warn("Error closing meta file for {} reduceId {}",
-              appAttemptShuffleMergeId, reduceId);
-          }
+            appAttemptShuffleMergeId, reduceId);
+        }
         try {
           indexFile.close();
         } catch (IOException ioe) {
           logger.warn("Error closing index file for {} reduceId {}",
-              appAttemptShuffleMergeId, reduceId);
+            appAttemptShuffleMergeId, reduceId);
         }
       }
     }

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
@@ -97,6 +97,7 @@ public class RemoteBlockPushResolver implements MergedShuffleFileManager {
 
   private static final Cleaner CLEANER = Cleaner.create();
   private static final Logger logger = LoggerFactory.getLogger(RemoteBlockPushResolver.class);
+
   public static final String MERGED_SHUFFLE_FILE_NAME_PREFIX = "shuffleMerged";
   public static final String SHUFFLE_META_DELIMITER = ":";
   public static final String MERGE_DIR_KEY = "mergeDir";

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
@@ -1945,27 +1945,27 @@ public class RemoteBlockPushResolver implements MergedShuffleFileManager {
         MergeShuffleFile metaFile,
         AppAttemptShuffleMergeId appAttemptShuffleMergeId,
         int reduceId) {
-      try {
-        if (dataChannel.isOpen()) {
-          dataChannel.close();
+        try {
+          if (dataChannel.isOpen()) {
+            dataChannel.close();
+          }
+        } catch (IOException ioe) {
+          logger.warn("Error closing data channel for {} reduceId {}",
+              appAttemptShuffleMergeId, reduceId);
         }
-      } catch (IOException ioe) {
-        logger.warn("Error closing data channel for {} reduceId {}",
-            appAttemptShuffleMergeId, reduceId);
-      }
-      try {
-        metaFile.close();
-      } catch (IOException ioe) {
-        logger.warn("Error closing meta file for {} reduceId {}",
-            appAttemptShuffleMergeId, reduceId);
+        try {
+          metaFile.close();
+        } catch (IOException ioe) {
+          logger.warn("Error closing meta file for {} reduceId {}",
+              appAttemptShuffleMergeId, reduceId);
+          }
+        try {
+          indexFile.close();
+        } catch (IOException ioe) {
+          logger.warn("Error closing index file for {} reduceId {}",
+              appAttemptShuffleMergeId, reduceId);
         }
-      try {
-        indexFile.close();
-      } catch (IOException ioe) {
-        logger.warn("Error closing index file for {} reduceId {}",
-            appAttemptShuffleMergeId, reduceId);
       }
-    }
     }
   }
 

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
@@ -1928,6 +1928,11 @@ public class RemoteBlockPushResolver implements MergedShuffleFileManager {
       return numIOExceptions;
     }
 
+    @VisibleForTesting
+    Cleaner.Cleanable getCleanable() {
+      return cleanable;
+    }
+
     private record ResourceCleaner(
         File dataFile,
         FileChannel dataChannel,

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
@@ -1873,7 +1873,10 @@ public class RemoteBlockPushResolver implements MergedShuffleFileManager {
 
     private void deleteAllFiles() {
       try {
-        dataFile.delete();
+        if (!dataFile.delete()) {
+          logger.warn("Error deleting data file for {} reduceId {}",
+            appAttemptShuffleMergeId, reduceId);
+        }
       } catch (Exception exception) {
         logger.warn("Error deleting data file for {} reduceId {}",
             appAttemptShuffleMergeId, reduceId);
@@ -1936,15 +1939,15 @@ public class RemoteBlockPushResolver implements MergedShuffleFileManager {
       @Override
       public void run() {
         closeAllFiles(dataChannel,
-            indexFile, metaFile, appAttemptShuffleMergeId, reduceId);
+          indexFile, metaFile, appAttemptShuffleMergeId, reduceId);
       }
 
       private void closeAllFiles(
-        FileChannel dataChannel,
-        MergeShuffleFile indexFile,
-        MergeShuffleFile metaFile,
-        AppAttemptShuffleMergeId appAttemptShuffleMergeId,
-        int reduceId) {
+          FileChannel dataChannel,
+          MergeShuffleFile indexFile,
+          MergeShuffleFile metaFile,
+          AppAttemptShuffleMergeId appAttemptShuffleMergeId,
+          int reduceId) {
         try {
           if (dataChannel.isOpen()) {
             dataChannel.close();

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
@@ -1943,8 +1943,8 @@ public class RemoteBlockPushResolver implements MergedShuffleFileManager {
 
       @Override
       public void run() {
-        closeAllFiles(dataChannel,
-          indexFile, metaFile, appAttemptShuffleMergeId, reduceId);
+        closeAllFiles(dataChannel, indexFile, metaFile, appAttemptShuffleMergeId,
+          reduceId);
       }
 
       private void closeAllFiles(

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/network/shuffle/ShuffleTestAccessor.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/network/shuffle/ShuffleTestAccessor.scala
@@ -187,7 +187,7 @@ object ShuffleTestAccessor {
   }
 
   def closePartitionFiles(partitionInfo: AppShufflePartitionInfo): Unit = {
-    partitionInfo.closeAllFilesAndDeleteIfNeeded(false)
+    partitionInfo.getCleanable.clean()
   }
 
   def clearAppShuffleInfo(mergeMgr: RemoteBlockPushResolver): Unit = {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
use java.lang.ref.Cleaner instead of finalize() for RemoteBlockPushResolver

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
The finalize() method has been marked as deprecated since Java 9 and will be removed in the future, java.lang.ref.Cleaner is the more recommended solution.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Pass GitHub Actions

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No