### PR TITLE
Revert "[SPARK-45536][BUILD] Lower the default `-Xmx` of `build/mvn` to 3g"

### DIFF
--- a/build/mvn
+++ b/build/mvn
@@ -36,7 +36,7 @@ _DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # Preserve the calling directory
 _CALLING_DIR="$(pwd)"
 # Options used during compilation
-_COMPILE_JVM_OPTS="-Xss128m -Xmx3g -XX:ReservedCodeCacheSize=128m"
+_COMPILE_JVM_OPTS="-Xss128m -Xmx4g -XX:ReservedCodeCacheSize=128m"
 
 # Installs any application tarball given a URL, the expected tarball name,
 # and, optionally, a checkable binary path to determine if the binary has


### PR DESCRIPTION
This reverts commit 3e2470de7ea8b97dcdd8875ef25f044998fb7588.

### What changes were proposed in this pull request?
This pr revert change of https://github.com/apache/spark/pull/43364. 

### Why are the changes needed?
It seems to have no effect on fixing `Publish snapshot`, it still failed
- https://github.com/apache/spark/actions/runs/6514229181/job/17696846279


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions

### Was this patch authored or co-authored using generative AI tooling?
No
