### PR TITLE
[MINOR][CORE] Add `@Deprecated` for `SparkLauncher#DEPRECATED_CHILD_CONNECTION_TIMEOUT`

### DIFF
--- a/launcher/src/main/java/org/apache/spark/launcher/SparkLauncher.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkLauncher.java
@@ -99,6 +99,7 @@ public class SparkLauncher extends AbstractLauncher<SparkLauncher> {
    * @deprecated use `CHILD_CONNECTION_TIMEOUT`
    * @since 1.6.0
    */
+  @Deprecated
   public static final String DEPRECATED_CHILD_CONNECTION_TIMEOUT =
     "spark.launcher.childConectionTimeout";
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr just add `@Deprecated` for `SparkLauncher#DEPRECATED_CHILD_CONNECTION_TIMEOUT`.


### Why are the changes needed?
From the javadoc, `DEPRECATED_CHILD_CONNECTION_TIMEOUT` has been deprecated, so it should carry a `@Deprecated` marker.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No