### PR TITLE
[SPARK-45542][CORE] Replace `setSafeMode(HdfsConstants.SafeModeAction, boolean)` with `setSafeMode(SafeModeAction, boolean)`

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -31,9 +31,8 @@ import scala.xml.Node
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
-import org.apache.hadoop.fs.{FileStatus, FileSystem, Path}
+import org.apache.hadoop.fs.{FileStatus, FileSystem, Path, SafeModeAction}
 import org.apache.hadoop.hdfs.DistributedFileSystem
-import org.apache.hadoop.hdfs.protocol.HdfsConstants
 import org.apache.hadoop.security.AccessControlException
 
 import org.apache.spark.{SecurityManager, SparkConf, SparkException}
@@ -1158,7 +1157,7 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
 
   private[history] def isFsInSafeMode(dfs: DistributedFileSystem): Boolean = {
     /* true to check only for Active NNs status */
-    dfs.setSafeMode(HdfsConstants.SafeModeAction.SAFEMODE_GET, true)
+    dfs.setSafeMode(SafeModeAction.GET, true)
   }
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?
The function `FsHistoryProvider#isFsInSafeMode` is using the deprecated API

https://github.com/apache/hadoop/blob/1be78238728da9266a4f88195058f08fd012bf9c/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DistributedFileSystem.java#L1702-L1722

```
/**
   * Enter, leave or get safe mode.
   *
   * @param action
   *          One of SafeModeAction.ENTER, SafeModeAction.LEAVE and
   *          SafeModeAction.GET.
   * @param isChecked
   *          If true check only for Active NNs status, else check first NN's
   *          status.
   *
   * @see org.apache.hadoop.hdfs.protocol.ClientProtocol#setSafeMode(HdfsConstants.SafeModeAction,
   * boolean)
   *
   * @deprecated please instead use
   *               {@link DistributedFileSystem#setSafeMode(SafeModeAction, boolean)}.
   */
  @Deprecated
  public boolean setSafeMode(HdfsConstants.SafeModeAction action,
      boolean isChecked) throws IOException {
    return dfs.setSafeMode(action, isChecked);
  }
```

This pr change to use

https://github.com/apache/hadoop/blob/1be78238728da9266a4f88195058f08fd012bf9c/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DistributedFileSystem.java#L1646-L1661

```
 /**
   * Enter, leave or get safe mode.
   *
   * @param action
   *          One of SafeModeAction.ENTER, SafeModeAction.LEAVE and
   *          SafeModeAction.GET.
   * @param isChecked
   *          If true check only for Active NNs status, else check first NN's
   *          status.
   */
  @Override
  @SuppressWarnings("deprecation")
  public boolean setSafeMode(SafeModeAction action, boolean isChecked)
      throws IOException {
    return this.setSafeMode(convertToClientProtocolSafeModeAction(action), isChecked);
  }
```

instead of it.

The conversion relationship from `HdfsConstants.SafeModeAction` to `SafeModeAction` refers to `convertToClientProtocolSafeModeAction` method.

https://github.com/apache/hadoop/blob/1be78238728da9266a4f88195058f08fd012bf9c/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DistributedFileSystem.java#L1663-L1686

```
/**
   * Translating the {@link SafeModeAction} into {@link HdfsConstants.SafeModeAction}
   * that is used by {@link DFSClient#setSafeMode(HdfsConstants.SafeModeAction, boolean)}.
   *
   * @param action any supported action listed in {@link SafeModeAction}.
   * @return the converted {@link HdfsConstants.SafeModeAction}.
   * @throws UnsupportedOperationException if the provided {@link SafeModeAction} cannot be
   *           translated.
   */
  private static HdfsConstants.SafeModeAction convertToClientProtocolSafeModeAction(
      SafeModeAction action) {
    switch (action) {
    case ENTER:
      return HdfsConstants.SafeModeAction.SAFEMODE_ENTER;
    case LEAVE:
      return HdfsConstants.SafeModeAction.SAFEMODE_LEAVE;
    case FORCE_EXIT:
      return HdfsConstants.SafeModeAction.SAFEMODE_FORCE_EXIT;
    case GET:
      return HdfsConstants.SafeModeAction.SAFEMODE_GET;
    default:
      throw new UnsupportedOperationException("Unsupported safe mode action " + action);
    }
  }
```

### Why are the changes needed?
Clean up deprecated API usage


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Pass GitHub Actions

### Was this patch authored or co-authored using generative AI tooling?
No