### PR TITLE
[DO-NOT-MERGE][PYTHON] Simple Pythonic catalog reference

### DIFF
--- a/python/pyspark/sql/__init__.py
+++ b/python/pyspark/sql/__init__.py
@@ -43,7 +43,7 @@ from pyspark.sql.types import Row
 from pyspark.sql.context import SQLContext, HiveContext, UDFRegistration, UDTFRegistration
 from pyspark.sql.session import SparkSession
 from pyspark.sql.column import Column
-from pyspark.sql.catalog import Catalog
+from pyspark.sql.catalog import Catalog, Reference
 from pyspark.sql.dataframe import DataFrame, DataFrameNaFunctions, DataFrameStatFunctions
 from pyspark.sql.group import GroupedData
 from pyspark.sql.observation import Observation
@@ -52,6 +52,7 @@ from pyspark.sql.window import Window, WindowSpec
 from pyspark.sql.pandas.group_ops import PandasCogroupedOps
 from pyspark.sql.utils import is_remote
 
+ref = Reference()
 
 __all__ = [
     "SparkSession",
@@ -74,4 +75,5 @@ __all__ = [
     "DataFrameWriterV2",
     "PandasCogroupedOps",
     "is_remote",
+    "ref",
 ]

--- a/python/pyspark/sql/catalog.py
+++ b/python/pyspark/sql/catalog.py
@@ -29,6 +29,18 @@ if TYPE_CHECKING:
     from pyspark.sql.types import DataType
 
 
+class Reference(str):
+    def __init__(self, prefix: str = ""):
+        object.__setattr__(self, "_prefix", prefix)
+
+    def __getattr__(self, key: str) -> "Reference":
+        prefix = object.__getattribute__(self, "_prefix")
+        if prefix:
+            return Reference(f"{prefix}.{key}")
+        else:
+            return Reference(key)
+
+
 class CatalogMetadata(NamedTuple):
     name: str
     description: Optional[str]


### PR DESCRIPTION
### What changes were proposed in this pull request?

```python
>>> from pyspark.sql import ref
>>> spark.range(10).write.saveAsTable(ref.my_table)
```

```python
>>> spark.table(ref.my_table)
DataFrame[id: bigint]
```

```python
>>> spark.table(ref.default.my_table)
DataFrame[id: bigint]
```

```python
>>> spark.sql(f"SELECT * from {ref.my_table}").show()
+---+
| id|
+---+
|  4|
|  0|
|  6|
...
```


### Why are the changes needed?

TBD

### Does this PR introduce _any_ user-facing change?

TBD

### How was this patch tested?

TBD

### Was this patch authored or co-authored using generative AI tooling?

No.
