### PR TITLE
[SPARK-45549][CORE] Remove unused `numExistingExecutors` in `CoarseGrainedSchedulerBackend`

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -731,11 +731,6 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
     false
   }
 
-  /**
-   * Return the number of executors currently registered with this backend.
-   */
-  private def numExistingExecutors: Int = synchronized { executorDataMap.size }
-
   override def getExecutorIds(): Seq[String] = synchronized {
     executorDataMap.keySet.toSeq
   }


### PR DESCRIPTION


### What changes were proposed in this pull request?

Remove unused `numExistingExecutors` in `CoarseGrainedSchedulerBackend`


### Why are the changes needed?
Remove unused code, make spark code cleaner


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
No need test


### Was this patch authored or co-authored using generative AI tooling?
No
