### PR TITLE
[SPARK-45543][SQL] `InferWindowGroupLimit` causes bug if the other window functions haven't the same window frame as the rank-like functions

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InferWindowGroupLimit.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InferWindowGroupLimit.scala
@@ -53,7 +53,8 @@ object InferWindowGroupLimit extends Rule[LogicalPlan] with PredicateHelper {
   }
 
   /**
-   * All window expressions should use expanding window, so that we can safely do early stop.
+   * All window expressions should use the same expanding window, so that
+   * we can safely do the early stop.
    */
   private def isExpandingWindow(
       windowExpression: NamedExpression): Boolean = windowExpression match {
@@ -73,8 +74,8 @@ object InferWindowGroupLimit extends Rule[LogicalPlan] with PredicateHelper {
     plan.transformWithPruning(_.containsAllPatterns(FILTER, WINDOW), ruleId) {
       case filter @ Filter(condition,
         window @ Window(windowExpressions, partitionSpec, orderSpec, child))
-        if !child.isInstanceOf[WindowGroupLimit] &&
-          windowExpressions.forall(isExpandingWindow) && orderSpec.nonEmpty =>
+        if !child.isInstanceOf[WindowGroupLimit] && windowExpressions.forall(isExpandingWindow) &&
+          orderSpec.nonEmpty =>
         val limits = windowExpressions.collect {
           case alias @ Alias(WindowExpression(rankLikeFunction, _), _)
             if support(rankLikeFunction) =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InferWindowGroupLimit.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InferWindowGroupLimit.scala
@@ -52,10 +52,18 @@ object InferWindowGroupLimit extends Rule[LogicalPlan] with PredicateHelper {
     if (limits.nonEmpty) Some(limits.min) else None
   }
 
-  private def support(
+  /**
+   * All window expressions should use expanding window, so that we can safely do early stop.
+   */
+  private def isExpandingWindow(
       windowExpression: NamedExpression): Boolean = windowExpression match {
-    case Alias(WindowExpression(_: Rank | _: DenseRank | _: RowNumber, WindowSpecDefinition(_, _,
+    case Alias(WindowExpression(_, WindowSpecDefinition(_, _,
     SpecifiedWindowFrame(RowFrame, UnboundedPreceding, CurrentRow))), _) => true
+    case _ => false
+  }
+
+  private def support(windowFunction: Expression): Boolean = windowFunction match {
+    case _: Rank | _: DenseRank | _: RowNumber => true
     case _ => false
   }
 
@@ -65,10 +73,11 @@ object InferWindowGroupLimit extends Rule[LogicalPlan] with PredicateHelper {
     plan.transformWithPruning(_.containsAllPatterns(FILTER, WINDOW), ruleId) {
       case filter @ Filter(condition,
         window @ Window(windowExpressions, partitionSpec, orderSpec, child))
-        if !child.isInstanceOf[WindowGroupLimit] && windowExpressions.exists(support) &&
-          orderSpec.nonEmpty =>
+        if !child.isInstanceOf[WindowGroupLimit] &&
+          windowExpressions.forall(isExpandingWindow) && orderSpec.nonEmpty =>
         val limits = windowExpressions.collect {
-          case alias @ Alias(WindowExpression(rankLikeFunction, _), _) if support(alias) =>
+          case alias @ Alias(WindowExpression(rankLikeFunction, _), _)
+            if support(rankLikeFunction) =>
             extractLimits(condition, alias.toAttribute).map((_, rankLikeFunction))
         }.flatten
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
https://github.com/apache/spark/pull/38799 Introduce the group limit of Window for rank-based filter to optimize top-k computation.
But it causes a bug if window expressions exists non-rank function which has the window frame is not the same as `(UnboundedPreceding, CurrentRow)`.
Please see the detail at https://issues.apache.org/jira/browse/SPARK-45543.


### Why are the changes needed?
Fix the bug.


### Does this PR introduce _any_ user-facing change?
'Yes'.


### How was this patch tested?
New test cases.


### Was this patch authored or co-authored using generative AI tooling?
'No'.
