### PR TITLE
[SPARK-45545][CORE] Pass SSLOptions wherever we create a SparkTransportConf

### DIFF
--- a/core/src/main/scala/org/apache/spark/SecurityManager.scala
+++ b/core/src/main/scala/org/apache/spark/SecurityManager.scala
@@ -106,7 +106,7 @@ private[spark] class SecurityManager(
   private val defaultSSLOptions =
     SSLOptions.parse(sparkConf, hadoopConf, "spark.ssl", defaults = None)
   // the SSL configuration for RPCs
-  val rpcSSLOptions = getSSLOptions("rpc")
+  private val rpcSSLOptions = getSSLOptions("rpc")
 
   def getSSLOptions(module: String): SSLOptions = {
     val opts =
@@ -291,6 +291,12 @@ private[spark] class SecurityManager(
    * @return Whether RPC SSL is enabled or not
    */
   def isSslRpcEnabled(): Boolean = sslRpcEnabled
+
+  /**
+   * Returns the SSLOptions object for the RPC namespace
+   * @return the SSLOptions object for the RP namespace
+   */
+  def getRpcSSLOptions(): SSLOptions = rpcSSLOptions
 
   /**
    * Gets the user used for authenticating SASL connections.

--- a/core/src/main/scala/org/apache/spark/SecurityManager.scala
+++ b/core/src/main/scala/org/apache/spark/SecurityManager.scala
@@ -106,7 +106,7 @@ private[spark] class SecurityManager(
   private val defaultSSLOptions =
     SSLOptions.parse(sparkConf, hadoopConf, "spark.ssl", defaults = None)
   // the SSL configuration for RPCs
-  private val rpcSSLOptions = getSSLOptions("rpc")
+  val rpcSSLOptions = getSSLOptions("rpc")
 
   def getSSLOptions(module: String): SSLOptions = {
     val opts =

--- a/core/src/main/scala/org/apache/spark/SecurityManager.scala
+++ b/core/src/main/scala/org/apache/spark/SecurityManager.scala
@@ -294,7 +294,7 @@ private[spark] class SecurityManager(
 
   /**
    * Returns the SSLOptions object for the RPC namespace
-   * @return the SSLOptions object for the RP namespace
+   * @return the SSLOptions object for the RPC namespace
    */
   def getRpcSSLOptions(): SSLOptions = rpcSSLOptions
 

--- a/core/src/main/scala/org/apache/spark/SparkEnv.scala
+++ b/core/src/main/scala/org/apache/spark/SparkEnv.scala
@@ -378,7 +378,7 @@ object SparkEnv extends Logging {
         conf,
         "shuffle",
         numUsableCores,
-        sslOptions = Some(securityManager.getSSLOptions("rpc"))
+        sslOptions = Some(securityManager.rpcSSLOptions)
       )
       Some(new ExternalBlockStoreClient(transConf, securityManager,
         securityManager.isAuthenticationEnabled(), conf.get(config.SHUFFLE_REGISTRATION_TIMEOUT)))

--- a/core/src/main/scala/org/apache/spark/SparkEnv.scala
+++ b/core/src/main/scala/org/apache/spark/SparkEnv.scala
@@ -374,7 +374,12 @@ object SparkEnv extends Logging {
     }
 
     val externalShuffleClient = if (conf.get(config.SHUFFLE_SERVICE_ENABLED)) {
-      val transConf = SparkTransportConf.fromSparkConf(conf, "shuffle", numUsableCores)
+      val transConf = SparkTransportConf.fromSparkConf(
+        conf,
+        "shuffle",
+        numUsableCores,
+        sslOptions = Some(securityManager.getSSLOptions("rpc"))
+      )
       Some(new ExternalBlockStoreClient(transConf, securityManager,
         securityManager.isAuthenticationEnabled(), conf.get(config.SHUFFLE_REGISTRATION_TIMEOUT)))
     } else {

--- a/core/src/main/scala/org/apache/spark/SparkEnv.scala
+++ b/core/src/main/scala/org/apache/spark/SparkEnv.scala
@@ -378,7 +378,7 @@ object SparkEnv extends Logging {
         conf,
         "shuffle",
         numUsableCores,
-        sslOptions = Some(securityManager.rpcSSLOptions)
+        sslOptions = Some(securityManager.getRpcSSLOptions())
       )
       Some(new ExternalBlockStoreClient(transConf, securityManager,
         securityManager.isAuthenticationEnabled(), conf.get(config.SHUFFLE_REGISTRATION_TIMEOUT)))

--- a/core/src/main/scala/org/apache/spark/deploy/ExternalShuffleService.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/ExternalShuffleService.scala
@@ -57,7 +57,7 @@ class ExternalShuffleService(sparkConf: SparkConf, securityManager: SecurityMana
       sparkConf,
       "shuffle",
       numUsableCores = 0,
-      sslOptions = Some(securityManager.rpcSSLOptions))
+      sslOptions = Some(securityManager.getRpcSSLOptions()))
   private val blockHandler = newShuffleBlockHandler(transportConf)
   private var transportContext: TransportContext = _
 

--- a/core/src/main/scala/org/apache/spark/deploy/ExternalShuffleService.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/ExternalShuffleService.scala
@@ -53,7 +53,11 @@ class ExternalShuffleService(sparkConf: SparkConf, securityManager: SecurityMana
   private val registeredExecutorsDB = "registeredExecutors"
 
   private val transportConf =
-    SparkTransportConf.fromSparkConf(sparkConf, "shuffle", numUsableCores = 0)
+    SparkTransportConf.fromSparkConf(
+      sparkConf,
+      "shuffle",
+      numUsableCores = 0,
+      sslOptions = Some(securityManager.getSSLOptions("rpc")))
   private val blockHandler = newShuffleBlockHandler(transportConf)
   private var transportContext: TransportContext = _
 

--- a/core/src/main/scala/org/apache/spark/deploy/ExternalShuffleService.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/ExternalShuffleService.scala
@@ -57,7 +57,7 @@ class ExternalShuffleService(sparkConf: SparkConf, securityManager: SecurityMana
       sparkConf,
       "shuffle",
       numUsableCores = 0,
-      sslOptions = Some(securityManager.getSSLOptions("rpc")))
+      sslOptions = Some(securityManager.rpcSSLOptions))
   private val blockHandler = newShuffleBlockHandler(transportConf)
   private var transportContext: TransportContext = _
 

--- a/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
+++ b/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
@@ -90,7 +90,9 @@ private[spark] class CoarseGrainedExecutorBackend(
 
     logInfo("Connecting to driver: " + driverUrl)
     try {
-      val shuffleClientTransportConf = SparkTransportConf.fromSparkConf(env.conf, "shuffle")
+      val securityManager = new SecurityManager(env.conf)
+      val shuffleClientTransportConf = SparkTransportConf.fromSparkConf(
+        env.conf, "shuffle", sslOptions = Some(securityManager.getSSLOptions("rpc")))
       if (NettyUtils.preferDirectBufs(shuffleClientTransportConf) &&
           PlatformDependent.maxDirectMemory() < env.conf.get(MAX_REMOTE_BLOCK_SIZE_FETCH_TO_MEM)) {
         throw new SparkException(s"Netty direct memory should at least be bigger than " +

--- a/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
+++ b/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
@@ -92,7 +92,7 @@ private[spark] class CoarseGrainedExecutorBackend(
     try {
       val securityManager = new SecurityManager(env.conf)
       val shuffleClientTransportConf = SparkTransportConf.fromSparkConf(
-        env.conf, "shuffle", sslOptions = Some(securityManager.rpcSSLOptions))
+        env.conf, "shuffle", sslOptions = Some(securityManager.getRpcSSLOptions()))
       if (NettyUtils.preferDirectBufs(shuffleClientTransportConf) &&
           PlatformDependent.maxDirectMemory() < env.conf.get(MAX_REMOTE_BLOCK_SIZE_FETCH_TO_MEM)) {
         throw new SparkException(s"Netty direct memory should at least be bigger than " +

--- a/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
+++ b/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
@@ -92,7 +92,7 @@ private[spark] class CoarseGrainedExecutorBackend(
     try {
       val securityManager = new SecurityManager(env.conf)
       val shuffleClientTransportConf = SparkTransportConf.fromSparkConf(
-        env.conf, "shuffle", sslOptions = Some(securityManager.getSSLOptions("rpc")))
+        env.conf, "shuffle", sslOptions = Some(securityManager.rpcSSLOptions))
       if (NettyUtils.preferDirectBufs(shuffleClientTransportConf) &&
           PlatformDependent.maxDirectMemory() < env.conf.get(MAX_REMOTE_BLOCK_SIZE_FETCH_TO_MEM)) {
         throw new SparkException(s"Netty direct memory should at least be bigger than " +

--- a/core/src/main/scala/org/apache/spark/network/netty/NettyBlockTransferService.scala
+++ b/core/src/main/scala/org/apache/spark/network/netty/NettyBlockTransferService.scala
@@ -70,7 +70,11 @@ private[spark] class NettyBlockTransferService(
     val rpcHandler = new NettyBlockRpcServer(conf.getAppId, serializer, blockDataManager)
     var serverBootstrap: Option[TransportServerBootstrap] = None
     var clientBootstrap: Option[TransportClientBootstrap] = None
-    this.transportConf = SparkTransportConf.fromSparkConf(conf, "shuffle", numCores)
+    this.transportConf = SparkTransportConf.fromSparkConf(
+      conf,
+      "shuffle",
+      numCores,
+      sslOptions = Some(securityManager.getSSLOptions("rpc")))
     if (authEnabled) {
       serverBootstrap = Some(new AuthServerBootstrap(transportConf, securityManager))
       clientBootstrap = Some(new AuthClientBootstrap(transportConf, conf.getAppId, securityManager))

--- a/core/src/main/scala/org/apache/spark/network/netty/NettyBlockTransferService.scala
+++ b/core/src/main/scala/org/apache/spark/network/netty/NettyBlockTransferService.scala
@@ -74,7 +74,7 @@ private[spark] class NettyBlockTransferService(
       conf,
       "shuffle",
       numCores,
-      sslOptions = Some(securityManager.getSSLOptions("rpc")))
+      sslOptions = Some(securityManager.rpcSSLOptions))
     if (authEnabled) {
       serverBootstrap = Some(new AuthServerBootstrap(transportConf, securityManager))
       clientBootstrap = Some(new AuthClientBootstrap(transportConf, conf.getAppId, securityManager))

--- a/core/src/main/scala/org/apache/spark/network/netty/NettyBlockTransferService.scala
+++ b/core/src/main/scala/org/apache/spark/network/netty/NettyBlockTransferService.scala
@@ -74,7 +74,7 @@ private[spark] class NettyBlockTransferService(
       conf,
       "shuffle",
       numCores,
-      sslOptions = Some(securityManager.rpcSSLOptions))
+      sslOptions = Some(securityManager.getRpcSSLOptions()))
     if (authEnabled) {
       serverBootstrap = Some(new AuthServerBootstrap(transportConf, securityManager))
       clientBootstrap = Some(new AuthClientBootstrap(transportConf, conf.getAppId, securityManager))

--- a/core/src/main/scala/org/apache/spark/rpc/netty/NettyRpcEnv.scala
+++ b/core/src/main/scala/org/apache/spark/rpc/netty/NettyRpcEnv.scala
@@ -57,7 +57,7 @@ private[netty] class NettyRpcEnv(
     "rpc",
     conf.get(RPC_IO_THREADS).getOrElse(numUsableCores),
     role,
-    sslOptions = Some(securityManager.getSSLOptions("rpc"))
+    sslOptions = Some(securityManager.rpcSSLOptions)
   )
 
   private val dispatcher: Dispatcher = new Dispatcher(this, numUsableCores)
@@ -397,7 +397,7 @@ private[netty] class NettyRpcEnv(
           clone,
           module,
           ioThreads,
-          sslOptions = Some(securityManager.getSSLOptions("rpc")))
+          sslOptions = Some(securityManager.rpcSSLOptions))
         val downloadContext = new TransportContext(downloadConf, new NoOpRpcHandler(), true)
         fileDownloadFactory = downloadContext.createClientFactory(createClientBootstraps())
       }

--- a/core/src/main/scala/org/apache/spark/rpc/netty/NettyRpcEnv.scala
+++ b/core/src/main/scala/org/apache/spark/rpc/netty/NettyRpcEnv.scala
@@ -56,7 +56,9 @@ private[netty] class NettyRpcEnv(
     conf.clone.set(RPC_IO_NUM_CONNECTIONS_PER_PEER, 1),
     "rpc",
     conf.get(RPC_IO_THREADS).getOrElse(numUsableCores),
-    role)
+    role,
+    sslOptions = Some(securityManager.getSSLOptions("rpc"))
+  )
 
   private val dispatcher: Dispatcher = new Dispatcher(this, numUsableCores)
 
@@ -391,7 +393,11 @@ private[netty] class NettyRpcEnv(
         }
 
         val ioThreads = clone.getInt("spark.files.io.threads", 1)
-        val downloadConf = SparkTransportConf.fromSparkConf(clone, module, ioThreads)
+        val downloadConf = SparkTransportConf.fromSparkConf(
+          clone,
+          module,
+          ioThreads,
+          sslOptions = Some(securityManager.getSSLOptions("rpc")))
         val downloadContext = new TransportContext(downloadConf, new NoOpRpcHandler(), true)
         fileDownloadFactory = downloadContext.createClientFactory(createClientBootstraps())
       }

--- a/core/src/main/scala/org/apache/spark/rpc/netty/NettyRpcEnv.scala
+++ b/core/src/main/scala/org/apache/spark/rpc/netty/NettyRpcEnv.scala
@@ -57,7 +57,7 @@ private[netty] class NettyRpcEnv(
     "rpc",
     conf.get(RPC_IO_THREADS).getOrElse(numUsableCores),
     role,
-    sslOptions = Some(securityManager.rpcSSLOptions)
+    sslOptions = Some(securityManager.getRpcSSLOptions())
   )
 
   private val dispatcher: Dispatcher = new Dispatcher(this, numUsableCores)
@@ -397,7 +397,7 @@ private[netty] class NettyRpcEnv(
           clone,
           module,
           ioThreads,
-          sslOptions = Some(securityManager.rpcSSLOptions))
+          sslOptions = Some(securityManager.getRpcSSLOptions()))
         val downloadContext = new TransportContext(downloadConf, new NoOpRpcHandler(), true)
         fileDownloadFactory = downloadContext.createClientFactory(createClientBootstraps())
       }

--- a/core/src/main/scala/org/apache/spark/shuffle/IndexShuffleBlockResolver.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/IndexShuffleBlockResolver.scala
@@ -61,7 +61,7 @@ private[spark] class IndexShuffleBlockResolver(
   private val transportConf = {
     val securityManager = new SecurityManager(conf)
     SparkTransportConf.fromSparkConf(
-      conf, "shuffle", sslOptions = Some(securityManager.getSSLOptions("rpc")))
+      conf, "shuffle", sslOptions = Some(securityManager.rpcSSLOptions))
   }
 
   private val remoteShuffleMaxDisk: Option[Long] =

--- a/core/src/main/scala/org/apache/spark/shuffle/IndexShuffleBlockResolver.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/IndexShuffleBlockResolver.scala
@@ -24,7 +24,7 @@ import java.nio.file.Files
 
 import scala.collection.mutable.ArrayBuffer
 
-import org.apache.spark.{SparkConf, SparkEnv, SparkException}
+import org.apache.spark.{SecurityManager, SparkConf, SparkEnv, SparkException}
 import org.apache.spark.errors.SparkCoreErrors
 import org.apache.spark.internal.{config, Logging}
 import org.apache.spark.io.NioBufferedFileInputStream
@@ -58,7 +58,11 @@ private[spark] class IndexShuffleBlockResolver(
 
   private lazy val blockManager = Option(_blockManager).getOrElse(SparkEnv.get.blockManager)
 
-  private val transportConf = SparkTransportConf.fromSparkConf(conf, "shuffle")
+  private val transportConf = {
+    val securityManager = new SecurityManager(conf)
+    SparkTransportConf.fromSparkConf(
+      conf, "shuffle", sslOptions = Some(securityManager.getSSLOptions("rpc")))
+  }
 
   private val remoteShuffleMaxDisk: Option[Long] =
     conf.get(config.STORAGE_DECOMMISSION_SHUFFLE_MAX_DISK_SIZE)

--- a/core/src/main/scala/org/apache/spark/shuffle/IndexShuffleBlockResolver.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/IndexShuffleBlockResolver.scala
@@ -61,7 +61,7 @@ private[spark] class IndexShuffleBlockResolver(
   private val transportConf = {
     val securityManager = new SecurityManager(conf)
     SparkTransportConf.fromSparkConf(
-      conf, "shuffle", sslOptions = Some(securityManager.rpcSSLOptions))
+      conf, "shuffle", sslOptions = Some(securityManager.getRpcSSLOptions()))
   }
 
   private val remoteShuffleMaxDisk: Option[Long] =

--- a/core/src/main/scala/org/apache/spark/shuffle/ShuffleBlockPusher.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/ShuffleBlockPusher.scala
@@ -110,7 +110,7 @@ private[spark] class ShuffleBlockPusher(conf: SparkConf) extends Logging {
     val numPartitions = dep.partitioner.numPartitions
     val securityManager = new SecurityManager(conf)
     val transportConf = SparkTransportConf.fromSparkConf(
-      conf, "shuffle", sslOptions = Some(securityManager.rpcSSLOptions))
+      conf, "shuffle", sslOptions = Some(securityManager.getRpcSSLOptions()))
     this.shuffleId = dep.shuffleId
     this.shuffleMergeId = dep.shuffleMergeId
     this.mapIndex = mapIndex

--- a/core/src/main/scala/org/apache/spark/shuffle/ShuffleBlockPusher.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/ShuffleBlockPusher.scala
@@ -25,7 +25,7 @@ import java.util.concurrent.ExecutorService
 import scala.collection.mutable.{ArrayBuffer, HashMap, HashSet, Queue}
 import scala.util.control.NonFatal
 
-import org.apache.spark.{ShuffleDependency, SparkConf, SparkContext, SparkEnv}
+import org.apache.spark.{SecurityManager, ShuffleDependency, SparkConf, SparkContext, SparkEnv}
 import org.apache.spark.annotation.Since
 import org.apache.spark.executor.{CoarseGrainedExecutorBackend, ExecutorBackend}
 import org.apache.spark.internal.Logging
@@ -108,7 +108,9 @@ private[spark] class ShuffleBlockPusher(conf: SparkConf) extends Logging {
       dep: ShuffleDependency[_, _, _],
       mapIndex: Int): Unit = {
     val numPartitions = dep.partitioner.numPartitions
-    val transportConf = SparkTransportConf.fromSparkConf(conf, "shuffle")
+    val securityManager = new SecurityManager(conf)
+    val transportConf = SparkTransportConf.fromSparkConf(
+      conf, "shuffle", sslOptions = Some(securityManager.getSSLOptions("rpc")))
     this.shuffleId = dep.shuffleId
     this.shuffleMergeId = dep.shuffleMergeId
     this.mapIndex = mapIndex

--- a/core/src/main/scala/org/apache/spark/shuffle/ShuffleBlockPusher.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/ShuffleBlockPusher.scala
@@ -110,7 +110,7 @@ private[spark] class ShuffleBlockPusher(conf: SparkConf) extends Logging {
     val numPartitions = dep.partitioner.numPartitions
     val securityManager = new SecurityManager(conf)
     val transportConf = SparkTransportConf.fromSparkConf(
-      conf, "shuffle", sslOptions = Some(securityManager.getSSLOptions("rpc")))
+      conf, "shuffle", sslOptions = Some(securityManager.rpcSSLOptions))
     this.shuffleId = dep.shuffleId
     this.shuffleMergeId = dep.shuffleMergeId
     this.mapIndex = mapIndex

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -1253,7 +1253,7 @@ private[spark] class BlockManager(
 
         case _ =>
           val transportConf = SparkTransportConf.fromSparkConf(
-            conf, "shuffle", sslOptions = Some(securityManager.rpcSSLOptions))
+            conf, "shuffle", sslOptions = Some(securityManager.getRpcSSLOptions()))
           new FileSegmentManagedBuffer(transportConf, file, 0, file.length)
       }
       Some(managedBuffer)

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -1252,7 +1252,8 @@ private[spark] class BlockManager(
             new EncryptedBlockData(file, blockSize, conf, key))
 
         case _ =>
-          val transportConf = SparkTransportConf.fromSparkConf(conf, "shuffle")
+          val transportConf = SparkTransportConf.fromSparkConf(
+            conf, "shuffle", sslOptions = Some(securityManager.getSSLOptions("rpc")))
           new FileSegmentManagedBuffer(transportConf, file, 0, file.length)
       }
       Some(managedBuffer)

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -1253,7 +1253,7 @@ private[spark] class BlockManager(
 
         case _ =>
           val transportConf = SparkTransportConf.fromSparkConf(
-            conf, "shuffle", sslOptions = Some(securityManager.getSSLOptions("rpc")))
+            conf, "shuffle", sslOptions = Some(securityManager.rpcSSLOptions))
           new FileSegmentManagedBuffer(transportConf, file, 0, file.length)
       }
       Some(managedBuffer)

--- a/core/src/test/scala/org/apache/spark/ExternalShuffleServiceSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ExternalShuffleServiceSuite.scala
@@ -49,8 +49,7 @@ class ExternalShuffleServiceSuite extends ShuffleSuite with BeforeAndAfterAll wi
   var transportContext: TransportContext = _
   var rpcHandler: ExternalBlockHandler = _
 
-  override def beforeAll(): Unit = {
-    super.beforeAll()
+  protected def initializeHandlers(): Unit = {
     val transportConf = SparkTransportConf.fromSparkConf(conf, "shuffle", numUsableCores = 2)
     rpcHandler = new ExternalBlockHandler(transportConf, null)
     transportContext = new TransportContext(transportConf, rpcHandler)
@@ -59,6 +58,11 @@ class ExternalShuffleServiceSuite extends ShuffleSuite with BeforeAndAfterAll wi
     conf.set(config.SHUFFLE_MANAGER, "sort")
     conf.set(config.SHUFFLE_SERVICE_ENABLED, true)
     conf.set(config.SHUFFLE_SERVICE_PORT, server.getPort)
+  }
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    initializeHandlers()
   }
 
   override def afterAll(): Unit = {

--- a/core/src/test/scala/org/apache/spark/SslExternalShuffleServiceSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SslExternalShuffleServiceSuite.scala
@@ -22,8 +22,6 @@ import org.apache.spark.internal.config
 import org.apache.spark.network.TransportContext
 import org.apache.spark.network.netty.SparkTransportConf
 import org.apache.spark.network.shuffle.ExternalBlockHandler
-import org.apache.spark.network.ssl.SslSampleConfigs
-
 
 /**
  * This suite creates an external shuffle server and routes all shuffle fetches through it.
@@ -34,8 +32,7 @@ import org.apache.spark.network.ssl.SslSampleConfigs
 class SslExternalShuffleServiceSuite extends ExternalShuffleServiceSuite {
 
   override def initializeHandlers(): Unit = {
-    SslSampleConfigs.createDefaultConfigMap().entrySet().
-      forEach(entry => conf.set(entry.getKey, entry.getValue))
+    SslTestUtils.updateWithSSLConfig(conf)
     val hadoopConf = SparkHadoopUtil.get.newConfiguration(conf);
     // Show that we can successfully inherit options defined in the `spark.ssl` namespace
     val defaultSslOptions = SSLOptions.parse(conf, hadoopConf, "spark.ssl")

--- a/core/src/test/scala/org/apache/spark/SslExternalShuffleServiceSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SslExternalShuffleServiceSuite.scala
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark
+
+import org.apache.spark.deploy.SparkHadoopUtil
+import org.apache.spark.internal.config
+import org.apache.spark.network.TransportContext
+import org.apache.spark.network.netty.SparkTransportConf
+import org.apache.spark.network.shuffle.ExternalBlockHandler
+import org.apache.spark.network.ssl.SslSampleConfigs
+
+
+/**
+ * This suite creates an external shuffle server and routes all shuffle fetches through it.
+ * Note that failures in this suite may arise due to changes in Spark that invalidate expectations
+ * set up in `ExternalShuffleBlockHandler`, such as changing the format of shuffle files or how
+ * we hash files into folders.
+ */
+class SslExternalShuffleServiceSuite extends ExternalShuffleServiceSuite {
+
+  override def initializeHandlers(): Unit = {
+    val updatedConfigs = SslSampleConfigs.createDefaultConfigMap()
+    updatedConfigs.entrySet().forEach(entry => conf.set(entry.getKey, entry.getValue))
+    val hadoopConf = SparkHadoopUtil.get.newConfiguration(conf);
+    // Show that we can successfully inherit options defined in the `spark.ssl` namespace
+    val defaultSslOptions = SSLOptions.parse(conf, hadoopConf, "spark.ssl")
+    val sslOptions = SSLOptions.parse(
+      conf, hadoopConf, "spark.ssl.rpc", defaults = Some(defaultSslOptions))
+    val transportConf = SparkTransportConf.fromSparkConf(
+      conf, "shuffle", numUsableCores = 2, sslOptions = Some(sslOptions))
+
+    rpcHandler = new ExternalBlockHandler(transportConf, null)
+    transportContext = new TransportContext(transportConf, rpcHandler)
+    server = transportContext.createServer()
+
+    conf.set(config.SHUFFLE_MANAGER, "sort")
+    conf.set(config.SHUFFLE_SERVICE_ENABLED, true)
+    conf.set(config.SHUFFLE_SERVICE_PORT, server.getPort)
+  }
+}

--- a/core/src/test/scala/org/apache/spark/SslExternalShuffleServiceSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SslExternalShuffleServiceSuite.scala
@@ -34,8 +34,8 @@ import org.apache.spark.network.ssl.SslSampleConfigs
 class SslExternalShuffleServiceSuite extends ExternalShuffleServiceSuite {
 
   override def initializeHandlers(): Unit = {
-    val updatedConfigs = SslSampleConfigs.createDefaultConfigMap()
-    updatedConfigs.entrySet().forEach(entry => conf.set(entry.getKey, entry.getValue))
+    SslSampleConfigs.createDefaultConfigMap().entrySet().
+      forEach(entry => conf.set(entry.getKey, entry.getValue))
     val hadoopConf = SparkHadoopUtil.get.newConfiguration(conf);
     // Show that we can successfully inherit options defined in the `spark.ssl` namespace
     val defaultSslOptions = SSLOptions.parse(conf, hadoopConf, "spark.ssl")

--- a/core/src/test/scala/org/apache/spark/SslShuffleNettySuite.scala
+++ b/core/src/test/scala/org/apache/spark/SslShuffleNettySuite.scala
@@ -17,12 +17,10 @@
 
 package org.apache.spark
 
-import org.apache.spark.network.ssl.SslSampleConfigs
 class SslShuffleNettySuite extends ShuffleNettySuite {
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    SslSampleConfigs.createDefaultConfigMap().entrySet().
-      forEach(entry => conf.set(entry.getKey, entry.getValue))
+    SslTestUtils.updateWithSSLConfig(conf)
   }
 }

--- a/core/src/test/scala/org/apache/spark/SslShuffleNettySuite.scala
+++ b/core/src/test/scala/org/apache/spark/SslShuffleNettySuite.scala
@@ -22,7 +22,7 @@ class SslShuffleNettySuite extends ShuffleNettySuite {
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    val updatedConfigs = SslSampleConfigs.createDefaultConfigMap()
-    updatedConfigs.entrySet().forEach(entry => conf.set(entry.getKey, entry.getValue))
+    SslSampleConfigs.createDefaultConfigMap().entrySet().
+      forEach(entry => conf.set(entry.getKey, entry.getValue))
   }
 }

--- a/core/src/test/scala/org/apache/spark/SslShuffleNettySuite.scala
+++ b/core/src/test/scala/org/apache/spark/SslShuffleNettySuite.scala
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark
+
+import org.apache.spark.network.ssl.SslSampleConfigs
+class SslShuffleNettySuite extends ShuffleNettySuite {
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    val updatedConfigs = SslSampleConfigs.createDefaultConfigMap()
+    updatedConfigs.entrySet().forEach(entry => conf.set(entry.getKey, entry.getValue))
+  }
+}

--- a/core/src/test/scala/org/apache/spark/executor/CoarseGrainedExecutorBackendSuite.scala
+++ b/core/src/test/scala/org/apache/spark/executor/CoarseGrainedExecutorBackendSuite.scala
@@ -38,7 +38,6 @@ import org.apache.spark._
 import org.apache.spark.TestUtils._
 import org.apache.spark.api.plugin.{DriverPlugin, ExecutorPlugin, PluginContext, SparkPlugin}
 import org.apache.spark.internal.config.PLUGINS
-import org.apache.spark.network.ssl.SslSampleConfigs
 import org.apache.spark.resource._
 import org.apache.spark.resource.ResourceUtils._
 import org.apache.spark.resource.TestResourceIDs._
@@ -638,9 +637,6 @@ class SslCoarseGrainedExecutorBackendSuite extends CoarseGrainedExecutorBackendS
   with LocalSparkContext with MockitoSugar {
 
   override def createSparkConf(): SparkConf = {
-    val conf = super.createSparkConf()
-    SslSampleConfigs.createDefaultConfigMap().entrySet().
-      forEach(entry => conf.set(entry.getKey, entry.getValue))
-    conf
+    SslTestUtils.updateWithSSLConfig(super.createSparkConf())
   }
 }

--- a/core/src/test/scala/org/apache/spark/executor/CoarseGrainedExecutorBackendSuite.scala
+++ b/core/src/test/scala/org/apache/spark/executor/CoarseGrainedExecutorBackendSuite.scala
@@ -639,8 +639,8 @@ class SslCoarseGrainedExecutorBackendSuite extends CoarseGrainedExecutorBackendS
 
   override def createSparkConf(): SparkConf = {
     val conf = super.createSparkConf()
-    val updatedConfigs = SslSampleConfigs.createDefaultConfigMap()
-    updatedConfigs.entrySet().forEach(entry => conf.set(entry.getKey, entry.getValue))
+    SslSampleConfigs.createDefaultConfigMap().entrySet().
+      forEach(entry => conf.set(entry.getKey, entry.getValue))
     conf
   }
 }

--- a/core/src/test/scala/org/apache/spark/network/netty/NettyBlockTransferSecuritySuite.scala
+++ b/core/src/test/scala/org/apache/spark/network/netty/NettyBlockTransferSecuritySuite.scala
@@ -45,46 +45,21 @@ import org.apache.spark.util.ThreadUtils
 
 class NettyBlockTransferSecuritySuite extends SparkFunSuite with MockitoSugar with Matchers {
 
-  private def sparkConfWithSsl(): SparkConf = {
-    val conf = new SparkConf()
-    val updatedConfigs = SslSampleConfigs.createDefaultConfigMap()
-    updatedConfigs.entrySet().forEach(entry => conf.set(entry.getKey, entry.getValue))
-    conf
+  def createSparkConf(): SparkConf = {
+    new SparkConf()
   }
 
   test("security default off") {
-    val conf = new SparkConf()
+    val conf = createSparkConf()
       .set("spark.app.id", "app-id")
     testConnection(conf, conf) match {
-      case Success(_) => // expected
-      case Failure(t) => fail(t)
-    }
-  }
-
-  test("ssl with cloned config") {
-    val conf = sparkConfWithSsl()
-      .set("spark.app.id", "app-id")
-    val conf1 = conf.clone
-
-    testConnection(conf, conf1) match {
       case Success(_) => // expected
       case Failure(t) => fail(t)
     }
   }
 
   test("security on same password") {
-    val conf = new SparkConf()
-      .set(NETWORK_AUTH_ENABLED, true)
-      .set(AUTH_SECRET, "good")
-      .set("spark.app.id", "app-id")
-    testConnection(conf, conf) match {
-      case Success(_) => // expected
-      case Failure(t) => fail(t)
-    }
-  }
-
-  test("security on same password with ssl") {
-    val conf = sparkConfWithSsl()
+    val conf = createSparkConf()
       .set(NETWORK_AUTH_ENABLED, true)
       .set(AUTH_SECRET, "good")
       .set("spark.app.id", "app-id")
@@ -95,7 +70,7 @@ class NettyBlockTransferSecuritySuite extends SparkFunSuite with MockitoSugar wi
   }
 
   test("security on mismatch password") {
-    val conf0 = new SparkConf()
+    val conf0 = createSparkConf()
       .set(NETWORK_AUTH_ENABLED, true)
       .set(AUTH_SECRET, "good")
       .set("spark.app.id", "app-id")
@@ -106,32 +81,8 @@ class NettyBlockTransferSecuritySuite extends SparkFunSuite with MockitoSugar wi
     }
   }
 
-  test("security on mismatch password over ssl") {
-    val conf0 = sparkConfWithSsl()
-      .set(NETWORK_AUTH_ENABLED, true)
-      .set(AUTH_SECRET, "good")
-      .set("spark.app.id", "app-id")
-    val conf1 = conf0.clone.set(AUTH_SECRET, "bad")
-    testConnection(conf0, conf1) match {
-      case Success(_) => fail("Should have failed")
-      case Failure(t) => t.getMessage should include("Mismatched response")
-    }
-  }
-
   test("security mismatch auth off on server") {
-    val conf0 = new SparkConf()
-      .set(NETWORK_AUTH_ENABLED, true)
-      .set(AUTH_SECRET, "good")
-      .set("spark.app.id", "app-id")
-    val conf1 = conf0.clone.set(NETWORK_AUTH_ENABLED, false)
-    testConnection(conf0, conf1) match {
-      case Success(_) => fail("Should have failed")
-      case Failure(t) => // any funny error may occur, sever will interpret SASL token as RPC
-    }
-  }
-
-  test("security mismatch auth off on server over ssl") {
-    val conf0 = sparkConfWithSsl()
+    val conf0 = createSparkConf()
       .set(NETWORK_AUTH_ENABLED, true)
       .set(AUTH_SECRET, "good")
       .set("spark.app.id", "app-id")
@@ -154,33 +105,8 @@ class NettyBlockTransferSecuritySuite extends SparkFunSuite with MockitoSugar wi
     }
   }
 
-  test("security mismatch auth off on client over ssl") {
-    val conf0 = sparkConfWithSsl()
-      .set(NETWORK_AUTH_ENABLED, false)
-      .set(AUTH_SECRET, "good")
-      .set("spark.app.id", "app-id")
-    val conf1 = conf0.clone.set(NETWORK_AUTH_ENABLED, true)
-    testConnection(conf0, conf1) match {
-      case Success(_) => fail("Should have failed")
-      case Failure(t) => t.getMessage should include("Expected SaslMessage")
-    }
-  }
-
   test("security with aes encryption") {
     val conf = new SparkConf()
-      .set(NETWORK_AUTH_ENABLED, true)
-      .set(AUTH_SECRET, "good")
-      .set("spark.app.id", "app-id")
-      .set(Network.NETWORK_CRYPTO_ENABLED, true)
-      .set(Network.NETWORK_CRYPTO_SASL_FALLBACK, false)
-    testConnection(conf, conf) match {
-      case Success(_) => // expected
-      case Failure(t) => fail(t)
-    }
-  }
-
-  test("security with aes encryption over ssl") {
-    val conf = sparkConfWithSsl()
       .set(NETWORK_AUTH_ENABLED, true)
       .set(AUTH_SECRET, "good")
       .set("spark.app.id", "app-id")
@@ -259,3 +185,12 @@ class NettyBlockTransferSecuritySuite extends SparkFunSuite with MockitoSugar wi
   }
 }
 
+class SslNettyBlockTransferSecuritySuite extends NettyBlockTransferSecuritySuite {
+
+  override def createSparkConf(): SparkConf = {
+    val conf = super.createSparkConf()
+    SslSampleConfigs.createDefaultConfigMap().entrySet().
+      forEach(entry => conf.set(entry.getKey, entry.getValue))
+    conf
+  }
+}

--- a/core/src/test/scala/org/apache/spark/rpc/RpcEnvSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rpc/RpcEnvSuite.scala
@@ -44,9 +44,13 @@ abstract class RpcEnvSuite extends SparkFunSuite {
 
   var env: RpcEnv = _
 
+  def createSparkConf(): SparkConf = {
+    new SparkConf()
+  }
+
   override def beforeAll(): Unit = {
     super.beforeAll()
-    val conf = new SparkConf()
+    val conf = createSparkConf()
     env = createRpcEnv(conf, "local", 0)
 
     val sparkEnv = mock(classOf[SparkEnv])
@@ -93,7 +97,7 @@ abstract class RpcEnvSuite extends SparkFunSuite {
       }
     })
 
-    val anotherEnv = createRpcEnv(new SparkConf(), "remote", 0, clientMode = true)
+    val anotherEnv = createRpcEnv(createSparkConf(), "remote", 0, clientMode = true)
     // Use anotherEnv to find out the RpcEndpointRef
     val rpcEndpointRef = anotherEnv.setupEndpointRef(env.address, "send-remotely")
     try {
@@ -145,7 +149,7 @@ abstract class RpcEnvSuite extends SparkFunSuite {
       }
     })
 
-    val anotherEnv = createRpcEnv(new SparkConf(), "remote", 0, clientMode = true)
+    val anotherEnv = createRpcEnv(createSparkConf(), "remote", 0, clientMode = true)
     // Use anotherEnv to find out the RpcEndpointRef
     val rpcEndpointRef = anotherEnv.setupEndpointRef(env.address, "ask-remotely")
     try {
@@ -168,7 +172,7 @@ abstract class RpcEnvSuite extends SparkFunSuite {
       }
     })
 
-    val conf = new SparkConf()
+    val conf = createSparkConf()
     val shortProp = "spark.rpc.short.timeout"
     val anotherEnv = createRpcEnv(conf, "remote", 0, clientMode = true)
     // Use anotherEnv to find out the RpcEndpointRef
@@ -198,7 +202,7 @@ abstract class RpcEnvSuite extends SparkFunSuite {
       }
     })
 
-    val conf = new SparkConf()
+    val conf = createSparkConf()
     val shortProp = "spark.rpc.short.timeout"
     val anotherEnv = createRpcEnv(conf, "remote", 0, clientMode = true)
     // Use anotherEnv to find out the RpcEndpointRef
@@ -467,7 +471,7 @@ abstract class RpcEnvSuite extends SparkFunSuite {
       }
     })
 
-    val anotherEnv = createRpcEnv(new SparkConf(), "remote", 0, clientMode = true)
+    val anotherEnv = createRpcEnv(createSparkConf(), "remote", 0, clientMode = true)
     // Use anotherEnv to find out the RpcEndpointRef
     val rpcEndpointRef = anotherEnv.setupEndpointRef(env.address, "sendWithReply-remotely")
     try {
@@ -507,7 +511,7 @@ abstract class RpcEnvSuite extends SparkFunSuite {
       }
     })
 
-    val anotherEnv = createRpcEnv(new SparkConf(), "remote", 0, clientMode = true)
+    val anotherEnv = createRpcEnv(createSparkConf(), "remote", 0, clientMode = true)
     // Use anotherEnv to find out the RpcEndpointRef
     val rpcEndpointRef = anotherEnv.setupEndpointRef(env.address, "sendWithReply-remotely-error")
     try {
@@ -556,8 +560,8 @@ abstract class RpcEnvSuite extends SparkFunSuite {
   }
 
   test("network events in sever RpcEnv when another RpcEnv is in server mode") {
-    val serverEnv1 = createRpcEnv(new SparkConf(), "server1", 0, clientMode = false)
-    val serverEnv2 = createRpcEnv(new SparkConf(), "server2", 0, clientMode = false)
+    val serverEnv1 = createRpcEnv(createSparkConf(), "server1", 0, clientMode = false)
+    val serverEnv2 = createRpcEnv(createSparkConf(), "server2", 0, clientMode = false)
     val (_, events) = setupNetworkEndpoint(serverEnv1, "network-events")
     val (serverRef2, _) = setupNetworkEndpoint(serverEnv2, "network-events")
     try {
@@ -585,9 +589,9 @@ abstract class RpcEnvSuite extends SparkFunSuite {
   }
 
   test("network events in sever RpcEnv when another RpcEnv is in client mode") {
-    val serverEnv = createRpcEnv(new SparkConf(), "server", 0, clientMode = false)
+    val serverEnv = createRpcEnv(createSparkConf(), "server", 0, clientMode = false)
     val (serverRef, events) = setupNetworkEndpoint(serverEnv, "network-events")
-    val clientEnv = createRpcEnv(new SparkConf(), "client", 0, clientMode = true)
+    val clientEnv = createRpcEnv(createSparkConf(), "client", 0, clientMode = true)
     try {
       val serverRefInClient = clientEnv.setupEndpointRef(serverRef.address, serverRef.name)
       // Send a message to set up the connection
@@ -615,8 +619,8 @@ abstract class RpcEnvSuite extends SparkFunSuite {
   }
 
   test("network events in client RpcEnv when another RpcEnv is in server mode") {
-    val clientEnv = createRpcEnv(new SparkConf(), "client", 0, clientMode = true)
-    val serverEnv = createRpcEnv(new SparkConf(), "server", 0, clientMode = false)
+    val clientEnv = createRpcEnv(createSparkConf(), "client", 0, clientMode = true)
+    val serverEnv = createRpcEnv(createSparkConf(), "server", 0, clientMode = false)
     val (_, events) = setupNetworkEndpoint(clientEnv, "network-events")
     val (serverRef, _) = setupNetworkEndpoint(serverEnv, "network-events")
     try {
@@ -652,7 +656,7 @@ abstract class RpcEnvSuite extends SparkFunSuite {
       }
     })
 
-    val anotherEnv = createRpcEnv(new SparkConf(), "remote", 0, clientMode = true)
+    val anotherEnv = createRpcEnv(createSparkConf(), "remote", 0, clientMode = true)
     // Use anotherEnv to find out the RpcEndpointRef
     val rpcEndpointRef =
       anotherEnv.setupEndpointRef(env.address, "sendWithReply-unserializable-error")
@@ -669,7 +673,7 @@ abstract class RpcEnvSuite extends SparkFunSuite {
   }
 
   test("port conflict") {
-    val anotherEnv = createRpcEnv(new SparkConf(), "remote", env.address.port)
+    val anotherEnv = createRpcEnv(createSparkConf(), "remote", env.address.port)
     try {
       assert(anotherEnv.address.port != env.address.port)
     } finally {
@@ -729,20 +733,20 @@ abstract class RpcEnvSuite extends SparkFunSuite {
   }
 
   test("send with authentication") {
-    testSend(new SparkConf()
+    testSend(createSparkConf()
       .set(NETWORK_AUTH_ENABLED, true)
       .set(AUTH_SECRET, "good"))
   }
 
   test("send with SASL encryption") {
-    testSend(new SparkConf()
+    testSend(createSparkConf()
       .set(NETWORK_AUTH_ENABLED, true)
       .set(AUTH_SECRET, "good")
       .set(SASL_ENCRYPTION_ENABLED, true))
   }
 
   test("send with AES encryption") {
-    testSend(new SparkConf()
+    testSend(createSparkConf()
       .set(NETWORK_AUTH_ENABLED, true)
       .set(AUTH_SECRET, "good")
       .set(Network.NETWORK_CRYPTO_ENABLED, true)
@@ -750,20 +754,20 @@ abstract class RpcEnvSuite extends SparkFunSuite {
   }
 
   test("ask with authentication") {
-    testAsk(new SparkConf()
+    testAsk(createSparkConf()
       .set(NETWORK_AUTH_ENABLED, true)
       .set(AUTH_SECRET, "good"))
   }
 
   test("ask with SASL encryption") {
-    testAsk(new SparkConf()
+    testAsk(createSparkConf()
       .set(NETWORK_AUTH_ENABLED, true)
       .set(AUTH_SECRET, "good")
       .set(SASL_ENCRYPTION_ENABLED, true))
   }
 
   test("ask with AES encryption") {
-    testAsk(new SparkConf()
+    testAsk(createSparkConf()
       .set(NETWORK_AUTH_ENABLED, true)
       .set(AUTH_SECRET, "good")
       .set(Network.NETWORK_CRYPTO_ENABLED, true)
@@ -861,7 +865,7 @@ abstract class RpcEnvSuite extends SparkFunSuite {
   test("file server") {
     withTempDir { tempDir =>
       withTempDir { destDir =>
-        val conf = new SparkConf()
+        val conf = createSparkConf()
 
         val file = new File(tempDir, "file")
         Files.write(UUID.randomUUID().toString(), file, UTF_8)
@@ -940,7 +944,7 @@ abstract class RpcEnvSuite extends SparkFunSuite {
       }
     })
 
-    val anotherEnv = createRpcEnv(new SparkConf(), "remote", 0)
+    val anotherEnv = createRpcEnv(createSparkConf(), "remote", 0)
     val endpoint = mock(classOf[RpcEndpoint])
     anotherEnv.setupEndpoint("SPARK-14699", endpoint)
 
@@ -960,7 +964,7 @@ abstract class RpcEnvSuite extends SparkFunSuite {
   test("isolated endpoints") {
     val latch = new CountDownLatch(1)
     val singleThreadedEnv = createRpcEnv(
-      new SparkConf().set(Network.RPC_NETTY_DISPATCHER_NUM_THREADS, 1), "singleThread", 0)
+      createSparkConf().set(Network.RPC_NETTY_DISPATCHER_NUM_THREADS, 1), "singleThread", 0)
     try {
       val blockingEndpoint = singleThreadedEnv
         .setupEndpoint("blocking", new IsolatedThreadSafeRpcEndpoint {

--- a/core/src/test/scala/org/apache/spark/rpc/netty/NettyRpcEnvSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rpc/netty/NettyRpcEnvSuite.scala
@@ -185,8 +185,8 @@ class NettyRpcEnvSuite extends RpcEnvSuite with MockitoSugar with TimeLimits {
 class SslNettyRpcEnvSuite extends NettyRpcEnvSuite with MockitoSugar with TimeLimits {
   override def createSparkConf(): SparkConf = {
     val conf = super.createSparkConf()
-    val updatedConfigs = SslSampleConfigs.createDefaultConfigMap()
-    updatedConfigs.entrySet().forEach(entry => conf.set(entry.getKey, entry.getValue))
+    SslSampleConfigs.createDefaultConfigMap().entrySet().
+      forEach(entry => conf.set(entry.getKey, entry.getValue))
     conf
   }
 }

--- a/core/src/test/scala/org/apache/spark/rpc/netty/NettyRpcEnvSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rpc/netty/NettyRpcEnvSuite.scala
@@ -26,7 +26,6 @@ import org.scalatestplus.mockito.MockitoSugar
 
 import org.apache.spark._
 import org.apache.spark.network.client.TransportClient
-import org.apache.spark.network.ssl.SslSampleConfigs
 import org.apache.spark.rpc._
 import org.apache.spark.util.ThreadUtils
 
@@ -184,9 +183,6 @@ class NettyRpcEnvSuite extends RpcEnvSuite with MockitoSugar with TimeLimits {
 
 class SslNettyRpcEnvSuite extends NettyRpcEnvSuite with MockitoSugar with TimeLimits {
   override def createSparkConf(): SparkConf = {
-    val conf = super.createSparkConf()
-    SslSampleConfigs.createDefaultConfigMap().entrySet().
-      forEach(entry => conf.set(entry.getKey, entry.getValue))
-    conf
+    SslTestUtils.updateWithSSLConfig(super.createSparkConf())
   }
 }

--- a/core/src/test/scala/org/apache/spark/shuffle/ShuffleBlockPusherSuite.scala
+++ b/core/src/test/scala/org/apache/spark/shuffle/ShuffleBlockPusherSuite.scala
@@ -489,8 +489,8 @@ class ShuffleBlockPusherSuite extends SparkFunSuite {
 class SslShuffleBlockPusherSuite extends ShuffleBlockPusherSuite {
   override def createSparkConf(): SparkConf = {
     val conf = super.createSparkConf()
-    val updatedConfigs = SslSampleConfigs.createDefaultConfigMap()
-    updatedConfigs.entrySet().forEach(entry => conf.set(entry.getKey, entry.getValue))
+    SslSampleConfigs.createDefaultConfigMap().entrySet().
+      forEach(entry => conf.set(entry.getKey, entry.getValue))
     conf
   }
 }

--- a/core/src/test/scala/org/apache/spark/shuffle/ShuffleBlockPusherSuite.scala
+++ b/core/src/test/scala/org/apache/spark/shuffle/ShuffleBlockPusherSuite.scala
@@ -37,7 +37,6 @@ import org.apache.spark.network.buffer.ManagedBuffer
 import org.apache.spark.network.server.BlockPushNonFatalFailure
 import org.apache.spark.network.server.BlockPushNonFatalFailure.ReturnCode
 import org.apache.spark.network.shuffle.{BlockPushingListener, BlockStoreClient}
-import org.apache.spark.network.ssl.SslSampleConfigs
 import org.apache.spark.network.util.TransportConf
 import org.apache.spark.serializer.JavaSerializer
 import org.apache.spark.shuffle.ShuffleBlockPusher.PushRequest
@@ -488,9 +487,6 @@ class ShuffleBlockPusherSuite extends SparkFunSuite {
 
 class SslShuffleBlockPusherSuite extends ShuffleBlockPusherSuite {
   override def createSparkConf(): SparkConf = {
-    val conf = super.createSparkConf()
-    SslSampleConfigs.createDefaultConfigMap().entrySet().
-      forEach(entry => conf.set(entry.getKey, entry.getValue))
-    conf
+    SslTestUtils.updateWithSSLConfig(super.createSparkConf())
   }
 }

--- a/core/src/test/scala/org/apache/spark/shuffle/sort/IndexShuffleBlockResolverSuite.scala
+++ b/core/src/test/scala/org/apache/spark/shuffle/sort/IndexShuffleBlockResolverSuite.scala
@@ -28,6 +28,7 @@ import org.roaringbitmap.RoaringBitmap
 
 import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.internal.config
+import org.apache.spark.network.ssl.SslSampleConfigs
 import org.apache.spark.shuffle.{IndexShuffleBlockResolver, ShuffleBlockInfo}
 import org.apache.spark.storage._
 import org.apache.spark.util.Utils
@@ -37,8 +38,12 @@ class IndexShuffleBlockResolverSuite extends SparkFunSuite {
   @Mock(answer = RETURNS_SMART_NULLS) private var blockManager: BlockManager = _
   @Mock(answer = RETURNS_SMART_NULLS) private var diskBlockManager: DiskBlockManager = _
 
+  def createSparkConf(): SparkConf = {
+    new SparkConf(loadDefaults = false)
+  }
+
   private var tempDir: File = _
-  private val conf: SparkConf = new SparkConf(loadDefaults = false)
+  private val conf: SparkConf = createSparkConf()
   private val appId = "TESTAPP"
 
   override def beforeEach(): Unit = {
@@ -273,5 +278,14 @@ class IndexShuffleBlockResolverSuite extends SparkFunSuite {
     assert(checksumAlgo === conf.get(config.SHUFFLE_CHECKSUM_ALGORITHM))
     val checksumsFromFile = resolver.getChecksums(checksumFile, 10)
     assert(checksumsInMemory === checksumsFromFile)
+  }
+}
+
+class SslIndexShuffleBlockResolverSuite extends IndexShuffleBlockResolverSuite {
+  override def createSparkConf(): SparkConf = {
+    val conf = super.createSparkConf()
+    val updatedConfigs = SslSampleConfigs.createDefaultConfigMap()
+    updatedConfigs.entrySet().forEach(entry => conf.set(entry.getKey, entry.getValue))
+    conf
   }
 }

--- a/core/src/test/scala/org/apache/spark/shuffle/sort/IndexShuffleBlockResolverSuite.scala
+++ b/core/src/test/scala/org/apache/spark/shuffle/sort/IndexShuffleBlockResolverSuite.scala
@@ -26,9 +26,8 @@ import org.mockito.Mockito._
 import org.mockito.invocation.InvocationOnMock
 import org.roaringbitmap.RoaringBitmap
 
-import org.apache.spark.{SparkConf, SparkFunSuite}
+import org.apache.spark.{SparkConf, SparkFunSuite, SslTestUtils}
 import org.apache.spark.internal.config
-import org.apache.spark.network.ssl.SslSampleConfigs
 import org.apache.spark.shuffle.{IndexShuffleBlockResolver, ShuffleBlockInfo}
 import org.apache.spark.storage._
 import org.apache.spark.util.Utils
@@ -283,9 +282,6 @@ class IndexShuffleBlockResolverSuite extends SparkFunSuite {
 
 class SslIndexShuffleBlockResolverSuite extends IndexShuffleBlockResolverSuite {
   override def createSparkConf(): SparkConf = {
-    val conf = super.createSparkConf()
-    SslSampleConfigs.createDefaultConfigMap().entrySet().
-      forEach(entry => conf.set(entry.getKey, entry.getValue))
-    conf
+    SslTestUtils.updateWithSSLConfig(super.createSparkConf())
   }
 }

--- a/core/src/test/scala/org/apache/spark/shuffle/sort/IndexShuffleBlockResolverSuite.scala
+++ b/core/src/test/scala/org/apache/spark/shuffle/sort/IndexShuffleBlockResolverSuite.scala
@@ -284,8 +284,8 @@ class IndexShuffleBlockResolverSuite extends SparkFunSuite {
 class SslIndexShuffleBlockResolverSuite extends IndexShuffleBlockResolverSuite {
   override def createSparkConf(): SparkConf = {
     val conf = super.createSparkConf()
-    val updatedConfigs = SslSampleConfigs.createDefaultConfigMap()
-    updatedConfigs.entrySet().forEach(entry => conf.set(entry.getKey, entry.getValue))
+    SslSampleConfigs.createDefaultConfigMap().entrySet().
+      forEach(entry => conf.set(entry.getKey, entry.getValue))
     conf
   }
 }

--- a/core/src/test/scala/org/apache/spark/storage/BlockManagerReplicationSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockManagerReplicationSuite.scala
@@ -50,7 +50,8 @@ trait BlockManagerReplicationBehavior extends SparkFunSuite
   with BeforeAndAfter
   with LocalSparkContext {
 
-  val conf: SparkConf
+  val conf: SparkConf = createConf()
+  protected def createConf(): SparkConf
 
   protected var rpcEnv: RpcEnv = null
   protected var master: BlockManagerMaster = null
@@ -459,15 +460,21 @@ trait BlockManagerReplicationBehavior extends SparkFunSuite
 }
 
 class BlockManagerReplicationSuite extends BlockManagerReplicationBehavior {
-  val conf = new SparkConf(false).set("spark.app.id", "test")
-  conf.set(Kryo.KRYO_SERIALIZER_BUFFER_SIZE.key, "1m")
+  override def createConf(): SparkConf = {
+    new SparkConf(false)
+      .set("spark.app.id", "test")
+      .set(Kryo.KRYO_SERIALIZER_BUFFER_SIZE.key, "1m")
+  }
 }
 
 class BlockManagerProactiveReplicationSuite extends BlockManagerReplicationBehavior {
-  val conf = new SparkConf(false).set("spark.app.id", "test")
-  conf.set(Kryo.KRYO_SERIALIZER_BUFFER_SIZE.key, "1m")
-  conf.set(STORAGE_REPLICATION_PROACTIVE, true)
-  conf.set(STORAGE_EXCEPTION_PIN_LEAK, true)
+  override def createConf(): SparkConf = {
+    new SparkConf(false)
+      .set("spark.app.id", "test")
+      .set(Kryo.KRYO_SERIALIZER_BUFFER_SIZE.key, "1m")
+      .set(STORAGE_REPLICATION_PROACTIVE, true)
+      .set(STORAGE_EXCEPTION_PIN_LEAK, true)
+  }
 
   (2 to 5).foreach { i =>
     test(s"proactive block replication - $i replicas - ${i - 1} block manager deletions") {
@@ -539,14 +546,17 @@ class DummyTopologyMapper(conf: SparkConf) extends TopologyMapper(conf) with Log
 }
 
 class BlockManagerBasicStrategyReplicationSuite extends BlockManagerReplicationBehavior {
-  val conf: SparkConf = new SparkConf(false).set("spark.app.id", "test")
-  conf.set(Kryo.KRYO_SERIALIZER_BUFFER_SIZE.key, "1m")
-  conf.set(
-    STORAGE_REPLICATION_POLICY,
-    classOf[BasicBlockReplicationPolicy].getName)
-  conf.set(
-    STORAGE_REPLICATION_TOPOLOGY_MAPPER,
-    classOf[DummyTopologyMapper].getName)
+  override def createConf(): SparkConf = {
+    new SparkConf(false)
+      .set("spark.app.id", "test")
+      .set(Kryo.KRYO_SERIALIZER_BUFFER_SIZE.key, "1m")
+      .set(
+        STORAGE_REPLICATION_POLICY,
+        classOf[BasicBlockReplicationPolicy].getName)
+      .set(
+        STORAGE_REPLICATION_TOPOLOGY_MAPPER,
+        classOf[DummyTopologyMapper].getName)
+  }
 }
 
 // BlockReplicationPolicy to prioritize BlockManagers based on hostnames

--- a/core/src/test/scala/org/apache/spark/storage/SslBlockManagerReplicationSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/SslBlockManagerReplicationSuite.scala
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.storage
+
+import org.apache.spark.SparkConf
+import org.apache.spark.network.ssl.SslSampleConfigs
+
+class SslBlockManagerReplicationSuite extends BlockManagerReplicationSuite {
+  override def createConf(): SparkConf = {
+    val conf = super.createConf()
+    val updatedConfigs = SslSampleConfigs.createDefaultConfigMap()
+    updatedConfigs.entrySet().forEach(entry => conf.set(entry.getKey, entry.getValue))
+    conf
+  }
+}
+
+class SslBlockManagerProactiveReplicationSuite extends BlockManagerProactiveReplicationSuite {
+  override def createConf(): SparkConf = {
+    val conf = super.createConf()
+    val updatedConfigs = SslSampleConfigs.createDefaultConfigMap()
+    updatedConfigs.entrySet().forEach(entry => conf.set(entry.getKey, entry.getValue))
+    conf
+  }
+}
+
+class SslBlockManagerBasicStrategyReplicationSuite
+  extends BlockManagerBasicStrategyReplicationSuite {
+  override def createConf(): SparkConf = {
+    val conf = super.createConf()
+    val updatedConfigs = SslSampleConfigs.createDefaultConfigMap()
+    updatedConfigs.entrySet().forEach(entry => conf.set(entry.getKey, entry.getValue))
+    conf
+  }
+}

--- a/core/src/test/scala/org/apache/spark/storage/SslBlockManagerReplicationSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/SslBlockManagerReplicationSuite.scala
@@ -17,33 +17,23 @@
 
 package org.apache.spark.storage
 
-import org.apache.spark.SparkConf
-import org.apache.spark.network.ssl.SslSampleConfigs
+import org.apache.spark.{SparkConf, SslTestUtils}
 
 class SslBlockManagerReplicationSuite extends BlockManagerReplicationSuite {
   override def createConf(): SparkConf = {
-    val conf = super.createConf()
-    SslSampleConfigs.createDefaultConfigMap().entrySet().
-      forEach(entry => conf.set(entry.getKey, entry.getValue))
-    conf
+    SslTestUtils.updateWithSSLConfig(super.createConf())
   }
 }
 
 class SslBlockManagerProactiveReplicationSuite extends BlockManagerProactiveReplicationSuite {
   override def createConf(): SparkConf = {
-    val conf = super.createConf()
-    SslSampleConfigs.createDefaultConfigMap().entrySet().
-      forEach(entry => conf.set(entry.getKey, entry.getValue))
-    conf
+    SslTestUtils.updateWithSSLConfig(super.createConf())
   }
 }
 
 class SslBlockManagerBasicStrategyReplicationSuite
   extends BlockManagerBasicStrategyReplicationSuite {
   override def createConf(): SparkConf = {
-    val conf = super.createConf()
-    SslSampleConfigs.createDefaultConfigMap().entrySet().
-      forEach(entry => conf.set(entry.getKey, entry.getValue))
-    conf
+    SslTestUtils.updateWithSSLConfig(super.createConf())
   }
 }

--- a/core/src/test/scala/org/apache/spark/storage/SslBlockManagerReplicationSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/SslBlockManagerReplicationSuite.scala
@@ -23,8 +23,8 @@ import org.apache.spark.network.ssl.SslSampleConfigs
 class SslBlockManagerReplicationSuite extends BlockManagerReplicationSuite {
   override def createConf(): SparkConf = {
     val conf = super.createConf()
-    val updatedConfigs = SslSampleConfigs.createDefaultConfigMap()
-    updatedConfigs.entrySet().forEach(entry => conf.set(entry.getKey, entry.getValue))
+    SslSampleConfigs.createDefaultConfigMap().entrySet().
+      forEach(entry => conf.set(entry.getKey, entry.getValue))
     conf
   }
 }
@@ -32,8 +32,8 @@ class SslBlockManagerReplicationSuite extends BlockManagerReplicationSuite {
 class SslBlockManagerProactiveReplicationSuite extends BlockManagerProactiveReplicationSuite {
   override def createConf(): SparkConf = {
     val conf = super.createConf()
-    val updatedConfigs = SslSampleConfigs.createDefaultConfigMap()
-    updatedConfigs.entrySet().forEach(entry => conf.set(entry.getKey, entry.getValue))
+    SslSampleConfigs.createDefaultConfigMap().entrySet().
+      forEach(entry => conf.set(entry.getKey, entry.getValue))
     conf
   }
 }
@@ -42,8 +42,8 @@ class SslBlockManagerBasicStrategyReplicationSuite
   extends BlockManagerBasicStrategyReplicationSuite {
   override def createConf(): SparkConf = {
     val conf = super.createConf()
-    val updatedConfigs = SslSampleConfigs.createDefaultConfigMap()
-    updatedConfigs.entrySet().forEach(entry => conf.set(entry.getKey, entry.getValue))
+    SslSampleConfigs.createDefaultConfigMap().entrySet().
+      forEach(entry => conf.set(entry.getKey, entry.getValue))
     conf
   }
 }

--- a/core/src/test/scala/org/apache/spark/util/SslTestUtils.scala
+++ b/core/src/test/scala/org/apache/spark/util/SslTestUtils.scala
@@ -15,20 +15,21 @@
  * limitations under the License.
  */
 
-package org.apache.spark.network.yarn
+package org.apache.spark
 
 import org.apache.spark.network.ssl.SslSampleConfigs
 
-class SslYarnShuffleServiceWithRocksDBBackendSuite
-  extends YarnShuffleServiceWithRocksDBBackendSuite {
+object SslTestUtils {
 
   /**
-   * Override to add "spark.ssl.rpc.*" configuration parameters...
+   * Updates a SparkConf to contain SSL configurations
+   *
+   * @param conf The config to update
+   * @return The passed in SparkConf with SSL configurations added
    */
-  override def beforeEach(): Unit = {
-    super.beforeEach()
-    // Same as SSLTestUtils.updateWithSSLConfig(), which is not available to import here.
+  def updateWithSSLConfig(conf: SparkConf): SparkConf = {
     SslSampleConfigs.createDefaultConfigMap().entrySet().
-      forEach(entry => yarnConfig.set(entry.getKey, entry.getValue))
+      forEach(entry => conf.set(entry.getKey, entry.getValue))
+    conf
   }
 }

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/network/yarn/SslYarnShuffleServiceSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/network/yarn/SslYarnShuffleServiceSuite.scala
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.network.yarn
+
+import org.apache.spark.network.ssl.SslSampleConfigs
+
+class SslYarnShuffleServiceWithRocksDBBackendSuite
+  extends YarnShuffleServiceWithRocksDBBackendSuite {
+
+  /**
+   * Override to add "spark.ssl.rpc.*" configuration parameters...
+   */
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    val updatedConfigs = SslSampleConfigs.createDefaultConfigMapForRpcNamespace()
+    updatedConfigs.entrySet().forEach(entry => yarnConfig.set(entry.getKey, entry.getValue))
+  }
+}

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/network/yarn/SslYarnShuffleServiceSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/network/yarn/SslYarnShuffleServiceSuite.scala
@@ -27,7 +27,7 @@ class SslYarnShuffleServiceWithRocksDBBackendSuite
    */
   override def beforeEach(): Unit = {
     super.beforeEach()
-    val updatedConfigs = SslSampleConfigs.createDefaultConfigMapForRpcNamespace()
-    updatedConfigs.entrySet().forEach(entry => yarnConfig.set(entry.getKey, entry.getValue))
+    SslSampleConfigs.createDefaultConfigMap().entrySet().
+      forEach(entry => conf.set(entry.getKey, entry.getValue))
   }
 }

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/network/yarn/SslYarnShuffleServiceSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/network/yarn/SslYarnShuffleServiceSuite.scala
@@ -28,6 +28,6 @@ class SslYarnShuffleServiceWithRocksDBBackendSuite
   override def beforeEach(): Unit = {
     super.beforeEach()
     SslSampleConfigs.createDefaultConfigMap().entrySet().
-      forEach(entry => conf.set(entry.getKey, entry.getValue))
+      forEach(entry => yarnConfig.set(entry.getKey, entry.getValue))
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This change ensures that RPC SSL options settings inheritance works properly after https://github.com/apache/spark/pull/43238 - we pass `sslOptions` wherever we call `fromSparkConf`.

In addition to that minor mechanical change, duplicate/add tests for every place that calls this method, to add a test case that runs with SSL support in the config.

### Why are the changes needed?

These changes are needed to ensure that the RPC SSL functionality can work properly with settings inheritance. In addition, through these tests we can ensure that any changes to these modules are also tested with SSL support and avoid regressions in the future.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Full integration testing also done as part of https://github.com/apache/spark/pull/42685

Added some tests and ran them:

```
build/sbt
> project core
> testOnly org.apache.spark.*Ssl*
> testOnly org.apache.spark.network.netty.NettyBlockTransferSecuritySuite
```

and

```
build/sbt -Pyarn
> project yarn
> testOnly org.apache.spark.network.yarn.SslYarnShuffleServiceWithRocksDBBackendSuite
```

### Was this patch authored or co-authored using generative AI tooling?

No
