### PR TITLE
SPARK-45478: Codegen sum(decimal_column / 2) computes div twice

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/EquivalentExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/EquivalentExpressions.scala
@@ -151,7 +151,8 @@ class EquivalentExpressions(
   //   2. ConditionalExpression: use its children that will always be evaluated.
   private def childrenToRecurse(expr: Expression): Seq[Expression] = expr match {
     case _: CodegenFallback => Nil
-    case c: ConditionalExpression => c.alwaysEvaluatedInputs.map(skipForShortcut)
+    case c: ConditionalExpression if !c.isInstanceOf[If] =>
+      c.alwaysEvaluatedInputs.map(skipForShortcut)
     case other => skipForShortcut(other).children
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
All children of If should be eliminate common  expression.


### Why are the changes needed?
There are three children in If: predicate, trueValue and falseValue.

There are two execution paths. 1: predicate and trueValue. 2: predicate and falseValue.

There are three conbinations of possible common subexpression. 1: predicate and trueValue. 2: predicate and falseValue. 3: trueValue and falseValue.

So if all possible common subexpression be eliminated, there is 2 3 possibility to improve the performance. For example, if there is common subexpression in predicate and falseValue, and common subexpression is executed only once, and it can improve the performance. Only there is common subexpression in trueValue and falseValue will not improve the performance and it will not draw back the performance, since whether trueValue and falseValue will be executed.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existing testcase


### Was this patch authored or co-authored using generative AI tooling?
no
