### PR TITLE
[SPARK-44667][INFRA][FOLLOWUP] Uninstall large ML libraries in `sparkr`

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -530,6 +530,8 @@ jobs:
           sparkr-coursier-
     - name: Free up disk space
       run: |
+        # uninstall libraries dedicated for ML testing
+        python3.9 -m pip uninstall -y torch torchvision torcheval torchtnt tensorboard mlflow deepspeed
         if [ -f ./dev/free_disk_space_container ]; then
           ./dev/free_disk_space_container
         fi
@@ -644,6 +646,8 @@ jobs:
           docs-maven-
     - name: Free up disk space
       run: |
+        # uninstall libraries dedicated for ML testing
+        python3.9 -m pip uninstall -y torch torchvision torcheval torchtnt tensorboard mlflow deepspeed
         if [ -f ./dev/free_disk_space_container ]; then
           ./dev/free_disk_space_container
         fi

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -646,8 +646,6 @@ jobs:
           docs-maven-
     - name: Free up disk space
       run: |
-        # uninstall libraries dedicated for ML testing
-        python3.9 -m pip uninstall -y torch torchvision torcheval torchtnt tensorboard mlflow deepspeed
         if [ -f ./dev/free_disk_space_container ]; then
           ./dev/free_disk_space_container
         fi
@@ -728,6 +726,8 @@ jobs:
         ./R/install-dev.sh
     - name: Install dependencies for documentation generation
       run: |
+        # uninstall libraries dedicated for ML testing
+        python3.9 -m pip uninstall -y torch torchvision torcheval torchtnt tensorboard mlflow deepspeed
         # pandoc is required to generate PySpark APIs as well in nbsphinx.
         apt-get install -y libcurl4-openssl-dev pandoc
         # TODO(SPARK-32407): Sphinx 3.1+ does not correctly index nested classes.

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -726,8 +726,6 @@ jobs:
         ./R/install-dev.sh
     - name: Install dependencies for documentation generation
       run: |
-        # uninstall libraries dedicated for ML testing
-        python3.9 -m pip uninstall -y torch torchvision torcheval torchtnt tensorboard mlflow deepspeed
         # pandoc is required to generate PySpark APIs as well in nbsphinx.
         apt-get install -y libcurl4-openssl-dev pandoc
         # TODO(SPARK-32407): Sphinx 3.1+ does not correctly index nested classes.


### PR DESCRIPTION
### What changes were proposed in this pull request?
Uninstall large ML libraries in SparkR testing


### Why are the changes needed?
to free more disk

~~in job `lint`, those libraries are needed in python linter, so try to uninstall them after linter~~


### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no
