### PR TITLE
[SPARK-45578][CORE] Remove `InaccessibleObjectException` usage by using `trySetAccessible`

### DIFF
--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/Platform.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/Platform.java
@@ -72,19 +72,11 @@ public final class Platform {
         cls.getDeclaredConstructor(Long.TYPE, Integer.TYPE) :
         cls.getDeclaredConstructor(Long.TYPE, Long.TYPE);
       Field cleanerField = cls.getDeclaredField("cleaner");
-      try {
-        constructor.setAccessible(true);
-        cleanerField.setAccessible(true);
-      } catch (RuntimeException re) {
-        // This is a Java 9+ exception, so needs to be handled without importing it
-        if ("InaccessibleObjectException".equals(re.getClass().getSimpleName())) {
-          // Continue, but the constructor/field are not available
-          // See comment below for more context
-          constructor = null;
-          cleanerField = null;
-        } else {
-          throw re;
-        }
+      if (!constructor.trySetAccessible()) {
+        constructor = null;
+      }
+      if (!cleanerField.trySetAccessible()) {
+        cleanerField = null;
       }
       // Have to set these values no matter what:
       DBB_CONSTRUCTOR = constructor;

--- a/core/src/main/scala/org/apache/spark/util/SizeEstimator.scala
+++ b/core/src/main/scala/org/apache/spark/util/SizeEstimator.scala
@@ -333,18 +333,14 @@ object SizeEstimator extends Logging {
         if (fieldClass.isPrimitive) {
           sizeCount(primitiveSize(fieldClass)) += 1
         } else {
-          // Note: in Java 9+ this would be better with trySetAccessible and canAccess
           try {
-            field.setAccessible(true) // Enable future get()'s on this field
-            pointerFields = field :: pointerFields
+            if (field.trySetAccessible()) { // Enable future get()'s on this field
+              pointerFields = field :: pointerFields
+            }
           } catch {
             // If the field isn't accessible, we can still record the pointer size
             // but can't know more about the field, so ignore it
             case _: SecurityException =>
-              // do nothing
-            // Java 9+ can throw InaccessibleObjectException but the class is Java 9+-only
-            case re: RuntimeException
-                if re.getClass.getSimpleName == "InaccessibleObjectException" =>
               // do nothing
           }
           sizeCount(pointerSize) += 1


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove `InaccessibleObjectException` usage by using `trySetAccessible` instead of `setAccessible`.

### Why are the changes needed?

`trySetAccessible` is available on Java 9+

- https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/reflect/AccessibleObject.html#trySetAccessible()

We can simplify the code for Apache Spark 4.0.0 because we support only Java 17 and 21 .

**BEFORE**
```
$ git grep InaccessibleObjectException
common/unsafe/src/main/java/org/apache/spark/unsafe/Platform.java:        if ("InaccessibleObjectException".equals(re.getClass().getSimpleName())) {
core/src/main/scala/org/apache/spark/util/SizeEstimator.scala:            // Java 9+ can throw InaccessibleObjectException but the class is Java 9+-only
core/src/main/scala/org/apache/spark/util/SizeEstimator.scala:                if re.getClass.getSimpleName == "InaccessibleObjectException" =>
```

**AFTER**
```
$ git grep InaccessibleObjectException
```

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.