### PR TITLE
[MINOR][DOCS] Update the docs for spark.sql.optimizer.canChangeCachedPlanOutputPartitioning configuration

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1558,7 +1558,7 @@ object SQLConf {
       .doc("Whether to forcibly enable some optimization rules that can change the output " +
         "partitioning of a cached query when executing it for caching. If it is set to true, " +
         "queries may need an extra shuffle to read the cached data. This configuration is " +
-        "disabled by default. Currently, the optimization rules enabled by this configuration " +
+        "enabled by default. The optimization rules enabled by this configuration " +
         s"are ${ADAPTIVE_EXECUTION_ENABLED.key} and ${AUTO_BUCKETED_SCAN_ENABLED.key}.")
       .version("3.2.0")
       .booleanConf


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes the documentation for `spark.sql.optimizer.canChangeCachedPlanOutputPartitioning` configuration by saying this is enabled by default. This is a followup of https://github.com/apache/spark/pull/40390 (but did not use a JIRA due to fixed versions properties in the JIRA). 

### Why are the changes needed?

To mention that this is enabled, to the end users.

### Does this PR introduce _any_ user-facing change?

No, it's an internal conf, not documented.

### How was this patch tested?

CI in this PR.

### Was this patch authored or co-authored using generative AI tooling?

No.