### PR TITLE
[MINOR][INFRA] Skip if JIRA ID is an empty string

### DIFF
--- a/dev/merge_spark_pr.py
+++ b/dev/merge_spark_pr.py
@@ -246,6 +246,9 @@ def resolve_jira_issue(merge_branches, comment, default_jira_id=""):
     jira_id = input("Enter a JIRA id [%s]: " % default_jira_id)
     if jira_id == "":
         jira_id = default_jira_id
+        if jira_id == "":
+            print("JIRA ID not found, skipping.")
+            return
 
     try:
         issue = asf_jira.issue(jira_id)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR skips when an empty string is provided as a JIRA ID.

### Why are the changes needed?

When you merge a minor PR that does not have a JIRA ID, and you say `y` to update associated JIRA, you face an error as below:

```
...
Would you like to update an associated JIRA? (y/n): y
Enter a JIRA id []:
ASF JIRA could not find
JiraError HTTP 405 url: https://issues.apache.org/jira/rest/api/2/issue/

	response headers = {'Date': 'Wed, 18 Oct 2023 02:44:24 GMT', 'Server': 'Apache', 'X-AREQUESTID': '164x103019855x17', 'X-ASESSIONID': '1bxvboa', 'Referrer-Policy': 'strict-origin-when-cross-origin', 'X-XSS-Protection': '1; mode=block', 'X-Content-Type-Options': 'nosniff', 'X-Frame-Options': 'SAMEORIGIN', 'Content-Security-Policy': "frame-ancestors 'self'", 'Strict-Transport-Security': 'max-age=31536000', 'X-Seraph-LoginReason': 'OK', 'X-AUSERNAME': 'gurwls223', 'Allow': 'POST,OPTIONS', 'Content-Type': 'text/html;charset=UTF-8', 'Content-Length': '0', 'Via': '1.1 jira2-he-de.apache.org', 'Keep-Alive': 'timeout=15, max=100', 'Connection': 'Keep-Alive'}
	response text =
...
```

After this PR, it doesn't fail but shows a warning `JIRA ID not found, skipping`.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

I am going to test this change against this PR.

### Was this patch authored or co-authored using generative AI tooling?

No.