### PR TITLE
[SPARK-45500][CORE][WEBUI][FOLLOWUP] Show `RELAUNCHING` drivers too

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/master/ui/MasterPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/ui/MasterPage.scala
@@ -156,7 +156,8 @@ private[ui] class MasterPage(parent: MasterWebUI) extends WebUIPage("") {
                 {state.completedDrivers.length} Completed
                 ({state.completedDrivers.count(_.state == DriverState.KILLED)} Killed,
                 {state.completedDrivers.count(_.state == DriverState.FAILED)} Failed,
-                {state.completedDrivers.count(_.state == DriverState.ERROR)} Error)
+                {state.completedDrivers.count(_.state == DriverState.ERROR)} Error,
+                {state.completedDrivers.count(_.state == DriverState.RELAUNCHING)} Relaunching)
               </li>
               <li><strong>Status:</strong> {state.status}</li>
             </ul>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up of #43328 to show `RELAUNCHING` drivers too.

### Why are the changes needed?

When we submit with `--supervise` option, the abnormally-completed driver is in `RELAUNCHING` status and newly launched driver is in `SUBMITTED` status.

https://github.com/apache/spark/blob/0cb4a84f6ab0c1bd101e6bc72be82987bbc02e9b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala#L995


![Screenshot 2023-10-17 at 8 01 01 PM](https://github.com/apache/spark/assets/9700541/22c614cb-3f5c-44a0-b5f5-8edf4a20c580)

### Does this PR introduce _any_ user-facing change?

Yes, but this is a new UI item.

### How was this patch tested?

Manual tests.

### Was this patch authored or co-authored using generative AI tooling?

No.