### PR TITLE
[SPARK-45576][CORE][FOLLOWUP] Remove unused imports to fix Java linter errors

### DIFF
--- a/common/network-common/src/test/java/org/apache/spark/network/ssl/ReloadingX509TrustManagerSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/ssl/ReloadingX509TrustManagerSuite.java
@@ -28,8 +28,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import static org.junit.jupiter.api.Assertions.*;
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove the unused imports.

### Why are the changes needed?

To recover `master` branch by fixing Java linter errors.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs. Or, manually checked like the following.
```
$ dev/lint-java
Using `mvn` from path: /Users/dongjoon/APACHE/spark-merge/build/apache-maven-3.9.5/bin/mvn
Using SPARK_LOCAL_IP=localhost
Checkstyle checks passed.
```


### Was this patch authored or co-authored using generative AI tooling?

No.