### PR TITLE
[SPARK-45588][PROTOBUF][CONNECT][MINOR] Scaladoc improvement for StreamingForeachBatchHelper

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -2927,7 +2927,7 @@ class SparkConnectPlanner(
     }
 
     // This is filled when a foreach batch runner started for Python.
-    var foreachBatchRunnerCleaner: Option[StreamingForeachBatchHelper.RunnerCleaner] = None
+    var foreachBatchRunnerCleaner: Option[AutoCloseable] = None
 
     if (writeOp.hasForeachBatch) {
       val foreachBatchFn = writeOp.getForeachBatch.getFunctionCase match {

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/StreamingForeachBatchHelper.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/StreamingForeachBatchHelper.scala
@@ -40,8 +40,9 @@ object StreamingForeachBatchHelper extends Logging {
 
   type ForeachBatchFnType = (DataFrame, Long) => Unit
 
+  // Visible for testing.
   /** An AutoClosable to clean up resources on query termination. Stops Python worker. */
-  private case class RunnerCleaner(runner: StreamingPythonRunner) extends AutoCloseable {
+  private[connect] case class RunnerCleaner(runner: StreamingPythonRunner) extends AutoCloseable {
     override def close(): Unit = {
       try runner.stop()
       catch {
@@ -100,7 +101,7 @@ object StreamingForeachBatchHelper extends Logging {
    * Starts up Python worker and initializes it with Python function. Returns a foreachBatch
    * function that sets up the session and Dataframe cache and and interacts with the Python
    * worker to execute user's function. In addition, it returns an AutoClosable. The caller
-   * should close it
+   * must ensure it is closed so that worker process and related resources are released.
    */
   def pythonForeachBatchWrapper(
       pythonFn: SimplePythonFunction,

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/StreamingForeachBatchHelper.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/StreamingForeachBatchHelper.scala
@@ -100,8 +100,8 @@ object StreamingForeachBatchHelper extends Logging {
   /**
    * Starts up Python worker and initializes it with Python function. Returns a foreachBatch
    * function that sets up the session and Dataframe cache and and interacts with the Python
-   * worker to execute user's function. In addition, it returns an AutoClosable. The caller
-   * must ensure it is closed so that worker process and related resources are released.
+   * worker to execute user's function. In addition, it returns an AutoClosable. The caller must
+   * ensure it is closed so that worker process and related resources are released.
    */
   def pythonForeachBatchWrapper(
       pythonFn: SimplePythonFunction,

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/StreamingForeachBatchHelper.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/StreamingForeachBatchHelper.scala
@@ -40,7 +40,8 @@ object StreamingForeachBatchHelper extends Logging {
 
   type ForeachBatchFnType = (DataFrame, Long) => Unit
 
-  case class RunnerCleaner(runner: StreamingPythonRunner) extends AutoCloseable {
+  /** An AutoClosable to clean up resources on query termination. Stops Python worker. */
+  private case class RunnerCleaner(runner: StreamingPythonRunner) extends AutoCloseable {
     override def close(): Unit = {
       try runner.stop()
       catch {
@@ -98,11 +99,12 @@ object StreamingForeachBatchHelper extends Logging {
   /**
    * Starts up Python worker and initializes it with Python function. Returns a foreachBatch
    * function that sets up the session and Dataframe cache and and interacts with the Python
-   * worker to execute user's function.
+   * worker to execute user's function. In addition, it returns an AutoClosable. The caller
+   * should close it
    */
   def pythonForeachBatchWrapper(
       pythonFn: SimplePythonFunction,
-      sessionHolder: SessionHolder): (ForeachBatchFnType, RunnerCleaner) = {
+      sessionHolder: SessionHolder): (ForeachBatchFnType, AutoCloseable) = {
 
     val port = SparkConnectService.localPort
     val connectUrl = s"sc://localhost:$port/;user_id=${sessionHolder.userId}"

--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectSessionHodlerSuite.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectSessionHodlerSuite.scala
@@ -207,10 +207,8 @@ class SparkConnectSessionHolderSuite extends SharedSparkSession {
       sessionHolder.streamingForeachBatchRunnerCleanerCache
         .registerCleanerForQuery(query2, cleaner2)
 
-      val (runner1, runner2) = (
-        cleaner1.asInstanceOf[RunnerCleaner].runner,
-        cleaner2.asInstanceOf[RunnerCleaner].runner
-      )
+      val (runner1, runner2) =
+        (cleaner1.asInstanceOf[RunnerCleaner].runner, cleaner2.asInstanceOf[RunnerCleaner].runner)
 
       // assert both python processes are running
       assert(!runner1.isWorkerStopped().get)

--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectSessionHodlerSuite.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectSessionHodlerSuite.scala
@@ -31,6 +31,7 @@ import org.apache.spark.api.python.SimplePythonFunction
 import org.apache.spark.sql.IntegratedUDFTestUtils
 import org.apache.spark.sql.connect.common.InvalidPlanInput
 import org.apache.spark.sql.connect.planner.{PythonStreamingQueryListener, StreamingForeachBatchHelper}
+import org.apache.spark.sql.connect.planner.StreamingForeachBatchHelper.RunnerCleaner
 import org.apache.spark.sql.test.SharedSparkSession
 
 class SparkConnectSessionHolderSuite extends SharedSparkSession {
@@ -206,7 +207,10 @@ class SparkConnectSessionHolderSuite extends SharedSparkSession {
       sessionHolder.streamingForeachBatchRunnerCleanerCache
         .registerCleanerForQuery(query2, cleaner2)
 
-      val (runner1, runner2) = (cleaner1.runner, cleaner2.runner)
+      val (runner1, runner2) = (
+        cleaner1.asInstanceOf[RunnerCleaner].runner,
+        cleaner2.asInstanceOf[RunnerCleaner].runner
+      )
 
       // assert both python processes are running
       assert(!runner1.isWorkerStopped().get)

--- a/connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufCatalystDataConversionSuite.scala
+++ b/connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufCatalystDataConversionSuite.scala
@@ -137,7 +137,7 @@ class ProtobufCatalystDataConversionSuite
       while (
         data != null &&
         (data.get(0) == defaultValue ||
-          (dt == BinaryType &&
+          (dt.fields(0).dataType == BinaryType &&
             data.get(0).asInstanceOf[Array[Byte]].isEmpty)))
         data = generator().asInstanceOf[Row]
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Couple of minor improvements to `StreamingForeachBatchHelper`:

  * Make `RunnerCleaner` private and add ScalaDoc.
  * Update contract for `pythonForeachBatchWrapper()` to inform that call should eventually should `close()` the `AutoClosable` returned. 
  
In addition, it also fixes a flake in Protobuf unit test.

### Why are the changes needed?
  - Code readability improvement.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
 - Existing tests.
 - For protobuf suite, verified with seed set to '399'. It fails before this PR and passes after.


### Was this patch authored or co-authored using generative AI tooling?
No.
