### PR TITLE
[SPARK-45553][PS] Deprecate `assertPandasOnSparkEqual`

### DIFF
--- a/python/pyspark/testing/pandasutils.py
+++ b/python/pyspark/testing/pandasutils.py
@@ -340,6 +340,10 @@ def assertPandasOnSparkEqual(
     (pandas-on-Spark or pandas object).
 
     .. versionadded:: 3.5.0
+    .. deprecated:: 4.0.0
+        `assertPandasOnSparkEqual` will be removed in the future version.
+        Use `ps.testing.assert_frame_equal`, `ps.testing.assert_series_equal`
+        and `ps.testing.assert_index_equal` instead.
 
     Parameters
     ----------

--- a/python/pyspark/testing/pandasutils.py
+++ b/python/pyspark/testing/pandasutils.py
@@ -341,8 +341,8 @@ def assertPandasOnSparkEqual(
 
     .. versionadded:: 3.5.0
 
-    .. deprecated:: 4.0.0
-        `assertPandasOnSparkEqual` will be removed in the future version.
+    .. deprecated:: 3.5.1
+        `assertPandasOnSparkEqual` will be removed in Spark 4.0.0.
         Use `ps.testing.assert_frame_equal`, `ps.testing.assert_series_equal`
         and `ps.testing.assert_index_equal` instead.
 
@@ -399,7 +399,7 @@ def assertPandasOnSparkEqual(
     >>> assertPandasOnSparkEqual(s1, s2, almost=True)  # pass, ps.Index obj are almost equal
     """
     warnings.warn(
-        "`assertPandasOnSparkEqual` will be removed in the future version. "
+        "`assertPandasOnSparkEqual` will be removed in Spark 4.0.0. "
         "Use `ps.testing.assert_frame_equal`, `ps.testing.assert_series_equal` "
         "and `ps.testing.assert_index_equal` instead.",
         FutureWarning,

--- a/python/pyspark/testing/pandasutils.py
+++ b/python/pyspark/testing/pandasutils.py
@@ -340,6 +340,7 @@ def assertPandasOnSparkEqual(
     (pandas-on-Spark or pandas object).
 
     .. versionadded:: 3.5.0
+
     .. deprecated:: 4.0.0
         `assertPandasOnSparkEqual` will be removed in the future version.
         Use `ps.testing.assert_frame_equal`, `ps.testing.assert_series_equal`
@@ -397,6 +398,12 @@ def assertPandasOnSparkEqual(
     >>> s2 = ps.Index([212.3, 100.0001])
     >>> assertPandasOnSparkEqual(s1, s2, almost=True)  # pass, ps.Index obj are almost equal
     """
+    warnings.warn(
+        "`assertPandasOnSparkEqual` will be removed in the future version. "
+        "Use `ps.testing.assert_frame_equal`, `ps.testing.assert_series_equal` "
+        "and `ps.testing.assert_index_equal` instead.",
+        FutureWarning,
+    )
     if actual is None and expected is None:
         return True
     elif actual is None or expected is None:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

This PR proposes to deprecate `assertPandasOnSparkEqual`.


### Why are the changes needed?

Now we have more pandas friendly testing utils such as `ps.testing.assert_frame_equal`, `ps.testing.assert_series_equal` and `ps.testing.assert_index_equal`.


### Does this PR introduce _any_ user-facing change?

Not for now, but `assertPandasOnSparkEqual` will be removed in the future version.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
The existing CI should pass.


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.
