### PR TITLE
[SPARK-45589][PYTHON][DOCS] Supplementary exception class

### DIFF
--- a/python/docs/source/reference/pyspark.errors.rst
+++ b/python/docs/source/reference/pyspark.errors.rst
@@ -33,11 +33,24 @@ Classes
     TempTableAlreadyExistsException
     ParseException
     IllegalArgumentException
+    ArithmeticException
+    UnsupportedOperationException
+    ArrayIndexOutOfBoundsException
+    DateTimeException
+    NumberFormatException
     StreamingQueryException
     QueryExecutionException
     PythonException
     UnknownException
+    SparkRuntimeException
     SparkUpgradeException
+    PySparkTypeError
+    PySparkValueError
+    PySparkAttributeError
+    PySparkRuntimeError
+    PySparkAssertionError
+    PySparkNotImplementedError
+    PySparkPicklingError
 
 
 Methods

--- a/python/docs/source/reference/pyspark.errors.rst
+++ b/python/docs/source/reference/pyspark.errors.rst
@@ -28,29 +28,29 @@ Classes
 .. autosummary::
     :toctree: api/
 
-    PySparkException
     AnalysisException
-    TempTableAlreadyExistsException
-    ParseException
-    IllegalArgumentException
     ArithmeticException
-    UnsupportedOperationException
     ArrayIndexOutOfBoundsException
     DateTimeException
+    IllegalArgumentException
     NumberFormatException
-    StreamingQueryException
-    QueryExecutionException
-    PythonException
-    UnknownException
-    SparkRuntimeException
-    SparkUpgradeException
-    PySparkTypeError
-    PySparkValueError
-    PySparkAttributeError
-    PySparkRuntimeError
+    ParseException
     PySparkAssertionError
+    PySparkAttributeError
+    PySparkException
     PySparkNotImplementedError
     PySparkPicklingError
+    PySparkRuntimeError
+    PySparkTypeError
+    PySparkValueError
+    PythonException
+    QueryExecutionException
+    SparkRuntimeException
+    SparkUpgradeException
+    StreamingQueryException
+    TempTableAlreadyExistsException
+    UnknownException
+    UnsupportedOperationException
 
 
 Methods


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to supplementary exception class for pyspark docs.

### Why are the changes needed?
Currently, there are only the following classes in the document,
<img width="762" alt="image" src="https://github.com/apache/spark/assets/15246973/c297d00b-5534-4751-9d97-90c0b4d14a81">

Actually:
<img width="461" alt="image" src="https://github.com/apache/spark/assets/15246973/42a8a0e3-ba90-4c33-8b2f-1deef3753896">


### Does this PR introduce _any_ user-facing change?
Yes, more complete documentation on exception classes.


### How was this patch tested?
- Pass GA.
- Manually test.


### Was this patch authored or co-authored using generative AI tooling?
No.
