### PR TITLE
[SPARK-45410][INFRA][FOLLOW-UP] Rename "Python - PyPy3.8 (master)" to "Build / Python-only (master, PyPy 3.8)"

### DIFF
--- a/.github/workflows/build_python.yml
+++ b/.github/workflows/build_python.yml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-name: "Python - PyPy3.8 (master)"
+name: "Build / Python-only (master, PyPy 3.8)"
 
 on:
   schedule:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a simple followup of https://github.com/apache/spark/pull/43209 that changes the build name from "Python - PyPy3.8 (master)" to "Build / Python-only (master, PyPy 3.8)"

### Why are the changes needed?

To move/group the build up when you click Actions (https://github.com/apache/spark/actions). For now, it looks as below:
![Screenshot 2023-10-18 at 4 16 23 PM](https://github.com/apache/spark/assets/6477701/617cb386-53b7-40e9-bfa2-3c4a72b0278f)

and you have to click and extend to see Python build:
![Screenshot 2023-10-18 at 4 16 19 PM](https://github.com/apache/spark/assets/6477701/ec258fb6-2449-4c9f-bb2e-340fc1efe78e)

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

N/A

### Was this patch authored or co-authored using generative AI tooling?

No
