### PR TITLE
[SPARK-45591][BUILD] Upgrade ASM to 9.6

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -258,7 +258,7 @@ transaction-api/1.1//transaction-api-1.1.jar
 txw2/3.0.2//txw2-3.0.2.jar
 univocity-parsers/2.9.1//univocity-parsers-2.9.1.jar
 wildfly-openssl/1.1.3.Final//wildfly-openssl-1.1.3.Final.jar
-xbean-asm9-shaded/4.23//xbean-asm9-shaded-4.23.jar
+xbean-asm9-shaded/4.24//xbean-asm9-shaded-4.24.jar
 xmlschema-core/2.3.0//xmlschema-core-2.3.0.jar
 xz/1.9//xz-1.9.jar
 zjsonpatch/0.3.0//zjsonpatch-0.3.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
     <maven.version>3.9.5</maven.version>
     <exec-maven-plugin.version>3.1.0</exec-maven-plugin.version>
     <sbt.project.name>spark</sbt.project.name>
-    <asm.version>9.5</asm.version>
+    <asm.version>9.6</asm.version>
     <slf4j.version>2.0.9</slf4j.version>
     <log4j.version>2.20.0</log4j.version>
     <!-- make sure to update IsolatedClientLoader whenever this version is changed -->
@@ -475,7 +475,7 @@
       <dependency>
         <groupId>org.apache.xbean</groupId>
         <artifactId>xbean-asm9-shaded</artifactId>
-        <version>4.23</version>
+        <version>4.24</version>
       </dependency>
 
       <!-- Shaded deps marked as provided. These are promoted to compile scope

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -37,9 +37,9 @@ addSbtPlugin("com.github.sbt" % "sbt-unidoc" % "0.5.0")
 
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.10.0")
 
-libraryDependencies += "org.ow2.asm"  % "asm" % "9.5"
+libraryDependencies += "org.ow2.asm"  % "asm" % "9.6"
 
-libraryDependencies += "org.ow2.asm"  % "asm-commons" % "9.5"
+libraryDependencies += "org.ow2.asm"  % "asm-commons" % "9.6"
 
 addSbtPlugin("com.simplytyped" % "sbt-antlr4" % "0.8.3")
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to upgrade ASM to 9.6.




### Why are the changes needed?
xbean-asm9-shaded 4.24 upgrade to use ASM 9.6 and ASM 9.6 is for Java 22:

- https://asm.ow2.io/versions.html
- https://issues.apache.org/jira/browse/XBEAN-341 | https://github.com/apache/geronimo-xbean/pull/39


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No