### PR TITLE
[MINOR][SQL] Update HintErrorLogger.scala to fix typo in the error message

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/HintErrorLogger.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/HintErrorLogger.scala
@@ -33,7 +33,7 @@ object HintErrorLogger extends HintErrorHandler with Logging {
   override def hintRelationsNotFound(
       name: String, parameters: Seq[Any], invalidRelations: Set[Seq[String]]): Unit = {
     invalidRelations.foreach { ident =>
-      logWarning(s"Count not find relation '${ident.quoted}' specified in hint " +
+      logWarning(s"Could not find relation '${ident.quoted}' specified in hint " +
         s"'${hintToPrettyString(name, parameters)}'.")
     }
   }


### PR DESCRIPTION
very trivial change to error message which contained a typo (I presume). Did read "Count not find relation" updated that to "Could not find relation" in log warning. 