### PR TITLE
[SPARK-45607][SQL] Collapse repartition operators with a project

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1225,6 +1225,17 @@ object CollapseRepartition extends Rule[LogicalPlan] {
     // child.
     case r @ RebalancePartitions(_, child: RebalancePartitions, _, _) =>
       r.withNewChildren(child.children)
+    // Case 5: case 2 with a Project
+    case r @ RepartitionByExpression(_,
+        project @ Project(_, child @ (Sort(_, true, _) | _: RepartitionOperation)), _, _) =>
+      r.withNewChildren(Seq(project.withNewChildren(child.children)))
+    // Case 6: case 3 with a Project
+    case r @ RebalancePartitions(_,
+        project @ Project(_, child @ (_: Sort | _: RepartitionOperation)), _, _) =>
+      r.withNewChildren(Seq(project.withNewChildren(child.children)))
+    // Case 7: case 4 with a Project
+    case r @ RebalancePartitions(_, project @ Project(_, child: RebalancePartitions), _, _) =>
+      r.withNewChildren(Seq(project.withNewChildren(child.children)))
   }
 }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Collapse repartition operators with a project.

For example, `df.repartition($"a").select($"a", $"b", $"a" + $"b").repartition($"b")`  is same to `df.select($"a", $"b", $"a" + $"b").repartition($"b")`


### Why are the changes needed?

Support more CollapseRepartition pattern.


### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Added UT

### Was this patch authored or co-authored using generative AI tooling?

No
