### PR TITLE
[SPARK-45428][PYTHON][DOCS] Add Matomo analytics to pyspark  docs pages

### DIFF
--- a/python/docs/source/_templates/layout.html
+++ b/python/docs/source/_templates/layout.html
@@ -1,0 +1,30 @@
+{% extends "!layout.html" %}
+
+{%- block extrahead %}
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="docsearch:language" content="{{ language }}">
+    {% for favicon in theme_favicons %}
+      {% if favicon.href[:4] == 'http'%}
+      <link rel="{{ favicon.rel }}" sizes="{{ favicon.sizes }}" href="{{ favicon.href }}">
+      {% else %}
+      <link rel="{{ favicon.rel }}" sizes="{{ favicon.sizes }}" href="{{ pathto('_static/' + favicon.href, 1) }}">
+      {% endif %}
+    {% endfor %}
+
+    <!-- Matomo -->
+    <script type="text/javascript">
+        var _paq = window._paq = window._paq || [];
+        /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+        _paq.push(["disableCookies"]);
+        _paq.push(['trackPageView']);
+        _paq.push(['enableLinkTracking']);
+        (function() {
+            var u="https://analytics.apache.org/";
+            _paq.push(['setTrackerUrl', u+'matomo.php']);
+            _paq.push(['setSiteId', '40']);
+            var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+            g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+        })();
+    </script>
+    <!-- End Matomo Code -->
+{% endblock %}


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to add Matomo analytics to pyspark  docs pages.

### Why are the changes needed?
After [SPARK-45286](https://issues.apache.org/jira/browse/SPARK-45286), We have added `Matomo analytics` functionality to `non pyspark documents`, and now we need to add the same logic to `pyspark documents`.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Manually test.
By comparing the content of HTML documents generated `before` and `after` the patch
<img width="832" alt="image" src="https://github.com/apache/spark/assets/15246973/9db1bbb3-70ca-4014-8685-e8cafc2eb4c2">

### Was this patch authored or co-authored using generative AI tooling?
No.
