### PR TITLE
[DO-NOT-MERGE][DSTREAM] Fatal error (e.g. OOM) during generating streaming jobs should fail the streaming context

### DIFF
--- a/streaming/src/test/scala/org/apache/spark/streaming/TestSuiteBase.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/TestSuiteBase.scala
@@ -109,6 +109,22 @@ class TestOutputStream[T: ClassTag](
 }
 
 /**
+ * This is a output stream just for testing. It throws `OutOfMemoryError` when generating
+ * its streaming job.
+ */
+class TestOOMOutputStream[T: ClassTag](
+    parent: DStream[T]) extends ForEachDStream[T](parent, (rdd: RDD[T], t: Time) => {
+    rdd.collect()
+  }, false) {
+
+  override def generateJob(time: Time): Option[Job] = {
+    // scalastyle:off throwerror
+    throw new OutOfMemoryError("TestOOMOutputStream")
+    // scalastyle:on throwerror
+  }
+}
+
+/**
  * This is a output stream just for the testsuites. All the output is collected into a
  * ConcurrentLinkedQueue. This queue is wiped clean on being restored from checkpoint.
  *


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Currently Spark streaming uses Scala.Try to catch NonFatal exception during generating streaming jobs in `JobGenerator.generateJobs`. But if any fatal error (e.g., `OutOfMemoryError`) happens, it won't be caught. Normally just error should propagate up and finally crash Spark runtime, but Spark streaming does this in separate thread.

If the fatal error crashes entire JVM, it also can bring Spark down. But for some customer cases, the OOM is thrown by `ByteArrayOutputStream` when it cannot grow up to new capacity (new capacity is overflow on Int range, see Java [source code](https://github.com/AdoptOpenJDK/openjdk-jdk11/blob/master/src/java.base/share/classes/java/io/ByteArrayOutputStream.java#L123)). So it is not actually running memory in JVM and JVM won't be down by that. Eventually the OOM is ignored by Spark streaming and next batches are continuing to execute. Such behavior causes unnoticed data loss for the streaming application. We should propagate all failures including fatal ones.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Making consistent behavior on Spark streaming on fatal and non-fatal errors.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

If user's streaming application contains fatal error during streaming job generation, previously it will be ignored. Now it will bring down the application.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Added unit test

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No

