### PR TITLE
[SPARK-45553][3.5][PS] Correct warning messages

### DIFF
--- a/python/pyspark/testing/pandasutils.py
+++ b/python/pyspark/testing/pandasutils.py
@@ -367,8 +367,6 @@ def assertPandasOnSparkEqual(
 
     .. deprecated:: 3.5.1
         `assertPandasOnSparkEqual` will be removed in Spark 4.0.0.
-        Use `ps.testing.assert_frame_equal`, `ps.testing.assert_series_equal`
-        and `ps.testing.assert_index_equal` instead.
 
     Parameters
     ----------
@@ -423,9 +421,7 @@ def assertPandasOnSparkEqual(
     >>> assertPandasOnSparkEqual(s1, s2, almost=True)  # pass, ps.Index obj are almost equal
     """
     warnings.warn(
-        "`assertPandasOnSparkEqual` will be removed in Spark 4.0.0. "
-        "Use `ps.testing.assert_frame_equal`, `ps.testing.assert_series_equal` "
-        "and `ps.testing.assert_index_equal` instead.",
+        "`assertPandasOnSparkEqual` will be removed in Spark 4.0.0. ",
         FutureWarning,
     )
     if actual is None and expected is None:


### PR DESCRIPTION


### What changes were proposed in this pull request?

This followups for https://github.com/apache/spark/pull/43426.


### Why are the changes needed?

To remove incorrect context from the warning message.

### Does this PR introduce _any_ user-facing change?

No.


### How was this patch tested?

The existing CI should pass


### Was this patch authored or co-authored using generative AI tooling?

No.
