### PR TITLE
[SPARK-45612][CORE] Allow cached RDDs to migrate to fallback storage during decommission

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -523,6 +523,14 @@ package object config {
       .booleanConf
       .createWithDefault(false)
 
+  private[spark] val STORAGE_DECOMMISSION_FALLBACK_MAX_THREADS =
+    ConfigBuilder("spark.storage.decommission.fallbackStorage.maxThreads")
+        .doc("Maximum number of threads to use in fallback storage I/O.")
+        .version("4.0.0")
+        .intConf
+        .checkValue(_ > 0, "The maximum number of threads should be positive")
+        .createWithDefault(8)
+
   private[spark] val STORAGE_DECOMMISSION_SHUFFLE_MAX_DISK_SIZE =
     ConfigBuilder("spark.storage.decommission.shuffleBlocks.maxDiskSize")
       .doc("Maximum disk space to use to store shuffle blocks before rejecting remote " +

--- a/core/src/test/scala/org/apache/spark/storage/BlockManagerDecommissionUnitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockManagerDecommissionUnitSuite.scala
@@ -23,7 +23,7 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 
 import org.mockito.{ArgumentMatchers => mc}
-import org.mockito.Mockito.{atLeast => least, mock, never, times, verify, when}
+import org.mockito.Mockito.{atLeast => least, mock, times, verify, when}
 import org.scalatest.concurrent.Eventually._
 import org.scalatest.matchers.must.Matchers
 
@@ -388,39 +388,6 @@ class BlockManagerDecommissionUnitSuite extends SparkFunSuite with Matchers {
       }
     } finally {
         bmDecomManager.stop()
-    }
-  }
-
-  test("SPARK-44547: test cached rdd migration no available hosts") {
-    val blockTransferService = mock(classOf[BlockTransferService])
-    val bm = mock(classOf[BlockManager])
-
-    val storedBlockId1 = RDDBlockId(0, 0)
-    val storedBlock1 =
-      new ReplicateBlock(storedBlockId1, Seq(BlockManagerId("replicaHolder", "host1", bmPort)), 1)
-
-    val migratableShuffleBlockResolver = mock(classOf[MigratableResolver])
-    registerShuffleBlocks(migratableShuffleBlockResolver, Set())
-    when(bm.getPeers(mc.any()))
-      .thenReturn(Seq(FallbackStorage.FALLBACK_BLOCK_MANAGER_ID))
-
-    when(bm.blockTransferService).thenReturn(blockTransferService)
-    when(bm.migratableResolver).thenReturn(migratableShuffleBlockResolver)
-    when(bm.getMigratableRDDBlocks())
-      .thenReturn(Seq(storedBlock1))
-
-    val bmDecomManager = new BlockManagerDecommissioner(sparkConf, bm)
-
-    try {
-      bmDecomManager.start()
-      eventually(timeout(100.second), interval(10.milliseconds)) {
-        verify(bm, never()).replicateBlock(
-          mc.eq(storedBlockId1), mc.any(), mc.any(), mc.eq(Some(3)))
-        assert(bmDecomManager.rddBlocksLeft)
-        assert(bmDecomManager.stoppedRDD)
-      }
-    } finally {
-      bmDecomManager.stop()
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Currently, the cached rdds won't be migrated to fallback storage if all peers have failed. This change allows us to upload cached rdds during decommission to fallback storage as a last resort. 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This is to improve efficiency and stability of Spark decommission process to save as many blocks as possible. 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, added a config to control the parallelism of fallback storage upload. 

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Tested with a unit test and run a sample Spark job to confirm it's working. 

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No