### PR TITLE
[SPARK-45613][CORE] Expose DeterministicLevel as a DeveloperApi

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -2176,6 +2176,7 @@ object RDD {
  * Note that, the output of an RDD usually relies on the parent RDDs. When the parent RDD's output
  * is INDETERMINATE, it's very likely the RDD's output is also INDETERMINATE.
  */
+@DeveloperApi
 object DeterministicLevel extends Enumeration {
   val DETERMINATE, UNORDERED, INDETERMINATE = Value
 }

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -2176,6 +2176,6 @@ object RDD {
  * Note that, the output of an RDD usually relies on the parent RDDs. When the parent RDD's output
  * is INDETERMINATE, it's very likely the RDD's output is also INDETERMINATE.
  */
-private[spark] object DeterministicLevel extends Enumeration {
+object DeterministicLevel extends Enumeration {
   val DETERMINATE, UNORDERED, INDETERMINATE = Value
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Expose `DeterministicLevel` as a `DeveloperApi`

### Why are the changes needed?
[`RDD.getOutputDeterministicLevel`](https://github.com/apache/spark/blob/b9ac7d38ea7f4f7e57c4bbb7b5e5bc836b2b1c58/core/src/main/scala/org/apache/spark/rdd/RDD.scala#L2079) is a `DeveloperApi` - unfortunately, this cannot be overridden by users as `DeterministicLevel` is `private[spark]`.
Expose it as a `DeveloperApi` to allow users to override this.

### Does this PR introduce _any_ user-facing change?
Yes, updates the visibility of `DeterministicLevel`

### How was this patch tested?
Visibility change, no test required.

### Was this patch authored or co-authored using generative AI tooling?
No