### PR TITLE
[SPARK-45484][SQL][FOLLOWUP][DOCS] Update the document of parquet compression codec

### DIFF
--- a/docs/sql-data-sources-parquet.md
+++ b/docs/sql-data-sources-parquet.md
@@ -423,7 +423,7 @@ Data source options of Parquet can be set via:
   <tr>
     <td><code>compression</code></td>
     <td><code>snappy</code></td>
-    <td>Compression codec to use when saving to file. This can be one of the known case-insensitive shorten names (none, uncompressed, snappy, gzip, lzo, brotli, lz4, and zstd). This will override <code>spark.sql.parquet.compression.codec</code>.</td>
+    <td>Compression codec to use when saving to file. This can be one of the known case-insensitive shorten names (none, uncompressed, snappy, gzip, lzo, brotli, lz4, lz4_raw, and zstd). This will override <code>spark.sql.parquet.compression.codec</code>.</td>
     <td>write</td>
   </tr>
 </table>
@@ -484,7 +484,7 @@ Configuration of Parquet can be done using the `setConf` method on `SparkSession
     Sets the compression codec used when writing Parquet files. If either <code>compression</code> or
     <code>parquet.compression</code> is specified in the table-specific options/properties, the precedence would be
     <code>compression</code>, <code>parquet.compression</code>, <code>spark.sql.parquet.compression.codec</code>. Acceptable values include:
-    none, uncompressed, snappy, gzip, lzo, brotli, lz4, zstd.
+    none, uncompressed, snappy, gzip, lzo, brotli, lz4, lz4_raw, zstd.
     Note that <code>brotli</code> requires <code>BrotliCodec</code> to be installed.
   </td>
   <td>1.1.1</td>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR follows up https://github.com/apache/spark/pull/43310 to update the document of parquet compression codec.


### Why are the changes needed?
Update the document of parquet compression codec.


### Does this PR introduce _any_ user-facing change?
'No'.


### How was this patch tested?
N/A


### Was this patch authored or co-authored using generative AI tooling?
'No'.
