### PR TITLE
[SPARK-45621] Add feature to evaluate subquery before push down filter Optimizer rule

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4516,6 +4516,14 @@ object SQLConf {
       .booleanConf
       .createWithDefault(false)
 
+    val ENABLE_SUBQUERY_EVALUATION =
+    buildConf("spark.sql.subquery.eval.enabled")
+      .internal()
+      .doc("When true, uncorrelated scalar subqueries will be evaluated in the optimizer")
+      .version("4.0.0")
+      .booleanConf
+      .createWithDefault(false)
+
   /**
    * Holds information about keys that have been deprecated.
    *
@@ -5397,6 +5405,8 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
 
   def legacyRaiseErrorWithoutErrorClass: Boolean =
       getConf(SQLConf.LEGACY_RAISE_ERROR_WITHOUT_ERROR_CLASS)
+
+  def enableSubqueryEvaluation: Boolean = getConf(ENABLE_SUBQUERY_EVALUATION)
 
   /** ********************** SQLConf functionality methods ************ */
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ExecuteUncorrelatedScalarSubquery.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ExecuteUncorrelatedScalarSubquery.scala
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution
+
+import org.apache.spark.sql.{AnalysisException, SparkSession}
+import org.apache.spark.sql.catalyst.expressions
+import org.apache.spark.sql.catalyst.expressions.Literal
+import org.apache.spark.sql.catalyst.expressions.SubExprUtils.hasOuterReferences
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.rules.Rule
+
+class ExecuteUncorrelatedScalarSubquery(spark: SparkSession) extends Rule[LogicalPlan] {
+  override def apply(plan: LogicalPlan): LogicalPlan = plan transformAllExpressions {
+    case subquery: expressions.ScalarSubquery if !hasOuterReferences(subquery.plan) =>
+      val result = SubqueryEvaluation.ifEnabled(spark) {
+        evaluate(subquery)
+      }
+      result.getOrElse(subquery)
+  }
+
+  private def evaluate(subquery: expressions.ScalarSubquery): Literal = {
+    val qe = new QueryExecution(spark, subquery.plan)
+    val (resultType, rows) = SQLExecution.withNewExecutionId(qe) {
+      val physicalPlan = qe.executedPlan
+      (physicalPlan.schema.fields.head.dataType, physicalPlan.executeCollect())
+    }
+
+    if (rows.length > 1) {
+      throw new AnalysisException(
+        s"More than one row returned by a subquery used as an expression:\n${subquery.plan}")
+    }
+
+    if (rows.length == 1) {
+      assert(rows(0).numFields == 1,
+        s"Expects 1 field, but got ${rows(0).numFields}; something went wrong in analysis")
+      Literal(rows(0).get(0, resultType), resultType)
+    } else {
+      // If there is no rows returned, the result should be null.
+      Literal(null, resultType)
+    }
+  }
+}
+
+object SubqueryEvaluation {
+  private val SUBQUERY_EVAL_KEY = "spark.sql.subquery.eval.enabled"
+
+  private def enabled(spark: SparkSession): Boolean = {
+    val enabled = spark.sparkContext.getLocalProperty(SUBQUERY_EVAL_KEY)
+    if (enabled != null) {
+      enabled.toBoolean
+    } else {
+      spark.sessionState.conf.enableSubqueryEvaluation
+    }
+  }
+
+  def ifEnabled[T](spark: SparkSession)(body: => T): Option[T] = {
+    if (enabled(spark)) {
+      Some(body)
+    } else {
+      None
+    }
+  }
+
+  def withoutSubqueryEvaluation[T](spark: SparkSession)(body: => T): T = {
+    val sc = spark.sparkContext
+    val originalValue = sc.getLocalProperty(SUBQUERY_EVAL_KEY)
+    try {
+      sc.setLocalProperty(SUBQUERY_EVAL_KEY, "false")
+      body
+    } finally {
+      sc.setLocalProperty(SUBQUERY_EVAL_KEY, originalValue)
+    }
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkOptimizer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkOptimizer.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.execution
 
 import org.apache.spark.sql.ExperimentalMethods
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.catalog.SessionCatalog
 import org.apache.spark.sql.catalyst.optimizer._
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
@@ -31,12 +32,14 @@ import org.apache.spark.sql.execution.python.{ExtractGroupingPythonUDFFromAggreg
 class SparkOptimizer(
     catalogManager: CatalogManager,
     catalog: SessionCatalog,
-    experimentalMethods: ExperimentalMethods)
+    experimentalMethods: ExperimentalMethods,
+    spark: SparkSession)
   extends Optimizer(catalogManager) {
 
   override def earlyScanPushDownRules: Seq[Rule[LogicalPlan]] =
     // TODO: move SchemaPruning into catalyst
     Seq(SchemaPruning) :+
+      new ExecuteUncorrelatedScalarSubquery(spark) :+
       GroupBasedRowLevelOperationScanPlanning :+
       V1Writes :+
       V2ScanRelationPushDown :+

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala
@@ -248,7 +248,7 @@ abstract class BaseSessionStateBuilder(
    * Note: this depends on `catalog` and `experimentalMethods` fields.
    */
   protected def optimizer: Optimizer = {
-    new SparkOptimizer(catalogManager, catalog, experimentalMethods) {
+    new SparkOptimizer(catalogManager, catalog, experimentalMethods, session) {
       override def earlyScanPushDownRules: Seq[Rule[LogicalPlan]] =
         super.earlyScanPushDownRules ++ customEarlyScanPushDownRules
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds a new feature(which is disabled by default to maintain current behavior) that would evaluate scalar subqueries in the Optimizer before rule to push down filter. 

Note that this PR is similar (in intent) to:
- https://github.com/apache/spark/pull/23802
- https://github.com/apache/spark/pull/41088
but is not the same. This is because the above two PRs requires the FileSourceScan. This PR will still work if, for example, you are using BatchScan.

### Why are the changes needed?
Some queries can benefit from having it's scalar subquery in the filter evaluated while planning so that the scalar result (from the subquery) can be push down. 

For example, a query like 

`select * from t2 where b > (select max(a) from t1) `

where t1 is a small table but t2 is a very large table can benefit if we first evaluate the subquery then push down the result to the pushed filter (instead of having the subquery in the post scan filter)

### Does this PR introduce _any_ user-facing change?
Yes. A new conf is added (which is disabled by default)

### How was this patch tested?
Unit tested and manually tested


### Was this patch authored or co-authored using generative AI tooling?
No
