### PR TITLE
[SPARK-43829][CONNECT] Improve SparkConnectPlanner by reuse Dataset and avoid construct new Dataset

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/SparkConnectPlanExecution.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/SparkConnectPlanExecution.scala
@@ -27,7 +27,7 @@ import io.grpc.stub.StreamObserver
 import org.apache.spark.SparkEnv
 import org.apache.spark.connect.proto
 import org.apache.spark.connect.proto.ExecutePlanResponse
-import org.apache.spark.sql.{DataFrame, Dataset}
+import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.connect.common.DataTypeProtoConverter
 import org.apache.spark.sql.connect.common.LiteralValueProtoConverter.toLiteralProto
@@ -47,9 +47,6 @@ import org.apache.spark.util.ThreadUtils
  */
 private[execution] class SparkConnectPlanExecution(executeHolder: ExecuteHolder) {
 
-  private val sessionHolder = executeHolder.sessionHolder
-  private val session = executeHolder.session
-
   def handlePlan(responseObserver: ExecuteResponseObserver[proto.ExecutePlanResponse]): Unit = {
     val request = executeHolder.request
     if (request.getPlan.getOpTypeCase != proto.Plan.OpTypeCase.ROOT) {
@@ -57,12 +54,7 @@ private[execution] class SparkConnectPlanExecution(executeHolder: ExecuteHolder)
         s"Illegal operation type ${request.getPlan.getOpTypeCase} to be handled here.")
     }
     val planner = new SparkConnectPlanner(executeHolder)
-    val tracker = executeHolder.eventsManager.createQueryPlanningTracker()
-    val dataframe =
-      Dataset.ofRows(
-        sessionHolder.session,
-        planner.transformRelation(request.getPlan.getRoot),
-        tracker)
+    val dataframe = planner.transformRelationAsDataset(request.getPlan.getRoot)
     responseObserver.onNext(createSchemaResponse(request.getSessionId, dataframe.schema))
     processAsArrowBatches(dataframe, responseObserver, executeHolder)
     responseObserver.onNext(MetricGenerator.createMetricsResponse(sessionHolder, dataframe))

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -42,7 +42,7 @@ import org.apache.spark.connect.proto.StreamingQueryManagerCommandResult.Streami
 import org.apache.spark.connect.proto.WriteStreamOperationStart.TriggerCase
 import org.apache.spark.internal.Logging
 import org.apache.spark.ml.{functions => MLFunctions}
-import org.apache.spark.sql.{Column, Dataset, Encoders, ForeachWriter, Observation, RelationalGroupedDataset, SparkSession}
+import org.apache.spark.sql.{Column, Dataset, Encoders, ForeachWriter, Observation, RelationalGroupedDataset, Row, SparkSession}
 import org.apache.spark.sql.avro.{AvroDataToCatalyst, CatalystDataToAvro}
 import org.apache.spark.sql.catalyst.{expressions, AliasIdentifier, FunctionIdentifier}
 import org.apache.spark.sql.catalyst.analysis.{GlobalTempView, LocalTempView, MultiAlias, NameParameterizedQuery, PosParameterizedQuery, UnresolvedAlias, UnresolvedAttribute, UnresolvedDataFrameStar, UnresolvedDeserializer, UnresolvedExtractValue, UnresolvedFunction, UnresolvedRegex, UnresolvedRelation, UnresolvedStar}
@@ -116,6 +116,47 @@ class SparkConnectPlanner(
     sys.env.getOrElse("PYSPARK_PYTHON", sys.env.getOrElse("PYSPARK_DRIVER_PYTHON", "python3"))
 
   // The root of the query plan is a relation and we apply the transformations to it.
+  def transformRelationAsDataset(rel: proto.Relation): Dataset[Row] = {
+    val dataset = rel.getRelTypeCase match {
+      case proto.Relation.RelTypeCase.DROP => transformDropAsDataset(rel.getDrop)
+      case proto.Relation.RelTypeCase.FILL_NA => transformNAFillAsDataset(rel.getFillNa)
+      case proto.Relation.RelTypeCase.DROP_NA => transformNADropAsDataset(rel.getDropNa)
+      case proto.Relation.RelTypeCase.REPLACE => transformReplaceAsDataset(rel.getReplace)
+      case proto.Relation.RelTypeCase.SUMMARY => transformStatSummaryAsDataset(rel.getSummary)
+      case proto.Relation.RelTypeCase.DESCRIBE => transformStatDescribeAsDataset(rel.getDescribe)
+      case proto.Relation.RelTypeCase.COV => transformStatCovAsDataset(rel.getCov)
+      case proto.Relation.RelTypeCase.CORR => transformStatCorrAsDataset(rel.getCorr)
+      case proto.Relation.RelTypeCase.CROSSTAB =>
+        transformStatCrosstabAsDataset(rel.getCrosstab)
+      case proto.Relation.RelTypeCase.FREQ_ITEMS =>
+        transformStatFreqItemsAsDataset(rel.getFreqItems)
+      case proto.Relation.RelTypeCase.SAMPLE_BY =>
+        transformStatSampleByAsDataset(rel.getSampleBy)
+      case proto.Relation.RelTypeCase.TO_SCHEMA => transformToSchemaAsDataset(rel.getToSchema)
+      case proto.Relation.RelTypeCase.TO_DF => transformToDFAsDataset(rel.getToDf)
+      case proto.Relation.RelTypeCase.APPLY_IN_PANDAS_WITH_STATE =>
+        transformApplyInPandasWithStateAsDataset(rel.getApplyInPandasWithState)
+      case proto.Relation.RelTypeCase.WITH_COLUMNS_RENAMED =>
+        transformWithColumnsRenamedAsDataset(rel.getWithColumnsRenamed)
+      case proto.Relation.RelTypeCase.WITH_COLUMNS =>
+        transformWithColumnsAsDataset(rel.getWithColumns)
+      case proto.Relation.RelTypeCase.WITH_WATERMARK =>
+        transformWithWatermarkAsDataset(rel.getWithWatermark)
+      case _ if executeHolderOpt.isDefined =>
+        Dataset.ofRows(
+          session,
+          transformRelation(rel),
+          executeHolder.eventsManager.createQueryPlanningTracker)
+      case _ =>
+        Dataset.ofRows(session, transformRelation(rel))
+    }
+
+    if (rel.hasCommon && rel.getCommon.hasPlanId) {
+      dataset.logicalPlan.setTagValue(LogicalPlan.PLAN_ID_TAG, rel.getCommon.getPlanId)
+    }
+    dataset
+  }
+
   def transformRelation(rel: proto.Relation): LogicalPlan = {
     val plan = rel.getRelTypeCase match {
       // DataFrame API
@@ -263,8 +304,7 @@ class SparkConnectPlanner(
   }
 
   private def transformShowString(rel: proto.ShowString): LogicalPlan = {
-    val showString = Dataset
-      .ofRows(session, transformRelation(rel.getInput))
+    val showString = transformRelationAsDataset(rel.getInput)
       .showString(rel.getNumRows, rel.getTruncate, rel.getVertical)
     LocalRelation.fromProduct(
       output = AttributeReference("show_string", StringType, false)() :: Nil,
@@ -272,8 +312,7 @@ class SparkConnectPlanner(
   }
 
   private def transformHtmlString(rel: proto.HtmlString): LogicalPlan = {
-    val htmlString = Dataset
-      .ofRows(session, transformRelation(rel.getInput))
+    val htmlString = transformRelationAsDataset(rel.getInput)
       .htmlString(rel.getNumRows, rel.getTruncate)
     LocalRelation.fromProduct(
       output = AttributeReference("html_string", StringType, false)() :: Nil,
@@ -321,7 +360,7 @@ class SparkConnectPlanner(
    */
   private def transformSample(rel: proto.Sample): LogicalPlan = {
     val plan = if (rel.getDeterministicOrder) {
-      val input = Dataset.ofRows(session, transformRelation(rel.getInput))
+      val input = transformRelationAsDataset(rel.getInput)
 
       // It is possible that the underlying dataframe doesn't guarantee the ordering of rows in its
       // constituent partitions each time a split is materialized which could result in
@@ -365,7 +404,7 @@ class SparkConnectPlanner(
     logical.Range(start, end, step, numPartitions)
   }
 
-  private def transformNAFill(rel: proto.NAFill): LogicalPlan = {
+  private def transformNAFillAsDataset(rel: proto.NAFill): Dataset[Row] = {
     if (rel.getValuesCount == 0) {
       throw InvalidPlanInput(s"values must contains at least 1 item!")
     }
@@ -375,41 +414,49 @@ class SparkConnectPlanner(
           s"values and cols should have the same length!")
     }
 
-    val dataset = Dataset.ofRows(session, transformRelation(rel.getInput))
+    val dataset = transformRelationAsDataset(rel.getInput)
 
     val cols = rel.getColsList.asScala.toArray
     val values = rel.getValuesList.asScala.toArray
     if (values.length == 1) {
       val value = LiteralValueProtoConverter.toCatalystValue(values.head)
       val columns = if (cols.nonEmpty) Some(cols.toImmutableArraySeq) else None
-      dataset.na.fillValue(value, columns).logicalPlan
+      dataset.na.fillValue(value, columns)
     } else {
       val valueMap = mutable.Map.empty[String, Any]
       cols.zip(values).foreach { case (col, value) =>
         valueMap.update(col, LiteralValueProtoConverter.toCatalystValue(value))
       }
-      dataset.na.fill(valueMap = valueMap.toMap).logicalPlan
+      dataset.na.fill(valueMap = valueMap.toMap)
     }
   }
 
-  private def transformNADrop(rel: proto.NADrop): LogicalPlan = {
-    val dataset = Dataset.ofRows(session, transformRelation(rel.getInput))
+  private def transformNAFill(rel: proto.NAFill): LogicalPlan = {
+    transformNAFillAsDataset(rel).logicalPlan
+  }
+
+  private def transformNADropAsDataset(rel: proto.NADrop): Dataset[Row] = {
+    val dataset = transformRelationAsDataset(rel.getInput)
 
     val cols = rel.getColsList.asScala.toArray
 
     (cols.nonEmpty, rel.hasMinNonNulls) match {
       case (true, true) =>
-        dataset.na.drop(minNonNulls = rel.getMinNonNulls, cols = cols).logicalPlan
+        dataset.na.drop(minNonNulls = rel.getMinNonNulls, cols = cols)
       case (true, false) =>
-        dataset.na.drop(cols = cols).logicalPlan
+        dataset.na.drop(cols = cols)
       case (false, true) =>
-        dataset.na.drop(minNonNulls = rel.getMinNonNulls).logicalPlan
+        dataset.na.drop(minNonNulls = rel.getMinNonNulls)
       case (false, false) =>
-        dataset.na.drop().logicalPlan
+        dataset.na.drop()
     }
   }
 
-  private def transformReplace(rel: proto.NAReplace): LogicalPlan = {
+  private def transformNADrop(rel: proto.NADrop): LogicalPlan = {
+    transformNADropAsDataset(rel).logicalPlan
+  }
+
+  private def transformReplaceAsDataset(rel: proto.NAReplace): Dataset[Row] = {
     val replacement = mutable.Map.empty[Any, Any]
     rel.getReplacementsList.asScala.foreach { replace =>
       replacement.update(
@@ -418,60 +465,65 @@ class SparkConnectPlanner(
     }
 
     if (rel.getColsCount == 0) {
-      Dataset
-        .ofRows(session, transformRelation(rel.getInput))
-        .na
+      transformRelationAsDataset(rel.getInput).na
         .replace("*", replacement.toMap)
-        .logicalPlan
     } else {
-      Dataset
-        .ofRows(session, transformRelation(rel.getInput))
-        .na
+      transformRelationAsDataset(rel.getInput).na
         .replace(rel.getColsList.asScala.toSeq, replacement.toMap)
-        .logicalPlan
     }
+  }
+
+  private def transformReplace(rel: proto.NAReplace): LogicalPlan = {
+    transformReplaceAsDataset(rel).logicalPlan
+  }
+
+  private def transformStatSummaryAsDataset(rel: proto.StatSummary): Dataset[Row] = {
+    transformRelationAsDataset(rel.getInput)
+      .summary(rel.getStatisticsList.asScala.toSeq: _*)
   }
 
   private def transformStatSummary(rel: proto.StatSummary): LogicalPlan = {
-    Dataset
-      .ofRows(session, transformRelation(rel.getInput))
-      .summary(rel.getStatisticsList.asScala.toSeq: _*)
-      .logicalPlan
+    transformStatSummaryAsDataset(rel).logicalPlan
+  }
+
+  private def transformStatDescribeAsDataset(rel: proto.StatDescribe): Dataset[Row] = {
+    transformRelationAsDataset(rel.getInput)
+      .describe(rel.getColsList.asScala.toSeq: _*)
   }
 
   private def transformStatDescribe(rel: proto.StatDescribe): LogicalPlan = {
-    Dataset
-      .ofRows(session, transformRelation(rel.getInput))
-      .describe(rel.getColsList.asScala.toSeq: _*)
-      .logicalPlan
+    transformStatDescribeAsDataset(rel).logicalPlan
+  }
+
+  private def transformStatCovAsDataset(rel: proto.StatCov): Dataset[Row] = {
+    val df = transformRelationAsDataset(rel.getInput)
+    StatFunctions
+      .calculateCovImpl(df, Seq(rel.getCol1, rel.getCol2))
   }
 
   private def transformStatCov(rel: proto.StatCov): LogicalPlan = {
-    val df = Dataset.ofRows(session, transformRelation(rel.getInput))
-    StatFunctions
-      .calculateCovImpl(df, Seq(rel.getCol1, rel.getCol2))
-      .logicalPlan
+    transformStatCovAsDataset(rel).logicalPlan
   }
 
-  private def transformStatCorr(rel: proto.StatCorr): LogicalPlan = {
-    val df = Dataset.ofRows(session, transformRelation(rel.getInput))
+  private def transformStatCorrAsDataset(rel: proto.StatCorr): Dataset[Row] = {
+    val df = transformRelationAsDataset(rel.getInput)
     if (rel.hasMethod) {
       StatFunctions
         .calculateCorrImpl(df, Seq(rel.getCol1, rel.getCol2), rel.getMethod)
-        .logicalPlan
     } else {
       StatFunctions
         .calculateCorrImpl(df, Seq(rel.getCol1, rel.getCol2))
-        .logicalPlan
     }
+  }
+
+  private def transformStatCorr(rel: proto.StatCorr): LogicalPlan = {
+    transformStatCorrAsDataset(rel).logicalPlan
   }
 
   private def transformStatApproxQuantile(rel: proto.StatApproxQuantile): LogicalPlan = {
     val cols = rel.getColsList.asScala.toArray
     val probabilities = rel.getProbabilitiesList.asScala.map(_.doubleValue()).toArray
-    val approxQuantile = Dataset
-      .ofRows(session, transformRelation(rel.getInput))
-      .stat
+    val approxQuantile = transformRelationAsDataset(rel.getInput).stat
       .approxQuantile(cols, probabilities, rel.getRelativeError)
     LocalRelation.fromProduct(
       output =
@@ -479,25 +531,30 @@ class SparkConnectPlanner(
       data = Tuple1.apply(approxQuantile) :: Nil)
   }
 
-  private def transformStatCrosstab(rel: proto.StatCrosstab): LogicalPlan = {
-    Dataset
-      .ofRows(session, transformRelation(rel.getInput))
-      .stat
+  private def transformStatCrosstabAsDataset(rel: proto.StatCrosstab): Dataset[Row] = {
+    transformRelationAsDataset(rel.getInput).stat
       .crosstab(rel.getCol1, rel.getCol2)
-      .logicalPlan
   }
 
-  private def transformStatFreqItems(rel: proto.StatFreqItems): LogicalPlan = {
+  private def transformStatCrosstab(rel: proto.StatCrosstab): LogicalPlan = {
+    transformStatCrosstabAsDataset(rel).logicalPlan
+  }
+
+  private def transformStatFreqItemsAsDataset(rel: proto.StatFreqItems): Dataset[Row] = {
     val cols = rel.getColsList.asScala.toSeq
-    val df = Dataset.ofRows(session, transformRelation(rel.getInput))
+    val df = transformRelationAsDataset(rel.getInput)
     if (rel.hasSupport) {
-      df.stat.freqItems(cols, rel.getSupport).logicalPlan
+      df.stat.freqItems(cols, rel.getSupport)
     } else {
-      df.stat.freqItems(cols).logicalPlan
+      df.stat.freqItems(cols)
     }
   }
 
-  private def transformStatSampleBy(rel: proto.StatSampleBy): LogicalPlan = {
+  private def transformStatFreqItems(rel: proto.StatFreqItems): LogicalPlan = {
+    transformStatFreqItemsAsDataset(rel).logicalPlan
+  }
+
+  private def transformStatSampleByAsDataset(rel: proto.StatSampleBy): Dataset[Row] = {
     val fractions = rel.getFractionsList.asScala.map { protoFraction =>
       val stratum = transformLiteral(protoFraction.getStratum) match {
         case Literal(s, StringType) if s != null => s.toString
@@ -506,31 +563,36 @@ class SparkConnectPlanner(
       (stratum, protoFraction.getFraction)
     }
 
-    Dataset
-      .ofRows(session, transformRelation(rel.getInput))
-      .stat
+    transformRelationAsDataset(rel.getInput).stat
       .sampleBy(
         col = Column(transformExpression(rel.getCol)),
         fractions = fractions.toMap,
         seed = if (rel.hasSeed) rel.getSeed else Utils.random.nextLong)
-      .logicalPlan
   }
 
-  private def transformToSchema(rel: proto.ToSchema): LogicalPlan = {
+  private def transformStatSampleBy(rel: proto.StatSampleBy): LogicalPlan = {
+    transformStatSampleByAsDataset(rel).logicalPlan
+  }
+
+  private def transformToSchemaAsDataset(rel: proto.ToSchema): Dataset[Row] = {
     val schema = transformDataType(rel.getSchema)
     assert(schema.isInstanceOf[StructType])
 
-    Dataset
-      .ofRows(session, transformRelation(rel.getInput))
+    transformRelationAsDataset(rel.getInput)
       .to(schema.asInstanceOf[StructType])
-      .logicalPlan
+  }
+
+  private def transformToSchema(rel: proto.ToSchema): LogicalPlan = {
+    transformToSchemaAsDataset(rel).logicalPlan
+  }
+
+  private def transformToDFAsDataset(rel: proto.ToDF): Dataset[Row] = {
+    transformRelationAsDataset(rel.getInput)
+      .toDF(rel.getColumnNamesList.asScala.toSeq: _*)
   }
 
   private def transformToDF(rel: proto.ToDF): LogicalPlan = {
-    Dataset
-      .ofRows(session, transformRelation(rel.getInput))
-      .toDF(rel.getColumnNamesList.asScala.toSeq: _*)
-      .logicalPlan
+    transformToDFAsDataset(rel).logicalPlan
   }
 
   private def transformMapPartitions(rel: proto.MapPartitions): LogicalPlan = {
@@ -595,8 +657,7 @@ class SparkConnectPlanner(
         val cols =
           rel.getGroupingExpressionsList.asScala.toSeq.map(expr =>
             Column(transformExpression(expr)))
-        val group = Dataset
-          .ofRows(session, transformRelation(rel.getInput))
+        val group = transformRelationAsDataset(rel.getInput)
           .groupBy(cols: _*)
 
         pythonUdf.evalType match {
@@ -718,11 +779,9 @@ class SparkConnectPlanner(
           rel.getOtherGroupingExpressionsList.asScala.toSeq.map(expr =>
             Column(transformExpression(expr)))
 
-        val input = Dataset
-          .ofRows(session, transformRelation(rel.getInput))
+        val input = transformRelationAsDataset(rel.getInput)
           .groupBy(inputCols: _*)
-        val other = Dataset
-          .ofRows(session, transformRelation(rel.getOther))
+        val other = transformRelationAsDataset(rel.getOther)
           .groupBy(otherCols: _*)
 
         val pythonUdf = createUserDefinedPythonFunction(commonUdf)
@@ -927,7 +986,8 @@ class SparkConnectPlanner(
     }
   }
 
-  private def transformApplyInPandasWithState(rel: proto.ApplyInPandasWithState): LogicalPlan = {
+  private def transformApplyInPandasWithStateAsDataset(
+      rel: proto.ApplyInPandasWithState): Dataset[Row] = {
     val pythonUdf = transformPythonUDF(rel.getFunc)
     val cols =
       rel.getGroupingExpressionsList.asScala.toSeq.map(expr => Column(transformExpression(expr)))
@@ -936,8 +996,7 @@ class SparkConnectPlanner(
 
     val stateSchema = parseSchema(rel.getStateSchema)
 
-    Dataset
-      .ofRows(session, transformRelation(rel.getInput))
+    transformRelationAsDataset(rel.getInput)
       .groupBy(cols: _*)
       .applyInPandasWithState(
         pythonUdf,
@@ -945,7 +1004,10 @@ class SparkConnectPlanner(
         stateSchema,
         rel.getOutputMode,
         rel.getTimeoutConf)
-      .logicalPlan
+  }
+
+  private def transformApplyInPandasWithState(rel: proto.ApplyInPandasWithState): LogicalPlan = {
+    transformApplyInPandasWithStateAsDataset(rel).logicalPlan
   }
 
   private def transformCommonInlineUserDefinedTableFunction(
@@ -982,25 +1044,25 @@ class SparkConnectPlanner(
       .logicalPlan
   }
 
+  private def transformWithColumnsRenamedAsDataset(
+      rel: proto.WithColumnsRenamed): Dataset[Row] = {
+    transformRelationAsDataset(rel.getInput)
+      .withColumnsRenamed(rel.getRenameColumnsMapMap)
+  }
+
   private def transformWithColumnsRenamed(rel: proto.WithColumnsRenamed): LogicalPlan = {
     if (rel.getRenamesCount > 0) {
       val (colNames, newColNames) = rel.getRenamesList.asScala.toSeq.map { rename =>
         (rename.getColName, rename.getNewColName)
       }.unzip
-      Dataset
-        .ofRows(session, transformRelation(rel.getInput))
-        .withColumnsRenamed(colNames, newColNames)
-        .logicalPlan
+      transformWithColumnsRenamedAsDataset(rel).logicalPlan
     } else {
       // for backward compatibility
-      Dataset
-        .ofRows(session, transformRelation(rel.getInput))
-        .withColumnsRenamed(rel.getRenameColumnsMapMap)
-        .logicalPlan
+      transformWithColumnsRenamedAsDataset(rel).logicalPlan
     }
   }
 
-  private def transformWithColumns(rel: proto.WithColumns): LogicalPlan = {
+  private def transformWithColumnsAsDataset(rel: proto.WithColumns): Dataset[Row] = {
     val (colNames, cols, metadata) =
       rel.getAliasesList.asScala.toSeq.map { alias =>
         if (alias.getNameCount != 1) {
@@ -1017,17 +1079,21 @@ class SparkConnectPlanner(
         (alias.getName(0), Column(transformExpression(alias.getExpr)), metadata)
       }.unzip3
 
-    Dataset
-      .ofRows(session, transformRelation(rel.getInput))
+    transformRelationAsDataset(rel.getInput)
       .withColumns(colNames, cols, metadata)
-      .logicalPlan
+  }
+
+  private def transformWithColumns(rel: proto.WithColumns): LogicalPlan = {
+    transformWithColumnsAsDataset(rel).logicalPlan
+  }
+
+  private def transformWithWatermarkAsDataset(rel: proto.WithWatermark): Dataset[Row] = {
+    transformRelationAsDataset(rel.getInput)
+      .withWatermark(rel.getEventTime, rel.getDelayThreshold)
   }
 
   private def transformWithWatermark(rel: proto.WithWatermark): LogicalPlan = {
-    Dataset
-      .ofRows(session, transformRelation(rel.getInput))
-      .withWatermark(rel.getEventTime, rel.getDelayThreshold)
-      .logicalPlan
+    transformWithWatermarkAsDataset(rel).logicalPlan
   }
 
   private def transformCachedLocalRelation(rel: proto.CachedLocalRelation): LogicalPlan = {
@@ -2279,8 +2345,8 @@ class SparkConnectPlanner(
   }
 
   private def transformAsOfJoin(rel: proto.AsOfJoin): LogicalPlan = {
-    val left = Dataset.ofRows(session, transformRelation(rel.getLeft))
-    val right = Dataset.ofRows(session, transformRelation(rel.getRight))
+    val left = transformRelationAsDataset(rel.getLeft)
+    val right = transformRelationAsDataset(rel.getRight)
     val leftAsOf = Column(transformExpression(rel.getLeftAsOf))
     val rightAsOf = Column(transformExpression(rel.getRightAsOf))
     val joinType = rel.getJoinType
@@ -2338,8 +2404,8 @@ class SparkConnectPlanner(
       sameOrderExpressions = Seq.empty)
   }
 
-  private def transformDrop(rel: proto.Drop): LogicalPlan = {
-    var output = Dataset.ofRows(session, transformRelation(rel.getInput))
+  private def transformDropAsDataset(rel: proto.Drop): Dataset[Row] = {
+    var output = transformRelationAsDataset(rel.getInput)
     if (rel.getColumnsCount > 0) {
       val cols = rel.getColumnsList.asScala.toSeq.map(expr => Column(transformExpression(expr)))
       output = output.drop(cols.head, cols.tail: _*)
@@ -2348,7 +2414,11 @@ class SparkConnectPlanner(
       val colNames = rel.getColumnNamesList.asScala.toSeq
       output = output.drop(colNames: _*)
     }
-    output.logicalPlan
+    output
+  }
+
+  private def transformDrop(rel: proto.Drop): LogicalPlan = {
+    transformDropAsDataset(rel).logicalPlan
   }
 
   private def transformAggregate(rel: proto.Aggregate): LogicalPlan = {
@@ -2756,11 +2826,8 @@ class SparkConnectPlanner(
    * @param writeOperation
    */
   private def handleWriteOperation(writeOperation: proto.WriteOperation): Unit = {
-    // Transform the input plan into the logical plan.
-    val plan = transformRelation(writeOperation.getInput)
     // And create a Dataset from the plan.
-    val tracker = executeHolder.eventsManager.createQueryPlanningTracker()
-    val dataset = Dataset.ofRows(session, plan, tracker)
+    val dataset = transformRelationAsDataset(writeOperation.getInput)
 
     val w = dataset.write
     if (writeOperation.getMode != proto.WriteOperation.SaveMode.SAVE_MODE_UNSPECIFIED) {
@@ -2828,11 +2895,8 @@ class SparkConnectPlanner(
    * @param writeOperation
    */
   def handleWriteOperationV2(writeOperation: proto.WriteOperationV2): Unit = {
-    // Transform the input plan into the logical plan.
-    val plan = transformRelation(writeOperation.getInput)
     // And create a Dataset from the plan.
-    val tracker = executeHolder.eventsManager.createQueryPlanningTracker()
-    val dataset = Dataset.ofRows(session, plan, tracker)
+    val dataset = transformRelationAsDataset(writeOperation.getInput)
 
     val w = dataset.writeTo(table = writeOperation.getTableName)
 
@@ -2889,9 +2953,8 @@ class SparkConnectPlanner(
   def handleWriteStreamOperationStart(
       writeOp: WriteStreamOperationStart,
       responseObserver: StreamObserver[ExecutePlanResponse]): Unit = {
-    val plan = transformRelation(writeOp.getInput)
     val tracker = executeHolder.eventsManager.createQueryPlanningTracker()
-    val dataset = Dataset.ofRows(session, plan, tracker)
+    val dataset = transformRelationAsDataset(writeOp.getInput)
     // Call manually as writeStream does not trigger ReadyForExecution
     tracker.setReadyForExecution()
 

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectAnalyzeHandler.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectAnalyzeHandler.scala
@@ -23,7 +23,6 @@ import io.grpc.stub.StreamObserver
 
 import org.apache.spark.connect.proto
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.Dataset
 import org.apache.spark.sql.connect.common.{DataTypeProtoConverter, InvalidPlanInput, StorageLevelProtoConverter}
 import org.apache.spark.sql.connect.planner.SparkConnectPlanner
 import org.apache.spark.sql.execution.{CodegenMode, CostMode, ExtendedMode, FormattedMode, SimpleMode}
@@ -55,9 +54,7 @@ private[connect] class SparkConnectAnalyzeHandler(
 
     request.getAnalyzeCase match {
       case proto.AnalyzePlanRequest.AnalyzeCase.SCHEMA =>
-        val schema = Dataset
-          .ofRows(session, planner.transformRelation(request.getSchema.getPlan.getRoot))
-          .schema
+        val schema = planner.transformRelationAsDataset(request.getSchema.getPlan.getRoot).schema
         builder.setSchema(
           proto.AnalyzePlanResponse.Schema
             .newBuilder()
@@ -65,9 +62,8 @@ private[connect] class SparkConnectAnalyzeHandler(
             .build())
 
       case proto.AnalyzePlanRequest.AnalyzeCase.EXPLAIN =>
-        val queryExecution = Dataset
-          .ofRows(session, planner.transformRelation(request.getExplain.getPlan.getRoot))
-          .queryExecution
+        val queryExecution =
+          planner.transformRelationAsDataset(request.getExplain.getPlan.getRoot).queryExecution
         val explainString = request.getExplain.getExplainMode match {
           case proto.AnalyzePlanRequest.Explain.ExplainMode.EXPLAIN_MODE_SIMPLE =>
             queryExecution.explainString(SimpleMode)
@@ -88,9 +84,8 @@ private[connect] class SparkConnectAnalyzeHandler(
             .build())
 
       case proto.AnalyzePlanRequest.AnalyzeCase.TREE_STRING =>
-        val schema = Dataset
-          .ofRows(session, planner.transformRelation(request.getTreeString.getPlan.getRoot))
-          .schema
+        val schema =
+          planner.transformRelationAsDataset(request.getTreeString.getPlan.getRoot).schema
         val treeString = if (request.getTreeString.hasLevel) {
           schema.treeString(request.getTreeString.getLevel)
         } else {
@@ -103,9 +98,8 @@ private[connect] class SparkConnectAnalyzeHandler(
             .build())
 
       case proto.AnalyzePlanRequest.AnalyzeCase.IS_LOCAL =>
-        val isLocal = Dataset
-          .ofRows(session, planner.transformRelation(request.getIsLocal.getPlan.getRoot))
-          .isLocal
+        val isLocal =
+          planner.transformRelationAsDataset(request.getIsLocal.getPlan.getRoot).isLocal
         builder.setIsLocal(
           proto.AnalyzePlanResponse.IsLocal
             .newBuilder()
@@ -113,9 +107,8 @@ private[connect] class SparkConnectAnalyzeHandler(
             .build())
 
       case proto.AnalyzePlanRequest.AnalyzeCase.IS_STREAMING =>
-        val isStreaming = Dataset
-          .ofRows(session, planner.transformRelation(request.getIsStreaming.getPlan.getRoot))
-          .isStreaming
+        val isStreaming =
+          planner.transformRelationAsDataset(request.getIsStreaming.getPlan.getRoot).isStreaming
         builder.setIsStreaming(
           proto.AnalyzePlanResponse.IsStreaming
             .newBuilder()
@@ -123,9 +116,8 @@ private[connect] class SparkConnectAnalyzeHandler(
             .build())
 
       case proto.AnalyzePlanRequest.AnalyzeCase.INPUT_FILES =>
-        val inputFiles = Dataset
-          .ofRows(session, planner.transformRelation(request.getInputFiles.getPlan.getRoot))
-          .inputFiles
+        val inputFiles =
+          planner.transformRelationAsDataset(request.getInputFiles.getPlan.getRoot).inputFiles
         builder.setInputFiles(
           proto.AnalyzePlanResponse.InputFiles
             .newBuilder()
@@ -148,29 +140,27 @@ private[connect] class SparkConnectAnalyzeHandler(
             .build())
 
       case proto.AnalyzePlanRequest.AnalyzeCase.SAME_SEMANTICS =>
-        val target = Dataset.ofRows(
-          session,
-          planner.transformRelation(request.getSameSemantics.getTargetPlan.getRoot))
-        val other = Dataset.ofRows(
-          session,
-          planner.transformRelation(request.getSameSemantics.getOtherPlan.getRoot))
+        val target =
+          planner.transformRelationAsDataset(request.getSameSemantics.getTargetPlan.getRoot)
+        val other =
+          planner.transformRelationAsDataset(request.getSameSemantics.getOtherPlan.getRoot)
         builder.setSameSemantics(
           proto.AnalyzePlanResponse.SameSemantics
             .newBuilder()
             .setResult(target.sameSemantics(other)))
 
       case proto.AnalyzePlanRequest.AnalyzeCase.SEMANTIC_HASH =>
-        val semanticHash = Dataset
-          .ofRows(session, planner.transformRelation(request.getSemanticHash.getPlan.getRoot))
-          .semanticHash()
+        val semanticHash =
+          planner
+            .transformRelationAsDataset(request.getSemanticHash.getPlan.getRoot)
+            .semanticHash()
         builder.setSemanticHash(
           proto.AnalyzePlanResponse.SemanticHash
             .newBuilder()
             .setResult(semanticHash))
 
       case proto.AnalyzePlanRequest.AnalyzeCase.PERSIST =>
-        val target = Dataset
-          .ofRows(session, planner.transformRelation(request.getPersist.getRelation))
+        val target = planner.transformRelationAsDataset(request.getPersist.getRelation)
         if (request.getPersist.hasStorageLevel) {
           target.persist(
             StorageLevelProtoConverter.toStorageLevel(request.getPersist.getStorageLevel))
@@ -180,8 +170,7 @@ private[connect] class SparkConnectAnalyzeHandler(
         builder.setPersist(proto.AnalyzePlanResponse.Persist.newBuilder().build())
 
       case proto.AnalyzePlanRequest.AnalyzeCase.UNPERSIST =>
-        val target = Dataset
-          .ofRows(session, planner.transformRelation(request.getUnpersist.getRelation))
+        val target = planner.transformRelationAsDataset(request.getUnpersist.getRelation)
         if (request.getUnpersist.hasBlocking) {
           target.unpersist(request.getUnpersist.getBlocking)
         } else {
@@ -190,8 +179,7 @@ private[connect] class SparkConnectAnalyzeHandler(
         builder.setUnpersist(proto.AnalyzePlanResponse.Unpersist.newBuilder().build())
 
       case proto.AnalyzePlanRequest.AnalyzeCase.GET_STORAGE_LEVEL =>
-        val target = Dataset
-          .ofRows(session, planner.transformRelation(request.getGetStorageLevel.getRelation))
+        val target = planner.transformRelationAsDataset(request.getGetStorageLevel.getRelation)
         val storageLevel = target.storageLevel
         builder.setGetStorageLevel(
           proto.AnalyzePlanResponse.GetStorageLevel

--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/plugin/SparkConnectPluginRegistrySuite.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/plugin/SparkConnectPluginRegistrySuite.scala
@@ -22,7 +22,6 @@ import com.google.protobuf
 import org.apache.spark.{SparkContext, SparkEnv, SparkException}
 import org.apache.spark.connect.proto
 import org.apache.spark.connect.proto.Relation
-import org.apache.spark.sql.Dataset
 import org.apache.spark.sql.catalyst.expressions.{Alias, Expression}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.connect.common.InvalidPlanInput
@@ -172,8 +171,7 @@ class SparkConnectPluginRegistrySuite extends SharedSparkSession with SparkConne
         "org.apache.spark.sql.connect.plugin.ExampleRelationPlugin",
       Connect.CONNECT_EXTENSIONS_EXPRESSION_CLASSES.key ->
         "org.apache.spark.sql.connect.plugin.ExampleExpressionPlugin") {
-      val plan = transform(buildRelation())
-      val ds = Dataset.ofRows(spark, plan)
+      val ds = transformAsDataset(buildRelation())
       val result = ds.collect()
       assert(result.length == 10)
       assert(result(0).schema.fieldNames(0) == "martin")


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently, `SparkConnectPlanner.transformRelation` always return the `LogicalPlan` of `Dataset`.
The `SparkConnectPlanExecution.handlePlan` constructs a new `Dataset` for it.

Sometimes, `SparkConnectPlanExecution.handlePlan` could reuse the `Dataset` created by `SparkConnectPlanner.transformRelation`.

This PR creates a common method `transformRelationAsDataset`, so as the `Dataset` could be reused in many places.


### Why are the changes needed?
Improve `SparkConnectPlanner` by reuse `Dataset` and avoid construct new `Dataset`.


### Does this PR introduce _any_ user-facing change?
'No'.
Just update inner implementation.


### How was this patch tested?
Exists test cases.


### Was this patch authored or co-authored using generative AI tooling?
'No'.
