### PR TITLE
[SPARK-40820][PYTHON][SQL] Creating StructType from Json

### DIFF
--- a/python/pyspark/sql/tests/test_types.py
+++ b/python/pyspark/sql/tests/test_types.py
@@ -1579,6 +1579,13 @@ class DataTypeVerificationTests(unittest.TestCase, PySparkErrorTestUtils):
         self.assertEqual(r, expected)
         self.assertEqual(repr(r), "Row(b=1, a=2)")
 
+    def test_struct_field_from_json(self):
+        # SPARK-40820: fromJson with only name and type
+        json = {"name": "c1", "type": "string"}
+        struct_field = StructField.fromJson(json)
+
+        self.assertEqual(repr(struct_field), "StructField('c1', StringType(), True)")
+
 
 class TypesTests(TypesTestsMixin, ReusedSQLTestCase):
     pass

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -769,8 +769,8 @@ class StructField(DataType):
         return StructField(
             json["name"],
             _parse_datatype_json_value(json["type"]),
-            json["nullable"],
-            json["metadata"],
+            json.get("nullable", True),
+            json.get("metadata"),
         )
 
     def needConversion(self) -> bool:

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/DataType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/DataType.scala
@@ -258,6 +258,11 @@ object DataType {
     ("nullable", JBool(nullable)),
     ("type", dataType: JValue)) =>
       StructField(name, parseDataType(dataType), nullable)
+    // Support reading schema when 'nullable' is missing.
+    case JSortedObject(
+    ("name", JString(name)),
+    ("type", dataType: JValue)) =>
+      StructField(name, parseDataType(dataType))
     case other =>
       throw new IllegalArgumentException(
         s"Failed to convert the JSON string '${compact(render(other))}' to a field.")

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
@@ -317,6 +317,29 @@ class DataTypeSuite extends SparkFunSuite {
     assert(message.contains("Unrecognized token 'abcd'"))
   }
 
+  // SPARK-40820: fromJson with only name and type
+  test("Deserialized and serialized schema without nullable or metadata in") {
+    val schema =
+      """
+        |{
+        |    "type": "struct",
+        |    "fields": [
+        |        {
+        |            "name": "c1",
+        |            "type": "string"
+        |        }
+        |    ]
+        |}
+        |""".stripMargin
+    val dt = DataType.fromJson(schema)
+
+    dt.simpleString equals "struct<c1:string>"
+    dt.json equals
+      """
+        |{"type":"struct","fields":[{"name":"c1","type":"string","nullable":false,"metadata":{}}]}
+        |""".stripMargin
+  }
+
   def checkDefaultSize(dataType: DataType, expectedDefaultSize: Int): Unit = {
     test(s"Check the default size of $dataType") {
       assert(dataType.defaultSize === expectedDefaultSize)


### PR DESCRIPTION
**What changes were proposed in this pull request?**
Read schema from json without nullable and metadata

**Why are the changes needed?**
In order to read schema from json and avoid having to set implicit values

**Does this PR introduce any user-facing change?**
Yes, avoiding filling json with implicit values

**How was this patch tested?**
Unit tests


When create a StructType from a Python dictionary you use [StructType.fromJson](https://github.com/apache/spark/blob/master/python/pyspark/sql/types.py#L792) or in scala [DataType.fromJson](https://github.com/apache/spark/blob/master/sql/api/src/main/scala/org/apache/spark/sql/types/DataType.scala#L158C7-L158C15)

To create a schema can be created as follows from the code below, but it requires to put inside the json: Nullable and Metadata, this is inconsistent because within the DataType class this by default.

```python
schema = {
            "name": "name",
            "type": "string"
        }

StructField.fromJson(schema)
```

Python Error:

```python
from pyspark.sql.types import StructField
schema = {
            "name": "c1",
            "type": "string"
        }
StructField.fromJson(schema)

>>
Traceback (most recent call last):
  File "code.py", line 90, in runcode
    exec(code, self.locals)
  File "<input>", line 1, in <module>
  File "pyspark/sql/types.py", line 583, in fromJson
    json["nullable"],
KeyError: 'nullable' 
 ```

Scala Error:
```scala
    val schema =
      """
        |{
        |    "type": "struct",
        |    "fields": [
        |        {
        |            "name": "c1",
        |            "type": "string",
        |            "nullable": false
        |        }
        |    ]
        |}
        |""".stripMargin
    DataType.fromJson(schema)

>>
Failed to convert the JSON string '{"name":"c1","type":"string"}' to a field.
java.lang.IllegalArgumentException: Failed to convert the JSON string '{"name":"c1","type":"string"}' to a field.
	at org.apache.spark.sql.types.DataType$.parseStructField(DataType.scala:268)
	at org.apache.spark.sql.types.DataType$.$anonfun$parseDataType$1(DataType.scala:225)
 ```
