### PR TITLE
[SPARK-41954][CORE] Add isDecommissioned in ExecutorDeadException

### DIFF
--- a/common/utils/src/main/scala/org/apache/spark/SparkException.scala
+++ b/common/utils/src/main/scala/org/apache/spark/SparkException.scala
@@ -126,10 +126,9 @@ private[spark] case class SparkUserAppException(exitCode: Int)
 /**
  * Exception thrown when the relative executor to access is dead.
  */
-private[spark] case class ExecutorDeadException(message: String)
+private[spark] case class ExecutorDeadException(message: String, isDecommissioned: Boolean = false)
   extends SparkException(errorClass = "INTERNAL_ERROR_NETWORK",
     messageParameters = Map("message" -> message), cause = null)
-
 /**
  * Exception thrown when Spark returns different result after upgrading to a new version.
  */

--- a/core/src/main/scala/org/apache/spark/storage/BlockManagerMasterEndpoint.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManagerMasterEndpoint.scala
@@ -81,6 +81,9 @@ class BlockManagerMasterEndpoint(
   // Set of block managers which are decommissioning
   private val decommissioningBlockManagerSet = new mutable.HashSet[BlockManagerId]
 
+  // Set of executors which are decommissioned
+  private val decommissionedExecutorIdSet = new mutable.HashSet[String]
+
   // Mapping from block id to the set of block managers that have the block.
   private val blockLocations = new JHashMap[BlockId, mutable.HashSet[BlockManagerId]]
 
@@ -188,7 +191,7 @@ class BlockManagerMasterEndpoint(
       context.reply(removeShufflePushMergerLocation(host))
 
     case IsExecutorAlive(executorId) =>
-      context.reply(blockManagerIdByExecutor.contains(executorId))
+      context.reply(isExecutorAlive(executorId))
 
     case GetMatchingBlockIds(filter, askStorageEndpoints) =>
       context.reply(getMatchingBlockIds(filter, askStorageEndpoints))
@@ -497,7 +500,9 @@ class BlockManagerMasterEndpoint(
 
     // Remove the block manager from blockManagerIdByExecutor.
     blockManagerIdByExecutor -= blockManagerId.executorId
-    decommissioningBlockManagerSet.remove(blockManagerId)
+    if (decommissioningBlockManagerSet.remove(blockManagerId)) {
+      decommissionedExecutorIdSet.add(blockManagerId.executorId)
+    }
 
     // Remove it from blockManagerInfo and remove all the blocks.
     blockManagerInfo.remove(blockManagerId)
@@ -666,6 +671,16 @@ class BlockManagerMasterEndpoint(
     // we need to keep the executor ID of the original executor to let the shuffle service know
     // which local directories should be used to look for the file
     BlockManagerId(blockManagerId.executorId, blockManagerId.host, externalShuffleServicePort)
+  }
+
+  /**
+   * @return (isExecutorAlive, isDecommissioned)
+   */
+  private def isExecutorAlive(executorId: String): (Boolean, Boolean) = {
+    val isAlive = blockManagerIdByExecutor.contains(executorId)
+    val isDecommissioned = decommissioningBlockManagerSet.map(_.executorId).contains(executorId) ||
+      decommissionedExecutorIdSet.contains(executorId)
+    (isAlive, isDecommissioned)
   }
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?
When one executor is dead, we want to know whether this dead executor is caused by decommission. 

### Why are the changes needed?
When one executor is dead, we want to know whether this dead executor is caused by decommission. 

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Added UT

### Was this patch authored or co-authored using generative AI tooling?
No
