### PR TITLE
[SPARK-45622][BUILD] java -target should use java.version instead of 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2962,7 +2962,7 @@
               <arg>-deprecation</arg>
               <arg>-feature</arg>
               <arg>-explaintypes</arg>
-              <arg>-target:17</arg>
+              <arg>-target:${java.version}</arg>
               <arg>-Wconf:cat=deprecation:wv,any:e</arg>
               <arg>-Wunused:imports</arg>
               <arg>-Wconf:cat=scaladoc:wv</arg>


### PR DESCRIPTION
### What changes were proposed in this pull request?
java -target should use java.version instead of 17

### Why are the changes needed?
java -target should use java.version instead of 17

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Manually tested

### Was this patch authored or co-authored using generative AI tooling?
No
