### PR TITLE
[SPARK-45624][CORE][TESTS] Use `AccessibleObject#canAccess` instead of `AccessibleObject#isAccessible`

### DIFF
--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -255,7 +255,7 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties {
 
   private def getFieldValue(obj: AnyRef, fieldName: String): Any = {
     val field: Field = obj.getClass().getDeclaredField(fieldName)
-    if (field.isAccessible()) {
+    if (field.canAccess(obj)) {
       field.get(obj)
     } else {
       field.setAccessible(true)


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr use `AccessibleObject#canAccess` instead of `AccessibleObject#isAccessible` due to `isAccessible` has been marked as deprecated since Java 9.

https://github.com/openjdk/jdk/blob/ecd25e7d6f9d69f9dbdbff0a4a9b9d6b19288593/src/java.base/share/classes/java/lang/reflect/AccessibleObject.java#L412-L428

```java
/**
     * Get the value of the {@code accessible} flag for this reflected object.
     *
     * @return the value of the object's {@code accessible} flag
     *
     * @deprecated
     * This method is deprecated because its name hints that it checks
     * if the reflected object is accessible when it actually indicates
     * if the checks for Java language access control are suppressed.
     * This method may return {@code false} on a reflected object that is
     * accessible to the caller. To test if this reflected object is accessible,
     * it should use {@link #canAccess(Object)}.
     *
     * @revised 9
     */
    @Deprecated(since="9")
    public boolean isAccessible() {
        return override;
    }
```

### Why are the changes needed?
Cleanup deprecated API usage.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Pass GitHub Actions

### Was this patch authored or co-authored using generative AI tooling?
No
