### PR TITLE
[SPARK-45625][BUILD] Upgrade log4j to 2.21.0

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -175,10 +175,10 @@ lapack/3.0.3//lapack-3.0.3.jar
 leveldbjni-all/1.8//leveldbjni-all-1.8.jar
 libfb303/0.9.3//libfb303-0.9.3.jar
 libthrift/0.12.0//libthrift-0.12.0.jar
-log4j-1.2-api/2.20.0//log4j-1.2-api-2.20.0.jar
-log4j-api/2.20.0//log4j-api-2.20.0.jar
-log4j-core/2.20.0//log4j-core-2.20.0.jar
-log4j-slf4j2-impl/2.20.0//log4j-slf4j2-impl-2.20.0.jar
+log4j-1.2-api/2.21.0//log4j-1.2-api-2.21.0.jar
+log4j-api/2.21.0//log4j-api-2.21.0.jar
+log4j-core/2.21.0//log4j-core-2.21.0.jar
+log4j-slf4j2-impl/2.21.0//log4j-slf4j2-impl-2.21.0.jar
 logging-interceptor/3.12.12//logging-interceptor-3.12.12.jar
 lz4-java/1.8.0//lz4-java-1.8.0.jar
 metrics-core/4.2.19//metrics-core-4.2.19.jar

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
     <sbt.project.name>spark</sbt.project.name>
     <asm.version>9.6</asm.version>
     <slf4j.version>2.0.9</slf4j.version>
-    <log4j.version>2.20.0</log4j.version>
+    <log4j.version>2.21.0</log4j.version>
     <!-- make sure to update IsolatedClientLoader whenever this version is changed -->
     <hadoop.version>3.3.6</hadoop.version>
     <!-- SPARK-41247: When updating `protobuf.version`, also need to update `protoVersion` in `SparkBuild.scala` -->


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims upgrade log4j from 2.20.0 to 2.21.0.


### Why are the changes needed?
Support for the zstd compression algorithm has been added in the new version: https://github.com/apache/logging-log4j2/issues/1508 | https://github.com/apache/logging-log4j2/pull/1514
Meanwhile, the new version starts to use Java 11 for building, and the runtime version is still compatible with Java 8: https://github.com/apache/logging-log4j2/pull/1369
The new version also brings some bug fixes, such as:
- Fixed logging of java.sql.Date objects by appending it before Log4J tries to call java.util.Date.toInstant() on it: https://github.com/apache/logging-log4j2/issues/1366
- Fixed concurrent date-time formatting issue in PatternLayout: https://github.com/apache/logging-log4j2/pull/1485
- Fixed buffer size in Log4jFixedFormatter date time formatter: https://github.com/apache/logging-log4j2/issues/1418
- Fixed the propagation of synchronous action failures in RollingFileManager and FileRenameAction: https://github.com/apache/logging-log4j2/issues/1445 | https://github.com/apache/logging-log4j2/pull/1549
- Fixed RollingFileManager to propagate failed synchronous actions correctly: https://github.com/apache/logging-log4j2/issues/1445
and more.

The complete release note is as follows:
- https://github.com/apache/logging-log4j2/releases/tag/rel%2F2.21.0

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions

### Was this patch authored or co-authored using generative AI tooling?
No