### PR TITLE
[SPARK-45631][SS][PYSPARK] Remove @abstractmethod from onQueryIdle in PySpark StreamingQueryListener

### DIFF
--- a/python/pyspark/sql/streaming/listener.py
+++ b/python/pyspark/sql/streaming/listener.py
@@ -107,7 +107,9 @@ class StreamingQueryListener(ABC):
         """
         pass
 
-    @abstractmethod
+    # NOTE: Do not mark this as abstract method, since we released this abstract class without
+    # this method in prior version and marking this as abstract method would break existing
+    # implementations.
     def onQueryIdle(self, event: "QueryIdleEvent") -> None:
         """
         Called when the query is idle and waiting for new data to process.


### PR DESCRIPTION
### What changes were proposed in this pull request?

Credit to @anishshri-db for the initial investigation and the fix.

This PR proposes to remove `@abstractmethod` annotation from `onQueryIdle` in PySpark StreamingQueryListener.

The function `onQueryIdle` was added with the annotation `@abstractmethod`, which does not pick up default implementation and enforces users to implement the new method. This breaks all existing streaming query listener implementations and enforces them to add the dummy function implementation at least.

This PR re-allows existing implementations to work properly without explicitly adding a new function `onQueryIdle`.

### Why are the changes needed?

We broke backward compatibility in [SPARK-43183](https://issues.apache.org/jira/browse/SPARK-43183) and we want to fix it.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Modified tests. Now tests are verifying two different implementations covering old interface vs new interface.

### Was this patch authored or co-authored using generative AI tooling?

No.