### PR TITLE
[SPARK-45633][PYTHON][SQL][TESTS] Make SQL test group depend on `analyze_udtf.py`

### DIFF
--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -198,7 +198,7 @@ sql = Module(
     dependencies=[catalyst],
     source_file_regexes=[
         "sql/core/",
-        "python/pyspark/sql/worker/",  # analyze_udtf is invoked in JVM and tested in SQLQueryTestSuite
+        "python/pyspark/sql/worker/",  # analyze_udtf is invoked and tested in JVM
     ],
     sbt_test_goals=[
         "sql/test",

--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -198,6 +198,7 @@ sql = Module(
     dependencies=[catalyst],
     source_file_regexes=[
         "sql/core/",
+        "python/pyspark/sql/worker/",  # analyze_udtf is invoked in JVM and tested in SQLQueryTestSuite
     ],
     sbt_test_goals=[
         "sql/test",


### PR DESCRIPTION
### What changes were proposed in this pull request?
`analyze_udtf` is invoked from `UserDefinedPythonTableFunctionAnalyzeRunner.runInPython`, and tested in `org.apache.spark.sql.execution.python.PythonUDTFSuite`


### Why are the changes needed?
to avoid https://github.com/apache/spark/pull/43470#issuecomment-1774628434


### Does this PR introduce _any_ user-facing change?
no, test only

### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no
