### PR TITLE
[SPARK-45648][INFRA] Add `sql/api` and `common/utils` to `modules.py`

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -141,11 +141,11 @@ jobs:
         # Note that the modules below are from sparktestsupport/modules.py.
         modules:
           - >-
-            core, unsafe, kvstore, avro,
+            core, unsafe, kvstore, avro, utils,
             network-common, network-shuffle, repl, launcher,
             examples, sketch, graphx
           - >-
-            catalyst, hive-thriftserver
+            api, catalyst, hive-thriftserver
           - >-
             mllib-local,mllib
           - >-

--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -157,6 +157,14 @@ unsafe = Module(
     ],
 )
 
+utils = Module(
+    name="utils",
+    dependencies=[tags],
+    source_file_regexes=[
+        "common/utils/",
+    ],
+)
+
 launcher = Module(
     name="launcher",
     dependencies=[tags],
@@ -179,9 +187,17 @@ core = Module(
     ],
 )
 
+api = Module(
+    name="api",
+    dependencies=[utils, unsafe],
+    source_file_regexes=[
+        "sql/api/",
+    ],
+)
+
 catalyst = Module(
     name="catalyst",
-    dependencies=[tags, core],
+    dependencies=[tags, core, api],
     source_file_regexes=[
         "sql/catalyst/",
     ],


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add `sql/api` and `common/utils` to `modules.py`


### Why are the changes needed?
new modules should be covered in `modules.py`, otherwise related tests maybe wrongly skipped in some cases


### Does this PR introduce _any_ user-facing change?
no, infra-only


### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no