### PR TITLE
[SPARK-44032][BUILD] Remove `threeten-extra` exclusion in `enforceBytecodeVersion` rule

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2857,12 +2857,6 @@
                     <maxJdkVersion>${java.version}</maxJdkVersion>
                     <ignoredScopes>test</ignoredScopes>
                     <ignoredScopes>provided</ignoredScopes>
-                    <excludes>
-                      <!--
-                        TODO(SPARK-44032): Remove the exclusion of threeten-extra when orc-core fixes the violation
-                      -->
-                      <exclude>org.threeten:threeten-extra</exclude>
-                    </excludes>
                   </enforceBytecodeVersion>
                 </rules>
               </configuration>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove an exclusion for `threeten-extra` dependency in `enforceBytecodeVersion` rule.

### Why are the changes needed?

`threeteen-extra` library has no problem with Apache Spark 4.0.0 because Spark's minimum JDK is 17.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.