### PR TITLE
[SPARK-45651][BUILD] Publish snapshot manually

### DIFF
--- a/.github/workflows/publish_snapshot.yml
+++ b/.github/workflows/publish_snapshot.yml
@@ -22,6 +22,7 @@ name: Publish Snapshot
 on:
   schedule:
   - cron: '0 0 * * *'
+  workflow_dispatch:
 
 jobs:
   publish-snapshot:

--- a/.github/workflows/publish_snapshot.yml
+++ b/.github/workflows/publish_snapshot.yml
@@ -23,6 +23,12 @@ on:
   schedule:
   - cron: '0 0 * * *'
   workflow_dispatch:
+    inputs:
+      branch:
+        description: 'list of branches to publish (JSON)'
+        required: true
+        # keep in sync with default value of strategy matrix 'branch'
+        default: '["master", "branch-3.5", "branch-3.4", "branch-3.3"]'
 
 jobs:
   publish-snapshot:
@@ -31,11 +37,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch:
-          - master
-          - branch-3.5
-          - branch-3.4
-          - branch-3.3
+        # keep in sync with default value of workflow_dispatch input 'branch'
+        branch: ${{ fromJSON( inputs.branch || '["master", "branch-3.5", "branch-3.4", "branch-3.3"]' ) }}
     steps:
     - name: Checkout Spark repository
       uses: actions/checkout@v3


### PR DESCRIPTION
### What changes were proposed in this pull request?
With a manual trigger, the workflow can be executed manually after merging a fix of the workflow to master. This also allows to run the workflow only on a subset of branches (e.g. those that failed).

### Why are the changes needed?
Sometime, publishing snapshots fails. If a fix of the workflow file is needed, that change can only be tested by waiting for the next day when the cron even triggers the next publish. This is quite a long turnaround to test fixes to that workflow (see #43364).

### Does this PR introduce _any_ user-facing change?
No, this is purely build CI related.

### How was this patch tested?
This can only be tested in master. Github workflow syntax tested in a private repo.

### Was this patch authored or co-authored using generative AI tooling?
No