### PR TITLE
[SPARK-45651][Build] Log memory usage of publish snapshot workflow

### DIFF
--- a/.github/workflows/publish_snapshot.yml
+++ b/.github/workflows/publish_snapshot.yml
@@ -70,4 +70,10 @@ jobs:
         GPG_KEY: "not_used"
         GPG_PASSPHRASE: "not_used"
         GIT_REF: ${{ matrix.branch }}
-      run: ./dev/create-release/release-build.sh publish-snapshot
+      run: |
+        while true
+        do
+          ps -u | sed -e "s/^/ps: $(date) /"
+          sleep 1
+        done &
+        ./dev/create-release/release-build.sh publish-snapshot

--- a/.github/workflows/publish_snapshot.yml
+++ b/.github/workflows/publish_snapshot.yml
@@ -73,7 +73,9 @@ jobs:
       run: |
         while true
         do
-          ps -u | sed -e "s/^/ps: $(date) /"
+          date
+          top -b -n 1 -i
           sleep 1
-        done &
+          echo
+        done | sed "s/^/mem: /" &
         ./dev/create-release/release-build.sh publish-snapshot


### PR DESCRIPTION
### What changes were proposed in this pull request?
This logs memory consumption while publishing snapshots. This is to investigate whether the suspected high memory usage is the root cause of `publish_snapshots` failures for master.

Merging this after #43512 allows to run this manually.

### Why are the changes needed?
The working assumption is that high memory usage is the root cause. This logging should provide proof or disproof for this assumption. This can be reverted once more is known or SPARK-45651 is fixed.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Locally

### Was this patch authored or co-authored using generative AI tooling?
No