### PR TITLE
[SPARK-45654][PYTHON] Add Python data source write API

### DIFF
--- a/python/pyspark/sql/datasource.py
+++ b/python/pyspark/sql/datasource.py
@@ -260,7 +260,7 @@ class DataSourceWriter(ABC):
     """
 
     @abstractmethod
-    def write(self, iterator: Iterator[Row]) -> Any:
+    def write(self, iterator: Iterator[Row]) -> "WriterCommitMessage":
         """
         Writes data into the data source.
 
@@ -279,11 +279,11 @@ class DataSourceWriter(ABC):
 
         Returns
         -------
-        commit message : any serializable object or None
+        WriterCommitMessage : a serializable commit message
         """
         ...
 
-    def commit(self, messages: List[Any]) -> None:
+    def commit(self, messages: List["WriterCommitMessage"]) -> None:
         """
         Commits this writing job with a list of commit messages.
 
@@ -294,12 +294,12 @@ class DataSourceWriter(ABC):
 
         Parameters
         ----------
-        messages : List[Any]
+        messages : List[WriterCommitMessage]
             A list of commit messages.
         """
         ...
 
-    def abort(self, messages: List[Any]) -> None:
+    def abort(self, messages: List["WriterCommitMessage"]) -> None:
         """
         Aborts this writing job due to task failures.
 
@@ -310,10 +310,20 @@ class DataSourceWriter(ABC):
 
         Parameters
         ----------
-        messages : List[Any]
+        messages : List[WriterCommitMessage]
             A list of commit messages.
         """
         ...
+
+
+@since(4.0)
+class WriterCommitMessage:
+    """
+    A commit message returned by the ``write`` method of ``DataSourceWriter`` and will be
+    sent back to the driver side as input parameter of ``commit`` or ``abort`` method.
+    """
+
+    ...
 
 
 @since(4.0)

--- a/python/pyspark/sql/datasource.py
+++ b/python/pyspark/sql/datasource.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
 __all__ = ["DataSource", "DataSourceReader", "DataSourceWriter", "DataSourceRegistration"]
 
 
+@since(4.0)
 class DataSource(ABC):
     """
     A base class for data sources.
@@ -155,6 +156,7 @@ class DataSource(ABC):
         raise NotImplementedError
 
 
+@since(4.0)
 class DataSourceReader(ABC):
     """
     A base class for data source readers. Data source readers are responsible for
@@ -250,6 +252,7 @@ class DataSourceReader(ABC):
         ...
 
 
+@since(4.0)
 class DataSourceWriter(ABC):
     """
     A base class for data source writers. Data source writers are responsible for saving

--- a/python/pyspark/sql/tests/test_python_datasource.py
+++ b/python/pyspark/sql/tests/test_python_datasource.py
@@ -33,6 +33,8 @@ class BasePythonDataSourceTestsMixin:
             ds.schema()
         with self.assertRaises(NotImplementedError):
             ds.reader(None)
+        with self.assertRaises(NotImplementedError):
+            ds.writer(None, None)
 
     def test_basic_data_source_reader_class(self):
         class MyDataSourceReader(DataSourceReader):


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR adds Python data source write API and `DataSourceWriter` class `datasource.py`.

Here is an overview of writer class: 

```python
class DataSourceWriter(ABC):
    @abstractmethod
    def write(self, iterator: Iterator[Row]) -> Any:
        ...
    
    def commit(self, messages: List[Any]) -> None:
        ...
    
    def abort(self, messages: List[Any]) -> None:
        ...
```

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To support Python data source write.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No. This PR alone does not introduce any user-facing change.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Unit test

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
--> 
No