### PR TITLE
[SPARK-45659][SQL][SS] Add `since` field to Java API marked as `@Deprecated`.

### DIFF
--- a/launcher/src/main/java/org/apache/spark/launcher/SparkLauncher.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkLauncher.java
@@ -99,7 +99,7 @@ public class SparkLauncher extends AbstractLauncher<SparkLauncher> {
    * @deprecated use `CHILD_CONNECTION_TIMEOUT`
    * @since 1.6.0
    */
-  @Deprecated
+  @Deprecated(since = "3.2.0")
   public static final String DEPRECATED_CHILD_CONNECTION_TIMEOUT =
     "spark.launcher.childConectionTimeout";
 

--- a/sql/api/src/main/java/org/apache/spark/sql/streaming/Trigger.java
+++ b/sql/api/src/main/java/org/apache/spark/sql/streaming/Trigger.java
@@ -98,7 +98,7 @@ public class Trigger {
    *             processing of watermark advancement including no-data batch.
    *             See the NOTES in {@link #AvailableNow()} for details.
    */
-  @Deprecated
+  @Deprecated(since = "3.4.0")
   public static Trigger Once() {
     return OneTimeTrigger$.MODULE$;
   }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/ExpressionDescription.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/ExpressionDescription.java
@@ -102,7 +102,7 @@ public @interface ExpressionDescription {
      *   {@link #examples}, {@link #note}, {@link #since} and {@link #deprecated} instead
      *   to document the extended usage.
      */
-    @Deprecated
+    @Deprecated(since = "3.0.0")
     String extended() default "";
     String arguments() default "";
     String examples() default "";

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/ExpressionInfo.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/ExpressionInfo.java
@@ -192,7 +192,7 @@ public class ExpressionInfo {
      * @deprecated This constructor is deprecated as of Spark 3.0. Use other constructors to fully
      *   specify each argument for extended usage.
      */
-    @Deprecated
+    @Deprecated(since = "3.0.0")
     public ExpressionInfo(String className, String db, String name, String usage, String extended) {
         // `arguments` and `examples` are concatenated for the extended description. So, here
         // simply pass the `extended` as `arguments` and an empty string for `examples`.

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/StagingTableCatalog.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/StagingTableCatalog.java
@@ -57,10 +57,10 @@ public interface StagingTableCatalog extends TableCatalog {
   /**
    * Stage the creation of a table, preparing it to be committed into the metastore.
    * <p>
-   * This is deprecated. Please override
+   * @deprecated This is deprecated. Please override
    * {@link #stageCreate(Identifier, Column[], Transform[], Map)} instead.
    */
-  @Deprecated
+  @Deprecated(since = "3.4.0")
   StagedTable stageCreate(
       Identifier ident,
       StructType schema,

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/Table.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/Table.java
@@ -52,9 +52,9 @@ public interface Table {
    * Returns the schema of this table. If the table is not readable and doesn't have a schema, an
    * empty schema can be returned here.
    * <p>
-   * This is deprecated. Please override {@link #columns} instead.
+   * @deprecated This is deprecated. Please override {@link #columns} instead.
    */
-  @Deprecated
+  @Deprecated(since = "3.4.0")
   StructType schema();
 
   /**

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TableCatalog.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TableCatalog.java
@@ -170,10 +170,10 @@ public interface TableCatalog extends CatalogPlugin {
   /**
    * Create a table in the catalog.
    * <p>
-   * This is deprecated. Please override
+   * @deprecated This is deprecated. Please override
    * {@link #createTable(Identifier, Column[], Transform[], Map)} instead.
    */
-  @Deprecated
+  @Deprecated(since = "3.4.0")
   Table createTable(
       Identifier ident,
       StructType schema,

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/WriteBuilder.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/WriteBuilder.java
@@ -56,7 +56,7 @@ public interface WriteBuilder {
    *
    * @deprecated use {@link #build()} instead.
    */
-  @Deprecated
+  @Deprecated(since = "3.2.0")
   default BatchWrite buildForBatch() {
     throw new UnsupportedOperationException(getClass().getName() +
       " does not support batch write");
@@ -67,7 +67,7 @@ public interface WriteBuilder {
    *
    * @deprecated use {@link #build()} instead.
    */
-  @Deprecated
+  @Deprecated(since = "3.2.0")
   default StreamingWrite buildForStreaming() {
     throw new UnsupportedOperationException(getClass().getName() +
       " does not support streaming write");

--- a/sql/core/src/main/java/org/apache/spark/sql/expressions/javalang/typed.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/expressions/javalang/typed.java
@@ -32,7 +32,7 @@ import org.apache.spark.sql.execution.aggregate.TypedSumLong;
  * @since 2.0.0
  * @deprecated As of release 3.0.0, please use the untyped builtin aggregate functions.
  */
-@Deprecated
+@Deprecated(since = "3.0.0")
 public class typed {
   // Note: make sure to keep in sync with typed.scala
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR supplements the `since` field for the following Java APIs that have been marked as  @Deprecated:

**Spark 3.0.0**

[SPARK-26861](https://issues.apache.org/jira/browse/SPARK-26861)
  - `org.apache.spark.sql.expressions.javalang.typed`
[SPARK-27606](https://issues.apache.org/jira/browse/SPARK-27606)
  - `org.apache.spark.sql.catalyst.expressions.ExpressionDescription#extended`
  - `org.apache.spark.sql.catalyst.expressions.ExpressionInfo#ExpressionInfo(String, String, String, String, String)`

**Spark 3.2.0**

[SPARK-33717](https://issues.apache.org/jira/browse/SPARK-33717)
  - `org.apache.spark.launcher.SparkLauncher#DEPRECATED_CHILD_CONNECTION_TIMEOUT`
[SPARK-33779](https://issues.apache.org/jira/browse/SPARK-33779)
  - `org.apache.spark.sql.connector.write.WriteBuilder#buildForBatch`
  - `org.apache.spark.sql.connector.write.WriteBuilder#buildForStreaming`
   
**Spark 3.4.0**

[SPARK-39805](https://issues.apache.org/jira/browse/SPARK-39805)
  - `org.apache.spark.sql.streaming.Trigger`
[SPARK-42398](https://issues.apache.org/jira/browse/SPARK-42398)
  - `org.apache.spark.sql.connector.catalog.TableCatalog#createTable(Identifier, StructType, Transform[], Map<String,String>) `
  - `org.apache.spark.sql.connector.catalog.StagingTableCatalog#stageCreate(Identifier, StructType, Transform[], Map<String,String>)`
  - `org.apache.spark.sql.connector.catalog.Table#schema`

### Why are the changes needed?
This facilitates tracing from which version the API started to be deprecated.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No
