### PR TITLE
[SPARK-45669][CORE] Ensure the continuity of rolling log index

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/EventLogFileWriters.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/EventLogFileWriters.scala
@@ -305,7 +305,7 @@ class RollingEventLogFilesWriter(
   private var countingOutputStream: Option[CountingOutputStream] = None
 
   // index and event log path will be updated soon in rollEventLogFile, which `start` will call
-  private var index: Long = 0L
+  private var index: Long = 1L
   private var currentEventLogFilePath: Path = _
 
   override def start(): Unit = {
@@ -340,7 +340,6 @@ class RollingEventLogFilesWriter(
   private[history] def rollEventLogFile(): Unit = {
     closeWriter()
 
-    index += 1
     currentEventLogFilePath = getEventLogFilePath(logDirForAppPath, appId, appAttemptId, index,
       compressionCodecName)
 
@@ -349,6 +348,7 @@ class RollingEventLogFilesWriter(
       new PrintWriter(
         new OutputStreamWriter(countingOutputStream.get, StandardCharsets.UTF_8))
     }
+    index += 1
   }
 
   override def stop(): Unit = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Ensure the continuity of rolling log index.


### Why are the changes needed?
Current the log file index will increment before running `initLogFile()`. When running `rollEventlogFile()`, the index will increment first, then create new log file to init event log writer.
 
If the log file creation fails, `initLogFile()` will throw an exception and stop running the method. The log file index will still increment next time `rollEventLogFile()` is called,
which will cause the file index to become discontinuous. EventLogFileReader can not read the event log files normally.
 
Therefore, we need to update the logic here to ensure the continuity of rolling log index.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existing unit test


### Was this patch authored or co-authored using generative AI tooling?
No
