### PR TITLE
[SPARK-45651][BUILD][FOLLOWUP] Reduce mvn -Xmx option to 2g in publish_snapshot workflow

### DIFF
--- a/.github/workflows/publish_snapshot.yml
+++ b/.github/workflows/publish_snapshot.yml
@@ -70,6 +70,7 @@ jobs:
         GPG_KEY: "not_used"
         GPG_PASSPHRASE: "not_used"
         GIT_REF: ${{ matrix.branch }}
+        MAVEN_MXM_OPT: 2g
       run: |
         while true
         do

--- a/dev/create-release/release-build.sh
+++ b/dev/create-release/release-build.sh
@@ -227,7 +227,7 @@ git clean -d -f -x
 rm -f .gitignore
 cd ..
 
-export MAVEN_OPTS="-Xss128m -Xmx12g -XX:ReservedCodeCacheSize=1g"
+export MAVEN_OPTS="-Xss128m -Xmx${MAVEN_MXM_OPT:-12g} -XX:ReservedCodeCacheSize=1g"
 
 if [[ "$1" == "package" ]]; then
   # Source and binary tarballs


### PR DESCRIPTION
### What changes were proposed in this pull request?
Limit max memory for `mvn clean deploy` to `2g` when run in `publish_snapshot` Github workflow.

### Why are the changes needed?
The host that runs the workflow has only 7G of memory, while the `release-build.sh` script sets the limit to 12g, causing the process to be killed (for branch `master`).

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Not tested

### Was this patch authored or co-authored using generative AI tooling?
No