### PR TITLE
[SPARK-45544][CORE] Integrate SSL support into TransportContext

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/TransportContext.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/TransportContext.java
@@ -23,13 +23,17 @@ import io.netty.handler.codec.MessageToMessageDecoder;
 import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.Nullable;
 
 import com.codahale.metrics.Counter;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.ssl.SslHandler;
+import io.netty.handler.stream.ChunkedWriteHandler;
 import io.netty.handler.timeout.IdleStateHandler;
+import io.netty.handler.codec.MessageToMessageEncoder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,6 +41,8 @@ import org.apache.spark.network.client.TransportClient;
 import org.apache.spark.network.client.TransportClientBootstrap;
 import org.apache.spark.network.client.TransportClientFactory;
 import org.apache.spark.network.client.TransportResponseHandler;
+import org.apache.spark.network.protocol.Message;
+import org.apache.spark.network.protocol.SslMessageEncoder;
 import org.apache.spark.network.protocol.MessageDecoder;
 import org.apache.spark.network.protocol.MessageEncoder;
 import org.apache.spark.network.server.ChunkFetchRequestHandler;
@@ -45,6 +51,7 @@ import org.apache.spark.network.server.TransportChannelHandler;
 import org.apache.spark.network.server.TransportRequestHandler;
 import org.apache.spark.network.server.TransportServer;
 import org.apache.spark.network.server.TransportServerBootstrap;
+import org.apache.spark.network.ssl.SSLFactory;
 import org.apache.spark.network.util.IOMode;
 import org.apache.spark.network.util.NettyUtils;
 import org.apache.spark.network.util.NettyLogger;
@@ -72,6 +79,8 @@ public class TransportContext implements Closeable {
   private final TransportConf conf;
   private final RpcHandler rpcHandler;
   private final boolean closeIdleConnections;
+  // Non-null if SSL is enabled, null otherwise.
+  @Nullable private final SSLFactory sslFactory;
   // Number of registered connections to the shuffle service
   private Counter registeredConnections = new Counter();
 
@@ -87,7 +96,8 @@ public class TransportContext implements Closeable {
    * RPC to load it and cause to load the non-exist matcher class again. JVM will report
    * `ClassCircularityError` to prevent such infinite recursion. (See SPARK-17714)
    */
-  private static final MessageEncoder ENCODER = MessageEncoder.INSTANCE;
+  private static final MessageToMessageEncoder<Message> ENCODER = MessageEncoder.INSTANCE;
+  private static final MessageToMessageEncoder<Message> SSL_ENCODER = SslMessageEncoder.INSTANCE;
   private static final MessageDecoder DECODER = MessageDecoder.INSTANCE;
 
   // Separate thread pool for handling ChunkFetchRequest. This helps to enable throttling
@@ -125,6 +135,7 @@ public class TransportContext implements Closeable {
     this.conf = conf;
     this.rpcHandler = rpcHandler;
     this.closeIdleConnections = closeIdleConnections;
+    this.sslFactory = createSslFactory();
 
     if (conf.getModuleName() != null &&
         conf.getModuleName().equalsIgnoreCase("shuffle") &&
@@ -171,8 +182,12 @@ public class TransportContext implements Closeable {
     return createServer(0, new ArrayList<>());
   }
 
-  public TransportChannelHandler initializePipeline(SocketChannel channel) {
-    return initializePipeline(channel, rpcHandler);
+  public TransportChannelHandler initializePipeline(SocketChannel channel, boolean isClient) {
+    return initializePipeline(channel, rpcHandler, isClient);
+  }
+
+  public boolean sslEncryptionEnabled() {
+    return this.sslFactory != null;
   }
 
   /**
@@ -189,15 +204,32 @@ public class TransportContext implements Closeable {
    */
   public TransportChannelHandler initializePipeline(
       SocketChannel channel,
-      RpcHandler channelRpcHandler) {
+      RpcHandler channelRpcHandler,
+      boolean isClient) {
     try {
       TransportChannelHandler channelHandler = createChannelHandler(channel, channelRpcHandler);
       ChannelPipeline pipeline = channel.pipeline();
+
       if (nettyLogger.getLoggingHandler() != null) {
         pipeline.addLast("loggingHandler", nettyLogger.getLoggingHandler());
       }
+
+      if (sslEncryptionEnabled()) {
+        SslHandler sslHandler;
+        try {
+          sslHandler = new SslHandler(
+            sslFactory.createSSLEngine(isClient, pipeline.channel().alloc()));
+        } catch (Exception e) {
+          throw new RuntimeException("Error creating Netty SslHandler", e);
+        }
+        pipeline.addFirst("NettySslEncryptionHandler", sslHandler);
+        // Cannot use zero-copy with HTTPS, so we add in our ChunkedWriteHandler just before the
+        // MessageEncoder
+        pipeline.addLast("chunkedWriter", new ChunkedWriteHandler());
+      }
+
       pipeline
-        .addLast("encoder", ENCODER)
+        .addLast("encoder", sslEncryptionEnabled()? SSL_ENCODER : ENCODER)
         .addLast(TransportFrameDecoder.HANDLER_NAME, NettyUtils.createFrameDecoder())
         .addLast("decoder", getDecoder())
         .addLast("idleStateHandler",
@@ -221,6 +253,33 @@ public class TransportContext implements Closeable {
 
   protected MessageToMessageDecoder<ByteBuf> getDecoder() {
     return DECODER;
+  }
+
+  private SSLFactory createSslFactory() {
+    if (conf.sslRpcEnabled()) {
+      if (conf.sslRpcEnabledAndKeysAreValid()) {
+        return new SSLFactory.Builder()
+          .openSslEnabled(conf.sslRpcOpenSslEnabled())
+          .requestedProtocol(conf.sslRpcProtocol())
+          .requestedCiphers(conf.sslRpcRequestedCiphers())
+          .keyStore(conf.sslRpcKeyStore(), conf.sslRpcKeyStorePassword())
+          .privateKey(conf.sslRpcPrivateKey())
+          .keyPassword(conf.sslRpcKeyPassword())
+          .certChain(conf.sslRpcCertChain())
+          .trustStore(
+            conf.sslRpcTrustStore(),
+            conf.sslRpcTrustStorePassword(),
+            conf.sslRpcTrustStoreReloadingEnabled(),
+            conf.sslRpctrustStoreReloadIntervalMs())
+          .build();
+      } else {
+        logger.error("RPC SSL encryption enabled but keys not found!" +
+          "Please ensure the configured keys are present.");
+        throw new RuntimeException("RPC SSL encryption enabled but keys not found!");
+      }
+    } else {
+      return null;
+    }
   }
 
   /**
@@ -254,6 +313,9 @@ public class TransportContext implements Closeable {
   public void close() {
     if (chunkFetchWorkers != null) {
       chunkFetchWorkers.shutdownGracefully();
+    }
+    if (sslFactory != null) {
+      sslFactory.destroy();
     }
   }
 }

--- a/common/network-common/src/main/java/org/apache/spark/network/TransportContext.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/TransportContext.java
@@ -209,7 +209,6 @@ public class TransportContext implements Closeable {
     try {
       TransportChannelHandler channelHandler = createChannelHandler(channel, channelRpcHandler);
       ChannelPipeline pipeline = channel.pipeline();
-
       if (nettyLogger.getLoggingHandler() != null) {
         pipeline.addLast("loggingHandler", nettyLogger.getLoggingHandler());
       }
@@ -217,8 +216,7 @@ public class TransportContext implements Closeable {
       if (sslEncryptionEnabled()) {
         SslHandler sslHandler;
         try {
-          sslHandler = new SslHandler(
-            sslFactory.createSSLEngine(isClient, pipeline.channel().alloc()));
+          sslHandler = new SslHandler(sslFactory.createSSLEngine(isClient, channel.alloc()));
         } catch (Exception e) {
           throw new RuntimeException("Error creating Netty SslHandler", e);
         }
@@ -275,7 +273,7 @@ public class TransportContext implements Closeable {
       } else {
         logger.error("RPC SSL encryption enabled but keys not found!" +
           "Please ensure the configured keys are present.");
-        throw new RuntimeException("RPC SSL encryption enabled but keys not found!");
+        throw new IllegalArgumentException("RPC SSL encryption enabled but keys not found!");
       }
     } else {
       return null;

--- a/common/network-common/src/main/java/org/apache/spark/network/TransportContext.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/TransportContext.java
@@ -218,7 +218,7 @@ public class TransportContext implements Closeable {
         try {
           sslHandler = new SslHandler(sslFactory.createSSLEngine(isClient, channel.alloc()));
         } catch (Exception e) {
-          throw new RuntimeException("Error creating Netty SslHandler", e);
+          throw new IllegalStateException("Error creating Netty SslHandler", e);
         }
         pipeline.addFirst("NettySslEncryptionHandler", sslHandler);
         // Cannot use zero-copy with HTTPS, so we add in our ChunkedWriteHandler just before the

--- a/common/network-common/src/main/java/org/apache/spark/network/client/TransportClientFactory.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/client/TransportClientFactory.java
@@ -39,6 +39,9 @@ import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.ssl.SslHandler;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.GenericFutureListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -268,7 +271,7 @@ public class TransportClientFactory implements Closeable {
     bootstrap.handler(new ChannelInitializer<SocketChannel>() {
       @Override
       public void initChannel(SocketChannel ch) {
-        TransportChannelHandler clientHandler = context.initializePipeline(ch);
+        TransportChannelHandler clientHandler = context.initializePipeline(ch, true);
         clientRef.set(clientHandler.getClient());
         channelRef.set(ch);
       }
@@ -292,6 +295,26 @@ public class TransportClientFactory implements Closeable {
           address, connCreateTimeout));
     } else if (cf.cause() != null) {
       throw new IOException(String.format("Failed to connect to %s", address), cf.cause());
+    }
+    if (context.sslEncryptionEnabled()) {
+      final SslHandler sslHandler = cf.channel().pipeline().get(SslHandler.class);
+      Future<Channel> future = sslHandler.handshakeFuture().addListener(
+        new GenericFutureListener<Future<Channel>>() {
+          @Override
+          public void operationComplete(final Future<Channel> handshakeFuture) {
+            if (handshakeFuture.isSuccess()) {
+              logger.debug("{} successfully completed TLS handshake to ", address);
+            } else {
+              if (logger.isDebugEnabled()) {
+                logger.debug(
+                  "failed to complete TLS handshake to " + address,
+                  handshakeFuture.cause());
+              }
+              cf.channel().close();
+            }
+          }
+      });
+      future.await(conf.connectionTimeoutMs());
     }
 
     TransportClient client = clientRef.get();

--- a/common/network-common/src/main/java/org/apache/spark/network/client/TransportClientFactory.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/client/TransportClientFactory.java
@@ -312,7 +312,6 @@ public class TransportClientFactory implements Closeable {
           }
       });
       if (!future.await(conf.connectionTimeoutMs())) {
-        logger.info("failed to connect to " + address + " within connection timeout");
         cf.channel().close();
         throw new IOException(
           String.format("Failed to connect to %s within connection timeout", address));

--- a/common/network-common/src/main/java/org/apache/spark/network/server/TransportServer.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/TransportServer.java
@@ -140,7 +140,7 @@ public class TransportServer implements Closeable {
         for (TransportServerBootstrap bootstrap : bootstraps) {
           rpcHandler = bootstrap.doBootstrap(ch, rpcHandler);
         }
-        context.initializePipeline(ch, rpcHandler);
+        context.initializePipeline(ch, rpcHandler, false);
       }
     });
 

--- a/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
@@ -402,14 +402,6 @@ public class TransportConf {
   }
 
   /**
-   * If we can dangerously fallback to unencrypted connections if RPC over SSL is enabled
-   * but the key files are not present
-   */
-  public boolean sslRpcDangerouslyFallbackIfKeysNotPresent() {
-    return conf.getBoolean("spark.ssl.rpc.dangerouslyFallbackIfKeysNotPresent", false);
-  }
-
-  /**
    * Flag indicating whether to share the pooled ByteBuf allocators between the different Netty
    * channels. If enabled then only two pooled ByteBuf allocators are created: one where caching
    * is allowed (for transport servers) and one where not (for transport clients).

--- a/common/network-common/src/test/java/org/apache/spark/network/ChunkFetchIntegrationSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/ChunkFetchIntegrationSuite.java
@@ -65,8 +65,13 @@ public class ChunkFetchIntegrationSuite {
   static ManagedBuffer bufferChunk;
   static ManagedBuffer fileChunk;
 
+  // This is split out so it can be invoked in a subclass with a different config
   @BeforeAll
   public static void setUp() throws Exception {
+    doSetUpWithConfig(new TransportConf("shuffle", MapConfigProvider.EMPTY));
+  }
+
+  public static void doSetUpWithConfig(final TransportConf conf) throws Exception {
     int bufSize = 100000;
     final ByteBuffer buf = ByteBuffer.allocate(bufSize);
     for (int i = 0; i < bufSize; i ++) {
@@ -88,7 +93,6 @@ public class ChunkFetchIntegrationSuite {
       Closeables.close(fp, shouldSuppressIOException);
     }
 
-    final TransportConf conf = new TransportConf("shuffle", MapConfigProvider.EMPTY);
     fileChunk = new FileSegmentManagedBuffer(conf, testFile, 10, testFile.length() - 25);
 
     streamManager = new StreamManager() {

--- a/common/network-common/src/test/java/org/apache/spark/network/SslChunkFetchIntegrationSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/SslChunkFetchIntegrationSuite.java
@@ -22,9 +22,7 @@ import java.nio.ByteBuffer;
 import java.util.Random;
 
 import com.google.common.io.Closeables;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/common/network-common/src/test/java/org/apache/spark/network/SslChunkFetchIntegrationSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/SslChunkFetchIntegrationSuite.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.network;
+
+import java.io.File;
+import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
+import java.util.Random;
+
+import com.google.common.io.Closeables;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.apache.spark.network.buffer.FileSegmentManagedBuffer;
+import org.apache.spark.network.buffer.ManagedBuffer;
+import org.apache.spark.network.buffer.NioManagedBuffer;
+import org.apache.spark.network.client.RpcResponseCallback;
+import org.apache.spark.network.client.TransportClient;
+import org.apache.spark.network.server.RpcHandler;
+import org.apache.spark.network.server.StreamManager;
+import org.apache.spark.network.util.TransportConf;
+import org.apache.spark.network.ssl.SslSampleConfigs;
+
+
+public class SslChunkFetchIntegrationSuite extends ChunkFetchIntegrationSuite {
+
+  @BeforeAll
+  public static void setUp() throws Exception {
+    int bufSize = 100000;
+    final ByteBuffer buf = ByteBuffer.allocate(bufSize);
+    for (int i = 0; i < bufSize; i ++) {
+      buf.put((byte) i);
+    }
+    buf.flip();
+    bufferChunk = new NioManagedBuffer(buf);
+
+    testFile = File.createTempFile("shuffle-test-file", "txt");
+    testFile.deleteOnExit();
+    RandomAccessFile fp = new RandomAccessFile(testFile, "rw");
+    boolean shouldSuppressIOException = true;
+    try {
+      byte[] fileContent = new byte[1024];
+      new Random().nextBytes(fileContent);
+      fp.write(fileContent);
+      shouldSuppressIOException = false;
+    } finally {
+      Closeables.close(fp, shouldSuppressIOException);
+    }
+
+    final TransportConf conf = new TransportConf(
+      "shuffle", SslSampleConfigs.createDefaultConfigProviderForRpcNamespace());
+    fileChunk = new FileSegmentManagedBuffer(conf, testFile, 10, testFile.length() - 25);
+
+    streamManager = new StreamManager() {
+      @Override
+      public ManagedBuffer getChunk(long streamId, int chunkIndex) {
+        assertEquals(STREAM_ID, streamId);
+        if (chunkIndex == BUFFER_CHUNK_INDEX) {
+          return new NioManagedBuffer(buf);
+        } else if (chunkIndex == FILE_CHUNK_INDEX) {
+          return new FileSegmentManagedBuffer(conf, testFile, 10, testFile.length() - 25);
+        } else {
+          throw new IllegalArgumentException("Invalid chunk index: " + chunkIndex);
+        }
+      }
+    };
+    RpcHandler handler = new RpcHandler() {
+      @Override
+      public void receive(
+          TransportClient client,
+          ByteBuffer message,
+          RpcResponseCallback callback) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public StreamManager getStreamManager() {
+        return streamManager;
+      }
+    };
+    context = new TransportContext(conf, handler);
+    server = context.createServer();
+    clientFactory = context.createClientFactory();
+  }
+}

--- a/common/network-common/src/test/java/org/apache/spark/network/client/SslTransportClientFactorySuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/client/SslTransportClientFactorySuite.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.network.client;
+
+import org.junit.jupiter.api.BeforeEach;
+
+import org.apache.spark.network.ssl.SslSampleConfigs;
+import org.apache.spark.network.server.NoOpRpcHandler;
+import org.apache.spark.network.server.RpcHandler;
+import org.apache.spark.network.util.TransportConf;
+import org.apache.spark.network.TransportContext;
+
+public class SslTransportClientFactorySuite extends TransportClientFactorySuite {
+
+  @BeforeEach
+  public void setUp() {
+    conf = new TransportConf(
+      "shuffle", SslSampleConfigs.createDefaultConfigProviderForRpcNamespace());
+    RpcHandler rpcHandler = new NoOpRpcHandler();
+    context = new TransportContext(conf, rpcHandler);
+    server1 = context.createServer();
+    server2 = context.createServer();
+  }
+}

--- a/common/network-common/src/test/java/org/apache/spark/network/client/TransportClientFactorySuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/client/TransportClientFactorySuite.java
@@ -44,10 +44,10 @@ import org.apache.spark.network.util.TransportConf;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class TransportClientFactorySuite {
-  private TransportConf conf;
-  private TransportContext context;
-  private TransportServer server1;
-  private TransportServer server2;
+  protected TransportConf conf;
+  protected TransportContext context;
+  protected TransportServer server1;
+  protected TransportServer server2;
 
   @BeforeEach
   public void setUp() {

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ShuffleTransportContext.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ShuffleTransportContext.java
@@ -53,8 +53,7 @@ import static org.apache.spark.network.util.NettyUtils.getRemoteAddress;
  * */
 public class ShuffleTransportContext extends TransportContext {
   private static final Logger logger = LoggerFactory.getLogger(ShuffleTransportContext.class);
-  @VisibleForTesting
-  protected static ShuffleMessageDecoder SHUFFLE_DECODER =
+  private static ShuffleMessageDecoder SHUFFLE_DECODER =
       new ShuffleMessageDecoder(MessageDecoder.INSTANCE);
   private final EventLoopGroup finalizeWorkers;
 
@@ -112,6 +111,11 @@ public class ShuffleTransportContext extends TransportContext {
   @Override
   protected MessageToMessageDecoder<ByteBuf> getDecoder() {
     return finalizeWorkers == null ? super.getDecoder() : SHUFFLE_DECODER;
+  }
+
+  @VisibleForTesting
+  protected static final void resetDecoderForTesting() {
+    SHUFFLE_DECODER = new ShuffleMessageDecoder(MessageDecoder.INSTANCE);
   }
 
   static class ShuffleMessageDecoder extends MessageToMessageDecoder<ByteBuf> {

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ShuffleTransportContext.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ShuffleTransportContext.java
@@ -20,9 +20,9 @@ package org.apache.spark.network.shuffle;
 import java.nio.ByteBuffer;
 import java.util.List;
 
-import com.google.common.annotations.VisibleForTesting;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.SimpleChannelInboundHandler;
@@ -113,11 +113,7 @@ public class ShuffleTransportContext extends TransportContext {
     return finalizeWorkers == null ? super.getDecoder() : SHUFFLE_DECODER;
   }
 
-  @VisibleForTesting
-  protected static final void resetDecoderForTesting() {
-    SHUFFLE_DECODER = new ShuffleMessageDecoder(MessageDecoder.INSTANCE);
-  }
-
+  @ChannelHandler.Sharable
   static class ShuffleMessageDecoder extends MessageToMessageDecoder<ByteBuf> {
 
     private final MessageDecoder delegate;

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ShuffleTransportContext.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ShuffleTransportContext.java
@@ -53,7 +53,7 @@ import static org.apache.spark.network.util.NettyUtils.getRemoteAddress;
  * */
 public class ShuffleTransportContext extends TransportContext {
   private static final Logger logger = LoggerFactory.getLogger(ShuffleTransportContext.class);
-  private static ShuffleMessageDecoder SHUFFLE_DECODER =
+  private static final ShuffleMessageDecoder SHUFFLE_DECODER =
       new ShuffleMessageDecoder(MessageDecoder.INSTANCE);
   private final EventLoopGroup finalizeWorkers;
 

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ShuffleTransportContext.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ShuffleTransportContext.java
@@ -20,6 +20,7 @@ package org.apache.spark.network.shuffle;
 import java.nio.ByteBuffer;
 import java.util.List;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
@@ -52,7 +53,8 @@ import static org.apache.spark.network.util.NettyUtils.getRemoteAddress;
  * */
 public class ShuffleTransportContext extends TransportContext {
   private static final Logger logger = LoggerFactory.getLogger(ShuffleTransportContext.class);
-  private static final ShuffleMessageDecoder SHUFFLE_DECODER =
+  @VisibleForTesting
+  protected static ShuffleMessageDecoder SHUFFLE_DECODER =
       new ShuffleMessageDecoder(MessageDecoder.INSTANCE);
   private final EventLoopGroup finalizeWorkers;
 
@@ -81,16 +83,16 @@ public class ShuffleTransportContext extends TransportContext {
   }
 
   @Override
-  public TransportChannelHandler initializePipeline(SocketChannel channel) {
-    TransportChannelHandler ch = super.initializePipeline(channel);
+  public TransportChannelHandler initializePipeline(SocketChannel channel, boolean isClient) {
+    TransportChannelHandler ch = super.initializePipeline(channel, isClient);
     addHandlerToPipeline(channel, ch);
     return ch;
   }
 
   @Override
   public TransportChannelHandler initializePipeline(SocketChannel channel,
-      RpcHandler channelRpcHandler) {
-    TransportChannelHandler ch = super.initializePipeline(channel, channelRpcHandler);
+      RpcHandler channelRpcHandler, boolean isClient) {
+    TransportChannelHandler ch = super.initializePipeline(channel, channelRpcHandler, isClient);
     addHandlerToPipeline(channel, ch);
     return ch;
   }

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalShuffleIntegrationSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalShuffleIntegrationSuite.java
@@ -32,7 +32,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 import org.apache.spark.network.buffer.FileSegmentManagedBuffer;
 import org.apache.spark.network.server.OneForOneStreamManager;
@@ -57,11 +56,11 @@ public class ExternalShuffleIntegrationSuite {
   private static final String APP_ID = "app-id";
   private static final String SORT_MANAGER = "org.apache.spark.shuffle.sort.SortShuffleManager";
 
-  private static final int RDD_ID = 1;
-  private static final int SPLIT_INDEX_VALID_BLOCK = 0;
+  protected static final int RDD_ID = 1;
+  protected static final int SPLIT_INDEX_VALID_BLOCK = 0;
   private static final int SPLIT_INDEX_MISSING_FILE = 1;
-  private static final int SPLIT_INDEX_CORRUPT_LENGTH = 2;
-  private static final int SPLIT_INDEX_VALID_BLOCK_TO_RM = 3;
+  protected static final int SPLIT_INDEX_CORRUPT_LENGTH = 2;
+  protected static final int SPLIT_INDEX_VALID_BLOCK_TO_RM = 3;
   private static final int SPLIT_INDEX_MISSING_BLOCK_TO_RM = 4;
 
   // Executor 0 is sort-based
@@ -86,6 +85,17 @@ public class ExternalShuffleIntegrationSuite {
     new byte[54321],
   };
 
+  private static TransportConf createTransportConf(String maxRetries, String rddEnabled) {
+    HashMap<String, String> config = new HashMap<>();
+    config.put("spark.shuffle.io.maxRetries", maxRetries);
+    config.put(Constants.SHUFFLE_SERVICE_FETCH_RDD_ENABLED, rddEnabled);
+    return new TransportConf("shuffle", new MapConfigProvider(config));
+  }
+
+  protected TransportConf createTransportConfForFetchNoServerTest() {
+    return createTransportConf("0", "false");
+  }
+
   @BeforeAll
   public static void beforeAll() throws IOException {
     Random rand = new Random();
@@ -105,10 +115,7 @@ public class ExternalShuffleIntegrationSuite {
     dataContext0.insertCachedRddData(RDD_ID, SPLIT_INDEX_VALID_BLOCK, exec0RddBlockValid);
     dataContext0.insertCachedRddData(RDD_ID, SPLIT_INDEX_VALID_BLOCK_TO_RM, exec0RddBlockToRemove);
 
-    HashMap<String, String> config = new HashMap<>();
-    config.put("spark.shuffle.io.maxRetries", "0");
-    config.put(Constants.SHUFFLE_SERVICE_FETCH_RDD_ENABLED, "true");
-    conf = new TransportConf("shuffle", new MapConfigProvider(config));
+    conf = createTransportConf("0", "true");
     handler = new ExternalBlockHandler(
       new OneForOneStreamManager(),
       new ExternalShuffleBlockResolver(conf, null) {
@@ -319,8 +326,7 @@ public class ExternalShuffleIntegrationSuite {
 
   @Test
   public void testFetchNoServer() throws Exception {
-    TransportConf clientConf = new TransportConf("shuffle",
-      new MapConfigProvider(ImmutableMap.of("spark.shuffle.io.maxRetries", "0")));
+    TransportConf clientConf = createTransportConfForFetchNoServerTest();
     registerExecutor("exec-0", dataContext0.createExecutorInfo(SORT_MANAGER));
     FetchResult execFetch = fetchBlocks("exec-0",
       new String[]{"shuffle_1_0_0", "shuffle_1_0_1"}, clientConf, 1 /* port */);

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalShuffleSecuritySuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalShuffleSecuritySuite.java
@@ -39,9 +39,18 @@ import org.apache.spark.network.util.TransportConf;
 
 public class ExternalShuffleSecuritySuite {
 
-  TransportConf conf = new TransportConf("shuffle", MapConfigProvider.EMPTY);
+  TransportConf conf = createTransportConf(false);
   TransportServer server;
   TransportContext transportContext;
+
+  protected TransportConf createTransportConf(boolean encrypt) {
+    if (encrypt) {
+      return new TransportConf("shuffle", new MapConfigProvider(
+        ImmutableMap.of("spark.authenticate.enableSaslEncryption", "true")));
+    } else {
+      return new TransportConf("shuffle", MapConfigProvider.EMPTY);
+    }
+  }
 
   @BeforeEach
   public void beforeEach() throws IOException {
@@ -92,8 +101,7 @@ public class ExternalShuffleSecuritySuite {
         throws IOException, InterruptedException {
     TransportConf testConf = conf;
     if (encrypt) {
-      testConf = new TransportConf("shuffle", new MapConfigProvider(
-        ImmutableMap.of("spark.authenticate.enableSaslEncryption", "true")));
+      testConf = createTransportConf(encrypt);
     }
 
     try (ExternalBlockStoreClient client =

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ShuffleTransportContextSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ShuffleTransportContextSuite.java
@@ -94,10 +94,6 @@ public class ShuffleTransportContextSuite {
     // SPARK-43987: test that the FinalizedHandler is added to the pipeline only when configured
     for (boolean enabled : new boolean[]{true, false}) {
       for (boolean client: new boolean[]{true, false}) {
-        // Since the decoder is not Shareable, reset it between test runs to avoid errors since it's
-        // used both across ShuffleTransportContextSuite and SslShuffleTransportContextSuite
-        // and server/clients
-        ShuffleTransportContext.resetDecoderForTesting();
         ShuffleTransportContext ctx = createShuffleTransportContext(enabled);
         SocketChannel channel = new NioSocketChannel();
         RpcHandler rpcHandler = mock(RpcHandler.class);

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ShuffleTransportContextSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ShuffleTransportContextSuite.java
@@ -40,7 +40,6 @@ import static org.mockito.Mockito.when;
 
 import org.apache.spark.network.buffer.NioManagedBuffer;
 import org.apache.spark.network.protocol.Message;
-import org.apache.spark.network.protocol.MessageDecoder;
 import org.apache.spark.network.protocol.MessageEncoder;
 import org.apache.spark.network.protocol.MessageWithHeader;
 import org.apache.spark.network.protocol.RpcRequest;
@@ -94,16 +93,15 @@ public class ShuffleTransportContextSuite {
   public void testInitializePipeline() throws IOException {
     // SPARK-43987: test that the FinalizedHandler is added to the pipeline only when configured
     for (boolean enabled : new boolean[]{true, false}) {
-      for (boolean isClient: new boolean[]{true, false}) {
+      for (boolean client: new boolean[]{true, false}) {
         // Since the decoder is not Shareable, reset it between test runs to avoid errors since it's
         // used both across ShuffleTransportContextSuite and SslShuffleTransportContextSuite
         // and server/clients
-        ShuffleTransportContext.SHUFFLE_DECODER = new ShuffleTransportContext.ShuffleMessageDecoder(
-          MessageDecoder.INSTANCE);
+        ShuffleTransportContext.resetDecoderForTesting();
         ShuffleTransportContext ctx = createShuffleTransportContext(enabled);
         SocketChannel channel = new NioSocketChannel();
         RpcHandler rpcHandler = mock(RpcHandler.class);
-        ctx.initializePipeline(channel, rpcHandler, isClient);
+        ctx.initializePipeline(channel, rpcHandler, client);
         String handlerName = ShuffleTransportContext.FinalizedHandler.HANDLER_NAME;
         if (enabled) {
           Assertions.assertNotNull(channel.pipeline().get(handlerName));

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/SslExternalShuffleIntegrationSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/SslExternalShuffleIntegrationSuite.java
@@ -17,17 +17,11 @@
 
 package org.apache.spark.network.shuffle;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
-import java.util.Random;
 
 import org.junit.jupiter.api.BeforeAll;
 
-import org.apache.spark.network.buffer.FileSegmentManagedBuffer;
-import org.apache.spark.network.buffer.ManagedBuffer;
-import org.apache.spark.network.server.OneForOneStreamManager;
-import org.apache.spark.network.TransportContext;
 import org.apache.spark.network.util.TransportConf;
 import org.apache.spark.network.ssl.SslSampleConfigs;
 

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/SslExternalShuffleIntegrationSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/SslExternalShuffleIntegrationSuite.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.network.shuffle;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Random;
+
+import org.junit.jupiter.api.BeforeAll;
+
+import org.apache.spark.network.buffer.FileSegmentManagedBuffer;
+import org.apache.spark.network.buffer.ManagedBuffer;
+import org.apache.spark.network.server.OneForOneStreamManager;
+import org.apache.spark.network.TransportContext;
+import org.apache.spark.network.util.TransportConf;
+import org.apache.spark.network.ssl.SslSampleConfigs;
+
+public class SslExternalShuffleIntegrationSuite extends ExternalShuffleIntegrationSuite {
+
+  private static TransportConf createTransportConf(String maxRetries, String rddEnabled) {
+    HashMap<String, String> config = new HashMap<>();
+    config.put("spark.shuffle.io.maxRetries", maxRetries);
+    config.put(Constants.SHUFFLE_SERVICE_FETCH_RDD_ENABLED, rddEnabled);
+    return new TransportConf(
+      "shuffle",
+      SslSampleConfigs.createDefaultConfigProviderForRpcNamespaceWithAdditionalEntries(config)
+    );
+  }
+
+  @Override
+  protected TransportConf createTransportConfForFetchNoServerTest() {
+    return createTransportConf("0", "false");
+  }
+
+  @BeforeAll
+  public static void beforeAll() throws IOException {
+    Random rand = new Random();
+
+    for (byte[] block : exec0Blocks) {
+      rand.nextBytes(block);
+    }
+    for (byte[] block: exec1Blocks) {
+      rand.nextBytes(block);
+    }
+    rand.nextBytes(exec0RddBlockValid);
+    rand.nextBytes(exec0RddBlockToRemove);
+
+    dataContext0 = new TestShuffleDataContext(2, 5);
+    dataContext0.create();
+    dataContext0.insertSortShuffleData(0, 0, exec0Blocks);
+    dataContext0.insertCachedRddData(RDD_ID, SPLIT_INDEX_VALID_BLOCK, exec0RddBlockValid);
+    dataContext0.insertCachedRddData(RDD_ID, SPLIT_INDEX_VALID_BLOCK_TO_RM, exec0RddBlockToRemove);
+
+    conf = createTransportConf("0", "true");
+    handler = new ExternalBlockHandler(
+      new OneForOneStreamManager(),
+      new ExternalShuffleBlockResolver(conf, null) {
+        @Override
+        public ManagedBuffer getRddBlockData(String appId, String execId, int rddId, int splitIdx) {
+          ManagedBuffer res;
+          if (rddId == RDD_ID) {
+            switch (splitIdx) {
+              case SPLIT_INDEX_CORRUPT_LENGTH:
+                res = new FileSegmentManagedBuffer(
+                  conf, new File("missing.file"), 0, 12);
+                break;
+              default:
+                res = super.getRddBlockData(appId, execId, rddId, splitIdx);
+            }
+          } else {
+            res = super.getRddBlockData(appId, execId, rddId, splitIdx);
+          }
+          return res;
+        }
+    });
+    transportContext = new TransportContext(conf, handler);
+    server = transportContext.createServer();
+  }
+}

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/SslExternalShuffleSecuritySuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/SslExternalShuffleSecuritySuite.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.network.shuffle;
+
+import com.google.common.collect.ImmutableMap;
+
+import org.apache.spark.network.ssl.SslSampleConfigs;
+import org.apache.spark.network.util.TransportConf;
+
+public class SslExternalShuffleSecuritySuite extends ExternalShuffleSecuritySuite {
+
+  @Override
+  protected TransportConf createTransportConf(boolean encrypt) {
+    if (encrypt) {
+      return new TransportConf(
+        "shuffle",
+        SslSampleConfigs.createDefaultConfigProviderForRpcNamespaceWithAdditionalEntries(
+          ImmutableMap.of(
+          "spark.authenticate.enableSaslEncryption",
+          "true")
+        )
+      );
+    } else {
+      return new TransportConf(
+        "shuffle",
+        SslSampleConfigs.createDefaultConfigProviderForRpcNamespace()
+      );
+    }
+  }
+}

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/SslShuffleTransportContextSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/SslShuffleTransportContextSuite.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.network.shuffle;
+
+import com.google.common.collect.ImmutableMap;
+
+import org.apache.spark.network.ssl.SslSampleConfigs;
+import org.apache.spark.network.util.TransportConf;
+
+public class SslShuffleTransportContextSuite extends ShuffleTransportContextSuite {
+
+  @Override
+  protected TransportConf createTransportConf(boolean separateFinalizeThread) {
+    return new TransportConf(
+      "shuffle",
+      SslSampleConfigs.createDefaultConfigProviderForRpcNamespaceWithAdditionalEntries(
+        ImmutableMap.of(
+          "spark.shuffle.server.finalizeShuffleMergeThreadsPercent",
+          separateFinalizeThread ? "1" : "0")
+      )
+    );
+  }
+}

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/network/yarn/SslYarnShuffleServiceSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/network/yarn/SslYarnShuffleServiceSuite.scala
@@ -28,7 +28,7 @@ class SslYarnShuffleServiceWithRocksDBBackendSuite
   override def beforeEach(): Unit = {
     super.beforeEach()
     // Same as SSLTestUtils.updateWithSSLConfig(), which is not available to import here.
-    SslSampleConfigs.createDefaultConfigMap().entrySet().
+    SslSampleConfigs.createDefaultConfigMapForRpcNamespace().entrySet().
       forEach(entry => yarnConfig.set(entry.getKey, entry.getValue))
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This integrates SSL support into TransportContext and related modules so that the RPC SSL functionality can work when properly configured.

### Why are the changes needed?

This is needed in order to support SSL for RPC connections.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

CI

Ran the following tests:

```
build/sbt -P yarn
> project network-common
> testOnly
> project network-shuffle
> testOnly
> project core
> testOnly *Ssl*
> project yarn
> testOnly org.apache.spark.network.yarn.SslYarnShuffleServiceWithRocksDBBackendSuite
```

I verified traffic was encrypted using TLS using two mechanisms:

* Enabled trace level logging for Netty and JDK SSL and saw logs confirming TLS handshakes were happening
* I ran wireshark on my machine and snooped on traffic while sending queries shuffling a fixed string. Without any encryption, I could find that string in the network traffic. With this encryption enabled, that string did not show up, and wireshark logs confirmed a TLS handshake was happening.

### Was this patch authored or co-authored using generative AI tooling?

No