### PR TITLE
[SPARK-45698][CORE][SQL][SS] Clean up the deprecated API usage related to `Buffer`

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -1042,7 +1042,7 @@ private[deploy] class Master(
         completedApps.take(toRemove).foreach { a =>
           applicationMetricsSystem.removeSource(a.appSource)
         }
-        completedApps.trimStart(toRemove)
+        completedApps.dropInPlace(toRemove)
       }
       completedApps += app // Remember it in our history
       waitingApps -= app
@@ -1204,7 +1204,7 @@ private[deploy] class Master(
         drivers -= driver
         if (completedDrivers.size >= retainedDrivers) {
           val toRemove = math.max(retainedDrivers / 10, 1)
-          completedDrivers.trimStart(toRemove)
+          completedDrivers.dropInPlace(toRemove)
         }
         completedDrivers += driver
         persistenceEngine.removeDriver(driver)

--- a/core/src/main/scala/org/apache/spark/util/SizeEstimator.scala
+++ b/core/src/main/scala/org/apache/spark/util/SizeEstimator.scala
@@ -180,7 +180,7 @@ object SizeEstimator extends Logging {
 
     def dequeue(): AnyRef = {
       val elem = stack.last
-      stack.trimEnd(1)
+      stack.dropRightInPlace(1)
       elem
     }
   }

--- a/core/src/main/scala/org/apache/spark/util/collection/ExternalAppendOnlyMap.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/ExternalAppendOnlyMap.scala
@@ -362,7 +362,7 @@ class ExternalAppendOnlyMap[K, V, C](
     private def removeFromBuffer[T](buffer: ArrayBuffer[T], index: Int): T = {
       val elem = buffer(index)
       buffer(index) = buffer(buffer.size - 1)  // This also works if index == buffer.size - 1
-      buffer.trimEnd(1)
+      buffer.dropRightInPlace(1)
       elem
     }
 

--- a/core/src/test/scala/org/apache/spark/deploy/IvyTestUtils.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/IvyTestUtils.scala
@@ -316,7 +316,7 @@ private[deploy] object IvyTestUtils {
       }
       if (withR) {
         val rFiles = createRFiles(root, className, artifact.groupId)
-        allFiles.append(rFiles: _*)
+        allFiles.appendAll(rFiles)
       }
       val jarFile = packJar(jarPath, artifact, allFiles.toSeq, useIvyLayout, withR)
       assert(jarFile.exists(), "Problem creating Jar file")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlan.scala
@@ -536,13 +536,13 @@ abstract class SparkPlan extends QueryPlan[SparkPlan] with Logging with Serializ
         while (buf.length < n && i < res.length) {
           val rows = decodeUnsafeRows(res(i)._2)
           if (n - buf.length >= res(i)._1) {
-            buf.prepend(rows.toArray[InternalRow]: _*)
+            buf.prependAll(rows.toArray[InternalRow])
           } else {
             val dropUntil = res(i)._1 - (n - buf.length)
             // Same as Iterator.drop but this only takes a long.
             var j: Long = 0L
             while (j < dropUntil) { rows.next(); j += 1L}
-            buf.prepend(rows.toArray[InternalRow]: _*)
+            buf.prependAll(rows.toArray[InternalRow])
           }
           i += 1
         }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/arrow/ArrowConverters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/arrow/ArrowConverters.scala
@@ -315,7 +315,7 @@ private[sql] object ArrowConverters extends Logging {
       val reader =
         new ArrowStreamReader(new ByteArrayInputStream(arrowBatchIter.next()), allocator)
       val root = if (reader.loadNextBatch()) reader.getVectorSchemaRoot else null
-      resources.append(reader, root)
+      resources.append(reader).append(root)
       if (root == null) {
         (Iterator.empty, null)
       } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/arrow/ArrowConverters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/arrow/ArrowConverters.scala
@@ -315,7 +315,7 @@ private[sql] object ArrowConverters extends Logging {
       val reader =
         new ArrowStreamReader(new ByteArrayInputStream(arrowBatchIter.next()), allocator)
       val root = if (reader.loadNextBatch()) reader.getVectorSchemaRoot else null
-      resources.append(reader).append(root)
+      resources.appendAll(Seq(reader, root))
       if (root == null) {
         (Iterator.empty, null)
       } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/ContinuousTextSocketSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/ContinuousTextSocketSource.scala
@@ -144,7 +144,7 @@ class TextSocketContinuousStream(
           " for partition " + partition + ". Max valid offset: " + max)
         }
         val n = offset - startOffset.offsets(partition)
-        buckets(partition).trimStart(n)
+        buckets(partition).dropInPlace(n)
     }
     startOffset = endOffset
     recordEndpoint.setStartOffsets(startOffset.offsets)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/memory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/memory.scala
@@ -279,7 +279,7 @@ case class MemoryStream[A : Encoder](
         s"Offsets committed out of order: $lastOffsetCommitted followed by $end")
     }
 
-    batches.trimStart(offsetDiff)
+    batches.dropInPlace(offsetDiff)
     lastOffsetCommitted = newOffset
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/TextSocketMicroBatchStream.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/TextSocketMicroBatchStream.scala
@@ -159,7 +159,7 @@ class TextSocketMicroBatchStream(host: String, port: Int, numPartitions: Int)
         s"Offsets committed out of order: $lastOffsetCommitted followed by $end")
     }
 
-    batches.trimStart(offsetDiff)
+    batches.dropInPlace(offsetDiff)
     lastOffsetCommitted = newOffset
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
@@ -756,10 +756,10 @@ class JoinSuite extends QueryTest with SharedSparkSession with AdaptiveSparkPlan
       }
 
       val expected = new ListBuffer[Row]()
-      expected.append(
+      expected.appendAll(Seq(
         Row(1, "1", 1, 1), Row(1, "1", 1, 2),
         Row(2, "2", 2, 1), Row(2, "2", 2, 2),
-        Row(3, "3", 3, 1), Row(3, "3", 3, 2)
+        Row(3, "3", 3, 1), Row(3, "3", 3, 2))
       )
       for (i <- 4 to 100) {
         expected.append(Row(i, i.toString, null, null))
@@ -830,10 +830,10 @@ class JoinSuite extends QueryTest with SharedSparkSession with AdaptiveSparkPlan
       }
 
       val expected = new ListBuffer[Row]()
-      expected.append(
+      expected.appendAll(Seq(
         Row(1, "1", 1, 1), Row(1, "1", 1, 2),
         Row(2, "2", 2, 1), Row(2, "2", 2, 2),
-        Row(3, "3", 3, 1), Row(3, "3", 3, 2)
+        Row(3, "3", 3, 1), Row(3, "3", 3, 2))
       )
       for (i <- 4 to 100) {
         expected.append(Row(i, i.toString, null, null))


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR cleans up the use of the following APIs in `s.c.mutable.Buffer`, as they have been deprecated after Scala 2.13.0 or Scala 2.13.4:

- `trimStart` -> `dropInPlace`
- `trimEnd` -> `dropRightInPlace`
- `append(elems: A*)` -> `appendAll`
- `prepend(elems: A*)` -> `prependAll(elems)`


```
  @deprecated("use dropInPlace instead", since = "2.13.4")
  def trimStart(n: Int): Unit = dropInPlace(n)

  @deprecated("use dropRightInPlace instead", since = "2.13.4")
  def trimEnd(n: Int): Unit = dropRightInPlace(n)

  @deprecated("Use appendAll instead", "2.13.0")
  @`inline` final def append(elems: A*): this.type = addAll(elems)

  @deprecated("Use prependAll instead", "2.13.0")
  @`inline` final def prepend(elems: A*): this.type = prependAll(elems)
```

### Why are the changes needed?
Clean up deprecated API usage.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Acitons.

### Was this patch authored or co-authored using generative AI tooling?
No