### PR TITLE
[SPARK-45707][SQL] Simplify `DataFrameStatFunctions.countMinSketch` with `CountMinSketchAgg`

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameStatSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameStatSuite.scala
@@ -508,7 +508,7 @@ class DataFrameStatSuite extends QueryTest with SharedSparkSession {
     assert(sketch4.relativeError() === 0.001 +- 1e04)
     assert(sketch4.confidence() === 0.99 +- 5e-3)
 
-    intercept[IllegalArgumentException] {
+    intercept[AnalysisException] {
       df.select($"id" cast DoubleType as "id")
         .stat
         .countMinSketch($"id", depth = 10, width = 20, seed = 42)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Simplify `DataFrameStatFunctions.countMinSketch` with `CountMinSketchAgg`


### Why are the changes needed?
to make it consistent with sql functions


### Does this PR introduce _any_ user-facing change?

better error messages: `IllegalArgumentException` -> `AnalysisException`


### How was this patch tested?
ci

### Was this patch authored or co-authored using generative AI tooling?
no
