### PR TITLE
[SPARK-45709][BUILD] Deploy packages when all packages are built

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3301,6 +3301,9 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-deploy-plugin</artifactId>
           <version>3.1.1</version>
+          <configuration>
+            <deployAtEnd>true</deployAtEnd>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Packages are deployed after all packages have been built. Currently, individual packages are deployed once they are built.

### Why are the changes needed?
When some package fails to build (SPARK_45651), earlier packages have been published already, leading to an inconsistent set of latest snapshots, which might cause `ClassNotFoundExceptions` like in https://github.com/apache/spark/pull/43102#issuecomment-1759541718. Packages should only be published once all have been built.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Locally: `./build/mvn deploy` builds all packages before it attempts to upload any.

### Was this patch authored or co-authored using generative AI tooling?
No