### PR TITLE
[SPARK-45684][SQL][SS][ML] Clean up the deprecated API usage related to `SeqOps`

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -672,7 +672,7 @@ class LogisticRegression @Since("1.2.0") (
       denseCoefficientMatrix.foreachActive { case (i, j, v) =>
         centers(j) += v
       }
-      centers.transform(_ / numCoefficientSets)
+      centers.mapInPlace(_ / numCoefficientSets)
       denseCoefficientMatrix.foreachActive { case (i, j, v) =>
         denseCoefficientMatrix.update(i, j, v - centers(j))
       }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -1835,7 +1835,7 @@ class AstBuilder extends DataTypeAstBuilder with SQLConfHelper with Logging {
 
     // Reverse the contexts to have them in the same sequence as in the SQL statement & turn them
     // into expressions.
-    val expressions = contexts.reverseMap(expression)
+    val expressions = contexts.reverseIterator.map(expression).to(ArrayBuffer)
 
     // Create a balanced tree.
     def reduceToExpressionTree(low: Int, high: Int): Expression = high - low match {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/QueryExecutionMetering.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/QueryExecutionMetering.scala
@@ -86,7 +86,7 @@ case class QueryExecutionMetering() {
     val colRunTime = "Effective Time / Total Time".padTo(len = 47, " ").mkString
     val colNumRuns = "Effective Runs / Total Runs".padTo(len = 47, " ").mkString
 
-    val ruleMetrics = map.toSeq.sortBy(_._2).reverseMap { case (name, time) =>
+    val ruleMetrics = map.toSeq.sortBy(_._2).reverseIterator.map { case (name, time) =>
       val timeEffectiveRun = timeEffectiveRunsMap.get(name)
       val numRuns = numRunsMap.get(name)
       val numEffectiveRun = numEffectiveRunsMap.get(name)

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
@@ -174,7 +174,7 @@ class StreamSuite extends StreamTest {
         try {
           query.processAllAvailable()
           val outputDf = spark.read.parquet(outputDir.getAbsolutePath).as[Long]
-          checkDatasetUnorderly[Long](outputDf, (0L to 10L).union((0L to 10L)).toArray: _*)
+          checkDatasetUnorderly[Long](outputDf, (0L to 10L).concat(0L to 10L): _*)
         } finally {
           query.stop()
         }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr clean up deprecated API usage related to `SeqOps` after Scala 2.13,

- `transform` -> `mapInPlace`
- `reverseMap` -> `.reverseIterator.map(f).to(...)`
- `union` -> `concat`

the changes are refer to 

```
  @deprecated("Use `mapInPlace` on an `IndexedSeq` instead", "2.13.0")
  @`inline`final def transform(f: A => A): this.type = {
    var i = 0
    val siz = size
    while (i < siz) { this(i) = f(this(i)); i += 1 }
    this
  }

  @deprecated("Use .reverseIterator.map(f).to(...) instead of .reverseMap(f)", "2.13.0")
  def reverseMap[B](f: A => B): CC[B] = iterableFactory.from(new View.Map(View.fromIteratorProvider(() => reverseIterator), f))

  @deprecated("Use `concat` instead", "2.13.0")
  @inline final def union[B >: A](that: Seq[B]): CC[B] = concat(that)
```



### Why are the changes needed?
Clean up deprecated Scala API usage


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No