### PR TITLE
[SPARK-45713][PYTHON] Support registering Python data sources

### DIFF
--- a/common/utils/src/main/resources/error/error-classes.json
+++ b/common/utils/src/main/resources/error/error-classes.json
@@ -812,6 +812,12 @@
     ],
     "sqlState" : "42K01"
   },
+  "DATA_SOURCE_ALREADY_EXISTS" : {
+    "message" : [
+      "Data source '<provider>' already exists in the registry. Please use a different name for the new data source."
+    ],
+    "sqlState" : "42710"
+  },
   "DATA_SOURCE_NOT_FOUND" : {
     "message" : [
       "Failed to find the data source: <provider>. Please find packages at `https://spark.apache.org/third-party-projects.html`."
@@ -2774,7 +2780,7 @@
   },
   "PYTHON_DATA_SOURCE_FAILED_TO_PLAN_IN_PYTHON" : {
     "message" : [
-      "Failed to plan Python data source <type> in Python: <msg>"
+      "Failed to <action> Python data source <type> in Python: <msg>"
     ],
     "sqlState" : "38000"
   },

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/CheckConnectJvmClientCompatibility.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/CheckConnectJvmClientCompatibility.scala
@@ -177,6 +177,7 @@ object CheckConnectJvmClientCompatibility {
         "org.apache.spark.sql.SparkSessionExtensionsProvider"),
       ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.sql.UDTFRegistration"),
       ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.sql.UDFRegistration$"),
+      ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.sql.DataSourceRegistration"),
 
       // DataFrame Reader & Writer
       ProblemFilters.exclude[Problem]("org.apache.spark.sql.DataFrameReader.json"), // rdd
@@ -227,6 +228,7 @@ object CheckConnectJvmClientCompatibility {
       ProblemFilters.exclude[Problem]("org.apache.spark.sql.SparkSession.listenerManager"),
       ProblemFilters.exclude[Problem]("org.apache.spark.sql.SparkSession.experimental"),
       ProblemFilters.exclude[Problem]("org.apache.spark.sql.SparkSession.udtf"),
+      ProblemFilters.exclude[Problem]("org.apache.spark.sql.SparkSession.dataSource"),
       ProblemFilters.exclude[Problem]("org.apache.spark.sql.SparkSession.createDataFrame"),
       ProblemFilters.exclude[Problem](
         "org.apache.spark.sql.SparkSession.baseRelationToDataFrame"),

--- a/python/pyspark/sql/datasource.py
+++ b/python/pyspark/sql/datasource.py
@@ -14,17 +14,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import sys
+
 from abc import ABC, abstractmethod
-from typing import Any, Dict, Iterator, Tuple, Union, TYPE_CHECKING
+from typing import final, Any, Dict, Iterator, List, Optional, Tuple, Type, Union, TYPE_CHECKING
 
 from pyspark.sql import Row
 from pyspark.sql.types import StructType
 
 if TYPE_CHECKING:
     from pyspark.sql._typing import OptionalPrimitiveType
+    from pyspark.sql.session import SparkSession
 
 
-__all__ = ["DataSource", "DataSourceReader"]
+__all__ = ["DataSource", "DataSourceReader", "DataSourceRegistration"]
 
 
 class DataSource(ABC):
@@ -41,23 +44,35 @@ class DataSource(ABC):
     ``spark.read.format(...).load()`` and save data using ``df.write.format(...).save()``.
     """
 
-    def __init__(self, options: Dict[str, "OptionalPrimitiveType"]):
+    @final
+    def __init__(
+        self,
+        paths: List[str],
+        userSpecifiedSchema: Optional[StructType],
+        options: Dict[str, "OptionalPrimitiveType"],
+    ) -> None:
         """
-        Initializes the data source with user-provided options.
+        Initializes the data source with user-provided information.
 
         Parameters
         ----------
+        paths : list
+            A list of paths to the data source.
+        userSpecifiedSchema : StructType, optional
+            The user-specified schema of the data source.
         options : dict
             A dictionary representing the options for this data source.
 
         Notes
         -----
-        This method should not contain any non-serializable objects.
+        This method should not be overridden.
         """
+        self.paths = paths
+        self.userSpecifiedSchema = userSpecifiedSchema
         self.options = options
 
-    @property
-    def name(self) -> str:
+    @classmethod
+    def name(cls) -> str:
         """
         Returns a string represents the format name of this data source.
 
@@ -66,20 +81,21 @@ class DataSource(ABC):
 
         Examples
         --------
-        >>> def name(self):
+        >>> def name(cls):
         ...     return "my_data_source"
         """
-        return self.__class__.__name__
+        return cls.__name__
 
     def schema(self) -> Union[StructType, str]:
         """
         Returns the schema of the data source.
 
-        It can reference the ``options`` field to infer the data source's schema when
-        users do not explicitly specify it. This method is invoked once when calling
-        ``spark.read.format(...).load()`` to get the schema for a data source read
-        operation. If this method is not implemented, and a user does not provide a
-        schema when reading the data source, an exception will be thrown.
+        It can refer any field initialized in the ``__init__`` method to infer the
+        data source's schema when users do not explicitly specify it. This method is
+        invoked once when calling ``spark.read.format(...).load()`` to get the schema
+        for a data source read operation. If this method is not implemented, and a
+        user does not provide a schema when reading the data source, an exception will
+        be thrown.
 
         Returns
         -------
@@ -212,3 +228,44 @@ class DataSourceReader(ABC):
         ...     yield Row(partition=partition, value=1)
         """
         ...
+
+
+class DataSourceRegistration:
+    def __init__(self, sparkSession: "SparkSession"):
+        self.sparkSession = sparkSession
+
+    def register(
+        self,
+        dataSource: Type["DataSource"],
+    ) -> None:
+        """Register a Python user-defined data source."""
+        from pyspark.sql.udf import _wrap_function
+
+        name = dataSource.name()
+        sc = self.sparkSession.sparkContext
+        wrapped = _wrap_function(sc, dataSource)
+        assert sc._jvm is not None
+        ds = sc._jvm.org.apache.spark.sql.execution.python.UserDefinedPythonDataSource(wrapped)
+        self.sparkSession._jsparkSession.dataSource().registerPython(name, ds)
+
+
+def _test() -> None:
+    import doctest
+    from pyspark.sql import SparkSession
+    import pyspark.sql.udf
+
+    globs = pyspark.sql.datasource.__dict__.copy()
+    spark = SparkSession.builder.master("local[4]").appName("sql.datasource tests").getOrCreate()
+    globs["spark"] = spark
+    (failure_count, test_count) = doctest.testmod(
+        pyspark.sql.datasource,
+        globs=globs,
+        optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE,
+    )
+    spark.stop()
+    if failure_count:
+        sys.exit(-1)
+
+
+if __name__ == "__main__":
+    _test()

--- a/python/pyspark/sql/datasource.py
+++ b/python/pyspark/sql/datasource.py
@@ -17,6 +17,7 @@
 from abc import ABC, abstractmethod
 from typing import final, Any, Dict, Iterator, List, Optional, Tuple, Type, Union, TYPE_CHECKING
 
+from pyspark import since
 from pyspark.sql import Row
 from pyspark.sql.types import StructType
 
@@ -40,8 +41,6 @@ class DataSource(ABC):
 
     After implementing this interface, you can start to load your data source using
     ``spark.read.format(...).load()`` and save data using ``df.write.format(...).save()``.
-
-    .. versionadded:: 4.0.0
     """
 
     @final
@@ -139,8 +138,6 @@ class DataSourceReader(ABC):
     """
     A base class for data source readers. Data source readers are responsible for
     outputting data from a data source.
-
-    .. versionadded:: 4.0.0
     """
 
     def partitions(self) -> Iterator[Any]:
@@ -232,12 +229,11 @@ class DataSourceReader(ABC):
         ...
 
 
+@since(4.0)
 class DataSourceRegistration:
     """
     Wrapper for data source registration. This instance can be accessed by
     :attr:`spark.dataSource`.
-
-    .. versionadded:: 4.0.0
     """
 
     def __init__(self, sparkSession: "SparkSession"):
@@ -248,8 +244,6 @@ class DataSourceRegistration:
         dataSource: Type["DataSource"],
     ) -> None:
         """Register a Python user-defined data source.
-
-        .. versionadded:: 4.0.0
 
         Parameters
         ----------

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -74,6 +74,7 @@ if TYPE_CHECKING:
     from pyspark.sql.streaming import StreamingQueryManager
     from pyspark.sql.udf import UDFRegistration
     from pyspark.sql.udtf import UDTFRegistration
+    from pyspark.sql.datasource import DataSourceRegistration
 
     # Running MyPy type checks will always require pandas and
     # other dependencies so importing here is fine.
@@ -862,6 +863,20 @@ class SparkSession(SparkConversionMixin):
         from pyspark.sql.udtf import UDTFRegistration
 
         return UDTFRegistration(self)
+
+    @property
+    def dataSource(self) -> "DataSourceRegistration":
+        """Returns a :class:`DataSourceRegistration` for data source registration.
+
+        .. versionadded:: 4.0.0
+
+        Returns
+        -------
+        :class:`DataSourceRegistration`
+        """
+        from pyspark.sql.datasource import DataSourceRegistration
+
+        return DataSourceRegistration(self)
 
     def range(
         self,

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -40,7 +40,7 @@ from typing import (
 
 from py4j.java_gateway import JavaObject
 
-from pyspark import SparkConf, SparkContext
+from pyspark import since, SparkConf, SparkContext
 from pyspark.rdd import RDD
 from pyspark.sql.column import _to_java_column
 from pyspark.sql.conf import RuntimeConfig
@@ -865,6 +865,7 @@ class SparkSession(SparkConversionMixin):
         return UDTFRegistration(self)
 
     @property
+    @since(4.0)
     def dataSource(self) -> "DataSourceRegistration":
         """Returns a :class:`DataSourceRegistration` for data source registration.
 

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -40,7 +40,7 @@ from typing import (
 
 from py4j.java_gateway import JavaObject
 
-from pyspark import since, SparkConf, SparkContext
+from pyspark import SparkConf, SparkContext
 from pyspark.rdd import RDD
 from pyspark.sql.column import _to_java_column
 from pyspark.sql.conf import RuntimeConfig
@@ -865,7 +865,6 @@ class SparkSession(SparkConversionMixin):
         return UDTFRegistration(self)
 
     @property
-    @since(4.0)
     def dataSource(self) -> "DataSourceRegistration":
         """Returns a :class:`DataSourceRegistration` for data source registration.
 

--- a/python/pyspark/sql/tests/test_python_datasource.py
+++ b/python/pyspark/sql/tests/test_python_datasource.py
@@ -26,9 +26,9 @@ class BasePythonDataSourceTestsMixin:
             ...
 
         options = dict(a=1, b=2)
-        ds = MyDataSource(options)
+        ds = MyDataSource(paths=[], userSpecifiedSchema=None, options=options)
         self.assertEqual(ds.options, options)
-        self.assertEqual(ds.name, "MyDataSource")
+        self.assertEqual(ds.name(), "MyDataSource")
         with self.assertRaises(NotImplementedError):
             ds.schema()
         with self.assertRaises(NotImplementedError):
@@ -42,6 +42,18 @@ class BasePythonDataSourceTestsMixin:
         reader = MyDataSourceReader()
         self.assertEqual(list(reader.partitions()), [None])
         self.assertEqual(list(reader.read(None)), [(None,)])
+
+    def test_register_data_source(self):
+        class MyDataSource(DataSource):
+            ...
+
+        self.spark.dataSource.register(MyDataSource)
+
+        self.assertTrue(
+            self.spark._jsparkSession.sharedState()
+            .dataSourceRegistry()
+            .dataSourceExists("MyDataSource")
+        )
 
 
 class PythonDataSourceTests(BasePythonDataSourceTestsMixin, ReusedSQLTestCase):

--- a/python/pyspark/sql/worker/create_data_source.py
+++ b/python/pyspark/sql/worker/create_data_source.py
@@ -1,0 +1,176 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+import sys
+from typing import IO, List
+
+from pyspark.accumulators import _accumulatorRegistry
+from pyspark.errors import PySparkAssertionError, PySparkRuntimeError
+from pyspark.java_gateway import local_connect_and_auth
+from pyspark.serializers import (
+    read_bool,
+    read_int,
+    write_int,
+    write_with_length,
+    SpecialLengths,
+)
+from pyspark.sql.datasource import DataSource
+from pyspark.sql.types import _parse_datatype_json_string, StructType
+from pyspark.util import handle_worker_exception
+from pyspark.worker_util import (
+    check_python_version,
+    read_command,
+    pickleSer,
+    send_accumulator_updates,
+    setup_broadcasts,
+    setup_memory_limits,
+    setup_spark_files,
+    utf8_deserializer,
+)
+
+
+def main(infile: IO, outfile: IO) -> None:
+    """
+    Main method for creating a Python data source instance.
+    """
+    try:
+        check_python_version(infile)
+
+        memory_limit_mb = int(os.environ.get("PYSPARK_PLANNER_MEMORY_MB", "-1"))
+        setup_memory_limits(memory_limit_mb)
+
+        setup_spark_files(infile)
+        setup_broadcasts(infile)
+
+        _accumulatorRegistry.clear()
+
+        # Receive the data source class.
+        data_source_cls = read_command(pickleSer, infile)
+        if not (isinstance(data_source_cls, type) and issubclass(data_source_cls, DataSource)):
+            raise PySparkAssertionError(
+                error_class="PYTHON_DATA_SOURCE_TYPE_MISMATCH",
+                message_parameters={
+                    "expected": "a subclass of DataSource",
+                    "actual": f"'{type(data_source_cls).__name__}'",
+                },
+            )
+
+        # Receive the provider name.
+        provider = utf8_deserializer.loads(infile)
+        if provider.lower() != data_source_cls.name().lower():
+            raise PySparkAssertionError(
+                error_class="PYTHON_DATA_SOURCE_TYPE_MISMATCH",
+                message_parameters={
+                    "expected": f"provider with name {data_source_cls.name()}",
+                    "actual": f"'{provider}'",
+                },
+            )
+
+        # Receive the paths.
+        num_paths = read_int(infile)
+        paths: List[str] = []
+        for _ in range(num_paths):
+            paths.append(utf8_deserializer.loads(infile))
+
+        # Receive the user-specified schema
+        user_specified_schema = None
+        if read_bool(infile):
+            user_specified_schema = _parse_datatype_json_string(utf8_deserializer.loads(infile))
+            if not isinstance(user_specified_schema, StructType):
+                raise PySparkAssertionError(
+                    error_class="PYTHON_DATA_SOURCE_TYPE_MISMATCH",
+                    message_parameters={
+                        "expected": "the user-defined schema to be a 'StructType'",
+                        "actual": f"'{type(data_source_cls).__name__}'",
+                    },
+                )
+
+        # Receive the options.
+        options = dict()
+        num_options = read_int(infile)
+        for _ in range(num_options):
+            key = utf8_deserializer.loads(infile)
+            value = utf8_deserializer.loads(infile)
+            options[key] = value
+
+        # Instantiate a data source.
+        try:
+            data_source = data_source_cls(
+                paths=paths,
+                userSpecifiedSchema=user_specified_schema,  # type: ignore
+                options=options,
+            )
+        except Exception as e:
+            raise PySparkRuntimeError(
+                error_class="PYTHON_DATA_SOURCE_CREATE_ERROR",
+                message_parameters={"type": "instance", "error": str(e)},
+            )
+
+        # Get the schema of the data source.
+        # If user_specified_schema is not None, use user_specified_schema.
+        # Otherwise, use the schema of the data source.
+        # Throw exception if the data source does not implement schema().
+        is_ddl_string = False
+        if user_specified_schema is None:
+            try:
+                schema = data_source.schema()
+                if isinstance(schema, str):
+                    # Here we cannot use _parse_datatype_string to parse the DDL string schema.
+                    # as it requires an active Spark session.
+                    is_ddl_string = True
+            except NotImplementedError:
+                raise PySparkRuntimeError(
+                    error_class="PYTHON_DATA_SOURCE_METHOD_NOT_IMPLEMENTED",
+                    message_parameters={"type": "instance", "method": "schema"},
+                )
+        else:
+            schema = user_specified_schema  # type: ignore
+
+        assert schema is not None
+
+        # Return the pickled data source instance.
+        pickleSer._write_with_length(data_source, outfile)
+
+        # Return the schema of the data source.
+        write_int(int(is_ddl_string), outfile)
+        if is_ddl_string:
+            write_with_length(schema.encode("utf-8"), outfile)  # type: ignore
+        else:
+            write_with_length(schema.json().encode("utf-8"), outfile)  # type: ignore
+
+    except BaseException as e:
+        handle_worker_exception(e, outfile)
+        sys.exit(-1)
+
+    send_accumulator_updates(outfile)
+
+    # check end of stream
+    if read_int(infile) == SpecialLengths.END_OF_STREAM:
+        write_int(SpecialLengths.END_OF_STREAM, outfile)
+    else:
+        # write a different value to tell JVM to not reuse this worker
+        write_int(SpecialLengths.END_OF_DATA_SECTION, outfile)
+        sys.exit(-1)
+
+
+if __name__ == "__main__":
+    # Read information about how to connect back to the JVM from the environment.
+    java_port = int(os.environ["PYTHON_WORKER_FACTORY_PORT"])
+    auth_secret = os.environ["PYTHON_WORKER_FACTORY_SECRET"]
+    (sock_file, _) = local_connect_and_auth(java_port, auth_secret)
+    main(sock_file, sock_file)

--- a/python/pyspark/sql/worker/create_data_source.py
+++ b/python/pyspark/sql/worker/create_data_source.py
@@ -47,6 +47,20 @@ from pyspark.worker_util import (
 def main(infile: IO, outfile: IO) -> None:
     """
     Main method for creating a Python data source instance.
+
+    This process is invoked from the `UserDefinedPythonDataSourceRunner.runInPython` method
+    in JVM. This process is responsible for creating a `DataSource` object and send the
+    information needed back to the JVM.
+
+    The JVM sends the following information to this process:
+    - a `DataSource` class representing the data source to be created.
+    - a provider name in string.
+    - a list of paths in string.
+    - an optional user-specified schema in json string.
+    - a dictionary of options in string.
+
+    This process then creates a `DataSource` instance using the above information and
+    sends the pickled instance as well as the schema back to the JVM.
     """
     try:
         check_python_version(infile)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -1173,10 +1173,14 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
   }
 
   def schemaIsNotStructTypeError(exp: Expression, dataType: DataType): Throwable = {
+    schemaIsNotStructTypeError(toSQLExpr(exp), dataType)
+  }
+
+  def schemaIsNotStructTypeError(inputSchema: String, dataType: DataType): Throwable = {
     new AnalysisException(
       errorClass = "INVALID_SCHEMA.NON_STRUCT_TYPE",
       messageParameters = Map(
-        "inputSchema" -> toSQLExpr(exp),
+        "inputSchema" -> inputSchema,
         "dataType" -> toSQLType(dataType)
       ))
   }
@@ -1980,10 +1984,10 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
     )
   }
 
-  def failToPlanDataSourceError(tpe: String, msg: String): Throwable = {
+  def failToPlanDataSourceError(action: String, tpe: String, msg: String): Throwable = {
     new AnalysisException(
       errorClass = "PYTHON_DATA_SOURCE_FAILED_TO_PLAN_IN_PYTHON",
-      messageParameters = Map("type" -> tpe, "msg" -> msg)
+      messageParameters = Map("action" -> action, "type" -> tpe, "msg" -> msg)
     )
   }
 
@@ -3799,5 +3803,11 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
       messageParameters = Map(
         "functionName" -> functionName,
         "reason" -> reason))
+  }
+
+  def dataSourceAlreadyExists(name: String): Throwable = {
+    new AnalysisException(
+      errorClass = "DATA_SOURCE_ALREADY_EXISTS",
+      messageParameters = Map("provider" -> name))
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataSourceRegistration.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataSourceRegistration.scala
@@ -19,17 +19,15 @@ package org.apache.spark.sql
 
 import org.apache.spark.annotation.Evolving
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.execution.datasources.DataSourceRegistry
+import org.apache.spark.sql.execution.datasources.DataSourceManager
 import org.apache.spark.sql.execution.python.UserDefinedPythonDataSource
 
 /**
  * Functions for registering user-defined data sources.
  * Use `SparkSession.dataSource` to access this.
- *
- * @since 4.0.0
  */
 @Evolving
-class DataSourceRegistration private[sql] (dataSourceRegistry: DataSourceRegistry)
+private[sql] class DataSourceRegistration private[sql] (dataSourceManager: DataSourceManager)
   extends Logging {
 
   protected[sql] def registerPython(
@@ -45,6 +43,6 @@ class DataSourceRegistration private[sql] (dataSourceRegistry: DataSourceRegistr
          | pythonExec: ${dataSource.dataSourceCls.pythonExec}
       """.stripMargin)
 
-    dataSourceRegistry.registerDataSource(name, dataSource.builder)
+    dataSourceManager.registerDataSource(name, dataSource.builder)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataSourceRegistration.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataSourceRegistration.scala
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+import org.apache.spark.annotation.Evolving
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.execution.datasources.DataSourceRegistry
+import org.apache.spark.sql.execution.python.UserDefinedPythonDataSource
+
+/**
+ * Functions for registering user-defined data sources.
+ * Use `SparkSession.dataSource` to access this.
+ *
+ * @since 4.0.0
+ */
+@Evolving
+class DataSourceRegistration private[sql] (dataSourceRegistry: DataSourceRegistry)
+  extends Logging {
+
+  protected[sql] def registerPython(
+      name: String,
+      dataSource: UserDefinedPythonDataSource): Unit = {
+    log.debug(
+      s"""
+         | Registering new Python data source:
+         | name: $name
+         | command: ${dataSource.dataSourceCls.command}
+         | envVars: ${dataSource.dataSourceCls.envVars}
+         | pythonIncludes: ${dataSource.dataSourceCls.pythonIncludes}
+         | pythonExec: ${dataSource.dataSourceCls.pythonExec}
+      """.stripMargin)
+
+    dataSourceRegistry.registerDataSource(name, dataSource.builder)
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -231,7 +231,7 @@ class SparkSession private(
   /**
    * A collection of methods for registering user-defined data sources.
    */
-  def dataSource: DataSourceRegistration = sharedState.dataSourceRegistration
+  private[sql] def dataSource: DataSourceRegistration = sharedState.dataSourceRegistration
 
   /**
    * Returns a `StreamingQueryManager` that allows managing all the

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -229,6 +229,11 @@ class SparkSession private(
   def udtf: UDTFRegistration = sessionState.udtfRegistration
 
   /**
+   * A collection of methods for registering user-defined data sources.
+   */
+  def dataSource: DataSourceRegistration = sharedState.dataSourceRegistration
+
+  /**
    * Returns a `StreamingQueryManager` that allows managing all the
    * `StreamingQuery`s active on `this`.
    *

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceRegistry.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceRegistry.scala
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources
+
+import java.util.Locale
+import javax.annotation.concurrent.GuardedBy
+
+import scala.collection.mutable
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.errors.QueryCompilationErrors
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+
+trait DataSourceRegistry {
+
+  type DataSourceBuilder = (
+    SparkSession,  // Spark session
+    String,  // provider name
+    Seq[String],  // paths
+    Option[StructType],  // user specified schema
+    CaseInsensitiveStringMap  // options
+  ) => LogicalPlan
+
+  def registerDataSource(name: String, builder: DataSourceBuilder): Unit
+
+  def dataSourceExists(name: String): Boolean
+
+  /** Create a copy of this registry with identical data sources as this registry. */
+  override def clone(): DataSourceRegistry = throw new CloneNotSupportedException()
+}
+
+class SimpleDataSourceRegistry extends DataSourceRegistry with Logging {
+  @GuardedBy("this")
+  protected val dataSourceBuilders = new mutable.HashMap[String, DataSourceBuilder]
+
+  private def normalize(name: String): String = name.toLowerCase(Locale.ROOT)
+
+  override def registerDataSource(name: String, builder: DataSourceBuilder): Unit = synchronized {
+    val normalizedName = normalize(name)
+    if (dataSourceBuilders.contains(normalizedName)) {
+      throw QueryCompilationErrors.dataSourceAlreadyExists(name)
+    }
+    // TODO(SPARK-45639): check if the data source is a DSv1 or DSv2 using loadDataSource.
+    dataSourceBuilders.put(normalizedName, builder)
+  }
+
+  override def dataSourceExists(name: String): Boolean = synchronized {
+    dataSourceBuilders.contains(normalize(name))
+  }
+
+  override def clone(): SimpleDataSourceRegistry = {
+    val registry = new SimpleDataSourceRegistry
+    dataSourceBuilders.iterator.foreach { case (name, builder) =>
+      registry.registerDataSource(name, builder)
+    }
+    registry
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/UserDefinedPythonDataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/UserDefinedPythonDataSource.scala
@@ -34,8 +34,8 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 /**
  * A user-defined Python data source. This is used by the Python API.
+ *
  * @param dataSourceCls The Python data source class.
- * @param schema The user-specified output schema of the data source.
  */
 case class UserDefinedPythonDataSource(dataSourceCls: PythonFunction) {
 
@@ -76,10 +76,16 @@ case class UserDefinedPythonDataSource(dataSourceCls: PythonFunction) {
   }
 }
 
+/**
+ * Used to store the result of creating a Python data source in the Python process.
+ */
 case class PythonDataSourceCreationResult(
     dataSource: Array[Byte],
     schema: StructType)
 
+/**
+ * A runner used to create a Python data source in a Python process and return the result.
+ */
 class UserDefinedPythonDataSourceRunner(
     dataSourceCls: PythonFunction,
     provider: String,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/UserDefinedPythonDataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/UserDefinedPythonDataSource.scala
@@ -20,25 +20,127 @@ package org.apache.spark.sql.execution.python
 import java.io.{DataInputStream, DataOutputStream}
 
 import scala.collection.mutable.ArrayBuffer
+import scala.jdk.CollectionConverters._
 
 import net.razorvine.pickle.Pickler
 
-import org.apache.spark.api.python.{PythonFunction, PythonWorkerUtils, SpecialLengths}
+import org.apache.spark.api.python.{PythonFunction, PythonWorkerUtils, SimplePythonFunction, SpecialLengths}
 import org.apache.spark.sql.{DataFrame, Dataset, SparkSession}
-import org.apache.spark.sql.catalyst.plans.logical.PythonDataSource
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, PythonDataSource}
 import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
 import org.apache.spark.sql.errors.QueryCompilationErrors
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.types.{DataType, StructType}
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 /**
  * A user-defined Python data source. This is used by the Python API.
+ * @param dataSourceCls The Python data source class.
+ * @param schema The user-specified output schema of the data source.
  */
-case class UserDefinedPythonDataSource(
-    dataSource: PythonFunction,
-    schema: StructType) {
-  def apply(session: SparkSession): DataFrame = {
-    val source = PythonDataSource(dataSource, schema, output = toAttributes(schema))
-    Dataset.ofRows(session, source)
+case class UserDefinedPythonDataSource(dataSourceCls: PythonFunction) {
+
+  def builder(
+      sparkSession: SparkSession,
+      provider: String,
+      paths: Seq[String],
+      userSpecifiedSchema: Option[StructType],
+      options: CaseInsensitiveStringMap): LogicalPlan = {
+
+    val runner = new UserDefinedPythonDataSourceRunner(
+      dataSourceCls, provider, paths, userSpecifiedSchema, options)
+
+    val result = runner.runInPython()
+    val pickledDataSourceInstance = result.dataSource
+
+    val dataSource = SimplePythonFunction(
+      command = pickledDataSourceInstance,
+      envVars = dataSourceCls.envVars,
+      pythonIncludes = dataSourceCls.pythonIncludes,
+      pythonExec = dataSourceCls.pythonExec,
+      pythonVer = dataSourceCls.pythonVer,
+      broadcastVars = dataSourceCls.broadcastVars,
+      accumulator = dataSourceCls.accumulator)
+    val schema = result.schema
+
+    PythonDataSource(dataSource, schema, output = toAttributes(schema))
+  }
+
+  def apply(
+      sparkSession: SparkSession,
+      provider: String,
+      paths: Seq[String] = Seq.empty,
+      userSpecifiedSchema: Option[StructType] = None,
+      options: CaseInsensitiveStringMap = CaseInsensitiveStringMap.empty): DataFrame = {
+    val plan = builder(sparkSession, provider, paths, userSpecifiedSchema, options)
+    Dataset.ofRows(sparkSession, plan)
+  }
+}
+
+case class PythonDataSourceCreationResult(
+    dataSource: Array[Byte],
+    schema: StructType)
+
+class UserDefinedPythonDataSourceRunner(
+    dataSourceCls: PythonFunction,
+    provider: String,
+    paths: Seq[String],
+    userSpecifiedSchema: Option[StructType],
+    options: CaseInsensitiveStringMap)
+  extends PythonPlannerRunner[PythonDataSourceCreationResult](dataSourceCls) {
+
+  override val workerModule = "pyspark.sql.worker.create_data_source"
+
+  override protected def writeToPython(dataOut: DataOutputStream, pickler: Pickler): Unit = {
+    // Send python data source
+    PythonWorkerUtils.writePythonFunction(dataSourceCls, dataOut)
+
+    // Send the provider name
+    PythonWorkerUtils.writeUTF(provider, dataOut)
+
+    // Send the paths
+    dataOut.writeInt(paths.length)
+    paths.foreach(PythonWorkerUtils.writeUTF(_, dataOut))
+
+    // Send the user-specified schema, if provided
+    dataOut.writeBoolean(userSpecifiedSchema.isDefined)
+    userSpecifiedSchema.map(_.json).foreach(PythonWorkerUtils.writeUTF(_, dataOut))
+
+    // Send the options
+    dataOut.writeInt(options.size)
+    options.entrySet.asScala.foreach { e =>
+      PythonWorkerUtils.writeUTF(e.getKey, dataOut)
+      PythonWorkerUtils.writeUTF(e.getValue, dataOut)
+    }
+  }
+
+  override protected def receiveFromPython(
+      dataIn: DataInputStream): PythonDataSourceCreationResult = {
+    // Receive the pickled data source or an exception raised in Python worker.
+    val length = dataIn.readInt()
+    if (length == SpecialLengths.PYTHON_EXCEPTION_THROWN) {
+      val msg = PythonWorkerUtils.readUTF(dataIn)
+      throw QueryCompilationErrors.failToPlanDataSourceError(
+        action = "create", tpe = "instance", msg = msg)
+    }
+
+    // Receive the pickled data source.
+    val pickledDataSourceInstance: Array[Byte] = PythonWorkerUtils.readBytes(length, dataIn)
+
+    // Receive the schema.
+    val isDDLString = dataIn.readInt()
+    val schemaStr = PythonWorkerUtils.readUTF(dataIn)
+    val schema = if (isDDLString == 1) {
+      DataType.fromDDL(schemaStr)
+    } else {
+      DataType.fromJson(schemaStr)
+    }
+    if (!schema.isInstanceOf[StructType]) {
+      throw QueryCompilationErrors.schemaIsNotStructTypeError(schemaStr, schema)
+    }
+
+    PythonDataSourceCreationResult(
+      dataSource = pickledDataSourceInstance,
+      schema = schema.asInstanceOf[StructType])
   }
 }
 
@@ -66,7 +168,8 @@ class UserDefinedPythonDataSourceReadRunner(
     val length = dataIn.readInt()
     if (length == SpecialLengths.PYTHON_EXCEPTION_THROWN) {
       val msg = PythonWorkerUtils.readUTF(dataIn)
-      throw QueryCompilationErrors.failToPlanDataSourceError("read", msg)
+      throw QueryCompilationErrors.failToPlanDataSourceError(
+        action = "plan", tpe = "read", msg = msg)
     }
 
     // Receive the pickled 'read' function.

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
@@ -30,9 +30,11 @@ import org.apache.hadoop.fs.{FsUrlStreamHandlerFactory, Path}
 
 import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.internal.Logging
+import org.apache.spark.sql.DataSourceRegistration
 import org.apache.spark.sql.catalyst.catalog._
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.execution.CacheManager
+import org.apache.spark.sql.execution.datasources.SimpleDataSourceRegistry
 import org.apache.spark.sql.execution.streaming.StreamExecution
 import org.apache.spark.sql.execution.ui.{SQLAppStatusListener, SQLAppStatusStore, SQLTab, StreamingQueryStatusStore}
 import org.apache.spark.sql.internal.StaticSQLConf._
@@ -104,6 +106,16 @@ private[sql] class SharedState(
    */
   @GuardedBy("activeQueriesLock")
   private[sql] val activeStreamingQueries = new ConcurrentHashMap[UUID, StreamExecution]()
+
+  /**
+   * A data source registry shared by all sessions.
+   */
+  lazy val dataSourceRegistry = new SimpleDataSourceRegistry()
+
+  /**
+   * A collection of method used for registering user-defined data sources.
+   */
+  lazy val dataSourceRegistration = new DataSourceRegistration(dataSourceRegistry)
 
   /**
    * A status store to query SQL status/metrics of this Spark application, based on SQL-specific

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
@@ -34,7 +34,7 @@ import org.apache.spark.sql.DataSourceRegistration
 import org.apache.spark.sql.catalyst.catalog._
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.execution.CacheManager
-import org.apache.spark.sql.execution.datasources.SimpleDataSourceRegistry
+import org.apache.spark.sql.execution.datasources.DataSourceManager
 import org.apache.spark.sql.execution.streaming.StreamExecution
 import org.apache.spark.sql.execution.ui.{SQLAppStatusListener, SQLAppStatusStore, SQLTab, StreamingQueryStatusStore}
 import org.apache.spark.sql.internal.StaticSQLConf._
@@ -108,14 +108,14 @@ private[sql] class SharedState(
   private[sql] val activeStreamingQueries = new ConcurrentHashMap[UUID, StreamExecution]()
 
   /**
-   * A data source registry shared by all sessions.
+   * A data source manager shared by all sessions.
    */
-  lazy val dataSourceRegistry = new SimpleDataSourceRegistry()
+  lazy val dataSourceManager = new DataSourceManager()
 
   /**
    * A collection of method used for registering user-defined data sources.
    */
-  lazy val dataSourceRegistration = new DataSourceRegistration(dataSourceRegistry)
+  lazy val dataSourceRegistration = new DataSourceRegistration(dataSourceManager)
 
   /**
    * A status store to query SQL status/metrics of this Spark application, based on SQL-specific

--- a/sql/core/src/test/scala/org/apache/spark/sql/IntegratedUDFTestUtils.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/IntegratedUDFTestUtils.scala
@@ -232,8 +232,8 @@ object IntegratedUDFTestUtils extends SQLHelper {
             "from pyspark.serializers import CloudPickleSerializer; " +
               s"f = open('$path', 'wb');" +
               s"exec(open('$codePath', 'r').read());" +
-              s"ds = $dataSourceName(options=dict());" +
-              "f.write(CloudPickleSerializer().dumps(ds))"),
+              s"dataSourceCls = $dataSourceName;" +
+              "f.write(CloudPickleSerializer().dumps(dataSourceCls))"),
           None,
           "PYTHONPATH" -> s"$pysparkPythonPath:$pythonPath").!!
         binaryPythonDataSource = Files.readAllBytes(path.toPath)
@@ -425,19 +425,16 @@ object IntegratedUDFTestUtils extends SQLHelper {
 
   def createUserDefinedPythonDataSource(
       name: String,
-      pythonScript: String,
-      schema: StructType): UserDefinedPythonDataSource = {
+      pythonScript: String): UserDefinedPythonDataSource = {
     UserDefinedPythonDataSource(
-      dataSource = SimplePythonFunction(
+      dataSourceCls = SimplePythonFunction(
         command = createPythonDataSource(name, pythonScript),
         envVars = workerEnv.clone().asInstanceOf[java.util.Map[String, String]],
         pythonIncludes = List.empty[String].asJava,
         pythonExec = pythonExec,
         pythonVer = pythonVer,
         broadcastVars = List.empty[Broadcast[PythonBroadcast]].asJava,
-        accumulator = null),
-      schema = schema
-    )
+        accumulator = null))
   }
 
   def createUserDefinedPythonTableFunction(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonDataSourceSuite.scala
@@ -25,26 +25,33 @@ import org.apache.spark.sql.types.StructType
 class PythonDataSourceSuite extends QueryTest with SharedSparkSession {
   import IntegratedUDFTestUtils._
 
+  private def dataSourceName = "SimpleDataSource"
+  private def simpleDataSourceReaderScript: String =
+    """
+      |class SimpleDataSourceReader(DataSourceReader):
+      |    def partitions(self):
+      |        return range(0, 2)
+      |    def read(self, partition):
+      |        yield (0, partition)
+      |        yield (1, partition)
+      |        yield (2, partition)
+      |""".stripMargin
+
   test("simple data source") {
     val dataSourceScript =
-      """
+      s"""
         |from pyspark.sql.datasource import DataSource, DataSourceReader
-        |class MyDataSourceReader(DataSourceReader):
-        |    def partitions(self):
-        |        return range(0, 2)
-        |    def read(self, partition):
-        |        yield (0, partition)
-        |        yield (1, partition)
-        |        yield (2, partition)
+        |$simpleDataSourceReaderScript
         |
-        |class MyDataSource(DataSource):
+        |class $dataSourceName(DataSource):
         |    def reader(self, schema):
-        |        return MyDataSourceReader()
+        |        return SimpleDataSourceReader()
         |""".stripMargin
     val schema = StructType.fromDDL("id INT, partition INT")
     val dataSource = createUserDefinedPythonDataSource(
-      name = "MyDataSource", pythonScript = dataSourceScript, schema = schema)
-    val df = dataSource(spark)
+      name = dataSourceName, pythonScript = dataSourceScript)
+    val df = dataSource.apply(
+      spark, provider = dataSourceName, userSpecifiedSchema = Some(schema))
     assert(df.rdd.getNumPartitions == 2)
     val plan = df.queryExecution.optimizedPlan
     plan match {
@@ -55,18 +62,106 @@ class PythonDataSourceSuite extends QueryTest with SharedSparkSession {
     checkAnswer(df, Seq(Row(0, 0), Row(0, 1), Row(1, 0), Row(1, 1), Row(2, 0), Row(2, 1)))
   }
 
+  test("simple data source with string schema") {
+    val dataSourceScript =
+      s"""
+         |from pyspark.sql.datasource import DataSource, DataSourceReader
+         |$simpleDataSourceReaderScript
+         |
+         |class $dataSourceName(DataSource):
+         |    def schema(self) -> str:
+         |        return "id INT, partition INT"
+         |
+         |    def reader(self, schema):
+         |        return SimpleDataSourceReader()
+         |""".stripMargin
+    val dataSource = createUserDefinedPythonDataSource(dataSourceName, dataSourceScript)
+    val df = dataSource(spark, provider = dataSourceName)
+    checkAnswer(df, Seq(Row(0, 0), Row(0, 1), Row(1, 0), Row(1, 1), Row(2, 0), Row(2, 1)))
+  }
+
+  test("simple data source with StructType schema") {
+    val dataSourceScript =
+      s"""
+         |from pyspark.sql.datasource import DataSource, DataSourceReader
+         |from pyspark.sql.types import IntegerType, StructType, StructField
+         |$simpleDataSourceReaderScript
+         |
+         |class $dataSourceName(DataSource):
+         |    def schema(self) -> str:
+         |        return StructType([
+         |            StructField("id", IntegerType()),
+         |            StructField("partition", IntegerType())
+         |        ])
+         |
+         |    def reader(self, schema):
+         |        return SimpleDataSourceReader()
+         |""".stripMargin
+    val dataSource = createUserDefinedPythonDataSource(dataSourceName, dataSourceScript)
+    val df = dataSource(spark, provider = dataSourceName)
+    checkAnswer(df, Seq(Row(0, 0), Row(0, 1), Row(1, 0), Row(1, 1), Row(2, 0), Row(2, 1)))
+  }
+
+  test("data source with invalid schema") {
+    val dataSourceScript =
+      s"""
+         |from pyspark.sql.datasource import DataSource, DataSourceReader
+         |$simpleDataSourceReaderScript
+         |
+         |class $dataSourceName(DataSource):
+         |    def schema(self) -> str:
+         |        return "INT"
+         |
+         |    def reader(self, schema):
+         |        return SimpleDataSourceReader()
+         |""".stripMargin
+    val dataSource = createUserDefinedPythonDataSource(dataSourceName, dataSourceScript)
+    checkError(
+      exception = intercept[AnalysisException](dataSource(spark, provider = dataSourceName)),
+      errorClass = "INVALID_SCHEMA.NON_STRUCT_TYPE",
+      parameters = Map("inputSchema" -> "INT", "dataType" -> "\"INT\""))
+  }
+
+  test("register data source") {
+    val dataSourceScript =
+      s"""
+         |from pyspark.sql.datasource import DataSource, DataSourceReader
+         |$simpleDataSourceReaderScript
+         |
+         |class $dataSourceName(DataSource):
+         |    def schema(self) -> str:
+         |        return "id INT, partition INT"
+         |
+         |    def reader(self, schema):
+         |        return SimpleDataSourceReader()
+         |""".stripMargin
+
+    val dataSource = createUserDefinedPythonDataSource(dataSourceName, dataSourceScript)
+    spark.dataSource.registerPython(dataSourceName, dataSource)
+    assert(spark.sharedState.dataSourceRegistry.dataSourceExists(dataSourceName))
+
+    // Check error when registering a data source with the same name.
+    val err = intercept[AnalysisException] {
+      spark.dataSource.registerPython(dataSourceName, dataSource)
+    }
+    checkError(
+      exception = err,
+      errorClass = "DATA_SOURCE_ALREADY_EXISTS",
+      parameters = Map("provider" -> dataSourceName))
+  }
+
   test("reader not implemented") {
     val dataSourceScript =
-      """
+       s"""
         |from pyspark.sql.datasource import DataSource, DataSourceReader
-        |class MyDataSource(DataSource):
+        |class $dataSourceName(DataSource):
         |    pass
         |""".stripMargin
     val schema = StructType.fromDDL("id INT, partition INT")
     val dataSource = createUserDefinedPythonDataSource(
-      name = "MyDataSource", pythonScript = dataSourceScript, schema = schema)
+      name = dataSourceName, pythonScript = dataSourceScript)
     val err = intercept[AnalysisException] {
-      dataSource(spark).collect()
+      dataSource(spark, dataSourceName, userSpecifiedSchema = Some(schema)).collect()
     }
     assert(err.getErrorClass == "PYTHON_DATA_SOURCE_FAILED_TO_PLAN_IN_PYTHON")
     assert(err.getMessage.contains("PYTHON_DATA_SOURCE_METHOD_NOT_IMPLEMENTED"))
@@ -74,17 +169,17 @@ class PythonDataSourceSuite extends QueryTest with SharedSparkSession {
 
   test("error creating reader") {
     val dataSourceScript =
-      """
+      s"""
         |from pyspark.sql.datasource import DataSource
-        |class MyDataSource(DataSource):
+        |class $dataSourceName(DataSource):
         |    def reader(self, schema):
         |        raise Exception("error creating reader")
         |""".stripMargin
     val schema = StructType.fromDDL("id INT, partition INT")
     val dataSource = createUserDefinedPythonDataSource(
-      name = "MyDataSource", pythonScript = dataSourceScript, schema = schema)
+      name = dataSourceName, pythonScript = dataSourceScript)
     val err = intercept[AnalysisException] {
-      dataSource(spark).collect()
+      dataSource(spark, dataSourceName, userSpecifiedSchema = Some(schema)).collect()
     }
     assert(err.getErrorClass == "PYTHON_DATA_SOURCE_FAILED_TO_PLAN_IN_PYTHON")
     assert(err.getMessage.contains("PYTHON_DATA_SOURCE_CREATE_ERROR"))
@@ -93,16 +188,16 @@ class PythonDataSourceSuite extends QueryTest with SharedSparkSession {
 
   test("data source assertion error") {
     val dataSourceScript =
-      """
-        |class MyDataSource:
+      s"""
+        |class $dataSourceName:
         |   def __init__(self, options):
         |       ...
         |""".stripMargin
     val schema = StructType.fromDDL("id INT, partition INT")
     val dataSource = createUserDefinedPythonDataSource(
-      name = "MyDataSource", pythonScript = dataSourceScript, schema = schema)
+      name = dataSourceName, pythonScript = dataSourceScript)
     val err = intercept[AnalysisException] {
-      dataSource(spark).collect()
+      dataSource(spark, dataSourceName, userSpecifiedSchema = Some(schema)).collect()
     }
     assert(err.getErrorClass == "PYTHON_DATA_SOURCE_FAILED_TO_PLAN_IN_PYTHON")
     assert(err.getMessage.contains("PYTHON_DATA_SOURCE_TYPE_MISMATCH"))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonDataSourceSuite.scala
@@ -38,6 +38,7 @@ class PythonDataSourceSuite extends QueryTest with SharedSparkSession {
       |""".stripMargin
 
   test("simple data source") {
+    assume(shouldTestPythonUDFs)
     val dataSourceScript =
       s"""
         |from pyspark.sql.datasource import DataSource, DataSourceReader
@@ -63,6 +64,7 @@ class PythonDataSourceSuite extends QueryTest with SharedSparkSession {
   }
 
   test("simple data source with string schema") {
+    assume(shouldTestPythonUDFs)
     val dataSourceScript =
       s"""
          |from pyspark.sql.datasource import DataSource, DataSourceReader
@@ -81,6 +83,7 @@ class PythonDataSourceSuite extends QueryTest with SharedSparkSession {
   }
 
   test("simple data source with StructType schema") {
+    assume(shouldTestPythonUDFs)
     val dataSourceScript =
       s"""
          |from pyspark.sql.datasource import DataSource, DataSourceReader
@@ -103,6 +106,7 @@ class PythonDataSourceSuite extends QueryTest with SharedSparkSession {
   }
 
   test("data source with invalid schema") {
+    assume(shouldTestPythonUDFs)
     val dataSourceScript =
       s"""
          |from pyspark.sql.datasource import DataSource, DataSourceReader
@@ -123,6 +127,7 @@ class PythonDataSourceSuite extends QueryTest with SharedSparkSession {
   }
 
   test("register data source") {
+    assume(shouldTestPythonUDFs)
     val dataSourceScript =
       s"""
          |from pyspark.sql.datasource import DataSource, DataSourceReader
@@ -138,7 +143,7 @@ class PythonDataSourceSuite extends QueryTest with SharedSparkSession {
 
     val dataSource = createUserDefinedPythonDataSource(dataSourceName, dataSourceScript)
     spark.dataSource.registerPython(dataSourceName, dataSource)
-    assert(spark.sharedState.dataSourceRegistry.dataSourceExists(dataSourceName))
+    assert(spark.sharedState.dataSourceManager.dataSourceExists(dataSourceName))
 
     // Check error when registering a data source with the same name.
     val err = intercept[AnalysisException] {
@@ -151,6 +156,7 @@ class PythonDataSourceSuite extends QueryTest with SharedSparkSession {
   }
 
   test("reader not implemented") {
+    assume(shouldTestPythonUDFs)
     val dataSourceScript =
        s"""
         |from pyspark.sql.datasource import DataSource, DataSourceReader
@@ -168,6 +174,7 @@ class PythonDataSourceSuite extends QueryTest with SharedSparkSession {
   }
 
   test("error creating reader") {
+    assume(shouldTestPythonUDFs)
     val dataSourceScript =
       s"""
         |from pyspark.sql.datasource import DataSource
@@ -187,6 +194,7 @@ class PythonDataSourceSuite extends QueryTest with SharedSparkSession {
   }
 
   test("data source assertion error") {
+    assume(shouldTestPythonUDFs)
     val dataSourceScript =
       s"""
         |class $dataSourceName:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR adds support for registering Python data sources.
Users can register a Python data source using the class:

```python
class MyDataSource(DataSource):
    ...

spark.dataSource.register(MyDataSource)
```

This will allow users to use the data source using its name (to be supported in SPARK-45639)
```python
spark.read.format("MyDataSource").load()
```

The data sources registered are stored in `sharedState` and can be accessed by all spark sessions.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To support Python data source.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. This PR adds a new API in spark session to support registering data sources.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Unit tests.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No