### PR TITLE
[SPARK-45690][CORE][SQL] Clean up deprecated type use of `BufferedIterator/CanBuildFrom/Traversable`

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/BlockManagerMaster.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManagerMaster.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.storage
 
-import scala.collection.generic.CanBuildFrom
+import scala.collection.BuildFrom
 import scala.collection.immutable.Iterable
 import scala.concurrent.Future
 
@@ -261,7 +261,7 @@ class BlockManagerMaster(
     val (blockManagerIds, futures) = response.unzip
     val cbf =
       implicitly[
-        CanBuildFrom[Iterable[Future[Option[BlockStatus]]],
+        BuildFrom[Iterable[Future[Option[BlockStatus]]],
         Option[BlockStatus],
         Iterable[Option[BlockStatus]]]]
     val blockStatus = timeout.awaitResult(

--- a/core/src/main/scala/org/apache/spark/util/collection/ExternalSorter.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/ExternalSorter.scala
@@ -20,6 +20,7 @@ package org.apache.spark.util.collection
 import java.io._
 import java.util.Comparator
 
+import scala.collection.BufferedIterator
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 

--- a/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
@@ -221,7 +221,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
    * same size and index.
    */
   private def toBlockList(
-      blockIds: Traversable[BlockId],
+      blockIds: Iterable[BlockId],
       blockSize: Long,
       blockMapIndex: Int): Seq[(BlockId, Long, Int)] = {
     blockIds.map(blockId => (blockId, blockSize, blockMapIndex)).toSeq

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/GroupedIterator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/GroupedIterator.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.execution
 
+import scala.collection.BufferedIterator
+
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Ascending, Attribute, Expression, SortOrder}
 import org.apache.spark.sql.catalyst.expressions.codegen.{GenerateOrdering, GenerateUnsafeProjection}


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr clean up type use of `BufferedIterator/CanBuildFrom/Traversable` due to they were marked as deprecated in Scala 2.13.0.
```
  @deprecated("Use scala.collection.BufferedIterator instead of scala.BufferedIterator", "2.13.0")
  type BufferedIterator[+A] = scala.collection.BufferedIterator[A]
```

```
  @deprecated("Use Iterable instead of Traversable", "2.13.0")
  type Traversable[+A] = scala.collection.Iterable[A]
```

```
  @deprecated("Use scala.collection.BuildFrom instead", "2.13.0")
  type CanBuildFrom[-From, -A, +C] = scala.collection.BuildFrom[From, A, C]
```

### Why are the changes needed?
Clean up deprecated type usage.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No