### PR TITLE
[SPARK-45716][PYTHON][CONNECT] Add StructType.treeString to Python

### DIFF
--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -583,6 +583,12 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
                 )
         return self._schema
 
+    def _tree_string(self, level: Optional[int] = None) -> str:
+        if level:
+            return self._jdf.schema().treeString(level)
+        else:
+            return self._jdf.schema().treeString()
+
     def printSchema(self, level: Optional[int] = None) -> None:
         """Prints out the schema in the tree format.
         Optionally allows to specify how many levels to print if schema is nested.
@@ -621,10 +627,7 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
          |    |-- _1: long (nullable = true)
          |    |-- _2: long (nullable = true)
         """
-        if level:
-            print(self._jdf.schema().treeString(level))
-        else:
-            print(self._jdf.schema().treeString())
+        print(self._tree_string(level))
 
     def explain(
         self, extended: Optional[Union[bool, str]] = None, mode: Optional[str] = None

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -1136,6 +1136,25 @@ class DataFrameTestsMixin:
             self.assertEqual(1, buf.getvalue().count("_1"))
             self.assertEqual(1, buf.getvalue().count("_2"))
 
+    def test_df_schema_tree_string(self):
+        schema = self.spark.createDataFrame([(1, (2, 2))], ["a", "b"]).schema
+        self.assertEqual(
+            schema.treeString(),
+            "".join(
+                [
+                    "root\n",
+                    " |-- a: long (nullable = true)\n",
+                    " |-- b: struct (nullable = true)\n",
+                    " |    |-- _1: long (nullable = true)\n",
+                    " |    |-- _2: long (nullable = true)\n",
+                ]
+            ),
+        )
+        self.assertEqual(
+            schema.treeString(1),
+            "root\n |-- a: long (nullable = true)\n |-- b: struct (nullable = true)\n",
+        )
+
     def test_join_without_on(self):
         df1 = self.spark.range(1).toDF("a")
         df2 = self.spark.range(1).toDF("b")

--- a/python/pyspark/sql/tests/test_types.py
+++ b/python/pyspark/sql/tests/test_types.py
@@ -1182,7 +1182,8 @@ class TypesTestsMixin:
             schema.treeString(),
             "".join(
                 [
-                    "root\n |-- level1: struct (nullable = true)\n",
+                    "root\n",
+                    " |-- level1: struct (nullable = true)\n",
                     " |    |-- f1: string (nullable = true)\n",
                 ]
             ),

--- a/python/pyspark/sql/tests/test_types.py
+++ b/python/pyspark/sql/tests/test_types.py
@@ -1174,6 +1174,21 @@ class TypesTestsMixin:
         for instance in instances:
             self.assertEqual(eval(repr(instance)), instance)
 
+    def test_tree_string(self):
+        schema = StructType(
+            [StructField("level1", StructType([StructField("f1", StringType(), True)]), True)]
+        )
+        self.assertEqual(
+            schema.treeString(),
+            "".join(
+                [
+                    "root\n |-- level1: struct (nullable = true)\n",
+                    " |    |-- f1: string (nullable = true)\n",
+                ]
+            ),
+        )
+        self.assertEqual(schema.treeString(1), "root\n |-- level1: struct (nullable = true)\n")
+
     def test_daytime_interval_type_constructor(self):
         # SPARK-37277: Test constructors in day time interval.
         self.assertEqual(DayTimeIntervalType().simpleString(), "interval day to second")

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1216,13 +1216,40 @@ class StructType(DataType):
         """
         return list(self.names)
 
-    def treeString(self, maxDepth: int = 0) -> str:
+    def treeString(self, maxDepth: Optional[int] = None) -> str:
+        """Return tree representation of the schema
+
+        .. versionadded:: 4.0.0
+
+        Parameters
+        ----------
+        maxDepth : int, optional, default None
+            Depth of the schema for nested schemas.
+
+        Examples
+        --------
+        >>> from pyspark.sql.types import *
+        >>> s = StructType(
+        ... [StructField("level1", StructType([StructField("f1", StringType(), True)]), True)]
+        ... )
+
+        >>> s.treeString()
+        'root\n |-- level1: struct (nullable = true)\n |    |-- f1: string (nullable = true)\n'
+        >>> print(s.treeString())
+        root
+         |-- level1: struct (nullable = true)
+         |    |-- f1: string (nullable = true)
+
+        >>> print(s.treeString(1))
+        root
+         |-- level1: struct (nullable = true)
+        """
         from pyspark.sql import SparkSession
 
         # Intentionally uses SparkSession so one implementation can be shared with/without
         # Spark Connect.
         schema = SparkSession.active().createDataFrame(data=[], schema=self)._jdf.schema()
-        if maxDepth > 0:
+        if maxDepth:
             string = schema.treeString(maxDepth)
         else:
             string = schema.treeString()

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1248,7 +1248,7 @@ class StructType(DataType):
 
         # Intentionally uses SparkSession so one implementation can be shared with/without
         # Spark Connect.
-        schema = SparkSession.active().createDataFrame(data=[], schema=self)._jdf.schema()
+        schema = SparkSession.active().createDataFrame(data=[], schema=self).schema()
         if maxDepth:
             string = schema.treeString(maxDepth)
         else:

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1249,7 +1249,7 @@ class StructType(DataType):
         # Intentionally uses SparkSession so one implementation can be shared with/without
         # Spark Connect.
         df = SparkSession.active().createDataFrame(data=[], schema=self)
-        if maxDepth > 0:
+        if maxDepth is not None and maxDepth > 0:
             string = df._tree_string(maxDepth)
         else:
             string = df._tree_string()

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1234,7 +1234,7 @@ class StructType(DataType):
         ... )
 
         >>> s.treeString()
-        'root\n |-- level1: struct (nullable = true)\n |    |-- f1: string (nullable = true)\n'
+        'root\\n |-- level1: struct (nullable = true)\\n |    |-- f1: string (nullable = true)\\n'
         >>> print(s.treeString())
         root
          |-- level1: struct (nullable = true)

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1216,6 +1216,18 @@ class StructType(DataType):
         """
         return list(self.names)
 
+    def treeString(self, maxDepth: int = 0) -> str:
+        from pyspark.sql import SparkSession
+
+        # Intentionally uses SparkSession so one implementation can be shared with/without
+        # Spark Connect.
+        schema = SparkSession.active().createDataFrame(data=[], schema=self)._jdf.schema()
+        if maxDepth > 0:
+            string = schema.treeString(maxDepth)
+        else:
+            string = schema.treeString()
+        return string
+
     def needConversion(self) -> bool:
         # We need convert Row()/namedtuple into tuple()
         return True

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1248,11 +1248,11 @@ class StructType(DataType):
 
         # Intentionally uses SparkSession so one implementation can be shared with/without
         # Spark Connect.
-        schema = SparkSession.active().createDataFrame(data=[], schema=self).schema()
-        if maxDepth:
-            string = schema.treeString(maxDepth)
+        df = SparkSession.active().createDataFrame(data=[], schema=self)
+        if maxDepth > 0:
+            string = df._tree_string(maxDepth)
         else:
-            string = schema.treeString()
+            string = df._tree_string()
         return string
 
     def needConversion(self) -> bool:


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR adds missing parity method StructType.treeString() to Python API. 

Usage examples:

**PySpark**
```
root@4691452b5bbd:/home/spark# bin/pyspark                    
Python 3.9.5 (default, Nov 23 2021, 15:27:38) 
..... 
>>> from pyspark.sql.types import *
>>> s = StructType([StructField("level1", StructType([StructField("f1", StringType(), True)]), True)])
>>> s.treeString()
'root\n |-- level1: struct (nullable = true)\n |    |-- f1: string (nullable = true)\n'
>>> s.treeString(9)
'root\n |-- level1: struct (nullable = true)\n |    |-- f1: string (nullable = true)\n'
>>> s.treeString(-1)
'root\n |-- level1: struct (nullable = true)\n |    |-- f1: string (nullable = true)\n'
>>> s.treeString(1)
'root\n |-- level1: struct (nullable = true)\n'
>>> print(s.treeString(1))
root
 |-- level1: struct (nullable = true)
```


**Connect**
```
root@4691452b5bbd:/home/spark# bin/pyspark --remote "local[*]"
Python 3.9.5 (default, Nov 23 2021, 15:27:38) 
......
>>> from pyspark.sql.types import *
>>> s = StructType(
... [StructField("level1", StructType([StructField("f1", StringType(), True)]), True)])
>>> s.treeString(       
... )
'root\n |-- level1: struct (nullable = true)\n |    |-- f1: string (nullable = true)\n'
>>> s.treeString(1)
'root\n |-- level1: struct (nullable = true)\n'
>>> s.treeString(0)
'root\n |-- level1: struct (nullable = true)\n |    |-- f1: string (nullable = true)\n'
>>> s.treeString(6)
'root\n |-- level1: struct (nullable = true)\n |    |-- f1: string (nullable = true)\n'
>>> s.treeString(-1)
'root\n |-- level1: struct (nullable = true)\n |    |-- f1: string (nullable = true)\n'
```

### Why are the changes needed?
To be compatible with Scala and allow users to access to the output of commonly used df.printSchema() without printing it out.

### Does this PR introduce _any_ user-facing change?
Yes, a new Python method


### How was this patch tested?
Added PySpark & Spark Connect test.


### Was this patch authored or co-authored using generative AI tooling?
No
