### PR TITLE
[SPARK-45691][CORE][SQL][TESTS] Clean up the deprecated API usage related to `RightProjection/LeftProjection/Either`

### DIFF
--- a/core/src/test/scala/org/apache/spark/storage/MemoryStoreSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/MemoryStoreSuite.scala
@@ -196,7 +196,7 @@ class MemoryStoreSuite
     assert(memoryStore.currentUnrollMemoryForThisTask > 0) // we returned an iterator
     assert(!memoryStore.contains("someBlock2"))
     assert(putResult.isLeft)
-    assertSameContents(bigList, putResult.left.get.toSeq, "putIterator")
+    assertSameContents(bigList, putResult.swap.getOrElse(fail()).toSeq, "putIterator")
     // The unroll memory was freed once the iterator returned by putIterator() was fully traversed.
     assert(memoryStore.currentUnrollMemoryForThisTask === 0)
   }
@@ -264,7 +264,7 @@ class MemoryStoreSuite
     assert(memoryStore.contains("b3"))
     assert(!memoryStore.contains("b4"))
     assert(memoryStore.currentUnrollMemoryForThisTask > 0) // we returned an iterator
-    result4.left.get.close()
+    result4.swap.getOrElse(fail()).close()
     assert(memoryStore.currentUnrollMemoryForThisTask === 0) // close released the unroll memory
   }
 
@@ -340,7 +340,7 @@ class MemoryStoreSuite
     assert(memoryStore.contains("b3"))
     assert(!memoryStore.contains("b4"))
     assert(memoryStore.currentUnrollMemoryForThisTask > 0) // we returned an iterator
-    result4.left.get.discard()
+    result4.swap.getOrElse(fail()).discard()
     assert(memoryStore.currentUnrollMemoryForThisTask === 0) // discard released the unroll memory
   }
 
@@ -357,7 +357,8 @@ class MemoryStoreSuite
     blockInfoManager.unlock("b1")
     assert(res.isLeft)
     assert(memoryStore.currentUnrollMemoryForThisTask > 0)
-    val valuesReturnedFromFailedPut = res.left.get.valuesIterator.toSeq // force materialization
+    val valuesReturnedFromFailedPut = res.swap.getOrElse(fail())
+      .valuesIterator.toSeq // force materialization
     assertSameContents(
       bigList, valuesReturnedFromFailedPut, "PartiallySerializedBlock.valuesIterator()")
     // The unroll memory was freed once the iterator was fully traversed.
@@ -378,7 +379,7 @@ class MemoryStoreSuite
     assert(res.isLeft)
     assert(memoryStore.currentUnrollMemoryForThisTask > 0)
     val bos = new ByteBufferOutputStream()
-    res.left.get.finishWritingToStream(bos)
+    res.swap.getOrElse(fail()).finishWritingToStream(bos)
     // The unroll memory was freed once the block was fully written.
     assert(memoryStore.currentUnrollMemoryForThisTask === 0)
     val deserializedValues = serializerManager.dataDeserializeStream[Any](

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/GroupBasedRowLevelOperationScanPlanning.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/GroupBasedRowLevelOperationScanPlanning.scala
@@ -51,9 +51,13 @@ object GroupBasedRowLevelOperationScanPlanning extends Rule[LogicalPlan] with Pr
         pushFilters(cond, relation.output, scanBuilder)
 
       val pushedFiltersStr = if (pushedFilters.isLeft) {
-        pushedFilters.left.get.mkString(", ")
+        pushedFilters.swap
+          .getOrElse(throw new NoSuchElementException("The left node doesn't have pushedFilters"))
+          .mkString(", ")
       } else {
-        pushedFilters.right.get.mkString(", ")
+        pushedFilters
+          .getOrElse(throw new NoSuchElementException("The right node doesn't have pushedFilters"))
+          .mkString(", ")
       }
 
       val (scan, output) = PushDownUtils.pruneColumns(scanBuilder, relation, relation.output, Nil)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
@@ -73,10 +73,13 @@ object V2ScanRelationPushDown extends Rule[LogicalPlan] with PredicateHelper {
       val (pushedFilters, postScanFiltersWithoutSubquery) = PushDownUtils.pushFilters(
         sHolder.builder, normalizedFiltersWithoutSubquery)
       val pushedFiltersStr = if (pushedFilters.isLeft) {
-        pushedFilters.left.get.mkString(", ")
+        pushedFilters.swap
+          .getOrElse(throw new NoSuchElementException("The left node doesn't have pushedFilters"))
+          .mkString(", ")
       } else {
-        sHolder.pushedPredicates = pushedFilters.right.get
-        pushedFilters.right.get.mkString(", ")
+        sHolder.pushedPredicates = pushedFilters
+          .getOrElse(throw new NoSuchElementException("The right node doesn't have pushedFilters"))
+        sHolder.pushedPredicates.mkString(", ")
       }
 
       val postScanFilters = postScanFiltersWithoutSubquery ++ normalizedFiltersWithSubquery

--- a/sql/hive/src/test/scala/org/apache/spark/sql/sources/HadoopFsRelationTest.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/sources/HadoopFsRelationTest.scala
@@ -713,7 +713,7 @@ abstract class HadoopFsRelationTest extends QueryTest with SQLTestUtils with Tes
             .format(dataSourceName)
             .load(path)
           assert(expectedResult.isLeft, s"Error was expected with $path but result found")
-          checkAnswer(testDf, expectedResult.left.get)
+          checkAnswer(testDf, expectedResult.swap.getOrElse(fail()))
         } catch {
           case e: java.util.NoSuchElementException if e.getMessage.contains("dataSchema") =>
             // Ignore error, the source format requires schema to be provided by user
@@ -722,7 +722,7 @@ abstract class HadoopFsRelationTest extends QueryTest with SQLTestUtils with Tes
           case e: Throwable =>
             assert(expectedResult.isRight, s"Was not expecting error with $path: " + e)
             assert(
-              e.getMessage.contains(expectedResult.right.get),
+              e.getMessage.contains(expectedResult.getOrElse(fail())),
               s"Did not find expected error message with $path")
         }
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?
`Either` became right-biased after Scala 2.13.0, so this pr was refactored according to the following scala-doc:

- Either

```
@deprecated("Either is now right-biased, use methods directly on Either", "2.13.0")
def right = Either.RightProjection(this)
```

- LeftProjection
```
@deprecated("use `Either.swap.getOrElse` instead", "2.13.0")
def get: A = e match {
    case Left(a) => a
    case _       => throw new NoSuchElementException("Either.left.get on Right")
}
```

- RightProjection
```
@deprecated("Either is now right-biased, calls to `right` should be removed", "2.13.0")
final case class RightProjection[+A, +B](e: Either[A, B]) {
...
    @deprecated("Use `Either.toOption.get` instead", "2.13.0")
    def get: B = e match {
      case Right(b) => b
      case _        => throw new NoSuchElementException("Either.right.get on Left")
    }
...
}
```

### Why are the changes needed?
Clean up deprecated Scala API usage


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions

### Was this patch authored or co-authored using generative AI tooling?
No
