### PR TITLE
[SPARK-45717][YARN] Avoid use `spark.yarn.user.classpath.first`

### DIFF
--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -1490,7 +1490,7 @@ private[spark] object Client extends Logging {
    * Populate the classpath entry in the given environment map.
    *
    * User jars are generally not added to the JVM's system classpath; those are handled by the AM
-   * and executor backend. When the deprecated `spark.yarn.user.classpath.first` is used, user jars
+   * and executor backend. When the `spark.driver.userClassPathFirst` is used, user jars
    * are included in the system classpath, though. The extra class path and other uploaded files are
    * always made available through the system class path.
    *
@@ -1515,7 +1515,7 @@ private[spark] object Client extends Logging {
 
     addClasspathEntry(Environment.PWD.$$() + Path.SEPARATOR + LOCALIZED_CONF_DIR, env)
 
-    if (sparkConf.get(USER_CLASS_PATH_FIRST)) {
+    if (sparkConf.get(USER_CLASS_PATH_FIRST) || sparkConf.get(DRIVER_USER_CLASS_PATH_FIRST)) {
       // in order to properly add the app jar when user classpath is first
       // we have to do the mainJar separate in order to send the right thing
       // into addFileToClasspath

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ClientSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ClientSuite.scala
@@ -106,7 +106,7 @@ class ClientSuite extends SparkFunSuite
     val conf = new Configuration()
     val sparkConf = new SparkConf()
       .set(SPARK_JARS, Seq(SPARK))
-      .set(USER_CLASS_PATH_FIRST, true)
+      .set(DRIVER_USER_CLASS_PATH_FIRST, true)
       .set("spark.yarn.dist.jars", ADDED)
     val env = new MutableHashMap[String, String]()
     val args = new ClientArguments(Array("--jar", USER))


### PR DESCRIPTION
### What changes were proposed in this pull request?
Use `spark.driver.userClassPathFirst` instead of `spark.yarn.user.classpath.first`.

### Why are the changes needed?
When we set `spark.yarn.user.classpath.first=true`, we get the following message.
```
23/10/30 14:32:16.855 pool-1-thread-1-ScalaTest-running-ClientSuite 
WARN SparkConf: The configuration key 'spark.yarn.user.classpath.first' has been deprecated as of Spark 1.3 and may be removed in the future. Please use spark.{driver,executor}.userClassPathFirst instead. 
```
### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
exist UT


### Was this patch authored or co-authored using generative AI tooling?
No