### PR TITLE
[SPARK-45683][CORE][SQL][SS][CONNECT][DSTREAM][YARN][SHELL][AVRO] Fix `method any2stringadd in object Predef is deprecated`

### DIFF
--- a/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
+++ b/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
@@ -800,7 +800,7 @@ abstract class AvroSuite
       val namespace = "org.apache.spark.avro"
       val parameters = Map("recordName" -> name, "recordNamespace" -> namespace)
 
-      val avroDir = tempDir + "/namedAvro"
+      val avroDir = s"$tempDir/namedAvro"
       spark.read.format("avro").load(testAvro)
         .write.options(parameters).format("avro").save(avroDir)
       checkReloadMatchesSaved(testAvro, avroDir)
@@ -1007,7 +1007,7 @@ abstract class AvroSuite
         Row("Munich", 8, new Timestamp(42), Decimal(3.14), arrayOfByte)))
       val cityDataFrame = spark.createDataFrame(cityRDD, testSchema)
 
-      val avroDir = tempDir + "/avro"
+      val avroDir = s"$tempDir/avro"
       cityDataFrame.write.format("avro").save(avroDir)
       assert(spark.read.format("avro").load(avroDir).collect().length == 3)
 
@@ -1039,7 +1039,7 @@ abstract class AvroSuite
         StructField("_1", DateType, false), StructField("_2", TimestampType, false)))
       val writeDs = Seq((currentDate, currentTime)).toDS()
 
-      val avroDir = tempDir + "/avro"
+      val avroDir = s"$tempDir/avro"
       writeDs.write.format("avro").save(avroDir)
       assert(spark.read.format("avro").load(avroDir).collect().length == 1)
 
@@ -1068,7 +1068,7 @@ abstract class AvroSuite
       )
       val writeDs = Seq((nullDate, nullTime)).toDS()
 
-      val avroDir = tempDir + "/avro"
+      val avroDir = s"$tempDir/avro"
       writeDs.write.format("avro").save(avroDir)
       val readValues =
         spark.read.schema(schema).format("avro").load(avroDir).as[(Date, Timestamp)].collect()

--- a/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/client/ArtifactManager.scala
+++ b/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/client/ArtifactManager.scala
@@ -111,7 +111,7 @@ class ArtifactManager(
   def addArtifacts(uris: Seq[URI]): Unit = addArtifacts(uris.flatMap(parseArtifacts))
 
   private[client] def isCachedArtifact(hash: String): Boolean = {
-    val artifactName = CACHE_PREFIX + "/" + hash
+    val artifactName = s"$CACHE_PREFIX/$hash"
     val request = proto.ArtifactStatusesRequest
       .newBuilder()
       .setUserContext(clientConfig.userContext)

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/artifact/util/ArtifactUtils.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/artifact/util/ArtifactUtils.scala
@@ -33,7 +33,7 @@ object ArtifactUtils {
     // and `normalizedPath` = "/base/file.txt".
     val normalizedPath = concatenatedPath.normalize()
     // Verify that the prefix of the `normalizedPath` starts with `basePath/`.
-    require(normalizedPath != basePath && normalizedPath.startsWith(basePath + "/"))
+    require(normalizedPath != basePath && normalizedPath.startsWith(s"$basePath/"))
     normalizedPath
   }
 

--- a/core/src/main/scala/org/apache/spark/deploy/client/StandaloneAppClient.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/client/StandaloneAppClient.scala
@@ -171,13 +171,13 @@ private[spark] class StandaloneAppClient(
         stop()
 
       case ExecutorAdded(id: Int, workerId: String, hostPort: String, cores: Int, memory: Int) =>
-        val fullId = appId + "/" + id
+        val fullId = s"$appId/$id"
         logInfo("Executor added: %s on %s (%s) with %d core(s)".format(fullId, workerId, hostPort,
           cores))
         listener.executorAdded(fullId, workerId, hostPort, cores, memory)
 
       case ExecutorUpdated(id, state, message, exitStatus, workerHost) =>
-        val fullId = appId + "/" + id
+        val fullId = s"$appId/$id"
         val messageText = message.map(s => " (" + s + ")").getOrElse("")
         logInfo("Executor updated: %s is now %s%s".format(fullId, state, messageText))
         if (ExecutorState.isFinished(state)) {

--- a/core/src/main/scala/org/apache/spark/rpc/RpcEndpoint.scala
+++ b/core/src/main/scala/org/apache/spark/rpc/RpcEndpoint.scala
@@ -67,7 +67,7 @@ private[spark] trait RpcEndpoint {
    * unmatched message, `SparkException` will be thrown and sent to `onError`.
    */
   def receive: PartialFunction[Any, Unit] = {
-    case _ => throw new SparkException(self + " does not implement 'receive'")
+    case _ => throw new SparkException(s"$self does not implement 'receive'")
   }
 
   /**
@@ -75,7 +75,7 @@ private[spark] trait RpcEndpoint {
    * `SparkException` will be thrown and sent to `onError`.
    */
   def receiveAndReply(context: RpcCallContext): PartialFunction[Any, Unit] = {
-    case _ => context.sendFailure(new SparkException(self + " won't reply anything"))
+    case _ => context.sendFailure(new SparkException(s"$self won't reply anything"))
   }
 
   /**

--- a/core/src/test/scala/org/apache/spark/FileSuite.scala
+++ b/core/src/test/scala/org/apache/spark/FileSuite.scala
@@ -380,12 +380,12 @@ class FileSuite extends SparkFunSuite with LocalSparkContext {
 
   test("file caching") {
     sc = new SparkContext("local", "test")
-    val out = new FileWriter(tempDir + "/input")
+    val out = new FileWriter(s"$tempDir/input")
     out.write("Hello world!\n")
     out.write("What's up?\n")
     out.write("Goodbye\n")
     out.close()
-    val rdd = sc.textFile(tempDir + "/input").cache()
+    val rdd = sc.textFile(s"$tempDir/input").cache()
     assert(rdd.count() === 3)
     assert(rdd.count() === 3)
     assert(rdd.count() === 3)

--- a/core/src/test/scala/org/apache/spark/deploy/RPackageUtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/RPackageUtilsSuite.scala
@@ -104,7 +104,7 @@ class RPackageUtilsSuite
     val deps = Seq(dep1, dep2).mkString(",")
     IvyTestUtils.withRepository(main, Some(deps), None, withR = true) { repo =>
       val jars = Seq(main, dep1, dep2).map { c =>
-        getJarPath(c, new File(new URI(repo))) + "dummy"
+        getJarPath(c, new File(new URI(repo))).toString + "dummy"
       }.mkString(",")
       RPackageUtils.checkAndBuildRPackage(jars, new BufferPrintStream, verbose = true)
       val individualJars = jars.split(",")

--- a/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
@@ -1633,7 +1633,7 @@ object JarCreationTest extends Logging {
         Utils.classForName(args(1))
       } catch {
         case t: Throwable =>
-          exception = t + "\n" + Utils.exceptionString(t)
+          exception = t.toString + "\n" + Utils.exceptionString(t)
           exception = exception.replaceAll("\n", "\n\t")
       }
       Option(exception).toSeq.iterator

--- a/core/src/test/scala/org/apache/spark/rdd/LocalCheckpointSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/LocalCheckpointSuite.scala
@@ -236,7 +236,7 @@ class LocalCheckpointSuite extends SparkFunSuite with LocalSparkContext {
       targetStorageLevel: StorageLevel): Unit = {
     require(targetStorageLevel !== StorageLevel.NONE)
     require(rdd.isLocallyCheckpointed)
-    val rdd1 = rdd.map { i => i + "1" }
+    val rdd1 = rdd.map { i => i.toString + "1" }
     val rdd2 = rdd1.map { i => i + "2" }
     val rdd3 = rdd2.map { i => i + "3" }
     val rddDependencies = rdd.dependencies

--- a/core/src/test/scala/org/apache/spark/scheduler/PoolSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/PoolSuite.scala
@@ -353,7 +353,7 @@ class PoolSuite extends SparkFunSuite with LocalSparkContext {
       Utils.getSparkClassLoader.getResource("fairscheduler-with-valid-data.xml").getFile)
     TestUtils.withHttpServer(xmlPath.getParent.toUri.getPath) { baseURL =>
       val conf = new SparkConf().set(SCHEDULER_ALLOCATION_FILE,
-        baseURL + "fairscheduler-with-valid-data.xml")
+        baseURL.toString + "fairscheduler-with-valid-data.xml")
       sc = new SparkContext(LOCAL, APP_NAME, conf)
 
       val rootPool = new Pool("", SchedulingMode.FAIR, 0, 0)

--- a/core/src/test/scala/org/apache/spark/scheduler/SparkListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/SparkListenerSuite.scala
@@ -328,10 +328,10 @@ class SparkListenerSuite extends SparkFunSuite with LocalSparkContext with Match
        */
       checkNonZeroAvg(
         taskInfoMetrics.map(_._2.executorRunTime),
-        stageInfo + " executorRunTime")
+        stageInfo.toString + " executorRunTime")
       checkNonZeroAvg(
         taskInfoMetrics.map(_._2.executorDeserializeTime),
-        stageInfo + " executorDeserializeTime")
+        stageInfo.toString + " executorDeserializeTime")
 
       /* Test is disabled (SEE SPARK-2208)
       if (stageInfo.rddInfos.exists(_.name == d4.name)) {

--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -352,7 +352,7 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties {
   def testOffsetBytes(isCompressed: Boolean): Unit = {
     withTempDir { tmpDir2 =>
       val suffix = getSuffix(isCompressed)
-      val f1Path = tmpDir2 + "/f1" + suffix
+      val f1Path = s"$tmpDir2/f1$suffix"
       writeLogFile(f1Path, "1\n2\n3\n4\n5\n6\n7\n8\n9\n".getBytes(UTF_8))
       val f1Length = Utils.getFileLength(new File(f1Path), workerConf)
 

--- a/repl/src/test/scala/org/apache/spark/repl/SingletonReplSuite.scala
+++ b/repl/src/test/scala/org/apache/spark/repl/SingletonReplSuite.scala
@@ -191,7 +191,7 @@ class SingletonReplSuite extends SparkFunSuite {
 
   test("interacting with files") {
     val tempDir = Utils.createTempDir()
-    val out = new FileWriter(tempDir + "/input")
+    val out = new FileWriter(s"$tempDir/input")
     out.write("Hello world!\n")
     out.write("What's up?\n")
     out.write("Goodbye\n")

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/network/yarn/YarnShuffleServiceSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/network/yarn/YarnShuffleServiceSuite.scala
@@ -421,7 +421,7 @@ abstract class YarnShuffleServiceSuite extends SparkFunSuite with Matchers {
 
     execStateFile.listFiles().foreach{_.delete()}
 
-    val out = new DataOutputStream(new FileOutputStream(execStateFile + "/CURRENT"))
+    val out = new DataOutputStream(new FileOutputStream(s"$execStateFile/CURRENT"))
     out.writeInt(42)
     out.close()
 

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/Decimal.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/Decimal.scala
@@ -277,7 +277,7 @@ final class Decimal extends Ordered[Decimal] with Serializable {
   private[sql] def roundToInt(): Int =
     roundToNumeric[Int](IntegerType, Int.MaxValue, Int.MinValue) (_.toInt) (_.toInt)
 
-  private def toSqlValue: String = this + "BD"
+  private def toSqlValue: String = this.toString + "BD"
 
   private def roundToNumeric[T <: AnyVal](integralType: IntegralType, maxValue: Int, minValue: Int)
       (f1: Long => T) (f2: Double => T): T = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
@@ -717,8 +717,8 @@ abstract class BinaryExpression extends Expression with BinaryLike[Expression] {
 
     if (nullable) {
       val nullSafeEval =
-        leftGen.code + ctx.nullSafeExec(left.nullable, leftGen.isNull) {
-          rightGen.code + ctx.nullSafeExec(right.nullable, rightGen.isNull) {
+        leftGen.code.toString + ctx.nullSafeExec(left.nullable, leftGen.isNull) {
+          rightGen.code.toString + ctx.nullSafeExec(right.nullable, rightGen.isNull) {
             s"""
               ${ev.isNull} = false; // resultCode could change nullability.
               $resultCode
@@ -869,9 +869,9 @@ abstract class TernaryExpression extends Expression with TernaryLike[Expression]
 
     if (nullable) {
       val nullSafeEval =
-        leftGen.code + ctx.nullSafeExec(children(0).nullable, leftGen.isNull) {
-          midGen.code + ctx.nullSafeExec(children(1).nullable, midGen.isNull) {
-            rightGen.code + ctx.nullSafeExec(children(2).nullable, rightGen.isNull) {
+        leftGen.code.toString + ctx.nullSafeExec(children(0).nullable, leftGen.isNull) {
+          midGen.code.toString + ctx.nullSafeExec(children(1).nullable, midGen.isNull) {
+            rightGen.code.toString + ctx.nullSafeExec(children(2).nullable, rightGen.isNull) {
               s"""
                 ${ev.isNull} = false; // resultCode could change nullability.
                 $resultCode
@@ -971,10 +971,10 @@ abstract class QuaternaryExpression extends Expression with QuaternaryLike[Expre
 
     if (nullable) {
       val nullSafeEval =
-        firstGen.code + ctx.nullSafeExec(children(0).nullable, firstGen.isNull) {
-          secondGen.code + ctx.nullSafeExec(children(1).nullable, secondGen.isNull) {
-            thridGen.code + ctx.nullSafeExec(children(2).nullable, thridGen.isNull) {
-              fourthGen.code + ctx.nullSafeExec(children(3).nullable, fourthGen.isNull) {
+        firstGen.code.toString + ctx.nullSafeExec(children(0).nullable, firstGen.isNull) {
+          secondGen.code.toString + ctx.nullSafeExec(children(1).nullable, secondGen.isNull) {
+            thridGen.code.toString + ctx.nullSafeExec(children(2).nullable, thridGen.isNull) {
+              fourthGen.code.toString + ctx.nullSafeExec(children(3).nullable, fourthGen.isNull) {
                 s"""
                   ${ev.isNull} = false; // resultCode could change nullability.
                   $resultCode
@@ -1093,11 +1093,11 @@ abstract class QuinaryExpression extends Expression {
 
     if (nullable) {
       val nullSafeEval =
-        firstGen.code + ctx.nullSafeExec(children(0).nullable, firstGen.isNull) {
-          secondGen.code + ctx.nullSafeExec(children(1).nullable, secondGen.isNull) {
-            thirdGen.code + ctx.nullSafeExec(children(2).nullable, thirdGen.isNull) {
-              fourthGen.code + ctx.nullSafeExec(children(3).nullable, fourthGen.isNull) {
-                fifthGen.code + ctx.nullSafeExec(children(4).nullable, fifthGen.isNull) {
+        firstGen.code.toString + ctx.nullSafeExec(children(0).nullable, firstGen.isNull) {
+          secondGen.code.toString + ctx.nullSafeExec(children(1).nullable, secondGen.isNull) {
+            thirdGen.code.toString + ctx.nullSafeExec(children(2).nullable, thirdGen.isNull) {
+              fourthGen.code.toString + ctx.nullSafeExec(children(3).nullable, fourthGen.isNull) {
+                fifthGen.code.toString + ctx.nullSafeExec(children(4).nullable, fifthGen.isNull) {
                   s"""
                       ${ev.isNull} = false; // resultCode could change nullability.
                       $resultCode
@@ -1237,19 +1237,19 @@ abstract class SeptenaryExpression extends Expression {
 
     if (nullable) {
       val nullSafeEval =
-        firstGen.code + ctx.nullSafeExec(children(0).nullable, firstGen.isNull) {
-          secondGen.code + ctx.nullSafeExec(children(1).nullable, secondGen.isNull) {
-            thirdGen.code + ctx.nullSafeExec(children(2).nullable, thirdGen.isNull) {
-              fourthGen.code + ctx.nullSafeExec(children(3).nullable, fourthGen.isNull) {
-                fifthGen.code + ctx.nullSafeExec(children(4).nullable, fifthGen.isNull) {
-                  sixthGen.code + ctx.nullSafeExec(children(5).nullable, sixthGen.isNull) {
+        firstGen.code.toString + ctx.nullSafeExec(children(0).nullable, firstGen.isNull) {
+          secondGen.code.toString + ctx.nullSafeExec(children(1).nullable, secondGen.isNull) {
+            thirdGen.code.toString + ctx.nullSafeExec(children(2).nullable, thirdGen.isNull) {
+              fourthGen.code.toString + ctx.nullSafeExec(children(3).nullable, fourthGen.isNull) {
+                fifthGen.code.toString + ctx.nullSafeExec(children(4).nullable, fifthGen.isNull) {
+                  sixthGen.code.toString + ctx.nullSafeExec(children(5).nullable, sixthGen.isNull) {
                     val nullSafeResultCode =
                       s"""
                       ${ev.isNull} = false; // resultCode could change nullability.
                       $resultCode
                       """
                     seventhGen.map { gen =>
-                      gen.code + ctx.nullSafeExec(children(6).nullable, gen.isNull) {
+                      gen.code.toString + ctx.nullSafeExec(children(6).nullable, gen.isNull) {
                         nullSafeResultCode
                       }
                     }.getOrElse(nullSafeResultCode)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateSafeProjection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateSafeProjection.scala
@@ -155,7 +155,7 @@ object GenerateSafeProjection extends CodeGenerator[Seq[Expression], Projection]
       case (e, i) =>
         val evaluationCode = e.genCode(ctx)
         val converter = convertToSafe(ctx, evaluationCode.value, e.dataType)
-        evaluationCode.code +
+        evaluationCode.code.toString +
           s"""
             if (${evaluationCode.isNull}) {
               mutableRow.setNullAt($i);

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -2003,8 +2003,8 @@ case class ArrayJoin(
          |${ev.value} = $buffer.build();""".stripMargin
 
     if (array.nullable || delimiter.nullable) {
-      arrayGen.code + ctx.nullSafeExec(array.nullable, arrayGen.isNull) {
-        delimiterGen.code + ctx.nullSafeExec(delimiter.nullable, delimiterGen.isNull) {
+      arrayGen.code.toString + ctx.nullSafeExec(array.nullable, arrayGen.isNull) {
+        delimiterGen.code.toString + ctx.nullSafeExec(delimiter.nullable, delimiterGen.isNull) {
           s"""
              |${ev.isNull} = false;
              |$resultCode""".stripMargin
@@ -3087,9 +3087,9 @@ case class Sequence(
 
     if (nullable) {
       val nullSafeEval =
-        startGen.code + ctx.nullSafeExec(start.nullable, startGen.isNull) {
-          stopGen.code + ctx.nullSafeExec(stop.nullable, stopGen.isNull) {
-            stepGen.code + ctx.nullSafeExec(stepOpt.exists(_.nullable), stepGen.isNull) {
+        startGen.code.toString + ctx.nullSafeExec(start.nullable, startGen.isNull) {
+          stopGen.code.toString + ctx.nullSafeExec(stop.nullable, stopGen.isNull) {
+            stepGen.code.toString + ctx.nullSafeExec(stepOpt.exists(_.nullable), stepGen.isNull) {
               s"""
                  |${ev.isNull} = false;
                  |$resultCode
@@ -5006,8 +5006,8 @@ case class ArrayInsert(
 
     if (nullable) {
       val nullSafeEval =
-        leftGen.code + ctx.nullSafeExec(first.nullable, leftGen.isNull) {
-          midGen.code + ctx.nullSafeExec(second.nullable, midGen.isNull) {
+        leftGen.code.toString + ctx.nullSafeExec(first.nullable, leftGen.isNull) {
+          midGen.code.toString + ctx.nullSafeExec(second.nullable, midGen.isNull) {
             s"""
               ${rightGen.code}
               ${ev.isNull} = false;

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/hash.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/hash.scala
@@ -303,7 +303,7 @@ abstract class HashExpression[E] extends Expression {
 
     val childrenHash = children.map { child =>
       val childGen = child.genCode(ctx)
-      childGen.code + ctx.nullSafeExec(child.nullable, childGen.isNull) {
+      childGen.code.toString + ctx.nullSafeExec(child.nullable, childGen.isNull) {
         computeHash(childGen.value, child.dataType, ev.value, ctx)
       }
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
@@ -2231,16 +2231,18 @@ case class Levenshtein(
     val resultCode = s"${ev.value} = ${leftGen.value}.levenshteinDistance(" +
       s"${rightGen.value}, ${thresholdGen.value});"
     if (nullable) {
-      val nullSafeEval = leftGen.code + ctx.nullSafeExec(children.head.nullable, leftGen.isNull) {
-        rightGen.code + ctx.nullSafeExec(children(1).nullable, rightGen.isNull) {
-          thresholdGen.code + ctx.nullSafeExec(thresholdExpr.nullable, thresholdGen.isNull) {
-            s"""
-              ${ev.isNull} = false;
-              $resultCode
-             """
+      val nullSafeEval =
+        leftGen.code.toString + ctx.nullSafeExec(children.head.nullable, leftGen.isNull) {
+          rightGen.code.toString + ctx.nullSafeExec(children(1).nullable, rightGen.isNull) {
+            thresholdGen.code.toString +
+              ctx.nullSafeExec(thresholdExpr.nullable, thresholdGen.isNull) {
+                s"""
+                  ${ev.isNull} = false;
+                  $resultCode
+                 """
+              }
           }
         }
-      }
       ev.copy(code = code"""
         boolean ${ev.isNull} = true;
         ${CodeGenerator.javaType(dataType)} ${ev.value} = ${CodeGenerator.defaultValue(dataType)};
@@ -2259,14 +2261,15 @@ case class Levenshtein(
     val rightGen = children(1).genCode(ctx)
     val resultCode = s"${ev.value} = ${leftGen.value}.levenshteinDistance(${rightGen.value});"
     if (nullable) {
-      val nullSafeEval = leftGen.code + ctx.nullSafeExec(children.head.nullable, leftGen.isNull) {
-        rightGen.code + ctx.nullSafeExec(children(1).nullable, rightGen.isNull) {
-          s"""
-            ${ev.isNull} = false;
-            $resultCode
-           """
+      val nullSafeEval =
+        leftGen.code.toString + ctx.nullSafeExec(children.head.nullable, leftGen.isNull) {
+          rightGen.code.toString + ctx.nullSafeExec(children(1).nullable, rightGen.isNull) {
+            s"""
+              ${ev.isNull} = false;
+              $resultCode
+             """
+          }
         }
-      }
       ev.copy(code = code"""
         boolean ${ev.isNull} = true;
         ${CodeGenerator.javaType(dataType)} ${ev.value} = ${CodeGenerator.defaultValue(dataType)};

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -1422,7 +1422,7 @@ case class Pivot(
         pivotValues.map(value => AttributeReference(value.toString, agg.dataType)())
       case _ =>
         pivotValues.flatMap { value =>
-          aggregates.map(agg => AttributeReference(value + "_" + agg.sql, agg.dataType)())
+          aggregates.map(agg => AttributeReference(s"${value}_${agg.sql}", agg.dataType)())
         }
     }
     groupByExprsOpt.getOrElse(Seq.empty).map(_.toAttribute) ++ pivotAgg

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -820,7 +820,7 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]]
     val redactedMap = SQLConf.get.redactOptions(map.toMap)
     // construct the redacted map as strings of the format "key=value"
     val keyValuePairs = redactedMap.toSeq.map { item =>
-      item._1 + "=" + item._2
+      s"${item._1}=${item._2}"
     }
     truncatedString(keyValuePairs, "[", ", ", "]", maxFields) :: Nil
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/package.scala
@@ -101,7 +101,7 @@ package object util extends Logging {
       val name = e.name.getOrElse(e.childSchema(e.ordinal).name)
       PrettyAttribute(usePrettyExpression(e.child).sql + "." + name, e.dataType)
     case e: GetArrayStructFields =>
-      PrettyAttribute(usePrettyExpression(e.child) + "." + e.field.name, e.dataType)
+      PrettyAttribute(s"${usePrettyExpression(e.child)}.${e.field.name}", e.dataType)
     case r: InheritAnalysisRules =>
       PrettyAttribute(r.makeSQLString(r.parameters.map(toPrettySQL)), r.dataType)
     case c: Cast if c.getTagValue(Cast.USER_SPECIFIED_CAST).isEmpty =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ddl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ddl.scala
@@ -87,7 +87,7 @@ case class CreateTempViewUsing(
 
   override def argString(maxFields: Int): String = {
     s"[tableIdent:$tableIdent " +
-      userSpecifiedSchema.map(_ + " ").getOrElse("") +
+      userSpecifiedSchema.map(_.toString() + " ").getOrElse("") +
       s"replace:$replace " +
       s"provider:$provider " +
       conf.redactOptions(options)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -2184,12 +2184,12 @@ abstract class DDLSuite extends QueryTest with DDLSuiteBase {
 
   test("Refresh table before drop database cascade") {
     withTempDir { tempDir =>
-      val file1 = new File(tempDir + "/first.csv")
+      val file1 = new File(s"$tempDir/first.csv")
       Utils.tryWithResource(new PrintWriter(file1)) { writer =>
         writer.write("first")
       }
 
-      val file2 = new File(tempDir + "/second.csv")
+      val file2 = new File(s"$tempDir/second.csv")
       Utils.tryWithResource(new PrintWriter(file2)) { writer =>
         writer.write("second")
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/binaryfile/BinaryFileFormatSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/binaryfile/BinaryFileFormatSuite.scala
@@ -165,7 +165,7 @@ class BinaryFileFormatSuite extends QueryTest with SharedSparkSession {
       val thrown = intercept[UnsupportedOperationException] {
         df.write
           .format(BINARY_FILE)
-          .save(tmpDir + "/test_save")
+          .save(s"$tmpDir/test_save")
       }
       assert(thrown.getMessage.contains("Write is not supported for binary file data source"))
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcFilterSuite.scala
@@ -650,7 +650,7 @@ class OrcFilterSuite extends OrcTest with SharedSparkSession {
     withTempPath { dir =>
       val count = 10
       val tableName = "spark_32622"
-      val tableDir1 = dir.getAbsoluteFile + "/table1"
+      val tableDir1 = s"${dir.getAbsoluteFile}/table1"
 
       // Physical ORC files have both `A` and `a` fields.
       withSQLConf(SQLConf.CASE_SENSITIVE.key -> "true") {
@@ -712,7 +712,7 @@ class OrcFilterSuite extends OrcTest with SharedSparkSession {
       }
 
       // Physical ORC files have only `A` field.
-      val tableDir2 = dir.getAbsoluteFile + "/table2"
+      val tableDir2 = s"${dir.getAbsoluteFile}/table2"
       withSQLConf(SQLConf.CASE_SENSITIVE.key -> "true") {
         spark.range(count).repartition(count).selectExpr("id - 1 as A")
           .write.mode("overwrite").orc(tableDir2)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
@@ -1866,7 +1866,7 @@ abstract class ParquetFilterSuite extends QueryTest with ParquetTest with Shared
     withTempPath { dir =>
       val count = 10
       val tableName = "spark_25207"
-      val tableDir = dir.getAbsoluteFile + "/table"
+      val tableDir = s"${dir.getAbsoluteFile}/table"
       withTable(tableName) {
         withSQLConf(SQLConf.CASE_SENSITIVE.key -> "true") {
           spark.range(count).selectExpr("id as A", "id as B", "id as b")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/AsyncProgressTrackingMicroBatchExecutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/AsyncProgressTrackingMicroBatchExecutionSuite.scala
@@ -1164,11 +1164,11 @@ class AsyncProgressTrackingMicroBatchExecutionSuite
           Execute { q =>
             // offset log and commit log entries for batch 0 should be purged
             waitPendingOffsetWrites(q)
-            getListOfFiles(checkpointLocation + "/offsets")
+            getListOfFiles(s"$checkpointLocation/offsets")
               .filter(file => !file.isHidden)
               .map(file => file.getName.toInt)
               .sorted should equal(Array(3, 7))
-            getListOfFiles(checkpointLocation + "/commits")
+            getListOfFiles(s"$checkpointLocation/commits")
               .filter(file => !file.isHidden)
               .map(file => file.getName.toInt)
               .sorted should equal(Array(3, 7))
@@ -1221,11 +1221,11 @@ class AsyncProgressTrackingMicroBatchExecutionSuite
           Execute { q =>
             // offset log and commit log entries for batch 3 and 7 should be purged
           waitPendingOffsetWrites(q)
-            getListOfFiles(checkpointLocation + "/offsets")
+            getListOfFiles(s"$checkpointLocation/offsets")
               .filter(file => !file.isHidden)
               .map(file => file.getName.toInt)
               .sorted should equal(Array(8, 12))
-            getListOfFiles(checkpointLocation + "/commits")
+            getListOfFiles(s"$checkpointLocation/commits")
               .filter(file => !file.isHidden)
               .map(file => file.getName.toInt)
               .sorted should equal(Array(8, 12))
@@ -1274,12 +1274,12 @@ class AsyncProgressTrackingMicroBatchExecutionSuite
             // wait for async log writes to complete
             waitPendingOffsetWrites(q)
             eventually(timeout(Span(5, Seconds))) {
-              getListOfFiles(checkpointLocation + "/offsets")
+              getListOfFiles(s"$checkpointLocation/offsets")
                 .filter(file => !file.isHidden)
                 .map(file => file.getName.toInt)
                 .sorted should equal(Array(0, 3))
 
-              getListOfFiles(checkpointLocation + "/commits")
+              getListOfFiles(s"$checkpointLocation/commits")
                 .filter(file => !file.isHidden)
                 .map(file => file.getName.toInt)
                 .sorted should equal(Array(0, 3))
@@ -1303,13 +1303,13 @@ class AsyncProgressTrackingMicroBatchExecutionSuite
             waitPendingOffsetWrites(q)
             // can contain batches 0, 3, 7 or 3, 7
             eventually(timeout(Span(5, Seconds))) {
-              getListOfFiles(checkpointLocation + "/offsets")
+              getListOfFiles(s"$checkpointLocation/offsets")
                 .filter(file => !file.isHidden)
                 .map(file => file.getName.toInt)
                 .sorted should contain allElementsOf (Array(3, 7))
 
               // can contain batches 0, 3, 7 or 3, 7
-              getListOfFiles(checkpointLocation + "/commits")
+              getListOfFiles(s"$checkpointLocation/commits")
                 .filter(file => !file.isHidden)
                 .map(file => file.getName.toInt)
                 .sorted should contain allElementsOf (Array(3, 7))
@@ -1330,11 +1330,11 @@ class AsyncProgressTrackingMicroBatchExecutionSuite
               waitPendingPurges(q)
 
               waitPendingOffsetWrites(q)
-              getListOfFiles(checkpointLocation + "/offsets")
+              getListOfFiles(s"$checkpointLocation/offsets")
                 .filter(file => !file.isHidden)
                 .map(file => file.getName.toInt)
                 .sorted should equal(Array(3, 7))
-              getListOfFiles(checkpointLocation + "/commits")
+              getListOfFiles(s"$checkpointLocation/commits")
                 .filter(file => !file.isHidden)
                 .map(file => file.getName.toInt)
                 .sorted should equal(Array(3, 7))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/MicroBatchExecutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/MicroBatchExecutionSuite.scala
@@ -63,11 +63,11 @@ class MicroBatchExecutionSuite extends StreamTest with BeforeAndAfter with Match
           AddData(inputData, 1),
           CheckNewAnswer(1),
           Execute { q =>
-            getListOfFiles(checkpointLocation + "/offsets")
+            getListOfFiles(s"$checkpointLocation/offsets")
               .filter(file => !file.isHidden)
               .map(file => file.getName.toInt)
               .sorted should equal(Array(0, 1))
-            getListOfFiles(checkpointLocation + "/commits")
+            getListOfFiles(s"$checkpointLocation/commits")
               .filter(file => !file.isHidden)
               .map(file => file.getName.toInt)
               .sorted should equal(Array(0, 1))
@@ -81,11 +81,11 @@ class MicroBatchExecutionSuite extends StreamTest with BeforeAndAfter with Match
               q.asInstanceOf[MicroBatchExecution].arePendingAsyncPurge should be(false)
             }
 
-            getListOfFiles(checkpointLocation + "/offsets")
+            getListOfFiles(s"$checkpointLocation/offsets")
               .filter(file => !file.isHidden)
               .map(file => file.getName.toInt)
               .sorted should equal(Array(1, 2, 3))
-            getListOfFiles(checkpointLocation + "/commits")
+            getListOfFiles(s"$checkpointLocation/commits")
               .filter(file => !file.isHidden)
               .map(file => file.getName.toInt)
               .sorted should equal(Array(1, 2, 3))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreIntegrationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreIntegrationSuite.scala
@@ -49,9 +49,9 @@ class RocksDBStateStoreIntegrationSuite extends StreamTest
           val storeCheckpointDir = StateStoreId(
             dir.getAbsolutePath + "/state", 0, 0).storeCheckpointLocation()
           val storeCheckpointFile = if (isChangelogCheckpointingEnabled) {
-            storeCheckpointDir + "/1.changelog"
+            s"$storeCheckpointDir/1.changelog"
           } else {
-            storeCheckpointDir + "/1.zip"
+            s"$storeCheckpointDir/1.zip"
           }
           new File(storeCheckpointFile).exists()
         }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
@@ -1411,7 +1411,7 @@ class FileStreamSourceSuite extends FileStreamSourceTest {
     withTempDirs { case (src, tmp) =>
       src.mkdirs()
 
-      val df = spark.readStream.format("text").load(src.getCanonicalPath).map(_ + "-x")
+      val df = spark.readStream.format("text").load(src.getCanonicalPath).map(_.toString + "-x")
       // Test `explain` not throwing errors
       df.explain()
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveSparkSubmitSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveSparkSubmitSuite.scala
@@ -636,7 +636,7 @@ object SparkSubmitClassLoaderTest extends Logging {
         Utils.classForName(args(1))
       } catch {
         case t: Throwable =>
-          exception = t + "\n" + Utils.exceptionString(t)
+          exception = t.toString + "\n" + Utils.exceptionString(t)
           exception = exception.replaceAll("\n", "\n\t")
       }
       Option(exception).toSeq.iterator

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/StatisticsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/StatisticsSuite.scala
@@ -77,12 +77,12 @@ class StatisticsSuite extends StatisticsCollectionTestBase with TestHiveSingleto
       withTable("csv_table") {
         withTempDir { tempDir =>
           // EXTERNAL OpenCSVSerde table pointing to LOCATION
-          val file1 = new File(tempDir + "/data1")
+          val file1 = new File(s"$tempDir/data1")
           Utils.tryWithResource(new PrintWriter(file1)) { writer =>
             writer.write("1,2")
           }
 
-          val file2 = new File(tempDir + "/data2")
+          val file2 = new File(s"$tempDir/data2")
           Utils.tryWithResource(new PrintWriter(file2)) { writer =>
             writer.write("1,2")
           }
@@ -937,7 +937,7 @@ class StatisticsSuite extends StatisticsCollectionTestBase with TestHiveSingleto
 
           withTempDir { loadPath =>
             // load data command
-            val file = new File(loadPath + "/data")
+            val file = new File(s"$loadPath/data")
             Utils.tryWithResource(new PrintWriter(file)) { writer =>
               writer.write("2,xyz")
             }
@@ -1461,7 +1461,7 @@ class StatisticsSuite extends StatisticsCollectionTestBase with TestHiveSingleto
     withTempDir { tempDir =>
       withTable("t1") {
         spark.range(5).write.mode(SaveMode.Overwrite).parquet(tempDir.getCanonicalPath)
-        Utils.tryWithResource(new PrintWriter(new File(tempDir + "/temp.crc"))) { writer =>
+        Utils.tryWithResource(new PrintWriter(new File(s"$tempDir/temp.crc"))) { writer =>
           writer.write("1,2")
         }
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
@@ -453,12 +453,12 @@ class HiveUDFSuite extends QueryTest with TestHiveSingleton with SQLTestUtils {
 
       // EXTERNAL OpenCSVSerde table pointing to LOCATION
 
-      val file1 = new File(tempDir + "/data1")
+      val file1 = new File(s"$tempDir/data1")
       Utils.tryWithResource(new PrintWriter(file1)) { writer =>
         writer.write("1,2")
       }
 
-      val file2 = new File(tempDir + "/data2")
+      val file2 = new File(s"$tempDir/data2")
       Utils.tryWithResource(new PrintWriter(file2)) { writer =>
         writer.write("1,2")
       }

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/DStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/DStream.scala
@@ -311,7 +311,7 @@ abstract class DStream[T: ClassTag] (
   /** Checks whether the 'time' is valid wrt slideDuration for generating RDD */
   private[streaming] def isTimeValid(time: Time): Boolean = {
     if (!isInitialized) {
-      throw new SparkException (this + " has not been initialized")
+      throw new SparkException (this.toString + " has not been initialized")
     } else if (time <= zeroTime || ! (time - zeroTime).isMultipleOf(slideDuration)) {
       logInfo(s"Time $time is invalid as zeroTime is $zeroTime" +
         s" , slideDuration is $slideDuration and difference is ${time - zeroTime}")
@@ -878,7 +878,7 @@ abstract class DStream[T: ClassTag] (
    */
   def slice(fromTime: Time, toTime: Time): Seq[RDD[T]] = ssc.withScope {
     if (!isInitialized) {
-      throw new SparkException(this + " has not been initialized")
+      throw new SparkException(this.toString + " has not been initialized")
     }
 
     val alignedToTime = if ((toTime - zeroTime).isMultipleOf(slideDuration)) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Method `any2stringadd` in object `Predef` is deprecated since Scala 2.13.0:

```
[error] /Users/yangjie01/SourceCode/git/spark-mine-sbt/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateSafeProjection.scala:158:24: method any2stringadd in object Predef is deprecated (since 2.13.0): Implicit injection of + is deprecated. Convert to String to call +
[error] Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=deprecation, site=org.apache.spark.sql.catalyst.expressions.codegen.GenerateSafeProjection.create.expressionCodes.$anonfun, origin=scala.Predef.any2stringadd, version=2.13.0
[error]         evaluationCode.code +
[error]                        ^
```

This PR fixed them by explicitly calling `.toString` before calling `+` or using `string interpolation`.


### Why are the changes needed?
Clean up Scala deprecated API usage.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions

### Was this patch authored or co-authored using generative AI tooling?
No