### PR TITLE
[SPARK-45723][PYTHON][CONNECT] Catalog methods avoid pandas conversion

### DIFF
--- a/python/pyspark/sql/connect/catalog.py
+++ b/python/pyspark/sql/connect/catalog.py
@@ -21,7 +21,7 @@ check_dependencies(__name__)
 from typing import Any, Callable, List, Optional, TYPE_CHECKING
 
 import warnings
-import pandas as pd
+import pyarrow as pa
 
 from pyspark.storagelevel import StorageLevel
 from pyspark.sql.types import StructType
@@ -45,15 +45,14 @@ class Catalog:
     def __init__(self, sparkSession: "SparkSession") -> None:
         self._sparkSession = sparkSession
 
-    def _execute_and_fetch(self, catalog: plan.LogicalPlan) -> pd.DataFrame:
-        pdf = DataFrame.withPlan(catalog, session=self._sparkSession).toPandas()
-        assert pdf is not None
-        return pdf
+    def _execute_and_fetch(self, catalog: plan.LogicalPlan) -> pa.Table:
+        table, _ = DataFrame.withPlan(catalog, session=self._sparkSession)._to_table()
+        assert table is not None
+        return table
 
     def currentCatalog(self) -> str:
-        pdf = self._execute_and_fetch(plan.CurrentCatalog())
-        assert pdf is not None
-        return pdf.iloc[0].iloc[0]
+        table = self._execute_and_fetch(plan.CurrentCatalog())
+        return table[0][0].as_py()
 
     currentCatalog.__doc__ = PySparkCatalog.currentCatalog.__doc__
 
@@ -63,17 +62,20 @@ class Catalog:
     setCurrentCatalog.__doc__ = PySparkCatalog.setCurrentCatalog.__doc__
 
     def listCatalogs(self, pattern: Optional[str] = None) -> List[CatalogMetadata]:
-        pdf = self._execute_and_fetch(plan.ListCatalogs(pattern=pattern))
+        table = self._execute_and_fetch(plan.ListCatalogs(pattern=pattern))
         return [
-            CatalogMetadata(name=row.iloc[0], description=row.iloc[1]) for _, row in pdf.iterrows()
+            CatalogMetadata(
+                name=table[0][i].as_py(),
+                description=table[1][i].as_py(),
+            )
+            for i in range(table.num_rows)
         ]
 
     listCatalogs.__doc__ = PySparkCatalog.listCatalogs.__doc__
 
     def currentDatabase(self) -> str:
-        pdf = self._execute_and_fetch(plan.CurrentDatabase())
-        assert pdf is not None
-        return pdf.iloc[0].iloc[0]
+        table = self._execute_and_fetch(plan.CurrentDatabase())
+        return table[0][0].as_py()
 
     currentDatabase.__doc__ = PySparkCatalog.currentDatabase.__doc__
 
@@ -83,70 +85,63 @@ class Catalog:
     setCurrentDatabase.__doc__ = PySparkCatalog.setCurrentDatabase.__doc__
 
     def listDatabases(self, pattern: Optional[str] = None) -> List[Database]:
-        pdf = self._execute_and_fetch(plan.ListDatabases(pattern=pattern))
+        table = self._execute_and_fetch(plan.ListDatabases(pattern=pattern))
         return [
             Database(
-                name=row.iloc[0],
-                catalog=row.iloc[1],
-                description=row.iloc[2],
-                locationUri=row.iloc[3],
+                name=table[0][i].as_py(),
+                catalog=table[1][i].as_py(),
+                description=table[2][i].as_py(),
+                locationUri=table[3][i].as_py(),
             )
-            for _, row in pdf.iterrows()
+            for i in range(table.num_rows)
         ]
 
     listDatabases.__doc__ = PySparkCatalog.listDatabases.__doc__
 
     def getDatabase(self, dbName: str) -> Database:
-        pdf = self._execute_and_fetch(plan.GetDatabase(db_name=dbName))
-        assert pdf is not None
-        row = pdf.iloc[0]
+        table = self._execute_and_fetch(plan.GetDatabase(db_name=dbName))
         return Database(
-            name=row[0],
-            catalog=row[1],
-            description=row[2],
-            locationUri=row[3],
+            name=table[0][0].as_py(),
+            catalog=table[1][0].as_py(),
+            description=table[2][0].as_py(),
+            locationUri=table[3][0].as_py(),
         )
 
     getDatabase.__doc__ = PySparkCatalog.getDatabase.__doc__
 
     def databaseExists(self, dbName: str) -> bool:
-        pdf = self._execute_and_fetch(plan.DatabaseExists(db_name=dbName))
-        assert pdf is not None
-        return pdf.iloc[0].iloc[0]
+        table = self._execute_and_fetch(plan.DatabaseExists(db_name=dbName))
+        return table[0][0].as_py()
 
     databaseExists.__doc__ = PySparkCatalog.databaseExists.__doc__
 
     def listTables(
         self, dbName: Optional[str] = None, pattern: Optional[str] = None
     ) -> List[Table]:
-        pdf = self._execute_and_fetch(plan.ListTables(db_name=dbName, pattern=pattern))
+        table = self._execute_and_fetch(plan.ListTables(db_name=dbName, pattern=pattern))
         return [
             Table(
-                name=row.iloc[0],
-                catalog=row.iloc[1],
-                # If None, returns None.
-                namespace=None if row.iloc[2] is None else list(row.iloc[2]),
-                description=row.iloc[3],
-                tableType=row.iloc[4],
-                isTemporary=row.iloc[5],
+                name=table[0][i].as_py(),
+                catalog=table[1][i].as_py(),
+                namespace=table[2][i].as_py(),
+                description=table[3][i].as_py(),
+                tableType=table[4][i].as_py(),
+                isTemporary=table[5][i].as_py(),
             )
-            for _, row in pdf.iterrows()
+            for i in range(table.num_rows)
         ]
 
     listTables.__doc__ = PySparkCatalog.listTables.__doc__
 
     def getTable(self, tableName: str) -> Table:
-        pdf = self._execute_and_fetch(plan.GetTable(table_name=tableName))
-        assert pdf is not None
-        row = pdf.iloc[0]
+        table = self._execute_and_fetch(plan.GetTable(table_name=tableName))
         return Table(
-            name=row.iloc[0],
-            catalog=row.iloc[1],
-            # If None, returns None.
-            namespace=None if row.iloc[2] is None else list(row.iloc[2]),
-            description=row.iloc[3],
-            tableType=row.iloc[4],
-            isTemporary=row.iloc[5],
+            name=table[0][0].as_py(),
+            catalog=table[1][0].as_py(),
+            namespace=table[2][0].as_py(),
+            description=table[3][0].as_py(),
+            tableType=table[4][0].as_py(),
+            isTemporary=table[5][0].as_py(),
         )
 
     getTable.__doc__ = PySparkCatalog.getTable.__doc__
@@ -154,67 +149,61 @@ class Catalog:
     def listFunctions(
         self, dbName: Optional[str] = None, pattern: Optional[str] = None
     ) -> List[Function]:
-        pdf = self._execute_and_fetch(plan.ListFunctions(db_name=dbName, pattern=pattern))
+        table = self._execute_and_fetch(plan.ListFunctions(db_name=dbName, pattern=pattern))
         return [
             Function(
-                name=row.iloc[0],
-                catalog=row.iloc[1],
-                # If None, returns None.
-                namespace=None if row.iloc[2] is None else list(row.iloc[2]),
-                description=row.iloc[3],
-                className=row.iloc[4],
-                isTemporary=row.iloc[5],
+                name=table[0][i].as_py(),
+                catalog=table[1][i].as_py(),
+                namespace=table[2][i].as_py(),
+                description=table[3][i].as_py(),
+                className=table[4][i].as_py(),
+                isTemporary=table[5][i].as_py(),
             )
-            for _, row in pdf.iterrows()
+            for i in range(table.num_rows)
         ]
 
     listFunctions.__doc__ = PySparkCatalog.listFunctions.__doc__
 
     def functionExists(self, functionName: str, dbName: Optional[str] = None) -> bool:
-        pdf = self._execute_and_fetch(
+        table = self._execute_and_fetch(
             plan.FunctionExists(function_name=functionName, db_name=dbName)
         )
-        assert pdf is not None
-        return pdf.iloc[0].iloc[0]
+        return table[0][0].as_py()
 
     functionExists.__doc__ = PySparkCatalog.functionExists.__doc__
 
     def getFunction(self, functionName: str) -> Function:
-        pdf = self._execute_and_fetch(plan.GetFunction(function_name=functionName))
-        assert pdf is not None
-        row = pdf.iloc[0]
+        table = self._execute_and_fetch(plan.GetFunction(function_name=functionName))
         return Function(
-            name=row.iloc[0],
-            catalog=row.iloc[1],
-            # If None, returns None.
-            namespace=None if row.iloc[2] is None else list(row.iloc[2]),
-            description=row.iloc[3],
-            className=row.iloc[4],
-            isTemporary=row.iloc[5],
+            name=table[0][0].as_py(),
+            catalog=table[1][0].as_py(),
+            namespace=table[2][0].as_py(),
+            description=table[3][0].as_py(),
+            className=table[4][0].as_py(),
+            isTemporary=table[5][0].as_py(),
         )
 
     getFunction.__doc__ = PySparkCatalog.getFunction.__doc__
 
     def listColumns(self, tableName: str, dbName: Optional[str] = None) -> List[Column]:
-        pdf = self._execute_and_fetch(plan.ListColumns(table_name=tableName, db_name=dbName))
+        table = self._execute_and_fetch(plan.ListColumns(table_name=tableName, db_name=dbName))
         return [
             Column(
-                name=row.iloc[0],
-                description=row.iloc[1],
-                dataType=row.iloc[2],
-                nullable=row.iloc[3],
-                isPartition=row.iloc[4],
-                isBucket=row.iloc[5],
+                name=table[0][i].as_py(),
+                description=table[1][i].as_py(),
+                dataType=table[2][i].as_py(),
+                nullable=table[3][i].as_py(),
+                isPartition=table[4][i].as_py(),
+                isBucket=table[5][i].as_py(),
             )
-            for _, row in pdf.iterrows()
+            for i in range(table.num_rows)
         ]
 
     listColumns.__doc__ = PySparkCatalog.listColumns.__doc__
 
     def tableExists(self, tableName: str, dbName: Optional[str] = None) -> bool:
-        pdf = self._execute_and_fetch(plan.TableExists(table_name=tableName, db_name=dbName))
-        assert pdf is not None
-        return pdf.iloc[0].iloc[0]
+        table = self._execute_and_fetch(plan.TableExists(table_name=tableName, db_name=dbName))
+        return table[0][0].as_py()
 
     tableExists.__doc__ = PySparkCatalog.tableExists.__doc__
 
@@ -263,23 +252,20 @@ class Catalog:
     createTable.__doc__ = PySparkCatalog.createTable.__doc__
 
     def dropTempView(self, viewName: str) -> bool:
-        pdf = self._execute_and_fetch(plan.DropTempView(view_name=viewName))
-        assert pdf is not None
-        return pdf.iloc[0].iloc[0]
+        table = self._execute_and_fetch(plan.DropTempView(view_name=viewName))
+        return table[0][0].as_py()
 
     dropTempView.__doc__ = PySparkCatalog.dropTempView.__doc__
 
     def dropGlobalTempView(self, viewName: str) -> bool:
-        pdf = self._execute_and_fetch(plan.DropGlobalTempView(view_name=viewName))
-        assert pdf is not None
-        return pdf.iloc[0].iloc[0]
+        table = self._execute_and_fetch(plan.DropGlobalTempView(view_name=viewName))
+        return table[0][0].as_py()
 
     dropGlobalTempView.__doc__ = PySparkCatalog.dropGlobalTempView.__doc__
 
     def isCached(self, tableName: str) -> bool:
-        pdf = self._execute_and_fetch(plan.IsCached(table_name=tableName))
-        assert pdf is not None
-        return pdf.iloc[0].iloc[0]
+        table = self._execute_and_fetch(plan.IsCached(table_name=tableName))
+        return table[0][0].as_py()
 
     isCached.__doc__ = PySparkCatalog.isCached.__doc__
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Catalog methods avoid pandas conversion


### Why are the changes needed?
minor optimization:

before: arrow table -> pandas dataframe -> scalar result

after: arrow table -> scalar result


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
ci

### Was this patch authored or co-authored using generative AI tooling?
no
