### PR TITLE
[SPARK-45724][SQL][TESTS] Add a separate LogAppender for tests that need to print `RuleExecutor.dumpTimeSpent()` to avoid truncation of Metrics

### DIFF
--- a/sql/core/src/test/resources/log4j2.properties
+++ b/sql/core/src/test/resources/log4j2.properties
@@ -29,6 +29,49 @@ appender.console.layout.pattern = %d{HH:mm:ss.SSS} %p %c: %maxLen{%m}{512}%n%ex{
 appender.console.filter.threshold.type = ThresholdFilter
 appender.console.filter.threshold.level = warn
 
+# SPARK-45724: Add Sql Metrics Console Appender for tests that need to
+# print `RuleExecutor.dumpTimeSpent()` to avoid truncation of Metrics.
+appender.sqlMetricsConsole.type = Console
+appender.sqlMetricsConsole.name = SQL_METRICS_CONSOLE
+appender.sqlMetricsConsole.target = SYSTEM_OUT
+appender.sqlMetricsConsole.layout.type = PatternLayout
+appender.sqlMetricsConsole.layout.pattern = %d{HH:mm:ss.SSS} %p %c: %m%n%ex
+
+logger.SQLQueryTestSuite.name = org.apache.spark.sql.SQLQueryTestSuite
+logger.SQLQueryTestSuite.level = warn
+logger.SQLQueryTestSuite.additivity = false
+logger.SQLQueryTestSuite.appenderRef.sqlMetricsConsole.ref = SQL_METRICS_CONSOLE
+
+logger.LogicalPlanTagInSparkPlanSuite.name = org.apache.spark.sql.execution.LogicalPlanTagInSparkPlanSuite
+logger.LogicalPlanTagInSparkPlanSuite.level = warn
+logger.LogicalPlanTagInSparkPlanSuite.additivity = false
+logger.LogicalPlanTagInSparkPlanSuite.appenderRef.sqlMetricsConsole.ref = SQL_METRICS_CONSOLE
+
+logger.SSBQuerySuite.name = org.apache.spark.sql.SSBQuerySuite
+logger.SSBQuerySuite.level = warn
+logger.SSBQuerySuite.additivity = false
+logger.SSBQuerySuite.appenderRef.sqlMetricsConsole.ref = SQL_METRICS_CONSOLE
+
+logger.TPCDSQueryANSISuite.name = org.apache.spark.sql.TPCDSQueryANSISuite
+logger.TPCDSQueryANSISuite.level = warn
+logger.TPCDSQueryANSISuite.additivity = false
+logger.TPCDSQueryANSISuite.appenderRef.sqlMetricsConsole.ref = SQL_METRICS_CONSOLE
+
+logger.TPCDSQuerySuite.name = org.apache.spark.sql.TPCDSQuerySuite
+logger.TPCDSQuerySuite.level = warn
+logger.TPCDSQuerySuite.additivity = false
+logger.TPCDSQuerySuite.appenderRef.sqlMetricsConsole.ref = SQL_METRICS_CONSOLE
+
+logger.TPCDSQueryWithStatsSuite.name = org.apache.spark.sql.TPCDSQueryWithStatsSuite
+logger.TPCDSQueryWithStatsSuite.level = warn
+logger.TPCDSQueryWithStatsSuite.additivity = false
+logger.TPCDSQueryWithStatsSuite.appenderRef.sqlMetricsConsole.ref = SQL_METRICS_CONSOLE
+
+logger.TPCHQuerySuite.name = org.apache.spark.sql.TPCHQuerySuite
+logger.TPCHQuerySuite.level = warn
+logger.TPCHQuerySuite.additivity = false
+logger.TPCHQuerySuite.appenderRef.sqlMetricsConsole.ref = SQL_METRICS_CONSOLE
+
 #File Appender
 appender.file.type = File
 appender.file.name = File

--- a/sql/hive-thriftserver/src/test/resources/log4j2.properties
+++ b/sql/hive-thriftserver/src/test/resources/log4j2.properties
@@ -38,6 +38,19 @@ appender.console.filter.1.b.regex = .*Thrift error occurred during processing of
 appender.console.filter.1.b.onMatch = deny
 appender.console.filter.1.b.onMismatch = neutral
 
+# SPARK-45724: Add Sql Metrics Console Appender for tests that need to
+# print `RuleExecutor.dumpTimeSpent()` to avoid truncation of Metrics.
+appender.sqlMetricsConsole.type = Console
+appender.sqlMetricsConsole.name = SQL_METRICS_CONSOLE
+appender.sqlMetricsConsole.target = SYSTEM_OUT
+appender.sqlMetricsConsole.layout.type = PatternLayout
+appender.sqlMetricsConsole.layout.pattern = %d{HH:mm:ss.SSS} %p %c: %m%n%ex
+
+logger.ThriftServerQueryTestSuite.name =org.apache.spark.sql.hive.thriftserver.ThriftServerQueryTestSuite
+logger.ThriftServerQueryTestSuite.level = warn
+logger.ThriftServerQueryTestSuite.additivity = false
+logger.ThriftServerQueryTestSuite.appenderRef.sqlMetricsConsole.ref = SQL_METRICS_CONSOLE
+
 #File Appender
 appender.file.type = File
 appender.file.name = File

--- a/sql/hive/src/test/resources/log4j2.properties
+++ b/sql/hive/src/test/resources/log4j2.properties
@@ -29,6 +29,19 @@ appender.console.layout.pattern = %d{HH:mm:ss.SSS} %p %c: %maxLen{%m}{512}%n%ex{
 appender.console.filter.threshold.type = ThresholdFilter
 appender.console.filter.threshold.level = warn
 
+# SPARK-45724: Add Sql Metrics Console Appender for tests that need to
+# print `RuleExecutor.dumpTimeSpent()` to avoid truncation of Metrics.
+appender.sqlMetricsConsole.type = Console
+appender.sqlMetricsConsole.name = SQL_METRICS_CONSOLE
+appender.sqlMetricsConsole.target = SYSTEM_OUT
+appender.sqlMetricsConsole.layout.type = PatternLayout
+appender.sqlMetricsConsole.layout.pattern = %d{HH:mm:ss.SSS} %p %c: %m%n%ex
+
+logger.HiveCompatibilitySuite.name = org.apache.spark.sql.hive.execution.HiveCompatibilitySuite
+logger.HiveCompatibilitySuite.level = warn
+logger.HiveCompatibilitySuite.additivity = false
+logger.HiveCompatibilitySuite.appenderRef.sqlMetricsConsole.ref = SQL_METRICS_CONSOLE
+
 #File Appender
 appender.file.type = File
 appender.file.name = File


### PR DESCRIPTION
### What changes were proposed in this pull request?
https://github.com/apache/spark/pull/42627 set a character length limit for the error message and a stack depth limit for error stack traces to the console appender in tests, but this prevents test cases that want to print `RuleExecutor.dumpTimeSpent()` from printing the full content of `Metrics of Analyzer/Optimizer Rules`. 

For example, when we execute `build/sbt "sql/testOnly org.apache.spark.sql.TPCDSQuerySuite" `, we expect to print the following content:


```
21:17:33.114 WARN org.apache.spark.sql.TPCDSQuerySuite: 
=== Metrics of Analyzer/Optimizer Rules ===
Total number of runs: 182086
Total time: 4.221805454 seconds

Rule                                                                                  Effective Time / Total Time                     Effective Runs / Total Runs                    

org.apache.spark.sql.catalyst.optimizer.Optimizer$OptimizeSubqueries                  656391832 / 657761083                           45 / 312                                       
org.apache.spark.sql.catalyst.analysis.Analyzer$ResolveReferences                     209532917 / 286447546                           573 / 1234                                     
org.apache.spark.sql.execution.datasources.PruneFileSourcePartitions                  238715661 / 241609707                           203 / 312                                      
org.apache.spark.sql.catalyst.optimizer.ColumnPruning                                 63600753 / 234425780                            387 / 2044                                     
org.apache.spark.sql.catalyst.analysis.DeduplicateRelations                           59485458 / 206222280                            155 / 1234                                     
org.apache.spark.sql.catalyst.analysis.UpdateAttributeNullability                     3079208 / 137877995                             4 / 934                                        
org.apache.spark.sql.catalyst.optimizer.PruneFilters                                  4147166 / 132285283                             4 / 1732                                       
org.apache.spark.sql.catalyst.optimizer.PushDownPredicates                            107897509 / 125084462                           931 / 2238                                     
org.apache.spark.sql.catalyst.analysis.Analyzer$ResolveSubquery                       109012041 / 114366501                           53 / 1234                                      
org.apache.spark.sql.catalyst.optimizer.InlineCTE                                     101349876 / 101466710                           54 / 312                                       
org.apache.spark.sql.catalyst.optimizer.InjectRuntimeFilter                           0 / 92098873                                    0 / 312                                        
org.apache.spark.sql.catalyst.analysis.TypeCoercionBase$CombinedTypeCoercionRule      44246780 / 91358601                             184 / 1234                                     
org.apache.spark.sql.catalyst.optimizer.InferFiltersFromConstraints                   81556996 / 82063666                             271 / 312                                      
org.apache.spark.sql.execution.datasources.FindDataSourceTable                        74798168 / 78256868                             223 / 1234                                     
org.apache.spark.sql.execution.datasources.SchemaPruning                              0 / 76585252                                    0 / 312                                        
org.apache.spark.sql.catalyst.analysis.ResolveSessionCatalog                          37733330 / 64439109                             24 / 1234                                      
org.apache.spark.sql.catalyst.optimizer.RewriteCorrelatedScalarSubquery               39675751 / 62437365                             7 / 1420                                       
org.apache.spark.sql.catalyst.optimizer.Optimizer$FinishAnalysis                      44831887 / 60677804                             150 / 312                                      
org.apache.spark.sql.catalyst.analysis.Analyzer$ResolveFunctions                      51808084 / 59051168                             312 / 1234                                     
org.apache.spark.sql.catalyst.optimizer.BooleanSimplification                         4117502 / 56255045                              5 / 1732                                       
org.apache.spark.sql.catalyst.optimizer.FoldablePropagation                           3021751 / 54461997                              24 / 1420                                      
org.apache.spark.sql.catalyst.optimizer.ConstantFolding                               26801791 / 50801422                             208 / 1420                                     
org.apache.spark.sql.catalyst.optimizer.MergeScalarSubqueries                         7459001 / 49317670                              3 / 312                                        
org.apache.spark.sql.catalyst.optimizer.RemoveRedundantAliases                        6183629 / 49123627                              46 / 1732                                      
org.apache.spark.sql.catalyst.analysis.Analyzer$ResolveRelations                      37477343 / 40669791                             223 / 1234                                     
org.apache.spark.sql.catalyst.analysis.Analyzer$AddMetadataColumns                    0 / 39216905                                    0 / 1234                                       
...                                      
org.apache.spark.sql.catalyst.analysis.ReplaceCharWithVarchar                         0 / 280084                                      0 / 306                                        
org.apache.spark.sql.catalyst.optimizer.Optimizer$UpdateCTERelationStats              0 / 156218                                      0 / 312                                        
     
21:17:33.116 WARN org.apache.spark.sql.TPCDSQuerySuite: 
=== Metrics of Whole-stage Codegen ===
Total code generation time: 0.0 seconds
Total compile time: 0.0 seconds

```


but the content printed after SPARK-44929 as follows:

```
=== Metrics of Analyzer/Optimizer Rules ===
Total number of runs: 182086
Total time: 4.355138411 seconds

Rule                                                                                  Effective Time / Total Time                     Effective Runs / Total Runs                    

org.apache.spark.sql.catalyst.optimizer.Optimizer$OptimizeSubqueries                  676293539 / 677834369                           45 / 312                                       
org.apache.spark.sql.catalyst.analysis.A...
21:19:12.466 WARN org.apache.spark.sql.TPCDSQuerySuite: 
=== Metrics of Whole-stage Codegen ===
Total code generation time: 0.0 seconds
Total compile time: 0.0 seconds
```

Similar problems exist for other test cases that need to print `RuleExecutor.dumpTimeSpent()`. They include: `SQLQueryTestSuite`,`LogicalPlanTagInSparkPlanSuite`,`SSBQuerySuite`,`TPCDSQueryANSISuite`,`TPCDSQuerySuite`,`TPCDSQueryWithStatsSuite`,`TPCHQuerySuite`, `HiveCompatibilitySuite` and `ThriftServerQueryTestSuite`.

So this pr customizes a new `LogAppender` for them to ensure the completeness of the `RuleExecutor.dumpTimeSpent()` print information.


### Why are the changes needed?
Ensuring the completeness of the `RuleExecutor.dumpTimeSpent()` print information.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Manually execute the following test commands and check the completeness of the `RuleExecutor.dumpTimeSpent()` printout information:
- build/sbt "sql/testOnly org.apache.spark.sql.SQLQueryTestSuite"
- build/sbt "sql/testOnly org.apache.spark.sql.execution.LogicalPlanTagInSparkPlanSuite"
- build/sbt "sql/testOnly org.apache.spark.sql.SSBQuerySuite"
- build/sbt "sql/testOnly org.apache.spark.sql.TPCDSQueryANSISuite"
- build/sbt "sql/testOnly org.apache.spark.sql.TPCDSQuerySuite"
- build/sbt "sql/testOnly org.apache.spark.sql.TPCDSQueryWithStatsSuite"
- build/sbt "sql/testOnly org.apache.spark.sql.TPCHQuerySuite"
- build/sbt "hive/testOnly org.apache.spark.sql.hive.execution.HiveCompatibilitySuite" -Phive
- build/sbt "hive-thriftserver/testOnly org.apache.spark.sql.hive.thriftserver.ThriftServerQueryTestSuite" -Phive-thriftserver 


### Was this patch authored or co-authored using generative AI tooling?
No
