### PR TITLE
[SPARK-45727][SS] Remove unused map in watermark propagation simulation

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/WatermarkPropagator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/WatermarkPropagator.scala
@@ -181,7 +181,6 @@ class PropagateWatermarkSimulator extends WatermarkPropagator with Logging {
   }
 
   private def doSimulate(batchId: Long, plan: SparkPlan, originWatermark: Long): Unit = {
-    val statefulOperatorIdToNodeId = mutable.HashMap[Long, Int]()
     val nodeToOutputWatermark = mutable.HashMap[Int, Option[Long]]()
     val nextStatefulOperatorToWatermark = mutable.HashMap[Long, Option[Long]]()
 
@@ -200,7 +199,6 @@ class PropagateWatermarkSimulator extends WatermarkPropagator with Logging {
 
       case node: StateStoreWriter =>
         val stOpId = node.stateInfo.get.operatorId
-        statefulOperatorIdToNodeId.put(stOpId, node.id)
 
         val inputWatermarks = getInputWatermarks(node, nodeToOutputWatermark)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Remove unused map in watermark propagation simulation


### Why are the changes needed?
Remove use of redundant/unused map


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existing unit tests

```
===== POSSIBLE THREAD LEAK IN SUITE o.a.s.sql.streaming.MultiStatefulOperatorsSuite, threads: rpc-boss-3-1 (daemon=true), ForkJoinPool.commonPool-worker-2 (daemon=true), shuffle-boss-6-1 (daemon=true), ForkJoinPool.commonPool-worker-1 (daemon=true) =====
[info] Run completed in 1 minute, 35 seconds.
[info] Total number of tests run: 9
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 9, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
```


### Was this patch authored or co-authored using generative AI tooling?
No
