### PR TITLE
[SPARK-45732][BUILD] Upgrade commons-text to 1.11.0

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -49,7 +49,7 @@ commons-lang3/3.13.0//commons-lang3-3.13.0.jar
 commons-logging/1.1.3//commons-logging-1.1.3.jar
 commons-math3/3.6.1//commons-math3-3.6.1.jar
 commons-pool/1.5.4//commons-pool-1.5.4.jar
-commons-text/1.10.0//commons-text-1.10.0.jar
+commons-text/1.11.0//commons-text-1.11.0.jar
 compress-lzf/1.1.2//compress-lzf-1.1.2.jar
 curator-client/5.2.0//curator-client-5.2.0.jar
 curator-framework/5.2.0//curator-framework-5.2.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -605,7 +605,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-text</artifactId>
-        <version>1.10.0</version>
+        <version>1.11.0</version>
       </dependency>
       <dependency>
         <groupId>commons-lang</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade `commons-text` from `1.10.0` to `1.11.0`.

### Why are the changes needed?
Release note: https://commons.apache.org/proper/commons-text/changes-report.html#a1.11.0
includes some bug fix, eg:
- Fix StringTokenizer.getTokenList to return an independent modifiable list. Fixes [TEXT-219](https://issues.apache.org/jira/browse/TEXT-219).
- Fix TextStringBuilder to over-allocate when ensuring capacity #452. Fixes [TEXT-228](https://issues.apache.org/jira/browse/TEXT-228).
- TextStringBuidler#hashCode() allocates a String on each call #387.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
