### PR TITLE
[SPARK-45734][BUILD] Upgrade commons-io to 2.15.0

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -43,7 +43,7 @@ commons-compiler/3.1.9//commons-compiler-3.1.9.jar
 commons-compress/1.24.0//commons-compress-1.24.0.jar
 commons-crypto/1.1.0//commons-crypto-1.1.0.jar
 commons-dbcp/1.4//commons-dbcp-1.4.jar
-commons-io/2.14.0//commons-io-2.14.0.jar
+commons-io/2.15.0//commons-io-2.15.0.jar
 commons-lang/2.6//commons-lang-2.6.jar
 commons-lang3/3.13.0//commons-lang3-3.13.0.jar
 commons-logging/1.1.3//commons-logging-1.1.3.jar

--- a/pom.xml
+++ b/pom.xml
@@ -192,7 +192,7 @@
     <netlib.ludovic.dev.version>3.0.3</netlib.ludovic.dev.version>
     <commons-codec.version>1.16.0</commons-codec.version>
     <commons-compress.version>1.24.0</commons-compress.version>
-    <commons-io.version>2.14.0</commons-io.version>
+    <commons-io.version>2.15.0</commons-io.version>
     <!-- org.apache.commons/commons-lang/-->
     <commons-lang2.version>2.6</commons-lang2.version>
     <!-- org.apache.commons/commons-lang3/-->


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr upgrade commons-io from 2.14.0 to 2.15.0

### Why are the changes needed?
The updates of `commons-io` 2.15.0 mainly focus on fixing bugs in file and stream handling, adding new file and stream handling features, and optimizing the performance of file content comparison:

1. Bug fixes: This version fixes multiple bugs, mainly in file and stream handling. For example, it fixes the encoding matching issue of `XmlStreamReader` (IO-810), the issue that `FileUtils.listFiles` and `FileUtils.iterateFiles` methods failed to close their internal streams (IO-811), and the issue that `StreamIterator` failed to close its internal stream (IO-811). In addition, it also fixes the null pointer exception information of `RandomAccessFileMode.create(Path)`, and the issue that `UnsynchronizedBufferedInputStream.read(byte[], int, int)` does not use the buffer (IO-816).

2. New features: This version adds some new classes and methods, such as `org.apache.commons.io.channels.FileChannels`, `RandomAccessFiles#contentEquals(RandomAccessFile, RandomAccessFile)`, `RandomAccessFiles#reset(RandomAccessFile)`, and `org.apache.commons.io.StreamIterator`. In addition, it also added `MessageDigestInputStream` and deprecated `MessageDigestCalculatingInputStream`.

3. Performance optimization: This version optimizes the performance of `PathUtils.fileContentEquals(Path, Path, LinkOption[], OpenOption[])`, `PathUtils.fileContentEquals(Path, Path)`, and `FileUtils.contentEquals(File, File)`. From the release notes, the related performance has improved by about 60%.

The full release notes as follow:

- https://commons.apache.org/proper/commons-io/changes-report.html#a2.15.0

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No
