### PR TITLE
[SPARK-45738][CONNECT]fix status conflict in ExecuteEventsManager and…

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/ExecuteEventsManager.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/ExecuteEventsManager.scala
@@ -264,11 +264,17 @@ case class ExecuteEventsManager(executeHolder: ExecuteHolder, clock: Clock) {
         is not within statuses $validStatuses for event $eventStatus
         """)
     }
-    if (sessionHolder.eventManager.status != SessionStatus.Started) {
-      throw new IllegalStateException(s"""
-        sessionId: $sessionId with status $sessionStatus
-        is not Started for event $eventStatus
-        """)
+    eventStatus match {
+      case ExecuteStatus.Pending
+           | ExecuteStatus.Started
+           | ExecuteStatus.Analyzed
+           | ExecuteStatus.ReadyForExecution =>
+        if (sessionHolder.eventManager.status != SessionStatus.Started) {
+          throw new IllegalStateException(s"""
+            sessionId: $sessionId with status $sessionStatus
+            is not Started for event $eventStatus
+            """)
+        }
     }
     _status = eventStatus
   }

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/ExecuteEventsManager.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/ExecuteEventsManager.scala
@@ -267,13 +267,20 @@ case class ExecuteEventsManager(executeHolder: ExecuteHolder, clock: Clock) {
     eventStatus match {
       case ExecuteStatus.Pending | ExecuteStatus.Started | ExecuteStatus.Analyzed |
           ExecuteStatus.ReadyForExecution =>
-        if (sessionHolder.eventManager.status != SessionStatus.Started) {
+        if (sessionStatus != SessionStatus.Started) {
           throw new IllegalStateException(s"""
             sessionId: $sessionId with status $sessionStatus
             is not Started for event $eventStatus
             """)
         }
-      case _ => // do nothing
+      case ExecuteStatus.Finished | ExecuteStatus.Failed | ExecuteStatus.Canceled |
+          ExecuteStatus.Closed =>
+        if (sessionStatus != SessionStatus.Started || sessionStatus != SessionStatus.Closed) {
+          throw new IllegalStateException(s"""
+            sessionId: $sessionId with status $sessionStatus
+            is not Started/Closed for event $eventStatus
+            """)
+        }
     }
     _status = eventStatus
   }

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/ExecuteEventsManager.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/ExecuteEventsManager.scala
@@ -265,10 +265,8 @@ case class ExecuteEventsManager(executeHolder: ExecuteHolder, clock: Clock) {
         """)
     }
     eventStatus match {
-      case ExecuteStatus.Pending
-           | ExecuteStatus.Started
-           | ExecuteStatus.Analyzed
-           | ExecuteStatus.ReadyForExecution =>
+      case ExecuteStatus.Pending | ExecuteStatus.Started | ExecuteStatus.Analyzed |
+          ExecuteStatus.ReadyForExecution =>
         if (sessionHolder.eventManager.status != SessionStatus.Started) {
           throw new IllegalStateException(s"""
             sessionId: $sessionId with status $sessionStatus

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/ExecuteEventsManager.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/ExecuteEventsManager.scala
@@ -275,7 +275,7 @@ case class ExecuteEventsManager(executeHolder: ExecuteHolder, clock: Clock) {
         }
       case ExecuteStatus.Finished | ExecuteStatus.Failed | ExecuteStatus.Canceled |
           ExecuteStatus.Closed =>
-        if (sessionStatus != SessionStatus.Started || sessionStatus != SessionStatus.Closed) {
+        if (sessionStatus != SessionStatus.Started && sessionStatus != SessionStatus.Closed) {
           throw new IllegalStateException(s"""
             sessionId: $sessionId with status $sessionStatus
             is not Started/Closed for event $eventStatus

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/ExecuteEventsManager.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/ExecuteEventsManager.scala
@@ -275,6 +275,7 @@ case class ExecuteEventsManager(executeHolder: ExecuteHolder, clock: Clock) {
             is not Started for event $eventStatus
             """)
         }
+      case _ => // do nothing
     }
     _status = eventStatus
   }

--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/service/ExecuteEventsManagerSuite.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/service/ExecuteEventsManagerSuite.scala
@@ -334,10 +334,82 @@ class ExecuteEventsManagerSuite
     }
   }
 
-  test("SPARK-43923: Started wrong session status") {
-    val events = setupEvents(ExecuteStatus.Started, SessionStatus.Pending)
+  test("SPARK-45738: Failed post when session status is `Pending`") {
+    val events = setupEvents(ExecuteStatus.Pending, SessionStatus.Pending)
     assertThrows[IllegalStateException] {
       events.postStarted()
+    }
+    assertThrows[IllegalStateException] {
+      events.postAnalyzed()
+    }
+    assertThrows[IllegalStateException] {
+      events.postReadyForExecution()
+    }
+    assertThrows[IllegalStateException] {
+      events.postFinished()
+    }
+    assertThrows[IllegalStateException] {
+      events.postFailed(DEFAULT_ERROR)
+    }
+    assertThrows[IllegalStateException] {
+      events.postCanceled()
+    }
+    assertThrows[IllegalStateException] {
+      events.postClosed()
+    }
+  }
+
+  test("SPARK-45738: Succeed post when session status is `Started`") {
+    val events = setupEvents(ExecuteStatus.Pending, SessionStatus.Started)
+    assertResult(None) {
+      events.postStarted()
+    }
+    assertResult(None) {
+      events.postAnalyzed()
+    }
+    assertResult(None) {
+      events.postReadyForExecution()
+    }
+    assertResult(None) {
+      events.postFinished()
+    }
+    assertResult(None) {
+      events.postFailed(DEFAULT_ERROR)
+    }
+    assertResult(None) {
+      events.postCanceled()
+    }
+    assertResult(None) {
+      events.postClosed()
+    }
+  }
+
+  test("SPARK-45738: Failed post when session status is `Closed`") {
+    val events = setupEvents(ExecuteStatus.Pending, SessionStatus.Closed)
+    assertThrows[IllegalStateException] {
+      events.postStarted()
+    }
+    assertThrows[IllegalStateException] {
+      events.postAnalyzed()
+    }
+    assertThrows[IllegalStateException] {
+      events.postReadyForExecution()
+    }
+  }
+
+  test("SPARK-45738: Succeed post when session status is `Closed`") {
+    val events = setupEvents(ExecuteStatus.Pending, SessionStatus.Closed)
+    assertResult(None) {
+      events.postFinished()
+    }
+    assertResult(None) {
+      events.postFailed(DEFAULT_ERROR)
+    }
+    assertResult(None) {
+      events.postCanceled()
+    }
+    assertResult(None) {
+      events.postClosed()
     }
   }
 

--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/service/ExecuteEventsManagerSuite.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/service/ExecuteEventsManagerSuite.scala
@@ -361,31 +361,31 @@ class ExecuteEventsManagerSuite
 
   test("SPARK-45738: Succeed post when session status is `Started`") {
     val events = setupEvents(ExecuteStatus.Pending, SessionStatus.Started)
-    assertResult(None) {
+    assertResult(()) {
       events.postStarted()
     }
-    assertResult(None) {
+    assertResult(()) {
       events.postAnalyzed()
     }
-    assertResult(None) {
+    assertResult(()) {
       events.postReadyForExecution()
     }
-    assertResult(None) {
+    assertResult(()) {
       events.postFinished()
     }
-    assertResult(None) {
+    assertResult(()) {
       events.postFailed(DEFAULT_ERROR)
     }
-    assertResult(None) {
+    assertResult(()) {
       events.postCanceled()
     }
-    assertResult(None) {
+    assertResult(()) {
       events.postClosed()
     }
   }
 
   test("SPARK-45738: Failed post when session status is `Closed`") {
-    val events = setupEvents(ExecuteStatus.Pending, SessionStatus.Closed)
+    val events = setupEvents(ExecuteStatus.Started, SessionStatus.Closed)
     assertThrows[IllegalStateException] {
       events.postStarted()
     }
@@ -398,17 +398,17 @@ class ExecuteEventsManagerSuite
   }
 
   test("SPARK-45738: Succeed post when session status is `Closed`") {
-    val events = setupEvents(ExecuteStatus.Pending, SessionStatus.Closed)
-    assertResult(None) {
+    val events = setupEvents(ExecuteStatus.Started, SessionStatus.Closed)
+    assertResult(()) {
       events.postFinished()
     }
-    assertResult(None) {
+    assertResult(()) {
       events.postFailed(DEFAULT_ERROR)
     }
-    assertResult(None) {
+    assertResult(()) {
       events.postCanceled()
     }
-    assertResult(None) {
+    assertResult(()) {
       events.postClosed()
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix issue [spark-45738](https://issues.apache.org/jira/projects/SPARK/issues/SPARK-45738?filter=reportedbyme)

Make `ExecuteEventsManager` more gracefully assert status in `SessionEventsManager`, don't throw exception when handling `Finished/Failed/Cancelled/Closed` events if status in SessionEventsManager is `Closed`. So ExecuteThreadRunner has chance to  response error to client when session is evicted.

### Why are the changes needed?

I inspected spark sever session manager codes, and found that this bug is caused by ExecuteEventsManager and SessionEventsManager status conflict.

When a session is `evicted`(SessionHolder.scala#L170), the status in SessionEventsManager(SessionEventsManager.scala#L72) will be changed to `Closed`, and the query within this session is cancelled. At the same time, the thread running the evicted session will throw exception(ExecuteThreadRunner.scala#L111) which is handled by ErrorUtils.handleError(ErrorUtils.scala#L211). However, this `handleError` will post failed or canceled event to ExecuteEventsManager(ErrorUtils.scala#L258), which will check the status of session in SessionEventsManager. If the status is `Closed`, it will throw exception. And **no chance to send error response**(ErrorUtils.scala#L265) to client, then the client wait forever.


### Does this PR introduce _any_ user-facing change?

No


### How was this patch tested?

Manually test. After this patch, the client will receive error when its session is evicted, as this image shows.

![after_pr](https://github.com/apache/spark/assets/24190835/24558b75-a133-4f21-be1c-baaeb0ad6082)

### Was this patch authored or co-authored using generative AI tooling?

No
