### PR TITLE
[SPARK-45743][BUILD] Upgrade dropwizard metrics 4.2.21

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -181,11 +181,11 @@ log4j-core/2.21.0//log4j-core-2.21.0.jar
 log4j-slf4j2-impl/2.21.0//log4j-slf4j2-impl-2.21.0.jar
 logging-interceptor/3.12.12//logging-interceptor-3.12.12.jar
 lz4-java/1.8.0//lz4-java-1.8.0.jar
-metrics-core/4.2.19//metrics-core-4.2.19.jar
-metrics-graphite/4.2.19//metrics-graphite-4.2.19.jar
-metrics-jmx/4.2.19//metrics-jmx-4.2.19.jar
-metrics-json/4.2.19//metrics-json-4.2.19.jar
-metrics-jvm/4.2.19//metrics-jvm-4.2.19.jar
+metrics-core/4.2.21//metrics-core-4.2.21.jar
+metrics-graphite/4.2.21//metrics-graphite-4.2.21.jar
+metrics-jmx/4.2.21//metrics-jmx-4.2.21.jar
+metrics-json/4.2.21//metrics-json-4.2.21.jar
+metrics-jvm/4.2.21//metrics-jvm-4.2.21.jar
 minlog/1.3.0//minlog-1.3.0.jar
 netty-all/4.1.99.Final//netty-all-4.1.99.Final.jar
 netty-buffer/4.1.99.Final//netty-buffer-4.1.99.Final.jar

--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@
     If you change codahale.metrics.version, you also need to change
     the link to metrics.dropwizard.io in docs/monitoring.md.
     -->
-    <codahale.metrics.version>4.2.19</codahale.metrics.version>
+    <codahale.metrics.version>4.2.21</codahale.metrics.version>
     <!-- Should be consistent with SparkBuild.scala and docs -->
     <avro.version>1.11.3</avro.version>
     <aws.kinesis.client.version>1.12.0</aws.kinesis.client.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr upgrade dropwizard metrics from 4.2.19 to 4.2.21.

### Why are the changes needed?
The new version includes the following major updates:
- https://github.com/dropwizard/metrics/pull/2652
- https://github.com/dropwizard/metrics/pull/3515
- https://github.com/dropwizard/metrics/pull/3523
- https://github.com/dropwizard/metrics/pull/3570

The full release notes as follows:
- https://github.com/dropwizard/metrics/releases/tag/v4.2.20
- https://github.com/dropwizard/metrics/releases/tag/v4.2.21

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No