### PR TITLE
[SPARK-45744][CORE] Switch `spark.history.store.serializer` to use `PROTOBUF` by default

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/History.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/History.scala
@@ -85,14 +85,12 @@ private[spark] object History {
 
   val LOCAL_STORE_SERIALIZER = ConfigBuilder("spark.history.store.serializer")
     .doc("Serializer for writing/reading in-memory UI objects to/from disk-based KV Store; " +
-      "JSON or PROTOBUF. JSON serializer is the only choice before Spark 3.4.0, thus it is the " +
-      "default value. PROTOBUF serializer is fast and compact, and it is the default " +
-      "serializer for disk-based KV store of live UI.")
+      "JSON or PROTOBUF (default). PROTOBUF serializer is fast and compact.")
     .version("3.4.0")
     .stringConf
     .transform(_.toUpperCase(Locale.ROOT))
     .checkValues(LocalStoreSerializer.values.map(_.toString))
-    .createWithDefault(LocalStoreSerializer.JSON.toString)
+    .createWithDefault(LocalStoreSerializer.PROTOBUF.toString)
 
   val MAX_LOCAL_DISK_USAGE = ConfigBuilder("spark.history.store.maxDiskUsage")
     .version("2.3.0")

--- a/docs/core-migration-guide.md
+++ b/docs/core-migration-guide.md
@@ -30,6 +30,8 @@ license: |
 
 - Since Spark 4.0, Spark workers will clean up worker and stopped application directories periodically. To restore the behavior before Spark 4.0, you can set `spark.worker.cleanup.enabled` to `false`.
 
+- Since Spark 4.0, `spark.history.store.serializer` is set to `PROTOBUF` by default. To restore the behavior before Spark 4.0, you can set `spark.history.store.serializer` to `JSON`.
+
 - Since Spark 4.0, `spark.shuffle.service.db.backend` is set to `ROCKSDB` by default which means Spark will use RocksDB store for shuffle service. To restore the behavior before Spark 4.0, you can set `spark.shuffle.service.db.backend` to `LEVELDB`.
 
 - In Spark 4.0, support for Apache Mesos as a resource manager was removed.

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -350,10 +350,10 @@ Security options for the Spark History Server are covered more detail in the
   </tr>
   <tr>
     <td>spark.history.store.serializer</td>
-    <td>JSON</td>
+    <td>PROTOBUF</td>
     <td>
-        Serializer for writing/reading in-memory UI objects to/from disk-based KV Store; JSON or PROTOBUF.
-        JSON serializer is the only choice before Spark 3.4.0, thus it is the default value.
+        Serializer for writing/reading in-memory UI objects to/from disk-based KV Store; JSON or PROTOBUF (default).
+        JSON serializer was the only choice before Spark 3.4.0.
         PROTOBUF serializer is fast and compact, compared to the JSON serializer.
     </td>
     <td>3.4.0</td>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to switch `spark.history.store.serializer` to use `PROTOBUF` by default in Apache Spark 4.0.0.

### Why are the changes needed?

Since Apache Spark 3.4.0, we has been supporting `PROTOBUF` which is faster and compact. In addition, Apache Spark 3.3.0 is going to reach the End-Of-Support on 2023-12-15. It means every supported Apache Spark releases have `PROTOBUF` features at the time when Apache Spark 4.0.0 is released. There was no issues for migrations.

**JSON**
```
66M     apps/local-1698706034616.rdb
```

**PROTOBUF**
```
40M     apps/local-1698706034616.rdb
```

### Does this PR introduce _any_ user-facing change?

The corresponding migration guide is added.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.