### PR TITLE
[MINOR][DOCS]Fix the variable name in the docs - testing_pyspark.ipynb

### DIFF
--- a/python/docs/source/getting_started/testing_pyspark.ipynb
+++ b/python/docs/source/getting_started/testing_pyspark.ipynb
@@ -318,7 +318,7 @@
     "                   {\"name\": \"Eve   A.\", \"age\": 28}] \n",
     "                    \n",
     "    # Create a Spark DataFrame\n",
-    "    original_df = spark.createDataFrame(sample_data)\n",
+    "    original_df = spark_fixture.createDataFrame(sample_data)\n",
     "    \n",
     "    # Apply the transformation function from before\n",
     "    transformed_df = remove_extra_spaces(original_df, \"name\")\n",
@@ -328,7 +328,7 @@
     "    {\"name\": \"Bob T.\", \"age\": 35}, \n",
     "    {\"name\": \"Eve A.\", \"age\": 28}]\n",
     "    \n",
-    "    expected_df = spark.createDataFrame(expected_data)\n",
+    "    expected_df = spark_fixture.createDataFrame(expected_data)\n",
     "\n",
     "    assertDataFrameEqual(transformed_df, expected_df)"
    ]


### PR DESCRIPTION
### What changes were proposed in this pull request?

I'm changing a variable name in one of the cells in the documentation regarding pyspark testing.


### Why are the changes needed?

Currently the code won't run. This simple fix will make the code in the documenatatnion usable.


### Does this PR introduce _any_ user-facing change?

No


### How was this patch tested?
I tested this code loccally with pytest and pyspark 3.5.0 
![image](https://github.com/apache/spark/assets/51126637/3a29a495-38d3-492c-b192-3e26af6fc72c)



### Was this patch authored or co-authored using generative AI tooling?
No
