### PR TITLE
[SPARK-45748][SQL] Add a .fromSQL helper function for Literals

### DIFF
--- a/common/utils/src/main/resources/error/error-classes.json
+++ b/common/utils/src/main/resources/error/error-classes.json
@@ -1866,6 +1866,29 @@
     },
     "sqlState" : "42K0E"
   },
+  "INVALID_LITERAL_VALUE_SQL_STRING_FOR_DESERIALIZATION" : {
+    "message" : [
+      "The given Literal value SQL string <sqlStr> (dataType: <dataType>) is invalid and can't be deserialized."
+    ],
+    "subClass" : {
+      "ANALYSIS_FAILURE" : {
+        "message" : [
+          "It cannot be analyzed successfully."
+        ]
+      },
+      "NOT_EXPECTED_LITERAL_TYPE" : {
+        "message" : [
+          "The deserialized expression <expr> is not an Literal with data type <dataType>."
+        ]
+      },
+      "PARSE_FAILURE" : {
+        "message" : [
+          "It cannot be parsed successfully."
+        ]
+      }
+    },
+    "sqlState" : "42894"
+  },
   "INVALID_NON_DETERMINISTIC_EXPRESSIONS" : {
     "message" : [
       "The operator expects a deterministic expression, but the actual expression is <sqlExprs>."

--- a/docs/sql-error-conditions.md
+++ b/docs/sql-error-conditions.md
@@ -1112,6 +1112,12 @@ The limit like expression `<expr>` is invalid.
 
 For more details see [INVALID_LIMIT_LIKE_EXPRESSION](sql-error-conditions-invalid-limit-like-expression-error-class.html)
 
+### INVALID_LITERAL_VALUE_SQL_STRING_FOR_DESERIALIZATION
+
+SQLSTATE: 42894
+
+The given Literal value SQL string `<sqlStr>` (dataType: `<dataType>`) is invalid and can't be deserialized.
+
 ### INVALID_NON_DETERMINISTIC_EXPRESSIONS
 
 [SQLSTATE: 42K0E](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -790,6 +790,23 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
     }
   }
 
+  def invalidLiteralValueSQLStringForDeserialization(
+      subErrorClass: String,
+      sqlString: String,
+      dataType: DataType,
+      cause: Option[Exception],
+      deserializedExpr: Option[Expression] = None): Throwable = {
+    new AnalysisException(
+      errorClass = s"INVALID_LITERAL_VALUE_SQL_STRING_FOR_DESERIALIZATION.$subErrorClass",
+      messageParameters = Map(
+        "sqlStr" -> sqlString,
+        "dataType" -> toSQLType(dataType),
+        "expr" -> deserializedExpr.map(toSQLExpr).getOrElse("")
+      ),
+      cause = cause
+    )
+  }
+
   def alterV2TableSetLocationWithPartitionNotSupportedError(): Throwable = {
     new AnalysisException(
       errorClass = "_LEGACY_ERROR_TEMP_1045",

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.errors
 import org.apache.spark.SPARK_DOC_ROOT
 import org.apache.spark.sql.{AnalysisException, ClassData, IntegratedUDFTestUtils, QueryTest, Row}
 import org.apache.spark.sql.api.java.{UDF1, UDF2, UDF23Test}
+import org.apache.spark.sql.catalyst.expressions.Literal
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.execution.datasources.v2.jdbc.JDBCTableCatalog
 import org.apache.spark.sql.expressions.SparkUserDefinedFunction
@@ -711,6 +712,33 @@ class QueryCompilationErrorsSuite
         "actualNum" -> "1",
         "docroot" -> SPARK_DOC_ROOT),
       context = ExpectedContext("", "", 7, 13, "CAST(1)")
+    )
+  }
+
+  test("INVALID_LITERAL_VALUE_SQL_STRING_FOR_DESERIALIZATION") {
+    checkError(
+      exception = intercept[AnalysisException] {
+        Literal.fromSQL("some random things", StringType.json)
+      },
+      errorClass = "INVALID_LITERAL_VALUE_SQL_STRING_FOR_DESERIALIZATION.PARSE_FAILURE",
+     parameters = Map("sqlStr" -> "some random things", "dataType" -> "\"STRING\"", "expr" -> ""),
+      sqlState = "42894"
+    )
+    checkError(
+      exception = intercept[AnalysisException] {
+        Literal.fromSQL("some_func('abc')", StringType.json)
+      },
+      errorClass = "INVALID_LITERAL_VALUE_SQL_STRING_FOR_DESERIALIZATION.ANALYSIS_FAILURE",
+      parameters = Map("sqlStr" -> "some_func('abc')", "dataType" -> "\"STRING\"", "expr" -> ""),
+      sqlState = "42894"
+    )
+    checkError(
+      exception = intercept[AnalysisException] {
+        Literal.fromSQL("'abc'", IntegerType.json)
+      },
+      errorClass = "INVALID_LITERAL_VALUE_SQL_STRING_FOR_DESERIALIZATION.ANALYSIS_FAILURE",
+      parameters = Map("sqlStr" -> "'abc'", "dataType" -> "\"INT\"", "expr" -> ""),
+      sqlState = "42894"
     )
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Two major changes in the PR
1.  Adds a `fromSQL` helper function for Literal object to parse and analyze the given sql value and data type of the literal, and construct a Literal. Together with `.sql`, these two methods provide handy function to serialize and deserialize a Literal.
2. Changes the timestamp (ltz) `.sql` output to adds the timezone information: `s"TIMESTAMP '$toString${SQLConf.get.sessionLocalTimeZone}'"`. This is to help correctly deserialize the value. 


### Why are the changes needed?
Provide handy helper functions.

### Does this PR introduce _any_ user-facing change?
One minor change for the `.sql` output for the TIMESTAMP type.


### How was this patch tested?
Added new tests.


### Was this patch authored or co-authored using generative AI tooling?
No.
