### PR TITLE
[SPARK-45749][CORE][WEBUI] Fix `Spark History Server` to sort `Duration` column properly

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/historypage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/historypage.js
@@ -192,7 +192,12 @@ $(document).ready(function() {
           },
           {name: startedColumnName, data: 'startTime' },
           {name: completedColumnName, data: 'endTime' },
-          {name: durationColumnName, type: "title-numeric", data: 'duration' },
+          {
+            name: durationColumnName,
+            type: "title-numeric",
+            data: 'duration',
+            render:  (id, type, row) => `<span title="${row.durationMillisec}">${row.duration}</span>`
+          },
           {name: 'user', data: 'sparkUser' },
           {name: 'lastUpdated', data: 'lastUpdated' },
           {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix an UI regression at Apache Spark 3.2.0 caused by SPARK-34123.

From Apache Spark **3.2.0** to **3.5.0**, `Spark History Server` cannot sort `Duration` column.

After this PR, Spark History Server can sort `Duration` column properly like Apache Spark 3.1.3 and before.

### Why are the changes needed?

Before SPARK-34123, Apache Spark had the `title` attribute for sorting.
- https://github.com/apache/spark/pull/31191
```
<td><span title="{{durationMillisec}}">{{duration}}</span></td>
```

Without `title`, `title-numeric` doesn't work.

### Does this PR introduce _any_ user-facing change?

No. This is a bug fix.

### How was this patch tested?

Manual test. Please use `Safari Private Browsing ` or `Chrome Incognito` mode.



<img width="96" alt="Screenshot 2023-10-31 at 5 47 34 PM" src="https://github.com/apache/spark/assets/9700541/8c8464d2-c58b-465c-8f98-edab1ec2317d">

<img width="94" alt="Screenshot 2023-10-31 at 5 47 29 PM" src="https://github.com/apache/spark/assets/9700541/03e8373d-bda3-4835-90ad-9a45670e853a">



### Was this patch authored or co-authored using generative AI tooling?

No.