### PR TITLE
[SPARK-45754][CORE] Support `spark.deploy.appIdPattern`

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -54,6 +54,7 @@ private[deploy] class Master(
     ThreadUtils.newDaemonSingleThreadScheduledExecutor("master-forward-message-thread")
 
   private val driverIdPattern = conf.get(DRIVER_ID_PATTERN)
+  private val appIdPattern = conf.get(APP_ID_PATTERN)
 
   // For application IDs
   private def createDateFormat = new SimpleDateFormat("yyyyMMddHHmmss", Locale.US)
@@ -1152,7 +1153,7 @@ private[deploy] class Master(
 
   /** Generate a new app ID given an app's submission date */
   private def newApplicationId(submitDate: Date): String = {
-    val appId = "app-%s-%04d".format(createDateFormat.format(submitDate), nextAppNumber)
+    val appId = appIdPattern.format(createDateFormat.format(submitDate), nextAppNumber)
     nextAppNumber += 1
     appId
   }

--- a/core/src/main/scala/org/apache/spark/internal/config/Deploy.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/Deploy.scala
@@ -90,4 +90,10 @@ private[spark] object Deploy {
     .stringConf
     .checkValue(!_.format("20231101000000", 0).exists(_.isWhitespace), "Whitespace is not allowed.")
     .createWithDefault("driver-%s-%04d")
+
+  val APP_ID_PATTERN = ConfigBuilder("spark.deploy.appIdPattern")
+    .doc("The pattern for app ID generation.")
+    .version("4.0.0")
+    .stringConf
+    .createWithDefault("app-%s-%04d")
 }

--- a/core/src/main/scala/org/apache/spark/internal/config/Deploy.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/Deploy.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.internal.config
 
+import java.util.Date
+
 private[spark] object Deploy {
   val RECOVERY_MODE = ConfigBuilder("spark.deploy.recoveryMode")
     .version("0.8.1")
@@ -92,8 +94,11 @@ private[spark] object Deploy {
     .createWithDefault("driver-%s-%04d")
 
   val APP_ID_PATTERN = ConfigBuilder("spark.deploy.appIdPattern")
-    .doc("The pattern for app ID generation.")
+    .doc("The pattern for app ID generation based on Java `String.format` method.. " +
+      "The default value is `app-%s-%04d` which represents the existing app id string, " +
+      "e.g., `app-20231031224509-0008`. Plesae be careful to generate unique IDs.")
     .version("4.0.0")
     .stringConf
+    .checkValue(!_.format(new Date(), 0).exists(_.isWhitespace), "Whitespace is not allowed.")
     .createWithDefault("app-%s-%04d")
 }

--- a/core/src/main/scala/org/apache/spark/internal/config/Deploy.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/Deploy.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.internal.config
 
-import java.util.Date
-
 private[spark] object Deploy {
   val RECOVERY_MODE = ConfigBuilder("spark.deploy.recoveryMode")
     .version("0.8.1")
@@ -99,6 +97,6 @@ private[spark] object Deploy {
       "e.g., `app-20231031224509-0008`. Plesae be careful to generate unique IDs.")
     .version("4.0.0")
     .stringConf
-    .checkValue(!_.format(new Date(), 0).exists(_.isWhitespace), "Whitespace is not allowed.")
+    .checkValue(!_.format("20231101000000", 0).exists(_.isWhitespace), "Whitespace is not allowed.")
     .createWithDefault("app-%s-%04d")
 }

--- a/core/src/test/scala/org/apache/spark/deploy/master/MasterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/master/MasterSuite.scala
@@ -1253,11 +1253,18 @@ class MasterSuite extends SparkFunSuite
     assert(m.contains("Whitespace is not allowed"))
   }
 
-  test("SPARK-45754: app id pattern") {
+  test("SPARK-45754: Support app id pattern") {
     val master = makeMaster(new SparkConf().set(APP_ID_PATTERN, "my-app-%2$05d"))
     val submitDate = new Date()
     assert(master.invokePrivate(_newApplicationId(submitDate)) === "my-app-00000")
     assert(master.invokePrivate(_newApplicationId(submitDate)) === "my-app-00001")
+  }
+
+  test("SPARK-45754: Prevent invalid app id patterns") {
+    val m = intercept[IllegalArgumentException] {
+      makeMaster(new SparkConf().set(APP_ID_PATTERN, "my app"))
+    }.getMessage
+    assert(m.contains("Whitespace is not allowed"))
   }
 }
 

--- a/core/src/test/scala/org/apache/spark/deploy/master/MasterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/master/MasterSuite.scala
@@ -803,6 +803,7 @@ class MasterSuite extends SparkFunSuite
     PrivateMethod[mutable.ArrayBuffer[DriverInfo]](Symbol("waitingDrivers"))
   private val _state = PrivateMethod[RecoveryState.Value](Symbol("state"))
   private val _newDriverId = PrivateMethod[String](Symbol("newDriverId"))
+  private val _newApplicationId = PrivateMethod[String](Symbol("newApplicationId"))
 
   private val workerInfo = makeWorkerInfo(4096, 10)
   private val workerInfos = Array(workerInfo, workerInfo, workerInfo)
@@ -1250,6 +1251,13 @@ class MasterSuite extends SparkFunSuite
       makeMaster(new SparkConf().set(DRIVER_ID_PATTERN, "my driver"))
     }.getMessage
     assert(m.contains("Whitespace is not allowed"))
+  }
+
+  test("SPARK-45754: app id pattern") {
+    val master = makeMaster(new SparkConf().set(APP_ID_PATTERN, "my-app-%2$05d"))
+    val submitDate = new Date()
+    assert(master.invokePrivate(_newApplicationId(submitDate)) === "my-app-00000")
+    assert(master.invokePrivate(_newApplicationId(submitDate)) === "my-app-00001")
   }
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `spark.deploy.appIdPattern` for Apache Spark 4.0.0.

### Why are the changes needed?

This allows the users to be able to control driver ID pattern.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs with the newly added test case.

### Was this patch authored or co-authored using generative AI tooling?

No.