### PR TITLE
[SPARK-45751][DOCS] Update the default value for spark.executor.logs.rolling.maxRetainedFile

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -666,7 +666,7 @@ Apart from these, the following properties are also available, and may be useful
 </tr>
 <tr>
   <td><code>spark.executor.logs.rolling.maxRetainedFiles</code></td>
-  <td>(none)</td>
+  <td>-1</td>
   <td>
     Sets the number of latest rolling log files that are going to be retained by the system.
     Older log files will be deleted. Disabled by default.


### PR DESCRIPTION
**What changes were proposed in this pull request?**
The PR updates the default value of 'spark.executor.logs.rolling.maxRetainedFiles' in configuration.html on the website

**Why are the changes needed?**
The default value of 'spark.executor.logs.rolling.maxRetainedFiles' is -1, but the website is wrong.

**Does this PR introduce any user-facing change?**
No

**How was this patch tested?**
It doesn't need to.

**Was this patch authored or co-authored using generative AI tooling?**
No