### PR TITLE
[SPARK-45760][SQL] Add With expression to avoid duplicating expressions

### DIFF
--- a/connector/connect/common/src/test/resources/query-tests/explain-results/function_count_if.explain
+++ b/connector/connect/common/src/test/resources/query-tests/explain-results/function_count_if.explain
@@ -1,3 +1,3 @@
-Aggregate [count(if ((_common_expr_1#0 = false)) null else _common_expr_1#0) AS count_if((a > 0))#0L]
-+- Project [id#0L, a#0, b#0, d#0, e#0, f#0, g#0, (a#0 > 0) AS _common_expr_1#0]
+Aggregate [count(if ((_common_expr_0#0 = false)) null else _common_expr_0#0) AS count_if((a > 0))#0L]
++- Project [id#0L, a#0, b#0, d#0, e#0, f#0, g#0, (a#0 > 0) AS _common_expr_0#0]
    +- LocalRelation <empty>, [id#0L, a#0, b#0, d#0, e#0, f#0, g#0]

--- a/connector/connect/common/src/test/resources/query-tests/explain-results/function_count_if.explain
+++ b/connector/connect/common/src/test/resources/query-tests/explain-results/function_count_if.explain
@@ -1,2 +1,3 @@
-Aggregate [count(if (((a#0 > 0) = false)) null else (a#0 > 0)) AS count_if((a > 0))#0L]
-+- LocalRelation <empty>, [id#0L, a#0, b#0, d#0, e#0, f#0, g#0]
+Aggregate [count(if ((_common_expr_1#0 = false)) null else _common_expr_1#0) AS count_if((a > 0))#0L]
++- Project [id#0L, a#0, b#0, d#0, e#0, f#0, g#0, (a#0 > 0) AS _common_expr_1#0]
+   +- LocalRelation <empty>, [id#0L, a#0, b#0, d#0, e#0, f#0, g#0]

--- a/connector/connect/common/src/test/resources/query-tests/explain-results/function_regexp_substr.explain
+++ b/connector/connect/common/src/test/resources/query-tests/explain-results/function_regexp_substr.explain
@@ -1,2 +1,3 @@
-Project [if ((regexp_extract(g#0, \d{2}(a|b|m), 0) = )) null else regexp_extract(g#0, \d{2}(a|b|m), 0) AS regexp_substr(g, \d{2}(a|b|m))#0]
-+- LocalRelation <empty>, [id#0L, a#0, b#0, d#0, e#0, f#0, g#0]
+Project [if ((_common_expr_2#0 = )) null else _common_expr_2#0 AS regexp_substr(g, \d{2}(a|b|m))#0]
++- Project [id#0L, a#0, b#0, d#0, e#0, f#0, g#0, regexp_extract(g#0, \d{2}(a|b|m), 0) AS _common_expr_2#0]
+   +- LocalRelation <empty>, [id#0L, a#0, b#0, d#0, e#0, f#0, g#0]

--- a/connector/connect/common/src/test/resources/query-tests/explain-results/function_regexp_substr.explain
+++ b/connector/connect/common/src/test/resources/query-tests/explain-results/function_regexp_substr.explain
@@ -1,3 +1,3 @@
-Project [if ((_common_expr_2#0 = )) null else _common_expr_2#0 AS regexp_substr(g, \d{2}(a|b|m))#0]
-+- Project [id#0L, a#0, b#0, d#0, e#0, f#0, g#0, regexp_extract(g#0, \d{2}(a|b|m), 0) AS _common_expr_2#0]
+Project [if ((_common_expr_0#0 = )) null else _common_expr_0#0 AS regexp_substr(g, \d{2}(a|b|m))#0]
++- Project [id#0L, a#0, b#0, d#0, e#0, f#0, g#0, regexp_extract(g#0, \d{2}(a|b|m), 0) AS _common_expr_0#0]
    +- LocalRelation <empty>, [id#0L, a#0, b#0, d#0, e#0, f#0, g#0]

--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/ProtoToParsedPlanTestSuite.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/ProtoToParsedPlanTestSuite.scala
@@ -187,7 +187,7 @@ class ProtoToParsedPlanTestSuite
         object Helper extends RuleExecutor[LogicalPlan] {
           val batches =
             Batch("Finish Analysis", Once, ReplaceExpressions) ::
-              Batch("Rewrite With expression", FixedPoint(10), RewriteWithExpression) :: Nil
+              Batch("Rewrite With expression", Once, RewriteWithExpression) :: Nil
         }
         Helper.execute(catalystPlan)
       }

--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/ProtoToParsedPlanTestSuite.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/ProtoToParsedPlanTestSuite.scala
@@ -29,7 +29,9 @@ import org.apache.spark.connect.proto
 import org.apache.spark.sql.catalyst.{catalog, QueryPlanningTracker}
 import org.apache.spark.sql.catalyst.analysis.{caseSensitiveResolution, Analyzer, FunctionRegistry, Resolver, TableFunctionRegistry}
 import org.apache.spark.sql.catalyst.catalog.SessionCatalog
-import org.apache.spark.sql.catalyst.optimizer.ReplaceExpressions
+import org.apache.spark.sql.catalyst.optimizer.{ReplaceExpressions, RewriteWithExpression}
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.rules.RuleExecutor
 import org.apache.spark.sql.connect.config.Connect
 import org.apache.spark.sql.connect.planner.SparkConnectPlanner
 import org.apache.spark.sql.connect.service.SessionHolder
@@ -181,8 +183,15 @@ class ProtoToParsedPlanTestSuite
       val planner = new SparkConnectPlanner(SessionHolder.forTesting(spark))
       val catalystPlan =
         analyzer.executeAndCheck(planner.transformRelation(relation), new QueryPlanningTracker)
-      val actual =
-        removeMemoryAddress(normalizeExprIds(ReplaceExpressions(catalystPlan)).treeString)
+      val finalAnalyzedPlan = {
+        object Helper extends RuleExecutor[LogicalPlan] {
+          val batches =
+            Batch("Finish Analysis", Once, ReplaceExpressions) ::
+            Batch("Rewrite With expression", FixedPoint(10), RewriteWithExpression) :: Nil
+        }
+        Helper.execute(catalystPlan)
+      }
+      val actual = removeMemoryAddress(normalizeExprIds(finalAnalyzedPlan).treeString)
       val goldenFile = goldenFilePath.resolve(relativePath).getParent.resolve(name + ".explain")
       Try(readGoldenFile(goldenFile)) match {
         case Success(expected) if expected == actual => // Test passes.

--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/ProtoToParsedPlanTestSuite.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/ProtoToParsedPlanTestSuite.scala
@@ -187,7 +187,7 @@ class ProtoToParsedPlanTestSuite
         object Helper extends RuleExecutor[LogicalPlan] {
           val batches =
             Batch("Finish Analysis", Once, ReplaceExpressions) ::
-            Batch("Rewrite With expression", FixedPoint(10), RewriteWithExpression) :: Nil
+              Batch("Rewrite With expression", FixedPoint(10), RewriteWithExpression) :: Nil
         }
         Helper.execute(catalystPlan)
       }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/With.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/With.scala
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.expressions
+
+import org.apache.spark.sql.catalyst.trees.TreePattern.{COMMON_EXPR_REF, TreePattern, WITH_EXPRESSION}
+import org.apache.spark.sql.types.DataType
+
+/**
+ * An expression holder that keeps a list of common expressions and allow the actual expression to
+ * reference these common expressions. The common expressions are guaranteed to be evaluated only
+ * once even if it's referenced more than once. This is similar to CTE but is expression-level.
+ */
+case class With(child: Expression, defs: Seq[CommonExpressionDef])
+  extends Expression with Unevaluable {
+  override val nodePatterns: Seq[TreePattern] = Seq(WITH_EXPRESSION)
+  override def dataType: DataType = child.dataType
+  override def nullable: Boolean = child.nullable
+  override def children: Seq[Expression] = child +: defs
+  override protected def withNewChildrenInternal(
+      newChildren: IndexedSeq[Expression]): Expression = {
+    copy(child = newChildren.head, defs = newChildren.tail.map(_.asInstanceOf[CommonExpressionDef]))
+  }
+}
+
+/**
+ * A wrapper of common expression to carry the id.
+ */
+case class CommonExpressionDef(child: Expression, id: Long = CommonExpressionDef.newId)
+  extends UnaryExpression with Unevaluable {
+  override def dataType: DataType = child.dataType
+  override protected def withNewChildInternal(newChild: Expression): Expression =
+    copy(child = newChild)
+}
+
+/**
+ * A reference to the common expression by its id. Only resolved common expressions can be
+ * referenced, so that we can determine the data type and nullable of the reference node.
+ */
+case class CommonExpressionRef(id: Long, dataType: DataType, nullable: Boolean)
+  extends LeafExpression with Unevaluable {
+  def this(exprDef: CommonExpressionDef) = this(exprDef.id, exprDef.dataType, exprDef.nullable)
+  override val nodePatterns: Seq[TreePattern] = Seq(COMMON_EXPR_REF)
+}
+
+object CommonExpressionDef {
+  private[sql] val curId = new java.util.concurrent.atomic.AtomicLong()
+  def newId: Long = curId.getAndIncrement()
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/nullExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/nullExpressions.scala
@@ -154,7 +154,11 @@ case class NullIf(left: Expression, right: Expression, replacement: Expression)
   extends RuntimeReplaceable with InheritAnalysisRules {
 
   def this(left: Expression, right: Expression) = {
-    this(left, right, If(EqualTo(left, right), Literal.create(null, left.dataType), left))
+    this(left, right, {
+      val commonExpr = CommonExpressionDef(left)
+      val ref = new CommonExpressionRef(commonExpr)
+      With(If(EqualTo(ref, right), Literal.create(null, left.dataType), ref), Seq(commonExpr))
+    })
   }
 
   override def parameters: Seq[Expression] = Seq(left, right)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -149,7 +149,7 @@ abstract class Optimizer(catalogManager: CatalogManager)
     Batch("Finish Analysis", Once, FinishAnalysis) ::
     // We must run this batch after `ReplaceExpressions`, as `RuntimeReplaceable` expression
     // may produce `With` expressions that need to be rewritten.
-    Batch("Rewrite With expression", fixedPoint, RewriteWithExpression) ::
+    Batch("Rewrite With expression", Once, RewriteWithExpression) ::
     //////////////////////////////////////////////////////////////////////////////////////////
     // Optimizer rules start here
     //////////////////////////////////////////////////////////////////////////////////////////

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -147,6 +147,9 @@ abstract class Optimizer(catalogManager: CatalogManager)
 
     val batches = (
     Batch("Finish Analysis", Once, FinishAnalysis) ::
+    // We must run this batch after `ReplaceExpressions`, as `RuntimeReplaceable` expression
+    // may produce `With` expressions that need to be rewritten.
+    Batch("Rewrite With expression", fixedPoint, RewriteWithExpression) ::
     //////////////////////////////////////////////////////////////////////////////////////////
     // Optimizer rules start here
     //////////////////////////////////////////////////////////////////////////////////////////

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteWithExpression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteWithExpression.scala
@@ -44,13 +44,13 @@ object RewriteWithExpression extends Rule[LogicalPlan] {
           case With(child, defs) if defs.forall(!_.containsPattern(WITH_EXPRESSION)) =>
             val idToCheapExpr = mutable.HashMap.empty[Long, Expression]
             val idToNonCheapExpr = mutable.HashMap.empty[Long, Alias]
-            defs.foreach { commonExprDef =>
+            defs.zipWithIndex.foreach { case (commonExprDef, index) =>
               if (CollapseProject.isCheap(commonExprDef.child)) {
                 idToCheapExpr(commonExprDef.id) = commonExprDef.child
               } else {
                 // TODO: we should calculate the ref count and also inline the common expression
                 //       if it's ref count is 1.
-                val alias = Alias(commonExprDef.child, s"_common_expr_${commonExprDef.id}")()
+                val alias = Alias(commonExprDef.child, s"_common_expr_$index")()
                 commonExprs += alias
                 idToNonCheapExpr(commonExprDef.id) = alias
               }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteWithExpression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteWithExpression.scala
@@ -63,7 +63,7 @@ object RewriteWithExpression extends Rule[LogicalPlan] {
         }
 
         var exprsToAdd = commonExprs.toSeq
-        val newChildren = p.children.map { child =>
+        val newChildren = newPlan.children.map { child =>
           val (newExprs, others) = exprsToAdd.partition(_.references.subsetOf(child.outputSet))
           exprsToAdd = others
           if (newExprs.nonEmpty) {
@@ -74,7 +74,7 @@ object RewriteWithExpression extends Rule[LogicalPlan] {
         }
 
         if (exprsToAdd.nonEmpty) {
-          // If we cannot rewrite the common expressions, force to inline them so that the query
+          // When we cannot rewrite the common expressions, force to inline them so that the query
           // can still run. This can happen if the join condition contains `With` and the common
           // expression references columns from both join sides.
           // TODO: things can go wrong if the common expression is nondeterministic. We don't fix

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteWithExpression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteWithExpression.scala
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import scala.collection.mutable
+
+import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeMap, CommonExpressionRef, Expression, With}
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Project}
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.catalyst.trees.TreePattern.{COMMON_EXPR_REF, WITH_EXPRESSION}
+
+/**
+ * Rewrites the `With` expressions by adding a `Project` to pre-evaluate the common expressions, or
+ * just inline them if they are cheap.
+ *
+ * Note: For now we only use `With` in a few `RuntimeReplaceable` expressions. If we expand its
+ *       usage, we should support aggregate/window functions as well.
+ */
+object RewriteWithExpression extends Rule[LogicalPlan] {
+  override def apply(plan: LogicalPlan): LogicalPlan = {
+    plan.transformWithPruning(_.containsPattern(WITH_EXPRESSION)) {
+      case p if p.expressions.exists(_.containsPattern(WITH_EXPRESSION)) =>
+        val commonExprs = mutable.ArrayBuffer.empty[Alias]
+        // `With` can be nested, we should only rewrite the leaf `With` expression, as the outer
+        // `With` needs to add its own Project, in the next iteration when it becomes leaf.
+        // This is done via "transform down" and check if the common expression definitions does not
+        // contain nested `With`.
+        var newPlan: LogicalPlan = p.transformExpressionsDown {
+          case With(child, defs) if defs.forall(!_.containsPattern(WITH_EXPRESSION)) =>
+            val idToCheapExpr = mutable.HashMap.empty[Long, Expression]
+            val idToNonCheapExpr = mutable.HashMap.empty[Long, Alias]
+            defs.foreach { commonExprDef =>
+              if (CollapseProject.isCheap(commonExprDef.child)) {
+                idToCheapExpr(commonExprDef.id) = commonExprDef.child
+              } else {
+                // TODO: we should calculate the ref count and also inline the common expression
+                //       if it's ref count is 1.
+                val alias = Alias(commonExprDef.child, s"_common_expr_${commonExprDef.id}")()
+                commonExprs += alias
+                idToNonCheapExpr(commonExprDef.id) = alias
+              }
+            }
+
+            child.transformWithPruning(_.containsPattern(COMMON_EXPR_REF)) {
+              case ref: CommonExpressionRef =>
+                idToCheapExpr.getOrElse(ref.id, idToNonCheapExpr(ref.id).toAttribute)
+            }
+        }
+
+        var exprsToAdd = commonExprs.toSeq
+        val newChildren = p.children.map { child =>
+          val (newExprs, others) = exprsToAdd.partition(_.references.subsetOf(child.outputSet))
+          exprsToAdd = others
+          if (newExprs.nonEmpty) {
+            Project(child.output ++ newExprs, child)
+          } else {
+            child
+          }
+        }
+
+        if (exprsToAdd.nonEmpty) {
+          // If we cannot rewrite the common expressions, force to inline them so that the query
+          // can still run. This can happen if the join condition contains `With` and the common
+          // expression references columns from both join sides.
+          // TODO: things can go wrong if the common expression is nondeterministic. We don't fix
+          //       it for now to match the old buggy behavior when certain `RuntimeReplaceable`
+          //       did not use the `With` expression.
+          val attrToExpr = AttributeMap(exprsToAdd.map { alias =>
+            alias.toAttribute -> alias.child
+          })
+          newPlan = newPlan.transformExpressionsUp {
+            case a: Attribute => attrToExpr.getOrElse(a, a)
+          }
+        }
+
+        newPlan = newPlan.withNewChildren(newChildren)
+        if (p.output == newPlan.output) {
+          newPlan
+        } else {
+          Project(p.output, newPlan)
+        }
+    }
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
@@ -36,6 +36,7 @@ object TreePattern extends Enumeration  {
   val CASE_WHEN: Value = Value
   val CAST: Value = Value
   val COALESCE: Value = Value
+  val COMMON_EXPR_REF: Value = Value
   val CONCAT: Value = Value
   val COUNT: Value = Value
   val CREATE_NAMED_STRUCT: Value = Value
@@ -132,6 +133,7 @@ object TreePattern extends Enumeration  {
   val TYPED_FILTER: Value = Value
   val WINDOW: Value = Value
   val WINDOW_GROUP_LIMIT: Value = Value
+  val WITH_EXPRESSION: Value = Value
   val WITH_WINDOW_DEFINITION: Value = Value
 
   // Unresolved expression patterns (Alphabetically ordered)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteWithExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteWithExpressionSuite.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.types.IntegerType
 class RewriteWithExpressionSuite extends PlanTest {
 
   object Optimizer extends RuleExecutor[LogicalPlan] {
-    val batches = Batch("Rewrite With expression", FixedPoint(10), RewriteWithExpression) :: Nil
+    val batches = Batch("Rewrite With expression", Once, RewriteWithExpression) :: Nil
   }
 
   private val testRelation = LocalRelation($"a".int, $"b".int)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteWithExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteWithExpressionSuite.scala
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.dsl.plans._
+import org.apache.spark.sql.catalyst.expressions.{CommonExpressionDef, CommonExpressionRef, With}
+import org.apache.spark.sql.catalyst.plans.PlanTest
+import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan}
+import org.apache.spark.sql.catalyst.rules.RuleExecutor
+
+class RewriteWithExpressionSuite extends PlanTest {
+
+  object Optimizer extends RuleExecutor[LogicalPlan] {
+    val batches = Batch("Rewrite With expression", FixedPoint(10), RewriteWithExpression) :: Nil
+  }
+
+  private val testRelation = LocalRelation($"a".int, $"b".int)
+  private val testRelation2 = LocalRelation($"x".int, $"y".int)
+
+  test("simple common expression") {
+    val a = testRelation.output.head
+    val commonExprDef = CommonExpressionDef(a)
+    val ref = new CommonExpressionRef(commonExprDef)
+    val plan = testRelation.select(With(ref + ref, Seq(commonExprDef)).as("col"))
+    comparePlans(Optimizer.execute(plan), testRelation.select((a + a).as("col")))
+  }
+
+  test("non-cheap common expression") {
+    val a = testRelation.output.head
+    val commonExprDef = CommonExpressionDef(a + a)
+    val ref = new CommonExpressionRef(commonExprDef)
+    val plan = testRelation.select(With(ref * ref, Seq(commonExprDef)).as("col"))
+    val commonExprName = "_common_expr_" + commonExprDef.id
+    comparePlans(
+      Optimizer.execute(plan),
+      testRelation
+        .select((testRelation.output :+ (a + a).as(commonExprName)): _*)
+        .select(($"$commonExprName" * $"$commonExprName").as("col"))
+        .analyze
+    )
+  }
+
+  test("nested WITH expression") {
+    val a = testRelation.output.head
+    val commonExprDef = CommonExpressionDef(a + a)
+    val ref = new CommonExpressionRef(commonExprDef)
+    val innerExpr = With(ref + ref, Seq(commonExprDef))
+    val innerCommonExprName = "_common_expr_" + commonExprDef.id
+
+    val b = testRelation.output.last
+    val outerCommonExprDef = CommonExpressionDef(innerExpr + b)
+    val outerRef = new CommonExpressionRef(outerCommonExprDef)
+    val outerExpr = With(outerRef * outerRef, Seq(outerCommonExprDef))
+    val outerCommonExprName = "_common_expr_" + outerCommonExprDef.id
+
+    val plan = testRelation.select(outerExpr.as("col"))
+    val rewrittenOuterExpr = ($"$innerCommonExprName" + $"$innerCommonExprName" + b)
+      .as(outerCommonExprName)
+    comparePlans(
+      Optimizer.execute(plan),
+      testRelation
+        .select((testRelation.output :+ (a + a).as(innerCommonExprName)): _*)
+        .select((testRelation.output :+ $"$innerCommonExprName" :+ rewrittenOuterExpr): _*)
+        .select(($"$outerCommonExprName" * $"$outerCommonExprName").as("col"))
+        .analyze
+    )
+  }
+
+  test("WITH expression in filter") {
+    val a = testRelation.output.head
+    val commonExprDef = CommonExpressionDef(a + a)
+    val ref = new CommonExpressionRef(commonExprDef)
+    val plan = testRelation.where(With(ref < 10 && ref > 0, Seq(commonExprDef)))
+    val commonExprName = "_common_expr_" + commonExprDef.id
+    comparePlans(
+      Optimizer.execute(plan),
+      testRelation
+        .select((testRelation.output :+ (a + a).as(commonExprName)): _*)
+        .where($"$commonExprName" < 10 && $"$commonExprName" > 0)
+        .select(testRelation.output: _*)
+        .analyze
+    )
+  }
+
+  test("WITH expression in join condition: only reference left child") {
+    val a = testRelation.output.head
+    val commonExprDef = CommonExpressionDef(a + a)
+    val ref = new CommonExpressionRef(commonExprDef)
+    val condition = With(ref < 10 && ref > 0, Seq(commonExprDef))
+    val plan = testRelation.join(testRelation2, condition = Some(condition))
+    val commonExprName = "_common_expr_" + commonExprDef.id
+    comparePlans(
+      Optimizer.execute(plan),
+      testRelation
+        .select((testRelation.output :+ (a + a).as(commonExprName)): _*)
+        .join(testRelation2, condition = Some($"$commonExprName" < 10 && $"$commonExprName" > 0))
+        .select((testRelation.output ++ testRelation2.output): _*)
+        .analyze
+    )
+  }
+
+  test("WITH expression in join condition: only reference right child") {
+    val x = testRelation2.output.head
+    val commonExprDef = CommonExpressionDef(x + x)
+    val ref = new CommonExpressionRef(commonExprDef)
+    val condition = With(ref < 10 && ref > 0, Seq(commonExprDef))
+    val plan = testRelation.join(testRelation2, condition = Some(condition))
+    val commonExprName = "_common_expr_" + commonExprDef.id
+    comparePlans(
+      Optimizer.execute(plan),
+      testRelation
+        .join(
+          testRelation2.select((testRelation2.output :+ (x + x).as(commonExprName)): _*),
+          condition = Some($"$commonExprName" < 10 && $"$commonExprName" > 0)
+        )
+        .select((testRelation.output ++ testRelation2.output): _*)
+        .analyze
+    )
+  }
+
+  test("WITH expression in join condition: reference both children") {
+    val a = testRelation.output.head
+    val x = testRelation2.output.head
+    val commonExprDef = CommonExpressionDef(a + x)
+    val ref = new CommonExpressionRef(commonExprDef)
+    val condition = With(ref < 10 && ref > 0, Seq(commonExprDef))
+    val plan = testRelation.join(testRelation2, condition = Some(condition))
+    comparePlans(
+      Optimizer.execute(plan),
+      testRelation
+        .join(
+          testRelation2,
+          // Can't pre-evaluate, have to inline
+          condition = Some((a + x) < 10 && (a + x) > 0)
+        )
+    )
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Sometimes we need to duplicate expressions when rewriting the plan. It's OK for small query, as codegen has common-subexpression-elimination (CSE) to avoid evaluating the same expression. However, when the query is big, duplicating expressions can lead to a very big expression tree and make catalyst rules very slow, or even OOM when updating a leaf node (need to copy all tree nodes).

This PR introduces a new expression to do expression-level CTE: it adds a Project to pre-evaluate the common expressions, so that they appear only once on the query plan tree, and are evaluated only once. `NullIf` now uses this new expression to avoid duplicating the `left` child expression.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
make catalyst more efficient.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
new test suite

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No