### PR TITLE
Temporarily pin R-win version to 4.3.2

### DIFF
--- a/dev/appveyor-install-dependencies.ps1
+++ b/dev/appveyor-install-dependencies.ps1
@@ -27,6 +27,7 @@ Function InstallR {
 
   $urlPath = ""
   $latestVer = $(ConvertFrom-JSON $(Invoke-WebRequest https://rversions.r-pkg.org/r-release-win).Content).version
+  $latestVer = "4.3.2"
   If ($rVer -ne $latestVer) {
     $urlPath = ("old/" + $rVer + "/")
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to temporarily pin R-win version to `4.3.2`.

- According to `appveyor-install-dependencies.ps1` logic, we should download R-win: `4.3.1`.
   https://rversions.r-pkg.org/r-release-win
    <img width="639" alt="image" src="https://github.com/apache/spark/assets/15246973/050d125f-fcd3-4f91-8331-6f6aba63b259">
- The address `https://cran.r-project.org/bin/windows/base/R-4.3.1-win.exe` of this file currently does not exist.
- The latest version of R-win currently is: 4.3.2
   https://cloud.r-project.org/bin/windows/base/
   <img width="1072" alt="image" src="https://github.com/apache/spark/assets/15246973/2d659798-2c85-48a2-bfe3-b91cc18628af">
- The above error json content resulted in `Spark's integration appveyor` failure:
   https://ci.appveyor.com/project/ApacheSoftwareFoundation/spark/builds/48423069
   <img width="1033" alt="image" src="https://github.com/apache/spark/assets/15246973/9f94de02-98aa-4fcf-9e49-e8faa9b0f01a">



### Why are the changes needed?
Make integration appveyor happy.

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Manually test.

### Was this patch authored or co-authored using generative AI tooling?
No.
