### PR TITLE
[SPARK-45694][SPARK-45695][SQL] Clean up deprecated API usage `View.force` and `ScalaNumberProxy.signum`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/EquivalentExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/EquivalentExpressions.scala
@@ -191,7 +191,7 @@ class EquivalentExpressions(
     val skip = useCount == 0 || expr.isInstanceOf[LeafExpression]
 
     if (!skip && !updateExprInMap(expr, map, useCount)) {
-      val uc = useCount.signum
+      val uc = useCount.sign
       childrenToRecurse(expr).foreach(updateExprTree(_, map, uc))
       commonChildrenToRecurse(expr).filter(_.nonEmpty).foreach(updateCommonExprs(_, map, uc))
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -362,10 +362,8 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]]
       case s: Seq[_] =>
         s.map(mapChild)
       case m: Map[_, _] =>
-        // `map.mapValues().view.force` return `Map` in Scala 2.12 but return `IndexedSeq` in Scala
-        // 2.13, call `toMap` method manually to compatible with Scala 2.12 and Scala 2.13
-        // `mapValues` is lazy and we need to force it to materialize
-        m.view.mapValues(mapChild).view.force.toMap
+        // `mapValues` is lazy and we need to force it to materialize by invoking `toIndexedSeq`
+        m.view.mapValues(mapChild).view.toIndexedSeq.toMap
       case arg: TreeNode[_] if containsChild(arg) => mapTreeNode(arg)
       case Some(child) => Some(mapChild(child))
       case nonChild: AnyRef => nonChild
@@ -784,13 +782,12 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]]
         arg.asInstanceOf[BaseType].clone()
       case Some(arg: TreeNode[_]) if containsChild(arg) =>
         Some(arg.asInstanceOf[BaseType].clone())
-      // `map.mapValues().view.force` return `Map` in Scala 2.12 but return `IndexedSeq` in Scala
-      // 2.13, call `toMap` method manually to compatible with Scala 2.12 and Scala 2.13
+      // `mapValues` is lazy and we need to force it to materialize by invoking `toIndexedSeq`
       case m: Map[_, _] => m.view.mapValues {
         case arg: TreeNode[_] if containsChild(arg) =>
           arg.asInstanceOf[BaseType].clone()
         case other => other
-      }.view.force.toMap // `mapValues` is lazy and we need to force it to materialize
+      }.view.toIndexedSeq.toMap
       case d: DataType => d // Avoid unpacking Structs
       case args: LazyList[_] => args.map(mapChild).force // Force materialization on stream
       case args: Iterable[_] => args.map(mapChild)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -362,8 +362,8 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]]
       case s: Seq[_] =>
         s.map(mapChild)
       case m: Map[_, _] =>
-        // `mapValues` is lazy and we need to force it to materialize by invoking `toIndexedSeq`
-        m.view.mapValues(mapChild).view.toIndexedSeq.toMap
+        // `mapValues` is lazy and we need to force it to materialize by converting to Map
+        m.view.mapValues(mapChild).toMap
       case arg: TreeNode[_] if containsChild(arg) => mapTreeNode(arg)
       case Some(child) => Some(mapChild(child))
       case nonChild: AnyRef => nonChild
@@ -782,12 +782,12 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]]
         arg.asInstanceOf[BaseType].clone()
       case Some(arg: TreeNode[_]) if containsChild(arg) =>
         Some(arg.asInstanceOf[BaseType].clone())
-      // `mapValues` is lazy and we need to force it to materialize by invoking `toIndexedSeq`
+      // `mapValues` is lazy and we need to force it to materialize by converting to Map
       case m: Map[_, _] => m.view.mapValues {
         case arg: TreeNode[_] if containsChild(arg) =>
           arg.asInstanceOf[BaseType].clone()
         case other => other
-      }.view.toIndexedSeq.toMap
+      }.toMap
       case d: DataType => d // Avoid unpacking Structs
       case args: LazyList[_] => args.map(mapChild).force // Force materialization on stream
       case args: Iterable[_] => args.map(mapChild)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Clean up deprecated API usage:
1. ScalaNumberProxy.signum -> use `sign` instead;
2. Map.view.mapValues.view.force.toMap -> replaced to Map.vew.mapValues.toMap;

### Why are the changes needed?
Eliminate compile warnings and no longer use deprecated scala APIs.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.

