### PR TITLE
[WIP][SPARK-4836][UI] Show all stage attempts on UI's job details page

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/jobs/JobPage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/JobPage.scala
@@ -236,10 +236,11 @@ private[ui] class JobPage(parent: JobsTab, store: AppStatusStore) extends WebUIP
     }
 
     val isComplete = jobData.status != JobExecutionStatus.RUNNING
-    val stages = jobData.stageIds.map { stageId =>
+    val stages = jobData.stageIds.flatMap { stageId =>
+      val allStageAttempts = store.stageData(stageId).reverse
       // This could be empty if the listener hasn't received information about the
       // stage or if the stage information has been garbage collected
-      store.asOption(store.lastStageAttempt(stageId)).getOrElse {
+      val latestAttempt = allStageAttempts.headOption.getOrElse {
         new v1.StageData(
           status = v1.StageStatus.PENDING,
           stageId = stageId,
@@ -310,6 +311,7 @@ private[ui] class JobPage(parent: JobsTab, store: AppStatusStore) extends WebUIP
           isShufflePushEnabled = false,
           shuffleMergersCount = 0)
       }
+      latestAttempt +: allStageAttempts.tail
     }
 
     val activeStages = Buffer[v1.StageData]()


### PR DESCRIPTION
### What changes were proposed in this pull request?

( 🚧 This PR is WIP, but I'm opening it early in the hopes of gathering early feedback)

This PR updates the Spark UI's job details page so that it shows information for all stage attempts, rather than only showing the latest attempt. 

### Why are the changes needed?

This makes it easier to debug jobs that were slow due to repeated stage failures.

### Does this PR introduce _any_ user-facing change?

Yes: it alters the Job Details page in the Spark UI.

Previously, only the latest stage attempt would be shown. If a stage failed and then subsequently succeeded then then only the last successful attempt would be shown in the tables and in the timeline view.

After my PR's changes, all stage attempts (that the UI still knows about) are shown:

![image](https://github.com/apache/spark/assets/50748/90abb73a-c8f0-41fc-98ba-71de2300b349)



### How was this patch tested?

🚧 WIP: I need to figure out the best strategy for adding tests.

### Was this patch authored or co-authored using generative AI tooling?

No.
