### PR TITLE
[SPARK-45742][CORE][FOLLOWUP] Remove unnecessary null check from `ArrayImplicits.SparkArrayOps#toImmutableArraySeq`

### DIFF
--- a/common/utils/src/main/scala/org/apache/spark/util/ArrayImplicits.scala
+++ b/common/utils/src/main/scala/org/apache/spark/util/ArrayImplicits.scala
@@ -30,7 +30,6 @@ private[spark] object ArrayImplicits {
      * Wraps an Array[T] as an immutable.ArraySeq[T] without copying.
      */
     def toImmutableArraySeq: immutable.ArraySeq[T] =
-      if (xs eq null) null
-      else immutable.ArraySeq.unsafeWrapArray(xs)
+      immutable.ArraySeq.unsafeWrapArray(xs)
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
The implementation of the `mmutable.ArraySeq.unsafeWrapArray` function is as follows:

```scala
  def unsafeWrapArray[T](x: Array[T]): ArraySeq[T] = ((x: @unchecked) match {
    case null              => null
    case x: Array[AnyRef]  => new ofRef[AnyRef](x)
    case x: Array[Int]     => new ofInt(x)
    case x: Array[Double]  => new ofDouble(x)
    case x: Array[Long]    => new ofLong(x)
    case x: Array[Float]   => new ofFloat(x)
    case x: Array[Char]    => new ofChar(x)
    case x: Array[Byte]    => new ofByte(x)
    case x: Array[Short]   => new ofShort(x)
    case x: Array[Boolean] => new ofBoolean(x)
    case x: Array[Unit]    => new ofUnit(x)
  }).asInstanceOf[ArraySeq[T]]
```

The first case of match is null, there is no need to do another manual null check, so this PR removes it.


### Why are the changes needed?
Remove unnecessary null check from `ArrayImplicits.SparkArrayOps#toImmutableArraySeq`


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existing test cases, such as `ArrayImplicitsSuite`.


### Was this patch authored or co-authored using generative AI tooling?
No
