### PR TITLE
[SPARK-45777][CORE] Support `spark.test.appId` in `LocalSchedulerBackend`

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/local/LocalSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/local/LocalSchedulerBackend.scala
@@ -110,7 +110,7 @@ private[spark] class LocalSchedulerBackend(
     val totalCores: Int)
   extends SchedulerBackend with ExecutorBackend with Logging {
 
-  private val appId = sys.props.getOrElse("spark.test.appId", "local-" + System.currentTimeMillis)
+  private val appId = conf.get("spark.test.appId", "local-" + System.currentTimeMillis)
   private var localEndpoint: RpcEndpointRef = null
   private val userClassPath = getUserClasspath(conf)
   private val listenerBus = scheduler.sc.listenerBus

--- a/core/src/main/scala/org/apache/spark/scheduler/local/LocalSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/local/LocalSchedulerBackend.scala
@@ -110,7 +110,7 @@ private[spark] class LocalSchedulerBackend(
     val totalCores: Int)
   extends SchedulerBackend with ExecutorBackend with Logging {
 
-  private val appId = "local-" + System.currentTimeMillis
+  private val appId = sys.props.getOrElse("spark.test.appId", "local-" + System.currentTimeMillis)
   private var localEndpoint: RpcEndpointRef = null
   private val userClassPath = getUserClasspath(conf)
   private val listenerBus = scheduler.sc.listenerBus


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `spark.test.appId` in `LocalSchedulerBackend` like the following.

```
$ bin/spark-shell --driver-java-options="-Dspark.test.appId=test-app-2023"
...
Spark context available as 'sc' (master = local[*], app id = test-app-2023).
```

```
$ bin/spark-shell -c spark.test.appId=test-app-2026 -c spark.eventLog.enabled=true -c spark.eventLog.dir=/Users/dongjoon/data/history
...
Spark context available as 'sc' (master = local[*], app id = test-app-2026).
```

### Why are the changes needed?

Like the other `spark.test.*` configurations, this enables the developers control the appId in `LocalSchedulerBackend`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual.

### Was this patch authored or co-authored using generative AI tooling?

No.