### PR TITLE
[SPARK-45779][INFRA] Add a check step for jira issue ticket to be resolved

### DIFF
--- a/dev/merge_spark_pr.py
+++ b/dev/merge_spark_pr.py
@@ -373,7 +373,10 @@ def resolve_jira_issue(merge_branches, comment, default_jira_id=""):
         resolution={"id": resolution.raw["id"]},
     )
 
-    print_jira_issue_summary(issue)
+    try:
+        print_jira_issue_summary(asf_jira.issue(issue.key))
+    except Exception:
+        print("Unable to fetch JIRA issue %s after resolving" % issue.key)
     print("Successfully resolved %s with fixVersions=%s!" % (issue.key, fix_versions))
 
 

--- a/dev/merge_spark_pr.py
+++ b/dev/merge_spark_pr.py
@@ -248,37 +248,49 @@ def cherry_pick(pr_num, merge_hash, default_branch):
     return pick_ref
 
 
-def resolve_jira_issue(merge_branches, comment, default_jira_id=""):
-    jira_id = input("Enter a JIRA id [%s]: " % default_jira_id)
+def print_jira_issue_summary(issue):
+    summary = issue.fields.summary
+    assignee = issue.fields.assignee
+    if assignee is not None:
+        assignee = assignee.displayName
+    status = issue.fields.status.name
+    print("=== JIRA %s ===" % issue.key)
+    print(
+        "summary\t\t%s\nassignee\t%s\nstatus\t\t%s\nurl\t\t%s/%s\n"
+        % (summary, assignee, status, JIRA_BASE, issue.key)
+    )
+
+
+def get_jira_issue(prompt, default_jira_id=""):
+    jira_id = input("%s[%s]: " % (prompt, default_jira_id))
     if jira_id == "":
         jira_id = default_jira_id
         if jira_id == "":
             print("JIRA ID not found, skipping.")
-            return
-
+            return None
     try:
         issue = asf_jira.issue(jira_id)
+        print_jira_issue_summary(issue)
+        status = issue.fields.status.name
+        if status == "Resolved" or status == "Closed":
+            print("JIRA issue %s already has status '%s'" % (jira_id, status))
+            return None
+        if input("Check if the JIRA information is as expected(y/n): ").lower() != "n":
+            return issue
+        else:
+            return get_jira_issue("Enter the revised JIRA ID again or leave blank to skip")
     except Exception as e:
-        fail("ASF JIRA could not find %s\n%s" % (jira_id, e))
+        print("ASF JIRA could not find %s: %s" % (jira_id, e))
+        return get_jira_issue("Enter the revised JIRA ID again or leave blank to skip")
 
-    cur_status = issue.fields.status.name
-    cur_summary = issue.fields.summary
-    cur_assignee = issue.fields.assignee
-    if cur_assignee is None:
-        cur_assignee = choose_jira_assignee(issue)
-    # Check again, we might not have chosen an assignee
-    if cur_assignee is None:
-        cur_assignee = "NOT ASSIGNED!!!"
-    else:
-        cur_assignee = cur_assignee.displayName
 
-    if cur_status == "Resolved" or cur_status == "Closed":
-        fail("JIRA issue %s already has status '%s'" % (jira_id, cur_status))
-    print("=== JIRA %s ===" % jira_id)
-    print(
-        "summary\t\t%s\nassignee\t%s\nstatus\t\t%s\nurl\t\t%s/%s\n"
-        % (cur_summary, cur_assignee, cur_status, JIRA_BASE, jira_id)
-    )
+def resolve_jira_issue(merge_branches, comment, default_jira_id=""):
+    issue = get_jira_issue("Enter a JIRA id", default_jira_id)
+    if issue is None:
+        return
+
+    if issue.fields.assignee is None:
+        choose_jira_assignee(issue)
 
     versions = asf_jira.project_versions("SPARK")
     # Consider only x.y.z, unreleased, unarchived versions
@@ -351,17 +363,18 @@ def resolve_jira_issue(merge_branches, comment, default_jira_id=""):
 
     jira_fix_versions = list(map(lambda v: get_version_json(v), fix_versions))
 
-    resolve = list(filter(lambda a: a["name"] == "Resolve Issue", asf_jira.transitions(jira_id)))[0]
+    resolve = list(filter(lambda a: a["name"] == "Resolve Issue", asf_jira.transitions(issue.key)))[0]
     resolution = list(filter(lambda r: r.raw["name"] == "Fixed", asf_jira.resolutions()))[0]
     asf_jira.transition_issue(
-        jira_id,
+        issue.key,
         resolve["id"],
         fixVersions=jira_fix_versions,
         comment=comment,
         resolution={"id": resolution.raw["id"]},
     )
 
-    print("Successfully resolved %s with fixVersions=%s!" % (jira_id, fix_versions))
+    print_jira_issue_summary(issue)
+    print("Successfully resolved %s with fixVersions=%s!" % (issue.key, fix_versions))
 
 
 def choose_jira_assignee(issue):

--- a/dev/merge_spark_pr.py
+++ b/dev/merge_spark_pr.py
@@ -363,7 +363,9 @@ def resolve_jira_issue(merge_branches, comment, default_jira_id=""):
 
     jira_fix_versions = list(map(lambda v: get_version_json(v), fix_versions))
 
-    resolve = list(filter(lambda a: a["name"] == "Resolve Issue", asf_jira.transitions(issue.key)))[0]
+    resolve = list(filter(lambda a: a["name"] == "Resolve Issue", asf_jira.transitions(issue.key)))[
+        0
+    ]
     resolution = list(filter(lambda r: r.raw["name"] == "Fixed", asf_jira.resolutions()))[0]
     asf_jira.transition_issue(
         issue.key,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR moves the step for printing the summary of the Jira issue and adds a confirmation step for committers before assigning it to a user.

Also, we show the final status of the Jira issue after resolution.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

The JIRA ID mentioned in the PR title can sometimes be incorrect due to carelessness. Double-checking the ID is necessary to ensure that it is accurate. It is now too late for the committers to modify the ID once they have seen the ticket summary.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
no

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Tested with SPARK-45776.

Note that the message below may seem noisy because I declined the merge script at first.

```
Would you like to update an associated JIRA? (y/n): y
Enter a JIRA id[SPARK-45776]:
=== JIRA SPARK-45776 ===
summary		Remove the defensive null check added in SPARK-39553.
assignee	None
status		Open
url		https://issues.apache.org/jira/browse/SPARK-45776

Check if the JIRA information is as expected(y/n): n
Enter the revised JIRA ID again or leave blank to skip[]: SPARK-45776
=== JIRA SPARK-45776 ===
summary		Remove the defensive null check added in SPARK-39553.
assignee	None
status		Open
url		https://issues.apache.org/jira/browse/SPARK-45776

Check if the JIRA information is as expected(y/n): y
JIRA is unassigned, choose assignee
[0] Yang Jie (Reporter)
Enter number of user, or userid, to assign to (blank to leave unassigned):0
Enter comma-separated fix version(s) [4.0.0]:
=== JIRA SPARK-45776 ===
summary		Remove the defensive null check added in SPARK-39553.
assignee        Yang Jie
status		RESOLVED
url		https://issues.apache.org/jira/browse/SPARK-45776

Successfully resolved SPARK-45776 with fixVersions=['4.0.0']!
Enter a JIRA id[SPARK-39553]:
```
### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

no
