### PR TITLE
[SPARK-45782][CORE][PYTHON] Add Dataframe API df.explainString()

### DIFF
--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -1854,7 +1854,12 @@ class DataFrame:
     def explain(
         self, extended: Optional[Union[bool, str]] = None, mode: Optional[str] = None
     ) -> None:
-        print(self._explain_string(extended=extended, mode=mode))
+        print(self.explainString(extended=extended, mode=mode))
+
+    def explainString(
+        self, extended: Optional[Union[bool, str]] = None, mode: Optional[str] = None
+    ) -> str:
+        return self._explain_string(extended=extended, mode=mode)
 
     explain.__doc__ = PySparkDataFrame.explain.__doc__
 

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -716,7 +716,6 @@ class DataFrameTestsMixin:
                 r"\n",
                 r"== Physical Plan ==\n",
                 r"\*\(1\) Scan ExistingRDD[_1#[\d]+,_2#[\d]+L]\n",
-                r"\n",
             ]
         )
         self.assertTrue(re.match(expected, actual))

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -697,6 +697,30 @@ class DataFrameTestsMixin:
             self.assertGreaterEqual(explain_output.count("what"), 1)
             self.assertGreaterEqual(explain_output.count("itworks"), 1)
 
+    def test_explain_string(self):
+        import re
+
+        df = self.spark.createDataFrame([("John", 30), ("Alice", 25), ("Bob", 28)])
+        actual = df.explainString(True)
+        expected = "".join(
+            [
+                r"== Parsed Logical Plan ==\n",
+                r"LogicalRDD [_1#[\d]+, _2#[\d]+L], false\n",
+                r"\n",
+                r"== Analyzed Logical Plan ==\n",
+                r"_1: string, _2: bigint\n",
+                r"LogicalRDD [_1#[\d]+, _2#[\d]+L], false\n",
+                r"\n",
+                r"== Optimized Logical Plan ==\n",
+                r"LogicalRDD [_1#[\d]+, _2#[\d]+L], false\n",
+                r"\n",
+                r"== Physical Plan ==\n",
+                r"\*\(1\) Scan ExistingRDD[_1#[\d]+,_2#[\d]+L]\n",
+                r"\n",
+            ]
+        )
+        self.assertTrue(re.match(expected, actual))
+
     def test_unpivot(self):
         # SPARK-39877: test the DataFrame.unpivot method
         df = self.spark.createDataFrame(

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -699,25 +699,44 @@ class DataFrameTestsMixin:
 
     def test_explain_string(self):
         import re
+        from pyspark.sql.connect.session import SparkSession as RemoteSparkSession
 
         df = self.spark.createDataFrame([("John", 30), ("Alice", 25), ("Bob", 28)])
         actual = df.explainString(True)
-        expected = "".join(
-            [
-                r"== Parsed Logical Plan ==\n",
-                r"LogicalRDD [_1#[\d]+, _2#[\d]+L], false\n",
-                r"\n",
-                r"== Analyzed Logical Plan ==\n",
-                r"_1: string, _2: bigint\n",
-                r"LogicalRDD [_1#[\d]+, _2#[\d]+L], false\n",
-                r"\n",
-                r"== Optimized Logical Plan ==\n",
-                r"LogicalRDD [_1#[\d]+, _2#[\d]+L], false\n",
-                r"\n",
-                r"== Physical Plan ==\n",
-                r"\*\(1\) Scan ExistingRDD[_1#[\d]+,_2#[\d]+L]\n",
-            ]
-        )
+        if isinstance(self.spark, RemoteSparkSession):
+            expected = "".join(
+                [
+                    r"== Parsed Logical Plan ==\n",
+                    r"LocalRelation [_1#[\d]+, _2#[\d]+L]\n",
+                    r"\n",
+                    r"== Analyzed Logical Plan ==\n",
+                    r"_1: string, _2: bigint\n",
+                    r"LocalRelation [_1#[\d]+, _2#[\d]+L]\n",
+                    r"\n",
+                    r"== Optimized Logical Plan ==\n",
+                    r"LocalRelation [_1#[\d]+, _2#[\d]+L]\n",
+                    r"\n",
+                    r"== Physical Plan ==\n",
+                    r"LocalTableScan [_1#[\d]+, _2#[\d]+L]\n",
+                ]
+            )
+        else:
+            expected = "".join(
+                [
+                    r"== Parsed Logical Plan ==\n",
+                    r"LogicalRDD [_1#[\d]+, _2#[\d]+L], false\n",
+                    r"\n",
+                    r"== Analyzed Logical Plan ==\n",
+                    r"_1: string, _2: bigint\n",
+                    r"LogicalRDD [_1#[\d]+, _2#[\d]+L], false\n",
+                    r"\n",
+                    r"== Optimized Logical Plan ==\n",
+                    r"LogicalRDD [_1#[\d]+, _2#[\d]+L], false\n",
+                    r"\n",
+                    r"== Physical Plan ==\n",
+                    r"\*\(1\) Scan ExistingRDD[_1#[\d]+,_2#[\d]+L]\n",
+                ]
+            )
         self.assertTrue(re.match(expected, actual))
 
     def test_unpivot(self):

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -585,16 +585,10 @@ class Dataset[T] private[sql](
    * @group basic
    * @since 3.0.0
    */
-  def explain(mode: String): Unit = sparkSession.withActive {
-    // Because temporary views are resolved during analysis when we create a Dataset, and
-    // `ExplainCommand` analyzes input query plan and resolves temporary views again. Using
-    // `ExplainCommand` here will probably output different query plans, compared to the results
-    // of evaluation of the Dataset. So just output QueryExecution's query plans here.
-
+  def explain(mode: String): Unit =
     // scalastyle:off println
-    println(queryExecution.explainString(ExplainMode.fromString(mode)))
+    println(explainString(mode))
     // scalastyle:on println
-  }
 
   /**
    * Prints the plans (logical and physical) to the console for debugging purposes.
@@ -617,6 +611,52 @@ class Dataset[T] private[sql](
    * @since 1.6.0
    */
   def explain(): Unit = explain(SimpleMode.name)
+
+  /**
+   * Returns the plans (logical and physical) with a format specified by a given explain mode.
+   *
+   * @param mode specifies the expected output format of plans.
+   *             <ul>
+   *             <li>`simple` Returns only a physical plan.</li>
+   *             <li>`extended`: Returns both logical and physical plans.</li>
+   *             <li>`codegen`: Returns a physical plan and generated codes if they are
+   *             available.</li>
+   *             <li>`cost`: Returns a logical plan and statistics if they are available.</li>
+   *             <li>`formatted`: Splits explain output into two sections: a physical plan outline
+   *             and node details.</li>
+   *             </ul>
+   * @group basic
+   * @since 4.0.0
+   */
+  def explainString(mode: String): String = sparkSession.withActive {
+    // Because temporary views are resolved during analysis when we create a Dataset, and
+    // `ExplainCommand` analyzes input query plan and resolves temporary views again. Using
+    // `ExplainCommand` here will probably output different query plans, compared to the results
+    // of evaluation of the Dataset. So just output QueryExecution's query plans here.
+
+    queryExecution.explainString(ExplainMode.fromString(mode))
+  }
+
+  /**
+   * Returns the plans (logical and physical) for debugging purposes.
+   *
+   * @param extended default `false`. If `false`, returns only the physical plan.
+   * @group basic
+   * @since 4.0.0
+   */
+  def explainString(extended: Boolean): String = if (extended) {
+    explainString(ExtendedMode.name)
+  } else {
+    explainString(SimpleMode.name)
+  }
+
+  /**
+   * Returns the physical plan for debugging purposes.
+   *
+   * @group basic
+   * @since 4.0.0
+   */
+  def explainString(): String = explainString(SimpleMode.name)
 
   /**
    * Returns all column names and their data types as an array.

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -2875,23 +2875,23 @@ class DataFrameSuite extends QueryTest
     }
   }
 
-  test("SPARK-00000: explainString method") {
+  test("SPARK-45782: explainString method") {
     val df = Seq(("John", 30), ("Alice", 25), ("Bob", 28)).toDF()
     val actual = df.explainString(true)
     val expected =
       """
-      |== Parsed Logical Plan ==\\n
-      |LogicalRDD \[_1#[\d]+, _2#[\d]+L\], false\\n
-      |\\n
-      |== Analyzed Logical Plan ==\\n
-      |_1: string, _2: bigint\\n
-      |LogicalRDD \[_1#[\d]+, _2#[\d]+L\], false\\n
-      |\\n
-      |== Optimized Logical Plan ==\\n
-      |LogicalRDD \[_1#[\d]+, _2#[\d]+L\], false\\n
-      |\\n
-      |== Physical Plan ==\\n
-      |\*\(1\) Scan ExistingRDD\[_1#[\d]+,_2#[\d]+L\]\\n
+      |== Parsed Logical Plan ==\n
+      |LocalRelation \[_1#[\d]+, _2#[\d]+\]\n
+      |\n
+      |== Analyzed Logical Plan ==\n
+      |_1: string, _2: int\n
+      |LocalRelation \[_1#[\d]+, _2#[\d]+\]\n
+      |\n
+      |== Optimized Logical Plan ==\n
+      |LocalRelation \[_1#[\d]+, _2#[\d]+\]\n
+      |\n
+      |== Physical Plan ==\n
+      |LocalTableScan \[_1#[\d]+, _2#[\d]+\]\n
       |""".stripMargin.replaceAll("\n", "").r
     assert(expected.matches(actual))
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -2875,6 +2875,28 @@ class DataFrameSuite extends QueryTest
     }
   }
 
+  test("SPARK-00000: explainString method") {
+    val df = Seq(("John", 30), ("Alice", 25), ("Bob", 28)).toDF()
+    val actual = df.explainString(true)
+    val expected =
+      """
+      |== Parsed Logical Plan ==\\n
+      |LogicalRDD \[_1#[\d]+, _2#[\d]+L\], false\\n
+      |\\n
+      |== Analyzed Logical Plan ==\\n
+      |_1: string, _2: bigint\\n
+      |LogicalRDD \[_1#[\d]+, _2#[\d]+L\], false\\n
+      |\\n
+      |== Optimized Logical Plan ==\\n
+      |LogicalRDD \[_1#[\d]+, _2#[\d]+L\], false\\n
+      |\\n
+      |== Physical Plan ==\\n
+      |\*\(1\) Scan ExistingRDD\[_1#[\d]+,_2#[\d]+L\]\\n
+      |\\n
+      |""".stripMargin.replaceAll("\n", "").r
+    assert(expected.matches(actual))
+  }
+
   test("SPARK-29442 Set `default` mode should override the existing mode") {
     val df = Seq(Tuple1(1)).toDF()
     val writer = df.write.mode("overwrite").mode("default")

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -2892,7 +2892,6 @@ class DataFrameSuite extends QueryTest
       |\\n
       |== Physical Plan ==\\n
       |\*\(1\) Scan ExistingRDD\[_1#[\d]+,_2#[\d]+L\]\\n
-      |\\n
       |""".stripMargin.replaceAll("\n", "").r
     assert(expected.matches(actual))
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR adds a new method df.explainString() which produces the same output as df.explain() but instead of printing it returns the output as String. This output then can be manipupated easily by users and saved to external drives. 

This is frequently needed feature for performance optimization purposes. Users often want to look into this output in running systems and so would like to save/extract this output from running systems (with some settings toggle) for later analysis.

Current API only provided for Scala i.e. 

`df.queryExecution.toString()`

and also not located in intuitive place where average Spark user (i.e. non Expert/Scala dev) can see it immediately.

For Python there are various workaround provided in Stackoverflow pages most of which suggesting to use internal Spark APIs e.g.: 
https://stackoverflow.com/questions/54124386/capturing-the-result-of-explain-in-pyspark

Alternatively, I see most ofthen Python users just capturing std output as below which is another workaround and not first choice for regular Spark/Pyhton users.

```
with io.StringIO() as buf ...`:
    df.explain(True)
```
 

So, it would help users a lot to have this output avalilable as:

`df.explainString()`

i.e. next to

`df.explain()`

so users can easily locate it and use.


### Why are the changes needed?
To help users debug performance issues on running systems


### Does this PR introduce _any_ user-facing change?
Yes, adds a new DataFrame method

### How was this patch tested?
New unit tests


### Was this patch authored or co-authored using generative AI tooling?
No
