### PR TITLE
[SPARK-45783][PYTHON][CONNECT] Improve error messages when Spark Connect mode is enabled but remote URL is not set

### DIFF
--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -483,10 +483,9 @@ class SparkSession(SparkConversionMixin):
 
                             if url is None:
                                 raise RuntimeError(
-                                    "Cannot create a Spark Connect session: the 'SPARK_CONNECT_MODE_ENABLED' "
-                                    "environment variable is set but the Spark Connect remote URL has not been set. "
-                                    "Please define the remote URL by setting either the 'spark.remote' option or "
-                                    "the 'SPARK_REMOTE' environment variable."
+                                    "Cannot create a Spark Connect session because the Spark Connect remote URL has "
+                                    "not been set. Please define the remote URL by setting either the 'spark.remote' "
+                                    "option or the 'SPARK_REMOTE' environment variable."
                                 )
 
                             if url.startswith("local"):

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -483,9 +483,10 @@ class SparkSession(SparkConversionMixin):
 
                             if url is None:
                                 raise RuntimeError(
-                                    "Cannot create a Spark Connect session because the Spark Connect remote URL has "
-                                    "not been set. Please define the remote URL by setting either the 'spark.remote' "
-                                    "option or the 'SPARK_REMOTE' environment variable."
+                                    "Cannot create a Spark Connect session because the "
+                                    "Spark Connect remote URL has not been set. Please define "
+                                    "the remote URL by setting either the 'spark.remote' option "
+                                    "or the 'SPARK_REMOTE' environment variable."
                                 )
 
                             if url.startswith("local"):

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -481,6 +481,14 @@ class SparkSession(SparkConversionMixin):
                         ):
                             url = opts.get("spark.remote", os.environ.get("SPARK_REMOTE"))
 
+                            if url is None:
+                                raise RuntimeError(
+                                    "Cannot create a Spark Connect session: the 'SPARK_CONNECT_MODE_ENABLED' "
+                                    "environment variable is set but the Spark Connect remote URL has not been set. "
+                                    "Please define the remote URL by setting either the 'spark.remote' option or "
+                                    "the 'SPARK_REMOTE' environment variable."
+                                )
+
                             if url.startswith("local"):
                                 os.environ["SPARK_LOCAL_REMOTE"] = "1"
                                 RemoteSparkSession._start_connect_server(url, opts)

--- a/python/pyspark/sql/tests/test_session.py
+++ b/python/pyspark/sql/tests/test_session.py
@@ -187,6 +187,11 @@ class SparkSessionTests3(unittest.TestCase):
             if sc is not None:
                 sc.stop()
 
+    def test_session_with_spark_connect_mode_enabled(self):
+        with unittest.mock.patch.dict(os.environ, {"SPARK_CONNECT_MODE_ENABLED": "1"}):
+            with self.assertRaisesRegex(RuntimeError, "Cannot create a Spark Connect session"):
+                SparkSession.builder.appName("test").getOrCreate()
+
 
 class SparkSessionTests4(ReusedSQLTestCase):
     def test_get_active_session_after_create_dataframe(self):

--- a/python/pyspark/sql/tests/test_session.py
+++ b/python/pyspark/sql/tests/test_session.py
@@ -17,6 +17,7 @@
 
 import os
 import unittest
+import unittest.mock
 
 from pyspark import SparkConf, SparkContext
 from pyspark.sql import SparkSession, SQLContext, Row


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR improves the error messages when `SPARK_CONNECT_MODE_ENABLED` is defined but neither `spark.remote` option nor the `SPARK_REMOTE` env var is set. 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To improve the error message. Currently the error looks like a bug:
```
url = opts.get("spark.remote", os.environ.get("SPARK_REMOTE"))
    
>          if url.startswith("local"):
E          AttributeError: 'NoneType' object has no attribute 'startswith'
```

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New unit test

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No