### PR TITLE
[SPARK-45790][INFRA] Move `graphx` to `mllib*` test pipeline

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -143,11 +143,11 @@ jobs:
           - >-
             core, unsafe, kvstore, avro, utils,
             network-common, network-shuffle, repl, launcher,
-            examples, sketch, graphx
+            examples, sketch
           - >-
             api, catalyst, hive-thriftserver
           - >-
-            mllib-local,mllib
+            mllib-local, mllib, graphx
           - >-
             streaming, sql-kafka-0-10, streaming-kafka-0-10,
             yarn, kubernetes, hadoop-cloud, spark-ganglia-lgpl,


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to move `graphx` module test from `core` pipeline to `mllib` pipeline.

### Why are the changes needed?

To off-load `core` test pipeline and avoid the situation where `graphx` patch triggers `core` pipeline.
- `core` test pipeline takes 1 and half hour in general.
- `mllib*` test pipeline seems to be stable in these day and finished in a hour.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs and manually check.

- https://github.com/dongjoon-hyun/spark/actions/runs/6753488512/job/18360020367
<img width="403" alt="Screenshot 2023-11-04 at 12 25 00 AM" src="https://github.com/apache/spark/assets/9700541/8de70994-65d6-4edc-a0b6-dd805878faad">


### Was this patch authored or co-authored using generative AI tooling?

No.