### PR TITLE
[SPARK-45803][CORE] Remove the no longer used `RpcAbortException`

### DIFF
--- a/common/utils/src/main/scala/org/apache/spark/util/SparkThreadUtils.scala
+++ b/common/utils/src/main/scala/org/apache/spark/util/SparkThreadUtils.scala
@@ -49,7 +49,7 @@ private[spark] object SparkThreadUtils {
     } catch {
       case e: SparkFatalException =>
         throw e.throwable
-      // TimeoutException and RpcAbortException is thrown in the current thread, so not need to warp
+      // TimeoutException is thrown in the current thread, so not need to warp
       // the exception.
       case NonFatal(t)
         if !t.isInstanceOf[TimeoutException] =>

--- a/core/src/main/scala/org/apache/spark/rpc/RpcEndpointRef.scala
+++ b/core/src/main/scala/org/apache/spark/rpc/RpcEndpointRef.scala
@@ -104,11 +104,6 @@ private[spark] abstract class RpcEndpointRef(conf: SparkConf)
 }
 
 /**
- * An exception thrown if the RPC is aborted.
- */
-private[spark] class RpcAbortException(message: String) extends Exception(message)
-
-/**
  * A wrapper for [[Future]] but add abort method.
  * This is used in long run RPC and provide an approach to abort the RPC.
  */


### PR DESCRIPTION
### What changes were proposed in this pull request?
`RpcAbortException` introduced in SPARK-28483 | https://github.com/apache/spark/pull/25235 and become unused after  SPARK-31472 | https://github.com/apache/spark/pull/28245. At the same time, `RpcAbortException` is a `private[spark]` definition, so this pr removes it.

### Why are the changes needed?
Clean up useless code.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No