### PR TITLE
[SPARK-45809][PYTHON][DOCS] Refine docstring of `lit`

### DIFF
--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -163,6 +163,8 @@ def lit(col: Any) -> Column:
 
     Examples
     --------
+    Example 1: Creating a literal column with an integer value.
+
     >>> df = spark.range(1)
     >>> df.select(lit(5).alias('height'), df.id).show()
     +------+---+
@@ -171,7 +173,7 @@ def lit(col: Any) -> Column:
     |     5|  0|
     +------+---+
 
-    Create a literal from a list.
+    Example 2: Creating a literal column from a list.
 
     >>> spark.range(1).select(lit([1, 2, 3])).show()
     +--------------+
@@ -179,6 +181,27 @@ def lit(col: Any) -> Column:
     +--------------+
     |     [1, 2, 3]|
     +--------------+
+
+    Example 3: Creating a literal column from a string.
+
+    >>> df = spark.range(1)
+    >>> df.select(lit("PySpark").alias('framework'), df.id).show()
+    +---------+---+
+    |framework| id|
+    +---------+---+
+    |  PySpark|  0|
+    +---------+---+
+
+    Example 4: Creating a literal column from a boolean value.
+
+    >>> df = spark.createDataFrame([(True, "Yes"), (False, "No")], ["flag", "response"])
+    >>> df.select(lit(False).alias('is_approved'), df.response).show()
+    +-----------+--------+
+    |is_approved|response|
+    +-----------+--------+
+    |      false|     Yes|
+    |      false|      No|
+    +-----------+--------+
     """
     if isinstance(col, Column):
         return col

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -165,8 +165,9 @@ def lit(col: Any) -> Column:
     --------
     Example 1: Creating a literal column with an integer value.
 
+    >>> import pyspark.sql.functions as sf
     >>> df = spark.range(1)
-    >>> df.select(lit(5).alias('height'), df.id).show()
+    >>> df.select(sf.lit(5).alias('height'), df.id).show()
     +------+---+
     |height| id|
     +------+---+
@@ -175,7 +176,8 @@ def lit(col: Any) -> Column:
 
     Example 2: Creating a literal column from a list.
 
-    >>> spark.range(1).select(lit([1, 2, 3])).show()
+    >>> import pyspark.sql.functions as sf
+    >>> spark.range(1).select(sf.lit([1, 2, 3])).show()
     +--------------+
     |array(1, 2, 3)|
     +--------------+
@@ -184,8 +186,9 @@ def lit(col: Any) -> Column:
 
     Example 3: Creating a literal column from a string.
 
+    >>> import pyspark.sql.functions as sf
     >>> df = spark.range(1)
-    >>> df.select(lit("PySpark").alias('framework'), df.id).show()
+    >>> df.select(sf.lit("PySpark").alias('framework'), df.id).show()
     +---------+---+
     |framework| id|
     +---------+---+
@@ -194,8 +197,9 @@ def lit(col: Any) -> Column:
 
     Example 4: Creating a literal column from a boolean value.
 
+    >>> import pyspark.sql.functions as sf
     >>> df = spark.createDataFrame([(True, "Yes"), (False, "No")], ["flag", "response"])
-    >>> df.select(lit(False).alias('is_approved'), df.response).show()
+    >>> df.select(sf.lit(False).alias('is_approved'), df.response).show()
     +-----------+--------+
     |is_approved|response|
     +-----------+--------+


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to improve the docstring of `lit`.

### Why are the changes needed?

For end users, and better usability of PySpark.

### Does this PR introduce _any_ user-facing change?

Yes, it fixes the user facing documentation.

### How was this patch tested?
Manually tested.

### Was this patch authored or co-authored using generative AI tooling?

No.