### PR TITLE
[SPARK-45810][Python] Create Python UDTF API to stop consuming rows from the input table

### DIFF
--- a/python/docs/source/user_guide/sql/python_udtf.rst
+++ b/python/docs/source/user_guide/sql/python_udtf.rst
@@ -105,7 +105,7 @@ To implement a Python UDTF, you first need to define a class implementing the me
             -----
             - It is possible for the `analyze` method to accept the exact arguments expected,
               mapping 1:1 with the arguments provided to the UDTF call.
-            - The `analyze` method can instead choose ot accept positional arguments if desired
+            - The `analyze` method can instead choose to accept positional arguments if desired
               (using `*args`) or keyword arguments (using `**kwargs`).
 
             Examples

--- a/python/docs/source/user_guide/sql/python_udtf.rst
+++ b/python/docs/source/user_guide/sql/python_udtf.rst
@@ -65,8 +65,8 @@ To implement a Python UDTF, you first need to define a class implementing the me
 
         def analyze(self, *args: Any) -> AnalyzeResult:
             """
-            Computes the output schema of a particular call to this function in response to the
-            arguments provided.
+            Static method to compute the output schema of a particular call to this function in
+            response to the arguments provided.
 
             This method is optional and only needed if the registration of the UDTF did not provide
             a static output schema to be use for all calls to the function. In this context,
@@ -101,12 +101,20 @@ To implement a Python UDTF, you first need to define a class implementing the me
                 partitionBy: Sequence[PartitioningColumn] = field(default_factory=tuple)
                 orderBy: Sequence[OrderingColumn] = field(default_factory=tuple)
 
+            Notes
+            -----
+            - It is possible for the `analyze` method to accept the exact arguments expected,
+              mapping 1:1 with the arguments provided to the UDTF call.
+            - The `analyze` method can instead choose ot accept positional arguments if desired
+              (with `*args`) or keyword arguments (with `**kwargs`).
+
             Examples
             --------
-            analyze implementation that returns one output column for each word in the input string
-            argument.
+            This is an `analyze` implementation that returns one output column for each word in the
+            input string argument.
 
-            >>> def analyze(self, text: str) -> AnalyzeResult:
+            >>> @staticmethod
+            ... def analyze(text: str) -> AnalyzeResult:
             ...     schema = StructType()
             ...     for index, word in enumerate(text.split(" ")):
             ...         schema = schema.add(f"word_{index}")
@@ -114,7 +122,8 @@ To implement a Python UDTF, you first need to define a class implementing the me
 
             Same as above, but using *args to accept the arguments.
 
-            >>> def analyze(self, *args) -> AnalyzeResult:
+            >>> @staticmethod
+            ... def analyze(*args) -> AnalyzeResult:
             ...     assert len(args) == 1, "This function accepts one argument only"
             ...     assert args[0].dataType == StringType(), "Only string arguments are supported"
             ...     text = args[0]
@@ -125,7 +134,8 @@ To implement a Python UDTF, you first need to define a class implementing the me
 
             Same as above, but using **kwargs to accept the arguments.
 
-            >>> def analyze(self, **kwargs) -> AnalyzeResult:
+            >>> @staticmethod
+            ... def analyze(**kwargs) -> AnalyzeResult:
             ...     assert len(kwargs) == 1, "This function accepts one argument only"
             ...     assert "text" in kwargs, "An argument named 'text' is required"
             ...     assert kwargs["text"].dataType == StringType(), "Only strings are supported"
@@ -135,10 +145,11 @@ To implement a Python UDTF, you first need to define a class implementing the me
             ...         schema = schema.add(f"word_{index}")
             ...     return AnalyzeResult(schema=schema)
 
-            analyze implementation that returns a constant output schema, but add custom information
-            in the result metadata to be consumed by future __init__ method calls:
+            An `analyze` implementation that returns a constant output schema, but add custom
+            information in the result metadata to be consumed by future __init__ method calls:
 
-            >>> def analyze(self, text: str) -> AnalyzeResult:
+            >>> @staticmethod
+            ... def analyze(text: str) -> AnalyzeResult:
             ...     @dataclass
             ...     class AnalyzeResultWithOtherMetadata(AnalyzeResult):
             ...         num_words: int

--- a/python/docs/source/user_guide/sql/python_udtf.rst
+++ b/python/docs/source/user_guide/sql/python_udtf.rst
@@ -190,6 +190,13 @@ To implement a Python UDTF, you first need to define a class implementing the me
             - It is also possible for UDTFs to accept the exact arguments expected, along with
               their types.
             - UDTFs can instead accept keyword arguments during the function call if needed.
+            - The `eval` method can raise a `SkipRestOfInputTableException` to indicate that the
+              UDTF wants to skip consuming all remaining rows from the current partition of the
+              input table. This will cause the UDTF to proceed directly to the `terminate` method.
+            - The `eval` method can raise any other exception to indicate that the UDTF should be
+              aborted entirely. This will cause the UDTF to skip the `terminate` method and proceed
+              directly to the `cleanup` method, and then the exception will be propagated to the
+              query processor causing the invoking query to fail.
 
             Examples
             --------

--- a/python/docs/source/user_guide/sql/python_udtf.rst
+++ b/python/docs/source/user_guide/sql/python_udtf.rst
@@ -106,7 +106,7 @@ To implement a Python UDTF, you first need to define a class implementing the me
             - It is possible for the `analyze` method to accept the exact arguments expected,
               mapping 1:1 with the arguments provided to the UDTF call.
             - The `analyze` method can instead choose ot accept positional arguments if desired
-              (with `*args`) or keyword arguments (with `**kwargs`).
+              (using `*args`) or keyword arguments (using `**kwargs`).
 
             Examples
             --------

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -51,6 +51,7 @@ from pyspark.sql.types import ArrayType, DataType, StringType, StructType, _from
 from pyspark.sql.udf import UserDefinedFunction, _create_py_udf  # noqa: F401
 from pyspark.sql.udtf import AnalyzeArgument, AnalyzeResult  # noqa: F401
 from pyspark.sql.udtf import OrderingColumn, PartitioningColumn  # noqa: F401
+from pyspark.sql.udtf import SkipRestOfInputTableException  # noqa: F401
 from pyspark.sql.udtf import UserDefinedTableFunction, _create_py_udtf
 
 # Keep pandas_udf and PandasUDFType import for backwards compatible import; moved in SPARK-28264

--- a/python/pyspark/sql/tests/test_udtf.py
+++ b/python/pyspark/sql/tests/test_udtf.py
@@ -2483,7 +2483,7 @@ class BaseUDTFTestsMixin:
             def eval(self, _: Row):
                 self._total += 1
                 if self._total >= 4:
-                    raise SkipRestOfInputTableException("StopIteration at self._total >= 4")
+                    raise SkipRestOfInputTableException("Stop at self._total >= 4")
 
             def terminate(self):
                 yield self._total,

--- a/python/pyspark/sql/tests/test_udtf.py
+++ b/python/pyspark/sql/tests/test_udtf.py
@@ -2512,8 +2512,7 @@ class BaseUDTFTestsMixin:
                 ORDER BY ALL
                 """
             ),
-            [Row(id_divided_by_ten=0, total=4),
-             Row(id_divided_by_ten=1, total=4)],
+            [Row(id_divided_by_ten=0, total=4), Row(id_divided_by_ten=1, total=4)],
         )
 
 

--- a/python/pyspark/sql/tests/test_udtf.py
+++ b/python/pyspark/sql/tests/test_udtf.py
@@ -44,6 +44,7 @@ from pyspark.sql.functions import (
     AnalyzeResult,
     OrderingColumn,
     PartitioningColumn,
+    SkipRestOfInputTableException,
 )
 from pyspark.sql.types import (
     ArrayType,
@@ -2467,7 +2468,7 @@ class BaseUDTFTestsMixin:
             [Row(count=20, buffer="abc")],
         )
 
-    def test_udtf_with_stop_iteration_exception(self):
+    def test_udtf_with_skip_rest_of_input_table_exception(self):
         @udtf
         class TestUDTF:
             def __init__(self):
@@ -2482,7 +2483,7 @@ class BaseUDTFTestsMixin:
             def eval(self, _: Row):
                 self._total += 1
                 if self._total >= 4:
-                    raise StopIteration("StopIteration at self._total >= 4")
+                    raise SkipRestOfInputTableException("StopIteration at self._total >= 4")
 
             def terminate(self):
                 yield self._total,

--- a/python/pyspark/sql/tests/test_udtf.py
+++ b/python/pyspark/sql/tests/test_udtf.py
@@ -2533,7 +2533,6 @@ class UDTFTests(BaseUDTFTestsMixin, ReusedSQLTestCase):
             super(UDTFTests, cls).tearDownClass()
 
 
-"""
 @unittest.skipIf(
     not have_pandas or not have_pyarrow, pandas_requirement_message or pyarrow_requirement_message
 )
@@ -2827,7 +2826,7 @@ class UDTFArrowTests(UDTFArrowTestsMixin, ReusedSQLTestCase):
             cls.spark.conf.unset("spark.sql.execution.pythonUDTF.arrow.enabled")
         finally:
             super(UDTFArrowTests, cls).tearDownClass()
-"""
+
 
 if __name__ == "__main__":
     from pyspark.sql.tests.test_udtf import *  # noqa: F401

--- a/python/pyspark/sql/tests/test_udtf.py
+++ b/python/pyspark/sql/tests/test_udtf.py
@@ -2533,7 +2533,7 @@ class UDTFTests(BaseUDTFTestsMixin, ReusedSQLTestCase):
             super(UDTFTests, cls).tearDownClass()
 
 
-'''
+"""
 @unittest.skipIf(
     not have_pandas or not have_pyarrow, pandas_requirement_message or pyarrow_requirement_message
 )
@@ -2827,7 +2827,7 @@ class UDTFArrowTests(UDTFArrowTestsMixin, ReusedSQLTestCase):
             cls.spark.conf.unset("spark.sql.execution.pythonUDTF.arrow.enabled")
         finally:
             super(UDTFArrowTests, cls).tearDownClass()
-'''
+"""
 
 if __name__ == "__main__":
     from pyspark.sql.tests.test_udtf import *  # noqa: F401

--- a/python/pyspark/sql/tests/test_udtf.py
+++ b/python/pyspark/sql/tests/test_udtf.py
@@ -2481,8 +2481,8 @@ class BaseUDTFTestsMixin:
 
             def eval(self, _: Row):
                 self._total += 1
-                if self._total >= 3:
-                    raise StopIteration("StopIteration at self._total >= 3")
+                if self._total >= 4:
+                    raise StopIteration("StopIteration at self._total >= 4")
 
             def terminate(self):
                 yield self._total,
@@ -2499,7 +2499,7 @@ class BaseUDTFTestsMixin:
                 FROM test_udtf(TABLE(t))
                 """
             ),
-            [Row(total=3)],
+            [Row(total=4)],
         )
 
 

--- a/python/pyspark/sql/udtf.py
+++ b/python/pyspark/sql/udtf.py
@@ -38,7 +38,8 @@ if TYPE_CHECKING:
     from pyspark.sql.dataframe import DataFrame
     from pyspark.sql.session import SparkSession
 
-__all__ = ["AnalyzeArgument", "AnalyzeResult", "UDTFRegistration"]
+__all__ = ["AnalyzeArgument", "AnalyzeResult", "PartitioningColumn", "OrderingColumn",
+           "SkipRestOfInputTableException", "UDTFRegistration"]
 
 
 @dataclass(frozen=True)
@@ -117,6 +118,12 @@ class AnalyzeResult:
     partitionBy: Sequence[PartitioningColumn] = field(default_factory=tuple)
     orderBy: Sequence[OrderingColumn] = field(default_factory=tuple)
 
+
+# This represents an exception that the 'eval' method may raise to indicate that it is done
+# consuming rows from the current partition of the input table. Then the UDTF's 'terminate' method
+# runs (if any).
+class SkipRestOfInputTableException(Exception):
+    pass
 
 def _create_udtf(
     cls: Type,

--- a/python/pyspark/sql/udtf.py
+++ b/python/pyspark/sql/udtf.py
@@ -125,10 +125,12 @@ class AnalyzeResult:
     orderBy: Sequence[OrderingColumn] = field(default_factory=tuple)
 
 
-# This represents an exception that the 'eval' method may raise to indicate that it is done
-# consuming rows from the current partition of the input table. Then the UDTF's 'terminate' method
-# runs (if any).
 class SkipRestOfInputTableException(Exception):
+    """
+    This represents an exception that the 'eval' method may raise to indicate that it is done
+    consuming rows from the current partition of the input table. Then the UDTF's 'terminate'
+    method runs (if any).
+    """
     pass
 
 

--- a/python/pyspark/sql/udtf.py
+++ b/python/pyspark/sql/udtf.py
@@ -131,6 +131,7 @@ class SkipRestOfInputTableException(Exception):
     consuming rows from the current partition of the input table. Then the UDTF's 'terminate'
     method runs (if any).
     """
+
     pass
 
 

--- a/python/pyspark/sql/udtf.py
+++ b/python/pyspark/sql/udtf.py
@@ -38,8 +38,14 @@ if TYPE_CHECKING:
     from pyspark.sql.dataframe import DataFrame
     from pyspark.sql.session import SparkSession
 
-__all__ = ["AnalyzeArgument", "AnalyzeResult", "PartitioningColumn", "OrderingColumn",
-           "SkipRestOfInputTableException", "UDTFRegistration"]
+__all__ = [
+    "AnalyzeArgument",
+    "AnalyzeResult",
+    "PartitioningColumn",
+    "OrderingColumn",
+    "SkipRestOfInputTableException",
+    "UDTFRegistration",
+]
 
 
 @dataclass(frozen=True)
@@ -124,6 +130,7 @@ class AnalyzeResult:
 # runs (if any).
 class SkipRestOfInputTableException(Exception):
     pass
+
 
 def _create_udtf(
     cls: Type,

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -995,6 +995,8 @@ def read_udtf(pickleSer, infile, eval_type):
             def func(*a: Any) -> Any:
                 try:
                     return f(*a)
+                except StopIteration:
+                    raise
                 except Exception as e:
                     raise PySparkRuntimeError(
                         error_class="UDTF_EXEC_ERROR",
@@ -1057,6 +1059,9 @@ def read_udtf(pickleSer, infile, eval_type):
                     yield from eval(*[a[o] for o in args_kwargs_offsets])
                 if terminate is not None:
                     yield from terminate()
+            except StopIteration:
+                if terminate is not None:
+                    yield from terminate()
             finally:
                 if cleanup is not None:
                     cleanup()
@@ -1098,6 +1103,8 @@ def read_udtf(pickleSer, infile, eval_type):
             def evaluate(*a) -> tuple:
                 try:
                     res = f(*a)
+                except StopIteration:
+                    raise
                 except Exception as e:
                     raise PySparkRuntimeError(
                         error_class="UDTF_EXEC_ERROR",
@@ -1142,6 +1149,9 @@ def read_udtf(pickleSer, infile, eval_type):
             try:
                 for a in it:
                     yield eval(*[a[o] for o in args_kwargs_offsets])
+                if terminate is not None:
+                    yield terminate()
+            except StopIteration:
                 if terminate is not None:
                     yield terminate()
             finally:

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -43,6 +43,7 @@ from pyspark.serializers import (
     CPickleSerializer,
     BatchedSerializer,
 )
+from pyspark.sql.functions import SkipRestOfInputTableException
 from pyspark.sql.pandas.serializers import (
     ArrowStreamPandasUDFSerializer,
     ArrowStreamPandasUDTFSerializer,
@@ -995,7 +996,7 @@ def read_udtf(pickleSer, infile, eval_type):
             def func(*a: Any) -> Any:
                 try:
                     return f(*a)
-                except StopIteration:
+                except SkipRestOfInputTableException:
                     raise
                 except Exception as e:
                     raise PySparkRuntimeError(
@@ -1059,7 +1060,7 @@ def read_udtf(pickleSer, infile, eval_type):
                     yield from eval(*[a[o] for o in args_kwargs_offsets])
                 if terminate is not None:
                     yield from terminate()
-            except StopIteration:
+            except SkipRestOfInputTableException:
                 if terminate is not None:
                     yield from terminate()
             finally:
@@ -1103,7 +1104,7 @@ def read_udtf(pickleSer, infile, eval_type):
             def evaluate(*a) -> tuple:
                 try:
                     res = f(*a)
-                except StopIteration:
+                except SkipRestOfInputTableException:
                     raise
                 except Exception as e:
                     raise PySparkRuntimeError(
@@ -1151,7 +1152,7 @@ def read_udtf(pickleSer, infile, eval_type):
                     yield eval(*[a[o] for o in args_kwargs_offsets])
                 if terminate is not None:
                     yield terminate()
-            except StopIteration:
+            except SkipRestOfInputTableException:
                 if terminate is not None:
                     yield terminate()
             finally:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR creates a Python UDTF API to stop consuming rows from the input table.

If the UDTF raises a `SkipRestOfInputTableException` exception in the `eval` method, then the UDTF stops consuming rows from the input table for that input partition, and finally calls the `terminate` method (if any) to represent a successful UDTF call.

For example:

```
@udtf(returnType="total: int")
class TestUDTF:
    def __init__(self):
        self._total = 0

    def eval(self, _: Row):
        self._total += 1
        if self._total >= 3:
            raise SkipRestOfInputTableException("Stop at self._total >= 3")

    def terminate(self):
        yield self._total,
```

### Why are the changes needed?

This is useful when the UDTF logic knows that we don't have to scan the input table anymore, and skip the rest of the I/O for that case.

### Does this PR introduce _any_ user-facing change?

Yes, see above.

### How was this patch tested?

This PR adds test coverage.

### Was this patch authored or co-authored using generative AI tooling?

No