### PR TITLE
[SPARK-45770][SQL][PYTHON][CONNECT] Introduce plan `DataFrameDropColumns` for `Dataframe.drop`

### DIFF
--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -105,6 +105,43 @@ class DataFrameTestsMixin:
         self.assertEqual(df.drop(col("name"), col("age")).columns, ["active"])
         self.assertEqual(df.drop(col("name"), col("age"), col("random")).columns, ["active"])
 
+    def test_drop_join(self):
+        left_df = self.spark.createDataFrame(
+            [(1, "a"), (2, "b"), (3, "c")],
+            ["join_key", "value1"],
+        )
+        right_df = self.spark.createDataFrame(
+            [(1, "aa"), (2, "bb"), (4, "dd")],
+            ["join_key", "value2"],
+        )
+        joined_df = left_df.join(
+            right_df,
+            on=left_df["join_key"] == right_df["join_key"],
+            how="left",
+        )
+
+        dropped_1 = joined_df.drop(left_df["join_key"])
+        self.assertEqual(dropped_1.columns, ["value1", "join_key", "value2"])
+        self.assertEqual(
+            dropped_1.sort("value1").collect(),
+            [
+                Row(value1="a", join_key=1, value2="aa"),
+                Row(value1="b", join_key=2, value2="bb"),
+                Row(value1="c", join_key=None, value2=None),
+            ],
+        )
+
+        dropped_2 = joined_df.drop(right_df["join_key"])
+        self.assertEqual(dropped_2.columns, ["join_key", "value1", "value2"])
+        self.assertEqual(
+            dropped_2.sort("value1").collect(),
+            [
+                Row(join_key=1, value1="a", value2="aa"),
+                Row(join_key=2, value1="b", value2="bb"),
+                Row(join_key=3, value1="c", value2=None),
+            ],
+        )
+
     def test_with_columns_renamed(self):
         df = self.spark.createDataFrame([("Alice", 50), ("Alice", 60)], ["name", "age"])
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -303,7 +303,7 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
       ResolveWindowFrame ::
       ResolveNaturalAndUsingJoin ::
       ResolveOutputRelation ::
-      new ResolveDropColumns(catalogManager) ::
+      new ResolveDataFrameDropColumns(catalogManager) ::
       new ResolveSetVariable(catalogManager) ::
       ExtractWindowExpressions ::
       GlobalAggregates ::

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -303,6 +303,7 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
       ResolveWindowFrame ::
       ResolveNaturalAndUsingJoin ::
       ResolveOutputRelation ::
+      new ResolveDropColumns(catalogManager) ::
       new ResolveSetVariable(catalogManager) ::
       ExtractWindowExpressions ::
       GlobalAggregates ::

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDataFrameDropColumns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDataFrameDropColumns.scala
@@ -30,7 +30,7 @@ class ResolveDataFrameDropColumns(val catalogManager: CatalogManager)
 
   override def apply(plan: LogicalPlan): LogicalPlan = plan.resolveOperatorsWithPruning(
     _.containsPattern(DF_DROP_COLUMNS)) {
-    case d: DataFrameDropColumns if d.childrenResolved && d.expressions.forall(_.resolved) =>
+    case d: DataFrameDropColumns if d.childrenResolved =>
       val dropped = d.dropList.map {
         case u: UnresolvedAttribute =>
           resolveExpressionByPlanChildren(u, d.child)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDropColumns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDropColumns.scala
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.analysis
+
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Project, UnresolvedDropColumns}
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.catalyst.trees.TreePattern.DROP_COLUMNS
+import org.apache.spark.sql.connector.catalog.CatalogManager
+
+/**
+ * A rule that rewrites DropColumns to Project.
+ */
+class ResolveDropColumns(val catalogManager: CatalogManager)
+  extends Rule[LogicalPlan] with ColumnResolutionHelper  {
+
+  override def apply(plan: LogicalPlan): LogicalPlan = plan.resolveOperatorsWithPruning(
+    _.containsPattern(DROP_COLUMNS)) {
+    case d: UnresolvedDropColumns =>
+      val dropped = d.dropList.map(resolveExpressionByPlanChildren(_, d.child))
+      val remaining = d.child.output.filterNot(attr => dropped.exists(_.semanticEquals(attr)))
+      if (remaining.size == d.child.output.size) {
+        d.child
+      } else {
+        Project(remaining, d.child)
+      }
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDropColumns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDropColumns.scala
@@ -31,7 +31,10 @@ class ResolveDropColumns(val catalogManager: CatalogManager)
   override def apply(plan: LogicalPlan): LogicalPlan = plan.resolveOperatorsWithPruning(
     _.containsPattern(DROP_COLUMNS)) {
     case d: UnresolvedDropColumns =>
-      val dropped = d.dropList.map(resolveExpressionByPlanChildren(_, d.child))
+      val dropped = d.dropList.map {
+        case u: UnresolvedAttribute => resolveExpressionByPlanChildren(u, d.child)
+        case e => e
+      }
       val remaining = d.child.output.filterNot(attr => dropped.exists(_.semanticEquals(attr)))
       if (remaining.size == d.child.output.size) {
         d.child

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDropColumns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDropColumns.scala
@@ -30,7 +30,7 @@ class ResolveDropColumns(val catalogManager: CatalogManager)
 
   override def apply(plan: LogicalPlan): LogicalPlan = plan.resolveOperatorsWithPruning(
     _.containsPattern(DROP_COLUMNS)) {
-    case d: UnresolvedDropColumns =>
+    case d: UnresolvedDropColumns if d.childrenResolved =>
       val dropped = d.dropList.map {
         case u: UnresolvedAttribute => resolveExpressionByPlanChildren(u, d.child)
         case e => e

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -237,9 +237,7 @@ object Project {
 
 case class UnresolvedDropColumns(dropList: Seq[Expression], child: LogicalPlan)
   extends UnaryNode {
-  override def output: Seq[Attribute] = {
-    child.output.filterNot(attr => dropList.exists(_.semanticEquals(attr)))
-  }
+  override def output: Seq[Attribute] = Nil
 
   override def maxRows: Option[Long] = child.maxRows
   override def maxRowsPerPartition: Option[Long] = child.maxRowsPerPartition

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -235,18 +235,17 @@ object Project {
   }
 }
 
-case class UnresolvedDropColumns(dropList: Seq[Expression], child: LogicalPlan)
-  extends UnaryNode {
+case class DataFrameDropColumns(dropList: Seq[Expression], child: LogicalPlan) extends UnaryNode {
   override def output: Seq[Attribute] = Nil
 
   override def maxRows: Option[Long] = child.maxRows
   override def maxRowsPerPartition: Option[Long] = child.maxRowsPerPartition
 
-  final override val nodePatterns: Seq[TreePattern] = Seq(DROP_COLUMNS)
+  final override val nodePatterns: Seq[TreePattern] = Seq(DF_DROP_COLUMNS)
 
   override lazy val resolved: Boolean = false
 
-  override protected def withNewChildInternal(newChild: LogicalPlan): UnresolvedDropColumns =
+  override protected def withNewChildInternal(newChild: LogicalPlan): DataFrameDropColumns =
     copy(child = newChild)
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
@@ -107,6 +107,7 @@ object TreePattern extends Enumeration  {
   val COMMAND: Value = Value
   val CTE: Value = Value
   val DISTINCT_LIKE: Value = Value
+  val DROP_COLUMNS: Value = Value
   val EVAL_PYTHON_UDF: Value = Value
   val EVAL_PYTHON_UDTF: Value = Value
   val EVENT_TIME_WATERMARK: Value = Value

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
@@ -106,8 +106,8 @@ object TreePattern extends Enumeration  {
   val AS_OF_JOIN: Value = Value
   val COMMAND: Value = Value
   val CTE: Value = Value
+  val DF_DROP_COLUMNS: Value = Value
   val DISTINCT_LIKE: Value = Value
-  val DROP_COLUMNS: Value = Value
   val EVAL_PYTHON_UDF: Value = Value
   val EVAL_PYTHON_UDTF: Value = Value
   val EVENT_TIME_WATERMARK: Value = Value

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -3065,7 +3065,7 @@ class Dataset[T] private[sql](
   @scala.annotation.varargs
   def drop(col: Column, cols: Column*): DataFrame = withOrigin {
     withPlan {
-      UnresolvedDropColumns((col +: cols).map(_.expr), logicalPlan)
+      DataFrameDropColumns((col +: cols).map(_.expr), logicalPlan)
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix column resolution in DataFrame.drop




### Why are the changes needed?

```
from pyspark.sql.functions import col

# create first dataframe
left_df = spark.createDataFrame([(1, 'a'), (2, 'b'), (3, 'c')], ['join_key', 'value1'])
# create second dataframe
right_df = spark.createDataFrame([(1, 'aa'), (2, 'bb'), (4, 'dd')], ['join_key', 'value2'])
joined_df = left_df.join(right_df, on=left_df['join_key'] == right_df['join_key'], how='left')
display(joined_df)
cleaned_df = joined_df.drop(left_df['join_key'])
display(cleaned_df) # error here

JVM stacktrace:
org.apache.spark.sql.AnalysisException: [AMBIGUOUS_REFERENCE] Reference `join_key` is ambiguous, could be: [`join_key`, `join_key`]. SQLSTATE: 42704
	at org.apache.spark.sql.errors.QueryCompilationErrors$.ambiguousReferenceError(QueryCompilationErrors.scala:1957)
	at org.apache.spark.sql.catalyst.expressions.package$AttributeSeq.resolve(package.scala:377)
	at org.apache.spark.sql.catalyst.plans.logical.LogicalPlan.resolve(LogicalPlan.scala:156)
	at org.apache.spark.sql.catalyst.plans.logical.LogicalPlan.resolveQuoted(LogicalPlan.scala:167)
	at org.apache.spark.sql.Dataset.$anonfun$drop$4(Dataset.scala:3071)
```



### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
ci

### Was this patch authored or co-authored using generative AI tooling?
no
