### PR TITLE
[SPARK-45821][CONNECT]make SparkSession._apply_options throw exception

### DIFF
--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -185,10 +185,7 @@ class SparkSession:
                         "spark.remote",
                         "spark.master",
                     ]:
-                        try:
-                            session.conf.set(k, v)
-                        except Exception as e:
-                            warnings.warn(str(e))
+                        session.conf.set(k, v)
 
         def create(self) -> "SparkSession":
             has_channel_builder = self._channel_builder is not None


### PR DESCRIPTION
### What changes were proposed in this pull request?

Make SparkSession._apply_options throw exception


### Why are the changes needed?

In current master branch, the following code will success which is unexpected.

```
from pyspark.sql import SparkSession
spark = SparkSession.builder.config("some_key", "some_value").remote(f"sc://an unreachable connect server").create()
print("here") # shouldn't be executed
```


### Does this PR introduce _any_ user-facing change?

No


### How was this patch tested?

No test. I didn't find pyspark connect unit tests...


### Was this patch authored or co-authored using generative AI tooling?

No