### PR TITLE
[SPARK-45841][SQL] Expose stack trace by `DataFrameQueryContext`

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/trees/QueryContexts.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/trees/QueryContexts.scala
@@ -134,15 +134,26 @@ case class SQLQueryContext(
   override def callSite: String = throw new UnsupportedOperationException
 }
 
-case class DataFrameQueryContext(
-    override val fragment: String,
-    override val callSite: String) extends QueryContext {
+case class DataFrameQueryContext(stackTrace: Seq[StackTraceElement]) extends QueryContext {
   override val contextType = QueryContextType.DataFrame
 
   override def objectType: String = throw new UnsupportedOperationException
   override def objectName: String = throw new UnsupportedOperationException
   override def startIndex: Int = throw new UnsupportedOperationException
   override def stopIndex: Int = throw new UnsupportedOperationException
+
+  override val fragment: String = {
+    stackTrace.headOption.map { firstElem =>
+      val methodName = firstElem.getMethodName
+      if (methodName.length > 1 && methodName(0) == '$') {
+        methodName.substring(1)
+      } else {
+        methodName
+      }
+    }.getOrElse("")
+  }
+
+  override val callSite: String = stackTrace.tail.headOption.map(_.toString).getOrElse("")
 
   override lazy val summary: String = {
     val builder = new StringBuilder
@@ -155,21 +166,5 @@ case class DataFrameQueryContext(
     builder ++= callSite
     builder += '\n'
     builder.result()
-  }
-}
-
-object DataFrameQueryContext {
-  def apply(elements: Array[StackTraceElement]): DataFrameQueryContext = {
-    val fragment = elements.headOption.map { firstElem =>
-      val methodName = firstElem.getMethodName
-      if (methodName.length > 1 && methodName(0) == '$') {
-        methodName.substring(1)
-      } else {
-        methodName
-      }
-    }.getOrElse("")
-    val callSite = elements.tail.headOption.map(_.toString).getOrElse("")
-
-    DataFrameQueryContext(fragment, callSite)
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to change the case class `DataFrameQueryContext`, and add stack traces as a field and override `callSite`, `fragment` using the new field `stackTrace`.

### Why are the changes needed?
By exposing the stack trace, we give users opportunity to see all stack traces needed for debugging.

### Does this PR introduce _any_ user-facing change?
No, `DataFrameQueryContext` hasn't been released yet.

### How was this patch tested?
By running the modified test suite:
```
$ build/sbt "test:testOnly *DatasetSuite"
```

### Was this patch authored or co-authored using generative AI tooling?
No.