### PR TITLE
[SPARK-23015][WINDOWS] Fix bug in Windows where starting multiple Spark instances within the same second causes a failure

### DIFF
--- a/bin/spark-class2.cmd
+++ b/bin/spark-class2.cmd
@@ -65,6 +65,8 @@ rem The launcher library prints the command to be executed in a single line suit
 rem executed by the batch interpreter. So read all the output of the launcher into a variable.
 :gen
 set LAUNCHER_OUTPUT=%temp%\spark-class-launcher-output-%RANDOM%%TIME::=0%.txt
+rem Remove space between the RANDOM and TIME output
+set LAUNCHER_OUTPUT=%LAUNCHER_OUTPUT: =%
 rem SPARK-28302: %RANDOM% would return the same number if we call it instantly after last call,
 rem so we should make it sure to generate unique file to avoid process collision of writing into
 rem the same file concurrently.

--- a/bin/spark-class2.cmd
+++ b/bin/spark-class2.cmd
@@ -64,7 +64,7 @@ if not "x%JAVA_HOME%"=="x" (
 rem The launcher library prints the command to be executed in a single line suitable for being
 rem executed by the batch interpreter. So read all the output of the launcher into a variable.
 :gen
-set LAUNCHER_OUTPUT=%temp%\spark-class-launcher-output-%RANDOM%.txt
+set LAUNCHER_OUTPUT=%temp%\spark-class-launcher-output-%RANDOM%%TIME::=0%.txt
 rem SPARK-28302: %RANDOM% would return the same number if we call it instantly after last call,
 rem so we should make it sure to generate unique file to avoid process collision of writing into
 rem the same file concurrently.

--- a/bin/spark-class2.cmd
+++ b/bin/spark-class2.cmd
@@ -64,12 +64,9 @@ if not "x%JAVA_HOME%"=="x" (
 rem The launcher library prints the command to be executed in a single line suitable for being
 rem executed by the batch interpreter. So read all the output of the launcher into a variable.
 :gen
-set LAUNCHER_OUTPUT=%temp%\spark-class-launcher-output-%RANDOM%%TIME::=0%.txt
-rem Remove space between the RANDOM and TIME output
-set LAUNCHER_OUTPUT=%LAUNCHER_OUTPUT: =%
-rem SPARK-28302: %RANDOM% would return the same number if we call it instantly after last call,
-rem so we should make it sure to generate unique file to avoid process collision of writing into
-rem the same file concurrently.
+FOR /F %%a IN ('POWERSHELL -COMMAND "$([guid]::NewGuid().ToString())"') DO (SET NEWGUID=%%a)
+set LAUNCHER_OUTPUT=%temp%\spark-class-launcher-output-%NEWGUID%.txt
+
 if exist %LAUNCHER_OUTPUT% goto :gen
 rem unset SHELL to indicate non-bash environment to launcher/Main
 set SHELL=

--- a/bin/spark-class2.cmd
+++ b/bin/spark-class2.cmd
@@ -63,11 +63,9 @@ if not "x%JAVA_HOME%"=="x" (
 
 rem The launcher library prints the command to be executed in a single line suitable for being
 rem executed by the batch interpreter. So read all the output of the launcher into a variable.
-:gen
 FOR /F %%a IN ('POWERSHELL -COMMAND "$([guid]::NewGuid().ToString())"') DO (SET NEWGUID=%%a)
 set LAUNCHER_OUTPUT=%temp%\spark-class-launcher-output-%NEWGUID%.txt
 
-if exist %LAUNCHER_OUTPUT% goto :gen
 rem unset SHELL to indicate non-bash environment to launcher/Main
 set SHELL=
 "%RUNNER%" -Xmx128m -cp "%LAUNCH_CLASSPATH%" org.apache.spark.launcher.Main %* > %LAUNCHER_OUTPUT%


### PR DESCRIPTION
### What changes were proposed in this pull request?
**Problem**
If you attempt to start multiple Spark instances within a second there is a high likelihood that this spark-class-launcher-output file will have the same name for multiple instances, causing the Spark launcher to fail. The error will look something like this:

```
WARNING - The process cannot access the file because it is being used by another process.
WARNING - The system cannot find the file C:\Users\CURRENTUSER\AppData\Local\Temp\spark-class-launcher-output-21229.txt.
WARNING - The process cannot access the file because it is being used by another process.
```

Windows' %RANDOM% is seeded with 1-second granularity. We often start ~20 instances at the same time daily in Windows and encounter this bug on a weekly basis

**Proposed Fix**
Instead of relying on %RANDOM% which has poor granularity, use Powershell to generate a GUID and append that to the end of the temp file name. We have been using this in production for around 2-3 months and have never encountered this bug since.


### Why are the changes needed?
My team runs Spark on Windows and we boot up 20+ instances within a few seconds on a daily basis. We encountered this bug weekly and have taken steps to mitigate it without changing the Spark source code like adding a random sleep between 1-300 seconds before starting Spark. Even with a random sleep, 20+ instances have a likelihood of sleeping a similar amount of time and starting at the same time. Also, relying on a random sleep before starting Spark is clunky, unreliable, and not a deterministic way to avoid this issue.

Eventually our team went ahead and edited the code in this .cmd file with this fix. I figured I should make a pull request for this as well.


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
You can pretty reliably recreate this bug by submitting 30 Spark jobs in Windows using spark-submit. Eventually the Spark launcher will overlap with another Spark launcher and fail.

You can pull my fixed spark-class2.cmd and try this again and there should be no incidence of this bug.

### Was this patch authored or co-authored using generative AI tooling?
no
