### PR TITLE
[SPARK-45828][SQL] Remove deprecated method in dsl

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala
@@ -152,9 +152,6 @@ package object dsl {
     def desc: SortOrder = SortOrder(expr, Descending)
     def desc_nullsFirst: SortOrder = SortOrder(expr, Descending, NullsFirst, Seq.empty)
     def as(alias: String): NamedExpression = Alias(expr, alias)()
-    // TODO: Remove at Spark 4.0.0
-    @deprecated("Use as(alias: String)", "3.4.0")
-    def as(alias: Symbol): NamedExpression = Alias(expr, alias.name)()
   }
 
   trait ExpressionConversions {
@@ -468,9 +465,6 @@ package object dsl {
           limit: Int): LogicalPlan =
         WindowGroupLimit(partitionSpec, orderSpec, rankLikeFunction, limit, logicalPlan)
 
-      // TODO: Remove at Spark 4.0.0
-      @deprecated("Use subquery(alias: String)", "3.4.0")
-      def subquery(alias: Symbol): LogicalPlan = SubqueryAlias(alias.name, logicalPlan)
       def subquery(alias: String): LogicalPlan = SubqueryAlias(alias, logicalPlan)
       def as(alias: String): LogicalPlan = SubqueryAlias(alias, logicalPlan)
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/TransposeWindowSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/TransposeWindowSuite.scala
@@ -146,15 +146,15 @@ class TransposeWindowSuite extends PlanTest {
   test("SPARK-38034: transpose two adjacent windows with compatible partitions " +
     "which is not a prefix") {
     val query = testRelation
-      .window(Seq(sum(c).as(Symbol("sum_a_2"))), partitionSpec4, orderSpec2)
-      .window(Seq(sum(c).as(Symbol("sum_a_1"))), partitionSpec3, orderSpec1)
+      .window(Seq(sum(c).as("sum_a_2")), partitionSpec4, orderSpec2)
+      .window(Seq(sum(c).as("sum_a_1")), partitionSpec3, orderSpec1)
 
     val analyzed = query.analyze
     val optimized = Optimize.execute(analyzed)
 
     val correctAnswer = testRelation
-      .window(Seq(sum(c).as(Symbol("sum_a_1"))), partitionSpec3, orderSpec1)
-      .window(Seq(sum(c).as(Symbol("sum_a_2"))), partitionSpec4, orderSpec2)
+      .window(Seq(sum(c).as("sum_a_1")), partitionSpec3, orderSpec1)
+      .window(Seq(sum(c).as("sum_a_2")), partitionSpec4, orderSpec2)
       .select(Symbol("a"), Symbol("b"), Symbol("c"), Symbol("d"),
         Symbol("sum_a_2"), Symbol("sum_a_1"))
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/LogicalPlanSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/LogicalPlanSuite.scala
@@ -126,12 +126,12 @@ class LogicalPlanSuite extends SparkFunSuite {
     assert(sort2.maxRows === Some(100))
     assert(sort2.maxRowsPerPartition === Some(100))
 
-    val c1 = Literal(1).as(Symbol("a")).toAttribute.newInstance().withNullability(true)
-    val c2 = Literal(2).as(Symbol("b")).toAttribute.newInstance().withNullability(true)
+    val c1 = Literal(1).as("a").toAttribute.newInstance().withNullability(true)
+    val c2 = Literal(2).as("b").toAttribute.newInstance().withNullability(true)
     val expand = Expand(
       Seq(Seq(Literal(null), Symbol("b")), Seq(Symbol("a"), Literal(null))),
       Seq(c1, c2),
-      sort.select(Symbol("id") as Symbol("a"), Symbol("id") + 1 as Symbol("b")))
+      sort.select(Symbol("id") as "a", Symbol("id") + 1 as "b"))
     assert(expand.maxRows === Some(200))
     assert(expand.maxRowsPerPartition === Some(68))
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to remove `some deprecated method` in dsl.


### Why are the changes needed?
After https://github.com/apache/spark/pull/36646 (Apache Spark 3.4.0), the method `def as(alias: Symbol): NamedExpression = Alias(expr, alias.name)()` and `def subquery(alias: Symbol): LogicalPlan = SubqueryAlias(alias.name, logicalPlan)` has been marked as `deprecated` and we need to remove it in `Spark 4.0`.

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.