### PR TITLE
[SPARK-45562][SQL][FOLLOW-UP] XML: Add SQL error class for missing rowTag option

### DIFF
--- a/common/utils/src/main/resources/error/error-classes.json
+++ b/common/utils/src/main/resources/error/error-classes.json
@@ -3899,7 +3899,7 @@
     },
     "sqlState" : "42605"
   },
-  "XML_ROW_TAG_OPTION_REQUIRED" : {
+  "XML_ROW_TAG_MISSING" : {
     "message" : [
       "<rowTag> option is required for reading files in XML format."
     ],

--- a/common/utils/src/main/resources/error/error-classes.json
+++ b/common/utils/src/main/resources/error/error-classes.json
@@ -3899,6 +3899,12 @@
     },
     "sqlState" : "42605"
   },
+  "XML_ROW_TAG_OPTION_REQUIRED" : {
+    "message" : [
+      "<rowTag> option is required for reading files in XML format."
+    ],
+    "sqlState" : "42000"
+  },
   "_LEGACY_ERROR_TEMP_0001" : {
     "message" : [
       "Invalid InsertIntoContext."

--- a/docs/sql-error-conditions.md
+++ b/docs/sql-error-conditions.md
@@ -2358,7 +2358,7 @@ The `<functionName>` requires `<expectedNum>` parameters but the actual number i
 
 For more details see [WRONG_NUM_ARGS](sql-error-conditions-wrong-num-args-error-class.html)
 
-### XML_ROW_TAG_OPTION_REQUIRED
+### XML_ROW_TAG_MISSING
 
 [SQLSTATE: 42000](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
 

--- a/docs/sql-error-conditions.md
+++ b/docs/sql-error-conditions.md
@@ -2357,3 +2357,9 @@ The operation `<operation>` requires a `<requiredType>`. But `<objectName>` is a
 The `<functionName>` requires `<expectedNum>` parameters but the actual number is `<actualNum>`.
 
 For more details see [WRONG_NUM_ARGS](sql-error-conditions-wrong-num-args-error-class.html)
+
+### XML_ROW_TAG_OPTION_REQUIRED
+
+[SQLSTATE: 42000](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+`<rowTag>` option is required for reading files in XML format.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -3817,4 +3817,11 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
       errorClass = "FOUND_MULTIPLE_DATA_SOURCES",
       messageParameters = Map("provider" -> provider))
   }
+
+  def xmlRowTagRequiredError(optionName: String): Throwable = {
+    new AnalysisException(
+      errorClass = "XML_ROW_TAG_OPTION_REQUIRED",
+      messageParameters = Map("rowTag" -> optionName)
+    )
+  }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -3821,7 +3821,7 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
   def xmlRowTagRequiredError(optionName: String): Throwable = {
     new AnalysisException(
       errorClass = "XML_ROW_TAG_OPTION_REQUIRED",
-      messageParameters = Map("rowTag" -> optionName)
+      messageParameters = Map("rowTag" -> toSQLId(optionName))
     )
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -3820,7 +3820,7 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
 
   def xmlRowTagRequiredError(optionName: String): Throwable = {
     new AnalysisException(
-      errorClass = "XML_ROW_TAG_OPTION_REQUIRED",
+      errorClass = "XML_ROW_TAG_MISSING",
       messageParameters = Map("rowTag" -> toSQLId(optionName))
     )
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/XmlSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/XmlSuite.scala
@@ -30,12 +30,13 @@ import org.apache.commons.lang3.exception.ExceptionUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.io.{LongWritable, Text}
 import org.apache.hadoop.io.compress.GzipCodec
-
 import org.apache.spark.SparkException
+
 import org.apache.spark.sql.{AnalysisException, Dataset, Encoders, QueryTest, Row, SaveMode}
 import org.apache.spark.sql.catalyst.util._
 import org.apache.spark.sql.catalyst.xml.XmlOptions
 import org.apache.spark.sql.catalyst.xml.XmlOptions._
+import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.execution.datasources.xml.TestUtils._
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.test.SharedSparkSession
@@ -1782,17 +1783,21 @@ class XmlSuite extends QueryTest with SharedSparkSession {
   test("Test XML Options Error Messages") {
     def checkXmlOptionErrorMessage(
       parameters: Map[String, String] = Map.empty,
-      msg: String): Unit = {
-      val e = intercept[IllegalArgumentException] {
+      msg: String,
+      exception: Throwable = new IllegalArgumentException().getCause): Unit = {
+      val e = intercept[Exception] {
         spark.read
           .options(parameters)
           .xml(getTestResourcePath(resDir + "ages.xml"))
           .collect()
       }
+      assert(e.getCause === exception)
       assert(e.getMessage.contains(msg))
     }
 
-    checkXmlOptionErrorMessage(Map.empty, "'rowTag' option is required.")
+    checkXmlOptionErrorMessage(Map.empty,
+      "[XML_ROW_TAG_OPTION_REQUIRED] rowTag option is required for reading files in XML format.",
+      QueryCompilationErrors.xmlRowTagRequiredError(XmlOptions.ROW_TAG).getCause)
     checkXmlOptionErrorMessage(Map("rowTag" -> ""),
       "'rowTag' option should not be an empty string.")
     checkXmlOptionErrorMessage(Map("rowTag" -> " "),

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/XmlSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/XmlSuite.scala
@@ -30,8 +30,8 @@ import org.apache.commons.lang3.exception.ExceptionUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.io.{LongWritable, Text}
 import org.apache.hadoop.io.compress.GzipCodec
-import org.apache.spark.SparkException
 
+import org.apache.spark.SparkException
 import org.apache.spark.sql.{AnalysisException, Dataset, Encoders, QueryTest, Row, SaveMode}
 import org.apache.spark.sql.catalyst.util._
 import org.apache.spark.sql.catalyst.xml.XmlOptions

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/XmlSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/XmlSuite.scala
@@ -1796,7 +1796,7 @@ class XmlSuite extends QueryTest with SharedSparkSession {
     }
 
     checkXmlOptionErrorMessage(Map.empty,
-      "[XML_ROW_TAG_OPTION_REQUIRED] `rowTag` option is required for reading files in XML format.",
+      "[XML_ROW_TAG_MISSING] `rowTag` option is required for reading files in XML format.",
       QueryCompilationErrors.xmlRowTagRequiredError(XmlOptions.ROW_TAG).getCause)
     checkXmlOptionErrorMessage(Map("rowTag" -> ""),
       "'rowTag' option should not be an empty string.")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/XmlSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/XmlSuite.scala
@@ -1796,7 +1796,7 @@ class XmlSuite extends QueryTest with SharedSparkSession {
     }
 
     checkXmlOptionErrorMessage(Map.empty,
-      "[XML_ROW_TAG_OPTION_REQUIRED] rowTag option is required for reading files in XML format.",
+      "[XML_ROW_TAG_OPTION_REQUIRED] `rowTag` option is required for reading files in XML format.",
       QueryCompilationErrors.xmlRowTagRequiredError(XmlOptions.ROW_TAG).getCause)
     checkXmlOptionErrorMessage(Map("rowTag" -> ""),
       "'rowTag' option should not be an empty string.")


### PR DESCRIPTION
### What changes were proposed in this pull request?
rowTag option is required for reading XML files. This PR adds a SQL error class for missing rowTag option.

### Why are the changes needed?
rowTag option is required for reading XML files. This PR adds a SQL error class for missing rowTag option.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Updated the unit test to check for error message.

### Was this patch authored or co-authored using generative AI tooling?
No