### PR TITLE
[SPARK-45829][DOCS] Update the default value for spark.executor.logs.rolling.maxSize

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -684,7 +684,7 @@ Apart from these, the following properties are also available, and may be useful
 </tr>
 <tr>
   <td><code>spark.executor.logs.rolling.maxSize</code></td>
-  <td>(none)</td>
+  <td>1024 * 1024</td>
   <td>
     Set the max size of the file in bytes by which the executor logs will be rolled over.
     Rolling is disabled by default. See <code>spark.executor.logs.rolling.maxRetainedFiles</code>


### PR DESCRIPTION
**What changes were proposed in this pull request?**
The PR updates the default value of 'spark.executor.logs.rolling.maxSize' in configuration.html on the website

**Why are the changes needed?**
The default value of 'spark.executor.logs.rolling.maxSize' is 1024 * 1024, but the website is wrong.

**Does this PR introduce any user-facing change?**
No

**How was this patch tested?**
It doesn't need to.

**Was this patch authored or co-authored using generative AI tooling?**
No