### PR TITLE
[SPARK-45832][SQL] Fix `Super method + is deprecated.`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveLateralColumnAliasReference.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveLateralColumnAliasReference.scala
@@ -170,7 +170,7 @@ object ResolveLateralColumnAliasReference extends Rule[LogicalPlan] {
           case (a: Alias, idx) =>
             val lcaResolved = unwrapLCAReference(a)
             // Insert the original alias instead of rewritten one to detect chained LCA
-            aliasMap += (a.toAttribute -> AliasEntry(a, idx))
+            aliasMap = AttributeMap(aliasMap.updated(a.toAttribute, AliasEntry(a, idx)))
             lcaResolved
           case (e, _) =>
             unwrapLCAReference(e)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/AttributeMap.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/AttributeMap.scala
@@ -49,9 +49,6 @@ class AttributeMap[A](val baseMap: Map[ExprId, (Attribute, A)])
 
   override def contains(k: Attribute): Boolean = get(k).isDefined
 
-  override def + [B1 >: A](kv: (Attribute, B1)): AttributeMap[B1] =
-    AttributeMap(baseMap.values.toMap + kv)
-
   override def updated[B1 >: A](key: Attribute, value: B1): Map[Attribute, B1] =
     baseMap.values.toMap + (key -> value)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
`AttributeMap` extends `scala.Map`. but the `+` has been deprecated in scala 2.13.
```
  @deprecated("Consider requiring an immutable Map or fall back to Map.concat.", "2.13.0")
  def + [V1 >: V](kv: (K, V1)): CC[K, V1] =
    mapFactory.from(new View.Appended(this, kv))
```
Then the compiler warnings `Super method + is deprecated.` occurs.

### Why are the changes needed?
Fix `Super method + is deprecated.`


### Does this PR introduce _any_ user-facing change?
'No'.


### How was this patch tested?
Manual test.


### Was this patch authored or co-authored using generative AI tooling?
'No'.
