### PR TITLE
[SPARK-45825][SQL][CORE][GRAPHX] Fix some scala compile warnings in module sql/catalyst

### DIFF
--- a/core/src/main/scala/org/apache/spark/executor/ExecutorMetrics.scala
+++ b/core/src/main/scala/org/apache/spark/executor/ExecutorMetrics.scala
@@ -46,7 +46,7 @@ class ExecutorMetrics private[spark] extends Serializable {
 
   private[spark] def this(metrics: Array[Long]) = {
     this()
-    Array.copy(metrics, 0, this.metrics, 0, Math.min(metrics.size, this.metrics.size))
+    Array.copy(metrics, 0, this.metrics, 0, Math.min(metrics.length, this.metrics.length))
   }
 
   private[spark] def this(metrics: AtomicLongArray) = {

--- a/core/src/main/scala/org/apache/spark/resource/ResourceUtils.scala
+++ b/core/src/main/scala/org/apache/spark/resource/ResourceUtils.scala
@@ -301,7 +301,7 @@ private[spark] object ResourceUtils extends Logging {
       allocations: Map[String, ResourceInformation],
       execReqs: Map[String, ExecutorResourceRequest]): Unit = {
     execReqs.foreach { case (rName, req) =>
-      require(allocations.contains(rName) && allocations(rName).addresses.size >= req.amount,
+      require(allocations.contains(rName) && allocations(rName).addresses.length >= req.amount,
         s"Resource: ${rName}, with addresses: " +
           s"${allocations(rName).addresses.mkString(",")} " +
           s"is less than what the user requested: ${req.amount})")

--- a/graphx/src/main/scala/org/apache/spark/graphx/lib/PageRank.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/lib/PageRank.scala
@@ -334,10 +334,10 @@ object PageRank extends Logging {
     require(sources.nonEmpty, s"The list of sources must be non-empty," +
       s" but got ${sources.mkString("[", ",", "]")}")
 
-    val zero = Vectors.sparse(sources.size, List()).asBreeze
+    val zero = Vectors.sparse(sources.length, List()).asBreeze
     // map of vid -> vector where for each vid, the _position of vid in source_ is set to 1.0
     val sourcesInitMap = sources.zipWithIndex.map { case (vid, i) =>
-      val v = Vectors.sparse(sources.size, Array(i), Array(1.0)).asBreeze
+      val v = Vectors.sparse(sources.length, Array(i), Array(1.0)).asBreeze
       (vid, v)
     }.toMap
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/InternalRow.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/InternalRow.scala
@@ -144,7 +144,7 @@ object InternalRow {
         case PhysicalCalendarIntervalType => (input, ordinal) => input.getInterval(ordinal)
         case t: PhysicalDecimalType => (input, ordinal) =>
           input.getDecimal(ordinal, t.precision, t.scale)
-        case t: PhysicalStructType => (input, ordinal) => input.getStruct(ordinal, t.fields.size)
+        case t: PhysicalStructType => (input, ordinal) => input.getStruct(ordinal, t.fields.length)
         case _: PhysicalArrayType => (input, ordinal) => input.getArray(ordinal)
         case _: PhysicalMapType => (input, ordinal) => input.getMap(ordinal)
         case _ => (input, ordinal) => input.get(ordinal, dt)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -2846,7 +2846,7 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
               generatorVisited = true
 
               val newGenChildren: Seq[Expression] = generator.children.zipWithIndex.map {
-                case (e, idx) => if (e.foldable) e else Alias(e, s"_gen_input_${idx}")()
+                case (e, idx) => if (e.foldable) e else Alias(e, s"_gen_input_$idx")()
               }
               val newGenerator = {
                 val g = generator.withNewChildren(newGenChildren.map { e =>
@@ -2855,7 +2855,7 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
                 if (outer) GeneratorOuter(g) else g
               }
               val newAliasedGenerator = if (names.length == 1) {
-                Alias(newGenerator, names(0))()
+                Alias(newGenerator, names.head)()
               } else {
                 MultiAlias(newGenerator, names)
               }
@@ -3340,7 +3340,7 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
             encOpt.map { enc =>
               val attrs = if (enc.isSerializedAsStructForTopLevel) {
                 // Value class that has been replaced with its underlying type
-                if (enc.schema.fields.size == 1 && enc.schema.fields.head.dataType == dataType) {
+                if (enc.schema.fields.length == 1 && enc.schema.fields.head.dataType == dataType) {
                   DataTypeUtils.toAttributes(enc.schema.asInstanceOf[StructType])
                 } else {
                   DataTypeUtils.toAttributes(dataType.asInstanceOf[StructType])

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -1125,7 +1125,7 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
     def failOnInvalidOuterReference(p: LogicalPlan): Unit = {
       p.expressions.foreach(checkMixedReferencesInsideAggregateExpr)
       val exprs = stripOuterReferences(p.expressions.filter(expr => containsOuter(expr)))
-      if (!canHostOuter(p) && !exprs.isEmpty) {
+      if (!canHostOuter(p) && exprs.nonEmpty) {
         p.failAnalysis(
           errorClass =
             "UNSUPPORTED_SUBQUERY_EXPRESSION_CATEGORY.CORRELATED_REFERENCE",

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ColumnResolutionHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ColumnResolutionHelper.scala
@@ -248,7 +248,7 @@ trait ColumnResolutionHelper extends Logging {
         if (nameParts.length == 2) {
           nameParts.head.equalsIgnoreCase(CatalogManager.SESSION_NAMESPACE)
         } else if (nameParts.length == 3) {
-          nameParts(0).equalsIgnoreCase(CatalogManager.SYSTEM_CATALOG_NAME) &&
+          nameParts.head.equalsIgnoreCase(CatalogManager.SYSTEM_CATALOG_NAME) &&
             nameParts(1).equalsIgnoreCase(CatalogManager.SESSION_NAMESPACE)
         } else {
           false

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -918,7 +918,7 @@ object FunctionRegistry {
       name: String,
       builder: T,
       expressions: Seq[Expression]) : Seq[Expression] = {
-    val rearrangedExpressions = if (!builder.functionSignature.isEmpty) {
+    val rearrangedExpressions = if (builder.functionSignature.isDefined) {
       val functionSignature = builder.functionSignature.get
       builder.rearrange(functionSignature, expressions, name)
     } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveCatalogs.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveCatalogs.scala
@@ -74,7 +74,7 @@ class ResolveCatalogs(val catalogManager: CatalogManager)
           nameParts, Seq(CatalogManager.SYSTEM_CATALOG_NAME, CatalogManager.SESSION_NAMESPACE))
       }
     } else if (nameParts.length == 3) {
-      if (nameParts(0).equalsIgnoreCase(CatalogManager.SYSTEM_CATALOG_NAME) &&
+      if (nameParts.head.equalsIgnoreCase(CatalogManager.SYSTEM_CATALOG_NAME) &&
         nameParts(1).equalsIgnoreCase(CatalogManager.SESSION_NAMESPACE)) {
         ResolvedIdentifier(FakeSystemCatalog, ident)
       } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -1092,7 +1092,7 @@ object TypeCoercion extends TypeCoercionBase {
     private def castExpr(expr: Expression, targetType: DataType): Expression = {
       (expr.dataType, targetType) match {
         case (NullType, dt) => Literal.create(null, targetType)
-        case (l, dt) if (l != dt) => Cast(expr, targetType)
+        case (l, dt) if l != dt => Cast(expr, targetType)
         case _ => expr
       }
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationChecker.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationChecker.scala
@@ -400,7 +400,7 @@ object UnsupportedOperationChecker extends Logging {
         case j @ Join(left, right, joinType, condition, _) =>
           if (left.isStreaming && right.isStreaming && outputMode != InternalOutputModes.Append) {
             throwError("Join between two streaming DataFrames/Datasets is not supported" +
-              s" in ${outputMode} output mode, only in Append output mode")
+              s" in $outputMode output mode, only in Append output mode")
           }
 
           joinType match {
@@ -522,9 +522,9 @@ object UnsupportedOperationChecker extends Logging {
 
     plan.foreachUp { implicit subPlan =>
       subPlan match {
-        case (_: Project | _: Filter | _: MapElements | _: MapPartitions |
+        case _: Project | _: Filter | _: MapElements | _: MapPartitions |
               _: DeserializeToObject | _: SerializeFromObject | _: SubqueryAlias |
-              _: TypedFilter) =>
+              _: TypedFilter =>
         case v: View if v.isTempViewStoringAnalyzedPlan =>
         case node if node.nodeName == "StreamingRelationV2" =>
         case node =>
@@ -533,7 +533,7 @@ object UnsupportedOperationChecker extends Logging {
 
       subPlan.expressions.foreach { e =>
         if (e.collectLeaves().exists {
-          case (_: CurrentTimestampLike | _: CurrentDate | _: LocalTimestamp) => true
+          case _: CurrentTimestampLike | _: CurrentDate | _: LocalTimestamp => true
           case _ => false
         }) {
           throwError(s"Continuous processing does not support current time operations.")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -70,7 +70,7 @@ case class CatalogStorageFormat(
     properties: Map[String, String]) {
 
   override def toString: String = {
-    toLinkedHashMap.map { case ((key, value)) =>
+    toLinkedHashMap.map { case (key, value) =>
       if (value.isEmpty) key else s"$key: $value"
     }.mkString("Storage(", ", ", ")")
   }
@@ -134,14 +134,14 @@ case class CatalogTablePartition(
   }
 
   override def toString: String = {
-    toLinkedHashMap.map { case ((key, value)) =>
+    toLinkedHashMap.map { case (key, value) =>
       if (value.isEmpty) key else s"$key: $value"
     }.mkString("CatalogPartition(\n\t", "\n\t", ")")
   }
 
   /** Readable string representation for the CatalogTablePartition. */
   def simpleString: String = {
-    toLinkedHashMap.map { case ((key, value)) =>
+    toLinkedHashMap.map { case (key, value) =>
       if (value.isEmpty) key else s"$key: $value"
     }.mkString("", "\n", "")
   }
@@ -451,14 +451,14 @@ case class CatalogTable(
   }
 
   override def toString: String = {
-    toLinkedHashMap.map { case ((key, value)) =>
+    toLinkedHashMap.map { case (key, value) =>
       if (value.isEmpty) key else s"$key: $value"
     }.mkString("CatalogTable(\n", "\n", ")")
   }
 
   /** Readable string representation for the CatalogTable. */
   def simpleString: String = {
-    toLinkedHashMap.map { case ((key, value)) =>
+    toLinkedHashMap.map { case (key, value) =>
       if (value.isEmpty) key else s"$key: $value"
     }.mkString("", "\n", "")
   }
@@ -631,17 +631,17 @@ case class CatalogColumnStat(
    */
   def toMap(colName: String): Map[String, String] = {
     val map = new scala.collection.mutable.HashMap[String, String]
-    map.put(s"${colName}.${CatalogColumnStat.KEY_VERSION}", CatalogColumnStat.VERSION.toString)
+    map.put(s"$colName.${CatalogColumnStat.KEY_VERSION}", CatalogColumnStat.VERSION.toString)
     distinctCount.foreach { v =>
-      map.put(s"${colName}.${CatalogColumnStat.KEY_DISTINCT_COUNT}", v.toString)
+      map.put(s"$colName.${CatalogColumnStat.KEY_DISTINCT_COUNT}", v.toString)
     }
     nullCount.foreach { v =>
-      map.put(s"${colName}.${CatalogColumnStat.KEY_NULL_COUNT}", v.toString)
+      map.put(s"$colName.${CatalogColumnStat.KEY_NULL_COUNT}", v.toString)
     }
-    avgLen.foreach { v => map.put(s"${colName}.${CatalogColumnStat.KEY_AVG_LEN}", v.toString) }
-    maxLen.foreach { v => map.put(s"${colName}.${CatalogColumnStat.KEY_MAX_LEN}", v.toString) }
-    min.foreach { v => map.put(s"${colName}.${CatalogColumnStat.KEY_MIN_VALUE}", v) }
-    max.foreach { v => map.put(s"${colName}.${CatalogColumnStat.KEY_MAX_VALUE}", v) }
+    avgLen.foreach { v => map.put(s"$colName.${CatalogColumnStat.KEY_AVG_LEN}", v.toString) }
+    maxLen.foreach { v => map.put(s"$colName.${CatalogColumnStat.KEY_MAX_LEN}", v.toString) }
+    min.foreach { v => map.put(s"$colName.${CatalogColumnStat.KEY_MIN_VALUE}", v) }
+    max.foreach { v => map.put(s"$colName.${CatalogColumnStat.KEY_MAX_VALUE}", v) }
     histogram.foreach { h =>
       CatalogTable.splitLargeTableProp(
         s"$colName.${CatalogColumnStat.KEY_HISTOGRAM}",
@@ -755,19 +755,19 @@ object CatalogColumnStat extends Logging {
 
     try {
       Some(CatalogColumnStat(
-        distinctCount = map.get(s"${colName}.${KEY_DISTINCT_COUNT}").map(v => BigInt(v.toLong)),
-        min = map.get(s"${colName}.${KEY_MIN_VALUE}"),
-        max = map.get(s"${colName}.${KEY_MAX_VALUE}"),
-        nullCount = map.get(s"${colName}.${KEY_NULL_COUNT}").map(v => BigInt(v.toLong)),
-        avgLen = map.get(s"${colName}.${KEY_AVG_LEN}").map(_.toLong),
-        maxLen = map.get(s"${colName}.${KEY_MAX_LEN}").map(_.toLong),
+        distinctCount = map.get(s"$colName.$KEY_DISTINCT_COUNT").map(v => BigInt(v.toLong)),
+        min = map.get(s"$colName.$KEY_MIN_VALUE"),
+        max = map.get(s"$colName.$KEY_MAX_VALUE"),
+        nullCount = map.get(s"$colName.$KEY_NULL_COUNT").map(v => BigInt(v.toLong)),
+        avgLen = map.get(s"$colName.$KEY_AVG_LEN").map(_.toLong),
+        maxLen = map.get(s"$colName.$KEY_MAX_LEN").map(_.toLong),
         histogram = CatalogTable.readLargeTableProp(map, s"$colName.$KEY_HISTOGRAM")
           .map(HistogramSerializer.deserialize),
-        version = map(s"${colName}.${KEY_VERSION}").toInt
+        version = map(s"$colName.$KEY_VERSION").toInt
       ))
     } catch {
       case NonFatal(e) =>
-        logWarning(s"Failed to parse column statistics for column ${colName} in table $table", e)
+        logWarning(s"Failed to parse column statistics for column $colName in table $table", e)
         None
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVHeaderChecker.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVHeaderChecker.scala
@@ -58,7 +58,7 @@ class CSVHeaderChecker(
   private def checkHeaderColumnNames(columnNames: Array[String]): Unit = {
     if (columnNames != null) {
       val fieldNames = schema.map(_.name).toIndexedSeq
-      val (headerLen, schemaSize) = (columnNames.size, fieldNames.length)
+      val (headerLen, schemaSize) = (columnNames.length, fieldNames.length)
       var errorMessage: Option[String] = None
 
       if (headerLen == schemaSize) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
@@ -66,7 +66,7 @@ class CSVOptions(
     paramValue match {
       case None => default
       case Some(null) => default
-      case Some(value) if value.length == 0 => '\u0000'
+      case Some(value) if value.isEmpty => '\u0000'
       case Some(value) if value.length == 1 => value.charAt(0)
       case _ => throw QueryExecutionErrors.paramExceedOneCharError(paramName)
     }
@@ -111,7 +111,7 @@ class CSVOptions(
   val charToEscapeQuoteEscaping = parameters.get(CHAR_TO_ESCAPE_QUOTE_ESCAPING) match {
     case None => None
     case Some(null) => None
-    case Some(value) if value.length == 0 => None
+    case Some(value) if value.isEmpty => None
     case Some(value) if value.length == 1 => Some(value.charAt(0))
     case _ => throw QueryExecutionErrors.paramExceedOneCharError(CHAR_TO_ESCAPE_QUOTE_ESCAPING)
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/UnivocityParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/UnivocityParser.scala
@@ -243,7 +243,7 @@ class UnivocityParser(
               throw e
             }
             val str = DateTimeUtils.cleanLegacyTimestampStr(UTF8String.fromString(datum))
-            DateTimeUtils.stringToTimestamp(str, options.zoneId).getOrElse(throw(e))
+            DateTimeUtils.stringToTimestamp(str, options.zoneId).getOrElse(throw e)
         }
       }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/AttributeSet.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/AttributeSet.scala
@@ -134,7 +134,7 @@ class AttributeSet private (private val baseSet: mutable.LinkedHashSet[Attribute
   def intersect(other: AttributeSet): AttributeSet =
     new AttributeSet(baseSet.intersect(other.baseSet))
 
-  override def foreach[U](f: (Attribute) => U): Unit = baseSet.map(_.a).foreach(f)
+  override def foreach[U](f: Attribute => U): Unit = baseSet.map(_.a).foreach(f)
 
   // We must force toSeq to not be strict otherwise we end up with a [[Stream]] that captures all
   // sorts of things in its closure.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/CallMethodViaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/CallMethodViaReflection.scala
@@ -160,7 +160,7 @@ case class CallMethodViaReflection(
   @transient private lazy val argExprs: Array[Expression] = children.drop(2).toArray
 
   /** Name of the class -- this has to be called after we verify children has at least two exprs. */
-  @transient private lazy val className = children(0).eval().asInstanceOf[UTF8String].toString
+  @transient private lazy val className = children.head.eval().asInstanceOf[UTF8String].toString
 
   /** True if the class exists and can be loaded. */
   @transient private lazy val classExists = CallMethodViaReflection.classExists(className)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -1073,7 +1073,7 @@ case class Cast(
   }
 
   private[this] def castStruct(from: StructType, to: StructType): Any => Any = {
-    val castFuncs: Array[(Any) => Any] = from.fields.zip(to.fields).map {
+    val castFuncs: Array[Any => Any] = from.fields.zip(to.fields).map {
       case (fromField, toField) => cast(fromField.dataType, toField.dataType)
     }
     // TODO: Could be faster?
@@ -1533,8 +1533,8 @@ case class Cast(
       val util = IntervalUtils.getClass.getCanonicalName.stripSuffix("$")
       (c, evPrim, evNull) =>
         code"""$evPrim = $util.safeStringToInterval($c);
-           if(${evPrim} == null) {
-             ${evNull} = true;
+           if($evPrim == null) {
+             $evNull = true;
            }
          """.stripMargin
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
@@ -862,14 +862,14 @@ abstract class TernaryExpression extends Expression with TernaryLike[Expression]
     ctx: CodegenContext,
     ev: ExprCode,
     f: (String, String, String) => String): ExprCode = {
-    val leftGen = children(0).genCode(ctx)
+    val leftGen = children.head.genCode(ctx)
     val midGen = children(1).genCode(ctx)
     val rightGen = children(2).genCode(ctx)
     val resultCode = f(leftGen.value, midGen.value, rightGen.value)
 
     if (nullable) {
       val nullSafeEval =
-        leftGen.code.toString + ctx.nullSafeExec(children(0).nullable, leftGen.isNull) {
+        leftGen.code.toString + ctx.nullSafeExec(children.head.nullable, leftGen.isNull) {
           midGen.code.toString + ctx.nullSafeExec(children(1).nullable, midGen.isNull) {
             rightGen.code.toString + ctx.nullSafeExec(children(2).nullable, rightGen.isNull) {
               s"""
@@ -963,7 +963,7 @@ abstract class QuaternaryExpression extends Expression with QuaternaryLike[Expre
     ctx: CodegenContext,
     ev: ExprCode,
     f: (String, String, String, String) => String): ExprCode = {
-    val firstGen = children(0).genCode(ctx)
+    val firstGen = children.head.genCode(ctx)
     val secondGen = children(1).genCode(ctx)
     val thridGen = children(2).genCode(ctx)
     val fourthGen = children(3).genCode(ctx)
@@ -971,7 +971,7 @@ abstract class QuaternaryExpression extends Expression with QuaternaryLike[Expre
 
     if (nullable) {
       val nullSafeEval =
-        firstGen.code.toString + ctx.nullSafeExec(children(0).nullable, firstGen.isNull) {
+        firstGen.code.toString + ctx.nullSafeExec(children.head.nullable, firstGen.isNull) {
           secondGen.code.toString + ctx.nullSafeExec(children(1).nullable, secondGen.isNull) {
             thridGen.code.toString + ctx.nullSafeExec(children(2).nullable, thridGen.isNull) {
               fourthGen.code.toString + ctx.nullSafeExec(children(3).nullable, fourthGen.isNull) {
@@ -1016,7 +1016,7 @@ abstract class QuinaryExpression extends Expression {
    */
   override def eval(input: InternalRow): Any = {
     val exprs = children
-    val v1 = exprs(0).eval(input)
+    val v1 = exprs.head.eval(input)
     if (v1 != null) {
       val v2 = exprs(1).eval(input)
       if (v2 != null) {
@@ -1083,7 +1083,7 @@ abstract class QuinaryExpression extends Expression {
       ctx: CodegenContext,
       ev: ExprCode,
       f: (String, String, String, String, String) => String): ExprCode = {
-    val firstGen = children(0).genCode(ctx)
+    val firstGen = children.head.genCode(ctx)
     val secondGen = children(1).genCode(ctx)
     val thirdGen = children(2).genCode(ctx)
     val fourthGen = children(3).genCode(ctx)
@@ -1093,7 +1093,7 @@ abstract class QuinaryExpression extends Expression {
 
     if (nullable) {
       val nullSafeEval =
-        firstGen.code.toString + ctx.nullSafeExec(children(0).nullable, firstGen.isNull) {
+        firstGen.code.toString + ctx.nullSafeExec(children.head.nullable, firstGen.isNull) {
           secondGen.code.toString + ctx.nullSafeExec(children(1).nullable, secondGen.isNull) {
             thirdGen.code.toString + ctx.nullSafeExec(children(2).nullable, thirdGen.isNull) {
               fourthGen.code.toString + ctx.nullSafeExec(children(3).nullable, fourthGen.isNull) {
@@ -1143,7 +1143,7 @@ abstract class SeptenaryExpression extends Expression {
    */
   override def eval(input: InternalRow): Any = {
     val exprs = children
-    val v1 = exprs(0).eval(input)
+    val v1 = exprs.head.eval(input)
     if (v1 != null) {
       val v2 = exprs(1).eval(input)
       if (v2 != null) {
@@ -1219,7 +1219,7 @@ abstract class SeptenaryExpression extends Expression {
       ev: ExprCode,
       f: (String, String, String, String, String, String, Option[String]) => String
     ): ExprCode = {
-    val firstGen = children(0).genCode(ctx)
+    val firstGen = children.head.genCode(ctx)
     val secondGen = children(1).genCode(ctx)
     val thirdGen = children(2).genCode(ctx)
     val fourthGen = children(3).genCode(ctx)
@@ -1237,7 +1237,7 @@ abstract class SeptenaryExpression extends Expression {
 
     if (nullable) {
       val nullSafeEval =
-        firstGen.code.toString + ctx.nullSafeExec(children(0).nullable, firstGen.isNull) {
+        firstGen.code.toString + ctx.nullSafeExec(children.head.nullable, firstGen.isNull) {
           secondGen.code.toString + ctx.nullSafeExec(children(1).nullable, secondGen.isNull) {
             thirdGen.code.toString + ctx.nullSafeExec(children(2).nullable, thirdGen.isNull) {
               fourthGen.code.toString + ctx.nullSafeExec(children(3).nullable, fourthGen.isNull) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ScalaUDF.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ScalaUDF.scala
@@ -163,7 +163,7 @@ case class ScalaUDF(
       val enc = inputEncoders(i).get
       val fromRow = enc.createDeserializer()
       val unwrappedValueClass = enc.isSerializedAsStruct &&
-        enc.schema.fields.size == 1 && enc.schema.fields.head.dataType == dataType
+        enc.schema.fields.length == 1 && enc.schema.fields.head.dataType == dataType
       val converter = if (enc.isSerializedAsStructForTopLevel && !unwrappedValueClass) {
         row: Any => fromRow(row.asInstanceOf[InternalRow])
       } else {
@@ -209,8 +209,8 @@ case class ScalaUDF(
       }
 
     case 1 =>
-      val func = function.asInstanceOf[(Any) => Any]
-      val child0 = children(0)
+      val func = function.asInstanceOf[Any => Any]
+      val child0 = children.head
       lazy val converter0 = createToScalaConverter(0, child0.dataType)
       (input: InternalRow) => {
         func(
@@ -219,7 +219,7 @@ case class ScalaUDF(
 
     case 2 =>
       val func = function.asInstanceOf[(Any, Any) => Any]
-      val child0 = children(0)
+      val child0 = children.head
       val child1 = children(1)
       lazy val converter0 = createToScalaConverter(0, child0.dataType)
       lazy val converter1 = createToScalaConverter(1, child1.dataType)
@@ -231,7 +231,7 @@ case class ScalaUDF(
 
     case 3 =>
       val func = function.asInstanceOf[(Any, Any, Any) => Any]
-      val child0 = children(0)
+      val child0 = children.head
       val child1 = children(1)
       val child2 = children(2)
       lazy val converter0 = createToScalaConverter(0, child0.dataType)
@@ -246,7 +246,7 @@ case class ScalaUDF(
 
     case 4 =>
       val func = function.asInstanceOf[(Any, Any, Any, Any) => Any]
-      val child0 = children(0)
+      val child0 = children.head
       val child1 = children(1)
       val child2 = children(2)
       val child3 = children(3)
@@ -264,7 +264,7 @@ case class ScalaUDF(
 
     case 5 =>
       val func = function.asInstanceOf[(Any, Any, Any, Any, Any) => Any]
-      val child0 = children(0)
+      val child0 = children.head
       val child1 = children(1)
       val child2 = children(2)
       val child3 = children(3)
@@ -285,7 +285,7 @@ case class ScalaUDF(
 
     case 6 =>
       val func = function.asInstanceOf[(Any, Any, Any, Any, Any, Any) => Any]
-      val child0 = children(0)
+      val child0 = children.head
       val child1 = children(1)
       val child2 = children(2)
       val child3 = children(3)
@@ -309,7 +309,7 @@ case class ScalaUDF(
 
     case 7 =>
       val func = function.asInstanceOf[(Any, Any, Any, Any, Any, Any, Any) => Any]
-      val child0 = children(0)
+      val child0 = children.head
       val child1 = children(1)
       val child2 = children(2)
       val child3 = children(3)
@@ -336,7 +336,7 @@ case class ScalaUDF(
 
     case 8 =>
       val func = function.asInstanceOf[(Any, Any, Any, Any, Any, Any, Any, Any) => Any]
-      val child0 = children(0)
+      val child0 = children.head
       val child1 = children(1)
       val child2 = children(2)
       val child3 = children(3)
@@ -366,7 +366,7 @@ case class ScalaUDF(
 
     case 9 =>
       val func = function.asInstanceOf[(Any, Any, Any, Any, Any, Any, Any, Any, Any) => Any]
-      val child0 = children(0)
+      val child0 = children.head
       val child1 = children(1)
       val child2 = children(2)
       val child3 = children(3)
@@ -399,7 +399,7 @@ case class ScalaUDF(
 
     case 10 =>
       val func = function.asInstanceOf[(Any, Any, Any, Any, Any, Any, Any, Any, Any, Any) => Any]
-      val child0 = children(0)
+      val child0 = children.head
       val child1 = children(1)
       val child2 = children(2)
       val child3 = children(3)
@@ -435,7 +435,7 @@ case class ScalaUDF(
 
     case 11 =>
       val func = function.asInstanceOf[(Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any) => Any]
-      val child0 = children(0)
+      val child0 = children.head
       val child1 = children(1)
       val child2 = children(2)
       val child3 = children(3)
@@ -474,7 +474,7 @@ case class ScalaUDF(
 
     case 12 =>
       val func = function.asInstanceOf[(Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any) => Any]
-      val child0 = children(0)
+      val child0 = children.head
       val child1 = children(1)
       val child2 = children(2)
       val child3 = children(3)
@@ -516,7 +516,7 @@ case class ScalaUDF(
 
     case 13 =>
       val func = function.asInstanceOf[(Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any) => Any]
-      val child0 = children(0)
+      val child0 = children.head
       val child1 = children(1)
       val child2 = children(2)
       val child3 = children(3)
@@ -561,7 +561,7 @@ case class ScalaUDF(
 
     case 14 =>
       val func = function.asInstanceOf[(Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any) => Any]
-      val child0 = children(0)
+      val child0 = children.head
       val child1 = children(1)
       val child2 = children(2)
       val child3 = children(3)
@@ -609,7 +609,7 @@ case class ScalaUDF(
 
     case 15 =>
       val func = function.asInstanceOf[(Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any) => Any]
-      val child0 = children(0)
+      val child0 = children.head
       val child1 = children(1)
       val child2 = children(2)
       val child3 = children(3)
@@ -660,7 +660,7 @@ case class ScalaUDF(
 
     case 16 =>
       val func = function.asInstanceOf[(Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any) => Any]
-      val child0 = children(0)
+      val child0 = children.head
       val child1 = children(1)
       val child2 = children(2)
       val child3 = children(3)
@@ -714,7 +714,7 @@ case class ScalaUDF(
 
     case 17 =>
       val func = function.asInstanceOf[(Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any) => Any]
-      val child0 = children(0)
+      val child0 = children.head
       val child1 = children(1)
       val child2 = children(2)
       val child3 = children(3)
@@ -771,7 +771,7 @@ case class ScalaUDF(
 
     case 18 =>
       val func = function.asInstanceOf[(Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any) => Any]
-      val child0 = children(0)
+      val child0 = children.head
       val child1 = children(1)
       val child2 = children(2)
       val child3 = children(3)
@@ -831,7 +831,7 @@ case class ScalaUDF(
 
     case 19 =>
       val func = function.asInstanceOf[(Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any) => Any]
-      val child0 = children(0)
+      val child0 = children.head
       val child1 = children(1)
       val child2 = children(2)
       val child3 = children(3)
@@ -894,7 +894,7 @@ case class ScalaUDF(
 
     case 20 =>
       val func = function.asInstanceOf[(Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any) => Any]
-      val child0 = children(0)
+      val child0 = children.head
       val child1 = children(1)
       val child2 = children(2)
       val child3 = children(3)
@@ -960,7 +960,7 @@ case class ScalaUDF(
 
     case 21 =>
       val func = function.asInstanceOf[(Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any) => Any]
-      val child0 = children(0)
+      val child0 = children.head
       val child1 = children(1)
       val child2 = children(2)
       val child3 = children(3)
@@ -1029,7 +1029,7 @@ case class ScalaUDF(
 
     case 22 =>
       val func = function.asInstanceOf[(Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any) => Any]
-      val child0 = children(0)
+      val child0 = children.head
       val child1 = children(1)
       val child2 = children(2)
       val child3 = children(3)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SortOrder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SortOrder.scala
@@ -149,25 +149,25 @@ case class SortPrefix(child: SortOrder) extends UnaryExpression {
   }
 
   private lazy val calcPrefix: Any => Long = child.child.dataType match {
-    case BooleanType => (raw) =>
+    case BooleanType => raw =>
       if (raw.asInstanceOf[Boolean]) 1 else 0
     case DateType | TimestampType | TimestampNTZType |
-         _: IntegralType | _: AnsiIntervalType => (raw) =>
+         _: IntegralType | _: AnsiIntervalType => raw =>
       raw.asInstanceOf[java.lang.Number].longValue()
-    case FloatType | DoubleType => (raw) => {
+    case FloatType | DoubleType => raw => {
       val dVal = raw.asInstanceOf[java.lang.Number].doubleValue()
       DoublePrefixComparator.computePrefix(dVal)
     }
-    case StringType => (raw) =>
+    case StringType => raw =>
       StringPrefixComparator.computePrefix(raw.asInstanceOf[UTF8String])
-    case BinaryType => (raw) =>
+    case BinaryType => raw =>
       BinaryPrefixComparator.computePrefix(raw.asInstanceOf[Array[Byte]])
     case dt: DecimalType if dt.precision <= Decimal.MAX_LONG_DIGITS =>
       _.asInstanceOf[Decimal].toUnscaledLong
     case dt: DecimalType if dt.precision - dt.scale <= Decimal.MAX_LONG_DIGITS =>
       val p = Decimal.MAX_LONG_DIGITS
       val s = p - (dt.precision - dt.scale)
-      (raw) => {
+      raw => {
         val value = raw.asInstanceOf[Decimal]
         if (value.changePrecision(p, s)) {
           value.toUnscaledLong
@@ -177,9 +177,9 @@ case class SortPrefix(child: SortOrder) extends UnaryExpression {
           Long.MaxValue
         }
       }
-    case dt: DecimalType => (raw) =>
+    case dt: DecimalType => raw =>
       DoublePrefixComparator.computePrefix(raw.asInstanceOf[Decimal].toDouble)
-    case _ => (Any) => 0L
+    case _ => Any => 0L
   }
 
   override def eval(input: InternalRow): Any = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproximatePercentile.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproximatePercentile.scala
@@ -215,12 +215,12 @@ case class ApproximatePercentile(
       case other: DataType =>
         throw QueryExecutionErrors.dataTypeUnexpectedError(other)
     }
-    if (result.length == 0) {
+    if (result.isEmpty) {
       null
     } else if (returnPercentileArray) {
       new GenericArrayData(result)
     } else {
-      result(0)
+      result.head
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/CountMinSketchAgg.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/CountMinSketchAgg.scala
@@ -220,6 +220,6 @@ object CountMinSketchAggExpressionBuilder extends ExpressionBuilder {
   override def functionSignature: Option[FunctionSignature] = Some(defaultFunctionSignature)
   override def build(funcName: String, expressions: Seq[Expression]): Expression = {
     assert(expressions.size == 4)
-    new CountMinSketchAgg(expressions(0), expressions(1), expressions(2), expressions(3))
+    new CountMinSketchAgg(expressions.head, expressions(1), expressions(2), expressions(3))
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/bitwiseExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/bitwiseExpressions.scala
@@ -184,15 +184,15 @@ case class BitwiseNot(child: Expression)
 
   override def toString: String = s"~$child"
 
-  private lazy val not: (Any) => Any = dataType match {
+  private lazy val not: Any => Any = dataType match {
     case ByteType =>
-      ((evalE: Byte) => (~evalE).toByte).asInstanceOf[(Any) => Any]
+      ((evalE: Byte) => (~evalE).toByte).asInstanceOf[Any => Any]
     case ShortType =>
-      ((evalE: Short) => (~evalE).toShort).asInstanceOf[(Any) => Any]
+      ((evalE: Short) => (~evalE).toShort).asInstanceOf[Any => Any]
     case IntegerType =>
-      ((evalE: Int) => ~evalE).asInstanceOf[(Any) => Any]
+      ((evalE: Int) => ~evalE).asInstanceOf[Any => Any]
     case LongType =>
-      ((evalE: Long) => ~evalE).asInstanceOf[(Any) => Any]
+      ((evalE: Long) => ~evalE).asInstanceOf[Any => Any]
   }
 
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeFormatter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeFormatter.scala
@@ -149,7 +149,7 @@ private class CodeFormatter {
       indentString
     }
     code.append(f"/* ${currentLine}%03d */")
-    if (line.trim().length > 0) {
+    if (line.trim().nonEmpty) {
       code.append(" ") // add a space after the line number comment.
       code.append(thisLineIndent)
       if (inCommentBlock && line.startsWith("*") || line.startsWith("*/")) code.append(" ")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -1640,7 +1640,7 @@ object CodeGenerator extends Logging {
         case _: PhysicalMapType => s"$input.getMap($ordinal)"
         case PhysicalNullType => "null"
         case PhysicalStringType => s"$input.getUTF8String($ordinal)"
-        case t: PhysicalStructType => s"$input.getStruct($ordinal, ${t.fields.size})"
+        case t: PhysicalStructType => s"$input.getStruct($ordinal, ${t.fields.length})"
         case _ => s"($jt)$input.get($ordinal, null)"
       }
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/javaCode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/javaCode.scala
@@ -176,7 +176,7 @@ trait Block extends TreeNode[Block] with JavaCode {
 
     @inline def transform(e: ExprValue): ExprValue = {
       val newE = f lift e
-      if (!newE.isDefined || newE.get.equals(e)) {
+      if (newE.isEmpty || newE.get.equals(e)) {
         e
       } else {
         changed = true
@@ -231,7 +231,7 @@ object Block {
      */
     def code(args: Any*): Block = {
       StringContext.checkLengths(args, sc.parts)
-      if (sc.parts.length == 0) {
+      if (sc.parts.isEmpty) {
         EmptyBlock
       } else {
         args.foreach {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeCreator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeCreator.scala
@@ -100,7 +100,7 @@ case class CreateArray(children: Seq[Expression], useStringTypeWhenEmpty: Boolea
     val (allocation, assigns, arrayData) =
       GenArrayData.genCodeToCreateArrayData(ctx, et, children, "createArray")
     ev.copy(
-      code = code"${allocation}${assigns}",
+      code = code"$allocation$assigns",
       value = JavaCode.variable(arrayData, dataType),
       isNull = FalseLiteral)
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/conditionalExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/conditionalExpressions.scala
@@ -364,9 +364,9 @@ case class CaseWhen(
     if (branches.length == 1) {
       // If we have only single branch we can use If expression and its codeGen
       If(
-        branches(0)._1,
-        branches(0)._2,
-        elseValue.getOrElse(Literal.create(null, branches(0)._2.dataType))).doGenCode(ctx, ev)
+        branches.head._1,
+        branches.head._2,
+        elseValue.getOrElse(Literal.create(null, branches.head._2.dataType))).doGenCode(ctx, ev)
     } else {
       multiBranchesCodegen(ctx, ev)
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -1141,7 +1141,7 @@ object ParseToTimestampNTZExpressionBuilder extends ExpressionBuilder {
   override def build(funcName: String, expressions: Seq[Expression]): Expression = {
     val numArgs = expressions.length
     if (numArgs == 1 || numArgs == 2) {
-      ParseToTimestamp(expressions(0), expressions.drop(1).lastOption, TimestampNTZType)
+      ParseToTimestamp(expressions.head, expressions.drop(1).lastOption, TimestampNTZType)
     } else {
       throw QueryCompilationErrors.wrongNumArgsError(funcName, Seq(1, 2), numArgs)
     }
@@ -1178,7 +1178,7 @@ object ParseToTimestampLTZExpressionBuilder extends ExpressionBuilder {
   override def build(funcName: String, expressions: Seq[Expression]): Expression = {
     val numArgs = expressions.length
     if (numArgs == 1 || numArgs == 2) {
-      ParseToTimestamp(expressions(0), expressions.drop(1).lastOption, TimestampType)
+      ParseToTimestamp(expressions.head, expressions.drop(1).lastOption, TimestampType)
     } else {
       throw QueryCompilationErrors.wrongNumArgsError(funcName, Seq(1, 2), numArgs)
     }
@@ -1317,9 +1317,9 @@ abstract class ToTimestamp
              |try {
              |  ${ev.value} = $formatterName.$parseMethod($datetimeStr.toString()) $downScaleCode;
              |} catch (java.time.DateTimeException e) {
-             |  ${parseErrorBranch}
+             |  $parseErrorBranch
              |} catch (java.text.ParseException e) {
-             |  ${parseErrorBranch}
+             |  $parseErrorBranch
              |}
              |""".stripMargin)
       }.getOrElse {
@@ -1337,9 +1337,9 @@ abstract class ToTimestamp
              |try {
              |  ${ev.value} = $timestampFormatter.$parseMethod($string.toString()) $downScaleCode;
              |} catch (java.time.DateTimeException e) {
-             |    ${parseErrorBranch}
+             |    $parseErrorBranch
              |} catch (java.text.ParseException e) {
-             |    ${parseErrorBranch}
+             |    $parseErrorBranch
              |}
              |""".stripMargin)
       }
@@ -2513,7 +2513,7 @@ object MakeTimestampNTZExpressionBuilder extends ExpressionBuilder {
     val numArgs = expressions.length
     if (numArgs == 6) {
       MakeTimestamp(
-        expressions(0),
+        expressions.head,
         expressions(1),
         expressions(2),
         expressions(3),
@@ -2560,7 +2560,7 @@ object MakeTimestampLTZExpressionBuilder extends ExpressionBuilder {
     val numArgs = expressions.length
     if (numArgs == 6 || numArgs == 7) {
       MakeTimestamp(
-        expressions(0),
+        expressions.head,
         expressions(1),
         expressions(2),
         expressions(3),
@@ -2836,7 +2836,7 @@ object DatePartExpressionBuilder extends ExpressionBuilder {
   override def build(funcName: String, expressions: Seq[Expression]): Expression = {
     val numArgs = expressions.length
     if (numArgs == 2) {
-      val field = expressions(0)
+      val field = expressions.head
       val source = expressions(1)
       Extract(field, source, Extract.createExpr(funcName, field, source))
     } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/generators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/generators.scala
@@ -105,7 +105,7 @@ case class UserDefinedGenerator(
   extends Generator with CodegenFallback {
 
   @transient private[this] var inputRow: InterpretedProjection = _
-  @transient private[this] var convertToScala: (InternalRow) => Row = _
+  @transient private[this] var convertToScala: InternalRow => Row = _
 
   private def initializeConverters(): Unit = {
     inputRow = new InterpretedProjection(children)
@@ -425,7 +425,7 @@ trait ExplodeGeneratorBuilderBase extends GeneratorBuilder {
     Some(FunctionSignature(Seq(InputParameter("collection"))))
   override def buildGenerator(funcName: String, expressions: Seq[Expression]): Generator = {
     assert(expressions.size == 1)
-    Explode(expressions(0))
+    Explode(expressions.head)
   }
 }
 
@@ -452,7 +452,7 @@ object ExplodeExpressionBuilder extends ExpressionBuilder {
     Some(FunctionSignature(Seq(InputParameter("collection"))))
 
   override def build(funcName: String, expressions: Seq[Expression]) : Expression =
-    Explode(expressions(0))
+    Explode(expressions.head)
 }
 
 // scalastyle:off line.size.limit

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/hash.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/hash.scala
@@ -529,9 +529,9 @@ abstract class InterpretedHashFunction {
       case s: Short => hashInt(s, seed)
       case i: Int => hashInt(i, seed)
       case l: Long => hashLong(l, seed)
-      case f: Float if (f == -0.0f) => hashInt(0, seed)
+      case f: Float if f == -0.0f => hashInt(0, seed)
       case f: Float => hashInt(java.lang.Float.floatToIntBits(f), seed)
-      case d: Double if (d == -0.0d) => hashLong(0L, seed)
+      case d: Double if d == -0.0d => hashLong(0L, seed)
       case d: Double => hashLong(java.lang.Double.doubleToLongBits(d), seed)
       case d: Decimal =>
         val precision = dataType.asInstanceOf[DecimalType].precision

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/maskExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/maskExpressions.scala
@@ -92,7 +92,7 @@ object MaskExpressionBuilder extends ExpressionBuilder {
 
   override def build(funcName: String, expressions: Seq[Expression]): Expression = {
     assert(expressions.size == 5)
-    new Mask(expressions(0), expressions(1), expressions(2), expressions(3), expressions(4))
+    new Mask(expressions.head, expressions(1), expressions(2), expressions(3), expressions(4))
   }
 }
 
@@ -197,7 +197,7 @@ case class Mask(
    */
   override def eval(input: InternalRow): Any = {
     Mask.transformInput(
-      children(0).eval(input),
+      children.head.eval(input),
       children(1).eval(input),
       children(2).eval(input),
       children(3).eval(input),
@@ -237,7 +237,7 @@ case class Mask(
       ctx: CodegenContext,
       ev: ExprCode,
       f: (String, String, String, String, String) => String): ExprCode = {
-    val firstGen = children(0).genCode(ctx)
+    val firstGen = children.head.genCode(ctx)
     val secondGen = children(1).genCode(ctx)
     val thirdGen = children(2).genCode(ctx)
     val fourthGen = children(3).genCode(ctx)
@@ -247,7 +247,7 @@ case class Mask(
     if (nullable) {
       // this function is somewhat like a `UnaryExpression`, in that only the first child
       // determines whether the result is null
-      val nullSafeEval = ctx.nullSafeExec(children(0).nullable, firstGen.isNull)(resultCode)
+      val nullSafeEval = ctx.nullSafeExec(children.head.nullable, firstGen.isNull)(resultCode)
       ev.copy(code = code"""
         ${firstGen.code}
         ${secondGen.code}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/numberFormatExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/numberFormatExpressions.scala
@@ -242,7 +242,7 @@ object ToCharacterBuilder extends ExpressionBuilder {
   override def build(funcName: String, expressions: Seq[Expression]): Expression = {
     val numArgs = expressions.length
     if (numArgs == 2) {
-      val (inputExpr, format) = (expressions(0), expressions(1))
+      val (inputExpr, format) = (expressions.head, expressions(1))
       inputExpr.dataType match {
         case _: DatetimeType => DateFormatClass(inputExpr, format)
         case _: BinaryType =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/package.scala
@@ -205,7 +205,7 @@ package object expressions  {
             tblPart.toLowerCase(Locale.ROOT), name.toLowerCase(Locale.ROOT))
           val attributes = collectMatches(name, qualified4Part.get(key)).filter { a =>
             assert(a.qualifier.length == 3)
-            resolver(catalogPart, a.qualifier(0)) && resolver(dbPart, a.qualifier(1)) &&
+            resolver(catalogPart, a.qualifier.head) && resolver(dbPart, a.qualifier(1)) &&
               resolver(tblPart, a.qualifier(2))
           }
           (attributes, nestedFields)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -726,7 +726,7 @@ case class InSet(child: Expression, hset: Set[Any]) extends UnaryExpression with
           break;
        """)
 
-    val switchCode = if (caseBranches.size > 0) {
+    val switchCode = if (caseBranches.nonEmpty) {
       code"""
         switch (${valueGen.value}) {
           ${caseBranches.mkString("\n")}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/urlExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/urlExpressions.scala
@@ -160,7 +160,7 @@ case class ParseUrl(children: Seq[Expression], failOnError: Boolean = SQLConf.ge
 
   // If the url is a constant, cache the URL object so that we don't need to convert url
   // from UTF8String to String to URL for every row.
-  @transient private lazy val cachedUrl = children(0) match {
+  @transient private lazy val cachedUrl = children.head match {
     case Literal(url: UTF8String, _) if url ne null => getUrl(url)
     case _ => null
   }
@@ -272,7 +272,7 @@ case class ParseUrl(children: Seq[Expression], failOnError: Boolean = SQLConf.ge
     val evaluated = children.map{e => e.eval(input).asInstanceOf[UTF8String]}
     if (evaluated.contains(null)) return null
     if (evaluated.size == 2) {
-      parseUrlWithoutKey(evaluated(0), evaluated(1))
+      parseUrlWithoutKey(evaluated.head, evaluated(1))
     } else {
       // 3-arg, i.e. QUERY with key
       assert(evaluated.size == 3)
@@ -280,7 +280,7 @@ case class ParseUrl(children: Seq[Expression], failOnError: Boolean = SQLConf.ge
         return null
       }
 
-      val query = parseUrlWithoutKey(evaluated(0), evaluated(1))
+      val query = parseUrlWithoutKey(evaluated.head, evaluated(1))
       if (query eq null) {
         return null
       }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonParser.scala
@@ -327,7 +327,7 @@ class JacksonParser(
 
     case dt: DecimalType =>
       (parser: JsonParser) => parseJsonToken[Decimal](parser, dataType) {
-        case (VALUE_NUMBER_INT | VALUE_NUMBER_FLOAT) =>
+        case VALUE_NUMBER_INT | VALUE_NUMBER_FLOAT =>
           Decimal(parser.getDecimalValue, dt.precision, dt.scale)
         case VALUE_STRING if parser.getTextLength >= 1 =>
           val bigDecimal = decimalParser(parser.getText)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/DecorrelateInnerQuery.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/DecorrelateInnerQuery.scala
@@ -473,7 +473,7 @@ object DecorrelateInnerQuery extends PredicateHelper {
       case _ : AttributeReference => true
       case Alias(_: AttributeReference, _) => true
       case Alias(_: Literal, _) => true
-      case Alias(a: AggregateExpression, _) if a.aggregateFunction.defaultResult == None => true
+      case Alias(a: AggregateExpression, _) if a.aggregateFunction.defaultResult.isEmpty => true
       case _ => false
     }
   }
@@ -952,7 +952,7 @@ object DecorrelateInnerQuery extends PredicateHelper {
               case _ => hasOuterReferences(right)
             }
             if (shouldDecorrelatePredicates && !shouldPushToLeft && !shouldPushToRight
-              && !predicates.isEmpty) {
+              && predicates.nonEmpty) {
               // Neither left nor right children of the join have correlations, but the join
               // predicate does, and the correlations can not be replaced via equivalences.
               // Introduce a domain join on the left side of the join

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/NestedColumnAliasing.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/NestedColumnAliasing.scala
@@ -241,7 +241,7 @@ object NestedColumnAliasing {
   def getAttributeToExtractValues(
       exprList: Seq[Expression],
       exclusiveAttrs: Seq[Attribute],
-      extractor: (Expression) => Seq[Expression] = collectRootReferenceAndExtractValue)
+      extractor: Expression => Seq[Expression] = collectRootReferenceAndExtractValue)
     : Map[Attribute, Seq[ExtractValue]] = {
 
     val nestedFieldReferences = new mutable.ArrayBuffer[ExtractValue]()

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -394,7 +394,7 @@ abstract class Optimizer(catalogManager: CatalogManager)
     val excludedRules = excludedRulesConf.filter { ruleName =>
       val nonExcludable = nonExcludableRules.contains(ruleName)
       if (nonExcludable) {
-        logWarning(s"Optimization rule '${ruleName}' was not excluded from the optimizer " +
+        logWarning(s"Optimization rule '$ruleName' was not excluded from the optimizer " +
           s"because this rule is a non-excludable rule.")
       }
       !nonExcludable
@@ -2359,7 +2359,7 @@ object RewriteIntersectAll extends Rule[LogicalPlan] {
 
       // Expressions to compute count and minimum of both the counts.
       val vCol1AggrExpr =
-        Alias(Count(unionPlan.output(0)).toAggregateExpression(), "vcol1_count")()
+        Alias(Count(unionPlan.output.head).toAggregateExpression(), "vcol1_count")()
       val vCol2AggrExpr =
         Alias(Count(unionPlan.output(1)).toAggregateExpression(), "vcol2_count")()
       val ifExpression = Alias(If(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PushDownLeftSemiAntiJoin.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PushDownLeftSemiAntiJoin.scala
@@ -258,12 +258,12 @@ object PushLeftSemiLeftAntiThroughJoin extends Rule[LogicalPlan] with PredicateH
 
       action match {
         case PushdownDirection.TO_LEFT_BRANCH
-          if (childJoinType == LeftOuter || childJoinType.isInstanceOf[InnerLike]) =>
+          if childJoinType == LeftOuter || childJoinType.isInstanceOf[InnerLike] =>
           // push down leftsemi/anti join to the left table
           val newLeft = Join(childLeft, right, joinType, joinCond, parentHint)
           Join(newLeft, childRight, childJoinType, childCondition, childHint)
         case PushdownDirection.TO_RIGHT_BRANCH
-          if (childJoinType == RightOuter || childJoinType.isInstanceOf[InnerLike]) =>
+          if childJoinType == RightOuter || childJoinType.isInstanceOf[InnerLike] =>
           // push down leftsemi/anti join to the right table
           val newRight = Join(childRight, right, joinType, joinCond, parentHint)
           Join(childLeft, newRight, childJoinType, childCondition, childHint)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
@@ -183,7 +183,7 @@ object ConstantPropagation extends Rule[LogicalPlan] {
         val (newLeft, _) = traverse(o.left, replaceChildren = true, nullIsFalse)
         val (newRight, _) = traverse(o.right, replaceChildren = true, nullIsFalse)
         val newSelf = if (newLeft.isDefined || newRight.isDefined) {
-          Some(Or(left = newLeft.getOrElse(o.left), right = newRight.getOrElse((o.right))))
+          Some(Or(left = newLeft.getOrElse(o.left), right = newRight.getOrElse(o.right)))
         } else {
           None
         }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
@@ -55,7 +55,7 @@ object ReorderJoin extends Rule[LogicalPlan] with PredicateHelper {
     assert(input.size >= 2)
     if (input.size == 2) {
       val (joinConditions, others) = conditions.partition(canEvaluateWithinJoin)
-      val ((left, leftJoinType), (right, rightJoinType)) = (input(0), input(1))
+      val ((left, leftJoinType), (right, rightJoinType)) = (input.head, input(1))
       val innerJoinType = (leftJoinType, rightJoinType) match {
         case (Inner, Inner) => Inner
         case (_, _) => Cross

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserUtils.scala
@@ -78,7 +78,7 @@ object ParserUtils extends SparkParserUtils {
   /** Convert a string node into a string without unescaping. */
   def stringWithoutUnescape(node: Token): String = {
     // STRING parser rule forces that the input always has quotes at the starting and ending.
-    node.getText.slice(1, node.getText.size - 1)
+    node.getText.slice(1, node.getText.length - 1)
   }
 
   /** Collect the entries if any. */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlan.scala
@@ -414,7 +414,7 @@ object LogicalPlanIntegrity {
       .orElse(LogicalPlanIntegrity.validateNoDanglingReferences(currentPlan))
       .orElse(LogicalPlanIntegrity.validateGroupByTypes(currentPlan))
       .orElse(LogicalPlanIntegrity.validateAggregateExpressions(currentPlan))
-      .map(err => s"${err}\nPrevious schema:${previousPlan.output.mkString(", ")}" +
+      .map(err => s"$err\nPrevious schema:${previousPlan.output.mkString(", ")}" +
         s"\nPrevious plan: ${previousPlan.treeString}")
     validation
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -1267,11 +1267,11 @@ object Expand {
     // Calculate the attribute masks of selected grouping set. For example, if we have GroupBy
     // attributes (a, b, c, d), grouping set (a, c) will produce the following sequence:
     // (15, 7, 13), whose binary form is (1111, 0111, 1101)
-    val masks = (mask +: groupingSetAttrs.map(attrMap).map(index =>
+    val masks = mask +: groupingSetAttrs.map(attrMap).map(index =>
       // 0 means that the column at the given index is a grouping column, 1 means it is not,
       // so we unset the bit in bitmap.
       ~(1L << (numAttributes - 1 - index))
-    ))
+    )
     // Reduce masks to generate an bitmask for the selected grouping set.
     masks.reduce(_ & _)
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/FilterEstimation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/FilterEstimation.scala
@@ -333,7 +333,7 @@ case class FilterEstimation(plan: Filter) extends Logging {
       }
 
       if (colStat.histogram.isEmpty) {
-        if (!colStat.distinctCount.isEmpty) {
+        if (colStat.distinctCount.isDefined) {
           // returns 1/ndv if there is no histogram
           Some(1.0 / colStat.distinctCount.get.toDouble)
         } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleIdCollection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleIdCollection.scala
@@ -214,7 +214,7 @@ object RuleIdCollection {
   def getRuleId(ruleName: String): RuleId = {
     val ruleIdOpt = ruleToId.get(ruleName)
     // Please add the rule name to `rulesWithIds` if rule id is not found.
-    if (!ruleIdOpt.isDefined) {
+    if (ruleIdOpt.isEmpty) {
       throw QueryExecutionErrors.ruleIdNotFoundForRuleError(ruleName)
     }
     ruleIdOpt.get

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -955,8 +955,8 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]]
     } else {
       number.i -= 1
       // Note that this traversal order must be the same as numberedTreeString.
-      innerChildren.map(_.getNodeNumbered(number)).find(_ != None).getOrElse {
-        children.map(_.getNodeNumbered(number)).find(_ != None).flatten
+      innerChildren.map(_.getNodeNumbered(number)).find(_.isDefined).getOrElse {
+        children.map(_.getNodeNumbered(number)).find(_.isDefined).flatten
       }
     }
   }
@@ -1122,7 +1122,7 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]]
       t.forall(_.isInstanceOf[DataType]) ||
       t.forall(_.isInstanceOf[Product]) =>
       JArray(t.map(parseToJson).toList)
-    case t: Seq[_] if t.length > 0 && t.head.isInstanceOf[String] =>
+    case t: Seq[_] if t.nonEmpty && t.head.isInstanceOf[String] =>
       JString(truncatedString(t, "[", ", ", "]", SQLConf.get.maxToStringFields))
     case t: Seq[_] => JNull
     case m: Map[_, _] => JNull

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/types/DataTypeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/types/DataTypeUtils.scala
@@ -139,16 +139,16 @@ object DataTypeUtils {
             }
         }
 
-        if (readFields.size > writeFields.size) {
-          val missingFieldsStr = readFields.takeRight(readFields.size - writeFields.size)
+        if (readFields.length > writeFields.length) {
+          val missingFieldsStr = readFields.takeRight(readFields.length - writeFields.length)
             .map(f => s"${toSQLId(f.name)}").mkString(", ")
           if (missingFieldsStr.nonEmpty) {
             throw QueryCompilationErrors.incompatibleDataToTableStructMissingFieldsError(
               tableName, context, missingFieldsStr)
           }
 
-        } else if (writeFields.size > readFields.size) {
-          val extraFieldsStr = writeFields.takeRight(writeFields.size - readFields.size)
+        } else if (writeFields.length > readFields.length) {
+          val extraFieldsStr = writeFields.takeRight(writeFields.length - readFields.length)
             .map(f => s"${toSQLId(f.name)}").mkString(", ")
           throw QueryCompilationErrors.incompatibleDataToTableExtraStructFieldsError(
             tableName, context, extraFieldsStr

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ArrayBasedMapData.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ArrayBasedMapData.scala
@@ -52,8 +52,8 @@ object ArrayBasedMapData {
    */
   def apply[K, V](
       javaMap: JavaMap[K, V],
-      keyConverter: (Any) => Any,
-      valueConverter: (Any) => Any): ArrayBasedMapData = {
+      keyConverter: Any => Any,
+      valueConverter: Any => Any): ArrayBasedMapData = {
 
     val keys: Array[Any] = new Array[Any](javaMap.size())
     val values: Array[Any] = new Array[Any](javaMap.size())
@@ -81,8 +81,8 @@ object ArrayBasedMapData {
    */
   def apply(
       map: scala.collection.Map[_, _],
-      keyConverter: (Any) => Any = identity,
-      valueConverter: (Any) => Any = identity): ArrayBasedMapData = {
+      keyConverter: Any => Any = identity,
+      valueConverter: Any => Any = identity): ArrayBasedMapData = {
     ArrayBasedMapData(map.iterator, map.size, keyConverter, valueConverter)
   }
 
@@ -103,8 +103,8 @@ object ArrayBasedMapData {
   def apply(
       iterator: Iterator[(_, _)],
       size: Int,
-      keyConverter: (Any) => Any,
-      valueConverter: (Any) => Any): ArrayBasedMapData = {
+      keyConverter: Any => Any,
+      valueConverter: Any => Any): ArrayBasedMapData = {
 
     val keys: Array[Any] = new Array[Any](size)
     val values: Array[Any] = new Array[Any](size)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ResolveDefaultColumnsUtil.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ResolveDefaultColumnsUtil.scala
@@ -374,7 +374,7 @@ object ResolveDefaultColumns extends QueryErrorsBase with ResolveDefaultColumnsU
    * above, for convenience.
    */
   def getExistenceDefaultsBitmask(schema: StructType): Array[Boolean] = {
-    Array.fill[Boolean](existenceDefaultValues(schema).size)(true)
+    Array.fill[Boolean](existenceDefaultValues(schema).length)(true)
   }
 
   /**
@@ -383,7 +383,7 @@ object ResolveDefaultColumns extends QueryErrorsBase with ResolveDefaultColumnsU
    */
   def resetExistenceDefaultsBitmask(schema: StructType, bitmask: Array[Boolean]): Unit = {
     val defaultValues = existenceDefaultValues(schema)
-    for (i <- 0 until defaultValues.size) {
+    for (i <- 0 until defaultValues.length) {
       bitmask(i) = (defaultValues(i) != null)
     }
   }
@@ -395,7 +395,7 @@ object ResolveDefaultColumns extends QueryErrorsBase with ResolveDefaultColumnsU
       bitmask: Array[Boolean]): Unit = {
     val existingValues = existenceDefaultValues(schema)
     if (hasExistenceDefaultValues(schema)) {
-      for (i <- 0 until existingValues.size) {
+      for (i <- 0 until existingValues.length) {
         if (bitmask(i)) {
           row.update(i, existingValues(i))
         }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/StringKeyHashMap.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/StringKeyHashMap.scala
@@ -32,7 +32,7 @@ object StringKeyHashMap {
 }
 
 
-class StringKeyHashMap[T](normalizer: (String) => String) {
+class StringKeyHashMap[T](normalizer: String => String) {
   private val base = new collection.mutable.HashMap[String, T]()
 
   def apply(key: String): T = base(normalizer(key))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/expressions/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/expressions/expressions.scala
@@ -95,7 +95,7 @@ private[sql] abstract class SingleColumnTransform(ref: NamedReference) extends R
 
   override def withReferences(newReferences: Seq[NamedReference]): Transform = {
     assert(newReferences.length == 1,
-      s"Tried rewriting a single column transform (${this}) with multiple references.")
+      s"Tried rewriting a single column transform ($this) with multiple references.")
     withNewRef(newReferences.head)
   }
 }
@@ -137,7 +137,7 @@ private[sql] object BucketTransform {
         arguments.drop(posOfLit + 1).map(_.asInstanceOf[NamedReference]))
     case NamedTransform("bucket", arguments) =>
       var numOfBucket: Int = -1
-      arguments(0) match {
+      arguments.head match {
         case Lit(value: Int, IntegerType) =>
           numOfBucket = value
         case _ => throw new SparkException("The first element in BucketTransform arguments " +

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/arrow/ArrowWriter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/arrow/ArrowWriter.scala
@@ -98,7 +98,7 @@ class ArrowWriter(val root: VectorSchemaRoot, fields: Array[ArrowFieldWriter]) {
 
   def write(row: InternalRow): Unit = {
     var i = 0
-    while (i < fields.size) {
+    while (i < fields.length) {
       fields(i).write(row, i)
       i += 1
     }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/QueryPlanningTrackerSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/QueryPlanningTrackerSuite.scala
@@ -84,7 +84,7 @@ class QueryPlanningTrackerSuite extends SparkFunSuite {
     assert(t.topRulesByTime(0) == Seq.empty)
     val top = t.topRulesByTime(2)
     assert(top.size == 2)
-    assert(top(0)._1 == "r4")
+    assert(top.head._1 == "r4")
     assert(top(1)._1 == "r3")
 
     // k > total size

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/ScalaReflectionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/ScalaReflectionSuite.scala
@@ -446,7 +446,7 @@ class ScalaReflectionSuite extends SparkFunSuite {
         case If(_, _, s: CreateNamedStruct) => s
       }.head
     val deserializer = deserializerFor[SpecialCharAsFieldData]
-    assert(serializer.dataType(0).name == "field.1")
+    assert(serializer.dataType.head.name == "field.1")
     assert(serializer.dataType(1).name == "field 2")
 
     val newInstance = deserializer.collect { case n: NewInstance => n }.head
@@ -454,7 +454,7 @@ class ScalaReflectionSuite extends SparkFunSuite {
     val argumentsFields = newInstance.arguments.flatMap { _.collect {
       case UpCast(u: UnresolvedExtractValue, _, _) => u.extraction.toString
     }}
-    assert(argumentsFields(0) == "field.1")
+    assert(argumentsFields.head == "field.1")
     assert(argumentsFields(1) == "field 2")
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnsiTypeCoercionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnsiTypeCoercionSuite.scala
@@ -549,7 +549,7 @@ class AnsiTypeCoercionSuite extends TypeCoercionSuiteBase {
   }
 
   test("greatest/least cast") {
-    for (operator <- Seq[(Seq[Expression] => Expression)](Greatest, Least)) {
+    for (operator <- Seq[Seq[Expression] => Expression](Greatest, Least)) {
       ruleTest(AnsiTypeCoercion.FunctionArgumentConversion,
         operator(Literal(1.0)
           :: Literal(1)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ExpressionTypeCheckingSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ExpressionTypeCheckingSuite.scala
@@ -688,7 +688,7 @@ class ExpressionTypeCheckingSuite extends SparkFunSuite with SQLHelper with Quer
   }
 
   test("check types for Greatest/Least") {
-    for (operator <- Seq[(Seq[Expression] => Expression)](Greatest, Least)) {
+    for (operator <- Seq[Seq[Expression] => Expression](Greatest, Least)) {
       val expr1 = operator(Seq($"booleanField"))
       assertErrorForWrongNumParameters(
         expr = expr1,

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/NamedParameterFunctionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/NamedParameterFunctionSuite.scala
@@ -52,7 +52,7 @@ object DummyExpressionBuilder extends ExpressionBuilder  {
     Some(defaultFunctionSignature)
 
   override def build(funcName: String, expressions: Seq[Expression]): Expression =
-    DummyExpression(expressions(0), expressions(1), expressions(2), expressions(3))
+    DummyExpression(expressions.head, expressions(1), expressions(2), expressions(3))
 }
 
 class NamedParameterFunctionSuite extends AnalysisTest {
@@ -143,7 +143,7 @@ class NamedParameterFunctionSuite extends AnalysisTest {
 
   test("INTERNAL_ERROR: Enforce optional arguments after required arguments") {
     val errorMessage = s"Function foo has an unexpected required argument for the provided" +
-      s" function signature ${illegalSignature}. All required arguments should come before" +
+      s" function signature $illegalSignature. All required arguments should come before" +
       s" optional arguments."
     checkError(
       exception = parseRearrangeException(illegalSignature, args, "foo"),

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveGroupingAnalyticsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveGroupingAnalyticsSuite.scala
@@ -111,7 +111,7 @@ class ResolveGroupingAnalyticsSuite extends AnalysisTest {
     val gExpressions = resultPlan.asInstanceOf[Aggregate].groupingExpressions
     assert(gExpressions.size == 3)
     val firstGroupingExprAttrName =
-      gExpressions(0).asInstanceOf[AttributeReference].name.replaceAll("#[0-9]*", "#0")
+      gExpressions.head.asInstanceOf[AttributeReference].name.replaceAll("#[0-9]*", "#0")
     assert(firstGroupingExprAttrName == "(a#0 * 2)")
     assert(gExpressions(1).asInstanceOf[AttributeReference].name == "b")
     assert(gExpressions(2).asInstanceOf[AttributeReference].name == VirtualColumn.groupingIdName)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveInlineTablesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveInlineTablesSuite.scala
@@ -89,7 +89,7 @@ class ResolveInlineTablesSuite extends AnalysisTest with BeforeAndAfter {
 
     assert(converted.output.map(_.dataType) == Seq(LongType))
     assert(converted.data.size == 2)
-    assert(converted.data(0).getLong(0) == 1L)
+    assert(converted.data.head.getLong(0) == 1L)
     assert(converted.data(1).getLong(0) == 2L)
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveUnionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveUnionSuite.scala
@@ -50,7 +50,7 @@ class ResolveUnionSuite extends AnalysisTest {
     val union1 = Union(table1 :: table2 :: Nil, true, false)
     val analyzed1 = analyzer.execute(union1)
     val projected1 =
-      Project(Seq(table2.output(3), table2.output(0), table2.output(1), table2.output(2)), table2)
+      Project(Seq(table2.output(3), table2.output.head, table2.output(1), table2.output(2)), table2)
     val expected1 = Union(table1 :: projected1 :: Nil)
     comparePlans(analyzed1, expected1)
 
@@ -59,7 +59,7 @@ class ResolveUnionSuite extends AnalysisTest {
     val analyzed2 = analyzer.execute(union2)
     val nullAttr1 = Alias(Literal(null, ByteType), "b")()
     val projected2 =
-      Project(Seq(table2.output(3), table2.output(0), nullAttr1, table2.output(2)), table3)
+      Project(Seq(table2.output(3), table2.output.head, nullAttr1, table2.output(2)), table3)
     val expected2 = Union(table1 :: projected2 :: Nil)
     comparePlans(analyzed2, expected2)
 
@@ -68,7 +68,7 @@ class ResolveUnionSuite extends AnalysisTest {
     val analyzed3 = analyzer.execute(union3)
     val nullAttr2 = Alias(Literal(null, DoubleType), "d")()
     val projected3 =
-      Project(Seq(table2.output(3), table2.output(0), nullAttr1, nullAttr2), table4)
+      Project(Seq(table2.output(3), table2.output.head, nullAttr1, nullAttr2), table4)
     val expected3 = Union(Union(table1 :: projected2 :: Nil) :: projected3 :: Nil)
     comparePlans(analyzed3, expected3)
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolvedUuidExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolvedUuidExpressionsSuite.scala
@@ -70,6 +70,6 @@ class ResolvedUuidExpressionsSuite extends AnalysisTest {
     val uuids2 = getUuidExpressions(resolvedPlan2)
     assert(uuids1.distinct.length == 3)
     assert(uuids2.distinct.length == 3)
-    assert(uuids1.intersect(uuids2).length == 0)
+    assert(uuids1.intersect(uuids2).isEmpty)
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/SubstituteUnresolvedOrdinalsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/SubstituteUnresolvedOrdinalsSuite.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.catalyst.expressions.Literal
 import org.apache.spark.sql.internal.SQLConf
 
 class SubstituteUnresolvedOrdinalsSuite extends AnalysisTest {
-  private lazy val a = testRelation2.output(0)
+  private lazy val a = testRelation2.output.head
   private lazy val b = testRelation2.output(1)
 
   test("unresolved ordinal should not be unresolved") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionSuite.scala
@@ -1114,7 +1114,7 @@ class TypeCoercionSuite extends TypeCoercionSuiteBase {
   }
 
   test("greatest/least cast") {
-    for (operator <- Seq[(Seq[Expression] => Expression)](Greatest, Least)) {
+    for (operator <- Seq[Seq[Expression] => Expression](Greatest, Least)) {
       ruleTest(TypeCoercion.FunctionArgumentConversion,
         operator(Literal(1.0)
           :: Literal(1)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationsSuite.scala
@@ -1111,7 +1111,7 @@ class UnsupportedOperationsSuite extends SparkFunSuite with SQLHelper {
             s"actual exception message:\n\t'${e.getMessage}'")
         }
       }
-      if (!errorClass.isEmpty) {
+      if (errorClass.nonEmpty) {
         assert(e.getErrorClass == errorClass)
       }
     }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/EncoderResolutionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/EncoderResolutionSuite.scala
@@ -251,7 +251,7 @@ class EncoderResolutionSuite extends PlanTest {
     checkError(exception = e1,
       errorClass = "CANNOT_UP_CAST_DATATYPE",
       parameters = Map("expression" -> "b",
-        "sourceType" -> ("\"BIGINT\""), "targetType" -> "\"INT\"",
+        "sourceType" -> "\"BIGINT\"", "targetType" -> "\"INT\"",
         "details" -> (
           s"""
           |The type path of the target object is:
@@ -268,7 +268,7 @@ class EncoderResolutionSuite extends PlanTest {
     checkError(exception = e2,
       errorClass = "CANNOT_UP_CAST_DATATYPE",
       parameters = Map("expression" -> "b.`b`",
-        "sourceType" -> ("\"DECIMAL(38,18)\""), "targetType" -> "\"BIGINT\"",
+        "sourceType" -> "\"DECIMAL(38,18)\"", "targetType" -> "\"BIGINT\"",
         "details" -> (
           s"""
           |The type path of the target object is:

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoderSuite.scala
@@ -517,9 +517,9 @@ class ExpressionEncoderSuite extends CodegenInterpretedPlanTest with AnalysisTes
     // test for nested product encoders
     {
       val schema = ExpressionEncoder[(Int, (String, Int))]().schema
-      assert(schema(0).nullable === false)
+      assert(schema.head.nullable === false)
       assert(schema(1).nullable)
-      assert(schema(1).dataType.asInstanceOf[StructType](0).nullable)
+      assert(schema(1).dataType.asInstanceOf[StructType].head.nullable)
       assert(schema(1).dataType.asInstanceOf[StructType](1).nullable === false)
     }
 
@@ -528,9 +528,9 @@ class ExpressionEncoderSuite extends CodegenInterpretedPlanTest with AnalysisTes
       val schema = ExpressionEncoder.tuple(
         ExpressionEncoder[Int](),
         ExpressionEncoder[(String, Int)]()).schema
-      assert(schema(0).nullable === false)
+      assert(schema.head.nullable === false)
       assert(schema(1).nullable)
-      assert(schema(1).dataType.asInstanceOf[StructType](0).nullable)
+      assert(schema(1).dataType.asInstanceOf[StructType].head.nullable)
       assert(schema(1).dataType.asInstanceOf[StructType](1).nullable === false)
     }
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/RowEncoderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/RowEncoderSuite.scala
@@ -329,7 +329,7 @@ class RowEncoderSuite extends CodegenInterpretedPlanTest {
     val pythonUDT = new PythonUserDefinedType(udtSQLType, "pyUDT", "serializedPyClass")
     val schema = new StructType().add("pythonUDT", pythonUDT, true)
     val encoder = ExpressionEncoder(schema)
-    assert(encoder.serializer(0).dataType == pythonUDT.sqlType)
+    assert(encoder.serializer.head.dataType == pythonUDT.sqlType)
   }
 
   test("encoding/decoding TimestampType to/from java.time.Instant") {
@@ -442,7 +442,7 @@ class RowEncoderSuite extends CodegenInterpretedPlanTest {
               fail(
                 s"""
                    |schema: ${schema.simpleString}
-                   |input: ${input}
+                   |input: $input
                  """.stripMargin, e)
           }
         }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/AttributeResolutionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/AttributeResolutionSuite.scala
@@ -33,7 +33,7 @@ class AttributeResolutionSuite extends SparkFunSuite {
     // Try to match attribute reference with name "a" with qualifier "ns1.ns2.t1".
     Seq(Seq("t1", "a"), Seq("ns2", "t1", "a"), Seq("ns1", "ns2", "t1", "a")).foreach { nameParts =>
       attrs.resolve(nameParts, resolver) match {
-        case Some(attr) => assert(attr.semanticEquals(attrs(0)))
+        case Some(attr) => assert(attr.semanticEquals(attrs.head))
         case _ => fail()
       }
     }
@@ -51,7 +51,7 @@ class AttributeResolutionSuite extends SparkFunSuite {
       Seq("t"), Seq("t", "t"), Seq("ns2", "t", "t"), Seq("ns1", "ns2", "t", "t")
     ).foreach { nameParts =>
       attrs.resolve(nameParts, resolver) match {
-        case Some(attr) => assert(attr.semanticEquals(attrs(0)))
+        case Some(attr) => assert(attr.semanticEquals(attrs.head))
         case _ => fail()
       }
     }
@@ -115,7 +115,7 @@ class AttributeResolutionSuite extends SparkFunSuite {
   test("attribute resolution with case insensitive resolver") {
     val attrs = Seq(AttributeReference("a", IntegerType)(qualifier = Seq("ns1", "t")))
     attrs.resolve(Seq("Ns1", "T", "A"), caseInsensitiveResolution) match {
-      case Some(attr) => assert(attr.semanticEquals(attrs(0)) && attr.name == "A")
+      case Some(attr) => assert(attr.semanticEquals(attrs.head) && attr.name == "A")
       case _ => fail()
     }
   }
@@ -125,7 +125,7 @@ class AttributeResolutionSuite extends SparkFunSuite {
     assert(attrs.resolve(Seq("Ns1", "T", "A"), caseSensitiveResolution).isEmpty)
     assert(attrs.resolve(Seq("ns1", "t", "A"), caseSensitiveResolution).isEmpty)
     attrs.resolve(Seq("ns1", "t", "a"), caseSensitiveResolution) match {
-      case Some(attr) => assert(attr.semanticEquals(attrs(0)))
+      case Some(attr) => assert(attr.semanticEquals(attrs.head))
       case _ => fail()
     }
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
@@ -639,7 +639,7 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
     val toInner = new StructType(
       (1 to N).map(i => StructField(s"i$i", IntegerType)).toArray)
     val inputInner = Row.fromSeq((1 to N).map(i => i + 0.5))
-    val outputInner = Row.fromSeq((1 to N))
+    val outputInner = Row.fromSeq(1 to N)
     val fromOuter = new StructType(
       (1 to N).map(i => StructField(s"s$i", fromInner)).toArray)
     val toOuter = new StructType(
@@ -653,7 +653,7 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
     val ctx = new CodegenContext
     cast("1", IntegerType).genCode(ctx)
     cast("2", LongType).genCode(ctx)
-    assert(ctx.inlinedMutableStates.length == 0)
+    assert(ctx.inlinedMutableStates.isEmpty)
   }
 
   test("up-cast") {
@@ -1213,8 +1213,8 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
       }
     }
 
-    Seq(("1", DayTimeIntervalType(DAY, DAY), (86400) * MICROS_PER_SECOND),
-      ("-1", DayTimeIntervalType(DAY, DAY), -(86400) * MICROS_PER_SECOND),
+    Seq(("1", DayTimeIntervalType(DAY, DAY), 86400 * MICROS_PER_SECOND),
+      ("-1", DayTimeIntervalType(DAY, DAY), -86400 * MICROS_PER_SECOND),
       ("1 01", DayTimeIntervalType(DAY, HOUR), (86400 + 3600) * MICROS_PER_SECOND),
       ("-1 01", DayTimeIntervalType(DAY, HOUR), -(86400 + 3600) * MICROS_PER_SECOND),
       ("1 01:01", DayTimeIntervalType(DAY, MINUTE), (86400 + 3600 + 60) * MICROS_PER_SECOND),
@@ -1224,8 +1224,8 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
       ("-1 01:01:01.12345", DayTimeIntervalType(DAY, SECOND),
         (-(86400 + 3600 + 60 + 1.12345) * MICROS_PER_SECOND).toLong),
 
-      ("01", DayTimeIntervalType(HOUR, HOUR), (3600) * MICROS_PER_SECOND),
-      ("-01", DayTimeIntervalType(HOUR, HOUR), -(3600) * MICROS_PER_SECOND),
+      ("01", DayTimeIntervalType(HOUR, HOUR), 3600 * MICROS_PER_SECOND),
+      ("-01", DayTimeIntervalType(HOUR, HOUR), -3600 * MICROS_PER_SECOND),
       ("01:01", DayTimeIntervalType(HOUR, MINUTE), (3600 + 60) * MICROS_PER_SECOND),
       ("-01:01", DayTimeIntervalType(HOUR, MINUTE), -(3600 + 60) * MICROS_PER_SECOND),
       ("01:01:01.12345", DayTimeIntervalType(HOUR, SECOND),
@@ -1233,16 +1233,16 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
       ("-01:01:01.12345", DayTimeIntervalType(HOUR, SECOND),
         (-(3600 + 60 + 1.12345) * MICROS_PER_SECOND).toLong),
 
-      ("01", DayTimeIntervalType(MINUTE, MINUTE), (60) * MICROS_PER_SECOND),
-      ("-01", DayTimeIntervalType(MINUTE, MINUTE), -(60) * MICROS_PER_SECOND),
-      ("01:01", DayTimeIntervalType(MINUTE, SECOND), ((60 + 1) * MICROS_PER_SECOND)),
+      ("01", DayTimeIntervalType(MINUTE, MINUTE), 60 * MICROS_PER_SECOND),
+      ("-01", DayTimeIntervalType(MINUTE, MINUTE), -60 * MICROS_PER_SECOND),
+      ("01:01", DayTimeIntervalType(MINUTE, SECOND), (60 + 1) * MICROS_PER_SECOND),
       ("01:01.12345", DayTimeIntervalType(MINUTE, SECOND),
         ((60 + 1.12345) * MICROS_PER_SECOND).toLong),
       ("-01:01.12345", DayTimeIntervalType(MINUTE, SECOND),
         (-(60 + 1.12345) * MICROS_PER_SECOND).toLong),
 
-      ("01.12345", DayTimeIntervalType(SECOND, SECOND), ((1.12345) * MICROS_PER_SECOND).toLong),
-      ("-01.12345", DayTimeIntervalType(SECOND, SECOND), (-(1.12345) * MICROS_PER_SECOND).toLong))
+      ("01.12345", DayTimeIntervalType(SECOND, SECOND), (1.12345 * MICROS_PER_SECOND).toLong),
+      ("-01.12345", DayTimeIntervalType(SECOND, SECOND), (-1.12345 * MICROS_PER_SECOND).toLong))
       .foreach { case (str, dataType, dt) =>
         checkEvaluation(cast(Literal.create(str), dataType), dt)
         checkEvaluation(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
@@ -695,28 +695,28 @@ class CollectionExpressionsSuite
       Literal.create(Seq(Array[Byte](1.toByte, 5.toByte)), ArrayType(BinaryType))
     )
 
-    checkEvaluation(ArraysZip(Seq(literals(0), literals(1))),
+    checkEvaluation(ArraysZip(Seq(literals.head, literals(1))),
       List(Row(9001, null), Row(9002, 1L), Row(9003, null), Row(null, 4L), Row(null, 11L)))
 
-    checkEvaluation(ArraysZip(Seq(literals(0), literals(2))),
+    checkEvaluation(ArraysZip(Seq(literals.head, literals(2))),
       List(Row(9001, -1), Row(9002, -3), Row(9003, 900), Row(null, null)))
 
-    checkEvaluation(ArraysZip(Seq(literals(0), literals(3))),
+    checkEvaluation(ArraysZip(Seq(literals.head, literals(3))),
       List(Row(9001, "a"), Row(9002, null), Row(9003, "c"), Row(null, null)))
 
-    checkEvaluation(ArraysZip(Seq(literals(0), literals(4))),
+    checkEvaluation(ArraysZip(Seq(literals.head, literals(4))),
       List(Row(9001, null), Row(9002, false), Row(9003, true), Row(null, null)))
 
-    checkEvaluation(ArraysZip(Seq(literals(0), literals(5))),
+    checkEvaluation(ArraysZip(Seq(literals.head, literals(5))),
       List(Row(9001, 1.1), Row(9002, null), Row(9003, 1.3), Row(null, null)))
 
-    checkEvaluation(ArraysZip(Seq(literals(0), literals(6))),
+    checkEvaluation(ArraysZip(Seq(literals.head, literals(6))),
       List(Row(9001, null), Row(9002, null), Row(9003, null), Row(null, null)))
 
-    checkEvaluation(ArraysZip(Seq(literals(0), literals(7))),
+    checkEvaluation(ArraysZip(Seq(literals.head, literals(7))),
       List(Row(9001, null), Row(9002, null), Row(9003, null), Row(null, null)))
 
-    checkEvaluation(ArraysZip(Seq(literals(0), literals(1), literals(2), literals(3))),
+    checkEvaluation(ArraysZip(Seq(literals.head, literals(1), literals(2), literals(3))),
       List(
         Row(9001, null, -1, "a"),
         Row(9002, 1L, -3, null),
@@ -731,7 +731,7 @@ class CollectionExpressionsSuite
         Row(true, 1.3, null, null, null),
         Row(null, null, null, null, null)))
 
-    checkEvaluation(ArraysZip(Seq(literals(9), literals(0))),
+    checkEvaluation(ArraysZip(Seq(literals(9), literals.head)),
       List(
         Row(List(1, 2, 3), 9001),
         Row(null, 9002),
@@ -744,7 +744,7 @@ class CollectionExpressionsSuite
     val longLiteral =
       Literal.create((0 to 1000).toSeq, ArrayType(IntegerType))
 
-    checkEvaluation(ArraysZip(Seq(literals(0), longLiteral)),
+    checkEvaluation(ArraysZip(Seq(literals.head, longLiteral)),
       List(Row(9001, 0), Row(9002, 1), Row(9003, 2)) ++
       (3 to 1000).map { Row(null, _) }.toList)
 
@@ -757,10 +757,11 @@ class CollectionExpressionsSuite
       Row(Seq(9002) ++ (0 to 1000).map { _ => null }.toSeq: _*),
       Row(Seq(9003) ++ (0 to 1000).map { _ => null }.toSeq: _*),
       Row(Seq(null) ++ (0 to 1000).map { _ => null }.toSeq: _*))
-    checkEvaluation(ArraysZip(Seq(literals(0)) ++ manyLiterals),
-      List(numbers(0), numbers(1), numbers(2), numbers(3)))
+    checkEvaluation(ArraysZip(Seq(literals.head) ++ manyLiterals),
+      List(numbers.head, numbers(1), numbers(2), numbers(3)))
 
-    checkEvaluation(ArraysZip(Seq(literals(0), Literal.create(null, ArrayType(IntegerType)))), null)
+    checkEvaluation(
+      ArraysZip(Seq(literals.head, Literal.create(null, ArrayType(IntegerType)))), null)
     checkEvaluation(ArraysZip(Seq()), List())
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ConditionalExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ConditionalExpressionSuite.scala
@@ -37,7 +37,7 @@ class ConditionalExpressionSuite extends SparkFunSuite with ExpressionEvalHelper
     )
 
     // dataType must match T.
-    def testIf(convert: (Integer => Any), dataType: DataType): Unit = {
+    def testIf(convert: Integer => Any, dataType: DataType): Unit = {
       for ((predicate, trueValue, falseValue, expected) <- testcases) {
         val trueValueConverted = if (trueValue == null) null else convert(trueValue)
         val falseValueConverted = if (falseValue == null) null else convert(falseValue)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ExpressionSetSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ExpressionSetSuite.scala
@@ -189,11 +189,11 @@ class ExpressionSetSuite extends SparkFunSuite {
 
     assert((initialSet + (aUpper + 1)).size == 1)
     assert((initialSet + (aUpper + 2)).size == 2)
-    assert((initialSet - (aUpper + 1)).size == 0)
+    assert((initialSet - (aUpper + 1)).isEmpty)
     assert((initialSet - (aUpper + 2)).size == 1)
 
     assert((initialSet + (aLower + 1)).size == 1)
-    assert((initialSet - (aLower + 1)).size == 0)
+    assert((initialSet - (aLower + 1)).isEmpty)
 
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/JsonExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/JsonExpressionsSuite.scala
@@ -257,7 +257,7 @@ class JsonExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper with 
   test("some big value") {
     val value = "x" * 3000
     checkEvaluation(
-      GetJsonObject(NonFoldableLiteral((s"""{"big": "$value"}""")),
+      GetJsonObject(NonFoldableLiteral(s"""{"big": "$value"}"""),
       NonFoldableLiteral("$.big")), value)
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ObjectExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ObjectExpressionsSuite.scala
@@ -486,8 +486,9 @@ class ObjectExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
         val row = RandomDataGenerator.randomRow(random, schema)
         val toRow = ExpressionEncoder(schema).createSerializer()
         val internalRow = toRow(row)
-        val lambda = LambdaVariable("dummy", schema(0).dataType, schema(0).nullable, id = 0)
-        checkEvaluationWithoutCodegen(lambda, internalRow.get(0, schema(0).dataType), internalRow)
+        val lambda = LambdaVariable("dummy", schema.head.dataType, schema.head.nullable, id = 0)
+        checkEvaluationWithoutCodegen(
+          lambda, internalRow.get(0, schema.head.dataType), internalRow)
       }
     }
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/PredicateSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/PredicateSuite.scala
@@ -197,16 +197,16 @@ class PredicateSuite extends SparkFunSuite with ExpressionEvalHelper {
         }
       }
       val input = inputData.map(NonFoldableLiteral.create(_, dataType))
-      val expected = if (inputData(0) == null) {
+      val expected = if (inputData.head == null) {
         null
-      } else if (inputData.slice(1, 10).contains(inputData(0))) {
+      } else if (inputData.slice(1, 10).contains(inputData.head)) {
         true
       } else if (inputData.slice(1, 10).contains(null)) {
         null
       } else {
         false
       }
-      checkInAndInSet(In(input(0), input.slice(1, 10)), expected)
+      checkInAndInSet(In(input.head, input.slice(1, 10)), expected)
     }
 
     val atomicTypes = DataTypeTestUtils.atomicTypes.filter { t =>

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/RegexpExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/RegexpExpressionsSuite.scala
@@ -223,7 +223,7 @@ class RegexpExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
       checkLiteralRow(s"""$escapeChar$escapeChar${escapeChar}__""" like(_, escapeChar),
         s"""%$escapeChar$escapeChar%$escapeChar%""", false)
       checkLiteralRow(s"""_$escapeChar$escapeChar$escapeChar%""" like(_, escapeChar),
-        s"""%$escapeChar${escapeChar}""", false)
+        s"""%$escapeChar$escapeChar""", false)
 
       // unicode
       // scalastyle:off nonascii
@@ -352,7 +352,7 @@ class RegexpExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     RegExpReplace(Literal("100"), Literal("(\\d+)"), Literal("num")).genCode(ctx)
     // four global variables (lastRegex, pattern, lastReplacement, and lastReplacementInUTF8)
     // are always required, which are allocated in type-based global array
-    assert(ctx.inlinedMutableStates.length == 0)
+    assert(ctx.inlinedMutableStates.isEmpty)
     assert(ctx.mutableStateInitCode.length == 4)
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/StringExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/StringExpressionsSuite.scala
@@ -127,7 +127,7 @@ class StringExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     val strings2 = (1 to N).map(x => Seq(s"s$x"))
     val inputsExpr2 = strings2.map(Literal.create(_, ArrayType(StringType)))
     checkEvaluation(
-      ConcatWs(sepExpr +: inputsExpr2), strings2.map(s => s(0)).mkString("#"))
+      ConcatWs(sepExpr +: inputsExpr2), strings2.map(s => s.head).mkString("#"))
   }
 
   test("elt") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/SubexpressionEliminationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/SubexpressionEliminationSuite.scala
@@ -147,7 +147,7 @@ class SubexpressionEliminationSuite extends SparkFunSuite with ExpressionEvalHel
     val equivalence = new EquivalentExpressions
     equivalence.addExprTree(add)
     // the `two` inside `fallback` should not be added
-    assert(equivalence.getAllExprStates(1).size == 0)
+    assert(equivalence.getAllExprStates(1).isEmpty)
     assert(equivalence.getAllExprStates().count(_.useCount == 1) == 3) // add, two, explode
   }
 
@@ -296,7 +296,7 @@ class SubexpressionEliminationSuite extends SparkFunSuite with ExpressionEvalHel
           }
 
           public void initialize(int partitionIndex) {
-            ${subExprsCode}
+            $subExprsCode
           }
 
           ${ctx.declareAddedFunctions()}
@@ -490,7 +490,7 @@ class SubexpressionEliminationSuite extends SparkFunSuite with ExpressionEvalHel
     checkShortcut(Not(And(Literal(true), equal)), 0)
 
     // always eliminate subexpression for left child
-    checkShortcut((And(equal, Literal(false))), 1)
+    checkShortcut(And(equal, Literal(false)), 1)
     checkShortcut(Or(equal, Literal(true)), 1)
     checkShortcut(Not(And(equal, Literal(false))), 1)
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/UnsafeRowConverterSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/UnsafeRowConverterSuite.scala
@@ -116,13 +116,13 @@ class UnsafeRowConverterSuite extends SparkFunSuite with Matchers with PlanTestB
     assert(DateTimeUtils.toJavaDate(unsafeRow.getInt(2)) === Date.valueOf("1970-01-01"))
     // Timestamp is represented as Long in unsafeRow
     DateTimeUtils.toJavaTimestamp(unsafeRow.getLong(3)) should be
-    (Timestamp.valueOf("2015-05-08 08:10:25"))
+    Timestamp.valueOf("2015-05-08 08:10:25")
 
     unsafeRow.setInt(2, DateTimeUtils.fromJavaDate(Date.valueOf("2015-06-22")))
     assert(DateTimeUtils.toJavaDate(unsafeRow.getInt(2)) === Date.valueOf("2015-06-22"))
     unsafeRow.setLong(3, DateTimeUtils.fromJavaTimestamp(Timestamp.valueOf("2015-06-22 08:10:25")))
     DateTimeUtils.toJavaTimestamp(unsafeRow.getLong(3)) should be
-    (Timestamp.valueOf("2015-06-22 08:10:25"))
+    Timestamp.valueOf("2015-06-22 08:10:25")
   }
 
   testBothCodegenAndInterpreted(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/aggregate/HistogramNumericSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/aggregate/HistogramNumericSuite.scala
@@ -149,7 +149,7 @@ class HistogramNumericSuite extends SparkFunSuite with SQLHelper {
     } {
       // We expect each relation under test to have exactly one output attribute.
       assert(relation.output.length == 1)
-      val relationAttributeType = relation.output(0).dataType
+      val relationAttributeType = relation.output.head.dataType
       val agg = new HistogramNumeric(UnresolvedAttribute("a"), nBins)
       val analyzed = relation.select(agg).analyze.expressions.head
       analyzed match {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeBlockSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeBlockSuite.scala
@@ -169,7 +169,7 @@ class CodeBlockSuite extends SparkFunSuite {
 
     val aliasedParam = JavaCode.variable("aliased", expr.javaType)
 
-    val block = code"${subBlocks(0)}\n${subBlocks(1)}\n${subBlocks(2)}"
+    val block = code"${subBlocks.head}\n${subBlocks(1)}\n${subBlocks(2)}"
     val transformedBlock = block.transform {
       case b: Block => b.transformExprValues {
         case SimpleExprValue("1 + 1", java.lang.Integer.TYPE) => aliasedParam
@@ -203,7 +203,7 @@ class CodeBlockSuite extends SparkFunSuite {
       }
     }.toSet
 
-    assert(transformedBlock.children(0).toString == expected1.toString)
+    assert(transformedBlock.children.head.toString == expected1.toString)
     assert(transformedBlock.children(1).toString == expected2.toString)
     assert(transformedBlock.children(2).toString == expected3.toString)
     assert(transformedBlock.toString == (expected1 + expected2 + expected3).toString)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/CollapseWindowSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/CollapseWindowSuite.scala
@@ -32,7 +32,7 @@ class CollapseWindowSuite extends PlanTest {
   }
 
   val testRelation = LocalRelation($"a".double, $"b".double, $"c".string)
-  val a = testRelation.output(0)
+  val a = testRelation.output.head
   val b = testRelation.output(1)
   val c = testRelation.output(2)
   val partitionSpec1 = Seq(c)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ColumnPruningSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ColumnPruningSuite.scala
@@ -130,7 +130,7 @@ class ColumnPruningSuite extends PlanTest {
         val aliases = NestedColumnAliasingSuite.collectGeneratedAliases(optimized).toSeq
 
         val selectedFields = UnresolvedAttribute("a") +: aliasedExprs(aliases)
-        val finalSelectedExprs = Seq(UnresolvedAttribute("a"), $"${aliases(0)}".as("c.d")) ++
+        val finalSelectedExprs = Seq(UnresolvedAttribute("a"), $"${aliases.head}".as("c.d")) ++
           generatorOutputs
 
         val correctAnswer =
@@ -149,14 +149,14 @@ class ColumnPruningSuite extends PlanTest {
     runTest(
       Explode($"c".getField("e")),
       aliases => Explode($"${aliases(1)}".as("c.e")),
-      aliases => Seq($"c".getField("d").as(aliases(0)), $"c".getField("e").as(aliases(1))),
+      aliases => Seq($"c".getField("d").as(aliases.head), $"c".getField("e").as(aliases(1))),
       Seq(2),
       Seq("explode")
     )
     runTest(Stack(2 :: $"c".getField("f") :: $"c".getField("g") :: Nil),
       aliases => Stack(2 :: $"${aliases(1)}".as("c.f") :: $"${aliases(2)}".as("c.g") :: Nil),
       aliases => Seq(
-        $"c".getField("d").as(aliases(0)),
+        $"c".getField("d").as(aliases.head),
         $"c".getField("f").as(aliases(1)),
         $"c".getField("g").as(aliases(2))),
       Seq(2, 3),
@@ -165,14 +165,14 @@ class ColumnPruningSuite extends PlanTest {
     runTest(
       PosExplode($"c".getField("e")),
       aliases => PosExplode($"${aliases(1)}".as("c.e")),
-      aliases => Seq($"c".getField("d").as(aliases(0)), $"c".getField("e").as(aliases(1))),
+      aliases => Seq($"c".getField("d").as(aliases.head), $"c".getField("e").as(aliases(1))),
       Seq(2),
       Seq("pos", "explode")
     )
     runTest(
       Inline($"c".getField("h")),
       aliases => Inline($"${aliases(1)}".as("c.h")),
-      aliases => Seq($"c".getField("d").as(aliases(0)), $"c".getField("h").as(aliases(1))),
+      aliases => Seq($"c".getField("d").as(aliases.head), $"c".getField("h").as(aliases(1))),
       Seq(2),
       Seq("h1", "h2")
     )

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ComputeCurrentTimeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ComputeCurrentTimeSuite.scala
@@ -136,7 +136,7 @@ class ComputeCurrentTimeSuite extends PlanTest {
   }
 
   test("No duplicate literals") {
-    def checkLiterals(f: (String) => Expression, expected: Int): Unit = {
+    def checkLiterals(f: String => Expression, expected: Int): Unit = {
       val timestamps = ZoneId.SHORT_IDS.asScala.flatMap { case (zoneId, _) =>
         // Request each timestamp multiple times.
         (1 to 5).map { _ => Alias(f(zoneId), zoneId)() }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/EliminateMapObjectsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/EliminateMapObjectsSuite.scala
@@ -46,7 +46,7 @@ class EliminateMapObjectsSuite extends PlanTest {
     val intQuery = intInput.deserialize[Array[Int]].analyze
     val intOptimized = Optimize.execute(intQuery)
     val intExpected = DeserializeToObject(
-      Invoke(intInput.output(0), "toIntArray", intObjType, Nil, Nil, true, false),
+      Invoke(intInput.output.head, "toIntArray", intObjType, Nil, Nil, true, false),
       AttributeReference("obj", intObjType, true)(), intInput)
     comparePlans(intOptimized, intExpected)
 
@@ -55,7 +55,7 @@ class EliminateMapObjectsSuite extends PlanTest {
     val doubleQuery = doubleInput.deserialize[Array[Double]].analyze
     val doubleOptimized = Optimize.execute(doubleQuery)
     val doubleExpected = DeserializeToObject(
-      Invoke(doubleInput.output(0), "toDoubleArray", doubleObjType, Nil, Nil, true, false),
+      Invoke(doubleInput.output.head, "toDoubleArray", doubleObjType, Nil, Nil, true, false),
       AttributeReference("obj", doubleObjType, true)(), doubleInput)
     comparePlans(doubleOptimized, doubleExpected)
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/InferWindowGroupLimitSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/InferWindowGroupLimitSuite.scala
@@ -49,7 +49,7 @@ class InferWindowGroupLimitSuite extends PlanTest {
   private val testRelation = LocalRelation.fromExternalRows(
     Seq("a".attr.int, "b".attr.int, "c".attr.int),
     1.to(6).map(_ => Row(1, 2, 3)))
-  private val a = testRelation.output(0)
+  private val a = testRelation.output.head
   private val b = testRelation.output(1)
   private val c = testRelation.output(2)
   private val rankLikeFunctions = Seq(RowNumber(), Rank(c :: Nil), DenseRank(c :: Nil))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LikeSimplificationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LikeSimplificationSuite.scala
@@ -168,8 +168,8 @@ class LikeSimplificationSuite extends PlanTest {
   test("simplify LikeAll") {
     val originalQuery =
       testRelation
-        .where(($"a" likeAll(
-    "abc%", "abc\\%", "%xyz", "abc\\%def", "abc%def", "%mn%", "%mn\\%", "", "abc")))
+        .where($"a" likeAll(
+    "abc%", "abc\\%", "%xyz", "abc\\%def", "abc%def", "%mn%", "%mn\\%", "", "abc"))
 
     val optimized = Optimize.execute(originalQuery.analyze)
     val correctAnswer = testRelation
@@ -185,8 +185,8 @@ class LikeSimplificationSuite extends PlanTest {
   test("simplify NotLikeAll") {
     val originalQuery =
       testRelation
-        .where(($"a" notLikeAll(
-          "abc%", "abc\\%", "%xyz", "abc\\%def", "abc%def", "%mn%", "%mn\\%", "", "abc")))
+        .where($"a" notLikeAll(
+          "abc%", "abc\\%", "%xyz", "abc\\%def", "abc%def", "%mn%", "%mn\\%", "", "abc"))
 
     val optimized = Optimize.execute(originalQuery.analyze)
     val correctAnswer = testRelation
@@ -202,15 +202,15 @@ class LikeSimplificationSuite extends PlanTest {
   test("simplify LikeAny") {
     val originalQuery =
       testRelation
-        .where(($"a" likeAny(
-          "abc%", "abc\\%", "%xyz", "abc\\%def", "abc%def", "%mn%", "%mn\\%", "", "abc")))
+        .where($"a" likeAny(
+          "abc%", "abc\\%", "%xyz", "abc\\%def", "abc%def", "%mn%", "%mn\\%", "", "abc"))
 
     val optimized = Optimize.execute(originalQuery.analyze)
     val correctAnswer = testRelation
-      .where(((StartsWith($"a", "abc") || EndsWith($"a", "xyz")) ||
+      .where((StartsWith($"a", "abc") || EndsWith($"a", "xyz")) ||
         (Length($"a") >= 6 && (StartsWith($"a", "abc") && EndsWith($"a", "def")) ||
           Contains($"a", "mn")) || (($"a" === "") || ($"a" === "abc")) ||
-        ($"a" likeAny("abc\\%", "abc\\%def", "%mn\\%"))))
+        ($"a" likeAny("abc\\%", "abc\\%def", "%mn\\%")))
       .analyze
 
     comparePlans(optimized, correctAnswer)
@@ -219,8 +219,8 @@ class LikeSimplificationSuite extends PlanTest {
   test("simplify NotLikeAny") {
     val originalQuery =
       testRelation
-        .where(($"a" notLikeAny(
-          "abc%", "abc\\%", "%xyz", "abc\\%def", "abc%def", "%mn%", "%mn\\%", "", "abc")))
+        .where($"a" notLikeAny(
+          "abc%", "abc\\%", "%xyz", "abc\\%def", "abc%def", "%mn%", "%mn\\%", "", "abc"))
 
     val optimized = Optimize.execute(originalQuery.analyze)
     val correctAnswer = testRelation
@@ -235,19 +235,19 @@ class LikeSimplificationSuite extends PlanTest {
 
   test("SPARK-39251: Simplify MultiLike if remainPatterns is empty") {
     comparePlans(
-      Optimize.execute(testRelation.where($"a" likeAll("abc%")).analyze),
+      Optimize.execute(testRelation.where($"a" likeAll "abc%").analyze),
       testRelation.where(StartsWith($"a", "abc")).analyze)
 
     comparePlans(
-      Optimize.execute(testRelation.where($"a" notLikeAll("abc%")).analyze),
+      Optimize.execute(testRelation.where($"a" notLikeAll "abc%").analyze),
       testRelation.where(Not(StartsWith($"a", "abc"))).analyze)
 
     comparePlans(
-      Optimize.execute(testRelation.where($"a" likeAny("abc%")).analyze),
+      Optimize.execute(testRelation.where($"a" likeAny "abc%").analyze),
       testRelation.where(StartsWith($"a", "abc")).analyze)
 
     comparePlans(
-      Optimize.execute(testRelation.where($"a" notLikeAny("abc%")).analyze),
+      Optimize.execute(testRelation.where($"a" notLikeAny "abc%").analyze),
       testRelation.where(Not(StartsWith($"a", "abc"))).analyze)
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LimitPushdownThroughWindowSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LimitPushdownThroughWindowSuite.scala
@@ -53,7 +53,7 @@ class LimitPushdownThroughWindowSuite extends PlanTest {
     Seq("a".attr.int, "b".attr.int, "c".attr.int),
     1.to(6).map(_ => Row(1, 2, 3)))
 
-  private val a = testRelation.output(0)
+  private val a = testRelation.output.head
   private val b = testRelation.output(1)
   private val c = testRelation.output(2)
   private val windowFrame = SpecifiedWindowFrame(RowFrame, UnboundedPreceding, CurrentRow)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/NormalizeFloatingPointNumbersSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/NormalizeFloatingPointNumbersSuite.scala
@@ -31,9 +31,9 @@ class NormalizeFloatingPointNumbersSuite extends PlanTest {
   }
 
   val testRelation1 = LocalRelation($"a".double)
-  val a = testRelation1.output(0)
+  val a = testRelation1.output.head
   val testRelation2 = LocalRelation($"a".double)
-  val b = testRelation2.output(0)
+  val b = testRelation2.output.head
 
   test("normalize floating points in window function expressions") {
     val query = testRelation1.window(Seq(sum(a).as("sum")), Seq(a), Seq(a.asc))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizeJsonExprsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizeJsonExprsSuite.scala
@@ -178,7 +178,7 @@ class OptimizeJsonExprsSuite extends PlanTest with ExpressionEvalHelper {
   test("SPARK-32958: prune unnecessary columns from GetArrayStructFields + from_json") {
     val options = Map.empty[String, String]
     val schema1 = ArrayType(StructType.fromDDL("a int, b int"), containsNull = true)
-    val field1 = schema1.elementType.asInstanceOf[StructType](0)
+    val field1 = schema1.elementType.asInstanceOf[StructType].head
 
     val query1 = testRelation2
       .select(GetArrayStructFields(
@@ -219,7 +219,7 @@ class OptimizeJsonExprsSuite extends PlanTest with ExpressionEvalHelper {
     comparePlans(optimized1, query1.analyze)
 
     val schema1 = ArrayType(StructType.fromDDL("a int, b int"), containsNull = true)
-    val field1 = schema1.elementType.asInstanceOf[StructType](0)
+    val field1 = schema1.elementType.asInstanceOf[StructType].head
 
     val query2 = testRelation2
       .select(GetArrayStructFields(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizeWindowFunctionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizeWindowFunctionsSuite.scala
@@ -32,7 +32,7 @@ class OptimizeWindowFunctionsSuite extends PlanTest {
   }
 
   val testRelation = LocalRelation($"a".double, $"b".double, $"c".string)
-  val a = testRelation.output(0)
+  val a = testRelation.output.head
   val b = testRelation.output(1)
   val c = testRelation.output(2)
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RemoveNoopUnionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RemoveNoopUnionSuite.scala
@@ -51,10 +51,10 @@ class RemoveNoopUnionSuite extends PlanTest {
   }
 
   test("SPARK-34474: Do not remove necessary Project 1") {
-    val child1 = Project(Seq(testRelation.output(0), testRelation.output(1),
-      (testRelation.output(0) + 1).as("expr")), testRelation)
-    val child2 = Project(Seq(testRelation.output(0), testRelation.output(1),
-      (testRelation.output(0) + 2).as("expr")), testRelation)
+    val child1 = Project(Seq(testRelation.output.head, testRelation.output(1),
+      (testRelation.output.head + 1).as("expr")), testRelation)
+    val child2 = Project(Seq(testRelation.output.head, testRelation.output(1),
+      (testRelation.output.head + 2).as("expr")), testRelation)
     val union = Union(child1 :: child2 :: Nil)
     val distinct = Distinct(union)
     val optimized = Optimize.execute(distinct)
@@ -62,8 +62,8 @@ class RemoveNoopUnionSuite extends PlanTest {
   }
 
   test("SPARK-34474: Do not remove necessary Project 2") {
-    val child1 = Project(Seq(testRelation.output(0), testRelation.output(1)), testRelation)
-    val child2 = Project(Seq(testRelation.output(1), testRelation.output(0)), testRelation)
+    val child1 = Project(Seq(testRelation.output.head, testRelation.output(1)), testRelation)
+    val child2 = Project(Seq(testRelation.output(1), testRelation.output.head), testRelation)
     val union = Union(child1 :: child2 :: Nil)
     val distinct = Distinct(union)
     val optimized = Optimize.execute(distinct)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ReplaceOperatorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ReplaceOperatorSuite.scala
@@ -196,7 +196,7 @@ class ReplaceOperatorSuite extends PlanTest {
 
   test("replace batch Deduplicate with Aggregate") {
     val input = LocalRelation($"a".int, $"b".int)
-    val attrA = input.output(0)
+    val attrA = input.output.head
     val attrB = input.output(1)
     val query = Deduplicate(Seq(attrA), input) // dropDuplicates("a")
     val optimized = Optimize.execute(query.analyze)
@@ -223,7 +223,7 @@ class ReplaceOperatorSuite extends PlanTest {
 
   test("don't replace streaming Deduplicate") {
     val input = LocalRelation(Seq($"a".int, $"b".int), isStreaming = true)
-    val attrA = input.output(0)
+    val attrA = input.output.head
     val query = Deduplicate(Seq(attrA), input) // dropDuplicates("a")
     val optimized = Optimize.execute(query.analyze)
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteAsOfJoinSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteAsOfJoinSuite.scala
@@ -29,14 +29,14 @@ class RewriteAsOfJoinSuite extends PlanTest {
   test("simple") {
     val left = LocalRelation($"a".int, $"b".int, $"c".int)
     val right = LocalRelation($"a".int, $"b".int, $"d".int)
-    val query = AsOfJoin(left, right, left.output(0), right.output(0), None, Inner,
+    val query = AsOfJoin(left, right, left.output.head, right.output.head, None, Inner,
       tolerance = None, allowExactMatches = true, direction = AsOfJoinDirection("backward"))
 
     val rewritten = RewriteAsOfJoin(query.analyze)
 
-    val filter = OuterReference(left.output(0)) >= right.output(0)
+    val filter = OuterReference(left.output.head) >= right.output.head
     val rightStruct = CreateStruct(right.output)
-    val orderExpression = OuterReference(left.output(0)) - right.output(0)
+    val orderExpression = OuterReference(left.output.head) - right.output.head
     val nearestRight = MinBy(rightStruct, orderExpression)
       .toAggregateExpression().as("__nearest_right__")
 
@@ -57,16 +57,16 @@ class RewriteAsOfJoinSuite extends PlanTest {
   test("condition") {
     val left = LocalRelation($"a".int, $"b".int, $"c".int)
     val right = LocalRelation($"a".int, $"b".int, $"d".int)
-    val query = AsOfJoin(left, right, left.output(0), right.output(0),
+    val query = AsOfJoin(left, right, left.output.head, right.output.head,
       Some(left.output(1) === right.output(1)), Inner,
       tolerance = None, allowExactMatches = true, direction = AsOfJoinDirection("backward"))
 
     val rewritten = RewriteAsOfJoin(query.analyze)
 
     val filter = OuterReference(left.output(1)) === right.output(1) &&
-      OuterReference(left.output(0)) >= right.output(0)
+      OuterReference(left.output.head) >= right.output.head
     val rightStruct = CreateStruct(right.output)
-    val orderExpression = OuterReference(left.output(0)) - right.output(0)
+    val orderExpression = OuterReference(left.output.head) - right.output.head
     val nearestRight = MinBy(rightStruct, orderExpression)
       .toAggregateExpression().as("__nearest_right__")
 
@@ -87,14 +87,14 @@ class RewriteAsOfJoinSuite extends PlanTest {
   test("left outer") {
     val left = LocalRelation($"a".int, $"b".int, $"c".int)
     val right = LocalRelation($"a".int, $"b".int, $"d".int)
-    val query = AsOfJoin(left, right, left.output(0), right.output(0), None, Inner,
+    val query = AsOfJoin(left, right, left.output.head, right.output.head, None, Inner,
       tolerance = None, allowExactMatches = true, direction = AsOfJoinDirection("backward"))
 
     val rewritten = RewriteAsOfJoin(query.analyze)
 
-    val filter = OuterReference(left.output(0)) >= right.output(0)
+    val filter = OuterReference(left.output.head) >= right.output.head
     val rightStruct = CreateStruct(right.output)
-    val orderExpression = OuterReference(left.output(0)) - right.output(0)
+    val orderExpression = OuterReference(left.output.head) - right.output.head
     val nearestRight = MinBy(rightStruct, orderExpression)
       .toAggregateExpression().as("__nearest_right__")
 
@@ -115,15 +115,15 @@ class RewriteAsOfJoinSuite extends PlanTest {
   test("tolerance") {
     val left = LocalRelation($"a".int, $"b".int, $"c".int)
     val right = LocalRelation($"a".int, $"b".int, $"d".int)
-    val query = AsOfJoin(left, right, left.output(0), right.output(0), None, Inner,
+    val query = AsOfJoin(left, right, left.output.head, right.output.head, None, Inner,
       tolerance = Some(1), allowExactMatches = true, direction = AsOfJoinDirection("backward"))
 
     val rewritten = RewriteAsOfJoin(query.analyze)
 
-    val filter = OuterReference(left.output(0)) >= right.output(0) &&
-      right.output(0) >= OuterReference(left.output(0)) - 1
+    val filter = OuterReference(left.output.head) >= right.output.head &&
+      right.output.head >= OuterReference(left.output.head) - 1
     val rightStruct = CreateStruct(right.output)
-    val orderExpression = OuterReference(left.output(0)) - right.output(0)
+    val orderExpression = OuterReference(left.output.head) - right.output.head
     val nearestRight = MinBy(rightStruct, orderExpression)
       .toAggregateExpression().as("__nearest_right__")
 
@@ -144,14 +144,14 @@ class RewriteAsOfJoinSuite extends PlanTest {
   test("allowExactMatches = false") {
     val left = LocalRelation($"a".int, $"b".int, $"c".int)
     val right = LocalRelation($"a".int, $"b".int, $"d".int)
-    val query = AsOfJoin(left, right, left.output(0), right.output(0), None, LeftOuter,
+    val query = AsOfJoin(left, right, left.output.head, right.output.head, None, LeftOuter,
       tolerance = None, allowExactMatches = false, direction = AsOfJoinDirection("backward"))
 
     val rewritten = RewriteAsOfJoin(query.analyze)
 
-    val filter = OuterReference(left.output(0)) > right.output(0)
+    val filter = OuterReference(left.output.head) > right.output.head
     val rightStruct = CreateStruct(right.output)
-    val orderExpression = OuterReference(left.output(0)) - right.output(0)
+    val orderExpression = OuterReference(left.output.head) - right.output.head
     val nearestRight = MinBy(rightStruct, orderExpression)
       .toAggregateExpression().as("__nearest_right__")
 
@@ -171,15 +171,15 @@ class RewriteAsOfJoinSuite extends PlanTest {
   test("tolerance & allowExactMatches = false") {
     val left = LocalRelation($"a".int, $"b".int, $"c".int)
     val right = LocalRelation($"a".int, $"b".int, $"d".int)
-    val query = AsOfJoin(left, right, left.output(0), right.output(0), None, Inner,
+    val query = AsOfJoin(left, right, left.output.head, right.output.head, None, Inner,
       tolerance = Some(1), allowExactMatches = false, direction = AsOfJoinDirection("backward"))
 
     val rewritten = RewriteAsOfJoin(query.analyze)
 
-    val filter = OuterReference(left.output(0)) > right.output(0) &&
-      right.output(0) > OuterReference(left.output(0)) - 1
+    val filter = OuterReference(left.output.head) > right.output.head &&
+      right.output.head > OuterReference(left.output.head) - 1
     val rightStruct = CreateStruct(right.output)
-    val orderExpression = OuterReference(left.output(0)) - right.output(0)
+    val orderExpression = OuterReference(left.output.head) - right.output.head
     val nearestRight = MinBy(rightStruct, orderExpression)
       .toAggregateExpression().as("__nearest_right__")
 
@@ -200,14 +200,14 @@ class RewriteAsOfJoinSuite extends PlanTest {
   test("direction = forward") {
     val left = LocalRelation($"a".int, $"b".int, $"c".int)
     val right = LocalRelation($"a".int, $"b".int, $"d".int)
-    val query = AsOfJoin(left, right, left.output(0), right.output(0), None, Inner,
+    val query = AsOfJoin(left, right, left.output.head, right.output.head, None, Inner,
       tolerance = None, allowExactMatches = true, direction = AsOfJoinDirection("forward"))
 
     val rewritten = RewriteAsOfJoin(query.analyze)
 
-    val filter = OuterReference(left.output(0)) <= right.output(0)
+    val filter = OuterReference(left.output.head) <= right.output.head
     val rightStruct = CreateStruct(right.output)
-    val orderExpression = right.output(0) - OuterReference(left.output(0))
+    val orderExpression = right.output.head - OuterReference(left.output.head)
     val nearestRight = MinBy(rightStruct, orderExpression)
       .toAggregateExpression().as("__nearest_right__")
 
@@ -228,16 +228,16 @@ class RewriteAsOfJoinSuite extends PlanTest {
   test("direction = nearest") {
     val left = LocalRelation($"a".int, $"b".int, $"c".int)
     val right = LocalRelation($"a".int, $"b".int, $"d".int)
-    val query = AsOfJoin(left, right, left.output(0), right.output(0), None, Inner,
+    val query = AsOfJoin(left, right, left.output.head, right.output.head, None, Inner,
       tolerance = None, allowExactMatches = true, direction = AsOfJoinDirection("nearest"))
 
     val rewritten = RewriteAsOfJoin(query.analyze)
 
     val filter = true
     val rightStruct = CreateStruct(right.output)
-    val orderExpression = If(OuterReference(left.output(0)) > right.output(0),
-      OuterReference(left.output(0)) - right.output(0),
-      right.output(0) - OuterReference(left.output(0)))
+    val orderExpression = If(OuterReference(left.output.head) > right.output.head,
+      OuterReference(left.output.head) - right.output.head,
+      right.output.head - OuterReference(left.output.head))
     val nearestRight = MinBy(rightStruct, orderExpression)
       .toAggregateExpression().as("__nearest_right__")
 
@@ -258,18 +258,18 @@ class RewriteAsOfJoinSuite extends PlanTest {
   test("tolerance & allowExactMatches = false & direction = nearest") {
     val left = LocalRelation($"a".int, $"b".int, $"c".int)
     val right = LocalRelation($"a".int, $"b".int, $"d".int)
-    val query = AsOfJoin(left, right, left.output(0), right.output(0), None, Inner,
+    val query = AsOfJoin(left, right, left.output.head, right.output.head, None, Inner,
       tolerance = Some(1), allowExactMatches = false, direction = AsOfJoinDirection("nearest"))
 
     val rewritten = RewriteAsOfJoin(query.analyze)
 
-    val filter = (!(OuterReference(left.output(0)) === right.output(0))) &&
-      ((right.output(0) > OuterReference(left.output(0)) - 1) &&
-        (right.output(0) < OuterReference(left.output(0)) + 1))
+    val filter = (!(OuterReference(left.output.head) === right.output.head)) &&
+      ((right.output.head > OuterReference(left.output.head) - 1) &&
+        (right.output.head < OuterReference(left.output.head) + 1))
     val rightStruct = CreateStruct(right.output)
-    val orderExpression = If(OuterReference(left.output(0)) > right.output(0),
-      OuterReference(left.output(0)) - right.output(0),
-      right.output(0) - OuterReference(left.output(0)))
+    val orderExpression = If(OuterReference(left.output.head) > right.output.head,
+      OuterReference(left.output.head) - right.output.head,
+      right.output.head - OuterReference(left.output.head))
     val nearestRight = MinBy(rightStruct, orderExpression)
       .toAggregateExpression().as("__nearest_right__")
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/TransposeWindowSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/TransposeWindowSuite.scala
@@ -33,7 +33,7 @@ class TransposeWindowSuite extends PlanTest {
 
   val testRelation = LocalRelation($"a".string, $"b".string, $"c".int, $"d".string)
 
-  val a = testRelation.output(0)
+  val a = testRelation.output.head
   val b = testRelation.output(1)
   val c = testRelation.output(2)
   val d = testRelation.output(3)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/complexTypesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/complexTypesSuite.scala
@@ -51,8 +51,8 @@ class ComplexTypesSuite extends PlanTest with ExpressionEvalHelper {
          SimplifyExtractValueOps) :: Nil
   }
 
-  private val idAtt = ($"id").long.notNull
-  private val nullableIdAtt = ($"nullable_id").long
+  private val idAtt = $"id".long.notNull
+  private val nullableIdAtt = $"nullable_id".long
 
   private val relation = LocalRelation(idAtt, nullableIdAtt)
   private val testRelation = LocalRelation($"a".int, $"b".int, $"c".int, $"d".double, $"e".int)
@@ -170,7 +170,7 @@ class ComplexTypesSuite extends PlanTest with ExpressionEvalHelper {
   test("SPARK-22570: CreateArray should not create a lot of global variables") {
     val ctx = new CodegenContext
     CreateArray(Seq(Literal(1))).genCode(ctx)
-    assert(ctx.inlinedMutableStates.length == 0)
+    assert(ctx.inlinedMutableStates.isEmpty)
   }
 
   test("SPARK-23208: Test code splitting for create array related methods") {
@@ -221,20 +221,20 @@ class ComplexTypesSuite extends PlanTest with ExpressionEvalHelper {
     val query = relation.select(
       GetMapValue(
         CreateMap(Seq(
-          $"id", ($"id" + 1L),
-          ($"id" + 1L), ($"id" + 2L),
-          ($"id" + 2L), ($"id" + 3L),
+          $"id", $"id" + 1L,
+          $"id" + 1L, $"id" + 2L,
+          $"id" + 2L, $"id" + 3L,
           Literal(13L), $"id",
-          ($"id" + 3L), ($"id" + 4L),
-          ($"id" + 4L), ($"id" + 5L))),
+          $"id" + 3L, $"id" + 4L,
+          $"id" + 4L, $"id" + 5L)),
         13L) as "a")
 
     val expected = relation
       .select(
         CaseWhen(Seq(
-          (EqualTo(13L, $"id"), ($"id" + 1L)),
-          (EqualTo(13L, ($"id" + 1L)), ($"id" + 2L)),
-          (EqualTo(13L, ($"id" + 2L)), ($"id" + 3L)),
+          (EqualTo(13L, $"id"), $"id" + 1L),
+          (EqualTo(13L, $"id" + 1L), $"id" + 2L),
+          (EqualTo(13L, $"id" + 2L), $"id" + 3L),
           (Literal(true), $"id"))) as "a")
     checkRule(query, expected)
   }
@@ -244,19 +244,19 @@ class ComplexTypesSuite extends PlanTest with ExpressionEvalHelper {
       .select(
         GetMapValue(
           CreateMap(Seq(
-            $"id", ($"id" + 1L),
-            ($"id" + 1L), ($"id" + 2L),
-            ($"id" + 2L), ($"id" + 3L),
-            ($"id" + 3L), ($"id" + 4L),
-            ($"id" + 4L), ($"id" + 5L))),
-            ($"id" + 3L)) as "a")
+            $"id", $"id" + 1L,
+            $"id" + 1L, $"id" + 2L,
+            $"id" + 2L, $"id" + 3L,
+            $"id" + 3L, $"id" + 4L,
+            $"id" + 4L, $"id" + 5L)),
+            $"id" + 3L) as "a")
     val expected = relation
       .select(
         CaseWhen(Seq(
-          (EqualTo($"id" + 3L, $"id"), ($"id" + 1L)),
-          (EqualTo($"id" + 3L, ($"id" + 1L)), ($"id" + 2L)),
-          (EqualTo($"id" + 3L, ($"id" + 2L)), ($"id" + 3L)),
-          (Literal(true), ($"id" + 4L)))) as "a")
+          (EqualTo($"id" + 3L, $"id"), $"id" + 1L),
+          (EqualTo($"id" + 3L, $"id" + 1L), $"id" + 2L),
+          (EqualTo($"id" + 3L, $"id" + 2L), $"id" + 3L),
+          (Literal(true), $"id" + 4L))) as "a")
     checkRule(query, expected)
   }
 
@@ -265,19 +265,19 @@ class ComplexTypesSuite extends PlanTest with ExpressionEvalHelper {
       .select(
         GetMapValue(
           CreateMap(Seq(
-            $"id", ($"id" + 1L),
-            ($"id" + 1L), ($"id" + 2L),
-            ($"id" + 2L), ($"id" + 3L),
-            ($"id" + 3L), ($"id" + 4L),
-            ($"id" + 4L), ($"id" + 5L))),
+            $"id", $"id" + 1L,
+            $"id" + 1L, $"id" + 2L,
+            $"id" + 2L, $"id" + 3L,
+            $"id" + 3L, $"id" + 4L,
+            $"id" + 4L, $"id" + 5L)),
           $"id" + 30L) as "a")
     val expected = relation.select(
       CaseWhen(Seq(
-        (EqualTo($"id" + 30L, $"id"), ($"id" + 1L)),
-        (EqualTo($"id" + 30L, ($"id" + 1L)), ($"id" + 2L)),
-        (EqualTo($"id" + 30L, ($"id" + 2L)), ($"id" + 3L)),
-        (EqualTo($"id" + 30L, ($"id" + 3L)), ($"id" + 4L)),
-        (EqualTo($"id" + 30L, ($"id" + 4L)), ($"id" + 5L)))) as "a")
+        (EqualTo($"id" + 30L, $"id"), $"id" + 1L),
+        (EqualTo($"id" + 30L, $"id" + 1L), $"id" + 2L),
+        (EqualTo($"id" + 30L, $"id" + 2L), $"id" + 3L),
+        (EqualTo($"id" + 30L, $"id" + 3L), $"id" + 4L),
+        (EqualTo($"id" + 30L, $"id" + 4L), $"id" + 5L))) as "a")
     checkRule(rel, expected)
   }
 
@@ -286,22 +286,22 @@ class ComplexTypesSuite extends PlanTest with ExpressionEvalHelper {
       .select(
         GetMapValue(
           CreateMap(Seq(
-            $"id", ($"id" + 1L),
-            ($"id" + 1L), ($"id" + 2L),
-            ($"id" + 2L), ($"id" + 3L),
+            $"id", $"id" + 1L,
+            $"id" + 1L, $"id" + 2L,
+            $"id" + 2L, $"id" + 3L,
             Literal(14L), $"id",
-            ($"id" + 3L), ($"id" + 4L),
-            ($"id" + 4L), ($"id" + 5L))),
+            $"id" + 3L, $"id" + 4L,
+            $"id" + 4L, $"id" + 5L)),
           13L) as "a")
 
     val expected = relation
       .select(
         CaseKeyWhen(13L,
-          Seq($"id", ($"id" + 1L),
-            ($"id" + 1L), ($"id" + 2L),
-            ($"id" + 2L), ($"id" + 3L),
-            ($"id" + 3L), ($"id" + 4L),
-            ($"id" + 4L), ($"id" + 5L))) as "a")
+          Seq($"id", $"id" + 1L,
+            $"id" + 1L, $"id" + 2L,
+            $"id" + 2L, $"id" + 3L,
+            $"id" + 3L, $"id" + 4L,
+            $"id" + 4L, $"id" + 5L)) as "a")
 
     checkRule(rel, expected)
   }
@@ -311,20 +311,20 @@ class ComplexTypesSuite extends PlanTest with ExpressionEvalHelper {
       .select(
         GetMapValue(
           CreateMap(Seq(
-            $"id", ($"id" + 1L),
-            ($"id" + 1L), ($"id" + 2L),
-            ($"id" + 2L), Literal.create(null, LongType),
+            $"id", $"id" + 1L,
+            $"id" + 1L, $"id" + 2L,
+            $"id" + 2L, Literal.create(null, LongType),
             Literal(2L), $"id",
-            ($"id" + 3L), ($"id" + 4L),
-            ($"id" + 4L), ($"id" + 5L))),
+            $"id" + 3L, $"id" + 4L,
+            $"id" + 4L, $"id" + 5L)),
           2L ) as "a")
 
     val expected = relation
       .select(
         CaseWhen(Seq(
-          (EqualTo(2L, $"id"), ($"id" + 1L)),
+          (EqualTo(2L, $"id"), $"id" + 1L),
           // these two are possible matches, we can't tell until runtime
-          (EqualTo(2L, ($"id" + 1L)), ($"id" + 2L)),
+          (EqualTo(2L, $"id" + 1L), $"id" + 2L),
           (EqualTo(2L, $"id" + 2L), Literal.create(null, LongType)),
           // this is a definite match (two constants),
           // but it cannot override a potential match with ('id + 2L),

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
@@ -885,7 +885,7 @@ class DDLParserSuite extends AnalysisTest {
             Seq(
               ("a", Literal(1)),
               ("b", Literal(Decimal(0.1))),
-              ("c" -> Literal(true)))),
+              "c" -> Literal(true))),
           None,
           None,
           None),

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/planning/PhysicalOperationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/planning/PhysicalOperationSuite.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.types.DoubleType
 
 class PhysicalOperationSuite extends SparkFunSuite {
   private val relation = TestRelations.testRelation2
-  private val colA = relation.output(0)
+  private val colA = relation.output.head
   private val colB = relation.output(1)
   private val aliasR = Alias(Rand(1), "r")()
   private val aliasId = Alias(MonotonicallyIncreasingID(), "id")()
@@ -36,7 +36,7 @@ class PhysicalOperationSuite extends SparkFunSuite {
     project1 match {
       case PhysicalOperation(projects, filters, _: LocalRelation) =>
         assert(projects.size === 2)
-        assert(projects(0) === colB)
+        assert(projects.head === colB)
         assert(projects(1) === aliasR)
         assert(filters.size === 1)
       case _ => assert(false)
@@ -48,7 +48,7 @@ class PhysicalOperationSuite extends SparkFunSuite {
     project2 match {
       case PhysicalOperation(projects, filters, _: LocalRelation) =>
         assert(projects.size === 2)
-        assert(projects(0) === colA)
+        assert(projects.head === colA)
         assert(projects(1) === colB)
         assert(filters.size === 1)
       case _ => assert(false)
@@ -60,7 +60,7 @@ class PhysicalOperationSuite extends SparkFunSuite {
     project3 match {
       case PhysicalOperation(projects, filters, _: Project) =>
         assert(projects.size === 2)
-        assert(projects(0) === colA)
+        assert(projects.head === colA)
         assert(projects(1) === colR)
         assert(filters.isEmpty)
       case _ => assert(false)
@@ -72,7 +72,7 @@ class PhysicalOperationSuite extends SparkFunSuite {
     project4 match {
       case PhysicalOperation(projects, _, _: LocalRelation) =>
         assert(projects.size === 2)
-        assert(projects(0) === colA)
+        assert(projects.head === colA)
         assert(projects(1) === aliasId)
       case _ => assert(false)
     }
@@ -94,7 +94,7 @@ class PhysicalOperationSuite extends SparkFunSuite {
     filter2 match {
       case PhysicalOperation(projects, filters, _: LocalRelation) =>
         assert(projects.size === 2)
-        assert(projects(0) === colA)
+        assert(projects.head === colA)
         assert(projects(1) === colB)
         assert(filters.size === 1)
       case _ => assert(false)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/QueryPlanSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/QueryPlanSuite.scala
@@ -40,7 +40,7 @@ class QueryPlanSuite extends SparkFunSuite {
       case _: Expression => Literal(1)
     }
 
-    val mappedOrigin = mappedQuery.expressions.apply(0).origin
+    val mappedOrigin = mappedQuery.expressions.head.origin
     assert(mappedOrigin == Origin.apply(Some(0), Some(0)))
   }
 
@@ -155,9 +155,9 @@ class QueryPlanSuite extends SparkFunSuite {
       .join(t2.select($"c", $"d"), LeftOuter, Some($"a" === $"c"))
       .select($"a" + $"d").analyze
     // The output Attribute of `plan` is nullable even though `d` is not nullable before the join.
-    assert(plan.output(0).nullable)
+    assert(plan.output.head.nullable)
     // The test rule with `transformUpWithNewOutput` should not change the nullability.
     val planAfterTestRule = testRule(plan)
-    assert(planAfterTestRule.output(0).nullable)
+    assert(planAfterTestRule.output.head.nullable)
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/ArrayBasedMapBuilderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/ArrayBasedMapBuilderSuite.scala
@@ -94,8 +94,8 @@ class ArrayBasedMapBuilderSuite extends SparkFunSuite with SQLHelper {
       val map = builder.build()
       assert(map.numElements() == 2)
       val entries = ArrayBasedMapData.toScalaMap(map).iterator.toSeq
-      assert(entries(0)._1.asInstanceOf[Array[Byte]].toSeq == Seq(1))
-      assert(entries(0)._2 == 3)
+      assert(entries.head._1.asInstanceOf[Array[Byte]].toSeq == Seq(1))
+      assert(entries.head._2 == 3)
       assert(entries(1)._1.asInstanceOf[Array[Byte]].toSeq == Seq(2))
       assert(entries(1)._2 == 2)
     }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/CaseInsensitiveMapSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/CaseInsensitiveMapSuite.scala
@@ -48,7 +48,7 @@ class CaseInsensitiveMapSuite extends SparkFunSuite {
   test("SPARK-32377: CaseInsensitiveMap should be deterministic for addition") {
     var m = CaseInsensitiveMap(Map.empty[String, String])
     Seq(("paTh", "1"), ("PATH", "2"), ("Path", "3"), ("patH", "4"), ("path", "5")).foreach { kv =>
-      m = (m + kv)
+      m = m + kv
       assert(m.get("path").contains(kv._2))
     }
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
@@ -369,8 +369,7 @@ class DateTimeUtilsSuite extends SparkFunSuite with Matchers with SQLHelper {
 
     assert(
       stringToTimestampWithoutTimeZone(
-        UTF8String.fromString("2021-11-22 10:54:27 +08:00"), false) ==
-      None)
+        UTF8String.fromString("2021-11-22 10:54:27 +08:00"), false).isEmpty)
   }
 
   test("SPARK-15379: special invalid date string") {
@@ -634,7 +633,7 @@ class DateTimeUtilsSuite extends SparkFunSuite with Matchers with SQLHelper {
   test("trailing characters while converting string to timestamp") {
     val s = UTF8String.fromString("2019-10-31T10:59:23Z:::")
     val time = DateTimeUtils.stringToTimestamp(s, defaultZoneId)
-    assert(time == None)
+    assert(time.isEmpty)
   }
 
   def testTrunc(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/RebaseDateTimeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/RebaseDateTimeSuite.scala
@@ -191,7 +191,7 @@ class RebaseDateTimeSuite extends SparkFunSuite with Matchers with SQLHelper {
       withClue(s"JSON file = $json") {
         val rebaseRecords = loadRebaseRecords(json)
         rebaseRecords.foreach { case (_, rebaseRecord) =>
-          assert(rebaseRecord.switches.size === rebaseRecord.diffs.size)
+          assert(rebaseRecord.switches.length === rebaseRecord.diffs.length)
           // Check ascending order of switches values
           assert(rebaseRecord.switches.toSeq === rebaseRecord.switches.sorted.toSeq)
         }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/CatalogSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/CatalogSuite.scala
@@ -933,7 +933,7 @@ class CatalogSuite extends SparkFunSuite {
       new BufferedRows("1").withRow(InternalRow(1, 1))
     ))
     assert(partTable.listPartitionIdentifiers(Array.empty, InternalRow.empty).length == 2)
-    assert(!partTable.rows.isEmpty)
+    assert(partTable.rows.nonEmpty)
     assert(partTable.truncateTable())
     assert(partTable.listPartitionIdentifiers(Array.empty, InternalRow.empty).length == 2)
     assert(partTable.rows.isEmpty)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryBaseTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryBaseTable.scala
@@ -558,7 +558,7 @@ abstract class InMemoryBaseTable(
       throwsException()
 
     def throwsException[T](): T = throw new IllegalStateException("The operation " +
-      s"${operation} isn't supported for streaming query.")
+      s"$operation isn't supported for streaming query.")
   }
 
   private object StreamingAppend extends TestStreamingWrite {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/expressions/TransformExtractorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/expressions/TransformExtractorSuite.scala
@@ -141,7 +141,7 @@ class TransformExtractorSuite extends SparkFunSuite {
     bucketTransform match {
       case BucketTransform(numBuckets, cols, _) =>
         assert(numBuckets === 16)
-        assert(cols(0).fieldNames === Seq("a", "b"))
+        assert(cols.head.fieldNames === Seq("a", "b"))
       case _ =>
         fail("Did not match BucketTransform extractor")
     }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DecimalSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DecimalSuite.scala
@@ -183,11 +183,11 @@ class DecimalSuite extends SparkFunSuite with PrivateMethodTester with SQLHelper
   }
 
   test("hash code") {
-    assert(Decimal(123).hashCode() === (123).##)
+    assert(Decimal(123).hashCode() === 123.##)
     assert(Decimal(-123).hashCode() === (-123).##)
     assert(Decimal(Int.MaxValue).hashCode() === Int.MaxValue.##)
     assert(Decimal(Long.MaxValue).hashCode() === Long.MaxValue.##)
-    assert(Decimal(BigDecimal(123)).hashCode() === (123).##)
+    assert(Decimal(BigDecimal(123)).hashCode() === 123.##)
 
     val reallyBig = BigDecimal("123182312312313232112312312123.1231231231")
     assert(Decimal(reallyBig).hashCode() === reallyBig.hashCode)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/StructTypeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/StructTypeSuite.scala
@@ -538,7 +538,7 @@ class StructTypeSuite extends SparkFunSuite with SQLHelper {
           .putString(ResolveDefaultColumns.CURRENT_DEFAULT_COLUMN_METADATA_KEY, "'abc'")
           .build()),
       StructField("c3", BooleanType)))
-    assert(ResolveDefaultColumns.existenceDefaultValues(source1).size == 3)
+    assert(ResolveDefaultColumns.existenceDefaultValues(source1).length == 3)
     assert(ResolveDefaultColumns.existenceDefaultValues(source1)(0) == 42)
     assert(ResolveDefaultColumns.existenceDefaultValues(source1)(1) == UTF8String.fromString("abc"))
     assert(ResolveDefaultColumns.existenceDefaultValues(source1)(2) == null)
@@ -553,7 +553,7 @@ class StructTypeSuite extends SparkFunSuite with SQLHelper {
           .putString(ResolveDefaultColumns.CURRENT_DEFAULT_COLUMN_METADATA_KEY, "1 + 1")
           .build())))
     val error = "fails to parse as a valid literal value"
-    assert(ResolveDefaultColumns.existenceDefaultValues(source2).size == 1)
+    assert(ResolveDefaultColumns.existenceDefaultValues(source2).length == 1)
     assert(ResolveDefaultColumns.existenceDefaultValues(source2)(0) == 2)
 
     // Negative test: StructType.defaultValues fails because the existence default value fails to


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix some scala compile warnings in package sql/catalyst. These scala compile warnings show below.

- `Replace .size with .length on arrays and strings`
- `The enclosing block is redundant`
- `Replace with .head`
- `Replace with .nonEmpty`
- `Replace with .isDefined`
- `Unnecessary parentheses`
- `Replace with .isEmpty`


### Why are the changes needed?
Improve the code and fix scala compile warnings


### Does this PR introduce _any_ user-facing change?
'No'.


### How was this patch tested?
Exists test cases.


### Was this patch authored or co-authored using generative AI tooling?
'No'.
