### PR TITLE
[SPARK-45848][BUILD]  Make `spark-version-info.properties` generated by `spark-build-info.ps1` include `docroot`

### DIFF
--- a/build/spark-build-info.ps1
+++ b/build/spark-build-info.ps1
@@ -41,6 +41,7 @@ user=$($Env:USERNAME)
 revision=$(git rev-parse HEAD)
 branch=$(git rev-parse --abbrev-ref HEAD)
 date=$([DateTime]::UtcNow | Get-Date -UFormat +%Y-%m-%dT%H:%M:%SZ)
-url=$(git config --get remote.origin.url)"
+url=$(git config --get remote.origin.url),
+docroot=https://spark.apache.org/docs/latest"
 
 Set-Content -Path $SparkBuildInfoPath -Value $SparkBuildInfoContent


### PR DESCRIPTION
### What changes were proposed in this pull request?
The `spark-version-info.properties` generated by `spark-build-info` include `docroot=https://spark.apache.org/docs/latest`, this pr make `spark-version-info.properties` generated by `spark-build-info.ps1` also include `docroot` part.

### Why are the changes needed?
Keep the items generated by `spark-build-info` and `spark-build-info.ps1` consistent


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Manual verification with this pr:
- `spark-version-info.properties` generated by `spark-build-info`
```
version=4.0.0-SNAPSHOT
user=yangjie01
revision=d92f634bdaf8d040b7c7a5ca675db3cb265486b5
branch=SPARK-45848
date=2023-11-09T06:21:05Z
url=git@github.com:LuciferYang/spark.git
docroot=https://spark.apache.org/docs/latest
```
- `spark-version-info.properties` generated by `spark-build-info.ps1`
```
version=4.0.0-SNAPSHOT
user=yangjie01
revision=d92f634bdaf8d040b7c7a5ca675db3cb265486b5
branch=SPARK-45848
date=2023-11-09T06:22:25Z
url=git@github.com:LuciferYang/spark.git,
docroot=https://spark.apache.org/docs/latest
```

### Was this patch authored or co-authored using generative AI tooling?
No