### PR TITLE
[SPARK-45658][SQL] Fix canonicalization of DynamicPruningSubquery to canonicalize build keys relative to build query output

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/DynamicPruning.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/DynamicPruning.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.catalyst.expressions
 
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, ExprCode}
+import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.logical.{HintInfo, LogicalPlan}
 import org.apache.spark.sql.catalyst.trees.TreePattern._
 import org.apache.spark.sql.catalyst.trees.UnaryLike
@@ -78,10 +79,11 @@ case class DynamicPruningSubquery(
   override def toString: String = s"dynamicpruning#${exprId.id} $conditionString"
 
   override lazy val canonicalized: DynamicPruning = {
+    val buildOutput = buildQuery.output
     copy(
       pruningKey = pruningKey.canonicalized,
       buildQuery = buildQuery.canonicalized,
-      buildKeys = buildKeys.map(_.canonicalized),
+      buildKeys = buildKeys.map(QueryPlan.normalizeExpressions(_, buildOutput)),
       exprId = ExprId(0))
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CanonicalizeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CanonicalizeSuite.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.catalyst.expressions
 
 import java.util.TimeZone
+
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.dsl.plans._

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CanonicalizeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CanonicalizeSuite.scala
@@ -18,11 +18,10 @@
 package org.apache.spark.sql.catalyst.expressions
 
 import java.util.TimeZone
-
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.dsl.plans._
-import org.apache.spark.sql.catalyst.plans.logical.Range
+import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, Range}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.MULTI_COMMUTATIVE_OP_OPT_THRESHOLD
 import org.apache.spark.sql.types.{BooleanType, Decimal, DecimalType, IntegerType, LongType, StringType, StructField, StructType, TimestampNTZType, TimestampType}
@@ -351,4 +350,22 @@ class CanonicalizeSuite extends SparkFunSuite {
     assert(op.canonicalized.toJSON.nonEmpty)
     SQLConf.get.setConfString(MULTI_COMMUTATIVE_OP_OPT_THRESHOLD.key, default.toString)
   }
+
+  test("SPARK-45658: DynamicPruningSubquery canonicalization build keys not canonicalized" +
+    " relative to build query output") {
+    val pruneExprId = NamedExpression.newExprId
+    val pruneKey = AttributeReference("dummy", IntegerType)(pruneExprId)
+    val testRelation = LocalRelation($"a".int, $"b".int, $"c".int)
+
+    val buildQueryPlan1 = testRelation.where("a".attr > 10).select($"b".attr * Literal(5)).analyze
+    val buildKeys1 = Seq(buildQueryPlan1.output.head)
+    val dps1 = DynamicPruningSubquery(pruneKey, buildQueryPlan1, buildKeys1, 0, true)
+
+    val buildQueryPlan2 = testRelation.where("a".attr > 10).select($"b".attr * Literal(5)).analyze
+    val buildKeys2 = Seq(buildQueryPlan2.output.head)
+    val dps2 = DynamicPruningSubquery(pruneKey, buildQueryPlan2, buildKeys2, 0, true)
+
+    assert(dps1.canonicalized == dps2.canonicalized)
+  }
+
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fixing the canonicalization of build keys in the DynamicPruningSubquery so that build keys are canonicalized relative to build query output.


### Why are the changes needed?
I discovered this issue while working on my other PR for pushing broadcast data of BroadcastHashJoin as a pruning filter. The bug appeared as two DynamicPruningSubquery though equivalent,  on canonicalization, were not matching. It turned out that the build keys expression were getting canonicalized relative to itself, instead of build query 's output.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Added bug test.


### Was this patch authored or co-authored using generative AI tooling?
No