### PR TITLE
[MINOR][SQL] Pass `cause` in `CannotReplaceMissingTableException` costructor

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CannotReplaceMissingTableException.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CannotReplaceMissingTableException.scala
@@ -28,4 +28,5 @@ class CannotReplaceMissingTableException(
   extends AnalysisException(
       errorClass = "TABLE_OR_VIEW_NOT_FOUND",
       messageParameters = Map("relationName"
-        -> quoteNameParts(tableIdentifier.namespace :+ tableIdentifier.name)))
+        -> quoteNameParts(tableIdentifier.namespace :+ tableIdentifier.name)),
+      cause = cause)


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to use the `cause` argument in the `CannotReplaceMissingTableException` constructor.

### Why are the changes needed?
To improve user experience with Spark SQL while troubleshooting issues. Currently, users don't see where the exception come from.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Manually.

### Was this patch authored or co-authored using generative AI tooling?
No.