### PR TITLE
[SPARK-45859][ML] Make UDF objects in ml.functions lazy

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/functions.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/functions.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.functions.udf
 @Since("3.0.0")
 object functions {
 // scalastyle:on
-  private[spark] val vectorToArrayUdf = udf { vec: Any =>
+  private[spark] lazy val vectorToArrayUdf = udf { vec: Any =>
     vec match {
       case v: Vector => v.toArray
       case v: OldVector => v.toArray
@@ -38,7 +38,7 @@ object functions {
     }
   }.asNonNullable()
 
-  private[spark] val vectorToArrayFloatUdf = udf { vec: Any =>
+  private[spark] lazy val vectorToArrayFloatUdf = udf { vec: Any =>
     vec match {
       case v: SparseVector =>
         val data = new Array[Float](v.size)
@@ -76,7 +76,7 @@ object functions {
     }
   }
 
-  private[spark] val arrayToVectorUdf = udf { array: Seq[Double] =>
+  private[spark] lazy val arrayToVectorUdf = udf { array: Seq[Double] =>
     Vectors.dense(array.toArray)
   }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/FunctionsLoadingSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/FunctionsLoadingSuite.scala
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ml
+
+import org.apache.spark._
+import org.apache.spark.ml.functions.{array_to_vector, vector_to_array}
+import org.apache.spark.sql.catalyst.util.quietly
+import org.apache.spark.sql.functions.col
+
+class FunctionsLoadingSuite extends SparkFunSuite with LocalSparkContext {
+
+  test("SPARK-45859: 'functions$' should not be affected by a broken class loader") {
+    quietly {
+      val conf = new SparkConf()
+        .setAppName("FunctionsLoadingSuite")
+        .setMaster("local-cluster[1,1,1024]")
+      sc = new SparkContext(conf)
+      // Make `functions$` be loaded by a broken class loader
+      intercept[SparkException] {
+        sc.parallelize(1 to 1).foreach { _ =>
+          val originalClassLoader = Thread.currentThread.getContextClassLoader
+          try {
+            Thread.currentThread.setContextClassLoader(new BrokenClassLoader)
+            vector_to_array(col("vector"))
+            array_to_vector(col("array"))
+          } finally {
+            Thread.currentThread.setContextClassLoader(originalClassLoader)
+          }
+        }
+      }
+
+      // We should be able to use `functions$` even it was loaded by a broken class loader
+      sc.parallelize(1 to 1).foreach { _ =>
+        vector_to_array(col("vector"))
+        array_to_vector(col("array"))
+      }
+    }
+  }
+}
+
+class BrokenClassLoader extends ClassLoader {
+  override def findClass(name: String): Class[_] = {
+    throw new Error(s"class $name")
+  }
+}

--- a/mllib/src/test/scala/org/apache/spark/ml/FunctionsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/FunctionsSuite.scala
@@ -131,6 +131,11 @@ class FunctionsSuite extends MLTest {
         vector_to_array(col("vector"))
         array_to_vector(col("array"))
       }
+
+      // this UT should be the last one in this test suite, since it uses
+      // a different `sc` from the standard one.
+      // stop it here in case new UTs are added after this one.
+      sc.stop()
     }
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/FunctionsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/FunctionsSuite.scala
@@ -17,11 +17,12 @@
 
 package org.apache.spark.ml
 
-import org.apache.spark.SparkException
+import org.apache.spark.{SparkConf, SparkContext, SparkException}
 import org.apache.spark.ml.functions.{array_to_vector, vector_to_array}
 import org.apache.spark.ml.linalg.{Vector, Vectors}
 import org.apache.spark.ml.util.MLTest
 import org.apache.spark.mllib.linalg.{Vectors => OldVectors}
+import org.apache.spark.sql.catalyst.util.quietly
 import org.apache.spark.sql.functions.col
 
 class FunctionsSuite extends MLTest {
@@ -100,5 +101,42 @@ class FunctionsSuite extends MLTest {
     val df3 = Seq(Tuple1(Array(1, 2))).toDF("c1")
     val resultVec3 = df3.select(array_to_vector(col("c1"))).collect()(0)(0).asInstanceOf[Vector]
     assert(resultVec3 === Vectors.dense(Array(1.0, 2.0)))
+  }
+
+  test("SPARK-45859: 'functions$' should not be affected by a broken class loader") {
+    quietly {
+      // Only one SparkContext should be running in this JVM (see SPARK-2243)
+      sc.stop()
+
+      val conf = new SparkConf()
+        .setAppName("FunctionsSuite")
+        .setMaster("local-cluster[1,1,1024]")
+      sc = new SparkContext(conf)
+      // Make `functions$` be loaded by a broken class loader
+      intercept[SparkException] {
+        sc.parallelize(1 to 1).foreach { _ =>
+          val originalClassLoader = Thread.currentThread.getContextClassLoader
+          try {
+            Thread.currentThread.setContextClassLoader(new BrokenClassLoader)
+            vector_to_array(col("vector"))
+            array_to_vector(col("array"))
+          } finally {
+            Thread.currentThread.setContextClassLoader(originalClassLoader)
+          }
+        }
+      }
+
+      // We should be able to use `functions$` even it was loaded by a broken class loader
+      sc.parallelize(1 to 1).foreach { _ =>
+        vector_to_array(col("vector"))
+        array_to_vector(col("array"))
+      }
+    }
+  }
+}
+
+class BrokenClassLoader extends ClassLoader {
+  override def findClass(name: String): Class[_] = {
+    throw new Error(s"class $name")
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Since JVM runs static codes only once, if loading functions$ fails, it will always report java.lang.NoClassDefFoundError: Could not initialize class
```
23/11/01 23:06:21 WARN TaskSetManager: Lost task 136.0 in stage 9565.0 (TID 4557384) (10.4.35.209 executor 16): TaskKilled (Stage cancelled: Job aborted due to stage failure: Task 2 in stage 9565.0 failed 4 times, most recent failure: Lost task 2.3 in stage 9565.0 (TID 4558369) (10.4.56.6 executor 71): java.io.IOException: unexpected exception type
	at java.io.ObjectStreamClass.throwMiscException(ObjectStreamClass.java:1750)
	at java.io.ObjectStreamClass.invokeReadResolve(ObjectStreamClass.java:1280)
	at java.io.ObjectInputStream.readOrdinaryObject(ObjectInputStream.java:2222)
	…
	at org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$3(Executor.scala:900)
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
	at com.databricks.spark.util.ExecutorFrameProfiler$.record(ExecutorFrameProfiler.scala:110)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:795)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:750)
Caused by: java.lang.reflect.InvocationTargetException
	at sun.reflect.GeneratedMethodAccessor520.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at java.lang.invoke.SerializedLambda.readResolve(SerializedLambda.java:230)
	at sun.reflect.GeneratedMethodAccessor224.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at java.io.ObjectStreamClass.invokeReadResolve(ObjectStreamClass.java:1274)
	... 388 more
Caused by: java.lang.NoClassDefFoundError: Could not initialize class org.apache.spark.ml.functions$
	... 396 more
```

This PR just changes `functions.*` as lazy avoid hitting this issue because the initialization codes of a lazy val is not in static codes.


### Why are the changes needed?
to fix a intermittent bug


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
new UT

### Was this patch authored or co-authored using generative AI tooling?
no
