### PR TITLE
[SPARK-45600][PYTHON] Make Python data source registration session level

### DIFF
--- a/python/pyspark/sql/tests/test_python_datasource.py
+++ b/python/pyspark/sql/tests/test_python_datasource.py
@@ -49,6 +49,35 @@ class BasePythonDataSourceTestsMixin:
         self.assertEqual(list(reader.partitions()), [None])
         self.assertEqual(list(reader.read(None)), [(None,)])
 
+    def test_data_source_register(self):
+        class TestReader(DataSourceReader):
+            def read(self, partition):
+                yield (0, 1)
+
+        class TestDataSource(DataSource):
+            def schema(self):
+                return "a INT, b INT"
+
+            def reader(self, schema):
+                return TestReader()
+
+        self.spark.dataSource.register(TestDataSource)
+        df = self.spark.read.format("TestDataSource").load()
+        assertDataFrameEqual(df, [Row(a=0, b=1)])
+
+        class MyDataSource(TestDataSource):
+            @classmethod
+            def name(cls):
+                return "TestDataSource"
+            def schema(self):
+                return "c INT, d INT"
+
+        # Should be able to register the data source with the same name.
+        self.spark.dataSource.register(MyDataSource)
+
+        df = self.spark.read.format("TestDataSource").load()
+        assertDataFrameEqual(df, [Row(c=0, d=1)])
+
     def test_in_memory_data_source(self):
         class InMemDataSourceReader(DataSourceReader):
             DEFAULT_NUM_PARTITIONS: int = 3

--- a/python/pyspark/sql/tests/test_python_datasource.py
+++ b/python/pyspark/sql/tests/test_python_datasource.py
@@ -69,6 +69,7 @@ class BasePythonDataSourceTestsMixin:
             @classmethod
             def name(cls):
                 return "TestDataSource"
+
             def schema(self):
                 return "c INT, d INT"
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
@@ -210,7 +210,7 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
     }
 
     val isUserDefinedDataSource =
-      sparkSession.sharedState.dataSourceManager.dataSourceExists(source)
+      sparkSession.sessionState.dataSourceManager.dataSourceExists(source)
 
     Try(DataSource.lookupDataSourceV2(source, sparkSession.sessionState.conf)) match {
       case Success(providerOpt) =>
@@ -243,7 +243,7 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
   }
 
   private def loadUserDefinedDataSource(paths: Seq[String]): DataFrame = {
-    val builder = sparkSession.sharedState.dataSourceManager.lookupDataSource(source)
+    val builder = sparkSession.sessionState.dataSourceManager.lookupDataSource(source)
     // Add `path` and `paths` options to the extra options if specified.
     val optionsWithPath = DataSourceV2Utils.getOptionsWithPaths(extraOptions, paths: _*)
     val plan = builder(sparkSession, source, userSpecifiedSchema, optionsWithPath)

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -233,7 +233,7 @@ class SparkSession private(
   /**
    * A collection of methods for registering user-defined data sources.
    */
-  private[sql] def dataSource: DataSourceRegistration = sharedState.dataSourceRegistration
+  private[sql] def dataSource: DataSourceRegistration = sessionState.dataSourceRegistration
 
   /**
    * Returns a `StreamingQueryManager` that allows managing all the

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala
@@ -121,6 +121,13 @@ abstract class BaseSessionStateBuilder(
   }
 
   /**
+   * Manages the registration of data sources
+   */
+  protected lazy val dataSourceManager: DataSourceManager = {
+    parentState.map(_.dataSourceManager.clone()).getOrElse(new DataSourceManager)
+  }
+
+  /**
    * Experimental methods that can be used to define custom optimization rules and custom planning
    * strategies.
    *
@@ -177,6 +184,12 @@ abstract class BaseSessionStateBuilder(
   protected def udfRegistration: UDFRegistration = new UDFRegistration(functionRegistry)
 
   protected def udtfRegistration: UDTFRegistration = new UDTFRegistration(tableFunctionRegistry)
+
+  /**
+   * A collection of method used for registering user-defined data sources.
+   */
+  protected def dataSourceRegistration: DataSourceRegistration =
+    new DataSourceRegistration(dataSourceManager)
 
   /**
    * Logical query plan analyzer for resolving unresolved attributes and relations.
@@ -376,6 +389,8 @@ abstract class BaseSessionStateBuilder(
       tableFunctionRegistry,
       udfRegistration,
       udtfRegistration,
+      dataSourceManager,
+      dataSourceRegistration,
       () => catalog,
       sqlParser,
       () => analyzer,

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SessionState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SessionState.scala
@@ -35,6 +35,7 @@ import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.connector.catalog.CatalogManager
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.adaptive.AdaptiveRulesHolder
+import org.apache.spark.sql.execution.datasources.DataSourceManager
 import org.apache.spark.sql.streaming.StreamingQueryManager
 import org.apache.spark.sql.util.ExecutionListenerManager
 import org.apache.spark.util.{DependencyUtils, Utils}
@@ -49,6 +50,8 @@ import org.apache.spark.util.{DependencyUtils, Utils}
  * @param udfRegistration Interface exposed to the user for registering user-defined functions.
  * @param udtfRegistration Interface exposed to the user for registering user-defined
  *                         table functions.
+ * @param dataSourceManager Internal catalog for managing data sources registered by users.
+ * @param dataSourceRegistration Interface exposed to users for registering data sources.
  * @param catalogBuilder a function to create an internal catalog for managing table and database
  *                       states.
  * @param sqlParser Parser that extracts expressions, plans, table identifiers etc. from SQL texts.
@@ -73,6 +76,8 @@ private[sql] class SessionState(
     val tableFunctionRegistry: TableFunctionRegistry,
     val udfRegistration: UDFRegistration,
     val udtfRegistration: UDTFRegistration,
+    val dataSourceManager: DataSourceManager,
+    val dataSourceRegistration: DataSourceRegistration,
     catalogBuilder: () => SessionCatalog,
     val sqlParser: ParserInterface,
     analyzerBuilder: () => Analyzer,

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
@@ -30,11 +30,9 @@ import org.apache.hadoop.fs.{FsUrlStreamHandlerFactory, Path}
 
 import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.DataSourceRegistration
 import org.apache.spark.sql.catalyst.catalog._
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.execution.CacheManager
-import org.apache.spark.sql.execution.datasources.DataSourceManager
 import org.apache.spark.sql.execution.streaming.StreamExecution
 import org.apache.spark.sql.execution.ui.{SQLAppStatusListener, SQLAppStatusStore, SQLTab, StreamingQueryStatusStore}
 import org.apache.spark.sql.internal.StaticSQLConf._
@@ -106,16 +104,6 @@ private[sql] class SharedState(
    */
   @GuardedBy("activeQueriesLock")
   private[sql] val activeStreamingQueries = new ConcurrentHashMap[UUID, StreamExecution]()
-
-  /**
-   * A data source manager shared by all sessions.
-   */
-  lazy val dataSourceManager = new DataSourceManager()
-
-  /**
-   * A collection of method used for registering user-defined data sources.
-   */
-  lazy val dataSourceRegistration = new DataSourceRegistration(dataSourceManager)
 
   /**
    * A status store to query SQL status/metrics of this Spark application, based on SQL-specific

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonDataSourceSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.execution.python
 
 import org.apache.spark.sql.{AnalysisException, IntegratedUDFTestUtils, QueryTest, Row}
 import org.apache.spark.sql.catalyst.plans.logical.{BatchEvalPythonUDTF, PythonDataSourcePartitions}
+import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.StructType
 
@@ -143,16 +144,35 @@ class PythonDataSourceSuite extends QueryTest with SharedSparkSession {
 
     val dataSource = createUserDefinedPythonDataSource(dataSourceName, dataSourceScript)
     spark.dataSource.registerPython(dataSourceName, dataSource)
-    assert(spark.sharedState.dataSourceManager.dataSourceExists(dataSourceName))
+    assert(spark.sessionState.dataSourceManager.dataSourceExists(dataSourceName))
+    val ds1 = spark.sessionState.dataSourceManager.lookupDataSource(dataSourceName)
+    checkAnswer(
+      ds1(spark, dataSourceName, Seq.empty, None, CaseInsensitiveMap(Map.empty)),
+      Seq(Row(0, 0), Row(0, 1), Row(1, 0), Row(1, 1), Row(2, 0), Row(2, 1)))
 
-    // Check error when registering a data source with the same name.
-    val err = intercept[AnalysisException] {
-      spark.dataSource.registerPython(dataSourceName, dataSource)
-    }
-    checkError(
-      exception = err,
-      errorClass = "DATA_SOURCE_ALREADY_EXISTS",
-      parameters = Map("provider" -> dataSourceName))
+    // Should be able to override an already registered data source.
+    val newScript =
+      s"""
+         |from pyspark.sql.datasource import DataSource, DataSourceReader
+         |class SimpleDataSourceReader(DataSourceReader):
+         |    def read(self, partition):
+         |        yield (0, )
+         |
+         |class $dataSourceName(DataSource):
+         |    def schema(self) -> str:
+         |        return "id INT"
+         |
+         |    def reader(self, schema):
+         |        return SimpleDataSourceReader()
+         |""".stripMargin
+    val newDataSource = createUserDefinedPythonDataSource(dataSourceName, newScript)
+    spark.dataSource.registerPython(dataSourceName, newDataSource)
+    assert(spark.sessionState.dataSourceManager.dataSourceExists(dataSourceName))
+
+    val ds2 = spark.sessionState.dataSourceManager.lookupDataSource(dataSourceName)
+    checkAnswer(
+      ds2(spark, dataSourceName, Seq.empty, None, CaseInsensitiveMap(Map.empty)),
+      Seq(Row(0)))
   }
 
   test("load data source") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonDataSourceSuite.scala
@@ -147,7 +147,7 @@ class PythonDataSourceSuite extends QueryTest with SharedSparkSession {
     assert(spark.sessionState.dataSourceManager.dataSourceExists(dataSourceName))
     val ds1 = spark.sessionState.dataSourceManager.lookupDataSource(dataSourceName)
     checkAnswer(
-      ds1(spark, dataSourceName, Seq.empty, None, CaseInsensitiveMap(Map.empty)),
+      ds1(spark, dataSourceName, None, CaseInsensitiveMap(Map.empty)),
       Seq(Row(0, 0), Row(0, 1), Row(1, 0), Row(1, 1), Row(2, 0), Row(2, 1)))
 
     // Should be able to override an already registered data source.
@@ -171,7 +171,7 @@ class PythonDataSourceSuite extends QueryTest with SharedSparkSession {
 
     val ds2 = spark.sessionState.dataSourceManager.lookupDataSource(dataSourceName)
     checkAnswer(
-      ds2(spark, dataSourceName, Seq.empty, None, CaseInsensitiveMap(Map.empty)),
+      ds2(spark, dataSourceName, None, CaseInsensitiveMap(Map.empty)),
       Seq(Row(0)))
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR makes dynamic Python data source registration session-scoped. Previously, registered data sources were stored in the `sharedState` and can be referenced by other sessions, which won't work with Spark Connect. 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To make Python data source support Spark Connect in the future.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New unit test

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No