### PR TITLE
[SPARK-45871][CONNECT] Optimizations collection conversion related to `.toBuffer` in the `connect` modules

### DIFF
--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -250,15 +250,18 @@ class SparkSession private[sql] (
           .setSql(sqlText)
           .addAllPosArguments(args.map(lit(_).expr).toImmutableArraySeq.asJava)))
     val plan = proto.Plan.newBuilder().setCommand(cmd)
-    // .toSeq forces that the iterator is consumed and closed
-    val responseSeq = client.execute(plan.build()).toSeq
+    val responseIter = client.execute(plan.build())
 
-    val response = responseSeq
-      .find(_.hasSqlCommandResult)
-      .getOrElse(throw new RuntimeException("SQLCommandResult must be present"))
-
-    // Update the builder with the values from the result.
-    builder.mergeFrom(response.getSqlCommandResult.getRelation)
+    try {
+      val response = responseIter
+        .find(_.hasSqlCommandResult)
+        .getOrElse(throw new RuntimeException("SQLCommandResult must be present"))
+      // Update the builder with the values from the result.
+      builder.mergeFrom(response.getSqlCommandResult.getRelation)
+    } finally {
+      // consume the rest of the iterator
+      responseIter.foreach(_ => ())
+    }
   }
 
   /**
@@ -309,15 +312,18 @@ class SparkSession private[sql] (
             .setSql(sqlText)
             .putAllNamedArguments(args.asScala.view.mapValues(lit(_).expr).toMap.asJava)))
       val plan = proto.Plan.newBuilder().setCommand(cmd)
-      // .toSeq forces that the iterator is consumed and closed
-      val responseSeq = client.execute(plan.build()).toSeq
+      val responseIter = client.execute(plan.build())
 
-      val response = responseSeq
-        .find(_.hasSqlCommandResult)
-        .getOrElse(throw new RuntimeException("SQLCommandResult must be present"))
-
-      // Update the builder with the values from the result.
-      builder.mergeFrom(response.getSqlCommandResult.getRelation)
+      try {
+        val response = responseIter
+          .find(_.hasSqlCommandResult)
+          .getOrElse(throw new RuntimeException("SQLCommandResult must be present"))
+        // Update the builder with the values from the result.
+        builder.mergeFrom(response.getSqlCommandResult.getRelation)
+      } finally {
+        // consume the rest of the iterator
+        responseIter.foreach(_ => ())
+      }
   }
 
   /**
@@ -543,8 +549,8 @@ class SparkSession private[sql] (
     f(builder)
     builder.getCommonBuilder.setPlanId(planIdGenerator.getAndIncrement())
     val plan = proto.Plan.newBuilder().setRoot(builder).build()
-    // .toBuffer forces that the iterator is consumed and closed
-    client.execute(plan).toBuffer
+    // .foreach forces that the iterator is consumed and closed
+    client.execute(plan).foreach(_ => ())
   }
 
   private[sql] def execute(command: proto.Command): Seq[ExecutePlanResponse] = {

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -250,7 +250,7 @@ class SparkSession private[sql] (
           .setSql(sqlText)
           .addAllPosArguments(args.map(lit(_).expr).toImmutableArraySeq.asJava)))
     val plan = proto.Plan.newBuilder().setCommand(cmd)
-    // .toBuffer forces that the iterator is consumed and closed
+    // .toSeq forces that the iterator is consumed and closed
     val responseSeq = client.execute(plan.build()).toSeq
 
     val response = responseSeq
@@ -309,7 +309,7 @@ class SparkSession private[sql] (
             .setSql(sqlText)
             .putAllNamedArguments(args.asScala.view.mapValues(lit(_).expr).toMap.asJava)))
       val plan = proto.Plan.newBuilder().setCommand(cmd)
-      // .toBuffer forces that the iterator is consumed and closed
+      // .toSeq forces that the iterator is consumed and closed
       val responseSeq = client.execute(plan.build()).toSeq
 
       val response = responseSeq
@@ -549,7 +549,7 @@ class SparkSession private[sql] (
 
   private[sql] def execute(command: proto.Command): Seq[ExecutePlanResponse] = {
     val plan = proto.Plan.newBuilder().setCommand(command).build()
-    // .toBuffer forces that the iterator is consumed and closed
+    // .toSeq forces that the iterator is consumed and closed
     client.execute(plan).toSeq
   }
 

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -251,7 +251,7 @@ class SparkSession private[sql] (
           .addAllPosArguments(args.map(lit(_).expr).toImmutableArraySeq.asJava)))
     val plan = proto.Plan.newBuilder().setCommand(cmd)
     // .toBuffer forces that the iterator is consumed and closed
-    val responseSeq = client.execute(plan.build()).toBuffer.toSeq
+    val responseSeq = client.execute(plan.build()).toSeq
 
     val response = responseSeq
       .find(_.hasSqlCommandResult)
@@ -310,7 +310,7 @@ class SparkSession private[sql] (
             .putAllNamedArguments(args.asScala.view.mapValues(lit(_).expr).toMap.asJava)))
       val plan = proto.Plan.newBuilder().setCommand(cmd)
       // .toBuffer forces that the iterator is consumed and closed
-      val responseSeq = client.execute(plan.build()).toBuffer.toSeq
+      val responseSeq = client.execute(plan.build()).toSeq
 
       val response = responseSeq
         .find(_.hasSqlCommandResult)
@@ -544,13 +544,13 @@ class SparkSession private[sql] (
     builder.getCommonBuilder.setPlanId(planIdGenerator.getAndIncrement())
     val plan = proto.Plan.newBuilder().setRoot(builder).build()
     // .toBuffer forces that the iterator is consumed and closed
-    client.execute(plan).toBuffer
+    client.execute(plan).foreach(_ => ())
   }
 
   private[sql] def execute(command: proto.Command): Seq[ExecutePlanResponse] = {
     val plan = proto.Plan.newBuilder().setCommand(command).build()
     // .toBuffer forces that the iterator is consumed and closed
-    client.execute(plan).toBuffer.toSeq
+    client.execute(plan).toSeq
   }
 
   private[sql] def registerUdf(udf: proto.CommonInlineUserDefinedFunction): Unit = {

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -544,7 +544,7 @@ class SparkSession private[sql] (
     builder.getCommonBuilder.setPlanId(planIdGenerator.getAndIncrement())
     val plan = proto.Plan.newBuilder().setRoot(builder).build()
     // .toBuffer forces that the iterator is consumed and closed
-    client.execute(plan).foreach(_ => ())
+    client.execute(plan).toBuffer
   }
 
   private[sql] def execute(command: proto.Command): Seq[ExecutePlanResponse] = {

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/SparkConnectClientSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/SparkConnectClientSuite.scala
@@ -403,12 +403,8 @@ class SparkConnectClientSuite extends ConnectFunSuite with BeforeAndAfterEach {
           .setSql("select * from range(10000000)")))
     val plan = proto.Plan.newBuilder().setCommand(cmd)
     val iter = client.execute(plan.build())
-    val reattachableIter = iter
-      .asInstanceOf[WrappedCloseableIterator[proto.ExecutePlanResponse]]
-      .innerIterator
-      .asInstanceOf[WrappedCloseableIterator[proto.ExecutePlanResponse]]
-      .innerIterator
-      .asInstanceOf[ExecutePlanResponseReattachableIterator]
+    val reattachableIter =
+      ExecutePlanResponseReattachableIterator.fromIterator(iter)
     iter.toSeq
     // If this assertion fails, we need to double check the correctness
     // of the return value from the SparkSession.sql

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/SparkConnectClientSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/SparkConnectClientSuite.scala
@@ -406,8 +406,12 @@ class SparkConnectClientSuite extends ConnectFunSuite with BeforeAndAfterEach {
     val reattachableIter =
       ExecutePlanResponseReattachableIterator.fromIterator(iter)
     iter.toSeq
-    // If this assertion fails, we need to double check the correctness
-    // of the return value from the SparkSession.sql
+    // In several places in SparkSession, we depend on `.toSeq` to consume and close the iterator.
+    // If this assertion fails, we need to double check the correctness of that.
+    // In scala 2.12 `s.c.TraversableOnce#toSeq` builds an `immutable.Stream`,
+    // which is a tail lazy structure and this would fail.
+    // In scala 2.13 `s.c.IterableOnceOps#toSeq` builds an `immutable.Seq` which is not
+    // lazy and will consume and close the iterator.
     assert(reattachableIter.resultComplete)
   }
 }

--- a/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/client/ExecutePlanResponseReattachableIterator.scala
+++ b/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/client/ExecutePlanResponseReattachableIterator.scala
@@ -324,3 +324,13 @@ class ExecutePlanResponseReattachableIterator(
   private def retry[T](fn: => T): T =
     GrpcRetryHandler.retry(retryPolicy)(fn)
 }
+
+private[connect] object ExecutePlanResponseReattachableIterator {
+  @scala.annotation.tailrec
+  private[connect] def fromIterator(
+      iter: Iterator[proto.ExecutePlanResponse]): ExecutePlanResponseReattachableIterator =
+    iter match {
+      case e: ExecutePlanResponseReattachableIterator => e
+      case w: WrappedCloseableIterator[proto.ExecutePlanResponse] => fromIterator(w.innerIterator)
+    }
+}

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectExecutionManager.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectExecutionManager.scala
@@ -144,7 +144,7 @@ private[connect] class SparkConnectExecutionManager() extends Logging {
     if (executions.isEmpty) {
       Left(lastExecutionTime.get)
     } else {
-      Right(executions.values.map(_.getExecuteInfo).toBuffer.toSeq)
+      Right(executions.values.map(_.getExecuteInfo).toSeq)
     }
   }
 
@@ -153,7 +153,7 @@ private[connect] class SparkConnectExecutionManager() extends Logging {
    * cache, and the tombstones will be eventually removed.
    */
   def listAbandonedExecutions: Seq[ExecuteInfo] = {
-    abandonedTombstones.asMap.asScala.values.toBuffer.toSeq
+    abandonedTombstones.asMap.asScala.values.toSeq
   }
 
   private[connect] def shutdown(): Unit = executionsLock.synchronized {
@@ -236,7 +236,7 @@ private[connect] class SparkConnectExecutionManager() extends Logging {
     executions.values.foreach(_.interruptGrpcResponseSenders())
   }
 
-  private[connect] def listExecuteHolders = executionsLock.synchronized {
-    executions.values.toBuffer.toSeq
+  private[connect] def listExecuteHolders: Seq[ExecuteHolder] = executionsLock.synchronized {
+    executions.values.toSeq
   }
 }

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectExecutionManager.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectExecutionManager.scala
@@ -144,7 +144,7 @@ private[connect] class SparkConnectExecutionManager() extends Logging {
     if (executions.isEmpty) {
       Left(lastExecutionTime.get)
     } else {
-      Right(executions.values.map(_.getExecuteInfo).toSeq)
+      Right(executions.values.map(_.getExecuteInfo).toBuffer.toSeq)
     }
   }
 

--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/SparkConnectServerTest.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/SparkConnectServerTest.scala
@@ -27,7 +27,7 @@ import org.scalatest.time.SpanSugar._
 
 import org.apache.spark.connect.proto
 import org.apache.spark.sql.catalyst.ScalaReflection
-import org.apache.spark.sql.connect.client.{CloseableIterator, CustomSparkConnectBlockingStub, ExecutePlanResponseReattachableIterator, GrpcRetryHandler, SparkConnectClient, SparkConnectStubState, WrappedCloseableIterator}
+import org.apache.spark.sql.connect.client.{CloseableIterator, CustomSparkConnectBlockingStub, ExecutePlanResponseReattachableIterator, GrpcRetryHandler, SparkConnectClient, SparkConnectStubState}
 import org.apache.spark.sql.connect.client.arrow.ArrowSerializer
 import org.apache.spark.sql.connect.common.config.ConnectCommon
 import org.apache.spark.sql.connect.config.Connect
@@ -147,15 +147,7 @@ trait SparkConnectServerTest extends SharedSparkSession {
 
   protected def getReattachableIterator(
       stubIterator: CloseableIterator[proto.ExecutePlanResponse]) = {
-    // This depends on the wrapping in CustomSparkConnectBlockingStub.executePlanReattachable:
-    // GrpcExceptionConverter.convertIterator
-    stubIterator
-      .asInstanceOf[WrappedCloseableIterator[proto.ExecutePlanResponse]]
-      .innerIterator
-      .asInstanceOf[WrappedCloseableIterator[proto.ExecutePlanResponse]]
-      // ExecutePlanResponseReattachableIterator
-      .innerIterator
-      .asInstanceOf[ExecutePlanResponseReattachableIterator]
+    ExecutePlanResponseReattachableIterator.fromIterator(stubIterator)
   }
 
   protected def assertNoActiveRpcs(): Unit = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR includes the following optimizations related to `.toBuffer` in the `connect`s module:

1. For the two functions `sql(String, java.util.Map[String, Any]): DataFrame` and `sql(String, Array[_]): DataFrame` in `SparkSession`, the approach of using `.find` directly on the `CloseableIterator` to locate the target and utilizing `.foreach` to consume the remaining elements replaced the previous method of converting to a collection using `toBuffer.toSeq` and then searching for the target using `.find`. This approach avoids the need for an unnecessary collection creation.
2. For function `execute(proto.Relation.Builder => Unit): Unit` in `SparkSession`, as no elements are returned, `.foreach` is used instead of `.toBuffer` to avoid an unnecessary collection creation.
3. For function `execute(command: proto.Command): Seq[ExecutePlanResponse]` in `SparkSession`, in Scala 2.12, `s.c.TraversableOnce#toSeq` returns an `immutable.Stream`, which is a tail-lazy structure that may not consume all elements. Therefore, it is necessary to use `s.c.TraversableOnce#toBuffer` for materialization. However, in Scala 2.13, `s.c.IterableOnceOps#toSeq` constructs an `immutable.Seq`, which is not a lazy data structure and ensures consumption of all elements. Therefore, in Scala 2.13, `.toSeq` can be used directly to replace `toBuffer.toSeq`, saving an extra collection transformation.
4. The optimizations for the two functions `listAbandonedExecutions: Seq[ExecuteInfo]` and `listExecuteHolders` in `SparkConnectExecutionManager` are consistent with item 3 above.

Additionally, to prevent helper function used for testing from creating copies, a `private[connect]` scope helper function was added to the companion object of `ExecutePlanResponseReattachableIterator`.

### Why are the changes needed?
Avoid unnecessary collection copies


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass GitHub Action
- Added new test cases to demonstrate that both `.toSeq` and `.foreach` can consume all elements in `ResponseReattachableIterator` in Scala 2.13.


### Was this patch authored or co-authored using generative AI tooling?
No