### PR TITLE
[SPARK-45875][CORE] Remove `MissingStageTableRowData` from `core` module

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/jobs/StageTable.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/StageTable.scala
@@ -90,13 +90,6 @@ private[ui] class StageTableRowData(
     val shuffleWrite: Long,
     val shuffleWriteWithUnit: String)
 
-private[ui] class MissingStageTableRowData(
-    stageInfo: v1.StageData,
-    stageId: Int,
-    attemptId: Int) extends StageTableRowData(
-  stageInfo, None, stageId, attemptId, "", None, new Date(0), "", -1, "", 0, "", 0, "", 0, "", 0,
-    "")
-
 /** Page showing list of all ongoing and recently finished stages */
 private[ui] class StagePagedTable(
     store: AppStatusStore,


### PR DESCRIPTION
### What changes were proposed in this pull request?
SPARK-15591(https://github.com/apache/spark/pull/13708) introduced the `MissingStageTableRowData`, but it is no longer used after SPARK-20648(https://github.com/apache/spark/pull/19698), so this PR removes it.



### Why are the changes needed?
Clean up unused code.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions

### Was this patch authored or co-authored using generative AI tooling?
No