### PR TITLE
Remove trailing slash from Conda cheat sheet URL in 'Using Conda' sec…

### DIFF
--- a/python/docs/source/getting_started/install.rst
+++ b/python/docs/source/getting_started/install.rst
@@ -119,7 +119,7 @@ While using pip in a conda environment is technically feasible (with the same co
 because pip does not interoperate with conda.
 
 For a short summary about useful conda commands, see their
-`cheat sheet <https://docs.conda.io/projects/conda/en/latest/user-guide/cheatsheet.html/>`_.
+`cheat sheet <https://docs.conda.io/projects/conda/en/latest/user-guide/cheatsheet.html>`_.
 
 
 Manually Downloading


### PR DESCRIPTION
…tion to fix 404 error

In the 'Using Conda' section of the Spark documentation, the cheat sheet URL includes a trailing slash, causing a 404 error when accessed. 

This commit removes the trailing slash to ensure the URL correctly directs to the intended page.

### What changes were proposed in this pull request?
The proposed change removes the trailing slash from the Conda cheat sheet URL in the 'Using Conda' section of the Spark documentation. This modification is intended to resolve the 404 error that occurs when the current URL with the trailing slash is accessed.


### Why are the changes needed?
The change is necessary because the existing URL with a trailing slash leads to a 404 error, hindering users' access to the Conda cheat sheet. Removing the slash will ensure the link directs users to the correct webpage, improving the documentation's usability.


### Does this PR introduce _any_ user-facing change?
No. This change only affects the documentation and does not alter the functionality of the Spark software itself.


### How was this patch tested?
This documentation fix was visually inspected to ensure the corrected URL resolves to the intended webpage without a 404 error. No additional code testing is necessary as this change is strictly within the documentation.


### Was this patch authored or co-authored using generative AI tooling?
No.