### PR TITLE
[SPARK-45522][BUILD][CORE][SQL][UI] Migrate from Jetty 9 to Jetty 10

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -368,7 +368,6 @@ xerces:xercesImpl
 org.codehaus.jackson:jackson-jaxrs
 org.codehaus.jackson:jackson-xc
 org.eclipse.jetty:jetty-client
-org.eclipse.jetty:jetty-continuation
 org.eclipse.jetty:jetty-http
 org.eclipse.jetty:jetty-io
 org.eclipse.jetty:jetty-jndi

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -148,11 +148,6 @@
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-continuation</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlet</artifactId>
       <scope>compile</scope>
     </dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -533,7 +533,7 @@
               <overWriteIfNewer>true</overWriteIfNewer>
               <useSubDirectoryPerType>true</useSubDirectoryPerType>
               <includeArtifactIds>
-                guava,protobuf-java,jetty-io,jetty-servlet,jetty-servlets,jetty-continuation,jetty-http,jetty-plus,jetty-util,jetty-server,jetty-security,jetty-proxy,jetty-client
+                guava,protobuf-java,jetty-io,jetty-servlet,jetty-servlets,jetty-http,jetty-plus,jetty-util,jetty-server,jetty-security,jetty-proxy,jetty-client
               </includeArtifactIds>
               <silent>true</silent>
             </configuration>
@@ -553,7 +553,6 @@
               <include>org.eclipse.jetty:jetty-http</include>
               <include>org.eclipse.jetty:jetty-proxy</include>
               <include>org.eclipse.jetty:jetty-client</include>
-              <include>org.eclipse.jetty:jetty-continuation</include>
               <include>org.eclipse.jetty:jetty-servlet</include>
               <include>org.eclipse.jetty:jetty-servlets</include>
               <include>org.eclipse.jetty:jetty-plus</include>

--- a/core/src/main/scala/org/apache/spark/SSLOptions.scala
+++ b/core/src/main/scala/org/apache/spark/SSLOptions.scala
@@ -87,7 +87,7 @@ private[spark] case class SSLOptions(
   /**
    * Creates a Jetty SSL context factory according to the SSL settings represented by this object.
    */
-  def createJettySslContextFactory(): Option[SslContextFactory] = {
+  def createJettySslContextFactoryServer(): Option[SslContextFactory.Server] = {
     if (enabled) {
       val sslContextFactory = new SslContextFactory.Server()
 

--- a/core/src/main/scala/org/apache/spark/TestUtils.scala
+++ b/core/src/main/scala/org/apache/spark/TestUtils.scala
@@ -256,9 +256,9 @@ private[spark] object TestUtils extends SparkTestUtils {
    * Returns the Location header from an HTTP(S) URL.
    */
   def redirectUrl(
-                        url: URL,
-                        method: String = "GET",
-                        headers: Seq[(String, String)] = Nil): String = {
+      url: URL,
+      method: String = "GET",
+      headers: Seq[(String, String)] = Nil): String = {
     withHttpConnection(url, method, headers = headers) { connection =>
       connection.getHeaderField("Location");
     }

--- a/core/src/main/scala/org/apache/spark/TestUtils.scala
+++ b/core/src/main/scala/org/apache/spark/TestUtils.scala
@@ -253,6 +253,19 @@ private[spark] object TestUtils extends SparkTestUtils {
   }
 
   /**
+   * Returns the Location header from an HTTP(S) URL.
+   */
+  def redirectUrl(
+                        url: URL,
+                        method: String = "GET",
+                        headers: Seq[(String, String)] = Nil): String = {
+    withHttpConnection(url, method, headers = headers) { connection =>
+      connection.getHeaderField("Location");
+    }
+  }
+
+
+  /**
    * Returns the response message from an HTTP(S) URL.
    */
   def httpResponseMessage(

--- a/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
@@ -325,6 +325,11 @@ private[spark] object JettyUtils extends Logging {
       // If SSL is configured, create the secure connector first.
       val securePort = sslOptions.createJettySslContextFactoryServer().map { factory =>
 
+        // spark-45522: SniHostCheck defaulted to true since Jetty 10, this will affect the standalone deployment.
+        val src = new SecureRequestCustomizer()
+        src.setSniHostCheck(false)
+        httpConfig.addCustomizer(src)
+
         val securePort = sslOptions.port.getOrElse(if (port > 0) Utils.userPort(port, 400) else 0)
         val secureServerName = if (serverName.nonEmpty) s"$serverName (HTTPS)" else serverName
 

--- a/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
@@ -325,7 +325,7 @@ private[spark] object JettyUtils extends Logging {
       // If SSL is configured, create the secure connector first.
       val securePort = sslOptions.createJettySslContextFactoryServer().map { factory =>
 
-        // spark-45522: SniHostCheck defaulted to true since Jetty 10,
+        // SPARK-45522: SniHostCheck defaulted to true since Jetty 10,
         // this will affect the standalone deployment.
         val src = new SecureRequestCustomizer()
         src.setSniHostCheck(false)

--- a/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
@@ -204,7 +204,7 @@ private[spark] object JettyUtils extends Logging {
         // SPARK-21176: Use the Jetty logic to calculate the number of selector threads (#CPUs/2),
         // but limit it to 8 max.
         val numSelectors = math.max(1, math.min(8, Runtime.getRuntime().availableProcessors() / 2))
-        new HttpClient(new HttpClientTransportOverHTTP(numSelectors), null)
+        new HttpClient(new HttpClientTransportOverHTTP(numSelectors))
       }
 
       override def filterServerResponseHeader(
@@ -325,8 +325,10 @@ private[spark] object JettyUtils extends Logging {
 
       // If SSL is configured, create the secure connector first.
       val securePort = sslOptions.createJettySslContextFactory().map { factory =>
+
         val securePort = sslOptions.port.getOrElse(if (port > 0) Utils.userPort(port, 400) else 0)
         val secureServerName = if (serverName.nonEmpty) s"$serverName (HTTPS)" else serverName
+
         val connectionFactories = AbstractConnectionFactory.getFactories(factory,
           new HttpConnectionFactory(httpConfig))
 

--- a/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
@@ -325,7 +325,8 @@ private[spark] object JettyUtils extends Logging {
       // If SSL is configured, create the secure connector first.
       val securePort = sslOptions.createJettySslContextFactoryServer().map { factory =>
 
-        // spark-45522: SniHostCheck defaulted to true since Jetty 10, this will affect the standalone deployment.
+        // spark-45522: SniHostCheck defaulted to true since Jetty 10,
+        // this will affect the standalone deployment.
         val src = new SecureRequestCustomizer()
         src.setSniHostCheck(false)
         httpConfig.addCustomizer(src)

--- a/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
@@ -324,7 +324,7 @@ private[spark] object JettyUtils extends Logging {
       httpConfig.setSendXPoweredBy(false)
 
       // If SSL is configured, create the secure connector first.
-      val securePort = sslOptions.createJettySslContextFactory().map { factory =>
+      val securePort = sslOptions.createJettySslContextFactoryServer().map { factory =>
 
         val securePort = sslOptions.port.getOrElse(if (port > 0) Utils.userPort(port, 400) else 0)
         val secureServerName = if (serverName.nonEmpty) s"$serverName (HTTPS)" else serverName

--- a/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
@@ -300,7 +300,6 @@ private[spark] object JettyUtils extends Logging {
         connector.setReuseAddress(!Utils.isWindows)
          // spark-45248: set the idle timeout to prevent slow DoS
         connector.setIdleTimeout(8000)
-        connector.setStopTimeout(stopTimeout)
 
         // Currently we only use "SelectChannelConnector"
         // Limit the max acceptor number to 8 so that we don't waste a lot of threads

--- a/core/src/test/scala/org/apache/spark/ui/UISuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/UISuite.scala
@@ -310,21 +310,16 @@ class UISuite extends SparkFunSuite {
       val httpPort = serverInfo.boundPort
 
       val tests = Seq(
-//        ("http", serverInfo.boundPort, HttpServletResponse.SC_FOUND))
-      // Failed on HTTPS
       ("http", serverInfo.boundPort, HttpServletResponse.SC_FOUND),
       ("https", serverInfo.securePort.get, HttpServletResponse.SC_OK))
 
       tests.foreach { case (scheme, port, expected) =>
         val urls = Seq(
-//          s"$scheme://$localhost:$port/test3")
           s"$scheme://$localhost:$port/root",
           s"$scheme://$localhost:$port/test1/root",
           s"$scheme://$localhost:$port/test2/root")
         urls.foreach { url =>
 
-//          val message = TestUtils.httpResponseMessage(new URL(url))
-//          assert(message === "test")
           val rc = TestUtils.httpResponseCode(new URL(url))
           assert(rc === expected, s"Unexpected status $rc for $url")
         }
@@ -403,28 +398,28 @@ class UISuite extends SparkFunSuite {
       stopServer(serverInfo)
     }
   }
-//
-//  test("SPARK-34449: Jetty 9.4.35.v20201120 and later no longer return status code 302 " +
-//       " and handle internally when request URL ends with a context path without trailing '/'") {
-//    val proxyRoot = "https://proxy.example.com:443/prefix"
-//    val (conf, securityMgr, sslOptions) = sslDisabledConf()
-//    conf.set(UI.PROXY_REDIRECT_URI, proxyRoot)
-//    val serverInfo = JettyUtils.startJettyServer("0.0.0.0", 0, sslOptions, conf)
-//
-//    try {
-//      val (_, ctx) = newContext("/ctx")
-//      serverInfo.addHandler(ctx, securityMgr)
-//      val urlStr = s"http://$localhost:${serverInfo.boundPort}/ctx"
-//
-//      assert(TestUtils.httpResponseCode(new URL(urlStr + "/")) === HttpServletResponse.SC_OK)
-//
-//      // In the case of trailing slash, 302 should be return and the redirect URL shouuld be part of the header.
-//      assert(TestUtils.redirectUrl(new URL(urlStr)) === proxyRoot + "/ctx/");
-//      assert(TestUtils.httpResponseCode(new URL(urlStr)) === HttpServletResponse.SC_FOUND)
-//    } finally {
-//      stopServer(serverInfo)
-//    }
-//  }
+
+  test("SPARK-45522: Jetty 10 and above shouuld return status code 302 with correct redirect url" +
+    " when request URL ends with a context path without trailing '/'") {
+    val proxyRoot = "https://proxy.example.com:443/prefix"
+    val (conf, securityMgr, sslOptions) = sslDisabledConf()
+    conf.set(UI.PROXY_REDIRECT_URI, proxyRoot)
+    val serverInfo = JettyUtils.startJettyServer("0.0.0.0", 0, sslOptions, conf)
+
+    try {
+      val (_, ctx) = newContext("/ctx")
+      serverInfo.addHandler(ctx, securityMgr)
+      val urlStr = s"http://$localhost:${serverInfo.boundPort}/ctx"
+
+      assert(TestUtils.httpResponseCode(new URL(urlStr + "/")) === HttpServletResponse.SC_OK)
+
+      // In the case of trailing slash, 302 should be return and the redirect URL shouuld be part of the header.
+      assert(TestUtils.redirectUrl(new URL(urlStr)) === proxyRoot + "/ctx/");
+      assert(TestUtils.httpResponseCode(new URL(urlStr)) === HttpServletResponse.SC_FOUND)
+    } finally {
+      stopServer(serverInfo)
+    }
+  }
 
   test("SPARK-34449: default thread pool size of different jetty servers") {
     val (conf, _, sslOptions) = sslDisabledConf()

--- a/core/src/test/scala/org/apache/spark/ui/UISuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/UISuite.scala
@@ -412,7 +412,8 @@ class UISuite extends SparkFunSuite {
 
       assert(TestUtils.httpResponseCode(new URL(urlStr + "/")) === HttpServletResponse.SC_OK)
 
-      // In the case of trailing slash, 302 should be return and the redirect URL shouuld be part of the header.
+      // In the case of trailing slash,
+      // 302 should be return and the redirect URL shouuld be part of the header.
       assert(TestUtils.redirectUrl(new URL(urlStr)) === proxyRoot + "/ctx/");
       assert(TestUtils.httpResponseCode(new URL(urlStr)) === HttpServletResponse.SC_FOUND)
     } finally {

--- a/core/src/test/scala/org/apache/spark/ui/UISuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/UISuite.scala
@@ -310,8 +310,8 @@ class UISuite extends SparkFunSuite {
       val httpPort = serverInfo.boundPort
 
       val tests = Seq(
-      ("http", serverInfo.boundPort, HttpServletResponse.SC_FOUND),
-      ("https", serverInfo.securePort.get, HttpServletResponse.SC_OK))
+        ("http", serverInfo.boundPort, HttpServletResponse.SC_FOUND),
+        ("https", serverInfo.securePort.get, HttpServletResponse.SC_OK))
 
       tests.foreach { case (scheme, port, expected) =>
         val urls = Seq(
@@ -319,7 +319,6 @@ class UISuite extends SparkFunSuite {
           s"$scheme://$localhost:$port/test1/root",
           s"$scheme://$localhost:$port/test2/root")
         urls.foreach { url =>
-
           val rc = TestUtils.httpResponseCode(new URL(url))
           assert(rc === expected, s"Unexpected status $rc for $url")
         }

--- a/core/src/test/scala/org/apache/spark/ui/UISuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/UISuite.scala
@@ -401,9 +401,9 @@ class UISuite extends SparkFunSuite {
 
       assert(TestUtils.httpResponseCode(new URL(urlStr + "/")) === HttpServletResponse.SC_OK)
 
-      // If the following assertion fails when we upgrade Jetty, it seems to change the behavior of
-      // handling context path which doesn't have the trailing slash.
-      assert(TestUtils.httpResponseCode(new URL(urlStr)) === HttpServletResponse.SC_OK)
+      // In the case of trailing slash, 302 should be return and the redirect URL shouuld be part of the header.
+      assert(TestUtils.redirectUrl(new URL(urlStr)) === proxyRoot + "/ctx/");
+      assert(TestUtils.httpResponseCode(new URL(urlStr)) === HttpServletResponse.SC_FOUND)
     } finally {
       stopServer(serverInfo)
     }

--- a/core/src/test/scala/org/apache/spark/ui/UISuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/UISuite.scala
@@ -317,7 +317,8 @@ class UISuite extends SparkFunSuite {
 
       tests.foreach { case (scheme, port, expected) =>
         val urls = Seq(
-//          s"$scheme://$localhost:$port/root",
+//          s"$scheme://$localhost:$port/test3")
+          s"$scheme://$localhost:$port/root",
           s"$scheme://$localhost:$port/test1/root",
           s"$scheme://$localhost:$port/test2/root")
         urls.foreach { url =>

--- a/core/src/test/scala/org/apache/spark/ui/UISuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/UISuite.scala
@@ -310,15 +310,20 @@ class UISuite extends SparkFunSuite {
       val httpPort = serverInfo.boundPort
 
       val tests = Seq(
-        ("http", serverInfo.boundPort, HttpServletResponse.SC_FOUND),
-        ("https", serverInfo.securePort.get, HttpServletResponse.SC_OK))
+//        ("http", serverInfo.boundPort, HttpServletResponse.SC_FOUND))
+      // Failed on HTTPS
+      ("http", serverInfo.boundPort, HttpServletResponse.SC_FOUND),
+      ("https", serverInfo.securePort.get, HttpServletResponse.SC_OK))
 
       tests.foreach { case (scheme, port, expected) =>
         val urls = Seq(
-          s"$scheme://$localhost:$port/root",
+//          s"$scheme://$localhost:$port/root",
           s"$scheme://$localhost:$port/test1/root",
           s"$scheme://$localhost:$port/test2/root")
         urls.foreach { url =>
+
+//          val message = TestUtils.httpResponseMessage(new URL(url))
+//          assert(message === "test")
           val rc = TestUtils.httpResponseCode(new URL(url))
           assert(rc === expected, s"Unexpected status $rc for $url")
         }

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -131,8 +131,8 @@ jersey-container-servlet/2.41//jersey-container-servlet-2.41.jar
 jersey-hk2/2.41//jersey-hk2-2.41.jar
 jersey-server/2.41//jersey-server-2.41.jar
 jettison/1.5.4//jettison-1.5.4.jar
-jetty-util-ajax/10.0.18//jetty-util-ajax-10.0.18.jar
-jetty-util/10.0.18//jetty-util-10.0.18.jar
+jetty-util-ajax/10.0.19//jetty-util-ajax-10.0.19.jar
+jetty-util/10.0.19//jetty-util-10.0.19.jar
 jline/2.14.6//jline-2.14.6.jar
 jline/3.22.0//jline-3.22.0.jar
 jna/5.13.0//jna-5.13.0.jar

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -131,8 +131,8 @@ jersey-container-servlet/2.41//jersey-container-servlet-2.41.jar
 jersey-hk2/2.41//jersey-hk2-2.41.jar
 jersey-server/2.41//jersey-server-2.41.jar
 jettison/1.5.4//jettison-1.5.4.jar
-jetty-util-ajax/9.4.53.v20231009//jetty-util-ajax-9.4.53.v20231009.jar
-jetty-util/9.4.53.v20231009//jetty-util-9.4.53.v20231009.jar
+jetty-util-ajax/10.0.18//jetty-util-ajax-10.0.18.jar
+jetty-util/10.0.18//jetty-util-10.0.18.jar
 jline/2.14.6//jline-2.14.6.jar
 jline/3.22.0//jline-3.22.0.jar
 jna/5.13.0//jna-5.13.0.jar

--- a/dev/test-dependencies.sh
+++ b/dev/test-dependencies.sh
@@ -51,7 +51,7 @@ OLD_VERSION=$($MVN -q \
 # dependency:get for guava and jetty-io are workaround for SPARK-37302.
 GUAVA_VERSION=$(build/mvn help:evaluate -Dexpression=guava.version -q -DforceStdout | grep -E "^[0-9.]+$")
 build/mvn dependency:get -Dartifact=com.google.guava:guava:${GUAVA_VERSION} -q
-JETTY_VERSION=$(build/mvn help:evaluate -Dexpression=jetty.version -q -DforceStdout | grep -E "^[0-9.]+v[0-9]+")
+JETTY_VERSION=$(build/mvn help:evaluate -Dexpression=jetty.version -q -DforceStdout | grep -E "[0-9]+\.[0-9]+\.[0-9]+")
 build/mvn dependency:get -Dartifact=org.eclipse.jetty:jetty-io:${JETTY_VERSION} -q
 if [ $? != 0 ]; then
     echo -e "Error while getting version string from Maven:\n$OLD_VERSION"

--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
     <parquet.version>1.13.1</parquet.version>
     <orc.version>1.9.2</orc.version>
     <orc.classifier>shaded-protobuf</orc.classifier>
-    <jetty.version>9.4.53.v20231009</jetty.version>
+    <jetty.version>10.0.18</jetty.version>
     <jakartaservlet.version>4.0.3</jakartaservlet.version>
     <chill.version>0.10.0</chill.version>
     <!--
@@ -486,12 +486,6 @@
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-http</artifactId>
-        <version>${jetty.version}</version>
-        <scope>provided</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-continuation</artifactId>
         <version>${jetty.version}</version>
         <scope>provided</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
     <parquet.version>1.13.1</parquet.version>
     <orc.version>1.9.2</orc.version>
     <orc.classifier>shaded-protobuf</orc.classifier>
-    <jetty.version>10.0.18</jetty.version>
+    <jetty.version>10.0.19</jetty.version>
     <jakartaservlet.version>4.0.3</jakartaservlet.version>
     <chill.version>0.10.0</chill.version>
     <!--

--- a/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/thrift/ThriftHttpCLIService.java
+++ b/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/thrift/ThriftHttpCLIService.java
@@ -84,7 +84,7 @@ public class ThriftHttpCLIService extends ThriftCLIService {
           throw new IllegalArgumentException(ConfVars.HIVE_SERVER2_SSL_KEYSTORE_PATH.varname
               + " Not configured for SSL connection");
         }
-        SslContextFactory sslContextFactory = new SslContextFactory.Server();
+        SslContextFactory.Server sslContextFactory = new SslContextFactory.Server();
         String[] excludedProtocols = hiveConf.getVar(ConfVars.HIVE_SSL_PROTOCOL_BLACKLIST).split(",");
         LOG.info("HTTP Server SSL: adding excluded protocols: " + Arrays.toString(excludedProtocols));
         sslContextFactory.addExcludeProtocols(excludedProtocols);

--- a/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/thrift/ThriftHttpCLIService.java
+++ b/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/thrift/ThriftHttpCLIService.java
@@ -84,16 +84,16 @@ public class ThriftHttpCLIService extends ThriftCLIService {
           throw new IllegalArgumentException(ConfVars.HIVE_SERVER2_SSL_KEYSTORE_PATH.varname
               + " Not configured for SSL connection");
         }
-        SslContextFactory.Server sslContextFactory = new SslContextFactory.Server();
+        SslContextFactory.Server sslContextFactoryServer = new SslContextFactory.Server();
         String[] excludedProtocols = hiveConf.getVar(ConfVars.HIVE_SSL_PROTOCOL_BLACKLIST).split(",");
         LOG.info("HTTP Server SSL: adding excluded protocols: " + Arrays.toString(excludedProtocols));
-        sslContextFactory.addExcludeProtocols(excludedProtocols);
+        sslContextFactoryServer.addExcludeProtocols(excludedProtocols);
         LOG.info("HTTP Server SSL: SslContextFactory.getExcludeProtocols = " +
-          Arrays.toString(sslContextFactory.getExcludeProtocols()));
-        sslContextFactory.setKeyStorePath(keyStorePath);
-        sslContextFactory.setKeyStorePassword(keyStorePassword);
+          Arrays.toString(sslContextFactoryServer.getExcludeProtocols()));
+        sslContextFactoryServer.setKeyStorePath(keyStorePath);
+        sslContextFactoryServer.setKeyStorePassword(keyStorePassword);
         connectionFactories = AbstractConnectionFactory.getFactories(
-            sslContextFactory, new HttpConnectionFactory());
+            sslContextFactoryServer, new HttpConnectionFactory());
       } else {
         connectionFactories = new ConnectionFactory[] { new HttpConnectionFactory() };
       }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This is an upgrade ticket to bump the Jetty version from 9 to 10.
This PR aims to bring incremental Jetty upgrades to Spark, as Jetty 9 support already reached EOL.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Jetty 9 is already beyond EOL, which means that we won't receive any security fix onward for Spark.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No, SNI host check is now defaulted to true on embedded Jetty, hence set it back to false to maintain backward compatibility.
Despite the redirect behaviour changed for trailing /, but modern browser should be able to pick up the 302 status code and perform redirect accordingly, hence there is no impact on user level.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Junit test case.


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No
