### PR TITLE
[SPARK-45893][HIVE] Support drop multiple partitions in batch for hive

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4016,6 +4016,18 @@ object SQLConf {
       .checkValue(_ > 0, "The value of spark.sql.addPartitionInBatch.size must be positive")
       .createWithDefault(100)
 
+  val DROP_PARTITION_BATCH_SIZE =
+    buildConf("spark.sql.dropPartitionInBatch.size")
+      .internal()
+      .doc("The number of partitions to be dropped in one turn when use " +
+        "`AlterTableDropPartitionCommand` or `RepairTableCommand` to drop partitions from table. " +
+        "The smaller batch size is, the less memory is required for the real handler, e.g. " +
+        "Hive Metastore.")
+      .version("4.0.0")
+      .intConf
+      .checkValue(_ > 0, "The value of spark.sql.dropPartitionInBatch.size must be positive")
+      .createWithDefault(100)
+
   val LEGACY_ALLOW_HASH_ON_MAPTYPE = buildConf("spark.sql.legacy.allowHashOnMapType")
     .internal()
     .doc("When set to true, hash expressions can be applied on elements of MapType. Otherwise, " +

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4016,6 +4016,15 @@ object SQLConf {
       .checkValue(_ > 0, "The value of spark.sql.addPartitionInBatch.size must be positive")
       .createWithDefault(100)
 
+  val DROP_PARTITION_IN_BATCH_ENABLED =
+    buildConf("spark.sql.dropPartitionInBatch.enabled")
+      .doc("When true, enable drop multiple partitions in a call to improve performance." +
+        "Spark will fall back to drop partitions one by one if the input partition value " +
+        "cannot be converted to the partition type correctly.")
+      .version("4.0.0")
+      .booleanConf
+      .createWithDefault(true)
+
   val DROP_PARTITION_BATCH_SIZE =
     buildConf("spark.sql.dropPartitionInBatch.size")
       .internal()

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/AlterTableDropPartitionSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/AlterTableDropPartitionSuiteBase.scala
@@ -146,14 +146,9 @@ trait AlterTableDropPartitionSuiteBase extends QueryTest with DDLCommandTestUtil
           } else {
             "`test_catalog`.`ns`.`tbl`"
           }
-          val expectedPartitionList = if (dropPartitionInBatch) {
-            "PARTITION (`id` = 1), PARTITION (`id` = 2)"
-          } else {
-            "PARTITION (`id` = 2)"
-          }
           checkError(e,
             errorClass = "PARTITIONS_NOT_FOUND",
-            parameters = Map("partitionList" -> expectedPartitionList,
+            parameters = Map("partitionList" -> "PARTITION (`id` = 2)",
               "tableName" -> expectedTableName))
 
           checkPartitions(t, Map("id" -> "1"))

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -659,7 +659,10 @@ private[hive] class HiveClientImpl(
       retainData: Boolean): Unit = withHiveState {
     def replaceNotExistException(e: Throwable): Unit = e match {
       case _ if e.getCause.isInstanceOf[NoSuchObjectException] =>
-        throw new NoSuchPartitionsException(db, table, specs)
+        val missingSpecs = specs.filter { spec =>
+          shim.getPartitionNames(client, db, table, spec.asJava, -1).isEmpty
+        }
+        throw new NoSuchPartitionsException(db, table, missingSpecs)
       case _ => throw e
     }
     def dropPartitionsOneByOne(): Unit = {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -59,7 +59,7 @@ import org.apache.spark.sql.catalyst.util.CharVarcharUtils
 import org.apache.spark.sql.connector.catalog.SupportsNamespaces._
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
 import org.apache.spark.sql.execution.QueryExecutionException
-import org.apache.spark.sql.hive.{HiveExternalCatalog, HiveUtils}
+import org.apache.spark.sql.hive.HiveExternalCatalog
 import org.apache.spark.sql.hive.HiveExternalCatalog.DATASOURCE_SCHEMA
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
@@ -656,51 +656,16 @@ private[hive] class HiveClientImpl(
       ignoreIfNotExists: Boolean,
       purge: Boolean,
       retainData: Boolean): Unit = withHiveState {
-    // TODO: figure out how to drop multiple partitions in one call
-    // do the check at first and collect all the matching partitions
-    val matchingParts =
-      specs.flatMap { s =>
-        assert(s.values.forall(_.nonEmpty), s"partition spec '$s' is invalid")
-        // The provided spec here can be a partial spec, i.e. it will match all partitions
-        // whose specs are supersets of this partial spec. E.g. If a table has partitions
-        // (b='1', c='1') and (b='1', c='2'), a partial spec of (b='1') will match both.
-        val dropPartitionByName = SQLConf.get.metastoreDropPartitionsByName
-        if (dropPartitionByName) {
-          val partitionNames = shim.getPartitionNames(client, db, table, s.asJava, -1)
-          if (partitionNames.isEmpty && !ignoreIfNotExists) {
-            throw new NoSuchPartitionsException(db, table, Seq(s))
-          }
-          partitionNames.map(HiveUtils.partitionNameToValues(_).toList.asJava)
-        } else {
-          val hiveTable = shim.getTable(client, db, table, true /* throw exception */)
-          val parts = shim.getPartitions(client, hiveTable, s.asJava)
-          if (parts.isEmpty && !ignoreIfNotExists) {
-            throw new NoSuchPartitionsException(db, table, Seq(s))
-          }
-          parts.map(_.getValues)
-        }
-      }.distinct
-    val droppedParts = ArrayBuffer.empty[java.util.List[String]]
-    matchingParts.foreach { partition =>
-      try {
-        shim.dropPartition(client, db, table, partition, !retainData, purge)
-      } catch {
-        case e: Exception =>
-          val remainingParts = matchingParts.toBuffer --= droppedParts
-          logError(
-            s"""
-               |======================
-               |Attempt to drop the partition specs in table '$table' database '$db':
-               |${specs.mkString("\n")}
-               |In this attempt, the following partitions have been dropped successfully:
-               |${droppedParts.mkString("\n")}
-               |The remaining partitions have not been dropped:
-               |${remainingParts.mkString("\n")}
-               |======================
-             """.stripMargin)
-          throw e
-      }
-      droppedParts += partition
+    def replaceNotExistException(e: Throwable): Unit = e match {
+      case _: HiveException if e.getCause.isInstanceOf[NoSuchObjectException] =>
+        throw new NoSuchPartitionsException(db, table, specs)
+      case _ => throw e
+    }
+    try {
+      shim.dropPartitions(client, db, table, specs, !retainData, ignoreIfNotExists, purge)
+    } catch {
+      case e: InvocationTargetException => replaceNotExistException(e.getCause)
+      case e: Throwable => replaceNotExistException(e)
     }
   }
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -59,9 +59,10 @@ import org.apache.spark.sql.catalyst.util.CharVarcharUtils
 import org.apache.spark.sql.connector.catalog.SupportsNamespaces._
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
 import org.apache.spark.sql.execution.QueryExecutionException
-import org.apache.spark.sql.hive.HiveExternalCatalog
+import org.apache.spark.sql.hive.{HiveExternalCatalog, HiveUtils}
 import org.apache.spark.sql.hive.HiveExternalCatalog.DATASOURCE_SCHEMA
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.internal.SQLConf.DROP_PARTITION_IN_BATCH_ENABLED
 import org.apache.spark.sql.types._
 import org.apache.spark.util.{CircularBuffer, Utils}
 
@@ -657,12 +658,70 @@ private[hive] class HiveClientImpl(
       purge: Boolean,
       retainData: Boolean): Unit = withHiveState {
     def replaceNotExistException(e: Throwable): Unit = e match {
-      case _: HiveException if e.getCause.isInstanceOf[NoSuchObjectException] =>
+      case _ if e.getCause.isInstanceOf[NoSuchObjectException] =>
         throw new NoSuchPartitionsException(db, table, specs)
       case _ => throw e
     }
+    def dropPartitionsOneByOne(): Unit = {
+      // do the check at first and collect all the matching partitions
+      val matchingParts =
+        specs.flatMap { s =>
+          assert(s.values.forall(_.nonEmpty), s"partition spec '$s' is invalid")
+          // The provided spec here can be a partial spec, i.e. it will match all partitions
+          // whose specs are supersets of this partial spec. E.g. If a table has partitions
+          // (b='1', c='1') and (b='1', c='2'), a partial spec of (b='1') will match both.
+          val dropPartitionByName = SQLConf.get.metastoreDropPartitionsByName
+          if (dropPartitionByName) {
+            val partitionNames = shim.getPartitionNames(client, db, table, s.asJava, -1)
+            if (partitionNames.isEmpty && !ignoreIfNotExists) {
+              throw new NoSuchPartitionsException(db, table, Seq(s))
+            }
+            partitionNames.map(HiveUtils.partitionNameToValues(_).toList.asJava)
+          } else {
+            val hiveTable = shim.getTable(client, db, table, true /* throw exception */)
+            val parts = shim.getPartitions(client, hiveTable, s.asJava)
+            if (parts.isEmpty && !ignoreIfNotExists) {
+              throw new NoSuchPartitionsException(db, table, Seq(s))
+            }
+            parts.map(_.getValues)
+          }
+        }.distinct
+      val droppedParts = ArrayBuffer.empty[java.util.List[String]]
+      matchingParts.foreach { partition =>
+        try {
+          shim.dropPartition(client, db, table, partition, !retainData, purge)
+        } catch {
+          case e: Exception =>
+            val remainingParts = matchingParts.toBuffer --= droppedParts
+            logError(
+              s"""
+                 |======================
+                 |Attempt to drop the partition specs in table '$table' database '$db':
+                 |In this attempt, the following partitions have been dropped successfully:
+                 |${droppedParts.mkString("\n")}
+                 |The remaining partitions have not been dropped:
+                 |${remainingParts.mkString("\n")}
+                 |======================
+               """.stripMargin)
+            throw e
+        }
+        droppedParts += partition
+      }
+    }
+
     try {
-      shim.dropPartitions(client, db, table, specs, !retainData, ignoreIfNotExists, purge)
+      val enableDropPartitionInBatch = SQLConf.get.getConf(DROP_PARTITION_IN_BATCH_ENABLED)
+      if (enableDropPartitionInBatch) {
+        try {
+          shim.dropPartitions(client, db, table, specs, !retainData, ignoreIfNotExists, purge)
+        } catch {
+          case e: IllegalArgumentException if enableDropPartitionInBatch =>
+            logWarning(s"${e.getMessage}, falling back to drop partitions one by one.")
+            dropPartitionsOneByOne()
+        }
+      } else {
+        dropPartitionsOneByOne()
+      }
     } catch {
       case e: InvocationTargetException => replaceNotExistException(e.getCause)
       case e: Throwable => replaceNotExistException(e)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
@@ -603,8 +603,7 @@ private[client] class Shim_v2_0 extends Shim with Logging {
         val colType = colTypes.get(partKey)
         assert(colType.isDefined, s"`$partKey` is not partition key.")
         val (typeInfo, converter) = partKeyToTypeInfoAndConverter.get(partKey).get
-        if (SQLConf.get.getConf(SQLConf.SKIP_TYPE_VALIDATION_ON_ALTER_PARTITION)
-          && null == converter.convert(partVal)) {
+        if (null == converter.convert(partVal)) {
           throw new IllegalArgumentException(
             s"Partition value '$partVal' cannot be cast to type '${colType.get}'")
         }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support drop multiple partitions in batch in `HiveShim`, including:
1. add a config `spark.sql.dropPartitionInBatch.enabled` to enable drop partitions in batch.
2. add a config `spark.sql.dropPartitionInBatch.size` to control the batch size of drop partitions.
3. Implement the `dropPartitions()` for different hive versions.
4. Fall back to drop partitions one by one if input value can not be cast to part type.


### Why are the changes needed?
To improve the performance of `dropPartitions()`.


### Does this PR introduce _any_ user-facing change?
Yes, user can use the new config `spark.sql.dropPartitionInBatch.size` to control the drop batch size.


### How was this patch tested?
Passing all existing tests.


### Was this patch authored or co-authored using generative AI tooling?
No.
