### PR TITLE
[SPARK-44001][PROTOBUF] Add option to allow unwrapping protobuf well known wrapper types

### DIFF
--- a/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/ProtobufSerializer.scala
+++ b/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/ProtobufSerializer.scala
@@ -18,7 +18,7 @@ package org.apache.spark.sql.protobuf
 
 import scala.jdk.CollectionConverters._
 
-import com.google.protobuf.{Duration, DynamicMessage, Timestamp, WireFormat}
+import com.google.protobuf.{BoolValue, ByteString, BytesValue, DoubleValue, Duration, DynamicMessage, FloatValue, Int32Value, Int64Value, StringValue, Timestamp, UInt32Value, UInt64Value, WireFormat}
 import com.google.protobuf.Descriptors.{Descriptor, FieldDescriptor}
 import com.google.protobuf.Descriptors.FieldDescriptor.JavaType._
 
@@ -172,6 +172,52 @@ private[sql] class ProtobufSerializer(
           // `ArrayList` backed by the specified array without data copying.
           java.util.Arrays.asList(result: _*)
         }
+
+      // Handle serializing primitives back into well known wrapper types.
+      case (BooleanType, MESSAGE)
+        if fieldDescriptor.getMessageType.getFullName == BoolValue.getDescriptor.getFullName =>
+        (getter, ordinal) =>
+          BoolValue.of(getter.getBoolean(ordinal))
+
+      case (IntegerType, MESSAGE)
+        if fieldDescriptor.getMessageType.getFullName == Int32Value.getDescriptor.getFullName =>
+        (getter, ordinal) =>
+          Int32Value.of(getter.getInt(ordinal))
+
+      case (IntegerType, MESSAGE)
+        if fieldDescriptor.getMessageType.getFullName == UInt32Value.getDescriptor.getFullName =>
+        (getter, ordinal) =>
+          UInt32Value.of(getter.getInt(ordinal))
+
+      case (LongType, MESSAGE)
+        if fieldDescriptor.getMessageType.getFullName == Int64Value.getDescriptor.getFullName =>
+        (getter, ordinal) =>
+          Int64Value.of(getter.getLong(ordinal))
+
+      case (LongType, MESSAGE)
+        if fieldDescriptor.getMessageType.getFullName == UInt64Value.getDescriptor.getFullName =>
+        (getter, ordinal) =>
+          UInt64Value.of(getter.getLong(ordinal))
+
+      case (StringType, MESSAGE)
+        if fieldDescriptor.getMessageType.getFullName == StringValue.getDescriptor.getFullName =>
+        (getter, ordinal) =>
+          StringValue.of(getter.getUTF8String(ordinal).toString)
+
+      case (BinaryType, MESSAGE)
+        if fieldDescriptor.getMessageType.getFullName == BytesValue.getDescriptor.getFullName =>
+        (getter, ordinal) =>
+          BytesValue.of(ByteString.copyFrom(getter.getBinary(ordinal)))
+
+      case (FloatType, MESSAGE)
+        if fieldDescriptor.getMessageType.getFullName == FloatValue.getDescriptor.getFullName =>
+        (getter, ordinal) =>
+          FloatValue.of(getter.getFloat(ordinal))
+
+      case (DoubleType, MESSAGE)
+        if fieldDescriptor.getMessageType.getFullName == DoubleValue.getDescriptor.getFullName =>
+        (getter, ordinal) =>
+          DoubleValue.of(getter.getDouble(ordinal))
 
       case (st: StructType, MESSAGE) =>
         val structConverter =

--- a/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/utils/ProtobufOptions.scala
+++ b/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/utils/ProtobufOptions.scala
@@ -180,6 +180,33 @@ private[sql] class ProtobufOptions(
   // can contain large unsigned values without overflow.
   val upcastUnsignedInts: Boolean =
     parameters.getOrElse("upcast.unsigned.ints", false.toString).toBoolean
+
+  // Whether to unwrap the struct representation for well known primitve wrapper types when
+  // deserializing. By default, the wrapper types for primitives (i.e. google.protobuf.Int32Value,
+  // google.protobuf.Int64Value, etc.) will get deserialized as structs. We allow the option to
+  // deserialize them as their respective primitives.
+  // https://protobuf.dev/reference/protobuf/google.protobuf/
+  //
+  // For example, given a message like:
+  // ```
+  // syntax = "proto3";
+  // message Example {
+  //   google.protobuf.Int32Value int_val = 1;
+  // }
+  // ```
+  //
+  // The message Example(Int32Value(1)) would be deserialized by default as
+  // {int_val: {value: 5}}
+  //
+  // However, with this option set, it would be deserialized as
+  // {int_val: 5}
+  //
+  // NOTE: With `emit.default.values`, we won't fill in the default primitive value during
+  // this unwrapping; this behavior preserves as much information as possible.
+  // Concretely, the behavior with emit defaults and this option set is:
+  //    nil => nil, Int32Value(0) => 0, Int32Value(100) => 100.
+  val unwrapWellKnownTypes: Boolean =
+    parameters.getOrElse("unwrap.primitive.wrapper.types", false.toString).toBoolean
 }
 
 private[sql] object ProtobufOptions {

--- a/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/utils/SchemaConverters.scala
+++ b/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/utils/SchemaConverters.scala
@@ -18,6 +18,7 @@ package org.apache.spark.sql.protobuf.utils
 
 import scala.jdk.CollectionConverters._
 
+import com.google.protobuf.{BoolValue, BytesValue, DoubleValue, FloatValue, Int32Value, Int64Value, StringValue, UInt32Value, UInt64Value}
 import com.google.protobuf.Descriptors.{Descriptor, FieldDescriptor}
 import com.google.protobuf.WireFormat
 
@@ -103,8 +104,46 @@ object SchemaConverters extends Logging {
           fd.getMessageType.getFields.get(1).getName.equals("nanos")) =>
         Some(TimestampType)
       case MESSAGE if protobufOptions.convertAnyFieldsToJson &&
-            fd.getMessageType.getFullName == "google.protobuf.Any" =>
+        fd.getMessageType.getFullName == "google.protobuf.Any" =>
         Some(StringType) // Any protobuf will be parsed and converted to json string.
+
+      // Unwrap well known primitive wrapper types if the option has been set.
+      case MESSAGE if fd.getMessageType.getFullName == BoolValue.getDescriptor.getFullName
+        && protobufOptions.unwrapWellKnownTypes =>
+        Some(BooleanType)
+      case MESSAGE if fd.getMessageType.getFullName == Int32Value.getDescriptor.getFullName
+        && protobufOptions.unwrapWellKnownTypes =>
+        Some(IntegerType)
+      case MESSAGE if fd.getMessageType.getFullName == UInt32Value.getDescriptor.getFullName
+        && protobufOptions.unwrapWellKnownTypes =>
+        if (protobufOptions.upcastUnsignedInts) {
+          Some(LongType)
+        } else {
+          Some(IntegerType)
+        }
+      case MESSAGE if fd.getMessageType.getFullName == Int64Value.getDescriptor.getFullName
+        && protobufOptions.unwrapWellKnownTypes =>
+        Some(LongType)
+      case MESSAGE if fd.getMessageType.getFullName == UInt64Value.getDescriptor.getFullName
+        && protobufOptions.unwrapWellKnownTypes =>
+        if (protobufOptions.upcastUnsignedInts) {
+          Some(DecimalType.LongDecimal)
+        } else {
+          Some(LongType)
+        }
+      case MESSAGE if fd.getMessageType.getFullName == StringValue.getDescriptor.getFullName
+        && protobufOptions.unwrapWellKnownTypes =>
+        Some(StringType)
+      case MESSAGE if fd.getMessageType.getFullName == BytesValue.getDescriptor.getFullName
+        && protobufOptions.unwrapWellKnownTypes =>
+        Some(BinaryType)
+      case MESSAGE if fd.getMessageType.getFullName == FloatValue.getDescriptor.getFullName
+        && protobufOptions.unwrapWellKnownTypes =>
+        Some(FloatType)
+      case MESSAGE if fd.getMessageType.getFullName == DoubleValue.getDescriptor.getFullName
+        && protobufOptions.unwrapWellKnownTypes =>
+        Some(DoubleType)
+
       case MESSAGE if fd.isRepeated && fd.getMessageType.getOptions.hasMapEntry =>
         var keyType: Option[DataType] = None
         var valueType: Option[DataType] = None

--- a/connector/protobuf/src/test/resources/protobuf/functions_suite.proto
+++ b/connector/protobuf/src/test/resources/protobuf/functions_suite.proto
@@ -27,6 +27,7 @@ import "timestamp.proto";
 import "duration.proto";
 import "basicmessage.proto";
 import "google/protobuf/any.proto";
+import "google/protobuf/wrappers.proto";
 
 option java_outer_classname = "SimpleMessageProtos";
 
@@ -323,4 +324,20 @@ message Proto3AllTypes {
     string option_b = 12;
   }
   map<string, string> map = 13;
+}
+
+message WellKnownWrapperTypes {
+  google.protobuf.BoolValue bool_val = 1;
+  google.protobuf.Int32Value int32_val = 2;
+  google.protobuf.UInt32Value uint32_val = 3;
+  google.protobuf.Int64Value int64_val = 4;
+  google.protobuf.UInt64Value uint64_val = 5;
+  google.protobuf.StringValue string_val = 6;
+  google.protobuf.BytesValue bytes_val = 7;
+  google.protobuf.FloatValue float_val = 8;
+  google.protobuf.DoubleValue double_val = 9;
+
+  // Sample repeated and map types
+  repeated google.protobuf.Int32Value int32_list = 10;
+  map<int32, google.protobuf.StringValue> wkt_map = 11;
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

JIRA: https://issues.apache.org/jira/browse/SPARK-44001

Under com.google.protobuf, there are some [well known primitive wrapper types](https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/wrappers.proto), useful for distinguishing between absence of primitive fields and their default values, as well as for use within `google.protobuf.Any` types. These types are:

```
DoubleValue
FloatValue
Int64Value
Uint64Value
Int32Value
Uint32Value
BoolValue
StringValue
BytesValue
```

Currently, when we deserialize these from a serialized protobuf into a spark struct, we expand them as if they were normal messages. Concretely, if we have

```
syntax = "proto3";

import "google/protobuf/wrappers.proto"

message WktExample {
  google.protobuf.BoolValue bool_val = 1;
  google.protobuf.Int32Value int32_val = 2;
}
```

And a message like

```
WktExample(true, 100)
```

Then the behavior today is to deserialize this as.

```
{"bool_val": {"value": true}, "int32_val": {"value": 100}}
```

This is quite difficult to work with and not in the spirit of the wrapper type, so it would be nice to have an option to unwrap them when deserializing, i.e.:

```
{"bool_val": true, "int32_val": 100}
```

This is also the default behavior by other popular deserialization libraries, including java protobuf util [Jsonformat](https://github.com/protocolbuffers/protobuf/blob/92619cdd433c5eed314d6b871060ac2340f52906/java/util/src/main/java/com/google/protobuf/util/JsonFormat.java#L761-L777) and golangs [jsonpb](https://github.com/gogo/protobuf/blob/f67b8970b736e53dbd7d0a27146c8f1ac52f74e5/jsonpb/jsonpb.go#L207-L214).

So for consistency with other libraries and improved usability, I add a deserialization option, `unwrap.protobuf.wkt` to enable this behavior. I add an option to avoid breaking any existing clients.

### Why are the changes needed?
Improved usability and consistency with other deserialization libraries.

### Does this PR introduce any user-facing change?
Yes, deserialization of well known types will change from the struct format to the inline format.

### How was this patch tested?
Added a unit test testing every well known type deserialization explicitly, as well as testing roundtrip.

### Was this patch authored or co-authored using generative AI tooling?
No