### PR TITLE
[SPARK-45894][SQL] hive table level setting hadoop.mapred.max.split.size

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -245,6 +245,13 @@ object SQLConf {
     .intConf
     .createWithDefault(100)
 
+  val MAPRED_MAX_SPLIT_SIZE_BY_TABLE =
+    buildConf("spark.hadoop.mapred.max.split.size.by.table")
+      .doc("Set hdfs sharding size through table. eg tablename1:size1;tablename2:size2.")
+      .version("3.2.0")
+      .stringConf
+      .createOptional
+
   val MULTI_COMMUTATIVE_OP_OPT_THRESHOLD =
     buildConf("spark.sql.analyzer.canonicalization.multiCommutativeOpMemoryOptThreshold")
       .internal()
@@ -4761,6 +4768,8 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
 
   def streamingNoDataMicroBatchesEnabled: Boolean =
     getConf(STREAMING_NO_DATA_MICRO_BATCHES_ENABLED)
+
+  def mapredMaxSplitSizeByTable: Option[String] = getConf(MAPRED_MAX_SPLIT_SIZE_BY_TABLE)
 
   def streamingMetricsEnabled: Boolean = getConf(STREAMING_METRICS_ENABLED)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -245,12 +245,6 @@ object SQLConf {
     .intConf
     .createWithDefault(100)
 
-  val MAPRED_MAX_SPLIT_SIZE_BY_TABLE =
-    buildConf("spark.hadoop.mapred.max.split.size.by.table")
-      .doc("Set hdfs sharding size through table. eg tablename1:size1;tablename2:size2.")
-      .version("3.2.0")
-      .stringConf
-      .createOptional
 
   val MULTI_COMMUTATIVE_OP_OPT_THRESHOLD =
     buildConf("spark.sql.analyzer.canonicalization.multiCommutativeOpMemoryOptThreshold")
@@ -4768,8 +4762,6 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
 
   def streamingNoDataMicroBatchesEnabled: Boolean =
     getConf(STREAMING_NO_DATA_MICRO_BATCHES_ENABLED)
-
-  def mapredMaxSplitSizeByTable: Option[String] = getConf(MAPRED_MAX_SPLIT_SIZE_BY_TABLE)
 
   def streamingMetricsEnabled: Boolean = getConf(STREAMING_METRICS_ENABLED)
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
@@ -56,6 +56,13 @@ private[spark] object HiveUtils extends Logging {
   /** The version of hive used internally by Spark SQL. */
   val builtinHiveVersion: String = HiveVersionInfo.getVersion
 
+  val MAX_SPLIT_SIZE_SET_BY_TABLE =
+    buildConf("spark.sql.hive.maxSplitSizeSetByTable")
+      .doc("Set hdfs sharding size through table. eg tablename1:size1;tablename2:size2.")
+      .version("4.0.0")
+      .stringConf
+      .createOptional
+
   val BUILTIN_HIVE_VERSION = buildStaticConf("spark.sql.hive.version")
     .doc("The compiled, a.k.a, builtin Hive version of the Spark distribution bundled with." +
         " Note that, this a read-only conf and only used to report the built-in hive version." +

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/HiveTableScanExec.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/HiveTableScanExec.scala
@@ -101,6 +101,16 @@ case class HiveTableScanExec(
     val c = sparkSession.sessionState.newHadoopConf()
     // append columns ids and names before broadcast
     addColumnMetadataToConf(c)
+
+    conf.mapredMaxSplitSizeByTable.getOrElse("").split(";").map {
+      tableSize =>
+        val tableSizeList = tableSize.split(":")
+        if (tableSizeList.size == 2) {
+          if (relation.tableMeta.qualifiedName.equals(tableSizeList(0))) {
+            c.set("mapreduce.input.fileinputformat.split.maxsize", tableSizeList(1))
+          }
+        }
+    }
     c
   }
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/HiveTableScanExec.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/HiveTableScanExec.scala
@@ -102,7 +102,7 @@ case class HiveTableScanExec(
     // append columns ids and names before broadcast
     addColumnMetadataToConf(c)
 
-    conf.mapredMaxSplitSizeByTable.getOrElse("").split(";").map {
+    HiveUtils.MAX_SPLIT_SIZE_SET_BY_TABLE.key.split(";").map {
       tableSize =>
         val tableSizeList = tableSize.split(":")
         if (tableSizeList.size == 2) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
In the scenario of hive table scan, by configuring the hadoop.mapred.max.split.size parameter, you can increase the parallelism of the scan hive table stage, thereby reducing the running time.

However, if a large table and a small table are in the same query, if only a separate hadoop.mapred.max.split.size parameter is configured, some stages will run a very large number of tasks, and some stages will The number of tasks running is very small. For runtime tasks, the hadoop.mapred.max.split.size parameter can be set separately for each hive table to ensure this balance.




<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
If a large table and a small table are in the same query, if only a separate hadoop.mapred.max.split.size parameter is configured, some stages will run a very large number of tasks, and some stages will The number of tasks running is very small. 

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->



