### PR TITLE
[SPARK-44493][SQL] Translate catalyst expression into partial datasource filter

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -393,7 +393,7 @@ trait FileSourceScanLike extends DataSourceScanExec {
     scalarSubqueryReplaced.filterNot(_.references.exists {
       case FileSourceConstantMetadataAttribute(_) => true
       case _ => false
-    }).flatMap(DataSourceStrategy.translateFilter(_, supportNestedPredicatePushdown))
+    }).flatMap(DataSourceStrategy.translateFilter(_, supportNestedPredicatePushdown, true))
   }
 
   // This field may execute subquery expressions and should not be accessed during planning.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileScanBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileScanBuilder.scala
@@ -77,7 +77,7 @@ abstract class FileScanBuilder(
     this.dataFilters = dataFilters
     val translatedFilters = mutable.ArrayBuffer.empty[sources.Filter]
     for (filterExpr <- dataFilters) {
-      val translated = DataSourceStrategy.translateFilter(filterExpr, true)
+      val translated = DataSourceStrategy.translateFilter(filterExpr, true, true)
       if (translated.nonEmpty) {
         translatedFilters += translated.get
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushDownUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushDownUtils.scala
@@ -54,7 +54,7 @@ object PushDownUtils {
         for (filterExpr <- filters) {
           val translated =
             DataSourceStrategy.translateFilterWithMapping(filterExpr, Some(translatedFilterToExpr),
-              nestedPredicatePushdownEnabled = true)
+              nestedPredicatePushdownEnabled = true, canPartialPushDown = false)
           if (translated.isEmpty) {
             untranslatableExprs += filterExpr
           } else {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
@@ -30,11 +30,9 @@ import org.apache.spark.paths.SparkPath.{fromUrlString => sp}
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.catalog.BucketSpec
-import org.apache.spark.sql.catalyst.expressions.{Expression, ExpressionSet}
 import org.apache.spark.sql.catalyst.util
 import org.apache.spark.sql.execution.{DataSourceScanExec, FileSourceScanExec, SparkPlan}
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2ScanRelation
-import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.test.SharedSparkSession
@@ -625,6 +623,33 @@ class FileSourceStrategySuite extends QueryTest with SharedSparkSession {
     }
   }
 
+  test("SPARK-44493: Push partial predicates are supported") {
+    def getPushedFilters(df: DataFrame): Option[String] = {
+      df.queryExecution.executedPlan.collectFirst {
+        case f: FileSourceScanExec => f.metadata.get("PushedFilters")
+      }.flatten
+    }
+
+    val table =
+      createTable(
+        files = Seq(
+          "p1=1/file1" -> 10,
+          "p1=2/file2" -> 10))
+
+    // 'Abs' are not supported push down
+    val df = table.where("(c1 > 0 AND Abs(c2) > 1) OR (c2 > 1)")
+    assert(getPhysicalFilters(df) contains resolve(df,
+      "(c1 > 0 AND Abs(c2) > 1) OR (c2 > 1)"))
+    assert(getPushedFilters(df).contains("[Or(GreaterThan(c1,0),GreaterThan(c2,1))]"))
+
+    assert(getPushedFilters(
+      table.where("Not(c1 <=> 0 AND Abs(c2) > 1) OR (c2 > 1)")).contains("[]"))
+
+    assert(getPushedFilters(
+      table.where("Not((c1 > 0) OR (c2 > 1))"))
+      .contains("[IsNotNull(c1), IsNotNull(c2), LessThanOrEqual(c1,0), LessThanOrEqual(c2,1)]"))
+  }
+
   // Helpers for checking the arguments passed to the FileFormat.
 
   protected val checkPartitionSchema =
@@ -644,19 +669,6 @@ class FileSourceStrategySuite extends QueryTest with SharedSparkSession {
            |actual: ${arg(LastArguments)}
          """.stripMargin)
     }
-  }
-
-  /** Returns a resolved expression for `str` in the context of `df`. */
-  def resolve(df: DataFrame, str: String): Expression = {
-    df.select(expr(str)).queryExecution.analyzed.expressions.head.children.head
-  }
-
-  /** Returns a set with all the filters present in the physical plan. */
-  def getPhysicalFilters(df: DataFrame): ExpressionSet = {
-    ExpressionSet(
-      df.queryExecution.executedPlan.collect {
-        case execution.FilterExec(f, _) => splitConjunctivePredicates(f)
-      }.flatten)
   }
 
   /** Plans the query and calls the provided validation function with the planned partitioning. */

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
@@ -2254,7 +2254,8 @@ class ParquetV2FilterSuite extends ParquetFilterSuite {
         case PhysicalOperation(_, filters,
             DataSourceV2ScanRelation(_, scan: ParquetScan, _, _, _)) =>
           assert(filters.nonEmpty, "No filter is analyzed from the given query")
-          val sourceFilters = filters.flatMap(DataSourceStrategy.translateFilter(_, true)).toArray
+          val sourceFilters =
+            filters.flatMap(DataSourceStrategy.translateFilter(_, true, true)).toArray
           val pushedFilters = scan.pushedFilters
           assert(pushedFilters.nonEmpty, "No filter is pushed down")
           val schema = new SparkToParquetSchemaConverter(conf).convert(df.schema)


### PR DESCRIPTION
### What changes were proposed in this pull request?

SPARK-22548 fixed incorrect nested AND expression pushed down to JDBC data source. But Parquet/ORC data sources do not need that fix because they always keep the `Filter` node.

<details><summary>For example</summary>
<p>

```sql
CREATE TABLE parquet_table (name string, theid int) using parquet;
EXPLAIN SELECT * FROM parquet_table WHERE (THEID > 0 AND TRIM(NAME) = 'mary') OR (NAME = 'fred');
```

```
-- Before SPARK-22548
== Physical Plan ==
*Filter (((THEID#21 > 0) && (trim(NAME#20) = mary)) || (NAME#20 = fred))
+- *FileScan parquet default.parquet_table[name#20,theid#21] PushedFilters: [Or(GreaterThan(theid,0),EqualTo(name,fred))]

-- After SPARK-22548(Actually we can push down [Or(GreaterThan(theid,0),EqualTo(name,fred))] to data source)
== Physical Plan ==
*Filter (((THEID#21 > 0) && (trim(NAME#20) = mary)) || (NAME#20 = fred))
+- *FileScan parquet default.parquet_table[name#20,theid#21] PushedFilters: []
```

</p>
</details> 

This PR adds a function parameter(named `canPartialPushDown`) to `DataSourceStrategy.translateFilter`. The caller side can set it to true if caller side always keep the `Filter` node to push down more filters.

### Why are the changes needed?

Pushdown more filters to improve query performance. This is a very common case and can significantly improve query performance. For example:
```sql
1. id IN (1677950,1468757,2059706,2053742,2047936,5387,2046791) OR (id=2351460 and very_heavy_udf(very_large_column, 'key') = 'EXPC')
2. (id IN (4279154) AND very_heavy_udf(very_large_column, 'key') IS NOT NULL) OR
(id = 3914 AND very_heavy_udf(very_large_column, 'sid') = 'p.2380')
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit test and benchmark test:
Before | After
-- | --
<img width="435" alt="image" src="https://github.com/apache/spark/assets/5399861/61b0e201-26c2-4bc9-bcab-3568eb4a46bd"> | <img width="422" alt="image" src="https://github.com/apache/spark/assets/5399861/841c83fc-b283-4c7a-9d9c-9ae85dbe3f5d">
<img width="435" alt="image" src="https://github.com/apache/spark/assets/5399861/8dd7a58b-4b16-4153-9dd1-ce9f3d072239"> | <img width="435" alt="image" src="https://github.com/apache/spark/assets/5399861/fe6980c8-2560-4be9-b661-dea7baf44b0d">


### Was this patch authored or co-authored using generative AI tooling?

No.
