### PR TITLE
[SPARK-45898][SQL] Rewrite catalog table APIs to use unresolved logical plan

### DIFF
--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientE2ETestSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientE2ETestSuite.scala
@@ -156,8 +156,8 @@ class ClientE2ETestSuite extends RemoteSparkSession with SQLHelper with PrivateM
     assert(ex.getErrorClass != null)
   }
 
-  test("throw NoSuchTableException") {
-    val ex = intercept[NoSuchTableException] {
+  test("table not found for spark.catalog.getTable") {
+    val ex = intercept[AnalysisException] {
       spark.catalog.getTable("test_table")
     }
     assert(ex.getErrorClass != null)

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientE2ETestSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientE2ETestSuite.scala
@@ -31,7 +31,7 @@ import org.scalatest.PrivateMethodTester
 
 import org.apache.spark.{SparkArithmeticException, SparkException, SparkUpgradeException}
 import org.apache.spark.SparkBuildInfo.{spark_version => SPARK_VERSION}
-import org.apache.spark.sql.catalyst.analysis.{NamespaceAlreadyExistsException, NoSuchDatabaseException, NoSuchTableException, TableAlreadyExistsException, TempTableAlreadyExistsException}
+import org.apache.spark.sql.catalyst.analysis.{NamespaceAlreadyExistsException, NoSuchDatabaseException, TableAlreadyExistsException, TempTableAlreadyExistsException}
 import org.apache.spark.sql.catalyst.encoders.AgnosticEncoders.StringEncoder
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
 import org.apache.spark.sql.catalyst.parser.ParseException

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1190,8 +1190,7 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
         identifier: Seq[String],
         viewOnly: Boolean = false): Option[LogicalPlan] = {
       lookupTempView(identifier).map { tempView =>
-        ResolvedTempView(
-          identifier.asIdentifier, tempView.tableMeta.schema, tempView.tableMeta.comment)
+        ResolvedTempView(identifier.asIdentifier, tempView.tableMeta)
       }.orElse {
         expandIdentifier(identifier) match {
           case CatalogAndIdentifier(catalog, ident) =>
@@ -1204,7 +1203,7 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
                 val v1Ident = v1Table.catalogTable.identifier
                 val v2Ident = Identifier.of(v1Ident.database.toArray, v1Ident.identifier)
                 ResolvedPersistentView(
-                  catalog, v2Ident, v1Table.catalogTable.schema, v1Table.v1Table.comment)
+                  catalog, v2Ident, v1Table.catalogTable)
               case table =>
                 ResolvedTable.create(catalog.asTableCatalog, ident, table)
             }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1190,7 +1190,8 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
         identifier: Seq[String],
         viewOnly: Boolean = false): Option[LogicalPlan] = {
       lookupTempView(identifier).map { tempView =>
-        ResolvedTempView(identifier.asIdentifier, tempView.tableMeta.schema)
+        ResolvedTempView(
+          identifier.asIdentifier, tempView.tableMeta.schema, tempView.tableMeta.comment)
       }.orElse {
         expandIdentifier(identifier) match {
           case CatalogAndIdentifier(catalog, ident) =>
@@ -1202,7 +1203,8 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
                 v1Table.v1Table.tableType == CatalogTableType.VIEW =>
                 val v1Ident = v1Table.catalogTable.identifier
                 val v2Ident = Identifier.of(v1Ident.database.toArray, v1Ident.identifier)
-                ResolvedPersistentView(catalog, v2Ident, v1Table.catalogTable.schema)
+                ResolvedPersistentView(
+                  catalog, v2Ident, v1Table.catalogTable.schema, v1Table.v1Table.comment)
               case table =>
                 ResolvedTable.create(catalog.asTableCatalog, ident, table)
             }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/v2ResolutionPlans.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/v2ResolutionPlans.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.catalyst.analysis
 
 import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
 import org.apache.spark.sql.catalyst.expressions.{Attribute, LeafExpression, Unevaluable}
 import org.apache.spark.sql.catalyst.plans.logical.{LeafNode, Statistics}
@@ -28,7 +29,7 @@ import org.apache.spark.sql.connector.catalog.{CatalogPlugin, FunctionCatalog, I
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
 import org.apache.spark.sql.connector.catalog.TableChange.ColumnPosition
 import org.apache.spark.sql.connector.catalog.functions.UnboundFunction
-import org.apache.spark.sql.types.{DataType, StructField, StructType}
+import org.apache.spark.sql.types.{DataType, StructField}
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.util.ArrayImplicits._
 
@@ -188,15 +189,14 @@ case class ResolvedFieldPosition(position: ColumnPosition) extends FieldPosition
 case class ResolvedPersistentView(
     catalog: CatalogPlugin,
     identifier: Identifier,
-    viewSchema: StructType,
-    comment: Option[String]) extends LeafNodeWithoutStats {
+    metadata: CatalogTable) extends LeafNodeWithoutStats {
   override def output: Seq[Attribute] = Nil
 }
 
 /**
  * A plan containing resolved (global) temp views.
  */
-case class ResolvedTempView(identifier: Identifier, viewSchema: StructType, comment: Option[String])
+case class ResolvedTempView(identifier: Identifier, metadata: CatalogTable)
   extends LeafNodeWithoutStats {
   override def output: Seq[Attribute] = Nil
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/v2ResolutionPlans.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/v2ResolutionPlans.scala
@@ -188,14 +188,15 @@ case class ResolvedFieldPosition(position: ColumnPosition) extends FieldPosition
 case class ResolvedPersistentView(
     catalog: CatalogPlugin,
     identifier: Identifier,
-    viewSchema: StructType) extends LeafNodeWithoutStats {
+    viewSchema: StructType,
+    comment: Option[String]) extends LeafNodeWithoutStats {
   override def output: Seq[Attribute] = Nil
 }
 
 /**
  * A plan containing resolved (global) temp views.
  */
-case class ResolvedTempView(identifier: Identifier, viewSchema: StructType)
+case class ResolvedTempView(identifier: Identifier, viewSchema: StructType, comment: Option[String])
   extends LeafNodeWithoutStats {
   override def output: Seq[Attribute] = Nil
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
@@ -551,12 +551,12 @@ class ResolveSessionCatalog(val catalogManager: CatalogManager)
 
   object ResolvedViewIdentifier {
     def unapply(resolved: LogicalPlan): Option[TableIdentifier] = resolved match {
-      case ResolvedPersistentView(catalog, ident, _) =>
+      case ResolvedPersistentView(catalog, ident, _, _) =>
         assert(isSessionCatalog(catalog))
         assert(ident.namespace().length == 1)
         Some(TableIdentifier(ident.name, Some(ident.namespace.head), Some(catalog.name)))
 
-      case ResolvedTempView(ident, _) => Some(ident.asTableIdentifier)
+      case ResolvedTempView(ident, _, _) => Some(ident.asTableIdentifier)
 
       case _ => None
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
@@ -551,12 +551,12 @@ class ResolveSessionCatalog(val catalogManager: CatalogManager)
 
   object ResolvedViewIdentifier {
     def unapply(resolved: LogicalPlan): Option[TableIdentifier] = resolved match {
-      case ResolvedPersistentView(catalog, ident, _, _) =>
+      case ResolvedPersistentView(catalog, ident, _) =>
         assert(isSessionCatalog(catalog))
         assert(ident.namespace().length == 1)
         Some(TableIdentifier(ident.name, Some(ident.namespace.head), Some(catalog.name)))
 
-      case ResolvedTempView(ident, _, _) => Some(ident.asTableIdentifier)
+      case ResolvedTempView(ident, _) => Some(ident.asTableIdentifier)
 
       case _ => None
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
@@ -22,14 +22,14 @@ import scala.util.control.NonFatal
 
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalog.{Catalog, CatalogMetadata, Column, Database, Function, Table}
-import org.apache.spark.sql.catalyst.{DefinedByConstructorParams, TableIdentifier}
+import org.apache.spark.sql.catalyst.DefinedByConstructorParams
 import org.apache.spark.sql.catalyst.analysis._
 import org.apache.spark.sql.catalyst.catalog._
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.apache.spark.sql.catalyst.expressions.{Expression, Literal}
 import org.apache.spark.sql.catalyst.plans.logical.{CreateTable, LocalRelation, LogicalPlan, OptionList, RecoverPartitions, ShowFunctions, ShowNamespaces, ShowTables, UnresolvedTableSpec, View}
 import org.apache.spark.sql.catalyst.types.DataTypeUtils
-import org.apache.spark.sql.connector.catalog.{CatalogManager, CatalogPlugin, CatalogV2Util, Identifier, SupportsNamespaces, Table => V2Table, TableCatalog, V1Table}
+import org.apache.spark.sql.connector.catalog.{CatalogManager, CatalogPlugin, SupportsNamespaces, TableCatalog}
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.{CatalogHelper, MultipartIdentifierHelper, NamespaceHelper, TransformHelper}
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.execution.command.ShowTablesCommand
@@ -163,69 +163,72 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
         makeTable(ns :+ tableName)
       } else {
         val ns = parseIdent(namespaceName)
-        makeTable(catalog.name() +: ns :+ tableName)
+        try {
+          makeTable(catalog.name() +: ns :+ tableName)
+        } catch {
+          case e: AnalysisException if e.getErrorClass == "UNSUPPORTED_FEATURE.HIVE_TABLE_TYPE" =>
+            new Table(
+              name = tableName,
+              catalog = catalog.name(),
+              namespace = ns.toArray,
+              description = null,
+              tableType = null,
+              isTemporary = false
+            )
+        }
       }
     }
     CatalogImpl.makeDataset(tables.toImmutableArraySeq, sparkSession)
   }
 
-  private def makeTable(nameParts: Seq[String]): Table = {
-    sessionCatalog.getRawLocalOrGlobalTempView(nameParts).map { tempView =>
-      new Table(
-        name = tempView.tableMeta.identifier.table,
-        catalog = null,
-        namespace = tempView.tableMeta.identifier.database.toArray,
-        description = tempView.tableMeta.comment.orNull,
-        tableType = "TEMPORARY",
-        isTemporary = true)
-    }.getOrElse {
-      val plan = UnresolvedIdentifier(nameParts)
+  private def tableExists(nameParts: Seq[String]): Boolean = {
+    val plan = UnresolvedTableOrView(nameParts, "Catalog.tableExists", true)
+    try {
       sparkSession.sessionState.executePlan(plan).analyzed match {
-        case ResolvedIdentifier(catalog: TableCatalog, ident) =>
-          val tableOpt = try {
-            loadTable(catalog, ident)
-          } catch {
-            // Even if the table exits, error may still happen. For example, Spark can't read Hive's
-            // index table. We return a Table without description and tableType in this case.
-            case NonFatal(_) =>
-              Some(new Table(
-                name = ident.name(),
-                catalog = catalog.name(),
-                namespace = ident.namespace(),
-                description = null,
-                tableType = null,
-                isTemporary = false))
-          }
-          tableOpt.getOrElse(throw QueryCompilationErrors.tableOrViewNotFound(nameParts))
-
-        case _ => throw QueryCompilationErrors.tableOrViewNotFound(nameParts)
+        case _: ResolvedTable => true
+        case _: ResolvedPersistentView => true
+        case _: ResolvedTempView => true
+        case _ => false
       }
+    } catch {
+      case e: AnalysisException if e.getErrorClass == "TABLE_OR_VIEW_NOT_FOUND" => false
     }
   }
 
-  private def loadTable(catalog: TableCatalog, ident: Identifier): Option[Table] = {
-    // TODO: support v2 view when it gets implemented.
-    CatalogV2Util.loadTable(catalog, ident).map {
-      case v1: V1Table if v1.v1Table.tableType == CatalogTableType.VIEW =>
-        new Table(
-          name = v1.v1Table.identifier.table,
-          catalog = catalog.name(),
-          namespace = v1.v1Table.identifier.database.toArray,
-          description = v1.v1Table.comment.orNull,
-          tableType = "VIEW",
-          isTemporary = false)
-      case t: V2Table =>
-        val isExternal = t.properties().getOrDefault(
+  private def makeTable(nameParts: Seq[String]): Table = {
+    val plan = UnresolvedTableOrView(nameParts, "Catalog.makeTable", true)
+    sparkSession.sessionState.executePlan(plan).analyzed match {
+      case ResolvedTable(catalog, ident, table, _) =>
+        val isExternal = table.properties().getOrDefault(
           TableCatalog.PROP_EXTERNAL, "false").equals("true")
         new Table(
           name = ident.name(),
           catalog = catalog.name(),
           namespace = ident.namespace(),
-          description = t.properties().get("comment"),
+          description = table.properties().get("comment"),
           tableType =
             if (isExternal) CatalogTableType.EXTERNAL.name
             else CatalogTableType.MANAGED.name,
           isTemporary = false)
+      case ResolvedPersistentView(catalog, identifier, _, comment) =>
+        new Table(
+          name = identifier.name(),
+          catalog = catalog.name(),
+          namespace = identifier.namespace(),
+          description = comment.orNull,
+          tableType = "VIEW",
+          isTemporary = false
+        )
+      case ResolvedTempView(identifier, _, _) =>
+        new Table(
+          name = identifier.name(),
+          catalog = null,
+          namespace = identifier.namespace(),
+          description = null,
+          tableType = "TEMPORARY",
+          isTemporary = true
+        )
+      case _ => throw QueryCompilationErrors.tableOrViewNotFound(nameParts)
     }
   }
 
@@ -385,10 +388,10 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
         val bucketColumnNames = bucketSpecOpt.map(_.bucketColumnNames).getOrElse(Nil)
         schemaToColumns(table.schema(), partitionColumnNames.contains, bucketColumnNames.contains)
 
-      case ResolvedPersistentView(_, _, schema) =>
+      case ResolvedPersistentView(_, _, schema, _) =>
         schemaToColumns(schema)
 
-      case ResolvedTempView(_, schema) =>
+      case ResolvedTempView(_, schema, _) =>
         schemaToColumns(schema)
 
       case _ => throw QueryCompilationErrors.tableOrViewNotFound(ident)
@@ -457,22 +460,24 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
     }
   }
 
+  private def toTableIdent(tableName: String): Seq[String] = {
+    val parsed = parseIdent(tableName)
+    // For backward compatibility (Spark 3.3 and prior), we should check if the table exists in
+    // the Hive Metastore first.
+    if (parsed.length <= 2 && !sessionCatalog.isTempView(parsed) &&
+      sessionCatalog.tableExists(parsed.asTableIdentifier)) {
+      qualifyV1Ident(parsed)
+    } else {
+      parsed
+    }
+  }
 
   /**
    * Gets the table or view with the specified name. This table can be a temporary view or a
    * table/view. This throws an `AnalysisException` when no `Table` can be found.
    */
   override def getTable(tableName: String): Table = {
-    val parsed = parseIdent(tableName)
-    // For backward compatibility (Spark 3.3 and prior), we should check if the table exists in
-    // the Hive Metastore first.
-    val nameParts = if (parsed.length <= 2 && !sessionCatalog.isTempView(parsed) &&
-      sessionCatalog.tableExists(parsed.asTableIdentifier)) {
-      qualifyV1Ident(parsed)
-    } else {
-      parsed
-    }
-    makeTable(nameParts)
+    makeTable(toTableIdent(tableName))
   }
 
   /**
@@ -531,27 +536,20 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
    * view or a table/view.
    */
   override def tableExists(tableName: String): Boolean = {
-    val parsed = parseIdent(tableName)
-    // For backward compatibility (Spark 3.3 and prior), we should check if the table exists in
-    // the Hive Metastore first. This also checks if it's a temp view.
-    (parsed.length <= 2 && {
-      val v1Ident = parsed.asTableIdentifier
-      sessionCatalog.isTempView(v1Ident) || sessionCatalog.tableExists(v1Ident)
-    }) || {
-      val plan = UnresolvedIdentifier(parsed)
-      sparkSession.sessionState.executePlan(plan).analyzed match {
-        case ResolvedIdentifier(catalog: TableCatalog, ident) => catalog.tableExists(ident)
-        case _ => false
-      }
-    }
+    tableExists(toTableIdent(tableName))
   }
 
   /**
    * Checks if the table or view with the specified name exists in the specified database.
    */
   override def tableExists(dbName: String, tableName: String): Boolean = {
-    val tableIdent = TableIdentifier(tableName, Option(dbName))
-    sessionCatalog.isTempView(tableIdent) || sessionCatalog.tableExists(tableIdent)
+    if (sessionCatalog.isGlobalTempViewDB(dbName)) {
+      tableExists(Seq(dbName, tableName))
+    } else {
+      // For backward compatibility (Spark 3.3 and prior), here we always look up the table from the
+      // Hive Metastore.
+      tableExists(Seq(CatalogManager.SESSION_CATALOG_NAME, dbName, tableName))
+    }
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
@@ -210,16 +210,16 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
             if (isExternal) CatalogTableType.EXTERNAL.name
             else CatalogTableType.MANAGED.name,
           isTemporary = false)
-      case ResolvedPersistentView(catalog, identifier, _, comment) =>
+      case ResolvedPersistentView(catalog, identifier, metadata) =>
         new Table(
           name = identifier.name(),
           catalog = catalog.name(),
           namespace = identifier.namespace(),
-          description = comment.orNull,
+          description = metadata.comment.orNull,
           tableType = "VIEW",
           isTemporary = false
         )
-      case ResolvedTempView(identifier, _, _) =>
+      case ResolvedTempView(identifier, _) =>
         new Table(
           name = identifier.name(),
           catalog = null,
@@ -388,11 +388,11 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
         val bucketColumnNames = bucketSpecOpt.map(_.bucketColumnNames).getOrElse(Nil)
         schemaToColumns(table.schema(), partitionColumnNames.contains, bucketColumnNames.contains)
 
-      case ResolvedPersistentView(_, _, schema, _) =>
-        schemaToColumns(schema)
+      case ResolvedPersistentView(_, _, metadata) =>
+        schemaToColumns(metadata.schema)
 
-      case ResolvedTempView(_, schema, _) =>
-        schemaToColumns(schema)
+      case ResolvedTempView(_, metadata) =>
+        schemaToColumns(metadata.schema)
 
       case _ => throw QueryCompilationErrors.tableOrViewNotFound(ident)
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

- Rewrite catalog table APIs to use unresolved logical plan (i.e. UnresolvedTableOrView) and return the result based on the analyzed logical plans.
- Remove the Hive index table support for `getTable` and `tableExists` APIs (i.e. throws AnalyzeException instead) since [indexing is removed since 3.0](https://cwiki.apache.org/confluence/display/hive/languagemanual+indexing) so that the behavior is consistent with SQL (e.g. DESCRIBE TABLE). Though `listTables` still works for the Hive index tables
- Put the entire view metadata in ResolvedTempView and ResolvedPersistentView.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

- Less duplicate logics. We should not directly invoke catalog APIs, but go through analyzer.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Existing tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No