### PR TITLE
[SPARK-45901][DOCS] Collect and update `spark-standalone.md` with new confs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -3495,32 +3495,6 @@ External users can query the static sql config values via `SparkSession.conf` or
 </tr>
 </table>
 
-### Deploy
-
-<table class="table table-striped">
-  <thead><tr><th>Property Name</th><th>Default</th><th>Meaning</th><th>Since Version</th></tr></thead>
-  <tr>
-    <td><code>spark.deploy.recoveryMode</code></td>
-    <td>NONE</td>
-    <td>The recovery mode setting to recover submitted Spark jobs with cluster mode when it failed and relaunches.
-    This is only applicable for cluster mode when running with Standalone.</td>
-    <td>0.8.1</td>
-  </tr>
-  <tr>
-    <td><code>spark.deploy.zookeeper.url</code></td>
-    <td>None</td>
-    <td>When `spark.deploy.recoveryMode` is set to ZOOKEEPER, this configuration is used to set the zookeeper URL to connect to.</td>
-    <td>0.8.1</td>
-  </tr>
-  <tr>
-    <td><code>spark.deploy.zookeeper.dir</code></td>
-    <td>None</td>
-    <td>When `spark.deploy.recoveryMode` is set to ZOOKEEPER, this configuration is used to set the zookeeper directory to store recovery state.</td>
-    <td>0.8.1</td>
-  </tr>
-</table>
-
-
 ### Cluster Managers
 
 Each cluster manager in Spark has additional configuration options. Configurations

--- a/docs/spark-standalone.md
+++ b/docs/spark-standalone.md
@@ -408,6 +408,16 @@ SPARK_WORKER_OPTS supports the following system properties:
   </td>
   <td>2.0.2</td>
 </tr>
+<tr>
+  <td><code>spark.worker.idPattern</code></td>
+  <td>worker-%s-%s-%d</td>
+  <td>
+    The pattern for worker ID generation based on Java `String.format` method.
+    The default value is `worker-%s-%s-%d` which represents the existing worker id string, e.g.,
+    `worker-20231109183042-[fe80::1%lo0]-39729`. Please be careful to generate unique IDs
+  </td>
+  <td>4.0.0</td>
+</tr>
 </table>
 
 # Resource Allocation and Configuration Overview

--- a/docs/spark-standalone.md
+++ b/docs/spark-standalone.md
@@ -218,7 +218,7 @@ SPARK_MASTER_OPTS supports the following system properties:
 </tr>
 <tr>
   <td><code>spark.deploy.defaultCores</code></td>
-  <td>(infinite)</td>
+  <td>Int.MaxValue</td>
   <td>
     Default number of cores to give to applications in Spark's standalone mode if they don't
     set <code>spark.cores.max</code>. If not set, applications always get all available
@@ -245,6 +245,43 @@ SPARK_MASTER_OPTS supports the following system properties:
   <td>1.6.3</td>
 </tr>
 <tr>
+  <td><code>spark.deploy.maxDrivers</code></td>
+  <td>Int.MaxValue</td>
+  <td>
+    The maximum number of running drivers.
+  </td>
+  <td>4.0.0</td>
+</tr>
+<tr>
+  <td><code>spark.deploy.appNumberModulo</code></td>
+  <td>(None)</td>
+  <td>
+    The modulo for app number. By default, the next of `app-yyyyMMddHHmmss-9999` is
+    `app-yyyyMMddHHmmss-10000`. If we have 10000 as modulo, it will be `app-yyyyMMddHHmmss-0000`.
+    In most cases, the prefix `app-yyyyMMddHHmmss` is increased already during creating 10000 applications.
+  </td>
+  <td>4.0.0</td>
+</tr>
+<tr>
+  <td><code>spark.deploy.driverIdPattern</code></td>
+  <td>driver-%s-%04d</td>
+  <td>
+    The pattern for driver ID generation based on Java `String.format` method.
+    The default value is `driver-%s-%04d` which represents the existing driver id string, e.g., `driver-20231031224459-0019`. Please be careful to generate unique IDs.
+  </td>
+  <td>4.0.0</td>
+</tr>
+<tr>
+  <td><code>spark.deploy.appIdPattern</code></td>
+  <td>app-%s-%04d</td>
+  <td>
+    The pattern for app ID generation based on Java `String.format` method.
+    The default value is `app-%s-%04d` which represents the existing app id string, e.g.,
+    `app-20231031224509-0008`. Plesae be careful to generate unique IDs.
+  </td>
+  <td>4.0.0</td>
+</tr>
+<tr>
   <td><code>spark.worker.timeout</code></td>
   <td>60</td>
   <td>
@@ -252,6 +289,14 @@ SPARK_MASTER_OPTS supports the following system properties:
     receives no heartbeats.
   </td>
   <td>0.6.2</td>
+</tr>
+<tr>
+  <td><code>spark.dead.worker.persistence</code></td>
+  <td>15</td>
+  <td>
+    Number of iterations to keep the deae worker information in UI. By default, the dead worker is visible for (15 + 1) * <code>spark.worker.timeout</code> since its last heartbeat.
+  </td>
+  <td>0.8.0</td>
 </tr>
 <tr>
   <td><code>spark.worker.resource.{resourceName}.amount</code></td>
@@ -542,15 +587,38 @@ ZooKeeper is the best way to go for production-level high availability, but if y
 In order to enable this recovery mode, you can set SPARK_DAEMON_JAVA_OPTS in spark-env using this configuration:
 
 <table class="table table-striped">
-  <thead><tr><th style="width:21%">System property</th><th>Meaning</th><th>Since Version</th></tr></thead>
+  <thead><tr><th style="width:21%">System property</th><th>Default Value</th><th>Meaning</th><th>Since Version</th></tr></thead>
   <tr>
     <td><code>spark.deploy.recoveryMode</code></td>
-    <td>Set to FILESYSTEM to enable single-node recovery mode (default: NONE).</td>
+    <td>NONE</td>
+    <td>The recovery mode setting to recover submitted Spark jobs with cluster mode when it failed and relaunches.
+      Set to FILESYSTEM to enable single-node recovery mode, ZOOKEEPER to use Zookeeper-based recovery mode, and
+      CUSTOM to provide a customer provider class via additional `spark.deploy.recoveryMode.factory` configuration.
+    </td>
     <td>0.8.1</td>
   </tr>
   <tr>
     <td><code>spark.deploy.recoveryDirectory</code></td>
+    <td>""</td>
     <td>The directory in which Spark will store recovery state, accessible from the Master's perspective.</td>
+    <td>0.8.1</td>
+  </tr>
+  <tr>
+    <td><code>spark.deploy.recoveryMode.factory</code></td>
+    <td>""</td>
+    <td>A class to implement <code>StandaloneRecoveryModeFactory</code> interface</td>
+    <td>1.2.0</td>
+  </tr>
+  <tr>
+    <td><code>spark.deploy.zookeeper.url</code></td>
+    <td>None</td>
+    <td>When `spark.deploy.recoveryMode` is set to ZOOKEEPER, this configuration is used to set the zookeeper URL to connect to.</td>
+    <td>0.8.1</td>
+  </tr>
+  <tr>
+    <td><code>spark.deploy.zookeeper.dir</code></td>
+    <td>None</td>
+    <td>When `spark.deploy.recoveryMode` is set to ZOOKEEPER, this configuration is used to set the zookeeper directory to store recovery state.</td>
     <td>0.8.1</td>
   </tr>
 </table>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to collect and make `spark-standalone.md` up-to-date with new configurations to improve UX.

### Why are the changes needed?

By collecting and syncing with the code, the users can find all informations in a single page.

1. For example, the existing `zookeeper`-related configuration in `Configuration -> Deploy` section although it's only applicable in `Spark Standalone` cluster. In addition, it's partially described. We had better move it to `Spark Standalone` page.
    - From: https://spark.apache.org/docs/latest/configuration.html#deploy
    - To: https://spark.apache.org/docs/latest/spark-standalone.html

2. Add missing configurations.
    - spark.dead.worker.persistence

3. Revise the default value
   - spark.deploy.defaultCores

3. Add all Spark 4.0.0 configurations.
    - spark.deploy.maxDrivers
    - spark.deploy.appNumberModulo
    - spark.deploy.driverIdPattern
    - spark.deploy.appIdPattern
    - spark.worker.idPattern

### Does this PR introduce _any_ user-facing change?

Yes, but this is a documentation only.

### How was this patch tested?

Manual review.

**CHANGED PART 1**
<img width="925" alt="Screenshot 2023-11-12 at 4 18 21 PM" src="https://github.com/apache/spark/assets/9700541/266f88dc-0fe2-4378-82a9-502fd8374737">

**CHANGED PART 2**
<img width="1444" alt="Screenshot 2023-11-12 at 4 18 08 PM" src="https://github.com/apache/spark/assets/9700541/c19f976e-f3b3-43b1-874f-46618fa19997">

**CHANGED PART 3**
<img width="924" alt="Screenshot 2023-11-12 at 4 54 38 PM" src="https://github.com/apache/spark/assets/9700541/5e6d620f-5a1e-44d9-92f8-b7c0f61e27a3">


### Was this patch authored or co-authored using generative AI tooling?

No.