### PR TITLE
[SPARK-45921][INFRA] Use Hadoop `3.3.5` winutils in AppVeyor build

### DIFF
--- a/dev/appveyor-install-dependencies.ps1
+++ b/dev/appveyor-install-dependencies.ps1
@@ -120,8 +120,8 @@ $env:PATH = "$tools\sbt\bin;" + $env:PATH
 Pop-Location
 
 # ========================== Hadoop bin package
-# This must match the version at https://github.com/cdarlint/winutils/tree/master/hadoop-3.2.0
-$hadoopVer = "3.2.0"
+# This must match the version at https://github.com/cdarlint/winutils/tree/master/hadoop-3.3.5
+$hadoopVer = "3.3.5"
 $hadoopPath = "$tools\hadoop"
 if (!(Test-Path $hadoopPath)) {
     New-Item -ItemType Directory -Force -Path $hadoopPath | Out-Null


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to use Hadoop `3.3.5` winutils in AppVeyor build.


### Why are the changes needed?
The last update occurred 3 years ago, https://github.com/apache/spark/pull/29042

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass `AppVeyor` test.


### Was this patch authored or co-authored using generative AI tooling?
No.
