### PR TITLE
[SPARK-45723][PYTHON][CONNECT][FOLLOWUP] Replace `toPandas` with `_to_table` in catalog methods

### DIFF
--- a/python/pyspark/sql/connect/catalog.py
+++ b/python/pyspark/sql/connect/catalog.py
@@ -223,7 +223,7 @@ class Catalog:
             options=options,
         )
         df = DataFrame.withPlan(catalog, session=self._sparkSession)
-        df.toPandas()  # Eager execution.
+        df._to_table()  # Eager execution.
         return df
 
     createExternalTable.__doc__ = PySparkCatalog.createExternalTable.__doc__
@@ -246,7 +246,7 @@ class Catalog:
             options=options,
         )
         df = DataFrame.withPlan(catalog, session=self._sparkSession)
-        df.toPandas()  # Eager execution.
+        df._to_table()  # Eager execution.
         return df
 
     createTable.__doc__ = PySparkCatalog.createTable.__doc__


### PR DESCRIPTION
### What changes were proposed in this pull request?
followup of https://github.com/apache/spark/pull/43583, replace `toPandas` with `_to_table` in catalog methods


### Why are the changes needed?
pandas conversion not needed


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no