### PR TITLE
[SPARK-45597][PYTHON][SQL] Support creating table using a Python data source in SQL (codegen)

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -1513,7 +1513,7 @@ object CodeGenerator extends Logging {
     (evaluator.getClazz().getConstructor().newInstance().asInstanceOf[GeneratedClass], codeStats)
   }
 
-  private def logGeneratedCode(code: CodeAndComment): Unit = {
+  def logGeneratedCode(code: CodeAndComment): Unit = {
     val maxLines = SQLConf.get.loggingMaxLinesForCodegen
     if (Utils.isTesting) {
       logError(s"\n${CodeFormatter.format(code, maxLines)}")
@@ -1527,7 +1527,7 @@ object CodeGenerator extends Logging {
    * # of inner classes) of generated classes by inspecting Janino classes.
    * Also, this method updates the metrics information.
    */
-  private def updateAndGetCompilationStats(evaluator: ClassBodyEvaluator): ByteCodeStats = {
+  def updateAndGetCompilationStats(evaluator: ClassBodyEvaluator): ByteCodeStats = {
     // First retrieve the generated classes.
     val classes = evaluator.getBytecodes.asScala
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
@@ -208,45 +208,10 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
       throw QueryCompilationErrors.pathOptionNotSetCorrectlyWhenReadingError()
     }
 
-    val isUserDefinedDataSource =
-      sparkSession.sessionState.dataSourceManager.dataSourceExists(source)
-
-    Try(DataSource.lookupDataSourceV2(source, sparkSession.sessionState.conf)) match {
-      case Success(providerOpt) =>
-        // The source can be successfully loaded as either a V1 or a V2 data source.
-        // Check if it is also a user-defined data source.
-        if (isUserDefinedDataSource) {
-          throw QueryCompilationErrors.foundMultipleDataSources(source)
-        }
-        providerOpt.flatMap { provider =>
-          DataSourceV2Utils.loadV2Source(
-            sparkSession, provider, userSpecifiedSchema, extraOptions, source, paths: _*)
-        }.getOrElse(loadV1Source(paths: _*))
-      case Failure(exception) =>
-        // Exceptions are thrown while trying to load the data source as a V1 or V2 data source.
-        // For the following not found exceptions, if the user-defined data source is defined,
-        // we can instead return the user-defined data source.
-        val isNotFoundError = exception match {
-          case _: NoClassDefFoundError | _: SparkClassNotFoundException => true
-          case e: SparkThrowable => e.getErrorClass == "DATA_SOURCE_NOT_FOUND"
-          case e: ServiceConfigurationError => e.getCause.isInstanceOf[NoClassDefFoundError]
-          case _ => false
-        }
-        if (isNotFoundError && isUserDefinedDataSource) {
-          loadUserDefinedDataSource(paths)
-        } else {
-          // Throw the original exception.
-          throw exception
-        }
-    }
-  }
-
-  private def loadUserDefinedDataSource(paths: Seq[String]): DataFrame = {
-    val builder = sparkSession.sessionState.dataSourceManager.lookupDataSource(source)
-    // Add `path` and `paths` options to the extra options if specified.
-    val optionsWithPath = DataSourceV2Utils.getOptionsWithPaths(extraOptions, paths: _*)
-    val plan = builder(sparkSession, source, userSpecifiedSchema, optionsWithPath)
-    Dataset.ofRows(sparkSession, plan)
+    DataSource.lookupDataSourceV2(source, sparkSession.sessionState.conf).flatMap { provider =>
+      DataSourceV2Utils.loadV2Source(sparkSession, provider, userSpecifiedSchema, extraOptions,
+        source, paths: _*)
+    }.getOrElse(loadV1Source(paths: _*))
   }
 
   private def loadV1Source(paths: String*) = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
@@ -17,12 +17,11 @@
 
 package org.apache.spark.sql
 
-import java.util.{Locale, Properties, ServiceConfigurationError}
+import java.util.{Locale, Properties}
 
 import scala.jdk.CollectionConverters._
-import scala.util.{Failure, Success, Try}
 
-import org.apache.spark.{Partition, SparkClassNotFoundException, SparkThrowable}
+import org.apache.spark.Partition
 import org.apache.spark.annotation.Stable
 import org.apache.spark.api.java.JavaRDD
 import org.apache.spark.internal.Logging

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceManager.scala
@@ -20,12 +20,23 @@ package org.apache.spark.sql.execution.datasources
 import java.util.Locale
 import java.util.concurrent.ConcurrentHashMap
 
+import scala.collection.immutable.Map
+
+import org.apache.commons.text.StringEscapeUtils
+import org.codehaus.commons.compiler.{CompileException, InternalCompilerException}
+import org.codehaus.janino.ClassBodyEvaluator
+
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.SparkSession
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.{DataFrame, Dataset, Row, SparkSession, SQLContext}
+import org.apache.spark.sql.catalyst.expressions.codegen.{CodeAndComment, CodeFormatter, CodeGenerator}
+import org.apache.spark.sql.catalyst.expressions.codegen.GeneratePredicate.newCodeGenContext
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
-import org.apache.spark.sql.errors.QueryCompilationErrors
+import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
+import org.apache.spark.sql.sources.{BaseRelation, DataSourceRegister, RelationProvider, SchemaRelationProvider, TableScan}
 import org.apache.spark.sql.types.StructType
+import org.apache.spark.util.{ParentClassLoader, Utils}
 
 /**
  * A manager for user-defined data sources. It is used to register and lookup data sources by
@@ -40,6 +51,8 @@ class DataSourceManager extends Logging {
     CaseInsensitiveMap[String]  // options
   ) => LogicalPlan
 
+  // TODO(SPARK-45917): Statically load Python Data Source so idempotently Python
+  //   Data Sources can be loaded even when the Driver is restarted.
   private val dataSourceBuilders = new ConcurrentHashMap[String, DataSourceBuilder]()
 
   private def normalize(name: String): String = name.toLowerCase(Locale.ROOT)
@@ -79,5 +92,109 @@ class DataSourceManager extends Logging {
     val manager = new DataSourceManager
     dataSourceBuilders.forEach((k, v) => manager.registerDataSource(k, v))
     manager
+  }
+}
+
+/**
+ * Data Source V1 default source wrapper for Python Data Source.
+ */
+abstract class PythonDefaultSource
+    extends RelationProvider
+    with SchemaRelationProvider
+    with DataSourceRegister {
+
+  override def createRelation(
+      sqlContext: SQLContext, parameters: Map[String, String]): BaseRelation =
+    new PythonRelation(shortName(), sqlContext, parameters, None)
+
+  override def createRelation(
+      sqlContext: SQLContext,
+      parameters: Map[String, String],
+      schema: StructType): BaseRelation =
+    new PythonRelation(shortName(), sqlContext, parameters, Some(schema))
+}
+
+/**
+ * Data Source V1 relation wrapper for Python Data Source.
+ */
+class PythonRelation(
+    source: String,
+    override val sqlContext: SQLContext,
+    parameters: Map[String, String],
+    maybeSchema: Option[StructType]) extends BaseRelation with TableScan {
+
+  private lazy val sourceDf: DataFrame = {
+    val caseInsensitiveMap = CaseInsensitiveMap(parameters)
+    // TODO(SPARK-45600): should be session-based.
+    val builder = sqlContext.sparkSession.sharedState.dataSourceManager.lookupDataSource(source)
+    val plan = builder(
+      sqlContext.sparkSession, source, caseInsensitiveMap.get("path").toSeq,
+      maybeSchema, caseInsensitiveMap)
+    Dataset.ofRows(sqlContext.sparkSession, plan)
+  }
+
+  override def schema: StructType = sourceDf.schema
+
+  override def buildScan(): RDD[Row] = sourceDf.rdd
+}
+
+/**
+ * Responsible for generating a class for Python Data Source
+ * that inherits Scala Data Source interface so other features work together
+ * with Python Data Source.
+ */
+object PythonDataSourceCodeGenerator extends Logging {
+  /**
+   * When you invoke `generateClass`, it generates a class that inherits [[PythonDefaultSource]]
+   * that has a different short name. The generated class name as follows:
+   * "org.apache.spark.sql.execution.datasources.$shortName.DefaultSource".
+   *
+   * The `shortName` should be registered via `spark.dataSource.register` first, then
+   * this method can generate corresponding Scala Data Source wrapper for the Python
+   * Data Source.
+   *
+   * @param shortName The short name registered for Python Data Source.
+   * @return
+   */
+  def generateClass(shortName: String): Class[_] = {
+    val ctx = newCodeGenContext()
+
+    val codeBody = s"""
+      @Override
+      public String shortName() {
+        return "${StringEscapeUtils.escapeJava(shortName)}";
+      }"""
+
+    val evaluator = new ClassBodyEvaluator()
+    val parentClassLoader = new ParentClassLoader(Utils.getContextOrSparkClassLoader)
+    evaluator.setParentClassLoader(parentClassLoader)
+    evaluator.setClassName(
+      s"org.apache.spark.sql.execution.python.datasources.$shortName.DefaultSource")
+    evaluator.setExtendedClass(classOf[PythonDefaultSource])
+
+    val code = CodeFormatter.stripOverlappingComments(
+      new CodeAndComment(codeBody, ctx.getPlaceHolderToComments()))
+
+    // Note that the default `CodeGenerator.compile` wraps everything into a `GeneratedClass`
+    // class, and the defined DataSource becomes a nested class that cannot properly define
+    // getConstructors, etc. Therefore, we cannot simply reuse this.
+    try {
+      evaluator.cook("generated.java", code.body)
+      CodeGenerator.updateAndGetCompilationStats(evaluator)
+    } catch {
+      case e: InternalCompilerException =>
+        val msg = QueryExecutionErrors.failedToCompileMsg(e)
+        logError(msg, e)
+        CodeGenerator.logGeneratedCode(code)
+        throw QueryExecutionErrors.internalCompilerError(e)
+      case e: CompileException =>
+        val msg = QueryExecutionErrors.failedToCompileMsg(e)
+        logError(msg, e)
+        CodeGenerator.logGeneratedCode(code)
+        throw QueryExecutionErrors.compilerError(e)
+    }
+
+    logDebug(s"Generated Python Data Source':\n${CodeFormatter.format(code)}")
+    evaluator.getClazz()
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonDataSourceSuite.scala
@@ -216,7 +216,6 @@ class PythonDataSourceSuite extends QueryTest with SharedSparkSession {
          |""".stripMargin
     val dataSource = createUserDefinedPythonDataSource(dataSourceName, dataSourceScript)
     spark.dataSource.registerPython("test", dataSource)
-
     checkAnswer(spark.read.format("test").load(), Seq(Row(null, 1)))
     checkAnswer(spark.read.format("test").load("1"), Seq(Row("1", 1)))
     checkAnswer(spark.read.format("test").load("1", "2"), Seq(Row("1", 1), Row("2", 1)))


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a sort of a followup of https://github.com/apache/spark/pull/43630 which proposes to support Python Data Source can be with SQL (in favour of https://github.com/apache/spark/pull/43949), SparkR and all other exiting combinations by wrapping the Python Data Source by DSv2 interface (but yet uses `V1Table` interface).

The approach is as follows:

1. PySpark registers a Python Data Source with its short name.
2. Later, when the Data Sources are looked up, JVM creates a class that inherits DSv2 class dynamically that has the same short name as registered in Python.
3. The returned class invokes Python Data Source, and works wherever it works with DSv2 even including SparkR, Scala, all SQL places.

Self-contained working example:

```python
from pyspark.sql.datasource import DataSource, DataSourceReader, InputPartition

class TestDataSourceReader(DataSourceReader):
    def __init__(self, options):
        self.options = options
    def partitions(self):
        return [InputPartition(i) for i in range(3)]
    def read(self, partition):
        yield partition.value, str(partition.value)

class TestDataSource(DataSource):
    @classmethod
    def name(cls):
        return "test"
    def schema(self):
        return "x INT, y STRING"
    def reader(self, schema) -> "DataSourceReader":
        return TestDataSourceReader(self.options)
```

```python
spark.dataSource.register(TestDataSource)
sql("CREATE TABLE tblA USING test")
sql("SELECT * from tblA").show()
```

results in:

```
+---+---+
|  x|  y|
+---+---+
|  0|  0|
|  1|  1|
|  2|  2|
+---+---+
```

_There are limitations and followups to make:_

1. ~~We should change the dynamically generated classname from `org.apache.spark.sql.execution.datasources.PythonTableScan` to something else that maps to individual Python Data Source so the classes are not confused.~~
2. Whenever you load Python Data Source, it creates a new class dynamically generated. Should probably cache. (SPARK-45916)
3. If you save this table after you restart your driver, the table cannot be loaded because the dynamically generated class does not exist anymore. Should figure out the way of reloading them (SPARK-45916 and SPARK-45917)
4. ~~Multi-paths are not supported (inherited from DSv1). Relates to https://github.com/apache/spark/pull/16611~~, resolved by https://github.com/apache/spark/pull/43809
5. ~~Using a wrapper of DSv1 might be a blocker to implement commit protocol in Python Data Source.~~. From my code reading, it'd be still possible.
6. Statically loading Python Data Sources is still not supported (SPARK-45917)

### Why are the changes needed?

In order for Python Data Source to be able to be used in all other place including SparkR, Scala together.

### Does this PR introduce _any_ user-facing change?

Yes. Users can register their Python Data Source, and use them in SQL, SparkR, etc.

### How was this patch tested?

Unittests were added, and manually tested.

### Was this patch authored or co-authored using generative AI tooling?

No.

Closes #44233