### PR TITLE
[SPARK-45912][SQL] Enhancement of XSDToSchema API: Change to HDFS API for cloud storage accessibility

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/ValidatorUtil.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/ValidatorUtil.scala
@@ -16,6 +16,7 @@
  */
 package org.apache.spark.sql.catalyst.xml
 
+import java.io.{File, FileInputStream, InputStream}
 import javax.xml.XMLConstants
 import javax.xml.transform.stream.StreamSource
 import javax.xml.validation.{Schema, SchemaFactory}
@@ -25,28 +26,18 @@ import org.apache.hadoop.fs.Path
 
 import org.apache.spark.SparkFiles
 import org.apache.spark.deploy.SparkHadoopUtil
-import org.apache.spark.util.Utils
+import org.apache.spark.internal.Logging
 
 /**
  * Utilities for working with XSD validation.
  */
-private[sql] object ValidatorUtil {
+private[sql] object ValidatorUtil extends Logging{
   // Parsing XSDs may be slow, so cache them by path:
 
   private val cache = CacheBuilder.newBuilder().softValues().build(
     new CacheLoader[String, Schema] {
       override def load(key: String): Schema = {
-        val in = try {
-          // Handle case where file exists as specified
-          val fs = Utils.getHadoopFileSystem(key, SparkHadoopUtil.get.conf)
-          fs.open(new Path(key))
-        } catch {
-          case _: Throwable =>
-            // Handle case where it was added with sc.addFile
-            val addFileUrl = SparkFiles.get(key)
-            val fs = Utils.getHadoopFileSystem(addFileUrl, SparkHadoopUtil.get.conf)
-            fs.open(new Path(addFileUrl))
-        }
+        val in = openSchemaFile(new Path(key))
         try {
           val schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI)
           schemaFactory.newSchema(new StreamSource(in))
@@ -55,6 +46,25 @@ private[sql] object ValidatorUtil {
         }
       }
     })
+
+  def openSchemaFile(xsdPath: Path): InputStream = {
+    try {
+      // Handle case where file exists as specified
+      val fs = xsdPath.getFileSystem(SparkHadoopUtil.get.conf)
+      fs.open(xsdPath)
+    } catch {
+      case e: Throwable =>
+        // Handle case where it was added with sc.addFile
+        // When they are added via sc.addFile, they are always downloaded to local file system
+        logInfo(s"$xsdPath was not found, falling back to look up files added by Spark")
+        val f = new File(SparkFiles.get(xsdPath.toString))
+        if (f.exists()) {
+          new FileInputStream(f)
+        } else {
+          throw e
+        }
+    }
+  }
 
   /**
    * Parses the XSD at the given local path and caches it.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/xml/XSDToSchema.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/xml/XSDToSchema.scala
@@ -59,8 +59,8 @@ object XSDToSchema {
         fs.open(new Path(addFileUrl))
     }
     val xmlSchemaCollection = new XmlSchemaCollection()
-    val xmlSchema = xmlSchemaCollection.read(new InputStreamReader(in))
     xmlSchemaCollection.setBaseUri(xsdPath.getParent.toString)
+    val xmlSchema = xmlSchemaCollection.read(new InputStreamReader(in))
     getStructType(xmlSchema)
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/xml/XSDToSchema.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/xml/XSDToSchema.scala
@@ -19,9 +19,9 @@ package org.apache.spark.sql.execution.datasources.xml
 import java.io.StringReader
 
 import scala.jdk.CollectionConverters._
-import scala.xml.InputSource
 
 import org.apache.hadoop.fs.Path
+import org.apache.hadoop.shaded.org.jline.utils.InputStreamReader
 import org.apache.ws.commons.schema._
 import org.apache.ws.commons.schema.constants.Constants
 
@@ -59,7 +59,7 @@ object XSDToSchema {
         fs.open(new Path(addFileUrl))
     }
     val xmlSchemaCollection = new XmlSchemaCollection()
-    val xmlSchema = xmlSchemaCollection.read(new InputSource(in))
+    val xmlSchema = xmlSchemaCollection.read(new InputStreamReader(in))
     xmlSchemaCollection.setBaseUri(xsdPath.getParent.toString)
     getStructType(xmlSchema)
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/xml/XSDToSchema.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/xml/XSDToSchema.scala
@@ -18,7 +18,7 @@ package org.apache.spark.sql.execution.datasources.xml
 
 import java.io.StringReader
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.xml.InputSource
 
 import org.apache.hadoop.fs.Path

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/util/XSDToSchemaSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/util/XSDToSchemaSuite.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.spark.sql.execution.datasources.xml.util
 
-import java.nio.file.Paths
+import org.apache.hadoop.fs.Path
 
 import org.apache.spark.sql.execution.datasources.xml.TestUtils._
 import org.apache.spark.sql.execution.datasources.xml.XSDToSchema
@@ -28,8 +28,7 @@ class XSDToSchemaSuite extends SharedSparkSession {
   private val resDir = "test-data/xml-resources/"
 
   test("Basic parsing") {
-    val parsedSchema = XSDToSchema.read(Paths.get(testFile(resDir + "basket.xsd")
-      .replace("file:/", "/")))
+    val parsedSchema = XSDToSchema.read(new Path(testFile(resDir + "basket.xsd")))
     val expectedSchema = buildSchema(
       field("basket",
         structField(
@@ -40,8 +39,7 @@ class XSDToSchemaSuite extends SharedSparkSession {
   }
 
   test("Relative path parsing") {
-    val parsedSchema = XSDToSchema.read(Paths.get(testFile(resDir + "include-example/first.xsd")
-      .replace("file:/", "/")))
+    val parsedSchema = XSDToSchema.read(new Path(testFile(resDir + "include-example/first.xsd")))
     val expectedSchema = buildSchema(
       field("basket",
         structField(
@@ -52,8 +50,7 @@ class XSDToSchemaSuite extends SharedSparkSession {
   }
 
   test("Test schema types and attributes") {
-    val parsedSchema = XSDToSchema.read(Paths.get(testFile(resDir + "catalog.xsd")
-      .replace("file:/", "/")))
+    val parsedSchema = XSDToSchema.read(new Path(testFile(resDir + "catalog.xsd")))
     val expectedSchema = buildSchema(
       field("catalog",
         structField(
@@ -76,23 +73,20 @@ class XSDToSchemaSuite extends SharedSparkSession {
   }
 
   test("Test xs:choice nullability") {
-    val parsedSchema = XSDToSchema.read(Paths.get(testFile(resDir + "choice.xsd")
-      .replace("file:/", "/")))
+    val parsedSchema = XSDToSchema.read(new Path(testFile(resDir + "choice.xsd")))
     val expectedSchema = buildSchema(
       field("el", structField(field("foo"), field("bar"), field("baz")), nullable = false))
     assert(expectedSchema === parsedSchema)
   }
 
   test("Two root elements") {
-    val parsedSchema = XSDToSchema.read(Paths.get(testFile(resDir + "twoelements.xsd")
-      .replace("file:/", "/")))
+    val parsedSchema = XSDToSchema.read(new Path(testFile(resDir + "twoelements.xsd")))
     val expectedSchema = buildSchema(field("bar", nullable = false), field("foo", nullable = false))
     assert(expectedSchema === parsedSchema)
   }
 
   test("xs:any schema") {
-    val parsedSchema = XSDToSchema.read(Paths.get(testFile(resDir + "xsany.xsd")
-      .replace("file:/", "/")))
+    val parsedSchema = XSDToSchema.read(new Path(testFile(resDir + "xsany.xsd")))
     val expectedSchema = buildSchema(
       field("root",
         structField(
@@ -117,8 +111,7 @@ class XSDToSchemaSuite extends SharedSparkSession {
   }
 
   test("Tests xs:long type / Issue 520") {
-    val parsedSchema = XSDToSchema.read(Paths.get(testFile(resDir + "long.xsd")
-      .replace("file:/", "/")))
+    val parsedSchema = XSDToSchema.read(new Path(testFile(resDir + "long.xsd")))
     val expectedSchema = buildSchema(
       field("test",
         structField(field("userId", LongType, nullable = false)), nullable = false))
@@ -126,8 +119,7 @@ class XSDToSchemaSuite extends SharedSparkSession {
   }
 
   test("Test xs:decimal type with restriction[fractionalDigits]") {
-    val parsedSchema = XSDToSchema.read(Paths.get(testFile(resDir +
-      "decimal-with-restriction.xsd").replace("file:/", "/")))
+    val parsedSchema = XSDToSchema.read(new Path(testFile(resDir + "decimal-with-restriction.xsd")))
     val expectedSchema = buildSchema(
       field("decimal_type_3", DecimalType(12, 6), nullable = false),
       field("decimal_type_1", DecimalType(38, 18), nullable = false),
@@ -137,8 +129,7 @@ class XSDToSchemaSuite extends SharedSparkSession {
   }
 
   test("Test ref attribute / Issue 617") {
-    val parsedSchema = XSDToSchema.read(Paths.get(testFile(resDir + "ref-attribute.xsd")
-      .replace("file:/", "/")))
+    val parsedSchema = XSDToSchema.read(new Path(testFile(resDir + "ref-attribute.xsd")))
     val expectedSchema = buildSchema(
       field(
         "book",
@@ -166,8 +157,8 @@ class XSDToSchemaSuite extends SharedSparkSession {
   }
 
   test("Test complex content with extension element / Issue 554") {
-    val parsedSchema = XSDToSchema.read(Paths.get(testFile(resDir +
-      "complex-content-extension.xsd").replace("file:/", "/")))
+    val parsedSchema =
+      XSDToSchema.read(new Path(testFile(resDir + "complex-content-extension.xsd")))
 
     val expectedSchema = buildSchema(
       field(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/util/XSDToSchemaSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/util/XSDToSchemaSuite.scala
@@ -16,6 +16,8 @@
  */
 package org.apache.spark.sql.execution.datasources.xml.util
 
+import java.io.FileNotFoundException
+
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.sql.execution.datasources.xml.TestUtils._
@@ -174,5 +176,11 @@ class XSDToSchemaSuite extends SharedSparkSession {
       )
     )
     assert(parsedSchema === expectedSchema)
+  }
+
+  test("SPARK-45912: Test XSDToSchema when open not found files") {
+    intercept[FileNotFoundException] {
+      XSDToSchema.read(new Path("/path/not/found"))
+    }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Previously, it utilized `java.nio.path`, which limited file reading to local file systems only. By changing this to an HDFS-compatible API, we now enable the XSDToSchema function to access files in cloud storage.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
We want to enable the XSDToSchema function to access files in cloud storage.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Unit tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No