### PR TITLE
[MINOR][DOCS] Correct additional Conda documentation URL to fix 404 errors

### DIFF
--- a/python/docs/source/getting_started/install.rst
+++ b/python/docs/source/getting_started/install.rst
@@ -86,7 +86,7 @@ Using Conda
 
 Conda is an open-source package management and environment management system (developed by
 `Anaconda <https://www.anaconda.com/>`_), which is best installed through
-`Miniconda <https://docs.conda.io/en/latest/miniconda.html/>`_ or `Miniforge <https://github.com/conda-forge/miniforge/>`_.
+`Miniconda <https://docs.conda.io/en/latest/miniconda.html>`_ or `Miniforge <https://github.com/conda-forge/miniforge/>`_.
 The tool is both cross-platform and language agnostic, and in practice, conda can replace both
 `pip <https://pip.pypa.io/en/latest/>`_ and `virtualenv <https://virtualenv.pypa.io/en/latest/>`_.
 
@@ -119,7 +119,7 @@ While using pip in a conda environment is technically feasible (with the same co
 because pip does not interoperate with conda.
 
 For a short summary about useful conda commands, see their
-`cheat sheet <https://docs.conda.io/projects/conda/en/latest/user-guide/cheatsheet.html/>`_.
+`cheat sheet <https://docs.conda.io/projects/conda/en/latest/user-guide/cheatsheet.html>`_.
 
 
 Manually Downloading


### PR DESCRIPTION
- Remove trailing slash from Conda cheat sheet URL in 'Using Conda' section.
- Correct the Miniconda documentation URL by removing the trailing slash.


### What changes were proposed in this pull request?
In addition to removing the trailing slash from the Conda cheat sheet URL in the 'Using Conda' section, this update also corrects the Miniconda documentation URL in the same section by removing the trailing slash. These modifications are intended to resolve the 404 errors that occur when the current URLs with the trailing slashes are accessed.

### Why are the changes needed?
The changes are necessary because the existing URLs with trailing slashes lead to 404 errors, hindering users' access to the Conda cheat sheet and Miniconda documentation. Removing the slashes will ensure the links direct users to the correct webpages, improving the documentation's usability.

### Does this PR introduce _any_ user-facing change?
No. This change only affects the documentation and does not alter the functionality of the Spark software itself.

### How was this patch tested?
Both documentation fixes were visually inspected to ensure the corrected URLs resolve to the intended webpages without 404 errors. No additional code testing is necessary as these changes are strictly within the documentation.

### Was this patch authored or co-authored using generative AI tooling?
No.
