### PR TITLE
[SPARK-46029][SQL] Escape the single quote, `_` and `%` for DS V2 pushdown

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/QuotingUtils.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/QuotingUtils.scala
@@ -71,17 +71,4 @@ object QuotingUtils {
 
     builder.toString()
   }
-
-  def escapeSpecialChar(str: String): String = {
-    val builder = new StringBuilder
-
-    str.foreach {
-      case '_' => builder ++= "\\_"
-      case '%' => builder ++= "\\%"
-      // TODO Support for escaping more special characters
-      case ch => builder += ch
-    }
-
-    builder.toString()
-  }
 }

--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/QuotingUtils.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/QuotingUtils.scala
@@ -71,4 +71,17 @@ object QuotingUtils {
 
     builder.toString()
   }
+
+  def escapeSpecialChar(str: String): String = {
+    val builder = new StringBuilder
+
+    str.foreach {
+      case '_' => builder ++= "\\_"
+      case '%' => builder ++= "\\%"
+      // TODO Support for escaping more special characters
+      case ch => builder += ch
+    }
+
+    builder.toString()
+  }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/util/V2ExpressionSQLBuilder.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/util/V2ExpressionSQLBuilder.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.StringJoiner;
 
+import org.apache.spark.sql.catalyst.util.QuotingUtils;
 import org.apache.spark.sql.connector.expressions.Cast;
 import org.apache.spark.sql.connector.expressions.Expression;
 import org.apache.spark.sql.connector.expressions.Extract;
@@ -238,21 +239,21 @@ public class V2ExpressionSQLBuilder {
     // Remove quotes at the beginning and end.
     // e.g. converts "'str'" to "str".
     String value = r.substring(1, r.length() - 1);
-    return l + " LIKE '" + value + "%'";
+    return l + " LIKE '" + QuotingUtils.escapeSpecialChar(value) + "%'";
   }
 
   protected String visitEndsWith(String l, String r) {
     // Remove quotes at the beginning and end.
     // e.g. converts "'str'" to "str".
     String value = r.substring(1, r.length() - 1);
-    return l + " LIKE '%" + value + "'";
+    return l + " LIKE '%" + QuotingUtils.escapeSpecialChar(value) + "'";
   }
 
   protected String visitContains(String l, String r) {
     // Remove quotes at the beginning and end.
     // e.g. converts "'str'" to "str".
     String value = r.substring(1, r.length() - 1);
-    return l + " LIKE '%" + value + "%'";
+    return l + " LIKE '%" + QuotingUtils.escapeSpecialChar(value) + "%'";
   }
 
   private String inputToSQL(Expression input) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/H2Dialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/H2Dialect.scala
@@ -242,6 +242,14 @@ private[sql] object H2Dialect extends JdbcDialect {
   }
 
   class H2SQLBuilder extends JDBCSQLBuilder {
+    override def escapeSpecialCharsForLikePattern(str: String): String = {
+      str.map {
+        case '_' => "\\_"
+        case '%' => "\\%"
+        case c => c.toString
+      }.mkString
+    }
+
     override def visitAggregateFunction(
         funcName: String, isDistinct: Boolean, inputs: Array[String]): String =
       if (isDistinct && distinctUnsupportedAggregateFunctions.contains(funcName)) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/V2PredicateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/V2PredicateSuite.scala
@@ -315,7 +315,7 @@ class V2PredicateSuite extends SparkFunSuite {
       Array[Expression](ref("a"), literal))
     assert(predicate1.equals(predicate2))
     assert(predicate1.references.map(_.describe()).toSeq == Seq("a"))
-    assert(predicate1.describe.equals("a LIKE 'str%'"))
+    assert(predicate1.describe.equals(raw"a LIKE 'str%' ESCAPE '\'"))
 
     val v1Filter = StringStartsWith("a", "str")
     assert(v1Filter.toV2.equals(predicate1))
@@ -332,7 +332,7 @@ class V2PredicateSuite extends SparkFunSuite {
       Array[Expression](ref("a"), literal))
     assert(predicate1.equals(predicate2))
     assert(predicate1.references.map(_.describe()).toSeq == Seq("a"))
-    assert(predicate1.describe.equals("a LIKE '%str'"))
+    assert(predicate1.describe.equals(raw"a LIKE '%str' ESCAPE '\'"))
 
     val v1Filter = StringEndsWith("a", "str")
     assert(v1Filter.toV2.equals(predicate1))
@@ -349,7 +349,7 @@ class V2PredicateSuite extends SparkFunSuite {
       Array[Expression](ref("a"), literal))
     assert(predicate1.equals(predicate2))
     assert(predicate1.references.map(_.describe()).toSeq == Seq("a"))
-    assert(predicate1.describe.equals("a LIKE '%str%'"))
+    assert(predicate1.describe.equals(raw"a LIKE '%str%' ESCAPE '\'"))
 
     val v1Filter = StringContains("a", "str")
     assert(v1Filter.toV2.equals(predicate1))

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
@@ -1131,7 +1131,7 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
 
     val df3 = spark.table("h2.test.employee").filter($"name".startsWith("a"))
     checkFiltersRemoved(df3)
-    checkPushedInfo(df3, "PushedFilters: [NAME IS NOT NULL, NAME LIKE 'a%']")
+    checkPushedInfo(df3, raw"PushedFilters: [NAME IS NOT NULL, NAME LIKE 'a%' ESCAPE '\']")
     checkAnswer(df3, Seq(Row(1, "amy", 10000, 1000, true), Row(2, "alex", 12000, 1200, false)))
 
     val df4 = spark.table("h2.test.employee").filter($"is_manager")
@@ -1275,82 +1275,91 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
     checkAnswer(df17, Seq(Row(6, "jen", 12000, 1200, true)))
   }
 
-  test("SPARK-38432: escape the quote, _ and % for DS V2 pushdown") {
+  test("SPARK-38432: escape the single quote, _ and % for DS V2 pushdown") {
     val df1 = spark.table("h2.test.address").filter($"email".startsWith("abc_"))
     checkFiltersRemoved(df1)
-    checkPushedInfo(df1, "PushedFilters: [EMAIL IS NOT NULL, EMAIL LIKE 'abc\\_%']")
+    checkPushedInfo(df1, raw"PushedFilters: [EMAIL IS NOT NULL, EMAIL LIKE 'abc\_%' ESCAPE '\']")
     checkAnswer(df1,
       Seq(Row("abc_%def@gmail.com"), Row("abc_'%def@gmail.com"), Row("abc_def@gmail.com")))
 
     val df2 = spark.table("h2.test.address").filter($"email".startsWith("abc%"))
     checkFiltersRemoved(df2)
-    checkPushedInfo(df2, "PushedFilters: [EMAIL IS NOT NULL, EMAIL LIKE 'abc\\%%']")
+    checkPushedInfo(df2, raw"PushedFilters: [EMAIL IS NOT NULL, EMAIL LIKE 'abc\%%' ESCAPE '\']")
     checkAnswer(df2, Seq(Row("abc%_def@gmail.com"), Row("abc%def@gmail.com")))
 
     val df3 = spark.table("h2.test.address").filter($"email".startsWith("abc%_"))
     checkFiltersRemoved(df3)
-    checkPushedInfo(df3, "PushedFilters: [EMAIL IS NOT NULL, EMAIL LIKE 'abc\\%\\_%']")
+    checkPushedInfo(df3, raw"PushedFilters: [EMAIL IS NOT NULL, EMAIL LIKE 'abc\%\_%' ESCAPE '\']")
     checkAnswer(df3, Seq(Row("abc%_def@gmail.com")))
 
     val df4 = spark.table("h2.test.address").filter($"email".startsWith("abc_%"))
     checkFiltersRemoved(df4)
-    checkPushedInfo(df4, "PushedFilters: [EMAIL IS NOT NULL, EMAIL LIKE 'abc\\_\\%%']")
+    checkPushedInfo(df4, raw"PushedFilters: [EMAIL IS NOT NULL, EMAIL LIKE 'abc\_\%%' ESCAPE '\']")
     checkAnswer(df4, Seq(Row("abc_%def@gmail.com")))
 
     val df5 = spark.table("h2.test.address").filter($"email".startsWith("abc_'%"))
     checkFiltersRemoved(df5)
-    checkPushedInfo(df5, "PushedFilters: [EMAIL IS NOT NULL, EMAIL LIKE 'abc\\_'\\%%']")
+    checkPushedInfo(df5,
+      raw"PushedFilters: [EMAIL IS NOT NULL, EMAIL LIKE 'abc\_\'\%%' ESCAPE '\']")
     checkAnswer(df5, Seq(Row("abc_'%def@gmail.com")))
 
     val df6 = spark.table("h2.test.address").filter($"email".endsWith("_def@gmail.com"))
     checkFiltersRemoved(df6)
-    checkPushedInfo(df6, "PushedFilters: [EMAIL IS NOT NULL, EMAIL LIKE '%\\_def@gmail.com']")
+    checkPushedInfo(df6,
+      raw"PushedFilters: [EMAIL IS NOT NULL, EMAIL LIKE '%\_def@gmail.com' ESCAPE '\']")
     checkAnswer(df6, Seq(Row("abc%_def@gmail.com"), Row("abc_def@gmail.com")))
 
     val df7 = spark.table("h2.test.address").filter($"email".endsWith("%def@gmail.com"))
     checkFiltersRemoved(df7)
-    checkPushedInfo(df7, "PushedFilters: [EMAIL IS NOT NULL, EMAIL LIKE '%\\%def@gmail.com']")
+    checkPushedInfo(df7,
+      raw"PushedFilters: [EMAIL IS NOT NULL, EMAIL LIKE '%\%def@gmail.com' ESCAPE '\']")
     checkAnswer(df7,
       Seq(Row("abc%def@gmail.com"), Row("abc_%def@gmail.com"), Row("abc_'%def@gmail.com")))
 
     val df8 = spark.table("h2.test.address").filter($"email".endsWith("%_def@gmail.com"))
     checkFiltersRemoved(df8)
-    checkPushedInfo(df8, "PushedFilters: [EMAIL IS NOT NULL, EMAIL LIKE '%\\%\\_def@gmail.com']")
+    checkPushedInfo(df8,
+      raw"PushedFilters: [EMAIL IS NOT NULL, EMAIL LIKE '%\%\_def@gmail.com' ESCAPE '\']")
     checkAnswer(df8, Seq(Row("abc%_def@gmail.com")))
 
     val df9 = spark.table("h2.test.address").filter($"email".endsWith("_%def@gmail.com"))
     checkFiltersRemoved(df9)
-    checkPushedInfo(df9, "PushedFilters: [EMAIL IS NOT NULL, EMAIL LIKE '%\\_\\%def@gmail.com']")
+    checkPushedInfo(df9,
+      raw"PushedFilters: [EMAIL IS NOT NULL, EMAIL LIKE '%\_\%def@gmail.com' ESCAPE '\']")
     checkAnswer(df9, Seq(Row("abc_%def@gmail.com")))
 
     val df10 = spark.table("h2.test.address").filter($"email".endsWith("_'%def@gmail.com"))
     checkFiltersRemoved(df10)
-    checkPushedInfo(df10, "PushedFilters: [EMAIL IS NOT NULL, EMAIL LIKE '%\\_'\\%def@gmail.com']")
+    checkPushedInfo(df10,
+      raw"PushedFilters: [EMAIL IS NOT NULL, EMAIL LIKE '%\_\'\%def@gmail.com' ESCAPE '\']")
     checkAnswer(df10, Seq(Row("abc_'%def@gmail.com")))
 
     val df11 = spark.table("h2.test.address").filter($"email".contains("c_d"))
     checkFiltersRemoved(df11)
-    checkPushedInfo(df11, "PushedFilters: [EMAIL IS NOT NULL, EMAIL LIKE '%c\\_d%']")
+    checkPushedInfo(df11, raw"PushedFilters: [EMAIL IS NOT NULL, EMAIL LIKE '%c\_d%' ESCAPE '\']")
     checkAnswer(df11, Seq(Row("abc_def@gmail.com")))
 
     val df12 = spark.table("h2.test.address").filter($"email".contains("c%d"))
     checkFiltersRemoved(df12)
-    checkPushedInfo(df12, "PushedFilters: [EMAIL IS NOT NULL, EMAIL LIKE '%c\\%d%']")
+    checkPushedInfo(df12, raw"PushedFilters: [EMAIL IS NOT NULL, EMAIL LIKE '%c\%d%' ESCAPE '\']")
     checkAnswer(df12, Seq(Row("abc%def@gmail.com")))
 
     val df13 = spark.table("h2.test.address").filter($"email".contains("c%_d"))
     checkFiltersRemoved(df13)
-    checkPushedInfo(df13, "PushedFilters: [EMAIL IS NOT NULL, EMAIL LIKE '%c\\%\\_d%']")
+    checkPushedInfo(df13,
+      raw"PushedFilters: [EMAIL IS NOT NULL, EMAIL LIKE '%c\%\_d%' ESCAPE '\']")
     checkAnswer(df13, Seq(Row("abc%_def@gmail.com")))
 
     val df14 = spark.table("h2.test.address").filter($"email".contains("c_%d"))
     checkFiltersRemoved(df14)
-    checkPushedInfo(df14, "PushedFilters: [EMAIL IS NOT NULL, EMAIL LIKE '%c\\_\\%d%']")
+    checkPushedInfo(df14,
+      raw"PushedFilters: [EMAIL IS NOT NULL, EMAIL LIKE '%c\_\%d%' ESCAPE '\']")
     checkAnswer(df14, Seq(Row("abc_%def@gmail.com")))
 
     val df15 = spark.table("h2.test.address").filter($"email".contains("c_'%d"))
     checkFiltersRemoved(df15)
-    checkPushedInfo(df15, "PushedFilters: [EMAIL IS NOT NULL, EMAIL LIKE '%c\\_'\\%d%']")
+    checkPushedInfo(df15,
+      raw"PushedFilters: [EMAIL IS NOT NULL, EMAIL LIKE '%c\_\'\%d%' ESCAPE '\']")
     checkAnswer(df15, Seq(Row("abc_'%def@gmail.com")))
   }
 
@@ -1439,10 +1448,11 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
         checkFiltersRemoved(df6, ansiMode)
         val expectedPlanFragment6 = if (ansiMode) {
           "PushedFilters: [BONUS IS NOT NULL, DEPT IS NOT NULL, " +
-            "CAST(BONUS AS string) LIKE '%30%', CAST(DEPT AS byte) > 1, " +
+            raw"CAST(BONUS AS string) LIKE '%30%' ESCAPE '\', CAST(DEPT AS byte) > 1, " +
             "CAST(DEPT AS short) > 1, CAST(BONUS AS decimal(20,2)) > 1200.00]"
         } else {
-          "PushedFilters: [BONUS IS NOT NULL, DEPT IS NOT NULL, CAST(BONUS AS string) LIKE '%30%']"
+          "PushedFilters: [BONUS IS NOT NULL, " +
+            raw"DEPT IS NOT NULL, CAST(BONUS AS string) LIKE '%30%' ESCAPE '\']"
         }
         checkPushedInfo(df6, expectedPlanFragment6)
         checkAnswer(df6, Seq(Row(2, "david", 10000, 1300, true)))


### PR DESCRIPTION
### What changes were proposed in this pull request?
Spark supports push down `startsWith`, `endWith` and `contains` to JDBC database with DS V2 pushdown.
But the `V2ExpressionSQLBuilder` didn't escape the single quote, `_` and `%`, it can cause unexpected result.


### Why are the changes needed?
Escape the single quote, `_` and `%` for DS V2 pushdown


### Does this PR introduce _any_ user-facing change?
'No'.


### How was this patch tested?
Exists test cases.


### Was this patch authored or co-authored using generative AI tooling?
'No'.
