### PR TITLE
[SPARK-45844][SQL][FOLLOWUP] Improve the caseSensitivityOrdering for XmlInferSchema

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/XmlInferSchema.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/XmlInferSchema.scala
@@ -214,12 +214,11 @@ private[sql] class XmlInferSchema(options: XmlOptions, caseSensitive: Boolean)
      * In case-insensitive mode, we will infer an array named by foo
      * (as it's the first one we encounter)
      */
-    val caseSensitivityOrdering: Ordering[String] = (x: String, y: String) =>
-      if (caseSensitive) {
-        x.compareTo(y)
-      } else {
-      x.compareToIgnoreCase(y)
-      }
+    val caseSensitivityOrdering: Ordering[String] = if (caseSensitive) {
+      (x: String, y: String) => x.compareTo(y)
+    } else {
+      (x: String, y: String) => x.compareToIgnoreCase(y)
+    }
 
     val nameToDataType =
       collection.mutable.TreeMap.empty[String, DataType](caseSensitivityOrdering)


### PR DESCRIPTION
### What changes were proposed in this pull request?
https://github.com/apache/spark/pull/43722 implement case-insensitivity for XML.
But there are a little issue looks weird.


### Why are the changes needed?
Improve the caseSensitivityOrdering for XmlInferSchema


### Does this PR introduce _any_ user-facing change?
'No'.


### How was this patch tested?
Exists test cases.


### Was this patch authored or co-authored using generative AI tooling?
'No'.
