### PR TITLE
[SPARK-45911][CORE] Make TLS1.3 the default for RPC SSL

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/ssl/SSLFactory.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/ssl/SSLFactory.java
@@ -175,7 +175,7 @@ public class SSLFactory {
      * @return The builder object
      */
     public Builder requestedProtocol(String requestedProtocol) {
-      this.requestedProtocol = requestedProtocol == null ? "TLSv1.2" : requestedProtocol;
+      this.requestedProtocol = requestedProtocol == null ? "TLSv1.3" : requestedProtocol;
       return this;
     }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

As title. I think we should encourage a safer default. This also makes it easier for FedRAMP compliance guidelines coming up on Jan 1, as users would not need to do additional configuration to enable TLS1.3.

### Why are the changes needed?

This improves a default setting for better security and improved performance.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

existing CI tests

I ran with logs enabled and verified that handshakes are now TLS1.3 where they previously were TLS1.2

### Was this patch authored or co-authored using generative AI tooling?

No