### PR TITLE
[SPARK-45562][SQL][FOLLOW-UP] XML: Fix SQLSTATE for missing rowTag error

### DIFF
--- a/common/utils/src/main/resources/error/error-classes.json
+++ b/common/utils/src/main/resources/error/error-classes.json
@@ -3921,7 +3921,7 @@
     "message" : [
       "<rowTag> option is required for reading files in XML format."
     ],
-    "sqlState" : "42000"
+    "sqlState" : "42KDF"
   },
   "_LEGACY_ERROR_TEMP_0001" : {
     "message" : [

--- a/docs/sql-error-conditions.md
+++ b/docs/sql-error-conditions.md
@@ -2375,9 +2375,3 @@ The operation `<operation>` requires a `<requiredType>`. But `<objectName>` is a
 The `<functionName>` requires `<expectedNum>` parameters but the actual number is `<actualNum>`.
 
 For more details see [WRONG_NUM_ARGS](sql-error-conditions-wrong-num-args-error-class.html)
-
-### XML_ROW_TAG_MISSING
-
-[SQLSTATE: 42000](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
-
-`<rowTag>` option is required for reading files in XML format.


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix the SQLSTATE for missing rowTag error added in this [PR](https://github.com/apache/spark/pull/43710).

### Why are the changes needed?
Same as above

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Unit test

### Was this patch authored or co-authored using generative AI tooling?
No