### PR TITLE
[SPARK-45929][SQL] Support groupingSets operation in dataframe api

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -1826,6 +1826,33 @@ class Dataset[T] private[sql](
   }
 
   /**
+   * Create multi-dimensional aggregation for the current Dataset using the specified grouping sets,
+   * so we can run aggregation on them.
+   * See [[RelationalGroupedDataset]] for all the available aggregate functions.
+   *
+   * {{{
+   *   // Compute the average for all numeric columns group by specific grouping sets.
+   *   ds.groupingSets(Seq(Seq($"department", $"group"),Seq()),$"department", $"group").avg()
+   *
+   *   // Compute the max age and average salary, group by specific grouping sets.
+   *   ds.groupingSets(Seq($"department", $"gender"), Seq()),$"department", $"group").agg(Map(
+   *     "salary" -> "avg",
+   *     "age" -> "max"
+   *   ))
+   * }}}
+   *
+   * @group untypedrel
+   * @since 3.5.0
+   */
+  @scala.annotation.varargs
+  def groupingSets(
+                    groupingSets: Seq[Seq[Column]],
+                    cols: Column*): RelationalGroupedDataset = {
+    RelationalGroupedDataset(toDF(), cols.map(_.expr),
+      RelationalGroupedDataset.GroupingSetsType(groupingSets.map(_.map(_.expr))))
+  }
+
+  /**
    * Groups the Dataset using the specified columns, so that we can run aggregation on them.
    * See [[RelationalGroupedDataset]] for all the available aggregate functions.
    *
@@ -1958,6 +1985,42 @@ class Dataset[T] private[sql](
     val colNames: Seq[String] = col1 +: cols
     RelationalGroupedDataset(
       toDF(), colNames.map(colName => resolve(colName)), RelationalGroupedDataset.CubeType)
+  }
+
+  /**
+   * Create multi-dimensional aggregation for the current Dataset using the specified grouping sets,
+   * so we can run aggregation on them.
+   * See [[RelationalGroupedDataset]] for all the available aggregate functions.
+   *
+   * This is a variant of groupingSets that can only group by existing columns using column names
+   * (i.e. cannot construct expressions).
+   *
+   * {{{
+   *   // Compute the average for all numeric columns group by specific grouping sets.
+   *   ds.groupingSets(Seq(Seq("department", "group"),Seq()),"department", "group").avg()
+   *
+   *   // Compute the max age and average salary, group by specific grouping sets.
+   *   ds.groupingSets(Seq($"department", $"gender"), Seq($"department"), Seq()).agg(Map(
+   *     "salary" -> "avg",
+   *     "age" -> "max"
+   *   ))
+   * }}}
+   *
+   * @group untypedrel
+   * @since 3.5.0
+   */
+  @scala.annotation.varargs
+  def groupingSets(
+                    groupingSets: Seq[Seq[String]],
+                    col1: String,
+                    cols: String*): RelationalGroupedDataset = {
+    val colNames: Seq[String] = col1 +: cols
+    RelationalGroupedDataset(
+      toDF(),
+      colNames.map(colName => resolve(colName)),
+      RelationalGroupedDataset.GroupingSetsType(
+        groupingSets.map(_.map(colName => resolve(colName))))
+    )
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -1845,10 +1845,10 @@ class Dataset[T] private[sql](
    * @since 4.0.0
    */
   @scala.annotation.varargs
-  def groupingSets(
-                    groupingSets: Seq[Seq[Column]],
-                    cols: Column*): RelationalGroupedDataset = {
-    RelationalGroupedDataset(toDF(), cols.map(_.expr),
+  def groupingSets(groupingSets: Seq[Seq[Column]], cols: Column*): RelationalGroupedDataset = {
+    RelationalGroupedDataset(
+      toDF(),
+      cols.map(_.expr),
       RelationalGroupedDataset.GroupingSetsType(groupingSets.map(_.map(_.expr))))
   }
 
@@ -1985,42 +1985,6 @@ class Dataset[T] private[sql](
     val colNames: Seq[String] = col1 +: cols
     RelationalGroupedDataset(
       toDF(), colNames.map(colName => resolve(colName)), RelationalGroupedDataset.CubeType)
-  }
-
-  /**
-   * Create multi-dimensional aggregation for the current Dataset using the specified grouping sets,
-   * so we can run aggregation on them.
-   * See [[RelationalGroupedDataset]] for all the available aggregate functions.
-   *
-   * This is a variant of groupingSets that can only group by existing columns using column names
-   * (i.e. cannot construct expressions).
-   *
-   * {{{
-   *   // Compute the average for all numeric columns group by specific grouping sets.
-   *   ds.groupingSets(Seq(Seq("department", "group"),Seq()),"department", "group").avg()
-   *
-   *   // Compute the max age and average salary, group by specific grouping sets.
-   *   ds.groupingSets(Seq($"department", $"gender"), Seq($"department"), Seq()).agg(Map(
-   *     "salary" -> "avg",
-   *     "age" -> "max"
-   *   ))
-   * }}}
-   *
-   * @group untypedrel
-   * @since 4.0.0
-   */
-  @scala.annotation.varargs
-  def groupingSets(
-                    groupingSets: Seq[Seq[String]],
-                    col1: String,
-                    cols: String*): RelationalGroupedDataset = {
-    val colNames: Seq[String] = col1 +: cols
-    RelationalGroupedDataset(
-      toDF(),
-      colNames.map(colName => resolve(colName)),
-      RelationalGroupedDataset.GroupingSetsType(
-        groupingSets.map(_.map(colName => resolve(colName))))
-    )
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2007,7 +2007,7 @@ class Dataset[T] private[sql](
    * }}}
    *
    * @group untypedrel
-   * @since 3.5.0
+   * @since 4.0.0
    */
   @scala.annotation.varargs
   def groupingSets(

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -1842,7 +1842,7 @@ class Dataset[T] private[sql](
    * }}}
    *
    * @group untypedrel
-   * @since 3.5.0
+   * @since 4.0.0
    */
   @scala.annotation.varargs
   def groupingSets(

--- a/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
@@ -80,6 +80,11 @@ class RelationalGroupedDataset protected[sql](
         Dataset.ofRows(
           df.sparkSession, Aggregate(Seq(Cube(groupingExprs.map(Seq(_)))),
             aliasedAgg, df.logicalPlan))
+      case RelationalGroupedDataset.GroupingSetsType(groupingSets) =>
+        Dataset.ofRows(
+          df.sparkSession,
+          Aggregate(Seq(GroupingSets(groupingSets, groupingExprs)),
+            aliasedAgg, df.logicalPlan))
       case RelationalGroupedDataset.PivotType(pivotCol, values) =>
         val aliasedGrps = groupingExprs.map(alias)
         Dataset.ofRows(
@@ -731,6 +736,11 @@ private[sql] object RelationalGroupedDataset {
    * To indicate it's the ROLLUP
    */
   private[sql] object RollupType extends GroupType
+
+  /**
+   * To indicate it's the GroupingSets
+   */
+  private[sql] case class GroupingSetsType(groupingSets: Seq[Seq[Expression]]) extends GroupType
 
   /**
    * To indicate it's the PIVOT

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
@@ -163,14 +163,17 @@ class DataFrameAggregateSuite extends QueryTest
 
   test("SPARK-45929 support grouping set operation in dataframe api") {
     checkAnswer(
-      courseSales.groupingSets(Seq(Seq("course", "year"), Seq()), "course", "year")
-        .agg(sum("earnings"), grouping_id()),
+      courseSales
+        .groupingSets(
+          Seq(Seq(Column("course"), Column("year")), Seq()),
+          Column("course"),
+          Column("year"))
+        .agg(sum(Column("earnings")), grouping_id()),
       Row("Java", 2012, 20000.0, 0) ::
         Row("Java", 2013, 30000.0, 0) ::
         Row("dotNET", 2012, 15000.0, 0) ::
         Row("dotNET", 2013, 48000.0, 0) ::
-        Row(null, null, 113000.0, 3) :: Nil
-    )
+        Row(null, null, 113000.0, 3) :: Nil)
   }
 
   test("grouping and grouping_id") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
@@ -161,6 +161,18 @@ class DataFrameAggregateSuite extends QueryTest
     assert(cube0.where("date IS NULL").count() > 0)
   }
 
+  test("SPARK-45929 support grouping set operation in dataframe api") {
+    checkAnswer(
+      courseSales.groupingSets(Seq(Seq("course", "year"), Seq()), "course", "year")
+        .agg(sum("earnings"), grouping_id()),
+      Row("Java", 2012, 20000.0, 0) ::
+        Row("Java", 2013, 30000.0, 0) ::
+        Row("dotNET", 2012, 15000.0, 0) ::
+        Row("dotNET", 2013, 48000.0, 0) ::
+        Row(null, null, 113000.0, 3) :: Nil
+    )
+  }
+
   test("grouping and grouping_id") {
     checkAnswer(
       courseSales.cube("course", "year")


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add groupingSets method in dataset api.

`select col1, col2, col3, sum(col4) FROM t GROUP col1, col2, col3 BY GROUPING SETS ((col1, col2), ())`
This SQL can be equivalently replaced with the following code: 
`df.groupingSets(Seq(Seq("col1", "col2"), Seq()), "col1", "col2", "col3").sum("col4")`

### Why are the changes needed?
Currently grouping sets can only be used in spark sql. This feature is not available when developing with the dataset api.

### Does this PR introduce _any_ user-facing change?
Yes. This PR introduces the use of groupingSets in the dataset api.

### How was this patch tested?
Tests added in `DataFrameAggregateSuite.scala`.


### Was this patch authored or co-authored using generative AI tooling?
No
