### PR TITLE
[SPARK-45935][PYTHON][DOCS] Fix RST files link substitutions error

### DIFF
--- a/python/docs/source/conf.py
+++ b/python/docs/source/conf.py
@@ -102,9 +102,9 @@ rst_epilog = """
 .. |examples| replace:: Examples
 .. _examples: https://github.com/apache/spark/tree/{0}/examples/src/main/python
 .. |downloading| replace:: Downloading
-.. _downloading: https://spark.apache.org/docs/{1}/building-spark.html
+.. _downloading: https://spark.apache.org/docs/{1}/#downloading
 .. |building_spark| replace:: Building Spark
-.. _building_spark: https://spark.apache.org/docs/{1}/#downloading
+.. _building_spark: https://spark.apache.org/docs/{1}/building-spark.html
 """.format(
     os.environ.get("GIT_HASH", "master"),
     os.environ.get("RELEASE_VERSION", "latest"),


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to fix RST files `link substitutions` error.
Target branch: branch-3.3, branch-3.4, branch-3.5, master.

### Why are the changes needed?
When I was reviewing Python documents, I found that `the actual address` of the link was incorrect, eg:
https://spark.apache.org/docs/latest/api/python/getting_started/install.html#installing-from-source
<img width="916" alt="image" src="https://github.com/apache/spark/assets/15246973/069c1875-1e21-45db-a236-15c27ee7b913">

`The ref link url` of `Building Spark`: from `https://spark.apache.org/docs/3.5.0/#downloading` to `https://spark.apache.org/docs/3.5.0/building-spark.html`.
We should fix it.

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Manually test.


### Was this patch authored or co-authored using generative AI tooling?
No.
