### PR TITLE
[SPARK-45954][SQL] Remove redundant shuffles

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
@@ -465,6 +465,7 @@ object QueryExecution {
       // PartitioningCollection.
       RemoveRedundantSorts,
       RemoveRedundantWindowGroupLimits,
+      RemoveRedundantShuffles,
       DisableUnnecessaryBucketedScan,
       ApplyColumnarRulesAndInsertTransitions(
         sparkSession.sessionState.columnarRules, outputsColumnar = false),

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
@@ -465,7 +465,6 @@ object QueryExecution {
       // PartitioningCollection.
       RemoveRedundantSorts,
       RemoveRedundantWindowGroupLimits,
-      RemoveRedundantShuffles,
       DisableUnnecessaryBucketedScan,
       ApplyColumnarRulesAndInsertTransitions(
         sparkSession.sessionState.columnarRules, outputsColumnar = false),
@@ -473,7 +472,9 @@ object QueryExecution {
       (if (subquery) {
         Nil
       } else {
-        Seq(ReuseExchangeAndSubquery)
+        Seq(
+          ReuseExchangeAndSubquery,
+          RemoveRedundantShuffles)
       })
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/RemoveRedundantShuffles.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/RemoveRedundantShuffles.scala
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution
+
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
+
+/**
+ * Remove redundant ShuffleExchangeExec node from the spark plan. A shuffle node is redundant when
+ * its child is also a shuffle.
+ */
+object RemoveRedundantShuffles extends Rule[SparkPlan] {
+  def apply(plan: SparkPlan): SparkPlan = plan transform {
+    case s1 @ ShuffleExchangeExec(_, s2: ShuffleExchangeExec, _, _) =>
+      s1.copy(child = s2.child)
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
@@ -128,7 +128,6 @@ case class AdaptiveSparkPlanExec(
       ReplaceHashWithSortAgg,
       RemoveRedundantSorts,
       RemoveRedundantWindowGroupLimits,
-      RemoveRedundantShuffles,
       DisableUnnecessaryBucketedScan,
       OptimizeSkewedJoin(ensureRequirements)
     ) ++ context.session.sessionState.adaptiveRulesHolder.queryStagePrepRules

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
@@ -128,6 +128,7 @@ case class AdaptiveSparkPlanExec(
       ReplaceHashWithSortAgg,
       RemoveRedundantSorts,
       RemoveRedundantWindowGroupLimits,
+      RemoveRedundantShuffles,
       DisableUnnecessaryBucketedScan,
       OptimizeSkewedJoin(ensureRequirements)
     ) ++ context.session.sessionState.adaptiveRulesHolder.queryStagePrepRules

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/RemoveRedundantShufflesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/RemoveRedundantShufflesSuite.scala
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution
+
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanHelper, DisableAdaptiveExecutionSuite, EnableAdaptiveExecutionSuite}
+import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SharedSparkSession
+
+abstract class RemoveRedundantShufflesSuiteBase
+    extends QueryTest
+    with SharedSparkSession
+    with AdaptiveSparkPlanHelper {
+  import testImplicits._
+
+  test("Remove redundant shuffle") {
+    withTempView("t1", "t2") {
+      spark.range(10).select($"id").createOrReplaceTempView("t1")
+      spark.range(20).select($"id").createOrReplaceTempView("t2")
+      Seq(-1, 1000000).foreach { threshold =>
+        withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> threshold.toString) {
+          val query = spark.table("t1").repartition(10).join(spark.table("t2"), "id")
+          val shuffleNum = collect(query.queryExecution.executedPlan) {
+            case j: ShuffleExchangeExec => j
+          }.size
+          if (threshold > 0) {
+            assert(shuffleNum === 1)
+          } else {
+            assert(shuffleNum === 2)
+          }
+        }
+      }
+    }
+  }
+}
+
+class RemoveRedundantShufflesSuite extends RemoveRedundantShufflesSuiteBase
+  with DisableAdaptiveExecutionSuite
+
+class RemoveRedundantShufflesSuiteAE extends RemoveRedundantShufflesSuiteBase
+  with EnableAdaptiveExecutionSuite


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds a new rule to remove redundant shuffles from the Spark plan if it and its child is not reused.

### Why are the changes needed?

Reduce shuffle to improve query performance. The use case is user add a repartition to increase parallelism for broadcast join, but this is useless for shuffle join.


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit test.


### Was this patch authored or co-authored using generative AI tooling?

No.