### PR TITLE
[SPARK-45956][BUILD] Upgrade `Apache ZooKeeper` to 3.9.1

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -20,7 +20,7 @@ arrow-format/14.0.0//arrow-format-14.0.0.jar
 arrow-memory-core/14.0.0//arrow-memory-core-14.0.0.jar
 arrow-memory-netty/14.0.0//arrow-memory-netty-14.0.0.jar
 arrow-vector/14.0.0//arrow-vector-14.0.0.jar
-audience-annotations/0.5.0//audience-annotations-0.5.0.jar
+audience-annotations/0.12.0//audience-annotations-0.12.0.jar
 avro-ipc/1.11.3//avro-ipc-1.11.3.jar
 avro-mapred/1.11.3//avro-mapred-1.11.3.jar
 avro/1.11.3//avro-1.11.3.jar
@@ -262,6 +262,6 @@ xbean-asm9-shaded/4.24//xbean-asm9-shaded-4.24.jar
 xmlschema-core/2.3.0//xmlschema-core-2.3.0.jar
 xz/1.9//xz-1.9.jar
 zjsonpatch/0.3.0//zjsonpatch-0.3.0.jar
-zookeeper-jute/3.6.3//zookeeper-jute-3.6.3.jar
-zookeeper/3.6.3//zookeeper-3.6.3.jar
+zookeeper-jute/3.7.2//zookeeper-jute-3.7.2.jar
+zookeeper/3.7.2//zookeeper-3.7.2.jar
 zstd-jni/1.5.5-7//zstd-jni-1.5.5-7.jar

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -179,8 +179,6 @@ log4j-1.2-api/2.21.0//log4j-1.2-api-2.21.0.jar
 log4j-api/2.21.0//log4j-api-2.21.0.jar
 log4j-core/2.21.0//log4j-core-2.21.0.jar
 log4j-slf4j2-impl/2.21.0//log4j-slf4j2-impl-2.21.0.jar
-logback-classic/1.2.10//logback-classic-1.2.10.jar
-logback-core/1.2.10//logback-core-1.2.10.jar
 logging-interceptor/3.12.12//logging-interceptor-3.12.12.jar
 lz4-java/1.8.0//lz4-java-1.8.0.jar
 metrics-core/4.2.21//metrics-core-4.2.21.jar

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -179,6 +179,8 @@ log4j-1.2-api/2.21.0//log4j-1.2-api-2.21.0.jar
 log4j-api/2.21.0//log4j-api-2.21.0.jar
 log4j-core/2.21.0//log4j-core-2.21.0.jar
 log4j-slf4j2-impl/2.21.0//log4j-slf4j2-impl-2.21.0.jar
+logback-classic/1.2.10//logback-classic-1.2.10.jar
+logback-core/1.2.10//logback-core-1.2.10.jar
 logging-interceptor/3.12.12//logging-interceptor-3.12.12.jar
 lz4-java/1.8.0//lz4-java-1.8.0.jar
 metrics-core/4.2.21//metrics-core-4.2.21.jar
@@ -197,6 +199,7 @@ netty-common/4.1.100.Final//netty-common-4.1.100.Final.jar
 netty-handler-proxy/4.1.100.Final//netty-handler-proxy-4.1.100.Final.jar
 netty-handler/4.1.100.Final//netty-handler-4.1.100.Final.jar
 netty-resolver/4.1.100.Final//netty-resolver-4.1.100.Final.jar
+netty-tcnative-boringssl-static/2.0.61.Final//netty-tcnative-boringssl-static-2.0.61.Final.jar
 netty-tcnative-boringssl-static/2.0.61.Final/linux-aarch_64/netty-tcnative-boringssl-static-2.0.61.Final-linux-aarch_64.jar
 netty-tcnative-boringssl-static/2.0.61.Final/linux-x86_64/netty-tcnative-boringssl-static-2.0.61.Final-linux-x86_64.jar
 netty-tcnative-boringssl-static/2.0.61.Final/osx-aarch_64/netty-tcnative-boringssl-static-2.0.61.Final-osx-aarch_64.jar
@@ -262,6 +265,6 @@ xbean-asm9-shaded/4.24//xbean-asm9-shaded-4.24.jar
 xmlschema-core/2.3.0//xmlschema-core-2.3.0.jar
 xz/1.9//xz-1.9.jar
 zjsonpatch/0.3.0//zjsonpatch-0.3.0.jar
-zookeeper-jute/3.7.2//zookeeper-jute-3.7.2.jar
-zookeeper/3.7.2//zookeeper-3.7.2.jar
+zookeeper-jute/3.9.1//zookeeper-jute-3.9.1.jar
+zookeeper/3.9.1//zookeeper-3.9.1.jar
 zstd-jni/1.5.5-7//zstd-jni-1.5.5-7.jar

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
     <protobuf.version>3.23.4</protobuf.version>
     <protoc-jar-maven-plugin.version>3.11.4</protoc-jar-maven-plugin.version>
     <yarn.version>${hadoop.version}</yarn.version>
-    <zookeeper.version>3.6.3</zookeeper.version>
+    <zookeeper.version>3.7.2</zookeeper.version>
     <curator.version>5.2.0</curator.version>
     <hive.group>org.apache.hive</hive.group>
     <hive.classifier>core</hive.classifier>

--- a/pom.xml
+++ b/pom.xml
@@ -1871,6 +1871,14 @@
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <!-- Hive 2.3 need this to init Hive's FunctionRegistry -->

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
     <protobuf.version>3.23.4</protobuf.version>
     <protoc-jar-maven-plugin.version>3.11.4</protoc-jar-maven-plugin.version>
     <yarn.version>${hadoop.version}</yarn.version>
-    <zookeeper.version>3.7.2</zookeeper.version>
+    <zookeeper.version>3.9.1</zookeeper.version>
     <curator.version>5.2.0</curator.version>
     <hive.group>org.apache.hive</hive.group>
     <hive.classifier>core</hive.classifier>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Upgrade Apache ZooKeeper from 3.6.3 to 3.9.1
[Releasenotes 3.9.1](https://zookeeper.apache.org/doc/r3.9.1/releasenotes.html)

### Why are the changes needed?
[CVE-2023-44981](https://nvd.nist.gov/vuln/detail/CVE-2023-44981) [9.1 CRITICAL](https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?name=CVE-2023-44981&vector=AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N&version=3.1&source=NIST)
[Explicit handling of DIGEST-MD5 vs GSSAPI in quorum auth](https://issues.apache.org/jira/browse/ZOOKEEPER-4753)


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA

### Was this patch authored or co-authored using generative AI tooling?
No.