### PR TITLE
[SPARK-45957] Fix SQL commands on streaming temp view

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -2587,7 +2587,7 @@ class SparkConnectPlanner(
       } else {
         // Trigger assertExecutedPlanPrepared to ensure post ReadyForExecution before finished
         // executedPlan is currently called by createMetricsResponse below
-        df.queryExecution.assertExecutedPlanPrepared() // Ideally, this should be avoided.
+        df.queryExecution.assertExecutedPlanPrepared()
       }
 
       result.setRelation(

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -2587,7 +2587,7 @@ class SparkConnectPlanner(
       } else {
         // Trigger assertExecutedPlanPrepared to ensure post ReadyForExecution before finished
         // executedPlan is currently called by createMetricsResponse below
-        df.queryExecution.assertExecutedPlanPrepared() // XXX This should be avoided.
+        df.queryExecution.assertExecutedPlanPrepared() // Ideally, this should be avoided.
       }
 
       result.setRelation(


### PR DESCRIPTION
**Update**: Closing this in favor of #43851

### What changes were proposed in this pull request?

This illustrates a bug in Spark Connect when we run an SQL command on streaming temp view.
That fix here avoids triggering physical plan on streaming dataframes (as a result does not include metrics in response).

```python
df = spark.readStream.format("rate").option("numPartitions", "1").load()
df.createOrReplaceTempView("temp_view")

view_df = spark.sql("SELECT * FROM temp_view") # FAILS
```

### Why are the changes needed?
Fixes a regression in Spark Connect compared to legacy.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
 - Added a pyspark test.
 - Manually with repro code above

### Was this patch authored or co-authored using generative AI tooling?
No 