### PR TITLE
[CONNECT][SPARK-45957] Avoid generating execution plan for non-executable commands

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -2552,6 +2552,7 @@ class SparkConnectPlanner(
     // To avoid explicit handling of the result on the client, we build the expected input
     // of the relation on the server. The client has to simply forward the result.
     val result = SqlCommandResult.newBuilder()
+    // Only filled when isCommand
     val metrics = ExecutePlanResponse.Metrics.newBuilder()
     if (isCommand) {
       // Convert the results to Arrow.
@@ -2612,7 +2613,8 @@ class SparkConnectPlanner(
         .setSqlCommandResult(result)
         .build())
 
-    // Send Metrics
+    // Send Metrics when isCommand (i.e. show tables) which is eagerly executed & has metrics
+    // Skip metrics when !isCommand (i.e. select 1) which is not executed & doesn't have metrics
     if (isCommand) {
       responseObserver.onNext(
         ExecutePlanResponse

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/utils/MetricGenerator.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/utils/MetricGenerator.scala
@@ -51,6 +51,12 @@ private[connect] object MetricGenerator extends AdaptiveSparkPlanHelper {
     allChildren(p).flatMap(c => transformPlan(c, p.id))
   }
 
+  private[connect] def transformPlan(
+      rows: DataFrame): Seq[ExecutePlanResponse.Metrics.MetricObject] = {
+    val executedPlan = rows.queryExecution.executedPlan
+    transformPlan(executedPlan, executedPlan.id)
+  }
+
   private def transformPlan(
       p: SparkPlan,
       parentId: Int): Seq[ExecutePlanResponse.Metrics.MetricObject] = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Remove the metric response for non executable commands (and the executedPlan generation)

### Why are the changes needed?
SQL command can be of 2 types:
1) Executable (i.e. `show tables`). They are eagerly executed and return a response. The execution can generate metrics that should be returned to the user.
2) Non executable. They are lazy and are not executed. As such they should not generate metrics.
We currently generate a executedPlan for both command & relations to attach the metrics. This is a performance concern for relations as generating the optimized & physical can take some time. Furthermore, streaming SQL relations cannot generate a physical plan in the same way (i.e. they need to use read / write stream). 

### Does this PR introduce _any_ user-facing change?
Yes, SQL non-executable commands will no longer return a metric response. This is a backward compatible change.


### How was this patch tested?
Unit


### Was this patch authored or co-authored using generative AI tooling?
No