### PR TITLE
[SPARK-45786][SQL][FOLLOWUP][TEST] Fix Decimal random number tests with ANSI enabled

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ArithmeticExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ArithmeticExpressionSuite.scala
@@ -308,40 +308,35 @@ class ArithmeticExpressionSuite extends SparkFunSuite with ExpressionEvalHelper 
           val mulResult = Decimal(mulExact.setScale(mulType.scale, RoundingMode.HALF_UP))
           val mulExpected =
             if (mulResult.precision > DecimalType.MAX_PRECISION) null else mulResult
-          tryCheckEvaluation(mulActual, mulExpected)
+          checkEvaluationOrException(mulActual, mulExpected)
 
           val divType = Divide(null, null).resultDecimalType(p1, s1, p2, s2)
           val divResult = Decimal(divExact.setScale(divType.scale, RoundingMode.HALF_UP))
           val divExpected =
             if (divResult.precision > DecimalType.MAX_PRECISION) null else divResult
-          tryCheckEvaluation(divActual, divExpected)
+          checkEvaluationOrException(divActual, divExpected)
 
           val remType = Remainder(null, null).resultDecimalType(p1, s1, p2, s2)
           val remResult = Decimal(remExact.setScale(remType.scale, RoundingMode.HALF_UP))
           val remExpected =
             if (remResult.precision > DecimalType.MAX_PRECISION) null else remResult
-          tryCheckEvaluation(remActual, remExpected)
+          checkEvaluationOrException(remActual, remExpected)
 
           val quotType = IntegralDivide(null, null).resultDecimalType(p1, s1, p2, s2)
           val quotResult = Decimal(quotExact.setScale(quotType.scale, RoundingMode.HALF_UP))
           val quotExpected =
             if (quotResult.precision > DecimalType.MAX_PRECISION) null else quotResult
-          tryCheckEvaluation(quotActual, quotExpected.toLong)
+          checkEvaluationOrException(quotActual, quotExpected.toLong)
         }
       }
 
-      def tryCheckEvaluation(actual: BinaryArithmetic, expected: Any): Unit = {
-        try {
+      def checkEvaluationOrException(actual: BinaryArithmetic, expected: Any): Unit =
+        if (SQLConf.get.ansiEnabled && expected == null) {
+          checkExceptionInExpression[SparkArithmeticException](actual,
+            "NUMERIC_VALUE_OUT_OF_RANGE")
+        } else {
           checkEvaluation(actual, expected)
         }
-        catch {
-          // Ignore NUMERIC_VALUE_OUT_OF_RANGE when ANSI is enabled
-          case e: org.scalatest.exceptions.TestFailedException
-            if e.cause.exists(c => c.isInstanceOf[SparkArithmeticException] &&
-              c.asInstanceOf[SparkArithmeticException].getErrorClass
-                == "NUMERIC_VALUE_OUT_OF_RANGE") && SQLConf.get.ansiEnabled =>
-        }
-      }
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This follow-up PR fixes the test for SPARK-45786 that is failing in GHA with SPARK_ANSI_SQL_MODE=true


### Why are the changes needed?
The issue discovered in https://github.com/apache/spark/pull/43678#discussion_r1395693417


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Test updated


### Was this patch authored or co-authored using generative AI tooling?
No