### PR TITLE
[SPARK-45764][FOLLOWUP][PYTHON][DOCS] Remove upper bound for `sphinx-copybutton`

### DIFF
--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -37,7 +37,7 @@ numpydoc
 jinja2<3.0.0
 sphinx<3.1.0
 sphinx-plotly-directive
-sphinx-copybutton<0.5.3
+sphinx-copybutton
 docutils<0.18.0
 # See SPARK-38279.
 markupsafe==2.0.1


### PR DESCRIPTION
### What changes were proposed in this pull request?

This follow-ups for https://github.com/apache/spark/pull/43799 to remove upper bound for `sphinx-copybutton`


### Why are the changes needed?

I think it's a good idea to take advantage of the latest version as long as a `sphinx-copybutton` runs properly with CI.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

The existing CI should pass.

### Was this patch authored or co-authored using generative AI tooling?

No.
