### PR TITLE
[SPARK-45968][INFRA] Upgrade github docker action to latest version

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -296,7 +296,7 @@ jobs:
       packages: write
     steps:
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -316,12 +316,12 @@ jobs:
           git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' merge --no-commit --progress --squash FETCH_HEAD
           git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' commit -m "Merged commit" --allow-empty
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: ./dev/infra/
           push: true

--- a/.github/workflows/build_infra_images_cache.yml
+++ b/.github/workflows/build_infra_images_cache.yml
@@ -40,18 +40,18 @@ jobs:
       - name: Checkout Spark repository
         uses: actions/checkout@v4
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: ./dev/infra/
           push: true


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade `github docker action` to latest version, includes:
- `docker/login-action` from `v2` to `v3`
- `docker/setup-qemu-action` from `v2` to `v3`
- `docker/setup-buildx-action` from `v2` to `v3`
- `docker/build-push-action` from `v3` to `v5`

### Why are the changes needed?
- `docker/login-action` v3 release notes:
   https://github.com/docker/login-action/releases/tag/v3.0.0
   <img width="747" alt="image" src="https://github.com/apache/spark/assets/15246973/2c40aff3-c6cd-433d-ad9c-db5409048005">

- `docker/setup-qemu-action` v3 release notes:
   https://github.com/docker/setup-qemu-action/releases/tag/v3.0.0
   <img width="738" alt="image" src="https://github.com/apache/spark/assets/15246973/cf758456-fef2-4bf8-a412-be3d69623dd0">

- `docker/setup-buildx-action` v3 release notes:
   https://github.com/docker/setup-buildx-action/releases/tag/v3.0.0
   <img width="745" alt="image" src="https://github.com/apache/spark/assets/15246973/846d8511-2b0f-4a99-8969-c28c007e7079">

- `docker/build-push-action` v5 release notes:
   https://github.com/docker/build-push-action/releases/tag/v5.0.0
   <img width="750" alt="image" src="https://github.com/apache/spark/assets/15246973/5cb4a0a4-f1f3-4275-aac3-d5e390cae1d2">
- `docker/build-push-action` v4 release notes:
   https://github.com/docker/build-push-action/releases/tag/v4.0.0

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
