### PR TITLE
[SPARK-45969][DOCS] Document configuration change of executor failure tracker

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -931,7 +931,7 @@ package object config {
 
   private[spark] val MAX_EXECUTOR_FAILURES =
     ConfigBuilder("spark.executor.maxNumFailures")
-      .doc("Spark exits if the number of failed executors exceeds this threshold. " +
+      .doc("The maximum number of executor failures before failing the application. " +
         "This configuration only takes effect on YARN, or Kubernetes when " +
         "`spark.kubernetes.allocation.pods.allocator` is set to 'direct'.")
       .version("3.5.0")
@@ -940,7 +940,7 @@ package object config {
 
   private[spark] val EXECUTOR_ATTEMPT_FAILURE_VALIDITY_INTERVAL_MS =
     ConfigBuilder("spark.executor.failuresValidityInterval")
-      .doc("Interval after which Executor failures will be considered independent and not " +
+      .doc("Interval after which executor failures will be considered independent and not " +
         "accumulate towards the attempt count. This configuration only takes effect on YARN, " +
         "or Kubernetes when `spark.kubernetes.allocation.pods.allocator` is set to 'direct'.")
       .version("3.5.0")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -526,7 +526,7 @@ of the most common options to set are:
   <td><code>spark.executor.maxNumFailures</code></td>
   <td>numExecutors * 2, with minimum of 3</td>
   <td>
-    Spark exits if the number of failed executors exceeds this threshold.
+    The maximum number of executor failures before failing the application.
     This configuration only takes effect on YARN, or Kubernetes when 
     `spark.kubernetes.allocation.pods.allocator` is set to 'direct'.
   </td>
@@ -536,7 +536,7 @@ of the most common options to set are:
   <td><code>spark.executor.failuresValidityInterval</code></td>
   <td>(none)</td>
   <td>
-    Interval after which Executor failures will be considered independent and
+    Interval after which executor failures will be considered independent and
     not accumulate towards the attempt count.
     This configuration only takes effect on YARN, or Kubernetes when 
     `spark.kubernetes.allocation.pods.allocator` is set to 'direct'.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -522,6 +522,27 @@ of the most common options to set are:
   </td>
   <td>3.2.0</td>
 </tr>
+<tr>
+  <td><code>spark.executor.maxNumFailures</code></td>
+  <td>numExecutors * 2, with minimum of 3</td>
+  <td>
+    Spark exits if the number of failed executors exceeds this threshold.
+    This configuration only takes effect on YARN, or Kubernetes when 
+    `spark.kubernetes.allocation.pods.allocator` is set to 'direct'.
+  </td>
+  <td>3.5.0</td>
+</tr>
+<tr>
+  <td><code>spark.executor.failuresValidityInterval</code></td>
+  <td>(none)</td>
+  <td>
+    Interval after which Executor failures will be considered independent and
+    not accumulate towards the attempt count.
+    This configuration only takes effect on YARN, or Kubernetes when 
+    `spark.kubernetes.allocation.pods.allocator` is set to 'direct'.
+  </td>
+  <td>3.5.0</td>
+</tr>
 </table>
 
 Apart from these, the following properties are also available, and may be useful in some situations:

--- a/docs/core-migration-guide.md
+++ b/docs/core-migration-guide.md
@@ -34,9 +34,9 @@ license: |
 
 ## Upgrading from Core 3.4 to 3.5
 
-- Since Spark 3.5, `spark.yarn.executor.failuresValidityInterval` is deprecated though still works. Use `spark.executor.failuresValidityInterval` instead.
+- Since Spark 3.5, `spark.yarn.executor.failuresValidityInterval` is deprecated. Use `spark.executor.failuresValidityInterval` instead.
 
-- Since Spark 3.5, `spark.yarn.max.executor.failures` is deprecated though still works. Use `spark.executor.maxNumFailures` instead.
+- Since Spark 3.5, `spark.yarn.max.executor.failures` is deprecated. Use `spark.executor.maxNumFailures` instead.
 
 ## Upgrading from Core 3.3 to 3.4
 

--- a/docs/core-migration-guide.md
+++ b/docs/core-migration-guide.md
@@ -32,6 +32,12 @@ license: |
 
 - In Spark 4.0, support for Apache Mesos as a resource manager was removed.
 
+## Upgrading from Core 3.4 to 3.5
+
+- Since Spark 3.5, `spark.yarn.executor.failuresValidityInterval` is deprecated though still works. Use `spark.executor.failuresValidityInterval` instead.
+
+- Since Spark 3.5, `spark.yarn.max.executor.failures` is deprecated though still works. Use `spark.executor.maxNumFailures` instead.
+
 ## Upgrading from Core 3.3 to 3.4
 
 - Since Spark 3.4, Spark driver will own `PersistentVolumnClaim`s and try to reuse if they are not assigned to live executors. To restore the behavior before Spark 3.4, you can set `spark.kubernetes.driver.ownPersistentVolumeClaim` to `false` and `spark.kubernetes.driver.reusePersistentVolumeClaim` to `false`.

--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -1650,6 +1650,27 @@ See the [configuration page](configuration.html) for information on Spark config
   </td>
   <td>3.3.0</td>
 </tr>
+<tr>
+  <td><code>spark.executor.maxNumFailures</code></td>
+  <td>numExecutors * 2, with minimum of 3</td>
+  <td>
+    Spark exits if the number of failed executors exceeds this threshold.
+    This configuration only takes effect when `spark.kubernetes.allocation.pods.allocator`
+    is set to 'direct'.
+  </td>
+  <td>3.5.0</td>
+</tr>
+<tr>
+  <td><code>spark.executor.failuresValidityInterval</code></td>
+  <td>(none)</td>
+  <td>
+    Interval after which Executor failures will be considered independent and
+    not accumulate towards the attempt count.
+    This configuration only takes effect when `spark.kubernetes.allocation.pods.allocator`
+    is set to 'direct'.
+  </td>
+  <td>3.5.0</td>
+</tr>
 </table>
 
 #### Pod template properties

--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -1650,27 +1650,6 @@ See the [configuration page](configuration.html) for information on Spark config
   </td>
   <td>3.3.0</td>
 </tr>
-<tr>
-  <td><code>spark.executor.maxNumFailures</code></td>
-  <td>numExecutors * 2, with minimum of 3</td>
-  <td>
-    Spark exits if the number of failed executors exceeds this threshold.
-    This configuration only takes effect when `spark.kubernetes.allocation.pods.allocator`
-    is set to 'direct'.
-  </td>
-  <td>3.5.0</td>
-</tr>
-<tr>
-  <td><code>spark.executor.failuresValidityInterval</code></td>
-  <td>(none)</td>
-  <td>
-    Interval after which Executor failures will be considered independent and
-    not accumulate towards the attempt count.
-    This configuration only takes effect when `spark.kubernetes.allocation.pods.allocator`
-    is set to 'direct'.
-  </td>
-  <td>3.5.0</td>
-</tr>
 </table>
 
 #### Pod template properties

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -292,14 +292,6 @@ To use a custom metrics.properties for the application master and executors, upd
   <td>1.4.0</td>
 </tr>
 <tr>
-  <td><code>spark.executor.maxNumFailures</code></td>
-  <td>numExecutors * 2, with minimum of 3</td>
-  <td>
-    Spark exits if the number of failed executors exceeds this threshold.
-  </td>
-  <td>3.5.0</td>
-</tr>
-<tr>
   <td><code>spark.yarn.historyServer.address</code></td>
   <td>(none)</td>
   <td>
@@ -498,15 +490,6 @@ To use a custom metrics.properties for the application master and executors, upd
     these HDFS configs from the job's local configuration files. This config is very similar to <code>mapreduce.job.send-token-conf</code>. Please check YARN-5910 for more details.
   </td>
   <td>3.3.0</td>
-</tr>
-<tr>
-  <td><code>spark.executor.failuresValidityInterval</code></td>
-  <td>(none)</td>
-  <td>
-    Interval after which Executor failures will be considered independent and
-    not accumulate towards the attempt count.
-  </td>
-  <td>3.5.0</td>
 </tr>
 <tr>
   <td><code>spark.yarn.submit.waitAppCompletion</code></td>

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -292,12 +292,12 @@ To use a custom metrics.properties for the application master and executors, upd
   <td>1.4.0</td>
 </tr>
 <tr>
-  <td><code>spark.yarn.max.executor.failures</code></td>
+  <td><code>spark.executor.maxNumFailures</code></td>
   <td>numExecutors * 2, with minimum of 3</td>
   <td>
-    The maximum number of executor failures before failing the application.
+    Spark exits if the number of failed executors exceeds this threshold.
   </td>
-  <td>1.0.0</td>
+  <td>3.5.0</td>
 </tr>
 <tr>
   <td><code>spark.yarn.historyServer.address</code></td>
@@ -500,13 +500,13 @@ To use a custom metrics.properties for the application master and executors, upd
   <td>3.3.0</td>
 </tr>
 <tr>
-  <td><code>spark.yarn.executor.failuresValidityInterval</code></td>
+  <td><code>spark.executor.failuresValidityInterval</code></td>
   <td>(none)</td>
   <td>
-  Defines the validity interval for executor failure tracking.
-  Executor failures which are older than the validity interval will be ignored.
+    Interval after which Executor failures will be considered independent and
+    not accumulate towards the attempt count.
   </td>
-  <td>2.0.0</td>
+  <td>3.5.0</td>
 </tr>
 <tr>
   <td><code>spark.yarn.submit.waitAppCompletion</code></td>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
It's a follow-up of SPARK-41210 (use a new JIRA ticket because it was released in 3.5.0), this PR updates docs/migration guide about configuration change of executor failure tracker

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Docs update is missing in previous changes, also is requested https://github.com/apache/spark/commit/40872e9a094f8459b0b6f626937ced48a8d98efb#r132516892 by @tgravescs 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, docs changed

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Review

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No