### PR TITLE
[SPARK-45971][CORE][SQL] Correct the package name of `SparkCollectionUtils` to `org.apache.spark.util`

### DIFF
--- a/common/utils/src/main/scala/org/apache/spark/util/SparkCollectionUtils.scala
+++ b/common/utils/src/main/scala/org/apache/spark/util/SparkCollectionUtils.scala
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.spark.sql.catalyst.util
+package org.apache.spark.util
 
 import scala.collection.immutable
 

--- a/core/src/main/scala/org/apache/spark/util/collection/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/Utils.scala
@@ -24,7 +24,7 @@ import scala.jdk.CollectionConverters._
 
 import com.google.common.collect.{Iterators => GuavaIterators, Ordering => GuavaOrdering}
 
-import org.apache.spark.sql.catalyst.util.SparkCollectionUtils
+import org.apache.spark.util.SparkCollectionUtils
 
 /**
  * Utility functions for collections.

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/StructType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/StructType.scala
@@ -29,9 +29,10 @@ import org.apache.spark.annotation.Stable
 import org.apache.spark.sql.catalyst.analysis.SqlApiAnalysis
 import org.apache.spark.sql.catalyst.parser.{DataTypeParser, LegacyTypeStringParser}
 import org.apache.spark.sql.catalyst.trees.Origin
-import org.apache.spark.sql.catalyst.util.{SparkCollectionUtils, SparkStringUtils, StringConcat}
+import org.apache.spark.sql.catalyst.util.{SparkStringUtils, StringConcat}
 import org.apache.spark.sql.errors.DataTypeErrors
 import org.apache.spark.sql.internal.SqlApiConf
+import org.apache.spark.util.SparkCollectionUtils
 
 /**
  * A [[StructType]] object can be constructed by


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr correct the package name of `SparkCollectionUtils` from `org.apache.spark.sql.catalyst.util`  to `org.apache.spark.util`.


### Why are the changes needed?
`SparkCollectionUtils` is in `common-utils` module, not in `catalyst` module, so it should not use the package name related 
 to `catalyst` module.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No