### PR TITLE
[SPARK-45963][SQL][DOCS][3.5] Restore documentation for DSv2 API

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -1401,7 +1401,7 @@ object Unidoc {
       .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/util/io")))
       .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/util/kvstore")))
       .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/sql/catalyst")))
-      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/sql/connect")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/sql/connect/")))
       .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/sql/execution")))
       .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/sql/internal")))
       .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/sql/hive")))

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/SupportsMetadataColumns.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/SupportsMetadataColumns.java
@@ -58,8 +58,8 @@ public interface SupportsMetadataColumns extends Table {
    * Determines how this data source handles name conflicts between metadata and data columns.
    * <p>
    * If true, spark will automatically rename the metadata column to resolve the conflict. End users
-   * can reliably select metadata columns (renamed or not) with {@link Dataset.metadataColumn}, and
-   * internal code can use {@link MetadataAttributeWithLogicalName} to extract the logical name from
+   * can reliably select metadata columns (renamed or not) with {@code Dataset.metadataColumn}, and
+   * internal code can use {@code MetadataAttributeWithLogicalName} to extract the logical name from
    * a metadata attribute.
    * <p>
    * If false, the data column will hide the metadata column. It is recommended that Table

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryBaseTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryBaseTable.scala
@@ -619,9 +619,9 @@ class BufferedRows(val key: Seq[Any] = Seq.empty) extends WriterCommitMessage
 }
 
 /**
- * Theoretically, [[InternalRow]] returned by [[HasPartitionKey#partitionKey()]]
+ * Theoretically, `InternalRow` returned by `HasPartitionKey#partitionKey()`
  * does not need to implement equal and hashcode methods.
- * But [[GenericInternalRow]] implements equals and hashcode methods already. Here we override it
+ * But `GenericInternalRow` implements equals and hashcode methods already. Here we override it
  * to simulate that it has not been implemented to verify codes correctness.
  */
 case class PartitionInternalRow(keys: Array[Any])


### PR DESCRIPTION
This PR cherry-picks https://github.com/apache/spark/pull/43855 to branch-3.5

---

### What changes were proposed in this pull request?

This PR restores the DSv2 documentation. https://github.com/apache/spark/pull/38392 mistakenly added `org/apache/spark/sql/connect` as a private that includes `org/apache/spark/sql/connector`.

### Why are the changes needed?

For end users to read DSv2 documentation.

### Does this PR introduce _any_ user-facing change?

Yes, it restores the DSv2 API documentation that used to be there https://spark.apache.org/docs/3.3.0/api/scala/org/apache/spark/sql/connector/catalog/index.html

### How was this patch tested?

Manually tested via:

```
SKIP_PYTHONDOC=1 SKIP_RDOC=1 SKIP_SQLDOC=1 bundle exec jekyll build
```

### Was this patch authored or co-authored using generative AI tooling?

No.