### PR TITLE
[SPARK-45963][SQL][DOCS][3.4] Restore documentation for DSv2 API

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -1388,7 +1388,7 @@ object Unidoc {
       .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/util/io")))
       .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/util/kvstore")))
       .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/sql/catalyst")))
-      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/sql/connect")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/sql/connect/")))
       .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/sql/execution")))
       .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/sql/internal")))
       .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/sql/hive")))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryBaseTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryBaseTable.scala
@@ -573,9 +573,9 @@ class BufferedRows(val key: Seq[Any] = Seq.empty) extends WriterCommitMessage
 }
 
 /**
- * Theoretically, [[InternalRow]] returned by [[HasPartitionKey#partitionKey()]]
+ * Theoretically, `InternalRow` returned by `HasPartitionKey#partitionKey()``
  * does not need to implement equal and hashcode methods.
- * But [[GenericInternalRow]] implements equals and hashcode methods already. Here we override it
+ * But `GenericInternalRow` implements equals and hashcode methods already. Here we override it
  * to simulate that it has not been implemented to verify codes correctness.
  */
 case class PartitionInternalRow(keys: Array[Any])

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryBaseTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryBaseTable.scala
@@ -573,7 +573,7 @@ class BufferedRows(val key: Seq[Any] = Seq.empty) extends WriterCommitMessage
 }
 
 /**
- * Theoretically, `InternalRow` returned by `HasPartitionKey#partitionKey()``
+ * Theoretically, `InternalRow` returned by `HasPartitionKey#partitionKey()`
  * does not need to implement equal and hashcode methods.
  * But `GenericInternalRow` implements equals and hashcode methods already. Here we override it
  * to simulate that it has not been implemented to verify codes correctness.


### PR DESCRIPTION
This PR cherry-picks https://github.com/apache/spark/pull/43855 to branch-3.4

---

### What changes were proposed in this pull request?

This PR restores the DSv2 documentation. https://github.com/apache/spark/pull/38392 mistakenly added `org/apache/spark/sql/connect` as a private that includes `org/apache/spark/sql/connector`.

### Why are the changes needed?

For end users to read DSv2 documentation.

### Does this PR introduce _any_ user-facing change?

Yes, it restores the DSv2 API documentation that used to be there https://spark.apache.org/docs/3.3.0/api/scala/org/apache/spark/sql/connector/catalog/index.html

### How was this patch tested?

Manually tested via:

```
SKIP_PYTHONDOC=1 SKIP_RDOC=1 SKIP_SQLDOC=1 bundle exec jekyll build
```

### Was this patch authored or co-authored using generative AI tooling?

No.