### PR TITLE
[SPARK-45973][INFRA] re-org `apt-get` installations

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -712,25 +712,15 @@ jobs:
     - name: Python code generation check
       if: inputs.branch != 'branch-3.3' && inputs.branch != 'branch-3.4'
       run: if test -f ./dev/connect-check-protos.py; then PATH=$PATH:$HOME/buf/bin PYTHON_EXECUTABLE=python3.9 ./dev/connect-check-protos.py; fi
-    - name: Install JavaScript linter dependencies
-      run: |
-        apt update
-        apt-get install -y nodejs npm
     - name: JS linter
       run: ./dev/lint-js
     - name: Install R linter dependencies and SparkR
       run: |
-        apt update
-        apt-get install -y libcurl4-openssl-dev libgit2-dev libssl-dev libxml2-dev \
-          libfontconfig1-dev libharfbuzz-dev libfribidi-dev libfreetype6-dev libpng-dev \
-          libtiff5-dev libjpeg-dev
         Rscript -e "install.packages(c('devtools'), repos='https://cloud.r-project.org/')"
         Rscript -e "devtools::install_version('lintr', version='2.0.1', repos='https://cloud.r-project.org')"
         ./R/install-dev.sh
     - name: Install dependencies for documentation generation
       run: |
-        # pandoc is required to generate PySpark APIs as well in nbsphinx.
-        apt-get install -y libcurl4-openssl-dev pandoc
         # TODO(SPARK-32407): Sphinx 3.1+ does not correctly index nested classes.
         #   See also https://github.com/sphinx-doc/sphinx/issues/7551.
         # Jinja2 3.0.0+ causes error when building with Sphinx.
@@ -741,8 +731,6 @@ jobs:
         python3.9 -m pip install ipython_genutils # See SPARK-38517
         python3.9 -m pip install sphinx_plotly_directive 'numpy>=1.20.0' pyarrow pandas 'plotly>=4.8'
         python3.9 -m pip install 'docutils<0.18.0' # See SPARK-39421
-        apt-get update -y
-        apt-get install -y ruby ruby-dev
         Rscript -e "install.packages(c('devtools', 'testthat', 'knitr', 'rmarkdown', 'markdown', 'e1071', 'roxygen2', 'ggplot2', 'mvtnorm', 'statmod'), repos='https://cloud.r-project.org/')"
         Rscript -e "devtools::install_version('pkgdown', version='2.0.1', repos='https://cloud.r-project.org')"
         Rscript -e "devtools::install_version('preferably', version='0.4', repos='https://cloud.r-project.org')"

--- a/dev/infra/Dockerfile
+++ b/dev/infra/Dockerfile
@@ -19,44 +19,48 @@
 # See also in https://hub.docker.com/_/ubuntu
 FROM ubuntu:focal-20221019
 
-ENV FULL_REFRESH_DATE 20221118
+ENV FULL_REFRESH_DATE 20231117
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV DEBCONF_NONINTERACTIVE_SEEN true
 
 RUN apt-get update && apt-get install -y \
-    software-properties-common \
-    git \
-    pkg-config  \
-    curl  \
-    wget  \
-    openjdk-17-jdk-headless  \
-    gfortran  \
-    libopenblas-dev  \
-    liblapack-dev \
     build-essential \
+    ca-certificates \
+    curl \
+    gfortran \
+    git \
     gnupg \
-    ca-certificates  \
-    pandoc \
-    libpython3-dev  \
-    python3-pip  \
-    python3-setuptools  \
-    python3.8  \
-    python3.9 \
-    r-base  \
-    libcurl4-openssl-dev  \
-    qpdf  \
-    zlib1g-dev \
-    libssl-dev  \
-    libpng-dev \
-    libharfbuzz-dev \
-    libfribidi-dev \
-    libtiff5-dev \
-    libgit2-dev \
-    libxml2-dev  \
-    libjpeg-dev \
+    libcurl4-openssl-dev \
     libfontconfig1-dev \
     libfreetype6-dev \
+    libfribidi-dev \
+    libgit2-dev \
+    libharfbuzz-dev \
+    libjpeg-dev \
+    liblapack-dev \
+    libopenblas-dev \
+    libpng-dev \
+    libpython3-dev \
+    libssl-dev \
+    libtiff5-dev \
+    libxml2-dev \
+    nodejs \
+    npm \
+    openjdk-17-jdk-headless \
+    pandoc \
+    pkg-config \
+    python3-pip \
+    python3-setuptools \
+    python3.8 \
+    python3.9 \
+    qpdf \
+    r-base \
+    ruby \
+    ruby-dev \
+    software-properties-common \
+    wget \
+    zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*
 
 RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.9


### PR DESCRIPTION
### What changes were proposed in this pull request?
`apt-get` installation clean up, after this PR, there is no `apt-get` command in `build_and_test`

### Why are the changes needed?
most `apt` packages (except `ruby`/`ruby-dev`) in `build_and_test` were already installed in dockerfile, seems no need to reinstall

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
ci

### Was this patch authored or co-authored using generative AI tooling?
no
