### PR TITLE
[SPARK-45681][UI][FOLLOWUP] Check maybeErrorClass instead of maybeErrorClass.length

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/utils.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/utils.js
@@ -251,7 +251,7 @@ function errorSummary(errorMessage) {
   let isMultiline = true;
   const maybeErrorClass = errorMessage.match(ERROR_CLASS_REGEX);
   let errorClassOrBrief;
-  if (maybeErrorClass.length === 2) {
+  if (maybeErrorClass) {
     errorClassOrBrief = maybeErrorClass[1];
   } else if (errorMessage.indexOf('\n') >= 0) {
     errorClassOrBrief = errorMessage.substring(0, errorMessage.indexOf('\n'));


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

The `String.match` function may return null if no matches are found. This reverts the suggestion from https://github.com/apache/spark/pull/43547#discussion_r1375487690 to avoid `TypeError: Cannot read properties of null (reading 'length')`



### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

bugfix

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
no

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

An UPCOMING javascript test framework for Spark UI

```javascript
FAIL  tests/utils.test.js
  ✓ formatDuration (2 ms)
  ✓ formatBytes
  ✓ formatTimeMillis (1 ms)
  ✕ errorSummary (1 ms)

  ● errorSummary

    TypeError: Cannot read properties of null (reading 'length')

      254 |   const maybeErrorClass = errorMessage.match(ERROR_CLASS_REGEX);
      255 |   let errorClassOrBrief;
    > 256 |   if (maybeErrorClass.length === 2) {
          |                       ^
      257 |     errorClassOrBrief = maybeErrorClass[1];
      258 |   } else if (errorMessage.indexOf('\n') >= 0) {
      259 |     errorClassOrBrief = errorMessage.substring(0, errorMessage.indexOf('\n'));

      at length (utils.js:256:23)
      at Object.errorSummary (tests/utils.test.js:58:10)

Test Suites: 1 failed, 1 total
Tests:       1 failed, 3 passed, 4 total
Snapshots:   0 total
Time:        0.149 s, estimated 1 s
```


```javascript
 PASS  tests/utils.test.js
  ✓ formatDuration (1 ms)
  ✓ formatBytes (1 ms)
  ✓ formatTimeMillis (1 ms)
  ✓ errorSummary

Test Suites: 1 passed, 1 total
Tests:       4 passed, 4 total
Snapshots:   0 total
```

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
no