### PR TITLE
[MINOR][CORE] Rename scheduler ref for readability

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/StandaloneSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/StandaloneSchedulerBackend.scala
@@ -41,10 +41,10 @@ import org.apache.spark.util.{ThreadUtils, Utils}
  * A [[SchedulerBackend]] implementation for Spark's standalone cluster manager.
  */
 private[spark] class StandaloneSchedulerBackend(
-    scheduler: TaskSchedulerImpl,
+   taskScheduler: TaskSchedulerImpl,
     sc: SparkContext,
     masters: Array[String])
-  extends CoarseGrainedSchedulerBackend(scheduler, sc.env.rpcEnv)
+  extends CoarseGrainedSchedulerBackend(taskScheduler, sc.env.rpcEnv)
   with StandaloneAppClientListener
   with Logging {
 
@@ -162,7 +162,7 @@ private[spark] class StandaloneSchedulerBackend(
       launcherBackend.setState(SparkAppHandle.State.KILLED)
       logError("Application has been killed. Reason: " + reason)
       try {
-        scheduler.error(reason)
+        taskScheduler.error(reason)
       } finally {
         // Ensure the application terminates, as we can no longer run jobs.
         sc.stopInNewThread()

--- a/core/src/test/scala/org/apache/spark/HeartbeatReceiverSuite.scala
+++ b/core/src/test/scala/org/apache/spark/HeartbeatReceiverSuite.scala
@@ -97,9 +97,9 @@ class HeartbeatReceiverSuite
   }
 
   test("task scheduler is set correctly") {
-    assert(heartbeatReceiver.scheduler === null)
+    assert(heartbeatReceiver.taskScheduler === null)
     heartbeatReceiverRef.askSync[Boolean](TaskSchedulerIsSet)
-    assert(heartbeatReceiver.scheduler !== null)
+    assert(heartbeatReceiver.taskScheduler !== null)
   }
 
   test("normal heartbeat") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Renames (standardize) the `TaskScheduler` reference variables from `scheduler`/`sched` etc to `taskScheduler`

### Why are the changes needed?
Multiple classes in  `core/` ( like `CoarseGrainedScheduler`, `StandaloneScheduler`, etc) currently hold reference to TaskScheduler in a variable `scheduler`/ `sched`, etc. This is confusing when reading scheduler code. This PR renames these reference variables to `taskScheduler` to make the code more readable.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Github Actions

### Was this patch authored or co-authored using generative AI tooling?
No