### PR TITLE
[SPARK-45978][INFRA] Skip unidoc step in `docker-integration-tests` GitHub Action job

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -930,6 +930,7 @@ jobs:
       GITHUB_PREV_SHA: ${{ github.event.before }}
       SPARK_LOCAL_IP: localhost
       ORACLE_DOCKER_IMAGE_NAME: gvenzl/oracle-free:23.3
+      SKIP_UNIDOC: true
       SKIP_MIMA: true
       SKIP_PACKAGING: true
     steps:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to skip `unidoc` step from docker-integration-tests GitHub Action job because we have a full doc generation job already.

### Why are the changes needed?

Save the GitHub Action resources and to mitigate the flakiness of docker-integratoin-tests.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.