### PR TITLE
[SPARK-45980][INFRA] Add `Python 3.11` to the Daily Python Github Action job

### DIFF
--- a/.github/workflows/build_python.yml
+++ b/.github/workflows/build_python.yml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-name: "Build / Python-only (master, PyPy 3.8/Python 3.10)"
+name: "Build / Python-only (master, PyPy 3.8/Python 3.10/Python 3.11)"
 
 on:
   schedule:
@@ -36,7 +36,7 @@ jobs:
       hadoop: hadoop3
       envs: >-
         {
-          "PYTHON_TO_TEST": "pypy3,python3.10"
+          "PYTHON_TO_TEST": "pypy3,python3.10,python3.11"
         }
       jobs: >-
         {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to enable `Python 3.11` testing in the following daily `Python-only` Github Action job.

https://github.com/apache/spark/actions/workflows/build_python.yml

### Why are the changes needed?

To provide `Python 3.11` test coverage to Apache Spark 4.0.0.

Since SPARK-45953 installed `Python 3.11` into the infra image, what we need is to add it to the daily job.
- #43877

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

We need to validate this in the daily GitHub Action job.

### Was this patch authored or co-authored using generative AI tooling?

No.