### PR TITLE
[SPARK-44973][SQL] Fix `ArrayIndexOutOfBoundsException` in `conv()`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/NumberConverter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/NumberConverter.scala
@@ -24,6 +24,13 @@ import org.apache.spark.unsafe.types.UTF8String
 object NumberConverter {
 
   /**
+   * The output string has a max length of one char per bit in the intermediate representation plus
+   * one char for the '-' sign.  This corresponds to the representation of `Long.MinValue` with
+   * `toBase` equal to -2.
+   */
+  private final val MAX_OUTPUT_LENGTH = 64 + 1
+
+  /**
    * Decode v into value[].
    *
    * @param v is treated as an unsigned 64-bit integer
@@ -148,7 +155,7 @@ object NumberConverter {
     var (negative, first) = if (n(0) == '-') (true, 1) else (false, 0)
 
     // Copy the digits in the right side of the array
-    val temp = new Array[Byte](Math.max(n.length, 64))
+    val temp = new Array[Byte](Math.max(n.length, MAX_OUTPUT_LENGTH))
     var v: Long = -1
 
     System.arraycopy(n, first, temp, temp.length - n.length + first, n.length - first)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/NumberConverter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/NumberConverter.scala
@@ -24,11 +24,11 @@ import org.apache.spark.unsafe.types.UTF8String
 object NumberConverter {
 
   /**
-   * The output string has a max length of one char per bit in the intermediate representation plus
-   * one char for the '-' sign.  This corresponds to the representation of `Long.MinValue` with
-   * `toBase` equal to -2.
+   * The output string has a max length of one char per bit in the 64-bit `Long` intermediate
+   * representation plus one char for the '-' sign.  This happens in practice when converting
+   * `Long.MinValue` with `toBase` equal to -2.
    */
-  private final val MAX_OUTPUT_LENGTH = 64 + 1
+  private final val MAX_OUTPUT_LENGTH = java.lang.Long.SIZE + 1
 
   /**
    * Decode v into value[].

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/NumberConverterSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/NumberConverterSuite.scala
@@ -56,9 +56,9 @@ class NumberConverterSuite extends SparkFunSuite {
   }
 
   test("SPARK-44973: conv must allocate enough space for all digits plus negative sign") {
-    checkConv(s"${Long.MinValue}", 10, -2, "-1" + "0" * 63)
-    checkConv("8" + "0" * 15, 16, -2, "-1" + "0" * 63)
-    checkConv("-8" + "0" * 15, 16, -2, "-1" + "0" * 63)
+    checkConv(s"${Long.MinValue}", 10, -2, BigInt(Long.MinValue).toString(2))
+    checkConv((BigInt(Long.MaxValue) + 1).toString(16), 16, -2, BigInt(Long.MinValue).toString(2))
+    checkConv(BigInt(Long.MinValue).toString(16), 16, -2, BigInt(Long.MinValue).toString(2))
   }
 
   test("byte to binary") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/NumberConverterSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/NumberConverterSuite.scala
@@ -55,6 +55,12 @@ class NumberConverterSuite extends SparkFunSuite {
     checkConv("-10", 11, 7, "45012021522523134134555")
   }
 
+  test("SPARK-44973: conv must allocate enough space for all digits plus negative sign") {
+    checkConv(s"${Long.MinValue}", 10, -2, "-1" + "0" * 63)
+    checkConv("8" + "0" * 15, 16, -2, "-1" + "0" * 63)
+    checkConv("-8" + "0" * 15, 16, -2, "-1" + "0" * 63)
+  }
+
   test("byte to binary") {
     checkToBinary(0.toByte)
     checkToBinary(1.toByte)

--- a/sql/core/src/test/scala/org/apache/spark/sql/MathFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/MathFunctionsSuite.scala
@@ -227,7 +227,7 @@ class MathFunctionsSuite extends QueryTest with SharedSparkSession {
     checkAnswer(df.selectExpr("""conv("-10", 16, -10)"""), Row("-16"))
   }
 
-  test("SPARK-33428: conv function should trim input string") {
+  test("SPARK-33428 conv function should trim input string") {
     val df = Seq(("abc"), ("  abc"), ("abc  "), ("  abc  ")).toDF("num")
     checkAnswer(df.select(conv($"num", 16, 10)),
       Seq(Row("2748"), Row("2748"), Row("2748"), Row("2748")))
@@ -235,7 +235,7 @@ class MathFunctionsSuite extends QueryTest with SharedSparkSession {
       Seq(Row("2748"), Row("2748"), Row("2748"), Row("2748")))
   }
 
-  test("SPARK-33428: conv function shouldn't raise error if input string is too big") {
+  test("SPARK-33428 conv function shouldn't raise error if input string is too big") {
     withSQLConf(SQLConf.ANSI_ENABLED.key -> false.toString) {
       val df = Seq((
         "aaaaaaa0aaaaaaa0aaaaaaa0aaaaaaa0aaaaaaa0aaaaaaa0aaaaaaa0aaaaaaa0aaaaaaa0")).toDF("num")
@@ -244,7 +244,7 @@ class MathFunctionsSuite extends QueryTest with SharedSparkSession {
     }
   }
 
-  test("SPARK-36229: inconsistent behaviour where returned value is above the 64 char threshold") {
+  test("SPARK-36229 inconsistently behaviour where returned value is above the 64 char threshold") {
     withSQLConf(SQLConf.ANSI_ENABLED.key -> false.toString) {
       val df = Seq(("?" * 64), ("?" * 65), ("a" * 4 + "?" * 60), ("a" * 4 + "?" * 61)).toDF("num")
       val expectedResult = Seq(Row("0"), Row("0"), Row("43690"), Row("43690"))
@@ -253,7 +253,7 @@ class MathFunctionsSuite extends QueryTest with SharedSparkSession {
     }
   }
 
-  test("SPARK-36229: conv should return result equal to -1 in base of toBase") {
+  test("SPARK-36229 conv should return result equal to -1 in base of toBase") {
     withSQLConf(SQLConf.ANSI_ENABLED.key -> false.toString) {
       val df = Seq(("aaaaaaa0aaaaaaa0a"), ("aaaaaaa0aaaaaaa0")).toDF("num")
       checkAnswer(df.select(conv($"num", 16, 10)),

--- a/sql/core/src/test/scala/org/apache/spark/sql/MathFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/MathFunctionsSuite.scala
@@ -227,7 +227,7 @@ class MathFunctionsSuite extends QueryTest with SharedSparkSession {
     checkAnswer(df.selectExpr("""conv("-10", 16, -10)"""), Row("-16"))
   }
 
-  test("SPARK-33428 conv function should trim input string") {
+  test("SPARK-33428: conv function should trim input string") {
     val df = Seq(("abc"), ("  abc"), ("abc  "), ("  abc  ")).toDF("num")
     checkAnswer(df.select(conv($"num", 16, 10)),
       Seq(Row("2748"), Row("2748"), Row("2748"), Row("2748")))
@@ -235,7 +235,7 @@ class MathFunctionsSuite extends QueryTest with SharedSparkSession {
       Seq(Row("2748"), Row("2748"), Row("2748"), Row("2748")))
   }
 
-  test("SPARK-33428 conv function shouldn't raise error if input string is too big") {
+  test("SPARK-33428: conv function shouldn't raise error if input string is too big") {
     withSQLConf(SQLConf.ANSI_ENABLED.key -> false.toString) {
       val df = Seq((
         "aaaaaaa0aaaaaaa0aaaaaaa0aaaaaaa0aaaaaaa0aaaaaaa0aaaaaaa0aaaaaaa0aaaaaaa0")).toDF("num")
@@ -244,7 +244,7 @@ class MathFunctionsSuite extends QueryTest with SharedSparkSession {
     }
   }
 
-  test("SPARK-36229 inconsistently behaviour where returned value is above the 64 char threshold") {
+  test("SPARK-36229: inconsistent behaviour where returned value is above the 64 char threshold") {
     withSQLConf(SQLConf.ANSI_ENABLED.key -> false.toString) {
       val df = Seq(("?" * 64), ("?" * 65), ("a" * 4 + "?" * 60), ("a" * 4 + "?" * 61)).toDF("num")
       val expectedResult = Seq(Row("0"), Row("0"), Row("43690"), Row("43690"))
@@ -253,7 +253,7 @@ class MathFunctionsSuite extends QueryTest with SharedSparkSession {
     }
   }
 
-  test("SPARK-36229 conv should return result equal to -1 in base of toBase") {
+  test("SPARK-36229: conv should return result equal to -1 in base of toBase") {
     withSQLConf(SQLConf.ANSI_ENABLED.key -> false.toString) {
       val df = Seq(("aaaaaaa0aaaaaaa0a"), ("aaaaaaa0aaaaaaa0")).toDF("num")
       checkAnswer(df.select(conv($"num", 16, 10)),
@@ -262,11 +262,14 @@ class MathFunctionsSuite extends QueryTest with SharedSparkSession {
     }
   }
 
-  test("SPARK-44973 conv must allocate enough space for all digits plus negative sign") {
+  test("SPARK-44973: conv must allocate enough space for all digits plus negative sign") {
     withSQLConf(SQLConf.ANSI_ENABLED.key -> false.toString) {
-      val df = Seq(("8" + "0"*15), ("-8" + "0" * 15)).toDF("num")
+      val df = Seq(
+        ((BigInt(Long.MaxValue) + 1).toString(16)),
+        (BigInt(Long.MinValue).toString(16))
+      ).toDF("num")
       checkAnswer(df.select(conv($"num", 16, -2)),
-        Seq(Row("-1" + "0" * 63), Row("-1" + "0" * 63)))
+        Seq(Row(BigInt(Long.MinValue).toString(2)), Row(BigInt(Long.MinValue).toString(2))))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/MathFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/MathFunctionsSuite.scala
@@ -262,6 +262,14 @@ class MathFunctionsSuite extends QueryTest with SharedSparkSession {
     }
   }
 
+  test("SPARK-44973 conv must allocate enough space for all digits plus negative sign") {
+    withSQLConf(SQLConf.ANSI_ENABLED.key -> false.toString) {
+      val df = Seq(("8" + "0"*15), ("-8" + "0" * 15)).toDF("num")
+      checkAnswer(df.select(conv($"num", 16, -2)),
+        Seq(Row("-1" + "0" * 63), Row("-1" + "0" * 63)))
+    }
+  }
+
   test("floor") {
     testOneToOneMathFunction(floor, (d: Double) => math.floor(d).toLong)
     // testOneToOneMathFunction does not validate the resulting data type


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Increase the size of the buffer allocated for the result of base conversion in `NumberConverter` to prevent ArrayIndexOutOfBoundsException when evaluating `conv(s"${Long.MinValue}", 10, -2)`.

### Why are the changes needed?

I don't think the ArrayIndexOutOfBoundsException is intended behaviour.

### Does this PR introduce _any_ user-facing change?

Users will no longer experience an ArrayIndexOutOfBoundsException for this specific set of arguments and will instead receive the expected base conversion.

### How was this patch tested?

New unit test cases

### Was this patch authored or co-authored using generative AI tooling?
No
