### PR TITLE
[SPARK-45991][BUILD] Upgrade `protobuf-java` to 3.25.1 to match with `protobuf` 4.25.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
     <!-- make sure to update IsolatedClientLoader whenever this version is changed -->
     <hadoop.version>3.3.6</hadoop.version>
     <!-- SPARK-41247: When updating `protobuf.version`, also need to update `protoVersion` in `SparkBuild.scala` -->
-    <protobuf.version>3.23.4</protobuf.version>
+    <protobuf.version>3.25.1</protobuf.version>
     <protoc-jar-maven-plugin.version>3.11.4</protoc-jar-maven-plugin.version>
     <yarn.version>${hadoop.version}</yarn.version>
     <zookeeper.version>3.9.1</zookeeper.version>

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -89,7 +89,7 @@ object BuildCommons {
 
   // Google Protobuf version used for generating the protobuf.
   // SPARK-41247: needs to be consistent with `protobuf.version` in `pom.xml`.
-  val protoVersion = "3.23.4"
+  val protoVersion = "3.25.1"
   // GRPC version used for Spark Connect.
   val gprcVersion = "1.56.0"
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `protobuf-java` to 3.25.1 in order to match with the corresponding `protobuf` 4.25.

### Why are the changes needed?

`protobuf 4.25` is matched with `protobuf-java 3.25`.
- https://github.com/protocolbuffers/protobuf/pull/14617

```
- set(protobuf_VERSION_STRING "4.24.0")
+ set(protobuf_VERSION_STRING "4.25.0")
- <version>3.24.0</version>
+ <version>3.25.0</version>
```

Note that I also ran

```
$ dev/connect-gen-protos.sh

$ git status
On branch SPARK-45991
Your branch is up to date with 'dongjoon/SPARK-45991'.

nothing to commit, working tree clean
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.