### PR TITLE
[SPARK-45992][BUILD] Switch from `fgrep` to `grep -F`

### DIFF
--- a/dev/make-distribution.sh
+++ b/dev/make-distribution.sh
@@ -141,7 +141,7 @@ SPARK_HADOOP_VERSION=$("$MVN" help:evaluate -Dexpression=hadoop.version $@ \
 SPARK_HIVE=$("$MVN" help:evaluate -Dexpression=project.activeProfiles -pl sql/hive $@ \
     | grep -v "INFO"\
     | grep -v "WARNING"\
-    | fgrep --count "<id>hive</id>";\
+    | grep -F --count "<id>hive</id>";\
     # Reset exit status to 0, otherwise the script stops here if the last grep finds nothing\
     # because we use "set -o pipefail"
     echo -n)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Switch from `fgrep` to `grep -F`

### Why are the changes needed?
`./dev/make-distribution.sh --name custom-spark --pip -Pkubernetes`

++ fgrep --count '<id>hive</id>'
fgrep: warning: fgrep is obsolescent; using grep -F

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?

before 
++ fgrep --count '<id>hive</id>'
fgrep: warning: fgrep is obsolescent; using grep -F

After 
Using `mvn` from path: /home/bjorn/spark/build/apache-maven-3.9.5/bin/mvn
+ SPARK_HADOOP_VERSION=3.3.6
++ /home/bjorn/spark/build/mvn help:evaluate -Dexpression=project.activeProfiles -pl sql/hive -Pkubernetes
++ grep -v INFO
++ grep -v WARNING
++ grep -F --count '<id>hive</id>'
Using `mvn` from path: /home/bjorn/spark/build/apache-maven-3.9.5/bin/mvn
++ echo -n

Pass GA

### Was this patch authored or co-authored using generative AI tooling?
No.