### PR TITLE
[SPARK-45994][PYTHON] Change `description-file` to `description_file`

### DIFF
--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -19,4 +19,4 @@
 universal = 1
 
 [metadata]
-description-file = README.md
+description_file = README.md


### PR DESCRIPTION
### What changes were proposed in this pull request?
Change `description-file` to `description_file`

### Why are the changes needed?

`./dev/make-distribution.sh --name custom-spark --pip -Pkubernetes > output.txt 2>&1`
in the file there is this

```
+ echo 'Building python distribution package'
Building python distribution package
+ pushd /home/bjorn/spark/python
+ rm -rf pyspark.egg-info
+ python3 setup.py sdist
/usr/lib/python3.11/site-packages/setuptools/dist.py:745: SetuptoolsDeprecationWarning: Invalid dash-separated options
!!

        ********************************************************************************
        Usage of dash-separated 'description-file' will not be supported in future
        versions. Please use the underscore name 'description_file' instead.

        This deprecation is overdue, please update your project and remove deprecated
        calls to avoid build errors in the future.

        See https://setuptools.pypa.io/en/latest/userguide/declarative_config.html for details.
        ********************************************************************************

!!
  opt = self.warn_dash_deprecation(opt, section)
running sdist
running egg_info
```
### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA

### Was this patch authored or co-authored using generative AI tooling?
No.