### PR TITLE
[SPARK-45995][R][INFRA] Upgrade R version from 4.3.1 to 4.3.2 in AppVeyor

### DIFF
--- a/dev/appveyor-install-dependencies.ps1
+++ b/dev/appveyor-install-dependencies.ps1
@@ -140,7 +140,7 @@ $env:PATH = "$env:HADOOP_HOME\bin;" + $env:PATH
 Pop-Location
 
 # ========================== R
-$rVer = "4.3.1"
+$rVer = "4.3.2"
 $rToolsVer = "4.0.2"
 
 InstallR


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support R 4.3.2 officially in Apache Spark 4.0.0 by upgrading AppVeyor to 4.3.2.

### Why are the changes needed?

To test the latest R version, see also https://cran.r-project.org/doc/manuals/r-release/NEWS.html

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

CI