### PR TITLE
[SPARK-45682][CORE][FOLLOW-UP] Restore console progress bar in Spark shells

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/ConsoleProgressBar.scala
+++ b/core/src/main/scala/org/apache/spark/ui/ConsoleProgressBar.scala
@@ -94,7 +94,7 @@ private[spark] class ConsoleProgressBar(sc: SparkContext) extends Logging {
     // only refresh if it's changed OR after 1 minute (or the ssh connection will be closed
     // after idle some time)
     if (bar != lastProgressBar || now - lastUpdateTime > 60 * 1000L) {
-      System.err.print(s"${CR}bar$CR")
+      System.err.print(s"$CR$bar$CR")
       lastUpdateTime = now
     }
     lastProgressBar = bar


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/43573 that restore the console progress bar in Spark shells.
Previously it was `CR + bar + CR` but mistakenly it was fixed as `s"${CR}bar$CR"`.

Before:

```
>>> spark.range(10000).repartition(4000).count()
bar
```

After:

```
>>> spark.range(10000).repartition(4000).count()
[Stage 5:==============>                                     (1121 + 16) / 4000]
```

### Why are the changes needed?

To have the proper working console bar. This is a regression.

### Does this PR introduce _any_ user-facing change?

Not yet because the main change has not been released out yet.

### How was this patch tested?

Manually tested:

```bash
./bin/pyspark
spark.range(10000).repartition(4000).count()
```

### Was this patch authored or co-authored using generative AI tooling?

No.