### PR TITLE
[SPARK-46007][TEST] Add `AmmoniteTest` test tag and mark `ReplE2ESuite`

### DIFF
--- a/common/tags/src/test/java/org/apache/spark/tags/AmmoniteTest.java
+++ b/common/tags/src/test/java/org/apache/spark/tags/AmmoniteTest.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.tags;
+
+import org.scalatest.TagAnnotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@TagAnnotation
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+public @interface AmmoniteTest { }

--- a/connector/connect/client/jvm/pom.xml
+++ b/connector/connect/client/jvm/pom.xml
@@ -72,6 +72,12 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-tags_${scala.binary.version}</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.scalacheck</groupId>
       <artifactId>scalacheck_${scala.binary.version}</artifactId>
       <scope>test</scope>

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/application/ReplE2ESuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/application/ReplE2ESuite.scala
@@ -26,9 +26,11 @@ import org.apache.commons.io.output.ByteArrayOutputStream
 import org.scalatest.BeforeAndAfterEach
 
 import org.apache.spark.sql.test.{IntegrationTestUtils, RemoteSparkSession}
+import org.apache.spark.tags.AmmoniteTest
 import org.apache.spark.util.IvyTestUtils
 import org.apache.spark.util.MavenUtils.MavenCoordinate
 
+@AmmoniteTest
 class ReplE2ESuite extends RemoteSparkSession with BeforeAndAfterEach {
 
   private val executorService = Executors.newSingleThreadExecutor()


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to introduce `AmmoniteTest` test tag and mark `ReplE2ESuite` in order to allow disable `Ammonite`-related tests selectively.

### Why are the changes needed?

There is a long-standing existing Ammonite issue.
- https://github.com/com-lihaoyi/Ammonite/issues/276

Although we use a hack in GitHub Action, it's non-trivial to run the tests in various environment. For example, some systems doesn't has `amm` installation in the PATH.

https://github.com/apache/spark/blob/398bff77b1c837aed55f4f10ff1157f7da813570/.github/workflows/build_and_test.yml#L264-L267

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

I manually verified that the test suite is ignored successfully.

```
$ build/sbt assembly/package "connect-client-jvm/testOnly org.apache.spark.sql.application.ReplE2ESuite" -Phive -Pconnect -Dtest.exclude.tags=org.apache.spark.tags.AmmoniteTest
...
[info] ReplE2ESuite:
[info] Run completed in 433 milliseconds.
[info] Total number of tests run: 0
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 0, failed 0, canceled 0, ignored 0, pending 0
[info] No tests were executed.
[success] Total time: 17 s, completed Nov 20, 2023, 4:00:37 AM
```

### Was this patch authored or co-authored using generative AI tooling?

No.