### PR TITLE
[SPARK-46010][BUILD] Upgrade `Node.js` to 18.X

### DIFF
--- a/dev/create-release/spark-rm/Dockerfile
+++ b/dev/create-release/spark-rm/Dockerfile
@@ -23,7 +23,8 @@
 # * Python (3.8.5)
 # * R-base/R-base-dev (4.0.3)
 # * Ruby (2.7.0)
-#
+# * Node.js (18.x)
+# 
 # You can test it as below:
 #   cd dev/create-release/spark-rm
 #   docker build -t spark-rm --build-arg UID=$UID .
@@ -67,7 +68,15 @@ RUN apt-get clean && apt-get update && $APT_INSTALL gnupg ca-certificates && \
   # Install build / source control tools
   $APT_INSTALL curl wget git maven ivy subversion make gcc lsof libffi-dev \
     pandoc pandoc-citeproc libssl-dev libcurl4-openssl-dev libxml2-dev && \
-  curl -sL https://deb.nodesource.com/setup_12.x | bash && \
+  # Define the desired Node.js major version
+  NODE_MAJOR=18 && \
+  # Create a directory for the new repository's keyring, if it doesn't exist
+  mkdir -p /etc/apt/keyrings && \
+  # Download the new repository's GPG key and save it in the keyring directory
+  curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+  # Add the new repository's source list with its GPG key for package verification
+  echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_MAJOR}.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
+  apt-get update && \
   $APT_INSTALL nodejs && \
   # Install needed python packages. Use pip for installing packages (for consistency).
   $APT_INSTALL python-is-python3 python3-pip python3-setuptools && \


### PR DESCRIPTION
### What changes were proposed in this pull request?
Upgrade `Node.js` from 12 to 18.X

https://github.com/nodesource/distributions/wiki/How-to-migrate-to-the-new-repository


### Why are the changes needed?

run docker build [spark](https://github.com/apache/spark/tree/master)/[dev](https://github.com/apache/spark/tree/master/dev)/[create-release](https://github.com/apache/spark/tree/master/dev/create-release)/[spark-rm](https://github.com/apache/spark/tree/master/dev/create-release/spark-rm)
/Dockerfile and then I get this

Processing triggers for libc-bin (2.31-0ubuntu9.12) ...

================================================================================
================================================================================

                              DEPRECATION WARNING

  Node.js 12.x is no longer actively supported!

  You will not receive security or critical stability updates for this version.

  You should migrate to a supported version of Node.js as soon as possible.
  Use the installation script that corresponds to the version of Node.js you
  wish to install. e.g.

   * https://deb.nodesource.com/setup_16.x — Node.js 16 "Gallium"
   * https://deb.nodesource.com/setup_18.x — Node.js 18 LTS "Hydrogen" (recommended)
   * https://deb.nodesource.com/setup_19.x — Node.js 19 "Nineteen"
   * https://deb.nodesource.com/setup_20.x — Node.js 20 "Iron" (current)

  Please see https://github.com/nodejs/Release for details about which
  version may be appropriate for you.

  The NodeSource Node.js distributions repository contains
  information both about supported versions of Node.js and supported Linux
  distributions. To learn more about usage, see the repository:
    https://github.com/nodesource/distributions

================================================================================
================================================================================

Continuing in 20 seconds ...


================================================================================
▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
================================================================================

                           SCRIPT DEPRECATION WARNING


  This script, located at https://deb.nodesource.com/setup_X, used to
  install Node.js is deprecated now and will eventually be made inactive.

  Please visit the NodeSource distributions Github and follow the
  instructions to migrate your repo.
  https://github.com/nodesource/distributions

  The NodeSource Node.js Linux distributions GitHub repository contains
  information about which versions of Node.js and which Linux distributions
  are supported and how to install it.
  https://github.com/nodesource/distributions


                          SCRIPT DEPRECATION WARNING

================================================================================
▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
================================================================================

TO AVOID THIS WAIT MIGRATE THE SCRIPT
Continuing in 60 seconds (press Ctrl-C to abort) ...

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?


### Was this patch authored or co-authored using generative AI tooling?
No.