### PR TITLE
[WIP][SPARK-46011][CONNECT] Session heartbeat/keepalive using ExtendSession RPC

### DIFF
--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/ArtifactSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/ArtifactSuite.scala
@@ -57,7 +57,7 @@ class ArtifactSuite extends ConnectFunSuite with BeforeAndAfterEach {
 
   private def createArtifactManager(): Unit = {
     channel = InProcessChannelBuilder.forName(getClass.getName).directExecutor().build()
-    state = new SparkConnectStubState(channel, RetryPolicy.defaultPolicies())
+    state = new SparkConnectStubState(channel, Configuration())
     bstub = new CustomSparkConnectBlockingStub(channel, state)
     stub = new CustomSparkConnectStub(channel, state)
     artifactManager = new ArtifactManager(Configuration(), "", bstub, stub)

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/SparkConnectClientBuilderParseTestSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/SparkConnectClientBuilderParseTestSuite.scala
@@ -48,7 +48,7 @@ class SparkConnectClientBuilderParseTestSuite extends ConnectFunSuite {
   argumentTest("user_id", "U1238", _.userId.get)
   argumentTest("user_name", "alice", _.userName.get)
   argumentTest("user_agent", "robert", _.userAgent.split(" ")(0))
-  argumentTest("session_id", UUID.randomUUID().toString, _.sessionId.get)
+  argumentTest("session_id", UUID.randomUUID().toString, _.sessionId)
 
   test("Argument - remote") {
     val builder =

--- a/connector/connect/common/src/main/protobuf/spark/connect/base.proto
+++ b/connector/connect/common/src/main/protobuf/spark/connect/base.proto
@@ -20,6 +20,7 @@ syntax = 'proto3';
 package spark.connect;
 
 import "google/protobuf/any.proto";
+import "google/protobuf/timestamp.proto";
 import "spark/connect/commands.proto";
 import "spark/connect/common.proto";
 import "spark/connect/expressions.proto";
@@ -846,6 +847,40 @@ message ReleaseSessionResponse {
   string server_side_session_id = 2;
 }
 
+// Next ID: 4
+message ExtendSessionRequest {
+  // (Required)
+  //
+  // The session_id of the request to reattach to.
+  // This must be an id of existing session.
+  string session_id = 1;
+
+  // (Required) User context
+  //
+  // user_context.user_id and session+id both identify a unique remote spark session on the
+  // server side.
+  UserContext user_context = 2;
+
+  // Provides optional information about the client sending the request. This field
+  // can be used for language or version specific information and is only intended for
+  // logging purposes and will not be interpreted by the server.
+  optional string client_type = 3;
+}
+
+// Next ID: 4
+message ExtendSessionResponse {
+  // Session id of the session on which the extend executed.
+  string session_id = 1;
+
+  // Server-side generated idempotency key that the client can use to assert that the server side
+  // session has not changed.
+  string server_side_session_id = 2;
+
+  // Session expiration time granted by the server.
+  // If session is to be extended, client has to make sure to call ExtendSession before that time.
+  google.protobuf.Timestamp expiration_time = 3;
+}
+
 message FetchErrorDetailsRequest {
 
   // (Required)
@@ -1008,6 +1043,14 @@ service SparkConnectService {
   // that session_id for the given user_id will fail. If the session didn't exist or was already
   // released, this is a noop.
   rpc ReleaseSession(ReleaseSessionRequest) returns (ReleaseSessionResponse) {}
+
+  // Extend a session lifetime.
+  // If an ExtendSession request is not used, the session will expire 1 hour after the last RPC,
+  // and every RPC will reset the expiration time. This is backwards compatible legacy behavior.
+  // If an ExtendSession request is ever used in a session, no other RPC request will be extending
+  // the session lifetime, and it will be defined entirely by the requested deadline in
+  // ExtendSessionRequest, and the returned granted deadline time in ExtendSessionResponse.
+  rpc ExtendSession(ExtendSessionRequest) returns (ExtendSessionResponse) {}
 
   // FetchErrorDetails retrieves the matched exception with details based on a provided error id.
   rpc FetchErrorDetails(FetchErrorDetailsRequest) returns (FetchErrorDetailsResponse) {}

--- a/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/client/CustomSparkConnectBlockingStub.scala
+++ b/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/client/CustomSparkConnectBlockingStub.scala
@@ -22,9 +22,9 @@ import io.grpc.ManagedChannel
 
 import org.apache.spark.connect.proto._
 
-private[connect] class CustomSparkConnectBlockingStub(
-    channel: ManagedChannel,
-    stubState: SparkConnectStubState) {
+private[connect] class CustomSparkConnectBlockingStub(stubState: SparkConnectStubState) {
+
+  private val channel: ManagedChannel = stubState.channel
 
   private val stub = SparkConnectServiceGrpc.newBlockingStub(channel)
 
@@ -34,6 +34,8 @@ private[connect] class CustomSparkConnectBlockingStub(
   private val grpcExceptionConverter = stubState.exceptionConverter
 
   def executePlan(request: ExecutePlanRequest): CloseableIterator[ExecutePlanResponse] = {
+    stubState.heartbeat.ping()
+
     grpcExceptionConverter.convert(
       request.getSessionId,
       request.getUserContext,
@@ -53,6 +55,8 @@ private[connect] class CustomSparkConnectBlockingStub(
 
   def executePlanReattachable(
       request: ExecutePlanRequest): CloseableIterator[ExecutePlanResponse] = {
+    stubState.heartbeat.ping()
+
     grpcExceptionConverter.convert(
       request.getSessionId,
       request.getUserContext,
@@ -68,6 +72,8 @@ private[connect] class CustomSparkConnectBlockingStub(
   }
 
   def analyzePlan(request: AnalyzePlanRequest): AnalyzePlanResponse = {
+    stubState.heartbeat.ping()
+
     grpcExceptionConverter.convert(
       request.getSessionId,
       request.getUserContext,
@@ -81,6 +87,8 @@ private[connect] class CustomSparkConnectBlockingStub(
   }
 
   def config(request: ConfigRequest): ConfigResponse = {
+    stubState.heartbeat.ping()
+
     grpcExceptionConverter.convert(
       request.getSessionId,
       request.getUserContext,
@@ -94,6 +102,8 @@ private[connect] class CustomSparkConnectBlockingStub(
   }
 
   def interrupt(request: InterruptRequest): InterruptResponse = {
+    stubState.heartbeat.ping()
+
     grpcExceptionConverter.convert(
       request.getSessionId,
       request.getUserContext,
@@ -107,6 +117,8 @@ private[connect] class CustomSparkConnectBlockingStub(
   }
 
   def releaseSession(request: ReleaseSessionRequest): ReleaseSessionResponse = {
+    stubState.heartbeat.ping()
+
     grpcExceptionConverter.convert(
       request.getSessionId,
       request.getUserContext,
@@ -120,6 +132,8 @@ private[connect] class CustomSparkConnectBlockingStub(
   }
 
   def artifactStatus(request: ArtifactStatusesRequest): ArtifactStatusesResponse = {
+    stubState.heartbeat.ping()
+
     grpcExceptionConverter.convert(
       request.getSessionId,
       request.getUserContext,

--- a/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/client/CustomSparkConnectStub.scala
+++ b/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/client/CustomSparkConnectStub.scala
@@ -21,14 +21,16 @@ import io.grpc.stub.StreamObserver
 
 import org.apache.spark.connect.proto.{AddArtifactsRequest, AddArtifactsResponse, SparkConnectServiceGrpc}
 
-private[client] class CustomSparkConnectStub(
-    channel: ManagedChannel,
-    stubState: SparkConnectStubState) {
+private[client] class CustomSparkConnectStub(stubState: SparkConnectStubState) {
+
+  private val channel: ManagedChannel = stubState.channel
 
   private val stub = SparkConnectServiceGrpc.newStub(channel)
 
   def addArtifacts(responseObserver: StreamObserver[AddArtifactsResponse])
       : StreamObserver[AddArtifactsRequest] = {
+    stubState.heartbeat.ping()
+
     stubState.responseValidator.wrapStreamObserver(
       stubState.retryHandler.RetryStreamObserver(responseObserver, stub.addArtifacts))
   }

--- a/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/client/SessionHeartbeat.scala
+++ b/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/client/SessionHeartbeat.scala
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connect.client
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+import scala.concurrent.duration.FiniteDuration
+import scala.util.control.NonFatal
+
+import com.google.protobuf.util.Timestamps
+
+import org.apache.spark.connect.proto
+import org.apache.spark.internal.Logging
+
+/**
+ * SessionHeartbeat controls a thread in the client that can periodically send ExtendSession
+ * requests to the server to keep the session alive. See SessionHeartbeat.Configuration for all
+ * available options.
+ */
+private[client] class SessionHeartbeat(stubState: SparkConnectStubState) extends Logging {
+
+  private val heartbeatConfig = stubState.configuration.extendSessionHeartbeat
+
+  private val clientConfig = stubState.configuration
+
+  private var expirationTime = System.currentTimeMillis()
+
+  private var lastActivityTime = System.currentTimeMillis()
+
+  private val bstub = proto.SparkConnectServiceGrpc.newBlockingStub(stubState.channel)
+
+  private val activityLock = new Object()
+
+  private val started = new AtomicBoolean(false)
+
+  private val stopped = new AtomicBoolean(false)
+
+  private val pingThread = new Thread() {
+    override def run(): Unit = {
+      while (!stubState.channel.isTerminated && !stopped.get()) {
+        // If configured to stop after inactivity, wait until there is activity.
+        if (heartbeatConfig.stopAfterInactivity.isDefined) {
+          activityLock.synchronized {
+            while (System.currentTimeMillis() - lastActivityTime <
+                heartbeatConfig.stopAfterInactivity.get.toMillis) {
+              activityLock.wait()
+            }
+          }
+        }
+
+        // Then wait until it's time to send the next ping.
+        val now = System.currentTimeMillis()
+        if (expirationTime < now) {
+          // If already past expirationTime, assume it's 1 minute in the future.
+          // We are either too late and will get an error anyway, or something else has gone wrong,
+          // in which case we don't want to flood calling the server.
+          expirationTime = now + heartbeatConfig.maximumInterval.toMillis
+        }
+        // Send ping at least every maximumInterval,
+        // but if the expirationTime is approaching send it sooner.
+        val nextPingTime =
+          now + Math.min(heartbeatConfig.maximumInterval.toMillis, (expirationTime - now) / 2)
+
+        Thread.sleep(Math.max(0, nextPingTime - System.currentTimeMillis()))
+
+        if (!stubState.channel.isTerminated) {
+          logDebug(s"Executing ExtendSession in session ${clientConfig.sessionId}")
+          // Ignore any errors when sending ExtendSession pings.
+          // Retries are handled by the outer loop and will become more frequent as the expiration
+          // time approaches. If there is an unrecoverable error in the session's connection,
+          // other foreground errors will be thrown, and the session will be closed, shutting down
+          // the heartbeat thread then, don't shut down after an error on its own.
+          try {
+            val request = proto.ExtendSessionRequest
+              .newBuilder()
+              .setSessionId(clientConfig.sessionId)
+              .setUserContext(stubState.userContext)
+              .setClientType(clientConfig.userAgent)
+              .build()
+            val response = bstub.extendSession(request)
+            expirationTime = Timestamps.toMillis(response.getExpirationTime)
+            logDebug(
+              s"ExtendSession response in session ${clientConfig.sessionId}, " +
+                s"new expirationTime: $expirationTime")
+          } catch {
+            case NonFatal(e) =>
+              logDebug(
+                "Caught exception during ExtendSession " +
+                  s"in session ${clientConfig.sessionId}",
+                e)
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Register that there is an RPC activity.
+   *
+   * In case of lazy start, it will start the ping thread. In case it should stop after
+   * inactivity, it refreshes activity time
+   */
+  def ping(): Unit = {
+    if (heartbeatConfig.enabled) {
+      if (started.getAndSet(true) == false) {
+        pingThread.start()
+      }
+      if (heartbeatConfig.stopAfterInactivity.isDefined) {
+        activityLock.synchronized {
+          lastActivityTime = System.currentTimeMillis()
+          activityLock.notifyAll()
+        }
+      }
+    }
+  }
+
+  def shutdown(): Unit = {
+    stopped.set(true)
+    pingThread.interrupt()
+    pingThread.join()
+  }
+
+  // If configuration says to not be lazy, start at constructor time.
+  if (!heartbeatConfig.lazyStart) {
+    ping()
+  }
+}
+
+object SessionHeartbeat {
+
+  /**
+   * Client configuration of ExtendSession heartbeat.
+   *
+   * After receiving ExtendSession, server will extend the session by CONNECT_SESSION_EXTEND_TIME
+   * server config (default: 10 minutes).
+   *
+   * If there is ever an ExtendSession heartbeat RPC sent by the client for the session, only
+   * ExtendSession RPCs will extend the session lifetime moving forward.
+   *
+   * If there has not ever been any ExtendSession heartbeat RPC sent by the client for the
+   * session, the server will extend the session lifetime after any RPC from the client, by
+   * CONNECT_SESSION_MANAGER_DEFAULT_SESSION_TIMEOUT (default: 1 hour). This is the legacy
+   * behavior of session management before ExtendSession was introduced.
+   *
+   * Heartbeat ExtendSession RPCs will be sent until the session is stopped with session.stop(),
+   * and optionally paused if there are no other RPCs for pauseAfterInactivity period.
+   *
+   * @param enabled
+   *   Whether session heartbeat is enabled. When disabled, server will default to keeping the
+   *   session alive for CONNECT_SESSION_MANAGER_DEFAULT_SESSION_TIMEOUT after the last RPC. When
+   *   enabled, only the ExtendSession RPCs send by the heartbeat extend the session lifetime.
+   * @param lazyStart
+   *   When true, only start sending heartbeat requests after the first RPC. When false, start
+   *   sending heartbeat requests immediately when the client is created.
+   * @param maximumInterval
+   *   Maximum Interval with which ExtendSession requests will be sent to the server. RPCs will be
+   *   send at the minimum of this interval, and half the time until the session expires.
+   * @param stopAfterInactivity
+   *   If set, the heartbeat will stop sending ExtendSession requests after there was no other
+   *   activity (sending other requests) in the client for the given duration. The heartbeat will
+   *   resume after any request is sent, but in the meanwhile, the session can expire.
+   */
+  case class Configuration(
+      enabled: Boolean = true,
+      lazyStart: Boolean = true,
+      maximumInterval: FiniteDuration = FiniteDuration(2, "min"),
+      stopAfterInactivity: Option[FiniteDuration] = Some(FiniteDuration(1, "hour")))
+}

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
@@ -93,6 +93,22 @@ object Connect {
       .intConf
       .createWithDefaultString("1000")
 
+  val CONNECT_SESSION_MANAGER_MAINTENANCE_INTERVAL =
+    buildStaticConf("spark.connect.session.manager.maintenanceInterval")
+      .internal()
+      .doc("Interval at which session manager will search for expired sessions to remove.")
+      .version("4.0.0")
+      .timeConf(TimeUnit.MILLISECONDS)
+      .createWithDefaultString("30s")
+
+  val CONNECT_SESSION_EXTEND_TIME =
+    buildStaticConf("spark.connect.session.manager.extendTime")
+      .internal()
+      .doc("Amount of time by which an ExtendSession extends the session expiration time.")
+      .version("4.0.0")
+      .timeConf(TimeUnit.MILLISECONDS)
+      .createWithDefaultString("10m")
+
   val CONNECT_EXECUTE_MANAGER_DETACHED_TIMEOUT =
     buildStaticConf("spark.connect.execute.manager.detachedTimeout")
       .internal()

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SessionHolder.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SessionHolder.scala
@@ -27,11 +27,12 @@ import scala.jdk.CollectionConverters._
 import com.google.common.base.Ticker
 import com.google.common.cache.CacheBuilder
 
-import org.apache.spark.{SparkException, SparkSQLException}
+import org.apache.spark.{SparkEnv, SparkException, SparkSQLException}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.connect.common.InvalidPlanInput
+import org.apache.spark.sql.connect.config.Connect.CONNECT_SESSION_EXTEND_TIME
 import org.apache.spark.sql.connect.planner.PythonStreamingQueryListener
 import org.apache.spark.sql.connect.planner.StreamingForeachBatchHelper
 import org.apache.spark.sql.connect.service.SessionHolder.{ERROR_CACHE_SIZE, ERROR_CACHE_TIMEOUT_SEC}
@@ -47,9 +48,19 @@ case class SessionKey(userId: String, sessionId: String)
 case class SessionHolder(userId: String, sessionId: String, session: SparkSession)
     extends Logging {
 
-  @volatile private var lastRpcAccessTime: Option[Long] = None
+  // Time when the session was started.
+  private val startTime: Long = System.currentTimeMillis()
 
-  @volatile private var isClosing: Boolean = false
+  // Time when the session was last accessed (retrieved from SparkConnectSessionManager)
+  @volatile private var lastAccessTime: Long = System.currentTimeMillis()
+
+  // Time when the session was closed.
+  @volatile private var closedTime: Option[Long] = None
+
+  // Time when the session is to expire, set by ExtendSession RPC.
+  // If it is set, and SparkConnectSessionManager periodic check finds it to be in the past,
+  // If not set, session expiration happens based on lastAccessTime and default timeout.
+  @volatile private var expirationTime: Option[Long] = None
 
   private val executions: ConcurrentMap[String, ExecuteHolder] =
     new ConcurrentHashMap[String, ExecuteHolder]()
@@ -92,8 +103,8 @@ case class SessionHolder(userId: String, sessionId: String, session: SparkSessio
    *
    * Called only by SparkConnectExecutionManager under executionsLock.
    */
-  private[service] def addExecuteHolder(executeHolder: ExecuteHolder): Unit = {
-    if (isClosing) {
+  private[service] def addExecuteHolder(executeHolder: ExecuteHolder): Unit = synchronized {
+    if (closedTime.isDefined) {
       // Do not accept new executions if the session is closing.
       throw new SparkSQLException(
         errorClass = "INVALID_HANDLE.SESSION_CLOSED",
@@ -186,7 +197,15 @@ case class SessionHolder(userId: String, sessionId: String, session: SparkSessio
   def classloader: ClassLoader = artifactManager.classloader
 
   private[connect] def updateAccessTime(): Unit = {
-    lastRpcAccessTime = Some(System.currentTimeMillis())
+    lastAccessTime = System.currentTimeMillis()
+    logInfo(s"Session $key accessed, time $lastAccessTime.")
+  }
+
+  private[connect] def extendSession(): Long = {
+    val extendTime = SparkEnv.get.conf.get(CONNECT_SESSION_EXTEND_TIME).toLong
+    expirationTime = Some(System.currentTimeMillis() + extendTime)
+    logInfo(s"Session $key extended until $expirationTime.")
+    expirationTime.get
   }
 
   /**
@@ -195,7 +214,6 @@ case class SessionHolder(userId: String, sessionId: String, session: SparkSessio
    * Called only by SparkConnectSessionManager.
    */
   private[connect] def initializeSession(): Unit = {
-    updateAccessTime()
     eventManager.postStarted()
   }
 
@@ -204,36 +222,38 @@ case class SessionHolder(userId: String, sessionId: String, session: SparkSessio
    *
    * Called only by SparkConnectSessionManager.
    */
-  private[connect] def close(): Unit = {
-    logInfo(s"Closing session with userId: $userId and sessionId: $sessionId")
+  private[connect] def close(): Unit = synchronized {
+    if (!closedTime.isDefined) {
+      logInfo(s"Closing session with userId: $userId and sessionId: $sessionId")
 
-    // After isClosing=true, SessionHolder.addExecuteHolder() will not allow new executions for
-    // this session. Because both SessionHolder.addExecuteHolder() and
-    // SparkConnectExecutionManager.removeAllExecutionsForSession() are executed under
-    // executionsLock, this guarantees that removeAllExecutionsForSession triggered below will
-    // remove all executions and no new executions will be added in the meanwhile.
-    isClosing = true
+      // After closedTime is defined, SessionHolder.addExecuteHolder() will not allow new executions
+      // for this session. Because both SessionHolder.addExecuteHolder() and
+      // SparkConnectExecutionManager.removeAllExecutionsForSession() are executed under
+      // executionsLock, this guarantees that removeAllExecutionsForSession triggered below will
+      // remove all executions and no new executions will be added in the meanwhile.
+      closedTime = Some(System.currentTimeMillis())
 
-    // Note on the below notes about concurrency:
-    // While closing the session can potentially race with operations started on the session, the
-    // intended use is that the client session will get closed when it's really not used anymore,
-    // or that it expires due to inactivity, in which case there should be no races.
+      // Note on the below notes about concurrency:
+      // While closing the session can potentially race with operations started on the session, the
+      // intended use is that the client session will get closed when it's really not used anymore,
+      // or that it expires due to inactivity, in which case there should be no races.
 
-    // Clean up all artifacts.
-    // Note: there can be concurrent AddArtifact calls still adding something.
-    artifactManager.cleanUpResources()
+      // Clean up all artifacts.
+      // Note: there can be concurrent AddArtifact calls still adding something.
+      artifactManager.cleanUpResources()
 
-    // Clean up running streaming queries.
-    // Note: there can be concurrent streaming queries being started.
-    SparkConnectService.streamingSessionManager.cleanupRunningQueries(this)
-    streamingForeachBatchRunnerCleanerCache.cleanUpAll() // Clean up any streaming workers.
-    removeAllListeners() // removes all listener and stop python listener processes if necessary.
+      // Clean up running streaming queries.
+      // Note: there can be concurrent streaming queries being started.
+      SparkConnectService.streamingSessionManager.cleanupRunningQueries(this)
+      streamingForeachBatchRunnerCleanerCache.cleanUpAll() // Clean up any streaming workers.
+      removeAllListeners() // removes all listener and stop python listener processes if necessary.
 
-    // Clean up all executions
-    // It is guaranteed at this point that no new addExecuteHolder are getting started.
-    SparkConnectService.executionManager.removeAllExecutionsForSession(this.key)
+      // Clean up all executions
+      // It is guaranteed at this point that no new addExecuteHolder are getting started.
+      SparkConnectService.executionManager.removeAllExecutionsForSession(this.key)
 
-    eventManager.postClosed()
+      eventManager.postClosed()
+    }
   }
 
   /**
@@ -251,7 +271,14 @@ case class SessionHolder(userId: String, sessionId: String, session: SparkSessio
 
   /** Get SessionInfo with information about this SessionHolder. */
   def getSessionHolderInfo: SessionHolderInfo =
-    SessionHolderInfo(userId, sessionId, eventManager.status, lastRpcAccessTime)
+    SessionHolderInfo(
+      userId = userId,
+      sessionId = sessionId,
+      status = eventManager.status,
+      startTime = startTime,
+      lastAccessTime = lastAccessTime,
+      expirationTime = expirationTime,
+      closedTime = closedTime)
 
   /**
    * Caches given DataFrame with the ID. The cache does not expire. The entry needs to be
@@ -350,4 +377,7 @@ case class SessionHolderInfo(
     userId: String,
     sessionId: String,
     status: SessionStatus,
-    lastRpcAccesTime: Option[Long])
+    startTime: Long,
+    lastAccessTime: Long,
+    expirationTime: Option[Long],
+    closedTime: Option[Long])

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectExecutionManager.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectExecutionManager.scala
@@ -100,6 +100,8 @@ private[connect] class SparkConnectExecutionManager() extends Logging {
     executionsLock.synchronized {
       executeHolder = executions.remove(key)
       executeHolder.foreach { e =>
+        // Put into abandonedTombstones under lock, so that if it's accessed it will end up
+        // with INVALID_HANDLE.OPERATION_ABANDONED error.
         if (abandoned) {
           abandonedTombstones.put(key, e.getExecuteInfo)
         }
@@ -111,7 +113,11 @@ private[connect] class SparkConnectExecutionManager() extends Logging {
       logInfo(s"ExecuteHolder $key is removed.")
     }
     // close the execution outside the lock
-    executeHolder.foreach(_.close())
+    executeHolder.foreach { e =>
+      e.close()
+      // Update in abandonedTombstones: above it wasn't yet updated with closedTime etc.
+      abandonedTombstones.put(key, e.getExecuteInfo)
+    }
   }
 
   private[connect] def getExecuteHolder(key: ExecuteKey): Option[ExecuteHolder] = {

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectExtendSessionHandler.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectExtendSessionHandler.scala
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connect.service
+
+import com.google.protobuf.util.Timestamps
+import io.grpc.stub.StreamObserver
+
+import org.apache.spark.connect.proto
+import org.apache.spark.internal.Logging
+
+class SparkConnectExtendSessionHandler(
+    responseObserver: StreamObserver[proto.ExtendSessionResponse])
+    extends Logging {
+
+  def handle(v: proto.ExtendSessionRequest): Unit = {
+    // Get (or create) the session and extend it.
+    val sessionHolder = SparkConnectService.sessionManager
+      .getOrCreateIsolatedSession(SessionKey(v.getUserContext.getUserId, v.getSessionId))
+    val expirationTime = sessionHolder.extendSession()
+
+    val response = proto.ExtendSessionResponse
+      .newBuilder()
+      .setSessionId(v.getSessionId)
+      .setServerSideSessionId(sessionHolder.serverSessionId)
+      .setExpirationTime(Timestamps.fromMillis(expirationTime))
+      .build()
+
+    responseObserver.onNext(response)
+    responseObserver.onCompleted()
+  }
+}

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
@@ -213,6 +213,22 @@ class SparkConnectService(debug: Boolean) extends AsyncService with BindableServ
         sessionId = request.getSessionId)
   }
 
+  /**
+   * Extend session.
+   */
+  override def extendSession(
+      request: proto.ExtendSessionRequest,
+      responseObserver: StreamObserver[proto.ExtendSessionResponse]): Unit = {
+    try {
+      new SparkConnectExtendSessionHandler(responseObserver).handle(request)
+    } catch
+      ErrorUtils.handleError(
+        "extendSession",
+        observer = responseObserver,
+        userId = request.getUserContext.getUserId,
+        sessionId = request.getSessionId)
+  }
+
   override def fetchErrorDetails(
       request: proto.FetchErrorDetailsRequest,
       responseObserver: StreamObserver[proto.FetchErrorDetailsResponse]): Unit = {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Recently, `ReleaseSession` RPC was added for the clients to be able to stop the session, and release resources on the server. However, if the client dies without sending it, the session will still linger on the server for 1 hour. In this PR, an `ExtendSession` RPC is added. Active client using it will actively send `ExtendSession` "ping" requests from a background thread. A server receiving those pings can be more aggressive in timing out the session once they stop. If a client does not send `ExtendSession`, the old behavior is preserved by the server.

TODO details.

### Why are the changes needed?

Better control of session lifecycle.

### Does this PR introduce _any_ user-facing change?

Changes the internal controls of keeping the Spark Connect session alive. The default should be close to what it was previously.

### How was this patch tested?

WIP

### Was this patch authored or co-authored using generative AI tooling?

Github Copilot was assisting in some boilerplate auto-completion.

Generated-by: Github Copilot