### PR TITLE
[SPARK-46012][CORE] EventLogFileReader should not read rolling logs if app status file is missing

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/EventLogFileReaders.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/EventLogFileReaders.scala
@@ -119,7 +119,8 @@ object EventLogFileReader extends Logging {
     if (isSingleEventLog(status)) {
       Some(new SingleFileEventLogFileReader(fs, status.getPath, Option(status)))
     } else if (isRollingEventLogs(status)) {
-      if (fs.listStatus(status.getPath).exists(RollingEventLogFilesWriter.isEventLogFile)) {
+      if (fs.listStatus(status.getPath).exists(RollingEventLogFilesWriter.isEventLogFile) &&
+          fs.listStatus(status.getPath).exists(RollingEventLogFilesWriter.isAppStatusFile)) {
         Some(new RollingEventLogFilesFileReader(fs, status.getPath))
       } else {
         logDebug(s"Rolling event log directory have no event log file at ${status.getPath}")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to prevent `EventLogFileReader` from reading rolling event logs if `appStatus` is missing.

### Why are the changes needed?

Since Apache Spark 3.0.0, `appstatus_` is supposed to exist.

https://github.com/apache/spark/blob/839f0c98bd85a14eadad13f8aaac876275ded5a4/core/src/main/scala/org/apache/spark/deploy/history/EventLogFileWriters.scala#L277-L283
### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.