### PR TITLE
[SPARK-46014][SQL][TESTS] Run `RocksDBStateStoreStreamingAggregationSuite` on a dedicated JVM

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -541,6 +541,7 @@ object SparkParallelTestGrouping {
     "org.apache.spark.sql.hive.thriftserver.ui.ThriftServerPageSuite",
     "org.apache.spark.sql.hive.thriftserver.ui.HiveThriftServer2ListenerSuite",
     "org.apache.spark.sql.kafka010.KafkaDelegationTokenSuite",
+    "org.apache.spark.sql.streaming.RocksDBStateStoreStreamingAggregationSuite",
     "org.apache.spark.shuffle.KubernetesLocalDiskShuffleDataIOSuite",
     "org.apache.spark.sql.hive.HiveScalaReflectionSuite"
   )


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to run `RocksDBStateStoreStreamingAggregationSuite` on a dedicated JVM to reduce the flakiness.

### Why are the changes needed?

`RocksDBStateStoreStreamingAggregationSuite` is flaky.
- https://github.com/apache/spark/actions/runs/6936862847/job/18869845206
- https://github.com/apache/spark/actions/runs/6926542106/job/18838877151
- https://github.com/apache/spark/actions/runs/6924927427/job/18834849433

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.