### PR TITLE
[SPARK-46013][PYTHON][SQL][DOCS] Improve data source load and save functions docs page

### DIFF
--- a/docs/sql-data-sources-load-save-functions.md
+++ b/docs/sql-data-sources-load-save-functions.md
@@ -209,6 +209,12 @@ file directly with SQL.
 {% include_example direct_sql r/RSparkSQLExample.R %}
 </div>
 
+<div data-lang="SQL"  markdown="1">
+{% highlight sql %}
+SELECT * FROM parquet.`examples/src/main/resources/users.parquet`
+{% endhighlight %}
+</div>
+
 </div>
 
 ### Save Modes
@@ -301,12 +307,10 @@ Bucketing and sorting are applicable only to persistent tables:
 <div data-lang="SQL"  markdown="1">
 {% highlight sql %}
 
-CREATE TABLE users_bucketed_by_name(
-  name STRING,
-  favorite_color STRING,
-  favorite_numbers array<integer>
-) USING parquet
-CLUSTERED BY(name) INTO 42 BUCKETS;
+CREATE TABLE people_bucketed
+USING json
+CLUSTERED BY(name) INTO 42 BUCKETS
+AS SELECT * FROM json.`examples/src/main/resources/people.json`;
 
 {% endhighlight %}
 </div>
@@ -334,11 +338,10 @@ while partitioning can be used with both `save` and `saveAsTable` when using the
 <div data-lang="SQL"  markdown="1">
 {% highlight sql %}
 
-CREATE TABLE users_by_favorite_color(
-  name STRING,
-  favorite_color STRING,
-  favorite_numbers array<integer>
-) USING csv PARTITIONED BY(favorite_color);
+CREATE TABLE users_by_favorite_color
+USING parquet
+PARTITIONED BY(favorite_color)
+AS SELECT * FROM parquet.`examples/src/main/resources/users.parquet`;
 
 {% endhighlight %}
 </div>
@@ -364,13 +367,11 @@ It is possible to use both partitioning and bucketing for a single table:
 <div data-lang="SQL"  markdown="1">
 {% highlight sql %}
 
-CREATE TABLE users_bucketed_and_partitioned(
-  name STRING,
-  favorite_color STRING,
-  favorite_numbers array<integer>
-) USING parquet
+CREATE TABLE users_partitioned_bucketed
+USING parquet
 PARTITIONED BY (favorite_color)
-CLUSTERED BY(name) SORTED BY (favorite_numbers) INTO 42 BUCKETS;
+CLUSTERED BY(name) SORTED BY (favorite_numbers) INTO 42 BUCKETS
+AS SELECT * FROM parquet.`examples/src/main/resources/users.parquet`;
 
 {% endhighlight %}
 </div>

--- a/examples/src/main/python/sql/datasource.py
+++ b/examples/src/main/python/sql/datasource.py
@@ -103,36 +103,41 @@ def generic_file_source_options_example(spark: SparkSession) -> None:
 
 def basic_datasource_example(spark: SparkSession) -> None:
     # $example on:generic_load_save_functions$
-    df = spark.read.load("examples/src/main/resources/users.parquet")
-    df.select("name", "favorite_color").write.save("namesAndFavColors.parquet")
+    users_df = spark.read.load("examples/src/main/resources/users.parquet")
+    users_df.select("name", "favorite_color").write.save("namesAndFavColors.parquet")
     # $example off:generic_load_save_functions$
 
     # $example on:write_partitioning$
-    df.write.partitionBy("favorite_color").format("parquet").save("namesPartByColor.parquet")
+    users_df = spark.read.load("examples/src/main/resources/users.parquet")
+    users_df.write.partitionBy("favorite_color").format("parquet").save("namesPartByColor.parquet")
     # $example off:write_partitioning$
 
     # $example on:write_partition_and_bucket$
-    df = spark.read.parquet("examples/src/main/resources/users.parquet")
-    (df
-        .write
+    users_df = spark.read.parquet("examples/src/main/resources/users.parquet")
+    (users_df.write
         .partitionBy("favorite_color")
         .bucketBy(42, "name")
         .saveAsTable("users_partitioned_bucketed"))
     # $example off:write_partition_and_bucket$
 
     # $example on:manual_load_options$
-    df = spark.read.load("examples/src/main/resources/people.json", format="json")
-    df.select("name", "age").write.save("namesAndAges.parquet", format="parquet")
+    people_df = spark.read.load("examples/src/main/resources/people.json", format="json")
+    people_df.select("name", "age").write.save("namesAndAges.parquet", format="parquet")
     # $example off:manual_load_options$
 
     # $example on:manual_load_options_csv$
-    df = spark.read.load("examples/src/main/resources/people.csv",
-                         format="csv", sep=";", inferSchema="true", header="true")
+    people_df = spark.read.load(
+        "examples/src/main/resources/people.csv",
+        format="csv",
+        sep=";",
+        inferSchema="true",
+        header="true"
+    )
     # $example off:manual_load_options_csv$
 
     # $example on:manual_save_options_orc$
-    df = spark.read.orc("examples/src/main/resources/users.orc")
-    (df.write.format("orc")
+    users_df = spark.read.orc("examples/src/main/resources/users.orc")
+    (users_df.write.format("orc")
         .option("orc.bloom.filter.columns", "favorite_color")
         .option("orc.dictionary.key.threshold", "1.0")
         .option("orc.column.encoding.direct", "name")
@@ -140,8 +145,8 @@ def basic_datasource_example(spark: SparkSession) -> None:
     # $example off:manual_save_options_orc$
 
     # $example on:manual_save_options_parquet$
-    df = spark.read.parquet("examples/src/main/resources/users.parquet")
-    (df.write.format("parquet")
+    users_df = spark.read.parquet("examples/src/main/resources/users.parquet")
+    (users_df.write.format("parquet")
         .option("parquet.bloom.filter.enabled#favorite_color", "true")
         .option("parquet.bloom.filter.expected.ndv#favorite_color", "1000000")
         .option("parquet.enable.dictionary", "true")
@@ -150,7 +155,8 @@ def basic_datasource_example(spark: SparkSession) -> None:
     # $example off:manual_save_options_parquet$
 
     # $example on:write_sorting_and_bucketing$
-    df.write.bucketBy(42, "name").sortBy("age").saveAsTable("people_bucketed")
+    people_df = spark.read.json("examples/src/main/resources/people.json")
+    people_df.write.bucketBy(42, "name").sortBy("age").saveAsTable("people_bucketed")
     # $example off:write_sorting_and_bucketing$
 
     # $example on:direct_sql$


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR improves the Python and SQL examples on this page https://spark.apache.org/docs/latest/sql-data-sources-load-save-functions.html (basic_datasource_examples.py).

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Currently, this Python example will fail with this error: `AnalysisException: [COLUMN_NOT_DEFINED_IN_TABLE] sort column age is not defined in table ...`

<img width="902" alt="Screenshot 2023-11-20 at 16 21 27" src="https://github.com/apache/spark/assets/66282705/ddfe5409-f9a6-4075-9181-7f0c6195615a">


Also, the SQL examples are inconsistent with the Python/Scala/Java ones. For example, this table should be created using the JSON/CSV data source, instead of parquet. And the table names in SQL examples are also inconsistent.
<img width="911" alt="Screenshot 2023-11-20 at 16 21 44" src="https://github.com/apache/spark/assets/66282705/43669934-1991-43b2-922e-86cf275dffb4">


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Manually run `basic_datasource_example` 

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No