### PR TITLE
[SPARK-46022][SPARK-46017][DOCS][PYTHON] Remove deprecated function APIs from documents

### DIFF
--- a/python/docs/source/reference/pyspark.sql/functions.rst
+++ b/python/docs/source/reference/pyspark.sql/functions.rst
@@ -496,6 +496,18 @@ Generator Functions
     stack
 
 
+Partition Transformation Functions
+----------------------------------
+.. autosummary::
+    :toctree: api/
+
+    partitioning.years
+    partitioning.months
+    partitioning.days
+    partitioning.hours
+    partitioning.bucket
+
+
 CSV Functions
 -------------
 .. autosummary::

--- a/python/docs/source/reference/pyspark.sql/functions.rst
+++ b/python/docs/source/reference/pyspark.sql/functions.rst
@@ -140,8 +140,6 @@ Mathematical Functions
     sqrt
     tan
     tanh
-    toDegrees
-    toRadians
     try_add
     try_divide
     try_multiply
@@ -225,14 +223,10 @@ Bitwise Functions
 
     bit_count
     bit_get
-    bitwiseNOT
     bitwise_not
     getbit
-    shiftLeft
     shiftleft
-    shiftRight
     shiftright
-    shiftRightUnsigned
     shiftrightunsigned
 
 
@@ -407,7 +401,6 @@ Aggregate Functions
     :toctree: api/
 
     any_value
-    approxCountDistinct
     approx_count_distinct
     approx_percentile
     array_agg
@@ -465,7 +458,6 @@ Aggregate Functions
     stddev_pop
     stddev_samp
     sum
-    sumDistinct
     sum_distinct
     try_avg
     try_sum
@@ -502,18 +494,6 @@ Generator Functions
     posexplode
     posexplode_outer
     stack
-
-
-Partition Transformation Functions
-----------------------------------
-.. autosummary::
-    :toctree: api/
-
-    partitioning.years
-    partitioning.months
-    partitioning.days
-    partitioning.hours
-    partitioning.bucket
 
 
 CSV Functions


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to remove deprecated functions API from documents.

This PR also fixes SPARK-46017 that was the known issue on Mac OS when building the PySpark docs below:
```
$ make clean html
...
reference/pyspark.ss/api/pyspark.sql.streaming.StreamingQueryManager.removeListereading sources... [ 98%] reference/pyspark.ss/api/pyspark.sql.streaming.StreamingQueryManager.resetTerminreading sources... [100%] user_guide/sql/type_conversions
...
Warning, treated as error:
/.../spark/python/docs/source/reference/pyspark.sql/functions.rst.rst:223:autosummary: stub file not found 'pyspark.sql.functions.shiftleft'. Check your autosummary_generate setting.
make: *** [html] Error 2
```
### Why are the changes needed?

To do not encourage using deprecated APIs by hiding them from API reference docs.


### Does this PR introduce _any_ user-facing change?

No, it's documentation update.


### How was this patch tested?

Manually built docs on Mac OS:

<img width="752" alt="Screenshot 2023-11-21 at 6 55 25 PM" src="https://github.com/apache/spark/assets/44108233/f97881e3-aaff-4062-bfa8-25c910b8e402">

The existing CI should pass.


### Was this patch authored or co-authored using generative AI tooling?

No.
