### PR TITLE
[SPARK-46033][SQL][TESTS] Fix flaky ArithmeticExpressionSuite

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ArithmeticExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ArithmeticExpressionSuite.scala
@@ -326,7 +326,8 @@ class ArithmeticExpressionSuite extends SparkFunSuite with ExpressionEvalHelper 
           val quotResult = Decimal(quotExact.setScale(quotType.scale, RoundingMode.HALF_UP))
           val quotExpected =
             if (quotResult.precision > DecimalType.MAX_PRECISION) null else quotResult
-          checkEvaluationOrException(quotActual, quotExpected.toLong)
+          checkEvaluationOrException(quotActual,
+            if (quotExpected == null) null else quotExpected.toLong)
         }
       }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to fix flaky ArithmeticExpressionSuite.
https://github.com/panbingkun/spark/actions/runs/6940660146/job/18879997046
<img width="1000" alt="image" src="https://github.com/apache/spark/assets/15246973/9fe6050a-7a06-4110-9152-d4512a49b284">


### Why are the changes needed?
Fix bug.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
- Manually test.
- Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
