### PR TITLE
[SPARK-46034][CORE] SparkContext add file should also copy file to local root path

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -1836,7 +1836,7 @@ class SparkContext(config: SparkConf) extends Logging {
       val uriToUse = if (!isLocal && scheme == "file") uri else new URI(key)
       val uriToDownload = UriBuilder.fromUri(uriToUse).fragment(null).build()
       val source = Utils.fetchFile(uriToDownload.toString, Utils.createTempDir(), conf,
-        hadoopConfiguration, timestamp, useCache = true, shouldUntar = false)
+        hadoopConfiguration, timestamp, useCache = false, shouldUntar = false)
       val dest = new File(
         root,
         if (uri.getFragment != null) uri.getFragment else source.getName)

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -1822,7 +1822,7 @@ class SparkContext(config: SparkConf) extends Logging {
       logInfo(s"Added file $path at $key with timestamp $timestamp")
       // Fetch the file locally so that closures which are run on the driver can still use the
       // SparkFiles API to access files.
-      Utils.fetchFile(uri.toString, root, conf, hadoopConfiguration, timestamp, useCache = false)
+      Utils.fetchFile(uri.toString, root, conf, hadoopConfiguration, timestamp, useCache = true)
       postEnvironmentUpdate()
     } else if (
       isArchive &&
@@ -1836,7 +1836,7 @@ class SparkContext(config: SparkConf) extends Logging {
       val uriToUse = if (!isLocal && scheme == "file") uri else new URI(key)
       val uriToDownload = UriBuilder.fromUri(uriToUse).fragment(null).build()
       val source = Utils.fetchFile(uriToDownload.toString, Utils.createTempDir(), conf,
-        hadoopConfiguration, timestamp, useCache = false, shouldUntar = false)
+        hadoopConfiguration, timestamp, useCache = true, shouldUntar = false)
       val dest = new File(
         root,
         if (uri.getFragment != null) uri.getFragment else source.getName)


### PR DESCRIPTION
### What changes were proposed in this pull request?
For below case
```
add jar hdfs://path/search_hadoop_udf-1.0.0-SNAPSHOT.jar;
add file hdfs://path/feature_map.txt;

CREATE or replace TEMPORARY FUNCTION si_to_fn AS "come.xx.xx.SlotIdToFeatName";

select si_to_fn(k, './feature_map.txt') as feat_name
from (    
  select 'slot_8116' as k  
) A; 
```

Exception when optimizing the plan to calculate the constant value on the driver side
```
java.io.FileNotFoundException: feature_map.txt (No such file or directory)
	at java.io.FileInputStream.open0(Native Method)
	at java.io.FileInputStream.open(FileInputStream.java:195)
	at java.io.FileInputStream.<init>(FileInputStream.java:138)
	at java.util.Scanner.<init>(Scanner.java:611)
	at com.shopee.deep.data_mart.udf.SlotIdToFeatName.udf(SlotIdToFeatName.java:62)
	at com.shopee.deep.data_mart.udf.SlotIdToFeatName.evaluate(SlotIdToFeatName.java:36)
	at org.apache.hadoop.hive.ql.udf.generic.GenericUDF.initializeAndFoldConstants(GenericUDF.java:170)
	at org.apache.spark.sql.hive.HiveGenericUDF.returnInspector$lzycompute(hiveUDFs.scala:154)
	at org.apache.spark.sql.hive.HiveGenericUDF.returnInspector(hiveUDFs.scala:153)
	at org.apache.spark.sql.hive.HiveGenericUDF.foldable(hiveUDFs.scala:144)
	at org.apache.spark.sql.catalyst.optimizer.FoldablePropagation$$anonfun$collectFoldables$1.applyOrElse(expressions.scala:908)
	at org.apache.spark.sql.catalyst.optimizer.FoldablePropagation$$anonfun$collectFoldables$1.applyOrElse(expressions.scala:907)
	at scala.collection.immutable.List.collect(List.scala:315)
	at org.apache.spark.sql.catalyst.optimizer.FoldablePropagation$.collectFoldables(expressions.scala:907)
	at org.apache.spark.sql.catalyst.optimizer.FoldablePropagation$.propagateFoldables(expressions.scala:830)
	at org.apache.spark.sql.catalyst.optimizer.FoldablePropagation$.$anonfun$propagateFoldables$6(expressions.scala:891)
	at scala.collection.TraversableLike.$anonfun$map$1(TraversableLike.scala:286)
	at scala.collection.Iterator.foreach(Iterator.scala:943)
	at scala.collection.Iterator.foreach$(Iterator.scala:943)
	at scala.collection.AbstractIterator.foreach(Iterator.scala:1431)
	at scala.collection.IterableLike.foreach(IterableLike.scala:74)
	at scala.collection.IterableLike.foreach$(IterableLike.scala:73)
	at scala.collection.AbstractIterable.foreach(Iterable.scala:56)
	at scala.collection.TraversableLike.map(TraversableLike.scala:286)
	at scala.collection.TraversableLike.map$(TraversableLike.scala:279)
	at scala.collection.AbstractTraversable.map(Traversable.scala:108)
	at org.apache.spark.sql.catalyst.trees.TreeNode.mapChildren(TreeNode.scala:595)
	at org.apache.spark.sql.catalyst.optimizer.FoldablePropagation$.propagateFoldables(expressions.scala:891)
	at org.apache.spark.sql.catalyst.optimizer.FoldablePropagation$.apply(expressions.scala:821)
	at org.apache.spark.sql.catalyst.optimizer.FoldablePropagation$.apply(expressions.scala:819)
	at org.apache.spark.sql.catalyst.rules.RuleExecutor.$anonfun$execute$2(RuleExecutor.scala:211)
```

The reason is when we call `ADD FILE` then call `SparkContext.addFile()`
Then driver will add the file and download it to  driver's  `driverTempDir`
<img width="824" alt="截屏2023-11-27 下午5 41 03" src="https://github.com/apache/spark/assets/46485123/8b9a8ca0-5c9f-48d8-bce4-2e9fe22a4181">
<img width="559" alt="截屏2023-11-27 下午5 41 08" src="https://github.com/apache/spark/assets/46485123/d5181f5a-1333-429f-a0b7-c9df35324d21">
<img width="1020" alt="截屏2023-11-27 下午5 41 18" src="https://github.com/apache/spark/assets/46485123/1f46c458-c1be-4a86-899f-cab2f5de5dd7">

In our case the `driverTenpDir` is 
```
/mnt/ssd/0/yarn/nm-local-dir/usercache/typhoon.bo/appcache/application_1698132018785_8173703/spark-21bedef6-1c5e-464e-9cb0-bb6903b3d84c/userFiles-a4929fdb-b634-4829-a7e3-00d82b0d521b/
```

but when executing the UDF in the driver side,  it uses the container's root path
```
/mnt/ssd/2/yarn/nm-local-dir/usercache/user/appcache/application_1698132018785_8173703/container_e59_1698132018785_8173703_01_000002/
```

Then the error happened.

In this pr,  support also download file to driver container executing root path when yarn-cluster mode.


### Why are the changes needed?
Fix bug


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
MT


### Was this patch authored or co-authored using generative AI tooling?
No
