### PR TITLE
[SPARK-46037][SQL] When Left Join build Left and codegen is turned off, ShuffledHashJoinExec may result in incorrect results

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashJoin.scala
@@ -138,9 +138,8 @@ trait HashJoin extends JoinCodegenSupport {
     UnsafeProjection.create(streamedBoundKeys)
 
   @transient protected[this] lazy val boundCondition = if (condition.isDefined) {
-    if (joinType == FullOuter && buildSide == BuildLeft) {
-      // Put join left side before right side. This is to be consistent with
-      // `ShuffledHashJoinExec.fullOuterJoin`.
+    if ((joinType == FullOuter || joinType == LeftOuter) && buildSide == BuildLeft) {
+      // Put join left side before right side. This is to be consistent with ShuffledHashJoinExec.
       Predicate.create(condition.get, buildPlan.output ++ streamedPlan.output).eval _
     } else {
       Predicate.create(condition.get, streamedPlan.output ++ buildPlan.output).eval _


### PR DESCRIPTION
### What changes were proposed in this pull request?

When Left Join build Left and codegen is turned off, ShuffledHashJoinExec may have incorrect results.

The cause of the problem is: the left side (buildPlan) of LeftJoinBuildLeft is placed in the first half of joinRow

### Why are the changes needed?
Make the query results correct.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
unit test.


### Was this patch authored or co-authored using generative AI tooling?
No.
