### PR TITLE
[SPARK-46038][BUILD] Upgrade log4j2 to 2.22.0

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -175,10 +175,10 @@ lapack/3.0.3//lapack-3.0.3.jar
 leveldbjni-all/1.8//leveldbjni-all-1.8.jar
 libfb303/0.9.3//libfb303-0.9.3.jar
 libthrift/0.12.0//libthrift-0.12.0.jar
-log4j-1.2-api/2.21.0//log4j-1.2-api-2.21.0.jar
-log4j-api/2.21.0//log4j-api-2.21.0.jar
-log4j-core/2.21.0//log4j-core-2.21.0.jar
-log4j-slf4j2-impl/2.21.0//log4j-slf4j2-impl-2.21.0.jar
+log4j-1.2-api/2.22.0//log4j-1.2-api-2.22.0.jar
+log4j-api/2.22.0//log4j-api-2.22.0.jar
+log4j-core/2.22.0//log4j-core-2.22.0.jar
+log4j-slf4j2-impl/2.22.0//log4j-slf4j2-impl-2.22.0.jar
 logging-interceptor/3.12.12//logging-interceptor-3.12.12.jar
 lz4-java/1.8.0//lz4-java-1.8.0.jar
 metrics-core/4.2.21//metrics-core-4.2.21.jar

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
     <sbt.project.name>spark</sbt.project.name>
     <asm.version>9.6</asm.version>
     <slf4j.version>2.0.9</slf4j.version>
-    <log4j.version>2.21.0</log4j.version>
+    <log4j.version>2.22.0</log4j.version>
     <!-- make sure to update IsolatedClientLoader whenever this version is changed -->
     <hadoop.version>3.3.6</hadoop.version>
     <!-- SPARK-41247: When updating `protobuf.version`, also need to update `protoVersion` in `SparkBuild.scala` -->


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade log4j2 from 2.21.0 to 2.22.0.


### Why are the changes needed?
This is the first log4j2 version that provides a CycloneDX Software Bill of Materials (SBOM) and the new version bring some new change and fix like:
- Change the order of evaluation of FormattedMessage formatters. Messages are evaluated using java.util.Format only if they don't comply to the java.text.MessageFormat or ParameterizedMessage format. (https://github.com/apache/logging-log4j2/issues/1223)
- Change default encoding of HTTP Basic Authentication to UTF-8 and add log4j2.configurationAuthorizationEncoding property to overwrite it. (https://github.com/apache/logging-log4j2/pull/1970)
- Removed unused FastDateParser which was causing unnecessary heap overhead ([LOG4J2-3672](https://issues.apache.org/jira/browse/LOG4J2-3672), https://github.com/apache/logging-log4j2/pull/1848)
- Fix MDC pattern converter causing issues for %notEmpty (https://github.com/apache/logging-log4j2/issues/1922)
- Fix NotSerializableException thrown when Logger is serialized with a ReusableMessageFactory (https://github.com/apache/logging-log4j2/issues/1884)

the full release note as follows:
-https://github.com/apache/logging-log4j2/releases/tag/rel%2F2.22.0

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No
