### PR TITLE
[SPARK-46012][CORE][FOLLOWUP] Invoke `fs.listStatus` once and reuse the result

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/EventLogFileReaders.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/EventLogFileReaders.scala
@@ -119,8 +119,9 @@ object EventLogFileReader extends Logging {
     if (isSingleEventLog(status)) {
       Some(new SingleFileEventLogFileReader(fs, status.getPath, Option(status)))
     } else if (isRollingEventLogs(status)) {
-      if (fs.listStatus(status.getPath).exists(RollingEventLogFilesWriter.isEventLogFile) &&
-          fs.listStatus(status.getPath).exists(RollingEventLogFilesWriter.isAppStatusFile)) {
+      val files = fs.listStatus(status.getPath)
+      if (files.exists(RollingEventLogFilesWriter.isEventLogFile) &&
+          files.exists(RollingEventLogFilesWriter.isAppStatusFile)) {
         Some(new RollingEventLogFilesFileReader(fs, status.getPath))
       } else {
         logDebug(s"Rolling event log directory have no event log file at ${status.getPath}")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a follow-up of #43914 and aims to invoke `fs.listStatus` once and reuse the result.

### Why are the changes needed?

This will prevent the increase of the number of `listStatus` invocation .

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs with the existing test case.

### Was this patch authored or co-authored using generative AI tooling?

No.