### PR TITLE
[SPARK-45649][SQL] Unify the prepare framework for OffsetWindowFunctionFrame

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWindowFramesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWindowFramesSuite.scala
@@ -65,6 +65,18 @@ class DataFrameWindowFramesSuite extends QueryTest with SharedSparkSession {
       Row(1, "1", null) :: Row(1, null, "3") :: Row(2, "2", null) :: Row(2, null, "4") :: Nil)
   }
 
+  test("lead/lag with positive offset that greater than window group size") {
+    val df = Seq((1, "1"), (2, "2"), (1, "3"), (2, "4")).toDF("key", "value")
+    val window = Window.partitionBy($"key").orderBy($"value")
+
+    checkAnswer(
+      df.select(
+        $"key",
+        lead("value", 3).over(window),
+        lag("value", 3).over(window)),
+      Row(1, null, null) :: Row(1, null, null) :: Row(2, null, null) :: Row(2, null, null) :: Nil)
+  }
+
   test("lead/lag with negative offset") {
     val df = Seq((1, "1"), (2, "2"), (1, "3"), (2, "4")).toDF("key", "value")
     val window = Window.partitionBy($"key").orderBy($"value")
@@ -75,6 +87,18 @@ class DataFrameWindowFramesSuite extends QueryTest with SharedSparkSession {
         lead("value", -1).over(window),
         lag("value", -1).over(window)),
       Row(1, null, "3") :: Row(1, "1", null) :: Row(2, null, "4") :: Row(2, "2", null) :: Nil)
+  }
+
+  test("lead/lag with negative offset that absolute value greater than window group size") {
+    val df = Seq((1, "1"), (2, "2"), (1, "3"), (2, "4")).toDF("key", "value")
+    val window = Window.partitionBy($"key").orderBy($"value")
+
+    checkAnswer(
+      df.select(
+        $"key",
+        lead("value", -3).over(window),
+        lag("value", -3).over(window)),
+      Row(1, null, null) :: Row(1, null, null) :: Row(2, null, null) :: Row(2, null, null) :: Nil)
   }
 
   test("reverse lead/lag with negative offset") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently, the implementation of the `prepare` of all the `OffsetWindowFunctionFrame` have the same code logic show below.
```
  override def prepare(rows: ExternalAppendOnlyUnsafeRowArray): Unit = {
    if (offset > rows.length) {
      fillDefaultValue(EmptyRow)
    } else {
      resetStates(rows)
      if (ignoreNulls) {
        ...
      } else {
        ...
      }
    }
  }
```
This PR want unify the prepare framework for `OffsetWindowFunctionFrame`

**Why the https://github.com/apache/spark/pull/43507 introduces the NPE bug?**
For example, there is a window group with the offset 5 and have 4 elements.
First, we don't call the `resetStates` due to the offset is greater than 4.
After that, we iterates the elements of the window group by visit input. But the input is null.

This PR also add two test cases about the absolute value of offset greater than the window group size.

### Why are the changes needed?
Unify the prepare framework for `OffsetWindowFunctionFrame`


### Does this PR introduce _any_ user-facing change?
'No'.
Inner update.


### How was this patch tested?
Exists test cases.


### Was this patch authored or co-authored using generative AI tooling?
'No'.
