### PR TITLE
[SPARK-46042][FOLLOWUP][CONNECT] Test and adapt to streaming RPC behavior change from grpc 1.56 to 1.59

### DIFF
--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/SparkConnectClientSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/SparkConnectClientSuite.scala
@@ -487,6 +487,8 @@ class SparkConnectClientSuite extends ConnectFunSuite with BeforeAndAfterEach {
   }
 
   test("GRPC stub unary call throws error immediately") {
+    // Spark Connect error retry handling depends on the error being returned from the unary
+    // call immediately.
     val channel = SparkConnectClient.Configuration(host = "ABC").createChannel()
     val stub = proto.SparkConnectServiceGrpc.newBlockingStub(channel)
     // The request is invalid, but it shouldn't even reach the server.
@@ -500,6 +502,8 @@ class SparkConnectClientSuite extends ConnectFunSuite with BeforeAndAfterEach {
   }
 
   test("GRPC stub server streaming call throws error on first next() / hasNext()") {
+    // Spark Connect error retry handling depends on the error being returned from the response
+    // iterator and not immediately upon iterator creation.
     val channel = SparkConnectClient.Configuration(host = "ABC").createChannel()
     val stub = proto.SparkConnectServiceGrpc.newBlockingStub(channel)
     // The request is invalid, but it shouldn't even reach the server.
@@ -515,6 +519,8 @@ class SparkConnectClientSuite extends ConnectFunSuite with BeforeAndAfterEach {
   }
 
   test("GRPC stub client streaming call throws error on first client request sent") {
+    // Spark Connect error retry handling depends on the error being returned from the response
+    // iterator and not immediately upon iterator creation or request being sent.
     val channel = SparkConnectClient.Configuration(host = "ABC").createChannel()
     val stub = proto.SparkConnectServiceGrpc.newStub(channel)
 

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/SparkConnectClientSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/SparkConnectClientSuite.scala
@@ -26,6 +26,9 @@ import io.grpc.{CallOptions, Channel, ClientCall, ClientInterceptor, MethodDescr
 import io.grpc.netty.NettyServerBuilder
 import io.grpc.stub.StreamObserver
 import org.scalatest.BeforeAndAfterEach
+import org.scalatest.concurrent.Eventually
+import org.scalatest.concurrent.Futures.timeout
+import org.scalatest.time.SpanSugar._
 
 import org.apache.spark.{SparkException, SparkThrowable}
 import org.apache.spark.connect.proto
@@ -481,6 +484,72 @@ class SparkConnectClientSuite extends ConnectFunSuite with BeforeAndAfterEach {
       ExecutePlanResponseReattachableIterator.fromIterator(iter)
     iter.foreach(_ => ())
     assert(reattachableIter.resultComplete)
+  }
+
+  test("GRPC stub unary call throws error immediately") {
+    val channel = SparkConnectClient.Configuration(host = "ABC").createChannel()
+    val stub = proto.SparkConnectServiceGrpc.newBlockingStub(channel)
+    // The request is invalid, but it shouldn't even reach the server.
+    val request = proto.AnalyzePlanRequest.newBuilder().build()
+
+    // calling unary call immediately throws connection exception
+    val ex = intercept[StatusRuntimeException] {
+      stub.analyzePlan(request)
+    }
+    assert(ex.getMessage.contains("UNAVAILABLE: Unable to resolve host ABC"))
+  }
+
+  test("GRPC stub server streaming call throws error on first next() / hasNext()") {
+    val channel = SparkConnectClient.Configuration(host = "ABC").createChannel()
+    val stub = proto.SparkConnectServiceGrpc.newBlockingStub(channel)
+    // The request is invalid, but it shouldn't even reach the server.
+    val request = proto.ExecutePlanRequest.newBuilder().build()
+
+    // creating the iterator doesn't throw exception
+    val iter = stub.executePlan(request)
+    // error is thrown only when the iterator is open.
+    val ex = intercept[StatusRuntimeException] {
+      iter.hasNext()
+    }
+    assert(ex.getMessage.contains("UNAVAILABLE: Unable to resolve host ABC"))
+  }
+
+  test("GRPC stub client streaming call throws error on first client request sent") {
+    val channel = SparkConnectClient.Configuration(host = "ABC").createChannel()
+    val stub = proto.SparkConnectServiceGrpc.newStub(channel)
+
+    var onNextResponse: Option[proto.AddArtifactsResponse] = None
+    var onErrorThrowable: Option[Throwable] = None
+    var onCompletedCalled: Boolean = false
+
+    val responseObserver = new StreamObserver[proto.AddArtifactsResponse] {
+      override def onNext(value: proto.AddArtifactsResponse): Unit = {
+        onNextResponse = Some(value)
+      }
+
+      override def onError(t: Throwable): Unit = {
+        onErrorThrowable = Some(t)
+      }
+
+      override def onCompleted(): Unit = {
+        onCompletedCalled = false
+      }
+    }
+
+    // calling client streaming call doesn't throw exception
+    val observer = stub.addArtifacts(responseObserver)
+
+    // but exception will get returned on the responseObserver.
+    Eventually.eventually(timeout(30.seconds)) {
+      assert(onNextResponse == None)
+      assert(onErrorThrowable.isDefined)
+      assert(onErrorThrowable.get.getMessage.contains("UNAVAILABLE: Unable to resolve host ABC"))
+      assert(onCompletedCalled == false)
+    }
+
+    // despite that, requests can be sent to the request observer without error being thrown.
+    observer.onNext(proto.AddArtifactsRequest.newBuilder().build())
+    observer.onCompleted()
   }
 }
 

--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectServiceE2ESuite.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectServiceE2ESuite.scala
@@ -33,6 +33,8 @@ class SparkConnectServiceE2ESuite extends SparkConnectServerTest {
   val BIG_ENOUGH_QUERY = "select * from range(1000000)"
 
   test("Execute is sent eagerly to the server upon iterator creation") {
+    // This behavior changed with grpc upgrade from 1.56.0 to 1.59.0.
+    // Testing to be aware of future changes.
     withClient { client =>
       val query = client.execute(buildPlan(BIG_ENOUGH_QUERY))
       // just creating the iterator triggers query to be sent to server.

--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectServiceE2ESuite.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectServiceE2ESuite.scala
@@ -36,7 +36,6 @@ class SparkConnectServiceE2ESuite extends SparkConnectServerTest {
     withClient { client =>
       val query1 = client.execute(buildPlan(BIG_ENOUGH_QUERY))
       val query2 = client.execute(buildPlan(BIG_ENOUGH_QUERY))
-      val query3 = client.execute(buildPlan("select 1"))
       // just creating the iterator is lazy, trigger query1 and query2 to be sent.
       query1.hasNext
       query2.hasNext
@@ -74,13 +73,6 @@ class SparkConnectServiceE2ESuite extends SparkConnectServerTest {
       assert(
         query2Error.getMessage.contains("OPERATION_CANCELED") ||
           query2Error.getMessage.contains("INVALID_HANDLE.OPERATION_ABANDONED"))
-
-      // query3 has not been submitted before, so it should now fail with SESSION_CLOSED
-      // TODO(SPARK-46042) Reenable a `releaseSession` test case in SparkConnectServiceE2ESuite
-      val query3Error = intercept[SparkException] {
-        query3.hasNext
-      }
-      assert(query3Error.getMessage.contains("INVALID_HANDLE.SESSION_CLOSED"))
 
       // No other requests should be allowed in the session, failing with SESSION_CLOSED
       val requestError = intercept[SparkException] {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a followup to https://github.com/apache/spark/pull/43955

In grpc 1.56, when calling a server streaming RPC like `client.execute`, the request would not be send to server until the first interaction with the resulting iterator (next or hasNext). In grpc 1.59, it appears that the request is send to the server immediately. See https://github.com/grpc/grpc-java/issues/10697.

I propose to embrace this new behaviour. I found it weird that calling `client.execute()` before wouldn't send the query to server until the first `hasNext()`. All the public APIs except for `toLocalIterator` consume the result immediately, so this change does not affect user facing behavior, except for the `toLocalIterator` change described below.

### Why are the changes needed?

Test and fix behavior after grpc upgrade.

Tested that reverting grpc to 1.56 makes the requests not be submitted by just calling `client.execute()`:
```
[info] - Execute is sent eagerly to the server upon iterator creation *** FAILED *** (30 seconds, 445 milliseconds)
[info]   The code passed to eventually never returned normally. Attempted 1941 times over 30.009993892 seconds. Last failure message: List() had length 0 instead of expected length 1. (SparkConnectServiceE2ESuite.scala:39)
```

The new tests added in SparkConnectClientSuite test that the error is thrown from the response iterator, and not directly when creating the iterator. GrpcRetryHandler and ExecutePlanResponseReattachableIterator rely on that assumption. Since it holds, they don't need changes.

### Does this PR introduce _any_ user-facing change?

Yes.
Calling `dataset.toLocalIterator` used in Spark Connect used to not send the query to the server until the resulted iterator was attempted to be opened with `hasNext` or `next`. Now, the query will be submitted upon the call to `toLocalIterator`.
Note that the behavior of `toLocalIterator` in Spark Connect was already different from non-Spark Connect. In non-Spark Connect, the query would be executed wholly lazily, submitting every result task as a separate job on demand as the iterator progressed. In Spark Connect, once the query was submitted to the server, the execution was not lazy.

### How was this patch tested?

Added tests and tweaked existing tests.

### Was this patch authored or co-authored using generative AI tooling?

I am using Github Copilot in my IDE. It helps auto-complete some trivial boilerplate code.
Generated-by: Github Copilot