### PR TITLE
[SPARK-46060][BUILD][TESTS] Upgrade `MySQL/MariaDB/PostgreSQL/DB2` test dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1251,25 +1251,25 @@
       <dependency>
         <groupId>com.mysql</groupId>
         <artifactId>mysql-connector-j</artifactId>
-        <version>8.0.33</version>
+        <version>8.2.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.mariadb.jdbc</groupId>
         <artifactId>mariadb-java-client</artifactId>
-        <version>2.7.9</version>
+        <version>2.7.11</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.postgresql</groupId>
         <artifactId>postgresql</artifactId>
-        <version>42.6.0</version>
+        <version>42.7.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>com.ibm.db2</groupId>
         <artifactId>jcc</artifactId>
-        <version>11.5.8.0</version>
+        <version>11.5.9.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade jdbc related test dependencies, include:
- com.mysql:mysql-connector-j from `8.0.33` to `8.2.0`
- org.mariadb.jdbc:mariadb-java-client from `2.7.9` to `2.7.11`
- org.postgresql:postgresql from `42.6.0` to `42.7.0`
- com.ibm.db2:jcc from `11.5.8.0` to `11.5.9.0`

### Why are the changes needed?
- com.mysql:mysql-connector-j from, release notes:
https://dev.mysql.com/doc/relnotes/connector-j/en/news-8-2-0.html
https://dev.mysql.com/doc/relnotes/connector-j/en/news-8-1-0.html

- org.mariadb.jdbc:mariadb-java-client, release notes:
https://mariadb.com/kb/en/mariadb-connector-j-2-7-11-release-notes/
https://mariadb.com/kb/en/mariadb-connector-j-2-7-10-release-notes/

- org.postgresql:postgresql, release notes:
https://jdbc.postgresql.org/changelogs/2023-11-20-42.7.0-release/


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
