### PR TITLE
[MINOR][BUILD] Remove scala-2.13 profile for Scalafmt in lint-scala script

### DIFF
--- a/dev/lint-scala
+++ b/dev/lint-scala
@@ -38,7 +38,7 @@ ERRORS=$(./build/mvn \
 if test ! -z "$ERRORS"; then
   echo -e "The scalafmt check failed on connector/connect at following occurrences:\n\n$ERRORS\n"
   echo "Before submitting your change, please make sure to format your code using the following command:"
-  echo "./build/mvn -Pscala-2.13 scalafmt:format -Dscalafmt.skip=false -Dscalafmt.validateOnly=false -Dscalafmt.changedOnly=false -pl connector/connect/common -pl connector/connect/server -pl connector/connect/client/jvm"
+  echo "./build/mvn scalafmt:format -Dscalafmt.skip=false -Dscalafmt.validateOnly=false -Dscalafmt.changedOnly=false -pl connector/connect/common -pl connector/connect/server -pl connector/connect/client/jvm"
   exit 1
 else
   echo -e "Scalafmt checks passed."


### PR DESCRIPTION
### What changes were proposed in this pull request?
Running:

```
./build/mvn -Pscala-2.13 scalafmt:format -Dscalafmt.skip=false -Dscalafmt.validateOnly=false -Dscalafmt.changedOnly=false -pl connector/connect/common -pl connector/connect/server -pl connector/connect/client/jvm
```

shows a warning:

```
[WARNING] The requested profile "scala-2.13" could not be activated because it does not exist.
```

This PR proposes to remove Scala flag in the output message at `dev/lint-scala` script abotu scalafmt.

### Why are the changes needed?

To remove the warning.

### Does this PR introduce _any_ user-facing change?

No, dev-only.


### How was this patch tested?

Manually tested the generated command:

```bash
./build/mvn scalafmt:format -Dscalafmt.skip=false -Dscalafmt.validateOnly=false -Dscalafmt.changedOnly=false -pl connector/connect/common -pl connector/connect/server -pl connector/connect/client/jvm
```

### Was this patch authored or co-authored using generative AI tooling?

No.
