### PR TITLE
[SPARK-46071][SQL] Optimize CaseWhen toJSON content

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/conditionalExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/conditionalExpressions.scala
@@ -17,6 +17,10 @@
 
 package org.apache.spark.sql.catalyst.expressions
 
+import org.json4s.JField
+import org.json4s.JsonAST.{JArray, JInt, JNothing}
+import org.json4s.JsonDSL.pair2Assoc
+
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.{TypeCheckResult, TypeCoercion}
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult.DataTypeMismatch
@@ -167,6 +171,17 @@ case class CaseWhen(
 
   override protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]): Expression =
     super.legacyWithNewChildren(newChildren)
+
+  override protected def jsonFields: List[JField] = {
+    ("branches" -> JArray(branches.map { case (c, v) =>
+      ("condition" -> JInt(children.indexOf(c))) ~
+        ("value" -> JInt(children.indexOf(v)))
+    }.toList)) ::
+      ("elseValue" -> elseValue
+        .map(children.indexOf)
+        .map(c => JInt(c))
+        .getOrElse(JNothing)) :: Nil
+  }
 
   // both then and else expressions should be considered.
   @transient

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/trees/TreeNodeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/trees/TreeNodeSuite.scala
@@ -1117,4 +1117,70 @@ class TreeNodeSuite extends SparkFunSuite with SQLHelper {
     } yield Add(Add(a_or_b, a_or_b), Add(c_or_d, c_or_d))
     assert(transformed2 == expected2)
   }
+
+  test("SPARK-46071 optimize toJSON for CaseWhen expression") {
+    compareJSON(
+      CaseWhen(Seq((EqualTo(Literal(1), Literal(2)), Literal(3))), Literal(4)).toJSON,
+      compact(
+        render(JArray(List(
+          JObject(
+            "class" -> JString(classOf[CaseWhen].getName),
+            "num-children" -> 3,
+            "branches" -> JArray(List(JObject("condition" -> 0, "value" -> 1))),
+            "elseValue" -> 2),
+          JObject(
+            "class" -> JString(classOf[EqualTo].getName),
+            "num-children" -> 2,
+            "left" -> 0,
+            "right" -> 1),
+          JObject(
+            "class" -> JString(classOf[Literal].getName),
+            "num-children" -> 0,
+            "value" -> "1",
+            "dataType" -> "integer"),
+          JObject(
+            "class" -> JString(classOf[Literal].getName),
+            "num-children" -> 0,
+            "value" -> "2",
+            "dataType" -> "integer"),
+          JObject(
+            "class" -> JString(classOf[Literal].getName),
+            "num-children" -> 0,
+            "value" -> "3",
+            "dataType" -> "integer"),
+          JObject(
+            "class" -> JString(classOf[Literal].getName),
+            "num-children" -> 0,
+            "value" -> "4",
+            "dataType" -> "integer"))))))
+
+    compareJSON(
+      CaseWhen(Seq((EqualTo(Literal(1), Literal(2)), Literal(3)))).toJSON,
+      compact(
+        render(JArray(List(
+          JObject(
+            "class" -> JString(classOf[CaseWhen].getName),
+            "num-children" -> 2,
+            "branches" -> JArray(List(JObject("condition" -> 0, "value" -> 1)))),
+          JObject(
+            "class" -> JString(classOf[EqualTo].getName),
+            "num-children" -> 2,
+            "left" -> 0,
+            "right" -> 1),
+          JObject(
+            "class" -> JString(classOf[Literal].getName),
+            "num-children" -> 0,
+            "value" -> "1",
+            "dataType" -> "integer"),
+          JObject(
+            "class" -> JString(classOf[Literal].getName),
+            "num-children" -> 0,
+            "value" -> "2",
+            "dataType" -> "integer"),
+          JObject(
+            "class" -> JString(classOf[Literal].getName),
+            "num-children" -> 0,
+            "value" -> "3",
+            "dataType" -> "integer"))))))
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Modify the toJSON return format of CaseWhen to avoid child expressions being populated multiple times in JSON.

**Before:**

```json
[
    {
        "class":"org.apache.spark.sql.catalyst.expressions.CaseWhen",
        "num-children":3,
        "branches":[
            {
                "product-class":"scala.Tuple2",
                "_1":[
                    {
                        "class":"org.apache.spark.sql.catalyst.expressions.EqualTo",
                        "num-children":2,
                        "left":0,
                        "right":1
                    },
                    {
                        "class":"org.apache.spark.sql.catalyst.expressions.Literal",
                        "num-children":0,
                        "value":"1",
                        "dataType":"integer"
                    },
                    {
                        "class":"org.apache.spark.sql.catalyst.expressions.Literal",
                        "num-children":0,
                        "value":"2",
                        "dataType":"integer"
                    }
                ],
                "_2":[
                    {
                        "class":"org.apache.spark.sql.catalyst.expressions.Literal",
                        "num-children":0,
                        "value":"3",
                        "dataType":"integer"
                    }
                ]
            }
        ],
        "elseValue":[
            {
                "class":"org.apache.spark.sql.catalyst.expressions.Literal",
                "num-children":0,
                "value":"4",
                "dataType":"integer"
            }
        ]
    },
    {
        "class":"org.apache.spark.sql.catalyst.expressions.EqualTo",
        "num-children":2,
        "left":0,
        "right":1
    },
    {
        "class":"org.apache.spark.sql.catalyst.expressions.Literal",
        "num-children":0,
        "value":"1",
        "dataType":"integer"
    },
    {
        "class":"org.apache.spark.sql.catalyst.expressions.Literal",
        "num-children":0,
        "value":"2",
        "dataType":"integer"
    },
    {
        "class":"org.apache.spark.sql.catalyst.expressions.Literal",
        "num-children":0,
        "value":"3",
        "dataType":"integer"
    },
    {
        "class":"org.apache.spark.sql.catalyst.expressions.Literal",
        "num-children":0,
        "value":"4",
        "dataType":"integer"
    }
]
```

**After:**

```json
[
    {
        "class":"org.apache.spark.sql.catalyst.expressions.CaseWhen",
        "num-children":3,
        "branches":[
            {
                "condition":0,
                "value":1
            }
        ],
        "elseValue":2
    },
    {
        "class":"org.apache.spark.sql.catalyst.expressions.EqualTo",
        "num-children":2,
        "left":0,
        "right":1
    },
    {
        "class":"org.apache.spark.sql.catalyst.expressions.Literal",
        "num-children":0,
        "value":1,
        "dataType":"integer"
    },
    {
        "class":"org.apache.spark.sql.catalyst.expressions.Literal",
        "num-children":0,
        "value":2,
        "dataType":"integer"
    },
    {
        "class":"org.apache.spark.sql.catalyst.expressions.Literal",
        "num-children":0,
        "value":3,
        "dataType":"integer"
    },
    {
        "class":"org.apache.spark.sql.catalyst.expressions.Literal",
        "num-children":0,
        "value":4,
        "dataType":"integer"
    }
]
```
### Why are the changes needed?
When executing the toJSON method on an expression nested in more than one case when, it is easy to cause OOM because the child expression is expanded multiple times.
eg. 
```
CASE 
    WHEN(`cost` <= 250) THEN '(245-250]'
    ELSE CASE 
        WHEN(`cost` <= 255) THEN '(250-255]'
            ELSE CASE 
                WHEN(`cost` <= 260) THEN '(255-260]'
                    ELSE CASE
                        WHEN(`cost` <= 265) THEN '(260-265]'
                        ELSE '----' 
                    END 
                END
            END
        END
    END
```


### Does this PR introduce _any_ user-facing change?
Yes. It changes the return result of CaseWhen's toJSON method.


### How was this patch tested?
Unit test


### Was this patch authored or co-authored using generative AI tooling?
No
