### PR TITLE
[SPARK-46073][SQL] Remove the special resolution of UnresolvedNamespace for certain commands

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveCatalogs.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveCatalogs.scala
@@ -47,21 +47,9 @@ class ResolveCatalogs(val catalogManager: CatalogManager)
         val CatalogAndIdentifier(catalog, identifier) = nameParts
         ResolvedIdentifier(catalog, identifier)
       }
-    case s @ ShowTables(UnresolvedNamespace(Seq()), _, _) =>
-      s.copy(namespace = ResolvedNamespace(currentCatalog,
-        catalogManager.currentNamespace.toImmutableArraySeq))
-    case s @ ShowTablesExtended(UnresolvedNamespace(Seq()), _, _) =>
-      s.copy(namespace = ResolvedNamespace(currentCatalog,
-        catalogManager.currentNamespace.toImmutableArraySeq))
-    case s @ ShowViews(UnresolvedNamespace(Seq()), _, _) =>
-      s.copy(namespace = ResolvedNamespace(currentCatalog,
-        catalogManager.currentNamespace.toImmutableArraySeq))
-    case s @ ShowFunctions(UnresolvedNamespace(Seq()), _, _, _, _) =>
-      s.copy(namespace = ResolvedNamespace(currentCatalog,
-        catalogManager.currentNamespace.toImmutableArraySeq))
-    case a @ AnalyzeTables(UnresolvedNamespace(Seq()), _) =>
-      a.copy(namespace = ResolvedNamespace(currentCatalog,
-        catalogManager.currentNamespace.toImmutableArraySeq))
+
+    case CurrentNamespace =>
+      ResolvedNamespace(currentCatalog, catalogManager.currentNamespace.toImmutableArraySeq)
     case UnresolvedNamespace(Seq()) =>
       ResolvedNamespace(currentCatalog, Seq.empty[String])
     case UnresolvedNamespace(CatalogAndNamespace(catalog, ns)) =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/v2ResolutionPlans.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/v2ResolutionPlans.scala
@@ -40,6 +40,12 @@ import org.apache.spark.util.ArrayImplicits._
 case class UnresolvedNamespace(multipartIdentifier: Seq[String]) extends UnresolvedLeafNode
 
 /**
+ * A variant of [[UnresolvedNamespace]] that should be resolved to [[ResolvedNamespace]]
+ * representing the current namespace of the current catalog.
+ */
+case object CurrentNamespace extends UnresolvedLeafNode
+
+/**
  * Holds the name of a table that has yet to be looked up in a catalog. It will be resolved to
  * [[ResolvedTable]] during analysis.
  */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -4080,7 +4080,7 @@ class AstBuilder extends DataTypeAstBuilder with SQLConfHelper with Logging {
     val ns = if (ctx.identifierReference() != null) {
       withIdentClause(ctx.identifierReference, UnresolvedNamespace(_))
     } else {
-      UnresolvedNamespace(Seq.empty[String])
+      CurrentNamespace
     }
     ShowTables(ns, Option(ctx.pattern).map(x => string(visitStringLit(x))))
   }
@@ -4107,7 +4107,7 @@ class AstBuilder extends DataTypeAstBuilder with SQLConfHelper with Logging {
       val ns = if (ctx.identifierReference() != null) {
         withIdentClause(ctx.identifierReference, UnresolvedNamespace)
       } else {
-        UnresolvedNamespace(Seq.empty[String])
+        CurrentNamespace
       }
       ShowTablesExtended(ns, string(visitStringLit(ctx.pattern)))
     }
@@ -4120,7 +4120,7 @@ class AstBuilder extends DataTypeAstBuilder with SQLConfHelper with Logging {
     val ns = if (ctx.identifierReference() != null) {
       withIdentClause(ctx.identifierReference, UnresolvedNamespace(_))
     } else {
-      UnresolvedNamespace(Seq.empty[String])
+      CurrentNamespace
     }
     ShowViews(ns, Option(ctx.pattern).map(x => string(visitStringLit(x))))
   }
@@ -4585,7 +4585,7 @@ class AstBuilder extends DataTypeAstBuilder with SQLConfHelper with Logging {
     val ns = if (ctx.identifierReference() != null) {
       withIdentClause(ctx.identifierReference, UnresolvedNamespace(_))
     } else {
-      UnresolvedNamespace(Seq.empty[String])
+      CurrentNamespace
     }
     AnalyzeTables(ns, noScan = ctx.identifier != null)
   }
@@ -4985,7 +4985,7 @@ class AstBuilder extends DataTypeAstBuilder with SQLConfHelper with Logging {
     } else if (legacy.isDefined) {
       ShowFunctions(UnresolvedNamespace(legacy.get.dropRight(1)), userScope, systemScope, pattern)
     } else {
-      ShowFunctions(UnresolvedNamespace(Nil), userScope, systemScope, pattern)
+      ShowFunctions(CurrentNamespace, userScope, systemScope, pattern)
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -4983,7 +4983,12 @@ class AstBuilder extends DataTypeAstBuilder with SQLConfHelper with Logging {
         withIdentClause(ctx.ns, UnresolvedNamespace(_)),
         userScope, systemScope, pattern)
     } else if (legacy.isDefined) {
-      ShowFunctions(UnresolvedNamespace(legacy.get.dropRight(1)), userScope, systemScope, pattern)
+      val ns = if (legacy.get.length > 1) {
+        UnresolvedNamespace(legacy.get.dropRight(1))
+      } else {
+        CurrentNamespace
+      }
+      ShowFunctions(ns, userScope, systemScope, pattern)
     } else {
       ShowFunctions(CurrentNamespace, userScope, systemScope, pattern)
     }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
@@ -2172,13 +2172,13 @@ class DDLParserSuite extends AnalysisTest {
   test("show views") {
     comparePlans(
       parsePlan("SHOW VIEWS"),
-      ShowViews(UnresolvedNamespace(Seq.empty[String]), None))
+      ShowViews(CurrentNamespace, None))
     comparePlans(
       parsePlan("SHOW VIEWS '*test*'"),
-      ShowViews(UnresolvedNamespace(Seq.empty[String]), Some("*test*")))
+      ShowViews(CurrentNamespace, Some("*test*")))
     comparePlans(
       parsePlan("SHOW VIEWS LIKE '*test*'"),
-      ShowViews(UnresolvedNamespace(Seq.empty[String]), Some("*test*")))
+      ShowViews(CurrentNamespace, Some("*test*")))
     comparePlans(
       parsePlan("SHOW VIEWS FROM testcat.ns1.ns2.tbl"),
       ShowViews(UnresolvedNamespace(Seq("testcat", "ns1", "ns2", "tbl")), None))
@@ -2273,6 +2273,8 @@ class DDLParserSuite extends AnalysisTest {
   test("SPARK-33687: analyze tables statistics") {
     comparePlans(parsePlan("ANALYZE TABLES IN a.b.c COMPUTE STATISTICS"),
       AnalyzeTables(UnresolvedNamespace(Seq("a", "b", "c")), noScan = false))
+    comparePlans(parsePlan("ANALYZE TABLES COMPUTE STATISTICS"),
+      AnalyzeTables(CurrentNamespace, noScan = false))
     comparePlans(parsePlan("ANALYZE TABLES FROM a COMPUTE STATISTICS NOSCAN"),
       AnalyzeTables(UnresolvedNamespace(Seq("a")), noScan = true))
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLContext.scala
@@ -29,7 +29,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config.ConfigEntry
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst._
-import org.apache.spark.sql.catalyst.analysis.UnresolvedNamespace
+import org.apache.spark.sql.catalyst.analysis.{CurrentNamespace, UnresolvedNamespace}
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.logical.ShowTables
 import org.apache.spark.sql.internal.{SessionState, SharedState, SQLConf}
@@ -669,7 +669,7 @@ class SQLContext private[sql](val sparkSession: SparkSession)
    * @since 1.3.0
    */
   def tables(): DataFrame = {
-    Dataset.ofRows(sparkSession, ShowTables(UnresolvedNamespace(Nil), None))
+    Dataset.ofRows(sparkSession, ShowTables(CurrentNamespace, None))
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
@@ -82,7 +82,7 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
    * Returns a list of databases available across all sessions.
    */
   override def listDatabases(): Dataset[Database] = {
-    val plan = ShowNamespaces(UnresolvedNamespace(Nil), None)
+    val plan = ShowNamespaces(CurrentNamespace, None)
     val qe = sparkSession.sessionState.executePlan(plan)
     val catalog = qe.analyzed.collectFirst {
       case ShowNamespaces(r: ResolvedNamespace, _, _) => r.catalog
@@ -271,7 +271,7 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
 
     // List built-in functions. We don't need to specify the namespace here as SHOW FUNCTIONS with
     // only system scope does not need to know the catalog and namespace.
-    val plan0 = ShowFunctions(UnresolvedNamespace(Nil), false, true, pattern)
+    val plan0 = ShowFunctions(CurrentNamespace, false, true, pattern)
     sparkSession.sessionState.executePlan(plan0).toRdd.collect().foreach { row =>
       // Built-in functions do not belong to any catalog or namespace. We can only look it up with
       // a single part name.

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
@@ -82,7 +82,7 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
    * Returns a list of databases available across all sessions.
    */
   override def listDatabases(): Dataset[Database] = {
-    val plan = ShowNamespaces(CurrentNamespace, None)
+    val plan = ShowNamespaces(UnresolvedNamespace(Nil), None)
     val qe = sparkSession.sessionState.executePlan(plan)
     val catalog = qe.analyzed.collectFirst {
       case ShowNamespaces(r: ResolvedNamespace, _, _) => r.catalog

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/QueryExecutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/QueryExecutionSuite.scala
@@ -20,7 +20,7 @@ import scala.io.Source
 
 import org.apache.spark.sql.{AnalysisException, Dataset, FastOperator}
 import org.apache.spark.sql.catalyst.{QueryPlanningTracker, QueryPlanningTrackerCallback}
-import org.apache.spark.sql.catalyst.analysis.UnresolvedNamespace
+import org.apache.spark.sql.catalyst.analysis.CurrentNamespace
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow
 import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.logical.{CommandResult, LogicalPlan, OneRowRelation, Project, ShowTables, SubqueryAlias}
@@ -250,7 +250,7 @@ class QueryExecutionSuite extends SharedSparkSession {
     def qe(logicalPlan: LogicalPlan, callback: QueryPlanningTrackerCallback): QueryExecution =
       new QueryExecution(spark, logicalPlan, new QueryPlanningTracker(Some(callback)))
 
-    val showTables = ShowTables(UnresolvedNamespace(Seq.empty[String]), None)
+    val showTables = ShowTables(CurrentNamespace, None)
     val showTablesQe = qe(showTables, mockCallback1)
     showTablesQe.assertAnalyzed()
     mockCallback1.assertAnalyzed()
@@ -278,7 +278,7 @@ class QueryExecutionSuite extends SharedSparkSession {
   test("SPARK-44145: non eagerly executed command setReadyForExecution") {
     val mockCallback = MockCallback()
 
-    val showTables = ShowTables(UnresolvedNamespace(Seq.empty[String]), None)
+    val showTables = ShowTables(CurrentNamespace, None)
     val showTablesQe = new QueryExecution(
       spark,
       showTables,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowFunctionsParserSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowFunctionsParserSuite.scala
@@ -17,12 +17,12 @@
 
 package org.apache.spark.sql.execution.command
 
-import org.apache.spark.sql.catalyst.analysis.{AnalysisTest, UnresolvedNamespace}
+import org.apache.spark.sql.catalyst.analysis.{AnalysisTest, CurrentNamespace, UnresolvedNamespace}
 import org.apache.spark.sql.catalyst.parser.CatalystSqlParser.parsePlan
 import org.apache.spark.sql.catalyst.plans.logical.ShowFunctions
 
 class ShowFunctionsParserSuite extends AnalysisTest {
-  val nsPlan = UnresolvedNamespace(Nil)
+  val nsPlan = CurrentNamespace
 
   test("show functions in the scope") {
     comparePlans(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowTablesParserSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowTablesParserSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.execution.command
 
-import org.apache.spark.sql.catalyst.analysis.{AnalysisTest, UnresolvedNamespace, UnresolvedPartitionSpec, UnresolvedTable}
+import org.apache.spark.sql.catalyst.analysis.{AnalysisTest, CurrentNamespace, UnresolvedNamespace, UnresolvedPartitionSpec, UnresolvedTable}
 import org.apache.spark.sql.catalyst.parser.CatalystSqlParser.parsePlan
 import org.apache.spark.sql.catalyst.plans.logical.{ShowTablePartition, ShowTables, ShowTablesExtended}
 import org.apache.spark.sql.test.SharedSparkSession
@@ -28,13 +28,13 @@ class ShowTablesParserSuite extends AnalysisTest with SharedSparkSession {
   test("show tables") {
     comparePlans(
       parsePlan("SHOW TABLES"),
-      ShowTables(UnresolvedNamespace(Seq.empty[String]), None))
+      ShowTables(CurrentNamespace, None))
     comparePlans(
       parsePlan("SHOW TABLES '*test*'"),
-      ShowTables(UnresolvedNamespace(Seq.empty[String]), Some("*test*")))
+      ShowTables(CurrentNamespace, Some("*test*")))
     comparePlans(
       parsePlan("SHOW TABLES LIKE '*test*'"),
-      ShowTables(UnresolvedNamespace(Seq.empty[String]), Some("*test*")))
+      ShowTables(CurrentNamespace, Some("*test*")))
     comparePlans(
       parsePlan(s"SHOW TABLES FROM $catalog.ns1.ns2.tbl"),
       ShowTables(UnresolvedNamespace(Seq(catalog, "ns1", "ns2", "tbl")), None))
@@ -52,7 +52,7 @@ class ShowTablesParserSuite extends AnalysisTest with SharedSparkSession {
   test("show table extended") {
     comparePlans(
       parsePlan("SHOW TABLE EXTENDED LIKE '*test*'"),
-      ShowTablesExtended(UnresolvedNamespace(Seq.empty[String]), "*test*"))
+      ShowTablesExtended(CurrentNamespace, "*test*"))
     comparePlans(
       parsePlan(s"SHOW TABLE EXTENDED FROM $catalog.ns1.ns2 LIKE '*test*'"),
       ShowTablesExtended(UnresolvedNamespace(Seq(catalog, "ns1", "ns2")), "*test*"))


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
It's a bit hacky that we have to special-cases some commands in `ResolveCatalogs` when resolving `UnresolvedNamespace`. This PR adds a new plan node `CurrentNamespace`, so that caller side can use it to get current namespace, instead of using `UnresolvedNamespace(Nil)` and special-case it in `ResolveCatalogs`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
code cleanup

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
no

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
existing tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No