### PR TITLE
[SPARK-45827][SQL] Variant fixes with codegen and vectorized reader disabled

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/InterpretedUnsafeProjection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/InterpretedUnsafeProjection.scala
@@ -294,7 +294,7 @@ object InterpretedUnsafeProjection {
    */
   @scala.annotation.tailrec
   private def getElementSize(dataType: DataType): Int = dataType match {
-    case NullType | StringType | BinaryType | CalendarIntervalType |
+    case NullType | StringType | BinaryType | CalendarIntervalType | VariantType |
          _: DecimalType | _: StructType | _: ArrayType | _: MapType => 8
     case udt: UserDefinedType[_] =>
       getElementSize(udt.sqlType)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowConverter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowConverter.scala
@@ -815,8 +815,8 @@ private[parquet] class ParquetRowConverter(
 
   /** Parquet converter for Variant */
   private final class ParquetVariantConverter(
-                                           parquetType: GroupType,
-                                           updater: ParentContainerUpdater)
+     parquetType: GroupType,
+     updater: ParentContainerUpdater)
     extends ParquetGroupConverter(updater) {
 
     private[this] var currentValue: Any = _
@@ -838,7 +838,7 @@ private[parquet] class ParquetRowConverter(
     override def end(): Unit = {
       updater.set(
         new VariantVal(currentValue.asInstanceOf[Array[Byte]],
-                       currentMetadata.asInstanceOf[Array[Byte]]))
+            currentMetadata.asInstanceOf[Array[Byte]]))
     }
 
     override def start(): Unit = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/VariantSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/VariantSuite.scala
@@ -19,8 +19,11 @@ package org.apache.spark.sql
 
 import java.io.File
 
+import scala.collection.mutable
 import scala.util.Random
 
+import org.apache.spark.sql.catalyst.expressions.CodegenObjectFactoryMode
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.unsafe.types.VariantVal
@@ -80,6 +83,59 @@ class VariantSuite extends QueryTest with SharedSparkSession {
       df.write.parquet(tempDir)
       val readResult = spark.read.parquet(tempDir).collect().map(_.get(0).asInstanceOf[VariantVal])
       assert(prepareAnswer(input) == prepareAnswer(readResult.toImmutableArraySeq))
+    }
+  }
+
+  test("array of variant") {
+    val rand = new Random(42)
+    val input = Seq.fill(3) {
+      if (rand.nextInt(10) == 0) {
+        null
+      } else {
+        val value = new Array[Byte](rand.nextInt(50))
+        rand.nextBytes(value)
+        val metadata = new Array[Byte](rand.nextInt(50))
+        rand.nextBytes(metadata)
+        val numElements = 3 // rand.nextInt(10)
+        Seq.fill(numElements)(new VariantVal(value, metadata))
+      }
+    }
+
+    val df = spark.createDataFrame(
+      spark.sparkContext.parallelize(input.map { v =>
+        Row.fromSeq(Seq(v))
+      }),
+      StructType.fromDDL("v array<variant>")
+    )
+
+    def prepareAnswer(values: Seq[Row]): Seq[String] = {
+      values.map(_.get(0)).map { v =>
+        if (v == null) {
+          "null"
+        } else {
+          v.asInstanceOf[mutable.ArraySeq[Any]]
+           .map(_.asInstanceOf[VariantVal].debugString()).mkString(",")
+        }
+      }.sorted
+    }
+
+    // Test conversion to UnsafeRow in both codegen and interpreted code paths.
+    val codegenModes = Seq(CodegenObjectFactoryMode.NO_CODEGEN.toString,
+                           CodegenObjectFactoryMode.FALLBACK.toString)
+    codegenModes.foreach { codegen =>
+      withTempDir { dir =>
+        withSQLConf(SQLConf.CODEGEN_FACTORY_MODE.key -> codegen) {
+          val tempDir = new File(dir, "files").getCanonicalPath
+          df.write.parquet(tempDir)
+          Seq(false, true).foreach { vectorizedReader =>
+            withSQLConf(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key ->
+                vectorizedReader.toString) {
+              val readResult = spark.read.parquet(tempDir).collect().toSeq
+              assert(prepareAnswer(df.collect().toSeq) == prepareAnswer(readResult))
+            }
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Fix two issues with the new Variant type:

1) In `InterpretedUnsafeProjection`, define element size to be 8, since Variant has variable length, so it is categorized as a reference type, which always has size 8. This only manifests as an issue when codegen is disabled and an array or struct contains Variant values.

2) Define and use a `ParquetGroupConverter` for Variant. The previous tests used the vectorized reader, so this issue didn't manifest.

### Why are the changes needed?

Fixes crashes when Variant is used.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Added a unit test that writes and reads an array of Variant values with codegen and the vectorized reader disabled. Reverting either of the two fixes causes the test to fail.

### Was this patch authored or co-authored using generative AI tooling?

No.