### PR TITLE
[SPARK-46076][PYTHON][TESTS] Remove `unittest` deprecated alias usage for Python 3.12

### DIFF
--- a/python/pyspark/ml/tests/test_linalg.py
+++ b/python/pyspark/ml/tests/test_linalg.py
@@ -362,7 +362,7 @@ class VectorUDTTests(MLlibTestCase):
             Row(v2=unwrapped_vec(1, None, None, [1.0, 2.0, 3.0])),
             Row(v2=unwrapped_vec(0, 3, [1, 2], [1.0, 5.5])),
         ]
-        self.assertEquals(results, expected)
+        self.assertEqual(results, expected)
 
 
 class MatrixUDTTests(MLlibTestCase):

--- a/python/pyspark/pandas/tests/indexes/test_base.py
+++ b/python/pyspark/pandas/tests/indexes/test_base.py
@@ -62,11 +62,11 @@ class IndexesTestsMixin:
             self.assert_eq(psdf.index.dtype, pdf.index.dtype)
 
         self.assert_eq(ps.Index([])._summary(), "Index: 0 entries")
-        with self.assertRaisesRegexp(ValueError, "The truth value of a Index is ambiguous."):
+        with self.assertRaisesRegex(ValueError, "The truth value of a Index is ambiguous."):
             bool(ps.Index([1]))
-        with self.assertRaisesRegexp(TypeError, "Index.name must be a hashable type"):
+        with self.assertRaisesRegex(TypeError, "Index.name must be a hashable type"):
             ps.Index([1, 2, 3], name=[(1, 2, 3)])
-        with self.assertRaisesRegexp(TypeError, "Index.name must be a hashable type"):
+        with self.assertRaisesRegex(TypeError, "Index.name must be a hashable type"):
             ps.Index([1.0, 2.0, 3.0], name=[(1, 2, 3)])
 
     def test_index_from_series(self):

--- a/python/pyspark/pandas/tests/indexes/test_category.py
+++ b/python/pyspark/pandas/tests/indexes/test_category.py
@@ -68,9 +68,9 @@ class CategoricalIndexTestsMixin:
         self.assert_eq(psidx.codes, pd.Index(pidx.codes))
         self.assert_eq(psidx.ordered, pidx.ordered)
 
-        with self.assertRaisesRegexp(TypeError, "Index.name must be a hashable type"):
+        with self.assertRaisesRegex(TypeError, "Index.name must be a hashable type"):
             ps.CategoricalIndex([1, 2, 3], name=[(1, 2, 3)])
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             TypeError, "Cannot perform 'all' with this index type: CategoricalIndex"
         ):
             ps.CategoricalIndex([1, 2, 3]).all()

--- a/python/pyspark/pandas/tests/indexes/test_datetime.py
+++ b/python/pyspark/pandas/tests/indexes/test_datetime.py
@@ -64,9 +64,9 @@ class DatetimeIndexTestsMixin:
         self.assertRaises(ValueError, lambda: f(freq="N"))
 
     def test_datetime_index(self):
-        with self.assertRaisesRegexp(TypeError, "Index.name must be a hashable type"):
+        with self.assertRaisesRegex(TypeError, "Index.name must be a hashable type"):
             ps.DatetimeIndex(["2004-01-01", "2002-12-31", "2000-04-01"], name=[(1, 2)])
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             TypeError, "Cannot perform 'all' with this index type: DatetimeIndex"
         ):
             ps.DatetimeIndex(["2004-01-01", "2002-12-31", "2000-04-01"]).all()

--- a/python/pyspark/pandas/tests/indexes/test_timedelta.py
+++ b/python/pyspark/pandas/tests/indexes/test_timedelta.py
@@ -90,9 +90,9 @@ class TimedeltaIndexTestsMixin:
         )
 
         # ps.TimedeltaIndex(ps.Index([1, 2, 3]))
-        with self.assertRaisesRegexp(TypeError, "Index.name must be a hashable type"):
+        with self.assertRaisesRegex(TypeError, "Index.name must be a hashable type"):
             ps.TimedeltaIndex([timedelta(1), timedelta(microseconds=2)], name=[(1, 2)])
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             TypeError, "Cannot perform 'all' with this index type: TimedeltaIndex"
         ):
             psidx.all()

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -1824,7 +1824,7 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
 
         self.assert_eq(cdf, df)
 
-        self.assertEquals(cobservation.get, observation.get)
+        self.assertEqual(cobservation.get, observation.get)
 
         observed_metrics = cdf.attrs["observed_metrics"]
         self.assert_eq(len(observed_metrics), 1)
@@ -3449,11 +3449,11 @@ class SparkConnectSessionTests(ReusedConnectTestCase):
         self.assertIsNotNone(self.spark._client)
         # Creates a new remote session.
         other = PySparkSession.builder.remote("sc://other.remote:114/").create()
-        self.assertNotEquals(self.spark, other)
+        self.assertNotEqual(self.spark, other)
 
         # Gets currently active session.
         same = PySparkSession.builder.remote("sc://other.remote.host:114/").getOrCreate()
-        self.assertEquals(other, same)
+        self.assertEqual(other, same)
         same.release_session_on_close = False  # avoid sending release to dummy connection
         same.stop()
 

--- a/python/pyspark/sql/tests/connect/test_connect_column.py
+++ b/python/pyspark/sql/tests/connect/test_connect_column.py
@@ -379,7 +379,7 @@ class SparkConnectColumnTests(SparkConnectSQLTestCase):
         self.assertEqual(len(pdf.index), 4)
 
         res = pd.DataFrame(data={"id": [0, 30, 60, 90]})
-        self.assert_(pdf.equals(res), f"{pdf.to_string()} != {res.to_string()}")
+        self.assertTrue(pdf.equals(res), f"{pdf.to_string()} != {res.to_string()}")
 
     def test_literal_with_acceptable_type(self):
         for value, dataType in [

--- a/python/pyspark/sql/tests/pandas/test_pandas_map.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_map.py
@@ -394,7 +394,7 @@ class MapInPandasTestsMixin:
 
             for offheap in ["true", "false"]:
                 with self.sql_conf({"spark.sql.columnVector.offheap.enabled": offheap}):
-                    self.assertEquals(
+                    self.assertEqual(
                         self.spark.read.parquet(path).mapInPandas(func, "id long").head(), Row(0)
                     )
         finally:

--- a/python/pyspark/sql/tests/pandas/test_pandas_udf_scalar.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_udf_scalar.py
@@ -1450,9 +1450,7 @@ class ScalarPandasUDFTestsMixin:
 
             for offheap in ["true", "false"]:
                 with self.sql_conf({"spark.sql.columnVector.offheap.enabled": offheap}):
-                    self.assertEqual(
-                        self.spark.read.parquet(path).select(udf("id")).head(), Row(0)
-                    )
+                    self.assertEqual(self.spark.read.parquet(path).select(udf("id")).head(), Row(0))
         finally:
             shutil.rmtree(path)
 

--- a/python/pyspark/sql/tests/pandas/test_pandas_udf_scalar.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_udf_scalar.py
@@ -181,7 +181,7 @@ class ScalarPandasUDFTestsMixin:
 
         mirror = pandas_udf(lambda s: s, df.dtypes[0][1])
 
-        self.assertEquals(
+        self.assertEqual(
             df.select(mirror(df.struct).alias("res")).first(),
             Row(
                 res=Row(
@@ -194,13 +194,13 @@ class ScalarPandasUDFTestsMixin:
         df = self.df_with_nested_maps
 
         str_repr = pandas_udf(lambda s: s.astype(str), StringType())
-        self.assertEquals(
+        self.assertEqual(
             df.select(str_repr(df.attributes).alias("res")).first(),
             Row(res="{'personal': {'name': 'John', 'city': 'New York'}}"),
         )
 
         extract_name = pandas_udf(lambda s: s.apply(lambda x: x["personal"]["name"]), StringType())
-        self.assertEquals(
+        self.assertEqual(
             df.select(extract_name(df.attributes).alias("res")).first(),
             Row(res="John"),
         )
@@ -209,7 +209,7 @@ class ScalarPandasUDFTestsMixin:
         df = self.df_with_nested_arrays
 
         str_repr = pandas_udf(lambda s: s.astype(str), StringType())
-        self.assertEquals(
+        self.assertEqual(
             df.select(str_repr(df.nested_array).alias("res")).first(),
             Row(res="[array([1, 2, 3], dtype=int32) array([4, 5], dtype=int32)]"),
         )
@@ -1450,7 +1450,7 @@ class ScalarPandasUDFTestsMixin:
 
             for offheap in ["true", "false"]:
                 with self.sql_conf({"spark.sql.columnVector.offheap.enabled": offheap}):
-                    self.assertEquals(
+                    self.assertEqual(
                         self.spark.read.parquet(path).select(udf("id")).head(), Row(0)
                     )
         finally:

--- a/python/pyspark/sql/tests/streaming/test_streaming.py
+++ b/python/pyspark/sql/tests/streaming/test_streaming.py
@@ -36,7 +36,7 @@ class StreamingTestsMixin:
             .start()
         )
         try:
-            self.assertEquals(query.name, "test_streaming_query_functions_basic")
+            self.assertEqual(query.name, "test_streaming_query_functions_basic")
             self.assertTrue(isinstance(query.id, str))
             self.assertTrue(isinstance(query.runId, str))
             self.assertTrue(query.isActive)

--- a/python/pyspark/sql/tests/streaming/test_streaming_listener.py
+++ b/python/pyspark/sql/tests/streaming/test_streaming_listener.py
@@ -58,19 +58,19 @@ class StreamingListenerTestsMixin:
         if exception:
             self.assertTrue(exception in event.exception)
         else:
-            self.assertEquals(event.exception, None)
+            self.assertEqual(event.exception, None)
 
         if error_class:
             self.assertTrue(error_class in event.errorClassOnException)
         else:
-            self.assertEquals(event.errorClassOnException, None)
+            self.assertEqual(event.errorClassOnException, None)
 
     def check_streaming_query_progress(self, progress):
         """Check StreamingQueryProgress"""
         self.assertTrue(isinstance(progress, StreamingQueryProgress))
         self.assertTrue(isinstance(progress.id, uuid.UUID))
         self.assertTrue(isinstance(progress.runId, uuid.UUID))
-        self.assertEquals(progress.name, "test")
+        self.assertEqual(progress.name, "test")
         try:
             json.loads(progress.json)
         except Exception:
@@ -208,41 +208,41 @@ class StreamingListenerTests(StreamingListenerTestsMixin, ReusedSQLTestCase):
                 ).getMethods()
             )
 
-        self.assertEquals(
+        self.assertEqual(
             get_number_of_public_methods(
                 "org.apache.spark.sql.streaming.StreamingQueryListener$QueryStartedEvent"
             ),
             15,
             msg,
         )
-        self.assertEquals(
+        self.assertEqual(
             get_number_of_public_methods(
                 "org.apache.spark.sql.streaming.StreamingQueryListener$QueryProgressEvent"
             ),
             12,
             msg,
         )
-        self.assertEquals(
+        self.assertEqual(
             get_number_of_public_methods(
                 "org.apache.spark.sql.streaming.StreamingQueryListener$QueryTerminatedEvent"
             ),
             15,
             msg,
         )
-        self.assertEquals(
+        self.assertEqual(
             get_number_of_public_methods("org.apache.spark.sql.streaming.StreamingQueryProgress"),
             38,
             msg,
         )
-        self.assertEquals(
+        self.assertEqual(
             get_number_of_public_methods("org.apache.spark.sql.streaming.StateOperatorProgress"),
             27,
             msg,
         )
-        self.assertEquals(
+        self.assertEqual(
             get_number_of_public_methods("org.apache.spark.sql.streaming.SourceProgress"), 21, msg
         )
-        self.assertEquals(
+        self.assertEqual(
             get_number_of_public_methods("org.apache.spark.sql.streaming.SinkProgress"), 19, msg
         )
 

--- a/python/pyspark/sql/tests/test_arrow.py
+++ b/python/pyspark/sql/tests/test_arrow.py
@@ -877,7 +877,7 @@ class ArrowTestsMixin:
                     }
                 ):
                     if arrow_enabled and struct_in_pandas == "legacy":
-                        with self.assertRaisesRegexp(
+                        with self.assertRaisesRegex(
                             UnsupportedOperationException, "DUPLICATED_FIELD_NAME_IN_ARROW_STRUCT"
                         ):
                             df.toPandas()

--- a/python/pyspark/sql/tests/test_arrow_python_udf.py
+++ b/python/pyspark/sql/tests/test_arrow_python_udf.py
@@ -59,9 +59,9 @@ class PythonUDFArrowTestsMixin(BaseUDFTestsMixin):
             .first()
         )
 
-        self.assertEquals(row[0], "[1, 2, 3]")
-        self.assertEquals(row[1], "{'a': 'b'}")
-        self.assertEquals(row[2], "Row(col1=1, col2=2)")
+        self.assertEqual(row[0], "[1, 2, 3]")
+        self.assertEqual(row[1], "{'a': 'b'}")
+        self.assertEqual(row[2], "Row(col1=1, col2=2)")
 
     def test_use_arrow(self):
         # useArrow=True
@@ -88,7 +88,7 @@ class PythonUDFArrowTestsMixin(BaseUDFTestsMixin):
             .first()
         )
 
-        self.assertEquals(row_true[0], row_none[0])  # "[1, 2, 3]"
+        self.assertEqual(row_true[0], row_none[0])  # "[1, 2, 3]"
 
         # useArrow=False
         row_false = (
@@ -101,13 +101,13 @@ class PythonUDFArrowTestsMixin(BaseUDFTestsMixin):
             )
             .first()
         )
-        self.assertEquals(row_false[0], "[1, 2, 3]")
+        self.assertEqual(row_false[0], "[1, 2, 3]")
 
     def test_eval_type(self):
-        self.assertEquals(
+        self.assertEqual(
             udf(lambda x: str(x), useArrow=True).evalType, PythonEvalType.SQL_ARROW_BATCHED_UDF
         )
-        self.assertEquals(
+        self.assertEqual(
             udf(lambda x: str(x), useArrow=False).evalType, PythonEvalType.SQL_BATCHED_UDF
         )
 
@@ -118,7 +118,7 @@ class PythonUDFArrowTestsMixin(BaseUDFTestsMixin):
         str_repr_func = self.spark.udf.register("str_repr", udf(lambda x: str(x), useArrow=True))
 
         # To verify that Arrow optimization is on
-        self.assertEquals(
+        self.assertEqual(
             df.selectExpr("str_repr(array) AS str_id").first()[0],
             "[1, 2, 3]",  # The input is a NumPy array when the Arrow optimization is on
         )
@@ -131,7 +131,7 @@ class PythonUDFArrowTestsMixin(BaseUDFTestsMixin):
 
     def test_nested_array_input(self):
         df = self.spark.range(1).selectExpr("array(array(1, 2), array(3, 4)) as nested_array")
-        self.assertEquals(
+        self.assertEqual(
             df.select(
                 udf(lambda x: str(x), returnType="string", useArrow=True)("nested_array")
             ).first()[0],
@@ -148,8 +148,8 @@ class PythonUDFArrowTestsMixin(BaseUDFTestsMixin):
         for ddl_type in int_ddl_types:
             # df_int_value
             res = df_int_value.select(udf(lambda x: x, ddl_type)("value").alias("res"))
-            self.assertEquals(res.collect(), [Row(res=1), Row(res=2)])
-            self.assertEquals(res.dtypes[0][1], ddl_type)
+            self.assertEqual(res.collect(), [Row(res=1), Row(res=2)])
+            self.assertEqual(res.dtypes[0][1], ddl_type)
 
         floating_results = [
             [Row(res=1.1), Row(res=2.2)],
@@ -158,12 +158,12 @@ class PythonUDFArrowTestsMixin(BaseUDFTestsMixin):
         for ddl_type, floating_res in zip(floating_ddl_types, floating_results):
             # df_int_value
             res = df_int_value.select(udf(lambda x: x, ddl_type)("value").alias("res"))
-            self.assertEquals(res.collect(), [Row(res=1.0), Row(res=2.0)])
-            self.assertEquals(res.dtypes[0][1], ddl_type)
+            self.assertEqual(res.collect(), [Row(res=1.0), Row(res=2.0)])
+            self.assertEqual(res.dtypes[0][1], ddl_type)
             # df_floating_value
             res = df_floating_value.select(udf(lambda x: x, ddl_type)("value").alias("res"))
-            self.assertEquals(res.collect(), floating_res)
-            self.assertEquals(res.dtypes[0][1], ddl_type)
+            self.assertEqual(res.collect(), floating_res)
+            self.assertEqual(res.dtypes[0][1], ddl_type)
 
         # invalid
         with self.assertRaises(PythonException):

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -903,7 +903,7 @@ class FunctionsTestsMixin:
             (3, "c"),
         ]
 
-        self.assertEquals(actual, expected)
+        self.assertEqual(actual, expected)
 
     def test_window_functions(self):
         df = self.spark.createDataFrame([(1, "1"), (2, "2"), (1, "2"), (1, "2")], ["key", "value"])

--- a/python/pyspark/sql/tests/test_udf.py
+++ b/python/pyspark/sql/tests/test_udf.py
@@ -825,7 +825,7 @@ class BaseUDFTestsMixin(object):
 
             for offheap in ["true", "false"]:
                 with self.sql_conf({"spark.sql.columnVector.offheap.enabled": offheap}):
-                    self.assertEquals(
+                    self.assertEqual(
                         self.spark.read.parquet(path).select(fUdf("id")).head(), Row(0)
                     )
         finally:
@@ -843,12 +843,12 @@ class BaseUDFTestsMixin(object):
         )
         # Input
         row = df.select(udf(lambda x: str(x))("nested_struct")).first()
-        self.assertEquals(
+        self.assertEqual(
             row[0], "Row(col1=1, col2=Row(col1='John', col2=30, col3=Row(col1='value', col2=10)))"
         )
         # Output
         row = df.select(udf(lambda x: x, returnType=df.dtypes[0][1])("nested_struct")).first()
-        self.assertEquals(
+        self.assertEqual(
             row[0], Row(col1=1, col2=Row(col1="John", col2=30, col3=Row(col1="value", col2=10)))
         )
 
@@ -856,7 +856,7 @@ class BaseUDFTestsMixin(object):
         df = self.spark.range(1).selectExpr("map('a', map('b', 'c')) as nested_map")
         # Input
         row = df.select(udf(lambda x: str(x))("nested_map")).first()
-        self.assertEquals(row[0], "{'a': {'b': 'c'}}")
+        self.assertEqual(row[0], "{'a': {'b': 'c'}}")
         # Output
 
         @udf(returnType=df.dtypes[0][1])
@@ -865,13 +865,13 @@ class BaseUDFTestsMixin(object):
             return x
 
         row = df.select(f("nested_map")).first()
-        self.assertEquals(row[0], {"a": {"b": "d"}})
+        self.assertEqual(row[0], {"a": {"b": "d"}})
 
     def test_nested_array(self):
         df = self.spark.range(1).selectExpr("array(array(1, 2), array(3, 4)) as nested_array")
         # Input
         row = df.select(udf(lambda x: str(x))("nested_array")).first()
-        self.assertEquals(row[0], "[[1, 2], [3, 4]]")
+        self.assertEqual(row[0], "[[1, 2], [3, 4]]")
         # Output
 
         @udf(returnType=df.dtypes[0][1])
@@ -880,7 +880,7 @@ class BaseUDFTestsMixin(object):
             return x
 
         row = df.select(f("nested_array")).first()
-        self.assertEquals(row[0], [[1, 2], [3, 4], [4, 5]])
+        self.assertEqual(row[0], [[1, 2], [3, 4], [4, 5]])
 
     def test_complex_return_types(self):
         row = (
@@ -894,9 +894,9 @@ class BaseUDFTestsMixin(object):
             .first()
         )
 
-        self.assertEquals(row[0], [1, 2, 3])
-        self.assertEquals(row[1], {"a": "b"})
-        self.assertEquals(row[2], Row(col1=1, col2=2))
+        self.assertEqual(row[0], [1, 2, 3])
+        self.assertEqual(row[1], {"a": "b"})
+        self.assertEqual(row[2], Row(col1=1, col2=2))
 
     def test_named_arguments(self):
         @udf("int")

--- a/python/pyspark/sql/tests/test_utils.py
+++ b/python/pyspark/sql/tests/test_utils.py
@@ -1747,8 +1747,8 @@ class UtilsTests(ReusedSQLTestCase, UtilsTestsMixin):
         try:
             self.spark.sql("""SELECT a""")
         except AnalysisException as e:
-            self.assertEquals(e.getErrorClass(), "UNRESOLVED_COLUMN.WITHOUT_SUGGESTION")
-            self.assertEquals(e.getSqlState(), "42703")
+            self.assertEqual(e.getErrorClass(), "UNRESOLVED_COLUMN.WITHOUT_SUGGESTION")
+            self.assertEqual(e.getSqlState(), "42703")
 
 
 if __name__ == "__main__":

--- a/python/pyspark/tests/test_util.py
+++ b/python/pyspark/tests/test_util.py
@@ -80,7 +80,7 @@ class UtilTests(PySparkTestCase):
         origin = os.environ["SPARK_HOME"]
         try:
             del os.environ["SPARK_HOME"]
-            self.assertEquals(origin, _find_spark_home())
+            self.assertEqual(origin, _find_spark_home())
         finally:
             os.environ["SPARK_HOME"] = origin
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove `unittest` alias usage for Python 3.12.

Currently, it fails like the following.
- https://github.com/apache/spark/actions/runs/6971394284/job/18971420822
```
======================================================================
ERROR [0.554s]: test_find_spark_home (pyspark.tests.test_util.UtilTests.test_find_spark_home)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/__w/spark/spark/python/pyspark/tests/test_util.py", line 83, in test_find_spark_home
    self.assertEquals(origin, _find_spark_home())
    ^^^^^^^^^^^^^^^^^
AttributeError: 'UtilTests' object has no attribute 'assertEquals'. Did you mean: 'assertEqual'?
```

### Why are the changes needed?

Python 3.12 removes the following deprecated aliases.

- https://docs.python.org/3/whatsnew/3.12.html#id3

<img width="802" alt="Screenshot 2023-11-23 at 12 52 33 PM" src="https://github.com/apache/spark/assets/9700541/0158c1a4-fcfc-4a02-85c5-7fcbd6c6a034">


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs with Python 3.9.

### Was this patch authored or co-authored using generative AI tooling?

No.