### PR TITLE
[MINOR][SS] Relax access constraints on fields of FileStreamSink so the class is extendable, split long method

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSink.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSink.scala
@@ -131,12 +131,12 @@ class FileStreamSink(
   import FileStreamSink._
 
   protected val hadoopConf: Configuration = sparkSession.sessionState.newHadoopConf()
-  protected val basePath = new Path(path)
+  protected val basePath: Path = new Path(path)
   protected val logPath: Path = getMetadataLogPath(basePath.getFileSystem(hadoopConf), basePath,
     sparkSession.sessionState.conf)
   protected val retention: Option[Long] = options.get("retention").map(Utils.timeStringAsMs)
-  protected val fileLog = new FileStreamSinkLog(FileStreamSinkLog.VERSION, sparkSession,
-    logPath.toString, retention)
+  protected val fileLog: FileStreamSinkLog =
+    new FileStreamSinkLog(FileStreamSinkLog.VERSION, sparkSession, logPath.toString, retention)
 
   protected def basicWriteJobStatsTracker: BasicWriteJobStatsTracker = {
     val serializableHadoopConf = new SerializableConfiguration(hadoopConf)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Relax access constraints on fields of FileStreamSink so the class is extendable, split long method into two methods. 


### Why are the changes needed?
I need to extend FileStreamSink, but it's not possible because of no access to fields of this class. This cosmetic change allows developer to reuse code of FileStreamSink- use output metadatalog of of the box in particular.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Not needed, it's change for developers on reusing code. Logic was not changed.


### Was this patch authored or co-authored using generative AI tooling?
No
