### PR TITLE
[SPARK-46081][INFRA] Set `DEDICATED_JVM_SBT_TESTS` in `build_java21.yml`

### DIFF
--- a/.github/workflows/build_java21.yml
+++ b/.github/workflows/build_java21.yml
@@ -38,6 +38,7 @@ jobs:
         {
           "SKIP_MIMA": "true",
           "SKIP_UNIDOC": "true",
+          "DEDICATED_JVM_SBT_TESTS": "org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormatV1Suite,org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormatV2Suite,org.apache.spark.sql.execution.datasources.orc.OrcSourceV1Suite,org.apache.spark.sql.execution.datasources.orc.OrcSourceV2Suite"
         }
       jobs: >-
         {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `DEDICATED_JVM_SBT_TESTS` environment variable in `build_java21.yml` to stabilize the following flaky test suites. Note that this is also flaky in other pipelines. The reason why we add this to `Java 21` build only is to focus on Java 21 issues in this pipeline.

### Why are the changes needed?

To stabilize those test suites in order to focus Java 21 issues in this pipeline.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

PR builder CI is irrelevant to this PR. After manual review, we need to check this in daily CI.

### Was this patch authored or co-authored using generative AI tooling?

No.