### PR TITLE
[SPARK-46082][PYTHON][CONNECT] Fix protobuf string representation for Pandas Functions API with Spark Connect

### DIFF
--- a/python/pyspark/sql/connect/group.py
+++ b/python/pyspark/sql/connect/group.py
@@ -378,7 +378,6 @@ class PandasCogroupedOps:
             evalType=PythonEvalType.SQL_COGROUPED_MAP_PANDAS_UDF,
         )
 
-        all_cols = self._extract_cols(self._gd1) + self._extract_cols(self._gd2)
         return DataFrame.withPlan(
             plan.CoGroupMap(
                 input=self._gd1._df._plan,
@@ -386,7 +385,6 @@ class PandasCogroupedOps:
                 other=self._gd2._df._plan,
                 other_grouping_cols=self._gd2._grouping_cols,
                 function=udf_obj,
-                cols=all_cols,
             ),
             session=self._gd1._df._session,
         )


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to rename `_func` to `_functions` in the protobuf instances for Pandas Functions API with Spark Connect so the string presentation includes them (see also https://github.com/apache/spark/pull/39223).

### Why are the changes needed?

In order to have the pretty string format for protobuf messages in Python side.

### Does this PR introduce _any_ user-facing change?

Yes,

```bash
./bin/pyspark --remote local
```

```python
df = spark.range(1)
print(df.mapInPandas(lambda x: x, df.schema)._plan.print())
```

**Before:**
```
<MapPartitions is_barrier='False'>
  <Range start='0', end='1', step='1', num_partitions='None'>
```
  
**After:**

```
<MapPartitions function='<lambda>(id)', is_barrier='False'>
  <Range start='0', end='1', step='1', num_partitions='None'>
```

### How was this patch tested?

Manually tested as above.

### Was this patch authored or co-authored using generative AI tooling?

No.
