### PR TITLE
[MINOR][DOCS] Update Description of `UnknownException` in PySpark Documentation

### DIFF
--- a/python/pyspark/errors/exceptions/base.py
+++ b/python/pyspark/errors/exceptions/base.py
@@ -192,7 +192,7 @@ class SparkUpgradeException(PySparkException):
 
 class UnknownException(PySparkException):
     """
-    None of the above exceptions.
+    None of the other exceptions.
     """
 
 

--- a/python/pyspark/errors/exceptions/captured.py
+++ b/python/pyspark/errors/exceptions/captured.py
@@ -311,5 +311,5 @@ class SparkNoSuchElementException(CapturedException, BaseUnknownException):
 
 class UnknownException(CapturedException, BaseUnknownException):
     """
-    None of the above exceptions.
+    None of the other exceptions.
     """


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to update the description of the `UnknownException` class in the PySpark documentation. The current description, "None of the above exceptions.", is being changed to "None of the other exceptions."


### Why are the changes needed?

The existing description, "None of the above exceptions.", implies that `UnknownException` does not cover any exceptions listed after it in the documentation. This can be misleading as there may be other exceptions defined below `UnknownException` as below:

<img width="757" alt="Screenshot 2023-11-24 at 11 11 26 AM" src="https://github.com/apache/spark/assets/44108233/93483c7e-1be0-41b1-8a74-7a667e8c603c">


The proposed change to "None of the other exceptions." provides a clearer and more accurate description, ensuring that it encompasses all exceptions not covered by previously listed specific exceptions.


### Does this PR introduce _any_ user-facing change?

No, it only involves a minor update to the documentation for clarity.


### How was this patch tested?

The existing CI should pass, especially PySpark documentation build.


### Was this patch authored or co-authored using generative AI tooling?

No.