### PR TITLE
[SPARK-46087][PYTHON] Sync PySpark dependencies in docs and dev requirements

### DIFF
--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -1,11 +1,11 @@
 # PySpark dependencies (required)
-py4j
+py4j>=0.10.9.7
 
 # PySpark dependencies (optional)
-numpy
-pyarrow
+numpy>=1.21
+pyarrow>=4.0.0
 six==1.16.0
-pandas
+pandas>=1.4.4
 scipy
 plotly
 mlflow>=2.3.1
@@ -52,8 +52,8 @@ black==23.9.1
 py
 
 # Spark Connect (required)
-grpcio==1.59.3
-grpcio-status==1.59.3
+grpcio>=1.59.3
+grpcio-status>=1.59.3
 protobuf==4.25.1
 googleapis-common-protos>=1.56.4
 


### PR DESCRIPTION

### What changes were proposed in this pull request?
This PR proposes to synchronize the versions of dependencies listed in the [PySpark documentation](https://spark.apache.org/docs/latest/api/python/getting_started/install.html#dependencies) with those specified in the [dev/requirements.txt](https://github.com/apache/spark/blob/master/dev/requirements.txt) file.


### Why are the changes needed?

Aligning the versions of dependencies ensures that the development environment reflects the actual user environment more accurately.

### Does this PR introduce _any_ user-facing change?

No API changes.


### How was this patch tested?

Build the documents from latest master branch manually and sync the version of dependencies:

<img width="774" alt="Screenshot 2023-11-24 at 2 49 09 PM" src="https://github.com/apache/spark/assets/44108233/4f539fc7-0bbc-4fe3-949f-b4c225122b56">



### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.
