### PR TITLE
[SPARK-46091][K8S] Respect the defined container SPARK_LOCAL_DIRS env

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/LocalDirsFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/LocalDirsFeatureStep.scala
@@ -41,6 +41,15 @@ private[spark] class LocalDirsFeatureStep(
     var localDirVolumes: Seq[Volume] = Seq()
     var localDirVolumeMounts: Seq[VolumeMount] = Seq()
 
+    // respect the defined container SPARK_LOCAL_DIRS env
+    pod.container.getEnv.asScala
+      .filter(_.getName == "SPARK_LOCAL_DIRS")
+      .lastOption.foreach { containerEnv =>
+      if (containerEnv.getValue != null) {
+        localDirs ++= containerEnv.getValue.split(",")
+      }
+    }
+
     if (localDirs.isEmpty) {
       // Cannot use Utils.getConfiguredLocalDirs because that will default to the Java system
       // property - we want to instead default to mounting an emptydir volume that doesn't already

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/LocalDirsFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/LocalDirsFeatureStep.scala
@@ -46,7 +46,8 @@ private[spark] class LocalDirsFeatureStep(
       .filter(_.getName == "SPARK_LOCAL_DIRS")
       .lastOption.foreach { containerEnv =>
       if (containerEnv.getValue != null) {
-        localDirs ++= containerEnv.getValue.split(",")
+        localDirs = randomize(localDirs ++
+          containerEnv.getValue.split(",").filterNot(localDirs.contains))
       }
     }
 

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/LocalDirsFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/LocalDirsFeatureStepSuite.scala
@@ -190,11 +190,8 @@ class LocalDirsFeatureStepSuite extends SparkFunSuite {
       .configurePod(SparkPod.initialPod())
     driverPod = new MountVolumesFeatureStep(kubernetesDriverConf).configurePod(driverPod)
     driverPod = new LocalDirsFeatureStep(kubernetesDriverConf).configurePod(driverPod)
-    assert(driverPod.container.getEnv.asScala.filter(_.getName == "SPARK_LOCAL_DIRS").last ==
-      new EnvVarBuilder()
-        .withName("SPARK_LOCAL_DIRS")
-        .withValue(expectedLocalDirs)
-        .build())
+    assert(driverPod.container.getEnv.asScala.filter(_.getName == "SPARK_LOCAL_DIRS")
+      .last.getValue.split(",").toSet == Set("/tmp", "/spark/1", "/spark/2"))
 
     val kubernetesExecutorConf =
       KubernetesTestConf.createExecutorConf(sparkConf = sparkConf, volumes = volumes)
@@ -205,10 +202,7 @@ class LocalDirsFeatureStepSuite extends SparkFunSuite {
       .configurePod(SparkPod.initialPod())
     executorPod = new MountVolumesFeatureStep(kubernetesDriverConf).configurePod(executorPod)
     executorPod = new LocalDirsFeatureStep(kubernetesExecutorConf).configurePod(executorPod)
-    assert(executorPod.container.getEnv.asScala.filter(_.getName == "SPARK_LOCAL_DIRS").last ==
-      new EnvVarBuilder()
-        .withName("SPARK_LOCAL_DIRS")
-        .withValue(expectedLocalDirs)
-        .build())
+    assert(executorPod.container.getEnv.asScala.filter(_.getName == "SPARK_LOCAL_DIRS")
+      .last.getValue.split(",").toSet == Set("/tmp", "/spark/1", "/spark/2"))
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

In this pr, it respects the defined container SPARK_LOCAL_DIRS env, and will combine it with the spark-local-dir-* volume mount paths as the final spark local dirs.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Here is a user case,

For spark on kubernetes, we leverage hostPath as spark local dirs.

But we do not mount the sub host paths directly to the pod, we mount a root path for spark driver/executor pod.

For example, the root host path is `/hadoop`.

And there are several sub disks under that, likes `hadoop/1, /hadoop/2, /hadoop/3, /hadoop4`.

And we have different machine models, some nodes have 4 disks and some nodes have 12 disks, so the sub disks numbers are different for different nodes.

So we want to define the SPARK_LOCAL_DIRS in the driver/executor pod env, the non-existing sub disks defined in `SPARK_LOCAL_DIRS` will be ignored, so that we can define the same container SPARK_LOCAL_DIRS env in the pod template for different machine models.

https://github.com/apache/spark/blob/132bb63a897f4f4049f34deefc065ed3eac6a90f/core/src/main/scala/org/apache/spark/storage/DiskBlockManager.scala#L250-L262

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes, the user defined container SPARK_LOCAL_DIRS env will be combined into final spark local dirs.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

UT.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.