### PR TITLE
[SPARK-46096][BUILD] Upgrade `sbt` to 1.9.7

### DIFF
--- a/dev/appveyor-install-dependencies.ps1
+++ b/dev/appveyor-install-dependencies.ps1
@@ -108,7 +108,7 @@ $env:JAVA_HOME = "$tools\$zuluFileName"
 $env:PATH = "$JAVA_HOME\bin;" + $env:PATH
 
 # ========================== SBT
-$sbtVer = "1.9.3"
+$sbtVer = "1.9.7"
 Start-FileDownload "https://github.com/sbt/sbt/releases/download/v$sbtVer/sbt-$sbtVer.zip" "sbt.zip"
 
 # extract

--- a/project/build.properties
+++ b/project/build.properties
@@ -15,4 +15,4 @@
 # limitations under the License.
 #
 # Please update the version in appveyor-install-dependencies.ps1 together.
-sbt.version=1.9.3
+sbt.version=1.9.7


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `set` from 1.9.3 to 1.9.7.

### Why are the changes needed?

Previously, we couldn't upgrade SBT due to its issues like the dependency resolution. SBT 1.9.7 is updated with Coursier 2.1.7.
- https://github.com/sbt/sbt/releases/tag/v1.9.7
  - https://github.com/sbt/sbt/pull/7392

In addition, the following is the list of previous release notes.
- https://github.com/sbt/sbt/releases/tag/v1.9.6
- https://github.com/sbt/sbt/releases/tag/v1.9.5 (This was an officially broken release)
  > Update: ⚠️ sbt 1.9.5 is broken, because it causes Scala compiler to generate wrong class names for anonymous class on lambda. While we investigate please refrain from publishing libraries with it.
- https://github.com/sbt/sbt/releases/tag/v1.9.4

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.

Closes #42673 