### PR TITLE
[SPARK-46097][SQL] Push down limit 1 through Union and Aggregate

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LimitPushdownSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LimitPushdownSuite.scala
@@ -357,8 +357,7 @@ class LimitPushdownSuite extends PlanTest {
     val unionQuery = Union(
       Union(
         testRelation.groupBy($"a", $"b")($"a", $"b"),
-        testRelation2.groupBy($"d", $"e")($"d", $"e"),
-      ),
+        testRelation2.groupBy($"d", $"e")($"d", $"e")),
       testRelation2.groupBy($"e", $"f")($"e", $"f")).limit(1)
 
     val correctAnswer = Union(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LimitPushdownSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LimitPushdownSuite.scala
@@ -353,7 +353,7 @@ class LimitPushdownSuite extends PlanTest {
     }
   }
 
-  test("SPARK-46097: Push down limit 1 though Union and Aggregate") {
+  test("SPARK-46097: Push down limit 1 through Union and Aggregate") {
     val unionQuery = Union(
       Union(
         testRelation.groupBy($"a", $"b")($"a", $"b"),


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR enhances `LimitPushDown` to support push down limit 1 through Union and Aggregate.

### Why are the changes needed?

Eliminate `shuffle` to improve query performance.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit test and benchmark test.

```scala
spark.range(300000000).selectExpr("id", "array(id, id % 10, id % 100) as eo").write.saveAsTable("t1")
spark.range(100000000).selectExpr("id", "array(id, id % 10, id % 1000) as eo").write.saveAsTable("t2")
println(spark.sql("SELECT DISTINCT * FROM t1 LATERAL VIEW explode_outer(eo) AS e UNION ALL SELECT DISTINCT * FROM t2 LATERAL VIEW explode_outer(eo) AS e").isEmpty)
```

Before this PR | After this PR
-- | --
<img width="430" alt="image" src="https://github.com/apache/spark/assets/5399861/6bca6a7b-440d-49ba-a12a-acb611085862"> | <img width="430" alt="image" src="https://github.com/apache/spark/assets/5399861/44bec0b7-b709-4cd4-aedb-ae2d8b6317a5">


### Was this patch authored or co-authored using generative AI tooling?

No.