### PR TITLE
[SPARK-46084][PS][FOLLOWUP] More refactoring by using `create_map`

### DIFF
--- a/python/pyspark/pandas/data_type_ops/categorical_ops.py
+++ b/python/pyspark/pandas/data_type_ops/categorical_ops.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+from itertools import chain
 from typing import cast, Any, Union
 
 import pandas as pd
@@ -134,7 +135,7 @@ def _to_cat(index_ops: IndexOpsLike) -> IndexOpsLike:
     if len(categories) == 0:
         scol = F.lit(None)
     else:
-        scol = F.lit(None)
-        for code, category in reversed(list(enumerate(categories))):
-            scol = F.when(index_ops.spark.column == F.lit(code), F.lit(category)).otherwise(scol)
+        kvs = chain(*[(F.lit(code), F.lit(category)) for code, category in enumerate(categories)])
+        map_scol = F.create_map(*kvs)
+        scol = map_scol[index_ops.spark.column]
     return index_ops._with_new_scol(scol)


### PR DESCRIPTION


### What changes were proposed in this pull request?

This PR follows-up for https://github.com/apache/spark/pull/43993 to make more refactoring for `CategoricalOps`.

### Why are the changes needed?

To optimize performance/debuggability/readability by using official API


### Does this PR introduce _any_ user-facing change?

No, it's internal refactoring


### How was this patch tested?

The existing CI should pass.


### Was this patch authored or co-authored using generative AI tooling?

No.
