### PR TITLE
[SPARK-46101][CORE][SQL][MLLIB][SS][R][CONNCT][GRAPHX] Reduce stack depth by replace (string|array).size with (string|array).length

### DIFF
--- a/common/utils/src/main/scala/org/apache/spark/util/MavenUtils.scala
+++ b/common/utils/src/main/scala/org/apache/spark/util/MavenUtils.scala
@@ -523,7 +523,7 @@ private[spark] object MavenUtils extends Logging {
 
       // Parse transitive parameters (e.g., transitive=true) in an Ivy URI, default value is true
       val transitiveParams = groupedParams.get("transitive")
-      if (transitiveParams.map(_.size).getOrElse(0) > 1) {
+      if (transitiveParams.map(_.length).getOrElse(0) > 1) {
         logWarning(
           "It's best to specify `transitive` parameter in ivy URI query only once." +
             " If there are multiple `transitive` parameter, we will select the last one")

--- a/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
+++ b/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
@@ -1068,7 +1068,7 @@ abstract class AvroSuite
       val readValues =
         spark.read.schema(schema).format("avro").load(avroDir).as[(Date, Timestamp)].collect()
 
-      assert(readValues.size == 1)
+      assert(readValues.length == 1)
       assert(readValues.head == ((nullDate, nullTime)))
     }
   }
@@ -1944,7 +1944,7 @@ abstract class AvroSuite
       df.write.format("avro").save(outputDir)
       val input = spark.read.format("avro").load(outputDir)
       assert(input.collect().toSet.size === 1024 * 3 + 1)
-      assert(input.rdd.partitions.size > 2)
+      assert(input.rdd.partitions.length > 2)
     }
   }
 

--- a/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/common/ProtoUtils.scala
+++ b/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/common/ProtoUtils.scala
@@ -33,7 +33,7 @@ private[connect] object ProtoUtils {
     message.getAllFields.asScala.iterator.foreach {
       case (field: FieldDescriptor, string: String)
           if field.getJavaType == FieldDescriptor.JavaType.STRING && string != null =>
-        val size = string.size
+        val size = string.length
         if (size > maxStringSize) {
           builder.setField(field, createString(string.take(maxStringSize), size))
         } else {
@@ -55,7 +55,7 @@ private[connect] object ProtoUtils {
 
       case (field: FieldDescriptor, byteArray: Array[Byte])
           if field.getJavaType == FieldDescriptor.JavaType.BYTE_STRING && byteArray != null =>
-        val size = byteArray.size
+        val size = byteArray.length
         if (size > MAX_BYTES_SIZE) {
           builder.setField(
             field,

--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectServiceSuite.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectServiceSuite.scala
@@ -115,7 +115,7 @@ class SparkConnectServiceSuite
         .build()
       val response2 = handler.process(request2, sparkSessionHolder)
       assert(response2.hasExplain)
-      assert(response2.getExplain.getExplainString.size > 0)
+      assert(response2.getExplain.getExplainString.length > 0)
 
       val request3 = proto.AnalyzePlanRequest
         .newBuilder()

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/OracleIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/OracleIntegrationSuite.scala
@@ -162,7 +162,7 @@ class OracleIntegrationSuite extends DockerJDBCIntegrationSuite with SharedSpark
   test("SPARK-16625 : Importing Oracle numeric types") {
     val df = sqlContext.read.jdbc(jdbcUrl, "numerics", new Properties)
     val rows = df.collect()
-    assert(rows.size == 1)
+    assert(rows.length == 1)
     val row = rows(0)
     // The main point of the below assertions is not to make sure that these Oracle types are
     // mapped to decimal types, but to make sure that the returned values are correct.
@@ -413,7 +413,7 @@ class OracleIntegrationSuite extends DockerJDBCIntegrationSuite with SharedSpark
     // read records from oracle_types
     val dfRead = sqlContext.read.jdbc(jdbcUrl, tableName, new Properties)
     val rows = dfRead.collect()
-    assert(rows.size == 1)
+    assert(rows.length == 1)
 
     // check data types
     val types = dfRead.schema.map(field => field.dataType)

--- a/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchSourceSuite.scala
+++ b/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchSourceSuite.scala
@@ -1687,7 +1687,7 @@ class KafkaMicroBatchV2SourceSuite extends KafkaMicroBatchSourceSuiteBase {
           KafkaSourceOffset(Map(tp -> 100L))).map(_.asInstanceOf[KafkaBatchInputPartition])
         withClue(s"minPartitions = $minPartitions generated factories " +
           s"${inputPartitions.mkString("inputPartitions(", ", ", ")")}\n\t") {
-          assert(inputPartitions.size == numPartitionsGenerated)
+          assert(inputPartitions.length == numPartitionsGenerated)
         }
       }
     }

--- a/connector/kafka-0-10/src/test/scala/org/apache/spark/streaming/kafka010/DirectKafkaStreamSuite.scala
+++ b/connector/kafka-0-10/src/test/scala/org/apache/spark/streaming/kafka010/DirectKafkaStreamSuite.scala
@@ -616,7 +616,7 @@ class DirectKafkaStreamSuite
       eventually(timeout(5.seconds), interval(10.milliseconds)) {
         // Assert that rate estimator values are used to determine maxMessagesPerPartition.
         // Funky "-" in message makes the complete assertion message read better.
-        assert(collectedData.asScala.exists(_.size == expectedSize),
+        assert(collectedData.asScala.exists(_.length == expectedSize),
           s" - No arrays of size $expectedSize for rate $rate found in $dataToString")
       }
     }

--- a/connector/kafka-0-10/src/test/scala/org/apache/spark/streaming/kafka010/KafkaRDDSuite.scala
+++ b/connector/kafka-0-10/src/test/scala/org/apache/spark/streaming/kafka010/KafkaRDDSuite.scala
@@ -137,7 +137,7 @@ class KafkaRDDSuite extends SparkFunSuite {
 
     val kafkaParams = getKafkaParams()
 
-    val offsetRanges = Array(OffsetRange(topic, 0, 0, messages.size))
+    val offsetRanges = Array(OffsetRange(topic, 0, 0, messages.length))
 
     val rdd = KafkaUtils.createRDD[String, String](sc, kafkaParams, offsetRanges, preferredHosts)
       .map(_.value)
@@ -146,12 +146,12 @@ class KafkaRDDSuite extends SparkFunSuite {
     assert(received === messages.toSet)
 
     // size-related method optimizations return sane results
-    assert(rdd.count() === messages.size)
-    assert(rdd.countApprox(0).getFinalValue().mean === messages.size)
+    assert(rdd.count() === messages.length)
+    assert(rdd.countApprox(0).getFinalValue().mean === messages.length)
     assert(!rdd.isEmpty())
-    assert(rdd.take(1).size === 1)
+    assert(rdd.take(1).length === 1)
     assert(rdd.take(1).head === messages.head)
-    assert(rdd.take(messages.size + 10).size === messages.size)
+    assert(rdd.take(messages.size + 10).length === messages.length)
 
     val emptyRdd = KafkaUtils.createRDD[String, String](
       sc, kafkaParams, Array(OffsetRange(topic, 0, 0, 0)), preferredHosts)
@@ -159,7 +159,7 @@ class KafkaRDDSuite extends SparkFunSuite {
     assert(emptyRdd.isEmpty())
 
     // invalid offset ranges throw exceptions
-    val badRanges = Array(OffsetRange(topic, 0, 0, messages.size + 1))
+    val badRanges = Array(OffsetRange(topic, 0, 0, messages.length + 1))
     intercept[SparkException] {
       val result = KafkaUtils.createRDD[String, String](sc, kafkaParams, badRanges, preferredHosts)
         .map(_.value)
@@ -201,7 +201,7 @@ class KafkaRDDSuite extends SparkFunSuite {
 
     val kafkaParams = getKafkaParams()
 
-    val offsetRanges = Array(OffsetRange(topic, 0, 0, messages.size))
+    val offsetRanges = Array(OffsetRange(topic, 0, 0, messages.length))
 
     val rdd = KafkaUtils.createRDD[String, String](
       sc, kafkaParams, offsetRanges, preferredHosts
@@ -216,12 +216,12 @@ class KafkaRDDSuite extends SparkFunSuite {
     assert(received === compactedMessages.toSet)
 
     // size-related method optimizations return sane results
-    assert(rdd.count() === compactedMessages.size)
-    assert(rdd.countApprox(0).getFinalValue().mean === compactedMessages.size)
+    assert(rdd.count() === compactedMessages.length)
+    assert(rdd.countApprox(0).getFinalValue().mean === compactedMessages.length)
     assert(!rdd.isEmpty())
-    assert(rdd.take(1).size === 1)
+    assert(rdd.take(1).length === 1)
     assert(rdd.take(1).head === compactedMessages.head)
-    assert(rdd.take(messages.size + 10).size === compactedMessages.size)
+    assert(rdd.take(messages.size + 10).length === compactedMessages.length)
 
     val emptyRdd = KafkaUtils.createRDD[String, String](
       sc, kafkaParams, Array(OffsetRange(topic, 0, 0, 0)), preferredHosts)
@@ -229,7 +229,7 @@ class KafkaRDDSuite extends SparkFunSuite {
     assert(emptyRdd.isEmpty())
 
     // invalid offset ranges throw exceptions
-    val badRanges = Array(OffsetRange(topic, 0, 0, messages.size + 1))
+    val badRanges = Array(OffsetRange(topic, 0, 0, messages.length + 1))
     intercept[SparkException] {
       val result = KafkaUtils.createRDD[String, String](sc, kafkaParams, badRanges, preferredHosts)
         .map(_.value)
@@ -268,7 +268,7 @@ class KafkaRDDSuite extends SparkFunSuite {
 
     kafkaTestUtils.sendMessages(topic, sentOnlyOne)
 
-    assert(rdd2.map(_.value).collect().size === 0, "got messages when there shouldn't be any")
+    assert(rdd2.map(_.value).collect().length === 0, "got messages when there shouldn't be any")
 
     // this is the "exactly 1 message" case, namely the single message from sentOnlyOne above
     val rdd3 = KafkaUtils.createRDD[String, String](sc, kafkaParams,

--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -344,7 +344,7 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties {
     }
     IOUtils.write(content, outputStream)
     outputStream.close()
-    content.size
+    content.length
   }
 
   private val workerConf = new SparkConf()

--- a/graphx/src/main/scala/org/apache/spark/graphx/lib/PageRank.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/lib/PageRank.scala
@@ -334,10 +334,10 @@ object PageRank extends Logging {
     require(sources.nonEmpty, s"The list of sources must be non-empty," +
       s" but got ${sources.mkString("[", ",", "]")}")
 
-    val zero = Vectors.sparse(sources.size, List()).asBreeze
+    val zero = Vectors.sparse(sources.length, List()).asBreeze
     // map of vid -> vector where for each vid, the _position of vid in source_ is set to 1.0
     val sourcesInitMap = sources.zipWithIndex.map { case (vid, i) =>
-      val v = Vectors.sparse(sources.size, Array(i), Array(1.0)).asBreeze
+      val v = Vectors.sparse(sources.length, Array(i), Array(1.0)).asBreeze
       (vid, v)
     }.toMap
 

--- a/graphx/src/test/scala/org/apache/spark/graphx/GraphOpsSuite.scala
+++ b/graphx/src/test/scala/org/apache/spark/graphx/GraphOpsSuite.scala
@@ -44,7 +44,7 @@ class GraphOpsSuite extends SparkFunSuite with LocalSparkContext {
       val nbrs = graph.collectNeighborIds(EdgeDirection.Either).cache()
       assert(nbrs.count() === 100)
       assert(graph.numVertices === nbrs.count())
-      nbrs.collect().foreach { case (vid, nbrs) => assert(nbrs.size === 2) }
+      nbrs.collect().foreach { case (vid, nbrs) => assert(nbrs.length === 2) }
       nbrs.collect().foreach {
         case (vid, nbrs) =>
           val s = nbrs.toSet
@@ -64,7 +64,7 @@ class GraphOpsSuite extends SparkFunSuite with LocalSparkContext {
       val graph = Graph.fromEdgeTuples(sc.parallelize(edgeArray.toImmutableArraySeq), 1)
       val canonicalizedEdges = graph.removeSelfEdges().edges.map(e => (e.srcId, e.dstId))
         .collect()
-      assert(canonicalizedEdges.toSet.size === canonicalizedEdges.size)
+      assert(canonicalizedEdges.toSet.size === canonicalizedEdges.length)
       assert(canonicalizedEdges.toSet === correctEdges)
     }
   }
@@ -112,7 +112,7 @@ class GraphOpsSuite extends SparkFunSuite with LocalSparkContext {
       val graph = getCycleGraph(sc, 100)
       val edges = graph.collectEdges(EdgeDirection.Out).cache()
       assert(edges.count() == 100)
-      edges.collect().foreach { case (vid, edges) => assert(edges.size == 1) }
+      edges.collect().foreach { case (vid, edges) => assert(edges.length == 1) }
       edges.collect().foreach {
         case (vid, edges) =>
           val s = edges.toSet
@@ -127,7 +127,7 @@ class GraphOpsSuite extends SparkFunSuite with LocalSparkContext {
       val graph = getCycleGraph(sc, 100)
       val edges = graph.collectEdges(EdgeDirection.In).cache()
       assert(edges.count() == 100)
-      edges.collect().foreach { case (vid, edges) => assert(edges.size == 1) }
+      edges.collect().foreach { case (vid, edges) => assert(edges.length == 1) }
       edges.collect().foreach {
         case (vid, edges) =>
           val s = edges.toSet
@@ -142,7 +142,7 @@ class GraphOpsSuite extends SparkFunSuite with LocalSparkContext {
       val graph = getCycleGraph(sc, 100)
       val edges = graph.collectEdges(EdgeDirection.Either).cache()
       assert(edges.count() == 100)
-      edges.collect().foreach { case (vid, edges) => assert(edges.size == 2) }
+      edges.collect().foreach { case (vid, edges) => assert(edges.length == 2) }
       edges.collect().foreach {
         case (vid, edges) =>
           val s = edges.toSet
@@ -158,7 +158,7 @@ class GraphOpsSuite extends SparkFunSuite with LocalSparkContext {
       val graph = getChainGraph(sc, 50)
       val edges = graph.collectEdges(EdgeDirection.Out).cache()
       assert(edges.count() == 49)
-      edges.collect().foreach { case (vid, edges) => assert(edges.size == 1) }
+      edges.collect().foreach { case (vid, edges) => assert(edges.length == 1) }
       edges.collect().foreach {
         case (vid, edges) =>
           val s = edges.toSet
@@ -175,7 +175,7 @@ class GraphOpsSuite extends SparkFunSuite with LocalSparkContext {
       // We expect only 49 because collectEdges does not return vertices that do
       // not have any edges in the specified direction.
       assert(edges.count() == 49)
-      edges.collect().foreach { case (vid, edges) => assert(edges.size == 1) }
+      edges.collect().foreach { case (vid, edges) => assert(edges.length == 1) }
       edges.collect().foreach {
         case (vid, edges) =>
           val s = edges.toSet
@@ -194,9 +194,9 @@ class GraphOpsSuite extends SparkFunSuite with LocalSparkContext {
       assert(edges.count() === 50)
       edges.collect().foreach {
         case (vid, edges) => if (vid > 0 && vid < 49) {
-          assert(edges.size == 2)
+          assert(edges.length == 2)
         } else {
-          assert(edges.size == 1)
+          assert(edges.length == 1)
         }
       }
       edges.collect().foreach {

--- a/graphx/src/test/scala/org/apache/spark/graphx/GraphSuite.scala
+++ b/graphx/src/test/scala/org/apache/spark/graphx/GraphSuite.scala
@@ -194,7 +194,7 @@ class GraphSuite extends SparkFunSuite with LocalSparkContext {
       val starWithEdgeAttrs = star.mapEdges(e => e.dstId)
 
       val edges = starWithEdgeAttrs.edges.collect()
-      assert(edges.size === n)
+      assert(edges.length === n)
       assert(edges.toSet === (1 to n).map(x => Edge(0, x, x)).toSet)
     }
   }

--- a/graphx/src/test/scala/org/apache/spark/graphx/VertexRDDSuite.scala
+++ b/graphx/src/test/scala/org/apache/spark/graphx/VertexRDDSuite.scala
@@ -69,7 +69,7 @@ class VertexRDDSuite extends SparkFunSuite with LocalSparkContext {
     withSpark { sc =>
       val vertexA = VertexRDD(sc.parallelize(0 until 75, 5).map(i => (i.toLong, 0)))
       val vertexB = VertexRDD(sc.parallelize(50 until 100, 2).map(i => (i.toLong, 1)))
-      assert(vertexA.partitions.size != vertexB.partitions.size)
+      assert(vertexA.partitions.length != vertexB.partitions.length)
       val vertexC = vertexA.minus(vertexB)
       assert(vertexC.map(_._1).collect().toSet === (0 until 50).toSet)
     }
@@ -103,7 +103,7 @@ class VertexRDDSuite extends SparkFunSuite with LocalSparkContext {
     withSpark { sc =>
       val vertexA = VertexRDD(sc.parallelize(0 until 24, 3).map(i => (i.toLong, 0)))
       val vertexB = VertexRDD(sc.parallelize(8 until 16, 2).map(i => (i.toLong, 1)))
-      assert(vertexA.partitions.size != vertexB.partitions.size)
+      assert(vertexA.partitions.length != vertexB.partitions.length)
       val vertexC = vertexA.diff(vertexB)
       assert(vertexC.map(_._1).collect().toSet === (8 until 16).toSet)
     }
@@ -129,7 +129,7 @@ class VertexRDDSuite extends SparkFunSuite with LocalSparkContext {
       val vertexA = VertexRDD(sc.parallelize(0 until 100, 2).map(i => (i.toLong, 1)))
       val vertexB = VertexRDD(
         vertexA.filter(v => v._1 % 2 == 0).partitionBy(new HashPartitioner(3)))
-      assert(vertexA.partitions.size != vertexB.partitions.size)
+      assert(vertexA.partitions.length != vertexB.partitions.length)
       val vertexC = vertexA.leftJoin(vertexB) { (vid, old, newOpt) =>
         old - newOpt.getOrElse(0)
       }
@@ -156,7 +156,7 @@ class VertexRDDSuite extends SparkFunSuite with LocalSparkContext {
       val vertexA = VertexRDD(sc.parallelize(0 until 100, 2).map(i => (i.toLong, 1)))
       val vertexB = VertexRDD(
         vertexA.filter(v => v._1 % 2 == 0).partitionBy(new HashPartitioner(3)))
-      assert(vertexA.partitions.size != vertexB.partitions.size)
+      assert(vertexA.partitions.length != vertexB.partitions.length)
       val vertexC = vertexA.innerJoin(vertexB) { (vid, old, newVal) =>
         old - newVal
       }

--- a/mllib-local/src/test/scala/org/apache/spark/ml/linalg/MatricesSuite.scala
+++ b/mllib-local/src/test/scala/org/apache/spark/ml/linalg/MatricesSuite.scala
@@ -864,10 +864,10 @@ class MatricesSuite extends SparkMLFunSuite {
     mat.toString(Int.MinValue, Int.MinValue)
     mat.toString(Int.MaxValue, Int.MaxValue)
     var lines = mat.toString(6, 50).split('\n')
-    assert(lines.size == 5 && lines.forall(_.size <= 50))
+    assert(lines.length == 5 && lines.forall(_.length <= 50))
 
     lines = mat.toString(5, 100).split('\n')
-    assert(lines.size == 5 && lines.forall(_.size <= 100))
+    assert(lines.length == 5 && lines.forall(_.length <= 100))
   }
 
   test("numNonzeros and numActives") {

--- a/mllib/src/main/scala/org/apache/spark/ml/r/IsotonicRegressionWrapper.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/r/IsotonicRegressionWrapper.scala
@@ -68,7 +68,7 @@ private[r] object IsotonicRegressionWrapper
     val featureAttrs = AttributeGroup.fromStructField(schema(rFormulaModel.getFeaturesCol))
       .attributes.get
     val features = featureAttrs.map(_.name.get)
-    require(features.size == 1)
+    require(features.length == 1)
 
     // assemble and fit the pipeline
     val isotonicRegression = new IsotonicRegression()

--- a/mllib/src/main/scala/org/apache/spark/ml/r/KMeansWrapper.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/r/KMeansWrapper.scala
@@ -43,7 +43,7 @@ private[r] class KMeansWrapper private (
 
   lazy val cluster: DataFrame = kMeansModel.summary.cluster
 
-  lazy val clusterSize: Int = kMeansModel.clusterCenters.size
+  lazy val clusterSize: Int = kMeansModel.clusterCenters.length
 
   def fitted(method: String): DataFrame = {
     if (method == "centers") {

--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/StreamingKMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/StreamingKMeans.scala
@@ -229,10 +229,10 @@ class StreamingKMeans @Since("1.2.0") (
    */
   @Since("1.2.0")
   def setInitialCenters(centers: Array[Vector], weights: Array[Double]): this.type = {
-    require(centers.size == weights.size,
+    require(centers.length == weights.length,
       "Number of initial centers must be equal to number of weights")
-    require(centers.size == k,
-      s"Number of initial centers must be ${k} but got ${centers.size}")
+    require(centers.length == k,
+      s"Number of initial centers must be ${k} but got ${centers.length}")
     require(weights.forall(_ >= 0),
       s"Weight for each initial center must be nonnegative but got [${weights.mkString(" ")}]")
     model = new StreamingKMeansModel(centers, weights)

--- a/mllib/src/main/scala/org/apache/spark/mllib/evaluation/RankingMetrics.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/evaluation/RankingMetrics.scala
@@ -162,7 +162,7 @@ class RankingMetrics[T: ClassTag] @Since("1.2.0") (predictionAndLabels: RDD[_ <:
       val useBinary = rel.isEmpty
       val labSet = lab.toSet
       val relMap = Utils.toMap(lab, rel)
-      if (!useBinary && lab.size != rel.size) {
+      if (!useBinary && lab.length != rel.length) {
         logWarning(
           "# of ground truth set and # of relevance value set should be equal, " +
             "check input data")

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/distributed/RowMatrix.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/distributed/RowMatrix.scala
@@ -703,7 +703,7 @@ class RowMatrix @Since("1.0.0") (
       colMags: Array[Double],
       gamma: Double): CoordinateMatrix = {
     require(gamma > 1.0, s"Oversampling should be greater than 1: $gamma")
-    require(colMags.size == this.numCols(), "Number of magnitudes didn't match column dimension")
+    require(colMags.length == this.numCols(), "Number of magnitudes didn't match column dimension")
     val sg = math.sqrt(gamma) // sqrt(gamma) used many times
 
     // Don't divide by zero for those columns with zero magnitude
@@ -718,11 +718,11 @@ class RowMatrix @Since("1.0.0") (
       val q = qBV.value
 
       val rand = new XORShiftRandom(index)
-      val scaled = new Array[Double](p.size)
+      val scaled = new Array[Double](p.length)
       iter.flatMap { row =>
         row match {
           case SparseVector(size, indices, values) =>
-            val nnz = indices.size
+            val nnz = indices.length
             var k = 0
             while (k < nnz) {
               scaled(k) = values(k) / q(indices(k))
@@ -747,7 +747,7 @@ class RowMatrix @Since("1.0.0") (
               buf
             }.flatten
           case DenseVector(values) =>
-            val n = values.size
+            val n = values.length
             var i = 0
             while (i < n) {
               scaled(i) = values(i) / q(i)

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/model/DecisionTreeModel.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/model/DecisionTreeModel.scala
@@ -244,7 +244,7 @@ object DecisionTreeModel extends Loader[DecisionTreeModel] with Logging {
       // Build node data into a tree.
       val trees = constructTrees(nodes)
       assert(trees.length == 1,
-        s"Decision tree should contain exactly one tree but got ${trees.size} trees.")
+        s"Decision tree should contain exactly one tree but got ${trees.length} trees.")
       val model = new DecisionTreeModel(trees(0), Algo.fromString(algo))
       assert(model.numNodes == numNodes, s"Unable to load DecisionTreeModel data from: $dataPath." +
         s" Expected $numNodes nodes but found ${model.numNodes}")

--- a/mllib/src/test/scala/org/apache/spark/ml/ann/GradientSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/ann/GradientSuite.scala
@@ -43,7 +43,7 @@ class GradientSuite extends SparkFunSuite with MLlibTestSparkContext {
       topology.layers(topology.layers.length - 1) = layerWithError
       val model = topology.model(seed = 12L)
       val weights = model.weights.toArray
-      val numWeights = weights.size
+      val numWeights = weights.length
       val gradient = Vectors.dense(Array.fill[Double](numWeights)(0.0))
       val loss = model.computeGradient(input, target, gradient, 1)
       val eps = 1e-4

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/Word2VecSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/Word2VecSuite.scala
@@ -37,7 +37,7 @@ class Word2VecSuite extends MLTest with DefaultReadWriteTest {
 
   test("Word2Vec") {
     val sentence = "a b " * 100 + "a c " * 10
-    val numOfWords = sentence.split(" ").size
+    val numOfWords = sentence.split(" ").length
     val doc = sc.parallelize(Seq(sentence, sentence)).map(line => line.split(" "))
 
     val codes = Map(

--- a/mllib/src/test/scala/org/apache/spark/ml/optim/aggregator/MultinomialLogisticBlockAggregatorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/optim/aggregator/MultinomialLogisticBlockAggregatorSuite.scala
@@ -114,7 +114,7 @@ class MultinomialLogisticBlockAggregatorSuite extends SparkFunSuite with MLlibTe
   test("check sizes") {
     val rng = new scala.util.Random
     val numFeatures = instances.head.features.size
-    val numClasses = instances.map(_.label).distinct.size
+    val numClasses = instances.map(_.label).distinct.length
     val coefWithIntercept = Vectors.dense(
       Array.fill(numClasses * (numFeatures + 1))(rng.nextDouble()))
     val coefWithoutIntercept = Vectors.dense(
@@ -140,7 +140,7 @@ class MultinomialLogisticBlockAggregatorSuite extends SparkFunSuite with MLlibTe
       Summarizer.getClassificationSummarizers(sc.parallelize(instances.toImmutableArraySeq))
     val featuresStd = featuresSummarizer.std
     val stdCoefMat = Matrices.dense(numClasses, numFeatures,
-      Array.tabulate(coefArray.size)(i => coefArray(i) / featuresStd(i / numClasses)))
+      Array.tabulate(coefArray.length)(i => coefArray(i) / featuresStd(i / numClasses)))
     val weightSum = instances.map(_.weight).sum
 
     // compute the loss
@@ -206,7 +206,7 @@ class MultinomialLogisticBlockAggregatorSuite extends SparkFunSuite with MLlibTe
       Summarizer.getClassificationSummarizers(sc.parallelize(instances.toImmutableArraySeq))
     val featuresStd = featuresSummarizer.std
     val stdCoefMat = Matrices.dense(numClasses, numFeatures,
-      Array.tabulate(coefArray.size)(i => coefArray(i) / featuresStd(i / numClasses)))
+      Array.tabulate(coefArray.length)(i => coefArray(i) / featuresStd(i / numClasses)))
     val weightSum = instances.map(_.weight).sum
 
     // compute the loss
@@ -280,7 +280,7 @@ class MultinomialLogisticBlockAggregatorSuite extends SparkFunSuite with MLlibTe
     val featuresStd = featuresSummarizer.std
     val featuresMean = featuresSummarizer.mean
     val stdCoefMat = Matrices.dense(numClasses, numFeatures,
-      Array.tabulate(coefArray.size)(i => coefArray(i) / featuresStd(i / numClasses)))
+      Array.tabulate(coefArray.length)(i => coefArray(i) / featuresStd(i / numClasses)))
     val weightSum = instances.map(_.weight).sum
 
     // compute the loss

--- a/mllib/src/test/scala/org/apache/spark/ml/recommendation/CollectTopKSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/recommendation/CollectTopKSuite.scala
@@ -55,7 +55,7 @@ class CollectTopKSuite extends MLTest {
       1 -> Array(39f),
       2 -> Array(18f, 45f)
     )
-    assert(topK.size === expected.size)
+    assert(topK.length === expected.size)
     topK.foreach { case (k, v) => assert(v === expected(k)) }
   }
 
@@ -71,7 +71,7 @@ class CollectTopKSuite extends MLTest {
       1 -> Array(39f),
       2 -> Array(18f, 45f, 51f)
     )
-    assert(topK.size === expected.size)
+    assert(topK.length === expected.size)
     topK.foreach { case (k, v) => assert(v === expected(k)) }
   }
 
@@ -88,7 +88,7 @@ class CollectTopKSuite extends MLTest {
       1 -> Array((3, 39f)),
       2 -> Array((3, 51f), (5, 45f))
     )
-    assert(topK.size === expected.size)
+    assert(topK.length === expected.size)
     topK.foreach { case (k, v) => assert(v === expected(k)) }
   }
 
@@ -105,7 +105,7 @@ class CollectTopKSuite extends MLTest {
       1 -> Array((3, 39f)),
       2 -> Array((3, 51f), (5, 45f), (6, 18f))
     )
-    assert(topK.size === expected.size)
+    assert(topK.length === expected.size)
     topK.foreach { case (k, v) => assert(v === expected(k)) }
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/LinearRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/LinearRegressionSuite.scala
@@ -202,7 +202,7 @@ class LinearRegressionSuite extends MLTest with DefaultReadWriteTest with PMMLRe
         coefficients = original.coefficients,
         intercept = original.intercept)
       val output = deserialized.transform(datasetWithDenseFeature)
-      assert(output.collect().size > 0) // simple assertion to ensure no exception thrown
+      assert(output.collect().length > 0) // simple assertion to ensure no exception thrown
     }
   }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/tree/impl/BaggedPointSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/tree/impl/BaggedPointSuite.scala
@@ -36,7 +36,7 @@ class BaggedPointSuite extends SparkFunSuite with MLlibTestSparkContext  {
     val baggedRDD = BaggedPoint.convertToBaggedRDD(rdd, 1.0, 1, false,
       (instance: Instance) => instance.weight * 4.0, seed = 42)
     baggedRDD.collect().foreach { baggedPoint =>
-      assert(baggedPoint.subsampleCounts.size === 1 && baggedPoint.subsampleCounts(0) === 1)
+      assert(baggedPoint.subsampleCounts.length === 1 && baggedPoint.subsampleCounts(0) === 1)
       assert(baggedPoint.sampleWeight === 2.0)
     }
   }

--- a/mllib/src/test/scala/org/apache/spark/ml/tree/impl/RandomForestSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/tree/impl/RandomForestSuite.scala
@@ -694,7 +694,7 @@ class RandomForestSuite extends SparkFunSuite with MLlibTestSparkContext {
     assert(prunedTree.numNodes === 5)
     assert(unprunedTree.numNodes === 7)
 
-    assert(RandomForestSuite.getSumLeafCounters(List(prunedTree.rootNode)) === arr.size)
+    assert(RandomForestSuite.getSumLeafCounters(List(prunedTree.rootNode)) === arr.length)
   }
 
   test("SPARK-3159 tree model redundancy - regression") {
@@ -723,7 +723,7 @@ class RandomForestSuite extends SparkFunSuite with MLlibTestSparkContext {
 
     assert(prunedTree.numNodes === 3)
     assert(unprunedTree.numNodes === 5)
-    assert(RandomForestSuite.getSumLeafCounters(List(prunedTree.rootNode)) === arr.size)
+    assert(RandomForestSuite.getSumLeafCounters(List(prunedTree.rootNode)) === arr.length)
   }
 
   test("weights at arbitrary scale") {

--- a/mllib/src/test/scala/org/apache/spark/ml/tuning/ParamGridBuilderSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/tuning/ParamGridBuilderSuite.scala
@@ -29,7 +29,7 @@ class ParamGridBuilderSuite extends SparkFunSuite {
 
   test("param grid builder") {
     def validateGrid(maps: Array[ParamMap], expected: mutable.Set[(Int, String)]): Unit = {
-      assert(maps.size === expected.size)
+      assert(maps.length === expected.size)
       maps.foreach { m =>
         val tuple = (m(maxIter), m(inputCol))
         assert(expected.contains(tuple))

--- a/mllib/src/test/scala/org/apache/spark/mllib/clustering/KMeansSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/clustering/KMeansSuite.scala
@@ -160,7 +160,7 @@ class KMeansSuite extends SparkFunSuite with MLlibTestSparkContext {
     val center = Vectors.dense(1.0, 3.0, 4.0)
 
     var model = KMeans.train(data, k = 1, maxIterations = 1)
-    assert(model.clusterCenters.size === 1)
+    assert(model.clusterCenters.length === 1)
     assert(model.clusterCenters.head ~== center absTol 1E-5)
 
     model = KMeans.train(data, k = 1, maxIterations = 2)

--- a/mllib/src/test/scala/org/apache/spark/mllib/fpm/AssociationRulesSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/fpm/AssociationRulesSuite.scala
@@ -63,7 +63,7 @@ class AssociationRulesSuite extends SparkFunSuite with MLlibTestSparkContext {
        > sum(arsDF$confidence == 1)
        [1] 23
      */
-    assert(results1.size === 23)
+    assert(results1.length === 23)
     assert(results1.count(rule => rule.confidence ~= 1.0D absTol 1e-6) == 23)
 
     val results2 = ar
@@ -84,7 +84,7 @@ class AssociationRulesSuite extends SparkFunSuite with MLlibTestSparkContext {
        > sum(arsDF$confidence == 1)
        [1] 23
      */
-    assert(results2.size === 30)
+    assert(results2.length === 30)
     assert(results2.count(rule => rule.confidence ~= 1.0D absTol 1e-6) == 23)
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/mllib/fpm/FPGrowthSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/fpm/FPGrowthSuite.scala
@@ -172,7 +172,7 @@ class FPGrowthSuite extends SparkFunSuite with MLlibTestSparkContext {
       .generateAssociationRules(0.9)
       .collect()
 
-    assert(rules.size === 23)
+    assert(rules.length === 23)
     assert(rules.count(rule => rule.confidence ~= 1.0D absTol 1e-6) == 23)
   }
 

--- a/mllib/src/test/scala/org/apache/spark/mllib/linalg/MatricesSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/linalg/MatricesSuite.scala
@@ -513,10 +513,10 @@ class MatricesSuite extends SparkFunSuite {
     mat.toString(Int.MinValue, Int.MinValue)
     mat.toString(Int.MaxValue, Int.MaxValue)
     var lines = mat.toString(6, 50).split('\n')
-    assert(lines.size == 5 && lines.forall(_.size <= 50))
+    assert(lines.length == 5 && lines.forall(_.length <= 50))
 
     lines = mat.toString(5, 100).split('\n')
-    assert(lines.size == 5 && lines.forall(_.size <= 100))
+    assert(lines.length == 5 && lines.forall(_.length <= 100))
   }
 
   test("numNonzeros and numActives") {

--- a/mllib/src/test/scala/org/apache/spark/mllib/optimization/GradientDescentSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/optimization/GradientDescentSuite.scala
@@ -101,7 +101,7 @@ class GradientDescentSuite extends SparkFunSuite with MLlibTestSparkContext with
     assert(loss.last - loss.head < 0, "loss isn't decreasing.")
 
     val lossDiff = loss.init.zip(loss.tail).map { case (lhs, rhs) => lhs - rhs }
-    assert(lossDiff.count(_ > 0).toDouble / lossDiff.size > 0.8)
+    assert(lossDiff.count(_ > 0).toDouble / lossDiff.length > 0.8)
   }
 
   test("Test the loss and gradient of first iteration with regularization.") {

--- a/mllib/src/test/scala/org/apache/spark/mllib/random/RandomRDDsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/random/RandomRDDsSuite.scala
@@ -41,7 +41,7 @@ class RandomRDDsSuite extends SparkFunSuite with MLlibTestSparkContext with Seri
       epsilon: Double = 0.01): Unit = {
     val stats = rdd.stats()
     assert(expectedSize === stats.count)
-    assert(expectedNumPartitions === rdd.partitions.size)
+    assert(expectedNumPartitions === rdd.partitions.length)
     assert(stats.mean ~== expectedMean absTol epsilon)
     assert(stats.stdev ~== expectedStddev absTol epsilon)
   }
@@ -54,7 +54,7 @@ class RandomRDDsSuite extends SparkFunSuite with MLlibTestSparkContext with Seri
       expectedMean: Double,
       expectedStddev: Double,
       epsilon: Double = 0.01): Unit = {
-    assert(expectedNumPartitions === rdd.partitions.size)
+    assert(expectedNumPartitions === rdd.partitions.length)
     val values = new ArrayBuffer[Double]()
     rdd.collect().foreach { vector => {
       assert(vector.size === expectedColumns)
@@ -72,7 +72,7 @@ class RandomRDDsSuite extends SparkFunSuite with MLlibTestSparkContext with Seri
     for ((size, numPartitions) <- List((10000, 6), (12345, 1), (1000, 101))) {
       val rdd = new RandomRDD(sc, size, numPartitions, new UniformGenerator, 0L)
       assert(rdd.count() === size)
-      assert(rdd.partitions.size === numPartitions)
+      assert(rdd.partitions.length === numPartitions)
 
       // check that partition sizes are balanced
       val partSizes = rdd.partitions.map(p =>
@@ -86,7 +86,7 @@ class RandomRDDsSuite extends SparkFunSuite with MLlibTestSparkContext with Seri
     val size = Int.MaxValue.toLong * 100L
     val numPartitions = 101
     val rdd = new RandomRDD(sc, size, numPartitions, new UniformGenerator, 0L)
-    assert(rdd.partitions.size === numPartitions)
+    assert(rdd.partitions.length === numPartitions)
     val count = rdd.partitions.foldLeft(0L) { (count, part) =>
       count + part.asInstanceOf[RandomRDDPartition[Double]].size
     }
@@ -144,7 +144,7 @@ class RandomRDDsSuite extends SparkFunSuite with MLlibTestSparkContext with Seri
 
     // mock distribution to check that partitions have unique seeds
     val random = RandomRDDs.randomRDD(sc, new MockDistro(), 1000L, 1000, 0L)
-    assert(random.collect().size === random.collect().distinct.size)
+    assert(random.collect().length === random.collect().distinct.length)
   }
 
   test("randomVectorRDD for different distributions") {

--- a/mllib/src/test/scala/org/apache/spark/mllib/stat/HypothesisTestSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/stat/HypothesisTestSuite.scala
@@ -142,7 +142,7 @@ class HypothesisTestSuite extends SparkFunSuite with MLlibTestSparkContext {
       new LabeledPoint(0.0, Vectors.sparse(numCols, Seq((100, 2.0)))),
       new LabeledPoint(0.1, Vectors.sparse(numCols, Seq((200, 1.0)))))
     val chi = Statistics.chiSqTest(sc.parallelize(sparseData.toImmutableArraySeq))
-    assert(chi.size === numCols)
+    assert(chi.length === numCols)
     assert(chi(1000) != null) // SPARK-3087
 
     // Detect continuous features or labels

--- a/mllib/src/test/scala/org/apache/spark/mllib/tree/EnsembleTestHelper.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/tree/EnsembleTestHelper.scala
@@ -42,7 +42,7 @@ object EnsembleTestHelper {
       epsilon: Double): Unit = {
     val values = new mutable.ArrayBuffer[Double]()
     data.foreach { row =>
-      assert(row.size == numCols)
+      assert(row.length == numCols)
       values ++= row
     }
     val stats = new StatCounter(values)

--- a/mllib/src/test/scala/org/apache/spark/mllib/tree/GradientBoostedTreesSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/tree/GradientBoostedTreesSuite.scala
@@ -45,7 +45,7 @@ class GradientBoostedTreesSuite extends SparkFunSuite with MLlibTestSparkContext
 
         val gbt = GradientBoostedTrees.train(rdd, boostingStrategy)
 
-        assert(gbt.trees.size === numIterations)
+        assert(gbt.trees.length === numIterations)
         try {
           EnsembleTestHelper.validateRegressor(
             gbt, GradientBoostedTreesSuite.data.toImmutableArraySeq, 0.06)
@@ -76,7 +76,7 @@ class GradientBoostedTreesSuite extends SparkFunSuite with MLlibTestSparkContext
 
         val gbt = GradientBoostedTrees.train(rdd, boostingStrategy)
 
-        assert(gbt.trees.size === numIterations)
+        assert(gbt.trees.length === numIterations)
         try {
           EnsembleTestHelper.validateRegressor(
             gbt, GradientBoostedTreesSuite.data.toImmutableArraySeq, 0.85, "mae")
@@ -108,7 +108,7 @@ class GradientBoostedTreesSuite extends SparkFunSuite with MLlibTestSparkContext
 
         val gbt = GradientBoostedTrees.train(rdd, boostingStrategy)
 
-        assert(gbt.trees.size === numIterations)
+        assert(gbt.trees.length === numIterations)
         try {
           EnsembleTestHelper.validateClassifier(
             gbt, GradientBoostedTreesSuite.data.toImmutableArraySeq, 0.9)

--- a/mllib/src/test/scala/org/apache/spark/mllib/util/MLUtilsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/util/MLUtilsSuite.scala
@@ -198,7 +198,7 @@ class MLUtilsSuite extends SparkFunSuite with MLlibTestSparkContext {
         assert(foldedRdds.length === folds)
         foldedRdds.foreach { case (training, validation) =>
           val result = validation.union(training).collect().sorted
-          val validationSize = validation.collect().size.toFloat
+          val validationSize = validation.collect().length.toFloat
           assert(validationSize > 0, "empty validation data")
           val p = 1 / folds.toFloat
           // Within 3 standard deviations of the mean
@@ -210,7 +210,7 @@ class MLUtilsSuite extends SparkFunSuite with MLlibTestSparkContext {
             s"Validation data ($validationSize) smaller than expected ($lowerBound)" )
           assert(validationSize < upperBound,
             s"Validation data ($validationSize) larger than expected ($upperBound)" )
-          assert(training.collect().size > 0, "empty training data")
+          assert(training.collect().length > 0, "empty training data")
           assert(result ===  collectedData,
             "Each training+validation set combined should contain all of the data.")
         }

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/StructType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/StructType.scala
@@ -560,7 +560,7 @@ object StructType extends AbstractDataType {
     mergeInternal(left, right, (s1: StructType, s2: StructType) => {
       val leftFields = s1.fields
       val rightFields = s2.fields
-      require(leftFields.size == rightFields.size, "To merge nullability, " +
+      require(leftFields.length == rightFields.length, "To merge nullability, " +
         "two structs must have same number of fields.")
 
       val newFields = leftFields.zip(rightFields).map {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/InternalRow.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/InternalRow.scala
@@ -145,7 +145,7 @@ object InternalRow {
         case PhysicalCalendarIntervalType => (input, ordinal) => input.getInterval(ordinal)
         case t: PhysicalDecimalType => (input, ordinal) =>
           input.getDecimal(ordinal, t.precision, t.scale)
-        case t: PhysicalStructType => (input, ordinal) => input.getStruct(ordinal, t.fields.size)
+        case t: PhysicalStructType => (input, ordinal) => input.getStruct(ordinal, t.fields.length)
         case _: PhysicalArrayType => (input, ordinal) => input.getArray(ordinal)
         case _: PhysicalMapType => (input, ordinal) => input.getMap(ordinal)
         case _ => (input, ordinal) => input.get(ordinal, dt)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -3358,7 +3358,7 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
             encOpt.map { enc =>
               val attrs = if (enc.isSerializedAsStructForTopLevel) {
                 // Value class that has been replaced with its underlying type
-                if (enc.schema.fields.size == 1 && enc.schema.fields.head.dataType == dataType) {
+                if (enc.schema.fields.length == 1 && enc.schema.fields.head.dataType == dataType) {
                   DataTypeUtils.toAttributes(enc.schema)
                 } else {
                   DataTypeUtils.toAttributes(dataType.asInstanceOf[StructType])

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVHeaderChecker.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVHeaderChecker.scala
@@ -58,7 +58,7 @@ class CSVHeaderChecker(
   private def checkHeaderColumnNames(columnNames: Array[String]): Unit = {
     if (columnNames != null) {
       val fieldNames = schema.map(_.name).toIndexedSeq
-      val (headerLen, schemaSize) = (columnNames.size, fieldNames.length)
+      val (headerLen, schemaSize) = (columnNames.length, fieldNames.length)
       var errorMessage: Option[String] = None
 
       if (headerLen == schemaSize) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ScalaUDF.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ScalaUDF.scala
@@ -163,7 +163,7 @@ case class ScalaUDF(
       val enc = inputEncoders(i).get
       val fromRow = enc.createDeserializer()
       val unwrappedValueClass = enc.isSerializedAsStruct &&
-        enc.schema.fields.size == 1 && enc.schema.fields.head.dataType == dataType
+        enc.schema.fields.length == 1 && enc.schema.fields.head.dataType == dataType
       val converter = if (enc.isSerializedAsStructForTopLevel && !unwrappedValueClass) {
         row: Any => fromRow(row.asInstanceOf[InternalRow])
       } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -1641,7 +1641,7 @@ object CodeGenerator extends Logging {
         case _: PhysicalMapType => s"$input.getMap($ordinal)"
         case PhysicalNullType => "null"
         case PhysicalStringType => s"$input.getUTF8String($ordinal)"
-        case t: PhysicalStructType => s"$input.getStruct($ordinal, ${t.fields.size})"
+        case t: PhysicalStructType => s"$input.getStruct($ordinal, ${t.fields.length})"
         case PhysicalVariantType => s"$input.getVariant($ordinal)"
         case _ => s"($jt)$input.get($ordinal, null)"
       }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
@@ -628,7 +628,7 @@ case class NewInstance(
 
     ev.isNull = resultIsNull
 
-    val constructorCall = cls.getConstructors.size match {
+    val constructorCall = cls.getConstructors.length match {
       // If there are no constructors, the `new` method will fail. In
       // this case we can try to call the apply method constructor
       // that might be defined on the companion object.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserUtils.scala
@@ -78,7 +78,7 @@ object ParserUtils extends SparkParserUtils {
   /** Convert a string node into a string without unescaping. */
   def stringWithoutUnescape(node: Token): String = {
     // STRING parser rule forces that the input always has quotes at the starting and ending.
-    node.getText.slice(1, node.getText.size - 1)
+    node.getText.slice(1, node.getText.length - 1)
   }
 
   /** Collect the entries if any. */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/types/DataTypeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/types/DataTypeUtils.scala
@@ -139,16 +139,16 @@ object DataTypeUtils {
             }
         }
 
-        if (readFields.size > writeFields.size) {
-          val missingFieldsStr = readFields.takeRight(readFields.size - writeFields.size)
+        if (readFields.length > writeFields.length) {
+          val missingFieldsStr = readFields.takeRight(readFields.length - writeFields.length)
             .map(f => s"${toSQLId(f.name)}").mkString(", ")
           if (missingFieldsStr.nonEmpty) {
             throw QueryCompilationErrors.incompatibleDataToTableStructMissingFieldsError(
               tableName, context, missingFieldsStr)
           }
 
-        } else if (writeFields.size > readFields.size) {
-          val extraFieldsStr = writeFields.takeRight(writeFields.size - readFields.size)
+        } else if (writeFields.length > readFields.length) {
+          val extraFieldsStr = writeFields.takeRight(writeFields.length - readFields.length)
             .map(f => s"${toSQLId(f.name)}").mkString(", ")
           throw QueryCompilationErrors.incompatibleDataToTableExtraStructFieldsError(
             tableName, context, extraFieldsStr

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ResolveDefaultColumnsUtil.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ResolveDefaultColumnsUtil.scala
@@ -375,7 +375,7 @@ object ResolveDefaultColumns extends QueryErrorsBase with ResolveDefaultColumnsU
    * above, for convenience.
    */
   def getExistenceDefaultsBitmask(schema: StructType): Array[Boolean] = {
-    Array.fill[Boolean](existenceDefaultValues(schema).size)(true)
+    Array.fill[Boolean](existenceDefaultValues(schema).length)(true)
   }
 
   /**
@@ -384,7 +384,7 @@ object ResolveDefaultColumns extends QueryErrorsBase with ResolveDefaultColumnsU
    */
   def resetExistenceDefaultsBitmask(schema: StructType, bitmask: Array[Boolean]): Unit = {
     val defaultValues = existenceDefaultValues(schema)
-    for (i <- 0 until defaultValues.size) {
+    for (i <- 0 until defaultValues.length) {
       bitmask(i) = (defaultValues(i) != null)
     }
   }
@@ -396,7 +396,7 @@ object ResolveDefaultColumns extends QueryErrorsBase with ResolveDefaultColumnsU
       bitmask: Array[Boolean]): Unit = {
     val existingValues = existenceDefaultValues(schema)
     if (hasExistenceDefaultValues(schema)) {
-      for (i <- 0 until existingValues.size) {
+      for (i <- 0 until existingValues.length) {
         if (bitmask(i)) {
           row.update(i, existingValues(i))
         }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/arrow/ArrowWriter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/arrow/ArrowWriter.scala
@@ -98,7 +98,7 @@ class ArrowWriter(val root: VectorSchemaRoot, fields: Array[ArrowFieldWriter]) {
 
   def write(row: InternalRow): Unit = {
     var i = 0
-    while (i < fields.size) {
+    while (i < fields.length) {
       fields(i).write(row, i)
       i += 1
     }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/RebaseDateTimeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/RebaseDateTimeSuite.scala
@@ -191,7 +191,7 @@ class RebaseDateTimeSuite extends SparkFunSuite with Matchers with SQLHelper {
       withClue(s"JSON file = $json") {
         val rebaseRecords = loadRebaseRecords(json)
         rebaseRecords.foreach { case (_, rebaseRecord) =>
-          assert(rebaseRecord.switches.size === rebaseRecord.diffs.size)
+          assert(rebaseRecord.switches.length === rebaseRecord.diffs.length)
           // Check ascending order of switches values
           assert(rebaseRecord.switches.toSeq === rebaseRecord.switches.sorted.toSeq)
         }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/StructTypeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/StructTypeSuite.scala
@@ -538,7 +538,7 @@ class StructTypeSuite extends SparkFunSuite with SQLHelper {
           .putString(ResolveDefaultColumns.CURRENT_DEFAULT_COLUMN_METADATA_KEY, "'abc'")
           .build()),
       StructField("c3", BooleanType)))
-    assert(ResolveDefaultColumns.existenceDefaultValues(source1).size == 3)
+    assert(ResolveDefaultColumns.existenceDefaultValues(source1).length == 3)
     assert(ResolveDefaultColumns.existenceDefaultValues(source1)(0) == 42)
     assert(ResolveDefaultColumns.existenceDefaultValues(source1)(1) == UTF8String.fromString("abc"))
     assert(ResolveDefaultColumns.existenceDefaultValues(source1)(2) == null)
@@ -553,7 +553,7 @@ class StructTypeSuite extends SparkFunSuite with SQLHelper {
           .putString(ResolveDefaultColumns.CURRENT_DEFAULT_COLUMN_METADATA_KEY, "1 + 1")
           .build())))
     val error = "fails to parse as a valid literal value"
-    assert(ResolveDefaultColumns.existenceDefaultValues(source2).size == 1)
+    assert(ResolveDefaultColumns.existenceDefaultValues(source2).length == 1)
     assert(ResolveDefaultColumns.existenceDefaultValues(source2)(0) == 2)
 
     // Negative test: StructType.defaultValues fails because the existence default value fails to

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -461,7 +461,7 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) {
 
       case SaveMode.Overwrite =>
         val conf = df.sparkSession.sessionState.conf
-        val dynamicPartitionOverwrite = table.table.partitioning.size > 0 &&
+        val dynamicPartitionOverwrite = table.table.partitioning.length > 0 &&
           conf.partitionOverwriteMode == PartitionOverwriteMode.DYNAMIC
 
         if (dynamicPartitionOverwrite) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/CommandResultExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/CommandResultExec.scala
@@ -77,7 +77,7 @@ case class CommandResultExec(
   }
 
   override def executeCollect(): Array[InternalRow] = {
-    longMetric("numOutputRows").add(unsafeRows.size)
+    longMetric("numOutputRows").add(unsafeRows.length)
     sendDriverMetrics()
     unsafeRows
   }
@@ -86,7 +86,7 @@ case class CommandResultExec(
 
   override def executeTake(limit: Int): Array[InternalRow] = {
     val taken = unsafeRows.take(limit)
-    longMetric("numOutputRows").add(taken.size)
+    longMetric("numOutputRows").add(taken.length)
     sendDriverMetrics()
     taken
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/LocalTableScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/LocalTableScanExec.scala
@@ -73,14 +73,14 @@ case class LocalTableScanExec(
   }
 
   override def executeCollect(): Array[InternalRow] = {
-    longMetric("numOutputRows").add(unsafeRows.size)
+    longMetric("numOutputRows").add(unsafeRows.length)
     sendDriverMetrics()
     unsafeRows
   }
 
   override def executeTake(limit: Int): Array[InternalRow] = {
     val taken = unsafeRows.take(limit)
-    longMetric("numOutputRows").add(taken.size)
+    longMetric("numOutputRows").add(taken.length)
     sendDriverMetrics()
     taken
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -88,7 +88,7 @@ object DataSourceAnalysis extends Rule[LogicalPlan] {
         targetAttributes, sourceAttributes, staticPartitions.size)
     }
 
-    if (providedPartitions.size != targetPartitionSchema.fields.size) {
+    if (providedPartitions.size != targetPartitionSchema.fields.length) {
       throw QueryCompilationErrors.insertMismatchedPartitionNumberError(
         targetPartitionSchema, providedPartitions.size)
     }
@@ -126,9 +126,9 @@ object DataSourceAnalysis extends Rule[LogicalPlan] {
 
     assert(partitionList.take(staticPartitions.size).forall(_.isDefined))
     val projectList =
-      sourceAttributes.take(targetAttributes.size - targetPartitionSchema.fields.size) ++
+      sourceAttributes.take(targetAttributes.size - targetPartitionSchema.fields.length) ++
         partitionList.take(staticPartitions.size).map(_.get) ++
-        sourceAttributes.takeRight(targetPartitionSchema.fields.size - staticPartitions.size)
+        sourceAttributes.takeRight(targetPartitionSchema.fields.length - staticPartitions.size)
 
     projectList
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcDeserializer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcDeserializer.scala
@@ -50,7 +50,7 @@ class OrcDeserializer(
     // existence default value to the columns whose IDs are not explicitly requested.
     val existingValues = ResolveDefaultColumns.existenceDefaultValues(requiredSchema)
     if (ResolveDefaultColumns.hasExistenceDefaultValues(requiredSchema)) {
-      for (i <- 0 until existingValues.size) {
+      for (i <- 0 until existingValues.length) {
         bitmask(i) =
           if (requestedColIds(i) != -1) {
             false

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowConverter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowConverter.scala
@@ -234,7 +234,7 @@ private[parquet] class ParquetRowConverter(
     // maintain a boolean array to track which fields have been explicitly assigned for each row.
     if (ResolveDefaultColumns.hasExistenceDefaultValues(catalystType)) {
       val existingValues = ResolveDefaultColumns.existenceDefaultValues(catalystType)
-      for (i <- 0 until existingValues.size) {
+      for (i <- 0 until existingValues.length) {
        bitmask(i) =
           // Assume the schema for a Parquet file-based table contains N fields. Then if we later
           // run a command "ALTER TABLE t ADD COLUMN c DEFAULT <value>" on the Parquet table, this

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreChangelog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreChangelog.scala
@@ -57,16 +57,16 @@ class StateStoreChangelogWriter(
 
   def put(key: Array[Byte], value: Array[Byte]): Unit = {
     assert(compressedStream != null)
-    compressedStream.writeInt(key.size)
+    compressedStream.writeInt(key.length)
     compressedStream.write(key)
-    compressedStream.writeInt(value.size)
+    compressedStream.writeInt(value.length)
     compressedStream.write(value)
     size += 1
   }
 
   def delete(key: Array[Byte]): Unit = {
     assert(compressedStream != null)
-    compressedStream.writeInt(key.size)
+    compressedStream.writeInt(key.length)
     compressedStream.write(key)
     // -1 in the value field means record deletion.
     compressedStream.writeInt(-1)

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameComplexTypeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameComplexTypeSuite.scala
@@ -82,7 +82,7 @@ class DataFrameComplexTypeSuite extends QueryTest with SharedSparkSession {
         )) as "items"
       ).collect()
 
-      assert(result.size === 1)
+      assert(result.length === 1)
       assert(result === Row(Seq(Seq(Row(1)), Seq(Row(2)), Seq(Row(3)))) :: Nil)
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -511,13 +511,13 @@ class DataFrameSuite extends QueryTest
       testData.select("key").coalesce(0)
     }
 
-    assert(testData.select("key").coalesce(1).rdd.partitions.size === 1)
+    assert(testData.select("key").coalesce(1).rdd.partitions.length === 1)
 
     checkAnswer(
       testData.select("key").coalesce(1).select("key"),
       testData.select("key").collect().toSeq)
 
-    assert(spark.emptyDataFrame.coalesce(1).rdd.partitions.size === 1)
+    assert(spark.emptyDataFrame.coalesce(1).rdd.partitions.length === 1)
   }
 
   test("convert $\"attribute name\" into unresolved attribute") {
@@ -914,7 +914,7 @@ class DataFrameSuite extends QueryTest
     checkAnswer(df2.drop("a.b").select("a.b"), Row(3))
 
     // "`" is treated as a normal char here with no interpreting, "`a`b" is a valid column name.
-    assert(df2.drop("`a.b`").columns.size == 2)
+    assert(df2.drop("`a.b`").columns.length == 2)
   }
 
   test("drop(name: String) search and drop all top level columns that matches the name") {
@@ -2503,7 +2503,7 @@ class DataFrameSuite extends QueryTest
     val df = Seq((1, 0), (2, 0), (3, 0)).toDF("a", "b")
     val sampleDf = df.sample(true, 2.00)
     val d = sampleDf.withColumn("c", monotonically_increasing_id()).select($"c").collect()
-    assert(d.size == d.distinct.size)
+    assert(d.length == d.distinct.length)
   }
 
   private def verifyNullabilityInFilterExec(

--- a/sql/core/src/test/scala/org/apache/spark/sql/JoinHintSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JoinHintSuite.scala
@@ -581,24 +581,24 @@ class JoinHintSuite extends PlanTest with SharedSparkSession with AdaptiveSparkP
       Seq((1, "1"), (2, "12.3"), (2, "123")).toDF("key", "value").createTempView("t2")
       val df1 = sql("SELECT /*+ shuffle_replicate_nl(t1) */ * from t1 join t2 ON t1.key = t2.key")
       val df2 = sql("SELECT * from t1 join t2 ON t1.key = t2.key")
-      assert(df1.collect().size == df2.collect().size)
+      assert(df1.collect().length == df2.collect().length)
 
       val df3 = sql("SELECT /*+ shuffle_replicate_nl(t1) */ * from t1 join t2")
       val df4 = sql("SELECT * from t1 join t2")
-      assert(df3.collect().size == df4.collect().size)
+      assert(df3.collect().length == df4.collect().length)
 
       val df5 = sql("SELECT /*+ shuffle_replicate_nl(t1) */ * from t1 join t2 ON t1.key < t2.key")
       val df6 = sql("SELECT * from t1 join t2 ON t1.key < t2.key")
-      assert(df5.collect().size == df6.collect().size)
+      assert(df5.collect().length == df6.collect().length)
 
       val df7 = sql("SELECT /*+ shuffle_replicate_nl(t1) */ * from t1 join t2 ON t1.key < 2")
       val df8 = sql("SELECT * from t1 join t2 ON t1.key < 2")
-      assert(df7.collect().size == df8.collect().size)
+      assert(df7.collect().length == df8.collect().length)
 
 
       val df9 = sql("SELECT /*+ shuffle_replicate_nl(t1) */ * from t1 join t2 ON t2.key < 2")
       val df10 = sql("SELECT * from t1 join t2 ON t2.key < 2")
-      assert(df9.collect().size == df10.collect().size)
+      assert(df9.collect().length == df10.collect().length)
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -3312,7 +3312,7 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
         sql("create temporary view t2 as select * from values ('val3a', 110L) as t2(t2a, t2b)")
         val df = sql("SELECT min, min from (SELECT (SELECT min(t2b) FROM t2) min " +
           "FROM t1 WHERE t1a = 'val1c')")
-        assert(df.collect().size == 0)
+        assert(df.collect().length == 0)
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
@@ -454,7 +454,7 @@ class SQLQueryTestSuite extends QueryTest with SharedSparkSession with SQLHelper
 
   def hasNoDuplicateColumns(schema: String): Boolean = {
     val columnAndTypes = schema.replaceFirst("^struct<", "").stripSuffix(">").split(",")
-    columnAndTypes.size == columnAndTypes.distinct.size
+    columnAndTypes.size == columnAndTypes.distinct.length
   }
 
   def expandCTEQueryAndCompareResult(

--- a/sql/core/src/test/scala/org/apache/spark/sql/SetCommandSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SetCommandSuite.scala
@@ -30,7 +30,7 @@ class SetCommandSuite extends QueryTest with SharedSparkSession with ResetSystem
     val nonexistentKey = "nonexistent"
 
     // "set" itself returns all config variables currently specified in SQLConf.
-    assert(sql("SET").collect().size === TestSQLContext.overrideConfs.size)
+    assert(sql("SET").collect().length === TestSQLContext.overrideConfs.size)
     sql("SET").collect().foreach { row =>
       val key = row.getString(0)
       val value = row.getString(1)

--- a/sql/core/src/test/scala/org/apache/spark/sql/UserDefinedTypeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/UserDefinedTypeSuite.scala
@@ -84,14 +84,14 @@ class UserDefinedTypeSuite extends QueryTest with SharedSparkSession with Parque
   test("register user type: MyDenseVector for MyLabeledPoint") {
     val labels: RDD[Double] = pointsRDD.select($"label").rdd.map { case Row(v: Double) => v }
     val labelsArrays: Array[Double] = labels.collect()
-    assert(labelsArrays.size === 2)
+    assert(labelsArrays.length === 2)
     assert(labelsArrays.contains(1.0))
     assert(labelsArrays.contains(0.0))
 
     val features: RDD[TestUDT.MyDenseVector] =
       pointsRDD.select($"features").rdd.map { case Row(v: TestUDT.MyDenseVector) => v }
     val featuresArrays: Array[TestUDT.MyDenseVector] = features.collect()
-    assert(featuresArrays.size === 2)
+    assert(featuresArrays.length === 2)
     assert(featuresArrays.contains(new TestUDT.MyDenseVector(Array(0.1, 1.0))))
     assert(featuresArrays.contains(new TestUDT.MyDenseVector(Array(0.2, 2.0))))
   }
@@ -277,7 +277,7 @@ class UserDefinedTypeSuite extends QueryTest with SharedSparkSession with Parque
     val unwrappedFeatures = pointsRDD.select(unwrap_udt(col("features")))
       .rdd.map { (row: Row) => row.getAs[Seq[Double]](0).toArray }
     val unwrappedFeaturesArrays: Array[Array[Double]] = unwrappedFeatures.collect()
-    assert(unwrappedFeaturesArrays.size === 2)
+    assert(unwrappedFeaturesArrays.length === 2)
 
     java.util.Arrays.equals(unwrappedFeaturesArrays(0), Array(0.1, 1.0))
     java.util.Arrays.equals(unwrappedFeaturesArrays(1), Array(0.2, 2.0))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/arrow/ArrowConvertersSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/arrow/ArrowConvertersSuite.scala
@@ -1267,7 +1267,7 @@ class ArrowConvertersSuite extends SharedSparkSession {
 
   test("interval is supported for arrow") {
     val collected = calendarIntervalData.toDF().toArrowBatchRdd.collect()
-    assert(collected.size == 1)
+    assert(collected.length == 1)
   }
 
   test("test Arrow Validator") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/InMemoryColumnarQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/InMemoryColumnarQuerySuite.scala
@@ -361,7 +361,7 @@ class InMemoryColumnarQuerySuite extends QueryTest
     checkAnswer(cached, expectedAnswer)
 
     // Check that the right size was calculated.
-    assert(cached.cacheBuilder.sizeInBytesStats.value === expectedAnswer.size * INT.defaultSize)
+    assert(cached.cacheBuilder.sizeInBytesStats.value === expectedAnswer.length * INT.defaultSize)
   }
 
    test("cached row count should be calculated") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -1437,7 +1437,7 @@ abstract class DDLSuite extends QueryTest with DDLSuiteBase {
           "tableName" -> "spark_catalog.default.partitionedtable",
           "specifiedPartCols" -> "", "existingPartCols" -> "a, b")
       )
-      assert(sql("select * from partitionedTable").collect().size == 1)
+      assert(sql("select * from partitionedTable").collect().length == 1)
       // Inserts new data successfully when partition columns are correctly specified in
       // partitionBy(...).
       // TODO: Right now, partition columns are always treated in a case-insensitive way.

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
@@ -64,7 +64,7 @@ class FileSourceStrategySuite extends QueryTest with SharedSparkSession {
     checkScan(table.select($"c1")) { partitions =>
       // 10 one byte files should fit in a single partition with 10 files.
       assert(partitions.size == 1, "when checking partitions")
-      assert(partitions.head.files.size == 10, "when checking partition 1")
+      assert(partitions.head.files.length == 10, "when checking partition 1")
       // 1 byte files are too small to split so we should read the whole thing.
       assert(partitions.head.files.head.start == 0)
       assert(partitions.head.files.head.length == 1)
@@ -87,8 +87,8 @@ class FileSourceStrategySuite extends QueryTest with SharedSparkSession {
       checkScan(table.select($"c1")) { partitions =>
         // 5 byte files should be laid out [(5, 5), (5)]
         assert(partitions.size == 2, "when checking partitions")
-        assert(partitions(0).files.size == 2, "when checking partition 1")
-        assert(partitions(1).files.size == 1, "when checking partition 2")
+        assert(partitions(0).files.length == 2, "when checking partition 1")
+        assert(partitions(1).files.length == 1, "when checking partition 2")
 
         // 5 byte files are too small to split so we should read the whole thing.
         assert(partitions.head.files.head.start == 0)
@@ -112,8 +112,8 @@ class FileSourceStrategySuite extends QueryTest with SharedSparkSession {
       checkScan(table.select($"c1")) { partitions =>
         // Files should be laid out [(0-10), (10-15, 4)]
         assert(partitions.size == 2, "when checking partitions")
-        assert(partitions(0).files.size == 1, "when checking partition 1")
-        assert(partitions(1).files.size == 2, "when checking partition 2")
+        assert(partitions(0).files.length == 1, "when checking partition 1")
+        assert(partitions(1).files.length == 2, "when checking partition 2")
 
         // Start by reading 10 bytes of the first file
         assert(partitions.head.files.head.start == 0)
@@ -145,10 +145,10 @@ class FileSourceStrategySuite extends QueryTest with SharedSparkSession {
       checkScan(table.select($"c1")) { partitions =>
         // Files should be laid out [(file1), (file2, file3), (file4, file5), (file6)]
         assert(partitions.size == 4, "when checking partitions")
-        assert(partitions(0).files.size == 1, "when checking partition 1")
-        assert(partitions(1).files.size == 2, "when checking partition 2")
-        assert(partitions(2).files.size == 2, "when checking partition 3")
-        assert(partitions(3).files.size == 1, "when checking partition 4")
+        assert(partitions(0).files.length == 1, "when checking partition 1")
+        assert(partitions(1).files.length == 2, "when checking partition 2")
+        assert(partitions(2).files.length == 2, "when checking partition 3")
+        assert(partitions(3).files.length == 1, "when checking partition 4")
 
         // First partition reads (file1)
         assert(partitions(0).files(0).start == 0)
@@ -186,7 +186,7 @@ class FileSourceStrategySuite extends QueryTest with SharedSparkSession {
     // Only one file should be read.
     checkScan(table.where("p1 = 1")) { partitions =>
       assert(partitions.size == 1, "when checking partitions")
-      assert(partitions.head.files.size == 1, "when files in partition 1")
+      assert(partitions.head.files.length == 1, "when files in partition 1")
     }
     // We don't need to reevaluate filters that are only on partitions.
     checkDataFilters(Set.empty)
@@ -194,7 +194,7 @@ class FileSourceStrategySuite extends QueryTest with SharedSparkSession {
     // Only one file should be read.
     checkScan(table.where("p1 = 1 AND c1 = 1 AND (p1 + c1) = 2")) { partitions =>
       assert(partitions.size == 1, "when checking partitions")
-      assert(partitions.head.files.size == 1, "when checking files in partition 1")
+      assert(partitions.head.files.length == 1, "when checking files in partition 1")
       assert(partitions.head.files.head.partitionValues.getInt(0) == 1,
         "when checking partition values")
     }
@@ -213,7 +213,7 @@ class FileSourceStrategySuite extends QueryTest with SharedSparkSession {
       // Only one file should be read.
       checkScan(table.where("P1 = 1")) { partitions =>
         assert(partitions.size == 1, "when checking partitions")
-        assert(partitions.head.files.size == 1, "when files in partition 1")
+        assert(partitions.head.files.length == 1, "when files in partition 1")
       }
       // We don't need to reevaluate filters that are only on partitions.
       checkDataFilters(Set.empty)
@@ -221,7 +221,7 @@ class FileSourceStrategySuite extends QueryTest with SharedSparkSession {
       // Only one file should be read.
       checkScan(table.where("P1 = 1 AND C1 = 1 AND (P1 + C1) = 2")) { partitions =>
         assert(partitions.size == 1, "when checking partitions")
-        assert(partitions.head.files.size == 1, "when checking files in partition 1")
+        assert(partitions.head.files.length == 1, "when checking files in partition 1")
         assert(partitions.head.files.head.partitionValues.getInt(0) == 1,
           "when checking partition values")
       }
@@ -267,17 +267,17 @@ class FileSourceStrategySuite extends QueryTest with SharedSparkSession {
       // No partition pruning
       checkScan(table) { partitions =>
         assert(partitions.size == 3)
-        assert(partitions(0).files.size == 5)
-        assert(partitions(1).files.size == 0)
-        assert(partitions(2).files.size == 2)
+        assert(partitions(0).files.length == 5)
+        assert(partitions(1).files.length == 0)
+        assert(partitions(2).files.length == 2)
       }
 
       // With partition pruning
       checkScan(table.where("p1=2")) { partitions =>
         assert(partitions.size == 3)
-        assert(partitions(0).files.size == 3)
-        assert(partitions(1).files.size == 0)
-        assert(partitions(2).files.size == 1)
+        assert(partitions(0).files.length == 3)
+        assert(partitions(1).files.length == 0)
+        assert(partitions(2).files.length == 1)
       }
     }
   }
@@ -362,8 +362,8 @@ class FileSourceStrategySuite extends QueryTest with SharedSparkSession {
         SQLConf.FILES_OPEN_COST_IN_BYTES.key -> "0") {
         checkScan(table.select($"c1")) { partitions =>
           assert(partitions.size == 2)
-          assert(partitions(0).files.size == 1)
-          assert(partitions(1).files.size == 2)
+          assert(partitions(0).files.length == 1)
+          assert(partitions(1).files.length == 2)
         }
       }
     }
@@ -378,9 +378,9 @@ class FileSourceStrategySuite extends QueryTest with SharedSparkSession {
         SQLConf.FILES_OPEN_COST_IN_BYTES.key -> "0") {
         checkScan(table.select($"c1")) { partitions =>
           assert(partitions.size == 3)
-          assert(partitions(0).files.size == 1)
-          assert(partitions(1).files.size == 2)
-          assert(partitions(2).files.size == 1)
+          assert(partitions(0).files.length == 1)
+          assert(partitions(1).files.length == 2)
+          assert(partitions(2).files.length == 1)
         }
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -330,7 +330,7 @@ abstract class CSVSuite
          """.stripMargin.replaceAll("\n", " "))
 
       assert(
-        spark.sql("SELECT makeName FROM carsTable where priceTag > 60000").collect().size === 1)
+        spark.sql("SELECT makeName FROM carsTable where priceTag > 60000").collect().length === 1)
     }
   }
 
@@ -343,7 +343,7 @@ abstract class CSVSuite
           .options(Map("header" -> "true", "mode" -> "dropmalformed"))
           .load(testFile(carsFile))
 
-        assert(cars.select("year").collect().size === 2)
+        assert(cars.select("year").collect().length === 2)
       }
     }
   }
@@ -354,9 +354,9 @@ abstract class CSVSuite
       .options(Map("header" -> "true", "inferSchema" -> "true"))
       .load(testFile(carsBlankColName))
 
-    assert(cars.select("customer").collect().size == 2)
-    assert(cars.select("_c0").collect().size == 2)
-    assert(cars.select("_c1").collect().size == 2)
+    assert(cars.select("customer").collect().length == 2)
+    assert(cars.select("_c0").collect().length == 2)
+    assert(cars.select("_c1").collect().length == 2)
   }
 
   test("test for FAILFAST parsing mode") {
@@ -405,8 +405,8 @@ abstract class CSVSuite
       .schema(StructType(List(StructField("column", StringType, false))))
       .load(testFile(emptyFile))
 
-    assert(result.collect().size === 0)
-    assert(result.schema.fieldNames.size === 1)
+    assert(result.collect().length === 0)
+    assert(result.schema.fieldNames.length === 1)
   }
 
   test("DDL test with empty file") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetInteroperabilitySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetInteroperabilitySuite.scala
@@ -187,7 +187,7 @@ class ParquetInteroperabilitySuite extends ParquetCompatibilityTest with SharedS
               (SQLConf.PARQUET_INT96_TIMESTAMP_CONVERSION.key, int96TimestampConversion.toString())
           ) {
             val readBack = spark.read.parquet(tableDir.getAbsolutePath).collect()
-            assert(readBack.size === 6)
+            assert(readBack.length === 6)
             // if we apply the conversion, we'll get the "right" values, as saved by impala in the
             // original file.  Otherwise, they're off by the local timezone offset, set to
             // America/Los_Angeles in tests

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/MemorySinkSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/MemorySinkSuite.scala
@@ -343,7 +343,7 @@ class MemorySinkSuite extends StreamTest with BeforeAndAfter {
   }
 
   private implicit def intsToDF(seq: Seq[Int])(implicit schema: StructType): DataFrame = {
-    require(schema.fields.size === 1)
+    require(schema.fields.length === 1)
     sqlContext.createDataset(seq).toDF(schema.fieldNames.head)
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/sources/RateStreamProviderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/sources/RateStreamProviderSuite.scala
@@ -165,7 +165,7 @@ class RateStreamProviderSuite extends StreamTest {
         checkpointLocation = temp.getCanonicalPath)
       val partitions = stream.planInputPartitions(LongOffset(0L), LongOffset(1L))
       val readerFactory = stream.createReaderFactory()
-      assert(partitions.size == 1)
+      assert(partitions.length == 1)
       val dataReader = readerFactory.createReader(partitions(0))
       val data = ArrayBuffer[InternalRow]()
       while (dataReader.next()) {
@@ -184,7 +184,7 @@ class RateStreamProviderSuite extends StreamTest {
         checkpointLocation = temp.getCanonicalPath)
       val partitions = stream.planInputPartitions(LongOffset(0L), LongOffset(1L))
       val readerFactory = stream.createReaderFactory()
-      assert(partitions.size == 11)
+      assert(partitions.length == 11)
 
       val readData = partitions
         .map(readerFactory.createReader)
@@ -359,7 +359,7 @@ class RateStreamProviderSuite extends StreamTest {
     val stream = new RateStreamContinuousStream(rowsPerSecond = 20, numPartitions = 2)
     val partitions = stream.planInputPartitions(stream.initialOffset)
     val readerFactory = stream.createContinuousReaderFactory()
-    assert(partitions.size == 2)
+    assert(partitions.length == 2)
 
     val data = scala.collection.mutable.ListBuffer[InternalRow]()
     partitions.foreach {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/sources/TextSocketStreamSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/sources/TextSocketStreamSuite.scala
@@ -358,7 +358,7 @@ class TextSocketStreamSuite extends StreamTest with SharedSparkSession {
       numPartitions = 2,
       options = new CaseInsensitiveStringMap(Map("includeTimestamp" -> "true").asJava))
     val partitions = stream.planInputPartitions(stream.initialOffset())
-    assert(partitions.size == 2)
+    assert(partitions.length == 2)
 
     val numRecords = 4
     // inject rows, read and check the data and offsets

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/CatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/CatalogSuite.scala
@@ -779,7 +779,7 @@ class CatalogSuite extends SharedSparkSession with AnalysisTest with BeforeAndAf
         Map("path" -> dir.getAbsolutePath), description2)
 
       val tables = spark.catalog.listTables("testcat.my_db").collect()
-      assert(tables.size == 2)
+      assert(tables.length == 2)
 
       val expectedTable1 =
         new Table(tableName, catalogName, Array(dbName), description,

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -336,31 +336,31 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
   }
 
   test("SELECT *") {
-    assert(sql("SELECT * FROM foobar").collect().size === 3)
+    assert(sql("SELECT * FROM foobar").collect().length === 3)
   }
 
   test("SELECT * WHERE (simple predicates)") {
-    assert(checkPushdown(sql("SELECT * FROM foobar WHERE THEID < 1")).collect().size == 0)
-    assert(checkPushdown(sql("SELECT * FROM foobar WHERE THEID != 2")).collect().size == 2)
-    assert(checkPushdown(sql("SELECT * FROM foobar WHERE THEID = 1")).collect().size == 1)
-    assert(checkPushdown(sql("SELECT * FROM foobar WHERE NAME = 'fred'")).collect().size == 1)
-    assert(checkPushdown(sql("SELECT * FROM foobar WHERE NAME <=> 'fred'")).collect().size == 1)
-    assert(checkPushdown(sql("SELECT * FROM foobar WHERE NAME > 'fred'")).collect().size == 2)
-    assert(checkPushdown(sql("SELECT * FROM foobar WHERE NAME != 'fred'")).collect().size == 2)
+    assert(checkPushdown(sql("SELECT * FROM foobar WHERE THEID < 1")).collect().length == 0)
+    assert(checkPushdown(sql("SELECT * FROM foobar WHERE THEID != 2")).collect().length == 2)
+    assert(checkPushdown(sql("SELECT * FROM foobar WHERE THEID = 1")).collect().length == 1)
+    assert(checkPushdown(sql("SELECT * FROM foobar WHERE NAME = 'fred'")).collect().length == 1)
+    assert(checkPushdown(sql("SELECT * FROM foobar WHERE NAME <=> 'fred'")).collect().length == 1)
+    assert(checkPushdown(sql("SELECT * FROM foobar WHERE NAME > 'fred'")).collect().length == 2)
+    assert(checkPushdown(sql("SELECT * FROM foobar WHERE NAME != 'fred'")).collect().length == 2)
 
     assert(checkPushdown(sql("SELECT * FROM foobar WHERE NAME IN ('mary', 'fred')"))
-      .collect().size == 2)
+      .collect().length == 2)
     assert(checkPushdown(sql("SELECT * FROM foobar WHERE NAME NOT IN ('fred')"))
-      .collect().size == 2)
+      .collect().length == 2)
     assert(checkPushdown(sql("SELECT * FROM foobar WHERE THEID = 1 OR NAME = 'mary'"))
-      .collect().size == 2)
+      .collect().length == 2)
     assert(checkPushdown(sql("SELECT * FROM foobar WHERE THEID = 1 OR NAME = 'mary' "
-      + "AND THEID = 2")).collect().size == 2)
-    assert(checkPushdown(sql("SELECT * FROM foobar WHERE NAME LIKE 'fr%'")).collect().size == 1)
-    assert(checkPushdown(sql("SELECT * FROM foobar WHERE NAME LIKE '%ed'")).collect().size == 1)
-    assert(checkPushdown(sql("SELECT * FROM foobar WHERE NAME LIKE '%re%'")).collect().size == 1)
-    assert(checkPushdown(sql("SELECT * FROM nulltypes WHERE A IS NULL")).collect().size == 1)
-    assert(checkPushdown(sql("SELECT * FROM nulltypes WHERE A IS NOT NULL")).collect().size == 0)
+      + "AND THEID = 2")).collect().length == 2)
+    assert(checkPushdown(sql("SELECT * FROM foobar WHERE NAME LIKE 'fr%'")).collect().length == 1)
+    assert(checkPushdown(sql("SELECT * FROM foobar WHERE NAME LIKE '%ed'")).collect().length == 1)
+    assert(checkPushdown(sql("SELECT * FROM foobar WHERE NAME LIKE '%re%'")).collect().length == 1)
+    assert(checkPushdown(sql("SELECT * FROM nulltypes WHERE A IS NULL")).collect().length == 1)
+    assert(checkPushdown(sql("SELECT * FROM nulltypes WHERE A IS NOT NULL")).collect().length == 0)
 
     // This is a test to reflect discussion in SPARK-12218.
     // The older versions of spark have this kind of bugs in parquet data source.
@@ -372,8 +372,10 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
       "WHERE (THEID > 0 AND TRIM(NAME) = 'mary') OR (NAME = 'fred')")
     assert(df2.collect().toSet === Set(Row("fred", 1), Row("mary", 2)))
 
-    assert(checkNotPushdown(sql("SELECT * FROM foobar WHERE (THEID + 1) < 2")).collect().size == 0)
-    assert(checkNotPushdown(sql("SELECT * FROM foobar WHERE (THEID + 2) != 4")).collect().size == 2)
+    val df3 = sql("SELECT * FROM foobar WHERE (THEID + 1) < 2")
+    assert(checkNotPushdown(df3).collect().length == 0)
+    val df4 = sql("SELECT * FROM foobar WHERE (THEID + 2) != 4")
+    assert(checkNotPushdown(df4).collect().length == 2)
   }
 
   test("SELECT COUNT(1) WHERE (predicates)") {
@@ -387,12 +389,13 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
   }
 
   test("SELECT * WHERE (quoted strings)") {
-    assert(sql("select * from foobar").where($"NAME" === "joe 'foo' \"bar\"").collect().size === 1)
+    val df = sql("select * from foobar").where($"NAME" === "joe 'foo' \"bar\"")
+    assert(df.collect().length === 1)
   }
 
   test("SELECT first field") {
     val names = sql("SELECT NAME FROM foobar").collect().map(x => x.getString(0)).sortWith(_ < _)
-    assert(names.size === 3)
+    assert(names.length === 3)
     assert(names(0).equals("fred"))
     assert(names(1).equals("joe 'foo' \"bar\""))
     assert(names(2).equals("mary"))
@@ -400,7 +403,7 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
 
   test("SELECT first field when fetchsize is two") {
     val names = sql("SELECT NAME FROM fetchtwo").collect().map(x => x.getString(0)).sortWith(_ < _)
-    assert(names.size === 3)
+    assert(names.length === 3)
     assert(names(0).equals("fred"))
     assert(names(1).equals("joe 'foo' \"bar\""))
     assert(names(2).equals("mary"))
@@ -408,7 +411,7 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
 
   test("SELECT second field") {
     val ids = sql("SELECT THEID FROM foobar").collect().map(x => x.getInt(0)).sortWith(_ < _)
-    assert(ids.size === 3)
+    assert(ids.length === 3)
     assert(ids(0) === 1)
     assert(ids(1) === 2)
     assert(ids(2) === 3)
@@ -416,7 +419,7 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
 
   test("SELECT second field when fetchsize is two") {
     val ids = sql("SELECT THEID FROM fetchtwo").collect().map(x => x.getInt(0)).sortWith(_ < _)
-    assert(ids.size === 3)
+    assert(ids.length === 3)
     assert(ids(0) === 1)
     assert(ids(1) === 2)
     assert(ids(2) === 3)
@@ -444,7 +447,7 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
 
   test("SELECT second field partitioned") {
     val ids = sql("SELECT THEID FROM parts").collect().map(x => x.getInt(0)).sortWith(_ < _)
-    assert(ids.size === 3)
+    assert(ids.length === 3)
     assert(ids(0) === 1)
     assert(ids(1) === 2)
     assert(ids(2) === 3)
@@ -497,7 +500,7 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
        """.stripMargin.replaceAll("\n", " "))
 
     val df = sql("SELECT * FROM renamed")
-    assert(df.schema.fields.size == 2)
+    assert(df.schema.fields.length == 2)
     assert(df.schema.fields(0).name == "NAME1")
     assert(df.schema.fields(1).name == "NAME2")
   }
@@ -1335,23 +1338,23 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
   }
 
   test("SPARK-18141: Predicates on quoted column names in the jdbc data source") {
-    assert(sql("SELECT * FROM mixedCaseCols WHERE Id < 1").collect().size == 0)
-    assert(sql("SELECT * FROM mixedCaseCols WHERE Id <= 1").collect().size == 1)
-    assert(sql("SELECT * FROM mixedCaseCols WHERE Id > 1").collect().size == 2)
-    assert(sql("SELECT * FROM mixedCaseCols WHERE Id >= 1").collect().size == 3)
-    assert(sql("SELECT * FROM mixedCaseCols WHERE Id = 1").collect().size == 1)
-    assert(sql("SELECT * FROM mixedCaseCols WHERE Id != 2").collect().size == 2)
-    assert(sql("SELECT * FROM mixedCaseCols WHERE Id <=> 2").collect().size == 1)
-    assert(sql("SELECT * FROM mixedCaseCols WHERE Name LIKE 'fr%'").collect().size == 1)
-    assert(sql("SELECT * FROM mixedCaseCols WHERE Name LIKE '%ed'").collect().size == 1)
-    assert(sql("SELECT * FROM mixedCaseCols WHERE Name LIKE '%re%'").collect().size == 1)
-    assert(sql("SELECT * FROM mixedCaseCols WHERE Name IS NULL").collect().size == 1)
-    assert(sql("SELECT * FROM mixedCaseCols WHERE Name IS NOT NULL").collect().size == 2)
-    assert(sql("SELECT * FROM mixedCaseCols").filter($"Name".isin()).collect().size == 0)
-    assert(sql("SELECT * FROM mixedCaseCols WHERE Name IN ('mary', 'fred')").collect().size == 2)
-    assert(sql("SELECT * FROM mixedCaseCols WHERE Name NOT IN ('fred')").collect().size == 1)
-    assert(sql("SELECT * FROM mixedCaseCols WHERE Id = 1 OR Name = 'mary'").collect().size == 2)
-    assert(sql("SELECT * FROM mixedCaseCols WHERE Name = 'mary' AND Id = 2").collect().size == 1)
+    assert(sql("SELECT * FROM mixedCaseCols WHERE Id < 1").collect().length == 0)
+    assert(sql("SELECT * FROM mixedCaseCols WHERE Id <= 1").collect().length == 1)
+    assert(sql("SELECT * FROM mixedCaseCols WHERE Id > 1").collect().length == 2)
+    assert(sql("SELECT * FROM mixedCaseCols WHERE Id >= 1").collect().length == 3)
+    assert(sql("SELECT * FROM mixedCaseCols WHERE Id = 1").collect().length == 1)
+    assert(sql("SELECT * FROM mixedCaseCols WHERE Id != 2").collect().length == 2)
+    assert(sql("SELECT * FROM mixedCaseCols WHERE Id <=> 2").collect().length == 1)
+    assert(sql("SELECT * FROM mixedCaseCols WHERE Name LIKE 'fr%'").collect().length == 1)
+    assert(sql("SELECT * FROM mixedCaseCols WHERE Name LIKE '%ed'").collect().length == 1)
+    assert(sql("SELECT * FROM mixedCaseCols WHERE Name LIKE '%re%'").collect().length == 1)
+    assert(sql("SELECT * FROM mixedCaseCols WHERE Name IS NULL").collect().length == 1)
+    assert(sql("SELECT * FROM mixedCaseCols WHERE Name IS NOT NULL").collect().length == 2)
+    assert(sql("SELECT * FROM mixedCaseCols").filter($"Name".isin()).collect().length == 0)
+    assert(sql("SELECT * FROM mixedCaseCols WHERE Name IN ('mary', 'fred')").collect().length == 2)
+    assert(sql("SELECT * FROM mixedCaseCols WHERE Name NOT IN ('fred')").collect().length == 1)
+    assert(sql("SELECT * FROM mixedCaseCols WHERE Id = 1 OR Name = 'mary'").collect().length == 2)
+    assert(sql("SELECT * FROM mixedCaseCols WHERE Name = 'mary' AND Id = 2").collect().length == 1)
   }
 
   test("SPARK-18419: Fix `asConnectionProperties` to filter case-insensitively") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
@@ -1466,7 +1466,7 @@ class FileStreamSourceSuite extends FileStreamSourceTest {
         val finalFile = new File(src, tempFile.getName)
         stringToFile(finalFile, i)
       }
-      assert(src.listFiles().size === numFiles)
+      assert(src.listFiles().length === numFiles)
 
       val files = spark.readStream.text(root.getCanonicalPath).as[(String, Int)]
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/MultiStatefulOperatorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/MultiStatefulOperatorsSuite.scala
@@ -882,7 +882,7 @@ class MultiStatefulOperatorsSuite
     q.processAllAvailable()
     val progressWithData = q.recentProgress.lastOption.get
     val stateOperators = progressWithData.stateOperators
-    assert(stateOperators.size === numTotalRows.size)
+    assert(stateOperators.length === numTotalRows.size)
     assert(stateOperators.map(_.numRowsTotal).toSeq === numTotalRows)
     true
   }
@@ -897,7 +897,7 @@ class MultiStatefulOperatorsSuite
       p.numInputRows == 0
     }.lastOption.get
     val stateOperators = progressWithData.stateOperators
-    assert(stateOperators.size === numRowsDroppedByWatermark.size)
+    assert(stateOperators.length === numRowsDroppedByWatermark.size)
     assert(stateOperators.map(_.numRowsDroppedByWatermark).toSeq === numRowsDroppedByWatermark)
     true
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamTest.scala
@@ -458,7 +458,7 @@ trait StreamTest extends QueryTest with SharedSparkSession with TimeLimits with 
         }
       }
       val c = Option(cause).map(exceptionToString(_))
-      val m = if (message != null && message.size > 0) Some(message) else None
+      val m = if (message != null && message.length > 0) Some(message) else None
       fail(
         s"""
            |${(m ++ c).mkString(": ")}

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryListenerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryListenerSuite.scala
@@ -333,7 +333,7 @@ class StreamingQueryListenerSuite extends StreamTest with BeforeAndAfter {
         }
         // `recentProgress` should not receive too many no data events
         actions += AssertOnQuery { q =>
-          q.recentProgress.size > 1 && q.recentProgress.size <= 11
+          q.recentProgress.length > 1 && q.recentProgress.length <= 11
         }
         testStream(input.toDS())(actions.toSeq: _*)
         spark.sparkContext.listenerBus.waitUntilEmpty()

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryStatusAndProgressSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryStatusAndProgressSuite.scala
@@ -279,7 +279,7 @@ class StreamingQueryStatusAndProgressSuite extends StreamTest with Eventually {
 
       // Make sure it generates the progress objects we want to test
       assert(progress.exists { p =>
-        p.sources.size >= 1 && p.stateOperators.size >= 1 && p.sink != null
+        p.sources.length >= 1 && p.stateOperators.length >= 1 && p.sink != null
       })
 
       val array = spark.sparkContext.parallelize(progress.toImmutableArraySeq).collect()

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQuerySuite.scala
@@ -491,7 +491,7 @@ class StreamingQuerySuite extends StreamTest with BeforeAndAfter with Logging wi
     val progress = getStreamingQuery(streamingInputDF.join(streamingInputDF, "value"))
       .recentProgress.head
     assert(progress.numInputRows === 20) // data is read multiple times in self-joins
-    assert(progress.sources.size === 1)
+    assert(progress.sources.length === 1)
     assert(progress.sources(0).numInputRows === 20)
   }
 
@@ -505,7 +505,7 @@ class StreamingQuerySuite extends StreamTest with BeforeAndAfter with Logging wi
     val progress = getStreamingQuery(streamingInputDF.join(staticInputDF, "value"))
       .recentProgress.head
     assert(progress.numInputRows === 10)
-    assert(progress.sources.size === 1)
+    assert(progress.sources.length === 1)
     assert(progress.sources(0).numInputRows === 10)
   }
 
@@ -518,7 +518,7 @@ class StreamingQuerySuite extends StreamTest with BeforeAndAfter with Logging wi
     // After the first trigger, the calculated input rows should be 10
     val progress = getStreamingQuery(streamingInputDF).recentProgress.head
     assert(progress.numInputRows === 10)
-    assert(progress.sources.size === 1)
+    assert(progress.sources.length === 1)
     assert(progress.sources(0).numInputRows === 10)
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/test/DataStreamReaderWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/test/DataStreamReaderWriterSuite.scala
@@ -629,7 +629,7 @@ class DataStreamReaderWriterSuite extends StreamTest with BeforeAndAfter {
         val queryCheckpointDir = new File(checkpointPath, queryName)
         assert(queryCheckpointDir.exists(), s"$queryCheckpointDir doesn't exist")
         assert(
-          checkpointPath.listFiles().size === 1,
+          checkpointPath.listFiles().length === 1,
           s"${checkpointPath.listFiles().toList} has 0 or more than 1 files ")
       }
     }
@@ -643,7 +643,7 @@ class DataStreamReaderWriterSuite extends StreamTest with BeforeAndAfter {
         ds.writeStream.format("console").start().stop()
         // Should create a random folder in `checkpointPath`
         assert(
-          checkpointPath.listFiles().size === 1,
+          checkpointPath.listFiles().length === 1,
           s"${checkpointPath.listFiles().toList} has 0 or more than 1 files ")
       }
     }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
@@ -784,21 +784,19 @@ class HiveQuerySuite extends HiveComparisonTest with SQLTestUtils with BeforeAnd
   test("SPARK-5383 alias for udfs with multi output columns") {
     assert(
       sql("select stack(2, key, value, key, value) as (a, b) from src limit 5")
-        .collect()
-        .size == 5)
+        .collect().length == 5)
 
     assert(
       sql("select a, b from (select stack(2, key, value, key, value) as (a, b) from src) t limit 5")
-        .collect()
-        .size == 5)
+        .collect().length == 5)
   }
 
   test("SPARK-5367: resolve star expression in udf") {
-    assert(sql("select concat(*) from src limit 5").collect().size == 5)
-    assert(sql("select concat(key, *) from src limit 5").collect().size == 5)
+    assert(sql("select concat(*) from src limit 5").collect().length == 5)
+    assert(sql("select concat(key, *) from src limit 5").collect().length == 5)
     if (!conf.ansiEnabled) {
-      assert(sql("select array(*) from src limit 5").collect().size == 5)
-      assert(sql("select array(key, *) from src limit 5").collect().size == 5)
+      assert(sql("select array(*) from src limit 5").collect().length == 5)
+      assert(sql("select array(key, *) from src limit 5").collect().length == 5)
     }
   }
 

--- a/streaming/src/test/scala/org/apache/spark/streaming/MasterFailureTest.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/MasterFailureTest.scala
@@ -45,7 +45,7 @@ object MasterFailureTest extends Logging {
 
   def main(args: Array[String]): Unit = {
     // scalastyle:off println
-    if (args.size < 2) {
+    if (args.length < 2) {
       println(
         "Usage: MasterFailureTest <local/HDFS directory> <# batches> " +
           "[<batch size in milliseconds>]")
@@ -53,7 +53,7 @@ object MasterFailureTest extends Logging {
     }
     val directory = args(0)
     val numBatches = args(1).toInt
-    val batchDuration = if (args.size > 2) Milliseconds(args(2).toInt) else Seconds(1)
+    val batchDuration = if (args.length > 2) Milliseconds(args(2).toInt) else Seconds(1)
 
     println("\n\n========================= MAP TEST =========================\n\n")
     testMap(directory, numBatches, batchDuration)

--- a/streaming/src/test/scala/org/apache/spark/streaming/ReceivedBlockTrackerSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/ReceivedBlockTrackerSuite.scala
@@ -395,7 +395,7 @@ class ReceivedBlockTrackerSuite extends SparkFunSuite with BeforeAndAfter with M
     val writer = HdfsUtils.getOutputStream(filePath, hadoopConf)
     events.foreach { event =>
       val bytes = Utils.serialize(event)
-      writer.writeInt(bytes.size)
+      writer.writeInt(bytes.length)
       writer.write(bytes)
     }
     writer.close()

--- a/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
@@ -268,7 +268,7 @@ class StreamingContextSuite
     ssc.start()
     ssc.stop(stopSparkContext = false)
     assert(ssc.getState() === StreamingContextState.STOPPED)
-    assert(sc.makeRDD(1 to 100).collect().size === 100)
+    assert(sc.makeRDD(1 to 100).collect().length === 100)
     sc.stop()
 
     // Implicitly do not stop SparkContext
@@ -278,7 +278,7 @@ class StreamingContextSuite
     addInputStream(ssc).register()
     ssc.start()
     ssc.stop()
-    assert(sc.makeRDD(1 to 100).collect().size === 100)
+    assert(sc.makeRDD(1 to 100).collect().length === 100)
     sc.stop()
   }
 
@@ -286,7 +286,7 @@ class StreamingContextSuite
     ssc = new StreamingContext(master, appName, batchDuration)
     addInputStream(ssc).register()
     ssc.stop(stopSparkContext = false)
-    assert(ssc.sc.makeRDD(1 to 100).collect().size === 100)
+    assert(ssc.sc.makeRDD(1 to 100).collect().length === 100)
     ssc.stop(stopSparkContext = true)
     // Check that the SparkContext is actually stopped:
     intercept[Exception] {

--- a/streaming/src/test/scala/org/apache/spark/streaming/rdd/MapWithStateRDDSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/rdd/MapWithStateRDDSuite.scala
@@ -60,7 +60,7 @@ class MapWithStateRDDSuite extends SparkFunSuite with RDDCheckpointTester {
     val rdd = MapWithStateRDD.createFromPairRDD[Int, Int, String, Int](
       sc.parallelize(data), partitioner, Time(123))
     assertRDD[Int, Int, String, Int](rdd, data.map { x => (x._1, x._2, 123)}.toSet, Set.empty)
-    assert(rdd.partitions.size === partitioner.numPartitions)
+    assert(rdd.partitions.length === partitioner.numPartitions)
 
     assert(rdd.partitioner === Some(partitioner))
   }

--- a/streaming/src/test/scala/org/apache/spark/streaming/util/WriteAheadLogSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/util/WriteAheadLogSuite.scala
@@ -615,9 +615,9 @@ object WriteAheadLogSuite {
     val writer = HdfsUtils.getOutputStream(file, hadoopConf)
     def writeToStream(bytes: Array[Byte]): Unit = {
       val offset = writer.getPos
-      writer.writeInt(bytes.size)
+      writer.writeInt(bytes.length)
       writer.write(bytes)
-      segments += FileBasedWriteAheadLogSegment(file, offset, bytes.size)
+      segments += FileBasedWriteAheadLogSegment(file, offset, bytes.length)
     }
     if (allowBatching) {
       writeToStream(wrapArrayArrayByte(data.toArray[String]).array())


### PR DESCRIPTION
### What changes were proposed in this pull request?
There are a lot of `[string|array].size` called.
In fact, the size calls the underlying length, this behavior increase the stack length.
We should call `[string|array].length` directly.
We also get the compile waring `Replace .size with .length on arrays and strings`


### Why are the changes needed?
Reduce stack depth by replace (string|array).size with (string|array).length


### Does this PR introduce _any_ user-facing change?
'No'.


### How was this patch tested?
Exists test cases.


### Was this patch authored or co-authored using generative AI tooling?
'No'.
