### PR TITLE
[SPARK-46106]If the hive table is a table, the outsourcing information will be displayed during ShowCreateTableCommand.

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -1172,7 +1172,12 @@ case class ShowCreateTableCommand(
 
         builder.toString()
       } else {
-        builder ++= s"CREATE TABLE ${table.quoted} "
+
+        if (tableMetadata.tableType == EXTERNAL) {
+          builder ++= s"CREATE EXTERNAL TABLE ${table.quoted} "
+        } else {
+          builder ++= s"CREATE TABLE ${table.quoted} "
+        }
 
         showCreateDataSourceTable(metadata, builder)
         builder.toString()


### PR DESCRIPTION
… will be displayed during ShowCreateTableCommand.

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
If the hive table is a table, the outsourcing information will be displayed during ShowCreateTableCommand.

For example:
CREATE EXTERNAL TABLE test_extaral_1 (a String);

When using SHOW CREATE TABLE test, if it is an external table, it is not displayed whether it is an external table.

spark-sql> show create table test_extaral_1;
createtab_stmt
CREATE TABLE `test`.`test_extaral_1` (
  `a` STRING)
USING orc
LOCATION '/test/test_extaral_1'

 

You can modify the display and see whether it is the appearance。

spark-sql> show create table test_extaral_1;
createtab_stmt

CREATE EXTERNAL TABLE `test`.`test_extaral_1` (
  `a` STRING)
USING orc
CREATE EXTERNAL TABLE `test`.`test_extaral_1` (
LOCATION '/test/test_extaral_1'


### Why are the changes needed?
This can help users quickly distinguish between internal and external surfaces。


### Does this PR introduce _any_ user-facing change?
NO


### How was this patch tested?



### Was this patch authored or co-authored using generative AI tooling?
