### PR TITLE
[SPARK-46106]If the hive table is a table, the outsourcing information will be displayed during ShowCreateTableCommand. #44018

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -1172,7 +1172,12 @@ case class ShowCreateTableCommand(
 
         builder.toString()
       } else {
-        builder ++= s"CREATE TABLE ${table.quoted} "
+
+        if (tableMetadata.tableType == EXTERNAL) {
+          builder ++= s"CREATE EXTERNAL TABLE ${table.quoted} "
+        } else {
+          builder ++= s"CREATE TABLE ${table.quoted} "
+        }
 
         showCreateDataSourceTable(metadata, builder)
         builder.toString()


### PR DESCRIPTION
… will be displayed during ShowCreateTableCommand.

###  What changes were proposed in this pull request?
If the hive table is a table, the outsourcing information will be displayed during ShowCreateTableCommand.

For example:
CREATE EXTERNAL TABLE test_extaral_1 (a String);

When using SHOW CREATE TABLE test, if it is an external table, it is not displayed whether it is an external table.

spark-sql> show create table test_extaral_1;
createtab_stmt
CREATE TABLE test.test_extaral_1 (
a STRING)
USING orc
LOCATION '/test/test_extaral_1'

You can modify the display and see whether it is the appearance。

spark-sql> show create table test_extaral_1;
createtab_stmt

CREATE EXTERNAL TABLE test.test_extaral_1 (
a STRING)
USING orc
CREATE EXTERNAL TABLE test.test_extaral_1 (
LOCATION '/test/test_extaral_1'

###  Why are the changes needed?
This can help users quickly distinguish between internal and external surfaces。

###  Does this PR introduce any user-facing change?
NO

###  How was this patch tested?
Was this patch authored or co-authored using generative AI tooling?