### PR TITLE
[SPARK-46111][DOCS][PYTHON] Add copyright to the PySpark official documentation.

### DIFF
--- a/python/docs/source/_templates/spark_footer.html
+++ b/python/docs/source/_templates/spark_footer.html
@@ -1,0 +1,3 @@
+<p class="copyright">
+    {{copyright}} The Apache Software Foundation, Licensed under the <a href="https://www.apache.org/licenses/LICENSE-2.0">Apache License, Version 2.0</a>.
+</p>

--- a/python/docs/source/conf.py
+++ b/python/docs/source/conf.py
@@ -12,6 +12,7 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+from datetime import datetime
 import sys
 import os
 import shutil
@@ -124,7 +125,8 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'PySpark'
-copyright = ''
+# We have our custom "spark_footer.html" template, using copyright for the current year.
+copyright = f"Copyright @ {datetime.now().year}"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -194,6 +196,7 @@ html_context = {
 # further.  For a list of options available for each theme, see the
 # documentation.
 html_theme_options = {
+    "footer_start": ["spark_footer", "sphinx-version"],
     "navbar_end": ["version-switcher", "theme-switcher"],
     "logo": {
         "image_light": "_static/spark-logo-light.png",


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to add the Apache Spark Foundation copyright notice to the bottom of the PySpark official documentation.


### Why are the changes needed?

Our current documentation is missing the copyright. The addition of the copyright notice is necessary to ensure compliance with the Apache Software Foundation's requirements for project documentation.

### Does this PR introduce _any_ user-facing change?

No API changes, but users will now see the Apache Spark Foundation copyright notice at the bottom of each page of the PySpark documentation as below:

## Before
<img width="278" alt="Screenshot 2023-11-27 at 11 49 38 AM" src="https://github.com/apache/spark/assets/44108233/fda0c23d-5a8c-457c-adde-08917282320f">


## After

<img width="770" alt="Screenshot 2023-11-27 at 11 35 35 AM" src="https://github.com/apache/spark/assets/44108233/bfecf5ca-7117-4269-8e85-59646ef60b70">



### How was this patch tested?

Manually build the docs and confirm.

### Was this patch authored or co-authored using generative AI tooling?

No.
