### PR TITLE
[MINOR][PYTHON] Remove obsolete TODOs for ignores at SQLContext and HiveContext

### DIFF
--- a/python/pyspark/sql/context.py
+++ b/python/pyspark/sql/context.py
@@ -59,7 +59,6 @@ if TYPE_CHECKING:
 __all__ = ["SQLContext", "HiveContext"]
 
 
-# TODO: ignore[attr-defined] will be removed, once SparkContext is inlined
 class SQLContext:
     """The entry point for working with structured data (rows and columns) in Spark, in Spark 1.x.
 
@@ -700,7 +699,6 @@ class SQLContext:
         return StreamingQueryManager(self._ssql_ctx.streams())
 
 
-# TODO: ignore[attr-defined] will be removed, once SparkContext is inlined
 class HiveContext(SQLContext):
     """A variant of Spark SQL that integrates with data stored in Hive.
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to Remove obsolete TODOs for ignores at ` SQLContext` and `HiveContext`.

### Why are the changes needed?

To remove obsolate TODOs added in https://github.com/apache/spark/pull/34185. Those ignores were already removed in https://github.com/apache/spark/pull/34944.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Linters

### Was this patch authored or co-authored using generative AI tooling?

No.
