### PR TITLE
[MINOR][PYTHON] Remove _inferSchema in SQLContext

### DIFF
--- a/python/pyspark/mllib/evaluation.py
+++ b/python/pyspark/mllib/evaluation.py
@@ -462,7 +462,7 @@ class RankingMetrics(JavaModelWrapper, Generic[T]):
         sc = predictionAndLabels.ctx
         sql_ctx = SQLContext.getOrCreate(sc)
         df = sql_ctx.createDataFrame(
-            predictionAndLabels, schema=sql_ctx._inferSchema(predictionAndLabels)
+            predictionAndLabels, schema=sql_ctx.sparkSession._inferSchema(predictionAndLabels)
         )
         java_model = callMLlibFunc("newRankingMetrics", df._jdf)
         super(RankingMetrics, self).__init__(java_model)
@@ -576,7 +576,7 @@ class MultilabelMetrics(JavaModelWrapper):
         sc = predictionAndLabels.ctx
         sql_ctx = SQLContext.getOrCreate(sc)
         df = sql_ctx.createDataFrame(
-            predictionAndLabels, schema=sql_ctx._inferSchema(predictionAndLabels)
+            predictionAndLabels, schema=sql_ctx.sparkSession._inferSchema(predictionAndLabels)
         )
         assert sc._jvm is not None
         java_class = sc._jvm.org.apache.spark.mllib.evaluation.MultilabelMetrics

--- a/python/pyspark/sql/context.py
+++ b/python/pyspark/sql/context.py
@@ -312,24 +312,6 @@ class SQLContext:
         )
         return self.sparkSession.udf.registerJavaFunction(name, javaClassName, returnType)
 
-    # TODO(andrew): delete this once we refactor things to take in SparkSession
-    def _inferSchema(self, rdd: RDD, samplingRatio: Optional[float] = None) -> StructType:
-        """
-        Infer schema from an RDD of Row or tuple.
-
-        Parameters
-        ----------
-        rdd : :class:`RDD`
-            an RDD of Row or tuple
-        samplingRatio : float, optional
-            sampling ratio, or no sampling (default)
-
-        Returns
-        -------
-        :class:`pyspark.sql.types.StructType`
-        """
-        return self.sparkSession._inferSchema(rdd, samplingRatio)
-
     @overload
     def createDataFrame(
         self,


### PR DESCRIPTION
### What changes were proposed in this pull request?

There are only two places that use `SQLContext_inferSchema` that can be safely converted to `SQLContext.sparkSession._inferSchema` instead.

### Why are the changes needed?

For code cleanup, and remove unused private method

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing test cases should cover them.

### Was this patch authored or co-authored using generative AI tooling?

No.