### PR TITLE
[SPARK-46117][DOCS][PYTHON] Enhancing readability of PySpark API reference by hiding verbose typehints.

### DIFF
--- a/python/docs/source/conf.py
+++ b/python/docs/source/conf.py
@@ -178,6 +178,7 @@ pygments_style = 'sphinx'
 # Look at the first line of the docstring for function and method signatures.
 autodoc_docstring_signature = True
 autosummary_generate = True
+autodoc_typehints = "none"
 
 # -- Options for HTML output ----------------------------------------------
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes an enhancement of readability of the PySpark API reference by hiding verbose typehints. This change aims to improve the readability of the documentation by reducing verbosity in the function/method signatures.


### Why are the changes needed?

Currently, the PySpark API documentation displays all type hints in the signatures, which can make the documentation appear cluttered and less readable.

By setting `autodoc_typehints` to 'none', we can achieve a cleaner and more concise presentation of our API, similar to how the Pandas documentation handles type hints. 

This approach has been effective in Pandas, making the documentation more approachable and easier to understand. We should follow the good example and apply the same behavior to the PySpark API reference.


### Does this PR introduce _any_ user-facing change?

No API changes, but the API reference turn into more readable as below:

## Before

<img width="747" alt="Screenshot 2023-11-27 at 3 53 33 PM" src="https://github.com/apache/spark/assets/44108233/35bb0ccc-0730-43ae-80d6-258d14c4d493">


## After

<img width="762" alt="Screenshot 2023-11-27 at 3 54 36 PM" src="https://github.com/apache/spark/assets/44108233/bd2e7c37-8e87-4d0d-9d73-d17d49ebb229">




### How was this patch tested?

Manually built docs.


### Was this patch authored or co-authored using generative AI tooling?

No.
