### PR TITLE
[SPARK-46006][YARN][FOLLOWUP] YarnAllocator set target executor number to 0 to cancel pending allocate request when driver stop

### DIFF
--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
@@ -385,7 +385,10 @@ private[yarn] class YarnAllocator(
     this.hostToLocalTaskCountPerResourceProfileId = hostToLocalTaskCountPerResourceProfileId
 
     if (resourceProfileToTotalExecs.isEmpty) {
-      targetNumExecutorsPerResourceProfileId.clear()
+      // Set target executor number to 0 to cancel pending allocate request.
+      targetNumExecutorsPerResourceProfileId.keys.foreach { rp =>
+        targetNumExecutorsPerResourceProfileId(rp) = 0
+      }
       allocatorNodeHealthTracker.setSchedulerExcludedNodes(excludedNodes)
       true
     } else {


### PR DESCRIPTION
### What changes were proposed in this pull request?
YarnAllocator set target executor number to 0 to cancel pending allocate request when driver stop
Now for this issue we do:

1. AllocationFailure should not be treated as exitCausedByApp when driver is shutting down https://github.com/apache/spark/pull/38622
2. Avoid new allocation requests when sc.stop stuck https://github.com/apache/spark/pull/43906
3. Cancel pending allocation request, this pr https://github.com/apache/spark/pull/44036

### Why are the changes needed?
Avoid unnecessary allocate request

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
MT


### Was this patch authored or co-authored using generative AI tooling?
No
