### PR TITLE
[SPARK-46120][CONNECT][PYTHON] Remove helper function `DataFrame.withPlan`

### DIFF
--- a/python/pyspark/sql/connect/catalog.py
+++ b/python/pyspark/sql/connect/catalog.py
@@ -46,7 +46,7 @@ class Catalog:
         self._sparkSession = sparkSession
 
     def _execute_and_fetch(self, catalog: plan.LogicalPlan) -> pa.Table:
-        table, _ = DataFrame.withPlan(catalog, session=self._sparkSession)._to_table()
+        table, _ = DataFrame(catalog, session=self._sparkSession)._to_table()
         assert table is not None
         return table
 
@@ -222,7 +222,7 @@ class Catalog:
             schema=schema,
             options=options,
         )
-        df = DataFrame.withPlan(catalog, session=self._sparkSession)
+        df = DataFrame(catalog, session=self._sparkSession)
         df._to_table()  # Eager execution.
         return df
 
@@ -245,7 +245,7 @@ class Catalog:
             description=description,
             options=options,
         )
-        df = DataFrame.withPlan(catalog, session=self._sparkSession)
+        df = DataFrame(catalog, session=self._sparkSession)
         df._to_table()  # Eager execution.
         return df
 

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -153,7 +153,7 @@ class DataFrame:
             "spark.sql.repl.eagerEval.truncate",
         )
         if repl_eager_eval_enabled == "true":
-            table, _ = DataFrame.withPlan(
+            table, _ = DataFrame(
                 plan.HtmlString(
                     child=self._plan,
                     num_rows=int(cast(str, repl_eager_eval_max_num_rows)),
@@ -182,7 +182,7 @@ class DataFrame:
         if len(cols) == 1 and isinstance(cols[0], list):
             cols = cols[0]
 
-        return DataFrame.withPlan(plan.Project(self._plan, *cols), session=self._session)
+        return DataFrame(plan.Project(self._plan, *cols), session=self._session)
 
     select.__doc__ = PySparkDataFrame.select.__doc__
 
@@ -196,7 +196,7 @@ class DataFrame:
             else:
                 sql_expr.extend([sql_expression(e) for e in element])
 
-        return DataFrame.withPlan(plan.Project(self._plan, *sql_expr), session=self._session)
+        return DataFrame(plan.Project(self._plan, *sql_expr), session=self._session)
 
     selectExpr.__doc__ = PySparkDataFrame.selectExpr.__doc__
 
@@ -219,7 +219,7 @@ class DataFrame:
     agg.__doc__ = PySparkDataFrame.agg.__doc__
 
     def alias(self, alias: str) -> "DataFrame":
-        return DataFrame.withPlan(plan.SubqueryAlias(self._plan, alias), session=self._session)
+        return DataFrame(plan.SubqueryAlias(self._plan, alias), session=self._session)
 
     alias.__doc__ = PySparkDataFrame.alias.__doc__
 
@@ -259,7 +259,7 @@ class DataFrame:
 
     def crossJoin(self, other: "DataFrame") -> "DataFrame":
         self._check_same_session(other)
-        return DataFrame.withPlan(
+        return DataFrame(
             plan.Join(left=self._plan, right=other._plan, on=None, how="cross"),
             session=self._session,
         )
@@ -279,7 +279,7 @@ class DataFrame:
                 error_class="VALUE_NOT_POSITIVE",
                 message_parameters={"arg_name": "numPartitions", "arg_value": str(numPartitions)},
             )
-        return DataFrame.withPlan(
+        return DataFrame(
             plan.Repartition(self._plan, num_partitions=numPartitions, shuffle=False),
             self._session,
         )
@@ -307,18 +307,18 @@ class DataFrame:
                     },
                 )
             if len(cols) == 0:
-                return DataFrame.withPlan(
+                return DataFrame(
                     plan.Repartition(self._plan, num_partitions=numPartitions, shuffle=True),
                     self._session,
                 )
             else:
-                return DataFrame.withPlan(
+                return DataFrame(
                     plan.RepartitionByExpression(self._plan, numPartitions, list(cols)),
                     self.sparkSession,
                 )
         elif isinstance(numPartitions, (str, Column)):
             cols = (numPartitions,) + cols
-            return DataFrame.withPlan(
+            return DataFrame(
                 plan.RepartitionByExpression(self._plan, None, list(cols)),
                 self.sparkSession,
             )
@@ -372,7 +372,7 @@ class DataFrame:
             else:
                 sort = []
                 sort.extend([_convert_col(c) for c in cols])
-                return DataFrame.withPlan(
+                return DataFrame(
                     plan.RepartitionByExpression(self._plan, numPartitions, sort),
                     self.sparkSession,
                 )
@@ -380,7 +380,7 @@ class DataFrame:
             cols = (numPartitions,) + cols
             sort = []
             sort.extend([_convert_col(c) for c in cols])
-            return DataFrame.withPlan(
+            return DataFrame(
                 plan.RepartitionByExpression(self._plan, None, sort),
                 self.sparkSession,
             )
@@ -403,11 +403,11 @@ class DataFrame:
             )
 
         if subset is None:
-            return DataFrame.withPlan(
+            return DataFrame(
                 plan.Deduplicate(child=self._plan, all_columns_as_keys=True), session=self._session
             )
         else:
-            return DataFrame.withPlan(
+            return DataFrame(
                 plan.Deduplicate(child=self._plan, column_names=subset), session=self._session
             )
 
@@ -423,12 +423,12 @@ class DataFrame:
             )
 
         if subset is None:
-            return DataFrame.withPlan(
+            return DataFrame(
                 plan.Deduplicate(child=self._plan, all_columns_as_keys=True, within_watermark=True),
                 session=self._session,
             )
         else:
-            return DataFrame.withPlan(
+            return DataFrame(
                 plan.Deduplicate(child=self._plan, column_names=subset, within_watermark=True),
                 session=self._session,
             )
@@ -438,7 +438,7 @@ class DataFrame:
     drop_duplicates_within_watermark = dropDuplicatesWithinWatermark
 
     def distinct(self) -> "DataFrame":
-        return DataFrame.withPlan(
+        return DataFrame(
             plan.Deduplicate(child=self._plan, all_columns_as_keys=True), session=self._session
         )
 
@@ -452,7 +452,7 @@ class DataFrame:
                 message_parameters={"arg_name": "cols", "arg_type": type(cols).__name__},
             )
 
-        return DataFrame.withPlan(
+        return DataFrame(
             plan.Drop(
                 child=self._plan,
                 columns=_cols,
@@ -467,7 +467,7 @@ class DataFrame:
             expr = sql_expression(condition)
         else:
             expr = condition
-        return DataFrame.withPlan(plan.Filter(child=self._plan, filter=expr), session=self._session)
+        return DataFrame(plan.Filter(child=self._plan, filter=expr), session=self._session)
 
     filter.__doc__ = PySparkDataFrame.filter.__doc__
 
@@ -622,7 +622,7 @@ class DataFrame:
         self._check_same_session(other)
         if how is not None and isinstance(how, str):
             how = how.lower().replace("_", "")
-        return DataFrame.withPlan(
+        return DataFrame(
             plan.Join(left=self._plan, right=other._plan, on=on, how=how),
             session=self._session,
         )
@@ -649,7 +649,7 @@ class DataFrame:
         if tolerance is not None:
             assert isinstance(tolerance, Column), "tolerance should be Column"
 
-        return DataFrame.withPlan(
+        return DataFrame(
             plan.AsOfJoin(
                 left=self._plan,
                 right=other._plan,
@@ -667,14 +667,12 @@ class DataFrame:
     _joinAsOf.__doc__ = PySparkDataFrame._joinAsOf.__doc__
 
     def limit(self, n: int) -> "DataFrame":
-        return DataFrame.withPlan(plan.Limit(child=self._plan, limit=n), session=self._session)
+        return DataFrame(plan.Limit(child=self._plan, limit=n), session=self._session)
 
     limit.__doc__ = PySparkDataFrame.limit.__doc__
 
     def tail(self, num: int) -> List[Row]:
-        return DataFrame.withPlan(
-            plan.Tail(child=self._plan, limit=num), session=self._session
-        ).collect()
+        return DataFrame(plan.Tail(child=self._plan, limit=num), session=self._session).collect()
 
     tail.__doc__ = PySparkDataFrame.tail.__doc__
 
@@ -729,7 +727,7 @@ class DataFrame:
         *cols: Union[int, str, Column, List[Union[int, str, Column]]],
         **kwargs: Any,
     ) -> "DataFrame":
-        return DataFrame.withPlan(
+        return DataFrame(
             plan.Sort(
                 self._plan,
                 columns=self._sort_cols(cols, kwargs),
@@ -747,7 +745,7 @@ class DataFrame:
         *cols: Union[int, str, Column, List[Union[int, str, Column]]],
         **kwargs: Any,
     ) -> "DataFrame":
-        return DataFrame.withPlan(
+        return DataFrame(
             plan.Sort(
                 self._plan,
                 columns=self._sort_cols(cols, kwargs),
@@ -804,7 +802,7 @@ class DataFrame:
 
         seed = int(seed) if seed is not None else None
 
-        return DataFrame.withPlan(
+        return DataFrame(
             plan.Sample(
                 child=self._plan,
                 lower_bound=0.0,
@@ -829,7 +827,7 @@ class DataFrame:
                 message_parameters={"arg_name": "colsMap", "arg_type": type(colsMap).__name__},
             )
 
-        return DataFrame.withPlan(plan.WithColumnsRenamed(self._plan, colsMap), self._session)
+        return DataFrame(plan.WithColumnsRenamed(self._plan, colsMap), self._session)
 
     withColumnsRenamed.__doc__ = PySparkDataFrame.withColumnsRenamed.__doc__
 
@@ -862,7 +860,7 @@ class DataFrame:
                     },
                 )
 
-        table, _ = DataFrame.withPlan(
+        table, _ = DataFrame(
             plan.ShowString(
                 child=self._plan,
                 num_rows=n,
@@ -886,7 +884,7 @@ class DataFrame:
             names.append(columnName)
             columns.append(column)
 
-        return DataFrame.withPlan(
+        return DataFrame(
             plan.WithColumns(
                 self._plan,
                 columnNames=names,
@@ -903,7 +901,7 @@ class DataFrame:
                 error_class="NOT_COLUMN",
                 message_parameters={"arg_name": "col", "arg_type": type(col).__name__},
             )
-        return DataFrame.withPlan(
+        return DataFrame(
             plan.WithColumns(
                 self._plan,
                 columnNames=[colName],
@@ -921,7 +919,7 @@ class DataFrame:
                 message_parameters={"arg_name": "metadata", "arg_type": type(metadata).__name__},
             )
 
-        return DataFrame.withPlan(
+        return DataFrame(
             plan.WithColumns(
                 self._plan,
                 columnNames=[columnName],
@@ -955,7 +953,7 @@ class DataFrame:
                 lst = [cols]
             return lst
 
-        return DataFrame.withPlan(
+        return DataFrame(
             plan.Unpivot(
                 self._plan,
                 to_jcols(ids),
@@ -986,7 +984,7 @@ class DataFrame:
                 },
             )
 
-        return DataFrame.withPlan(
+        return DataFrame(
             plan.WithWatermark(
                 self._plan,
                 event_time=eventTime,
@@ -1036,7 +1034,7 @@ class DataFrame:
                         },
                     )
 
-        return DataFrame.withPlan(
+        return DataFrame(
             plan.Hint(self._plan, name, list(parameters)),
             session=self._session,
         )
@@ -1071,7 +1069,7 @@ class DataFrame:
         while j < length:
             lowerBound = normalizedCumWeights[j - 1]
             upperBound = normalizedCumWeights[j]
-            samplePlan = DataFrame.withPlan(
+            samplePlan = DataFrame(
                 plan.Sample(
                     child=self._plan,
                     lower_bound=lowerBound,
@@ -1110,7 +1108,7 @@ class DataFrame:
         if isinstance(observation, Observation):
             return observation._on(self, *exprs)
         elif isinstance(observation, str):
-            return DataFrame.withPlan(
+            return DataFrame(
                 plan.CollectMetrics(self._plan, observation, list(exprs)),
                 self._session,
             )
@@ -1138,7 +1136,7 @@ class DataFrame:
 
     def unionAll(self, other: "DataFrame") -> "DataFrame":
         self._check_same_session(other)
-        return DataFrame.withPlan(
+        return DataFrame(
             plan.SetOperation(self._plan, other._plan, "union", is_all=True), session=self._session
         )
 
@@ -1146,7 +1144,7 @@ class DataFrame:
 
     def unionByName(self, other: "DataFrame", allowMissingColumns: bool = False) -> "DataFrame":
         self._check_same_session(other)
-        return DataFrame.withPlan(
+        return DataFrame(
             plan.SetOperation(
                 self._plan,
                 other._plan,
@@ -1161,7 +1159,7 @@ class DataFrame:
 
     def subtract(self, other: "DataFrame") -> "DataFrame":
         self._check_same_session(other)
-        return DataFrame.withPlan(
+        return DataFrame(
             plan.SetOperation(self._plan, other._plan, "except", is_all=False),
             session=self._session,
         )
@@ -1170,7 +1168,7 @@ class DataFrame:
 
     def exceptAll(self, other: "DataFrame") -> "DataFrame":
         self._check_same_session(other)
-        return DataFrame.withPlan(
+        return DataFrame(
             plan.SetOperation(self._plan, other._plan, "except", is_all=True), session=self._session
         )
 
@@ -1178,7 +1176,7 @@ class DataFrame:
 
     def intersect(self, other: "DataFrame") -> "DataFrame":
         self._check_same_session(other)
-        return DataFrame.withPlan(
+        return DataFrame(
             plan.SetOperation(self._plan, other._plan, "intersect", is_all=False),
             session=self._session,
         )
@@ -1187,7 +1185,7 @@ class DataFrame:
 
     def intersectAll(self, other: "DataFrame") -> "DataFrame":
         self._check_same_session(other)
-        return DataFrame.withPlan(
+        return DataFrame(
             plan.SetOperation(self._plan, other._plan, "intersect", is_all=True),
             session=self._session,
         )
@@ -1268,7 +1266,7 @@ class DataFrame:
         else:
             _values = [value]
 
-        return DataFrame.withPlan(
+        return DataFrame(
             plan.NAFill(child=self._plan, cols=_cols, values=_values),
             session=self._session,
         )
@@ -1327,7 +1325,7 @@ class DataFrame:
                     message_parameters={"arg_name": "subset", "arg_type": type(subset).__name__},
                 )
 
-        return DataFrame.withPlan(
+        return DataFrame(
             plan.NADrop(child=self._plan, cols=_cols, min_non_nulls=min_non_nulls),
             session=self._session,
         )
@@ -1439,7 +1437,7 @@ class DataFrame:
                 message_parameters={},
             )
 
-        return DataFrame.withPlan(
+        return DataFrame(
             plan.NAReplace(child=self._plan, cols=subset, replacements=rep_dict),
             session=self._session,
         )
@@ -1460,7 +1458,7 @@ class DataFrame:
                     error_class="NOT_LIST_OF_STR",
                     message_parameters={"arg_name": "statistics", "arg_type": type(s).__name__},
                 )
-        return DataFrame.withPlan(
+        return DataFrame(
             plan.StatSummary(child=self._plan, statistics=_statistics),
             session=self._session,
         )
@@ -1477,7 +1475,7 @@ class DataFrame:
                 _cols.append(column)
             else:
                 _cols.extend([s for s in column])
-        return DataFrame.withPlan(
+        return DataFrame(
             plan.StatDescribe(child=self._plan, cols=_cols),
             session=self._session,
         )
@@ -1495,7 +1493,7 @@ class DataFrame:
                 error_class="NOT_STR",
                 message_parameters={"arg_name": "col2", "arg_type": type(col2).__name__},
             )
-        table, _ = DataFrame.withPlan(
+        table, _ = DataFrame(
             plan.StatCov(child=self._plan, col1=col1, col2=col2),
             session=self._session,
         )._to_table()
@@ -1521,7 +1519,7 @@ class DataFrame:
                 error_class="VALUE_NOT_PEARSON",
                 message_parameters={"arg_name": "method", "arg_value": method},
             )
-        table, _ = DataFrame.withPlan(
+        table, _ = DataFrame(
             plan.StatCorr(child=self._plan, col1=col1, col2=col2, method=method),
             session=self._session,
         )._to_table()
@@ -1592,7 +1590,7 @@ class DataFrame:
                 },
             )
         relativeError = float(relativeError)
-        table, _ = DataFrame.withPlan(
+        table, _ = DataFrame(
             plan.StatApproxQuantile(
                 child=self._plan,
                 cols=list(col),
@@ -1618,7 +1616,7 @@ class DataFrame:
                 error_class="NOT_STR",
                 message_parameters={"arg_name": "col2", "arg_type": type(col2).__name__},
             )
-        return DataFrame.withPlan(
+        return DataFrame(
             plan.StatCrosstab(child=self._plan, col1=col1, col2=col2),
             session=self._session,
         )
@@ -1637,7 +1635,7 @@ class DataFrame:
             )
         if not support:
             support = 0.01
-        return DataFrame.withPlan(
+        return DataFrame(
             plan.StatFreqItems(child=self._plan, cols=cols, support=support),
             session=self._session,
         )
@@ -1674,7 +1672,7 @@ class DataFrame:
                 )
             fractions[k] = float(v)
         seed = seed if seed is not None else random.randint(0, sys.maxsize)
-        return DataFrame.withPlan(
+        return DataFrame(
             plan.StatSampleBy(child=self._plan, col=col, fractions=fractions, seed=seed),
             session=self._session,
         )
@@ -1819,7 +1817,7 @@ class DataFrame:
 
     def to(self, schema: StructType) -> "DataFrame":
         assert schema is not None
-        return DataFrame.withPlan(
+        return DataFrame(
             plan.ToSchema(child=self._plan, schema=schema),
             session=self._session,
         )
@@ -1833,7 +1831,7 @@ class DataFrame:
                     error_class="NOT_LIST_OF_STR",
                     message_parameters={"arg_name": "cols", "arg_type": type(col_).__name__},
                 )
-        return DataFrame.withPlan(plan.ToDF(self._plan, list(cols)), self._session)
+        return DataFrame(plan.ToDF(self._plan, list(cols)), self._session)
 
     toDF.__doc__ = PySparkDataFrame.toDF.__doc__
 
@@ -2029,7 +2027,7 @@ class DataFrame:
             evalType=evalType,
         )
 
-        return DataFrame.withPlan(
+        return DataFrame(
             plan.MapPartitions(
                 child=self._plan, function=udf_obj, cols=self.columns, is_barrier=barrier
             ),
@@ -2119,17 +2117,9 @@ class DataFrame:
 
     # SparkConnect specific API
     def offset(self, n: int) -> "DataFrame":
-        return DataFrame.withPlan(plan.Offset(child=self._plan, offset=n), session=self._session)
+        return DataFrame(plan.Offset(child=self._plan, offset=n), session=self._session)
 
     offset.__doc__ = PySparkDataFrame.offset.__doc__
-
-    @classmethod
-    def withPlan(cls, plan: plan.LogicalPlan, session: "SparkSession") -> "DataFrame":
-        """
-        Main initialization method used to construct a new data frame with a child plan.
-        This is for internal purpose.
-        """
-        return DataFrame(plan=plan, session=session)
 
 
 class DataFrameNaFunctions:

--- a/python/pyspark/sql/connect/group.py
+++ b/python/pyspark/sql/connect/group.py
@@ -134,7 +134,7 @@ class GroupedData:
             assert all(isinstance(c, Column) for c in exprs), "all exprs should be Column"
             aggregate_cols = cast(List[Column], list(exprs))
 
-        return DataFrame.withPlan(
+        return DataFrame(
             plan.Aggregate(
                 child=self._df._plan,
                 group_type=self._group_type,
@@ -176,7 +176,7 @@ class GroupedData:
             # if no column is provided, then all numerical columns are selected
             agg_cols = numerical_cols
 
-        return DataFrame.withPlan(
+        return DataFrame(
             plan.Aggregate(
                 child=self._df._plan,
                 group_type=self._group_type,
@@ -296,7 +296,7 @@ class GroupedData:
             evalType=PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF,
         )
 
-        return DataFrame.withPlan(
+        return DataFrame(
             plan.GroupMap(
                 child=self._df._plan,
                 grouping_cols=self._grouping_cols,
@@ -335,7 +335,7 @@ class GroupedData:
             stateStructType.json() if isinstance(stateStructType, StructType) else stateStructType
         )
 
-        return DataFrame.withPlan(
+        return DataFrame(
             plan.ApplyInPandasWithState(
                 child=self._df._plan,
                 grouping_cols=self._grouping_cols,
@@ -378,7 +378,7 @@ class PandasCogroupedOps:
             evalType=PythonEvalType.SQL_COGROUPED_MAP_PANDAS_UDF,
         )
 
-        return DataFrame.withPlan(
+        return DataFrame(
             plan.CoGroupMap(
                 input=self._gd1._df._plan,
                 input_grouping_cols=self._gd1._grouping_cols,

--- a/python/pyspark/sql/connect/observation.py
+++ b/python/pyspark/sql/connect/observation.py
@@ -49,7 +49,7 @@ class Observation:
             raise IllegalArgumentException("Observation does not support streaming Datasets")
 
         self._result = {}
-        return DataFrame.withPlan(plan.CollectMetrics(df._plan, self, list(exprs)), df._session)
+        return DataFrame(plan.CollectMetrics(df._plan, self, list(exprs)), df._session)
 
     _on.__doc__ = PySparkObservation._on.__doc__
 

--- a/python/pyspark/sql/connect/readwriter.py
+++ b/python/pyspark/sql/connect/readwriter.py
@@ -134,7 +134,7 @@ class DataFrameReader(OptionUtils):
     def _df(self, plan: LogicalPlan) -> "DataFrame":
         from pyspark.sql.connect.dataframe import DataFrame
 
-        return DataFrame.withPlan(plan, self._client)
+        return DataFrame(plan, self._client)
 
     def table(self, tableName: str) -> "DataFrame":
         return self._df(Read(tableName, self._options))

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -381,7 +381,7 @@ class SparkSession:
             )
         elif isinstance(data, Sized) and len(data) == 0:
             if _schema is not None:
-                return DataFrame.withPlan(LocalRelation(table=None, schema=_schema.json()), self)
+                return DataFrame(LocalRelation(table=None, schema=_schema.json()), self)
             else:
                 raise PySparkValueError(
                     error_class="CANNOT_INFER_EMPTY_SCHEMA",
@@ -547,7 +547,7 @@ class SparkSession:
         if cache_threshold[0] is not None and int(cache_threshold[0]) <= _table.nbytes:
             plan = CachedLocalRelation(self._cache_local_relation(local_relation))
 
-        df = DataFrame.withPlan(plan, self)
+        df = DataFrame(plan, self)
         if _cols is not None and len(_cols) > 0:
             df = df.toDF(*_cols)
         return df
@@ -558,9 +558,9 @@ class SparkSession:
         cmd = SQL(sqlQuery, args)
         data, properties = self.client.execute_command(cmd.command(self._client))
         if "sql_command_result" in properties:
-            return DataFrame.withPlan(CachedRelation(properties["sql_command_result"]), self)
+            return DataFrame(CachedRelation(properties["sql_command_result"]), self)
         else:
-            return DataFrame.withPlan(cmd, self)
+            return DataFrame(cmd, self)
 
     sql.__doc__ = PySparkSession.sql.__doc__
 
@@ -580,7 +580,7 @@ class SparkSession:
         if numPartitions is not None:
             numPartitions = int(numPartitions)
 
-        return DataFrame.withPlan(
+        return DataFrame(
             Range(
                 start=int(start), end=int(actual_end), step=int(step), num_partitions=numPartitions
             ),
@@ -769,7 +769,7 @@ class SparkSession:
         This is used in ForeachBatch() runner, where the remote DataFrame refers to the
         output of a micro batch.
         """
-        return DataFrame.withPlan(CachedRemoteRelation(remote_id), self)
+        return DataFrame(CachedRemoteRelation(remote_id), self)
 
     @staticmethod
     def _start_connect_server(master: str, opts: Dict[str, Any]) -> None:

--- a/python/pyspark/sql/connect/streaming/readwriter.py
+++ b/python/pyspark/sql/connect/streaming/readwriter.py
@@ -52,7 +52,7 @@ class DataStreamReader(OptionUtils):
     def _df(self, plan: LogicalPlan) -> "DataFrame":
         from pyspark.sql.connect.dataframe import DataFrame
 
-        return DataFrame.withPlan(plan, self._client)
+        return DataFrame(plan, self._client)
 
     def format(self, source: str) -> "DataStreamReader":
         self._format = source

--- a/python/pyspark/sql/connect/udtf.py
+++ b/python/pyspark/sql/connect/udtf.py
@@ -167,7 +167,7 @@ class UserDefinedTableFunction:
         session = SparkSession.active()
 
         plan = self._build_common_inline_user_defined_table_function(*args, **kwargs)
-        return DataFrame.withPlan(plan, session)
+        return DataFrame(plan, session)
 
     def asDeterministic(self) -> "UserDefinedTableFunction":
         self.deterministic = True


### PR DESCRIPTION
### What changes were proposed in this pull request?
Remove helper function `DataFrame.withPlan`


### Why are the changes needed?
this helper function just invoke the constructor, should be redundant

```
    @classmethod
    def withPlan(cls, plan: plan.LogicalPlan, session: "SparkSession") -> "DataFrame":
        """
        Main initialization method used to construct a new data frame with a child plan.
        This is for internal purpose.
        """
        return DataFrame(plan=plan, session=session)
```


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no