### PR TITLE
[SPARK-46119][SQL] Override `toString` method for `UnresolvedAlias`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
@@ -713,6 +713,8 @@ case class UnresolvedAlias(
 
   override lazy val resolved = false
 
+  override def toString: String = prettyName + s"${child.toString}"
+
   override protected def withNewChildInternal(newChild: Expression): UnresolvedAlias =
     copy(child = newChild)
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
@@ -713,7 +713,7 @@ case class UnresolvedAlias(
 
   override lazy val resolved = false
 
-  override def toString: String = prettyName + s"${child.toString}"
+  override def toString: String = s"$prettyName(${child.toString})"
 
   override protected def withNewChildInternal(newChild: Expression): UnresolvedAlias =
     copy(child = newChild)

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/explain-aqe.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/explain-aqe.sql.out
@@ -40,7 +40,7 @@ EXPLAIN EXTENDED
   SELECT sum(distinct val)
   FROM explain_temp1
 -- !query analysis
-ExplainCommand 'Project [unresolvedalias('sum(distinct 'val), None)], ExtendedMode
+ExplainCommand 'Project [unresolvedalias('sum(distinct 'val))], ExtendedMode
 
 
 -- !query
@@ -129,7 +129,7 @@ EXPLAIN FORMATTED
   SELECT (SELECT Avg(key) FROM explain_temp1) + (SELECT Avg(key) FROM explain_temp1)
   FROM explain_temp1
 -- !query analysis
-ExplainCommand 'Project [unresolvedalias((scalar-subquery#x [] + scalar-subquery#x []), None)], FormattedMode
+ExplainCommand 'Project [unresolvedalias((scalar-subquery#x [] + scalar-subquery#x []))], FormattedMode
 
 
 -- !query
@@ -172,7 +172,7 @@ EXPLAIN FORMATTED
     COUNT(key) FILTER (WHERE val > 1)
   FROM explain_temp1
 -- !query analysis
-ExplainCommand 'Project [('COUNT('val) + 'SUM('key)) AS TOTAL#x, unresolvedalias('COUNT('key, ('val > 1)), None)], FormattedMode
+ExplainCommand 'Project [('COUNT('val) + 'SUM('key)) AS TOTAL#x, unresolvedalias('COUNT('key, ('val > 1)))], FormattedMode
 
 
 -- !query
@@ -181,7 +181,7 @@ EXPLAIN FORMATTED
   FROM explain_temp4
   GROUP BY key
 -- !query analysis
-ExplainCommand 'Aggregate ['key], ['key, unresolvedalias('sort_array('collect_set('val))[0], None)], FormattedMode
+ExplainCommand 'Aggregate ['key], ['key, unresolvedalias('sort_array('collect_set('val))[0])], FormattedMode
 
 
 -- !query
@@ -190,7 +190,7 @@ EXPLAIN FORMATTED
   FROM explain_temp4
   GROUP BY key
 -- !query analysis
-ExplainCommand 'Aggregate ['key], ['key, unresolvedalias('MIN('val), None)], FormattedMode
+ExplainCommand 'Aggregate ['key], ['key, unresolvedalias('MIN('val))], FormattedMode
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/explain.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/explain.sql.out
@@ -40,7 +40,7 @@ EXPLAIN EXTENDED
   SELECT sum(distinct val)
   FROM explain_temp1
 -- !query analysis
-ExplainCommand 'Project [unresolvedalias('sum(distinct 'val), None)], ExtendedMode
+ExplainCommand 'Project [unresolvedalias('sum(distinct 'val))], ExtendedMode
 
 
 -- !query
@@ -129,7 +129,7 @@ EXPLAIN FORMATTED
   SELECT (SELECT Avg(key) FROM explain_temp1) + (SELECT Avg(key) FROM explain_temp1)
   FROM explain_temp1
 -- !query analysis
-ExplainCommand 'Project [unresolvedalias((scalar-subquery#x [] + scalar-subquery#x []), None)], FormattedMode
+ExplainCommand 'Project [unresolvedalias((scalar-subquery#x [] + scalar-subquery#x []))], FormattedMode
 
 
 -- !query
@@ -172,7 +172,7 @@ EXPLAIN FORMATTED
     COUNT(key) FILTER (WHERE val > 1)
   FROM explain_temp1
 -- !query analysis
-ExplainCommand 'Project [('COUNT('val) + 'SUM('key)) AS TOTAL#x, unresolvedalias('COUNT('key, ('val > 1)), None)], FormattedMode
+ExplainCommand 'Project [('COUNT('val) + 'SUM('key)) AS TOTAL#x, unresolvedalias('COUNT('key, ('val > 1)))], FormattedMode
 
 
 -- !query
@@ -181,7 +181,7 @@ EXPLAIN FORMATTED
   FROM explain_temp4
   GROUP BY key
 -- !query analysis
-ExplainCommand 'Aggregate ['key], ['key, unresolvedalias('sort_array('collect_set('val))[0], None)], FormattedMode
+ExplainCommand 'Aggregate ['key], ['key, unresolvedalias('sort_array('collect_set('val))[0])], FormattedMode
 
 
 -- !query
@@ -190,7 +190,7 @@ EXPLAIN FORMATTED
   FROM explain_temp4
   GROUP BY key
 -- !query analysis
-ExplainCommand 'Aggregate ['key], ['key, unresolvedalias('MIN('val), None)], FormattedMode
+ExplainCommand 'Aggregate ['key], ['key, unresolvedalias('MIN('val))], FormattedMode
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/explain-aqe.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/explain-aqe.sql.out
@@ -55,7 +55,7 @@ EXPLAIN EXTENDED
 struct<plan:string>
 -- !query output
 == Parsed Logical Plan ==
-'Project [unresolvedalias('sum(distinct 'val), None)]
+'Project [unresolvedalias('sum(distinct 'val))]
 +- 'UnresolvedRelation [explain_temp1], [], false
 
 == Analyzed Logical Plan ==

--- a/sql/core/src/test/resources/sql-tests/results/explain.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/explain.sql.out
@@ -55,7 +55,7 @@ EXPLAIN EXTENDED
 struct<plan:string>
 -- !query output
 == Parsed Logical Plan ==
-'Project [unresolvedalias('sum(distinct 'val), None)]
+'Project [unresolvedalias('sum(distinct 'val))]
 +- 'UnresolvedRelation [explain_temp1], [], false
 
 == Analyzed Logical Plan ==


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR overrides `toString` method for `UnresolvedAlias`.

### Why are the changes needed?

Improve readability.

Before:
```
unresolvedalias((cast('dt as timestamp) = 2023-01-02 01:00:00), Some(org.apache.spark.sql.Column$$Lambda$3109/0x0000000801f62838@ea45a5b))
```

After:
```
unresolvedalias(cast('dt as timestamp) = 2023-01-02 01:00:00)
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit test.

### Was this patch authored or co-authored using generative AI tooling?

No.