### PR TITLE
[SPARK-46123][DOCS][PYTHON] Using brighter color for document title for better visibility

### DIFF
--- a/python/docs/source/_static/css/pyspark.css
+++ b/python/docs/source/_static/css/pyspark.css
@@ -24,7 +24,7 @@ body {
 }
 
 h1,h2 {
-    color:#1B5162!important;
+    color:#17A2B8!important;
 }
 
 h3 {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to adjust the font color of the titles in the PySpark documentation.


### Why are the changes needed?

For better visibility. The current title font color is not optimal for readability especially in dark mode, which can hinder user experience.


### Does this PR introduce _any_ user-facing change?

No API changes, but the font color for titles has been updated to a lighter shade, improving contrast and readability as below:

## Before

<img width="1025" alt="Screenshot 2023-11-27 at 5 57 42 PM" src="https://github.com/apache/spark/assets/44108233/19ee6e80-24ac-475f-94d1-1b5e95ef381a">

## After

<img width="1023" alt="Screenshot 2023-11-27 at 5 56 49 PM" src="https://github.com/apache/spark/assets/44108233/6a0d44e3-d28e-44ff-9ee2-1f5d69ef8aa1">


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
By manually building docs.


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.
