### PR TITLE
[SPARK-46129][DOCS][PYTHON] Add GitHub link icon to PySpark doc header

### DIFF
--- a/python/docs/source/conf.py
+++ b/python/docs/source/conf.py
@@ -194,11 +194,12 @@ html_context = {
 # further.  For a list of options available for each theme, see the
 # documentation.
 html_theme_options = {
-    "navbar_end": ["version-switcher", "theme-switcher"],
+    "navbar_end": ["version-switcher", "theme-switcher", "navbar-icon-links"],
     "logo": {
         "image_light": "_static/spark-logo-light.png",
         "image_dark": "_static/spark-logo-dark.png",
-    }
+    },
+    "github_url": "https://github.com/apache/spark",
 }
 
 # Add any paths that contain custom themes here, relative to this directory.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR  proposes to introduce a GitHub link icon in the header of the PySpark documentation, similar to what is currently implemented in the Pandas documentation.

### Why are the changes needed?

This change aligns with the practices of other open-source projects like Pandas, facilitating community engagement and collaboration.

### Does this PR introduce _any_ user-facing change?

No API changes, but a GitHub link icon will be added to the top right corner of the PySpark documentation header. This icon will be linked to the PySpark GitHub repository as below:

<img width="1064" alt="Screenshot 2023-11-28 at 10 17 06 AM" src="https://github.com/apache/spark/assets/44108233/d9907965-7275-4cdd-bb47-f704615160a9">




### How was this patch tested?

Visually checked by manually building docs.

### Was this patch authored or co-authored using generative AI tooling?

No.
