### PR TITLE
[SPARK-46127][PYTHON][TESTS] Disable pyspark.tests.test_worker.WorkerSegfaultNonDaemonTest.test_python_segfault with Python 3.12

### DIFF
--- a/python/pyspark/tests/test_worker.py
+++ b/python/pyspark/tests/test_worker.py
@@ -230,6 +230,7 @@ class WorkerSegfaultTest(ReusedPySparkTestCase):
         _conf.set("spark.python.worker.faulthandler.enabled", "true")
         return _conf
 
+    @unittest.skipIf(sys.version_info < (3, 12), "SPARK-46130: Flaky with Python 3.12")
     def test_python_segfault(self):
         try:
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR disables `pyspark.tests.test_worker.WorkerSegfaultNonDaemonTest.test_python_segfault` with Python 3.12 for now.

### Why are the changes needed?

This test is flaky, and stops the tests run till the end, e.g., see https://github.com/apache/spark/actions/runs/7006848931/job/19059701743

How `faulthandler` is used is correct, as documented in the standard Python documentation. So I do believe this is a bug from Python 3.12. I will track separately in Python side.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Manually:

```bash
python/run-tests --python-executable=python3  --testnames 'pyspark.tests.test_worker WorkerSegfaultNonDaemonTest.test_python_segfault'
```

### Was this patch authored or co-authored using generative AI tooling?

No.