### PR TITLE
[SPARK-46127][TESTS][PYTHON][FOLLOW-UP] Fix skip condition from " < (3, 12)" to " > (3, 11)"

### DIFF
--- a/python/pyspark/tests/test_worker.py
+++ b/python/pyspark/tests/test_worker.py
@@ -230,7 +230,7 @@ class WorkerSegfaultTest(ReusedPySparkTestCase):
         _conf.set("spark.python.worker.faulthandler.enabled", "true")
         return _conf
 
-    @unittest.skipIf(sys.version_info < (3, 12), "SPARK-46130: Flaky with Python 3.12")
+    @unittest.skipIf(sys.version_info > (3, 11), "SPARK-46130: Flaky with Python 3.12")
     def test_python_segfault(self):
         try:
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to fix the test condition from " < (3, 12)" to " > (3, 11)". 

### Why are the changes needed?

Incorrect condition. The test has to be skipped with Python 3.12+

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manually.

### Was this patch authored or co-authored using generative AI tooling?

No.
