### PR TITLE
[SPARK-46139][SQL][TESTS] Fix `QueryExecutionErrorsSuite` with Java 21

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
@@ -424,6 +424,11 @@ class QueryExecutionErrorsSuite
     } else {
       "`luckyCharOfWord \\(QueryExecutionErrorsSuite\\$\\$Lambda\\$\\d+/\\w+\\)`"
     }
+    val reason = if (Utils.isJavaVersionAtLeast21) {
+      "java.lang.StringIndexOutOfBoundsException: Range \\[5, 6\\) out of bounds for length 5"
+    } else {
+      "java.lang.StringIndexOutOfBoundsException: begin 5, end 6, length 5"
+    }
 
     checkError(
       exception = e.getCause.asInstanceOf[SparkException],
@@ -432,7 +437,7 @@ class QueryExecutionErrorsSuite
         "functionName" -> functionNameRegex,
         "signature" -> "string, int",
         "result" -> "string",
-        "reason" -> "java.lang.StringIndexOutOfBoundsException: begin 5, end 6, length 5"),
+        "reason" -> reason),
       matchPVals = true)
   }
 
@@ -450,6 +455,11 @@ class QueryExecutionErrorsSuite
     } else {
       "`QueryExecutionErrorsSuite\\$\\$Lambda\\$\\d+/\\w+`"
     }
+    val reason = if (Utils.isJavaVersionAtLeast21) {
+      "java.lang.StringIndexOutOfBoundsException: Range \\[5, 6\\) out of bounds for length 5"
+    } else {
+      "java.lang.StringIndexOutOfBoundsException: begin 5, end 6, length 5"
+    }
 
     checkError(
       exception = e.getCause.asInstanceOf[SparkException],
@@ -457,7 +467,7 @@ class QueryExecutionErrorsSuite
       parameters = Map("functionName" -> functionNameRegex,
         "signature" -> "string, int",
         "result" -> "string",
-        "reason" -> "java.lang.StringIndexOutOfBoundsException: begin 5, end 6, length 5"),
+        "reason" -> reason),
       matchPVals = true)
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the Java 21 daily tests, there are two test failures in `QueryExecutionErrorsSuite`: execute user defined function with registered UDF` and `FAILED_EXECUTE_UDF: execute user defined function`

- https://github.com/apache/spark/actions/runs/6993283399/job/19066715935
- https://github.com/apache/spark/actions/runs/7000424685/job/19066731946
- https://github.com/apache/spark/actions/runs/7014008773/job/19081075487


```
[info] - FAILED_EXECUTE_UDF: execute user defined function with registered UDF *** FAILED *** (48 milliseconds)
[info]   java.lang.IllegalArgumentException: For parameter 'reason' value 'java.lang.StringIndexOutOfBoundsException: Range [5, 6) out of bounds for length 5' does not match: java.lang.StringIndexOutOfBoundsException: begin 5, end 6, length 5
[info]   at org.apache.spark.SparkFunSuite.$anonfun$checkError$2(SparkFunSuite.scala:357)
[info]   at org.apache.spark.SparkFunSuite.$anonfun$checkError$2$adapted(SparkFunSuite.scala:352)
[info]   at scala.collection.IterableOnceOps.foreach(IterableOnce.scala:576)
[info]   at scala.collection.IterableOnceOps.foreach$(IterableOnce.scala:574)
[info]   at scala.collection.AbstractIterable.foreach(Iterable.scala:933)
[info]   at org.apache.spark.SparkFunSuite.checkError(SparkFunSuite.scala:352)
[info]   at org.apache.spark.sql.errors.QueryExecutionErrorsSuite.$anonfun$new$58(QueryExecutionErrorsSuite.scala:428)
... 
[info] - FAILED_EXECUTE_UDF: execute user defined function *** FAILED *** (32 milliseconds)
[info]   java.lang.IllegalArgumentException: For parameter 'reason' value 'java.lang.StringIndexOutOfBoundsException: Range [5, 6) out of bounds for length 5' does not match: java.lang.StringIndexOutOfBoundsException: begin 5, end 6, length 5
[info]   at org.apache.spark.SparkFunSuite.$anonfun$checkError$2(SparkFunSuite.scala:357)
[info]   at org.apache.spark.SparkFunSuite.$anonfun$checkError$2$adapted(SparkFunSuite.scala:352)
[info]   at scala.collection.IterableOnceOps.foreach(IterableOnce.scala:576)
[info]   at scala.collection.IterableOnceOps.foreach$(IterableOnce.scala:574)
[info]   at scala.collection.AbstractIterable.foreach(Iterable.scala:933)
[info]   at org.apache.spark.SparkFunSuite.checkError(SparkFunSuite.scala:352)
[info]   at org.apache.spark.sql.errors.QueryExecutionErrorsSuite.$anonfun$new$61(QueryExecutionErrorsSuite.scala:454)
```

This is due to different error messages when testing with Java 21 compared to Java 17:

- Java 17

```
org.apache.spark.SparkException: [FAILED_EXECUTE_UDF] User defined function (`luckyCharOfWord (QueryExecutionErrorsSuite$$Lambda$4610/0x000000e002355808)`: (string, int) => string) failed due to: java.lang.StringIndexOutOfBoundsException: begin 5, end 6, length 5. SQLSTATE: 39000
	at org.apache.spark.sql.errors.QueryExecutionErrors$.failedExecuteUserDefinedFunctionError(QueryExecutionErrors.scala:195)
	at org.apache.spark.sql.errors.QueryExecutionErrors.failedExecuteUserDefinedFunctionError(QueryExecutionErrors.scala)
	at org.apache.spark.sql.catalyst.expressions.GeneratedClass$GeneratedIteratorForCodegenStage1.processNext(Unknown Source)
	at org.apache.spark.sql.execution.BufferedRowIterator.hasNext(BufferedRowIterator.java:43)
	at org.apache.spark.sql.execution.WholeStageCodegenEvaluatorFactory$WholeStageCodegenPartitionEvaluator$$anon$1.hasNext(WholeStageCodegenEvaluatorFactory.scala:43)
	at org.apache.spark.sql.execution.SparkPlan.$anonfun$getByteArrayRdd$1(SparkPlan.scala:388)
	at org.apache.spark.rdd.RDD.$anonfun$mapPartitionsInternal$2(RDD.scala:891)
```

- Java 21
```
org.apache.spark.SparkException: [FAILED_EXECUTE_UDF] User defined function (`luckyCharOfWord (QueryExecutionErrorsSuite$$Lambda/0x00000070022eec08)`: (string, int) => string) failed due to: java.lang.StringIndexOutOfBoundsException: Range [5, 6) out of bounds for length 5. SQLSTATE: 39000
	at org.apache.spark.sql.errors.QueryExecutionErrors$.failedExecuteUserDefinedFunctionError(QueryExecutionErrors.scala:195)
	at org.apache.spark.sql.errors.QueryExecutionErrors.failedExecuteUserDefinedFunctionError(QueryExecutionErrors.scala)
	at org.apache.spark.sql.catalyst.expressions.GeneratedClass$GeneratedIteratorForCodegenStage1.processNext(Unknown Source)
	at org.apache.spark.sql.execution.BufferedRowIterator.hasNext(BufferedRowIterator.java:43)
	at org.apache.spark.sql.execution.WholeStageCodegenEvaluatorFactory$WholeStageCodegenPartitionEvaluator$$anon$1.hasNext(WholeStageCodegenEvaluatorFactory.scala:43)
	at org.apache.spark.sql.execution.SparkPlan.$anonfun$getByteArrayRdd$1(SparkPlan.scala:388)
	at org.apache.spark.rdd.RDD.$anonfun$mapPartitionsInternal$2(RDD.scala:891)
```

This PR makes the tests pass by using different `reason` for matching based on the different Java versions.



### Why are the changes needed?
Fix `QueryExecutionErrorsSuite` with Java 21


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Run `build/sbt "sql/testOnly org.apache.spark.sql.errors.QueryExecutionErrorsSuite"` with Java 21, all test passed.

```
java -version                                                                 
openjdk version "21.0.1" 2023-10-17 LTS
OpenJDK Runtime Environment Zulu21.30+15-CA (build 21.0.1+12-LTS)
OpenJDK 64-Bit Server VM Zulu21.30+15-CA (build 21.0.1+12-LTS, mixed mode, sharing)

build/sbt "sql/testOnly org.apache.spark.sql.errors.QueryExecutionErrorsSuite"
[info] Run completed in 8 seconds, 951 milliseconds.
[info] Total number of tests run: 49
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 49, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
```

### Was this patch authored or co-authored using generative AI tooling?
No