### PR TITLE
[SPARK-46141][SQL] Change default for spark.sql.legacy.ctePrecedencePolicy to CORRECTED

### DIFF
--- a/docs/sql-ref-syntax-qry-select-cte.md
+++ b/docs/sql-ref-syntax-qry-select-cte.md
@@ -101,10 +101,6 @@ SELECT * FROM v;
 |  1|  2|  3|  4|
 +---+---+---+---+
 
--- If name conflict is detected in nested CTE, then AnalysisException is thrown by default.
--- SET spark.sql.legacy.ctePrecedencePolicy = CORRECTED (which is recommended),
--- inner CTE definitions take precedence over outer definitions.
-SET spark.sql.legacy.ctePrecedencePolicy = CORRECTED;
 WITH
     t AS (SELECT 1),
     t2 AS (

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3872,14 +3872,14 @@ object SQLConf {
   val LEGACY_CTE_PRECEDENCE_POLICY = buildConf("spark.sql.legacy.ctePrecedencePolicy")
     .internal()
     .doc("When LEGACY, outer CTE definitions takes precedence over inner definitions. If set to " +
-      "CORRECTED, inner CTE definitions take precedence. The default value is EXCEPTION, " +
-      "AnalysisException is thrown while name conflict is detected in nested CTE. This config " +
+      "EXCEPTION, AnalysisException is thrown while name conflict is detected in nested CTE." +
+      "The default is CORRECTED, inner CTE definitions take precedence. This config " +
       "will be removed in future versions and CORRECTED will be the only behavior.")
     .version("3.0.0")
     .stringConf
     .transform(_.toUpperCase(Locale.ROOT))
     .checkValues(LegacyBehaviorPolicy.values.map(_.toString))
-    .createWithDefault(LegacyBehaviorPolicy.EXCEPTION.toString)
+    .createWithDefault(LegacyBehaviorPolicy.CORRECTED.toString)
 
   val LEGACY_INLINE_CTE_IN_COMMANDS = buildConf("spark.sql.legacy.inlineCTEInCommands")
     .internal()

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/cte-nested.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/cte-nested.sql.out
@@ -93,16 +93,23 @@ WITH
   )
 SELECT * FROM t2
 -- !query analysis
-org.apache.spark.sql.AnalysisException
-{
-  "errorClass" : "AMBIGUOUS_ALIAS_IN_NESTED_CTE",
-  "sqlState" : "42KD0",
-  "messageParameters" : {
-    "config" : "\"spark.sql.legacy.ctePrecedencePolicy\"",
-    "docroot" : "https://spark.apache.org/docs/latest",
-    "name" : "`t`"
-  }
-}
+WithCTE
+:- CTERelationDef xxxx, false
+:  +- SubqueryAlias t
+:     +- Project [1 AS 1#x]
+:        +- OneRowRelation
+:- CTERelationDef xxxx, false
+:  +- SubqueryAlias t
+:     +- Project [2 AS 2#x]
+:        +- OneRowRelation
+:- CTERelationDef xxxx, false
+:  +- SubqueryAlias t2
+:     +- Project [2#x]
+:        +- SubqueryAlias t
+:           +- CTERelationRef xxxx, true, [2#x], false
++- Project [2#x]
+   +- SubqueryAlias t2
+      +- CTERelationRef xxxx, true, [2#x], false
 
 
 -- !query
@@ -157,16 +164,32 @@ WITH
   )
 SELECT * FROM t2
 -- !query analysis
-org.apache.spark.sql.AnalysisException
-{
-  "errorClass" : "AMBIGUOUS_ALIAS_IN_NESTED_CTE",
-  "sqlState" : "42KD0",
-  "messageParameters" : {
-    "config" : "\"spark.sql.legacy.ctePrecedencePolicy\"",
-    "docroot" : "https://spark.apache.org/docs/latest",
-    "name" : "`t`"
-  }
-}
+WithCTE
+:- CTERelationDef xxxx, false
+:  +- SubqueryAlias t
+:     +- Project [1 AS 1#x]
+:        +- OneRowRelation
+:- CTERelationDef xxxx, false
+:  +- SubqueryAlias t
+:     +- Project [2 AS 2#x]
+:        +- OneRowRelation
+:- CTERelationDef xxxx, false
+:  +- SubqueryAlias t
+:     +- Project [3 AS 3#x]
+:        +- OneRowRelation
+:- CTERelationDef xxxx, false
+:  +- SubqueryAlias t2
+:     +- Project [3#x]
+:        +- SubqueryAlias t
+:           +- CTERelationRef xxxx, true, [3#x], false
+:- CTERelationDef xxxx, false
+:  +- SubqueryAlias t2
+:     +- Project [3#x]
+:        +- SubqueryAlias t2
+:           +- CTERelationRef xxxx, true, [3#x], false
++- Project [3#x]
+   +- SubqueryAlias t2
+      +- CTERelationRef xxxx, true, [3#x], false
 
 
 -- !query
@@ -265,16 +288,21 @@ SELECT (
   SELECT * FROM t
 )
 -- !query analysis
-org.apache.spark.sql.AnalysisException
-{
-  "errorClass" : "AMBIGUOUS_ALIAS_IN_NESTED_CTE",
-  "sqlState" : "42KD0",
-  "messageParameters" : {
-    "config" : "\"spark.sql.legacy.ctePrecedencePolicy\"",
-    "docroot" : "https://spark.apache.org/docs/latest",
-    "name" : "`t`"
-  }
-}
+WithCTE
+:- CTERelationDef xxxx, false
+:  +- SubqueryAlias t
+:     +- Project [1 AS 1#x]
+:        +- OneRowRelation
++- Project [scalar-subquery#x [] AS scalarsubquery()#x]
+   :  +- WithCTE
+   :     :- CTERelationDef xxxx, false
+   :     :  +- SubqueryAlias t
+   :     :     +- Project [2 AS 2#x]
+   :     :        +- OneRowRelation
+   :     +- Project [2#x]
+   :        +- SubqueryAlias t
+   :           +- CTERelationRef xxxx, true, [2#x], false
+   +- OneRowRelation
 
 
 -- !query
@@ -286,16 +314,23 @@ SELECT (
   )
 )
 -- !query analysis
-org.apache.spark.sql.AnalysisException
-{
-  "errorClass" : "AMBIGUOUS_ALIAS_IN_NESTED_CTE",
-  "sqlState" : "42KD0",
-  "messageParameters" : {
-    "config" : "\"spark.sql.legacy.ctePrecedencePolicy\"",
-    "docroot" : "https://spark.apache.org/docs/latest",
-    "name" : "`t`"
-  }
-}
+WithCTE
+:- CTERelationDef xxxx, false
+:  +- SubqueryAlias t
+:     +- Project [1 AS 1#x]
+:        +- OneRowRelation
++- Project [scalar-subquery#x [] AS scalarsubquery()#x]
+   :  +- Project [scalar-subquery#x [] AS scalarsubquery()#x]
+   :     :  +- WithCTE
+   :     :     :- CTERelationDef xxxx, false
+   :     :     :  +- SubqueryAlias t
+   :     :     :     +- Project [2 AS 2#x]
+   :     :     :        +- OneRowRelation
+   :     :     +- Project [2#x]
+   :     :        +- SubqueryAlias t
+   :     :           +- CTERelationRef xxxx, true, [2#x], false
+   :     +- OneRowRelation
+   +- OneRowRelation
 
 
 -- !query
@@ -308,16 +343,28 @@ SELECT (
   )
 )
 -- !query analysis
-org.apache.spark.sql.AnalysisException
-{
-  "errorClass" : "AMBIGUOUS_ALIAS_IN_NESTED_CTE",
-  "sqlState" : "42KD0",
-  "messageParameters" : {
-    "config" : "\"spark.sql.legacy.ctePrecedencePolicy\"",
-    "docroot" : "https://spark.apache.org/docs/latest",
-    "name" : "`t`"
-  }
-}
+WithCTE
+:- CTERelationDef xxxx, false
+:  +- SubqueryAlias t
+:     +- Project [1 AS 1#x]
+:        +- OneRowRelation
++- Project [scalar-subquery#x [] AS scalarsubquery()#x]
+   :  +- WithCTE
+   :     :- CTERelationDef xxxx, false
+   :     :  +- SubqueryAlias t
+   :     :     +- Project [2 AS 2#x]
+   :     :        +- OneRowRelation
+   :     +- Project [scalar-subquery#x [] AS scalarsubquery()#x]
+   :        :  +- WithCTE
+   :        :     :- CTERelationDef xxxx, false
+   :        :     :  +- SubqueryAlias t
+   :        :     :     +- Project [3 AS 3#x]
+   :        :     :        +- OneRowRelation
+   :        :     +- Project [3#x]
+   :        :        +- SubqueryAlias t
+   :        :           +- CTERelationRef xxxx, true, [3#x], false
+   :        +- OneRowRelation
+   +- OneRowRelation
 
 
 -- !query
@@ -328,16 +375,25 @@ WHERE c IN (
   SELECT * FROM t
 )
 -- !query analysis
-org.apache.spark.sql.AnalysisException
-{
-  "errorClass" : "AMBIGUOUS_ALIAS_IN_NESTED_CTE",
-  "sqlState" : "42KD0",
-  "messageParameters" : {
-    "config" : "\"spark.sql.legacy.ctePrecedencePolicy\"",
-    "docroot" : "https://spark.apache.org/docs/latest",
-    "name" : "`t`"
-  }
-}
+WithCTE
+:- CTERelationDef xxxx, false
+:  +- SubqueryAlias t
+:     +- Project [1#x AS c#x]
+:        +- Project [1 AS 1#x]
+:           +- OneRowRelation
++- Project [c#x]
+   +- Filter c#x IN (list#x [])
+      :  +- WithCTE
+      :     :- CTERelationDef xxxx, false
+      :     :  +- SubqueryAlias t
+      :     :     +- Project [2#x AS c#x]
+      :     :        +- Project [2 AS 2#x]
+      :     :           +- OneRowRelation
+      :     +- Project [c#x]
+      :        +- SubqueryAlias t
+      :           +- CTERelationRef xxxx, true, [c#x], false
+      +- SubqueryAlias t
+         +- CTERelationRef xxxx, true, [c#x], false
 
 
 -- !query
@@ -377,16 +433,23 @@ WITH
   )
 SELECT * FROM t
 -- !query analysis
-org.apache.spark.sql.AnalysisException
-{
-  "errorClass" : "AMBIGUOUS_ALIAS_IN_NESTED_CTE",
-  "sqlState" : "42KD0",
-  "messageParameters" : {
-    "config" : "\"spark.sql.legacy.ctePrecedencePolicy\"",
-    "docroot" : "https://spark.apache.org/docs/latest",
-    "name" : "`aBc`"
-  }
-}
+WithCTE
+:- CTERelationDef xxxx, false
+:  +- SubqueryAlias abc
+:     +- Project [1 AS 1#x]
+:        +- OneRowRelation
+:- CTERelationDef xxxx, false
+:  +- SubqueryAlias aBc
+:     +- Project [2 AS 2#x]
+:        +- OneRowRelation
+:- CTERelationDef xxxx, false
+:  +- SubqueryAlias t
+:     +- Project [2#x]
+:        +- SubqueryAlias aBC
+:           +- CTERelationRef xxxx, true, [2#x], false
++- Project [2#x]
+   +- SubqueryAlias t
+      +- CTERelationRef xxxx, true, [2#x], false
 
 
 -- !query
@@ -396,16 +459,21 @@ SELECT (
   SELECT * FROM aBC
 )
 -- !query analysis
-org.apache.spark.sql.AnalysisException
-{
-  "errorClass" : "AMBIGUOUS_ALIAS_IN_NESTED_CTE",
-  "sqlState" : "42KD0",
-  "messageParameters" : {
-    "config" : "\"spark.sql.legacy.ctePrecedencePolicy\"",
-    "docroot" : "https://spark.apache.org/docs/latest",
-    "name" : "`aBc`"
-  }
-}
+WithCTE
+:- CTERelationDef xxxx, false
+:  +- SubqueryAlias abc
+:     +- Project [1 AS 1#x]
+:        +- OneRowRelation
++- Project [scalar-subquery#x [] AS scalarsubquery()#x]
+   :  +- WithCTE
+   :     :- CTERelationDef xxxx, false
+   :     :  +- SubqueryAlias aBc
+   :     :     +- Project [2 AS 2#x]
+   :     :        +- OneRowRelation
+   :     +- Project [2#x]
+   :        +- SubqueryAlias aBC
+   :           +- CTERelationRef xxxx, true, [2#x], false
+   +- OneRowRelation
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/cte-nonlegacy.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/cte-nonlegacy.sql.out
@@ -93,23 +93,16 @@ WITH
   )
 SELECT * FROM t2
 -- !query analysis
-WithCTE
-:- CTERelationDef xxxx, false
-:  +- SubqueryAlias t
-:     +- Project [1 AS 1#x]
-:        +- OneRowRelation
-:- CTERelationDef xxxx, false
-:  +- SubqueryAlias t
-:     +- Project [2 AS 2#x]
-:        +- OneRowRelation
-:- CTERelationDef xxxx, false
-:  +- SubqueryAlias t2
-:     +- Project [2#x]
-:        +- SubqueryAlias t
-:           +- CTERelationRef xxxx, true, [2#x], false
-+- Project [2#x]
-   +- SubqueryAlias t2
-      +- CTERelationRef xxxx, true, [2#x], false
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "AMBIGUOUS_ALIAS_IN_NESTED_CTE",
+  "sqlState" : "42KD0",
+  "messageParameters" : {
+    "config" : "\"spark.sql.legacy.ctePrecedencePolicy\"",
+    "docroot" : "https://spark.apache.org/docs/latest",
+    "name" : "`t`"
+  }
+}
 
 
 -- !query
@@ -164,32 +157,16 @@ WITH
   )
 SELECT * FROM t2
 -- !query analysis
-WithCTE
-:- CTERelationDef xxxx, false
-:  +- SubqueryAlias t
-:     +- Project [1 AS 1#x]
-:        +- OneRowRelation
-:- CTERelationDef xxxx, false
-:  +- SubqueryAlias t
-:     +- Project [2 AS 2#x]
-:        +- OneRowRelation
-:- CTERelationDef xxxx, false
-:  +- SubqueryAlias t
-:     +- Project [3 AS 3#x]
-:        +- OneRowRelation
-:- CTERelationDef xxxx, false
-:  +- SubqueryAlias t2
-:     +- Project [3#x]
-:        +- SubqueryAlias t
-:           +- CTERelationRef xxxx, true, [3#x], false
-:- CTERelationDef xxxx, false
-:  +- SubqueryAlias t2
-:     +- Project [3#x]
-:        +- SubqueryAlias t2
-:           +- CTERelationRef xxxx, true, [3#x], false
-+- Project [3#x]
-   +- SubqueryAlias t2
-      +- CTERelationRef xxxx, true, [3#x], false
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "AMBIGUOUS_ALIAS_IN_NESTED_CTE",
+  "sqlState" : "42KD0",
+  "messageParameters" : {
+    "config" : "\"spark.sql.legacy.ctePrecedencePolicy\"",
+    "docroot" : "https://spark.apache.org/docs/latest",
+    "name" : "`t`"
+  }
+}
 
 
 -- !query
@@ -288,21 +265,16 @@ SELECT (
   SELECT * FROM t
 )
 -- !query analysis
-WithCTE
-:- CTERelationDef xxxx, false
-:  +- SubqueryAlias t
-:     +- Project [1 AS 1#x]
-:        +- OneRowRelation
-+- Project [scalar-subquery#x [] AS scalarsubquery()#x]
-   :  +- WithCTE
-   :     :- CTERelationDef xxxx, false
-   :     :  +- SubqueryAlias t
-   :     :     +- Project [2 AS 2#x]
-   :     :        +- OneRowRelation
-   :     +- Project [2#x]
-   :        +- SubqueryAlias t
-   :           +- CTERelationRef xxxx, true, [2#x], false
-   +- OneRowRelation
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "AMBIGUOUS_ALIAS_IN_NESTED_CTE",
+  "sqlState" : "42KD0",
+  "messageParameters" : {
+    "config" : "\"spark.sql.legacy.ctePrecedencePolicy\"",
+    "docroot" : "https://spark.apache.org/docs/latest",
+    "name" : "`t`"
+  }
+}
 
 
 -- !query
@@ -314,23 +286,16 @@ SELECT (
   )
 )
 -- !query analysis
-WithCTE
-:- CTERelationDef xxxx, false
-:  +- SubqueryAlias t
-:     +- Project [1 AS 1#x]
-:        +- OneRowRelation
-+- Project [scalar-subquery#x [] AS scalarsubquery()#x]
-   :  +- Project [scalar-subquery#x [] AS scalarsubquery()#x]
-   :     :  +- WithCTE
-   :     :     :- CTERelationDef xxxx, false
-   :     :     :  +- SubqueryAlias t
-   :     :     :     +- Project [2 AS 2#x]
-   :     :     :        +- OneRowRelation
-   :     :     +- Project [2#x]
-   :     :        +- SubqueryAlias t
-   :     :           +- CTERelationRef xxxx, true, [2#x], false
-   :     +- OneRowRelation
-   +- OneRowRelation
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "AMBIGUOUS_ALIAS_IN_NESTED_CTE",
+  "sqlState" : "42KD0",
+  "messageParameters" : {
+    "config" : "\"spark.sql.legacy.ctePrecedencePolicy\"",
+    "docroot" : "https://spark.apache.org/docs/latest",
+    "name" : "`t`"
+  }
+}
 
 
 -- !query
@@ -343,28 +308,16 @@ SELECT (
   )
 )
 -- !query analysis
-WithCTE
-:- CTERelationDef xxxx, false
-:  +- SubqueryAlias t
-:     +- Project [1 AS 1#x]
-:        +- OneRowRelation
-+- Project [scalar-subquery#x [] AS scalarsubquery()#x]
-   :  +- WithCTE
-   :     :- CTERelationDef xxxx, false
-   :     :  +- SubqueryAlias t
-   :     :     +- Project [2 AS 2#x]
-   :     :        +- OneRowRelation
-   :     +- Project [scalar-subquery#x [] AS scalarsubquery()#x]
-   :        :  +- WithCTE
-   :        :     :- CTERelationDef xxxx, false
-   :        :     :  +- SubqueryAlias t
-   :        :     :     +- Project [3 AS 3#x]
-   :        :     :        +- OneRowRelation
-   :        :     +- Project [3#x]
-   :        :        +- SubqueryAlias t
-   :        :           +- CTERelationRef xxxx, true, [3#x], false
-   :        +- OneRowRelation
-   +- OneRowRelation
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "AMBIGUOUS_ALIAS_IN_NESTED_CTE",
+  "sqlState" : "42KD0",
+  "messageParameters" : {
+    "config" : "\"spark.sql.legacy.ctePrecedencePolicy\"",
+    "docroot" : "https://spark.apache.org/docs/latest",
+    "name" : "`t`"
+  }
+}
 
 
 -- !query
@@ -375,25 +328,16 @@ WHERE c IN (
   SELECT * FROM t
 )
 -- !query analysis
-WithCTE
-:- CTERelationDef xxxx, false
-:  +- SubqueryAlias t
-:     +- Project [1#x AS c#x]
-:        +- Project [1 AS 1#x]
-:           +- OneRowRelation
-+- Project [c#x]
-   +- Filter c#x IN (list#x [])
-      :  +- WithCTE
-      :     :- CTERelationDef xxxx, false
-      :     :  +- SubqueryAlias t
-      :     :     +- Project [2#x AS c#x]
-      :     :        +- Project [2 AS 2#x]
-      :     :           +- OneRowRelation
-      :     +- Project [c#x]
-      :        +- SubqueryAlias t
-      :           +- CTERelationRef xxxx, true, [c#x], false
-      +- SubqueryAlias t
-         +- CTERelationRef xxxx, true, [c#x], false
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "AMBIGUOUS_ALIAS_IN_NESTED_CTE",
+  "sqlState" : "42KD0",
+  "messageParameters" : {
+    "config" : "\"spark.sql.legacy.ctePrecedencePolicy\"",
+    "docroot" : "https://spark.apache.org/docs/latest",
+    "name" : "`t`"
+  }
+}
 
 
 -- !query
@@ -433,23 +377,16 @@ WITH
   )
 SELECT * FROM t
 -- !query analysis
-WithCTE
-:- CTERelationDef xxxx, false
-:  +- SubqueryAlias abc
-:     +- Project [1 AS 1#x]
-:        +- OneRowRelation
-:- CTERelationDef xxxx, false
-:  +- SubqueryAlias aBc
-:     +- Project [2 AS 2#x]
-:        +- OneRowRelation
-:- CTERelationDef xxxx, false
-:  +- SubqueryAlias t
-:     +- Project [2#x]
-:        +- SubqueryAlias aBC
-:           +- CTERelationRef xxxx, true, [2#x], false
-+- Project [2#x]
-   +- SubqueryAlias t
-      +- CTERelationRef xxxx, true, [2#x], false
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "AMBIGUOUS_ALIAS_IN_NESTED_CTE",
+  "sqlState" : "42KD0",
+  "messageParameters" : {
+    "config" : "\"spark.sql.legacy.ctePrecedencePolicy\"",
+    "docroot" : "https://spark.apache.org/docs/latest",
+    "name" : "`aBc`"
+  }
+}
 
 
 -- !query
@@ -459,21 +396,16 @@ SELECT (
   SELECT * FROM aBC
 )
 -- !query analysis
-WithCTE
-:- CTERelationDef xxxx, false
-:  +- SubqueryAlias abc
-:     +- Project [1 AS 1#x]
-:        +- OneRowRelation
-+- Project [scalar-subquery#x [] AS scalarsubquery()#x]
-   :  +- WithCTE
-   :     :- CTERelationDef xxxx, false
-   :     :  +- SubqueryAlias aBc
-   :     :     +- Project [2 AS 2#x]
-   :     :        +- OneRowRelation
-   :     +- Project [2#x]
-   :        +- SubqueryAlias aBC
-   :           +- CTERelationRef xxxx, true, [2#x], false
-   +- OneRowRelation
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "AMBIGUOUS_ALIAS_IN_NESTED_CTE",
+  "sqlState" : "42KD0",
+  "messageParameters" : {
+    "config" : "\"spark.sql.legacy.ctePrecedencePolicy\"",
+    "docroot" : "https://spark.apache.org/docs/latest",
+    "name" : "`aBc`"
+  }
+}
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/inputs/cte-nonlegacy.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/cte-nonlegacy.sql
@@ -1,2 +1,2 @@
---SET spark.sql.legacy.ctePrecedencePolicy = corrected
+--SET spark.sql.legacy.ctePrecedencePolicy = EXCEPTION
 --IMPORT cte-nested.sql

--- a/sql/core/src/test/resources/sql-tests/results/cte-nested.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/cte-nested.sql.out
@@ -70,18 +70,9 @@ WITH
   )
 SELECT * FROM t2
 -- !query schema
-struct<>
+struct<2:int>
 -- !query output
-org.apache.spark.sql.AnalysisException
-{
-  "errorClass" : "AMBIGUOUS_ALIAS_IN_NESTED_CTE",
-  "sqlState" : "42KD0",
-  "messageParameters" : {
-    "config" : "\"spark.sql.legacy.ctePrecedencePolicy\"",
-    "docroot" : "https://spark.apache.org/docs/latest",
-    "name" : "`t`"
-  }
-}
+2
 
 
 -- !query
@@ -115,18 +106,9 @@ WITH
   )
 SELECT * FROM t2
 -- !query schema
-struct<>
+struct<3:int>
 -- !query output
-org.apache.spark.sql.AnalysisException
-{
-  "errorClass" : "AMBIGUOUS_ALIAS_IN_NESTED_CTE",
-  "sqlState" : "42KD0",
-  "messageParameters" : {
-    "config" : "\"spark.sql.legacy.ctePrecedencePolicy\"",
-    "docroot" : "https://spark.apache.org/docs/latest",
-    "name" : "`t`"
-  }
-}
+3
 
 
 -- !query
@@ -177,18 +159,9 @@ SELECT (
   SELECT * FROM t
 )
 -- !query schema
-struct<>
+struct<scalarsubquery():int>
 -- !query output
-org.apache.spark.sql.AnalysisException
-{
-  "errorClass" : "AMBIGUOUS_ALIAS_IN_NESTED_CTE",
-  "sqlState" : "42KD0",
-  "messageParameters" : {
-    "config" : "\"spark.sql.legacy.ctePrecedencePolicy\"",
-    "docroot" : "https://spark.apache.org/docs/latest",
-    "name" : "`t`"
-  }
-}
+2
 
 
 -- !query
@@ -200,18 +173,9 @@ SELECT (
   )
 )
 -- !query schema
-struct<>
+struct<scalarsubquery():int>
 -- !query output
-org.apache.spark.sql.AnalysisException
-{
-  "errorClass" : "AMBIGUOUS_ALIAS_IN_NESTED_CTE",
-  "sqlState" : "42KD0",
-  "messageParameters" : {
-    "config" : "\"spark.sql.legacy.ctePrecedencePolicy\"",
-    "docroot" : "https://spark.apache.org/docs/latest",
-    "name" : "`t`"
-  }
-}
+2
 
 
 -- !query
@@ -224,18 +188,9 @@ SELECT (
   )
 )
 -- !query schema
-struct<>
+struct<scalarsubquery():int>
 -- !query output
-org.apache.spark.sql.AnalysisException
-{
-  "errorClass" : "AMBIGUOUS_ALIAS_IN_NESTED_CTE",
-  "sqlState" : "42KD0",
-  "messageParameters" : {
-    "config" : "\"spark.sql.legacy.ctePrecedencePolicy\"",
-    "docroot" : "https://spark.apache.org/docs/latest",
-    "name" : "`t`"
-  }
-}
+3
 
 
 -- !query
@@ -246,18 +201,9 @@ WHERE c IN (
   SELECT * FROM t
 )
 -- !query schema
-struct<>
+struct<c:int>
 -- !query output
-org.apache.spark.sql.AnalysisException
-{
-  "errorClass" : "AMBIGUOUS_ALIAS_IN_NESTED_CTE",
-  "sqlState" : "42KD0",
-  "messageParameters" : {
-    "config" : "\"spark.sql.legacy.ctePrecedencePolicy\"",
-    "docroot" : "https://spark.apache.org/docs/latest",
-    "name" : "`t`"
-  }
-}
+
 
 
 -- !query
@@ -283,18 +229,9 @@ WITH
   )
 SELECT * FROM t
 -- !query schema
-struct<>
+struct<2:int>
 -- !query output
-org.apache.spark.sql.AnalysisException
-{
-  "errorClass" : "AMBIGUOUS_ALIAS_IN_NESTED_CTE",
-  "sqlState" : "42KD0",
-  "messageParameters" : {
-    "config" : "\"spark.sql.legacy.ctePrecedencePolicy\"",
-    "docroot" : "https://spark.apache.org/docs/latest",
-    "name" : "`aBc`"
-  }
-}
+2
 
 
 -- !query
@@ -304,18 +241,9 @@ SELECT (
   SELECT * FROM aBC
 )
 -- !query schema
-struct<>
+struct<scalarsubquery():int>
 -- !query output
-org.apache.spark.sql.AnalysisException
-{
-  "errorClass" : "AMBIGUOUS_ALIAS_IN_NESTED_CTE",
-  "sqlState" : "42KD0",
-  "messageParameters" : {
-    "config" : "\"spark.sql.legacy.ctePrecedencePolicy\"",
-    "docroot" : "https://spark.apache.org/docs/latest",
-    "name" : "`aBc`"
-  }
-}
+2
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/cte-nonlegacy.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/cte-nonlegacy.sql.out
@@ -70,9 +70,18 @@ WITH
   )
 SELECT * FROM t2
 -- !query schema
-struct<2:int>
+struct<>
 -- !query output
-2
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "AMBIGUOUS_ALIAS_IN_NESTED_CTE",
+  "sqlState" : "42KD0",
+  "messageParameters" : {
+    "config" : "\"spark.sql.legacy.ctePrecedencePolicy\"",
+    "docroot" : "https://spark.apache.org/docs/latest",
+    "name" : "`t`"
+  }
+}
 
 
 -- !query
@@ -106,9 +115,18 @@ WITH
   )
 SELECT * FROM t2
 -- !query schema
-struct<3:int>
+struct<>
 -- !query output
-3
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "AMBIGUOUS_ALIAS_IN_NESTED_CTE",
+  "sqlState" : "42KD0",
+  "messageParameters" : {
+    "config" : "\"spark.sql.legacy.ctePrecedencePolicy\"",
+    "docroot" : "https://spark.apache.org/docs/latest",
+    "name" : "`t`"
+  }
+}
 
 
 -- !query
@@ -159,9 +177,18 @@ SELECT (
   SELECT * FROM t
 )
 -- !query schema
-struct<scalarsubquery():int>
+struct<>
 -- !query output
-2
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "AMBIGUOUS_ALIAS_IN_NESTED_CTE",
+  "sqlState" : "42KD0",
+  "messageParameters" : {
+    "config" : "\"spark.sql.legacy.ctePrecedencePolicy\"",
+    "docroot" : "https://spark.apache.org/docs/latest",
+    "name" : "`t`"
+  }
+}
 
 
 -- !query
@@ -173,9 +200,18 @@ SELECT (
   )
 )
 -- !query schema
-struct<scalarsubquery():int>
+struct<>
 -- !query output
-2
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "AMBIGUOUS_ALIAS_IN_NESTED_CTE",
+  "sqlState" : "42KD0",
+  "messageParameters" : {
+    "config" : "\"spark.sql.legacy.ctePrecedencePolicy\"",
+    "docroot" : "https://spark.apache.org/docs/latest",
+    "name" : "`t`"
+  }
+}
 
 
 -- !query
@@ -188,9 +224,18 @@ SELECT (
   )
 )
 -- !query schema
-struct<scalarsubquery():int>
+struct<>
 -- !query output
-3
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "AMBIGUOUS_ALIAS_IN_NESTED_CTE",
+  "sqlState" : "42KD0",
+  "messageParameters" : {
+    "config" : "\"spark.sql.legacy.ctePrecedencePolicy\"",
+    "docroot" : "https://spark.apache.org/docs/latest",
+    "name" : "`t`"
+  }
+}
 
 
 -- !query
@@ -201,9 +246,18 @@ WHERE c IN (
   SELECT * FROM t
 )
 -- !query schema
-struct<c:int>
+struct<>
 -- !query output
-
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "AMBIGUOUS_ALIAS_IN_NESTED_CTE",
+  "sqlState" : "42KD0",
+  "messageParameters" : {
+    "config" : "\"spark.sql.legacy.ctePrecedencePolicy\"",
+    "docroot" : "https://spark.apache.org/docs/latest",
+    "name" : "`t`"
+  }
+}
 
 
 -- !query
@@ -229,9 +283,18 @@ WITH
   )
 SELECT * FROM t
 -- !query schema
-struct<2:int>
+struct<>
 -- !query output
-2
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "AMBIGUOUS_ALIAS_IN_NESTED_CTE",
+  "sqlState" : "42KD0",
+  "messageParameters" : {
+    "config" : "\"spark.sql.legacy.ctePrecedencePolicy\"",
+    "docroot" : "https://spark.apache.org/docs/latest",
+    "name" : "`aBc`"
+  }
+}
 
 
 -- !query
@@ -241,9 +304,18 @@ SELECT (
   SELECT * FROM aBC
 )
 -- !query schema
-struct<scalarsubquery():int>
+struct<>
 -- !query output
-2
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "AMBIGUOUS_ALIAS_IN_NESTED_CTE",
+  "sqlState" : "42KD0",
+  "messageParameters" : {
+    "config" : "\"spark.sql.legacy.ctePrecedencePolicy\"",
+    "docroot" : "https://spark.apache.org/docs/latest",
+    "name" : "`aBc`"
+  }
+}
 
 
 -- !query


### PR DESCRIPTION
### What changes were proposed in this pull request?

Change default for spark.sql.legacy.ctePrecedencePolicy to CORRECTED

### Why are the changes needed?

This change has been long planned. We have been running with EXCEPTION for years with an announcement that CORRECTED will eventually become the only option. To get there, changing the default to CORRECTED is the next step.

### Does this PR introduce _any_ user-facing change?

Yes, we now allow nested CTEs to share the same name by default.

### How was this patch tested?

Run the existing QA: cte-nested.sql

### Was this patch authored or co-authored using generative AI tooling?

No