### PR TITLE
[SPARK-46145][SQL] spark.catalog.listTables does not throw exception when the table or view is not found

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/CatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/CatalogSuite.scala
@@ -28,6 +28,7 @@ import org.apache.spark.sql.catalyst.{DefinedByConstructorParams, FunctionIdenti
 import org.apache.spark.sql.catalyst.analysis.AnalysisTest
 import org.apache.spark.sql.catalyst.catalog._
 import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.expressions.GenericInternalRow
 import org.apache.spark.sql.catalyst.plans.logical.Range
 import org.apache.spark.sql.connector.FakeV2Provider
 import org.apache.spark.sql.connector.catalog.{CatalogManager, Identifier, InMemoryCatalog}
@@ -36,6 +37,7 @@ import org.apache.spark.sql.connector.catalog.functions._
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
 import org.apache.spark.storage.StorageLevel
+import org.apache.spark.unsafe.types.UTF8String
 
 
 /**
@@ -1048,6 +1050,16 @@ class CatalogSuite extends SharedSparkSession with AnalysisTest with BeforeAndAf
       func2.catalog === "testcat" && func2.description === "hello" &&
       func2.isTemporary === false &&
       func2.className.startsWith("org.apache.spark.sql.internal.CatalogSuite"))
+  }
+
+  test("SPARK-46145: listTables does not throw exception when the table or view is not found") {
+    val impl = spark.catalog.asInstanceOf[CatalogImpl]
+    for (temp <- Seq(true, false)) {
+      val row =
+        new GenericInternalRow(Array(UTF8String.fromString("db"), UTF8String.fromString("t"), temp))
+      impl.resolveTable(row,
+        spark.sessionState.catalogManager.catalog(CatalogManager.SESSION_CATALOG_NAME))
+    }
   }
 
   private def getConstructorParameterValues(obj: DefinedByConstructorParams): Seq[AnyRef] = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/CatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/CatalogSuite.scala
@@ -1054,9 +1054,9 @@ class CatalogSuite extends SharedSparkSession with AnalysisTest with BeforeAndAf
 
   test("SPARK-46145: listTables does not throw exception when the table or view is not found") {
     val impl = spark.catalog.asInstanceOf[CatalogImpl]
-    for (temp <- Seq((true, ""), (false, "non_existing_db"))) {
+    for ((isTemp, dbName) <- Seq((true, ""), (false, "non_existing_db"))) {
       val row = new GenericInternalRow(
-        Array(UTF8String.fromString(temp._2), UTF8String.fromString("non_existing_table"), temp._1))
+        Array(UTF8String.fromString(dbName), UTF8String.fromString("non_existing_table"), isTemp))
       impl.resolveTable(row, CatalogManager.SESSION_CATALOG_NAME)
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/CatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/CatalogSuite.scala
@@ -1054,11 +1054,10 @@ class CatalogSuite extends SharedSparkSession with AnalysisTest with BeforeAndAf
 
   test("SPARK-46145: listTables does not throw exception when the table or view is not found") {
     val impl = spark.catalog.asInstanceOf[CatalogImpl]
-    for (temp <- Seq(true, false)) {
-      val row =
-        new GenericInternalRow(Array(UTF8String.fromString("db"), UTF8String.fromString("t"), temp))
-      impl.resolveTable(row,
-        spark.sessionState.catalogManager.catalog(CatalogManager.SESSION_CATALOG_NAME))
+    for (temp <- Seq((true, ""), (false, "non_existing_db"))) {
+      val row = new GenericInternalRow(
+        Array(UTF8String.fromString(temp._2), UTF8String.fromString("non_existing_table"), temp._1))
+      impl.resolveTable(row, CatalogManager.SESSION_CATALOG_NAME)
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
There is a race condition case when using `spark.catalog.listTables`. It happens when one client is calling `listTables` while another client is delete some of the tables. In this case `listTables` might throw `TABLE_OR_VIEW_NOT_FOUND` when it tries to access a table or view that is deleted concurrently. 

This PR proposes to improve `spark.catalog.listTables` not throw the exception but return normally.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This is to improve user experience when using `spark.catalog.listTables` under the concurrent case. 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
UT

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
NO