### PR TITLE
[SPARK-46147][PS][TESTS] Fix the doctest in pyspark.pandas.series.Seires.to_dict (Python 3.12)

### DIFF
--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -1631,7 +1631,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         >>> from collections import OrderedDict, defaultdict
         >>> s.to_dict(OrderedDict)
-        OrderedDict([(0, 1), (1, 2), (2, 3), (3, 4)])
+        OrderedDict(...)
 
         >>> dd = defaultdict(list)
         >>> s.to_dict(dd)  # doctest: +ELLIPSIS


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to fix doctest, `pyspark.pandas.series.Seires.to_dict`, compatible with Python 3.12.

```
File "/__w/spark/spark/python/pyspark/pandas/series.py", line 1633, in pyspark.pandas.series.Series.to_dict
Failed example:
    s.to_dict(OrderedDict)
Expected:
    OrderedDict([(0, 1), (1, 2), (2, 3), (3, 4)])
Got:
    OrderedDict({0: 1, 1: 2, 2: 3, 3: 4})
```

### Why are the changes needed?

For the proper test for Python 3.12. It is failing, see https://github.com/apache/spark/actions/runs/7020654429/job/19100966337

### Does this PR introduce _any_ user-facing change?

No. A bit of user-facing doc change but very trival.

### How was this patch tested?

Fixed unittests. Manually tested via:

```bash
python/run-tests --python-executable=python3  --testnames 'pyspark.pandas.series'
...
Tests passed in 383 seconds
```

### Was this patch authored or co-authored using generative AI tooling?

No.