### PR TITLE
[SPARK-46149][ML][PYTHON][TESTS] Skip 'TorchDistributorLocalUnitTests.test_end_to_end_run_locally' with Python 3.12

### DIFF
--- a/python/pyspark/ml/torch/tests/test_distributor.py
+++ b/python/pyspark/ml/torch/tests/test_distributor.py
@@ -398,6 +398,9 @@ class TorchDistributorLocalUnitTestsMixin:
             test_file_path, learning_rate_str
         )
 
+    @unittest.skipIf(
+        sys.version_info > (3, 11), "SPARK-46078: Fails with dev torch with Python 3.12"
+    )
     def test_end_to_end_run_locally(self) -> None:
         train_fn = create_training_function(self.mnist_dir_path)
         output = TorchDistributor(num_processes=2, local_mode=True, use_gpu=False).run(

--- a/python/pyspark/ml/torch/tests/test_distributor.py
+++ b/python/pyspark/ml/torch/tests/test_distributor.py
@@ -399,7 +399,7 @@ class TorchDistributorLocalUnitTestsMixin:
         )
 
     @unittest.skipIf(
-        sys.version_info > (3, 11), "SPARK-46078: Fails with dev torch with Python 3.12"
+        sys.version_info > (3, 12), "SPARK-46078: Fails with dev torch with Python 3.12"
     )
     def test_end_to_end_run_locally(self) -> None:
         train_fn = create_training_function(self.mnist_dir_path)

--- a/python/pyspark/tests/test_worker.py
+++ b/python/pyspark/tests/test_worker.py
@@ -230,7 +230,7 @@ class WorkerSegfaultTest(ReusedPySparkTestCase):
         _conf.set("spark.python.worker.faulthandler.enabled", "true")
         return _conf
 
-    @unittest.skipIf(sys.version_info > (3, 11), "SPARK-46130: Flaky with Python 3.12")
+    @unittest.skipIf(sys.version_info > (3, 12), "SPARK-46130: Flaky with Python 3.12")
     def test_python_segfault(self):
         try:
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to skip doctest, `TorchDistributorLocalUnitTests.test_end_to_end_run_locally` with Python 3.12.

### Why are the changes needed?

- For the proper test for Python 3.12. It is failing, see SPARK-46149 and https://github.com/apache/spark/actions/runs/7020654429/job/19100964890

- Current dev torch version does not work very well with Python 3.12. It should be enabled together with SPARK-46078.

- The build with Python 3.12 halts so can't see if other tests pass fine.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Yes:

```
./python/run-tests --python-executables=python3  --testnames 'pyspark.ml.torch.tests.test_distributor TorchDistributorLocalUnitTests'
...
Tests passed in 14 seconds
```

### Was this patch authored or co-authored using generative AI tooling?

No.