### PR TITLE
[SPARK-46151][PYTHON][DOCS] Hide the `More drop-down button` in the PySpark docs navigation bar

### DIFF
--- a/python/docs/source/conf.py
+++ b/python/docs/source/conf.py
@@ -196,6 +196,7 @@ html_context = {
 # further.  For a list of options available for each theme, see the
 # documentation.
 html_theme_options = {
+    "header_links_before_dropdown": 6,
     "navbar_end": ["version-switcher", "theme-switcher", "navbar-icon-links"],
     "footer_start": ["spark_footer", "sphinx-version"],
     "logo": {


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to hide the `More drop-down button` in the PySpark docs navigation bar.

### Why are the changes needed?
Because there is `only one item` under the `More drop-down button`, as following:
<img width="1408" alt="image" src="https://github.com/apache/spark/assets/15246973/3597523c-a1b9-4932-9a0d-8b565d3e9015">

Obviously, in our scenario, eliminating `More drop-down button` and directly displaying `Migration Guides menu` in the navigation bar is more intuitive and convenient.

After:
<img width="1416" alt="image" src="https://github.com/apache/spark/assets/15246973/a13938c4-99ae-47a9-a2fa-b90419a14b35">

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Manually test.

### Was this patch authored or co-authored using generative AI tooling?
No.
