### PR TITLE
[SPARK-46154][INFRA] Add a new Daily testing GitHub Action job for Maven with Java 21

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -283,14 +283,6 @@ jobs:
         name: unit-tests-log-${{ matrix.modules }}-${{ matrix.comment }}-${{ matrix.java }}-${{ matrix.hadoop }}-${{ matrix.hive }}
         path: "**/target/unit-tests.log"
 
-  maven-test:
-    name: "Run Maven Test"
-    permissions:
-      packages: write
-    uses: ./.github/workflows/maven_test.yml
-    with:
-      java: 21
-
   infra-image:
     name: "Base image build"
     needs: precondition

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -283,6 +283,14 @@ jobs:
         name: unit-tests-log-${{ matrix.modules }}-${{ matrix.comment }}-${{ matrix.java }}-${{ matrix.hadoop }}-${{ matrix.hive }}
         path: "**/target/unit-tests.log"
 
+  maven-test:
+    name: "Run Maven Test"
+    permissions:
+      packages: write
+    uses: ./.github/workflows/maven_test.yml
+    with:
+      java: 21
+
   infra-image:
     name: "Base image build"
     needs: precondition

--- a/.github/workflows/build_maven_java21.yml
+++ b/.github/workflows/build_maven_java21.yml
@@ -1,0 +1,34 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: "Build using Maven (master, Scala 2.13, Hadoop 3, JDK 21)"
+
+on:
+  schedule:
+    - cron: '0 14 * * *'
+
+jobs:
+  run-build:
+    permissions:
+      packages: write
+    name: Run
+    uses: ./.github/workflows/maven_test.yml
+    if: github.repository == 'apache/spark'
+    with:
+      java: 21


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims add a new Daily testing GitHub Action job for Maven with Java 21

### Why are the changes needed?
Need Daily testing for Maven with Java 21.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Monitor GA after merge



### Was this patch authored or co-authored using generative AI tooling?
No
