### PR TITLE
[MINOR][PYTHON][DOCS] Fix some outdated info for development/testing.rst

### DIFF
--- a/python/docs/source/development/testing.rst
+++ b/python/docs/source/development/testing.rst
@@ -38,7 +38,7 @@ After that, the PySpark test cases can be run via using ``python/run-tests``. Fo
 
 Note that you may set ``OBJC_DISABLE_INITIALIZE_FORK_SAFETY`` environment variable to ``YES`` if you are running tests on Mac OS.
 
-Please see the guidance on how to `build Spark <https://github.com/apache/spark#building-spark>`_,
+Please see the guidance on how to |building_spark|_,
 `run tests for a module, or individual tests <https://spark.apache.org/developer-tools.html>`_.
 
 
@@ -86,4 +86,4 @@ For the Apache Spark release:
 
 .. code-block:: bash
 
-    bin/pyspark --remote "local[*]" --packages org.apache.spark:spark-connect_2.12:3.4.0
+    bin/pyspark --remote "local[*]" --packages org.apache.spark:spark-connect_2.13:$SPARK_VERSION


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to fix some outdated info for `development/testing.rst`.

### Why are the changes needed?
Fix some outdated.
- `https://github.com/apache/spark#building-spark` -> `https://spark.apache.org/docs/latest/building-spark.html`
<img width="654" alt="image" src="https://github.com/apache/spark/assets/15246973/b9c05d07-bfb3-48b9-946a-4836c3e61cd4">

- scala version `2.12` -> `2.13`


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Manually test.

### Was this patch authored or co-authored using generative AI tooling?
No.
