### PR TITLE
created rough service

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/PodEventService.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/PodEventService.scala
@@ -1,0 +1,58 @@
+import io.fabric8.kubernetes.api.model.Pod
+import io.fabric8.kubernetes.client.{DefaultKubernetesClient, Watch, Watcher, KubernetesClientException}
+import io.fabric8.kubernetes.client.Watcher.Action
+import io.grpc.{Server, ServerBuilder, Status, StatusRuntimeException}
+import io.grpc.stub.StreamObserver
+
+import scala.collection.mutable
+
+class PodEventService extends PodEventServiceGrpc.PodEventServiceImplBase {
+  private val client = new DefaultKubernetesClient()
+  private val podEvents = mutable.Queue[Pod]()
+
+  private val watcher: Watcher[Pod] = new Watcher[Pod] {
+    override def eventReceived(action: Action, pod: Pod): Unit = {
+      podEvents.enqueue(pod)
+    }
+
+    override def onClose(cause: KubernetesClientException): Unit = {
+      if (cause != null) {
+        // The watcher was closed due to an exception
+        println(s"Watcher closed due to exception: ${cause.getMessage}")
+        // TODO: Handle the exception, e.g. restart the watcher
+      } else {
+        // The watcher was closed normally
+        println("Watcher closed")
+      }
+    }
+  }
+
+  private val watch: Watch = client.pods().watch(watcher)
+
+  override def getPodEvents(request: GetPodEventsRequest, responseObserver: StreamObserver[GetPodEventsResponse]): Unit = {
+    try {
+      val events = podEvents.dequeueAll(_ => true)
+      val response = GetPodEventsResponse.newBuilder().addAllEvents(events).build()
+      responseObserver.onNext(response)
+      responseObserver.onCompleted()
+    } catch {
+      case e: Exception =>
+        responseObserver.onError(new StatusRuntimeException(Status.INTERNAL.withDescription(e.getMessage)))
+    }
+  }
+}
+
+object PodEventService {
+  def main(args: Array[String]): Unit = {
+    val server: Server = ServerBuilder.forPort(8080)
+      .addService(new PodEventService)
+      .build
+      .start
+
+    Runtime.getRuntime.addShutdownHook(new Thread() {
+      override def run(): Unit = server.shutdown()
+    })
+
+    server.awaitTermination()
+  }
+}

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/PodEventService.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/PodEventService.scala
@@ -1,0 +1,55 @@
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatestplus.mockito.MockitoSugar
+import org.mockito.Mockito._
+import org.mockito.ArgumentMatchers._
+import io.fabric8.kubernetes.api.model.Pod
+import io.fabric8.kubernetes.client.{KubernetesClient, Watch, Watcher}
+import io.grpc.stub.StreamObserver
+import io.grpc.StatusRuntimeException
+import io.grpc.Status
+
+class PodEventServiceSpec extends AnyFlatSpec with MockitoSugar {
+  "PodEventService" should "enqueue pod events" in {
+    val client = mock[KubernetesClient]
+    val watch = mock[Watch]
+    val pod = new Pod()
+    when(client.pods().watch(any[Watcher[Pod]])).thenReturn(watch)
+
+    val service = new PodEventService(client)
+    service.watcher.eventReceived(Watcher.Action.ADDED, pod)
+
+    assert(service.podEvents.size == 1)
+    assert(service.podEvents.dequeue() == pod)
+  }
+
+  it should "handle getPodEvents requests" in {
+    val client = mock[KubernetesClient]
+    val watch = mock[Watch]
+    val pod = new Pod()
+    when(client.pods().watch(any[Watcher[Pod]])).thenReturn(watch)
+
+    val service = new PodEventService(client)
+    service.podEvents.enqueue(pod)
+
+    val request = GetPodEventsRequest.newBuilder().build()
+    val responseObserver = mock[StreamObserver[GetPodEventsResponse]]
+    service.getPodEvents(request, responseObserver)
+
+    verify(responseObserver).onNext(any[GetPodEventsResponse])
+    verify(responseObserver).onCompleted()
+  }
+
+  it should "handle exceptions in getPodEvents" in {
+    val client = mock[KubernetesClient]
+    val watch = mock[Watch]
+    when(client.pods().watch(any[Watcher[Pod]])).thenReturn(watch)
+
+    val service = new PodEventService(client)
+
+    val request = GetPodEventsRequest.newBuilder().build()
+    val responseObserver = mock[StreamObserver[GetPodEventsResponse]]
+    service.getPodEvents(request, responseObserver)
+
+    verify(responseObserver).onError(any[StatusRuntimeException])
+  }
+}


### PR DESCRIPTION
All the Pod events are stored in a queue. The sslContext creation and error handling upon closing need to be modified. Tests also need to be looked at.