### PR TITLE
[SPARK-45940][PYTHON] Add InputPartition to DataSourceReader interface

### DIFF
--- a/python/pyspark/sql/datasource.py
+++ b/python/pyspark/sql/datasource.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 from abc import ABC, abstractmethod
-from typing import final, Any, Dict, Iterable, Iterator, List, Tuple, Type, Union, TYPE_CHECKING
+from typing import final, Any, Dict, Iterator, List, Sequence, Tuple, Type, Union, TYPE_CHECKING
 
 from pyspark.sql import Row
 from pyspark.sql.types import StructType
@@ -154,7 +154,7 @@ class InputPartition:
 
     Notes
     -----
-    This class must be serializable.
+    This class must be picklable.
 
     Examples
     --------
@@ -175,10 +175,10 @@ class InputPartition:
     ...     return [RangeInputPartition(1, 3), RangeInputPartition(4, 6)]
     """
 
-    def __init__(self, value):
+    def __init__(self, value: Any) -> None:
         self.value = value
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         attributes = ", ".join([f"{k}={v!r}" for k, v in self.__dict__.items()])
         return f"{self.__class__.__name__}({attributes})"
 
@@ -191,7 +191,7 @@ class DataSourceReader(ABC):
     .. versionadded: 4.0.0
     """
 
-    def partitions(self) -> List[InputPartition]:
+    def partitions(self) -> Sequence[InputPartition]:
         """
         Returns an iterator of partitions for this data source.
 
@@ -209,13 +209,13 @@ class DataSourceReader(ABC):
 
         Returns
         -------
-        Iterator[Any]
-            An iterator of partitions for this data source. The partition value can be
-            any serializable objects.
+        Sequence[InputPartition]
+            A sequence of partitions for this data source. Each partition value
+            must be an instance of `InputPartition` or a subclass of it.
 
         Notes
         -----
-        This method should not return any un-picklable objects.
+        All partition values must be picklable objects.
 
         Examples
         --------
@@ -354,7 +354,7 @@ class WriterCommitMessage:
 
     Notes
     -----
-    This class must be serializable.
+    This class must be picklable.
     """
 
     ...

--- a/python/pyspark/sql/datasource.py
+++ b/python/pyspark/sql/datasource.py
@@ -242,7 +242,7 @@ class DataSourceReader(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def read(self, partition: Any) -> Iterator[Union[Tuple, Row]]:
+    def read(self, partition: InputPartition) -> Iterator[Union[Tuple, Row]]:
         """
         Generates data for a given partition and returns an iterator of tuples or rows.
 

--- a/python/pyspark/sql/tests/test_python_datasource.py
+++ b/python/pyspark/sql/tests/test_python_datasource.py
@@ -17,7 +17,7 @@
 import os
 import unittest
 
-from pyspark.sql.datasource import DataSource, DataSourceReader
+from pyspark.sql.datasource import DataSource, DataSourceReader, InputPartition
 from pyspark.sql.types import Row
 from pyspark.testing import assertDataFrameEqual
 from pyspark.testing.sqlutils import ReusedSQLTestCase
@@ -46,7 +46,6 @@ class BasePythonDataSourceTestsMixin:
                 yield None,
 
         reader = MyDataSourceReader()
-        self.assertEqual(list(reader.partitions()), [None])
         self.assertEqual(list(reader.read(None)), [(None,)])
 
     def test_data_source_register(self):
@@ -91,10 +90,10 @@ class BasePythonDataSourceTestsMixin:
                     num_partitions = int(self.options["num_partitions"])
                 else:
                     num_partitions = self.DEFAULT_NUM_PARTITIONS
-                return range(num_partitions)
+                return [InputPartition(i) for i in range(num_partitions)]
 
             def read(self, partition):
-                yield partition, str(partition)
+                yield partition.value, str(partition.value)
 
         class InMemoryDataSource(DataSource):
             @classmethod

--- a/python/pyspark/sql/worker/plan_data_source_read.py
+++ b/python/pyspark/sql/worker/plan_data_source_read.py
@@ -137,9 +137,9 @@ def main(infile: IO, outfile: IO) -> None:
                     },
                 )
             if len(partitions) == 0:
-                partitions = [None]
+                partitions = [None]  # type: ignore
         except NotImplementedError:
-            partitions = [None]
+            partitions = [None]  # type: ignore
         except Exception as e:
             raise PySparkRuntimeError(
                 error_class="PYTHON_DATA_SOURCE_CREATE_ERROR",

--- a/python/pyspark/sql/worker/plan_data_source_read.py
+++ b/python/pyspark/sql/worker/plan_data_source_read.py
@@ -28,7 +28,7 @@ from pyspark.serializers import (
     SpecialLengths,
     CloudPickleSerializer,
 )
-from pyspark.sql.datasource import DataSource
+from pyspark.sql.datasource import DataSource, InputPartition
 from pyspark.sql.types import _parse_datatype_json_string, StructType
 from pyspark.util import handle_worker_exception
 from pyspark.worker_util import (
@@ -110,10 +110,41 @@ def main(infile: IO, outfile: IO) -> None:
                 message_parameters={"type": "reader", "error": str(e)},
             )
 
-        # Generate all partitions.
-        partitions = list(reader.partitions() or [])
-        if len(partitions) == 0:
+        # Get the partitions if any.
+        try:
+            partitions = reader.partitions()
+            if not isinstance(partitions, list):
+                raise PySparkRuntimeError(
+                    error_class="PYTHON_DATA_SOURCE_CREATE_ERROR",
+                    message_parameters={
+                        "type": "reader",
+                        "error": (
+                            "Expect 'partitions' to return a list, but got "
+                            f"'{type(partitions).__name__}'"
+                        ),
+                    },
+                )
+            if not all(isinstance(p, InputPartition) for p in partitions):
+                partition_types = ", ".join([f"'{type(p).__name__}'" for p in partitions])
+                raise PySparkRuntimeError(
+                    error_class="PYTHON_DATA_SOURCE_CREATE_ERROR",
+                    message_parameters={
+                        "type": "reader",
+                        "error": (
+                            "All elements in 'partitions' should be of type "
+                            f"'InputPartition', but got {partition_types}"
+                        ),
+                    },
+                )
+            if len(partitions) == 0:
+                partitions = [None]
+        except NotImplementedError:
             partitions = [None]
+        except Exception as e:
+            raise PySparkRuntimeError(
+                error_class="PYTHON_DATA_SOURCE_CREATE_ERROR",
+                message_parameters={"type": "reader", "error": str(e)},
+            )
 
         # Construct a UDTF.
         class PythonDataSourceReaderUDTF:

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonDataSourceSuite.scala
@@ -29,20 +29,21 @@ class PythonDataSourceSuite extends QueryTest with SharedSparkSession {
   private def dataSourceName = "SimpleDataSource"
   private def simpleDataSourceReaderScript: String =
     """
+      |from pyspark.sql.datasource import DataSourceReader, InputPartition
       |class SimpleDataSourceReader(DataSourceReader):
       |    def partitions(self):
-      |        return range(0, 2)
+      |        return [InputPartition(i) for i in range(2)]
       |    def read(self, partition):
-      |        yield (0, partition)
-      |        yield (1, partition)
-      |        yield (2, partition)
+      |        yield (0, partition.value)
+      |        yield (1, partition.value)
+      |        yield (2, partition.value)
       |""".stripMargin
 
   test("simple data source") {
     assume(shouldTestPythonUDFs)
     val dataSourceScript =
       s"""
-        |from pyspark.sql.datasource import DataSource, DataSourceReader
+        |from pyspark.sql.datasource import DataSource
         |$simpleDataSourceReaderScript
         |
         |class $dataSourceName(DataSource):
@@ -179,7 +180,7 @@ class PythonDataSourceSuite extends QueryTest with SharedSparkSession {
     assume(shouldTestPythonUDFs)
     val dataSourceScript =
       s"""
-         |from pyspark.sql.datasource import DataSource, DataSourceReader
+         |from pyspark.sql.datasource import DataSource, DataSourceReader, InputPartition
          |import json
          |
          |class SimpleDataSourceReader(DataSourceReader):
@@ -193,10 +194,14 @@ class PythonDataSourceSuite extends QueryTest with SharedSparkSession {
          |            paths = [self.options["path"]]
          |        else:
          |            paths = []
-         |        return paths
+         |        return [InputPartition(p) for p in paths]
          |
          |    def read(self, path):
-         |        yield (path, 1)
+         |        if path is not None:
+         |            assert isinstance(path, InputPartition)
+         |            yield (path.value, 1)
+         |        else:
+         |            yield (path, 1)
          |
          |class $dataSourceName(DataSource):
          |    @classmethod
@@ -271,5 +276,110 @@ class PythonDataSourceSuite extends QueryTest with SharedSparkSession {
     assert(err.getErrorClass == "PYTHON_DATA_SOURCE_FAILED_TO_PLAN_IN_PYTHON")
     assert(err.getMessage.contains("PYTHON_DATA_SOURCE_TYPE_MISMATCH"))
     assert(err.getMessage.contains("PySparkAssertionError"))
+  }
+
+  test("data source read with custom partitions") {
+    val dataSourceScript =
+      s"""
+         |from pyspark.sql.datasource import DataSource, DataSourceReader, InputPartition
+         |class RangePartition(InputPartition):
+         |    def __init__(self, start, end):
+         |        self.start = start
+         |        self.end = end
+         |
+         |class SimpleDataSourceReader(DataSourceReader):
+         |    def partitions(self):
+         |        return [RangePartition(1, 2), RangePartition(3, 4)]
+         |
+         |    def read(self, partition: RangePartition):
+         |        start, end = partition.start, partition.end
+         |        for i in range(start, end):
+         |            yield (i, )
+         |
+         |class $dataSourceName(DataSource):
+         |    def schema(self) -> str:
+         |        return "id INT"
+         |
+         |    def reader(self, schema):
+         |        return SimpleDataSourceReader()
+         |""".stripMargin
+    val dataSource = createUserDefinedPythonDataSource(dataSourceName, dataSourceScript)
+    val df = dataSource(spark, provider = dataSourceName)
+    checkAnswer(df, Seq(Row(1), Row(3)))
+  }
+
+  test("data source read with empty partitions") {
+    val dataSourceScript =
+      s"""
+         |from pyspark.sql.datasource import DataSource, DataSourceReader
+         |class SimpleDataSourceReader(DataSourceReader):
+         |    def partitions(self):
+         |        return []
+         |
+         |    def read(self, partition):
+         |        if partition is None:
+         |            yield ("success", )
+         |        else:
+         |            yield ("failed", )
+         |
+         |class $dataSourceName(DataSource):
+         |    def schema(self) -> str:
+         |        return "status STRING"
+         |
+         |    def reader(self, schema):
+         |        return SimpleDataSourceReader()
+         |""".stripMargin
+    val dataSource = createUserDefinedPythonDataSource(dataSourceName, dataSourceScript)
+    val df = dataSource(spark, provider = dataSourceName)
+    checkAnswer(df, Row("success"))
+  }
+
+  test("data source read with invalid partitions") {
+    val reader1 =
+      s"""
+         |class SimpleDataSourceReader(DataSourceReader):
+         |    def partitions(self):
+         |        return 1
+         |    def read(self, partition):
+         |        ...
+         |""".stripMargin
+
+    val reader2 =
+      s"""
+         |class SimpleDataSourceReader(DataSourceReader):
+         |    def partitions(self):
+         |        return [1, 2]
+         |    def read(self, partition):
+         |        ...
+         |""".stripMargin
+
+    val reader3 =
+      s"""
+         |class SimpleDataSourceReader(DataSourceReader):
+         |    def partitions(self):
+         |        raise Exception("error")
+         |    def read(self, partition):
+         |        ...
+         |""".stripMargin
+
+    Seq(reader1, reader2, reader3).foreach { readerScript =>
+      val dataSourceScript =
+        s"""
+           |from pyspark.sql.datasource import DataSource, DataSourceReader
+           |$readerScript
+           |
+           |class $dataSourceName(DataSource):
+           |    def schema(self) -> str:
+           |        return "id INT"
+           |
+           |    def reader(self, schema):
+           |        return SimpleDataSourceReader()
+           |""".stripMargin
+      val dataSource = createUserDefinedPythonDataSource(dataSourceName, dataSourceScript)
+      val err = intercept[AnalysisException](
+        dataSource(spark, provider = dataSourceName).collect())
+      assert(err.getErrorClass == "PYTHON_DATA_SOURCE_FAILED_TO_PLAN_IN_PYTHON")
+      assert(err.getMessage.contains("PYTHON_DATA_SOURCE_CREATE_ERROR"))
+    }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR introduces a new Python class `InputPartition` that represents the partition value returned by the `partitions` method in DataSourceReader.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Before this PR, the `partitions` method can return anything, and it can be confusing to infer what is the `partition` argument in the `read(self, partition)` method.

Adding `InputPartition` can make the Python data source API more intuitive and user-friendly. 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No 

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New unit tests.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No