### PR TITLE
[SPARK-46177][PYTHON][CONNECT][ML][TESTS] Skip 'CrossValidatorTests.test_crossvalidator_with_fold_col' with Python 3.12

### DIFF
--- a/python/pyspark/ml/tests/connect/test_legacy_mode_tuning.py
+++ b/python/pyspark/ml/tests/connect/test_legacy_mode_tuning.py
@@ -18,6 +18,7 @@
 
 import tempfile
 import unittest
+import sys
 
 import numpy as np
 
@@ -248,6 +249,9 @@ class CrossValidatorTestsMixin:
             np.testing.assert_allclose(cv_model.avgMetrics, loaded_cv_model.avgMetrics)
             np.testing.assert_allclose(cv_model.stdMetrics, loaded_cv_model.stdMetrics)
 
+    @unittest.skipIf(
+        sys.version_info > (3, 12), "SPARK-46078: Fails with dev torch with Python 3.12"
+    )
     def test_crossvalidator_with_fold_col(self):
         sk_dataset = load_breast_cancer()
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to skip doctest `CrossValidatorTests.test_crossvalidator_with_fold_col` with Python 3.12.

### Why are the changes needed?

- For the proper test for Python 3.12. It is failing, see SPARK-46177 and https://github.com/apache/spark/actions/runs/7034467411/job/19154766502

- Current dev torch version does not work very well with Python 3.12. It should be enabled together with SPARK-46078.

- The build with Python 3.12 halts so can't see if other tests pass fine.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Manually tested.

### Was this patch authored or co-authored using generative AI tooling?

No.