### PR TITLE
[SPARK-45093][CONNECT][PYTHON] Properly support error handling and conversion for AddArtifactHandler

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectAddArtifactsHandler.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectAddArtifactsHandler.scala
@@ -24,7 +24,6 @@ import scala.collection.mutable
 import scala.util.control.NonFatal
 
 import com.google.common.io.CountingOutputStream
-import io.grpc.StatusRuntimeException
 import io.grpc.stub.StreamObserver
 
 import org.apache.spark.connect.proto
@@ -32,6 +31,7 @@ import org.apache.spark.connect.proto.{AddArtifactsRequest, AddArtifactsResponse
 import org.apache.spark.connect.proto.AddArtifactsResponse.ArtifactSummary
 import org.apache.spark.sql.artifact.ArtifactManager
 import org.apache.spark.sql.artifact.util.ArtifactUtils
+import org.apache.spark.sql.connect.utils.ErrorUtils
 import org.apache.spark.util.Utils
 
 /**
@@ -51,7 +51,7 @@ class SparkConnectAddArtifactsHandler(val responseObserver: StreamObserver[AddAr
   private var chunkedArtifact: StagedChunkedArtifact = _
   private var holder: SessionHolder = _
 
-  override def onNext(req: AddArtifactsRequest): Unit = {
+  override def onNext(req: AddArtifactsRequest): Unit = try {
     if (this.holder == null) {
       this.holder = SparkConnectService.getOrCreateIsolatedSession(
         req.getUserContext.getUserId,
@@ -78,6 +78,11 @@ class SparkConnectAddArtifactsHandler(val responseObserver: StreamObserver[AddAr
     } else {
       throw new UnsupportedOperationException(s"Unsupported data transfer request: $req")
     }
+  } catch {
+    ErrorUtils.handleNonQueryError("addArtifact - onNext",
+      responseObserver, Some(this.holder), Some( () => {
+      cleanUpStagedArtifacts()
+    }))
   }
 
   override def onError(throwable: Throwable): Unit = {
@@ -128,7 +133,8 @@ class SparkConnectAddArtifactsHandler(val responseObserver: StreamObserver[AddAr
       responseObserver.onNext(builder.build())
       responseObserver.onCompleted()
     } catch {
-      case e: StatusRuntimeException => onError(e)
+      ErrorUtils.handleNonQueryError("addArtifact - onNext",
+        responseObserver, Some(this.holder))
     }
   }
 

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectAddArtifactsHandler.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectAddArtifactsHandler.scala
@@ -79,13 +79,21 @@ class SparkConnectAddArtifactsHandler(val responseObserver: StreamObserver[AddAr
       throw new UnsupportedOperationException(s"Unsupported data transfer request: $req")
     }
   } catch {
-    ErrorUtils.handleNonQueryError(
-      "addArtifact - onNext",
+    ErrorUtils.handleError(
+      "addArtifacts.onNext",
       responseObserver,
-      Some(this.holder),
-      Some(() => {
-        cleanUpStagedArtifacts()
-      }))
+      holder.userId,
+      holder.sessionId,
+      None,
+      false)
+
+//    ErrorUtils.handleNonQueryError(
+//      "addArtifacts.onNext",
+//      responseObserver,
+//      Some(this.holder),
+//      Some(() => {
+//        cleanUpStagedArtifacts()
+//      }))
   }
 
   override def onError(throwable: Throwable): Unit = {
@@ -136,7 +144,10 @@ class SparkConnectAddArtifactsHandler(val responseObserver: StreamObserver[AddAr
       responseObserver.onNext(builder.build())
       responseObserver.onCompleted()
     } catch {
-      ErrorUtils.handleNonQueryError("addArtifact - onNext", responseObserver, Some(this.holder))
+      ErrorUtils.handleNonQueryError(
+        "addArtifacts.onCompleted",
+        responseObserver,
+        Some(this.holder))
     }
   }
 

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectAddArtifactsHandler.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectAddArtifactsHandler.scala
@@ -85,15 +85,10 @@ class SparkConnectAddArtifactsHandler(val responseObserver: StreamObserver[AddAr
       holder.userId,
       holder.sessionId,
       None,
-      false)
-
-//    ErrorUtils.handleNonQueryError(
-//      "addArtifacts.onNext",
-//      responseObserver,
-//      Some(this.holder),
-//      Some(() => {
-//        cleanUpStagedArtifacts()
-//      }))
+      false,
+      Some(() => {
+        cleanUpStagedArtifacts()
+      }))
   }
 
   override def onError(throwable: Throwable): Unit = {
@@ -144,10 +139,16 @@ class SparkConnectAddArtifactsHandler(val responseObserver: StreamObserver[AddAr
       responseObserver.onNext(builder.build())
       responseObserver.onCompleted()
     } catch {
-      ErrorUtils.handleNonQueryError(
-        "addArtifacts.onCompleted",
+      ErrorUtils.handleError(
+        "addArtifacts.onComplete",
         responseObserver,
-        Some(this.holder))
+        holder.userId,
+        holder.sessionId,
+        None,
+        false,
+        Some(() => {
+          cleanUpStagedArtifacts()
+        }))
     }
   }
 

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectAddArtifactsHandler.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectAddArtifactsHandler.scala
@@ -79,10 +79,13 @@ class SparkConnectAddArtifactsHandler(val responseObserver: StreamObserver[AddAr
       throw new UnsupportedOperationException(s"Unsupported data transfer request: $req")
     }
   } catch {
-    ErrorUtils.handleNonQueryError("addArtifact - onNext",
-      responseObserver, Some(this.holder), Some( () => {
-      cleanUpStagedArtifacts()
-    }))
+    ErrorUtils.handleNonQueryError(
+      "addArtifact - onNext",
+      responseObserver,
+      Some(this.holder),
+      Some(() => {
+        cleanUpStagedArtifacts()
+      }))
   }
 
   override def onError(throwable: Throwable): Unit = {
@@ -133,8 +136,7 @@ class SparkConnectAddArtifactsHandler(val responseObserver: StreamObserver[AddAr
       responseObserver.onNext(builder.build())
       responseObserver.onCompleted()
     } catch {
-      ErrorUtils.handleNonQueryError("addArtifact - onNext",
-        responseObserver, Some(this.holder))
+      ErrorUtils.handleNonQueryError("addArtifact - onNext", responseObserver, Some(this.holder))
     }
   }
 

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/utils/ErrorUtils.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/utils/ErrorUtils.scala
@@ -27,7 +27,7 @@ import scala.util.control.NonFatal
 
 import com.google.protobuf.{Any => ProtoAny}
 import com.google.rpc.{Code => RPCCode, ErrorInfo, Status => RPCStatus}
-import io.grpc.{Status, StatusRuntimeException}
+import io.grpc.Status
 import io.grpc.protobuf.StatusProto
 import io.grpc.stub.StreamObserver
 import org.apache.commons.lang3.StringUtils

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/utils/ErrorUtils.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/utils/ErrorUtils.scala
@@ -231,10 +231,10 @@ private[connect] object ErrorUtils extends Logging {
         StatusProto.toStatusRuntimeException(buildStatusFromThrowable(e, sessionHolderOpt))
       case e: StatusRuntimeException => e
       case e: Throwable =>
-          Status.UNKNOWN
-            .withCause(e)
-            .withDescription(StringUtils.abbreviate(e.getMessage, 2048))
-            .asRuntimeException()
+        Status.UNKNOWN
+          .withCause(e)
+          .withDescription(StringUtils.abbreviate(e.getMessage, 2048))
+          .asRuntimeException()
     }
     partial.andThen {
       // All values must be throwable.

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -1575,12 +1575,15 @@ class SparkConnectClient(object):
             raise SparkConnectGrpcException(str(rpc_error)) from None
 
     def add_artifacts(self, *paths: str, pyfile: bool, archive: bool, file: bool) -> None:
-        for path in paths:
-            for attempt in self._retrying():
-                with attempt:
-                    self._artifact_manager.add_artifacts(
-                        path, pyfile=pyfile, archive=archive, file=file
-                    )
+        try:
+            for path in paths:
+                for attempt in self._retrying():
+                    with attempt:
+                        self._artifact_manager.add_artifacts(
+                            path, pyfile=pyfile, archive=archive, file=file
+                        )
+        except Exception as error:
+            self._handle_error(error)
 
     def copy_from_local_to_fs(self, local_path: str, dest_path: str) -> None:
         for attempt in self._retrying():

--- a/python/pyspark/sql/tests/connect/client/test_artifact.py
+++ b/python/pyspark/sql/tests/connect/client/test_artifact.py
@@ -56,6 +56,24 @@ class ArtifactTestsMixin:
             SparkSession.builder.remote(f"sc://localhost:{ChannelBuilder.default_port()}").create()
         )
 
+    def test_artifacts_cannot_be_overwritten(self):
+        with tempfile.TemporaryDirectory() as d:
+            pyfile_path = os.path.join(d, "my_pyfile.py")
+            with open(pyfile_path, "w+") as f:
+                f.write("my_func = lambda: 10")
+
+            self.spark.addArtifacts(pyfile_path, pyfile=True)
+
+            # Writing the same file twice is fine, and should not throw.
+            self.spark.addArtifacts(pyfile_path, pyfile=True)
+
+            with open(pyfile_path, "w+") as f:
+                f.write("my_func = lambda: 11")
+
+            with self.assertRaises(Exception):
+                self.spark.addArtifacts(pyfile_path, pyfile=True)
+
+
     def check_add_zipped_package(self, spark_session):
         with tempfile.TemporaryDirectory() as d:
             package_path = os.path.join(d, "my_zipfile")

--- a/python/pyspark/sql/tests/connect/client/test_artifact.py
+++ b/python/pyspark/sql/tests/connect/client/test_artifact.py
@@ -20,6 +20,7 @@ import tempfile
 import unittest
 import os
 
+from pyspark.errors.exceptions.connect import SparkConnectGrpcException
 from pyspark.sql import SparkSession
 from pyspark.testing.connectutils import ReusedConnectTestCase, should_test_connect
 from pyspark.testing.utils import SPARK_HOME
@@ -70,9 +71,10 @@ class ArtifactTestsMixin:
             with open(pyfile_path, "w+") as f:
                 f.write("my_func = lambda: 11")
 
-            with self.assertRaises(Exception):
+            with self.assertRaisesRegex(
+                SparkConnectGrpcException, "\(java.lang.RuntimeException\) Duplicate Artifact"
+            ):
                 self.spark.addArtifacts(pyfile_path, pyfile=True)
-
 
     def check_add_zipped_package(self, spark_session):
         with tempfile.TemporaryDirectory() as d:

--- a/python/pyspark/sql/tests/connect/client/test_artifact.py
+++ b/python/pyspark/sql/tests/connect/client/test_artifact.py
@@ -72,7 +72,7 @@ class ArtifactTestsMixin:
                 f.write("my_func = lambda: 11")
 
             with self.assertRaisesRegex(
-                SparkConnectGrpcException, "\(java.lang.RuntimeException\) Duplicate Artifact"
+                SparkConnectGrpcException, "\\(java.lang.RuntimeException\\) Duplicate Artifact"
             ):
                 self.spark.addArtifacts(pyfile_path, pyfile=True)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This patch improves the error handling when errors are happening in the `AddArtifact` path. In particular, the `AddArtifactHandler` would not properly return exceptions but all exceptions would end up yielding `UNKNOWN` errors. This patch makes sure we wrap the errors in the add artifact path the same way as we're wrapping the errors in the normal query execution path.

In addition, it adds tests and verification for this behavior in Scala and in Python.

### Why are the changes needed?
Stability

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Added UT for Scala and Python

### Was this patch authored or co-authored using generative AI tooling?
No