### PR TITLE
[SPARK-46186][CONNECT] Fix illegal state transition when ExecuteThreadRunner interrupted before started

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/ExecuteThreadRunner.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/ExecuteThreadRunner.scala
@@ -51,7 +51,7 @@ private[connect] class ExecuteThreadRunner(executeHolder: ExecuteHolder) extends
   private val lock = new Object
 
   /** Launches the execution in a background thread, returns immediately. */
-  def start(): Unit = {
+  private[connect] def start(): Unit = {
     lock.synchronized {
       assert(!started)
       // Do not start if already interrupted.
@@ -63,7 +63,7 @@ private[connect] class ExecuteThreadRunner(executeHolder: ExecuteHolder) extends
   }
 
   /** Joins the background execution thread after it is finished. */
-  def join(): Unit = {
+  private[connect] def join(): Unit = {
     // only called when the execution is completed or interrupted.
     assert(completed || interrupted)
     executionThread.join()
@@ -74,7 +74,7 @@ private[connect] class ExecuteThreadRunner(executeHolder: ExecuteHolder) extends
    * @return
    *   true if it was not interrupted before, false if it was already interrupted or completed.
    */
-  def interrupt(): Boolean = {
+  private[connect] def interrupt(): Boolean = {
     lock.synchronized {
       if (!started && !interrupted) {
         // execution thread hasn't started yet, and will not be started.

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/ExecuteThreadRunner.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/ExecuteThreadRunner.scala
@@ -42,6 +42,8 @@ private[connect] class ExecuteThreadRunner(executeHolder: ExecuteHolder) extends
   // forwarding of thread locals needs to be taken into account.
   private val executionThread: Thread = new ExecutionThread()
 
+  private var started: Boolean = false
+
   private var interrupted: Boolean = false
 
   private var completed: Boolean = false
@@ -50,11 +52,20 @@ private[connect] class ExecuteThreadRunner(executeHolder: ExecuteHolder) extends
 
   /** Launches the execution in a background thread, returns immediately. */
   def start(): Unit = {
-    executionThread.start()
+    lock.synchronized {
+      assert(!started)
+      // Do not start if already interrupted.
+      if (!interrupted) {
+        executionThread.start()
+        started = true
+      }
+    }
   }
 
   /** Joins the background execution thread after it is finished. */
   def join(): Unit = {
+    // only called when the execution is completed or interrupted.
+    assert(completed || interrupted)
     executionThread.join()
   }
 
@@ -65,7 +76,19 @@ private[connect] class ExecuteThreadRunner(executeHolder: ExecuteHolder) extends
    */
   def interrupt(): Boolean = {
     lock.synchronized {
-      if (!interrupted && !completed) {
+      if (!started && !interrupted) {
+        // execution thread hasn't started yet, and will not be started.
+        // handle the interrupted error here directly.
+        interrupted = true
+        ErrorUtils.handleError(
+          "execute",
+          executeHolder.responseObserver,
+          executeHolder.sessionHolder.userId,
+          executeHolder.sessionHolder.sessionId,
+          Some(executeHolder.eventsManager),
+          interrupted)(new SparkSQLException("OPERATION_CANCELED", Map.empty))
+        true
+      } else if (!interrupted && !completed) {
         // checking completed prevents sending interrupt onError after onCompleted
         interrupted = true
         executionThread.interrupt()

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/ExecuteHolder.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/ExecuteHolder.scala
@@ -128,13 +128,6 @@ private[connect] class ExecuteHolder(
     runner.start()
   }
 
-  /**
-   * Wait for the execution thread to finish and join it.
-   */
-  def join(): Unit = {
-    runner.join()
-  }
-
   def addObservation(name: String, observation: Observation): Unit = synchronized {
     observations += (name -> observation)
   }

--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/execution/ReattachableExecuteSuite.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/execution/ReattachableExecuteSuite.scala
@@ -23,6 +23,7 @@ import org.scalatest.concurrent.Eventually
 import org.scalatest.time.SpanSugar._
 
 import org.apache.spark.{SparkEnv, SparkException}
+import org.apache.spark.connect.proto
 import org.apache.spark.sql.connect.SparkConnectServerTest
 import org.apache.spark.sql.connect.config.Connect
 import org.apache.spark.sql.connect.service.SparkConnectService
@@ -293,6 +294,32 @@ class ReattachableExecuteSuite extends SparkConnectServerTest {
         stub.reattachExecute(buildReattachExecuteRequest(operationId, Some(lastSeenResponse)))
       assert(reattach2.hasNext)
       while (reattach2.hasNext) reattach2.next()
+    }
+  }
+
+  test("SPARK-46186 interrupt directly after query start") {
+    // This test depends on fast timing.
+    // If something is wrong, it can fail only from time to time.
+    withRawBlockingStub { stub =>
+      val operationId = UUID.randomUUID().toString
+      val interruptRequest = proto.InterruptRequest
+        .newBuilder
+        .setUserContext(userContext)
+        .setSessionId(defaultSessionId)
+        .setInterruptType(proto.InterruptRequest.InterruptType.INTERRUPT_TYPE_OPERATION_ID)
+        .setOperationId(operationId)
+        .build()
+      val iter = stub.executePlan(
+        buildExecutePlanRequest(buildPlan(MEDIUM_RESULTS_QUERY), operationId = operationId))
+      // wait for execute holder to exist, but the execute thread may not have started yet.
+      Eventually.eventually(timeout(eventuallyTimeout)) {
+        assert(SparkConnectService.executionManager.listExecuteHolders.length == 1)
+      }
+      stub.interrupt(interruptRequest)
+      val e = intercept[StatusRuntimeException] {
+        while (iter.hasNext) iter.next()
+      }
+      assert(e.getMessage.contains("OPERATION_CANCELED"))
     }
   }
 

--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/execution/ReattachableExecuteSuite.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/execution/ReattachableExecuteSuite.scala
@@ -302,8 +302,7 @@ class ReattachableExecuteSuite extends SparkConnectServerTest {
     // If something is wrong, it can fail only from time to time.
     withRawBlockingStub { stub =>
       val operationId = UUID.randomUUID().toString
-      val interruptRequest = proto.InterruptRequest
-        .newBuilder
+      val interruptRequest = proto.InterruptRequest.newBuilder
         .setUserContext(userContext)
         .setSessionId(defaultSessionId)
         .setInterruptType(proto.InterruptRequest.InterruptType.INTERRUPT_TYPE_OPERATION_ID)


### PR DESCRIPTION
### What changes were proposed in this pull request?

A race condition sending interrupt (or releaseSession) just after execute could cause:
```
[info]   org.apache.spark.SparkException: java.lang.IllegalStateException: 
[info]         operationId: fa653330-587a-41c7-a4a9-7987f070dcba with status Started
[info]         is not within statuses List(Finished, Failed, Canceled) for event Closed
```
and
```
[info]   org.apache.spark.SparkException: java.lang.IllegalStateException: 
[info]         operationId: fa653330-587a-41c7-a4a9-7987f070dcba with status Closed
[info]         is not within statuses List(Started, Analyzed, ReadyForExecution, Finished, Failed) for event Canceled
```
when the interrupt arrives before the thread in ExecuteThreadRunner is started.

This would cause in ExecuteHolder close:
```
      runner.interrupt() <- just sets interrupted = true
      runner.join() <- thread didn't start yet, so join() returns immediately, doesn't wait for thread to be actually interrupted
      ...
      eventsManager.postClosed() <- causes the first failure, because thread wasn't running and didn't move to Canceled
```
Afterwards, assuming we allowed the transition, the thread will get started, and then want to immediately move to Canceled, notice the `interrupted` state. Then it would hit the 2nd error, not allowing Canceled after Closed.

While we could consider allowing the first transition (Started -> Closed), we don't want any events to be coming after Closed, so that listeners can clean their state after Closed.

Fix is to handle interrupts coming before the thread started, and then prevent the thread from even starting if it was interruped.

### Why are the changes needed?

This was detected after grpc 1.56 to 1.59 upgrade and causes some tests in SparkConnectServiceE2ESuite and ReattachableExecuteSuite to be flaky.
With the grpc upgrade, execute is eagerly sent to the server, and in some test we cleanup and release the session without waiting for the execution to start. This has triggered this flakiness. 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Test added. The test depends on timing, so may not fail reliably but only from time to time.

### Was this patch authored or co-authored using generative AI tooling?

Github Copilot was assisting in some boilerplate auto-completion.

Generated-by: Github Copilot