### PR TITLE
[MINOR][DOCS] Fix the result file description of CoalescedRDDBenchmark

### DIFF
--- a/core/src/test/scala/org/apache/spark/rdd/CoalescedRDDBenchmark.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/CoalescedRDDBenchmark.scala
@@ -33,7 +33,7 @@ import org.apache.spark.benchmark.{Benchmark, BenchmarkBase}
  *   2. build/sbt "core/Test/runMain <this class>"
  *   3. generate result:
  *      SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "core/Test/runMain <this class>"
- *      Results will be written to "benchmarks/CoalescedRDD-results.txt".
+ *      Results will be written to "benchmarks/CoalescedRDDBenchmark-results.txt".
  * }}}
  * */
 object CoalescedRDDBenchmark extends BenchmarkBase {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix the result file description of CoalescedRDDBenchmark.

### Why are the changes needed?

The following comment is wrong.

https://github.com/apache/spark/blob/99b80a7f17e20b5ae7cd5add886dcf2ccaa8c4f2/core/src/test/scala/org/apache/spark/rdd/CoalescedRDDBenchmark.scala#L36

It's because the actual file is the following.
- https://github.com/apache/spark/blob/master/core/benchmarks/CoalescedRDDBenchmark-results.txt

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.