### PR TITLE
[SPARK-46191][CORE] Improve `FileSystemPersistenceEngine.persist` error msg in case of the existing file

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/master/FileSystemPersistenceEngine.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/FileSystemPersistenceEngine.scala
@@ -58,6 +58,7 @@ private[master] class FileSystemPersistenceEngine(
   }
 
   private def serializeIntoFile(file: File, value: AnyRef): Unit = {
+    if (file.exists()) { throw new IllegalStateException("File already exists: " + file) }
     val created = file.createNewFile()
     if (!created) { throw new IllegalStateException("Could not create file: " + file) }
     val fileOut = new FileOutputStream(file)

--- a/core/src/test/scala/org/apache/spark/deploy/master/PersistenceEngineSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/master/PersistenceEngineSuite.scala
@@ -40,6 +40,19 @@ class PersistenceEngineSuite extends SparkFunSuite {
     }
   }
 
+  test("SPARK-46191: FileSystemPersistenceEngine.persist error message for the existing file") {
+    withTempDir { dir =>
+      val conf = new SparkConf()
+      val serializer = new JavaSerializer(conf)
+      val engine = new FileSystemPersistenceEngine(dir.getAbsolutePath, serializer)
+      engine.persist("test_1", "test_1_value")
+      val m = intercept[IllegalStateException] {
+        engine.persist("test_1", "test_1_value")
+      }.getMessage
+      assert(m.contains("File already exists"))
+    }
+  }
+
   test("ZooKeeperPersistenceEngine") {
     val conf = new SparkConf()
     // TestingServer logs the port conflict exception rather than throwing an exception.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to improve `FileSystemPersistenceEngine.persist`'s error message in case of the existing file.

### Why are the changes needed?

`FileSystemPersistenceEngine.persist` fails when a file exists in the location where `key` points.
It's helpful for us to distinguish this error from the normal file creation failures due to the other disk issues like, READ-ONLY mount.

### Does this PR introduce _any_ user-facing change?

No. This changes only a error message for a better UX.

### How was this patch tested?

Pass the CIs with the newly added test case.

### Was this patch authored or co-authored using generative AI tooling?

No.