### PR TITLE
[SPARK-46194][BUILD] Remove TODO comments left in SPARK-33775

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2973,10 +2973,6 @@
               <arg>-Wconf:cat=deprecation:wv,any:e</arg>
               <arg>-Wunused:imports</arg>
               <arg>-Wconf:cat=scaladoc:wv</arg>
-              <!--
-                SPARK-33775 Suppress compilation warnings that contain the following contents.
-                TODO(SPARK-33805): Undo the corresponding deprecated usage suppression rule after fixed.
-              -->
               <arg>-Wconf:msg=^(?=.*?method|value|type|object|trait|inheritance)(?=.*?deprecated)(?=.*?since 2.13).+$:e</arg>
               <arg>-Wconf:msg=^(?=.*?Widening conversion from)(?=.*?is deprecated because it loses precision).+$:e</arg>
               <!-- SPARK-45610 Convert "Auto-application to `()` is deprecated" to compile error, as it will become a compile error in Scala 3. -->

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -232,9 +232,6 @@ object SparkBuild extends PomBuild {
         "-Wconf:cat=deprecation:wv,any:e",
         // 2.13-specific warning hits to be muted (as narrowly as possible) and addressed separately
         "-Wunused:imports",
-        // SPARK-33775 Suppress compilation warnings that contain the following contents.
-        // TODO(SPARK-33805): Undo the corresponding deprecated usage suppression rule after
-        //  fixed.
         "-Wconf:msg=^(?=.*?method|value|type|object|trait|inheritance)(?=.*?deprecated)(?=.*?since 2.13).+$:e",
         "-Wconf:msg=^(?=.*?Widening conversion from)(?=.*?is deprecated because it loses precision).+$:e",
         // SPARK-45610 Convert "Auto-application to `()` is deprecated" to compile error, as it will become a compile error in Scala 3.


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr just remove TODO SPARK-33805 because after https://github.com/apache/spark/pull/43890 merged, all TODOs related to cleaning up deprecated Scala APIs have been completed.


### Why are the changes needed?
Remove completed TODO.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No