### PR TITLE
[SPARK-46196][PYTHON][DOCS] Add missing `toDegrees/toRadians/atan2/approxCountDistinct` function descriptions

### DIFF
--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -2546,6 +2546,9 @@ def tanh(col: "ColumnOrName") -> Column:
 @_try_remote_functions
 def toDegrees(col: "ColumnOrName") -> Column:
     """
+    Converts an angle measured in radians to an approximately equivalent angle
+    measured in degrees.
+
     .. versionadded:: 1.4.0
 
     .. versionchanged:: 3.4.0
@@ -2561,6 +2564,9 @@ def toDegrees(col: "ColumnOrName") -> Column:
 @_try_remote_functions
 def toRadians(col: "ColumnOrName") -> Column:
     """
+    Converts an angle measured in degrees to an approximately equivalent angle
+    measured in radians.
+
     .. versionadded:: 1.4.0
 
     .. versionchanged:: 3.4.0
@@ -4025,6 +4031,9 @@ def radians(col: "ColumnOrName") -> Column:
 @_try_remote_functions
 def atan2(col1: Union["ColumnOrName", float], col2: Union["ColumnOrName", float]) -> Column:
     """
+    Compute the angle in radians between the positive x-axis of a plane
+    and the point given by the coordinates
+
     .. versionadded:: 1.4.0
 
     .. versionchanged:: 3.4.0
@@ -4412,6 +4421,9 @@ def percent_rank() -> Column:
 @_try_remote_functions
 def approxCountDistinct(col: "ColumnOrName", rsd: Optional[float] = None) -> Column:
     """
+    This aggregate function returns a new :class:`~pyspark.sql.Column`, which estimates
+    the approximate distinct count of elements in a specified column or a group of columns.
+
     .. versionadded:: 1.3.0
 
     .. versionchanged:: 3.4.0


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add missing function descriptions


### Why are the changes needed?
they are missing in https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/functions.html

![image](https://github.com/apache/spark/assets/7322292/dd6cc2f2-0e5a-4a9d-ba91-3ffbb0ebb3a7)



### Does this PR introduce _any_ user-facing change?
yes, doc changes


### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no
