### PR TITLE
[SPARK-46199][PYTHON][DOCS] Add PyPi link icon to PySpark doc header

### DIFF
--- a/python/docs/source/conf.py
+++ b/python/docs/source/conf.py
@@ -204,7 +204,18 @@ html_theme_options = {
         "image_light": "_static/spark-logo-light.png",
         "image_dark": "_static/spark-logo-dark.png",
     },
-    "github_url": "https://github.com/apache/spark",
+    "icon_links": [
+        {
+            "name": "GitHub",
+            "url": "https://github.com/apache/spark",
+            "icon": "fa-brands fa-github",
+        },
+        {
+            "name": "PyPI",
+            "url": "https://pypi.org/project/pyspark",
+            "icon": "fa-solid fa-box",
+        },
+    ]
 }
 
 # Add any paths that contain custom themes here, relative to this directory.


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR  proposes to introduce a `PyPi link icon` in the header of the PySpark documentation, similar to what is currently implemented in the `pydata-sphinx-theme` docs.
https://pydata-sphinx-theme.readthedocs.io/en/v0.13.3/user_guide/styling.html#
<img width="1417" alt="image" src="https://github.com/apache/spark/assets/15246973/4bb66f51-96e7-45d5-890b-03a4700f1ec7">

### Why are the changes needed?
 This change aligns with the practices of other open-source projects like `pydata-sphinx-theme`, facilitating community engagement and collaboration.


### Does this PR introduce _any_ user-facing change?
No API changes, but a `PyPi link icon` will be added to the top right corner of the PySpark docs header. This icon will be linked to the `PySpark PyPi` as below:
<img width="1419" alt="image" src="https://github.com/apache/spark/assets/15246973/4c5a70a0-cb30-4615-827d-97610a71d5e4">

### How was this patch tested?
Manually test.

### Was this patch authored or co-authored using generative AI tooling?
No.
