### PR TITLE
[SPARK-46203][SQL][HIVE] Support get partitions by names in partition filter

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalog.scala
@@ -246,6 +246,26 @@ trait ExternalCatalog {
       partialSpec: Option[TablePartitionSpec] = None): Seq[String]
 
   /**
+   * List the original names from external catalog for all partitions that belong to
+   * the specified table, assuming it exists.
+   *
+   * For a table with partition columns p1, p2, p3, each partition name is formatted as
+   * `p1=v1/p2=v2/p3=v3`. Each partition column name and value is an escaped path name, and can be
+   * decoded with the `ExternalCatalogUtils.unescapePathName` method.
+   *
+   * A partial partition spec may optionally be provided to filter the partitions returned, as
+   * described in the `listPartitions` method.
+   *
+   * @param db database name
+   * @param table table name
+   * @param partialSpec partition spec
+   */
+  def listCatalogPartitionNames(
+      db: String,
+      table: String,
+      partialSpec: Option[TablePartitionSpec] = None): Seq[String]
+
+  /**
    * List the metadata of all partitions that belong to the specified table, assuming it exists.
    *
    * A partial partition spec may optionally be provided to filter the partitions returned.
@@ -275,6 +295,19 @@ trait ExternalCatalog {
       table: String,
       predicates: Seq[Expression],
       defaultTimeZoneId: String): Seq[CatalogTablePartition]
+
+  /**
+   * List the metadata of partitions that belong to the specified table, assuming it exists, whose
+   * names are in the list of partition names.
+   *
+   * @param db database name
+   * @param table table name
+   * @param partitionNames list of partition names
+   */
+  def listPartitionsByNames(
+      db: String,
+      table: String,
+      partitionNames: Seq[String]): Seq[CatalogTablePartition]
 
   // --------------------------------------------------------------------------
   // Functions

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogWithListener.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogWithListener.scala
@@ -247,6 +247,13 @@ class ExternalCatalogWithListener(delegate: ExternalCatalog)
     delegate.listPartitionNames(db, table, partialSpec)
   }
 
+  override def listCatalogPartitionNames(
+      db: String,
+      table: String,
+      partialSpec: Option[TablePartitionSpec]): Seq[String] = {
+    delegate.listCatalogPartitionNames(db, table, partialSpec)
+  }
+
   override def listPartitions(
       db: String,
       table: String,
@@ -260,6 +267,13 @@ class ExternalCatalogWithListener(delegate: ExternalCatalog)
       predicates: Seq[Expression],
       defaultTimeZoneId: String): Seq[CatalogTablePartition] = {
     delegate.listPartitionsByFilter(db, table, predicates, defaultTimeZoneId)
+  }
+
+  override def listPartitionsByNames(
+      db: String,
+      table: String,
+      partitionNames: Seq[String]): Seq[CatalogTablePartition] = {
+    delegate.listPartitionsByNames(db, table, partitionNames)
   }
 
   // --------------------------------------------------------------------------

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
@@ -579,6 +579,13 @@ class InMemoryCatalog(
     }.sorted
   }
 
+  override def listCatalogPartitionNames(
+      db: String,
+      table: String,
+      partSpec: Option[TablePartitionSpec]): Seq[String] = synchronized {
+    listPartitionNames(db, table, partSpec)
+  }
+
   override def listPartitions(
       db: String,
       table: String,
@@ -602,6 +609,14 @@ class InMemoryCatalog(
     val catalogTable = getTable(db, table)
     val allPartitions = listPartitions(db, table)
     prunePartitionsByFilter(catalogTable, allPartitions, predicates, defaultTimeZoneId)
+  }
+
+  override def listPartitionsByNames(
+      db: String,
+      table: String,
+      partitionNames: Seq[String]): Seq[CatalogTablePartition] = synchronized {
+    requireTableExists(db, table)
+    partitionNames.map(parsePathFragment).flatMap(catalog(db).tables(table).partitions.get)
   }
 
   // --------------------------------------------------------------------------

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1271,6 +1271,16 @@ object SQLConf {
       .booleanConf
       .createWithDefault(false)
 
+  val HIVE_METASTORE_GET_PARTITION_BY_NAME =
+    buildConf("spark.sql.hive.getPartitionByName.enabled")
+      .doc("When true, Spark will get all partition names first, and then get partitions " +
+           "based on the filtered partition names, which can alleviate the strain on the " +
+           "Hive metastore service, particularly when querying tables with large partitions. " +
+           "To improve the performance of filter, Spark will start a job to do the filter.")
+      .version("4.0.0")
+      .booleanConf
+      .createWithDefault(false)
+
   val HIVE_METASTORE_PARTITION_PRUNING =
     buildConf("spark.sql.hive.metastorePartitionPruning")
       .doc("When true, some predicates will be pushed down into the Hive metastore so that " +
@@ -4918,6 +4928,8 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
   def isOrcSchemaMergingEnabled: Boolean = getConf(ORC_SCHEMA_MERGING_ENABLED)
 
   def metastoreDropPartitionsByName: Boolean = getConf(HIVE_METASTORE_DROP_PARTITION_BY_NAME)
+
+  def metastoreGetPartitionsByName: Boolean = getConf(HIVE_METASTORE_GET_PARTITION_BY_NAME)
 
   def metastorePartitionPruning: Boolean = getConf(HIVE_METASTORE_PARTITION_PRUNING)
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogSuite.scala
@@ -573,6 +573,25 @@ abstract class ExternalCatalogSuite extends SparkFunSuite {
     }
   }
 
+  test("list partitions by names") {
+    val catalog = newBasicCatalog()
+
+    def checkAnswer(
+        table: CatalogTable, names: Seq[String], expected: Set[CatalogTablePartition])
+        : Unit = {
+
+      assertResult(expected.map(_.spec)) {
+        catalog.listPartitionsByNames(table.database, table.identifier.identifier, names)
+          .map(_.spec).toSet
+      }
+    }
+
+    val tbl2 = catalog.getTable("db2", "tbl2")
+
+    checkAnswer(tbl2, Seq("a=1/b=2", "a=3/b=4"), Set(part1, part2))
+    checkAnswer(tbl2, Seq("a=1/b=2"), Set(part1))
+  }
+
   test("drop partitions") {
     val catalog = newBasicCatalog()
     assert(catalogPartitionsEqual(catalog, "db2", "tbl2", Seq(part1, part2)))

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/OptimizeMetadataOnlyQuery.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/OptimizeMetadataOnlyQuery.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.execution
 import java.util.Locale
 
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.catalog.{HiveTableRelation, SessionCatalog}
+import org.apache.spark.sql.catalyst.catalog.{ExternalCatalogUtils, HiveTableRelation, SessionCatalog}
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.catalyst.planning.PhysicalOperation
@@ -136,7 +136,8 @@ case class OptimizeMetadataOnlyQuery(catalog: SessionCatalog) extends Rule[Logic
               // for the case where partitions have already been pruned by PruneHiveTablePartitions
               case Some(parts) => parts
               case None => if (partFilters.nonEmpty) {
-                catalog.listPartitionsByFilter(relation.tableMeta.identifier, normalizedFilters)
+                ExternalCatalogUtils.listPartitionsByFilter(
+                  conf, catalog, relation.tableMeta, normalizedFilters)
               } else {
                 catalog.listPartitions(relation.tableMeta.identifier)
               }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/CatalogFileIndex.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/CatalogFileIndex.scala
@@ -71,7 +71,8 @@ class CatalogFileIndex(
     if (table.partitionColumnNames.nonEmpty) {
       val startTime = System.nanoTime()
       val selectedPartitions = ExternalCatalogUtils.listPartitionsByFilter(
-        sparkSession.sessionState.conf, sparkSession.sessionState.catalog, table, filters)
+        sparkSession.sparkContext, sparkSession.sessionState.conf,
+        sparkSession.sessionState.catalog, table, filters)
       val partitions = selectedPartitions.map { p =>
         val path = new Path(p.location)
         val fs = path.getFileSystem(hadoopConf)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClient.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClient.scala
@@ -245,6 +245,11 @@ private[hive] trait HiveClient {
       catalogTable: RawHiveTable,
       predicates: Seq[Expression]): Seq[CatalogTablePartition]
 
+  /** Returns partitions based on partition names for the given table. */
+  def getPartitionsByNames(
+      rawHiveTable: RawHiveTable,
+      partitionNames: Seq[String]): Seq[CatalogTablePartition]
+
   /** Loads a static partition into an existing table. */
   def loadPartition(
       loadPath: String,

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -809,6 +809,16 @@ private[hive] class HiveClientImpl(
     parts
   }
 
+  override def getPartitionsByNames(
+      rawHiveTable: RawHiveTable,
+      partitionNames: Seq[String]): Seq[CatalogTablePartition] = withHiveState {
+    val hiveTable = rawHiveTable.rawTable.asInstanceOf[HiveTable]
+    hiveTable.setOwner(userName)
+    val parts = shim.getPartitionsByNames(client, hiveTable, partitionNames).map(fromHivePartition)
+    HiveCatalogMetrics.incrementFetchedPartitions(parts.length)
+    parts
+  }
+
   override def listTables(dbName: String): Seq[String] = withHiveState {
     shim.getAllTables(client, dbName)
   }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/PruneHiveTablePartitions.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/PruneHiveTablePartitions.scala
@@ -100,7 +100,7 @@ private[sql] class PruneHiveTablePartitions(session: SparkSession)
       if filters.nonEmpty && relation.isPartitioned && relation.prunedPartitions.isEmpty =>
       val partitionKeyFilters = getPartitionKeyFilters(filters, relation)
       if (partitionKeyFilters.nonEmpty) {
-        val newPartitions = ExternalCatalogUtils.listPartitionsByFilter(conf,
+        val newPartitions = ExternalCatalogUtils.listPartitionsByFilter(session.sparkContext, conf,
           session.sessionState.catalog, relation.tableMeta, partitionKeyFilters.toSeq)
         val newTableMeta = updateTableMeta(relation, newPartitions, partitionKeyFilters)
         val newRelation = relation.copy(


### PR DESCRIPTION
### What changes were proposed in this pull request?
In this path, we introduce a new switch that enable filtering partitions in Spark side, and then get target partitions by the high performance API `Hive#getPartitionsByNames`.
1. Add a switch `spark.sql.hive.getPartitionByName.enabled` that enable doing partition filter in Spark and get partitions by name through HMS.
2. Unify the `listPartitionsByFilter` call through `ExternalCatalogUtils` to make sure most partition prunes can use the new switch.
3. Implement `listPartitionsByNames` api in different catalogs.

### Why are the changes needed?
`Hive#getPartitionsByFilter` API is low-performance and would cause Hive MetaStore backend DBS suffer heavy load if there are many calls to tables containing many partitions. There are mainly two advantages of this path:
1. Improve the performance of `listPartitionsByFilter` when querying tables containing large partitions.
2. Reduce the load on the db behind Hive MetaStore and maintain the health of HMS.

### Does this PR introduce _any_ user-facing change?
Yes, the user can turn on `spark.sql.hive.getPartitionByName.enabled` if the spark app needs do partition filter on tables containing large number of partitions. 


### How was this patch tested?
Add a unit test.

### Was this patch authored or co-authored using generative AI tooling?
No.
