### PR TITLE
[SPARK-46205][CORE] Improve `PersistenceEngine` performance with `KryoSerializer`

### DIFF
--- a/core/benchmarks/PersistenceEngineBenchmark-jdk21-results.txt
+++ b/core/benchmarks/PersistenceEngineBenchmark-jdk21-results.txt
@@ -4,10 +4,12 @@ PersistenceEngineBenchmark
 
 OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1051-azure
 AMD EPYC 7763 64-Core Processor
-1000 Workers:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------------------------------
-ZooKeeperPersistenceEngine                         1183           1266         129          0.0     1183158.2       1.0X
-FileSystemPersistenceEngine                         218            222           4          0.0      218005.2       5.4X
-BlackHolePersistenceEngine                            0              0           0         29.5          34.0   34846.9X
+1000 Workers:                                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------------
+ZooKeeperPersistenceEngine with JavaSerializer            1100           1255         150          0.0     1099532.9       1.0X
+ZooKeeperPersistenceEngine with KryoSerializer             946            967          20          0.0      946367.3       1.2X
+FileSystemPersistenceEngine with JavaSerializer            218            223           4          0.0      217851.5       5.0X
+FileSystemPersistenceEngine with KryoSerializer             79             87          12          0.0       78611.1      14.0X
+BlackHolePersistenceEngine                                   0              0           0         42.0          23.8   46191.1X
 
 

--- a/core/benchmarks/PersistenceEngineBenchmark-results.txt
+++ b/core/benchmarks/PersistenceEngineBenchmark-results.txt
@@ -4,10 +4,12 @@ PersistenceEngineBenchmark
 
 OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1051-azure
 AMD EPYC 7763 64-Core Processor
-1000 Workers:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------------------------------
-ZooKeeperPersistenceEngine                         1086           1215         162          0.0     1085606.9       1.0X
-FileSystemPersistenceEngine                         224            225           1          0.0      223834.2       4.9X
-BlackHolePersistenceEngine                            0              0           0         40.7          24.6   44209.4X
+1000 Workers:                                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------------
+ZooKeeperPersistenceEngine with JavaSerializer            1202           1298         138          0.0     1201614.2       1.0X
+ZooKeeperPersistenceEngine with KryoSerializer             951           1004          48          0.0      950559.0       1.3X
+FileSystemPersistenceEngine with JavaSerializer            212            217           6          0.0      211623.2       5.7X
+FileSystemPersistenceEngine with KryoSerializer             79             81           2          0.0       79132.5      15.2X
+BlackHolePersistenceEngine                                   0              0           0         30.9          32.4   37109.8X
 
 

--- a/core/src/main/scala/org/apache/spark/deploy/master/FileSystemPersistenceEngine.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/FileSystemPersistenceEngine.scala
@@ -67,10 +67,10 @@ private[master] class FileSystemPersistenceEngine(
       out = serializer.newInstance().serializeStream(fileOut)
       out.writeObject(value)
     } {
-      fileOut.close()
       if (out != null) {
         out.close()
       }
+      fileOut.close()
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/internal/config/Deploy.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/Deploy.scala
@@ -17,11 +17,27 @@
 
 package org.apache.spark.internal.config
 
+import java.util.Locale
+
 private[spark] object Deploy {
   val RECOVERY_MODE = ConfigBuilder("spark.deploy.recoveryMode")
     .version("0.8.1")
     .stringConf
     .createWithDefault("NONE")
+
+  object RecoverySerializer extends Enumeration {
+    val JAVA, KRYO = Value
+  }
+
+  val RECOVERY_SERIALIZER = ConfigBuilder("spark.deploy.recoverySerializer")
+    .doc("Serializer for writing/reading objects to/from persistence engines; " +
+      "JAVA or KRYO. Java serializer has been the default mode since Spark 0.8.1." +
+      "KRYO serializer is a new fast and compact mode from Spark 4.0.0.")
+    .version("4.0.0")
+    .stringConf
+    .transform(_.toUpperCase(Locale.ROOT))
+    .checkValues(RecoverySerializer.values.map(_.toString))
+    .createWithDefault(RecoverySerializer.JAVA.toString)
 
   val RECOVERY_MODE_FACTORY = ConfigBuilder("spark.deploy.recoveryMode.factory")
     .version("1.2.0")

--- a/core/src/test/scala/org/apache/spark/deploy/master/PersistenceEngineSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/master/PersistenceEngineSuite.scala
@@ -26,8 +26,9 @@ import org.apache.curator.test.TestingServer
 import org.apache.spark.{SecurityManager, SparkConf, SparkFunSuite}
 import org.apache.spark.internal.config.Deploy.ZOOKEEPER_URL
 import org.apache.spark.rpc.{RpcEndpoint, RpcEnv}
-import org.apache.spark.serializer.{JavaSerializer, Serializer}
+import org.apache.spark.serializer.{JavaSerializer, KryoSerializer, Serializer}
 import org.apache.spark.util.Utils
+
 
 class PersistenceEngineSuite extends SparkFunSuite {
 
@@ -50,6 +51,18 @@ class PersistenceEngineSuite extends SparkFunSuite {
         engine.persist("test_1", "test_1_value")
       }.getMessage
       assert(m.contains("File already exists"))
+    }
+  }
+
+  test("SPARK-46205: Support KryoSerializer in FileSystemPersistenceEngine") {
+    withTempDir { dir =>
+      val conf = new SparkConf()
+      val serializer = new KryoSerializer(conf)
+      val engine = new FileSystemPersistenceEngine(dir.getAbsolutePath, serializer)
+      engine.persist("test_1", "test_1_value")
+      engine.read[String]("test_1")
+      engine.unpersist("test_1")
+      engine.close()
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/deploy/master/PersistenceEngineSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/master/PersistenceEngineSuite.scala
@@ -29,7 +29,6 @@ import org.apache.spark.rpc.{RpcEndpoint, RpcEnv}
 import org.apache.spark.serializer.{JavaSerializer, KryoSerializer, Serializer}
 import org.apache.spark.util.Utils
 
-
 class PersistenceEngineSuite extends SparkFunSuite {
 
   test("FileSystemPersistenceEngine") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to improve `PersistenceEngine` performance with `KryoSerializer` via introducing a new configuration, `spark.deploy.recoverySerializer`.

### Why are the changes needed?

Allow users to choose a better serializer to get a better performance in their environment. Especially, `KryoSerializer` is about **3x faster** than `JavaSerializer` with `FileSystemPersistenceEngine`.

```
================================================================================================
PersistenceEngineBenchmark
================================================================================================

OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1051-azure
AMD EPYC 7763 64-Core Processor
1000 Workers:                                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------------------------------------
ZooKeeperPersistenceEngine with JavaSerializer            1202           1298         138          0.0     1201614.2       1.0X
ZooKeeperPersistenceEngine with KryoSerializer             951           1004          48          0.0      950559.0       1.3X
FileSystemPersistenceEngine with JavaSerializer            212            217           6          0.0      211623.2       5.7X
FileSystemPersistenceEngine with KryoSerializer             79             81           2          0.0       79132.5      15.2X
BlackHolePersistenceEngine                                   0              0           0         30.9          32.4   37109.8X
```

### Does this PR introduce _any_ user-facing change?

No. The default behavior is the same.

### How was this patch tested?

Pass the CIs with the new added test cases.

### Was this patch authored or co-authored using generative AI tooling?

No.