### PR TITLE
[SPARK-46206][PS] Use a narrower scope exception for SQL processor

### DIFF
--- a/python/pyspark/pandas/sql_processor.py
+++ b/python/pyspark/pandas/sql_processor.py
@@ -220,7 +220,7 @@ def _get_ipython_scope() -> Dict[str, Any]:
 
         shell = get_ipython()
         return shell.user_ns
-    except (NameError, AttributeError):
+    except (AttributeError, ModuleNotFoundError):
         return None
 
 

--- a/python/pyspark/pandas/sql_processor.py
+++ b/python/pyspark/pandas/sql_processor.py
@@ -206,9 +206,7 @@ def _get_local_scope() -> Dict[str, Any]:
     # Get 2 scopes above (_get_local_scope -> sql -> ...) to capture the vars there.
     try:
         return inspect.stack()[_CAPTURE_SCOPES][0].f_locals
-    except Exception:
-        # TODO (rxin, thunterdb): use a narrower scope exception.
-        # See https://github.com/databricks/koalas/pull/448
+    except IndexError:
         return {}
 
 
@@ -222,9 +220,7 @@ def _get_ipython_scope() -> Dict[str, Any]:
 
         shell = get_ipython()
         return shell.user_ns
-    except Exception:
-        # TODO (rxin, thunterdb): use a narrower scope exception.
-        # See https://github.com/databricks/koalas/pull/448
+    except (NameError, AttributeError):
         return None
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to refine the exception handling in SQL processor functions by replacing the general `Exception` class with more specific exception types.


### Why are the changes needed?

The current exception handling uses the broad `Exception` type, which can obscure the root cause of issues. By specifying more accurate exceptions, the code becomes clearer:

- In `_get_local_scope()`, an `IndexError` is more appropriate as it explicitly handles the case where the index is out of range when accessing the call stack using `inspect.stack()`.
- In `_get_ipython_scope()`, `AttributeError` and `ModuleNotFoundError` could occur if the IPython environment is not available or the expected attributes in the IPython shell object are missing.

Using these specific exceptions enhances the maintainability and readability of the code, making it easier for developers to understand and handle errors more effectively.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?

The existing test suite `pyspark.pandas.tests.test_sql::SQLTests` should pass.


### Was this patch authored or co-authored using generative AI tooling?

No.
