### PR TITLE
[SPARK-41532][CONNECT][PYTHON][FOLLOWUP] Expose `SessionNotSameException` as PySpark exceptions

### DIFF
--- a/python/docs/source/reference/pyspark.errors.rst
+++ b/python/docs/source/reference/pyspark.errors.rst
@@ -46,6 +46,7 @@ Classes
     PySparkIndexError
     PythonException
     QueryExecutionException
+    SessionNotSameException
     SparkRuntimeException
     SparkUpgradeException
     SparkNoSuchElementException

--- a/python/pyspark/errors/__init__.py
+++ b/python/pyspark/errors/__init__.py
@@ -21,6 +21,7 @@ PySpark exceptions.
 from pyspark.errors.exceptions.base import (  # noqa: F401
     PySparkException,
     AnalysisException,
+    SessionNotSameException,
     TempTableAlreadyExistsException,
     ParseException,
     IllegalArgumentException,
@@ -50,6 +51,7 @@ from pyspark.errors.exceptions.base import (  # noqa: F401
 __all__ = [
     "PySparkException",
     "AnalysisException",
+    "SessionNotSameException",
     "TempTableAlreadyExistsException",
     "ParseException",
     "IllegalArgumentException",


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to expose `SessionNotSameException` as PySpark exceptions.


### Why are the changes needed?

`SessionNotSameException` was defined from https://github.com/apache/spark/pull/40684, but was not added into all exception API list.

All PySpark-specific exceptions defined in `python/pyspark/errors/exceptions/base.py` also should be exposed from `python/pyspark/errors/__init__.py`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

The existing CI should pass.


### Was this patch authored or co-authored using generative AI tooling?

No.
