### PR TITLE
[SPARK-46214][BUILD] Upgrade commons-io to 2.15.1

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -43,7 +43,7 @@ commons-compiler/3.1.9//commons-compiler-3.1.9.jar
 commons-compress/1.25.0//commons-compress-1.25.0.jar
 commons-crypto/1.1.0//commons-crypto-1.1.0.jar
 commons-dbcp/1.4//commons-dbcp-1.4.jar
-commons-io/2.15.0//commons-io-2.15.0.jar
+commons-io/2.15.1//commons-io-2.15.1.jar
 commons-lang/2.6//commons-lang-2.6.jar
 commons-lang3/3.14.0//commons-lang3-3.14.0.jar
 commons-logging/1.1.3//commons-logging-1.1.3.jar

--- a/pom.xml
+++ b/pom.xml
@@ -193,7 +193,7 @@
     <netlib.ludovic.dev.version>3.0.3</netlib.ludovic.dev.version>
     <commons-codec.version>1.16.0</commons-codec.version>
     <commons-compress.version>1.25.0</commons-compress.version>
-    <commons-io.version>2.15.0</commons-io.version>
+    <commons-io.version>2.15.1</commons-io.version>
     <!-- org.apache.commons/commons-lang/-->
     <commons-lang2.version>2.6</commons-lang2.version>
     <!-- org.apache.commons/commons-lang3/-->


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade `commons-io` from 2.15.0 to 2.15.1.


### Why are the changes needed?
- The full release notes: https://commons.apache.org/proper/commons-io/changes-report.html#a2.15.1
- The version mainly focus on fixing bugs:
Fix FileChannels.contentEquals().
Avoid NullPointerException in RegexFileFilter.RegexFileFilter(Pattern).
Avoid NullPointerException in RegexFileFilter.accept(Path, BasicFileAttributes)

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
