### PR TITLE
[SPARK-46216][CORE] Improve `FileSystemPersistenceEngine` to support compressions

### DIFF
--- a/core/benchmarks/PersistenceEngineBenchmark-jdk21-results.txt
+++ b/core/benchmarks/PersistenceEngineBenchmark-jdk21-results.txt
@@ -4,12 +4,20 @@ PersistenceEngineBenchmark
 
 OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1051-azure
 AMD EPYC 7763 64-Core Processor
-1000 Workers:                                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
--------------------------------------------------------------------------------------------------------------------------------
-ZooKeeperPersistenceEngine with JavaSerializer            1100           1255         150          0.0     1099532.9       1.0X
-ZooKeeperPersistenceEngine with KryoSerializer             946            967          20          0.0      946367.3       1.2X
-FileSystemPersistenceEngine with JavaSerializer            218            223           4          0.0      217851.5       5.0X
-FileSystemPersistenceEngine with KryoSerializer             79             87          12          0.0       78611.1      14.0X
-BlackHolePersistenceEngine                                   0              0           0         42.0          23.8   46191.1X
+2000 Workers:                                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+----------------------------------------------------------------------------------------------------------------------------------------
+ZooKeeperPersistenceEngine with JavaSerializer                     2254           2329         119          0.0     1126867.1       1.0X
+ZooKeeperPersistenceEngine with KryoSerializer                     1911           1912           1          0.0      955667.1       1.2X
+FileSystemPersistenceEngine with JavaSerializer                     438            448          15          0.0      218868.1       5.1X
+FileSystemPersistenceEngine with JavaSerializer (lz4)               187            195           8          0.0       93337.8      12.1X
+FileSystemPersistenceEngine with JavaSerializer (lzf)               193            216          20          0.0       96678.8      11.7X
+FileSystemPersistenceEngine with JavaSerializer (snappy)            175            183          10          0.0       87652.3      12.9X
+FileSystemPersistenceEngine with JavaSerializer (zstd)              243            255          14          0.0      121695.2       9.3X
+FileSystemPersistenceEngine with KryoSerializer                     150            160          15          0.0       75089.7      15.0X
+FileSystemPersistenceEngine with KryoSerializer (lz4)               170            177          10          0.0       84996.7      13.3X
+FileSystemPersistenceEngine with KryoSerializer (lzf)               192            203          12          0.0       96019.1      11.7X
+FileSystemPersistenceEngine with KryoSerializer (snappy)            184            202          16          0.0       92241.3      12.2X
+FileSystemPersistenceEngine with KryoSerializer (zstd)              232            238           5          0.0      116075.2       9.7X
+BlackHolePersistenceEngine                                            0              0           0         27.3          36.6   30761.0X
 
 

--- a/core/benchmarks/PersistenceEngineBenchmark-results.txt
+++ b/core/benchmarks/PersistenceEngineBenchmark-results.txt
@@ -4,12 +4,20 @@ PersistenceEngineBenchmark
 
 OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1051-azure
 AMD EPYC 7763 64-Core Processor
-1000 Workers:                                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
--------------------------------------------------------------------------------------------------------------------------------
-ZooKeeperPersistenceEngine with JavaSerializer            1202           1298         138          0.0     1201614.2       1.0X
-ZooKeeperPersistenceEngine with KryoSerializer             951           1004          48          0.0      950559.0       1.3X
-FileSystemPersistenceEngine with JavaSerializer            212            217           6          0.0      211623.2       5.7X
-FileSystemPersistenceEngine with KryoSerializer             79             81           2          0.0       79132.5      15.2X
-BlackHolePersistenceEngine                                   0              0           0         30.9          32.4   37109.8X
+2000 Workers:                                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+----------------------------------------------------------------------------------------------------------------------------------------
+ZooKeeperPersistenceEngine with JavaSerializer                     2276           2360         115          0.0     1137909.6       1.0X
+ZooKeeperPersistenceEngine with KryoSerializer                     1883           1906          34          0.0      941364.2       1.2X
+FileSystemPersistenceEngine with JavaSerializer                     431            436           7          0.0      215436.9       5.3X
+FileSystemPersistenceEngine with JavaSerializer (lz4)               209            216           9          0.0      104404.1      10.9X
+FileSystemPersistenceEngine with JavaSerializer (lzf)               199            202           2          0.0       99489.5      11.4X
+FileSystemPersistenceEngine with JavaSerializer (snappy)            192            199           9          0.0       95872.9      11.9X
+FileSystemPersistenceEngine with JavaSerializer (zstd)              258            264           6          0.0      129249.4       8.8X
+FileSystemPersistenceEngine with KryoSerializer                     139            151          13          0.0       69374.5      16.4X
+FileSystemPersistenceEngine with KryoSerializer (lz4)               159            165           8          0.0       79588.9      14.3X
+FileSystemPersistenceEngine with KryoSerializer (lzf)               180            195          18          0.0       89844.0      12.7X
+FileSystemPersistenceEngine with KryoSerializer (snappy)            164            183          18          0.0       82016.0      13.9X
+FileSystemPersistenceEngine with KryoSerializer (zstd)              206            218          11          0.0      102838.9      11.1X
+BlackHolePersistenceEngine                                            0              0           0         35.1          28.5   39908.5X
 
 

--- a/core/src/main/scala/org/apache/spark/deploy/master/FileSystemPersistenceEngine.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/FileSystemPersistenceEngine.scala
@@ -22,6 +22,7 @@ import java.io._
 import scala.reflect.ClassTag
 
 import org.apache.spark.internal.Logging
+import org.apache.spark.io.CompressionCodec
 import org.apache.spark.serializer.{DeserializationStream, SerializationStream, Serializer}
 import org.apache.spark.util.ArrayImplicits._
 import org.apache.spark.util.Utils
@@ -36,7 +37,8 @@ import org.apache.spark.util.Utils
  */
 private[master] class FileSystemPersistenceEngine(
     val dir: String,
-    val serializer: Serializer)
+    val serializer: Serializer,
+    val codec: Option[CompressionCodec] = None)
   extends PersistenceEngine with Logging {
 
   new File(dir).mkdir()
@@ -61,7 +63,8 @@ private[master] class FileSystemPersistenceEngine(
     if (file.exists()) { throw new IllegalStateException("File already exists: " + file) }
     val created = file.createNewFile()
     if (!created) { throw new IllegalStateException("Could not create file: " + file) }
-    val fileOut = new FileOutputStream(file)
+    var fileOut: OutputStream = new FileOutputStream(file)
+    codec.foreach { c => fileOut = c.compressedOutputStream(fileOut) }
     var out: SerializationStream = null
     Utils.tryWithSafeFinally {
       out = serializer.newInstance().serializeStream(fileOut)
@@ -75,7 +78,8 @@ private[master] class FileSystemPersistenceEngine(
   }
 
   private def deserializeFromFile[T](file: File)(implicit m: ClassTag[T]): T = {
-    val fileIn = new FileInputStream(file)
+    var fileIn: InputStream = new FileInputStream(file)
+    codec.foreach { c => fileIn = c.compressedInputStream(new FileInputStream(file)) }
     var in: DeserializationStream = null
     try {
       in = serializer.newInstance().deserializeStream(fileIn)

--- a/core/src/main/scala/org/apache/spark/deploy/master/RecoveryModeFactory.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/RecoveryModeFactory.scala
@@ -58,8 +58,8 @@ private[master] class FileSystemRecoveryModeFactory(conf: SparkConf, serializer:
 
   def createPersistenceEngine(): PersistenceEngine = {
     logInfo("Persisting recovery state to directory: " + recoveryDir)
-    new FileSystemPersistenceEngine(recoveryDir, serializer,
-      Some(CompressionCodec.createCodec(conf, conf.get(RECOVERY_COMPRESSION_CODEC))))
+    val codec = conf.get(RECOVERY_COMPRESSION_CODEC).map(c => CompressionCodec.createCodec(conf, c))
+    new FileSystemPersistenceEngine(recoveryDir, serializer, codec)
   }
 
   def createLeaderElectionAgent(master: LeaderElectable): LeaderElectionAgent = {

--- a/core/src/main/scala/org/apache/spark/deploy/master/RecoveryModeFactory.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/RecoveryModeFactory.scala
@@ -20,7 +20,8 @@ package org.apache.spark.deploy.master
 import org.apache.spark.SparkConf
 import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.internal.Logging
-import org.apache.spark.internal.config.Deploy.RECOVERY_DIRECTORY
+import org.apache.spark.internal.config.Deploy.{RECOVERY_COMPRESSION_CODEC, RECOVERY_DIRECTORY}
+import org.apache.spark.io.CompressionCodec
 import org.apache.spark.serializer.Serializer
 
 /**
@@ -57,7 +58,8 @@ private[master] class FileSystemRecoveryModeFactory(conf: SparkConf, serializer:
 
   def createPersistenceEngine(): PersistenceEngine = {
     logInfo("Persisting recovery state to directory: " + recoveryDir)
-    new FileSystemPersistenceEngine(recoveryDir, serializer)
+    new FileSystemPersistenceEngine(recoveryDir, serializer,
+      Some(CompressionCodec.createCodec(conf, conf.get(RECOVERY_COMPRESSION_CODEC))))
   }
 
   def createLeaderElectionAgent(master: LeaderElectable): LeaderElectionAgent = {

--- a/core/src/main/scala/org/apache/spark/internal/config/Deploy.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/Deploy.scala
@@ -19,8 +19,6 @@ package org.apache.spark.internal.config
 
 import java.util.Locale
 
-import org.apache.spark.io.CompressionCodec
-
 private[spark] object Deploy {
   val RECOVERY_MODE = ConfigBuilder("spark.deploy.recoveryMode")
     .version("0.8.1")
@@ -42,12 +40,11 @@ private[spark] object Deploy {
     .createWithDefault(RecoverySerializer.JAVA.toString)
 
   val RECOVERY_COMPRESSION_CODEC = ConfigBuilder("spark.deploy.recoveryCompressionCodec")
-    .doc("A compression codec for persistence engines. lz4 (default), lzf, snappy, and zstd. " +
-      "Currently, only FILESYSTEM mode supports this configuration.")
+    .doc("A compression codec for persistence engines. none (default), lz4, lzf, snappy, and " +
+      "zstd. Currently, only FILESYSTEM mode supports this configuration.")
     .version("4.0.0")
     .stringConf
-    .transform(_.toLowerCase(Locale.ROOT))
-    .createWithDefaultString(CompressionCodec.LZ4)
+    .createOptional
 
   val RECOVERY_MODE_FACTORY = ConfigBuilder("spark.deploy.recoveryMode.factory")
     .version("1.2.0")

--- a/core/src/main/scala/org/apache/spark/internal/config/Deploy.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/Deploy.scala
@@ -19,6 +19,8 @@ package org.apache.spark.internal.config
 
 import java.util.Locale
 
+import org.apache.spark.io.CompressionCodec
+
 private[spark] object Deploy {
   val RECOVERY_MODE = ConfigBuilder("spark.deploy.recoveryMode")
     .version("0.8.1")
@@ -38,6 +40,14 @@ private[spark] object Deploy {
     .transform(_.toUpperCase(Locale.ROOT))
     .checkValues(RecoverySerializer.values.map(_.toString))
     .createWithDefault(RecoverySerializer.JAVA.toString)
+
+  val RECOVERY_COMPRESSION_CODEC = ConfigBuilder("spark.deploy.recoveryCompressionCodec")
+    .doc("A compression codec for persistence engines. lz4 (default), lzf, snappy, and zstd. " +
+      "Currently, only FILESYSTEM mode supports this configuration.")
+    .version("4.0.0")
+    .stringConf
+    .transform(_.toLowerCase(Locale.ROOT))
+    .createWithDefaultString(CompressionCodec.LZ4)
 
   val RECOVERY_MODE_FACTORY = ConfigBuilder("spark.deploy.recoveryMode.factory")
     .version("1.2.0")

--- a/core/src/test/scala/org/apache/spark/deploy/master/PersistenceEngineSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/master/PersistenceEngineSuite.scala
@@ -25,6 +25,7 @@ import org.apache.curator.test.TestingServer
 
 import org.apache.spark.{SecurityManager, SparkConf, SparkFunSuite}
 import org.apache.spark.internal.config.Deploy.ZOOKEEPER_URL
+import org.apache.spark.io.CompressionCodec
 import org.apache.spark.rpc.{RpcEndpoint, RpcEnv}
 import org.apache.spark.serializer.{JavaSerializer, KryoSerializer, Serializer}
 import org.apache.spark.util.Utils
@@ -62,6 +63,18 @@ class PersistenceEngineSuite extends SparkFunSuite {
       engine.read[String]("test_1")
       engine.unpersist("test_1")
       engine.close()
+    }
+  }
+
+  test("SPARK-46216: FileSystemPersistenceEngine with compression") {
+    val conf = new SparkConf()
+    CompressionCodec.ALL_COMPRESSION_CODECS.foreach { c =>
+      val codec = CompressionCodec.createCodec(conf, c)
+      withTempDir { dir =>
+        testPersistenceEngine(conf, serializer =>
+          new FileSystemPersistenceEngine(dir.getAbsolutePath, serializer, Some(codec))
+        )
+      }
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to improve `FileSystemPersistenceEngine` to support compressions via a new configuration, `spark.deploy.recoveryCompressionCodec`.

### Why are the changes needed?

To allow the users to choose a proper compression codec for their workloads. For `JavaSerializer` case, `LZ4` compression is **2x** faster than the baseline (no compression).
```
OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1051-azure
AMD EPYC 7763 64-Core Processor
2000 Workers:                                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
----------------------------------------------------------------------------------------------------------------------------------------
ZooKeeperPersistenceEngine with JavaSerializer                     2276           2360         115          0.0     1137909.6       1.0X
ZooKeeperPersistenceEngine with KryoSerializer                     1883           1906          34          0.0      941364.2       1.2X
FileSystemPersistenceEngine with JavaSerializer                     431            436           7          0.0      215436.9       5.3X
FileSystemPersistenceEngine with JavaSerializer (lz4)               209            216           9          0.0      104404.1      10.9X
FileSystemPersistenceEngine with JavaSerializer (lzf)               199            202           2          0.0       99489.5      11.4X
FileSystemPersistenceEngine with JavaSerializer (snappy)            192            199           9          0.0       95872.9      11.9X
FileSystemPersistenceEngine with JavaSerializer (zstd)              258            264           6          0.0      129249.4       8.8X
FileSystemPersistenceEngine with KryoSerializer                     139            151          13          0.0       69374.5      16.4X
FileSystemPersistenceEngine with KryoSerializer (lz4)               159            165           8          0.0       79588.9      14.3X
FileSystemPersistenceEngine with KryoSerializer (lzf)               180            195          18          0.0       89844.0      12.7X
FileSystemPersistenceEngine with KryoSerializer (snappy)            164            183          18          0.0       82016.0      13.9X
FileSystemPersistenceEngine with KryoSerializer (zstd)              206            218          11          0.0      102838.9      11.1X
BlackHolePersistenceEngine                                            0              0           0         35.1          28.5   39908.5X
```

### Does this PR introduce _any_ user-facing change?

No, this is a new feature.

### How was this patch tested?

Pass the CIs with the newly added test case.

### Was this patch authored or co-authored using generative AI tooling?

No.