### PR TITLE
[SPARK-46218][BUILD] Upgrade commons-cli to 1.6.0

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -35,7 +35,7 @@ breeze_2.13/2.1.0//breeze_2.13-2.1.0.jar
 cats-kernel_2.13/2.8.0//cats-kernel_2.13-2.8.0.jar
 chill-java/0.10.0//chill-java-0.10.0.jar
 chill_2.13/0.10.0//chill_2.13-0.10.0.jar
-commons-cli/1.5.0//commons-cli-1.5.0.jar
+commons-cli/1.6.0//commons-cli-1.6.0.jar
 commons-codec/1.16.0//commons-codec-1.16.0.jar
 commons-collections/3.2.2//commons-collections-3.2.2.jar
 commons-collections4/4.4//commons-collections4-4.4.jar

--- a/pom.xml
+++ b/pom.xml
@@ -220,7 +220,7 @@
     <htmlunit.version>2.70.0</htmlunit.version>
     <maven-antrun.version>3.1.0</maven-antrun.version>
     <commons-crypto.version>1.1.0</commons-crypto.version>
-    <commons-cli.version>1.5.0</commons-cli.version>
+    <commons-cli.version>1.6.0</commons-cli.version>
     <bouncycastle.version>1.70</bouncycastle.version>
     <tink.version>1.9.0</tink.version>
     <netty.version>4.1.100.Final</netty.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade `commons-cli` from `1.5.0` to `1.6.0`.

### Why are the changes needed?
- The last upgrade occurred two years ago, https://github.com/apache/spark/pull/34707
- The full release notes: https://commons.apache.org/proper/commons-cli/changes-report.html#a1.6.0
- The version mainly focus on fixing bugs:
Fix NPE in CommandLine.resolveOption(String). Fixes [CLI-283](https://issues.apache.org/jira/browse/CLI-283).
CommandLine.addOption(Option) should not allow a null Option. Fixes [CLI-283](https://issues.apache.org/jira/browse/CLI-283).
CommandLine.addArgs(String) should not allow a null String. Fixes [CLI-283](https://issues.apache.org/jira/browse/CLI-283).
NullPointerException thrown by CommandLineParser.parse(). Fixes [CLI-317](https://issues.apache.org/jira/browse/CLI-317).
StringIndexOutOfBoundsException thrown by CommandLineParser.parse(). Fixes [CLI-313](https://issues.apache.org/jira/browse/CLI-313).

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
