### PR TITLE
[SPARK-46222][PYTHON][TESTS] Test invalid error class (pyspark.errors.utils)

### DIFF
--- a/python/pyspark/errors/tests/test_errors.py
+++ b/python/pyspark/errors/tests/test_errors.py
@@ -19,6 +19,7 @@
 import json
 import unittest
 
+from pyspark.errors import PySparkValueError
 from pyspark.errors.error_classes import ERROR_CLASSES_JSON
 from pyspark.errors.utils import ErrorClassesReader
 
@@ -45,6 +46,10 @@ class ErrorsTest(unittest.TestCase):
             return error_classes_json
 
         json.loads(ERROR_CLASSES_JSON, object_pairs_hook=detect_duplication)
+
+    def test_invalid_error_class(self):
+        with self.assertRaisesRegex(ValueError, "Cannot find main error class"):
+            PySparkValueError(error_class="invalid", message_parameters={})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds a test for invalid error classes

### Why are the changes needed?

![Screenshot 2023-12-04 at 8 50 37 AM](https://github.com/apache/spark/assets/6477701/47e80d92-3f28-4fb3-a2aa-8745f7fb40ec)

https://app.codecov.io/gh/apache/spark/blob/master/python%2Fpyspark%2Ferrors%2Futils.py

This is not being tested.

### Does this PR introduce _any_ user-facing change?

No, test-only

### How was this patch tested?

Manually ran the new unittest.

### Was this patch authored or co-authored using generative AI tooling?

Np.