### PR TITLE
[SPARK-46223][PS] Test SparkPandasNotImplementedError with cleaning up unused code

### DIFF
--- a/python/pyspark/pandas/exceptions.py
+++ b/python/pyspark/pandas/exceptions.py
@@ -29,28 +29,18 @@ class SparkPandasIndexingError(Exception):
     pass
 
 
-def code_change_hint(pandas_function: Optional[str], spark_target_function: Optional[str]) -> str:
-    if pandas_function is not None and spark_target_function is not None:
-        return "You are trying to use pandas function {}, use spark function {}".format(
-            pandas_function, spark_target_function
-        )
-    elif pandas_function is not None and spark_target_function is None:
-        return (
-            "You are trying to use pandas function {}, checkout the spark "
-            "user guide to find a relevant function"
-        ).format(pandas_function)
-    elif pandas_function is None and spark_target_function is not None:
-        return "Use spark function {}".format(spark_target_function)
-    else:  # both none
-        return "Checkout the spark user guide to find a relevant function"
+def code_change_hint(pandas_function: str, spark_target_function: str) -> str:
+    return "You are trying to use pandas function {}, use spark function {}".format(
+        pandas_function, spark_target_function
+    )
 
 
 class SparkPandasNotImplementedError(NotImplementedError):
     def __init__(
         self,
-        pandas_function: Optional[str] = None,
-        spark_target_function: Optional[str] = None,
-        description: str = "",
+        pandas_function: str,
+        spark_target_function: str,
+        description: str,
     ):
         self.pandas_source = pandas_function
         self.spark_target = spark_target_function

--- a/python/pyspark/pandas/tests/test_indexing.py
+++ b/python/pyspark/pandas/tests/test_indexing.py
@@ -22,7 +22,7 @@ import numpy as np
 import pandas as pd
 
 from pyspark import pandas as ps
-from pyspark.pandas.exceptions import SparkPandasIndexingError
+from pyspark.pandas.exceptions import SparkPandasIndexingError, SparkPandasNotImplementedError
 from pyspark.testing.pandasutils import ComparisonTestBase, compare_both
 
 
@@ -901,6 +901,12 @@ class IndexingTest(ComparisonTestBase):
             self.assert_eq(psdf.iloc[:1, indexer], pdf.iloc[:1, indexer])
             self.assert_eq(psdf.iloc[:-1, indexer], pdf.iloc[:-1, indexer])
             # self.assert_eq(psdf.iloc[psdf.index == 2, indexer], pdf.iloc[pdf.index == 2, indexer])
+
+        self.assertRaisesRegex(
+            SparkPandasNotImplementedError,
+            ".iloc requires numeric slice, conditional boolean",
+            lambda: ps.range(10).iloc["a", :],
+        )
 
     def test_iloc_multiindex_columns(self):
         arrays = [np.array(["bar", "bar", "baz", "baz"]), np.array(["one", "two", "one", "two"])]


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds a test for `SparkPandasNotImplementedError`, and clean up some unused code.

### Why are the changes needed?

![Screenshot 2023-12-04 at 9 07 36 AM](https://github.com/apache/spark/assets/6477701/87f7dcb5-b448-4841-ab6a-dd92eb07a795)

This is not being tested (https://app.codecov.io/gh/apache/spark/blob/master/python%2Fpyspark%2Fpandas%2Fexceptions.py).

### Does this PR introduce _any_ user-facing change?

No, test-only

### How was this patch tested?

Manually ran the new unittest.

### Was this patch authored or co-authored using generative AI tooling?

No.