### PR TITLE
[SPARK-46224][PYTHON][MLLIB][TESTS] Test string representation of TestResult (pyspark.mllib.stat.test)

### DIFF
--- a/python/pyspark/mllib/tests/test_stat.py
+++ b/python/pyspark/mllib/tests/test_stat.py
@@ -65,6 +65,7 @@ class ChiSqTestTests(MLlibTestCase):
 
         observed = Vectors.dense([4, 6, 5])
         pearson = Statistics.chiSqTest(observed)
+        self.assertIn("Chi squared test summary", str(pearson))
 
         # Validated against the R command `chisq.test(c(4, 6, 5), p=c(1/3, 1/3, 1/3))`
         self.assertEqual(pearson.statistic, 0.4)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds a test for `toString` on the model via `TestResult` within `pyspark.mllib.stat.test`. 

### Why are the changes needed?

![Screenshot 2023-12-04 at 9 19 37 AM](https://github.com/apache/spark/assets/6477701/8a360172-0913-43ce-a5f0-a68cdefe252c)

https://app.codecov.io/gh/apache/spark/blob/master/python%2Fpyspark%2Fmllib%2Fstat%2Ftest.py#L28

This is not being tested.

### Does this PR introduce _any_ user-facing change?

No, test-only

### How was this patch tested?

Manually ran the new unittest.

### Was this patch authored or co-authored using generative AI tooling?

No.