### PR TITLE
[SPARK-40559][PYTHON][DOCS][FOLLOW-UP] Fix the docstring and document both applyInArrows

### DIFF
--- a/python/docs/source/reference/pyspark.sql/grouping.rst
+++ b/python/docs/source/reference/pyspark.sql/grouping.rst
@@ -26,6 +26,7 @@ Grouping
 
     GroupedData.agg
     GroupedData.apply
+    GroupedData.applyInArrow
     GroupedData.applyInPandas
     GroupedData.applyInPandasWithState
     GroupedData.avg
@@ -36,4 +37,5 @@ Grouping
     GroupedData.min
     GroupedData.pivot
     GroupedData.sum
+    PandasCogroupedOps.applyInArrow
     PandasCogroupedOps.applyInPandas

--- a/python/pyspark/sql/pandas/group_ops.py
+++ b/python/pyspark/sql/pandas/group_ops.py
@@ -633,9 +633,9 @@ class PandasCogroupedOps:
         Applies a function to each cogroup using Arrow and returns the result
         as a `DataFrame`.
 
-        The function should take two `pyarrow.Table`s and return another
+        The function should take two `pyarrow.Table`\\s and return another
         `pyarrow.Table`. Alternatively, the user can pass a function that takes
-        a tuple of `pyarrow.Scalar` grouping key(s) and the two `pyarrow.Table`s.
+        a tuple of `pyarrow.Scalar` grouping key(s) and the two `pyarrow.Table`\\s.
         For each side of the cogroup, all columns are passed together as a
         `pyarrow.Table` to the user-function and the returned `pyarrow.Table` are combined as
         a :class:`DataFrame`.
@@ -651,9 +651,9 @@ class PandasCogroupedOps:
         Parameters
         ----------
         func : function
-            a Python native function that takes two `pyarrow.Table`s, and
+            a Python native function that takes two `pyarrow.Table`\\s, and
             outputs a `pyarrow.Table`, or that takes one tuple (grouping keys) and two
-            ``pyarrow.Table``s, and outputs a ``pyarrow.Table``.
+            ``pyarrow.Table``\\s, and outputs a ``pyarrow.Table``.
         schema : :class:`pyspark.sql.types.DataType` or str
             the return type of the `func` in PySpark. The value can be either a
             :class:`pyspark.sql.types.DataType` object or a DDL-formatted type string.
@@ -682,7 +682,7 @@ class PandasCogroupedOps:
         the grouping key(s) will be passed as the first argument and the data will be passed as the
         second and third arguments.  The grouping key(s) will be passed as a tuple of Arrow scalars
         types, e.g., `pyarrow.Int32Scalar` and `pyarrow.FloatScalar`. The data will still be passed
-        in as two `pyarrow.Table`s containing all columns from the original Spark DataFrames.
+        in as two `pyarrow.Table`\\s containing all columns from the original Spark DataFrames.
 
         >>> def summarize(key, l, r):
         ...     return pyarrow.Table.from_pydict({

--- a/python/pyspark/sql/pandas/group_ops.py
+++ b/python/pyspark/sql/pandas/group_ops.py
@@ -407,7 +407,6 @@ class PandasGroupedOpsMixin:
         >>> df.groupby("id").applyInArrow(
         ...     normalize, schema="id long, v double").show()  # doctest: +SKIP
         +---+-------------------+
-        +---+-------------------+
         | id|                  v|
         +---+-------------------+
         |  1|-0.7071067811865475|
@@ -467,7 +466,7 @@ class PandasGroupedOpsMixin:
         into memory, so the user should be aware of the potential OOM risk if data is skewed
         and certain groups are too large to fit in memory.
 
-        This API is experimental.
+        This API is unstable, and for developers.
 
         See Also
         --------
@@ -707,7 +706,7 @@ class PandasCogroupedOps:
         into memory, so the user should be aware of the potential OOM risk if data is skewed
         and certain groups are too large to fit in memory.
 
-        This API is experimental.
+        This API is unstable, and for developers.
 
         See Also
         --------


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/38624 that documents both applyInArrows with a docstring fix.

### Why are the changes needed?

For end users to refer the API documentation.

### Does this PR introduce _any_ user-facing change?

No, the main change has not been released out yet.

### How was this patch tested?

Existing CI, and documentation build.

### Was this patch authored or co-authored using generative AI tooling?

No.
