### PR TITLE
[SPARK-46048][PYTHON][CONNECT][FOLLOWUP] Correct the string representation

### DIFF
--- a/python/pyspark/sql/connect/group.py
+++ b/python/pyspark/sql/connect/group.py
@@ -109,6 +109,8 @@ class GroupedData:
             type_str = "RollUp"
         elif self._group_type == "cube":
             type_str = "Cube"
+        elif self._group_type == "grouping_sets":
+            type_str = "GroupingSets"
         else:
             type_str = "Pivot"
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Correct the string representation


### Why are the changes needed?
to fix a minor issue

### Does this PR introduce _any_ user-facing change?
yes

before:
```
In [1]: spark.range(10).groupingSets([])
Out[1]: GroupedData[grouping expressions: [], value: [id: bigint], type: Pivot]
```

after:
```
In [2]: spark.range(10).groupingSets([])
Out[2]: GroupedData[grouping expressions: [], value: [id: bigint], type: GroupingSets]
```


### How was this patch tested?
manually test, it is trivial so I don't add a doctest


### Was this patch authored or co-authored using generative AI tooling?
no
