### PR TITLE
[SPARK-46241][PYTHON][CONNECT] Fix error handling routine so it wouldn't fall into infinite recursion

### DIFF
--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -1515,7 +1515,7 @@ class SparkConnectClient(object):
         -------
         Throws the appropriate internal Python exception.
         """
-        if True or self._forbid_recursive_error_handling.can_enter:
+        if self._forbid_recursive_error_handling.can_enter:
             with self._forbid_recursive_error_handling:
                 if isinstance(error, grpc.RpcError):
                     self._handle_rpc_error(error)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove _display_server_stack_trace and always display error stack trace if we have one

### Why are the changes needed?

There is a certain codepath which can make existing error handling fall into infinite recursion. I.e. consider following codepath:

`[Some error happens] -> _handle_error -> _handle_rpc_error -> _display_server_stack_trace -> RuntimeConf.get -> SparkConnectClient.config -> [An error happens] -> _handle_error`.

There can be other similar codepaths

### Does this PR introduce _any_ user-facing change?

Gets rid of occasionally infinite recursive error handling (which can cause downgraded user experience)

### How was this patch tested?
N/A

### Was this patch authored or co-authored using generative AI tooling?
No