### PR TITLE
[SPARK-46228][SQL] Insert window group limit node for limit outside of window

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InferWindowGroupLimit.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InferWindowGroupLimit.scala
@@ -18,13 +18,14 @@
 package org.apache.spark.sql.catalyst.optimizer
 
 import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, CurrentRow, DenseRank, EqualTo, Expression, GreaterThan, GreaterThanOrEqual, IntegerLiteral, LessThan, LessThanOrEqual, Literal, NamedExpression, PredicateHelper, Rank, RowFrame, RowNumber, SizeBasedWindowFunction, SpecifiedWindowFrame, UnboundedPreceding, WindowExpression, WindowSpecDefinition}
-import org.apache.spark.sql.catalyst.plans.logical.{Filter, Limit, LocalRelation, LogicalPlan, Window, WindowGroupLimit}
+import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules.Rule
-import org.apache.spark.sql.catalyst.trees.TreePattern.{FILTER, WINDOW}
+import org.apache.spark.sql.catalyst.trees.TreePattern.{FILTER, LIMIT, WINDOW}
 
 /**
  * Inserts a `WindowGroupLimit` below `Window` if the `Window` has rank-like functions
- * and the function results are further filtered by limit-like predicates. Example query:
+ * and the function results are further filtered by limit-like predicates or cumulative
+ * aggregation with limit excludes `SizeBasedWindowFunction`. Example query:
  * {{{
  *   SELECT *, ROW_NUMBER() OVER(PARTITION BY k ORDER BY a) AS rn FROM Tab1 WHERE rn = 5
  *   SELECT *, ROW_NUMBER() OVER(PARTITION BY k ORDER BY a) AS rn FROM Tab1 WHERE 5 = rn
@@ -32,6 +33,9 @@ import org.apache.spark.sql.catalyst.trees.TreePattern.{FILTER, WINDOW}
  *   SELECT *, ROW_NUMBER() OVER(PARTITION BY k ORDER BY a) AS rn FROM Tab1 WHERE 5 > rn
  *   SELECT *, ROW_NUMBER() OVER(PARTITION BY k ORDER BY a) AS rn FROM Tab1 WHERE rn <= 5
  *   SELECT *, ROW_NUMBER() OVER(PARTITION BY k ORDER BY a) AS rn FROM Tab1 WHERE 5 >= rn
+ *   SELECT *, ROW_NUMBER() OVER(PARTITION BY k ORDER BY a) AS rn FROM Tab1 LIMIT 5
+ *   SELECT *, SUM(b) OVER(PARTITION BY k ORDER BY a) AS s FROM Tab1 LIMIT 5
+ *   SELECT *, SUM(b) OVER(ORDER BY a) AS s FROM Tab1 LIMIT 5
  * }}}
  */
 object InferWindowGroupLimit extends Rule[LogicalPlan] with PredicateHelper {
@@ -69,10 +73,55 @@ object InferWindowGroupLimit extends Rule[LogicalPlan] with PredicateHelper {
     case _ => false
   }
 
+  /**
+   * Whether support inferring WindowGroupLimit from Limit outside of Window. Check if:
+   * 1. The window orderSpec exists unfoldable one or all window expressions should use the same
+   *  expanding window.
+   * 2. All window expressions should not have SizeBasedWindowFunction.
+   * 3. The Limit could not be pushed down through Window.
+   */
+  private def limitSupport(limit: Int, window: Window): Boolean =
+    limit <= conf.windowGroupLimitThreshold && window.child.maxRows.forall(_ > limit) &&
+      !window.child.isInstanceOf[WindowGroupLimit] &&
+      (window.orderSpec.exists(!_.child.foldable) ||
+        window.windowExpressions.forall(isExpandingWindow)) &&
+      window.windowExpressions.forall {
+        case Alias(WindowExpression(windowFunction, WindowSpecDefinition(_, _,
+        SpecifiedWindowFrame(_, UnboundedPreceding, CurrentRow))), _)
+          if !windowFunction.isInstanceOf[SizeBasedWindowFunction] &&
+            // LimitPushDownThroughWindow have better performance than WindowGroupLimit if the
+            // window function is rank-like and Window partitionSpec is empty.
+            (!support(windowFunction) || window.partitionSpec.nonEmpty) => true
+        case _ => false
+      }
+
+  private def selectRankLikeFunction(windowExpressions: Seq[NamedExpression]): Expression =
+    // If windowExpressions all are RowFrame, choose SimpleLimitIterator,
+    // else RankLimitIterator to obtain enough rows for ensure data accuracy.
+    if (windowExpressions.forall(isExpandingWindow)) {
+      new RowNumber
+    } else {
+      new Rank
+    }
+
   def apply(plan: LogicalPlan): LogicalPlan = {
     if (conf.windowGroupLimitThreshold == -1) return plan
 
-    plan.transformWithPruning(_.containsAllPatterns(FILTER, WINDOW), ruleId) {
+    plan.transformWithPruning(
+      t => t.containsPattern(WINDOW) && t.containsAnyPattern(FILTER, LIMIT), ruleId) {
+      case localLimit @ LocalLimit(IntegerLiteral(limit),
+        window @ Window(windowExpressions, partitionSpec, orderSpec, child))
+        if limitSupport(limit, window) =>
+        val windowGroupLimit = WindowGroupLimit(
+          partitionSpec, orderSpec, selectRankLikeFunction(windowExpressions), limit, child)
+        localLimit.withNewChildren(Seq(window.withNewChildren(Seq(windowGroupLimit))))
+      case localLimit @ LocalLimit(IntegerLiteral(limit), project @ Project(_,
+        window @ Window(windowExpressions, partitionSpec, orderSpec, child)))
+        if limitSupport(limit, window) =>
+        val windowGroupLimit = WindowGroupLimit(
+          partitionSpec, orderSpec, selectRankLikeFunction(windowExpressions), limit, child)
+        localLimit.withNewChildren(Seq(
+          project.withNewChildren(Seq(window.withNewChildren(Seq(windowGroupLimit))))))
       case filter @ Filter(condition,
         window @ Window(windowExpressions, partitionSpec, orderSpec, child))
         if !child.isInstanceOf[WindowGroupLimit] && windowExpressions.forall(isExpandingWindow) &&

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InferWindowGroupLimit.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InferWindowGroupLimit.scala
@@ -23,9 +23,9 @@ import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.trees.TreePattern.{FILTER, LIMIT, WINDOW}
 
 /**
- * Inserts a `WindowGroupLimit` below `Window` if the `Window` has rank-like functions
- * and the function results are further filtered by limit-like predicates or cumulative
- * aggregation with limit excludes `SizeBasedWindowFunction`. Example query:
+ * Inserts a `WindowGroupLimit` below `Window` if the `Window` has rank-like functions and the
+ * function results are further filtered by limit-like predicates or an actual limit. Example
+ * query:
  * {{{
  *   SELECT *, ROW_NUMBER() OVER(PARTITION BY k ORDER BY a) AS rn FROM Tab1 WHERE rn = 5
  *   SELECT *, ROW_NUMBER() OVER(PARTITION BY k ORDER BY a) AS rn FROM Tab1 WHERE 5 = rn


### PR DESCRIPTION
### What changes were proposed in this pull request?

In ad hoc queries we often need to limit the number of rows returned, if query is limit outside of window and the calculation of top k of the window function only depends on the rows with rank <= k, similar to top-k, we can insert node `WindowGroupLimit` to reduce shuffle. 

It supports following pattern:
```
SELECT (... (row_number|rank|dense_rank|sum|max...)()
    OVER (
PARTITION BY ...
ORDER BY  ... ) AS v)
LIMIT k
```
Limit k outside of window can be converted into top k for each window group, finally gobal limit k. The calculation of the top k values ​​after sorting for each window group only needs rows with partial rank <= k, so we can safely discard rows with partial rank > k, anywhere. 
`WindowGroupLimit` basically adds a per-window-group limit before and after the shuffle to reduce the input data of window processing .
More specifically, the before-shuffle per-window-group limit:
adds an extra local sort to determine window group boundaries
applies per-group limit to reduce the data size of shuffle, and all the downstream operators.

Whether support inferring WindowGroupLimit from Limit outside of Window. That is the calculation of top k of the window function only depends on the rows with rank <= k. Check if: 
1. Window frame: first lower/upper must be 'UnboundedPreceding'/'CurrentRow', secondly window orderSpec exists unfoldable one or all window expressions are `RowFrame`. Because when orderSpec is foldable and window expressions is `RangeFrame`, aggregation calculation requires the use of all rows in the window group.
2. Window function: All window expressions should not have `SizeBasedWindowFunction`, for example `CumeDist`, `NTile`, `PercentRank`. Because aggregation calculation of `SizeBasedWindowFunction` requires the use of all rows in the window group.
3. The Limit could not be pushed down through Window. Because `LimitPushDownThroughWindow` have better performance than `WindowGroupLimit`.

The effect is similar to #38799. This is beneficial, assuming the per-window-group data size is large. Otherwise, the method to determine window group boundaries is pure overhead. The config `spark.sql.window.group.limit.threshold` could avoid the overhead if the per-window-group data size is small enough.

### Why are the changes needed?
Reduce the shuffle write to improve the performance. 


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
1. UT
2. manual test on TPC-DS
    TPC-DS data size: 10Gb.
    This improvement is valid for TPC-DS q67-changed
```
SELECT *
FROM
  (SELECT
    i_category,
    i_class,
    i_brand,
    i_product_name,
    d_year,
    d_qoy,
    d_moy,
    s_store_id,
    sumsales,
    rank()
    OVER (PARTITION BY i_category
      ORDER BY sumsales DESC) rk
  FROM
    (SELECT
      i_category,
      i_class,
      i_brand,
      i_product_name,
      d_year,
      d_qoy,
      d_moy,
      s_store_id,
      coalesce(ss_sales_price * ss_quantity, 0) sumsales
    FROM store_sales, date_dim, store, item
    WHERE ss_sold_date_sk = d_date_sk
      AND ss_item_sk = i_item_sk
      AND ss_store_sk = s_store_sk
      AND d_month_seq BETWEEN 1200 AND 1200 + 11
    ) dw1) dw2
LIMIT 100
```

TPC-DS Query | Before(Seconds) | After(Seconds) | Speedup(Percent)
-- | -- | -- | --
q67-changed | 18.246 | 10.799 | 168.96%



### Was this patch authored or co-authored using generative AI tooling?
No.
