### PR TITLE
[SPARK-46234][PYTHON] Introduce `PySparkKeyError` for PySpark error framework

### DIFF
--- a/python/docs/source/reference/pyspark.errors.rst
+++ b/python/docs/source/reference/pyspark.errors.rst
@@ -38,6 +38,7 @@ Classes
     PySparkAssertionError
     PySparkAttributeError
     PySparkException
+    PySparkKeyError
     PySparkNotImplementedError
     PySparkPicklingError
     PySparkRuntimeError

--- a/python/pyspark/errors/__init__.py
+++ b/python/pyspark/errors/__init__.py
@@ -46,6 +46,7 @@ from pyspark.errors.exceptions.base import (  # noqa: F401
     PySparkAssertionError,
     PySparkNotImplementedError,
     PySparkPicklingError,
+    PySparkKeyError,
 )
 
 
@@ -77,4 +78,5 @@ __all__ = [
     "PySparkAssertionError",
     "PySparkNotImplementedError",
     "PySparkPicklingError",
+    "PySparkKeyError",
 ]

--- a/python/pyspark/errors/error_classes.py
+++ b/python/pyspark/errors/error_classes.py
@@ -382,6 +382,11 @@ ERROR_CLASSES_JSON = """
       "Attribute `<attr_name>` is not supported in Spark Connect as it depends on the JVM. If you need to use this attribute, do not use Spark Connect when creating your session. Visit https://spark.apache.org/docs/latest/sql-getting-started.html#starting-point-sparksession for creating regular Spark Session in detail."
     ]
   },
+  "KEY_NOT_EXISTS" : {
+    "message" : [
+      "Key `<key>` is not exists."
+    ]
+  },
   "KEY_VALUE_PAIR_REQUIRED" : {
     "message" : [
       "Key-value pair or a list of pairs is required."

--- a/python/pyspark/errors/exceptions/base.py
+++ b/python/pyspark/errors/exceptions/base.py
@@ -264,3 +264,9 @@ class PySparkImportError(PySparkException, ImportError):
     """
     Wrapper class for ImportError to support error classes.
     """
+
+
+class PySparkKeyError(PySparkException, KeyError):
+    """
+    Wrapper class for KeyError to support error classes.
+    """

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -55,6 +55,7 @@ from pyspark.errors import (
     PySparkTypeError,
     PySparkValueError,
     PySparkIndexError,
+    PySparkKeyError,
 )
 
 if has_numpy:
@@ -1042,7 +1043,9 @@ class StructType(DataType):
             for field in self:
                 if field.name == key:
                     return field
-            raise KeyError("No StructField named {0}".format(key))
+            raise PySparkKeyError(
+                error_class="KEY_NOT_EXISTS", message_parameters={"key": str(key)}
+            )
         elif isinstance(key, int):
             try:
                 return self.fields[key]
@@ -2563,7 +2566,9 @@ class Row(tuple):
             idx = self.__fields__.index(item)
             return super(Row, self).__getitem__(idx)
         except IndexError:
-            raise KeyError(item)
+            raise PySparkKeyError(
+                error_class="KEY_NOT_EXISTS", message_parameters={"key": str(item)}
+            )
         except ValueError:
             raise PySparkValueError(item)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to introduce `PySparkKeyError` for error framework, and migrate Python built-in `KeyError` into `PySparkKeyError`.

### Why are the changes needed?

For better error handling.


### Does this PR introduce _any_ user-facing change?

No API changes, but it's improve the user-facing error messages.

### How was this patch tested?

The existing CI should pass


### Was this patch authored or co-authored using generative AI tooling?

No.
