### PR TITLE
[SPARK-46236][PYTHON][DOCS] Using brighter color for docs h3 title for better visibility

### DIFF
--- a/python/docs/source/_static/css/pyspark.css
+++ b/python/docs/source/_static/css/pyspark.css
@@ -27,10 +27,6 @@ h1,h2 {
     color:#17A2B8!important;
 }
 
-h3 {
-    color: #555555
-}
-
 /* Top menu */
 #navbar-main {
     background: #1B5162!important;


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to using brighter color for docs `h3 title` for better visibility.

### Why are the changes needed?
- Before:
   Dark theme:
   <img width="760" alt="image" src="https://github.com/apache/spark/assets/15246973/ee024e67-d86b-4960-968f-329b32d3e370">

   Light theme:
   <img width="761" alt="image" src="https://github.com/apache/spark/assets/15246973/20a562ed-b9b5-44f6-bf52-30967fb7dc3a">

- After:
   Dark theme:
   <img width="780" alt="image" src="https://github.com/apache/spark/assets/15246973/546139b5-a94c-4dec-a4fb-24299b3388ba">

   Light theme:
   <img width="769" alt="image" src="https://github.com/apache/spark/assets/15246973/4d912002-4c9e-46d0-a397-bcca0024f160">

### Does this PR introduce _any_ user-facing change?
No API changes, but the font color of the `h3 title` has been updated to a brighter color, improving contrast and readability.

### How was this patch tested?
Manually test.


### Was this patch authored or co-authored using generative AI tooling?
No.
