### PR TITLE
[SPARK-46243][SQL][DOCS] Describe arguments of `decode()`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
@@ -2623,17 +2623,20 @@ case class Decode(params: Seq[Expression], replacement: Expression)
 }
 
 /**
- * Decodes the first argument into a String using the provided character set
- * (one of 'US-ASCII', 'ISO-8859-1', 'UTF-8', 'UTF-16BE', 'UTF-16LE', 'UTF-16').
- * If either argument is null, the result will also be null.
+ * Decodes the first argument into a String using the provided character set.
  */
 // scalastyle:off line.size.limit
 @ExpressionDescription(
-  usage = "_FUNC_(bin, charset) - Decodes the first argument using the second argument character set.",
+  usage = "_FUNC_(bin, charset) - Decodes the first argument using the second argument character set. If either argument is null, the result will also be null.",
   examples = """
     Examples:
       > SELECT _FUNC_(encode('abc', 'utf-8'), 'utf-8');
        abc
+  """,
+  arguments = """
+    Arguments:
+      * bin - a binary expression to decode
+      * charset - one of the charsets 'US-ASCII', 'ISO-8859-1', 'UTF-8', 'UTF-16BE', 'UTF-16LE', 'UTF-16' to decode `bin` into a STRING. It is case insensitive.
   """,
   since = "1.5.0",
   group = "string_funcs")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
@@ -2594,6 +2594,11 @@ object Decode {
       the corresponding result. If no match is found, then it returns default. If default
       is omitted, it returns null.
   """,
+  arguments = """
+    Arguments:
+      * bin - a binary expression to decode
+      * charset - one of the charsets 'US-ASCII', 'ISO-8859-1', 'UTF-8', 'UTF-16BE', 'UTF-16LE', 'UTF-16' to decode `bin` into a STRING. It is case insensitive.
+  """,
   examples = """
     Examples:
       > SELECT _FUNC_(encode('abc', 'utf-8'), 'utf-8');


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to update the description of the `StringDecode` expression and apparently the `decode()` function by describing the arguments `bin` and `charset`.

#### The updated docs:
<img width="743" alt="Screenshot 2023-12-04 at 12 24 36" src="https://github.com/apache/spark/assets/1580697/a177f81d-2f39-45ff-bc28-b217dad4e128">


### Why are the changes needed?
To improve user experience with Spark SQL by documenting the public function.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By manually checking the generated docs.

### Was this patch authored or co-authored using generative AI tooling?
No.