### PR TITLE
[SPARK-46239][CORE] Hide `Jetty` info

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
@@ -315,9 +315,9 @@ private[spark] object JettyUtils extends Logging {
       httpConfig.setRequestHeaderSize(requestHeaderSize)
 
       // Hide information.
-      logDebug(s"Using setSendServerVersion: false ")
+      logDebug(s"Using setSendServerVersion: false")
       httpConfig.setSendServerVersion(false)
-      logDebug(s"Using setSendXPoweredBy: false ")
+      logDebug(s"Using setSendXPoweredBy: false")
       httpConfig.setSendXPoweredBy(false)
 
       // If SSL is configured, create the secure connector first.

--- a/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
@@ -314,7 +314,7 @@ private[spark] object JettyUtils extends Logging {
       logDebug(s"Using requestHeaderSize: $requestHeaderSize")
       httpConfig.setRequestHeaderSize(requestHeaderSize)
 
-      // spark-46239: Hide version information to avoid obtaining remote WWW service information through HTTP.
+      // Hide information.
       logDebug(s"Using setSendServerVersion: false ")
       httpConfig.setSendServerVersion(false)
       logDebug(s"Using setSendXPoweredBy: false ")

--- a/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
@@ -315,9 +315,9 @@ private[spark] object JettyUtils extends Logging {
       httpConfig.setRequestHeaderSize(requestHeaderSize)
 
       // Hide information.
-      logDebug(s"Using setSendServerVersion: false")
+      logDebug("Using setSendServerVersion: false")
       httpConfig.setSendServerVersion(false)
-      logDebug(s"Using setSendXPoweredBy: false")
+      logDebug("Using setSendXPoweredBy: false")
       httpConfig.setSendXPoweredBy(false)
 
       // If SSL is configured, create the secure connector first.

--- a/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
@@ -314,6 +314,12 @@ private[spark] object JettyUtils extends Logging {
       logDebug(s"Using requestHeaderSize: $requestHeaderSize")
       httpConfig.setRequestHeaderSize(requestHeaderSize)
 
+      // spark-46239: Hide version information to avoid obtaining remote WWW service information through HTTP.
+      logDebug(s"Using setSendServerVersion: false ")
+      httpConfig.setSendServerVersion(false)
+      logDebug(s"Using setSendXPoweredBy: false ")
+      httpConfig.setSendXPoweredBy(false)
+
       // If SSL is configured, create the secure connector first.
       val securePort = sslOptions.createJettySslContextFactory().map { factory =>
         val securePort = sslOptions.port.getOrElse(if (port > 0) Utils.userPort(port, 400) else 0)


### PR DESCRIPTION
**What changes were proposed in this pull request?**
The PR sets parameters to hide the version of  jetty in spark.

**Why are the changes needed?**
It can avoid obtaining remote WWW service information through HTTP.

**Does this PR introduce any user-facing change?**
No

**How was this patch tested?**
Manual review

**Was this patch authored or co-authored using generative AI tooling?**
No