### PR TITLE
[SPARK-45684][SQL][SS][TESTS][FOLLOWUP] Use `++` instead of `s.c.SeqOps#concat`

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
@@ -174,7 +174,7 @@ class StreamSuite extends StreamTest {
         try {
           query.processAllAvailable()
           val outputDf = spark.read.parquet(outputDir.getAbsolutePath).as[Long]
-          checkDatasetUnorderly[Long](outputDf, (0L to 10L).concat(0L to 10L): _*)
+          checkDatasetUnorderly[Long](outputDf, (0L to 10L) ++ (0L to 10L): _*)
         } finally {
           query.stop()
         }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr use `++` instead of `s.c.SeqOps#concat` to address comments: https://github.com/apache/spark/pull/43575#discussion_r1414163363


### Why are the changes needed?
 `++` is alias for `concat`,  but the readability of ++ is better.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No