### PR TITLE
[SPARK-46229][PYTHON][CONNECT][FOLLOW-UP] Remove unnecessary Python version check lower than 3.8

### DIFF
--- a/python/pyspark/sql/connect/_typing.py
+++ b/python/pyspark/sql/connect/_typing.py
@@ -14,9 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from typing import Protocol, Tuple
 from types import FunctionType
-from typing import Any, Callable, Iterable, Union, Optional, NewType
+from typing import Any, Callable, Iterable, Union, Optional, NewType, Protocol, Tuple
 import datetime
 import decimal
 

--- a/python/pyspark/sql/connect/_typing.py
+++ b/python/pyspark/sql/connect/_typing.py
@@ -14,14 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import sys
-
-if sys.version_info >= (3, 8):
-    from typing import Protocol, Tuple
-else:
-    from typing_extensions import Protocol
-
-from typing import Tuple
+from typing import Protocol, Tuple
 from types import FunctionType
 from typing import Any, Callable, Iterable, Union, Optional, NewType
 import datetime


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR addresses the review comment https://github.com/apache/spark/pull/44146#discussion_r1414336068.

### Why are the changes needed?

We don't support Python lower than 3.8 so we can remove that if-else on Python version.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests via CI.

### Was this patch authored or co-authored using generative AI tooling?

No.