### PR TITLE
[SPARK-46253][PYTHON] Plan Python data source read using MapInArrow

### DIFF
--- a/python/pyspark/errors/error_classes.py
+++ b/python/pyspark/errors/error_classes.py
@@ -697,6 +697,16 @@ ERROR_CLASSES_JSON = """
         "Unable to create the Python data source <type> because the '<method>' method hasn't been implemented."
     ]
   },
+  "PYTHON_DATA_SOURCE_READ_INVALID_RETURN_TYPE" : {
+    "message" : [
+        "The data type of the returned value ('<type>') from the Python data source '<name>' is not supported. Supported types: <supported_types>."
+    ]
+  },
+  "PYTHON_DATA_SOURCE_READ_RETURN_SCHEMA_MISMATCH" : {
+    "message" : [
+      "The number of columns in the result does not match the required schema. Expected column count: <expected>, Actual column count: <actual>. Please make sure the values returned by the 'read' method have the same number of columns as required by the output schema."
+    ]
+  },
   "PYTHON_DATA_SOURCE_TYPE_MISMATCH" : {
     "message" : [
       "Expected <expected>, but got <actual>."

--- a/python/pyspark/sql/tests/test_python_datasource.py
+++ b/python/pyspark/sql/tests/test_python_datasource.py
@@ -16,9 +16,11 @@
 #
 import os
 import unittest
+from typing import Callable, Union
 
+from pyspark.errors import PythonException
 from pyspark.sql.datasource import DataSource, DataSourceReader, InputPartition
-from pyspark.sql.types import Row
+from pyspark.sql.types import Row, StructType
 from pyspark.testing import assertDataFrameEqual
 from pyspark.testing.sqlutils import ReusedSQLTestCase
 from pyspark.testing.utils import SPARK_HOME
@@ -77,6 +79,107 @@ class BasePythonDataSourceTestsMixin:
 
         df = self.spark.read.format("TestDataSource").load()
         assertDataFrameEqual(df, [Row(c=0, d=1)])
+
+    def register_data_source(
+        self,
+        read_func: Callable,
+        partition_func: Callable = None,
+        output: Union[str, StructType] = "i int, j int",
+        name: str = "test",
+    ):
+        class TestDataSourceReader(DataSourceReader):
+            def __init__(self, schema):
+                self.schema = schema
+
+            def partitions(self):
+                if partition_func is not None:
+                    return partition_func()
+                else:
+                    raise NotImplementedError
+
+            def read(self, partition):
+                return read_func(self.schema, partition)
+
+        class TestDataSource(DataSource):
+            @classmethod
+            def name(cls):
+                return name
+
+            def schema(self):
+                return output
+
+            def reader(self, schema) -> "DataSourceReader":
+                return TestDataSourceReader(schema)
+
+        self.spark.dataSource.register(TestDataSource)
+
+    def test_data_source_read_output_tuple(self):
+        self.register_data_source(read_func=lambda schema, partition: iter([(0, 1)]))
+        df = self.spark.read.format("test").load()
+        assertDataFrameEqual(df, [Row(0, 1)])
+
+    def test_data_source_read_output_list(self):
+        self.register_data_source(read_func=lambda schema, partition: iter([[0, 1]]))
+        df = self.spark.read.format("test").load()
+        assertDataFrameEqual(df, [Row(0, 1)])
+
+    def test_data_source_read_output_row(self):
+        self.register_data_source(read_func=lambda schema, partition: iter([Row(0, 1)]))
+        df = self.spark.read.format("test").load()
+        assertDataFrameEqual(df, [Row(0, 1)])
+
+    def test_data_source_read_output_none(self):
+        self.register_data_source(read_func=lambda schema, partition: None)
+        df = self.spark.read.format("test").load()
+        with self.assertRaisesRegex(PythonException, "PYTHON_DATA_SOURCE_READ_INVALID_RETURN_TYPE"):
+            assertDataFrameEqual(df, [])
+
+    def test_data_source_read_output_empty_iter(self):
+        self.register_data_source(read_func=lambda schema, partition: iter([]))
+        df = self.spark.read.format("test").load()
+        assertDataFrameEqual(df, [])
+
+    def test_data_source_read_cast_output_schema(self):
+        self.register_data_source(
+            read_func=lambda schema, partition: iter([(0, 1)]), output="i long, j string"
+        )
+        df = self.spark.read.format("test").load()
+        assertDataFrameEqual(df, [Row(i=0, j="1")])
+
+    def test_data_source_read_output_with_partition(self):
+        def partition_func():
+            return [InputPartition(0), InputPartition(1)]
+
+        def read_func(schema, partition):
+            if partition.value == 0:
+                return iter([])
+            elif partition.value == 1:
+                yield (0, 1)
+
+        self.register_data_source(read_func=read_func, partition_func=partition_func)
+        df = self.spark.read.format("test").load()
+        assertDataFrameEqual(df, [Row(0, 1)])
+
+    def test_data_source_read_output_with_schema_mismatch(self):
+        self.register_data_source(read_func=lambda schema, partition: iter([(0, 1)]))
+        df = self.spark.read.format("test").schema("i int").load()
+        with self.assertRaisesRegex(
+            PythonException, "PYTHON_DATA_SOURCE_READ_RETURN_SCHEMA_MISMATCH"
+        ):
+            df.collect()
+        self.register_data_source(
+            read_func=lambda schema, partition: iter([(0, 1)]), output="i int, j int, k int"
+        )
+        with self.assertRaisesRegex(
+            PythonException, "PYTHON_DATA_SOURCE_READ_RETURN_SCHEMA_MISMATCH"
+        ):
+            df.collect()
+
+    def test_read_with_invalid_return_row_type(self):
+        self.register_data_source(read_func=lambda schema, partition: iter([1]))
+        df = self.spark.read.format("test").load()
+        with self.assertRaisesRegex(PythonException, "PYTHON_DATA_SOURCE_READ_INVALID_RETURN_TYPE"):
+            df.collect()
 
     def test_in_memory_data_source(self):
         class InMemDataSourceReader(DataSourceReader):

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/pythonLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/pythonLogicalOperators.scala
@@ -134,9 +134,9 @@ case class PythonDataSourcePartitions(
 }
 
 object PythonDataSourcePartitions {
-  def getOutputAttrs: Seq[Attribute] = {
-    toAttributes(new StructType().add("partition", BinaryType))
-  }
+  def schema: StructType = new StructType().add("partition", BinaryType)
+
+  def getOutputAttrs: Seq[Attribute] = toAttributes(schema)
 }
 
 /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PlanPythonDataSourceScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PlanPythonDataSourceScan.scala
@@ -51,7 +51,10 @@ object PlanPythonDataSourceScan extends Rule[LogicalPlan] {
   def apply(plan: LogicalPlan): LogicalPlan = plan.transformDownWithPruning(
     _.containsPattern(PYTHON_DATA_SOURCE)) {
     case ds @ PythonDataSource(dataSource: PythonFunction, schema, _) =>
-      val info = new UserDefinedPythonDataSourceReadRunner(dataSource, schema).runInPython()
+      val inputSchema = PythonDataSourcePartitions.schema
+
+      val info = new UserDefinedPythonDataSourceReadRunner(
+        dataSource, inputSchema, schema).runInPython()
 
       val readerFunc = SimplePythonFunction(
         command = info.func.toImmutableArraySeq,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PlanPythonDataSourceScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PlanPythonDataSourceScan.scala
@@ -18,8 +18,8 @@
 package org.apache.spark.sql.execution.datasources
 
 import org.apache.spark.api.python.{PythonEvalType, PythonFunction, SimplePythonFunction}
-import org.apache.spark.sql.catalyst.expressions.PythonUDTF
-import org.apache.spark.sql.catalyst.plans.logical.{Generate, LogicalPlan, Project, PythonDataSource, PythonDataSourcePartitions}
+import org.apache.spark.sql.catalyst.expressions.PythonUDF
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Project, PythonDataSource, PythonDataSourcePartitions, PythonMapInArrow}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.trees.TreePattern.PYTHON_DATA_SOURCE
 import org.apache.spark.sql.execution.python.UserDefinedPythonDataSourceReadRunner
@@ -40,12 +40,12 @@ import org.apache.spark.util.ArrayImplicits._
  * class. Post this rule, the plan is transformed into:
  *
  *  Project [output]
- *  +- Generate [python_data_source_read_udtf, ...]
+ *  +- PythonMapInArrow [read_from_data_source, ...]
  *     +- PythonDataSourcePartitions [partition_bytes]
  *
  * The PythonDataSourcePartitions contains a list of serialized partition values for the data
- * source. The `DataSourceReader.read` method will be planned as a UDTF that accepts a partition
- * value and yields the scanning output.
+ * source. The `DataSourceReader.read` method will be planned as a MapInArrow operator that
+ * accepts a partition value and yields the scanning output.
  */
 object PlanPythonDataSourceScan extends Rule[LogicalPlan] {
   def apply(plan: LogicalPlan): LogicalPlan = plan.transformDownWithPruning(
@@ -65,27 +65,22 @@ object PlanPythonDataSourceScan extends Rule[LogicalPlan] {
       val partitionPlan = PythonDataSourcePartitions(
         PythonDataSourcePartitions.getOutputAttrs, info.partitions)
 
-      // Construct a Python UDTF for the reader function.
-      val pythonUDTF = PythonUDTF(
-        name = "python_data_source_read",
+      val pythonUDF = PythonUDF(
+        name = "read_from_data_source",
         func = readerFunc,
-        elementSchema = schema,
+        dataType = schema,
         children = partitionPlan.output,
-        evalType = PythonEvalType.SQL_TABLE_UDF,
-        udfDeterministic = false,
-        pickledAnalyzeResult = None)
+        evalType = PythonEvalType.SQL_MAP_ARROW_ITER_UDF,
+        udfDeterministic = false)
 
-      // Later the rule `ExtractPythonUDTFs` will turn this Generate
-      // into a evaluable Python UDTF node.
-      val generate = Generate(
-        generator = pythonUDTF,
-        unrequiredChildIndex = Nil,
-        outer = false,
-        qualifier = None,
-        generatorOutput = ds.output,
-        child = partitionPlan)
+      // Construct the plan.
+      val plan = PythonMapInArrow(
+        pythonUDF,
+        ds.output,
+        partitionPlan,
+        isBarrier = false)
 
       // Project out partition values.
-      Project(ds.output, generate)
+      Project(ds.output, plan)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/PythonPlannerRunner.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/PythonPlannerRunner.scala
@@ -77,8 +77,6 @@ abstract class PythonPlannerRunner[T](func: PythonFunction) {
 
     envVars.put("SPARK_JOB_ARTIFACT_UUID", jobArtifactUUID.getOrElse("default"))
 
-    envVars.put("ARROW_MAX_RECORDS_PER_BATCH", SQLConf.get.arrowMaxRecordsPerBatch.toString)
-
     EvaluatePython.registerPicklers()
     val pickler = new Pickler(/* useMemo = */ true,
       /* valueCompare = */ false)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/PythonPlannerRunner.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/PythonPlannerRunner.scala
@@ -77,6 +77,8 @@ abstract class PythonPlannerRunner[T](func: PythonFunction) {
 
     envVars.put("SPARK_JOB_ARTIFACT_UUID", jobArtifactUUID.getOrElse("default"))
 
+    envVars.put("ARROW_MAX_RECORDS_PER_BATCH", SQLConf.get.arrowMaxRecordsPerBatch.toString)
+
     EvaluatePython.registerPicklers()
     val pickler = new Pickler(/* useMemo = */ true,
       /* valueCompare = */ false)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/UserDefinedPythonDataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/UserDefinedPythonDataSource.scala
@@ -29,6 +29,7 @@ import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, PythonDataSourc
 import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
 import org.apache.spark.sql.errors.QueryCompilationErrors
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{DataType, StructType}
 import org.apache.spark.util.ArrayImplicits._
 
@@ -169,8 +170,11 @@ class UserDefinedPythonDataSourceReadRunner(
     // Send input schema
     PythonWorkerUtils.writeUTF(inputSchema.json, dataOut)
 
-    // Send schema
+    // Send output schema
     PythonWorkerUtils.writeUTF(outputSchema.json, dataOut)
+
+    // Send configurations
+    dataOut.writeInt(SQLConf.get.arrowMaxRecordsPerBatch)
   }
 
   override protected def receiveFromPython(dataIn: DataInputStream): PythonDataSourceReadInfo = {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR changes how we plan Python data source read. Instead of using a regular Python UDTF, we can use an arrow UDF and plan the data source read using the MapInArrow operator. 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To improve the performance

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No 

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Unit tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No