### PR TITLE
[SPARK-46256][CORE] Parallel Compression Support for ZSTD

### DIFF
--- a/core/benchmarks/ZStandardBenchmark-jdk21-results.txt
+++ b/core/benchmarks/ZStandardBenchmark-jdk21-results.txt
@@ -6,22 +6,44 @@ OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1051-azure
 AMD EPYC 7763 64-Core Processor
 Benchmark ZStandardCompressionCodec:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------
-Compression 10000 times at level 1 without buffer pool            675            925         281          0.0       67464.0       1.0X
-Compression 10000 times at level 2 without buffer pool            901            902           3          0.0       90079.7       0.7X
-Compression 10000 times at level 3 without buffer pool            994            998           6          0.0       99413.5       0.7X
-Compression 10000 times at level 1 with buffer pool               813            813           0          0.0       81311.2       0.8X
-Compression 10000 times at level 2 with buffer pool               873            874           0          0.0       87335.4       0.8X
-Compression 10000 times at level 3 with buffer pool               987            987           1          0.0       98671.2       0.7X
+Compression 10000 times at level 1 without buffer pool            672            681          10          0.0       67171.0       1.0X
+Compression 10000 times at level 2 without buffer pool            715            718           4          0.0       71458.8       0.9X
+Compression 10000 times at level 3 without buffer pool            831            835           4          0.0       83139.1       0.8X
+Compression 10000 times at level 1 with buffer pool               609            611           2          0.0       60881.5       1.1X
+Compression 10000 times at level 2 with buffer pool               648            649           1          0.0       64791.0       1.0X
+Compression 10000 times at level 3 with buffer pool               744            751           6          0.0       74392.4       0.9X
 
 OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1051-azure
 AMD EPYC 7763 64-Core Processor
 Benchmark ZStandardCompressionCodec:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------
-Decompression 10000 times from level 1 without buffer pool            826            829           3          0.0       82582.8       1.0X
-Decompression 10000 times from level 2 without buffer pool            827            829           2          0.0       82728.9       1.0X
-Decompression 10000 times from level 3 without buffer pool            821            823           2          0.0       82099.0       1.0X
-Decompression 10000 times from level 1 with buffer pool               755            755           1          0.0       75470.0       1.1X
-Decompression 10000 times from level 2 with buffer pool               756            758           3          0.0       75579.0       1.1X
-Decompression 10000 times from level 3 with buffer pool               755            755           0          0.0       75526.6       1.1X
+Decompression 10000 times from level 1 without buffer pool            842            849          12          0.0       84240.0       1.0X
+Decompression 10000 times from level 2 without buffer pool            842            846           6          0.0       84185.2       1.0X
+Decompression 10000 times from level 3 without buffer pool            843            844           1          0.0       84285.4       1.0X
+Decompression 10000 times from level 1 with buffer pool               770            771           1          0.0       77024.9       1.1X
+Decompression 10000 times from level 2 with buffer pool               771            771           0          0.0       77120.4       1.1X
+Decompression 10000 times from level 3 with buffer pool               770            771           0          0.0       77031.9       1.1X
+
+OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1051-azure
+AMD EPYC 7763 64-Core Processor
+Parallel Compression at level 3:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Parallel Compression with 0 workers                  48             50           3          0.0      376597.0       1.0X
+Parallel Compression with 1 workers                  41             42           3          0.0      318927.3       1.2X
+Parallel Compression with 2 workers                  38             40           2          0.0      297410.2       1.3X
+Parallel Compression with 4 workers                  37             39           1          0.0      287605.8       1.3X
+Parallel Compression with 8 workers                  39             40           1          0.0      301948.1       1.2X
+Parallel Compression with 16 workers                 41             43           1          0.0      317095.6       1.2X
+
+OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1051-azure
+AMD EPYC 7763 64-Core Processor
+Parallel Compression at level 9:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Parallel Compression with 0 workers                 174            175           1          0.0     1360596.3       1.0X
+Parallel Compression with 1 workers                 189            228          24          0.0     1477060.7       0.9X
+Parallel Compression with 2 workers                 109            118          15          0.0      851455.9       1.6X
+Parallel Compression with 4 workers                 114            118           3          0.0      891964.9       1.5X
+Parallel Compression with 8 workers                 115            122           4          0.0      899748.7       1.5X
+Parallel Compression with 16 workers                119            123           2          0.0      931210.7       1.5X
 
 

--- a/core/benchmarks/ZStandardBenchmark-results.txt
+++ b/core/benchmarks/ZStandardBenchmark-results.txt
@@ -2,26 +2,48 @@
 Benchmark ZStandardCompressionCodec
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.9+0 on Mac OS X 14.1.2
-Apple M2 Max
+OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1051-azure
+AMD EPYC 7763 64-Core Processor
 Benchmark ZStandardCompressionCodec:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------
-Compression 10000 times at level 1 without buffer pool           1573           1576           4          0.0      157331.9       1.0X
-Compression 10000 times at level 2 without buffer pool           1907           1972          92          0.0      190663.7       0.8X
-Compression 10000 times at level 3 without buffer pool           2004           2038          49          0.0      200351.7       0.8X
-Compression 10000 times at level 1 with buffer pool              2223           2278          77          0.0      222348.1       0.7X
-Compression 10000 times at level 2 with buffer pool              2376           2384          11          0.0      237598.2       0.7X
-Compression 10000 times at level 3 with buffer pool              2357           2372          21          0.0      235745.3       0.7X
+Compression 10000 times at level 1 without buffer pool            666            669           3          0.0       66598.6       1.0X
+Compression 10000 times at level 2 without buffer pool            711            711           1          0.0       71077.5       0.9X
+Compression 10000 times at level 3 without buffer pool            816            816           0          0.0       81575.8       0.8X
+Compression 10000 times at level 1 with buffer pool               591            592           1          0.0       59095.6       1.1X
+Compression 10000 times at level 2 with buffer pool               630            632           1          0.0       62995.1       1.1X
+Compression 10000 times at level 3 with buffer pool               742            742           0          0.0       74180.7       0.9X
 
-OpenJDK 64-Bit Server VM 17.0.9+0 on Mac OS X 14.1.2
-Apple M2 Max
+OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1051-azure
+AMD EPYC 7763 64-Core Processor
 Benchmark ZStandardCompressionCodec:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------
-Decompression 10000 times from level 1 without buffer pool            588            590           2          0.0       58753.5       1.0X
-Decompression 10000 times from level 2 without buffer pool            560            574          18          0.0       55997.1       1.0X
-Decompression 10000 times from level 3 without buffer pool            593            604          11          0.0       59274.0       1.0X
-Decompression 10000 times from level 1 with buffer pool               535            564          21          0.0       53459.2       1.1X
-Decompression 10000 times from level 2 with buffer pool               523            545          17          0.0       52335.3       1.1X
-Decompression 10000 times from level 3 with buffer pool               596            638          45          0.0       59619.8       1.0X
+Decompression 10000 times from level 1 without buffer pool            600            602           1          0.0       60024.1       1.0X
+Decompression 10000 times from level 2 without buffer pool            600            603           2          0.0       59973.0       1.0X
+Decompression 10000 times from level 3 without buffer pool            601            602           1          0.0       60075.9       1.0X
+Decompression 10000 times from level 1 with buffer pool               553            553           0          0.0       55316.4       1.1X
+Decompression 10000 times from level 2 with buffer pool               553            554           1          0.0       55271.5       1.1X
+Decompression 10000 times from level 3 with buffer pool               553            553           0          0.0       55261.4       1.1X
+
+OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1051-azure
+AMD EPYC 7763 64-Core Processor
+Parallel Compression at level 3:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Parallel Compression with 0 workers                  49             50           1          0.0      380070.1       1.0X
+Parallel Compression with 1 workers                  41             42           4          0.0      319807.1       1.2X
+Parallel Compression with 2 workers                  38             41           2          0.0      297706.4       1.3X
+Parallel Compression with 4 workers                  38             40           2          0.0      296505.8       1.3X
+Parallel Compression with 8 workers                  39             41           1          0.0      305793.6       1.2X
+Parallel Compression with 16 workers                 43             44           1          0.0      332233.1       1.1X
+
+OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1051-azure
+AMD EPYC 7763 64-Core Processor
+Parallel Compression at level 9:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Parallel Compression with 0 workers                 175            175           0          0.0     1363800.8       1.0X
+Parallel Compression with 1 workers                 186            187           3          0.0     1455096.4       0.9X
+Parallel Compression with 2 workers                 110            115           6          0.0      863272.6       1.6X
+Parallel Compression with 4 workers                 104            108           2          0.0      810721.1       1.7X
+Parallel Compression with 8 workers                 110            112           2          0.0      859303.5       1.6X
+Parallel Compression with 16 workers                109            112           2          0.0      847863.6       1.6X
 
 

--- a/core/benchmarks/ZStandardBenchmark-results.txt
+++ b/core/benchmarks/ZStandardBenchmark-results.txt
@@ -2,26 +2,26 @@
 Benchmark ZStandardCompressionCodec
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1051-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.9+0 on Mac OS X 14.1.2
+Apple M2 Max
 Benchmark ZStandardCompressionCodec:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------
-Compression 10000 times at level 1 without buffer pool            657            659           2          0.0       65716.9       1.0X
-Compression 10000 times at level 2 without buffer pool            706            707           1          0.0       70617.1       0.9X
-Compression 10000 times at level 3 without buffer pool            788            788           0          0.0       78755.6       0.8X
-Compression 10000 times at level 1 with buffer pool               585            586           1          0.0       58455.1       1.1X
-Compression 10000 times at level 2 with buffer pool               614            616           1          0.0       61437.2       1.1X
-Compression 10000 times at level 3 with buffer pool               717            717           0          0.0       71705.1       0.9X
+Compression 10000 times at level 1 without buffer pool           1573           1576           4          0.0      157331.9       1.0X
+Compression 10000 times at level 2 without buffer pool           1907           1972          92          0.0      190663.7       0.8X
+Compression 10000 times at level 3 without buffer pool           2004           2038          49          0.0      200351.7       0.8X
+Compression 10000 times at level 1 with buffer pool              2223           2278          77          0.0      222348.1       0.7X
+Compression 10000 times at level 2 with buffer pool              2376           2384          11          0.0      237598.2       0.7X
+Compression 10000 times at level 3 with buffer pool              2357           2372          21          0.0      235745.3       0.7X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1051-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.9+0 on Mac OS X 14.1.2
+Apple M2 Max
 Benchmark ZStandardCompressionCodec:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------
-Decompression 10000 times from level 1 without buffer pool            595            596           0          0.0       59535.3       1.0X
-Decompression 10000 times from level 2 without buffer pool            594            595           1          0.0       59432.7       1.0X
-Decompression 10000 times from level 3 without buffer pool            595            600          10          0.0       59485.8       1.0X
-Decompression 10000 times from level 1 with buffer pool               549            549           1          0.0       54859.6       1.1X
-Decompression 10000 times from level 2 with buffer pool               549            550           0          0.0       54948.0       1.1X
-Decompression 10000 times from level 3 with buffer pool               549            549           0          0.0       54917.9       1.1X
+Decompression 10000 times from level 1 without buffer pool            588            590           2          0.0       58753.5       1.0X
+Decompression 10000 times from level 2 without buffer pool            560            574          18          0.0       55997.1       1.0X
+Decompression 10000 times from level 3 without buffer pool            593            604          11          0.0       59274.0       1.0X
+Decompression 10000 times from level 1 with buffer pool               535            564          21          0.0       53459.2       1.1X
+Decompression 10000 times from level 2 with buffer pool               523            545          17          0.0       52335.3       1.1X
+Decompression 10000 times from level 3 with buffer pool               596            638          45          0.0       59619.8       1.0X
 
 

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1910,6 +1910,16 @@ package object config {
       .booleanConf
       .createWithDefault(true)
 
+  private[spark] val IO_COMPRESSION_ZSTD_WORKERS =
+    ConfigBuilder("spark.io.compression.zstd.workers")
+      .doc("Thread size spawned to compress in parallel when using Zstd. When value <= 0, " +
+        "no worker is spawned, it works in single-threaded mode. When value > 0, it triggers " +
+        "asynchronous mode, corresponding number of threads are spawned. More workers improve " +
+        "performance, but also increase memory cost.")
+      .version("4.0.0")
+      .intConf
+      .createWithDefault(8)
+
   private[spark] val IO_COMPRESSION_ZSTD_LEVEL =
     ConfigBuilder("spark.io.compression.zstd.level")
       .doc("Compression level for Zstd compression codec. Increasing the compression " +

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1912,13 +1912,14 @@ package object config {
 
   private[spark] val IO_COMPRESSION_ZSTD_WORKERS =
     ConfigBuilder("spark.io.compression.zstd.workers")
-      .doc("Thread size spawned to compress in parallel when using Zstd. When value <= 0, " +
+      .doc("Thread size spawned to compress in parallel when using Zstd. When the value is 0, " +
         "no worker is spawned, it works in single-threaded mode. When value > 0, it triggers " +
         "asynchronous mode, corresponding number of threads are spawned. More workers improve " +
         "performance, but also increase memory cost.")
       .version("4.0.0")
       .intConf
-      .createWithDefault(8)
+      .checkValue(_ >=0, "The number of workers must not be negative.")
+      .createWithDefault(0)
 
   private[spark] val IO_COMPRESSION_ZSTD_LEVEL =
     ConfigBuilder("spark.io.compression.zstd.level")

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1918,7 +1918,7 @@ package object config {
         "performance, but also increase memory cost.")
       .version("4.0.0")
       .intConf
-      .checkValue(_ >=0, "The number of workers must not be negative.")
+      .checkValue(_ >= 0, "The number of workers must not be negative.")
       .createWithDefault(0)
 
   private[spark] val IO_COMPRESSION_ZSTD_LEVEL =

--- a/core/src/main/scala/org/apache/spark/io/CompressionCodec.scala
+++ b/core/src/main/scala/org/apache/spark/io/CompressionCodec.scala
@@ -233,10 +233,12 @@ class ZStdCompressionCodec(conf: SparkConf) extends CompressionCodec {
     NoPool.INSTANCE
   }
 
+  private val workers = conf.get(IO_COMPRESSION_ZSTD_WORKERS)
+
   override def compressedOutputStream(s: OutputStream): OutputStream = {
     // Wrap the zstd output stream in a buffered output stream, so that we can
     // avoid overhead excessive of JNI call while trying to compress small amount of data.
-    val os = new ZstdOutputStreamNoFinalizer(s, bufferPool).setLevel(level)
+    val os = new ZstdOutputStreamNoFinalizer(s, bufferPool).setLevel(level).setWorkers(workers)
     new BufferedOutputStream(os, bufferSize)
   }
 
@@ -244,7 +246,9 @@ class ZStdCompressionCodec(conf: SparkConf) extends CompressionCodec {
     // SPARK-29322: Set "closeFrameOnFlush" to 'true' to let continuous input stream not being
     // stuck on reading open frame.
     val os = new ZstdOutputStreamNoFinalizer(s, bufferPool)
-      .setLevel(level).setCloseFrameOnFlush(true)
+      .setLevel(level)
+      .setWorkers(workers)
+      .setCloseFrameOnFlush(true)
     new BufferedOutputStream(os, bufferSize)
   }
 

--- a/core/src/test/scala/org/apache/spark/io/ZStandardBenchmark.scala
+++ b/core/src/test/scala/org/apache/spark/io/ZStandardBenchmark.scala
@@ -17,11 +17,11 @@
 
 package org.apache.spark.io
 
-import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, ObjectOutputStream}
 
 import org.apache.spark.SparkConf
 import org.apache.spark.benchmark.{Benchmark, BenchmarkBase}
-import org.apache.spark.internal.config.{IO_COMPRESSION_ZSTD_BUFFERPOOL_ENABLED, IO_COMPRESSION_ZSTD_BUFFERSIZE, IO_COMPRESSION_ZSTD_LEVEL}
+import org.apache.spark.internal.config.{IO_COMPRESSION_ZSTD_BUFFERPOOL_ENABLED, IO_COMPRESSION_ZSTD_BUFFERSIZE, IO_COMPRESSION_ZSTD_LEVEL, IO_COMPRESSION_ZSTD_WORKERS}
 
 
 /**
@@ -49,6 +49,7 @@ object ZStandardBenchmark extends BenchmarkBase {
       val benchmark2 = new Benchmark(name, N, output = output)
       decompressionBenchmark(benchmark2, N)
       benchmark2.run()
+      parallelCompressionBenchmark()
     }
   }
 
@@ -98,6 +99,30 @@ object ZStandardBenchmark extends BenchmarkBase {
             is.close()
           }
         }
+      }
+    }
+  }
+
+  private def parallelCompressionBenchmark(): Unit = {
+    val N = 128
+    val data = (1 until 128 * 1024 * 1024).toArray
+
+    Seq(3, 9).foreach { level =>
+      val benchmark = new Benchmark(s"Parallel Compression at level $level", N, output = output)
+      Seq(0, 1, 2, 4, 8, 16).foreach { workers =>
+        val conf = new SparkConf(false)
+          .set(IO_COMPRESSION_ZSTD_LEVEL, level)
+          .set(IO_COMPRESSION_ZSTD_WORKERS, workers)
+        benchmark.addCase(s"Parallel Compression with $workers workers") { _ =>
+          val baos = new ByteArrayOutputStream()
+          val zcos = new ZStdCompressionCodec(conf).compressedOutputStream(baos)
+          val oos = new ObjectOutputStream(zcos)
+          1 to N foreach { _ =>
+            oos.writeObject(data)
+          }
+          oos.close()
+        }
+        benchmark.run()
       }
     }
   }

--- a/core/src/test/scala/org/apache/spark/io/ZStandardBenchmark.scala
+++ b/core/src/test/scala/org/apache/spark/io/ZStandardBenchmark.scala
@@ -104,11 +104,12 @@ object ZStandardBenchmark extends BenchmarkBase {
   }
 
   private def parallelCompressionBenchmark(): Unit = {
-    val N = 128
-    val data = (1 until 128 * 1024 * 1024).toArray
+    val numberOfLargeObjectToWrite = 128
+    val data: Array[Byte] = (1 until 256 * 1024 * 1024).map(_.toByte).toArray
 
     Seq(3, 9).foreach { level =>
-      val benchmark = new Benchmark(s"Parallel Compression at level $level", N, output = output)
+      val benchmark = new Benchmark(
+        s"Parallel Compression at level $level", numberOfLargeObjectToWrite, output = output)
       Seq(0, 1, 2, 4, 8, 16).foreach { workers =>
         val conf = new SparkConf(false)
           .set(IO_COMPRESSION_ZSTD_LEVEL, level)
@@ -117,7 +118,7 @@ object ZStandardBenchmark extends BenchmarkBase {
           val baos = new ByteArrayOutputStream()
           val zcos = new ZStdCompressionCodec(conf).compressedOutputStream(baos)
           val oos = new ObjectOutputStream(zcos)
-          1 to N foreach { _ =>
+          1 to numberOfLargeObjectToWrite foreach { _ =>
             oos.writeObject(data)
           }
           oos.close()

--- a/core/src/test/scala/org/apache/spark/io/ZStandardBenchmark.scala
+++ b/core/src/test/scala/org/apache/spark/io/ZStandardBenchmark.scala
@@ -123,8 +123,8 @@ object ZStandardBenchmark extends BenchmarkBase {
           }
           oos.close()
         }
-        benchmark.run()
       }
+      benchmark.run()
     }
   }
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1761,6 +1761,17 @@ Apart from these, the following properties are also available, and may be useful
   <td>2.3.0</td>
 </tr>
 <tr>
+  <td><code>spark.io.compression.zstd.workers</code></td>
+  <td>8</td>
+  <td>
+    Thread size spawned to compress in parallel when using Zstd. When value <= 0
+    no worker is spawned, it works in single-threaded mode. When value > 0, it triggers
+    asynchronous mode, corresponding number of threads are spawned. More workers improve
+    performance, but also increase memory cost.
+  </td>
+  <td>4.0.0</td>
+</tr>
+<tr>
   <td><code>spark.kryo.classesToRegister</code></td>
   <td>(none)</td>
   <td>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1764,7 +1764,7 @@ Apart from these, the following properties are also available, and may be useful
   <td><code>spark.io.compression.zstd.workers</code></td>
   <td>8</td>
   <td>
-    Thread size spawned to compress in parallel when using Zstd. When value <= 0
+    Thread size spawned to compress in parallel when using Zstd. When value is 0
     no worker is spawned, it works in single-threaded mode. When value > 0, it triggers
     asynchronous mode, corresponding number of threads are spawned. More workers improve
     performance, but also increase memory cost.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1762,7 +1762,7 @@ Apart from these, the following properties are also available, and may be useful
 </tr>
 <tr>
   <td><code>spark.io.compression.zstd.workers</code></td>
-  <td>8</td>
+  <td>0</td>
   <td>
     Thread size spawned to compress in parallel when using Zstd. When value is 0
     no worker is spawned, it works in single-threaded mode. When value > 0, it triggers


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR adds a new configuration named `spark.io.compression.zstd.workers`, which enables Parallel Compression Support for ZSTD.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Sufficient performance improvement.

```
[info] OpenJDK 64-Bit Server VM 17.0.9+0 on Mac OS X 14.1.2
[info] Apple M2 Max
[info] Parallel Compression at level 9:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
[info] ------------------------------------------------------------------------------------------------------------------------
[info] Parallel Compression with 0 workers                 883            885           3          0.0     6896156.6       1.0X
[info] Parallel Compression with 1 workers                 785            789           3          0.0     6136529.9       1.1X
[info] Parallel Compression with 2 workers                 428            431           3          0.0     3346625.6       2.1X
[info] Parallel Compression with 4 workers                 273            275           1          0.0     2131454.4       3.2X
[info] Parallel Compression with 8 workers                 215            218           2          0.0     1681013.7       4.1X
[info] Parallel Compression with 16 workers                222            226           4          0.0     1733805.3       4.0X
```
 
### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes, we introduced a new configuration for this new feature.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

It's done by new benchmarks added in ZStandardCompressionCodec.

https://github.com/yaooqinn/spark/actions/runs/7095872839
https://github.com/yaooqinn/spark/actions/runs/7095873975
 
### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

no