### PR TITLE
[SPARK-46259][PYTHON][DOCS] Add an appropriate link for error class usage documentation.

### DIFF
--- a/python/docs/source/development/contributing.rst
+++ b/python/docs/source/development/contributing.rst
@@ -246,9 +246,9 @@ To throw a standardized user-facing error or exception, developers should specif
 Usage
 ~~~~~
 
-1. Check if an appropriate error class already exists in `error_classes.py`.
+1. Check if an appropriate error class already exists in `Error classes in PySpark <errors.rst#error-classes-in-pyspark>`_.
    If true, use the error class and skip to step 3.
-2. Add a new class to `error_classes.py`; keep in mind the invariants below.
+2. Add a new class to `error_classes.py <https://github.com/apache/spark/blob/master/python/pyspark/errors/error_classes.py>`_; keep in mind the invariants below.
 3. Check if the exception type already extends `PySparkException`.
    If true, skip to step 5.
 4. Mix `PySparkException` into the exception.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to add appropriate link for error class usage documentation.


### Why are the changes needed?

The current [Usage of Contributing Error and Exception documentation](https://spark.apache.org/docs/latest/api/python/development/contributing.html#usage) is lack of information where users exactly can search the existing error classes, and also where users can add a new error classes. We should add an appropriate link to make the documentation clearer.


### Does this PR introduce _any_ user-facing change?

No API changes, but this improves the usability of error class usage documentation:

**Before**

<img width="724" alt="Screenshot 2023-12-05 at 12 25 32 PM" src="https://github.com/apache/spark/assets/44108233/df9f80e2-2f99-413c-aca2-0e8634440a46">


**After**
<img width="712" alt="Screenshot 2023-12-05 at 12 24 25 PM" src="https://github.com/apache/spark/assets/44108233/bba6d43f-bf85-4e3b-86ea-df9bad4634a6">


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Manually build docs and confirm.


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.
