### PR TITLE
[SPARK-46277][PYTHON] Validate startup urls with the config being set

### DIFF
--- a/python/pyspark/errors/error_classes.py
+++ b/python/pyspark/errors/error_classes.py
@@ -84,14 +84,14 @@ ERROR_CLASSES_JSON = """
       "Argument `<arg_name>` cannot be None."
     ]
   },
-  "CANNOT_CONFIGURE_SPARK_CONNECT": {
+  "CANNOT_CONFIGURE_SPARK_CONNECT_MASTER": {
     "message": [
-      "Spark Connect server cannot be configured with Spark master; however, found URL for Spark master [<url>]."
+      "Spark Connect server and Spark master cannot be configured together: Spark master [<master_url>], Spark Connect [<connect_url>]."
     ]
   },
-  "CANNOT_CONFIGURE_SPARK_MASTER": {
+  "CANNOT_CONFIGURE_SPARK_CONNECT": {
     "message": [
-      "Spark master cannot be configured with Spark Connect server; however, found URL for Spark Connect [<url>]."
+      "Spark Connect server cannot be configured: Existing [<existing_url>], New [<new_url>]."
     ]
   },
   "CANNOT_CONVERT_COLUMN_INTO_BOOL": {

--- a/python/pyspark/errors/error_classes.py
+++ b/python/pyspark/errors/error_classes.py
@@ -84,14 +84,14 @@ ERROR_CLASSES_JSON = """
       "Argument `<arg_name>` cannot be None."
     ]
   },
-  "CANNOT_CONFIGURE_SPARK_CONNECT_MASTER": {
-    "message": [
-      "Spark Connect server and Spark master cannot be configured together: Spark master [<master_url>], Spark Connect [<connect_url>]."
-    ]
-  },
   "CANNOT_CONFIGURE_SPARK_CONNECT": {
     "message": [
       "Spark Connect server cannot be configured: Existing [<existing_url>], New [<new_url>]."
+    ]
+  },
+  "CANNOT_CONFIGURE_SPARK_CONNECT_MASTER": {
+    "message": [
+      "Spark Connect server and Spark master cannot be configured together: Spark master [<master_url>], Spark Connect [<connect_url>]."
     ]
   },
   "CANNOT_CONVERT_COLUMN_INTO_BOOL": {

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -286,17 +286,17 @@ class SparkSession(SparkConversionMixin):
             with self._lock:
                 if conf is not None:
                     for k, v in conf.getAll():
-                        self._validate_startup_urls()
                         self._options[k] = v
+                        self._validate_startup_urls()
                 elif map is not None:
                     for k, v in map.items():  # type: ignore[assignment]
                         v = to_str(v)  # type: ignore[assignment]
-                        self._validate_startup_urls()
                         self._options[k] = v
+                        self._validate_startup_urls()
                 else:
                     value = to_str(value)
-                    self._validate_startup_urls()
                     self._options[cast(str, key)] = value
+                    self._validate_startup_urls()
                 return self
 
         def _validate_startup_urls(

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -306,22 +306,16 @@ class SparkSession(SparkConversionMixin):
             Helper function that validates the combination of startup URLs and raises an exception
             if incompatible options are selected.
             """
-            if "spark.master" in self._options and (
+            if ("spark.master" in self._options or "MASTER" in os.environ) and (
                 "spark.remote" in self._options or "SPARK_REMOTE" in os.environ
             ):
                 raise PySparkRuntimeError(
-                    error_class="CANNOT_CONFIGURE_SPARK_MASTER",
+                    error_class="CANNOT_CONFIGURE_SPARK_CONNECT_MASTER",
                     message_parameters={
-                        "url": self._options.get("spark.remote", os.environ.get("SPARK_REMOTE"))
-                    },
-                )
-            if "spark.remote" in self._options and (
-                "spark.master" in self._options or "MASTER" in os.environ
-            ):
-                raise PySparkRuntimeError(
-                    error_class="CANNOT_CONFIGURE_SPARK_CONNECT",
-                    message_parameters={
-                        "url": self._options.get("spark.master", os.environ.get("MASTER"))
+                        "master_url": self._options.get("spark.master", os.environ.get("MASTER")),
+                        "connect_url": self._options.get(
+                            "spark.remote", os.environ.get("SPARK_REMOTE")
+                        ),
                     },
                 )
 
@@ -333,8 +327,8 @@ class SparkSession(SparkConversionMixin):
                     raise PySparkRuntimeError(
                         error_class="CANNOT_CONFIGURE_SPARK_CONNECT",
                         message_parameters={
-                            "new_url": os.environ["SPARK_REMOTE"],
-                            "existing_url": remote,
+                            "existing_url": os.environ["SPARK_REMOTE"],
+                            "new_url": remote,
                         },
                     )
 

--- a/python/pyspark/sql/tests/test_session.py
+++ b/python/pyspark/sql/tests/test_session.py
@@ -352,6 +352,22 @@ class SparkSessionBuilderTests(unittest.TestCase):
             if session is not None:
                 session.stop()
 
+    def test_create_spark_context_with_invalid_configs(self):
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "Spark master cannot be configured with Spark "
+            "Connect server; however, found URL for Spark Connect",
+        ):
+            SparkSession.builder.config(map={"spark.master": "x", "spark.remote": "y"})
+
+        with unittest.mock.patch.dict(
+            "os.environ", {"SPARK_REMOTE": "remote_url", "SPARK_LOCAL_REMOTE": "true"}
+        ):
+            with self.assertRaisesRegex(
+                RuntimeError, "Only one Spark Connect client URL can be set"
+            ):
+                SparkSession.builder.config("spark.remote", "different_remote_url")
+
 
 class SparkExtensionsTest(unittest.TestCase):
     # These tests are separate because it uses 'spark.sql.extensions' which is


### PR DESCRIPTION
### What changes were proposed in this pull request?
Validate startup urls with the config being set, see example in the "Does this PR introduce _any_ user-facing change".


### Why are the changes needed?
Clear and user-friendly error messages.


### Does this PR introduce _any_ user-facing change?
Yes.

FROM
```py
>>> SparkSession.builder.config(map={"spark.master": "x", "spark.remote": "y"})
<pyspark.sql.session.SparkSession.Builder object at 0x7fa310115b20

>>> SparkSession.builder.config(map={"spark.master": "x", "spark.remote": "y"}).config("x", "z")  # Only raises the error when adding new configs
Traceback (most recent call last):
...
RuntimeError: Spark master cannot be configured with Spark Connect server; however, found URL for Spark Connect [y]
```

TO
```py
>>> SparkSession.builder.config(map={"spark.master": "x", "spark.remote": "y"})
Traceback (most recent call last):
...
RuntimeError: Spark master cannot be configured with Spark Connect server; however, found URL for Spark Connect [y]
```

### How was this patch tested?
Unit tests.

### Was this patch authored or co-authored using generative AI tooling?
No.
