### PR TITLE
[SPARK-46279][SQL] Support write partition values to data files in FileFormatWritter

### DIFF
--- a/docs/sql-data-sources-parquet.md
+++ b/docs/sql-data-sources-parquet.md
@@ -426,6 +426,12 @@ Data source options of Parquet can be set via:
     <td>Compression codec to use when saving to file. This can be one of the known case-insensitive shorten names (none, uncompressed, snappy, gzip, lzo, brotli, lz4, lz4_raw, and zstd). This will override <code>spark.sql.parquet.compression.codec</code>.</td>
     <td>write</td>
   </tr>
+  <tr>
+    <td><code>writePartitionColumns</code></td>
+    <td><code>false</code></td>
+    <td>Write partition columns to parquet files</td>
+    <td>write</td>
+  </tr>
 </table>
 Other generic options can be found in <a href="https://spark.apache.org/docs/latest/sql-data-sources-generic-options.html"> Generic Files Source Options</a>
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceUtils.scala
@@ -53,6 +53,11 @@ object DataSourceUtils extends PredicateHelper {
   val PARTITION_OVERWRITE_MODE = "partitionOverwriteMode"
 
   /**
+   * The key control if it should write partition columns to data files
+   */
+  val WRITE_PARTITION_COLUMNS = "writePartitionColumns"
+
+  /**
    * Utility methods for converting partitionBy columns to options and back.
    */
   private implicit val formats: Formats = Serialization.formats(NoTypeHints)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatWriter.scala
@@ -95,8 +95,7 @@ object FileFormatWriter extends Logging {
       bucketSpec: Option[BucketSpec],
       statsTrackers: Seq[WriteJobStatsTracker],
       options: Map[String, String],
-      numStaticPartitionCols: Int = 0,
-      writePartitionColumns: Boolean = false)
+      numStaticPartitionCols: Int = 0)
     : Set[String] = {
     require(partitionColumns.size >= numStaticPartitionCols)
 
@@ -120,6 +119,10 @@ object FileFormatWriter extends Logging {
     val dataSchema = dataColumns.toStructType
     DataSourceUtils.verifySchema(fileFormat, dataSchema)
     DataSourceUtils.checkFieldNames(fileFormat, dataSchema)
+
+    val writePartitionColumns = caseInsensitiveOptions
+      .get(DataSourceUtils.WRITE_PARTITION_COLUMNS)
+      .exists(_.toBoolean == true)
 
     val outputDataColumns =
       if (writePartitionColumns) dataColumns ++ partitionColumns else dataColumns


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Support write partition values to data files in FileFormatWritter

### Why are the changes needed?
This allows parquet files to be read correctly without relying on engine to read partition values from the path, and enables cases where individual parquet files can be copied and shared without losing partition information. 

### Does this PR introduce _any_ user-facing change?
Yes. exposed new dataframe writer option. 

### How was this patch tested?
Unit test


### Was this patch authored or co-authored using generative AI tooling?
No
