### PR TITLE
[SPARK-46232][PYTHON][FOLLOWUP] Migrate `ValueError` into `PySparkValueError`

### DIFF
--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -738,8 +738,9 @@ class CogroupPandasUDFSerializer(ArrowStreamPandasUDFSerializer):
                 )
 
             elif dataframes_in_group != 0:
-                raise ValueError(
-                    "Invalid number of pandas.DataFrames in group {0}".format(dataframes_in_group)
+                raise PySparkValueError(
+                    error_class="INVALID_NUMBER_OF_DATAFRAMES_IN_GROUP",
+                    message_parameters={"dataframes_in_group": str(dataframes_in_group)},
                 )
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR followups for https://github.com/apache/spark/pull/44149 to address missing case.

### Why are the changes needed?

To improve error handling.

### Does this PR introduce _any_ user-facing change?

No API changes.

### How was this patch tested?

The existing CI should pass.

### Was this patch authored or co-authored using generative AI tooling?

No.