### PR TITLE
[SPARK-46284][PYTHON][CONNECT] Add `session_user` function to Python

### DIFF
--- a/python/docs/source/reference/pyspark.sql/functions.rst
+++ b/python/docs/source/reference/pyspark.sql/functions.rst
@@ -585,6 +585,7 @@ Misc Functions
     monotonically_increasing_id
     raise_error
     reflect
+    session_user
     spark_partition_id
     try_aes_decrypt
     try_reflect

--- a/python/pyspark/sql/connect/functions/builtin.py
+++ b/python/pyspark/sql/connect/functions/builtin.py
@@ -3613,6 +3613,13 @@ def user() -> Column:
 user.__doc__ = pysparkfuncs.user.__doc__
 
 
+def session_user() -> Column:
+    return _invoke_function("session_user")
+
+
+session_user.__doc__ = pysparkfuncs.session_user.__doc__
+
+
 def assert_true(col: "ColumnOrName", errMsg: Optional[Union[Column, str]] = None) -> Column:
     if errMsg is None:
         return _invoke_function_over_columns("assert_true", col)

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -8915,6 +8915,25 @@ def user() -> Column:
 
 
 @_try_remote_functions
+def session_user() -> Column:
+    """Returns the user name of current execution context.
+
+    .. versionadded:: 4.0.0
+
+    Examples
+    --------
+    >>> import pyspark.sql.functions as sf
+    >>> spark.range(1).select(sf.session_user()).show() # doctest: +SKIP
+    +--------------+
+    |current_user()|
+    +--------------+
+    | ruifeng.zheng|
+    +--------------+
+    """
+    return _invoke_function("session_user")
+
+
+@_try_remote_functions
 def crc32(col: "ColumnOrName") -> Column:
     """
     Calculates the cyclic redundancy check value  (CRC32) of a binary column and

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -66,7 +66,6 @@ class FunctionsTestsMixin:
             "random",  # namespace conflict with python built-in module
             "uuid",  # namespace conflict with python built-in module
             "chr",  # namespace conflict with python built-in function
-            "session_user",  # Scala only for now, needs implementation
             "partitioning$",  # partitioning expressions for DSv2
         ]
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
`session_user` function was added in Scala in https://github.com/apache/spark/pull/42549, this PR adds it to Python

### Why are the changes needed?
for parity


### Does this PR introduce _any_ user-facing change?
yes
```
    >>> import pyspark.sql.functions as sf
    >>> spark.range(1).select(sf.session_user()).show() # doctest: +SKIP
    +--------------+
    |current_user()|
    +--------------+
    | ruifeng.zheng|
    +--------------+
```


### How was this patch tested?
ci

### Was this patch authored or co-authored using generative AI tooling?
no
