### PR TITLE
[SPARK-46287][PYTHON][CONNECT] `DataFrame.isEmpty` should work with all datatypes

### DIFF
--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -178,7 +178,7 @@ class DataFrame:
     write.__doc__ = PySparkDataFrame.write.__doc__
 
     def isEmpty(self) -> bool:
-        return len(self.take(1)) == 0
+        return len(self.select().take(1)) == 0
 
     isEmpty.__doc__ = PySparkDataFrame.isEmpty.__doc__
 

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -2004,6 +2004,11 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
         self.assertFalse(self.connect.sql("SELECT 1 AS X").isEmpty())
         self.assertTrue(self.connect.sql("SELECT 1 AS X LIMIT 0").isEmpty())
 
+    def test_is_empty_with_unsupported_types(self):
+        df = self.spark.sql("SELECT INTERVAL '10-8' YEAR TO MONTH AS interval")
+        self.assertEqual(df.count(), 1)
+        self.assertFalse(df.isEmpty())
+
     def test_session(self):
         self.assertEqual(self.connect, self.connect.sql("SELECT 1").sparkSession)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
`DataFrame.isEmpty` should work with all datatypes

the schema maybe not compatible with arrow, so should not use `collect/take` to check `isEmpty`


### Why are the changes needed?
bugfix


### Does this PR introduce _any_ user-facing change?
before:
```
In [1]: spark.sql("SELECT INTERVAL '10-8' YEAR TO MONTH AS interval").isEmpty()
23/12/06 20:39:58 WARN CheckAllocator: More than one DefaultAllocationManager on classpath. Choosing first found
--------------------------------------------------------------------------- / 1]
KeyError                                  Traceback (most recent call last)
Cell In[1], line 1
----> 1 spark.sql("SELECT INTERVAL '10-8' YEAR TO MONTH AS interval").isEmpty()

File ~/Dev/spark/python/pyspark/sql/connect/dataframe.py:181, in DataFrame.isEmpty(self)
    180 def isEmpty(self) -> bool:
--> 181     return len(self.take(1)) == 0

...

File ~/.dev/miniconda3/envs/spark_dev_311/lib/python3.11/site-packages/pyarrow/public-api.pxi:208, in pyarrow.lib.pyarrow_wrap_array()

File ~/.dev/miniconda3/envs/spark_dev_311/lib/python3.11/site-packages/pyarrow/array.pxi:3659, in pyarrow.lib.get_array_class_from_type()

KeyError: 21
```

after
```
In [1]: spark.sql("SELECT INTERVAL '10-8' YEAR TO MONTH AS interval").isEmpty()
23/12/06 20:40:26 WARN CheckAllocator: More than one DefaultAllocationManager on classpath. Choosing first found
Out[1]: False
```

### How was this patch tested?
added ut


### Was this patch authored or co-authored using generative AI tooling?
no