### PR TITLE
[SPARK-45720] Upgrade AWS SDK to v2 for Spark Kinesis connector module

### DIFF
--- a/connector/kinesis-asl-assembly/pom.xml
+++ b/connector/kinesis-asl-assembly/pom.xml
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>${aws.kinesis.client.guava.version}</version>
+      <version>${connect.guava.version}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -168,6 +168,9 @@
           <relocation>
             <pattern>com.google.common</pattern>
             <shadedPattern>${spark.shade.packageName}.kinesis.guava</shadedPattern>
+            <includes>
+              <include>com.google.common.**</include>
+            </includes>
           </relocation>
           <relocation>
             <pattern>software.amazon.awssdk</pattern>

--- a/connector/kinesis-asl-assembly/pom.xml
+++ b/connector/kinesis-asl-assembly/pom.xml
@@ -55,6 +55,12 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${aws.kinesis.client.guava.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-client</artifactId>
       <scope>provided</scope>
@@ -158,6 +164,16 @@
             <include>*:*</include>
           </includes>
         </artifactSet>
+        <relocations>
+          <relocation>
+            <pattern>com.google.common</pattern>
+            <shadedPattern>${spark.shade.packageName}.kinesis.guava</shadedPattern>
+          </relocation>
+          <relocation>
+            <pattern>software.amazon.awssdk</pattern>
+            <shadedPattern>${spark.shade.packageName}.software.amazon.awssdk</shadedPattern>
+          </relocation>
+        </relocations>
         <filters>
           <filter>
             <artifact>*:*</artifact>

--- a/connector/kinesis-asl-assembly/pom.xml
+++ b/connector/kinesis-asl-assembly/pom.xml
@@ -61,6 +61,11 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-client</artifactId>
       <scope>provided</scope>
@@ -170,6 +175,13 @@
             <shadedPattern>${spark.shade.packageName}.kinesis.guava</shadedPattern>
             <includes>
               <include>com.google.common.**</include>
+            </includes>
+          </relocation>
+          <relocation>
+            <pattern>com.google.protobuf</pattern>
+            <shadedPattern>${spark.shade.packageName}.kinesis.protobuf</shadedPattern>
+            <includes>
+              <include>com.google.protobuf.**</include>
             </includes>
           </relocation>
           <relocation>

--- a/connector/kinesis-asl/pom.xml
+++ b/connector/kinesis-asl/pom.xml
@@ -59,6 +59,10 @@
       <version>${aws.kinesis.client.version}</version>
       <exclusions>
         <exclusion>
+          <groupId>com.github.luben</groupId>
+          <artifactId>zstd-jni</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>com.kjetland</groupId>
           <artifactId>mbknor-jackson-jsonschema_2.12</artifactId>
         </exclusion>

--- a/connector/kinesis-asl/pom.xml
+++ b/connector/kinesis-asl/pom.xml
@@ -117,7 +117,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>${aws.kinesis.client.guava.version}</version>
+      <version>${connect.guava.version}</version>
     </dependency>
 
     <!--

--- a/connector/kinesis-asl/pom.xml
+++ b/connector/kinesis-asl/pom.xml
@@ -101,6 +101,12 @@
       <version>${fasterxml.jackson.version}</version>
     </dependency>
     <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <version>${jaxb.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/connector/kinesis-asl/pom.xml
+++ b/connector/kinesis-asl/pom.xml
@@ -54,14 +54,34 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.amazonaws</groupId>
+      <groupId>software.amazon.kinesis</groupId>
       <artifactId>amazon-kinesis-client</artifactId>
       <version>${aws.kinesis.client.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.kjetland</groupId>
+          <artifactId>mbknor-jackson-jsonschema_2.12</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <!-- The Kinesis-client-library depends on glue-schema-registry which depends on 
+    mbknor-jackson-jsonschema_2.12. As Spark 4.0 dropped support for Scala 2.12, we have to 
+    explicitly import mbknor-jackson-jsonschema_2.13 here until glue-schema-registry is updated 
+    to depend on mbknor-jackson-jsonschema_2.13 -->
+    <dependency>
+      <groupId>com.kjetland</groupId>
+      <artifactId>mbknor-jackson-jsonschema_2.13</artifactId>
+      <version>${mbknor.jsonschema.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk-sts</artifactId>
-      <version>${aws.java.sdk.version}</version>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>sts</artifactId>
+      <version>${aws.java.sdk.v2.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>apache-client</artifactId>
+      <version>${aws.java.sdk.v2.version}</version>
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>
@@ -89,6 +109,11 @@
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-tags_${scala.binary.version}</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${aws.kinesis.client.guava.version}</version>
     </dependency>
 
     <!--

--- a/connector/kinesis-asl/src/main/java/org/apache/spark/streaming/kinesis/KinesisInitialPositions.java
+++ b/connector/kinesis-asl/src/main/java/org/apache/spark/streaming/kinesis/KinesisInitialPositions.java
@@ -16,7 +16,8 @@
  */
 package org.apache.spark.streaming.kinesis;
 
-import com.amazonaws.services.kinesis.clientlibrary.lib.worker.InitialPositionInStream;
+
+import software.amazon.kinesis.common.InitialPositionInStream;
 
 import java.io.Serializable;
 import java.util.Date;

--- a/connector/kinesis-asl/src/main/java/org/apache/spark/streaming/kinesis/KinesisInitialPositions.java
+++ b/connector/kinesis-asl/src/main/java/org/apache/spark/streaming/kinesis/KinesisInitialPositions.java
@@ -16,7 +16,6 @@
  */
 package org.apache.spark.streaming.kinesis;
 
-
 import software.amazon.kinesis.common.InitialPositionInStream;
 
 import java.io.Serializable;

--- a/connector/kinesis-asl/src/main/scala/org/apache/spark/examples/streaming/KinesisExampleUtils.scala
+++ b/connector/kinesis-asl/src/main/scala/org/apache/spark/examples/streaming/KinesisExampleUtils.scala
@@ -19,16 +19,16 @@ package org.apache.spark.examples.streaming
 
 import scala.jdk.CollectionConverters._
 
-import com.amazonaws.regions.RegionUtils
-import com.amazonaws.services.kinesis.AmazonKinesis
+import software.amazon.awssdk.regions.servicemetadata.KinesisServiceMetadata
 
 private[streaming] object KinesisExampleUtils {
   def getRegionNameByEndpoint(endpoint: String): String = {
     val uri = new java.net.URI(endpoint)
-    RegionUtils.getRegionsForService(AmazonKinesis.ENDPOINT_PREFIX)
+    val kinesisServiceMetadata = new KinesisServiceMetadata()
+    kinesisServiceMetadata.regions
       .asScala
-      .find(_.getAvailableEndpoints.asScala.toSeq.contains(uri.getHost))
-      .map(_.getName)
+      .find(r => kinesisServiceMetadata.endpointFor(r).toString.equals(uri.getHost))
+      .map(_.id)
       .getOrElse(
         throw new IllegalArgumentException(s"Could not resolve region for endpoint: $endpoint"))
   }

--- a/connector/kinesis-asl/src/main/scala/org/apache/spark/examples/streaming/KinesisExampleUtils.scala
+++ b/connector/kinesis-asl/src/main/scala/org/apache/spark/examples/streaming/KinesisExampleUtils.scala
@@ -27,7 +27,7 @@ private[streaming] object KinesisExampleUtils {
     val kinesisServiceMetadata = new KinesisServiceMetadata()
     kinesisServiceMetadata.regions
       .asScala
-      .find(r => kinesisServiceMetadata.endpointFor(r).toString.equals(uri.getHost))
+      .find(r => kinesisServiceMetadata.endpointFor(r).equals(uri))
       .map(_.id)
       .getOrElse(
         throw new IllegalArgumentException(s"Could not resolve region for endpoint: $endpoint"))

--- a/connector/kinesis-asl/src/main/scala/org/apache/spark/examples/streaming/KinesisExampleUtils.scala
+++ b/connector/kinesis-asl/src/main/scala/org/apache/spark/examples/streaming/KinesisExampleUtils.scala
@@ -27,7 +27,7 @@ private[streaming] object KinesisExampleUtils {
     val kinesisServiceMetadata = new KinesisServiceMetadata()
     kinesisServiceMetadata.regions
       .asScala
-      .find(r => kinesisServiceMetadata.endpointFor(r).equals(uri))
+      .find(r => kinesisServiceMetadata.endpointFor(r).toString.equals(uri.getHost))
       .map(_.id)
       .getOrElse(
         throw new IllegalArgumentException(s"Could not resolve region for endpoint: $endpoint"))

--- a/connector/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisCheckpointer.scala
+++ b/connector/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisCheckpointer.scala
@@ -57,9 +57,8 @@ private[kinesis] class KinesisCheckpointer(
   /**
    * Stop tracking the specified shardId.
    *
-   * If a checkpointer is provided, e.g. on IRecordProcessor.shutdown [[ShutdownReason.TERMINATE]],
-   * we will use that to make the final checkpoint. If `null` is provided, we will not make the
-   * checkpoint, e.g. in case of [[ShutdownReason.ZOMBIE]].
+   * If a checkpointer is provided, we will use that to make the final checkpoint. If `null`
+   * is provided, we will not make the checkpoint, e.g. in case of [[ShutdownReason.ZOMBIE]].
    */
   def removeCheckpointer(shardId: String, checkpointer: RecordProcessorCheckpointer): Unit = {
     synchronized {

--- a/connector/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisReceiver.scala
+++ b/connector/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisReceiver.scala
@@ -237,8 +237,8 @@ private[kinesis] class KinesisReceiver[T](
         scheduler.shutdown()
         scheduler = null
       }
-      workerThread.join()
-      workerThread = null
+      schedulerThread.join()
+      schedulerThread = null
       logInfo(log"Stopped receiver for schedulerId ${MDC(WORKER_URL, schedulerId)}")
     }
     schedulerId = null

--- a/connector/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisRecordProcessor.scala
+++ b/connector/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisRecordProcessor.scala
@@ -24,7 +24,7 @@ import software.amazon.kinesis.lifecycle.events.{InitializationInput, LeaseLostI
 import software.amazon.kinesis.processor.ShardRecordProcessor
 
 import org.apache.spark.internal.{Logging, MDC}
-import org.apache.spark.internal.LogKeys.{REASON, RETRY_INTERVAL, SHARD_ID, WORKER_URL}
+import org.apache.spark.internal.LogKeys.{RETRY_INTERVAL, SHARD_ID, WORKER_URL}
 
 /**
  * Kinesis-specific implementation of the Kinesis Client Library (KCL) IRecordProcessor.
@@ -98,8 +98,9 @@ private[kinesis] class KinesisRecordProcessor[T](receiver: KinesisReceiver[T], s
       }
     } else {
       /* RecordProcessor has been stopped. */
-      logInfo(log"Stopped: KinesisReceiver has stopped for schedulerId ${MDC(WORKER_URL, schedulerId)}" +
-          log" and shardId ${MDC(SHARD_ID, shardId)}. No more records will be processed.")
+      logInfo(log"Stopped: KinesisReceiver has stopped for schedulerId " +
+        log"${MDC(WORKER_URL, schedulerId)} and shardId ${MDC(SHARD_ID, shardId)}. " +
+        log"No more records will be processed.")
     }
   }
 
@@ -111,7 +112,7 @@ private[kinesis] class KinesisRecordProcessor[T](receiver: KinesisReceiver[T], s
    * Currently this has no functionality.
    */
   override def leaseLost(leaseLostInput: LeaseLostInput): Unit = {
-    logInfo(log"The lease for shardId: $shardId is lost.")
+    logInfo(log"The lease for shardId: ${MDC(WORKER_URL, schedulerId)} is lost.")
   }
 
   /**

--- a/connector/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisRecordProcessor.scala
+++ b/connector/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisRecordProcessor.scala
@@ -16,15 +16,12 @@
  */
 package org.apache.spark.streaming.kinesis
 
-import java.util.List
-
 import scala.util.Random
 import scala.util.control.NonFatal
 
-import com.amazonaws.services.kinesis.clientlibrary.exceptions.{InvalidStateException, KinesisClientLibDependencyException, ShutdownException, ThrottlingException}
-import com.amazonaws.services.kinesis.clientlibrary.interfaces.{IRecordProcessor, IRecordProcessorCheckpointer}
-import com.amazonaws.services.kinesis.clientlibrary.lib.worker.ShutdownReason
-import com.amazonaws.services.kinesis.model.Record
+import software.amazon.kinesis.exceptions.{InvalidStateException, KinesisClientLibDependencyException, ShutdownException, ThrottlingException}
+import software.amazon.kinesis.lifecycle.events.{InitializationInput, LeaseLostInput, ProcessRecordsInput, ShardEndedInput, ShutdownRequestedInput}
+import software.amazon.kinesis.processor.ShardRecordProcessor
 
 import org.apache.spark.internal.{Logging, MDC}
 import org.apache.spark.internal.LogKeys.{REASON, RETRY_INTERVAL, SHARD_ID, WORKER_URL}
@@ -32,16 +29,16 @@ import org.apache.spark.internal.LogKeys.{REASON, RETRY_INTERVAL, SHARD_ID, WORK
 /**
  * Kinesis-specific implementation of the Kinesis Client Library (KCL) IRecordProcessor.
  * This implementation operates on the Array[Byte] from the KinesisReceiver.
- * The Kinesis Worker creates an instance of this KinesisRecordProcessor for each
+ * The Kinesis scheduler creates an instance of this KinesisRecordProcessor for each
  * shard in the Kinesis stream upon startup.  This is normally done in separate threads,
  * but the KCLs within the KinesisReceivers will balance themselves out if you create
  * multiple Receivers.
  *
  * @param receiver Kinesis receiver
- * @param workerId for logging purposes
+ * @param schedulerId for logging purposes
  */
-private[kinesis] class KinesisRecordProcessor[T](receiver: KinesisReceiver[T], workerId: String)
-  extends IRecordProcessor with Logging {
+private[kinesis] class KinesisRecordProcessor[T](receiver: KinesisReceiver[T], schedulerId: String)
+  extends ShardRecordProcessor with Logging {
 
   // shardId populated during initialize()
   @volatile
@@ -52,35 +49,27 @@ private[kinesis] class KinesisRecordProcessor[T](receiver: KinesisReceiver[T], w
    *
    * @param shardId assigned by the KCL to this particular RecordProcessor.
    */
-  override def initialize(shardId: String): Unit = {
-    this.shardId = shardId
-    logInfo(log"Initialized workerId ${MDC(WORKER_URL, workerId)} " +
+  override def initialize(initializationInput: InitializationInput): Unit = {
+    this.shardId = initializationInput.shardId
+    logInfo(log"Initialized schedulerId ${MDC(WORKER_URL, schedulerId)} " +
       log"with shardId ${MDC(SHARD_ID, shardId)}")
   }
 
-  /**
-   * This method is called by the KCL when a batch of records is pulled from the Kinesis stream.
-   * This is the record-processing bridge between the KCL's IRecordProcessor.processRecords()
-   * and Spark Streaming's Receiver.store().
-   *
-   * @param batch list of records from the Kinesis stream shard
-   * @param checkpointer used to update Kinesis when this batch has been processed/stored
-   *   in the DStream
-   */
-  override def processRecords(batch: List[Record],
-      checkpointer: IRecordProcessorCheckpointer): Unit = {
+  override def processRecords(processRecordsInput: ProcessRecordsInput): Unit = {
+    val batch = processRecordsInput.records
+    val checkpointer = processRecordsInput.checkpointer
     if (!receiver.isStopped()) {
       try {
         // Limit the number of processed records from Kinesis stream. This is because the KCL cannot
         // control the number of aggregated records to be fetched even if we set `MaxRecords`
-        // in `KinesisClientLibConfiguration`. For example, if we set 10 to the number of max
-        // records in a worker and a producer aggregates two records into one message, the worker
+        // in `PollingConfig`. For example, if we set 10 to the number of max records
+        // in a scheduler and a producer aggregates two records into one message, the scheduler
         // possibly 20 records every callback function called.
         val maxRecords = receiver.getCurrentLimit
         for (start <- 0 until batch.size by maxRecords) {
           val miniBatch = batch.subList(start, math.min(start + maxRecords, batch.size))
           receiver.addRecords(shardId, miniBatch)
-          logDebug(s"Stored: Worker $workerId stored ${miniBatch.size} records " +
+          logDebug(s"Stored: Scheduler $schedulerId stored ${miniBatch.size} records " +
             s"for shardId $shardId")
         }
         receiver.setCheckpointer(shardId, checkpointer)
@@ -91,56 +80,40 @@ private[kinesis] class KinesisRecordProcessor[T](receiver: KinesisReceiver[T], w
            *  This will potentially cause records since the last checkpoint to be processed
            *     more than once.
            */
-          logError(log"Exception: WorkerId ${MDC(WORKER_URL, workerId)} encountered and " +
-            log"exception while storing or checkpointing a batch for workerId " +
-            log"${MDC(WORKER_URL, workerId)} and shardId ${MDC(SHARD_ID, shardId)}.", e)
+          logError(log"Exception: SchedulerId ${MDC(WORKER_URL, schedulerId)} encountered and " +
+            log"exception while storing or checkpointing a batch for schedulerId " +
+            log"${MDC(WORKER_URL, schedulerId)} and shardId ${MDC(SHARD_ID, shardId)}.", e)
 
-          /* Rethrow the exception to the Kinesis Worker that is managing this RecordProcessor. */
+          /* Rethrow the exception to the Kinesis scheduler that is managing
+           this RecordProcessor. */
           throw e
       }
     } else {
       /* RecordProcessor has been stopped. */
-      logInfo(log"Stopped: KinesisReceiver has stopped for workerId ${MDC(WORKER_URL, workerId)}" +
+      logInfo(log"Stopped: KinesisReceiver has stopped for schedulerId ${MDC(WORKER_URL, schedulerId)}" +
           log" and shardId ${MDC(SHARD_ID, shardId)}. No more records will be processed.")
     }
   }
 
-  /**
-   * Kinesis Client Library is shutting down this Worker for 1 of 2 reasons:
-   * 1) the stream is resharding by splitting or merging adjacent shards
-   *     (ShutdownReason.TERMINATE)
-   * 2) the failed or latent Worker has stopped sending heartbeats for whatever reason
-   *     (ShutdownReason.ZOMBIE)
-   *
-   * @param checkpointer used to perform a Kinesis checkpoint for ShutdownReason.TERMINATE
-   * @param reason for shutdown (ShutdownReason.TERMINATE or ShutdownReason.ZOMBIE)
-   */
-  override def shutdown(
-      checkpointer: IRecordProcessorCheckpointer,
-      reason: ShutdownReason): Unit = {
-    logInfo(log"Shutdown: Shutting down workerId ${MDC(WORKER_URL, workerId)} " +
-      log"with reason ${MDC(REASON, reason)}")
-    // null if not initialized before shutdown:
-    if (shardId == null) {
-      logWarning(log"No shardId for workerId ${MDC(WORKER_URL, workerId)}?")
-    } else {
-      reason match {
-        /*
-         * TERMINATE Use Case.  Checkpoint.
-         * Checkpoint to indicate that all records from the shard have been drained and processed.
-         * It's now OK to read from the new shards that resulted from a resharding event.
-         */
-        case ShutdownReason.TERMINATE => receiver.removeCheckpointer(shardId, checkpointer)
+  override def leaseLost(leaseLostInput: LeaseLostInput): Unit = {
+    logInfo(log"The lease for shardId: $shardId is lost.")
+  }
 
-        /*
-         * ZOMBIE Use Case or Unknown reason.  NoOp.
-         * No checkpoint because other workers may have taken over and already started processing
-         *    the same records.
-         * This may lead to records being processed more than once.
-         * Return null so that we don't checkpoint
-         */
-        case _ => receiver.removeCheckpointer(shardId, null)
-      }
+  override def shardEnded(shardEndedInput: ShardEndedInput): Unit = {
+    log.info(s"Reached shard end. Checkpointing for shardId: $shardId")
+    if (shardId == null) {
+      logWarning("shardId is not initialized for this record processor.")
+    } else {
+      receiver.removeCheckpointer(shardId, shardEndedInput.checkpointer)
+    }
+  }
+
+  override def shutdownRequested(shutdownRequestedInput: ShutdownRequestedInput): Unit = {
+    logInfo(log"Shutdown: Shutting down schedulerId: ${MDC(WORKER_URL, schedulerId)} ")
+    if (shardId == null) {
+      logWarning(log"No shardId for schedulerId ${MDC(WORKER_URL, schedulerId)}?")
+    } else {
+      receiver.removeCheckpointer(shardId, shutdownRequestedInput.checkpointer)
     }
   }
 }

--- a/connector/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisRecordProcessor.scala
+++ b/connector/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisRecordProcessor.scala
@@ -112,7 +112,7 @@ private[kinesis] class KinesisRecordProcessor[T](receiver: KinesisReceiver[T], s
    * Currently this has no functionality.
    */
   override def leaseLost(leaseLostInput: LeaseLostInput): Unit = {
-    logInfo(log"The lease for shardId: ${MDC(WORKER_URL, schedulerId)} is lost.")
+    logInfo(log"The lease for shardId: ${MDC(SHARD_ID, shardId)} is lost.")
   }
 
   /**
@@ -126,9 +126,9 @@ private[kinesis] class KinesisRecordProcessor[T](receiver: KinesisReceiver[T], s
    * processing of the shard.
    */
   override def shardEnded(shardEndedInput: ShardEndedInput): Unit = {
-    log.info(s"Reached shard end. Checkpointing for shardId: $shardId")
+    logInfo(log"Reached shard end. Checkpointing for shardId: ${MDC(SHARD_ID, shardId)}")
     if (shardId == null) {
-      logWarning("shardId is not initialized for this record processor.")
+      logWarning(log"No shardId for schedulerId ${MDC(WORKER_URL, schedulerId)}?")
     } else {
       receiver.removeCheckpointer(shardId, shardEndedInput.checkpointer)
     }

--- a/connector/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisUtilsPythonHelper.scala
+++ b/connector/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisUtilsPythonHelper.scala
@@ -16,8 +16,8 @@
  */
 package org.apache.spark.streaming.kinesis
 
-import com.amazonaws.services.kinesis.clientlibrary.lib.worker.InitialPositionInStream
-import com.amazonaws.services.kinesis.metrics.interfaces.MetricsLevel
+import software.amazon.kinesis.common.InitialPositionInStream
+import software.amazon.kinesis.metrics.MetricsLevel
 
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.streaming.Duration

--- a/connector/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/SparkAWSCredentials.scala
+++ b/connector/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/SparkAWSCredentials.scala
@@ -30,7 +30,7 @@ import org.apache.spark.internal.Logging
  */
 private[kinesis] sealed trait SparkAWSCredentials extends Serializable {
   /**
-   * Return an AWSCredentialProvider instance that can be used by the Kinesis Client
+   * Return an AwsCredentialProvider instance that can be used by the Kinesis Client
    * Library to authenticate to AWS services (Kinesis, CloudWatch and DynamoDB).
    */
   def provider: AwsCredentialsProvider
@@ -44,7 +44,7 @@ private[kinesis] final case object DefaultCredentials extends SparkAWSCredential
 
 /**
  * Returns StaticCredentialsProvider constructed using basic AWS keypair. Falls back to using
- * DefaultCredentialsProviderChain if unable to construct a AWSCredentialsProviderChain
+ * DefaultCredentialsProvider if unable to construct a StaticCredentialsProvider
  * instance with the provided arguments (e.g. if they are null).
  */
 private[kinesis] final case class BasicCredentials(
@@ -56,13 +56,13 @@ private[kinesis] final case class BasicCredentials(
   } catch {
     case e: IllegalArgumentException =>
       logWarning("Unable to construct StaticCredentialsProvider with provided keypair; " +
-        "falling back to DefaultCredentialsProviderChain.", e)
+        "falling back to DefaultCredentialsProvider.", e)
       DefaultCredentialsProvider.create()
   }
 }
 
 /**
- * Returns an STSAssumeRoleSessionCredentialsProvider instance which assumes an IAM
+ * Returns an StsAssumeRoleCredentialsProvider instance which assumes an IAM
  * role in order to authenticate against resources in an external account.
  */
 private[kinesis] final case class STSCredentials(
@@ -109,8 +109,8 @@ object SparkAWSCredentials {
      *
      * @note The given AWS keypair will be saved in DStream checkpoints if checkpointing is
      * enabled. Make sure that your checkpoint directory is secure. Prefer using the
-     * default provider chain instead if possible
-     * (http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#credentials-default).
+     * default credentials provider instead if possible
+     * (https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials-chain.html).
      *
      * @param accessKeyId AWS access key ID
      * @param secretKey AWS secret key

--- a/connector/kinesis-asl/src/test/java/org/apache/spark/streaming/kinesis/JavaKinesisInputDStreamBuilderSuite.java
+++ b/connector/kinesis-asl/src/test/java/org/apache/spark/streaming/kinesis/JavaKinesisInputDStreamBuilderSuite.java
@@ -17,7 +17,6 @@
 
 package org.apache.spark.streaming.kinesis;
 
-import com.amazonaws.services.kinesis.clientlibrary.lib.worker.InitialPositionInStream;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -26,6 +25,7 @@ import org.apache.spark.storage.StorageLevel;
 import org.apache.spark.streaming.Duration;
 import org.apache.spark.streaming.LocalJavaStreamingContext;
 import org.apache.spark.streaming.Seconds;
+import software.amazon.kinesis.common.InitialPositionInStream;
 
 public class JavaKinesisInputDStreamBuilderSuite extends LocalJavaStreamingContext {
   /**

--- a/connector/kinesis-asl/src/test/scala/org/apache/spark/streaming/kinesis/KinesisCheckpointerSuite.scala
+++ b/connector/kinesis-asl/src/test/scala/org/apache/spark/streaming/kinesis/KinesisCheckpointerSuite.scala
@@ -22,13 +22,13 @@ import java.util.concurrent.TimeoutException
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.concurrent.duration._
 
-import com.amazonaws.services.kinesis.clientlibrary.interfaces.IRecordProcessorCheckpointer
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.mockito.invocation.InvocationOnMock
 import org.scalatest.{BeforeAndAfterEach, PrivateMethodTester}
 import org.scalatest.concurrent.Eventually
 import org.scalatestplus.mockito.MockitoSugar
+import software.amazon.kinesis.processor.RecordProcessorCheckpointer
 
 import org.apache.spark.streaming.{Duration, TestSuiteBase}
 import org.apache.spark.util.ManualClock
@@ -39,7 +39,7 @@ class KinesisCheckpointerSuite extends TestSuiteBase
   with PrivateMethodTester
   with Eventually {
 
-  private val workerId = "dummyWorkerId"
+  private val schedulerId = "dummySchedulerId"
   private val shardId = "dummyShardId"
   private val seqNum = "123"
   private val otherSeqNum = "245"
@@ -48,7 +48,7 @@ class KinesisCheckpointerSuite extends TestSuiteBase
   private val someOtherSeqNum = Some(otherSeqNum)
 
   private var receiverMock: KinesisReceiver[Array[Byte]] = _
-  private var checkpointerMock: IRecordProcessorCheckpointer = _
+  private var checkpointerMock: RecordProcessorCheckpointer = _
   private var kinesisCheckpointer: KinesisCheckpointer = _
   private var clock: ManualClock = _
 
@@ -56,9 +56,13 @@ class KinesisCheckpointerSuite extends TestSuiteBase
 
   override def beforeEach(): Unit = {
     receiverMock = mock[KinesisReceiver[Array[Byte]]]
-    checkpointerMock = mock[IRecordProcessorCheckpointer]
+    checkpointerMock = mock[RecordProcessorCheckpointer]
     clock = new ManualClock()
-    kinesisCheckpointer = new KinesisCheckpointer(receiverMock, checkpointInterval, workerId, clock)
+    kinesisCheckpointer = new KinesisCheckpointer(
+      receiverMock,
+      checkpointInterval,
+      schedulerId,
+      clock)
   }
 
   test("checkpoint is not called twice for the same sequence number") {

--- a/connector/kinesis-asl/src/test/scala/org/apache/spark/streaming/kinesis/KinesisInputDStreamBuilderSuite.scala
+++ b/connector/kinesis-asl/src/test/scala/org/apache/spark/streaming/kinesis/KinesisInputDStreamBuilderSuite.scala
@@ -21,10 +21,10 @@ import java.util.Calendar
 
 import scala.jdk.CollectionConverters._
 
-import com.amazonaws.services.kinesis.clientlibrary.lib.worker.{InitialPositionInStream, KinesisClientLibConfiguration}
-import com.amazonaws.services.kinesis.metrics.interfaces.MetricsLevel
 import org.scalatest.BeforeAndAfterEach
 import org.scalatestplus.mockito.MockitoSugar
+import software.amazon.kinesis.common.InitialPositionInStream
+import software.amazon.kinesis.metrics.{MetricsConfig, MetricsLevel}
 
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.streaming.{Duration, Seconds, StreamingContext, TestSuiteBase}
@@ -101,7 +101,7 @@ class KinesisInputDStreamBuilderSuite extends TestSuiteBase with BeforeAndAfterE
     val customCloudWatchCreds = mock[SparkAWSCredentials]
     val customMetricsLevel = MetricsLevel.NONE
     val customMetricsEnabledDimensions =
-      KinesisClientLibConfiguration.METRICS_ALWAYS_ENABLED_DIMENSIONS.asScala.toSet
+      MetricsConfig.METRICS_ALWAYS_ENABLED_DIMENSIONS.asScala.toSet
 
     val dstream = builder
       .endpointUrl(customEndpointUrl)

--- a/connector/kinesis-asl/src/test/scala/org/apache/spark/streaming/kinesis/KinesisTestUtils.scala
+++ b/connector/kinesis-asl/src/test/scala/org/apache/spark/streaming/kinesis/KinesisTestUtils.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.streaming.kinesis
 
+import java.net.URI
 import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
 import java.util.concurrent.TimeUnit
@@ -26,12 +27,15 @@ import scala.collection.mutable.ArrayBuffer
 import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Random, Success, Try}
 
-import com.amazonaws.auth.{AWSCredentials, DefaultAWSCredentialsProviderChain}
-import com.amazonaws.regions.RegionUtils
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient
-import com.amazonaws.services.dynamodbv2.document.DynamoDB
-import com.amazonaws.services.kinesis.{AmazonKinesis, AmazonKinesisClient}
-import com.amazonaws.services.kinesis.model._
+import software.amazon.awssdk.auth.credentials.{AwsCredentials, DefaultCredentialsProvider}
+import software.amazon.awssdk.core.SdkBytes
+import software.amazon.awssdk.http.apache.ApacheHttpClient
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.regions.servicemetadata.KinesisServiceMetadata
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+import software.amazon.awssdk.services.dynamodb.model.DeleteTableRequest
+import software.amazon.awssdk.services.kinesis.KinesisClient
+import software.amazon.awssdk.services.kinesis.model.{CreateStreamRequest, DeleteStreamRequest, DescribeStreamRequest, MergeShardsRequest, PutRecordRequest, ResourceNotFoundException, Shard, SplitShardRequest, StreamDescription}
 
 import org.apache.spark.internal.{Logging, MDC}
 import org.apache.spark.internal.LogKeys.{STREAM_NAME, TABLE_NAME}
@@ -55,16 +59,21 @@ private[kinesis] class KinesisTestUtils(streamShardCount: Int = 2) extends Loggi
   @volatile
   private var _streamName: String = _
 
-  protected lazy val kinesisClient = {
-    val client = new AmazonKinesisClient(KinesisTestUtils.getAWSCredentials())
-    client.setEndpoint(endpointUrl)
-    client
+  protected lazy val kinesisClient: KinesisClient = {
+    KinesisClient.builder()
+      .credentialsProvider(DefaultCredentialsProvider.create())
+      .region(Region.of(regionName))
+      .httpClientBuilder(ApacheHttpClient.builder())
+      .endpointOverride(URI.create(endpointUrl))
+      .build()
   }
 
   private lazy val dynamoDB = {
-    val dynamoDBClient = new AmazonDynamoDBClient(new DefaultAWSCredentialsProviderChain())
-    dynamoDBClient.setRegion(RegionUtils.getRegion(regionName))
-    new DynamoDB(dynamoDBClient)
+    DynamoDbClient.builder()
+      .credentialsProvider(DefaultCredentialsProvider.create())
+      .region(Region.of(regionName))
+      .httpClientBuilder(ApacheHttpClient.builder())
+      .build()
   }
 
   protected def getProducer(aggregate: Boolean): KinesisDataGenerator = {
@@ -86,9 +95,10 @@ private[kinesis] class KinesisTestUtils(streamShardCount: Int = 2) extends Loggi
 
     // Create a stream. The number of shards determines the provisioned throughput.
     logInfo(s"Creating stream ${_streamName}")
-    val createStreamRequest = new CreateStreamRequest()
-    createStreamRequest.setStreamName(_streamName)
-    createStreamRequest.setShardCount(streamShardCount)
+    val createStreamRequest = CreateStreamRequest.builder()
+      .streamName(_streamName)
+      .shardCount(streamShardCount)
+      .build()
     kinesisClient.createStream(createStreamRequest)
 
     // The stream is now being created. Wait for it to become active.
@@ -97,26 +107,30 @@ private[kinesis] class KinesisTestUtils(streamShardCount: Int = 2) extends Loggi
     logInfo(s"Created stream ${_streamName}")
   }
 
-  def getShards(): Seq[Shard] = {
-    kinesisClient.describeStream(_streamName).getStreamDescription.getShards.asScala.toSeq
+  def getShards: Seq[Shard] = {
+    val describeStreamRequest = DescribeStreamRequest.builder()
+      .streamName(_streamName)
+      .build()
+    kinesisClient.describeStream(describeStreamRequest).streamDescription.shards.asScala.toSeq
   }
 
   def splitShard(shardId: String): Unit = {
-    val splitShardRequest = new SplitShardRequest()
-    splitShardRequest.withStreamName(_streamName)
-    splitShardRequest.withShardToSplit(shardId)
-    // Set a half of the max hash value
-    splitShardRequest.withNewStartingHashKey("170141183460469231731687303715884105728")
+    val splitShardRequest = SplitShardRequest.builder()
+      .streamName(_streamName)
+      .shardToSplit(shardId)
+      .newStartingHashKey("170141183460469231731687303715884105728")
+      .build()
     kinesisClient.splitShard(splitShardRequest)
     // Wait for the shards to become active
     waitForStreamToBeActive(_streamName)
   }
 
   def mergeShard(shardToMerge: String, adjacentShardToMerge: String): Unit = {
-    val mergeShardRequest = new MergeShardsRequest
-    mergeShardRequest.withStreamName(_streamName)
-    mergeShardRequest.withShardToMerge(shardToMerge)
-    mergeShardRequest.withAdjacentShardToMerge(adjacentShardToMerge)
+    val mergeShardRequest = MergeShardsRequest.builder()
+      .streamName(_streamName)
+      .shardToMerge(shardToMerge)
+      .adjacentShardToMerge(adjacentShardToMerge)
+      .build()
     kinesisClient.mergeShards(mergeShardRequest)
     // Wait for the shards to become active
     waitForStreamToBeActive(_streamName)
@@ -142,9 +156,12 @@ private[kinesis] class KinesisTestUtils(streamShardCount: Int = 2) extends Loggi
   }
 
   def deleteStream(): Unit = {
+    val deleteStreamRequest = DeleteStreamRequest.builder()
+      .streamName(streamName)
+      .build()
     try {
       if (streamCreated) {
-        kinesisClient.deleteStream(streamName)
+        kinesisClient.deleteStream(deleteStreamRequest)
       }
     } catch {
       case e: Exception =>
@@ -153,10 +170,11 @@ private[kinesis] class KinesisTestUtils(streamShardCount: Int = 2) extends Loggi
   }
 
   def deleteDynamoDBTable(tableName: String): Unit = {
+    val deleteTableRequest = DeleteTableRequest.builder()
+      .tableName(tableName)
+      .build()
     try {
-      val table = dynamoDB.getTable(tableName)
-      table.delete()
-      table.waitForDelete()
+      dynamoDB.deleteTable(deleteTableRequest)
     } catch {
       case e: Exception =>
         logWarning(log"Could not delete DynamoDB table ${MDC(TABLE_NAME, tableName)}", e)
@@ -165,11 +183,14 @@ private[kinesis] class KinesisTestUtils(streamShardCount: Int = 2) extends Loggi
 
   private def describeStream(streamNameToDescribe: String): Option[StreamDescription] = {
     try {
-      val describeStreamRequest = new DescribeStreamRequest().withStreamName(streamNameToDescribe)
-      val desc = kinesisClient.describeStream(describeStreamRequest).getStreamDescription()
+      val describeStreamRequest = DescribeStreamRequest.builder()
+        .streamName(streamNameToDescribe)
+        .build()
+      val desc = kinesisClient.describeStream(describeStreamRequest).streamDescription
       Some(desc)
     } catch {
       case rnfe: ResourceNotFoundException =>
+        logWarning(s"Could not describe stream $streamNameToDescribe", rnfe)
         None
     }
   }
@@ -188,9 +209,9 @@ private[kinesis] class KinesisTestUtils(streamShardCount: Int = 2) extends Loggi
     while (System.nanoTime() - startTimeNs < TimeUnit.SECONDS.toNanos(createStreamTimeoutSeconds)) {
       Thread.sleep(TimeUnit.SECONDS.toMillis(describeStreamPollTimeSeconds))
       describeStream(streamNameToWaitFor).foreach { description =>
-        val streamStatus = description.getStreamStatus()
+        val streamStatus = description.streamStatus
         logDebug(s"\t- current state: $streamStatus\n")
-        if ("ACTIVE".equals(streamStatus)) {
+        if ("ACTIVE".equals(streamStatus.toString)) {
           return
         }
       }
@@ -207,10 +228,11 @@ private[kinesis] object KinesisTestUtils {
 
   def getRegionNameByEndpoint(endpoint: String): String = {
     val uri = new java.net.URI(endpoint)
-    RegionUtils.getRegionsForService(AmazonKinesis.ENDPOINT_PREFIX)
+    val kinesisServiceMetadata = new KinesisServiceMetadata()
+    kinesisServiceMetadata.regions
       .asScala
-      .find(_.getAvailableEndpoints.asScala.toSeq.contains(uri.getHost))
-      .map(_.getName)
+      .find(r => kinesisServiceMetadata.endpointFor(r).toString.equals(uri.getHost))
+      .map(_.id)
       .getOrElse(
         throw new IllegalArgumentException(s"Could not resolve region for endpoint: $endpoint"))
   }
@@ -245,20 +267,20 @@ private[kinesis] object KinesisTestUtils {
   }
 
   def isAWSCredentialsPresent: Boolean = {
-    Try { new DefaultAWSCredentialsProviderChain().getCredentials() }.isSuccess
+    Try { DefaultCredentialsProvider.create().resolveCredentials() }.isSuccess
   }
 
-  def getAWSCredentials(): AWSCredentials = {
+  def getAwsCredentials: AwsCredentials = {
     assert(shouldRunTests,
       "Kinesis test not enabled, should not attempt to get AWS credentials")
-    Try { new DefaultAWSCredentialsProviderChain().getCredentials() } match {
+    Try { DefaultCredentialsProvider.create().resolveCredentials() } match {
       case Success(cred) => cred
       case Failure(e) =>
         throw new Exception(
           s"""
              |Kinesis tests enabled using environment variable $envVarNameForEnablingTests
              |but could not find AWS credentials. Please follow instructions in AWS documentation
-             |to set the credentials in your system such that the DefaultAWSCredentialsProviderChain
+             |to set the credentials in your system such that the DefaultCredentialsProvider
              |can find the credentials.
            """.stripMargin)
     }
@@ -272,19 +294,21 @@ private[kinesis] trait KinesisDataGenerator {
 }
 
 private[kinesis] class SimpleDataGenerator(
-    client: AmazonKinesisClient) extends KinesisDataGenerator {
+    client: KinesisClient) extends KinesisDataGenerator {
   override def sendData(streamName: String, data: Seq[Int]): Map[String, Seq[(Int, String)]] = {
     val shardIdToSeqNumbers = new mutable.HashMap[String, ArrayBuffer[(Int, String)]]()
     data.foreach { num =>
       val str = num.toString
       val data = ByteBuffer.wrap(str.getBytes(StandardCharsets.UTF_8))
-      val putRecordRequest = new PutRecordRequest().withStreamName(streamName)
-        .withData(data)
-        .withPartitionKey(str)
+      val putRecordRequest = PutRecordRequest.builder()
+        .streamName(streamName)
+        .data(SdkBytes.fromByteBuffer(data))
+        .partitionKey(str)
+        .build()
 
-      val putRecordResult = client.putRecord(putRecordRequest)
-      val shardId = putRecordResult.getShardId
-      val seqNumber = putRecordResult.getSequenceNumber()
+      val putRecordResponse = client.putRecord(putRecordRequest)
+      val shardId = putRecordResponse.shardId
+      val seqNumber = putRecordResponse.sequenceNumber
       val sentSeqNumbers = shardIdToSeqNumbers.getOrElseUpdate(shardId,
         new ArrayBuffer[(Int, String)]())
       sentSeqNumbers += ((num, seqNumber))

--- a/connector/kinesis-asl/src/test/scala/org/apache/spark/streaming/kinesis/KinesisTestUtils.scala
+++ b/connector/kinesis-asl/src/test/scala/org/apache/spark/streaming/kinesis/KinesisTestUtils.scala
@@ -118,6 +118,7 @@ private[kinesis] class KinesisTestUtils(streamShardCount: Int = 2) extends Loggi
     val splitShardRequest = SplitShardRequest.builder()
       .streamName(_streamName)
       .shardToSplit(shardId)
+      // Set a half of the max hash value
       .newStartingHashKey("170141183460469231731687303715884105728")
       .build()
     kinesisClient.splitShard(splitShardRequest)
@@ -231,7 +232,7 @@ private[kinesis] object KinesisTestUtils {
     val kinesisServiceMetadata = new KinesisServiceMetadata()
     kinesisServiceMetadata.regions
       .asScala
-      .find(r => kinesisServiceMetadata.endpointFor(r).toString.equals(uri.getHost))
+      .find(r => kinesisServiceMetadata.endpointFor(r).equals(uri))
       .map(_.id)
       .getOrElse(
         throw new IllegalArgumentException(s"Could not resolve region for endpoint: $endpoint"))
@@ -270,7 +271,7 @@ private[kinesis] object KinesisTestUtils {
     Try { DefaultCredentialsProvider.create().resolveCredentials() }.isSuccess
   }
 
-  def getAwsCredentials: AwsCredentials = {
+  def getAWSCredentials(): AwsCredentials = {
     assert(shouldRunTests,
       "Kinesis test not enabled, should not attempt to get AWS credentials")
     Try { DefaultCredentialsProvider.create().resolveCredentials() } match {

--- a/connector/kinesis-asl/src/test/scala/org/apache/spark/streaming/kinesis/KinesisTestUtils.scala
+++ b/connector/kinesis-asl/src/test/scala/org/apache/spark/streaming/kinesis/KinesisTestUtils.scala
@@ -232,7 +232,7 @@ private[kinesis] object KinesisTestUtils {
     val kinesisServiceMetadata = new KinesisServiceMetadata()
     kinesisServiceMetadata.regions
       .asScala
-      .find(r => kinesisServiceMetadata.endpointFor(r).equals(uri))
+      .find(r => kinesisServiceMetadata.endpointFor(r).toString.equals(uri.getHost))
       .map(_.id)
       .getOrElse(
         throw new IllegalArgumentException(s"Could not resolve region for endpoint: $endpoint"))
@@ -285,6 +285,13 @@ private[kinesis] object KinesisTestUtils {
              |can find the credentials.
            """.stripMargin)
     }
+  }
+
+  def main(args: Array[String]): Unit = {
+    // scalastyle:off println
+    val endpointUrl = "https://kinesis.us-west-2.amazonaws.com"
+    println(s"Result: ${getRegionNameByEndpoint(endpointUrl)}")
+    // scalastyle:on println
   }
 }
 

--- a/docs/streaming-kinesis-integration.md
+++ b/docs/streaming-kinesis-integration.md
@@ -115,7 +115,7 @@ A Kinesis stream can be set up at one of the valid Kinesis endpoints with 1 or m
 
     You may also provide the following settings. This is currently only supported in Scala and Java.
 
-    - A "message handler function" that takes a Kinesis `Record` and returns a generic object `T`, in case you would like to use other data included in a `Record` such as partition key.
+	- A "message handler function" that takes a Kinesis `KinesisClientRecord` and returns a generic object `T`, in case you would like to use other data included in a `Record` such as partition key.
 
     <div class="codetabs">
     <div data-lang="scala" markdown="1">
@@ -125,8 +125,7 @@ A Kinesis stream can be set up at one of the valid Kinesis endpoints with 1 or m
     import org.apache.spark.streaming.kinesis.KinesisInputDStream
     import org.apache.spark.streaming.{Seconds, StreamingContext}
     import org.apache.spark.streaming.kinesis.KinesisInitialPositions
-    import com.amazonaws.services.kinesis.clientlibrary.lib.worker.KinesisClientLibConfiguration
-    import com.amazonaws.services.kinesis.metrics.interfaces.MetricsLevel
+    import software.amazon.kinesis.metrics.MetricsLevel
 
     val kinesisStream = KinesisInputDStream.builder
         .streamingContext(streamingContext)
@@ -138,7 +137,7 @@ A Kinesis stream can be set up at one of the valid Kinesis endpoints with 1 or m
         .checkpointInterval([checkpoint interval])
         .storageLevel(StorageLevel.MEMORY_AND_DISK_2)
         .metricsLevel(MetricsLevel.DETAILED)
-        .metricsEnabledDimensions(KinesisClientLibConfiguration.DEFAULT_METRICS_ENABLED_DIMENSIONS.asScala.toSet)
+        .metricsEnabledDimensions(KinesisInputDStream.DEFAULT_METRICS_ENABLED_DIMENSIONS.asScala.toSet)
         .buildWithMessageHandler([message handler])
     ```
 
@@ -150,8 +149,7 @@ A Kinesis stream can be set up at one of the valid Kinesis endpoints with 1 or m
     import org.apache.spark.streaming.Seconds;
     import org.apache.spark.streaming.StreamingContext;
     import org.apache.spark.streaming.kinesis.KinesisInitialPositions;
-    import com.amazonaws.services.kinesis.clientlibrary.lib.worker.KinesisClientLibConfiguration;
-    import com.amazonaws.services.kinesis.metrics.interfaces.MetricsLevel;
+    import software.amazon.kinesis.metrics.MetricsLevel;
     import scala.collection.JavaConverters;
 
     KinesisInputDStream<byte[]> kinesisStream = KinesisInputDStream.builder()
@@ -166,7 +164,7 @@ A Kinesis stream can be set up at one of the valid Kinesis endpoints with 1 or m
         .metricsLevel(MetricsLevel.DETAILED)
         .metricsEnabledDimensions(
             JavaConverters.asScalaSetConverter(
-                KinesisClientLibConfiguration.DEFAULT_METRICS_ENABLED_DIMENSIONS
+   KinesisInputDStream.DEFAULT_METRICS_ENABLED_DIMENSIONS
             )
             .asScala().toSet()
         )
@@ -194,7 +192,7 @@ A Kinesis stream can be set up at one of the valid Kinesis endpoints with 1 or m
 
     - `[initial position]`: Can be either `KinesisInitialPositions.TrimHorizon` or `KinesisInitialPositions.Latest` or `KinesisInitialPositions.AtTimestamp` (see [`Kinesis Checkpointing`](#kinesis-checkpointing) section and [`Amazon Kinesis API documentation`](http://docs.aws.amazon.com/streams/latest/dev/developing-consumers-with-sdk.html) for more details).
 
-    - `[message handler]`: A function that takes a Kinesis `Record` and outputs generic `T`.
+	- `[message handler]`: A function that takes a Kinesis `KinesisClientRecord` and outputs generic `T`.
 
     In other versions of the API, you can also specify the AWS access key and secret key directly.
 

--- a/pom.xml
+++ b/pom.xml
@@ -158,8 +158,6 @@
     <!-- Should be consistent with SparkBuild.scala and docs -->
     <avro.version>1.11.3</avro.version>
     <aws.kinesis.client.version>2.5.2</aws.kinesis.client.version>
-    <!-- Should be consistent with Kinesis client dependency -->
-    <aws.kinesis.client.guava.version>32.1.1-jre</aws.kinesis.client.guava.version>
     <mbknor.jsonschema.version>1.0.39</mbknor.jsonschema.version>
     <aws.java.sdk.v2.version>2.24.6</aws.java.sdk.v2.version>
     <!-- the producer is used in tests -->

--- a/pom.xml
+++ b/pom.xml
@@ -157,9 +157,10 @@
     <codahale.metrics.version>4.2.25</codahale.metrics.version>
     <!-- Should be consistent with SparkBuild.scala and docs -->
     <avro.version>1.11.3</avro.version>
-    <aws.kinesis.client.version>1.12.0</aws.kinesis.client.version>
+    <aws.kinesis.client.version>2.5.2</aws.kinesis.client.version>
     <!-- Should be consistent with Kinesis client dependency -->
-    <aws.java.sdk.version>1.11.655</aws.java.sdk.version>
+    <aws.kinesis.client.guava.version>32.1.1-jre</aws.kinesis.client.guava.version>
+    <mbknor.jsonschema.version>1.0.39</mbknor.jsonschema.version>
     <aws.java.sdk.v2.version>2.24.6</aws.java.sdk.v2.version>
     <!-- the producer is used in tests -->
     <aws.kinesis.producer.version>0.12.8</aws.kinesis.producer.version>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

As Spark is moving to 4.0, one of the major improvement is to upgrade AWS SDK to v2.

Currently other than directly using AWS SDKv1 codes, the Spark Kinesis connector is also 
using on these libraries that depends on SDKv1:
* Kinesis Client Library (KCL) allows users to easily consume and process data from Amazon Kinesis
* Kinesis Producer Library (KPL) allows users to create reliable and efficient message producers for Amazon Kinesis 

The main purpose of this PR is to upgrading AWS SDK to v2 for the Spark Kinesis 
conector. While the changes includes upgrading AWS SDK and KCL to v2, we will not 
upgrade KPL because it has not yet been migrated to SDKv2.

* Parent Jira: parent Jira: https://issues.apache.org/jira/browse/SPARK-44124. 
* Previous PR to setup Kinesis tests in Github Actions: https://github.com/apache/spark/pull/43736
* Previous stale PR: https://github.com/apache/spark/pull/42581

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

As the GA of AWS SDK v2, the SDKv1 has entered maintenance mode where its future 
release are only limited to address critical bug and security issues. More details about the SDK maintenance policy can be found here. To keep Spark’s dependent softwares up to date, we should consider upgrading the SDK to v2.
These changes could keep Spark Kinesis connector up to date, and enable users to
receive continuous support from the above libraries.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes. With this change, the Spark Kinesis connector will no longer work with SDKv1. 
Any applications that are running with previous version of Spark Kinesis connector
 would require update before migrating to Spark 4.0.

AWS SDKv2 and KCLv2 contain several major changes
that are not backward compatible with their previous versions. And some public classes
in the module (i.e. KinesisInputDStream) are using one of these breaking changes. Thus
these user-facing classes require updates as well.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
*  

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No
