### PR TITLE
[SPARK-46275] Protobuf: Return null in permissive mode when deserialization fails.

### DIFF
--- a/connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufCatalystDataConversionSuite.scala
+++ b/connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufCatalystDataConversionSuite.scala
@@ -80,20 +80,9 @@ class ProtobufCatalystDataConversionSuite
         .eval()
     }
 
-    val expected = {
-      val expectedSchema = ProtobufUtils.buildDescriptor(descBytes, badSchema)
-      SchemaConverters.toSqlType(expectedSchema).dataType match {
-        case st: StructType =>
-          Row.fromSeq((0 until st.length).map { _ =>
-            null
-          })
-        case _ => null
-      }
-    }
-
     checkEvaluation(
       ProtobufDataToCatalyst(binary, badSchema, Some(descBytes), Map("mode" -> "PERMISSIVE")),
-      expected)
+      null)
   }
 
   protected def prepareExpectedResult(expected: Any): Any = expected match {

--- a/connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufCatalystDataConversionSuite.scala
+++ b/connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufCatalystDataConversionSuite.scala
@@ -82,7 +82,7 @@ class ProtobufCatalystDataConversionSuite
 
     checkEvaluation(
       ProtobufDataToCatalyst(binary, badSchema, Some(descBytes), Map("mode" -> "PERMISSIVE")),
-      null)
+      expected = null)
   }
 
   protected def prepareExpectedResult(expected: Any): Any = expected match {


### PR DESCRIPTION

### What changes were proposed in this pull request?
This updates the the behavior of `from_protobuf()` built function when underlying record fails to deserialize. 

  * **Current behvior**: 
    * By default, this would throw an error and the query fails. [This part is not changed in the PR] 
    * When `mode` is set to 'PERMISSIVE' it returns a non-null struct with each of the inner fields set to null e.g. `{ "field_a": null, "field_b": null }`  etc.
       * This is not very convenient to the users. They don't know if this was due to malformed record or if the input itself has null. It is very hard to check for each field for null in SQL query (imagine a sql query with a struct that has 10 fields).
      
  * **New behavior**
    * When `mode` is set to 'PERMISSIVE' it simply returns `null`.


### Why are the changes needed?
This makes it easier for users to detect and handle malformed records.


### Does this PR introduce _any_ user-facing change?
Yes, but this does not change the contract. In fact, it clarifies it. 

### How was this patch tested?
 - Unit tests are updated.


### Was this patch authored or co-authored using generative AI tooling?
No.