### PR TITLE
[SPARK-46292][CORE][UI] Show a summary of workers in MasterPage

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/master/ui/MasterPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/ui/MasterPage.scala
@@ -144,7 +144,11 @@ private[ui] class MasterPage(parent: MasterWebUI) extends WebUIPage("") {
                   </li>
                 }.getOrElse { Seq.empty }
               }
-              <li><strong>Alive Workers:</strong> {aliveWorkers.length}</li>
+              <li><strong>Workers:</strong> {aliveWorkers.length} Alive,
+                {workers.count(_.state == WorkerState.DEAD)} Dead,
+                {workers.count(_.state == WorkerState.DECOMMISSIONED)} Decommissioned,
+                {workers.count(_.state == WorkerState.UNKNOWN)} Unknown
+              </li>
               <li><strong>Cores in use:</strong> {aliveWorkers.map(_.cores).sum} Total,
                 {aliveWorkers.map(_.coresUsed).sum} Used</li>
               <li><strong>Memory in use:</strong>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to show a summary of workers in MasterPage.

### Why are the changes needed?

Although `Alive Workers` is a useful information, it's insufficient to analyze the whole cluster status because we don't know how many workers are in other status. Especially, this is useful during the recovery process of Spark Master HA setting.

In short, this helps the users identify the issues intuitively.

```
- Alive Workers: 1
+ Workers: 1 Alive, 1 Dead, 0 Decommissioned, 0 Unknown
```

Here is a screenshot.

![Screenshot 2023-12-06 at 3 13 43 PM](https://github.com/apache/spark/assets/9700541/f078b6ae-ab22-4721-8c67-661121bb9807)


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual test.

### Was this patch authored or co-authored using generative AI tooling?

No.