### PR TITLE
[MINOR][PYTHON][DOCS] Rename "Koalas" > "Pandas-on-Spark" for testing util doc

### DIFF
--- a/python/pyspark/testing/pandasutils.py
+++ b/python/pyspark/testing/pandasutils.py
@@ -480,8 +480,8 @@ class PandasOnSparkTestUtils:
         check_row_order: bool = True,
     ):
         """
-        Asserts if two arbitrary objects are equal or not. If given objects are Koalas DataFrame
-        or Series, they are converted into pandas' and compared.
+        Asserts if two arbitrary objects are equal or not. If given objects are
+        Pandas-on-Spark DataFrame or Series, they are converted into pandas' and compared.
 
         :param left: object to compare
         :param right: object to compare


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to rename Koalas to Pandas-on-Spark for testing util documentation.


### Why are the changes needed?

To get rid of legacy documentation.

### Does this PR introduce _any_ user-facing change?

No API changes.


### How was this patch tested?

The existing CI should pass.

### Was this patch authored or co-authored using generative AI tooling?

No.