### PR TITLE
[SPARK-46294][SQL] Clean up semantics of init vs zero value

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/metric/SQLMetrics.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/metric/SQLMetrics.scala
@@ -40,14 +40,16 @@ import org.apache.spark.util.AccumulatorContext.internOption
 class SQLMetric(val metricType: String,
                 initValue: Long = 0L,
                 zeroValue: Long = 0L) extends AccumulatorV2[Long, Long] {
-  // If a metric has value equal to its initValue, then it should be filtered out before aggregating with
-  // SQLMetrics.stringValue().
-  // zeroValue defines the lowest value considered valid. If a SQLMetric is invalid, it is set to zeroValue upon
-  // receiving any updates, and it also reports zeroValue as its value to avoid exposing it to the user programatically.
+  // If a metric has value equal to its initValue, then it should be filtered out before
+  // aggregating with SQLMetrics.stringValue().
+  // zeroValue defines the lowest value considered valid. If a SQLMetric is invalid, it is set to
+  // zeroValue upon receiving any updates, and it also reports zeroValue as its value to avoid
+  // exposing it to the user programatically.
   //
-  // For many SQLMetrics, we use initValue = -1 and zeroValue = 0 to indicate that the metric is by default invalid.
-  // At the end of a task, we will update the metric making it valid, and the invalid metrics will be filtered out
-  // when calculating min, max, etc. as a workaround for SPARK-11013.
+  // For many SQLMetrics, we use initValue = -1 and zeroValue = 0 to indicate that the metric is
+  // by default invalid. At the end of a task, we will update the metric making it valid, and the
+  // invalid metrics will be filtered out when calculating min, max, etc. as a workaround for
+  // SPARK-11013.
   private var _value = initValue
 
   override def copy(): SQLMetric = {
@@ -86,11 +88,8 @@ class SQLMetric(val metricType: String,
 
   def +=(v: Long): Unit = add(v)
 
-  // We may use -1 as initial value of the accumulator, so that the SQL UI can filter out
-  // invalid accumulator values (0 is a valid metric value) when calculating min, max, etc.
-  // However, users can also access the SQL metrics values programmatically via this method.
-  // We should be consistent with the SQL UI and don't expose -1 to users.
-  // See `SQLMetrics.stringValue`. If this is invalid, returns zeroValue.
+  // _value may be invalid, in many cases being -1. We should not expose it to the user
+  // and instead return zeroValue.
   override def value: Long = if (!isValid) zeroValue else _value
 
   // Provide special identifier as metadata so we can tell that this is a `SQLMetric` later

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/metric/SQLMetrics.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/metric/SQLMetrics.scala
@@ -37,36 +37,44 @@ import org.apache.spark.util.AccumulatorContext.internOption
  * the executor side are automatically propagated and shown in the SQL UI through metrics. Updates
  * on the driver side must be explicitly posted using [[SQLMetrics.postDriverMetricUpdates()]].
  */
-class SQLMetric(val metricType: String, initValue: Long = 0L) extends AccumulatorV2[Long, Long] {
-  // This is a workaround for SPARK-11013.
-  // We may use -1 as initial value of the accumulator, if the accumulator is valid, we will
-  // update it at the end of task and the value will be at least 0. Then we can filter out the -1
-  // values before calculate max, min, etc.
-  private[this] var _value = initValue
-  private var _zeroValue = initValue
+class SQLMetric(val metricType: String,
+                initValue: Long = 0L,
+                zeroValue: Long = 0L) extends AccumulatorV2[Long, Long] {
+  // If a metric has value equal to its initValue, then it should be filtered out before aggregating with
+  // SQLMetrics.stringValue().
+  // zeroValue defines the lowest value considered valid. If a SQLMetric is invalid, it is set to zeroValue upon
+  // receiving any updates, and it also reports zeroValue as its value to avoid exposing it to the user programatically.
+  //
+  // For many SQLMetrics, we use initValue = -1 and zeroValue = 0 to indicate that the metric is by default invalid.
+  // At the end of a task, we will update the metric making it valid, and the invalid metrics will be filtered out
+  // when calculating min, max, etc. as a workaround for SPARK-11013.
+  private var _value = initValue
 
   override def copy(): SQLMetric = {
-    val newAcc = new SQLMetric(metricType, _value)
-    newAcc._zeroValue = initValue
+    val newAcc = new SQLMetric(metricType, initValue, zeroValue)
+    newAcc._value = _value
     newAcc
   }
 
-  override def reset(): Unit = _value = _zeroValue
+  override def reset(): Unit = _value = initValue
 
   override def merge(other: AccumulatorV2[Long, Long]): Unit = other match {
     case o: SQLMetric =>
-      if (o.value > 0) {
-        if (_value < 0) _value = 0
+      if (o.isValid) {
+        if (!isValid) _value = zeroValue
         _value += o.value
       }
     case _ => throw QueryExecutionErrors.cannotMergeClassWithOtherClassError(
       this.getClass.getName, other.getClass.getName)
   }
 
-  override def isZero: Boolean = _value == _zeroValue
+  // This is used to decide whether the metric should be filtered.
+  override def isZero: Boolean = _value == initValue
+
+  def isValid = value >= zeroValue
 
   override def add(v: Long): Unit = {
-    if (_value < 0) _value = 0
+    if (!isValid) _value = zeroValue
     _value += v
   }
 
@@ -82,8 +90,8 @@ class SQLMetric(val metricType: String, initValue: Long = 0L) extends Accumulato
   // invalid accumulator values (0 is a valid metric value) when calculating min, max, etc.
   // However, users can also access the SQL metrics values programmatically via this method.
   // We should be consistent with the SQL UI and don't expose -1 to users.
-  // See `SQLMetrics.stringValue`. When there is no valid accumulator values, 0 is the metric value.
-  override def value: Long = if (_value < 0) 0 else _value
+  // See `SQLMetrics.stringValue`. If this is invalid, returns zeroValue.
+  override def value: Long = if (!isValid) zeroValue else _value
 
   // Provide special identifier as metadata so we can tell that this is a `SQLMetric` later
   override def toInfo(update: Option[Any], value: Option[Any]): AccumulableInfo = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/metric/SQLMetrics.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/metric/SQLMetrics.scala
@@ -37,9 +37,10 @@ import org.apache.spark.util.AccumulatorContext.internOption
  * the executor side are automatically propagated and shown in the SQL UI through metrics. Updates
  * on the driver side must be explicitly posted using [[SQLMetrics.postDriverMetricUpdates()]].
  */
-class SQLMetric(val metricType: String,
-                initValue: Long = 0L,
-                zeroValue: Long = 0L) extends AccumulatorV2[Long, Long] {
+class SQLMetric(
+    val metricType: String,
+    initValue: Long = 0L,
+    zeroValue: Long = 0L) extends AccumulatorV2[Long, Long] {
   // initValue defines the initial value of the metric. zeroValue defines the lowest value
   // considered valid. If a SQLMetric is invalid, it is set to zeroValue upon receiving any
   // updates, and it also reports zeroValue as its value to avoid exposing it to the user
@@ -72,6 +73,8 @@ class SQLMetric(val metricType: String,
   // This is used to filter out metrics. Metrics with value equal to initValue should
   // be filtered out, since they are either invalid or safe to filter without changing
   // the aggregation defined in [[SQLMetrics.stringValue]].
+  // Note that we don't use zeroValue here since we may want to collect zeroValue metrics
+  // for calculating min, max, etc. See SPARK-11013.
   override def isZero: Boolean = _value == initValue
 
   def isValid: Boolean = _value >= zeroValue

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/metric/SQLMetrics.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/metric/SQLMetrics.scala
@@ -73,7 +73,7 @@ class SQLMetric(val metricType: String,
   // This is used to decide whether the metric should be filtered.
   override def isZero: Boolean = _value == initValue
 
-  def isValid = value >= zeroValue
+  def isValid: Boolean = value >= zeroValue
 
   override def add(v: Long): Unit = {
     if (!isValid) _value = zeroValue


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Cleaning up the semantics of init and zero value to the following. This also helps define what an "invalid" metric is.

initValue is the starting value for a SQLMetric. If a metric has value equal to its initValue, then it can/should be filtered out before aggregating with SQLMetrics.stringValue().
 
zeroValue defines the lowest value considered valid. If a SQLMetric is invalid, it is set to zeroValue upon receiving any updates, and it also reports zeroValue as its value to avoid exposing it to the user programatically (concern previouosly addressed in [SPARK-41442](https://issues.apache.org/jira/browse/SPARK-41442)).

For many SQLMetrics, we use initValue = -1 and zeroValue = 0 to indicate that the metric is by default invalid. Whenever an invalid metric is updated, it sets itself to zeroValue and becomes valid. Invalid metrics will be filtered out when calculating min, max, etc. as a workaround for [SPARK-11013](https://issues.apache.org/jira/browse/SPARK-11013).

### Why are the changes needed?

The semantics of initValue and _zeroValue in SQLMetrics is a little bit confusing, since they effectively mean the same thing. Changing it to the following would be clearer, especially in terms of defining what an "invalid" metric is.

### Does this PR introduce _any_ user-facing change?
No. This shouldn't change any behavior.

### How was this patch tested?
Existing tests.

### Was this patch authored or co-authored using generative AI tooling?
No.
