### PR TITLE
[SPARK-46296][PYTHON][TESTS] Test missing test coverage for captured errors (pyspark.errors.exceptions)

### DIFF
--- a/python/pyspark/errors/exceptions/captured.py
+++ b/python/pyspark/errors/exceptions/captured.py
@@ -104,7 +104,7 @@ class CapturedException(PySparkException):
         if self._origin is not None and is_instance_of(
             gw, self._origin, "org.apache.spark.SparkThrowable"
         ):
-            return self._origin.getMessageParameters()
+            return dict(self._origin.getMessageParameters())
         else:
             return None
 

--- a/python/pyspark/sql/tests/test_utils.py
+++ b/python/pyspark/sql/tests/test_utils.py
@@ -1749,6 +1749,14 @@ class UtilsTests(ReusedSQLTestCase, UtilsTestsMixin):
         except AnalysisException as e:
             self.assertEqual(e.getErrorClass(), "UNRESOLVED_COLUMN.WITHOUT_SUGGESTION")
             self.assertEqual(e.getSqlState(), "42703")
+            self.assertEqual(e.getMessageParameters(), {"objectName": "`a`"})
+
+        try:
+            self.spark.sql("""SELECT assert_true(FALSE)""")
+        except AnalysisException as e:
+            self.assertIsNone(e.getErrorClass())
+            self.assertIsNone(e.getSqlState())
+            self.assertEqual(e.getMessageParameters(), {})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds tests for negative cases of `getErrorClass` and `getSqlState`. And test case for `getMessageParameters` for errors.

### Why are the changes needed?

To improve the test coverage.

See https://app.codecov.io/gh/apache/spark/commit/1a651753f4e760643d719add3b16acd311454c76/blob/python/pyspark/errors/exceptions/captured.py This is not being tested.

### Does this PR introduce _any_ user-facing change?

No, test-only

### How was this patch tested?

Manually ran the new unittest.

### Was this patch authored or co-authored using generative AI tooling?

Np.