### PR TITLE
[SPARK-46297][PYTHON][INFRA] Exclude generated files from the code coverage report

### DIFF
--- a/python/run-tests-with-coverage
+++ b/python/run-tests-with-coverage
@@ -60,10 +60,10 @@ find $COVERAGE_DIR/coverage_data -size 0 -print0 | xargs -0 rm -fr
 echo "Combining collected coverage data under $COVERAGE_DIR/coverage_data"
 $COV_EXEC combine
 echo "Creating XML report file at python/coverage.xml"
-$COV_EXEC xml --ignore-errors --include "pyspark/*" --omit "pyspark/cloudpickle/*"
+$COV_EXEC xml --ignore-errors --include "pyspark/*" --omit "pyspark/cloudpickle/*" --omit "pyspark/sql/connect/proto/*"
 echo "Reporting the coverage data at $COVERAGE_DIR/coverage_data/coverage"
-$COV_EXEC report --include "pyspark/*" --omit "pyspark/cloudpickle/*"
+$COV_EXEC report --include "pyspark/*" --omit "pyspark/cloudpickle/*" --omit "pyspark/sql/connect/proto/*"
 echo "Generating HTML files for PySpark coverage under $COVERAGE_DIR/htmlcov"
-$COV_EXEC html --ignore-errors --include "pyspark/*" --directory "$COVERAGE_DIR/htmlcov" --omit "pyspark/cloudpickle/*"
+$COV_EXEC html --ignore-errors --include "pyspark/*" --directory "$COVERAGE_DIR/htmlcov" --omit "pyspark/cloudpickle/*" --omit "pyspark/sql/connect/proto/*"
 
 popd


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to exclude generated files from the code coverage report, `pyspark/sql/connect/proto/*`.

### Why are the changes needed?

For correct test coverage report, and make it easier to read.

https://app.codecov.io/gh/apache/spark/commit/1a651753f4e760643d719add3b16acd311454c76/tree/python/pyspark/sql/connect/proto

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Manually tested.

### Was this patch authored or co-authored using generative AI tooling?

No.