### PR TITLE
[SPARK-46298][PYTHON][CONNECT] Match deprecation warning, test case, and error of Catalog.createExternalTable

### DIFF
--- a/python/pyspark/sql/catalog.py
+++ b/python/pyspark/sql/catalog.py
@@ -1237,14 +1237,6 @@ class Catalog:
         """
         self._jcatalog.refreshByPath(path)
 
-    def _reset(self) -> None:
-        """(Internal use only) Drop all existing databases (except "default"), tables,
-        partitions and functions, and set the current database to "default".
-
-        This is mainly used for tests.
-        """
-        self._jsparkSession.sessionState().catalog().reset()
-
 
 def _test() -> None:
     import os

--- a/python/pyspark/sql/connect/plan.py
+++ b/python/pyspark/sql/connect/plan.py
@@ -1997,40 +1997,6 @@ class FunctionExists(LogicalPlan):
         return plan
 
 
-class CreateExternalTable(LogicalPlan):
-    def __init__(
-        self,
-        table_name: str,
-        path: str,
-        source: Optional[str] = None,
-        schema: Optional[DataType] = None,
-        options: Mapping[str, str] = {},
-    ) -> None:
-        super().__init__(None)
-        self._table_name = table_name
-        self._path = path
-        self._source = source
-        self._schema = schema
-        self._options = options
-
-    def plan(self, session: "SparkConnectClient") -> proto.Relation:
-        plan = self._create_proto_relation()
-        plan.catalog.create_external_table.table_name = self._table_name
-        if self._path is not None:
-            plan.catalog.create_external_table.path = self._path
-        if self._source is not None:
-            plan.catalog.create_external_table.source = self._source
-        if self._schema is not None:
-            plan.catalog.create_external_table.schema.CopyFrom(
-                pyspark_types_to_proto_types(self._schema)
-            )
-        for k in self._options.keys():
-            v = self._options.get(k)
-            if v is not None:
-                plan.catalog.create_external_table.options[k] = v
-        return plan
-
-
 class CreateTable(LogicalPlan):
     def __init__(
         self,

--- a/python/pyspark/sql/tests/test_catalog.py
+++ b/python/pyspark/sql/tests/test_catalog.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 from pyspark import StorageLevel
-from pyspark.errors import AnalysisException
+from pyspark.errors import AnalysisException, PySparkTypeError
 from pyspark.sql.types import StructType, StructField, IntegerType
 from pyspark.testing.sqlutils import ReusedSQLTestCase
 
@@ -81,6 +81,13 @@ class CatalogTestsMixin:
 
                     schema = StructType([StructField("a", IntegerType(), True)])
                     description = "this a table created via Catalog.createTable()"
+
+                    with self.assertRaisesRegex(PySparkTypeError, "should be a struct type"):
+                        # Test deprecated API and negative error case.
+                        spark.catalog.createExternalTable(
+                            "invalid_table_creation", schema=IntegerType(), description=description
+                        )
+
                     spark.catalog.createTable(
                         "tab3_via_catalog", schema=schema, description=description
                     )


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds tests for catalog error cases for `createExternalTable`.

Also, this PR includes several minor cleanups:
- Show a deprecation for `spark.catalog.createExternalTable` (to match with the non-Spark Connect)
- Remove `_reset` at `Catalog` which is not used anywhere.
- Switch the implementation of Spark Connect `spark.catalog.createExternalTable` to directly call `spark.catalog.createTable`, and remove the corresponding Python protobuf definition.
  - this PR does not remove the protobuf message definition itself for potential compatibility concern.

### Why are the changes needed?

- For feature parity.
- To improve the test coverage.
    See https://app.codecov.io/gh/apache/spark/commit/1a651753f4e760643d719add3b16acd311454c76/blob/python/pyspark/sql/catalog.py

This is not being tested.

### Does this PR introduce _any_ user-facing change?

Virtually no (except the ones descried above)

### How was this patch tested?

Manually ran the new unittest.

### Was this patch authored or co-authored using generative AI tooling?

No.