### PR TITLE
[SPARK-45597][PYTHON][SQL] Support creating table using a Python data source in SQL (single wrapper)

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -1513,7 +1513,7 @@ object CodeGenerator extends Logging {
     (evaluator.getClazz().getConstructor().newInstance().asInstanceOf[GeneratedClass], codeStats)
   }
 
-  def logGeneratedCode(code: CodeAndComment): Unit = {
+  private def logGeneratedCode(code: CodeAndComment): Unit = {
     val maxLines = SQLConf.get.loggingMaxLinesForCodegen
     if (Utils.isTesting) {
       logError(s"\n${CodeFormatter.format(code, maxLines)}")
@@ -1527,7 +1527,7 @@ object CodeGenerator extends Logging {
    * # of inner classes) of generated classes by inspecting Janino classes.
    * Also, this method updates the metrics information.
    */
-  def updateAndGetCompilationStats(evaluator: ClassBodyEvaluator): ByteCodeStats = {
+  private def updateAndGetCompilationStats(evaluator: ClassBodyEvaluator): ByteCodeStats = {
     // First retrieve the generated classes.
     val classes = evaluator.getBytecodes.asScala
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -1513,7 +1513,7 @@ object CodeGenerator extends Logging {
     (evaluator.getClazz().getConstructor().newInstance().asInstanceOf[GeneratedClass], codeStats)
   }
 
-  private def logGeneratedCode(code: CodeAndComment): Unit = {
+  def logGeneratedCode(code: CodeAndComment): Unit = {
     val maxLines = SQLConf.get.loggingMaxLinesForCodegen
     if (Utils.isTesting) {
       logError(s"\n${CodeFormatter.format(code, maxLines)}")
@@ -1527,7 +1527,7 @@ object CodeGenerator extends Logging {
    * # of inner classes) of generated classes by inspecting Janino classes.
    * Also, this method updates the metrics information.
    */
-  private def updateAndGetCompilationStats(evaluator: ClassBodyEvaluator): ByteCodeStats = {
+  def updateAndGetCompilationStats(evaluator: ClassBodyEvaluator): ByteCodeStats = {
     // First retrieve the generated classes.
     val classes = evaluator.getBytecodes.asScala
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
@@ -208,45 +208,10 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
       throw QueryCompilationErrors.pathOptionNotSetCorrectlyWhenReadingError()
     }
 
-    val isUserDefinedDataSource =
-      sparkSession.sessionState.dataSourceManager.dataSourceExists(source)
-
-    Try(DataSource.lookupDataSourceV2(source, sparkSession.sessionState.conf)) match {
-      case Success(providerOpt) =>
-        // The source can be successfully loaded as either a V1 or a V2 data source.
-        // Check if it is also a user-defined data source.
-        if (isUserDefinedDataSource) {
-          throw QueryCompilationErrors.foundMultipleDataSources(source)
-        }
-        providerOpt.flatMap { provider =>
-          DataSourceV2Utils.loadV2Source(
-            sparkSession, provider, userSpecifiedSchema, extraOptions, source, paths: _*)
-        }.getOrElse(loadV1Source(paths: _*))
-      case Failure(exception) =>
-        // Exceptions are thrown while trying to load the data source as a V1 or V2 data source.
-        // For the following not found exceptions, if the user-defined data source is defined,
-        // we can instead return the user-defined data source.
-        val isNotFoundError = exception match {
-          case _: NoClassDefFoundError | _: SparkClassNotFoundException => true
-          case e: SparkThrowable => e.getErrorClass == "DATA_SOURCE_NOT_FOUND"
-          case e: ServiceConfigurationError => e.getCause.isInstanceOf[NoClassDefFoundError]
-          case _ => false
-        }
-        if (isNotFoundError && isUserDefinedDataSource) {
-          loadUserDefinedDataSource(paths)
-        } else {
-          // Throw the original exception.
-          throw exception
-        }
-    }
-  }
-
-  private def loadUserDefinedDataSource(paths: Seq[String]): DataFrame = {
-    val builder = sparkSession.sessionState.dataSourceManager.lookupDataSource(source)
-    // Add `path` and `paths` options to the extra options if specified.
-    val optionsWithPath = DataSourceV2Utils.getOptionsWithPaths(extraOptions, paths: _*)
-    val plan = builder(sparkSession, source, userSpecifiedSchema, optionsWithPath)
-    Dataset.ofRows(sparkSession, plan)
+    DataSource.lookupDataSourceV2(source, sparkSession.sessionState.conf).flatMap { provider =>
+      DataSourceV2Utils.loadV2Source(sparkSession, provider, userSpecifiedSchema, extraOptions,
+        source, paths: _*)
+    }.getOrElse(loadV1Source(paths: _*))
   }
 
   private def loadV1Source(paths: String*) = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
@@ -17,12 +17,11 @@
 
 package org.apache.spark.sql
 
-import java.util.{Locale, Properties, ServiceConfigurationError}
+import java.util.{Locale, Properties}
 
 import scala.jdk.CollectionConverters._
-import scala.util.{Failure, Success, Try}
 
-import org.apache.spark.{Partition, SparkClassNotFoundException, SparkThrowable}
+import org.apache.spark.Partition
 import org.apache.spark.annotation.Stable
 import org.apache.spark.api.java.JavaRDD
 import org.apache.spark.internal.Logging

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -780,7 +780,7 @@ class SparkSession private(
     DataSource.lookupDataSource(runner, sessionState.conf) match {
       case source if classOf[ExternalCommandRunner].isAssignableFrom(source) =>
         Dataset.ofRows(self, ExternalCommandExecutor(
-          source.getDeclaredConstructor().newInstance()
+          DataSource.newDataSourceInstance(runner, source)
             .asInstanceOf[ExternalCommandRunner], command, options))
 
       case _ =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
@@ -1022,11 +1022,9 @@ object DDLUtils extends Logging {
 
   def checkDataColNames(provider: String, schema: StructType): Unit = {
     val source = try {
-      DataSource.lookupDataSource(provider, SQLConf.get) match {
-        case cls if classOf[PythonTableProvider].isAssignableFrom(cls) =>
-          cls.getConstructor(classOf[String]).newInstance(provider)
-        case cls => cls.getDeclaredConstructor().newInstance()
-      }
+      DataSource.newDataSourceInstance(
+        provider,
+        DataSource.lookupDataSource(provider, SQLConf.get))
     } catch {
       case e: Throwable =>
         logError(s"Failed to find data source: $provider when check data column names.", e)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
@@ -45,7 +45,7 @@ import org.apache.spark.sql.connector.catalog.CatalogManager.SESSION_CATALOG_NAM
 import org.apache.spark.sql.connector.catalog.SupportsNamespaces._
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.errors.QueryExecutionErrors.hiveTableWithAnsiIntervalsError
-import org.apache.spark.sql.execution.datasources.{DataSource, DataSourceUtils, FileFormat, HadoopFsRelation, LogicalRelation}
+import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.execution.datasources.v2.FileDataSourceV2
 import org.apache.spark.sql.internal.{HiveSerDe, SQLConf}
 import org.apache.spark.sql.types._
@@ -1022,7 +1022,11 @@ object DDLUtils extends Logging {
 
   def checkDataColNames(provider: String, schema: StructType): Unit = {
     val source = try {
-      DataSource.lookupDataSource(provider, SQLConf.get).getConstructor().newInstance()
+      DataSource.lookupDataSource(provider, SQLConf.get) match {
+        case cls if classOf[PythonTableProvider].isAssignableFrom(cls) =>
+          cls.getConstructor(classOf[String]).newInstance(provider)
+        case cls => cls.getDeclaredConstructor().newInstance()
+      }
     } catch {
       case e: Throwable =>
         logError(s"Failed to find data source: $provider when check data column names.", e)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -39,7 +39,7 @@ import org.apache.spark.sql.catalyst.util._
 import org.apache.spark.sql.catalyst.util.ResolveDefaultColumns.CURRENT_DEFAULT_COLUMN_METADATA_KEY
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.TableIdentifierHelper
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
-import org.apache.spark.sql.execution.datasources.{DataSource, PythonTableProvider}
+import org.apache.spark.sql.execution.datasources.DataSource
 import org.apache.spark.sql.execution.datasources.csv.CSVFileFormat
 import org.apache.spark.sql.execution.datasources.json.JsonFileFormat
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
@@ -264,12 +264,9 @@ case class AlterTableAddColumnsCommand(
     }
 
     if (DDLUtils.isDatasourceTable(catalogTable)) {
-      val instance = DataSource.lookupDataSource(catalogTable.provider.get, conf) match {
-        case cls if classOf[PythonTableProvider].isAssignableFrom(cls) =>
-          cls.getConstructor(classOf[String]).newInstance(catalogTable.provider.get)
-        case cls => cls.getDeclaredConstructor().newInstance()
-      }
-      instance match {
+      DataSource.newDataSourceInstance(
+          catalogTable.provider.get,
+          DataSource.lookupDataSource(catalogTable.provider.get, conf)) match {
         // For datasource table, this command can only support the following File format.
         // TextFileFormat only default to one column "value"
         // Hive type is already considered as hive serde table, so the logic will not

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceManager.scala
@@ -20,12 +20,23 @@ package org.apache.spark.sql.execution.datasources
 import java.util.Locale
 import java.util.concurrent.ConcurrentHashMap
 
+import scala.collection.immutable.Map
+
+import org.apache.commons.text.StringEscapeUtils
+import org.codehaus.commons.compiler.{CompileException, InternalCompilerException}
+import org.codehaus.janino.ClassBodyEvaluator
+
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.SparkSession
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.{DataFrame, Dataset, Row, SparkSession, SQLContext}
+import org.apache.spark.sql.catalyst.expressions.codegen.{CodeAndComment, CodeFormatter, CodeGenerator}
+import org.apache.spark.sql.catalyst.expressions.codegen.GeneratePredicate.newCodeGenContext
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
-import org.apache.spark.sql.errors.QueryCompilationErrors
+import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
+import org.apache.spark.sql.sources.{BaseRelation, DataSourceRegister, RelationProvider, SchemaRelationProvider, TableScan}
 import org.apache.spark.sql.types.StructType
+import org.apache.spark.util.{ParentClassLoader, Utils}
 
 /**
  * A manager for user-defined data sources. It is used to register and lookup data sources by
@@ -40,6 +51,8 @@ class DataSourceManager extends Logging {
     CaseInsensitiveMap[String]  // options
   ) => LogicalPlan
 
+  // TODO(SPARK-45917): Statically load Python Data Source so idempotently Python
+  //   Data Sources can be loaded even when the Driver is restarted.
   private val dataSourceBuilders = new ConcurrentHashMap[String, DataSourceBuilder]()
 
   private def normalize(name: String): String = name.toLowerCase(Locale.ROOT)
@@ -79,5 +92,109 @@ class DataSourceManager extends Logging {
     val manager = new DataSourceManager
     dataSourceBuilders.forEach((k, v) => manager.registerDataSource(k, v))
     manager
+  }
+}
+
+/**
+ * Data Source V1 default source wrapper for Python Data Source.
+ */
+abstract class PythonDefaultSource
+    extends RelationProvider
+    with SchemaRelationProvider
+    with DataSourceRegister {
+
+  override def createRelation(
+      sqlContext: SQLContext, parameters: Map[String, String]): BaseRelation =
+    new PythonRelation(shortName(), sqlContext, parameters, None)
+
+  override def createRelation(
+      sqlContext: SQLContext,
+      parameters: Map[String, String],
+      schema: StructType): BaseRelation =
+    new PythonRelation(shortName(), sqlContext, parameters, Some(schema))
+}
+
+/**
+ * Data Source V1 relation wrapper for Python Data Source.
+ */
+class PythonRelation(
+    source: String,
+    override val sqlContext: SQLContext,
+    parameters: Map[String, String],
+    maybeSchema: Option[StructType]) extends BaseRelation with TableScan {
+
+  private lazy val sourceDf: DataFrame = {
+    val caseInsensitiveMap = CaseInsensitiveMap(parameters)
+    // TODO(SPARK-45600): should be session-based.
+    val builder = sqlContext.sparkSession.sharedState.dataSourceManager.lookupDataSource(source)
+    val plan = builder(
+      sqlContext.sparkSession, source, caseInsensitiveMap.get("path").toSeq,
+      maybeSchema, caseInsensitiveMap)
+    Dataset.ofRows(sqlContext.sparkSession, plan)
+  }
+
+  override def schema: StructType = sourceDf.schema
+
+  override def buildScan(): RDD[Row] = sourceDf.rdd
+}
+
+/**
+ * Responsible for generating a class for Python Data Source
+ * that inherits Scala Data Source interface so other features work together
+ * with Python Data Source.
+ */
+object PythonDataSourceCodeGenerator extends Logging {
+  /**
+   * When you invoke `generateClass`, it generates a class that inherits [[PythonDefaultSource]]
+   * that has a different short name. The generated class name as follows:
+   * "org.apache.spark.sql.execution.datasources.$shortName.DefaultSource".
+   *
+   * The `shortName` should be registered via `spark.dataSource.register` first, then
+   * this method can generate corresponding Scala Data Source wrapper for the Python
+   * Data Source.
+   *
+   * @param shortName The short name registered for Python Data Source.
+   * @return
+   */
+  def generateClass(shortName: String): Class[_] = {
+    val ctx = newCodeGenContext()
+
+    val codeBody = s"""
+      @Override
+      public String shortName() {
+        return "${StringEscapeUtils.escapeJava(shortName)}";
+      }"""
+
+    val evaluator = new ClassBodyEvaluator()
+    val parentClassLoader = new ParentClassLoader(Utils.getContextOrSparkClassLoader)
+    evaluator.setParentClassLoader(parentClassLoader)
+    evaluator.setClassName(
+      s"org.apache.spark.sql.execution.python.datasources.$shortName.DefaultSource")
+    evaluator.setExtendedClass(classOf[PythonDefaultSource])
+
+    val code = CodeFormatter.stripOverlappingComments(
+      new CodeAndComment(codeBody, ctx.getPlaceHolderToComments()))
+
+    // Note that the default `CodeGenerator.compile` wraps everything into a `GeneratedClass`
+    // class, and the defined DataSource becomes a nested class that cannot properly define
+    // getConstructors, etc. Therefore, we cannot simply reuse this.
+    try {
+      evaluator.cook("generated.java", code.body)
+      CodeGenerator.updateAndGetCompilationStats(evaluator)
+    } catch {
+      case e: InternalCompilerException =>
+        val msg = QueryExecutionErrors.failedToCompileMsg(e)
+        logError(msg, e)
+        CodeGenerator.logGeneratedCode(code)
+        throw QueryExecutionErrors.internalCompilerError(e)
+      case e: CompileException =>
+        val msg = QueryExecutionErrors.failedToCompileMsg(e)
+        logError(msg, e)
+        CodeGenerator.logGeneratedCode(code)
+        throw QueryExecutionErrors.compilerError(e)
+    }
+
+    logDebug(s"Generated Python Data Source':\n${CodeFormatter.format(code)}")
+    evaluator.getClazz()
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceManager.scala
@@ -20,23 +20,22 @@ package org.apache.spark.sql.execution.datasources
 import java.util.Locale
 import java.util.concurrent.ConcurrentHashMap
 
-import scala.collection.immutable.Map
-
-import org.apache.commons.text.StringEscapeUtils
-import org.codehaus.commons.compiler.{CompileException, InternalCompilerException}
-import org.codehaus.janino.ClassBodyEvaluator
+import scala.jdk.CollectionConverters._
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, Dataset, Row, SparkSession, SQLContext}
-import org.apache.spark.sql.catalyst.expressions.codegen.{CodeAndComment, CodeFormatter, CodeGenerator}
-import org.apache.spark.sql.catalyst.expressions.codegen.GeneratePredicate.newCodeGenContext
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
-import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
-import org.apache.spark.sql.sources.{BaseRelation, DataSourceRegister, RelationProvider, SchemaRelationProvider, TableScan}
+import org.apache.spark.sql.connector.catalog.{SupportsRead, Table, TableCapability, TableProvider}
+import org.apache.spark.sql.connector.catalog.TableCapability.BATCH_READ
+import org.apache.spark.sql.connector.expressions.Transform
+import org.apache.spark.sql.connector.read.{Scan, ScanBuilder, V1Scan}
+import org.apache.spark.sql.errors.QueryCompilationErrors
+import org.apache.spark.sql.sources.{BaseRelation, TableScan}
 import org.apache.spark.sql.types.StructType
-import org.apache.spark.util.{ParentClassLoader, Utils}
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
 
 /**
  * A manager for user-defined data sources. It is used to register and lookup data sources by
@@ -96,105 +95,58 @@ class DataSourceManager extends Logging {
 }
 
 /**
- * Data Source V1 default source wrapper for Python Data Source.
+ * Data Source V2 wrapper for Python Data Source.
  */
-abstract class PythonDefaultSource
-    extends RelationProvider
-    with SchemaRelationProvider
-    with DataSourceRegister {
+class PythonTableProvider(shortName: String) extends TableProvider {
+  private var sourceDataFrame: DataFrame = _
 
-  override def createRelation(
-      sqlContext: SQLContext, parameters: Map[String, String]): BaseRelation =
-    new PythonRelation(shortName(), sqlContext, parameters, None)
-
-  override def createRelation(
-      sqlContext: SQLContext,
-      parameters: Map[String, String],
-      schema: StructType): BaseRelation =
-    new PythonRelation(shortName(), sqlContext, parameters, Some(schema))
-}
-
-/**
- * Data Source V1 relation wrapper for Python Data Source.
- */
-class PythonRelation(
-    source: String,
-    override val sqlContext: SQLContext,
-    parameters: Map[String, String],
-    maybeSchema: Option[StructType]) extends BaseRelation with TableScan {
-
-  private lazy val sourceDf: DataFrame = {
-    val caseInsensitiveMap = CaseInsensitiveMap(parameters)
+  private def getOrCreateSourceDataFrame(
+      options: CaseInsensitiveStringMap, maybeSchema: Option[StructType]): DataFrame = {
+    if (sourceDataFrame != null) return sourceDataFrame
     // TODO(SPARK-45600): should be session-based.
-    val builder = sqlContext.sparkSession.sharedState.dataSourceManager.lookupDataSource(source)
+    val builder = SparkSession.active.sessionState.dataSourceManager.lookupDataSource(shortName)
     val plan = builder(
-      sqlContext.sparkSession, source, caseInsensitiveMap.get("path").toSeq,
-      maybeSchema, caseInsensitiveMap)
-    Dataset.ofRows(sqlContext.sparkSession, plan)
+      SparkSession.active,
+      shortName,
+      maybeSchema,
+      CaseInsensitiveMap(options.asCaseSensitiveMap().asScala.toMap))
+    sourceDataFrame = Dataset.ofRows(SparkSession.active, plan)
+    sourceDataFrame
   }
 
-  override def schema: StructType = sourceDf.schema
+  override def inferSchema(options: CaseInsensitiveStringMap): StructType =
+    getOrCreateSourceDataFrame(options, None).schema
 
-  override def buildScan(): RDD[Row] = sourceDf.rdd
-}
+  override def getTable(
+      schema: StructType,
+      partitioning: Array[Transform],
+      properties: java.util.Map[String, String]): Table = {
+    val givenSchema = schema
+    new Table with SupportsRead {
+      override def name(): String = shortName
 
-/**
- * Responsible for generating a class for Python Data Source
- * that inherits Scala Data Source interface so other features work together
- * with Python Data Source.
- */
-object PythonDataSourceCodeGenerator extends Logging {
-  /**
-   * When you invoke `generateClass`, it generates a class that inherits [[PythonDefaultSource]]
-   * that has a different short name. The generated class name as follows:
-   * "org.apache.spark.sql.execution.datasources.$shortName.DefaultSource".
-   *
-   * The `shortName` should be registered via `spark.dataSource.register` first, then
-   * this method can generate corresponding Scala Data Source wrapper for the Python
-   * Data Source.
-   *
-   * @param shortName The short name registered for Python Data Source.
-   * @return
-   */
-  def generateClass(shortName: String): Class[_] = {
-    val ctx = newCodeGenContext()
+      override def capabilities(): java.util.Set[TableCapability] = java.util.EnumSet.of(BATCH_READ)
 
-    val codeBody = s"""
-      @Override
-      public String shortName() {
-        return "${StringEscapeUtils.escapeJava(shortName)}";
-      }"""
+      override def newScanBuilder(options: CaseInsensitiveStringMap): ScanBuilder = {
+        new ScanBuilder with V1Scan {
+          override def build(): Scan = this
+          override def toV1TableScan[T <: BaseRelation with TableScan](
+              context: SQLContext): T = {
+            new BaseRelation with TableScan {
+              // Avoid Row <> InternalRow conversion
+              override val needConversion: Boolean = false
+              override def buildScan(): RDD[Row] =
+                getOrCreateSourceDataFrame(options, Some(givenSchema))
+                  .queryExecution.toRdd.asInstanceOf[RDD[Row]]
+              override def schema: StructType = givenSchema
+              override def sqlContext: SQLContext = context
+            }.asInstanceOf[T]
+          }
+          override def readSchema(): StructType = givenSchema
+        }
+      }
 
-    val evaluator = new ClassBodyEvaluator()
-    val parentClassLoader = new ParentClassLoader(Utils.getContextOrSparkClassLoader)
-    evaluator.setParentClassLoader(parentClassLoader)
-    evaluator.setClassName(
-      s"org.apache.spark.sql.execution.python.datasources.$shortName.DefaultSource")
-    evaluator.setExtendedClass(classOf[PythonDefaultSource])
-
-    val code = CodeFormatter.stripOverlappingComments(
-      new CodeAndComment(codeBody, ctx.getPlaceHolderToComments()))
-
-    // Note that the default `CodeGenerator.compile` wraps everything into a `GeneratedClass`
-    // class, and the defined DataSource becomes a nested class that cannot properly define
-    // getConstructors, etc. Therefore, we cannot simply reuse this.
-    try {
-      evaluator.cook("generated.java", code.body)
-      CodeGenerator.updateAndGetCompilationStats(evaluator)
-    } catch {
-      case e: InternalCompilerException =>
-        val msg = QueryExecutionErrors.failedToCompileMsg(e)
-        logError(msg, e)
-        CodeGenerator.logGeneratedCode(code)
-        throw QueryExecutionErrors.internalCompilerError(e)
-      case e: CompileException =>
-        val msg = QueryExecutionErrors.failedToCompileMsg(e)
-        logError(msg, e)
-        CodeGenerator.logGeneratedCode(code)
-        throw QueryExecutionErrors.compilerError(e)
+      override def schema(): StructType = givenSchema
     }
-
-    logDebug(s"Generated Python Data Source':\n${CodeFormatter.format(code)}")
-    evaluator.getClazz()
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamReader.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.connector.catalog.{SupportsRead, TableProvider}
 import org.apache.spark.sql.connector.catalog.TableCapability._
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.execution.command.DDLUtils
-import org.apache.spark.sql.execution.datasources.DataSource
+import org.apache.spark.sql.execution.datasources.{DataSource, PythonTableProvider}
 import org.apache.spark.sql.execution.datasources.json.JsonUtils.checkJsonSchema
 import org.apache.spark.sql.execution.datasources.v2.{DataSourceV2Utils, FileDataSourceV2}
 import org.apache.spark.sql.execution.datasources.xml.XmlUtils.checkXmlSchema
@@ -156,8 +156,11 @@ final class DataStreamReader private[sql](sparkSession: SparkSession) extends Lo
       extraOptions + ("path" -> path.get)
     }
 
-    val ds = DataSource.lookupDataSource(source, sparkSession.sessionState.conf).
-      getConstructor().newInstance()
+    val ds = DataSource.lookupDataSource(source, sparkSession.sessionState.conf) match {
+      case cls if classOf[PythonTableProvider].isAssignableFrom(cls) =>
+        cls.getConstructor(classOf[String]).newInstance(source)
+      case cls => cls.getDeclaredConstructor().newInstance()
+    }
     // We need to generate the V1 data source so we can pass it to the V2 relation as a shim.
     // We can't be sure at this point whether we'll actually want to use V2, since we don't know the
     // writer or whether the query is continuous.

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/DataStreamWriter.scala
@@ -38,7 +38,7 @@ import org.apache.spark.sql.connector.catalog.{Identifier, SupportsWrite, Table,
 import org.apache.spark.sql.connector.catalog.TableCapability._
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.execution.command.DDLUtils
-import org.apache.spark.sql.execution.datasources.{DataSource, PythonTableProvider}
+import org.apache.spark.sql.execution.datasources.DataSource
 import org.apache.spark.sql.execution.datasources.v2.{DataSourceV2Utils, FileDataSourceV2}
 import org.apache.spark.sql.execution.streaming._
 import org.apache.spark.sql.execution.streaming.sources._
@@ -382,11 +382,7 @@ final class DataStreamWriter[T] private[sql](ds: Dataset[T]) {
       }
 
       val sink = if (classOf[TableProvider].isAssignableFrom(cls) && !useV1Source) {
-        val provider = cls match {
-          case cls if classOf[PythonTableProvider].isAssignableFrom(cls) =>
-            cls.getConstructor(classOf[String]).newInstance(source).asInstanceOf[TableProvider]
-          case cls => cls.getDeclaredConstructor().newInstance().asInstanceOf[TableProvider]
-        }
+        val provider = DataSource.newDataSourceInstance(source, cls).asInstanceOf[TableProvider]
         val sessionOptions = DataSourceV2Utils.extractSessionConfigs(
           source = provider, conf = df.sparkSession.sessionState.conf)
         val finalOptions = sessionOptions.filter { case (k, _) => !optionsWithPath.contains(k) } ++

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonDataSourceSuite.scala
@@ -216,7 +216,6 @@ class PythonDataSourceSuite extends QueryTest with SharedSparkSession {
          |""".stripMargin
     val dataSource = createUserDefinedPythonDataSource(dataSourceName, dataSourceScript)
     spark.dataSource.registerPython("test", dataSource)
-
     checkAnswer(spark.read.format("test").load(), Seq(Row(null, 1)))
     checkAnswer(spark.read.format("test").load("1"), Seq(Row("1", 1)))
     checkAnswer(spark.read.format("test").load("1", "2"), Seq(Row("1", 1), Row("2", 1)))


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is another approach of https://github.com/apache/spark/pull/43784 which proposes to support Python Data Source can be with SQL (in favour of https://github.com/apache/spark/pull/43949), SparkR and all other exiting combinations by wrapping the Python Data Source by DSv2 interface (but yet uses `V1Table` interface).

The approach is: one Python Data Source wrapper looks up Python data sources

Self-contained working example:

```python
from pyspark.sql.datasource import DataSource, DataSourceReader, InputPartition

class TestDataSourceReader(DataSourceReader):
    def __init__(self, options):
        self.options = options
    def partitions(self):
        return [InputPartition(i) for i in range(3)]
    def read(self, partition):
        yield partition.value, str(partition.value)

class TestDataSource(DataSource):
    @classmethod
    def name(cls):
        return "test"
    def schema(self):
        return "x INT, y STRING"
    def reader(self, schema) -> "DataSourceReader":
        return TestDataSourceReader(self.options)
```

```python
spark.dataSource.register(TestDataSource)
sql("CREATE TABLE tblA USING test")
sql("SELECT * from tblA").show()
```

results in:

```
+---+---+
|  x|  y|
+---+---+
|  0|  0|
|  1|  1|
|  2|  2|
+---+---+
```

_There are limitations and followups to make:_

1. Statically loading Python Data Sources is still not supported (SPARK-45917)

### Why are the changes needed?

In order for Python Data Source to be able to be used in all other place including SparkR, Scala together.

### Does this PR introduce _any_ user-facing change?

Yes. Users can register their Python Data Source, and use them in SQL, SparkR, etc.

### How was this patch tested?

Unittests were added, and manually tested.

### Was this patch authored or co-authored using generative AI tooling?

No.

Closes #43784