### PR TITLE
[SPARK-46306][PS] Fix `LocIndexer` to work properly when the key is missing

### DIFF
--- a/python/pyspark/pandas/indexing.py
+++ b/python/pyspark/pandas/indexing.py
@@ -563,6 +563,16 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
         else:
             psdf_or_psser = psdf
 
+        if isinstance(key, list):
+            result_index = psdf_or_psser.index
+            if len(key) != len(result_index):
+                # Since the result Index size is expected to be small,
+                # we can collect data for checking missing key to follow the behavior of Pandas.
+                result_index_list = psdf_or_psser.index.tolist()
+                for item in key:
+                    if item not in result_index_list:
+                        raise KeyError(f"{item} not in index")
+
         if remaining_index is not None and remaining_index == 0:
             pdf_or_pser = psdf_or_psser.head(2)._to_pandas()
             length = len(pdf_or_pser)

--- a/python/pyspark/pandas/indexing.py
+++ b/python/pyspark/pandas/indexing.py
@@ -568,7 +568,7 @@ class LocIndexerLike(IndexerLike, metaclass=ABCMeta):
             if len(key) != len(result_index):
                 # Since the result Index size is expected to be small,
                 # we can collect data for checking missing key to follow the behavior of Pandas.
-                result_index_list = psdf_or_psser.index.tolist()
+                result_index_list = result_index.index.tolist()
                 for item in key:
                     if item not in result_index_list:
                         raise KeyError(f"{item} not in index")

--- a/python/pyspark/pandas/tests/test_indexing.py
+++ b/python/pyspark/pandas/tests/test_indexing.py
@@ -333,20 +333,11 @@ class IndexingTest(ComparisonTestBase):
         self.assert_eq(psdf.loc[[5]], pdf.loc[[5]])
         self.assert_eq(psdf.loc[:], pdf.loc[:])
 
-        # TODO?: self.assert_eq(psdf.loc[[3, 4, 1, 8]], pdf.loc[[3, 4, 1, 8]])
-        # TODO?: self.assert_eq(psdf.loc[[3, 4, 1, 9]], pdf.loc[[3, 4, 1, 9]])
-        # TODO?: self.assert_eq(psdf.loc[np.array([3, 4, 1, 9])], pdf.loc[np.array([3, 4, 1, 9])])
-
         self.assert_eq(psdf.a.loc[5:5], pdf.a.loc[5:5])
         self.assert_eq(psdf.a.loc[3:8], pdf.a.loc[3:8])
         self.assert_eq(psdf.a.loc[:8], pdf.a.loc[:8])
         self.assert_eq(psdf.a.loc[3:], pdf.a.loc[3:])
         self.assert_eq(psdf.a.loc[[5]], pdf.a.loc[[5]])
-
-        # TODO?: self.assert_eq(psdf.a.loc[[3, 4, 1, 8]], pdf.a.loc[[3, 4, 1, 8]])
-        # TODO?: self.assert_eq(psdf.a.loc[[3, 4, 1, 9]], pdf.a.loc[[3, 4, 1, 9]])
-        # TODO?: self.assert_eq(psdf.a.loc[np.array([3, 4, 1, 9])],
-        #                       pdf.a.loc[np.array([3, 4, 1, 9])])
 
         self.assert_eq(psdf.a.loc[[]], pdf.a.loc[[]])
         self.assert_eq(psdf.a.loc[np.array([])], pdf.a.loc[np.array([])])
@@ -361,6 +352,8 @@ class IndexingTest(ComparisonTestBase):
 
         self.assertRaises(KeyError, lambda: psdf.loc[10])
         self.assertRaises(KeyError, lambda: psdf.a.loc[10])
+        self.assertRaises(KeyError, lambda: psdf.loc[[3, 4, 1, 8]])
+        self.assertRaises(KeyError, lambda: psdf.a.loc[[3, 4, 1, 8]])
 
         # monotonically increasing index test
         pdf = pd.DataFrame({"a": [1, 2, 3, 4, 5, 6, 7, 8, 9]}, index=[0, 1, 1, 2, 2, 2, 4, 5, 6])


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to fix `LocIndexer` to work properly when the key is missing.

### Why are the changes needed?

To match the behavior with Pandas.

### Does this PR introduce _any_ user-facing change?

For given DataFrame:

```python
>>> psdf = ps.DataFrame(
...     {"a": [1, 2, 3, 4, 5, 6, 7, 8, 9], "b": [4, 5, 6, 3, 2, 1, 0, 0, 0]},
...     index=[0, 1, 3, 5, 6, 8, 9, 9, 9],
... )
>>> psdf
   a  b
0  1  4
1  2  5
3  3  6
5  4  3
6  5  2
8  6  1
9  7  0
9  8  0
9  9  0
```

**Before**
```python
>>> psdf.loc[[3, 4, 1, 8]]
   a  b
1  2  5
3  3  6
8  6  1
```

**After**
```python
>>> psdf.loc[[3, 4, 1, 8]]
...
KeyError: '4 not in index'
```

### How was this patch tested?

Added unit tests.

### Was this patch authored or co-authored using generative AI tooling?

No.