### PR TITLE
[SPARK-46307][PS][TESTS] Enable `fill_value` tests for `GroupByTests.test_shift`

### DIFF
--- a/python/pyspark/pandas/tests/groupby/test_groupby.py
+++ b/python/pyspark/pandas/tests/groupby/test_groupby.py
@@ -200,9 +200,10 @@ class GroupByTestsMixin:
         self.assert_eq(
             psdf.groupby("a").shift().sort_index(), pdf.groupby("a").shift().sort_index()
         )
-        # TODO: seems like a pandas' bug when fill_value is not None?
-        # self.assert_eq(psdf.groupby(['a', 'b']).shift(periods=-1, fill_value=0).sort_index(),
-        #                pdf.groupby(['a', 'b']).shift(periods=-1, fill_value=0).sort_index())
+        self.assert_eq(
+            psdf.groupby(["a", "b"]).shift(periods=-1, fill_value=0).sort_index(),
+            pdf.groupby(["a", "b"]).shift(periods=-1, fill_value=0).sort_index(),
+        )
         self.assert_eq(
             psdf.groupby(["b"])["a"].shift().sort_index(),
             pdf.groupby(["b"])["a"].shift().sort_index(),
@@ -247,11 +248,10 @@ class GroupByTestsMixin:
             psdf.groupby(("x", "a")).shift().sort_index(),
             pdf.groupby(("x", "a")).shift().sort_index(),
         )
-        # TODO: seems like a pandas' bug when fill_value is not None?
-        # self.assert_eq(psdf.groupby([('x', 'a'), ('x', 'b')]).shift(periods=-1,
-        #                                                            fill_value=0).sort_index(),
-        #                pdf.groupby([('x', 'a'), ('x', 'b')]).shift(periods=-1,
-        #                                                            fill_value=0).sort_index())
+        self.assert_eq(
+            psdf.groupby([("x", "a"), ("x", "b")]).shift(periods=-1, fill_value=0).sort_index(),
+            pdf.groupby([("x", "a"), ("x", "b")]).shift(periods=-1, fill_value=0).sort_index(),
+        )
 
     @staticmethod
     def test_is_multi_agg_with_relabel():


### PR DESCRIPTION

### What changes were proposed in this pull request?

This PR proposes to enable `fill_value` tests for `GroupByTests.test_shift` since the Pandas bug has been fixed.


### Why are the changes needed?

To increase the test coverage.


### Does this PR introduce _any_ user-facing change?

No, it's test-only.

### How was this patch tested?

Enable the commented tests and manually verify.

### Was this patch authored or co-authored using generative AI tooling?

No.