### PR TITLE
[SPARK-46311][CORE] Log the final state of drivers during `Master.removeDriver`

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -1251,7 +1251,7 @@ private[deploy] class Master(
       exception: Option[Exception]): Unit = {
     drivers.find(d => d.id == driverId) match {
       case Some(driver) =>
-        logInfo(s"Removing driver: $driverId")
+        logInfo(s"Removing driver: $driverId ($finalState)")
         drivers -= driver
         if (completedDrivers.size >= retainedDrivers) {
           val toRemove = math.max(retainedDrivers / 10, 1)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to log the final state of drivers during `Master.removeDriver`.

### Why are the changes needed?

We can easily identify the status of all drivers from Master log in a centralized manner.

```
- 23/12/07 13:51:41 INFO Master: Removing driver: driver-20231207135138-0000
+ 23/12/07 13:51:41 INFO Master: Removing driver: driver-20231207135138-0000 (FINISHED)
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.