### PR TITLE
[SPARK-46313][CORE] Log `Spark HA` recovery duration

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -604,8 +604,11 @@ private[deploy] class Master(
     workers.count(_.state == WorkerState.UNKNOWN) == 0 &&
       apps.count(_.state == ApplicationState.UNKNOWN) == 0
 
+  private var recoveryStartTimeNs = 0L
+
   private def beginRecovery(storedApps: Seq[ApplicationInfo], storedDrivers: Seq[DriverInfo],
       storedWorkers: Seq[WorkerInfo]): Unit = {
+    recoveryStartTimeNs = System.nanoTime()
     for (app <- storedApps) {
       logInfo("Trying to recover app: " + app.id)
       try {
@@ -662,7 +665,8 @@ private[deploy] class Master(
 
     state = RecoveryState.ALIVE
     schedule()
-    logInfo("Recovery complete - resuming operations!")
+    val timeTakenNs = System.nanoTime() - recoveryStartTimeNs
+    logInfo(s"Recovery complete in ${timeTakenNs / 1000000000d}s - resuming operations!")
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -666,7 +666,7 @@ private[deploy] class Master(
     state = RecoveryState.ALIVE
     schedule()
     val timeTakenNs = System.nanoTime() - recoveryStartTimeNs
-    logInfo(s"Recovery complete in ${timeTakenNs / 1000000000d}s - resuming operations!")
+    logInfo(f"Recovery complete in ${timeTakenNs / 1000000000d}%.3fs - resuming operations!")
   }
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to log `Spark HA` recovery duration.

### Why are the changes needed?

It will show the elapsed time like the following.
```
- 23/12/07 18:25:29 INFO Master: Recovery complete - resuming operations!
- 23/12/07 18:25:29 INFO Master: Recovery complete in 60.020s - resuming operations!
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs and manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.