### PR TITLE
[SPARK-46315][PYTHON][TESTS] Test invalid key for spark.conf.get (pyspark.sql.conf)

### DIFF
--- a/python/pyspark/sql/tests/test_conf.py
+++ b/python/pyspark/sql/tests/test_conf.py
@@ -16,7 +16,7 @@
 #
 from decimal import Decimal
 
-from pyspark.errors import IllegalArgumentException
+from pyspark.errors import IllegalArgumentException, PySparkTypeError
 from pyspark.testing.sqlutils import ReusedSQLTestCase
 
 
@@ -62,6 +62,18 @@ class ConfTestsMixin:
 
         with self.assertRaises(Exception):
             spark.conf.set("foo", Decimal(1))
+
+        with self.assertRaises(PySparkTypeError) as pe:
+            spark.conf.get(123)
+
+        self.check_error(
+            exception=pe.exception,
+            error_class="NOT_STR",
+            message_parameters={
+                "arg_name": "key",
+                "arg_type": "int",
+            },
+        )
 
         spark.conf.unset("foo")
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds tests for negative cases for `spark.conf.get` (`pyspark.sql.conf`)

### Why are the changes needed?

To improve the test coverage.

https://app.codecov.io/gh/apache/spark/blob/master/python%2Fpyspark%2Fsql%2Fconf.py

### Does this PR introduce _any_ user-facing change?

No, test-only

### How was this patch tested?

Manually ran the new unittest.

### Was this patch authored or co-authored using generative AI tooling?

No.