### PR TITLE
[SPARK-46316][CORE] Enable `buf-lint-action` on `core` module

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -583,6 +583,10 @@ jobs:
       uses: bufbuild/buf-setup-action@v1
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Protocol Buffers Linter
+      uses: bufbuild/buf-lint-action@v1
+      with:
+        input: core/src/main/protobuf
     # Change 'branch-3.5' to 'branch-4.0' in master branch after cutting branch-4.0 branch.
     - name: Breaking change detection against branch-3.5
       uses: bufbuild/buf-breaking-action@v1

--- a/core/src/main/protobuf/buf.yaml
+++ b/core/src/main/protobuf/buf.yaml
@@ -1,0 +1,23 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+version: v1
+breaking:
+  use:
+    - FILE
+lint:
+  use:
+    - BASIC


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to enable `buf-lint-action` on `core` module.

### Why are the changes needed?

To enforce the community guideline.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

![Screenshot 2023-12-07 at 7 40 54 PM](https://github.com/apache/spark/assets/9700541/7777b23f-d8be-410a-bc61-88f8b477a3b0)

### Was this patch authored or co-authored using generative AI tooling?

No.