### PR TITLE
[SPARK-46318][PYTHON][INFRA] Exclude ported pyspark.loose_version from the code coverage report

### DIFF
--- a/python/run-tests-with-coverage
+++ b/python/run-tests-with-coverage
@@ -60,10 +60,10 @@ find $COVERAGE_DIR/coverage_data -size 0 -print0 | xargs -0 rm -fr
 echo "Combining collected coverage data under $COVERAGE_DIR/coverage_data"
 $COV_EXEC combine
 echo "Creating XML report file at python/coverage.xml"
-$COV_EXEC xml --ignore-errors --include "pyspark/*" --omit "pyspark/cloudpickle/*" --omit "pyspark/sql/connect/proto/*"
+$COV_EXEC xml --ignore-errors --include "pyspark/*" --omit "pyspark/cloudpickle/*" --omit "pyspark/sql/connect/proto/*" --omit "python/pyspark/loose_version.py"
 echo "Reporting the coverage data at $COVERAGE_DIR/coverage_data/coverage"
-$COV_EXEC report --include "pyspark/*" --omit "pyspark/cloudpickle/*" --omit "pyspark/sql/connect/proto/*"
+$COV_EXEC report --include "pyspark/*" --omit "pyspark/cloudpickle/*" --omit "pyspark/sql/connect/proto/*" --omit "python/pyspark/loose_version.py"
 echo "Generating HTML files for PySpark coverage under $COVERAGE_DIR/htmlcov"
-$COV_EXEC html --ignore-errors --include "pyspark/*" --directory "$COVERAGE_DIR/htmlcov" --omit "pyspark/cloudpickle/*" --omit "pyspark/sql/connect/proto/*"
+$COV_EXEC html --ignore-errors --include "pyspark/*" --directory "$COVERAGE_DIR/htmlcov" --omit "pyspark/cloudpickle/*" --omit "pyspark/sql/connect/proto/*" --omit "python/pyspark/loose_version.py"
 
 popd


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to exclude ported (from Python) `pyspark.loose_version` from the code coverage report.

### Why are the changes needed?

For correct test coverage report, and make it easier to read.

https://app.codecov.io/gh/apache/spark/blob/master/python%2Fpyspark%2Floose_version.py

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Manually tested.

### Was this patch authored or co-authored using generative AI tooling?

No.