### PR TITLE
[SPARK-46321][PS][TESTS] Re-ennable `IndexesTests.test_asof` that was skipped due to Pandas bug

### DIFF
--- a/python/pyspark/pandas/tests/indexes/test_base.py
+++ b/python/pyspark/pandas/tests/indexes/test_base.py
@@ -1278,11 +1278,10 @@ class IndexesTestsMixin:
         pidx = pd.DatetimeIndex(["2014-01-03", "2014-01-02", "2013-12-31"])
         psidx = ps.from_pandas(pidx)
 
-        # TODO: a pandas bug?
-        # self.assert_eq(psidx.asof("2014-01-01"), pidx.asof("2014-01-01"))
-        # self.assert_eq(psidx.asof("2014-01-02"), pidx.asof("2014-01-02"))
-        # self.assert_eq(psidx.asof("1999-01-02"), pidx.asof("1999-01-02"))
-        # self.assert_eq(repr(psidx.asof("2015-01-02")), repr(pidx.asof("2015-01-02")))
+        self.assert_eq(psidx.asof("2014-01-01"), pidx.asof("2014-01-01"))
+        self.assert_eq(psidx.asof("2014-01-02"), pidx.asof("2014-01-02"))
+        self.assert_eq(psidx.asof("1999-01-02"), pidx.asof("1999-01-02"))
+        self.assert_eq(repr(psidx.asof("2015-01-02")), repr(pidx.asof("2015-01-02")))
         self.assert_eq(psidx.asof("2014-01-01"), pd.Timestamp("2014-01-02 00:00:00"))
         self.assert_eq(psidx.asof("2014-01-02"), pd.Timestamp("2014-01-02 00:00:00"))
         self.assert_eq(psidx.asof("1999-01-02"), pd.Timestamp("2013-12-31 00:00:00"))


### PR DESCRIPTION

### What changes were proposed in this pull request?

This PR proposes to re-ennable `IndexesTests.test_asof` that was skipped due to Pandas bug


### Why are the changes needed?

The pandas bug has been fixed, so we can improve the test coverage.


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Enabling the UTs.

### Was this patch authored or co-authored using generative AI tooling?
No.