### PR TITLE
[SPARK-46323][PYTHON] Fix the output name of pyspark.sql.functions.now

### DIFF
--- a/python/pyspark/sql/connect/functions/builtin.py
+++ b/python/pyspark/sql/connect/functions/builtin.py
@@ -2864,7 +2864,7 @@ current_timestamp.__doc__ = pysparkfuncs.current_timestamp.__doc__
 
 
 def now() -> Column:
-    return _invoke_function("current_timestamp")
+    return _invoke_function("now")
 
 
 now.__doc__ = pysparkfuncs.now.__doc__

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -6838,15 +6838,16 @@ def now() -> Column:
 
     Examples
     --------
+    >>> from pyspark.sql import functions as sf
     >>> df = spark.range(1)
-    >>> df.select(now()).show(truncate=False) # doctest: +SKIP
-    +-----------------------+
-    |now()    |
-    +-----------------------+
-    |2022-08-26 21:23:22.716|
-    +-----------------------+
+    >>> df.select(sf.now()).show(truncate=False) # doctest: +SKIP
+    +--------------------------+
+    |now()                     |
+    +--------------------------+
+    |2023-12-08 15:18:18.482269|
+    +--------------------------+
     """
-    return _invoke_function("current_timestamp")
+    return _invoke_function("now")
 
 
 @_try_remote_functions

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -1376,6 +1376,14 @@ class FunctionsTestsMixin:
         for i in range(3):
             self.assertEqual(res[0][i * 2], res[0][i * 2 + 1])
 
+    def test_current_timestamp(self):
+        df = self.spark.range(1).select(F.current_timestamp())
+        self.assertIsInstance(df.first()[0], datetime.datetime)
+        self.assertEqual(df.schema.names[0], "current_timestamp()")
+        df = self.spark.range(1).select(F.now())
+        self.assertIsInstance(df.first()[0], datetime.datetime)
+        self.assertEqual(df.schema.names[0], "now()")
+
 
 class FunctionsTests(ReusedSQLTestCase, FunctionsTestsMixin):
     pass


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to fix `current_timestamp()` to `now()` in its output name when you invoke `pyspark.sql.functions.now`.

### Why are the changes needed?

To show the correct name of the functions being used.

### Does this PR introduce _any_ user-facing change?

Yes.

```python
from pyspark.sql import functions as sf
df.select(sf.now()).show(truncate=False)
```

Before:

```
+--------------------------+
|current_timestamp()       |
+--------------------------+
|2023-12-08 15:15:58.767781|
+--------------------------+
```


After:

```
+--------------------------+
|now()                     |
+--------------------------+
|2023-12-08 15:18:18.482269|
+--------------------------+
```


### How was this patch tested?

Manually tested, and unittests were added.

### Was this patch authored or co-authored using generative AI tooling?

No.
