### PR TITLE
[SPARK-46325][CONNECT] Remove unnecessary override functions when constructing `WrappedCloseableIterator` in `ResponseValidator#wrapIterator`

### DIFF
--- a/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/client/ResponseValidator.scala
+++ b/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/client/ResponseValidator.scala
@@ -65,20 +65,9 @@ class ResponseValidator extends Logging {
 
       override def innerIterator: Iterator[T] = inner
 
-      override def hasNext: Boolean = {
-        innerIterator.hasNext
-      }
-
       override def next(): T = {
         verifyResponse {
           innerIterator.next()
-        }
-      }
-
-      override def close(): Unit = {
-        innerIterator match {
-          case it: CloseableIterator[T] => it.close()
-          case _ => // nothing
         }
       }
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr removes the overridden `hasNext` and `close` functions in the construction of `WrappedCloseableIterator` in `ResponseValidator#wrapIterator`, as these functions are identical to those defined in `WrappedCloseableIterator`.

- WrappedCloseableIterator

https://github.com/apache/spark/blob/9ffdcc398ed5560f34778d005da697f6ad0a15ee/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/client/CloseableIterator.scala#L30-L42

- ResponseValidator#wrapIterator

https://github.com/apache/spark/blob/9ffdcc398ed5560f34778d005da697f6ad0a15ee/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/client/ResponseValidator.scala#L62-L85

### Why are the changes needed?
Remove unnecessary override functions.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No
