### PR TITLE
[SPARK-46335][BUILD] Upgrade Maven to 3.9.6 for MNG-7913

### DIFF
--- a/dev/appveyor-install-dependencies.ps1
+++ b/dev/appveyor-install-dependencies.ps1
@@ -81,7 +81,7 @@ if (!(Test-Path $tools)) {
 # ========================== Maven
 # Push-Location $tools
 #
-# $mavenVer = "3.9.5"
+# $mavenVer = "3.9.6"
 # Start-FileDownload "https://archive.apache.org/dist/maven/maven-3/$mavenVer/binaries/apache-maven-$mavenVer-bin.zip" "maven.zip"
 #
 # # extract

--- a/docs/building-spark.md
+++ b/docs/building-spark.md
@@ -27,7 +27,7 @@ license: |
 ## Apache Maven
 
 The Maven-based build is the build of reference for Apache Spark.
-Building Spark using Maven requires Maven 3.9.5 and Java 17/21.
+Building Spark using Maven requires Maven 3.9.6 and Java 17/21.
 Spark requires Scala 2.13; support for Scala 2.12 was removed in Spark 4.0.0.
 
 ### Setting up Maven's Memory Usage

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
     <java.version>17</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
-    <maven.version>3.9.5</maven.version>
+    <maven.version>3.9.6</maven.version>
     <exec-maven-plugin.version>3.1.0</exec-maven-plugin.version>
     <sbt.project.name>spark</sbt.project.name>
     <asm.version>9.6</asm.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `Apache Maven` to 3.9.6.

### Why are the changes needed?

Apache Maven 3.9.6 has MNG-7913 to improve Java supports. Although it's only for up to Java 19, this is better than the previous condition (up to Java 14).
- https://github.com/apache/maven/pull/1286

> To version that supports gleaning JSR330 component classes up to Java 19. The reasoning of this change is only to allow 3rd party Maven plugins/Maven extensions/other JSR330 components (managed by Maven embedded Sisu) to use bytecode newer that Java 14 (Sisu 0.3.5).

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.