### PR TITLE
[SPARK-46337][SQL][CONNECT][PYTHON] Make `CTESubstitution` retain the `PLAN_ID_TAG`

### DIFF
--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -515,6 +515,18 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
         self.assertEqual(cdf7.schema, sdf7.schema)
         self.assertEqual(cdf7.collect(), sdf7.collect())
 
+    def test_join_with_cte(self):
+        sdf1 = self.spark.range(10)
+        sdf2 = self.spark.sql("with dt as (select 1 as ida) select ida as id from dt")
+        sdf3 = sdf1.join(sdf2, sdf1.id == sdf2.id)
+
+        cdf1 = self.connect.range(10)
+        cdf2 = self.connect.sql("with dt as (select 1 as ida) select ida as id from dt")
+        cdf3 = cdf1.join(cdf2, cdf1.id == cdf2.id)
+
+        self.assertEqual(sdf3.schema, cdf3.schema)
+        self.assertEqual(sdf3.collect(), cdf3.collect())
+
     def test_invalid_column(self):
         # SPARK-41812: fail df1.select(df2.col)
         data1 = [Row(a=1, b=2, c=3)]

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -516,12 +516,14 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
         self.assertEqual(cdf7.collect(), sdf7.collect())
 
     def test_join_with_cte(self):
+        cte_query = "with dt as (select 1 as ida) select ida as id from dt"
+
         sdf1 = self.spark.range(10)
-        sdf2 = self.spark.sql("with dt as (select 1 as ida) select ida as id from dt")
+        sdf2 = self.spark.sql(cte_query)
         sdf3 = sdf1.join(sdf2, sdf1.id == sdf2.id)
 
         cdf1 = self.connect.range(10)
-        cdf2 = self.connect.sql("with dt as (select 1 as ida) select ida as id from dt")
+        cdf2 = self.connect.sql(cte_query)
         cdf3 = cdf1.join(cdf2, cdf1.id == cdf2.id)
 
         self.assertEqual(sdf3.schema, cdf3.schema)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ColumnResolutionHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ColumnResolutionHelper.scala
@@ -514,7 +514,7 @@ trait ColumnResolutionHelper extends Logging with DataTypeErrorsBase {
         //  df2 = spark.createDataFrame([Row(a = 1, b = 2)]])
         //  df1.select(df2.a)   <-   illegal reference df2.a
         throw new AnalysisException(s"When resolving $u, " +
-          s"fail to find subplan with plan_id=$planId in $q")
+          s"fail to find subplan with plan_id=$planId in\n$q")
       }
     })
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make `CTESubstitution` retain the `PLAN_ID_TAG`


### Why are the changes needed?
before this PR:
```
df1 = spark.range(10)
df2 = spark.sql("with dt as (select 1 as ida) select ida as id from dt")
df1.join(df2, df1.id == df2.id)

AnalysisException: When resolving 'id, fail to find subplan with plan_id=2 in 'Join Inner, '`==`('id, 'id)
:- Range (0, 10, step=1, splits=Some(12))
+- WithCTE
   :- CTERelationDef 4, false
   :  +- SubqueryAlias dt
   :     +- Project [1 AS ida#22]
   :        +- OneRowRelation
   +- Project [ida#22 AS id#21]
      +- SubqueryAlias dt
         +- CTERelationRef 4, true, [ida#22], false
```

### Does this PR introduce _any_ user-facing change?
yes


### How was this patch tested?
added ut


### Was this patch authored or co-authored using generative AI tooling?
no