### PR TITLE
[SPARK-45597][PYTHON][SQL] Support creating table using a Python data source in SQL

### DIFF
--- a/common/utils/src/main/resources/error/error-classes.json
+++ b/common/utils/src/main/resources/error/error-classes.json
@@ -875,15 +875,9 @@
     ],
     "sqlState" : "42710"
   },
-  "DATA_SOURCE_NOT_EXIST" : {
-    "message" : [
-      "Data source '<provider>' not found. Please make sure the data source is registered."
-    ],
-    "sqlState" : "42704"
-  },
   "DATA_SOURCE_NOT_FOUND" : {
     "message" : [
-      "Failed to find the data source: <provider>. Please find packages at `https://spark.apache.org/third-party-projects.html`."
+      "Failed to find the data source: <provider>. Please find packages at `https://spark.apache.org/third-party-projects.html`, or register it first."
     ],
     "sqlState" : "42K02"
   },

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/pythonLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/pythonLogicalOperators.scala
@@ -108,8 +108,7 @@ case class PythonMapInArrow(
  */
 case class PythonDataSource(
     dataSource: PythonFunction,
-    outputSchema: StructType,
-    override val output: Seq[Attribute]) extends LeafNode {
+    output: Seq[Attribute]) extends LeafNode {
   require(output.forall(_.resolved),
     "Unresolved attributes found when constructing PythonDataSource.")
   override protected def stringArgs: Iterator[Any] = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
@@ -42,6 +42,7 @@ object TreePattern extends Enumeration  {
   val CREATE_NAMED_STRUCT: Value = Value
   val CURRENT_LIKE: Value = Value
   val DESERIALIZE_TO_OBJECT: Value = Value
+  val DATA_SOURCE_V2_RELATION: Value = Value
   val DYNAMIC_PRUNING_EXPRESSION: Value = Value
   val DYNAMIC_PRUNING_SUBQUERY: Value = Value
   val EXISTS_SUBQUERY = Value

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -3844,12 +3844,6 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
       messageParameters = Map("provider" -> name))
   }
 
-  def dataSourceDoesNotExist(name: String): Throwable = {
-    new AnalysisException(
-      errorClass = "DATA_SOURCE_NOT_EXIST",
-      messageParameters = Map("provider" -> name))
-  }
-
   def foundMultipleDataSources(provider: String): Throwable = {
     new AnalysisException(
       errorClass = "FOUND_MULTIPLE_DATA_SOURCES",

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Relation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Relation.scala
@@ -21,6 +21,7 @@ import org.apache.spark.SparkException
 import org.apache.spark.sql.catalyst.analysis.{MultiInstanceRelation, NamedRelation}
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeMap, AttributeReference, Expression, SortOrder}
 import org.apache.spark.sql.catalyst.plans.logical.{ColumnStat, ExposesMetadataColumns, Histogram, HistogramBin, LeafNode, LogicalPlan, Statistics}
+import org.apache.spark.sql.catalyst.trees.TreePattern._
 import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
 import org.apache.spark.sql.catalyst.util.{quoteIfNeeded, truncatedString, CharVarcharUtils}
 import org.apache.spark.sql.connector.catalog.{CatalogPlugin, FunctionCatalog, Identifier, SupportsMetadataColumns, Table, TableCapability}
@@ -49,6 +50,8 @@ case class DataSourceV2Relation(
   extends LeafNode with MultiInstanceRelation with NamedRelation with ExposesMetadataColumns {
 
   import DataSourceV2Implicits._
+
+  final override val nodePatterns: Seq[TreePattern] = Seq(DATA_SOURCE_V2_RELATION)
 
   lazy val funCatalog: Option[FunctionCatalog] = catalog.collect {
     case c: FunctionCatalog => c

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
@@ -17,12 +17,11 @@
 
 package org.apache.spark.sql
 
-import java.util.{Locale, Properties, ServiceConfigurationError}
+import java.util.{Locale, Properties}
 
 import scala.jdk.CollectionConverters._
-import scala.util.{Failure, Success, Try}
 
-import org.apache.spark.{Partition, SparkClassNotFoundException, SparkThrowable}
+import org.apache.spark.Partition
 import org.apache.spark.annotation.Stable
 import org.apache.spark.api.java.JavaRDD
 import org.apache.spark.internal.Logging
@@ -209,45 +208,13 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
       throw QueryCompilationErrors.pathOptionNotSetCorrectlyWhenReadingError()
     }
 
-    val isUserDefinedDataSource =
-      sparkSession.sessionState.dataSourceManager.dataSourceExists(source)
-
-    Try(DataSource.lookupDataSourceV2(source, sparkSession.sessionState.conf)) match {
-      case Success(providerOpt) =>
-        // The source can be successfully loaded as either a V1 or a V2 data source.
-        // Check if it is also a user-defined data source.
-        if (isUserDefinedDataSource) {
-          throw QueryCompilationErrors.foundMultipleDataSources(source)
-        }
-        providerOpt.flatMap { provider =>
-          DataSourceV2Utils.loadV2Source(
-            sparkSession, provider, userSpecifiedSchema, extraOptions, source, paths: _*)
-        }.getOrElse(loadV1Source(paths: _*))
-      case Failure(exception) =>
-        // Exceptions are thrown while trying to load the data source as a V1 or V2 data source.
-        // For the following not found exceptions, if the user-defined data source is defined,
-        // we can instead return the user-defined data source.
-        val isNotFoundError = exception match {
-          case _: NoClassDefFoundError | _: SparkClassNotFoundException => true
-          case e: SparkThrowable => e.getErrorClass == "DATA_SOURCE_NOT_FOUND"
-          case e: ServiceConfigurationError => e.getCause.isInstanceOf[NoClassDefFoundError]
-          case _ => false
-        }
-        if (isNotFoundError && isUserDefinedDataSource) {
-          loadUserDefinedDataSource(paths)
-        } else {
-          // Throw the original exception.
-          throw exception
-        }
-    }
-  }
-
-  private def loadUserDefinedDataSource(paths: Seq[String]): DataFrame = {
-    val builder = sparkSession.sessionState.dataSourceManager.lookupDataSource(source)
-    // Add `path` and `paths` options to the extra options if specified.
-    val optionsWithPath = DataSourceV2Utils.getOptionsWithPaths(extraOptions, paths: _*)
-    val plan = builder(sparkSession, source, userSpecifiedSchema, optionsWithPath)
-    Dataset.ofRows(sparkSession, plan)
+    DataSource.lookupDataSourceV2(
+      source,
+      sparkSession.sessionState.conf,
+      sparkSession.sessionState.dataSourceManager).flatMap { provider =>
+      DataSourceV2Utils.loadV2Source(sparkSession, provider, userSpecifiedSchema, extraOptions,
+        source, paths: _*)
+    }.getOrElse(loadV1Source(paths: _*))
   }
 
   private def loadV1Source(paths: String*) = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -894,7 +894,10 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) {
   }
 
   private def lookupV2Provider(): Option[TableProvider] = {
-    DataSource.lookupDataSourceV2(source, df.sparkSession.sessionState.conf) match {
+    DataSource.lookupDataSourceV2(
+      source,
+      df.sparkSession.sessionState.conf,
+      df.sparkSession.sessionState.dataSourceManager) match {
       // TODO(SPARK-28396): File source v2 write path is currently broken.
       case Some(_: FileDataSourceV2) => None
       case other => other

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataSourceRegistration.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataSourceRegistration.scala
@@ -43,6 +43,6 @@ private[sql] class DataSourceRegistration private[sql] (dataSourceManager: DataS
          | pythonExec: ${dataSource.dataSourceCls.pythonExec}
       """.stripMargin)
 
-    dataSourceManager.registerDataSource(name, dataSource.builder)
+    dataSourceManager.registerDataSource(name, dataSource.getBuilder)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
@@ -31,7 +31,7 @@ import org.apache.spark.sql.connector.catalog.{CatalogManager, CatalogV2Util, Lo
 import org.apache.spark.sql.connector.expressions.Transform
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
 import org.apache.spark.sql.execution.command._
-import org.apache.spark.sql.execution.datasources.{CreateTable => CreateTableV1}
+import org.apache.spark.sql.execution.datasources.{CreateTable => CreateTableV1, DataSourceManager}
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Utils
 import org.apache.spark.sql.internal.{HiveSerDe, SQLConf}
 import org.apache.spark.sql.internal.connector.V1Function
@@ -44,7 +44,9 @@ import org.apache.spark.util.ArrayImplicits._
  * identifiers to construct the v1 commands, so that v1 commands do not need to qualify identifiers
  * again, which may lead to inconsistent behavior if the current database is changed in the middle.
  */
-class ResolveSessionCatalog(val catalogManager: CatalogManager)
+class ResolveSessionCatalog(
+    val catalogManager: CatalogManager,
+    dataSourceManager: DataSourceManager = new DataSourceManager)
   extends Rule[LogicalPlan] with LookupCatalog {
   import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
   import org.apache.spark.sql.connector.catalog.CatalogV2Util._
@@ -612,7 +614,7 @@ class ResolveSessionCatalog(val catalogManager: CatalogManager)
   }
 
   private def isV2Provider(provider: String): Boolean = {
-    DataSourceV2Utils.getTableProvider(provider, conf).isDefined
+    DataSourceV2Utils.getTableProvider(provider, conf, dataSourceManager).isDefined
   }
 
   private object DatabaseInSessionCatalog {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceManager.scala
@@ -21,26 +21,16 @@ import java.util.Locale
 import java.util.concurrent.ConcurrentHashMap
 
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
-import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
-import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 /**
- * A manager for user-defined data sources. It is used to register and lookup data sources by
- * their short names or fully qualified names.
+ * A manager for user-defined data sources. It is used to register and lookup data sources by names.
  */
 class DataSourceManager extends Logging {
-
-  private type DataSourceBuilder = (
-    SparkSession,  // Spark session
-    String,  // provider name
-    Option[StructType],  // user specified schema
-    CaseInsensitiveMap[String]  // options
-  ) => LogicalPlan
-
-  private val dataSourceBuilders = new ConcurrentHashMap[String, DataSourceBuilder]()
+  private val dataSourceBuilders = new ConcurrentHashMap[String, UserDefinedDataSourceBuilder]()
 
   private def normalize(name: String): String = name.toLowerCase(Locale.ROOT)
 
@@ -48,7 +38,7 @@ class DataSourceManager extends Logging {
    * Register a data source builder for the given provider.
    * Note that the provider name is case-insensitive.
    */
-  def registerDataSource(name: String, builder: DataSourceBuilder): Unit = {
+  def registerDataSource(name: String, builder: UserDefinedDataSourceBuilder): Unit = {
     val normalizedName = normalize(name)
     val previousValue = dataSourceBuilders.put(normalizedName, builder)
     if (previousValue != null) {
@@ -60,12 +50,8 @@ class DataSourceManager extends Logging {
    * Returns a data source builder for the given provider and throw an exception if
    * it does not exist.
    */
-  def lookupDataSource(name: String): DataSourceBuilder = {
-    if (dataSourceExists(name)) {
-      dataSourceBuilders.get(normalize(name))
-    } else {
-      throw QueryCompilationErrors.dataSourceDoesNotExist(name)
-    }
+  def getDataSource(name: String): Option[UserDefinedDataSourceBuilder] = {
+    Option(dataSourceBuilders.get(normalize(name)))
   }
 
   /**
@@ -80,4 +66,17 @@ class DataSourceManager extends Logging {
     dataSourceBuilders.forEach((k, v) => manager.registerDataSource(k, v))
     manager
   }
+}
+
+trait UserDefinedDataSourceBuilder {
+  def build(
+      provider: String,
+      userSpecifiedSchema: Option[StructType],
+      options: CaseInsensitiveStringMap): UserDefinedDataSourcePlanBuilder
+}
+
+trait UserDefinedDataSourcePlanBuilder {
+  def schema: StructType
+
+  def build(output: Seq[Attribute]): LogicalPlan
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PlanPythonDataSourceScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PlanPythonDataSourceScan.scala
@@ -50,8 +50,8 @@ import org.apache.spark.util.ArrayImplicits._
 object PlanPythonDataSourceScan extends Rule[LogicalPlan] {
   def apply(plan: LogicalPlan): LogicalPlan = plan.transformDownWithPruning(
     _.containsPattern(PYTHON_DATA_SOURCE)) {
-    case ds @ PythonDataSource(dataSource: PythonFunction, schema, _) =>
-      val info = new UserDefinedPythonDataSourceReadRunner(dataSource, schema).runInPython()
+    case ds @ PythonDataSource(dataSource: PythonFunction, _) =>
+      val info = new UserDefinedPythonDataSourceReadRunner(dataSource, ds.schema).runInPython()
 
       val readerFunc = SimplePythonFunction(
         command = info.func.toImmutableArraySeq,
@@ -69,7 +69,7 @@ object PlanPythonDataSourceScan extends Rule[LogicalPlan] {
       val pythonUDTF = PythonUDTF(
         name = "python_data_source_read",
         func = readerFunc,
-        elementSchema = schema,
+        elementSchema = ds.schema,
         children = partitionPlan.output,
         evalType = PythonEvalType.SQL_TABLE_UDF,
         udfDeterministic = false,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/RewriteUserDefinedDataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/RewriteUserDefinedDataSource.scala
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources
+
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.catalyst.trees.TreePattern._
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
+
+object RewriteUserDefinedDataSource extends Rule[LogicalPlan] {
+  override def apply(plan: LogicalPlan): LogicalPlan = plan.resolveOperatorsUpWithPruning(
+    _.containsPattern(DATA_SOURCE_V2_RELATION)) {
+    case r: DataSourceV2Relation if r.table.isInstanceOf[UserDefinedDataSourceTable] =>
+      val table = r.table.asInstanceOf[UserDefinedDataSourceTable]
+      table.builder.build(r.output)
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/UserDefinedDataSourceTableProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/UserDefinedDataSourceTableProvider.scala
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources
+
+import java.util
+
+import org.apache.spark.SparkException
+import org.apache.spark.sql.connector.catalog.{SupportsRead, SupportsWrite, Table, TableCapability, TableProvider}
+import org.apache.spark.sql.connector.expressions.Transform
+import org.apache.spark.sql.connector.read.ScanBuilder
+import org.apache.spark.sql.connector.write.{LogicalWriteInfo, WriteBuilder}
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+class UserDefinedDataSourceTableProvider(
+    name: String,
+    builder: UserDefinedDataSourceBuilder) extends TableProvider {
+  private var planBuilder: UserDefinedDataSourcePlanBuilder = _
+
+  override def inferSchema(options: CaseInsensitiveStringMap): StructType = {
+    assert(planBuilder == null)
+    // When we reach here, it means there is no user-specified schema
+    planBuilder = builder.build(name, userSpecifiedSchema = None, options = options)
+    planBuilder.schema
+  }
+
+  override def getTable(
+      schema: StructType,
+      partitioning: Array[Transform],
+      properties: util.Map[String, String]): Table = {
+    assert(partitioning.isEmpty)
+    if (planBuilder == null) {
+      // When we reach here, it means there is user-specified schema
+      planBuilder = builder.build(
+        name,
+        userSpecifiedSchema = Some(schema),
+        options = new CaseInsensitiveStringMap(properties))
+    } else {
+      assert(schema == planBuilder.schema)
+    }
+    UserDefinedDataSourceTable(name, planBuilder)
+  }
+}
+
+case class UserDefinedDataSourceTable(
+    name: String,
+    builder: UserDefinedDataSourcePlanBuilder) extends Table
+  with SupportsRead with SupportsWrite {
+  override def schema(): StructType = builder.schema
+  override def capabilities(): util.Set[TableCapability] = {
+    util.EnumSet.of(TableCapability.BATCH_READ, TableCapability.BATCH_WRITE)
+  }
+  override def newScanBuilder(options: CaseInsensitiveStringMap): ScanBuilder = {
+    throw SparkException.internalError(
+      "UserDefinedDataSourceTable.newScanBuilder should not be called.")
+  }
+  override def newWriteBuilder(info: LogicalWriteInfo): WriteBuilder = {
+    throw SparkException.internalError(
+      "UserDefinedDataSourceTable.newWriteBuilder should not be called.")
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ddl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ddl.scala
@@ -99,7 +99,8 @@ case class CreateTempViewUsing(
     }
 
     val catalog = sparkSession.sessionState.catalog
-    val analyzedPlan = DataSource.lookupDataSourceV2(provider, sparkSession.sessionState.conf)
+    val analyzedPlan = DataSource.lookupDataSourceV2(
+        provider, sparkSession.sessionState.conf, sparkSession.sessionState.dataSourceManager)
       .flatMap { tblProvider =>
         DataSourceV2Utils.loadV2Source(sparkSession, tblProvider, userSpecifiedSchema,
           CaseInsensitiveMap(options), provider)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Utils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Utils.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.connector.catalog.{CatalogV2Util, SessionConfigSuppo
 import org.apache.spark.sql.connector.catalog.TableCapability.BATCH_READ
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.execution.command.DDLUtils
-import org.apache.spark.sql.execution.datasources.DataSource
+import org.apache.spark.sql.execution.datasources.{DataSource, DataSourceManager}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{LongType, StructType}
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
@@ -156,11 +156,14 @@ private[sql] object DataSourceV2Utils extends Logging {
   /**
    * Returns the table provider for the given format, or None if it cannot be found.
    */
-  def getTableProvider(provider: String, conf: SQLConf): Option[TableProvider] = {
+  def getTableProvider(
+      provider: String,
+      conf: SQLConf,
+      dataSourceManager: DataSourceManager): Option[TableProvider] = {
     // Return earlier since `lookupDataSourceV2` may fail to resolve provider "hive" to
     // `HiveFileFormat`, when running tests in sql/core.
     if (DDLUtils.isHiveTable(Some(provider))) return None
-    DataSource.lookupDataSourceV2(provider, conf) match {
+    DataSource.lookupDataSourceV2(provider, conf, dataSourceManager) match {
       // TODO(SPARK-28396): Currently file source v2 can't work with tables.
       case Some(p) if !p.isInstanceOf[FileDataSourceV2] => Some(p)
       case _ => None

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala
@@ -171,7 +171,7 @@ abstract class BaseSessionStateBuilder(
     catalog
   }
 
-  protected lazy val v2SessionCatalog = new V2SessionCatalog(catalog)
+  protected lazy val v2SessionCatalog = new V2SessionCatalog(catalog, dataSourceManager)
 
   protected lazy val catalogManager = new CatalogManager(v2SessionCatalog, catalog)
 
@@ -199,10 +199,11 @@ abstract class BaseSessionStateBuilder(
   protected def analyzer: Analyzer = new Analyzer(catalogManager) {
     override val extendedResolutionRules: Seq[Rule[LogicalPlan]] =
       new FindDataSourceTable(session) +:
+        RewriteUserDefinedDataSource +:
         new ResolveSQLOnFile(session) +:
         new FallBackFileSourceV2(session) +:
         ResolveEncodersInScalaAgg +:
-        new ResolveSessionCatalog(this.catalogManager) +:
+        new ResolveSessionCatalog(this.catalogManager, dataSourceManager) +:
         ResolveWriteToStream +:
         new EvalSubqueriesForTimeTravel +:
         customResolutionRules

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionStateBuilder.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionStateBuilder.scala
@@ -87,10 +87,11 @@ class HiveSessionStateBuilder(
     override val extendedResolutionRules: Seq[Rule[LogicalPlan]] =
       new ResolveHiveSerdeTable(session) +:
         new FindDataSourceTable(session) +:
+        RewriteUserDefinedDataSource +:
         new ResolveSQLOnFile(session) +:
         new FallBackFileSourceV2(session) +:
         ResolveEncodersInScalaAgg +:
-        new ResolveSessionCatalog(catalogManager) +:
+        new ResolveSessionCatalog(catalogManager, dataSourceManager) +:
         ResolveWriteToStream +:
         new EvalSubqueriesForTimeTravel +:
         new DetermineTableStats(session) +:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR adds a general framework to support any user-defined data source (name is not finalized yet) as a v2 source.

A user-defined data source is a data source defined outside of JVM. For now, it can only be the Python data source. A user-defined data source can use arbitrary query plans to read it. This PR looks up user-defined data sources and turns them into `DataSourceV2Relation` with a fake v2 table. Then there is a rule to turn `DataSourceV2Relation` into the query plan that the user-defined data source needs.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Unify the code to look up data sources.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, now people can use python data source in SQL CREATE TABLE.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
new test

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No