### PR TITLE
[SPARK-46363][CORE][SQL] Improve the java text block with java15 feature.

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/TransportContext.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/TransportContext.java
@@ -272,8 +272,9 @@ public class TransportContext implements Closeable {
             conf.sslRpctrustStoreReloadIntervalMs())
           .build();
       } else {
-        logger.error("RPC SSL encryption enabled but keys not found!" +
-          "Please ensure the configured keys are present.");
+        logger.error("""
+          RPC SSL encryption enabled but keys not found!\
+          Please ensure the configured keys are present.""");
         throw new IllegalArgumentException("RPC SSL encryption enabled but keys not found!");
       }
     } else {

--- a/common/network-common/src/main/java/org/apache/spark/network/buffer/FileSegmentManagedBuffer.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/buffer/FileSegmentManagedBuffer.java
@@ -68,9 +68,10 @@ public final class FileSegmentManagedBuffer extends ManagedBuffer {
         channel.position(offset);
         while (buf.remaining() != 0) {
           if (channel.read(buf) == -1) {
-            throw new IOException(String.format("Reached EOF before filling buffer\n" +
-              "offset=%s\nfile=%s\nbuf.remaining=%s",
-              offset, file.getAbsoluteFile(), buf.remaining()));
+            throw new IOException("""
+              Reached EOF before filling buffer
+              offset=%s\nfile=%s\nbuf.remaining=%s
+              """.formatted(offset, file.getAbsoluteFile(), buf.remaining()));
           }
         }
         buf.flip();

--- a/common/network-common/src/main/java/org/apache/spark/network/server/TransportChannelHandler.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/TransportChannelHandler.java
@@ -162,9 +162,10 @@ public class TransportChannelHandler extends SimpleChannelInboundHandler<Message
         if (e.state() == IdleState.ALL_IDLE && isActuallyOverdue) {
           if (responseHandler.hasOutstandingRequests()) {
             String address = getRemoteAddress(ctx.channel());
-            logger.error("Connection to {} has been quiet for {} ms while there are outstanding " +
-              "requests. Assuming connection is dead; please adjust" +
-              " spark.{}.io.connectionTimeout if this is wrong.",
+            logger.error("""
+              Connection to {} has been quiet for {} ms while there are outstanding requests. \
+              Assuming connection is dead; please adjust spark.{}.io.connectionTimeout if \
+              this is wrong.""",
               address, requestTimeoutNs / 1000 / 1000, transportContext.getConf().getModuleName());
             client.timeOut();
             ctx.close();

--- a/common/network-common/src/main/java/org/apache/spark/network/server/TransportRequestHandler.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/TransportRequestHandler.java
@@ -223,8 +223,9 @@ public class TransportRequestHandler extends MessageHandler<RequestMessage> {
              callback.onSuccess(ex.getResponse());
              streamHandler.onFailure(streamId, ex);
            } catch (Exception ex) {
-             IOException ioExc = new IOException("Failure post-processing complete stream;" +
-               " failing this rpc and leaving channel active", ex);
+             IOException ioExc = new IOException("""
+               Failure post-processing complete stream; \
+               failing this rpc and leaving channel active""", ex);
              callback.onFailure(ioExc);
              streamHandler.onFailure(streamId, ioExc);
            }

--- a/common/network-common/src/main/java/org/apache/spark/network/ssl/ReloadingX509TrustManager.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/ssl/ReloadingX509TrustManager.java
@@ -127,8 +127,9 @@ public final class ReloadingX509TrustManager
     if (tm != null) {
       tm.checkClientTrusted(chain, authType);
     } else {
-      throw new CertificateException("Unknown client chain certificate: " +
-        chain[0].toString() + ". Please ensure the correct trust store is specified in the config");
+      throw new CertificateException("""
+        Unknown client chain certificate: %s. Please ensure the correct trust store is specified \
+        in the config""".formatted(chain[0].toString()));
     }
   }
 
@@ -139,8 +140,9 @@ public final class ReloadingX509TrustManager
     if (tm != null) {
       tm.checkServerTrusted(chain, authType);
     } else {
-      throw new CertificateException("Unknown server chain certificate: " +
-        chain[0].toString() + ". Please ensure the correct trust store is specified in the config");
+      throw new CertificateException("""
+        Unknown server chain certificate: %s. Please ensure the correct trust store is specified \
+        in the config""".formatted(chain[0].toString()));
     }
   }
 

--- a/common/network-common/src/main/java/org/apache/spark/network/util/LevelDBProvider.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/LevelDBProvider.java
@@ -58,8 +58,9 @@ public class LevelDBProvider {
         } else {
           // the leveldb file seems to be corrupt somehow.  Lets just blow it away and create a new
           // one, so we can keep processing new apps
-          logger.error("error opening leveldb file {}.  Creating new file, will not be able to " +
-              "recover state for existing applications", dbFile, e);
+          logger.error("""
+            error opening leveldb file {}.  Creating new file, will not be able to recover state \
+            for existing applications""", dbFile, e);
           if (dbFile.isDirectory()) {
             for (File f : dbFile.listFiles()) {
               if (!f.delete()) {
@@ -115,8 +116,9 @@ public class LevelDBProvider {
     } else {
       StoreVersion version = mapper.readValue(bytes, StoreVersion.class);
       if (version.major != newversion.major) {
-        throw new IOException("cannot read state DB with version " + version + ", incompatible " +
-            "with current version " + newversion);
+        throw new IOException("""
+          cannot read state DB with version %s, incompatible with current version %s
+          """.formatted(version, newversion));
       }
       storeVersion(db, newversion, mapper);
     }

--- a/common/network-common/src/main/java/org/apache/spark/network/util/RocksDBProvider.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/RocksDBProvider.java
@@ -75,8 +75,9 @@ public class RocksDBProvider {
           } else {
             // the RocksDB file seems to be corrupt somehow.  Let's just blow it away and create
             // a new one, so we can keep processing new apps
-            logger.error("error opening rocksdb file {}. Creating new file, will not be able to " +
-              "recover state for existing applications", dbFile, e);
+            logger.error("""
+              error opening rocksdb file {}. Creating new file, will not be able to recover state \
+              for existing applications""", dbFile, e);
             if (dbFile.isDirectory()) {
               for (File f : Objects.requireNonNull(dbFile.listFiles())) {
                 if (!f.delete()) {
@@ -156,8 +157,9 @@ public class RocksDBProvider {
       } else {
         StoreVersion version = mapper.readValue(bytes, StoreVersion.class);
         if (version.major != newversion.major) {
-          throw new IOException("cannot read state DB with version " + version + ", incompatible " +
-            "with current version " + newversion);
+          throw new IOException("""
+            cannot read state DB with version %s, incompatible with current version %s\
+            """.formatted(version, newversion));
         }
         storeVersion(db, newversion, mapper);
       }

--- a/common/network-common/src/test/java/org/apache/spark/network/crypto/AuthEngineSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/crypto/AuthEngineSuite.java
@@ -40,14 +40,14 @@ public class AuthEngineSuite {
 
   private static final String clientPrivate =
       "efe6b68b3fce92158e3637f6ef9d937e75558928dd4b401de04b43d300a73186";
-  private static final String clientChallengeHex =
-      "fb00000005617070496400000010890b6e960f48e998777267a7e4e623220000003c48ad7dc7ec9466da9" +
-      "3bda9f11488dc9404050e02c661d87d67c782444944c6e369b27e0a416c30845a2d9e64271511ca98b41d" +
-      "65f8c426e18ff380f6";
-  private static final String serverResponseHex =
-      "fb00000005617070496400000010708451c9dd2792c97c1ca66e6df449ef0000003c64fe899ecdaf458d4" +
-      "e25e9d5c5a380b8e6d1a184692fac065ed84f8592c18e9629f9c636809dca2ffc041f20346eb53db78738" +
-      "08ecad08b46b5ee3ff";
+  private static final String clientChallengeHex = """
+    fb00000005617070496400000010890b6e960f48e998777267a7e4e623220000003c48ad7dc7ec9466da9\
+    3bda9f11488dc9404050e02c661d87d67c782444944c6e369b27e0a416c30845a2d9e64271511ca98b41d\
+    65f8c426e18ff380f6""";
+  private static final String serverResponseHex = """
+    fb00000005617070496400000010708451c9dd2792c97c1ca66e6df449ef0000003c64fe899ecdaf458d4\
+    e25e9d5c5a380b8e6d1a184692fac065ed84f8592c18e9629f9c636809dca2ffc041f20346eb53db78738\
+    08ecad08b46b5ee3ff""";
   private static final String sharedKey =
       "31963f15a320d5c90333f7ecf5cf3a31c7eaf151de07fef8494663a9f47cfd31";
   private static final String inputIv = "fc6a5dc8b90a9dad8f54f08b51a59ed2";

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockStoreClient.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockStoreClient.java
@@ -102,8 +102,9 @@ public class ExternalBlockStoreClient extends BlockStoreClient {
     try {
       this.comparableAppAttemptId = Integer.parseInt(appAttemptId);
     } catch (NumberFormatException e) {
-      logger.warn("Push based shuffle requires comparable application attemptId, " +
-        "but the appAttemptId {} cannot be parsed to Integer", appAttemptId, e);
+      logger.warn("""
+        Push based shuffle requires comparable application attemptId, \
+        but the appAttemptId {} cannot be parsed to Integer""", appAttemptId, e);
     }
   }
 

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
@@ -228,9 +228,9 @@ public class RemoteBlockPushResolver implements MergedShuffleFileManager {
     AppShuffleMergePartitionsInfo shufflePartitionsWithMergeId =
       shuffles.compute(shuffleId, (id, mergePartitionsInfo) -> {
         if (mergePartitionsInfo == null) {
-          logger.info("{} attempt {} shuffle {} shuffleMerge {}: creating a new shuffle " +
-              "merge metadata", appShuffleInfo.appId, appShuffleInfo.attemptId, shuffleId,
-              shuffleMergeId);
+          logger.info("""
+            {} attempt {} shuffle {} shuffleMerge {}: creating a new shuffle merge metadata
+            """, appShuffleInfo.appId, appShuffleInfo.attemptId, shuffleId, shuffleMergeId);
           return new AppShuffleMergePartitionsInfo(shuffleMergeId, false);
         } else {
           int latestShuffleMergeId = mergePartitionsInfo.shuffleMergeId;
@@ -247,9 +247,10 @@ public class RemoteBlockPushResolver implements MergedShuffleFileManager {
             AppAttemptShuffleMergeId currrentAppAttemptShuffleMergeId =
                 new AppAttemptShuffleMergeId(appShuffleInfo.appId, appShuffleInfo.attemptId,
                     shuffleId, latestShuffleMergeId);
-            logger.info("{}: creating a new shuffle merge metadata since received " +
-                "shuffleMergeId {} is higher than latest shuffleMergeId {}",
-                currrentAppAttemptShuffleMergeId, shuffleMergeId, latestShuffleMergeId);
+            logger.info("""
+              {}: creating a new shuffle merge metadata since received shuffleMergeId {} is \
+              higher than latest shuffleMergeId {}
+              """, currrentAppAttemptShuffleMergeId, shuffleMergeId, latestShuffleMergeId);
             submitCleanupTask(() ->
                 closeAndDeleteOutdatedPartitions(currrentAppAttemptShuffleMergeId,
                     mergePartitionsInfo.shuffleMergePartitions));
@@ -281,14 +282,14 @@ public class RemoteBlockPushResolver implements MergedShuffleFileManager {
         return newAppShufflePartitionInfo(appShuffleInfo, shuffleId, shuffleMergeId, reduceId,
             dataFile, indexFile, metaFile);
       } catch (IOException e) {
-        logger.error("{} attempt {} shuffle {} shuffleMerge {}: cannot create merged shuffle " +
-            "partition with data file {}, index file {}, and meta file {}", appShuffleInfo.appId,
-            appShuffleInfo.attemptId, shuffleId, shuffleMergeId, dataFile.getAbsolutePath(),
-            indexFile.getAbsolutePath(), metaFile.getAbsolutePath());
-        throw new RuntimeException(
-          String.format("Cannot initialize merged shuffle partition for appId %s shuffleId %s "
-            + "shuffleMergeId %s reduceId %s", appShuffleInfo.appId, shuffleId, shuffleMergeId,
-              reduceId), e);
+        logger.error("""
+          {} attempt {} shuffle {} shuffleMerge {}: cannot create merged shuffle partition with \
+          data file {}, index file {}, and meta file {}
+          """, appShuffleInfo.appId, appShuffleInfo.attemptId, shuffleId, shuffleMergeId,
+          dataFile.getAbsolutePath(), indexFile.getAbsolutePath(), metaFile.getAbsolutePath());
+        throw new RuntimeException("""
+          Cannot initialize merged shuffle partition for appId %s shuffleId %s shuffleMergeId %s \
+          reduceId %s""".formatted(appShuffleInfo.appId, shuffleId, shuffleMergeId, reduceId), e);
       }
     });
   }
@@ -316,10 +317,10 @@ public class RemoteBlockPushResolver implements MergedShuffleFileManager {
     AppShuffleInfo appShuffleInfo = validateAndGetAppShuffleInfo(appId);
     AppShuffleMergePartitionsInfo partitionsInfo = appShuffleInfo.shuffles.get(shuffleId);
     if (null != partitionsInfo && partitionsInfo.shuffleMergeId > shuffleMergeId) {
-      throw new RuntimeException(String.format(
-        "MergedBlockMeta fetch for shuffle %s with shuffleMergeId %s reduceId %s is %s",
-        shuffleId, shuffleMergeId, reduceId,
-        ErrorHandler.BlockFetchErrorHandler.STALE_SHUFFLE_BLOCK_FETCH));
+      throw new RuntimeException("""
+        MergedBlockMeta fetch for shuffle %s with shuffleMergeId %s reduceId %s is %s\
+        """.formatted(shuffleId, shuffleMergeId, reduceId,
+          ErrorHandler.BlockFetchErrorHandler.STALE_SHUFFLE_BLOCK_FETCH));
     }
     File indexFile = new File(
       appShuffleInfo.getMergedShuffleIndexFilePath(shuffleId, shuffleMergeId, reduceId));
@@ -421,10 +422,10 @@ public class RemoteBlockPushResolver implements MergedShuffleFileManager {
   public void removeShuffleMerge(RemoveShuffleMerge msg) {
     AppShuffleInfo appShuffleInfo = validateAndGetAppShuffleInfo(msg.appId);
     if (appShuffleInfo.attemptId != msg.appAttemptId) {
-      throw new IllegalArgumentException(
-          String.format("The attempt id %s in this RemoveShuffleMerge message does not match "
-                  + "with the current attempt id %s stored in shuffle service for application %s",
-              msg.appAttemptId, appShuffleInfo.attemptId, msg.appId));
+      throw new IllegalArgumentException("""
+        The attempt id %s in this RemoveShuffleMerge message does not match with the current \
+        attempt id %s stored in shuffle service for application %s
+        """.formatted(msg.appAttemptId, appShuffleInfo.attemptId, msg.appId));
     }
     appShuffleInfo.shuffles.compute(msg.shuffleId, (shuffleId, mergePartitionsInfo) -> {
       if (mergePartitionsInfo == null) {
@@ -460,9 +461,11 @@ public class RemoteBlockPushResolver implements MergedShuffleFileManager {
                   mergePartitionsInfo.getReduceIds(), false));
         }
       } else {
-        throw new RuntimeException(String.format("Asked to remove old shuffle merged data for " +
-                "application %s shuffleId %s shuffleMergeId %s, but current shuffleMergeId %s ",
-            msg.appId, msg.shuffleId, shuffleMergeIdToDelete, mergePartitionsInfo.shuffleMergeId));
+        throw new RuntimeException("""
+          Asked to remove old shuffle merged data for application %s shuffleId %s shuffleMergeId \
+          %s, but current shuffleMergeId %s \
+          """.formatted(msg.appId, msg.shuffleId,
+             shuffleMergeIdToDelete, mergePartitionsInfo.shuffleMergeId));
       }
       writeAppAttemptShuffleMergeInfoToDB(new AppAttemptShuffleMergeId(
           msg.appId, msg.appAttemptId, msg.shuffleId, shuffleMergeIdToDelete));
@@ -750,10 +753,10 @@ public class RemoteBlockPushResolver implements MergedShuffleFileManager {
       // related case, not the block push case, just throw it in server side now.
       // TODO we may use a new exception class to include the finalizeShuffleMerge
       // related case just as the BlockPushNonFatalFailure contains the block push cases.
-      throw new IllegalArgumentException(
-        String.format("The attempt id %s in this FinalizeShuffleMerge message does not match "
-            + "with the current attempt id %s stored in shuffle service for application %s",
-          msg.appAttemptId, appShuffleInfo.attemptId, msg.appId));
+      throw new IllegalArgumentException("""
+        The attempt id %s in this FinalizeShuffleMerge message does not match with the current \
+        attempt id %s stored in shuffle service for application %s\
+        """.formatted(msg.appAttemptId, appShuffleInfo.attemptId, msg.appId));
     }
     AppAttemptShuffleMergeId appAttemptShuffleMergeId = new AppAttemptShuffleMergeId(
         msg.appId, msg.appAttemptId, msg.shuffleId, msg.shuffleMergeId);
@@ -859,9 +862,9 @@ public class RemoteBlockPushResolver implements MergedShuffleFileManager {
         int attemptId = Integer.valueOf(
           metaMap.getOrDefault(ATTEMPT_ID_KEY, String.valueOf(UNDEFINED_ATTEMPT_ID)));
         if (mergeDir == null) {
-          throw new IllegalArgumentException(
-            String.format("Failed to get the merge directory information from the " +
-              "shuffleManagerMeta %s in executor registration message", shuffleManagerMeta));
+          throw new IllegalArgumentException("""
+            Failed to get the merge directory information from the shuffleManagerMeta %s \
+            in executor registration message""".formatted(shuffleManagerMeta));
         }
         if (attemptId == UNDEFINED_ATTEMPT_ID) {
           // When attemptId is -1, there is no attemptId stored in the ExecutorShuffleInfo.

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalShuffleBlockResolverSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ExternalShuffleBlockResolverSuite.java
@@ -122,8 +122,9 @@ public class ExternalShuffleBlockResolverSuite {
     // its not legacy yet, but keeping this here in case anybody changes it
     String legacyAppIdJson = "{\"appId\":\"foo\", \"execId\":\"bar\"}";
     assertEquals(appId, mapper.readValue(legacyAppIdJson, AppExecId.class));
-    String legacyShuffleJson = "{\"localDirs\": [\"/bippy\", \"/flippy\"], " +
-      "\"subDirsPerLocalDir\": 7, \"shuffleManager\": " + "\"" + SORT_MANAGER + "\"}";
+    String legacyShuffleJson = """
+       {"localDirs": ["/bippy", "/flippy"], "subDirsPerLocalDir": 7, "shuffleManager": "%s"}
+       """.formatted(SORT_MANAGER);
     assertEquals(shuffleInfo, mapper.readValue(legacyShuffleJson, ExecutorShuffleInfo.class));
   }
 

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/RemoteBlockPushResolverSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/RemoteBlockPushResolverSuite.java
@@ -479,9 +479,10 @@ public class RemoteBlockPushResolverSuite {
     IllegalArgumentException re = assertThrows(IllegalArgumentException.class,
       () -> registerExecutor(testApp, prepareLocalDirs(activeLocalDirs, MERGE_DIRECTORY),
         INVALID_MERGE_DIRECTORY_META));
-    assertEquals("Failed to get the merge directory information from the shuffleManagerMeta " +
-      "shuffleManager:{\"mergeDirInvalid\": \"merge_manager_2\", \"attemptId\": \"2\"} in " +
-      "executor registration message", re.getMessage());
+    assertEquals("""
+      Failed to get the merge directory information from the shuffleManagerMeta \
+      shuffleManager:{"mergeDirInvalid": "merge_manager_2", "attemptId": "2"} in \
+      executor registration message""", re.getMessage());
   }
 
   @Test
@@ -1007,10 +1008,10 @@ public class RemoteBlockPushResolverSuite {
     IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
       () -> pushResolver.finalizeShuffleMerge(
               new FinalizeShuffleMerge(testApp, ATTEMPT_ID_1, 0, 0)));
-    assertEquals(e.getMessage(),
-      String.format("The attempt id %s in this FinalizeShuffleMerge message does not " +
-        "match with the current attempt id %s stored in shuffle service for application %s",
-        ATTEMPT_ID_1, ATTEMPT_ID_2, testApp));
+    assertEquals(e.getMessage(), """
+      The attempt id %s in this FinalizeShuffleMerge message does not match with the current \
+      attempt id %s stored in shuffle service for application %s\
+      """.formatted(ATTEMPT_ID_1, ATTEMPT_ID_2, testApp));
   }
 
   @Test
@@ -1164,20 +1165,23 @@ public class RemoteBlockPushResolverSuite {
     pushResolver.finalizeShuffleMerge(new FinalizeShuffleMerge(TEST_APP, NO_ATTEMPT_ID, 0, 2));
     RuntimeException re0 = assertThrows(RuntimeException.class,
       () -> pushResolver.getMergedBlockMeta(TEST_APP, 0, 0, 0));
-    assertEquals("MergedBlockMeta fetch for shuffle 0 with shuffleMergeId 0 reduceId 0"
-      + " is stale shuffle block fetch request as shuffle blocks of a higher shuffleMergeId for"
-      + " the shuffle is available", re0.getMessage());
+    assertEquals("""
+      MergedBlockMeta fetch for shuffle 0 with shuffleMergeId 0 reduceId 0 is stale shuffle block \
+      fetch request as shuffle blocks of a higher shuffleMergeId for the shuffle is available\
+      """, re0.getMessage());
     RuntimeException re1 = assertThrows(RuntimeException.class,
       () -> pushResolver.finalizeShuffleMerge(
               new FinalizeShuffleMerge(TEST_APP, NO_ATTEMPT_ID, 0, 1)));
-    assertEquals("Shuffle merge finalize request for shuffle 0 with shuffleMergeId 1 is stale"
-      + " shuffle finalize request as shuffle blocks of a higher shuffleMergeId for the shuffle"
-      + " is already being pushed", re1.getMessage());
+    assertEquals("""
+      Shuffle merge finalize request for shuffle 0 with shuffleMergeId 1 is stale shuffle \
+      finalize request as shuffle blocks of a higher shuffleMergeId for the shuffle is already \
+      being pushed""", re1.getMessage());
     RuntimeException re2 = assertThrows(RuntimeException.class,
       () -> pushResolver.getMergedBlockData(TEST_APP, 0, 1, 0, 0));
-    assertEquals("MergedBlockData fetch for shuffle 0 with shuffleMergeId 1 reduceId 0"
-      + " is stale shuffle block fetch request as shuffle blocks of a higher shuffleMergeId for"
-      + " the shuffle is available", re2.getMessage());
+    assertEquals("""
+      MergedBlockData fetch for shuffle 0 with shuffleMergeId 1 reduceId 0 is stale shuffle block \
+      fetch request as shuffle blocks of a higher shuffleMergeId for the shuffle is available\
+      """, re2.getMessage());
     MergedBlockMeta blockMeta = pushResolver.getMergedBlockMeta(TEST_APP, 0, 2, 0);
     validateChunks(TEST_APP, 0, 2, 0, blockMeta, new int[]{4}, new int[][]{{0}});
   }
@@ -1359,15 +1363,16 @@ public class RemoteBlockPushResolverSuite {
 
     // Intentionally keep these hard-coded strings in here, to check backwards-compatibility.
     // It is not legacy yet, but keeping this here in case anybody changes it
-    String legacyAppAttemptIdJson = "{\"appId\": \"foo\", \"attemptId\":\"1\"}";
+    String legacyAppAttemptIdJson = """
+      {"appId": "foo", "attemptId":"1"}""";
     assertEquals(appAttemptId,
       mapper.readValue(legacyAppAttemptIdJson, RemoteBlockPushResolver.AppAttemptId.class));
-    String legacyAppPathInfoJson =
-      "{\"activeLocalDirs\": [\"/foo\", \"/bar\"], \"subDirsPerLocalDir\":\"64\"}";
+    String legacyAppPathInfoJson = """
+      {"activeLocalDirs": ["/foo", "/bar"], "subDirsPerLocalDir":"64"}""";
     assertEquals(pathInfo,
       mapper.readValue(legacyAppPathInfoJson, RemoteBlockPushResolver.AppPathsInfo.class));
-    String legacyPartitionIdJson = "{\"appId\":\"foo\", \"attemptId\":\"1\", "
-      + "\"shuffleId\":\"1\", \"shuffleMergeId\":\"1\"}";
+    String legacyPartitionIdJson = """
+      {"appId":"foo", "attemptId":"1", "shuffleId":"1", "shuffleMergeId":"1"}""";
     assertEquals(partitionId, mapper.readValue(legacyPartitionIdJson,
       RemoteBlockPushResolver.AppAttemptShuffleMergeId.class));
   }

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/UTF8StringBuilder.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/UTF8StringBuilder.java
@@ -50,9 +50,9 @@ public class UTF8StringBuilder {
   // Grows the buffer by at least `neededSize`
   private void grow(int neededSize) {
     if (neededSize > ARRAY_MAX - totalSize()) {
-      throw new UnsupportedOperationException(
-        "Cannot grow internal buffer by size " + neededSize + " because the size after growing " +
-          "exceeds size limitation " + ARRAY_MAX);
+      throw new UnsupportedOperationException("""
+        Cannot grow internal buffer by size %d because the size after growing exceeds size \
+        limitation %d""".formatted(neededSize, ARRAY_MAX));
     }
     final int length = totalSize() + neededSize;
     if (buffer.length < length) {

--- a/common/utils/src/main/java/org/apache/spark/network/util/ByteUnit.java
+++ b/common/utils/src/main/java/org/apache/spark/network/util/ByteUnit.java
@@ -39,8 +39,9 @@ public enum ByteUnit {
     if (multiplier > u.multiplier) {
       long ratio = multiplier / u.multiplier;
       if (Long.MAX_VALUE / ratio < d) {
-        throw new IllegalArgumentException("Conversion of " + d + " exceeds Long.MAX_VALUE in "
-          + name() + ". Try a larger unit (e.g. MiB instead of KiB)");
+        throw new IllegalArgumentException("""
+          Conversion of %d exceeds Long.MAX_VALUE in %s. \
+          Try a larger unit (e.g. MiB instead of KiB)""".formatted(d, name()));
       }
       return d * ratio;
     } else {

--- a/common/utils/src/main/java/org/apache/spark/network/util/JavaUtils.java
+++ b/common/utils/src/main/java/org/apache/spark/network/util/JavaUtils.java
@@ -109,8 +109,9 @@ public class JavaUtils {
         deleteRecursivelyUsingUnixNative(file);
         return;
       } catch (IOException e) {
-        logger.warn("Attempt to delete using native Unix OS command failed for path = {}. " +
-                        "Falling back to Java IO way", file.getAbsolutePath(), e);
+        logger.warn("""
+          Attempt to delete using native Unix OS command failed for path = {}. \
+          Falling back to Java IO way""", file.getAbsolutePath(), e);
       }
     }
 
@@ -249,11 +250,10 @@ public class JavaUtils {
       // If suffix is valid use that, otherwise none was provided and use the default passed
       return unit.convert(val, suffix != null ? timeSuffixes.get(suffix) : unit);
     } catch (NumberFormatException e) {
-      String timeError = "Time must be specified as seconds (s), " +
-              "milliseconds (ms), microseconds (us), minutes (m or min), hour (h), or day (d). " +
-              "E.g. 50s, 100ms, or 250us.";
-
-      throw new NumberFormatException(timeError + "\n" + e.getMessage());
+      throw new NumberFormatException("""
+        Time must be specified as seconds (s), milliseconds (ms), microseconds (us), \
+        minutes (m or min), hour (h), or day (d). E.g. 50s, 100ms, or 250us.
+        %s""".formatted(e.getMessage()));
     }
   }
 
@@ -303,11 +303,10 @@ public class JavaUtils {
       }
 
     } catch (NumberFormatException e) {
-      String byteError = "Size must be specified as bytes (b), " +
-        "kibibytes (k), mebibytes (m), gibibytes (g), tebibytes (t), or pebibytes(p). " +
-        "E.g. 50b, 100k, or 250m.";
-
-      throw new NumberFormatException(byteError + "\n" + e.getMessage());
+      throw new NumberFormatException("""
+        Size must be specified as bytes (b), kibibytes (k), mebibytes (m), gibibytes (g), \
+        tebibytes (t), or pebibytes(p). E.g. 50b, 100k, or 250m.
+        %s""".formatted(e.getMessage()));
     }
   }
 
@@ -386,8 +385,9 @@ public class JavaUtils {
     while (dir == null) {
       attempts += 1;
       if (attempts > maxAttempts) {
-        throw new IOException("Failed to create a temp directory (under " + root + ") after " +
-          maxAttempts + " attempts!");
+        throw new IOException("""
+          Failed to create a temp directory (under %s) after %d attempts!
+          """.formatted(root, maxAttempts));
       }
       try {
         dir = new File(root, namePrefix + "-" + UUID.randomUUID());
@@ -407,8 +407,8 @@ public class JavaUtils {
     int expected = dst.remaining();
     while (dst.hasRemaining()) {
       if (channel.read(dst) < 0) {
-        throw new EOFException(String.format("Not enough bytes in channel (expected %d).",
-          expected));
+        throw new EOFException("""
+          Not enough bytes in channel (expected %d).""".formatted(expected));
       }
     }
   }

--- a/core/src/main/java/org/apache/spark/shuffle/sort/UnsafeShuffleWriter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/UnsafeShuffleWriter.java
@@ -119,10 +119,9 @@ public class UnsafeShuffleWriter<K, V> extends ShuffleWriter<K, V> {
       ShuffleExecutorComponents shuffleExecutorComponents) throws SparkException {
     final int numPartitions = handle.dependency().partitioner().numPartitions();
     if (numPartitions > SortShuffleManager.MAX_SHUFFLE_OUTPUT_PARTITIONS_FOR_SERIALIZED_MODE()) {
-      throw new IllegalArgumentException(
-        "UnsafeShuffleWriter can only be used for shuffles with at most " +
-        SortShuffleManager.MAX_SHUFFLE_OUTPUT_PARTITIONS_FOR_SERIALIZED_MODE() +
-        " reduce partitions");
+      throw new IllegalArgumentException("""
+        UnsafeShuffleWriter can only be used for shuffles with at most %d reduce partitions\
+        """.formatted(SortShuffleManager.MAX_SHUFFLE_OUTPUT_PARTITIONS_FOR_SERIALIZED_MODE()));
     }
     this.blockManager = blockManager;
     this.memoryManager = memoryManager;
@@ -191,8 +190,7 @@ public class UnsafeShuffleWriter<K, V> extends ShuffleWriter<K, V> {
           if (success) {
             throw e;
           } else {
-            logger.error("In addition to a failure during writing, we failed during " +
-                         "cleanup.", e);
+            logger.error("In addition to a failure during writing, we failed during cleanup.", e);
           }
         }
       }

--- a/core/src/main/java/org/apache/spark/shuffle/sort/io/LocalDiskShuffleMapOutputWriter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/io/LocalDiskShuffleMapOutputWriter.java
@@ -103,12 +103,12 @@ public class LocalDiskShuffleMapOutputWriter implements ShuffleMapOutputWriter {
     // after calling transferTo in kernel version 2.6.32. This issue is described at
     // https://bugs.openjdk.java.net/browse/JDK-7052359 and SPARK-3948.
     if (outputFileChannel != null && outputFileChannel.position() != bytesWrittenToMergedFile) {
-      throw new IOException(
-          "Current position " + outputFileChannel.position() + " does not equal expected " +
-              "position " + bytesWrittenToMergedFile + " after transferTo. Please check your " +
-              " kernel version to see if it is 2.6.32, as there is a kernel bug which will lead " +
-              "to unexpected behavior when using transferTo. You can set " +
-              "spark.file.transferTo=false to disable this NIO feature.");
+      throw new IOException("""
+        Current position %d does not equal expected position %d after transferTo. \
+        Please check your kernel version to see if it is 2.6.32, as there is a kernel bug \
+        which will lead to unexpected behavior when using transferTo. \
+        You can set spark.file.transferTo=false to disable this NIO feature.\
+        """.formatted(outputFileChannel.position(), bytesWrittenToMergedFile));
     }
     cleanUp();
     File resolvedTmp = outputTempFile != null && outputTempFile.isFile() ? outputTempFile : null;
@@ -170,9 +170,9 @@ public class LocalDiskShuffleMapOutputWriter implements ShuffleMapOutputWriter {
     public OutputStream openStream() throws IOException {
       if (partStream == null) {
         if (outputFileChannel != null) {
-          throw new IllegalStateException("Requested an output channel for a previous write but" +
-              " now an output stream has been requested. Should not be using both channels" +
-              " and streams to write.");
+          throw new IllegalStateException("""
+            Requested an output channel for a previous write but now an output stream has been \
+            requested. Should not be using both channels and streams to write.""");
         }
         initStream();
         partStream = new PartitionWriterStream(partitionId);
@@ -184,9 +184,9 @@ public class LocalDiskShuffleMapOutputWriter implements ShuffleMapOutputWriter {
     public Optional<WritableByteChannelWrapper> openChannelWrapper() throws IOException {
       if (partChannel == null) {
         if (partStream != null) {
-          throw new IllegalStateException("Requested an output stream for a previous write but" +
-              " now an output channel has been requested. Should not be using both channels" +
-              " and streams to write.");
+          throw new IllegalStateException("""
+            Requested an output stream for a previous write but now an output channel has been \
+            requested. Should not be using both channels and streams to write.""");
         }
         initChannel();
         partChannel = new PartitionWriterChannel(partitionId);

--- a/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeExternalSorter.java
+++ b/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeExternalSorter.java
@@ -785,8 +785,8 @@ public final class UnsafeExternalSorter extends MemoryConsumer {
         if (iter.hasNext()) {
           iter.loadNext();
         } else {
-          throw new ArrayIndexOutOfBoundsException("Failed to move the iterator " + steps +
-            " steps forward");
+          throw new ArrayIndexOutOfBoundsException("""
+            Failed to move the iterator %d steps forward""".formatted(steps));
         }
       }
     }

--- a/core/src/test/java/org/apache/spark/JavaJdbcRDDSuite.java
+++ b/core/src/test/java/org/apache/spark/JavaJdbcRDDSuite.java
@@ -46,9 +46,9 @@ public class JavaJdbcRDDSuite implements Serializable {
         "jdbc:derby:target/" + dbName + ";create=true")) {
 
       try (Statement create = connection.createStatement()) {
-        create.execute(
-          "CREATE TABLE FOO(ID INTEGER NOT NULL GENERATED ALWAYS AS IDENTITY" +
-                  " (START WITH 1, INCREMENT BY 1), DATA INTEGER)");
+        create.execute("""
+          CREATE TABLE FOO(ID INTEGER NOT NULL GENERATED ALWAYS AS IDENTITY \
+          (START WITH 1, INCREMENT BY 1), DATA INTEGER)""");
       }
 
       try (PreparedStatement insert = connection.prepareStatement(

--- a/launcher/src/main/java/org/apache/spark/launcher/LauncherServer.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/LauncherServer.java
@@ -269,10 +269,10 @@ class LauncherServer implements Closeable {
 
     value = SparkLauncher.launcherConfig.get(SparkLauncher.DEPRECATED_CHILD_CONNECTION_TIMEOUT);
     if (value != null) {
-        LOG.log(Level.WARNING,
-                "Property '" + SparkLauncher.DEPRECATED_CHILD_CONNECTION_TIMEOUT +
-                "' is deprecated, please switch to '" + SparkLauncher.CHILD_CONNECTION_TIMEOUT +
-                "'.");
+        LOG.log(Level.WARNING, """
+            Property '%s' is deprecated, please switch to '%s'.""".formatted(
+                SparkLauncher.DEPRECATED_CHILD_CONNECTION_TIMEOUT,
+                SparkLauncher.CHILD_CONNECTION_TIMEOUT));
         return Long.parseLong(value);
     }
     return DEFAULT_CONNECT_TIMEOUT;

--- a/launcher/src/main/java/org/apache/spark/launcher/SparkClassCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkClassCommandBuilder.java
@@ -90,9 +90,9 @@ class SparkClassCommandBuilder extends AbstractCommandBuilder {
     for (String key : javaOptsKeys) {
       String envValue = System.getenv(key);
       if (!isEmpty(envValue) && envValue.contains("Xmx")) {
-        String msg = String.format("%s is not allowed to specify max heap(Xmx) memory settings " +
-                "(was %s). Use the corresponding configuration instead.", key, envValue);
-        throw new IllegalArgumentException(msg);
+        throw new IllegalArgumentException("""
+          %s is not allowed to specify max heap(Xmx) memory settings \
+          (was %s). Use the corresponding configuration instead.""".formatted(key, envValue));
       }
       addOptionString(cmd, envValue);
     }

--- a/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
@@ -314,10 +314,10 @@ class SparkSubmitCommandBuilder extends AbstractCommandBuilder {
     if (!isEmpty(javaOptions)) {
       for (String javaOption: CommandBuilderUtils.parseOptionString(javaOptions)) {
         if (javaOption.startsWith("-Xmx")) {
-            String msg = String.format("Not allowed to specify max heap(Xmx) memory settings " +
-              "through java options (was %s). Use the corresponding --driver-memory or " +
-              "spark.driver.memory configuration instead.", javaOptions);
-            throw new IllegalArgumentException(msg);
+            throw new IllegalArgumentException("""
+              Not allowed to specify max heap(Xmx) memory settings through java options (was %s). \
+              Use the corresponding --driver-memory or spark.driver.memory configuration instead.
+              """.formatted(javaOptions));
         }
       }
     }
@@ -327,9 +327,9 @@ class SparkSubmitCommandBuilder extends AbstractCommandBuilder {
     // For backwards compatibility, if a script is specified in
     // the pyspark command line, then run it using spark-submit.
     if (!appArgs.isEmpty() && appArgs.get(0).endsWith(".py")) {
-      System.err.println(
-        "Running python applications through 'pyspark' is not supported as of Spark 2.0.\n" +
-        "Use ./bin/spark-submit <python file>");
+      System.err.println("""
+        Running python applications through 'pyspark' is not supported as of Spark 2.0.
+        Use ./bin/spark-submit <python file>""");
       System.exit(-1);
     }
 
@@ -379,9 +379,9 @@ class SparkSubmitCommandBuilder extends AbstractCommandBuilder {
 
   private List<String> buildSparkRCommand(Map<String, String> env) throws IOException {
     if (!appArgs.isEmpty() && (appArgs.get(0).endsWith(".R") || appArgs.get(0).endsWith(".r"))) {
-      System.err.println(
-        "Running R applications through 'sparkR' is not supported as of Spark 2.0.\n" +
-        "Use ./bin/spark-submit <R file>");
+      System.err.println("""
+        Running R applications through 'sparkR' is not supported as of Spark 2.0.
+        "Use ./bin/spark-submit <R file>""");
       System.exit(-1);
     }
     // When launching the SparkR shell, store the spark-submit arguments in the SPARKR_SUBMIT_ARGS

--- a/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitCommandBuilderSuite.java
+++ b/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitCommandBuilderSuite.java
@@ -81,8 +81,9 @@ public class SparkSubmitCommandBuilderSuite extends BaseSuite {
       parser.DRIVER_CLASS_PATH,
       "/driverCp",
       parser.DRIVER_JAVA_OPTIONS,
-      "-Xmx64g -Dprop=Other -Dprop1=\"-Xmx -Xmx\" -Dprop2=\"-Xmx '-Xmx\" " +
-        "-Dprop3='-Xmx -Xmx' -Dprop4='-Xmx \"-Xmx'",
+      """
+        -Xmx64g -Dprop=Other -Dprop1="-Xmx -Xmx" -Dprop2="-Xmx '-Xmx" \
+        -Dprop3='-Xmx -Xmx' -Dprop4='-Xmx "-Xmx'""",
       SparkLauncher.NO_RESOURCE);
     assertThrows(IllegalArgumentException.class, () -> buildCommand(sparkSubmitArgs, env));
   }
@@ -96,8 +97,9 @@ public class SparkSubmitCommandBuilderSuite extends BaseSuite {
       parser.DRIVER_CLASS_PATH,
       "/driverCp",
       parser.DRIVER_JAVA_OPTIONS,
-      "-Dprop=-Xmx -Dprop1=\"-Xmx -Xmx\" -Dprop2=\"-Xmx '-Xmx\" " +
-        "-Dprop3='-Xmx -Xmx' -Dprop4='-Xmx \"-Xmx'",
+      """
+         -Dprop=-Xmx -Dprop1="-Xmx -Xmx" -Dprop2="-Xmx '-Xmx" \
+         -Dprop3='-Xmx -Xmx' -Dprop4='-Xmx "-Xmx'""",
       SparkLauncher.NO_RESOURCE);
     buildCommand(sparkSubmitArgs, env);
   }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/ExpressionInfo.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/ExpressionInfo.java
@@ -145,36 +145,41 @@ public class ExpressionInfo {
         }
         if (!note.isEmpty()) {
             if (!note.contains("    ") || !note.endsWith("  ")) {
-                throw new IllegalArgumentException("'note' is malformed in the expression [" +
-                    this.name + "]. It should start with a newline and 4 leading spaces; end " +
-                    "with a newline and two spaces; however, got [" + note + "].");
+                throw new IllegalArgumentException("""
+                  'note' is malformed in the expression [%s]. It should start with a newline and \
+                  4 leading spaces; end with a newline and two spaces; however, got [%s].\
+                  """.formatted(this.name, note));
             }
             this.extended += "\n    Note:\n      " + note.trim() + "\n";
         }
         if (!group.isEmpty() && !validGroups.contains(group)) {
-            throw new IllegalArgumentException("'group' is malformed in the expression [" +
-                this.name + "]. It should be a value in " + validGroups + "; however, " +
-                "got [" + group + "].");
+            throw new IllegalArgumentException("""
+              'group' is malformed in the expression [%s]. \
+              It should be a value in %s; however, got [%s]. \
+              """.formatted(this.name, validGroups, group));
         }
         if (!source.isEmpty() && !validSources.contains(source)) {
-            throw new IllegalArgumentException("'source' is malformed in the expression [" +
-                    this.name + "]. It should be a value in " + validSources + "; however, " +
-                    "got [" + source + "].");
+            throw new IllegalArgumentException("""
+              'source' is malformed in the expression [%s]. \
+              It should be a value in %s; however, got [%s].\
+              """.formatted(this.name, validGroups, source));
         }
         if (!since.isEmpty()) {
             if (Integer.parseInt(since.split("\\.")[0]) < 0) {
-                throw new IllegalArgumentException("'since' is malformed in the expression [" +
-                    this.name + "]. It should not start with a negative number; however, " +
-                    "got [" + since + "].");
+                throw new IllegalArgumentException("""
+                  'since' is malformed in the expression [%s]. \
+                  It should not start with a negative number; however, got [%s].\
+                  """.formatted(this.name, since));
             }
             this.extended += "\n    Since: " + since + "\n";
         }
         if (!deprecated.isEmpty()) {
             if (!deprecated.contains("    ") || !deprecated.endsWith("  ")) {
-                throw new IllegalArgumentException("'deprecated' is malformed in the " +
-                    "expression [" + this.name + "]. It should start with a newline and 4 " +
-                    "leading spaces; end with a newline and two spaces; however, got [" +
-                    deprecated + "].");
+                throw new IllegalArgumentException("""
+                  'deprecated' is malformed in the expression [%s]. \
+                  It should start with a newline and 4 leading spaces; \
+                  end with a newline and two spaces; however, got [%s].
+                  """.formatted(this.name, deprecated));
             }
             this.extended += "\n    Deprecated:\n      " + deprecated.trim() + "\n";
         }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/UnsafeArrayData.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/UnsafeArrayData.java
@@ -429,8 +429,8 @@ public final class UnsafeArrayData extends ArrayData implements Externalizable, 
     final long valueRegionInBytes = (long)elementSize * length;
     final long totalSizeInLongs = (headerInBytes + valueRegionInBytes + 7) / 8;
     if (totalSizeInLongs > Integer.MAX_VALUE / 8) {
-      throw new UnsupportedOperationException("Cannot convert this array to unsafe format as " +
-        "it's too big.");
+      throw new UnsupportedOperationException(
+        "Cannot convert this array to unsafe format as it's too big.");
     }
 
     final long[] data = new long[(int)totalSizeInLongs];
@@ -451,8 +451,8 @@ public final class UnsafeArrayData extends ArrayData implements Externalizable, 
     final long valueRegionInBytes = (long)elementSize * length;
     final long totalSizeInLongs = (headerInBytes + valueRegionInBytes + 7) / 8;
     if (totalSizeInLongs > Integer.MAX_VALUE / 8) {
-      throw new UnsupportedOperationException("Cannot convert this array to unsafe format as " +
-        "it's too big.");
+      throw new UnsupportedOperationException(
+        "Cannot convert this array to unsafe format as it's too big.");
     }
 
     final long[] data = new long[(int)totalSizeInLongs];

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolder.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/BufferHolder.java
@@ -48,9 +48,9 @@ final class BufferHolder {
   BufferHolder(UnsafeRow row, int initialSize) {
     int bitsetWidthInBytes = UnsafeRow.calculateBitSetWidthInBytes(row.numFields());
     if (row.numFields() > (ARRAY_MAX - initialSize - bitsetWidthInBytes) / 8) {
-      throw new UnsupportedOperationException(
-        "Cannot create BufferHolder for input UnsafeRow because there are " +
-          "too many fields (number of fields: " + row.numFields() + ")");
+      throw new UnsupportedOperationException("""
+        Cannot create BufferHolder for input UnsafeRow because \
+        there are too many fields (number of fields: %d)""".formatted(row.numFields()));
     }
     this.fixedSize = bitsetWidthInBytes + 8 * row.numFields();
     int roundedSize = ByteArrayMethods.roundNumberOfBytesToNearestWord(fixedSize + initialSize);
@@ -64,13 +64,13 @@ final class BufferHolder {
    */
   void grow(int neededSize) {
     if (neededSize < 0) {
-      throw new IllegalArgumentException(
-        "Cannot grow BufferHolder by size " + neededSize + " because the size is negative");
+      throw new IllegalArgumentException("""
+        Cannot grow BufferHolder by size %d because the size is negative""".formatted(neededSize));
     }
     if (neededSize > ARRAY_MAX - totalSize()) {
-      throw new IllegalArgumentException(
-        "Cannot grow BufferHolder by size " + neededSize + " because the size after growing " +
-          "exceeds size limitation " + ARRAY_MAX);
+      throw new IllegalArgumentException("""
+        Cannot grow BufferHolder by size %d because the size after growing exceeds \
+        size limitation %d""".formatted(neededSize, ARRAY_MAX));
     }
     final int length = totalSize() + neededSize;
     if (buffer.length < length) {

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/SupportsPartitionManagement.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/SupportsPartitionManagement.java
@@ -103,9 +103,10 @@ public interface SupportsPartitionManagement extends Table {
       if (ident.numFields() == partitionNames.length) {
         return listPartitionIdentifiers(partitionNames, ident).length > 0;
       } else {
-        throw new IllegalArgumentException("The number of fields (" + ident.numFields() +
-          ") in the partition identifier is not equal to the partition schema length (" +
-          partitionNames.length + "). The identifier might not refer to one partition.");
+        throw new IllegalArgumentException("""
+          The number of fields (%d) in the partition identifier is not equal to \
+          the partition schema length (%d). The identifier might not refer to one partition.\
+          """.formatted(ident.numFields(), partitionNames.length));
       }
     }
 

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/orc/OrcColumnVectorUtils.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/orc/OrcColumnVectorUtils.java
@@ -58,9 +58,9 @@ class OrcColumnVectorUtils {
       OrcColumnVector valuesVector = toOrcColumnVector(mapType.valueType(), mapVector.values);
       return new OrcMapColumnVector(type, vector, keysVector, valuesVector);
     } else {
-      throw new IllegalArgumentException(
-        String.format("OrcColumnVectorUtils.toOrcColumnVector should not take %s as type " +
-          "and %s as vector", type, vector));
+      throw new IllegalArgumentException("""
+        OrcColumnVectorUtils.toOrcColumnVector should not take %s as type and %s as vector
+        """.formatted(type, vector));
     }
   }
 }

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/orc/OrcColumnarBatchReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/orc/OrcColumnarBatchReader.java
@@ -184,9 +184,9 @@ public class OrcColumnarBatchReader extends RecordReader<Void, ColumnarBatch> {
           if (defaultValue == null) {
             missingCol.putNulls(0, capacity);
           } else if (missingCol.appendObjects(capacity, defaultValue).isEmpty()) {
-            throw new IllegalArgumentException("Cannot assign default column value to result " +
-              "column batch in vectorized Orc reader because the data type is not supported: " +
-              defaultValue);
+            throw new IllegalArgumentException("""
+              Cannot assign default column value to result column batch in vectorized Orc reader \
+              because the data type is not supported: %s""".formatted(defaultValue));
           }
           missingCol.setIsConstant();
           orcVectorWrappers[i] = missingCol;

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/WritableColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/WritableColumnVector.java
@@ -121,18 +121,23 @@ public abstract class WritableColumnVector extends ColumnVector {
   }
 
   private void throwUnsupportedException(int requiredCapacity, Throwable cause) {
-    String message = "Cannot reserve additional contiguous bytes in the vectorized reader (" +
-        (requiredCapacity >= 0 ? "requested " + requiredCapacity + " bytes" : "integer overflow") +
-        "). As a workaround, you can reduce the vectorized reader batch size, or disable the " +
-        "vectorized reader, or disable " + SQLConf.BUCKETING_ENABLED().key() + " if you read " +
-        "from bucket table. For Parquet file format, refer to " +
-        SQLConf.PARQUET_VECTORIZED_READER_BATCH_SIZE().key() +
-        " (default " + SQLConf.PARQUET_VECTORIZED_READER_BATCH_SIZE().defaultValueString() +
-        ") and " + SQLConf.PARQUET_VECTORIZED_READER_ENABLED().key() + "; for ORC file format, " +
-        "refer to " + SQLConf.ORC_VECTORIZED_READER_BATCH_SIZE().key() +
-        " (default " + SQLConf.ORC_VECTORIZED_READER_BATCH_SIZE().defaultValueString() +
-        ") and " + SQLConf.ORC_VECTORIZED_READER_ENABLED().key() + ".";
-    throw new RuntimeException(message, cause);
+    String message =
+      requiredCapacity >= 0 ? "requested " + requiredCapacity + " bytes" : "integer overflow";
+
+    throw new RuntimeException("""
+      Cannot reserve additional contiguous bytes in the vectorized reader (%s). \
+      As a workaround, you can reduce the vectorized reader batch size, or disable the vectorized \
+      reader, or disable %s if you read from bucket table. For Parquet file format, refer to %s \
+      (default %s) and %s; for ORC file format, refer to %s (default %s) and %s.
+      """.formatted(
+        message,
+        SQLConf.BUCKETING_ENABLED().key(),
+        SQLConf.PARQUET_VECTORIZED_READER_BATCH_SIZE().key(),
+        SQLConf.PARQUET_VECTORIZED_READER_BATCH_SIZE().defaultValueString(),
+        SQLConf.PARQUET_VECTORIZED_READER_ENABLED().key(),
+        SQLConf.ORC_VECTORIZED_READER_BATCH_SIZE().key(),
+        SQLConf.ORC_VECTORIZED_READER_BATCH_SIZE().defaultValueString(),
+        SQLConf.ORC_VECTORIZED_READER_ENABLED().key()), cause);
   }
 
   @Override

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaApplySchemaSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaApplySchemaSuite.java
@@ -147,13 +147,13 @@ public class JavaApplySchemaSuite implements Serializable {
 
   @Test
   public void applySchemaToJSON() {
-    Dataset<String> jsonDS = spark.createDataset(Arrays.asList(
-      "{\"string\":\"this is a simple string.\", \"integer\":10, \"long\":21474836470, " +
-        "\"bigInteger\":92233720368547758070, \"double\":1.7976931348623157E308, " +
-        "\"boolean\":true, \"null\":null}",
-      "{\"string\":\"this is another simple string.\", \"integer\":11, \"long\":21474836469, " +
-        "\"bigInteger\":92233720368547758069, \"double\":1.7976931348623157E305, " +
-        "\"boolean\":false, \"null\":null}"), Encoders.STRING());
+    Dataset<String> jsonDS = spark.createDataset(Arrays.asList("""
+       {"string":"this is a simple string.", "integer":10, "long":21474836470, \
+       "bigInteger":92233720368547758070, "double":1.7976931348623157E308, "boolean":true, \
+       "null":null}""", """
+       {"string":"this is another simple string.", "integer":11, "long":21474836469, \
+       "bigInteger":92233720368547758069, "double":1.7976931348623157E305, "boolean":false, \
+       "null":null}"""), Encoders.STRING());
     List<StructField> fields = new ArrayList<>(7);
     fields.add(DataTypes.createStructField("bigInteger", DataTypes.createDecimalType(20, 0),
       true));

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaSaveLoadSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaSaveLoadSuite.java
@@ -60,7 +60,8 @@ public class JavaSaveLoadSuite {
 
     List<String> jsonObjects = new ArrayList<>(10);
     for (int i = 0; i < 10; i++) {
-      jsonObjects.add("{\"a\":" + i + ", \"b\":\"str" + i + "\"}");
+      jsonObjects.add("""
+         {"a":%d, "b":"str%d"}""".formatted(i, i));
     }
     Dataset<String> ds = spark.createDataset(jsonObjects, Encoders.STRING());
     df = spark.read().json(ds);

--- a/sql/core/src/test/java/test/org/apache/spark/sql/connector/catalog/functions/JavaRandomAdd.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/connector/catalog/functions/JavaRandomAdd.java
@@ -56,8 +56,9 @@ public class JavaRandomAdd implements UnboundFunction {
 
   @Override
   public String description() {
-    return "rand_add: add a random integer to the input\n" +
-      "rand_add(int) -> int";
+    return """
+      rand_add: add a random integer to the input
+      rand_add(int) -> int""";
   }
 
   public abstract static class JavaRandomAddBase implements ScalarFunction<Integer> {

--- a/sql/core/src/test/java/test/org/apache/spark/sql/connector/catalog/functions/JavaStrLen.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/connector/catalog/functions/JavaStrLen.java
@@ -54,8 +54,9 @@ public class JavaStrLen implements UnboundFunction {
 
   @Override
   public String description() {
-    return "strlen: returns the length of the input string\n" +
-        " strlen(string) -> int";
+    return """
+      strlen: returns the length of the input string
+       strlen(string) -> int""";
   }
 
   private abstract static class JavaStrLenBase implements ScalarFunction<Integer> {

--- a/sql/hive/src/test/java/org/apache/spark/sql/hive/JavaMetastoreDataSourcesSuite.java
+++ b/sql/hive/src/test/java/org/apache/spark/sql/hive/JavaMetastoreDataSourcesSuite.java
@@ -67,7 +67,8 @@ public class JavaMetastoreDataSourcesSuite {
 
     List<String> jsonObjects = new ArrayList<>(10);
     for (int i = 0; i < 10; i++) {
-      jsonObjects.add("{\"a\":" + i + ", \"b\":\"str" + i + "\"}");
+      jsonObjects.add("""
+        {"a":%d, "b":"str%d"}""".formatted(i, i));
     }
     Dataset<String> ds = sqlContext.createDataset(jsonObjects, Encoders.STRING());
     df = sqlContext.read().json(ds);


### PR DESCRIPTION
### What changes were proposed in this pull request?
Now, Spark upgraded to Java17 which contains many new feature. The text block is a feature released in Java15.
When using text blocks, the code looks more concise.

For example,
```
String timeError = "Time must be specified as seconds (s), " +
   "milliseconds (ms), microseconds (us), minutes (m or min), hour (h), or day (d). " +
   "E.g. 50s, 100ms, or 250us.";
```
Can be changed to.
```
String timeError = """
   Time must be specified as seconds (s), milliseconds (ms), microseconds (us), \
   minutes (m or min), hour (h), or day (d). E.g. 50s, 100ms, or 250us.""";
```

This PR is a initial one used for discussion and decision-making.
Shall we improve and simplify the long string with  java15 text block?


### Why are the changes needed?
Using [JEP 378: Text Blocks](https://openjdk.org/jeps/378) can bring the following benefits:

- Simplify the task of writing Java programs by making it easy to express strings that span several lines of source code, while avoiding escape sequences in common cases.
- Enhance the readability of strings in Java programs that denote code written in non-Java languages.
- Support migration from string literals by stipulating that any new construct can express the same set of strings as a string literal, interpret the same escape sequences, and be manipulated in the same ways as a string literal.
- Add escape sequences for managing explicit white space and newline control.


### Does this PR introduce _any_ user-facing change?
'No'.


### How was this patch tested?
GA.


### Was this patch authored or co-authored using generative AI tooling?
'No'.
