### PR TITLE
[DOCS][MINOR] Fix typos

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -3288,7 +3288,7 @@ Spark subsystems.
 
 Runtime SQL configurations are per-session, mutable Spark SQL configurations. They can be set with initial values by the config file
 and command-line options with `--conf/-c` prefixed, or by setting `SparkConf` that are used to create `SparkSession`.
-Also, they can be set and queried by SET commands and rest to their initial values by RESET command,
+Also, they can be set and queried by SET commands and reset to their initial values by RESET commands,
 or by `SparkSession.conf`'s setter and getter methods in runtime.
 
 {% include_relative generated-runtime-sql-config-table.html %}


### PR DESCRIPTION
`rest` -> `reset`