### PR TITLE
[WIP][SPARK-46349] Prevent nested SortOrder instances in SortOrder expressions

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SortOrder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SortOrder.scala
@@ -67,6 +67,11 @@ case class SortOrder(
     sameOrderExpressions: Seq[Expression])
   extends Expression with Unevaluable {
 
+  require(
+    !child.isInstanceOf[SortOrder],
+    "When instantiating SortOrder, the child expression can't be an already sorted expression"
+  )
+
   override def children: Seq[Expression] = child +: sameOrderExpressions
 
   override def checkInputDataTypes(): TypeCheckResult =

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/SortOrderExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/SortOrderExpressionsSuite.scala
@@ -95,4 +95,11 @@ class SortOrderExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper 
           "functionName" -> "`sortorder`",
           "dataType" -> "\"MAP<STRING, STRING>\"")))
   }
+
+  test("SortOrder cannot accept sorted expression as a child") {
+    val e1 = SortOrder(Literal(1), Ascending)
+    intercept[IllegalArgumentException] {
+      SortOrder(e1, Ascending)
+    }
+  }
 }


### PR DESCRIPTION
Hello everyone,

This is my first contribution to the project. I welcome any feedback and edits to improve this pull request.

Issue Addressed:
Currently, it's possible to create redundant sort expressions in both Scala and Python APIs, leading to potentially incorrect and confusing SQL statements. For example:

Scala:
```scala
spark.range(10).orderBy($"id".desc.asc).show()
```
Python:
```python
spark.range(10).orderBy(f.desc('id'), ascending=False).show()
```
Such usage generates SQL like order by id DESC NULLS LAST DESC NULLS LAST, causing non-descriptive error messages.

Solution:
This pull request introduces a constraint in the SortOrder class, ensuring that its child cannot be another instance of SortOrder. This change prevents the creation of nested, redundant sort expressions.

Additionally, in PySpark's DataFrame.sort, there's an ascending keyword argument that could conflict with already sorted expressions. I've added an exception handler to generate more descriptive error messages in such cases.

Tests:
A test case has been added to verify that no double ordering occurs after this fix.

I look forward to your feedback and thank you for considering this contribution.