### PR TITLE
[SPARK-46215][CORE][FOLLOWUP] Handle symbolic links

### DIFF
--- a/core/src/test/scala/org/apache/spark/deploy/master/PersistenceEngineSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/master/PersistenceEngineSuite.scala
@@ -19,6 +19,7 @@
 package org.apache.spark.deploy.master
 
 import java.net.ServerSocket
+import java.nio.file.{Files, Paths}
 import java.util.concurrent.ThreadLocalRandom
 
 import org.apache.curator.test.TestingServer
@@ -68,6 +69,21 @@ class PersistenceEngineSuite extends SparkFunSuite {
       val conf = new SparkConf()
       testPersistenceEngine(conf, serializer =>
         new FileSystemPersistenceEngine(dir.getAbsolutePath + "/a/b/c/dir", serializer)
+      )
+    }
+  }
+
+  test("SPARK-46215: FileSystemPersistenceEngine with a symbolic link") {
+    withTempDir { dir =>
+      val target = Paths.get(dir.getAbsolutePath(), "target")
+      val link = Paths.get(dir.getAbsolutePath(), "symbolic_link");
+
+      Files.createDirectories(target)
+      Files.createSymbolicLink(link, target);
+
+      val conf = new SparkConf()
+      testPersistenceEngine(conf, serializer =>
+        new FileSystemPersistenceEngine(link.toAbsolutePath.toString, serializer)
       )
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix a regression on symbolic links.

### Why are the changes needed?

To have the same behavior with symbolic links.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs with newly added test case.

I also verified this on Mac's `/tmp` directory.
```
$ ls -al /tmp
lrwxr-xr-x@ 1 root  wheel  11 Nov 17 02:37 /tmp -> private/tmp
```

**MASTER**
```
23/12/10 16:04:53 INFO FileSystemRecoveryModeFactory: Persisting recovery state to directory: /tmp
23/12/10 16:04:53 INFO Master: I have been elected leader! New state: ALIVE
23/12/10 16:08:39 INFO Master: Registering worker 127.0.0.1:50535 with 8 cores, 15.0 GiB RAM
```

**PERSISTED DATA**
```
$ ls -al /tmp/worker_*
-rw-r--r--@ 1 dongjoon  wheel  1354 Dec 10 16:08 /tmp/worker_worker-20231210160839-127.0.0.1-50535
```

### Was this patch authored or co-authored using generative AI tooling?

No.