### PR TITLE
[SPARK-46356][BUILD] Upgrade `sbt-assembly` to 2.1.5, `sbt-checkstyle-plugin` to 4.0.1

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-addSbtPlugin("software.purpledragon" % "sbt-checkstyle-plugin" % "4.0.0")
+addSbtPlugin("software.purpledragon" % "sbt-checkstyle-plugin" % "4.0.1")
 
 // sbt-checkstyle-plugin uses an old version of checkstyle. Match it to Maven's.
 // If you are changing the dependency setting for checkstyle plugin,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -25,7 +25,7 @@ libraryDependencies += "com.puppycrawl.tools" % "checkstyle" % "9.3"
 // checkstyle uses guava 31.0.1-jre.
 libraryDependencies += "com.google.guava" % "guava" % "31.0.1-jre"
 
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.1.1")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.1.5")
 
 addSbtPlugin("com.github.sbt" % "sbt-eclipse" % "6.0.0")
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade `sbt-assembly` from `2.1.1` to `2.1.5`.

### Why are the changes needed?
1.`sbt-assembly`, the full release notes:
- v2.1.5: https://github.com/sbt/sbt-assembly/releases/tag/v2.1.5
- v2.1.4: https://github.com/sbt/sbt-assembly/releases/tag/v2.1.4
- v2.1.3: https://github.com/sbt/sbt-assembly/releases/tag/v2.1.3
- v2.1.2: https://github.com/sbt/sbt-assembly/releases/tag/v2.1.2

2.`sbt-checkstyle-plugin` `v4.0.0` VS `v4.0.1`
https://github.com/stringbean/sbt-checkstyle-plugin/compare/v4.0.0...v4.0.1

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA.

### Was this patch authored or co-authored using generative AI tooling?
No.