### PR TITLE
[SPARK-46354] [SQL] Increase the limit on the number of dynamic partitions written to 'InsertIntoHadoopFsRelationCommand'

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -2771,4 +2771,14 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
         "parameter" -> toSQLId("charset"),
         "charset" -> charset))
   }
+
+  def writePartitionExceedConfigSizeWhenDynamicPartitionError(current: Int, max: Int): Throwable = {
+    new SparkException(
+      s"Your current number of partitions inserted is  $current" +
+        s" .the current number of spark.sql.max.dynamic.partitions.pernode` is $max" +
+        s" ,It has exceeded the maximum value .We suggest that you insert multiple batches " +
+        s"Of course, you can also increase the maximum value by setting " +
+        s"`spark.sql.max.dynamic.partitions.pernode`,but we do not recommend doing so"
+    )
+  }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4601,6 +4601,15 @@ object SQLConf {
     .booleanConf
     .createWithDefault(false)
 
+  val MAX_DYNAMIC_PARTITIONS_PERNODE = {
+    buildConf("spark.sql.max.dynamic.partitions.pernode")
+      .internal()
+      .doc("Maximum number of partitions inserted in a single dynamic partition")
+      .version("3.3.2")
+      .intConf
+      .createWithDefault(10000)
+  }
+
   /**
    * Holds information about keys that have been deprecated.
    *

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelationCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelationCommand.scala
@@ -76,7 +76,6 @@ case class InsertIntoHadoopFsRelationCommand(
 
   val MAX_DYNAMIC_PARTITIONS = SQLConf.get.getConf(SQLConf.MAX_DYNAMIC_PARTITIONS_PERNODE)
 
-
   override def requiredOrdering: Seq[SortOrder] =
     V1WritesUtils.getSortOrder(outputColumns, partitionColumns, bucketSpec, options,
       staticPartitions.size)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelationCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelationCommand.scala
@@ -75,7 +75,6 @@ case class InsertIntoHadoopFsRelationCommand(
   }
 
   val MAX_DYNAMIC_PARTITIONS = SQLConf.get.getConf(SQLConf.MAX_DYNAMIC_PARTITIONS_PERNODE)
-
   override def requiredOrdering: Seq[SortOrder] =
     V1WritesUtils.getSortOrder(outputColumns, partitionColumns, bucketSpec, options,
       staticPartitions.size)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Increase the limit on the number of write dynamic partitions


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Prevent excessive single write to dynamic partitions from putting pressure on HMS.

`InsertIntoHiveTable 'limits the number of single dynamic partition writes, while' InsertIntoHadoopFsRelationCommand 'does not limit the number of single dynamic partitions and should be aligned with it.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Added dynamic partition write restriction to 'InsertIntoHadoopFsRelationCommand'


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
production cluster testing



### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
NO