### PR TITLE
[SPARK-43299][FOLLOWUP][CONNECT][SS] Followup on StreamingQueryExceptions

### DIFF
--- a/common/utils/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryException.scala
+++ b/common/utils/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryException.scala
@@ -47,7 +47,14 @@ class StreamingQueryException private[sql](
       cause: Throwable,
       errorClass: String,
       messageParameters: Map[String, String]) = {
-    this("", message, cause, null, null, errorClass, messageParameters)
+    this(
+      messageParameters.get("queryDebugString").getOrElse(null),
+      message,
+      cause,
+      messageParameters.get("startOffset").getOrElse(null),
+      messageParameters.get("endOffset").getOrElse(null),
+      errorClass,
+      messageParameters)
   }
 
   def this(

--- a/common/utils/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryException.scala
+++ b/common/utils/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryException.scala
@@ -48,11 +48,11 @@ class StreamingQueryException private[sql](
       errorClass: String,
       messageParameters: Map[String, String]) = {
     this(
-      messageParameters.get("queryDebugString").getOrElse(null),
+      messageParameters.get("queryDebugString").getOrElse(""),
       message,
       cause,
-      messageParameters.get("startOffset").getOrElse(null),
-      messageParameters.get("endOffset").getOrElse(null),
+      messageParameters.get("startOffset").getOrElse(""),
+      messageParameters.get("endOffset").getOrElse(""),
       errorClass,
       messageParameters)
   }

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/streaming/StreamingQuery.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/streaming/StreamingQuery.scala
@@ -109,30 +109,31 @@ trait StreamingQuery {
   def lastProgress: StreamingQueryProgress
 
   /**
-   * Waits for the termination of `this` query, either by `query.stop()` or by an exception.
-   * If the query has terminated with an exception, then the exception will be thrown.
+   * Waits for the termination of `this` query, either by `query.stop()` or by an exception. If
+   * the query has terminated with an exception, then the exception will be thrown.
    *
    * If the query has terminated, then all subsequent calls to this method will either return
-   * immediately (if the query was terminated by `stop()`), or throw the exception
-   * immediately (if the query has terminated with exception).
+   * immediately (if the query was terminated by `stop()`), or throw the exception immediately (if
+   * the query has terminated with exception).
    *
-   * @throws StreamingQueryException if the query has terminated with an exception.
+   * @throws StreamingQueryException
+   *   if the query has terminated with an exception.
    * @since 3.5.0
    */
   @throws[StreamingQueryException]
   def awaitTermination(): Unit
 
   /**
-   * Waits for the termination of `this` query, either by `query.stop()` or by an exception.
-   * If the query has terminated with an exception, then the exception will be thrown.
-   * Otherwise, it returns whether the query has terminated or not within the `timeoutMs`
-   * milliseconds.
+   * Waits for the termination of `this` query, either by `query.stop()` or by an exception. If
+   * the query has terminated with an exception, then the exception will be thrown. Otherwise, it
+   * returns whether the query has terminated or not within the `timeoutMs` milliseconds.
    *
    * If the query has terminated, then all subsequent calls to this method will either return
    * `true` immediately (if the query was terminated by `stop()`), or throw the exception
    * immediately (if the query has terminated with exception).
    *
-   * @throws StreamingQueryException if the query has terminated with an exception
+   * @throws StreamingQueryException
+   *   if the query has terminated with an exception
    * @since 3.5.0
    */
   @throws[StreamingQueryException]

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/streaming/StreamingQuery.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/streaming/StreamingQuery.scala
@@ -110,28 +110,32 @@ trait StreamingQuery {
 
   /**
    * Waits for the termination of `this` query, either by `query.stop()` or by an exception.
+   * If the query has terminated with an exception, then the exception will be thrown.
    *
    * If the query has terminated, then all subsequent calls to this method will either return
-   * immediately (if the query was terminated by `stop()`).
+   * immediately (if the query was terminated by `stop()`), or throw the exception
+   * immediately (if the query has terminated with exception).
    *
+   * @throws StreamingQueryException if the query has terminated with an exception.
    * @since 3.5.0
    */
-  // TODO(SPARK-43299): verity the behavior of this method after JVM client-side error-handling
-  // framework is supported and modify the doc accordingly.
+  @throws[StreamingQueryException]
   def awaitTermination(): Unit
 
   /**
-   * Waits for the termination of `this` query, either by `query.stop()` or by an exception. If
-   * the query has terminated with an exception, then the exception will be thrown. Otherwise, it
-   * returns whether the query has terminated or not within the `timeoutMs` milliseconds.
+   * Waits for the termination of `this` query, either by `query.stop()` or by an exception.
+   * If the query has terminated with an exception, then the exception will be thrown.
+   * Otherwise, it returns whether the query has terminated or not within the `timeoutMs`
+   * milliseconds.
    *
-   * If the query has terminated, then all subsequent calls to this method will return `true`
-   * immediately.
+   * If the query has terminated, then all subsequent calls to this method will either return
+   * `true` immediately (if the query was terminated by `stop()`), or throw the exception
+   * immediately (if the query has terminated with exception).
    *
+   * @throws StreamingQueryException if the query has terminated with an exception
    * @since 3.5.0
    */
-  // TODO(SPARK-43299): verity the behavior of this method after JVM client-side error-handling
-  // framework is supported and modify the doc accordingly.
+  @throws[StreamingQueryException]
   def awaitTermination(timeoutMs: Long): Boolean
 
   /**

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryManager.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryManager.scala
@@ -83,22 +83,23 @@ class StreamingQueryManager private[sql] (sparkSession: SparkSession) extends Lo
   }
 
   /**
-   * Wait until any of the queries on the associated SQLContext has terminated since the
-   * creation of the context, or since `resetTerminated()` was called. If any query was terminated
-   * with an exception, then the exception will be thrown.
+   * Wait until any of the queries on the associated SQLContext has terminated since the creation
+   * of the context, or since `resetTerminated()` was called. If any query was terminated with an
+   * exception, then the exception will be thrown.
    *
    * If a query has terminated, then subsequent calls to `awaitAnyTermination()` will either
-   * return immediately (if the query was terminated by `query.stop()`),
-   * or throw the exception immediately (if the query was terminated with exception). Use
-   * `resetTerminated()` to clear past terminations and wait for new terminations.
+   * return immediately (if the query was terminated by `query.stop()`), or throw the exception
+   * immediately (if the query was terminated with exception). Use `resetTerminated()` to clear
+   * past terminations and wait for new terminations.
    *
-   * In the case where multiple queries have terminated since `resetTermination()` was called,
-   * if any query has terminated with exception, then `awaitAnyTermination()` will
-   * throw any of the exception. For correctly documenting exceptions across multiple queries,
-   * users need to stop all of them after any of them terminates with exception, and then check the
+   * In the case where multiple queries have terminated since `resetTermination()` was called, if
+   * any query has terminated with exception, then `awaitAnyTermination()` will throw any of the
+   * exception. For correctly documenting exceptions across multiple queries, users need to stop
+   * all of them after any of them terminates with exception, and then check the
    * `query.exception()` for each query.
    *
-   * @throws StreamingQueryException if any query has terminated with an exception
+   * @throws StreamingQueryException
+   *   if any query has terminated with an exception
    * @since 3.5.0
    */
   @throws[StreamingQueryException]
@@ -107,23 +108,24 @@ class StreamingQueryManager private[sql] (sparkSession: SparkSession) extends Lo
   }
 
   /**
-   * Wait until any of the queries on the associated SQLContext has terminated since the
-   * creation of the context, or since `resetTerminated()` was called. Returns whether any query
-   * has terminated or not (multiple may have terminated). If any query has terminated with an
+   * Wait until any of the queries on the associated SQLContext has terminated since the creation
+   * of the context, or since `resetTerminated()` was called. Returns whether any query has
+   * terminated or not (multiple may have terminated). If any query has terminated with an
    * exception, then the exception will be thrown.
    *
    * If a query has terminated, then subsequent calls to `awaitAnyTermination()` will either
-   * return `true` immediately (if the query was terminated by `query.stop()`),
-   * or throw the exception immediately (if the query was terminated with exception). Use
-   * `resetTerminated()` to clear past terminations and wait for new terminations.
+   * return `true` immediately (if the query was terminated by `query.stop()`), or throw the
+   * exception immediately (if the query was terminated with exception). Use `resetTerminated()`
+   * to clear past terminations and wait for new terminations.
    *
-   * In the case where multiple queries have terminated since `resetTermination()` was called,
-   * if any query has terminated with exception, then `awaitAnyTermination()` will
-   * throw any of the exception. For correctly documenting exceptions across multiple queries,
-   * users need to stop all of them after any of them terminates with exception, and then check the
+   * In the case where multiple queries have terminated since `resetTermination()` was called, if
+   * any query has terminated with exception, then `awaitAnyTermination()` will throw any of the
+   * exception. For correctly documenting exceptions across multiple queries, users need to stop
+   * all of them after any of them terminates with exception, and then check the
    * `query.exception()` for each query.
    *
-   * @throws StreamingQueryException if any query has terminated with an exception
+   * @throws StreamingQueryException
+   *   if any query has terminated with an exception
    * @since 3.5.0
    */
   @throws[StreamingQueryException]

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryManager.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryManager.scala
@@ -83,46 +83,50 @@ class StreamingQueryManager private[sql] (sparkSession: SparkSession) extends Lo
   }
 
   /**
-   * Wait until any of the queries on the associated SQLContext has terminated since the creation
-   * of the context, or since `resetTerminated()` was called. If any query was terminated with an
-   * exception, then the exception will be thrown.
+   * Wait until any of the queries on the associated SQLContext has terminated since the
+   * creation of the context, or since `resetTerminated()` was called. If any query was terminated
+   * with an exception, then the exception will be thrown.
    *
    * If a query has terminated, then subsequent calls to `awaitAnyTermination()` will either
-   * return immediately (if the query was terminated by `query.stop()`), or throw the exception
-   * immediately (if the query was terminated with exception). Use `resetTerminated()` to clear
-   * past terminations and wait for new terminations.
+   * return immediately (if the query was terminated by `query.stop()`),
+   * or throw the exception immediately (if the query was terminated with exception). Use
+   * `resetTerminated()` to clear past terminations and wait for new terminations.
    *
-   * For correctly documenting exceptions across multiple queries, users need to stop all of them
-   * after any of them terminates with exception, and then check the `query.exception()` for each
-   * query.
+   * In the case where multiple queries have terminated since `resetTermination()` was called,
+   * if any query has terminated with exception, then `awaitAnyTermination()` will
+   * throw any of the exception. For correctly documenting exceptions across multiple queries,
+   * users need to stop all of them after any of them terminates with exception, and then check the
+   * `query.exception()` for each query.
    *
+   * @throws StreamingQueryException if any query has terminated with an exception
    * @since 3.5.0
    */
-  // TODO(SPARK-43299): verity the behavior of this method after JVM client-side error-handling
-  // framework is supported and modify the doc accordingly.
+  @throws[StreamingQueryException]
   def awaitAnyTermination(): Unit = {
     executeManagerCmd(_.getAwaitAnyTerminationBuilder.build())
   }
 
   /**
-   * Wait until any of the queries on the associated SQLContext has terminated since the creation
-   * of the context, or since `resetTerminated()` was called. Returns whether any query has
-   * terminated or not (multiple may have terminated). If any query has terminated with an
+   * Wait until any of the queries on the associated SQLContext has terminated since the
+   * creation of the context, or since `resetTerminated()` was called. Returns whether any query
+   * has terminated or not (multiple may have terminated). If any query has terminated with an
    * exception, then the exception will be thrown.
    *
    * If a query has terminated, then subsequent calls to `awaitAnyTermination()` will either
-   * return `true` immediately (if the query was terminated by `query.stop()`), or throw the
-   * exception immediately (if the query was terminated with exception). Use `resetTerminated()`
-   * to clear past terminations and wait for new terminations.
+   * return `true` immediately (if the query was terminated by `query.stop()`),
+   * or throw the exception immediately (if the query was terminated with exception). Use
+   * `resetTerminated()` to clear past terminations and wait for new terminations.
    *
-   * For correctly documenting exceptions across multiple queries, users need to stop all of them
-   * after any of them terminates with exception, and then check the `query.exception()` for each
-   * query.
+   * In the case where multiple queries have terminated since `resetTermination()` was called,
+   * if any query has terminated with exception, then `awaitAnyTermination()` will
+   * throw any of the exception. For correctly documenting exceptions across multiple queries,
+   * users need to stop all of them after any of them terminates with exception, and then check the
+   * `query.exception()` for each query.
    *
+   * @throws StreamingQueryException if any query has terminated with an exception
    * @since 3.5.0
    */
-  // TODO(SPARK-43299): verity the behavior of this method after JVM client-side error-handling
-  // framework is supported and modify the doc accordingly.
+  @throws[StreamingQueryException]
   def awaitAnyTermination(timeoutMs: Long): Boolean = {
     require(timeoutMs > 0, "Timeout has to be positive")
     executeManagerCmd(

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/streaming/ClientStreamingQuerySuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/streaming/ClientStreamingQuerySuite.scala
@@ -216,8 +216,7 @@ class ClientStreamingQuerySuite extends QueryTest with SQLHelper with Logging {
           exception.getCause.getCause.getCause.getMessage
             .contains("java.lang.RuntimeException: Number 2 encountered!"))
       }
-    }
-    finally {
+    } finally {
       spark.streams.resetTerminated()
     }
   }

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/streaming/ClientStreamingQuerySuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/streaming/ClientStreamingQuerySuite.scala
@@ -207,8 +207,8 @@ class ClientStreamingQuerySuite extends QueryTest with SQLHelper with Logging {
         assert(exception.getErrorClass != null)
         assert(exception.getMessageParameters().get("id") == query.id.toString)
         assert(exception.getMessageParameters().get("runId") == query.runId.toString)
-        assert(exception.getMessageParameters().get("startOffset") != null)
-        assert(exception.getMessageParameters().get("endOffset") != null)
+        assert(!exception.getMessageParameters().get("startOffset").isEmpty)
+        assert(!exception.getMessageParameters().get("endOffset").isEmpty)
         assert(exception.getCause.isInstanceOf[SparkException])
         assert(exception.getCause.getCause.isInstanceOf[SparkException])
         assert(exception.getCause.getCause.getCause.isInstanceOf[SparkException])
@@ -222,7 +222,7 @@ class ClientStreamingQuerySuite extends QueryTest with SQLHelper with Logging {
     }
   }
 
-  test("throw exception in streaming, manager") {
+  test("throw exception in streaming, check with StreamingQueryManager") {
     // Disable spark.sql.pyspark.jvmStacktrace.enabled to avoid hitting the
     // netty header limit.
     withSQLConf("spark.sql.pyspark.jvmStacktrace.enabled" -> "false") {
@@ -253,8 +253,8 @@ class ClientStreamingQuerySuite extends QueryTest with SQLHelper with Logging {
       assert(exception.getErrorClass != null)
       assert(exception.getMessageParameters().get("id") == query.id.toString)
       assert(exception.getMessageParameters().get("runId") == query.runId.toString)
-      assert(exception.getMessageParameters().get("startOffset") != null)
-      assert(exception.getMessageParameters().get("endOffset") != null)
+      assert(!exception.getMessageParameters().get("startOffset").isEmpty)
+      assert(!exception.getMessageParameters().get("endOffset").isEmpty)
       assert(exception.getCause.isInstanceOf[SparkException])
       assert(exception.getCause.getCause.isInstanceOf[SparkException])
       assert(exception.getCause.getCause.getCause.isInstanceOf[SparkException])

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/streaming/ClientStreamingQuerySuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/streaming/ClientStreamingQuerySuite.scala
@@ -176,55 +176,7 @@ class ClientStreamingQuerySuite extends QueryTest with SQLHelper with Logging {
   }
 
   test("throw exception in streaming") {
-    // Disable spark.sql.pyspark.jvmStacktrace.enabled to avoid hitting the
-    // netty header limit.
     try {
-      withSQLConf("spark.sql.pyspark.jvmStacktrace.enabled" -> "false") {
-        val session = spark
-        import session.implicits._
-
-        val checkForTwo = udf((value: Int) => {
-          if (value == 2) {
-            throw new RuntimeException("Number 2 encountered!")
-          }
-          value
-        })
-
-        val query = spark.readStream
-          .format("rate")
-          .option("rowsPerSecond", "1")
-          .load()
-          .select(checkForTwo($"value").as("checkedValue"))
-          .writeStream
-          .outputMode("append")
-          .format("console")
-          .start()
-
-        val exception = intercept[StreamingQueryException] {
-          query.awaitTermination()
-        }
-
-        assert(exception.getErrorClass != null)
-        assert(exception.getMessageParameters().get("id") == query.id.toString)
-        assert(exception.getMessageParameters().get("runId") == query.runId.toString)
-        assert(!exception.getMessageParameters().get("startOffset").isEmpty)
-        assert(!exception.getMessageParameters().get("endOffset").isEmpty)
-        assert(exception.getCause.isInstanceOf[SparkException])
-        assert(exception.getCause.getCause.isInstanceOf[SparkException])
-        assert(exception.getCause.getCause.getCause.isInstanceOf[SparkException])
-        assert(
-          exception.getCause.getCause.getCause.getMessage
-            .contains("java.lang.RuntimeException: Number 2 encountered!"))
-      }
-    } finally {
-      spark.streams.resetTerminated()
-    }
-  }
-
-  test("throw exception in streaming, check with StreamingQueryManager") {
-    // Disable spark.sql.pyspark.jvmStacktrace.enabled to avoid hitting the
-    // netty header limit.
-    withSQLConf("spark.sql.pyspark.jvmStacktrace.enabled" -> "false") {
       val session = spark
       import session.implicits._
 
@@ -246,7 +198,7 @@ class ClientStreamingQuerySuite extends QueryTest with SQLHelper with Logging {
         .start()
 
       val exception = intercept[StreamingQueryException] {
-        spark.streams.awaitAnyTermination()
+        query.awaitTermination()
       }
 
       assert(exception.getErrorClass != null)
@@ -260,7 +212,47 @@ class ClientStreamingQuerySuite extends QueryTest with SQLHelper with Logging {
       assert(
         exception.getCause.getCause.getCause.getMessage
           .contains("java.lang.RuntimeException: Number 2 encountered!"))
+    } finally {
+      spark.streams.resetTerminated()
     }
+  }
+
+  test("throw exception in streaming, check with StreamingQueryManager") {
+    val session = spark
+    import session.implicits._
+
+    val checkForTwo = udf((value: Int) => {
+      if (value == 2) {
+        throw new RuntimeException("Number 2 encountered!")
+      }
+      value
+    })
+
+    val query = spark.readStream
+      .format("rate")
+      .option("rowsPerSecond", "1")
+      .load()
+      .select(checkForTwo($"value").as("checkedValue"))
+      .writeStream
+      .outputMode("append")
+      .format("console")
+      .start()
+
+    val exception = intercept[StreamingQueryException] {
+      spark.streams.awaitAnyTermination()
+    }
+
+    assert(exception.getErrorClass != null)
+    assert(exception.getMessageParameters().get("id") == query.id.toString)
+    assert(exception.getMessageParameters().get("runId") == query.runId.toString)
+    assert(!exception.getMessageParameters().get("startOffset").isEmpty)
+    assert(!exception.getMessageParameters().get("endOffset").isEmpty)
+    assert(exception.getCause.isInstanceOf[SparkException])
+    assert(exception.getCause.getCause.isInstanceOf[SparkException])
+    assert(exception.getCause.getCause.getCause.isInstanceOf[SparkException])
+    assert(
+      exception.getCause.getCause.getCause.getMessage
+        .contains("java.lang.RuntimeException: Number 2 encountered!"))
   }
 
   test("foreach Row") {

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -87,6 +87,9 @@ object MimaExcludes {
     ProblemFilters.exclude[Problem]("org.sparkproject.spark_protobuf.protobuf.*"),
     ProblemFilters.exclude[Problem]("org.apache.spark.sql.protobuf.utils.SchemaConverters.*"),
 
+    // SPARK-43299: Convert StreamingQueryException in Scala Client
+    ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.sql.streaming.StreamingQueryException"),
+
     // SPARK-45856: Move ArtifactManager from Spark Connect into SparkSession (sql/core)
     ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.storage.CacheId.apply"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.storage.CacheId.userId"),

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -87,9 +87,6 @@ object MimaExcludes {
     ProblemFilters.exclude[Problem]("org.sparkproject.spark_protobuf.protobuf.*"),
     ProblemFilters.exclude[Problem]("org.apache.spark.sql.protobuf.utils.SchemaConverters.*"),
 
-    // SPARK-43299: Convert StreamingQueryException in Scala Client
-    ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.sql.streaming.StreamingQueryException"),
-
     // SPARK-45856: Move ArtifactManager from Spark Connect into SparkSession (sql/core)
     ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.storage.CacheId.apply"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.storage.CacheId.userId"),

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
@@ -329,7 +329,11 @@ abstract class StreamExecution(
           messageParameters = Map(
             "id" -> id.toString,
             "runId" -> runId.toString,
-            "message" -> message))
+            "message" -> message,
+            "queryDebugString" -> toDebugString(includeLogicalPlan = isInitialized),
+            "startOffset" -> committedOffsets.toOffsetSeq(sources, offsetSeqMetadata).toString,
+            "endOffset" -> availableOffsets.toOffsetSeq(sources, offsetSeqMetadata).toString
+          ))
         logError(s"Query $prettyIdString terminated with error", e)
         updateStatusMessage(s"Terminated with exception: $message")
         // Rethrow the fatal errors to allow the user using `Thread.UncaughtExceptionHandler` to


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Follow up on streaming query exception in Scala connect client.
1. Change back API document, remove the "todo"s
2. Add a new test for the streamingQueryManager's awaitAnyTermination API
3. Slightly modified the constructor of `StreamingQueryException` by adding the `queryDebugString`, `startOffset` and `endOffset` to `messageParameters`, this enables us to reconstruct the exception with these fields in client side.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  4. If you fix a bug, you can clarify why it is a bug.
-->
Necessary build ups for spark connect.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New Unit test

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No