### PR TITLE
[SPARK-46376][SQL][TESTS] Simplify the code to generate the Spark tarball `filename` in the `HiveExternalCatalogVersionsSuite`.

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogVersionsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogVersionsSuite.scala
@@ -40,8 +40,8 @@ import org.apache.spark.sql.catalyst.catalog.CatalogTableType
 import org.apache.spark.sql.internal.StaticSQLConf.WAREHOUSE_PATH
 import org.apache.spark.sql.test.SQLTestUtils
 import org.apache.spark.tags.{ExtendedHiveTest, SlowHiveTest}
-import org.apache.spark.util.{Utils, VersionUtils}
 import org.apache.spark.util.ArrayImplicits._
+import org.apache.spark.util.Utils
 
 /**
  * Test HiveExternalCatalog backward compatibility.
@@ -95,13 +95,7 @@ class HiveExternalCatalogVersionsSuite extends SparkSubmitTestUtils {
       mirrors.distinct :+ "https://archive.apache.org/dist" :+ PROCESS_TABLES.releaseMirror
     logInfo(s"Trying to download Spark $version from $sites")
     for (site <- sites) {
-      val filename = VersionUtils.majorMinorPatchVersion(version) match {
-        case Some((major, _, _)) if major > 3 => s"spark-$version-bin-hadoop3.tgz"
-        case Some((3, minor, _)) if minor >= 3 => s"spark-$version-bin-hadoop3.tgz"
-        case Some((3, minor, _)) if minor < 3 => s"spark-$version-bin-hadoop3.2.tgz"
-        case Some((_, _, _)) => s"spark-$version-bin-hadoop2.7.tgz"
-        case None => s"spark-$version-bin-hadoop2.7.tgz"
-      }
+      val filename = s"spark-$version-bin-hadoop3.tgz"
       val url = s"$site/spark/spark-$version/$filename"
       logInfo(s"Downloading Spark $version from $url")
       try {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR simplifies the code used to generate the Spark tarball `filename` in `HiveExternalCatalogVersionsSuite` because the minimum tested version is Spark 3.4.

### Why are the changes needed?
Simplify the code to generate the Spark tarball `filename`


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No