### PR TITLE
[SPARK-46360][PYTHON][FOLLOWUP][DOCS] Add `getMessage` to API reference

### DIFF
--- a/python/docs/source/reference/pyspark.errors.rst
+++ b/python/docs/source/reference/pyspark.errors.rst
@@ -68,5 +68,6 @@ Methods
     :toctree: api/
 
     PySparkException.getErrorClass
+    PySparkException.getMessage
     PySparkException.getMessageParameters
     PySparkException.getSqlState


### PR DESCRIPTION

### What changes were proposed in this pull request?

This PR followups https://github.com/apache/spark/pull/44292 to add documentation.


### Why are the changes needed?

To address missing documentation.


### Does this PR introduce _any_ user-facing change?

No API changes, but `getMessage` is added to API reference page.


### How was this patch tested?

The existing doc build in CI should pass.

### Was this patch authored or co-authored using generative AI tooling?

No.