### PR TITLE
[SPARK-46377][INFRA] Upgrade labeler action to v5

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -34,7 +34,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-    - uses: actions/labeler@v4
+    - uses: actions/labeler@v5
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         sync-labels: true


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade `labeler action` from v4 to v5.

### Why are the changes needed?
The full release notes: https://github.com/actions/labeler/releases/tag/v5.0.0
Version 5 of this action updated the [runtime to Node.js 20](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runs-for-javascript-actions). All scripts are now run with Node.js 20 instead of Node.js 16 and are affected by any breaking changes between Node.js 16 and 20.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
- Pass GA.
- Manually continuous observation.

### Was this patch authored or co-authored using generative AI tooling?
No.
