### PR TITLE
[MINOR][SQL] Convert `UnresolvedException` to an internal error

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
@@ -39,7 +39,7 @@ import org.apache.spark.util.ArrayImplicits._
 class UnresolvedException(function: String)
   extends SparkException(
     errorClass = "INTERNAL_ERROR",
-    messageParameters = Map("message" -> s"Invalid call to `$function` on unresolved object"),
+    messageParameters = Map("message" -> s"Invalid call to $function on unresolved object"),
     cause = null)
 
 /** Parent trait for unresolved node types */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
@@ -37,7 +37,10 @@ import org.apache.spark.util.ArrayImplicits._
  * resolved.
  */
 class UnresolvedException(function: String)
-  extends AnalysisException(s"Invalid call to $function on unresolved object")
+  extends SparkException(
+    errorClass = "INTERNAL_ERROR",
+    messageParameters = Map("message" -> s"Invalid call to `$function` on unresolved object"),
+    cause = null)
 
 /** Parent trait for unresolved node types */
 trait UnresolvedNode extends LogicalPlan {


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to change the parent class of `UnresolvedException` from `AnalysisException` to `SparkException` with the error class `INTERNAL_ERROR`. If an user observes the error, this is definitely a bug in the compiler.

### Why are the changes needed?
To unify all Spark exceptions, and assign an error class. So, this should improve user experience with Spark SQL.

### Does this PR introduce _any_ user-facing change?
No, users shouldn't face to the error in regular cases.

### How was this patch tested?
By existing GAs.

### Was this patch authored or co-authored using generative AI tooling?
No.