### PR TITLE
[SPARK-21195][CORE] Dynamically register metrics from sources as they are reported

### DIFF
--- a/core/src/main/scala/org/apache/spark/metrics/MetricsSystem.scala
+++ b/core/src/main/scala/org/apache/spark/metrics/MetricsSystem.scala
@@ -22,7 +22,7 @@ import java.util.concurrent.TimeUnit
 
 import scala.collection.mutable
 
-import com.codahale.metrics.{Metric, MetricRegistry}
+import com.codahale.metrics.{Counter, Gauge, Histogram, Meter, Metric, MetricRegistry, MetricRegistryListener, Timer}
 import org.eclipse.jetty.servlet.ServletContextHandler
 
 import org.apache.spark.{SecurityManager, SparkConf}
@@ -68,13 +68,15 @@ import org.apache.spark.util.Utils
  * [options] represent the specific property of this source or sink.
  */
 private[spark] class MetricsSystem private (
-    val instance: String, conf: SparkConf) extends Logging {
+    val instance: String,
+    conf: SparkConf,
+    registry: MetricRegistry)
+  extends Logging {
 
   private[this] val metricsConfig = new MetricsConfig(conf)
 
   private val sinks = new mutable.ArrayBuffer[Sink]
-  private val sources = new mutable.ArrayBuffer[Source]
-  private val registry = new MetricRegistry()
+  private val sourcesWithListeners = new mutable.HashMap[Source, MetricRegistryListener]
 
   private var running: Boolean = false
 
@@ -108,6 +110,9 @@ private[spark] class MetricsSystem private (
     if (running) {
       sinks.foreach(_.stop())
       registry.removeMatching((_: String, _: Metric) => true)
+      sourcesWithListeners.synchronized {
+        sourcesWithListeners.keySet.foreach(removeSource)
+      }
     } else {
       logWarning("Stopping a MetricsSystem that is not running")
     }
@@ -152,25 +157,21 @@ private[spark] class MetricsSystem private (
     } else { defaultName }
   }
 
-  def getSourcesByName(sourceName: String): Seq[Source] = sources.synchronized {
-    sources.filter(_.sourceName == sourceName).toSeq
+  def getSourcesByName(sourceName: String): Seq[Source] = sourcesWithListeners.synchronized {
+    sourcesWithListeners.keySet.filter(_.sourceName == sourceName).toSeq
   }
 
   def registerSource(source: Source): Unit = {
-    sources.synchronized {
-      sources += source
+    val listener = new MetricsSystemListener(buildRegistryName(source))
+    sourcesWithListeners.synchronized {
+      sourcesWithListeners += source -> listener
     }
-    try {
-      val regName = buildRegistryName(source)
-      registry.register(regName, source.metricRegistry)
-    } catch {
-      case e: IllegalArgumentException => logInfo("Metrics already registered", e)
-    }
+    source.metricRegistry.addListener(listener)
   }
 
   def removeSource(source: Source): Unit = {
-    sources.synchronized {
-      sources -= source
+    sourcesWithListeners.synchronized {
+      sourcesWithListeners.remove(source).foreach(source.metricRegistry.removeListener)
     }
     val regName = buildRegistryName(source)
     registry.removeMatching((name: String, _: Metric) => name.startsWith(regName))
@@ -235,6 +236,48 @@ private[spark] class MetricsSystem private (
   }
 
   def metricsProperties(): Properties = metricsConfig.properties
+
+  private[spark] class MetricsSystemListener(prefix: String) extends MetricRegistryListener {
+    def metricName(name: String): String = MetricRegistry.name(prefix, name)
+
+    def registerMetric[T <: Metric](name: String, metric: T): Unit = {
+      try {
+        registry.register(metricName(name), metric)
+      } catch {
+        case e: IllegalArgumentException => logInfo("Metrics already registered", e)
+      }
+    }
+
+    override def onHistogramAdded(name: String, histogram: Histogram): Unit =
+      registerMetric(name, histogram)
+
+    override def onCounterAdded(name: String, counter: Counter): Unit =
+      registerMetric(name, counter)
+
+    override def onMeterAdded(name: String, meter: Meter): Unit =
+      registerMetric(name, meter)
+
+    override def onGaugeAdded(name: String, gauge: Gauge[_]): Unit =
+      registerMetric(name, gauge)
+
+    override def onTimerAdded(name: String, timer: Timer): Unit =
+      registerMetric(name, timer)
+
+    override def onHistogramRemoved(name: String): Unit =
+      registry.remove(metricName(name))
+
+    override def onGaugeRemoved(name: String): Unit =
+      registry.remove(metricName(name))
+
+    override def onMeterRemoved(name: String): Unit =
+      registry.remove(metricName(name))
+
+    override def onCounterRemoved(name: String): Unit =
+      registry.remove(metricName(name))
+
+    override def onTimerRemoved(name: String): Unit =
+      registry.remove(metricName(name))
+  }
 }
 
 private[spark] object MetricsSystem {
@@ -252,8 +295,11 @@ private[spark] object MetricsSystem {
     }
   }
 
-  def createMetricsSystem(instance: String, conf: SparkConf): MetricsSystem = {
-    new MetricsSystem(instance, conf)
+  def createMetricsSystem(
+      instance: String,
+      conf: SparkConf,
+      registry: MetricRegistry = new MetricRegistry): MetricsSystem = {
+    new MetricsSystem(instance, conf, registry)
   }
 }
 

--- a/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
@@ -23,9 +23,10 @@ import java.util.Locale
 import java.util.concurrent.{CountDownLatch, TimeUnit}
 import java.util.concurrent.atomic.AtomicInteger
 
-import scala.collection.mutable.ArrayBuffer
+import scala.collection.mutable.HashMap
 import scala.collection.mutable.Queue
 
+import com.codahale.metrics.MetricRegistryListener
 import org.apache.commons.io.FileUtils
 import org.scalatest.{Assertions, PrivateMethodTester}
 import org.scalatest.concurrent.{Signaler, ThreadSignaler, TimeLimits}
@@ -1027,8 +1028,10 @@ object testPackage extends Assertions {
  * This includes methods to access private methods and fields in StreamingContext and MetricsSystem
  */
 private object StreamingContextSuite extends PrivateMethodTester {
-  private val _sources = PrivateMethod[ArrayBuffer[Source]](Symbol("sources"))
-  private def getSources(metricsSystem: MetricsSystem): ArrayBuffer[Source] = {
+  private val _sources =
+    PrivateMethod[HashMap[Source, MetricRegistryListener]](Symbol("sourcesWithListeners"))
+  private def getSources(
+      metricsSystem: MetricsSystem): HashMap[Source, MetricRegistryListener] = {
     metricsSystem.invokePrivate(_sources())
   }
   private val _streamingSource = PrivateMethod[StreamingSource](Symbol("streamingSource"))


### PR DESCRIPTION
### What changes were proposed in this pull request?
MetricSystem picks up new metrics from sources that are added throughout execution. If you do measurements via dynamic proxies you might not want to redeclare all metrics that the proxies will create and you'd prefer them to get populated as they're being produced. Right now all sources are processed only onceat startup and metrics are picked up only if they have been registered statically at compile time. Behaviour I am proposing lets you not have to declare metrics in two places.

This had been previously suggested in #18406, #29980,  #31267, #35357, #36889, #38209, #39755, #41120 and #42684.

### Why are the changes needed?
Currently there's no way to access MetricRegistry that MetricsSystem uses to hold its state and as such it's not possible to reprocess a source. MetricsSystem throws if any metric had already been registered previously.

n.b. the MetricRegistry is added as a constructor argument to make testing easier but could as well be accessed via reflection as a private variable.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Added tests
