### PR TITLE
[SPARK-46386][PYTHON] Improve assertions of observation (pyspark.sql.observation)

### DIFF
--- a/python/pyspark/errors/error_classes.py
+++ b/python/pyspark/errors/error_classes.py
@@ -715,7 +715,7 @@ ERROR_CLASSES_JSON = """
   "NO_OBSERVE_BEFORE_GET" : {
     "message" : [
       "Should observe by calling `DataFrame.observe` before `get`."
-    ]  
+    ]
   },
   "NO_SCHEMA_AND_DRIVER_DEFAULT_SCHEME" : {
     "message" : [

--- a/python/pyspark/errors/error_classes.py
+++ b/python/pyspark/errors/error_classes.py
@@ -836,7 +836,7 @@ ERROR_CLASSES_JSON = """
   "REUSE_OBSERVATION" : {
     "message" : [
       "An Observation can be used with a DataFrame only once."
-    ]  
+    ]
   },
   "SCHEMA_MISMATCH_FOR_PANDAS_UDF" : {
     "message" : [

--- a/python/pyspark/errors/error_classes.py
+++ b/python/pyspark/errors/error_classes.py
@@ -712,6 +712,11 @@ ERROR_CLASSES_JSON = """
       "No active Spark session found. Please create a new Spark session before running the code."
     ]
   },
+  "NO_OBSERVE_BEFORE_GET" : {
+    "message" : [
+      "Should observe by calling `DataFrame.observe` before `get`."
+    ]  
+  },
   "NO_SCHEMA_AND_DRIVER_DEFAULT_SCHEME" : {
     "message" : [
       "Only allows <arg_name> to be a path without scheme, and Spark Driver should use the default scheme to determine the destination file system."
@@ -827,6 +832,11 @@ ERROR_CLASSES_JSON = """
     "message" : [
       "The maximum number of retries has been exceeded."
     ]
+  },
+  "REUSE_OBSERVATION" : {
+    "message" : [
+      "An Observation can be used with a DataFrame only once."
+    ]  
   },
   "SCHEMA_MISMATCH_FOR_PANDAS_UDF" : {
     "message" : [

--- a/python/pyspark/sql/connect/observation.py
+++ b/python/pyspark/sql/connect/observation.py
@@ -51,7 +51,8 @@ class Observation:
     __init__.__doc__ = PySparkObservation.__init__.__doc__
 
     def _on(self, df: DataFrame, *exprs: Column) -> DataFrame:
-        assert self._result is None, "an Observation can be used with a DataFrame only once"
+        if self._result is not None:
+            raise PySparkAssertionError(error_class="REUSE_OBSERVATION", message_parameters={})
 
         if self._name is None:
             self._name = str(uuid.uuid4())

--- a/python/pyspark/sql/connect/observation.py
+++ b/python/pyspark/sql/connect/observation.py
@@ -21,6 +21,7 @@ from pyspark.errors import (
     PySparkTypeError,
     PySparkValueError,
     IllegalArgumentException,
+    PySparkAssertionError,
 )
 from pyspark.sql.connect.column import Column
 from pyspark.sql.connect.dataframe import DataFrame
@@ -68,7 +69,9 @@ class Observation:
 
     @property
     def get(self) -> Dict[str, Any]:
-        assert self._result is not None
+        if self._result is None:
+            raise PySparkAssertionError(error_class="NO_OBSERVE_BEFORE_GET", message_parameters={})
+
         return self._result
 
     get.__doc__ = PySparkObservation.get.__doc__

--- a/python/pyspark/sql/observation.py
+++ b/python/pyspark/sql/observation.py
@@ -19,7 +19,7 @@ from typing import Any, Dict, Optional
 
 from py4j.java_gateway import JavaObject, JVMView
 
-from pyspark.errors import PySparkTypeError, PySparkValueError
+from pyspark.errors import PySparkTypeError, PySparkValueError, PySparkAssertionError
 from pyspark.sql import column
 from pyspark.sql.column import Column
 from pyspark.sql.dataframe import DataFrame
@@ -114,7 +114,8 @@ class Observation:
         :class:`DataFrame`
             the observed :class:`DataFrame`.
         """
-        assert self._jo is None, "an Observation can be used with a DataFrame only once"
+        if self._jo is not None:
+            raise PySparkAssertionError(error_class="REUSE_OBSERVATION", message_parameters={})
 
         self._jvm = df._sc._jvm
         assert self._jvm is not None
@@ -137,7 +138,9 @@ class Observation:
         dict
             the observed metrics
         """
-        assert self._jo is not None, "call DataFrame.observe"
+        if self._jo is None:
+            raise PySparkAssertionError(error_class="NO_OBSERVE_BEFORE_GET", message_parameters={})
+
         jmap = self._jo.getAsJava()
         # return a pure Python dict, not jmap which is a py4j JavaMap
         return {k: v for k, v in jmap.items()}


### PR DESCRIPTION
### What changes were proposed in this pull request?
Improve and test assertions of observation (pyspark.sql.observation).


### Why are the changes needed?
Better error handling.

### Does this PR introduce _any_ user-facing change?
Yes, PySparkAssertionError is raised in the cases below:

```py
>>> observation = Observation()
>>> observation.get()
Traceback (most recent call last):
...
pyspark.errors.exceptions.base.PySparkAssertionError: [NO_OBSERVE_BEFORE_GET] Should observe by calling `DataFrame.observe` before `get`.
>>> df.observe(observation, count(lit(1)))
DataFrame[id: bigint, val: double, label: string]
>>> df.observe(observation, count(lit(1)))
Traceback (most recent call last):
...
    raise PySparkAssertionError(error_class="REUSE_OBSERVATION", message_parameters={})
pyspark.errors.exceptions.base.PySparkAssertionError: [REUSE_OBSERVATION] An Observation can be used with a DataFrame only once.
```


### How was this patch tested?
Test change only.


### Was this patch authored or co-authored using generative AI tooling?
No.