### PR TITLE
[SPARK-46389][CORE] Manually close the `RocksDB/LevelDB` instance when `checkVersion` throw Exception

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/util/LevelDBProvider.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/LevelDBProvider.java
@@ -80,7 +80,12 @@ public class LevelDBProvider {
         }
       }
       // if there is a version mismatch, we throw an exception, which means the service is unusable
-      checkVersion(tmpDb, version, mapper);
+      try {
+        checkVersion(tmpDb, version, mapper);
+      } catch (IOException ioe) {
+        tmpDb.close();
+        throw ioe;
+      }
     }
     return tmpDb;
   }

--- a/common/network-common/src/main/java/org/apache/spark/network/util/RocksDBProvider.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/RocksDBProvider.java
@@ -100,7 +100,11 @@ public class RocksDBProvider {
           // is unusable
           checkVersion(tmpDb, version, mapper);
         } catch (RocksDBException e) {
+          tmpDb.close();
           throw new IOException(e.getMessage(), e);
+        } catch (IOException ioe) {
+          tmpDb.close();
+          throw ioe;
         }
       }
       return tmpDb;


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the process of initializing the `DB` in `RocksDBProvider/LevelDBProvider`, there is a `checkVersion` step that may throw an exception. After the exception is thrown, the upper-level caller cannot hold the already opened `RockDB/LevelDB` instance, so it cannot perform resource cleanup, which poses a potential risk of handle leakage. So this PR manually closes the `RocksDB/LevelDB` instance when `checkVersion` throws an exception.

### Why are the changes needed?
Should close the `RocksDB/LevelDB` instance when `checkVersion` throw Exception


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No