### PR TITLE
[SPARK-46394][SQL] Fix spark.catalog.listDatabases() issues on schemas with special characters when `spark.sql.legacy.keepCommandOutputSchema` set to true 

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/CatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/CatalogSuite.scala
@@ -177,9 +177,19 @@ class CatalogSuite extends SharedSparkSession with AnalysisTest with BeforeAndAf
         spark.sharedState.externalCatalog.createDatabase(utils.newDb("my`db2"), false)
         assert(spark.catalog.listDatabases().collect().map(_.name).toSet ==
           Set("default", "`my-db1`", "`my``db2`"))
-        assert(spark.catalog.listDatabases("my*").collect().map(_.name).toSet == Set.empty)
-        assert(spark.catalog.listDatabases("`my*`").collect().map(_.name).toSet ==
-          Set("`my-db1`", "`my``db2`"))
+        if (legacy) {
+          assert(
+            spark.catalog.listDatabases("my*").collect().map(_.name).toSet ==
+              Set("`my-db1`", "`my``db2`")
+          )
+          assert(spark.catalog.listDatabases("`my*`").collect().map(_.name).toSet == Set.empty)
+        } else {
+          assert(spark.catalog.listDatabases("my*").collect().map(_.name).toSet == Set.empty)
+          assert(
+            spark.catalog.listDatabases("`my*`").collect().map(_.name).toSet ==
+              Set("`my-db1`", "`my``db2`")
+          )
+        }
         assert(spark.catalog.listDatabases("you*").collect().map(_.name).toSet ==
           Set.empty[String])
         dropDatabase("my-db1")

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/CatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/CatalogSuite.scala
@@ -167,6 +167,34 @@ class CatalogSuite extends SharedSparkSession with AnalysisTest with BeforeAndAf
       Set("default", "my_db2"))
   }
 
+  test("list databases with special character") {
+    Seq(true, false).foreach { legacy =>
+      withSQLConf(SQLConf.LEGACY_KEEP_COMMAND_OUTPUT_SCHEMA.key -> legacy.toString) {
+        spark.catalog.setCurrentCatalog(CatalogManager.SESSION_CATALOG_NAME)
+        assert(spark.catalog.listDatabases().collect().map(_.name).toSet == Set("default"))
+        // use externalCatalog to bypass the database name validation in SessionCatalog
+        spark.sharedState.externalCatalog.createDatabase(utils.newDb("my-db1"), false)
+        spark.sharedState.externalCatalog.createDatabase(utils.newDb("my`db2"), false)
+        assert(spark.catalog.listDatabases().collect().map(_.name).toSet ==
+          Set("default", "`my-db1`", "`my``db2`"))
+        assert(spark.catalog.listDatabases("my*").collect().map(_.name).toSet == Set.empty)
+        assert(spark.catalog.listDatabases("`my*`").collect().map(_.name).toSet ==
+          Set("`my-db1`", "`my``db2`"))
+        assert(spark.catalog.listDatabases("you*").collect().map(_.name).toSet ==
+          Set.empty[String])
+        dropDatabase("my-db1")
+        assert(spark.catalog.listDatabases().collect().map(_.name).toSet ==
+          Set("default", "`my``db2`"))
+        dropDatabase("my`db2") // cleanup
+
+        spark.catalog.setCurrentCatalog("testcat")
+        sql(s"CREATE NAMESPACE testcat.`my-db`")
+        assert(spark.catalog.listDatabases().collect().map(_.name).toSet == Set("`my-db`"))
+        sql(s"DROP NAMESPACE testcat.`my-db`") // cleanup
+      }
+    }
+  }
+
   test("list databases with current catalog") {
     spark.catalog.setCurrentCatalog("testcat")
     sql(s"CREATE NAMESPACE testcat.my_db")

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/CatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/CatalogSuite.scala
@@ -177,6 +177,9 @@ class CatalogSuite extends SharedSparkSession with AnalysisTest with BeforeAndAf
         spark.sharedState.externalCatalog.createDatabase(utils.newDb("my`db2"), false)
         assert(spark.catalog.listDatabases().collect().map(_.name).toSet ==
           Set("default", "`my-db1`", "`my``db2`"))
+        // TODO: ideally there should be no difference between legacy and non-legacy mode. However,
+        //  in non-legacy mode, the ShowNamespacesExec does the quoting before pattern matching,
+        //  requiring the pattern to be quoted. This is not ideal, we should fix it in the future.
         if (legacy) {
           assert(
             spark.catalog.listDatabases("my*").collect().map(_.name).toSet ==


### PR DESCRIPTION
### What changes were proposed in this pull request?
When the SQL conf `spark.sql.legacy.keepCommandOutputSchema` is set to true:
Before:
```
// support there is a xyyu-db-with-hyphen schema in the catalog
spark.catalog.listDatabases()

[INVALID_IDENTIFIER] The identifier xyyu-db-with-hyphen is invalid. Please, consider quoting it with back-quotes as `xyyu-db-with-hyphen`. SQLSTATE: 42602 (line 1, pos 4)
```

After:
```
spark.catalog.listDatabases()

.. `xyyu-db-with-hyphen` ..
```

This PR fixes the issue by falling back to original name when the parsing failed.


### Why are the changes needed?
To fix the bug.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Newly added tests.


### Was this patch authored or co-authored using generative AI tooling?
No.
