### PR TITLE
[SPARK-46153][SQL] XML: Add TimestampNTZType support

### DIFF
--- a/docs/sql-data-sources-xml.md
+++ b/docs/sql-data-sources-xml.md
@@ -168,6 +168,13 @@ Data source options of XML can be set via:
   </tr>
 
   <tr>
+    <td><code>timestampNTZFormat</code></td>
+    <td>yyyy-MM-dd'T'HH:mm:ss[.SSS]</td>
+    <td>Sets the string that indicates a timestamp without timezone format. Custom date formats follow the formats at <a href="https://spark.apache.org/docs/latest/sql-ref-datetime-pattern.html">Datetime Patterns</a>. This applies to timestamp without timezone type, note that zone-offset and time-zone components are not supported when writing or reading this data type.</td>
+    <td>read/write</td>
+  </tr>
+
+  <tr>
     <td><code>dateFormat</code></td>
     <td><code>yyyy-MM-dd</code></td>
     <td>Sets the string that indicates a date format. Custom date formats follow the formats at <a href="https://spark.apache.org/docs/latest/sql-ref-datetime-pattern.html"> datetime pattern</a>. This applies to date type.</td>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/StaxXmlGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/StaxXmlGenerator.scala
@@ -26,7 +26,7 @@ import com.sun.xml.txw2.output.IndentingXMLStreamWriter
 import org.apache.hadoop.shaded.com.ctc.wstx.api.WstxOutputProperties
 
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.util.{ArrayData, DateFormatter, MapData, TimestampFormatter}
+import org.apache.spark.sql.catalyst.util.{ArrayData, DateFormatter, DateTimeUtils, MapData, TimestampFormatter}
 import org.apache.spark.sql.catalyst.util.LegacyDateFormats.FAST_DATE_FORMAT
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
@@ -47,6 +47,13 @@ class StaxXmlGenerator(
     options.locale,
     legacyFormat = FAST_DATE_FORMAT,
     isParsing = false)
+
+  private val timestampNTZFormatter = TimestampFormatter(
+    options.timestampNTZFormatInWrite,
+    options.zoneId,
+    legacyFormat = FAST_DATE_FORMAT,
+    isParsing = false,
+    forTimestampNTZ = true)
 
   private val dateFormatter = DateFormatter(
     options.dateFormatInWrite,
@@ -166,6 +173,8 @@ class StaxXmlGenerator(
       gen.writeCharacters(timestampFormatter.format(v.toInstant()))
     case (TimestampType, v: Long) =>
       gen.writeCharacters(timestampFormatter.format(v))
+    case (TimestampNTZType, v: Long) =>
+      gen.writeCharacters(timestampNTZFormatter.format(DateTimeUtils.microsToLocalDateTime(v)))
     case (DateType, v: Int) =>
       gen.writeCharacters(dateFormatter.format(v))
     case (IntegerType, v: Int) => gen.writeCharacters(v.toString)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/StaxXmlParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/StaxXmlParser.scala
@@ -54,6 +54,13 @@ class StaxXmlParser(
     legacyFormat = FAST_DATE_FORMAT,
     isParsing = true)
 
+  private lazy val timestampNTZFormatter = TimestampFormatter(
+    options.timestampNTZFormatInRead,
+    options.zoneId,
+    legacyFormat = FAST_DATE_FORMAT,
+    isParsing = true,
+    forTimestampNTZ = true)
+
   private lazy val dateFormatter = DateFormatter(
     options.dateFormatInRead,
     options.locale,
@@ -461,6 +468,7 @@ class StaxXmlParser(
         case dt: DecimalType =>
           Decimal(decimalParser(datum), dt.precision, dt.scale)
         case _: TimestampType => parseXmlTimestamp(datum, options)
+        case _: TimestampNTZType => timestampNTZFormatter.parseWithoutTimeZone(datum, false)
         case _: DateType => parseXmlDate(datum, options)
         case _: StringType => UTF8String.fromString(datum)
         case _ => throw new IllegalArgumentException(s"Unsupported type: ${castType.typeName}")
@@ -504,6 +512,7 @@ class StaxXmlParser(
         case StringType => castTo(value, StringType)
         case DateType => castTo(value, DateType)
         case TimestampType => castTo(value, TimestampType)
+        case TimestampNTZType => castTo(value, TimestampNTZType)
         case FloatType => signSafeToFloat(value)
         case ByteType => castTo(value, ByteType)
         case ShortType => castTo(value, ShortType)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/XmlInferSchema.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/XmlInferSchema.scala
@@ -34,6 +34,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.expressions.ExprUtils
 import org.apache.spark.sql.catalyst.util.{DateFormatter, PermissiveMode, TimestampFormatter}
 import org.apache.spark.sql.catalyst.util.LegacyDateFormats.FAST_DATE_FORMAT
+import org.apache.spark.sql.internal.{LegacyBehaviorPolicy, SQLConf}
 import org.apache.spark.sql.types._
 
 class XmlInferSchema(options: XmlOptions, caseSensitive: Boolean)
@@ -48,6 +49,13 @@ class XmlInferSchema(options: XmlOptions, caseSensitive: Boolean)
     options.locale,
     legacyFormat = FAST_DATE_FORMAT,
     isParsing = true)
+
+  private lazy val timestampNTZFormatter = TimestampFormatter(
+    options.timestampNTZFormatInRead,
+    options.zoneId,
+    legacyFormat = FAST_DATE_FORMAT,
+    isParsing = true,
+    forTimestampNTZ = true)
 
   private lazy val dateFormatter = DateFormatter(
     options.dateFormatInRead,
@@ -138,6 +146,7 @@ class XmlInferSchema(options: XmlOptions, caseSensitive: Boolean)
 
     if (options.inferSchema) {
       lazy val decimalTry = tryParseDecimal(value)
+      lazy val timestampNTZTry = tryParseTimestampNTZ(value)
       value match {
         case null => NullType
         case v if v.isEmpty => NullType
@@ -146,6 +155,7 @@ class XmlInferSchema(options: XmlOptions, caseSensitive: Boolean)
         case v if isDouble(v) => DoubleType
         case v if isBoolean(v) => BooleanType
         case v if isDate(v) => DateType
+        case v if timestampNTZTry.isDefined => timestampNTZTry.get
         case v if isTimestamp(v) => TimestampType
         case _ => StringType
       }
@@ -392,6 +402,23 @@ class XmlInferSchema(options: XmlOptions, caseSensitive: Boolean)
     }
   }
 
+  private def tryParseTimestampNTZ(field: String): Option[DataType] = {
+    // We can only parse the value as TimestampNTZType if it does not have zone-offset or
+    // time-zone component and can be parsed with the timestamp formatter.
+    // Otherwise, it is likely to be a timestamp with timezone.
+    val timestampType = SQLConf.get.timestampType
+    try {
+      if ((SQLConf.get.legacyTimeParserPolicy == LegacyBehaviorPolicy.LEGACY ||
+        timestampType == TimestampNTZType) &&
+        timestampNTZFormatter.parseWithoutTimeZoneOptional(field, false).isDefined) {
+        return Some(timestampType)
+      }
+    } catch {
+      case _: Exception =>
+    }
+    None
+  }
+
   private def isDate(value: String): Boolean = {
     (allCatch opt dateFormatter.parse(value)).isDefined
   }
@@ -454,6 +481,8 @@ class XmlInferSchema(options: XmlOptions, caseSensitive: Boolean)
           } else {
             DecimalType(range + scale, scale)
           }
+        case (TimestampNTZType, TimestampType) | (TimestampType, TimestampNTZType) =>
+          TimestampType
 
         case (StructType(fields1), StructType(fields2)) =>
           val newFields = (fields1 ++ fields2)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/XmlSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/XmlSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution.datasources.xml
 import java.nio.charset.{StandardCharsets, UnsupportedCharsetException}
 import java.nio.file.{Files, Path, Paths}
 import java.sql.{Date, Timestamp}
-import java.time.Instant
+import java.time.{Instant, LocalDateTime}
 import java.util.TimeZone
 
 import scala.collection.mutable
@@ -2177,5 +2177,198 @@ class XmlSuite extends QueryTest with SharedSparkSession {
         "this is a simple string.")
     )
     testWriteReadRoundTrip(df, Map("nullValue" -> "null", "prefersDecimal" -> "true"))
+  }
+
+  test("Write and infer TIMESTAMP_NTZ values with a non-default pattern") {
+    withTempPath { path =>
+      val exp = spark.sql(
+        """
+      select timestamp_ntz'2020-12-12 12:12:12' as col0 union all
+      select timestamp_ntz'2020-12-12 12:12:12.123456' as col0
+      """)
+      exp.write
+        .option("timestampNTZFormat", "yyyy-MM-dd HH:mm:ss.SSSSSS")
+        .option("rowTag", "ROW")
+        .xml(path.getAbsolutePath)
+
+      withSQLConf(SQLConf.TIMESTAMP_TYPE.key -> SQLConf.TimestampTypes.TIMESTAMP_NTZ.toString) {
+        val res = spark.read
+          .option("timestampNTZFormat", "yyyy-MM-dd HH:mm:ss.SSSSSS")
+          .option("rowTag", "ROW")
+          .xml(path.getAbsolutePath)
+
+        assert(res.dtypes === exp.dtypes)
+        checkAnswer(res, exp)
+      }
+    }
+  }
+
+  test("Write and infer TIMESTAMP_LTZ values with a non-default pattern") {
+    withTempPath { path =>
+      val exp = spark.sql(
+        """
+      select timestamp_ltz'2020-12-12 12:12:12' as col0 union all
+      select timestamp_ltz'2020-12-12 12:12:12.123456' as col0
+      """)
+      exp.write
+        .option("timestampFormat", "yyyy-MM-dd HH:mm:ss.SSSSSS")
+        .option("rowTag", "ROW")
+        .xml(path.getAbsolutePath)
+
+      withSQLConf(SQLConf.TIMESTAMP_TYPE.key -> SQLConf.TimestampTypes.TIMESTAMP_LTZ.toString) {
+        val res = spark.read
+          .option("timestampFormat", "yyyy-MM-dd HH:mm:ss.SSSSSS")
+          .option("rowTag", "ROW")
+          .xml(path.getAbsolutePath)
+
+        assert(res.dtypes === exp.dtypes)
+        checkAnswer(res, exp)
+      }
+    }
+  }
+
+  test("Roundtrip in reading and writing TIMESTAMP_NTZ values with custom schema") {
+    withTempPath { path =>
+      val exp = spark.sql(
+        """
+      select
+        timestamp_ntz'2020-12-12 12:12:12' as col1,
+        timestamp_ltz'2020-12-12 12:12:12' as col2
+      """)
+
+      exp.write.option("rowTag", "ROW").xml(path.getAbsolutePath)
+
+      val res = spark.read
+        .schema("col1 TIMESTAMP_NTZ, col2 TIMESTAMP_LTZ")
+        .option("rowTag", "ROW")
+        .xml(path.getAbsolutePath)
+
+      checkAnswer(res, exp)
+    }
+  }
+
+  test("Timestamp type inference for a column with TIMESTAMP_NTZ values") {
+    withTempPath { path =>
+      val exp = spark.sql(
+        """
+      select timestamp_ntz'2020-12-12 12:12:12' as col0 union all
+      select timestamp_ntz'2020-12-12 12:12:12' as col0
+      """)
+
+      exp.write.option("rowTag", "ROW").xml(path.getAbsolutePath)
+
+      val timestampTypes = Seq(
+        SQLConf.TimestampTypes.TIMESTAMP_NTZ.toString,
+        SQLConf.TimestampTypes.TIMESTAMP_LTZ.toString)
+
+      timestampTypes.foreach { timestampType =>
+        withSQLConf(SQLConf.TIMESTAMP_TYPE.key -> timestampType) {
+          val res = spark.read.option("rowTag", "ROW").xml(path.getAbsolutePath)
+
+          if (timestampType == SQLConf.TimestampTypes.TIMESTAMP_NTZ.toString) {
+            checkAnswer(res, exp)
+          } else {
+            checkAnswer(
+              res,
+              spark.sql(
+                """
+              select timestamp_ltz'2020-12-12 12:12:12' as col0 union all
+              select timestamp_ltz'2020-12-12 12:12:12' as col0
+              """)
+            )
+          }
+        }
+      }
+    }
+  }
+
+  test("Timestamp type inference for a mix of TIMESTAMP_NTZ and TIMESTAMP_LTZ") {
+    withTempPath { path =>
+      Seq(
+        "<ROW><col0>2020-12-12T12:12:12.000</col0></ROW>",
+        "<ROW><col0>2020-12-12T17:12:12.000Z</col0></ROW>",
+        "<ROW><col0>2020-12-12T17:12:12.000+05:00</col0></ROW>",
+        "<ROW><col0>2020-12-12T12:12:12.000</col0></ROW>"
+      ).toDF("data")
+        .coalesce(1)
+        .write.text(path.getAbsolutePath)
+
+      // TODO: enable "legacy" policy when the backward compatible parsing is implemented.
+      for (policy <- Seq("exception", "corrected")) {
+        withSQLConf(SQLConf.LEGACY_TIME_PARSER_POLICY.key -> policy) {
+          val res = spark.read.option("rowTag", "ROW").xml(path.getAbsolutePath)
+
+          // NOTE:
+          // Every value is tested for all types in XML schema inference so the sequence of
+          // ["timestamp_ntz", "timestamp_ltz", "timestamp_ntz"] results in "timestamp_ltz".
+          // This is different from CSV where inference starts from the last inferred type.
+          //
+          // This is why the similar test in CSV has a different result in "legacy" mode.
+
+          val exp = spark.sql("""
+            select timestamp_ltz'2020-12-12T12:12:12.000' as col0 union all
+            select timestamp_ltz'2020-12-12T17:12:12.000Z' as col0 union all
+            select timestamp_ltz'2020-12-12T17:12:12.000+05:00' as col0 union all
+            select timestamp_ltz'2020-12-12T12:12:12.000' as col0
+            """)
+          checkAnswer(res, exp)
+        }
+      }
+    }
+  }
+
+  test("Malformed records when reading TIMESTAMP_LTZ as TIMESTAMP_NTZ") {
+    withTempPath { path =>
+      Seq(
+        "<ROW><col0>2020-12-12T12:12:12.000</col0></ROW>",
+        "<ROW><col0>2020-12-12T12:12:12.000Z</col0></ROW>",
+        "<ROW><col0>2020-12-12T12:12:12.000+05:00</col0></ROW>",
+        "<ROW><col0>2020-12-12T12:12:12.000</col0></ROW>"
+      ).toDF("data")
+        .coalesce(1)
+        .write.text(path.getAbsolutePath)
+
+      for (timestampNTZFormat <- Seq(None, Some("yyyy-MM-dd'T'HH:mm:ss[.SSS]"))) {
+        val reader = spark.read.schema("col0 TIMESTAMP_NTZ")
+        val res = timestampNTZFormat match {
+          case Some(format) =>
+            reader.option("timestampNTZFormat", format)
+              .option("rowTag", "ROW").xml(path.getAbsolutePath)
+          case None =>
+            reader.option("rowTag", "ROW").xml(path.getAbsolutePath)
+        }
+
+        checkAnswer(
+          res,
+          Seq(
+            Row(LocalDateTime.of(2020, 12, 12, 12, 12, 12)),
+            Row(null),
+            Row(null),
+            Row(LocalDateTime.of(2020, 12, 12, 12, 12, 12))
+          )
+        )
+      }
+    }
+  }
+
+  test("Fail to write TIMESTAMP_NTZ if timestampNTZFormat contains zone offset") {
+    val patterns = Seq(
+      "yyyy-MM-dd HH:mm:ss XXX",
+      "yyyy-MM-dd HH:mm:ss Z",
+      "yyyy-MM-dd HH:mm:ss z")
+
+    val exp = spark.sql("select timestamp_ntz'2020-12-12 12:12:12' as col0")
+    for (pattern <- patterns) {
+      withTempPath { path =>
+        val err = intercept[SparkException] {
+          exp.write.option("timestampNTZFormat", pattern)
+            .option("rowTag", "ROW").xml(path.getAbsolutePath)
+        }
+        assert(
+          err.getMessage.contains("Unsupported field: OffsetSeconds") ||
+            err.getMessage.contains("Unable to extract value") ||
+            err.getMessage.contains("Unable to extract ZoneId"))
+      }
+    }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add TimestampNTZType support in XML data source.

### Why are the changes needed?
To bring in parity with json/csv.

### Does this PR introduce _any_ user-facing change?
Yes, adds support for TimestampNTZType.

### How was this patch tested?
New unit tests.

### Was this patch authored or co-authored using generative AI tooling?
No
