### PR TITLE
[SPARK-46379][PS][TESTS][FOLLOWUPS]  Deduplicate `test_interpolate_error`

### DIFF
--- a/python/pyspark/pandas/tests/frame/test_interpolate.py
+++ b/python/pyspark/pandas/tests/frame/test_interpolate.py
@@ -22,42 +22,6 @@ from pyspark.testing.pandasutils import PandasOnSparkTestCase, TestUtils
 
 
 class FrameInterpolateMixin:
-    def test_interpolate_error(self):
-        psdf = ps.range(10)
-
-        with self.assertRaisesRegex(
-            NotImplementedError, "interpolate currently works only for method='linear'"
-        ):
-            psdf.interpolate(method="quadratic")
-
-        with self.assertRaisesRegex(
-            NotImplementedError, "interpolate currently works only for method='linear'"
-        ):
-            psdf.id.interpolate(method="quadratic")
-
-        with self.assertRaisesRegex(ValueError, "limit must be > 0"):
-            psdf.interpolate(limit=0)
-
-        with self.assertRaisesRegex(ValueError, "limit must be > 0"):
-            psdf.id.interpolate(limit=0)
-
-        with self.assertRaisesRegex(ValueError, "invalid limit_direction"):
-            psdf.interpolate(limit_direction="jump")
-
-        with self.assertRaisesRegex(ValueError, "invalid limit_direction"):
-            psdf.id.interpolate(limit_direction="jump")
-
-        with self.assertRaisesRegex(ValueError, "invalid limit_area"):
-            psdf.interpolate(limit_area="jump")
-
-        with self.assertRaisesRegex(ValueError, "invalid limit_area"):
-            psdf.id.interpolate(limit_area="jump")
-
-        with self.assertRaisesRegex(
-            TypeError, "Cannot interpolate with all object-dtype columns in the DataFrame."
-        ):
-            ps.DataFrame({"A": ["a", "b", "c"], "B": ["a", "b", "c"]}).interpolate()
-
     def _test_interpolate(self, pobj):
         psobj = ps.from_pandas(pobj)
         self.assert_eq(


### PR DESCRIPTION
### What changes were proposed in this pull request?
this is a followup of https://github.com/apache/spark/pull/44313/, which happened to duplicate `test_interpolate_error`

### Why are the changes needed?
don't need to test it twice


### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
ci

### Was this patch authored or co-authored using generative AI tooling?
no
