### PR TITLE
Revert "[SPARK-46377][INFRA] Upgrade labeler action to v5"

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -34,7 +34,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-    - uses: actions/labeler@v5
+    - uses: actions/labeler@v4
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         sync-labels: true


### PR DESCRIPTION
### What changes were proposed in this pull request?
This reverts commit 270da6f9b7b331e455d1f0bd1309fb87bc8740ab.


### Why are the changes needed?
Master CI failed:

```
Run actions/labeler@v5
The configuration file (path: .github/labeler.yml) was not found locally, fetching via the api
Error: Error: found unexpected type for label 'INFRA' (should be array of config options)
Error: found unexpected type for label 'INFRA' (should be array of config options)
```


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GA


### Was this patch authored or co-authored using generative AI tooling?
No