### PR TITLE
[SPARK-46416][CORE] Add `@tailrec` to  `HadoopFSUtils#shouldFilterOutPath`

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/HadoopFSUtils.scala
+++ b/core/src/main/scala/org/apache/spark/util/HadoopFSUtils.scala
@@ -349,6 +349,7 @@ private[spark] object HadoopFSUtils extends Logging {
   private val underscoreEnd: Regex = "/_[^=/]*$".r
 
   /** Checks if we should filter out this path. */
+  @scala.annotation.tailrec
   def shouldFilterOutPath(path: String): Boolean = {
     if (path.contains("/.") || path.endsWith("._COPYING_")) return true
     underscoreEnd.findFirstIn(path) match {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr adds the `@scala.annotation.tailrec` annotation to the `shouldFilterOutPath` function in `HadoopFSUtils`.

### Why are the changes needed?
To improve performance.




### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No
