### PR TITLE
[SPARK-45005][PS][TESTS][FOLLOWUPS] Deduplicate `test_properties`

### DIFF
--- a/python/pyspark/pandas/tests/indexes/test_datetime.py
+++ b/python/pyspark/pandas/tests/indexes/test_datetime.py
@@ -71,32 +71,6 @@ class DatetimeIndexTestsMixin:
         ):
             ps.DatetimeIndex(["2004-01-01", "2002-12-31", "2000-04-01"]).all()
 
-    def test_properties(self):
-        for psidx, pidx in self.idx_pairs:
-            self.assert_eq(psidx.year, pidx.year)
-            self.assert_eq(psidx.month, pidx.month)
-            self.assert_eq(psidx.day, pidx.day)
-            self.assert_eq(psidx.hour, pidx.hour)
-            self.assert_eq(psidx.minute, pidx.minute)
-            self.assert_eq(psidx.second, pidx.second)
-            self.assert_eq(psidx.microsecond, pidx.microsecond)
-            self.assert_eq(psidx.dayofweek, pidx.dayofweek)
-            self.assert_eq(psidx.weekday, pidx.weekday)
-            self.assert_eq(psidx.dayofyear, pidx.dayofyear)
-            self.assert_eq(psidx.quarter, pidx.quarter)
-            self.assert_eq(psidx.daysinmonth, pidx.daysinmonth)
-            self.assert_eq(psidx.days_in_month, pidx.days_in_month)
-            self.assert_eq(psidx.is_month_start, pd.Index(pidx.is_month_start))
-            self.assert_eq(psidx.is_month_end, pd.Index(pidx.is_month_end))
-            self.assert_eq(psidx.is_quarter_start, pd.Index(pidx.is_quarter_start))
-            self.assert_eq(psidx.is_quarter_end, pd.Index(pidx.is_quarter_end))
-            self.assert_eq(psidx.is_year_start, pd.Index(pidx.is_year_start))
-            self.assert_eq(psidx.is_year_end, pd.Index(pidx.is_year_end))
-            self.assert_eq(psidx.is_leap_year, pd.Index(pidx.is_leap_year))
-
-            self.assert_eq(psidx.day_of_year, pidx.day_of_year)
-            self.assert_eq(psidx.day_of_week, pidx.day_of_week)
-
     def test_ceil(self):
         for psidx, pidx in self.idx_pairs:
             for freq in self.fixed_freqs:

--- a/python/pyspark/pandas/tests/indexes/test_datetime_property.py
+++ b/python/pyspark/pandas/tests/indexes/test_datetime_property.py
@@ -14,9 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-import unittest
-
 import numpy as np
 import pandas as pd
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

`test_properties` in `pyspark.pandas.tests.indexes.test_datetime` was moved to `pyspark.pandas.tests.indexes.test_datetime_property` in https://github.com/apache/spark/commit/c76e3f61dd7b56dbff43bba7144df939c03f0f66 , but that commit forgot to remove it in `pyspark.pandas.tests.indexes.test_datetime`, so `test_properties` and its parity test are tested twice.


### Why are the changes needed?
deduplicate test


### Does this PR introduce _any_ user-facing change?
no, test-only


### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no
