### PR TITLE
[SPARK-46409][CONNECT] Fix spark-connect-scala-client launch script

### DIFF
--- a/connector/connect/bin/spark-connect-scala-client
+++ b/connector/connect/bin/spark-connect-scala-client
@@ -52,4 +52,22 @@ if [ -z "$SCCLASSPATH" ]; then
   SCCLASSPATH=$(connector/connect/bin/spark-connect-scala-client-classpath)
 fi
 
-exec java -cp "$SCCLASSPATH" org.apache.spark.sql.application.ConnectRepl "$@"
+JVM_ARGS="-XX:+IgnoreUnrecognizedVMOptions \
+  --add-opens=java.base/java.lang=ALL-UNNAMED \
+  --add-opens=java.base/java.lang.invoke=ALL-UNNAMED \
+  --add-opens=java.base/java.lang.reflect=ALL-UNNAMED \
+  --add-opens=java.base/java.io=ALL-UNNAMED \
+  --add-opens=java.base/java.net=ALL-UNNAMED \
+  --add-opens=java.base/java.nio=ALL-UNNAMED \
+  --add-opens=java.base/java.util=ALL-UNNAMED \
+  --add-opens=java.base/java.util.concurrent=ALL-UNNAMED \
+  --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED \
+  --add-opens=java.base/jdk.internal.ref=ALL-UNNAMED \
+  --add-opens=java.base/sun.nio.ch=ALL-UNNAMED \
+  --add-opens=java.base/sun.nio.cs=ALL-UNNAMED \
+  --add-opens=java.base/sun.security.action=ALL-UNNAMED \
+  --add-opens=java.base/sun.util.calendar=ALL-UNNAMED \
+  --add-opens=java.security.jgss/sun.security.krb5=ALL-UNNAMED \
+  -Djdk.reflect.useDirectMethodHandle=false "
+
+exec java $JVM_ARGS -cp "$SCCLASSPATH" org.apache.spark.sql.application.ConnectRepl "$@"


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently, ClosureCleaner integration with SparkConnect is breaking Scala UDFs, as ClosureCleaner relies heavily on using reflection, which has some compatibility issues with Java 17. This PR adds a couple of options to Spark Connect Scala Client launch script to fix this issue.

### Why are the changes needed?
To make Spark Connect Scala Client work with Scala UDFs


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Manually run SparkConnect with java 17 and tested that I can run Scala UDF


### Was this patch authored or co-authored using generative AI tooling?
No