### PR TITLE
[SPARK-46422][PS][TESTS] Move `test_window` to `pyspark.pandas.tests.window.*`

### DIFF
--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -760,6 +760,7 @@ pyspark_pandas = Module(
         "pyspark.pandas.tests.reshape.test_get_dummies_object",
         "pyspark.pandas.tests.reshape.test_get_dummies_prefix",
         "pyspark.pandas.tests.reshape.test_merge_asof",
+        "pyspark.pandas.tests.window.test_missing",
         "pyspark.pandas.tests.window.test_rolling",
         "pyspark.pandas.tests.window.test_rolling_adv",
         "pyspark.pandas.tests.window.test_rolling_count",
@@ -776,7 +777,6 @@ pyspark_pandas = Module(
         "pyspark.pandas.tests.test_sql",
         "pyspark.pandas.tests.test_typedef",
         "pyspark.pandas.tests.test_utils",
-        "pyspark.pandas.tests.test_window",
     ],
     excluded_python_implementations=[
         "PyPy"  # Skip these tests under PyPy since they require numpy, pandas, and pyarrow and
@@ -1032,7 +1032,6 @@ pyspark_pandas_connect_part0 = Module(
         "pyspark.pandas.tests.connect.test_parity_sql",
         "pyspark.pandas.tests.connect.test_parity_typedef",
         "pyspark.pandas.tests.connect.test_parity_utils",
-        "pyspark.pandas.tests.connect.test_parity_window",
         "pyspark.pandas.tests.connect.indexes.test_parity_base",
         "pyspark.pandas.tests.connect.indexes.test_parity_align",
         "pyspark.pandas.tests.connect.indexes.test_parity_indexing",
@@ -1144,6 +1143,7 @@ pyspark_pandas_connect_part2 = Module(
         "pyspark.pandas.tests.connect.window.test_parity_ewm_error",
         "pyspark.pandas.tests.connect.window.test_parity_ewm_mean",
         "pyspark.pandas.tests.connect.window.test_parity_groupby_ewm_mean",
+        "pyspark.pandas.tests.connect.window.test_parity_missing",
         "pyspark.pandas.tests.connect.window.test_parity_rolling",
         "pyspark.pandas.tests.connect.window.test_parity_rolling_adv",
         "pyspark.pandas.tests.connect.window.test_parity_rolling_count",

--- a/python/pyspark/pandas/tests/connect/window/test_parity_missing.py
+++ b/python/pyspark/pandas/tests/connect/window/test_parity_missing.py
@@ -16,19 +16,21 @@
 #
 import unittest
 
-from pyspark.pandas.tests.test_window import ExpandingRollingTestsMixin
+from pyspark.pandas.tests.window.test_missing import MissingMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase
-from pyspark.testing.pandasutils import PandasOnSparkTestUtils, TestUtils
+from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
-class ExpandingRollingParityTests(
-    ExpandingRollingTestsMixin, PandasOnSparkTestUtils, TestUtils, ReusedConnectTestCase
+class MissingParityTests(
+    MissingMixin,
+    PandasOnSparkTestUtils,
+    ReusedConnectTestCase,
 ):
     pass
 
 
 if __name__ == "__main__":
-    from pyspark.pandas.tests.connect.test_parity_window import *  # noqa: F401
+    from pyspark.pandas.tests.connect.window.test_parity_missing import *  # noqa: F401
 
     try:
         import xmlrunner  # type: ignore[import]

--- a/python/pyspark/pandas/tests/window/test_missing.py
+++ b/python/pyspark/pandas/tests/window/test_missing.py
@@ -27,10 +27,10 @@ from pyspark.pandas.missing.window import (
     MissingPandasLikeExponentialMoving,
     MissingPandasLikeExponentialMovingGroupby,
 )
-from pyspark.testing.pandasutils import PandasOnSparkTestCase, TestUtils
+from pyspark.testing.pandasutils import PandasOnSparkTestCase
 
 
-class ExpandingRollingTestsMixin:
+class MissingMixin:
     def test_missing(self):
         psdf = ps.DataFrame({"a": [1, 2, 3, 4, 5, 6, 7, 8, 9]})
 
@@ -448,13 +448,16 @@ class ExpandingRollingTestsMixin:
                 getattr(psdf.a.ewm(com=0.5), name)()  # Series
 
 
-class ExpandingRollingTests(ExpandingRollingTestsMixin, PandasOnSparkTestCase, TestUtils):
+class MissingTests(
+    MissingMixin,
+    PandasOnSparkTestCase,
+):
     pass
 
 
 if __name__ == "__main__":
     import unittest
-    from pyspark.pandas.tests.test_window import *  # noqa: F401
+    from pyspark.pandas.tests.window.test_missing import *  # noqa: F401
 
     try:
         import xmlrunner


### PR DESCRIPTION
### What changes were proposed in this pull request?
1, Move `test_window` to `pyspark.pandas.tests.window.*`
2, rename to `test_missing`


### Why are the changes needed?
we use `pyspark.pandas.tests.window.*` to place all window-related tests;
`test_window` is confusing, it just test the missing stuffs


### Does this PR introduce _any_ user-facing change?
no, test-only


### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no