### PR TITLE
[MINOR][SQL][PYTHON] Rename Python plan node names

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -551,7 +551,7 @@ class SparkConnectPlanner(
               baseRel,
               isBarrier)
           case PythonEvalType.SQL_MAP_ARROW_ITER_UDF =>
-            logical.PythonMapInArrow(
+            logical.MapInArrow(
               pythonUdf,
               DataTypeUtils.toAttributes(pythonUdf.dataType.asInstanceOf[StructType]),
               baseRel,

--- a/python/pyspark/sql/pandas/map_ops.py
+++ b/python/pyspark/sql/pandas/map_ops.py
@@ -220,7 +220,7 @@ class PandasMapOpsMixin:
             func, returnType=schema, functionType=PythonEvalType.SQL_MAP_ARROW_ITER_UDF
         )  # type: ignore[call-overload]
         udf_column = udf(*[self[col] for col in self.columns])
-        jdf = self._jdf.pythonMapInArrow(udf_column._jc.expr(), barrier)
+        jdf = self._jdf.mapInArrow(udf_column._jc.expr(), barrier)
         return DataFrame(jdf, self.sparkSession)
 
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -748,7 +748,7 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
             !o.isInstanceOf[Generate] &&
             !o.isInstanceOf[CreateVariable] &&
             !o.isInstanceOf[MapInPandas] &&
-            !o.isInstanceOf[PythonMapInArrow] &&
+            !o.isInstanceOf[MapInArrow] &&
             // Lateral join is checked in checkSubqueryExpression.
             !o.isInstanceOf[LateralJoin] =>
             // The rule above is used to check Aggregate operator.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/DeduplicateRelations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/DeduplicateRelations.scala
@@ -151,8 +151,8 @@ object DeduplicateRelations extends Rule[LogicalPlan] {
         _.output.map(_.exprId.id),
         newMap => newMap.copy(output = newMap.output.map(_.newInstance())))
 
-    case p: PythonMapInArrow =>
-      deduplicateAndRenew[PythonMapInArrow](
+    case p: MapInArrow =>
+      deduplicateAndRenew[MapInArrow](
         existingRelations,
         p,
         _.output.map(_.exprId.id),
@@ -388,7 +388,7 @@ object DeduplicateRelations extends Rule[LogicalPlan] {
         newVersion.copyTagsFrom(oldVersion)
         Seq((oldVersion, newVersion))
 
-      case oldVersion @ PythonMapInArrow(_, output, _, _)
+      case oldVersion @ MapInArrow(_, output, _, _)
         if oldVersion.outputSet.intersect(conflictingAttributes).nonEmpty =>
         val newVersion = oldVersion.copy(output = output.map(_.newInstance()))
         newVersion.copyTagsFrom(oldVersion)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/pythonLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/pythonLogicalOperators.scala
@@ -89,7 +89,7 @@ case class MapInPandas(
  * Map partitions using a udf: iter(pyarrow.RecordBatch) -> iter(pyarrow.RecordBatch).
  * This is used by DataFrame.mapInArrow() in PySpark
  */
-case class PythonMapInArrow(
+case class MapInArrow(
     functionExpr: Expression,
     output: Seq[Attribute],
     child: LogicalPlan,
@@ -97,7 +97,7 @@ case class PythonMapInArrow(
 
   override val producedAttributes = AttributeSet(output)
 
-  override protected def withNewChildInternal(newChild: LogicalPlan): PythonMapInArrow =
+  override protected def withNewChildInternal(newChild: LogicalPlan): MapInArrow =
     copy(child = newChild)
 }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
@@ -741,7 +741,7 @@ class AnalysisSuite extends AnalysisTest with Matchers {
       false)
     val output = DataTypeUtils.toAttributes(pythonUdf.dataType.asInstanceOf[StructType])
     val project = Project(Seq(UnresolvedAttribute("a")), testRelation)
-    val mapInArrow = PythonMapInArrow(
+    val mapInArrow = MapInArrow(
       pythonUdf,
       output,
       project,

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -3554,7 +3554,7 @@ class Dataset[T] private[sql](
   private[sql] def pythonMapInArrow(func: PythonUDF, isBarrier: Boolean = false): DataFrame = {
     Dataset.ofRows(
       sparkSession,
-      PythonMapInArrow(
+      MapInArrow(
         func,
         toAttributes(func.dataType.asInstanceOf[StructType]),
         logicalPlan,

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -3551,7 +3551,7 @@ class Dataset[T] private[sql](
    * defines a transformation: `iter(pyarrow.RecordBatch)` -> `iter(pyarrow.RecordBatch)`.
    * Each partition is each iterator consisting of `pyarrow.RecordBatch`s as batches.
    */
-  private[sql] def pythonMapInArrow(func: PythonUDF, isBarrier: Boolean = false): DataFrame = {
+  private[sql] def mapInArrow(func: PythonUDF, isBarrier: Boolean = false): DataFrame = {
     Dataset.ofRows(
       sparkSession,
       MapInArrow(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -839,7 +839,7 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
       case logical.MapInPandas(func, output, child, isBarrier) =>
         execution.python.MapInPandasExec(func, output, planLater(child), isBarrier) :: Nil
       case logical.PythonMapInArrow(func, output, child, isBarrier) =>
-        execution.python.PythonMapInArrowExec(func, output, planLater(child), isBarrier) :: Nil
+        execution.python.MapInArrowExec(func, output, planLater(child), isBarrier) :: Nil
       case logical.AttachDistributedSequence(attr, child) =>
         execution.python.AttachDistributedSequenceExec(attr, planLater(child)) :: Nil
       case logical.MapElements(f, _, _, objAttr, child) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -838,7 +838,7 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
           func, output, planLater(left), planLater(right)) :: Nil
       case logical.MapInPandas(func, output, child, isBarrier) =>
         execution.python.MapInPandasExec(func, output, planLater(child), isBarrier) :: Nil
-      case logical.PythonMapInArrow(func, output, child, isBarrier) =>
+      case logical.MapInArrow(func, output, child, isBarrier) =>
         execution.python.MapInArrowExec(func, output, planLater(child), isBarrier) :: Nil
       case logical.AttachDistributedSequence(attr, child) =>
         execution.python.AttachDistributedSequenceExec(attr, planLater(child)) :: Nil

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/FlatMapCoGroupsInArrowExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/FlatMapCoGroupsInArrowExec.scala
@@ -48,7 +48,7 @@ case class FlatMapCoGroupsInArrowExec(
     output: Seq[Attribute],
     left: SparkPlan,
     right: SparkPlan)
-  extends FlatMapCoGroupsInPythonExec {
+  extends FlatMapCoGroupsInBatchExec {
 
   protected val pythonEvalType: Int = PythonEvalType.SQL_COGROUPED_MAP_ARROW_UDF
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/FlatMapCoGroupsInBatchExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/FlatMapCoGroupsInBatchExec.scala
@@ -31,7 +31,7 @@ import org.apache.spark.sql.execution.python.PandasGroupUtils._
 /**
  * Base class for Python-based FlatMapCoGroupsIn*Exec.
  */
-trait FlatMapCoGroupsInPythonExec extends SparkPlan with BinaryExecNode with PythonSQLMetrics {
+trait FlatMapCoGroupsInBatchExec extends SparkPlan with BinaryExecNode with PythonSQLMetrics {
   val leftGroup: Seq[Attribute]
   val rightGroup: Seq[Attribute]
   val func: Expression

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/FlatMapCoGroupsInPandasExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/FlatMapCoGroupsInPandasExec.scala
@@ -48,7 +48,7 @@ case class FlatMapCoGroupsInPandasExec(
     output: Seq[Attribute],
     left: SparkPlan,
     right: SparkPlan)
-  extends FlatMapCoGroupsInPythonExec {
+  extends FlatMapCoGroupsInBatchExec {
 
   protected val pythonEvalType: Int = PythonEvalType.SQL_COGROUPED_MAP_PANDAS_UDF
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/FlatMapGroupsInArrowExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/FlatMapGroupsInArrowExec.scala
@@ -46,7 +46,7 @@ case class FlatMapGroupsInArrowExec(
     func: Expression,
     output: Seq[Attribute],
     child: SparkPlan)
-  extends FlatMapGroupsInPythonExec {
+  extends FlatMapGroupsInBatchExec {
 
   protected val pythonEvalType: Int = PythonEvalType.SQL_GROUPED_MAP_ARROW_UDF
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/FlatMapGroupsInBatchExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/FlatMapGroupsInBatchExec.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.types.StructType
 /**
  * Base class for Python-based FlatMapGroupsIn*Exec.
  */
-trait FlatMapGroupsInPythonExec extends SparkPlan with UnaryExecNode with PythonSQLMetrics {
+trait FlatMapGroupsInBatchExec extends SparkPlan with UnaryExecNode with PythonSQLMetrics {
   val groupingAttributes: Seq[Attribute]
   val func: Expression
   val output: Seq[Attribute]

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/FlatMapGroupsInPandasExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/FlatMapGroupsInPandasExec.scala
@@ -44,7 +44,7 @@ case class FlatMapGroupsInPandasExec(
     func: Expression,
     output: Seq[Attribute],
     child: SparkPlan)
-  extends FlatMapGroupsInPythonExec {
+  extends FlatMapGroupsInBatchExec {
 
   protected val pythonEvalType: Int = PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/MapInArrowExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/MapInArrowExec.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.execution.SparkPlan
  * A relation produced by applying a function that takes an iterator of PyArrow's record batches
  * and outputs an iterator of PyArrow's record batches.
  */
-case class PythonMapInArrowExec(
+case class MapInArrowExec(
     func: Expression,
     output: Seq[Attribute],
     child: SparkPlan,
@@ -34,6 +34,6 @@ case class PythonMapInArrowExec(
 
   override protected val pythonEvalType: Int = PythonEvalType.SQL_MAP_ARROW_ITER_UDF
 
-  override protected def withNewChildInternal(newChild: SparkPlan): PythonMapInArrowExec =
+  override protected def withNewChildInternal(newChild: SparkPlan): MapInArrowExec =
     copy(child = newChild)
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a sort of a followup of https://github.com/apache/spark/pull/38624 that proposes to rename the plan nodes for Python as below:

From:

```
package org.apache.spark.sql.execution.python

MapInBatchExec
├── MapInPandasExec
└── *PythonMapInArrowExec* (and *PythonMapInArrow*)

*FlatMapCoGroupsInPythonExec*
├── FlatMapCoGroupsInArrowExec
└── FlatMapCoGroupsInPandasExec

*FlatMapGroupsInPythonExec*
├── FlatMapGroupsInArrowExec
└── FlatMapGroupsInPandasExec
```

To:

```
package org.apache.spark.sql.execution.python

MapInBatchExec
├── MapInPandasExec
└── *MapInArrowExec* (and *MapInArrow*)

*FlatMapCoGroupsInBatchExec*
├── FlatMapCoGroupsInArrowExec
└── FlatMapCoGroupsInPandasExec

*FlatMapGroupsInBatchExec*
├── FlatMapGroupsInArrowExec
└── FlatMapGroupsInPandasExec
```

### Why are the changes needed?

To have the consistent names for Python related execution nodes.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing CI should pass.

### Was this patch authored or co-authored using generative AI tooling?

No.