### PR TITLE
[SPARK-46427][PYTHON][SQL] Change Python Data Source's description to be pretty in explain

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/UserDefinedPythonDataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/UserDefinedPythonDataSource.scala
@@ -101,6 +101,8 @@ class PythonTableProvider extends TableProvider {
             new PythonPartitionReaderFactory(
               source, readerFunc, outputSchema, jobArtifactUUID)
           }
+
+          override def description: String = "(Python)"
         }
       }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR implements `Scan.description` so it has a better string description in `DataFrame.explain`.

```python
spark.table("pythonSourceTable").explain(True)
```

Before:

```
== Physical Plan ==
*(1) Project [x#0, y#1]
+- BatchScan test[x#0, y#1] class org.apache.spark.sql.execution.python.PythonTableProvider$$anon$1$$anon$2 RuntimeFilters: []
```

After:

```
== Physical Plan ==
*(1) Project [x#0, y#1]
+- BatchScan test[x#0, y#1] (Python) RuntimeFilters: []
```

### Why are the changes needed?

Now it shows the class name for nested classes, which isn't quite pretty.

### Does this PR introduce _any_ user-facing change?

It changes the plan description but the main change has not been released out yet. So no.

### How was this patch tested?

Manually tested as above.

### Was this patch authored or co-authored using generative AI tooling?

No.