### PR TITLE
[SPARK-46431][SS] Convert `IllegalStateException` to `internalError` in session iterators

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/MergingSessionsIterator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/MergingSessionsIterator.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.execution.aggregate
 
+import org.apache.spark.SparkException
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, GenericInternalRow, JoinedRow, MutableProjection, NamedExpression, SpecificInternalRow, UnsafeProjection, UnsafeRow}
 import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
@@ -155,7 +156,7 @@ class MergingSessionsIterator(
       if (currentGroupingKey == groupingKey) {
         if (sessionStart < getSessionStart(currentSession)) {
           errorOnIterator = true
-          throw new IllegalStateException("Input iterator is not sorted based on session!")
+          throw SparkException.internalError("Input iterator is not sorted based on session!")
         } else if (sessionStart <= getSessionEnd(currentSession)) {
           // expanding session length if needed
           expandEndOfCurrentSession(sessionEnd)
@@ -208,7 +209,7 @@ class MergingSessionsIterator(
 
   override final def hasNext: Boolean = {
     if (errorOnIterator) {
-      throw new IllegalStateException("The iterator is already corrupted.")
+      throw SparkException.internalError("The iterator is already corrupted.")
     }
     sortedInputHasNewGroup
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/UpdatingSessionsIterator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/UpdatingSessionsIterator.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.execution.aggregate
 
 import scala.collection.mutable
 
+import org.apache.spark.SparkException
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.codegen.GenerateUnsafeProjection
@@ -173,7 +174,7 @@ class UpdatingSessionsIterator(
 
   private def handleBrokenPreconditionForSort(): Unit = {
     errorOnIterator = true
-    throw new IllegalStateException("The iterator must be sorted by key and session start!")
+    throw SparkException.internalError("The iterator must be sorted by key and session start!")
   }
 
   private val join = new JoinedRow
@@ -215,7 +216,7 @@ class UpdatingSessionsIterator(
 
   private def assertIteratorNotCorrupted(): Unit = {
     if (errorOnIterator) {
-      throw new IllegalStateException("The iterator is already corrupted.")
+      throw SparkException.internalError("The iterator is already corrupted.")
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/UpdatingSessionsIteratorSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/UpdatingSessionsIteratorSuite.scala
@@ -266,18 +266,27 @@ class UpdatingSessionsIteratorSuite extends SharedSparkSession {
     assert(iterator.hasNext)
 
     // when calling next() it can detect error and throws IllegalStateException
-    intercept[IllegalStateException] {
-      iterator.next()
-    }
+    checkError(
+      exception = intercept[SparkException] {
+        iterator.next()
+      },
+      errorClass = "INTERNAL_ERROR",
+      parameters = Map("message" -> "The iterator must be sorted by key and session start!"))
 
     // afterwards, calling either hasNext() or next() will throw IllegalStateException
-    intercept[IllegalStateException] {
-      iterator.hasNext
-    }
+    checkError(
+      exception = intercept[SparkException] {
+        iterator.hasNext
+      },
+      errorClass = "INTERNAL_ERROR",
+      parameters = Map("message" -> "The iterator is already corrupted."))
 
-    intercept[IllegalStateException] {
-      iterator.next()
-    }
+    checkError(
+      exception = intercept[SparkException] {
+        iterator.next()
+      },
+      errorClass = "INTERNAL_ERROR",
+      parameters = Map("message" -> "The iterator is already corrupted."))
   }
 
   test("throws exception if data is not sorted by key") {
@@ -299,18 +308,27 @@ class UpdatingSessionsIteratorSuite extends SharedSparkSession {
     // second row itself is OK but while finding end of session it reads third row, and finds
     // its key is already finished processing, hence precondition for sorting is broken, and
     // it throws IllegalStateException
-    intercept[IllegalStateException] {
-      iterator.next()
-    }
+    checkError(
+      exception = intercept[SparkException] {
+        iterator.next()
+      },
+      errorClass = "INTERNAL_ERROR",
+      parameters = Map("message" -> "The iterator must be sorted by key and session start!"))
 
     // afterwards, calling either hasNext() or next() will throw IllegalStateException
-    intercept[IllegalStateException] {
-      iterator.hasNext
-    }
+    checkError(
+      exception = intercept[SparkException] {
+        iterator.hasNext
+      },
+      errorClass = "INTERNAL_ERROR",
+      parameters = Map("message" -> "The iterator is already corrupted."))
 
-    intercept[IllegalStateException] {
-      iterator.next()
-    }
+    checkError(
+      exception = intercept[SparkException] {
+        iterator.next()
+      },
+      errorClass = "INTERNAL_ERROR",
+      parameters = Map("message" -> "The iterator is already corrupted."))
   }
 
   test("no key") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to convert `IllegalStateException` in the two classes `UpdatingSessionsIterator` and `MergingSessionsIterator` to `SparkException.internalError`.

### Why are the changes needed?
To improve user experience with Spark SQL by unifying the error messages, and apply the same approach as in other sub-systems.

### Does this PR introduce _any_ user-facing change?
No, the exceptions shouldn't be visible to users in regular cases.

### How was this patch tested?
By running the modified test suites:
```
$ build/sbt "test:testOnly *UpdatingSessionsIteratorSuite"
$ build/sbt "test:testOnly *MergingSessionsIteratorSuite"
```

### Was this patch authored or co-authored using generative AI tooling?
No.