### PR TITLE
[SPARK-45231][INFRA][FOLLOWUP] Remove unrecognized and meaningless command about Ammonite from the GA testing workflow.

### DIFF
--- a/.github/workflows/maven_test.yml
+++ b/.github/workflows/maven_test.yml
@@ -174,7 +174,7 @@ jobs:
         shell: 'script -q -e -c "bash {0}"'
         run: |
           # Fix for TTY related issues when launching the Ammonite REPL in tests.
-          export TERM=vt100 && script -qfc 'echo exit | amm -s' && rm typescript
+          export TERM=vt100
           # `set -e` to make the exit status as expected due to use `script -q -e -c` to run the commands
           set -e
           export MAVEN_OPTS="-Xss64m -Xmx4g -Xms4g -XX:ReservedCodeCacheSize=128m -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN"


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr is followup https://github.com/apache/spark/pull/42993

### Why are the changes needed?
Remove unrecognized and meaningless command about Ammonite from the GA testing workflow.


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
