### PR TITLE
[SPARK-45993][INFRA] scalac: remove deprecated option -target

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2974,7 +2974,7 @@
               <arg>-deprecation</arg>
               <arg>-feature</arg>
               <arg>-explaintypes</arg>
-              <arg>-target:17</arg>
+              <arg>-release:17</arg>
               <arg>-Wconf:cat=deprecation:wv,any:e</arg>
               <arg>-Wunused:imports</arg>
               <arg>-Wconf:cat=scaladoc:wv</arg>
@@ -3016,7 +3016,7 @@
             <javacArgs>
               <javacArg>-source</javacArg>
               <javacArg>${java.version}</javacArg>
-              <javacArg>-target</javacArg>
+              <javacArg>-release</javacArg>
               <javacArg>${java.version}</javacArg>
               <javacArg>-Xlint:all,-serial,-path,-try</javacArg>
             </javacArgs>

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -326,7 +326,7 @@ object SparkBuild extends PomBuild {
     ),
 
     (Compile / scalacOptions) ++= Seq(
-      s"-target:${javaVersion.value}",
+      s"-release:${javaVersion.value}",
       "-sourcepath", (ThisBuild / baseDirectory).value.getAbsolutePath  // Required for relative source links in scaladoc
     ),
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR changes the option provided to scalac from `-target`, which is deprecated, to `-release`.

### Why are the changes needed?

This PR eliminates a bunch of warning that are emitted during compilation that look like this:

```
[warn] -target is deprecated: Use -release instead to compile against the correct platform API.
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

```
./build/sbt -Phive -Phive-thriftserver clean package
./build/mvn -Phive -Phive-thriftserver -DskipTests clean package
```

Both of these command run successfully and without emitting the above mentioned warning.

### Was this patch authored or co-authored using generative AI tooling?

No.