### PR TITLE
[SPARK-46435][INFRA] Exclude `branch-3.3` from `publish_snapshot.yml`

### DIFF
--- a/.github/workflows/publish_snapshot.yml
+++ b/.github/workflows/publish_snapshot.yml
@@ -28,7 +28,7 @@ on:
         description: 'list of branches to publish (JSON)'
         required: true
         # keep in sync with default value of strategy matrix 'branch'
-        default: '["master", "branch-3.5", "branch-3.4", "branch-3.3"]'
+        default: '["master", "branch-3.5", "branch-3.4"]'
 
 jobs:
   publish-snapshot:
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         # keep in sync with default value of workflow_dispatch input 'branch'
-        branch: ${{ fromJSON( inputs.branch || '["master", "branch-3.5", "branch-3.4", "branch-3.3"]' ) }}
+        branch: ${{ fromJSON( inputs.branch || '["master", "branch-3.5", "branch-3.4"]' ) }}
     steps:
     - name: Checkout Spark repository
       uses: actions/checkout@v4
@@ -52,13 +52,13 @@ jobs:
         restore-keys: |
           snapshot-maven-
     - name: Install Java 8 for branch-3.x
-      if: matrix.branch == 'branch-3.5' || matrix.branch == 'branch-3.4' || matrix.branch == 'branch-3.3'
+      if: matrix.branch == 'branch-3.5' || matrix.branch == 'branch-3.4'
       uses: actions/setup-java@v4
       with:
         distribution: temurin
         java-version: 8
     - name: Install Java 17
-      if: matrix.branch != 'branch-3.5' && matrix.branch != 'branch-3.4' && matrix.branch != 'branch-3.3'
+      if: matrix.branch != 'branch-3.5' && matrix.branch != 'branch-3.4'
       uses: actions/setup-java@v4
       with:
         distribution: temurin


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to exclude `branch-3.3` from `publish_snapshot.yml`.

### Why are the changes needed?

We don't need to publish the snapshot of branch-3.3 because it reached the End-Of-Life status.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.