### PR TITLE
[SPARK-46437][DOCS] Remove cruft from the built-in SQL functions documentation

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,1 +1,2 @@
 generated-*.html
+_generated_function_html/

--- a/docs/sql-ref-functions-builtin.md
+++ b/docs/sql-ref-functions-builtin.md
@@ -17,202 +17,105 @@ license: |
   limitations under the License.
 ---
 
-{% for static_file in site.static_files %}
-    {% if static_file.name == 'generated-agg-funcs-table.html' %}
+* Table of contents
+{:toc}
+
 ### Aggregate Functions
 {% include_relative generated-agg-funcs-table.html %}
 #### Examples
 {% include_relative generated-agg-funcs-examples.html %}
-        {% break %}
-    {% endif %}
-{% endfor %}
 
-{% for static_file in site.static_files %}
-    {% if static_file.name == 'generated-window-funcs-table.html' %}
 ### Window Functions
 {% include_relative generated-window-funcs-table.html %}
 #### Examples
 {% include_relative generated-window-funcs-examples.html %}
-        {% break %}
-    {% endif %}
-{% endfor %}
 
-{% for static_file in site.static_files %}
-    {% if static_file.name == 'generated-array-funcs-table.html' %}
 ### Array Functions
 {% include_relative generated-array-funcs-table.html %}
 #### Examples
 {% include_relative generated-array-funcs-examples.html %}
-        {% break %}
-    {% endif %}
-{% endfor %}
 
-{% for static_file in site.static_files %}
-{% if static_file.name == 'generated-collection-funcs-table.html' %}
 ### Collection Functions
 {% include_relative generated-collection-funcs-table.html %}
 #### Examples
 {% include_relative generated-collection-funcs-examples.html %}
-{% break %}
-{% endif %}
-{% endfor %}
 
-{% for static_file in site.static_files %}
-{% if static_file.name == 'generated-struct-funcs-table.html' %}
 ### STRUCT Functions
 {% include_relative generated-struct-funcs-table.html %}
 #### Examples
 {% include_relative generated-struct-funcs-examples.html %}
-{% break %}
-{% endif %}
-{% endfor %}
 
-{% for static_file in site.static_files %}
-    {% if static_file.name == 'generated-map-funcs-table.html' %}
 ### Map Functions
 {% include_relative generated-map-funcs-table.html %}
 #### Examples
 {% include_relative generated-map-funcs-examples.html %}
-        {% break %}
-    {% endif %}
-{% endfor %}
 
-{% for static_file in site.static_files %}
-    {% if static_file.name == 'generated-datetime-funcs-table.html' %}
 ### Date and Timestamp Functions
 {% include_relative generated-datetime-funcs-table.html %}
 #### Examples
 {% include_relative generated-datetime-funcs-examples.html %}
-        {% break %}
-    {% endif %}
-{% endfor %}
 
-{% for static_file in site.static_files %}
-    {% if static_file.name == 'generated-math-funcs-table.html' %}
 ### Mathematical Functions
 {% include_relative generated-math-funcs-table.html %}
 #### Examples
 {% include_relative generated-math-funcs-examples.html %}
-        {% break %}
-    {% endif %}
-{% endfor %}
 
-{% for static_file in site.static_files %}
-    {% if static_file.name == 'generated-string-funcs-table.html' %}
 ### String Functions
 {% include_relative generated-string-funcs-table.html %}
 #### Examples
 {% include_relative generated-string-funcs-examples.html %}
-        {% break %}
-    {% endif %}
-{% endfor %}
 
-{% for static_file in site.static_files %}
-    {% if static_file.name == 'generated-conditional-funcs-table.html' %}
 ### Conditional Functions
 {% include_relative generated-conditional-funcs-table.html %}
 #### Examples
 {% include_relative generated-conditional-funcs-examples.html %}
-        {% break %}
-    {% endif %}
-{% endfor %}
 
-{% for static_file in site.static_files %}
-{% if static_file.name == 'generated-hash-funcs-table.html' %}
 ### Hash Functions
 {% include_relative generated-hash-funcs-table.html %}
 #### Examples
 {% include_relative generated-hash-funcs-examples.html %}
-{% break %}
-{% endif %}
-{% endfor %}
 
-{% for static_file in site.static_files %}
-{% if static_file.name == 'generated-csv-funcs-table.html' %}
 ### CSV Functions
 {% include_relative generated-csv-funcs-table.html %}
 #### Examples
 {% include_relative generated-csv-funcs-examples.html %}
-{% break %}
-{% endif %}
-{% endfor %}
 
-{% for static_file in site.static_files %}
-{% if static_file.name == 'generated-json-funcs-table.html' %}
 ### JSON Functions
 {% include_relative generated-json-funcs-table.html %}
 #### Examples
 {% include_relative generated-json-funcs-examples.html %}
-{% break %}
-{% endif %}
-{% endfor %}
 
-{% for static_file in site.static_files %}
-{% if static_file.name == 'generated-xml-funcs-table.html' %}
 ### XML Functions
 {% include_relative generated-xml-funcs-table.html %}
 #### Examples
 {% include_relative generated-xml-funcs-examples.html %}
-{% break %}
-{% endif %}
-{% endfor %}
 
-{% for static_file in site.static_files %}
-{% if static_file.name == 'generated-url-funcs-table.html' %}
 ### URL Functions
 {% include_relative generated-url-funcs-table.html %}
 #### Examples
 {% include_relative generated-url-funcs-examples.html %}
-{% break %}
-{% endif %}
-{% endfor %}
 
-{% for static_file in site.static_files %}
-    {% if static_file.name == 'generated-bitwise-funcs-table.html' %}
 ### Bitwise Functions
 {% include_relative generated-bitwise-funcs-table.html %}
 #### Examples
 {% include_relative generated-bitwise-funcs-examples.html %}
-        {% break %}
-    {% endif %}
-{% endfor %}
 
-{% for static_file in site.static_files %}
-    {% if static_file.name == 'generated-conversion-funcs-table.html' %}
 ### Conversion Functions
 {% include_relative generated-conversion-funcs-table.html %}
 #### Examples
 {% include_relative generated-conversion-funcs-examples.html %}
-        {% break %}
-    {% endif %}
-{% endfor %}
 
-{% for static_file in site.static_files %}
-    {% if static_file.name == 'generated-predicate-funcs-table.html' %}
 ### Predicate Functions
 {% include_relative generated-predicate-funcs-table.html %}
 #### Examples
 {% include_relative generated-predicate-funcs-examples.html %}
-        {% break %}
-    {% endif %}
-{% endfor %}
 
-{% for static_file in site.static_files %}
-    {% if static_file.name == 'generated-misc-funcs-table.html' %}
 ### Misc Functions
 {% include_relative generated-misc-funcs-table.html %}
 #### Examples
 {% include_relative generated-misc-funcs-examples.html %}
-        {% break %}
-    {% endif %}
-{% endfor %}
 
-{% for static_file in site.static_files %}
-    {% if static_file.name == 'generated-generator-funcs-table.html' %}
 ### Generator Functions
 {% include_relative generated-generator-funcs-table.html %}
 #### Examples
 {% include_relative generated-generator-funcs-examples.html %}
-        {% break %}
-    {% endif %}
-{% endfor %}

--- a/docs/sql-ref-functions-builtin.md
+++ b/docs/sql-ref-functions-builtin.md
@@ -21,101 +21,101 @@ license: |
 {:toc}
 
 ### Aggregate Functions
-{% include_relative generated-agg-funcs-table.html %}
+{% include_relative _generated_function_html/agg-funcs-table.html %}
 #### Examples
-{% include_relative generated-agg-funcs-examples.html %}
+{% include_relative _generated_function_html/agg-funcs-examples.html %}
 
 ### Window Functions
-{% include_relative generated-window-funcs-table.html %}
+{% include_relative _generated_function_html/window-funcs-table.html %}
 #### Examples
-{% include_relative generated-window-funcs-examples.html %}
+{% include_relative _generated_function_html/window-funcs-examples.html %}
 
 ### Array Functions
-{% include_relative generated-array-funcs-table.html %}
+{% include_relative _generated_function_html/array-funcs-table.html %}
 #### Examples
-{% include_relative generated-array-funcs-examples.html %}
+{% include_relative _generated_function_html/array-funcs-examples.html %}
 
 ### Collection Functions
-{% include_relative generated-collection-funcs-table.html %}
+{% include_relative _generated_function_html/collection-funcs-table.html %}
 #### Examples
-{% include_relative generated-collection-funcs-examples.html %}
+{% include_relative _generated_function_html/collection-funcs-examples.html %}
 
 ### STRUCT Functions
-{% include_relative generated-struct-funcs-table.html %}
+{% include_relative _generated_function_html/struct-funcs-table.html %}
 #### Examples
-{% include_relative generated-struct-funcs-examples.html %}
+{% include_relative _generated_function_html/struct-funcs-examples.html %}
 
 ### Map Functions
-{% include_relative generated-map-funcs-table.html %}
+{% include_relative _generated_function_html/map-funcs-table.html %}
 #### Examples
-{% include_relative generated-map-funcs-examples.html %}
+{% include_relative _generated_function_html/map-funcs-examples.html %}
 
 ### Date and Timestamp Functions
-{% include_relative generated-datetime-funcs-table.html %}
+{% include_relative _generated_function_html/datetime-funcs-table.html %}
 #### Examples
-{% include_relative generated-datetime-funcs-examples.html %}
+{% include_relative _generated_function_html/datetime-funcs-examples.html %}
 
 ### Mathematical Functions
-{% include_relative generated-math-funcs-table.html %}
+{% include_relative _generated_function_html/math-funcs-table.html %}
 #### Examples
-{% include_relative generated-math-funcs-examples.html %}
+{% include_relative _generated_function_html/math-funcs-examples.html %}
 
 ### String Functions
-{% include_relative generated-string-funcs-table.html %}
+{% include_relative _generated_function_html/string-funcs-table.html %}
 #### Examples
-{% include_relative generated-string-funcs-examples.html %}
+{% include_relative _generated_function_html/string-funcs-examples.html %}
 
 ### Conditional Functions
-{% include_relative generated-conditional-funcs-table.html %}
+{% include_relative _generated_function_html/conditional-funcs-table.html %}
 #### Examples
-{% include_relative generated-conditional-funcs-examples.html %}
+{% include_relative _generated_function_html/conditional-funcs-examples.html %}
 
 ### Hash Functions
-{% include_relative generated-hash-funcs-table.html %}
+{% include_relative _generated_function_html/hash-funcs-table.html %}
 #### Examples
-{% include_relative generated-hash-funcs-examples.html %}
+{% include_relative _generated_function_html/hash-funcs-examples.html %}
 
 ### CSV Functions
-{% include_relative generated-csv-funcs-table.html %}
+{% include_relative _generated_function_html/csv-funcs-table.html %}
 #### Examples
-{% include_relative generated-csv-funcs-examples.html %}
+{% include_relative _generated_function_html/csv-funcs-examples.html %}
 
 ### JSON Functions
-{% include_relative generated-json-funcs-table.html %}
+{% include_relative _generated_function_html/json-funcs-table.html %}
 #### Examples
-{% include_relative generated-json-funcs-examples.html %}
+{% include_relative _generated_function_html/json-funcs-examples.html %}
 
 ### XML Functions
-{% include_relative generated-xml-funcs-table.html %}
+{% include_relative _generated_function_html/xml-funcs-table.html %}
 #### Examples
-{% include_relative generated-xml-funcs-examples.html %}
+{% include_relative _generated_function_html/xml-funcs-examples.html %}
 
 ### URL Functions
-{% include_relative generated-url-funcs-table.html %}
+{% include_relative _generated_function_html/url-funcs-table.html %}
 #### Examples
-{% include_relative generated-url-funcs-examples.html %}
+{% include_relative _generated_function_html/url-funcs-examples.html %}
 
 ### Bitwise Functions
-{% include_relative generated-bitwise-funcs-table.html %}
+{% include_relative _generated_function_html/bitwise-funcs-table.html %}
 #### Examples
-{% include_relative generated-bitwise-funcs-examples.html %}
+{% include_relative _generated_function_html/bitwise-funcs-examples.html %}
 
 ### Conversion Functions
-{% include_relative generated-conversion-funcs-table.html %}
+{% include_relative _generated_function_html/conversion-funcs-table.html %}
 #### Examples
-{% include_relative generated-conversion-funcs-examples.html %}
+{% include_relative _generated_function_html/conversion-funcs-examples.html %}
 
 ### Predicate Functions
-{% include_relative generated-predicate-funcs-table.html %}
+{% include_relative _generated_function_html/predicate-funcs-table.html %}
 #### Examples
-{% include_relative generated-predicate-funcs-examples.html %}
+{% include_relative _generated_function_html/predicate-funcs-examples.html %}
 
 ### Misc Functions
-{% include_relative generated-misc-funcs-table.html %}
+{% include_relative _generated_function_html/misc-funcs-table.html %}
 #### Examples
-{% include_relative generated-misc-funcs-examples.html %}
+{% include_relative _generated_function_html/misc-funcs-examples.html %}
 
 ### Generator Functions
-{% include_relative generated-generator-funcs-table.html %}
+{% include_relative _generated_function_html/generator-funcs-table.html %}
 #### Examples
-{% include_relative generated-generator-funcs-examples.html %}
+{% include_relative _generated_function_html/generator-funcs-examples.html %}

--- a/docs/sql-ref-functions-builtin.md
+++ b/docs/sql-ref-functions-builtin.md
@@ -22,100 +22,120 @@ license: |
 
 ### Aggregate Functions
 {% include_relative _generated_function_html/agg-funcs-table.html %}
-#### Examples
+
+**Examples**
 {% include_relative _generated_function_html/agg-funcs-examples.html %}
 
 ### Window Functions
 {% include_relative _generated_function_html/window-funcs-table.html %}
-#### Examples
+
+**Examples**
 {% include_relative _generated_function_html/window-funcs-examples.html %}
 
 ### Array Functions
 {% include_relative _generated_function_html/array-funcs-table.html %}
-#### Examples
+
+**Examples**
 {% include_relative _generated_function_html/array-funcs-examples.html %}
 
 ### Collection Functions
 {% include_relative _generated_function_html/collection-funcs-table.html %}
-#### Examples
+
+**Examples**
 {% include_relative _generated_function_html/collection-funcs-examples.html %}
 
 ### STRUCT Functions
 {% include_relative _generated_function_html/struct-funcs-table.html %}
-#### Examples
+
+**Examples**
 {% include_relative _generated_function_html/struct-funcs-examples.html %}
 
 ### Map Functions
 {% include_relative _generated_function_html/map-funcs-table.html %}
-#### Examples
+
+**Examples**
 {% include_relative _generated_function_html/map-funcs-examples.html %}
 
 ### Date and Timestamp Functions
 {% include_relative _generated_function_html/datetime-funcs-table.html %}
-#### Examples
+
+**Examples**
 {% include_relative _generated_function_html/datetime-funcs-examples.html %}
 
 ### Mathematical Functions
 {% include_relative _generated_function_html/math-funcs-table.html %}
-#### Examples
+
+**Examples**
 {% include_relative _generated_function_html/math-funcs-examples.html %}
 
 ### String Functions
 {% include_relative _generated_function_html/string-funcs-table.html %}
-#### Examples
+
+**Examples**
 {% include_relative _generated_function_html/string-funcs-examples.html %}
 
 ### Conditional Functions
 {% include_relative _generated_function_html/conditional-funcs-table.html %}
-#### Examples
+
+**Examples**
 {% include_relative _generated_function_html/conditional-funcs-examples.html %}
 
 ### Hash Functions
 {% include_relative _generated_function_html/hash-funcs-table.html %}
-#### Examples
+
+**Examples**
 {% include_relative _generated_function_html/hash-funcs-examples.html %}
 
 ### CSV Functions
 {% include_relative _generated_function_html/csv-funcs-table.html %}
-#### Examples
+
+**Examples**
 {% include_relative _generated_function_html/csv-funcs-examples.html %}
 
 ### JSON Functions
 {% include_relative _generated_function_html/json-funcs-table.html %}
-#### Examples
+
+**Examples**
 {% include_relative _generated_function_html/json-funcs-examples.html %}
 
 ### XML Functions
 {% include_relative _generated_function_html/xml-funcs-table.html %}
-#### Examples
+
+**Examples**
 {% include_relative _generated_function_html/xml-funcs-examples.html %}
 
 ### URL Functions
 {% include_relative _generated_function_html/url-funcs-table.html %}
-#### Examples
+
+**Examples**
 {% include_relative _generated_function_html/url-funcs-examples.html %}
 
 ### Bitwise Functions
 {% include_relative _generated_function_html/bitwise-funcs-table.html %}
-#### Examples
+
+**Examples**
 {% include_relative _generated_function_html/bitwise-funcs-examples.html %}
 
 ### Conversion Functions
 {% include_relative _generated_function_html/conversion-funcs-table.html %}
-#### Examples
+
+**Examples**
 {% include_relative _generated_function_html/conversion-funcs-examples.html %}
 
 ### Predicate Functions
 {% include_relative _generated_function_html/predicate-funcs-table.html %}
-#### Examples
+
+**Examples**
 {% include_relative _generated_function_html/predicate-funcs-examples.html %}
 
 ### Misc Functions
 {% include_relative _generated_function_html/misc-funcs-table.html %}
-#### Examples
+
+**Examples**
 {% include_relative _generated_function_html/misc-funcs-examples.html %}
 
 ### Generator Functions
 {% include_relative _generated_function_html/generator-funcs-table.html %}
-#### Examples
+
+**Examples**
 {% include_relative _generated_function_html/generator-funcs-examples.html %}

--- a/docs/sql-ref-functions.md
+++ b/docs/sql-ref-functions.md
@@ -20,7 +20,7 @@ license: |
 ---
 
 Spark SQL provides two function features to meet a wide range of user needs: built-in functions and user-defined functions (UDFs).
-Built-in functions are commonly used routines that Spark SQL predefines and a complete list of the functions can be found in the [Built-in Functions](api/sql/) API document. UDFs allow users to define their own functions when the system’s built-in functions are not enough to perform the desired task.
+Built-in functions are commonly used routines that Spark SQL predefines and a complete list of the functions can be found in the [Built-in Functions](api/sql/index.html) API document. UDFs allow users to define their own functions when the system’s built-in functions are not enough to perform the desired task.
 
 ### Built-in Functions
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Remove a bunch of Liquid directives that are not necessary.
- Add a table of contents to the built-in SQL functions page.
- Move the generated HTML for built-in SQL functions to a subdirectory.

### Why are the changes needed?

To reduce confusion for maintainers.

### Does this PR introduce _any_ user-facing change?

Yes. It adds a table of contents and change the heading style of the examples.

Otherwise, the generated docs are identical.

### How was this patch tested?

I built Spark, ran `./sql/create-docs.sh`, and reviewed the generated docs in my browser.

The page is too long to screenshot completely, but here are a couple of screenshots.

<img width="500" alt="Screenshot 2023-12-20 at 7 06 36 PM" src="https://github.com/apache/spark/assets/1039369/b285d8a2-6eab-488d-9e28-2fdc9cc833a9">
<img width="500" alt="Screenshot 2023-12-20 at 7 06 48 PM" src="https://github.com/apache/spark/assets/1039369/2f9670bc-773a-48a8-a0d0-54206b8a4887">

### Was this patch authored or co-authored using generative AI tooling?

No.