### PR TITLE
[SPARK-46448][SQL] InlineTable column should be nullable when converted to Decimal might cause null

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveInlineTables.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveInlineTables.scala
@@ -104,7 +104,7 @@ object ResolveInlineTables extends Rule[LogicalPlan]
         case d: DecimalType =>
           StructField(name, tpe,
             nullable = column.exists(_.nullable) ||
-              inputTypes.exists(t => Cast.canNullSafeCastToDecimal(t, d)))
+              inputTypes.exists(t => !Cast.canNullSafeCastToDecimal(t, d)))
         case _ => StructField(name, tpe, nullable = column.exists(_.nullable))
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -4714,7 +4714,7 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
     df5.crossJoin(df6)
   }
 
-  test("SPARK-46448: InlineTable column should be nullable when converted to Decimal might cause null") {
+  test("SPARK-46448: InlineTable column is nullable if converting to Decimal could be null") {
     val plan = sql("SELECT * FROM values(-0.172787979),(533704665545018957788294905796.5)")
     assert(plan.schema.fields.length == 1)
     assert(plan.schema.fields.head.nullable)

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -4713,6 +4713,12 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
     val df6 = df3.join(df2, col("df3.zaak_id") === col("df2.customer_id"), "outer")
     df5.crossJoin(df6)
   }
+
+  test("SPARK-46448: InlineTable column should be nullable when converted to Decimal might cause null") {
+    val plan = sql("SELECT * FROM values(-0.172787979),(533704665545018957788294905796.5)")
+    assert(plan.schema.fields.length == 1)
+    assert(plan.schema.fields.head.nullable)
+  }
 }
 
 case class Foo(bar: Option[String])


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
InlineTable column can also be nullable when there is type conversion to Decimal and it is not safe to be converted to null. So this PR updates the column nullability to true when there is type conversion to Decimal and the conversion is safe to make the new type null.

Note that given current implementation for conversion to Decimal, it is not likely null will happen, however because `canNullSafeCastToDecimal` still could return false so we need a defensive check for that case. 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This is to make the nullability behavior consistent after type conversion in InlineTable.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
NO

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
UT

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
NO