### PR TITLE
[SPARK-46454][SQL][DSTREAM] Remove redundant `.headOption`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/StructFilters.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/StructFilters.scala
@@ -95,7 +95,7 @@ object StructFilters {
   }
 
   private def zip[A, B](a: Option[A], b: Option[B]): Option[(A, B)] = {
-    a.zip(b).headOption
+    a.zip(b)
   }
 
   private def toLiteral(value: Any): Option[Literal] = {

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/BatchInfo.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/BatchInfo.scala
@@ -53,14 +53,14 @@ case class BatchInfo(
    * processing. Essentially, it is `processingEndTime` - `processingStartTime`.
    */
   def processingDelay: Option[Long] = processingEndTime.zip(processingStartTime)
-    .map(x => x._1 - x._2).headOption
+    .map(x => x._1 - x._2)
 
   /**
    * Time taken for all the jobs of this batch to finish processing from the time they
    * were submitted.  Essentially, it is `processingDelay` + `schedulingDelay`.
    */
   def totalDelay: Option[Long] = schedulingDelay.zip(processingDelay)
-    .map(x => x._1 + x._2).headOption
+    .map(x => x._1 + x._2)
 
   /**
    * The number of recorders received by the receivers in this batch.


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr just remove redundant `.headOption` due to ` Option(xxx).headOption` is a redundant call.

### Why are the changes needed?
Remove redundant `.headOption`


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No