### PR TITLE
[WIP] Fix bundler to 2.4.22 to unclock CI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -765,7 +765,7 @@ jobs:
         python3.9 -m pip install ipython_genutils # See SPARK-38517
         python3.9 -m pip install sphinx_plotly_directive 'numpy>=1.20.0' pyarrow pandas 'plotly>=4.8'
         python3.9 -m pip install 'docutils<0.18.0' # See SPARK-39421
-        gem install bundler
+        gem install bundler -v 2.4.22
         cd docs
         bundle install
     - name: R linter


### PR DESCRIPTION
### What changes were proposed in this pull request?

On pull request update / Build (pull_request_target) failed at "Install dependencies for documentation generation", as shown below
```
ERROR:  Error installing bundler:
	The last version of bundler (>= 0) to support your Ruby & RubyGems was 2.4.22. Try installing it with `gem install bundler -v 2.4.22`
	bundler requires Ruby version >= 3.0.0. The current ruby version is 2.7.0.0.
Error: Process completed with exit code 1.
```

Upgrading Ruby might affect other dependencies on the system, so I propose to fix the bundler version to unblock CI.

### Why are the changes needed?
Unblock On pull request update / Build (pull_request_target)


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Manual test.


### Was this patch authored or co-authored using generative AI tooling?
No.
