### PR TITLE
[SPARK-46460][Optimizer]The filter of partition including cast function may lead the partition pruning to disable

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -2150,20 +2150,33 @@ object OptimizeLimitZero extends Rule[LogicalPlan] {
 object EliminateCast extends Rule[LogicalPlan] {
   override def apply(plan: LogicalPlan): LogicalPlan =
     plan.transformAllExpressionsWithPruning(_.containsPattern(CAST)) {
-      case bc @ BinaryComparison(left @ Cast(child, _, tz, ae), right @ Literal(_, _)) =>
-        val value = Cast(right, child.dataType, tz, ae).eval(EmptyRow)
-        val clazz = bc.getClass
-        val mainCons = clazz.getConstructor(classOf[Expression], classOf[Expression])
-        mainCons.setAccessible(true)
-        mainCons.newInstance(child, Literal.create(value, child.dataType))
-          .asInstanceOf[bc.type]
-      case bc @ BinaryComparison(left @ Literal(_, _), right @ Cast(child, _, tz, ae)) =>
-        val value = Cast(left, child.dataType, tz, ae).eval(EmptyRow)
-        val clazz = bc.getClass
-        val mainCons = clazz.getConstructor(classOf[Expression], classOf[Expression])
-        mainCons.setAccessible(true)
-        mainCons.newInstance(Literal.create(value, child.dataType), child)
-        mainCons.newInstance(child, Literal.create(value, child.dataType))
-          .asInstanceOf[bc.type]
+      case bc @ BinaryComparison(left @ Cast(child, dt, tz, ae), right @ Literal(_, _)) =>
+        if (canEliminate(child.dataType, dt)) {
+          val value = Cast(right, child.dataType, tz, ae).eval(EmptyRow)
+          val clazz = bc.getClass
+          val mainCons = clazz.getConstructor(classOf[Expression], classOf[Expression])
+          mainCons.setAccessible(true)
+          mainCons.newInstance(child, Literal.create(value, child.dataType))
+            .asInstanceOf[bc.type]
+        } else {
+          bc
+        }
+
+      case bc @ BinaryComparison(left @ Literal(_, _), right @ Cast(child, dt, tz, ae)) =>
+        if (canEliminate(child.dataType, dt)) {
+          val value = Cast(left, child.dataType, tz, ae).eval(EmptyRow)
+          val clazz = bc.getClass
+          val mainCons = clazz.getConstructor(classOf[Expression], classOf[Expression])
+          mainCons.setAccessible(true)
+          mainCons.newInstance(Literal.create(value, child.dataType), child)
+          mainCons.newInstance(child, Literal.create(value, child.dataType))
+            .asInstanceOf[bc.type]
+        } else {
+          bc
+        }
     }
+  def canEliminate(row: DataType, target: DataType): Boolean = {
+    ! ((row.isInstanceOf[StringType] && target.isInstanceOf[NumericType]) ||
+      (target.isInstanceOf[StringType] && row.isInstanceOf[NumericType]))
+  }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkOptimizer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkOptimizer.scala
@@ -37,7 +37,8 @@ class SparkOptimizer(
 
   override def earlyScanPushDownRules: Seq[Rule[LogicalPlan]] =
     // TODO: move SchemaPruning into catalyst
-    SchemaPruning :: V2ScanRelationPushDown :: V2Writes :: PruneFileSourcePartitions :: Nil
+    SchemaPruning :: V2ScanRelationPushDown :: V2Writes ::
+      EliminateCast:: PruneFileSourcePartitions :: Nil
 
   override def defaultBatches: Seq[Batch] = (preOptimizationBatches ++ super.defaultBatches :+
     Batch("Optimize Metadata Only Query", Once, OptimizeMetadataOnlyQuery(catalog)) :+


### PR DESCRIPTION
### What changes were proposed in this pull request?
The filter of partition includes cast function may lead the partition pruning to disable. I supposed a new rule to fix it, but I am not sure if the rule is necessary.
The issue is open on JIRA. Link:[SPARK-46460](https://issues.apache.org/jira/browse/SPARK-46460)

### Why are the changes needed?
The changes can avoid filter condition failure caused by cast function.


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
UT

### Was this patch authored or co-authored using generative AI tooling?
no