### PR TITLE
[SPARK-46463][PS][TESTS] Reorganize `OpsOnDiffFramesGroupByExpandingTests`

### DIFF
--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -742,7 +742,9 @@ pyspark_pandas = Module(
         "pyspark.pandas.tests.test_internal",
         "pyspark.pandas.tests.test_namespace",
         "pyspark.pandas.tests.test_numpy_compat",
-        "pyspark.pandas.tests.test_ops_on_diff_frames_groupby_expanding",
+        "pyspark.pandas.tests.diff_frames_ops.test_groupby_expanding",
+        "pyspark.pandas.tests.diff_frames_ops.test_groupby_expanding_adv",
+        "pyspark.pandas.tests.diff_frames_ops.test_groupby_expanding_count",
         "pyspark.pandas.tests.test_ops_on_diff_frames_groupby_rolling",
         "pyspark.pandas.tests.test_repr",
         "pyspark.pandas.tests.resample.test_on",
@@ -1128,7 +1130,6 @@ pyspark_pandas_connect_part1 = Module(
         "pyspark.pandas.tests.connect.reshape.test_parity_get_dummies_object",
         "pyspark.pandas.tests.connect.reshape.test_parity_get_dummies_prefix",
         "pyspark.pandas.tests.connect.reshape.test_parity_merge_asof",
-        "pyspark.pandas.tests.connect.test_parity_ops_on_diff_frames_groupby_expanding",
     ],
     excluded_python_implementations=[
         "PyPy"  # Skip these tests under PyPy since they require numpy, pandas, and pyarrow and
@@ -1229,6 +1230,9 @@ pyspark_pandas_connect_part3 = Module(
         "pyspark.pandas.tests.connect.diff_frames_ops.test_parity_groupby_shift",
         "pyspark.pandas.tests.connect.diff_frames_ops.test_parity_groupby_split_apply_combine",
         "pyspark.pandas.tests.connect.diff_frames_ops.test_parity_groupby_transform",
+        "pyspark.pandas.tests.connect.diff_frames_ops.test_parity_groupby_expanding",
+        "pyspark.pandas.tests.connect.diff_frames_ops.test_parity_groupby_expanding_adv",
+        "pyspark.pandas.tests.connect.diff_frames_ops.test_parity_groupby_expanding_count",
     ],
     excluded_python_implementations=[
         "PyPy"  # Skip these tests under PyPy since they require numpy, pandas, and pyarrow and

--- a/python/pyspark/pandas/tests/connect/diff_frames_ops/test_parity_groupby_expanding.py
+++ b/python/pyspark/pandas/tests/connect/diff_frames_ops/test_parity_groupby_expanding.py
@@ -1,0 +1,41 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import unittest
+
+from pyspark.pandas.tests.diff_frames_ops.test_groupby_expanding import GroupByExpandingMixin
+from pyspark.testing.connectutils import ReusedConnectTestCase
+from pyspark.testing.pandasutils import PandasOnSparkTestUtils
+
+
+class GroupByExpandingParityTests(
+    GroupByExpandingMixin,
+    PandasOnSparkTestUtils,
+    ReusedConnectTestCase,
+):
+    pass
+
+
+if __name__ == "__main__":
+    from pyspark.pandas.tests.connect.diff_frames_ops.test_parity_groupby_expanding import *  # noqa
+
+    try:
+        import xmlrunner  # type: ignore[import]
+
+        testRunner = xmlrunner.XMLTestRunner(output="target/test-reports", verbosity=2)
+    except ImportError:
+        testRunner = None
+    unittest.main(testRunner=testRunner, verbosity=2)

--- a/python/pyspark/pandas/tests/connect/diff_frames_ops/test_parity_groupby_expanding_adv.py
+++ b/python/pyspark/pandas/tests/connect/diff_frames_ops/test_parity_groupby_expanding_adv.py
@@ -16,24 +16,21 @@
 #
 import unittest
 
-from pyspark.pandas.tests.test_ops_on_diff_frames_groupby_expanding import (
-    OpsOnDiffFramesGroupByExpandingTestsMixin,
-)
+from pyspark.pandas.tests.diff_frames_ops.test_groupby_expanding_adv import GroupByExpandingAdvMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase
-from pyspark.testing.pandasutils import PandasOnSparkTestUtils, TestUtils
+from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
-class OpsOnDiffFramesGroupByExpandingParityTests(
-    OpsOnDiffFramesGroupByExpandingTestsMixin,
+class GroupByExpandingAdvParityTests(
+    GroupByExpandingAdvMixin,
     PandasOnSparkTestUtils,
-    TestUtils,
     ReusedConnectTestCase,
 ):
     pass
 
 
 if __name__ == "__main__":
-    from pyspark.pandas.tests.connect.test_parity_ops_on_diff_frames_groupby_expanding import *
+    from pyspark.pandas.tests.connect.diff_frames_ops.test_parity_groupby_expanding_adv import *  # noqa
 
     try:
         import xmlrunner  # type: ignore[import]

--- a/python/pyspark/pandas/tests/connect/diff_frames_ops/test_parity_groupby_expanding_count.py
+++ b/python/pyspark/pandas/tests/connect/diff_frames_ops/test_parity_groupby_expanding_count.py
@@ -1,0 +1,43 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import unittest
+
+from pyspark.pandas.tests.diff_frames_ops.test_groupby_expanding_count import (
+    GroupByExpandingCountMixin,
+)
+from pyspark.testing.connectutils import ReusedConnectTestCase
+from pyspark.testing.pandasutils import PandasOnSparkTestUtils
+
+
+class GroupByExpandingCountParityTests(
+    GroupByExpandingCountMixin,
+    PandasOnSparkTestUtils,
+    ReusedConnectTestCase,
+):
+    pass
+
+
+if __name__ == "__main__":
+    from pyspark.pandas.tests.connect.diff_frames_ops.test_parity_groupby_expanding_count import *  # noqa
+
+    try:
+        import xmlrunner  # type: ignore[import]
+
+        testRunner = xmlrunner.XMLTestRunner(output="target/test-reports", verbosity=2)
+    except ImportError:
+        testRunner = None
+    unittest.main(testRunner=testRunner, verbosity=2)

--- a/python/pyspark/pandas/tests/diff_frames_ops/test_groupby_expanding.py
+++ b/python/pyspark/pandas/tests/diff_frames_ops/test_groupby_expanding.py
@@ -19,20 +19,11 @@ import pandas as pd
 
 from pyspark import pandas as ps
 from pyspark.pandas.config import set_option, reset_option
-from pyspark.testing.pandasutils import PandasOnSparkTestCase, TestUtils
+from pyspark.testing.pandasutils import PandasOnSparkTestCase
+from pyspark.testing.sqlutils import SQLTestUtils
 
 
-class OpsOnDiffFramesGroupByExpandingTestsMixin:
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        set_option("compute.ops_on_diff_frames", True)
-
-    @classmethod
-    def tearDownClass(cls):
-        reset_option("compute.ops_on_diff_frames")
-        super().tearDownClass()
-
+class GroupByExpandingTestingFuncMixin:
     def _test_groupby_expanding_func(self, f):
         pser = pd.Series([1, 2, 3])
         pkey = pd.Series([1, 2, 3], name="a")
@@ -63,8 +54,17 @@ class OpsOnDiffFramesGroupByExpandingTestsMixin:
             getattr(pdf.groupby(pkey)[["b"]].expanding(2), f)().sort_index(),
         )
 
-    def test_groupby_expanding_count(self):
-        self._test_groupby_expanding_func("count")
+
+class GroupByExpandingMixin(GroupByExpandingTestingFuncMixin):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        set_option("compute.ops_on_diff_frames", True)
+
+    @classmethod
+    def tearDownClass(cls):
+        reset_option("compute.ops_on_diff_frames")
+        super().tearDownClass()
 
     def test_groupby_expanding_min(self):
         self._test_groupby_expanding_func("min")
@@ -78,22 +78,18 @@ class OpsOnDiffFramesGroupByExpandingTestsMixin:
     def test_groupby_expanding_sum(self):
         self._test_groupby_expanding_func("sum")
 
-    def test_groupby_expanding_std(self):
-        self._test_groupby_expanding_func("std")
 
-    def test_groupby_expanding_var(self):
-        self._test_groupby_expanding_func("var")
-
-
-class OpsOnDiffFramesGroupByExpandingTests(
-    OpsOnDiffFramesGroupByExpandingTestsMixin, PandasOnSparkTestCase, TestUtils
+class GroupByExpandingTests(
+    GroupByExpandingMixin,
+    PandasOnSparkTestCase,
+    SQLTestUtils,
 ):
     pass
 
 
 if __name__ == "__main__":
     import unittest
-    from pyspark.pandas.tests.test_ops_on_diff_frames_groupby_expanding import *  # noqa: F401
+    from pyspark.pandas.tests.diff_frames_ops.test_groupby_expanding import *  # noqa
 
     try:
         import xmlrunner

--- a/python/pyspark/pandas/tests/diff_frames_ops/test_groupby_expanding_adv.py
+++ b/python/pyspark/pandas/tests/diff_frames_ops/test_groupby_expanding_adv.py
@@ -1,0 +1,62 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from pyspark.pandas.config import set_option, reset_option
+from pyspark.testing.pandasutils import PandasOnSparkTestCase
+from pyspark.testing.sqlutils import SQLTestUtils
+from pyspark.pandas.tests.diff_frames_ops.test_groupby_expanding import (
+    GroupByExpandingTestingFuncMixin,
+)
+
+
+class GroupByExpandingAdvMixin(GroupByExpandingTestingFuncMixin):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        set_option("compute.ops_on_diff_frames", True)
+
+    @classmethod
+    def tearDownClass(cls):
+        reset_option("compute.ops_on_diff_frames")
+        super().tearDownClass()
+
+    def test_groupby_expanding_std(self):
+        self._test_groupby_expanding_func("std")
+
+    def test_groupby_expanding_var(self):
+        self._test_groupby_expanding_func("var")
+
+
+class GroupByExpandingAdvTests(
+    GroupByExpandingAdvMixin,
+    PandasOnSparkTestCase,
+    SQLTestUtils,
+):
+    pass
+
+
+if __name__ == "__main__":
+    import unittest
+    from pyspark.pandas.tests.diff_frames_ops.test_groupby_expanding_adv import *  # noqa
+
+    try:
+        import xmlrunner
+
+        testRunner = xmlrunner.XMLTestRunner(output="target/test-reports", verbosity=2)
+    except ImportError:
+        testRunner = None
+    unittest.main(testRunner=testRunner, verbosity=2)

--- a/python/pyspark/pandas/tests/diff_frames_ops/test_groupby_expanding_count.py
+++ b/python/pyspark/pandas/tests/diff_frames_ops/test_groupby_expanding_count.py
@@ -1,0 +1,59 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from pyspark.pandas.config import set_option, reset_option
+from pyspark.testing.pandasutils import PandasOnSparkTestCase
+from pyspark.testing.sqlutils import SQLTestUtils
+from pyspark.pandas.tests.diff_frames_ops.test_groupby_expanding import (
+    GroupByExpandingTestingFuncMixin,
+)
+
+
+class GroupByExpandingCountMixin(GroupByExpandingTestingFuncMixin):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        set_option("compute.ops_on_diff_frames", True)
+
+    @classmethod
+    def tearDownClass(cls):
+        reset_option("compute.ops_on_diff_frames")
+        super().tearDownClass()
+
+    def test_groupby_expanding_count(self):
+        self._test_groupby_expanding_func("count")
+
+
+class GroupByExpandingCountTests(
+    GroupByExpandingCountMixin,
+    PandasOnSparkTestCase,
+    SQLTestUtils,
+):
+    pass
+
+
+if __name__ == "__main__":
+    import unittest
+    from pyspark.pandas.tests.diff_frames_ops.test_groupby_expanding_count import *  # noqa
+
+    try:
+        import xmlrunner
+
+        testRunner = xmlrunner.XMLTestRunner(output="target/test-reports", verbosity=2)
+    except ImportError:
+        testRunner = None
+    unittest.main(testRunner=testRunner, verbosity=2)


### PR DESCRIPTION
### What changes were proposed in this pull request?
break `OpsOnDiffFramesGroupByExpandingTests` into small tests


### Why are the changes needed?
for parallelism


### Does this PR introduce _any_ user-facing change?
no, test-only


### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no