### PR TITLE
[MINOR][PYTHON][DOCS] Fix typo in pyspark.sql.functions.greatest docstring

### DIFF
--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -5907,12 +5907,12 @@ def greatest(*cols: "ColumnOrName") -> Column:
     Parameters
     ----------
     col : :class:`~pyspark.sql.Column` or str
-        columns to check for gratest value.
+        columns to check for greatest value.
 
     Returns
     -------
     :class:`~pyspark.sql.Column`
-        gratest value.
+        greatest value.
 
     Examples
     --------


### PR DESCRIPTION
### What changes were proposed in this pull request?
The description of f.greatest had two small typos in them. This PR fixes these typos.

### Why are the changes needed?
Proper English should be used in documentation.

### Does this PR introduce _any_ user-facing change?
Yes, the correct english word is now used in the pyspark docs.

### How was this patch tested?
Not tested

### Was this patch authored or co-authored using generative AI tooling?
No
