### PR TITLE
[SPARK-46465][PYTHON][DOCS][FOLLOWUPS] Add `Column.isNaN` to API references

### DIFF
--- a/python/docs/source/reference/pyspark.sql/column.rst
+++ b/python/docs/source/reference/pyspark.sql/column.rst
@@ -46,6 +46,7 @@ Column
     Column.getField
     Column.getItem
     Column.ilike
+    Column.isNaN
     Column.isNotNull
     Column.isNull
     Column.isin


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add `Column.isNaN` to API references


### Why are the changes needed?
it's missing in https://github.com/apache/spark/pull/44422

### Does this PR introduce _any_ user-facing change?
yes, document


### How was this patch tested?
ci

### Was this patch authored or co-authored using generative AI tooling?
no
