### PR TITLE
[SPARK-46380][SQL][FOLLOWUP] Simplify the code for ResolveInlineTables and ResolveInlineTablesSuite

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveInlineTablesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveInlineTablesSuite.scala
@@ -86,8 +86,9 @@ class ResolveInlineTablesSuite extends AnalysisTest with BeforeAndAfter {
 
   test("cast and execute") {
     val table = UnresolvedInlineTable(Seq("c1"), Seq(Seq(lit(1)), Seq(lit(2L))))
-    val resolved = ResolveInlineTables.findCommonTypesAndCast(table)
-    val converted = ResolveInlineTables.earlyEvalIfPossible(resolved).asInstanceOf[LocalRelation]
+    val resolved = ResolveInlineTables(table)
+    assert(resolved.isInstanceOf[LocalRelation])
+    val converted = resolved.asInstanceOf[LocalRelation]
 
     assert(converted.output.map(_.dataType) == Seq(LongType))
     assert(converted.data.size == 2)
@@ -98,12 +99,11 @@ class ResolveInlineTablesSuite extends AnalysisTest with BeforeAndAfter {
   test("cast and execute CURRENT_LIKE expressions") {
     val table = UnresolvedInlineTable(Seq("c1"), Seq(
       Seq(CurrentTimestamp()), Seq(CurrentTimestamp())))
-    val casted = ResolveInlineTables.findCommonTypesAndCast(table)
-    val earlyEval = ResolveInlineTables.earlyEvalIfPossible(casted)
+    val resolved = ResolveInlineTables(table)
     // Early eval should keep it in expression form.
-    assert(earlyEval.isInstanceOf[ResolvedInlineTable])
+    assert(resolved.isInstanceOf[ResolvedInlineTable])
 
-    EvalInlineTables(ComputeCurrentTime(earlyEval)) match {
+    EvalInlineTables(ComputeCurrentTime(resolved)) match {
       case LocalRelation(output, data, _) =>
         assert(output.map(_.dataType) == Seq(TimestampType))
         assert(data.size == 2)


### PR DESCRIPTION
### What changes were proposed in this pull request?
https://github.com/apache/spark/pull/44316 replace current time/date prior to evaluating inline table expressions.
This PR propose to simplify the code for `ResolveInlineTables` and let `ResolveInlineTablesSuite` apply the rule `ResolveInlineTables`.


### Why are the changes needed?
Simplify the code for `ResolveInlineTables` and `ResolveInlineTablesSuite`.


### Does this PR introduce _any_ user-facing change?
'No'.


### How was this patch tested?
Test cases updated.
GA tests.


### Was this patch authored or co-authored using generative AI tooling?
'No'.
