### PR TITLE
[SPARK-46484][SQL][CONNECT] Retain `plan_id` in `ResolveUnpivot` and `UnpivotCoercion `

### DIFF
--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -963,6 +963,16 @@ class DataFrameTestsMixin:
             ):
                 df.unpivot("id", ["int", "str"], "var", "val").collect()
 
+    def test_unpivot_groupby(self):
+        df = self.spark.createDataFrame(
+            [(1, 11, 1.1), (2, 12, 1.2)],
+            ["id", "int", "double"],
+        )
+        self.assertEqual(
+            df.unpivot("id", ["int", "double"], "var", "val").groupBy("id").count().count(),
+            2,
+        )
+
     def test_observe(self):
         # SPARK-36263: tests the DataFrame.observe(Observation, *Column) method
         from pyspark.sql import Observation

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -963,13 +963,13 @@ class DataFrameTestsMixin:
             ):
                 df.unpivot("id", ["int", "str"], "var", "val").collect()
 
-    def test_unpivot_groupby(self):
+    def test_melt_groupby(self):
         df = self.spark.createDataFrame(
-            [(1, 11, 1.1), (2, 12, 1.2)],
-            ["id", "int", "double"],
+            [(1, 2, 3, 4, 5, 6)],
+            ["f1", "f2", "label", "pred", "model_version", "ts"],
         )
         self.assertEqual(
-            df.unpivot("id", ["int", "double"], "var", "val").groupBy("id").count().count(),
+            df.melt("model_version", ["label", "f2"], "f1", "f2").groupby("f1").count().count(),
             2,
         )
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -912,7 +912,8 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
 
       // TypeCoercionBase.UnpivotCoercion determines valueType
       // and casts values once values are set and resolved
-      case Unpivot(Some(ids), Some(values), aliases, variableColumnName, valueColumnNames, child) =>
+      case up @ Unpivot(Some(ids), Some(values), aliases,
+      variableColumnName, valueColumnNames, child) =>
 
         def toString(values: Seq[NamedExpression]): String =
           values.map(v => v.name).mkString("_")
@@ -938,7 +939,9 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
         val output = (ids.map(_.toAttribute) :+ variableAttr) ++ valueAttrs
 
         // expand the unpivot expressions
-        Expand(exprs, output, child)
+        val expand = Expand(exprs, output, child)
+        expand.copyTagsFrom(up)
+        expand
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -897,13 +897,18 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
         ids.forall(_.isInstanceOf[AttributeReference]) =>
         val idAttrs = AttributeSet(up.ids.get)
         val values = up.child.output.filterNot(idAttrs.contains)
-        up.copy(values = Some(values.map(Seq(_))))
+        val newUnpivot = up.copy(values = Some(values.map(Seq(_))))
+        newUnpivot.copyTagsFrom(up)
+        newUnpivot
+
       case up @ Unpivot(None, Some(values), _, _, _, _) if up.childrenResolved &&
         values.forall(_.forall(_.resolved)) &&
         values.forall(_.forall(_.isInstanceOf[AttributeReference])) =>
         val valueAttrs = AttributeSet(up.values.get.flatten)
         val ids = up.child.output.filterNot(valueAttrs.contains)
-        up.copy(ids = Some(ids))
+        val newUnpivot = up.copy(ids = Some(ids))
+        newUnpivot.copyTagsFrom(up)
+        newUnpivot
 
       case up: Unpivot if !up.childrenResolved || !up.ids.exists(_.forall(_.resolved)) ||
         !up.values.exists(_.nonEmpty) || !up.values.exists(_.forall(_.forall(_.resolved))) ||

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -223,7 +223,9 @@ abstract class TypeCoercionBase {
           }
         )
 
-        up.copy(values = Some(values))
+        val newUnpivot = up.copy(values = Some(values))
+        newUnpivot.copyTagsFrom(up)
+        newUnpivot
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Retain `plan_id` in `ResolveUnpivot` and `UnpivotCoercion`


### Why are the changes needed?
they drop the plan id and cause:
```
In [1]: df = spark.createDataFrame([(1, 2, 3, 4, 5, 6)], ["f1", "f2", "label", "pred", "model_version", "ts"])
   ...: df.melt("model_version", ["label", "f2"], "f1", "f2").groupby("f1").count().count()
23/12/22 11:37:52 WARN CheckAllocator: More than one DefaultAllocationManager on classpath. Choosing first found
---------------------------------------------------------------------------
AnalysisException                         Traceback (most recent call last)

...

AnalysisException: When resolving 'f1, fail to find subplan with plan_id=2 in 'Aggregate ['f1], ['f1, count(1) AS count#125L]
+- Expand [[model_version#117L, label, label#115L], [model_version#117L, f2, f2#114L]], [model_version#117L, f1#126, f2#127L]
   +- Project [f1#101L AS f1#113L, f2#102L AS f2#114L, label#103L AS label#115L, pred#104L AS pred#116L, model_version#105L AS model_version#117L, ts#106L AS ts#118L]
      +- LocalRelation [f1#101L, f2#102L, label#103L, pred#104L, model_version#105L, ts#106L]


JVM stacktrace:
org.apache.spark.sql.AnalysisException
	at org.apache.spark.sql.catalyst.analysis.ColumnResolutionHelper.$anonfun$resolveUnresolvedAttributeByPlanId$3(ColumnResolutionHelper.scala:521)
	at scala.Option.getOrElse(Option.scala:201)
	at org.apache.spark.sql.catalyst.analysis.ColumnResolutionHelper.$anonfun$resolveUnresolvedAttributeByPlanId$2(ColumnResolutionHelper.scala:516)
	at scala.collection.mutable.HashMap.getOrElseUpdate(HashMap.scala:469)
	at org.apache.spark.sql.catalyst.analysis.ColumnResolutionHelper.resolveUnresolvedAttributeByPlanId(ColumnResolutionHelper.scala:511)
	at org.apache.spark.sql.catalyst.analysis.ColumnResolutionHelper.tryResolveColumnByPlanId(ColumnResolutionHelper.scala:494)

```


### Does this PR introduce _any_ user-facing change?
yes, bug fix


### How was this patch tested?
added ut

### Was this patch authored or co-authored using generative AI tooling?
no
