### PR TITLE
[SPARK-46488][SQL] Skipping trimAll call during timestamp parsing

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/SparkDateTimeUtils.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/SparkDateTimeUtils.scala
@@ -363,8 +363,8 @@ trait SparkDateTimeUtils {
   }
 
   def stringToDateAnsi(
-                        s: UTF8String,
-                        context: QueryContext = null): Int = {
+      s: UTF8String,
+      context: QueryContext = null): Int = {
     stringToDate(s).getOrElse {
       throw ExecutionErrors.invalidInputInCastToDatetimeError(s, DateType, context)
     }
@@ -579,9 +579,9 @@ trait SparkDateTimeUtils {
   }
 
   def stringToTimestampAnsi(
-                             s: UTF8String,
-                             timeZoneId: ZoneId,
-                             context: QueryContext = null): Long = {
+      s: UTF8String,
+      timeZoneId: ZoneId,
+      context: QueryContext = null): Long = {
     stringToTimestamp(s, timeZoneId).getOrElse {
       throw ExecutionErrors.invalidInputInCastToDatetimeError(s, TimestampType, context)
     }

--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/SparkDateTimeUtils.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/SparkDateTimeUtils.scala
@@ -315,7 +315,8 @@ trait SparkDateTimeUtils {
     var currentSegmentValue = 0
     var currentSegmentDigits = 0
     val bytes = s.getBytes
-    var (j, strEndTrimmed) = getTrimmedStartEnd(bytes)
+    var j = getTrimmedStart(bytes)
+    val strEndTrimmed = getTrimmedEnd(j, bytes)
 
     if (j == strEndTrimmed) {
       return None
@@ -419,7 +420,8 @@ trait SparkDateTimeUtils {
     var currentSegmentValue = 0
     var currentSegmentDigits = 0
     val bytes = s.getBytes
-    var (j, strEndTrimmed) = getTrimmedStartEnd(bytes)
+    var j = getTrimmedStart(bytes)
+    val strEndTrimmed = getTrimmedEnd(j, bytes)
 
     if (j == strEndTrimmed) {
       return (Array.empty, None, false)
@@ -618,26 +620,36 @@ trait SparkDateTimeUtils {
   }
 
   /**
-   * This method retrieves the start and end indices of a byte array after trimming
-   * any whitespace or ISO control characters.
-   * This way we can avoid allocating a new string with trimAll method
-   * and just operate between the trimmed indices.
+   * Returns the index of the first non-whitespace and non-ISO control character in the byte array.
    *
-   * @param bytes The byte array to be trimmed.
-   * @return A tuple of two integers; first being the start and second the end trimmed index.
+   * @param bytes The byte array to be processed.
+   * @return The start index after trimming.
    */
-  private def getTrimmedStartEnd(bytes: Array[Byte]): (Int, Int) = {
-    var (start, end) = (0, bytes.length - 1)
+  @inline private def getTrimmedStart(bytes: Array[Byte]) = {
+    var start = 0
 
     while (start < bytes.length && UTF8String.isWhitespaceOrISOControl(bytes(start))) {
       start += 1
     }
 
+    start
+  }
+
+  /**
+   * Returns the index of the last non-whitespace and non-ISO control character in the byte array.
+   *
+   * @param start The starting index for the search.
+   * @param bytes The byte array to be processed.
+   * @return The end index after trimming.
+   */
+  @inline private def getTrimmedEnd(start: Int, bytes: Array[Byte]) = {
+    var end = bytes.length - 1
+
     while (end > start && UTF8String.isWhitespaceOrISOControl(bytes(end))) {
       end -= 1
     }
 
-    (start, end + 1)
+    end + 1
   }
 }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
@@ -350,7 +350,7 @@ class DateTimeUtilsSuite extends SparkFunSuite with Matchers with SQLHelper {
       }
 
       permuteWithWhitespaceAndControl(
-        "INVALID_INPUT", " ", "2015-03-18\u000312:03:17", "2015-03-18 12:", "2015-03-18 123"
+        "INVALID_INPUT", "\t", "", "2015-03-18\u000312:03:17", "2015-03-18 12:", "2015-03-18 123"
       ).foreach { s =>
         checkStringToTimestamp(s, None)
       }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
@@ -128,22 +128,25 @@ class DateTimeUtilsSuite extends SparkFunSuite with Matchers with SQLHelper {
   }
 
   test("SPARK-32559: string to date trim Control Characters") {
-    Seq("2015-03-18", "2015-03-18T123321", " 2015-03-18 123321", "+2015-03-18")
-      .foreach {
-        input => Seq(input, "\u0003", "\u0003", " ", " ")
-          .permutations.map(p => p.mkString).foreach {
-          s => assert(toDate(s).get === days(2015, 3, 18))
-        }
+    val expected = days(2015, 3, 18)
+    permuteWithWhitespaceAndControl(
+      "2015-03-18", "2015-03-18T123321", " 2015-03-18 123321", "+2015-03-18"
+    ).foreach { s =>
+      assert(toDate(s).get === expected)
     }
 
-    Seq("INVALID_INPUT", " ", "1999-08-", "2015-03-18\u0003123321", "2015-03-18Q123321")
-      .foreach {
-        input =>
-          Seq(input, "\u0003", "\u0003", " ", " ").permutations.map(p => p.mkString).foreach {
-            s => assert(toDate(s).isEmpty)
-          }
-      }
+    permuteWithWhitespaceAndControl(
+      "INVALID_INPUT", " ", "1999-08-", "2015-03-18\u0003123321", "2015-03-18Q123321"
+    ).foreach { s =>
+      assert(toDate(s).isEmpty)
+    }
   }
+
+  private def permuteWithWhitespaceAndControl(values: String*): Seq[String] =
+    values.flatMap { input =>
+      Seq(input, "\u0003", "\u0003", " ", " ")
+        .permutations.map(_.mkString)
+    }
 
   test("string to date") {
     assert(toDate("2015-01-28").get === days(2015, 1, 28))
@@ -337,6 +340,20 @@ class DateTimeUtilsSuite extends SparkFunSuite with Matchers with SQLHelper {
       zoneId = getZoneId("Europe/Moscow")
       expected = Option(date(2015, 3, 18, 12, 3, 17, 123456, zid = zoneId))
       checkStringToTimestamp("2015-03-18T12:03:17.123456 Europe/Moscow", expected)
+
+      // Check whitespace and control character permutations
+      expected = Option(date(2015, 3, 18, 12, 3, 17, zid = zid))
+      permuteWithWhitespaceAndControl(
+        "2015-03-18 12:03:17", "2015-03-18T12:03:17"
+      ).foreach { s =>
+        checkStringToTimestamp(s, expected)
+      }
+
+      permuteWithWhitespaceAndControl(
+        "INVALID_INPUT", " ", "2015-03-18\u000312:03:17", "2015-03-18 12:", "2015-03-18 123"
+      ).foreach { s =>
+        checkStringToTimestamp(s, None)
+      }
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR is a follow up to [46173](https://github.com/apache/spark/pull/44110) which added skipping the trimAll calls during date parsing.

Now I'm doing the same just for timestamp parsing.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
These changes should drastically improve edge case where input string in cast to date has many whitespace as prefix/sufix.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
I added the tests to check for cases with prefixes and suffixes of whitespaces and control chars.

Also there are benchmark tests in the previous [PR](https://github.com/apache/spark/pull/44110)

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No