### PR TITLE
[SPARK-46493][INFRA] Upgrade `apache-rat` in the `dev/check-license` to 0.15

### DIFF
--- a/dev/check-license
+++ b/dev/check-license
@@ -58,7 +58,7 @@ else
     declare java_cmd=java
 fi
 
-export RAT_VERSION=0.14
+export RAT_VERSION=0.15
 export rat_jar="$FWDIR"/lib/apache-rat-${RAT_VERSION}.jar
 mkdir -p "$FWDIR"/lib
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This ps upgraded `apache-rat` used in the `dev/check-license` from 0.14 to 0.15

### Why are the changes needed?
This new version brings some bug fix:

- [RAT-309](https://issues.apache.org/jira/browse/RAT-309) : Upgrade Maven Reporting API to 3.1.1/Complete with Maven Reporting Impl 3.2.0
- [RAT-307](https://issues.apache.org/jira/browse/RAT-307):  Update to focal (Ubuntu 20.04) on Travis to circumvent build errors and be able to use more modern JDK versions. Deprecate openJDK8 build with focal as it is not supported on Travis.

The full release notes as follow:
- https://creadur.apache.org/release-notes/RELEASE-NOTES-015.txt

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No