### PR TITLE
[SPARK-46494][SQL] Remove the parse rule of `First`, `Last` and `any_value`.

### DIFF
--- a/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
+++ b/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
@@ -991,9 +991,6 @@ primaryExpression
     | name=(CAST | TRY_CAST) LEFT_PAREN expression AS dataType RIGHT_PAREN                     #cast
     | primaryExpression DOUBLE_COLON dataType                                                  #castByColon
     | STRUCT LEFT_PAREN (argument+=namedExpression (COMMA argument+=namedExpression)*)? RIGHT_PAREN #struct
-    | FIRST LEFT_PAREN expression (IGNORE NULLS)? RIGHT_PAREN                                  #first
-    | ANY_VALUE LEFT_PAREN expression (IGNORE NULLS)? RIGHT_PAREN                              #any_value
-    | LAST LEFT_PAREN expression (IGNORE NULLS)? RIGHT_PAREN                                   #last
     | POSITION LEFT_PAREN substr=valueExpression IN str=valueExpression RIGHT_PAREN            #position
     | constant                                                                                 #constantDefault
     | ASTERISK exceptClause?                                                                   #star

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -36,7 +36,6 @@ import org.apache.spark.sql.catalyst.{FunctionIdentifier, SQLConfHelper, TableId
 import org.apache.spark.sql.catalyst.analysis._
 import org.apache.spark.sql.catalyst.catalog.{BucketSpec, CatalogStorageFormat, ClusterBySpec}
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.expressions.aggregate.{AnyValue, First, Last}
 import org.apache.spark.sql.catalyst.parser.SqlBaseParser._
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical._
@@ -2224,30 +2223,6 @@ class AstBuilder extends DataTypeAstBuilder with SQLConfHelper with Logging {
    */
   override def visitStruct(ctx: StructContext): Expression = withOrigin(ctx) {
     CreateStruct.create(ctx.argument.asScala.map(expression).toSeq)
-  }
-
-  /**
-   * Create a [[First]] expression.
-   */
-  override def visitFirst(ctx: FirstContext): Expression = withOrigin(ctx) {
-    val ignoreNullsExpr = ctx.IGNORE != null
-    First(expression(ctx.expression), ignoreNullsExpr).toAggregateExpression()
-  }
-
-  /**
-   * Create an [[AnyValue]] expression.
-   */
-  override def visitAny_value(ctx: Any_valueContext): Expression = withOrigin(ctx) {
-    val ignoreNullsExpr = ctx.IGNORE != null
-    AnyValue(expression(ctx.expression), ignoreNullsExpr).toAggregateExpression()
-  }
-
-  /**
-   * Create a [[Last]] expression.
-   */
-  override def visitLast(ctx: LastContext): Expression = withOrigin(ctx) {
-    val ignoreNullsExpr = ctx.IGNORE != null
-    Last(expression(ctx.expression), ignoreNullsExpr).toAggregateExpression()
   }
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR propose to remove the parse rule of `First`, `Last` and `any_value`.


### Why are the changes needed?
Spark have separate parse rule for `First`, `Last` and `any_value`.
In fact, the parse rule for general function call support works well.


### Does this PR introduce _any_ user-facing change?
'No'.


### How was this patch tested?
Exists test cases.


### Was this patch authored or co-authored using generative AI tooling?
'No'.
