### PR TITLE
[SPARK-46532][CONNECT] Pass message parameters in metadata of `ErrorInfo`

### DIFF
--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientE2ETestSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientE2ETestSuite.scala
@@ -85,7 +85,11 @@ class ClientE2ETestSuite extends RemoteSparkSession with SQLHelper with PrivateM
                 |""".stripMargin)
             .collect()
         }
-        assert(ex.getErrorClass != null)
+        assert(ex.getErrorClass ===
+          "INCONSISTENT_BEHAVIOR_CROSS_VERSION.PARSE_DATETIME_BY_NEW_PARSER")
+        assert(ex.getMessageParameters.asScala == Map(
+          "datetime" -> "'02-29'",
+          "config" -> "\"spark.sql.legacy.timeParserPolicy\""))
         if (enrichErrorEnabled) {
           assert(ex.getCause.isInstanceOf[DateTimeException])
         } else {

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientE2ETestSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientE2ETestSuite.scala
@@ -85,11 +85,13 @@ class ClientE2ETestSuite extends RemoteSparkSession with SQLHelper with PrivateM
                 |""".stripMargin)
             .collect()
         }
-        assert(ex.getErrorClass ===
-          "INCONSISTENT_BEHAVIOR_CROSS_VERSION.PARSE_DATETIME_BY_NEW_PARSER")
-        assert(ex.getMessageParameters.asScala == Map(
-          "datetime" -> "'02-29'",
-          "config" -> "\"spark.sql.legacy.timeParserPolicy\""))
+        assert(
+          ex.getErrorClass ===
+            "INCONSISTENT_BEHAVIOR_CROSS_VERSION.PARSE_DATETIME_BY_NEW_PARSER")
+        assert(
+          ex.getMessageParameters.asScala == Map(
+            "datetime" -> "'02-29'",
+            "config" -> "\"spark.sql.legacy.timeParserPolicy\""))
         if (enrichErrorEnabled) {
           assert(ex.getCause.isInstanceOf[DateTimeException])
         } else {

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/streaming/ClientStreamingQuerySuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/streaming/ClientStreamingQuerySuite.scala
@@ -178,9 +178,7 @@ class ClientStreamingQuerySuite extends QueryTest with SQLHelper with Logging {
   test("throw exception in streaming") {
     // Disable spark.sql.pyspark.jvmStacktrace.enabled to avoid hitting the
     // netty header limit.
-    withSQLConf(
-      "spark.sql.pyspark.jvmStacktrace.enabled" -> "false",
-      "spark.connect.grpc.maxMetadataSize" -> "0") {
+    withSQLConf("spark.sql.pyspark.jvmStacktrace.enabled" -> "false") {
       val session = spark
       import session.implicits._
 

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/streaming/ClientStreamingQuerySuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/streaming/ClientStreamingQuerySuite.scala
@@ -178,7 +178,9 @@ class ClientStreamingQuerySuite extends QueryTest with SQLHelper with Logging {
   test("throw exception in streaming") {
     // Disable spark.sql.pyspark.jvmStacktrace.enabled to avoid hitting the
     // netty header limit.
-    withSQLConf("spark.sql.pyspark.jvmStacktrace.enabled" -> "false") {
+    withSQLConf(
+      "spark.sql.pyspark.jvmStacktrace.enabled" -> "false",
+      "spark.connect.grpc.maxMetadataSize" -> "0") {
       val session = spark
       import session.implicits._
 

--- a/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/client/GrpcExceptionConverter.scala
+++ b/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/client/GrpcExceptionConverter.scala
@@ -372,10 +372,14 @@ private[client] object GrpcExceptionConverter {
       .addAllErrorTypeHierarchy(classes.toImmutableArraySeq.asJava)
 
     if (errorClass != null) {
+      val messageParameters = JsonMethods
+        .parse(info.getMetadataOrDefault("messageParameters", "{}"))
+        .extract[Map[String, String]]
       builder.setSparkThrowable(
         FetchErrorDetailsResponse.SparkThrowable
           .newBuilder()
           .setErrorClass(errorClass)
+          .putAllMessageParameters(messageParameters.asJava)
           .build())
     }
 

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
@@ -256,4 +256,13 @@ object Connect {
       .version("4.0.0")
       .booleanConf
       .createWithDefault(true)
+
+  val CONNECT_GRPC_MAX_METADATA_SIZE =
+    buildStaticConf("spark.connect.grpc.maxMetadataSize")
+      .doc(
+        "Sets the maximum size of metadata fields. For instance, it restricts metadata fields " +
+          "in `ErrorInfo`.")
+      .version("4.0.0")
+      .bytesConf(ByteUnit.BYTE)
+      .createWithDefault(1024)
 }

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/utils/ErrorUtils.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/utils/ErrorUtils.scala
@@ -182,8 +182,10 @@ private[connect] object ErrorUtils extends Logging {
         val errorClass = e.getErrorClass
         if (errorClass != null && errorClass.nonEmpty) {
           errorInfo.putMetadata("errorClass", errorClass)
-          errorInfo.putMetadata("messageParameters", JsonMethods.compact(JsonMethods.render(
-            map2jvalue(e.getMessageParameters.asScala.toMap))))
+          errorInfo.putMetadata(
+            "messageParameters",
+            JsonMethods.compact(
+              JsonMethods.render(map2jvalue(e.getMessageParameters.asScala.toMap))))
         }
       case _ =>
     }

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/utils/ErrorUtils.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/utils/ErrorUtils.scala
@@ -182,6 +182,8 @@ private[connect] object ErrorUtils extends Logging {
         val errorClass = e.getErrorClass
         if (errorClass != null && errorClass.nonEmpty) {
           errorInfo.putMetadata("errorClass", errorClass)
+          errorInfo.putMetadata("messageParameters", JsonMethods.compact(JsonMethods.render(
+            map2jvalue(e.getMessageParameters.asScala.toMap))))
         }
       case _ =>
     }

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/utils/ErrorUtils.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/utils/ErrorUtils.scala
@@ -66,8 +66,6 @@ private[connect] object ErrorUtils extends Logging {
   // The maximum length of the error chain.
   private[connect] val MAX_ERROR_CHAIN_LENGTH = 5
 
-  private val MAX_METADATA_FIELD_SIZE = 4 * 1024
-
   /**
    * Convert Throwable to a protobuf message FetchErrorDetailsResponse.
    * @param st

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/utils/ErrorUtils.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/utils/ErrorUtils.scala
@@ -174,6 +174,7 @@ private[connect] object ErrorUtils extends Logging {
         "classes",
         JsonMethods.compact(JsonMethods.render(allClasses(st.getClass).map(_.getName))))
 
+    val maxMetadataSize = SparkEnv.get.conf.get(Connect.CONNECT_GRPC_MAX_METADATA_SIZE)
     // Add the SQL State and Error Class to the response metadata of the ErrorInfoObject.
     st match {
       case e: SparkThrowable =>
@@ -185,7 +186,7 @@ private[connect] object ErrorUtils extends Logging {
         if (errorClass != null && errorClass.nonEmpty) {
           val messageParameters = JsonMethods.compact(
             JsonMethods.render(map2jvalue(e.getMessageParameters.asScala.toMap)))
-          if (messageParameters.length <= MAX_METADATA_FIELD_SIZE) {
+          if (messageParameters.length <= maxMetadataSize) {
             errorInfo.putMetadata("errorClass", errorClass)
             errorInfo.putMetadata("messageParameters", messageParameters)
           }
@@ -207,8 +208,10 @@ private[connect] object ErrorUtils extends Logging {
     val withStackTrace =
       if (sessionHolderOpt.exists(
           _.session.conf.get(SQLConf.PYSPARK_JVM_STACKTRACE_ENABLED) && stackTrace.nonEmpty)) {
-        val maxSize = SparkEnv.get.conf.get(Connect.CONNECT_JVM_STACK_TRACE_MAX_SIZE)
-        errorInfo.putMetadata("stackTrace", StringUtils.abbreviate(stackTrace.get, maxSize))
+        val maxSize = Math.min(
+          SparkEnv.get.conf.get(Connect.CONNECT_JVM_STACK_TRACE_MAX_SIZE),
+          maxMetadataSize)
+        errorInfo.putMetadata("stackTrace", StringUtils.abbreviate(stackTrace.get, maxSize.toInt))
       } else {
         errorInfo
       }

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/utils/ErrorUtils.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/utils/ErrorUtils.scala
@@ -183,8 +183,8 @@ private[connect] object ErrorUtils extends Logging {
         }
         val errorClass = e.getErrorClass
         if (errorClass != null && errorClass.nonEmpty) {
-          val messageParameters = JsonMethods.compact(JsonMethods.render(
-            map2jvalue(e.getMessageParameters.asScala.toMap)))
+          val messageParameters = JsonMethods.compact(
+            JsonMethods.render(map2jvalue(e.getMessageParameters.asScala.toMap)))
           if (messageParameters.length <= MAX_METADATA_FIELD_SIZE) {
             errorInfo.putMetadata("errorClass", errorClass)
             errorInfo.putMetadata("messageParameters", messageParameters)

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -3452,7 +3452,7 @@ class SparkConnectSessionTests(ReusedConnectTestCase):
         self.spark.stop()
         spark = (
             PySparkSession.builder.config(conf=self.conf())
-            .config("spark.connect.jvmStacktrace.maxSize", 128)
+            .config("spark.connect.grpc.maxMetadataSize", 128)
             .remote("local[4]")
             .getOrCreate()
         )


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to put message parameters together with an error class in the `messageParameter` field in metadata of `ErrorInfo`.

### Why are the changes needed?
To be able to create an error from an error class and message parameters. Before the changes, it is not possible to re-construct an error having only an error class.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By running the modified test:
```
$ build/sbt "connect-client-jvm/testOnly *ClientE2ETestSuite"
```

### Was this patch authored or co-authored using generative AI tooling?
No.