### PR TITLE
[MINOR][INFRA] Comments in GitHub scripts should start with #

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -260,8 +260,13 @@ jobs:
       env: ${{ fromJSON(inputs.envs) }}
       shell: 'script -q -e -c "bash {0}"'
       run: |
-        ls -al /home/runner/work/_temp/*
-        find /home/runner/work/_temp/ -maxdepth 1 -type f -size -1k -name "*-*-*-*-*" | xargs cat *
+        echo "1"
+        ls -al /home/runner/work/_temp
+        echo "2"
+        find /home/runner/work/_temp/ -maxdepth 1 -type f -size -5k -name "*"
+        echo "3"
+        find /home/runner/work/_temp/ -maxdepth 1 -type f -size -5k -name "*-*-*-*-*" | xargs cat
+        echo "4"
         # Fix for TTY related issues when launching the Ammonite REPL in tests.
         export TERM=vt100
         # Hive "other tests" test needs larger metaspace size based on experiment.

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -260,18 +260,11 @@ jobs:
       env: ${{ fromJSON(inputs.envs) }}
       shell: 'script -q -e -c "bash {0}"'
       run: |
-        echo "1"
-        ls -al /home/runner/work/_temp
-        echo "2"
-        find /home/runner/work/_temp/ -maxdepth 1 -type f -size -5k -name "*"
-        echo "3"
-        find /home/runner/work/_temp/ -maxdepth 1 -type f -size -5k -name "*-*-*-*-*" | xargs cat
-        echo "4"
         # Fix for TTY related issues when launching the Ammonite REPL in tests.
         export TERM=vt100
         # Hive "other tests" test needs larger metaspace size based on experiment.
         if [[ "$MODULES_TO_TEST" == "hive" ]] && [[ "$EXCLUDED_TAGS" == "org.apache.spark.tags.SlowHiveTest" ]]; then export METASPACE_SIZE=2g; fi
-        // SPARK-46283: should delete the following env replacement after SPARK 3.x EOL
+        # SPARK-46283: should delete the following env replacement after SPARK 3.x EOL
         if [[ "$MODULES_TO_TEST" == *"streaming-kinesis-asl"* ]] && [[ "${{ inputs.branch }}" =~ ^branch-3 ]]; then 
           MODULES_TO_TEST=${MODULES_TO_TEST//streaming-kinesis-asl, /}
         fi

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -261,6 +261,7 @@ jobs:
       shell: 'script -q -e -c "bash {0}"'
       run: |
         ls -al /home/runner/work/_temp/*
+        find /home/runner/work/_temp/ -name "*" -type file -depth 1 | xargs cat *
         # Fix for TTY related issues when launching the Ammonite REPL in tests.
         export TERM=vt100
         # Hive "other tests" test needs larger metaspace size based on experiment.

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -260,6 +260,7 @@ jobs:
       env: ${{ fromJSON(inputs.envs) }}
       shell: 'script -q -e -c "bash {0}"'
       run: |
+        ls -al /home/runner/work/_temp/*
         # Fix for TTY related issues when launching the Ammonite REPL in tests.
         export TERM=vt100
         # Hive "other tests" test needs larger metaspace size based on experiment.

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -261,7 +261,7 @@ jobs:
       shell: 'script -q -e -c "bash {0}"'
       run: |
         ls -al /home/runner/work/_temp/*
-        find /home/runner/work/_temp/ -name "*" -type file -depth 1 | xargs cat *
+        find /home/runner/work/_temp/ -name "*-*-*-*-*" -type file -depth 1 | xargs cat *
         # Fix for TTY related issues when launching the Ammonite REPL in tests.
         export TERM=vt100
         # Hive "other tests" test needs larger metaspace size based on experiment.

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -261,7 +261,7 @@ jobs:
       shell: 'script -q -e -c "bash {0}"'
       run: |
         ls -al /home/runner/work/_temp/*
-        find /home/runner/work/_temp/ -name "*-*-*-*-*" -type file -depth 1 | xargs cat *
+        find /home/runner/work/_temp/ -maxdepth 1 -type f -size -1k -name "*-*-*-*-*" | xargs cat *
         # Fix for TTY related issues when launching the Ammonite REPL in tests.
         export TERM=vt100
         # Hive "other tests" test needs larger metaspace size based on experiment.


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to fix a typo in github action script, `comments` in GitHub scripts should start with `#`.

### Why are the changes needed?
In the GitHub runtime logs, we often observe runtime prompts similar to the one below:
https://github.com/panbingkun/spark/actions/runs/7167111730/job/19513821177
https://github.com/panbingkun/spark/actions/runs/7167111730/job/19513823103
<img width="690" alt="image" src="https://github.com/apache/spark/assets/15246973/26d39f6c-e6e3-4887-9344-a8fa251a255e">
Although it does not affect the overall task execution, I think it is necessary to correct it.

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Manually test.


### Was this patch authored or co-authored using generative AI tooling?
No.
