### PR TITLE
[MINOR][DOCS] Python docs also require Pandoc

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -28,8 +28,7 @@ whichever version of Spark you currently have checked out of revision control.
 
 ## Prerequisites
 
-The Spark documentation build uses a number of tools to build HTML docs and API docs in Scala, Java,
-Python, R and SQL.
+The Spark documentation build uses a number of tools to build HTML docs and API docs in Scala, Java, Python, R, and SQL.
 
 You need to have [Ruby](https://www.ruby-lang.org/en/documentation/installation/) and
 [Python](https://docs.python.org/2/using/unix.html#getting-and-installing-the-latest-version-of-python)
@@ -48,6 +47,8 @@ $ bundle install
 
 Note: If you are on a system with both Ruby 1.9 and Ruby 2.0 you may need to replace gem with gem2.0.
 
+To generate the Python or R docs, you'll need to [install Pandoc](https://pandoc.org/installing.html).
+
 ### SQL and Python API Documentation (Optional)
 
 To generate SQL and Python API docs, you'll need to install these libraries:
@@ -59,8 +60,7 @@ $ pip install --upgrade -r dev/requirements.txt
 
 ### R API Documentation (Optional)
 
-If you'd like to generate R API documentation, you'll need to [install Pandoc](https://pandoc.org/installing.html)
-and install these libraries:
+If you'd like to generate R API documentation, install these libraries:
 
 ```sh
 $ sudo Rscript -e 'install.packages(c("knitr", "devtools", "testthat", "rmarkdown"), repos="https://cloud.r-project.org/")'


### PR DESCRIPTION
### What changes were proposed in this pull request?

Clarify in the README for building docs that the Python API docs also require Pandoc, not just R.

### Why are the changes needed?

Attempting to build the Python API docs without Pandoc installed will yield the following error:

```
reading sources... [  0%] getting_started/quickstart_connect                                                
Notebook error:
PandocMissing in getting_started/quickstart_connect.ipynb:
Pandoc wasn't found.
Please check that pandoc is installed:
https://pandoc.org/installing.html
make: *** [html] Error 2
                    ------------------------------------------------
      Jekyll 4.3.2   Please append `--trace` to the `build` command 
                     for any additional information or backtrace. 
                    ------------------------------------------------
.../spark/docs/_plugins/copy_api_dirs.rb:130:in `<top (required)>': Python doc generation failed (RuntimeError)
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Via trying to build the Python docs without Pandoc.

### Was this patch authored or co-authored using generative AI tooling?

No.