### PR TITLE
[MINOR][DOCS] Fix rst link in Python API docs for .sql()

### DIFF
--- a/python/pyspark/pandas/sql_formatter.py
+++ b/python/pyspark/pandas/sql_formatter.py
@@ -109,13 +109,13 @@ def sql(
     args : dict or list
         A dictionary of parameter names to Python objects or a list of Python objects
         that can be converted to SQL literal expressions. See
-        <a href="https://spark.apache.org/docs/latest/sql-ref-datatypes.html">
-        Supported Data Types</a> for supported value types in Python.
+        `Supported Data Types`_ for supported value types in Python.
         For example, dictionary keys: "rank", "name", "birthdate";
         dictionary values: 1, "Steven", datetime.date(2023, 4, 2).
         A value can be also a `Column` of a literal or collection constructor functions such
         as `map()`, `array()`, `struct()`, in that case it is taken as is.
 
+        .. _Supported Data Types: https://spark.apache.org/docs/latest/sql-ref-datatypes.html
 
         .. versionadded:: 3.4.0
 
@@ -176,7 +176,7 @@ def sql(
     1  2
     2  3
 
-    And substitude named parameters with the `:` prefix by SQL literals.
+    And substitute named parameters with the `:` prefix by SQL literals.
 
     >>> ps.sql("SELECT * FROM range(10) WHERE id > :bound1", args={"bound1":7})
        id

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -1548,12 +1548,13 @@ class SparkSession(SparkConversionMixin):
         args : dict or list
             A dictionary of parameter names to Python objects or a list of Python objects
             that can be converted to SQL literal expressions. See
-            <a href="https://spark.apache.org/docs/latest/sql-ref-datatypes.html">
-            Supported Data Types</a> for supported value types in Python.
+            `Supported Data Types`_ for supported value types in Python.
             For example, dictionary keys: "rank", "name", "birthdate";
             dictionary or list values: 1, "Steven", datetime.date(2023, 4, 2).
             A value can be also a `Column` of a literal or collection constructor functions such
             as `map()`, `array()`, `struct()`, in that case it is taken as is.
+
+            .. _Supported Data Types: https://spark.apache.org/docs/latest/sql-ref-datatypes.html
 
             .. versionadded:: 3.4.0
 
@@ -1631,7 +1632,7 @@ class SparkSession(SparkConversionMixin):
         |  3|  6|
         +---+---+
 
-        And substitude named parameters with the `:` prefix by SQL literals.
+        And substitute named parameters with the `:` prefix by SQL literals.
 
         >>> from pyspark.sql.functions import create_map
         >>> spark.sql(


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes the rst markup for a link in the documentation for `pyspark.sql.SparkSession.sql` and `pyspark.pandas.sql`.

### Why are the changes needed?

The current markup is incorrect.

Technically, though the markup in this PR is correct, the link target is incorrect. We should be linking to page relative to the site root, rather than hardcoding a link to `/latest/`. However, I could not figure out how to do that in rst, and building the API docs takes a really long time, and I could not make it build incrementally.

### Does this PR introduce _any_ user-facing change?

Yes, the markup goes from looking like this:

<img width="500" src="https://github.com/apache/spark/assets/1039369/077566a3-79df-4aa2-a0f7-d819f608f673">

To looking like this:

<img width="500" src="https://github.com/apache/spark/assets/1039369/b1453761-3f9c-435e-89e1-cfd3748cce9c">

### How was this patch tested?

I built the docs as follows:

```
SKIP_SCALADOC=1 SKIP_RDOC=1 SKIP_SQLDOC=1 bundle exec jekyll serve
```

And reviewed the output in my browser.

### Was this patch authored or co-authored using generative AI tooling?

No.