### PR TITLE
[SPARK-46510][CORE] Spark shell log filter should be applied to all AbstractAppender

### DIFF
--- a/common/utils/src/main/scala/org/apache/spark/internal/Logging.scala
+++ b/common/utils/src/main/scala/org/apache/spark/internal/Logging.scala
@@ -21,7 +21,7 @@ import scala.jdk.CollectionConverters._
 
 import org.apache.logging.log4j.{Level, LogManager}
 import org.apache.logging.log4j.core.{Filter, LifeCycle, LogEvent, Logger => Log4jLogger, LoggerContext}
-import org.apache.logging.log4j.core.appender.ConsoleAppender
+import org.apache.logging.log4j.core.appender.AbstractAppender
 import org.apache.logging.log4j.core.config.DefaultConfiguration
 import org.apache.logging.log4j.core.filter.AbstractFilter
 import org.slf4j.{Logger, LoggerFactory}
@@ -169,8 +169,8 @@ trait Logging {
           }
           Logging.sparkShellThresholdLevel = replLevel
           rootLogger.getAppenders().asScala.foreach {
-            case (_, ca: ConsoleAppender) =>
-              ca.addFilter(new SparkShellLoggingFilter())
+            case (_, appender: AbstractAppender) =>
+              appender.addFilter(new SparkShellLoggingFilter())
             case _ => // no-op
           }
         }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Current code `SparkShellLoggingFilter` only applied to `ConsoleAppender`, if we define `AsyncAppender` and ref to console appender it won't work. I think here we should apply  `SparkShellLoggingFilter` to all `AbstractAppender` since all of them support `addFilter()`


### Why are the changes needed?
Support more use case


### Does this PR introduce _any_ user-facing change?
User can use the feature of shell in all log4j configuration.

### How was this patch tested?
MT

### Was this patch authored or co-authored using generative AI tooling?
No