### PR TITLE
[SPARK-45914][PYTHON] Support commit and abort API for Python data source write 

### DIFF
--- a/python/pyspark/sql/tests/test_python_datasource.py
+++ b/python/pyspark/sql/tests/test_python_datasource.py
@@ -225,10 +225,25 @@ class BasePythonDataSourceTestsMixin:
         assertDataFrameEqual(df, [Row(x=0, y="0"), Row(x=1, y="1")])
         self.assertEqual(df.rdd.getNumPartitions(), 2)
 
-    def test_custom_json_data_source(self):
-        import json
+    def test_custom_json_data_source_read(self):
+        data_source = self._get_test_json_data_source()
+        self.spark.dataSource.register(data_source)
+        path1 = os.path.join(SPARK_HOME, "python/test_support/sql/people.json")
+        path2 = os.path.join(SPARK_HOME, "python/test_support/sql/people1.json")
+        assertDataFrameEqual(
+            self.spark.read.format("my-json").load(path1),
+            [Row(name="Michael", age=None), Row(name="Andy", age=30), Row(name="Justin", age=19)],
+        )
+        assertDataFrameEqual(
+            self.spark.read.format("my-json").load(path2),
+            [Row(name="Jonathan", age=None)],
+        )
 
-        class JsonDataSourceReader(DataSourceReader):
+    def _get_test_json_data_source(self):
+        import json
+        from dataclasses import dataclass
+
+        class TestJsonReader(DataSourceReader):
             def __init__(self, options):
                 self.options = options
 
@@ -242,18 +257,39 @@ class BasePythonDataSourceTestsMixin:
                             data = json.loads(line)
                             yield data.get("name"), data.get("age")
 
-        class JsonDataSourceWriter(DataSourceWriter):
+        @dataclass
+        class TestCommitMessage(WriterCommitMessage):
+            count: int
+
+        class TestJsonWriter(DataSourceWriter):
             def __init__(self, options):
                 self.options = options
+                self.path = self.options.get("path")
 
             def write(self, iterator):
-                path = self.options.get("path")
-                with open(path, "w") as file:
-                    for row in iterator:
-                        file.write(json.dumps(row.asDict()) + "\n")
-                return WriterCommitMessage()
+                from pyspark import TaskContext
 
-        class JsonDataSource(DataSource):
+                context = TaskContext.get()
+                output_path = f"{self.path}/{context.partitionId}.json"
+                count = 0
+                with open(output_path, "w") as file:
+                    for row in iterator:
+                        count += 1
+                        if "id" in row and row.id > 5:
+                            raise Exception("id > 5")
+                        file.write(json.dumps(row.asDict()) + "\n")
+                return TestCommitMessage(count=count)
+
+            def commit(self, messages):
+                total_count = sum(message.count for message in messages)
+                with open(self.path + "/_success.txt", "a") as file:
+                    file.write(f"count: {total_count}\n")
+
+            def abort(self, messages):
+                with open(f"{self.path}/_failed.txt", "a") as file:
+                    file.write("failed")
+
+        class TestJsonDataSource(DataSource):
             @classmethod
             def name(cls):
                 return "my-json"
@@ -262,35 +298,40 @@ class BasePythonDataSourceTestsMixin:
                 return "name STRING, age INT"
 
             def reader(self, schema) -> "DataSourceReader":
-                return JsonDataSourceReader(self.options)
+                return TestJsonReader(self.options)
 
             def writer(self, schema, overwrite):
-                return JsonDataSourceWriter(self.options)
+                return TestJsonWriter(self.options)
 
-        self.spark.dataSource.register(JsonDataSource)
-        # Test data source read.
-        path1 = os.path.join(SPARK_HOME, "python/test_support/sql/people.json")
-        path2 = os.path.join(SPARK_HOME, "python/test_support/sql/people1.json")
-        assertDataFrameEqual(
-            self.spark.read.format("my-json").load(path1),
-            [Row(name="Michael", age=None), Row(name="Andy", age=30), Row(name="Justin", age=19)],
-        )
-        assertDataFrameEqual(
-            self.spark.read.format("my-json").load(path2),
-            [Row(name="Jonathan", age=None)],
-        )
-        # Test data source write.
-        df = self.spark.read.json(path1)
+        return TestJsonDataSource
+
+    def test_custom_json_data_source_write(self):
+        data_source = self._get_test_json_data_source()
+        self.spark.dataSource.register(data_source)
+        input_path = os.path.join(SPARK_HOME, "python/test_support/sql/people.json")
+        df = self.spark.read.json(input_path)
         with tempfile.TemporaryDirectory() as d:
-            path = os.path.join(d, "res.json")
-            df.write.format("my-json").mode("append").save(path)
-            with open(path, "r") as file:
+            df.write.format("my-json").mode("append").save(d)
+            assertDataFrameEqual(self.spark.read.json(d), self.spark.read.json(input_path))
+
+    def test_custom_json_data_source_commit(self):
+        data_source = self._get_test_json_data_source()
+        self.spark.dataSource.register(data_source)
+        with tempfile.TemporaryDirectory() as d:
+            self.spark.range(0, 5, 1, 3).write.format("my-json").mode("append").save(d)
+            with open(os.path.join(d, "_success.txt"), "r") as file:
                 text = file.read()
-            assert text == (
-                '{"age": null, "name": "Michael"}\n'
-                '{"age": 30, "name": "Andy"}\n'
-                '{"age": 19, "name": "Justin"}\n'
-            )
+            assert text == "count: 5\n"
+
+    def test_custom_json_data_source_abort(self):
+        data_source = self._get_test_json_data_source()
+        self.spark.dataSource.register(data_source)
+        with tempfile.TemporaryDirectory() as d:
+            with self.assertRaises(PythonException):
+                self.spark.range(0, 8, 1, 3).write.format("my-json").mode("append").save(d)
+            with open(os.path.join(d, "_failed.txt"), "r") as file:
+                text = file.read()
+            assert text == "failed"
 
 
 class PythonDataSourceTests(BasePythonDataSourceTestsMixin, ReusedSQLTestCase):

--- a/python/pyspark/sql/worker/commit_data_source_write.py
+++ b/python/pyspark/sql/worker/commit_data_source_write.py
@@ -1,0 +1,121 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import os
+import sys
+from typing import IO
+
+from pyspark.accumulators import _accumulatorRegistry
+from pyspark.errors import PySparkAssertionError
+from pyspark.java_gateway import local_connect_and_auth
+from pyspark.serializers import (
+    read_bool,
+    read_int,
+    write_int,
+    SpecialLengths,
+)
+from pyspark.sql.datasource import DataSourceWriter, WriterCommitMessage
+from pyspark.util import handle_worker_exception
+from pyspark.worker_util import (
+    check_python_version,
+    pickleSer,
+    send_accumulator_updates,
+    setup_broadcasts,
+    setup_memory_limits,
+    setup_spark_files,
+)
+
+
+def main(infile: IO, outfile: IO) -> None:
+    """
+    Main method for committing or aborting a data source write operation.
+
+    This process is invoked from the `UserDefinedPythonDataSourceCommitRunner.runInPython`
+    method in the BatchWrite implementation of the PythonTableProvider. It is
+    responsible for invoking either the `commit` or the `abort` method on a data source
+    writer instance, given a list of commit messages.
+    """
+    try:
+        check_python_version(infile)
+
+        memory_limit_mb = int(os.environ.get("PYSPARK_PLANNER_MEMORY_MB", "-1"))
+        setup_memory_limits(memory_limit_mb)
+
+        setup_spark_files(infile)
+        setup_broadcasts(infile)
+
+        _accumulatorRegistry.clear()
+
+        # Receive the data source writer instance.
+        writer = pickleSer._read_with_length(infile)
+        if not isinstance(writer, DataSourceWriter):
+            raise PySparkAssertionError(
+                error_class="PYTHON_DATA_SOURCE_TYPE_MISMATCH",
+                message_parameters={
+                    "expected": "an instance of DataSourceWriter",
+                    "actual": f"'{type(writer).__name__}'",
+                },
+            )
+
+        # Receive the commit messages.
+        num_messages = read_int(infile)
+        commit_messages = []
+        for _ in range(num_messages):
+            message = pickleSer._read_with_length(infile)
+            if message is not None and not isinstance(message, WriterCommitMessage):
+                raise PySparkAssertionError(
+                    error_class="PYTHON_DATA_SOURCE_TYPE_MISMATCH",
+                    message_parameters={
+                        "expected": "an instance of WriterCommitMessage",
+                        "actual": f"'{type(message).__name__}'",
+                    },
+                )
+            commit_messages.append(message)
+
+        # Receive a boolean to indicate whether to invoke `abort`.
+        abort = read_bool(infile)
+
+        # Commit or abort the Python data source write.
+        # Note the commit messages can be None if there are failed tasks.
+        if abort:
+            writer.abort(commit_messages)  # type: ignore[arg-type]
+        else:
+            writer.commit(commit_messages)  # type: ignore[arg-type]
+
+        # Send a status code back to JVM.
+        write_int(0, outfile)
+
+    except BaseException as e:
+        handle_worker_exception(e, outfile)
+        sys.exit(-1)
+
+    send_accumulator_updates(outfile)
+
+    # check end of stream
+    if read_int(infile) == SpecialLengths.END_OF_STREAM:
+        write_int(SpecialLengths.END_OF_STREAM, outfile)
+    else:
+        # write a different value to tell JVM to not reuse this worker
+        write_int(SpecialLengths.END_OF_DATA_SECTION, outfile)
+        sys.exit(-1)
+
+
+if __name__ == "__main__":
+    # Read information about how to connect back to the JVM from the environment.
+    java_port = int(os.environ["PYTHON_WORKER_FACTORY_PORT"])
+    auth_secret = os.environ["PYTHON_WORKER_FACTORY_SECRET"]
+    (sock_file, _) = local_connect_and_auth(java_port, auth_secret)
+    main(sock_file, sock_file)

--- a/python/pyspark/sql/worker/write_into_data_source.py
+++ b/python/pyspark/sql/worker/write_into_data_source.py
@@ -211,6 +211,9 @@ def main(infile: IO, outfile: IO) -> None:
         command = (data_source_write_func, return_type)
         pickleSer._write_with_length(command, outfile)
 
+        # Return the picked writer.
+        pickleSer._write_with_length(writer, outfile)
+
     except BaseException as e:
         handle_worker_exception(e, outfile)
         sys.exit(-1)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonDataSourceSuite.scala
@@ -655,4 +655,94 @@ class PythonDataSourceSuite extends QueryTest with SharedSparkSession {
         Seq(Row(2)))
     }
   }
+
+  test("data source write commit and abort") {
+    assume(shouldTestPandasUDFs)
+    val dataSourceScript =
+      s"""
+         |import json
+         |from dataclasses import dataclass
+         |from pyspark import TaskContext
+         |from pyspark.sql.datasource import DataSource, DataSourceWriter, WriterCommitMessage
+         |
+         |@dataclass
+         |class SimpleCommitMessage(WriterCommitMessage):
+         |    partition_id: int
+         |    count: int
+         |
+         |class SimpleDataSourceWriter(DataSourceWriter):
+         |    def __init__(self, options):
+         |        self.options = options
+         |        self.path = self.options.get("path")
+         |        assert self.path is not None
+         |
+         |    def write(self, iterator):
+         |        context = TaskContext.get()
+         |        partition_id = context.partitionId()
+         |        output_path = f"{self.path}/{partition_id}.json"
+         |        cnt = 0
+         |        with open(output_path, "w") as file:
+         |            for row in iterator:
+         |                if row.id >= 10:
+         |                    raise Exception("invalid value")
+         |                file.write(json.dumps(row.asDict()) + "\\n")
+         |                cnt += 1
+         |        return SimpleCommitMessage(partition_id=partition_id, count=cnt)
+         |
+         |    def commit(self, messages) -> None:
+         |        status = dict(num_files=len(messages), count=sum(m.count for m in messages))
+         |
+         |        with open(f"{self.path}/success.json", "a") as file:
+         |            file.write(json.dumps(status) + "\\n")
+         |
+         |    def abort(self, messages) -> None:
+         |        with open(f"{self.path}/failed.txt", "a") as file:
+         |            file.write("failed\\n")
+         |
+         |class SimpleDataSource(DataSource):
+         |    def writer(self, schema, saveMode):
+         |        return SimpleDataSourceWriter(self.options)
+         |""".stripMargin
+    val dataSource = createUserDefinedPythonDataSource(dataSourceName, dataSourceScript)
+    spark.dataSource.registerPython(dataSourceName, dataSource)
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+
+      withClue("commit") {
+        sql("SELECT * FROM range(0, 5, 1, 3)")
+          .write.format(dataSourceName)
+          .mode("append")
+          .save(path)
+        checkAnswer(
+          spark.read.format("json")
+            .schema("num_files bigint, count bigint")
+            .load(path + "/success.json"),
+          Seq(Row(3, 5)))
+      }
+
+      withClue("commit again") {
+        sql("SELECT * FROM range(5, 7, 1, 1)")
+          .write.format(dataSourceName)
+          .mode("append")
+          .save(path)
+        checkAnswer(
+          spark.read.format("json")
+            .schema("num_files bigint, count bigint")
+            .load(path + "/success.json"),
+          Seq(Row(3, 5), Row(1, 2)))
+      }
+
+      withClue("abort") {
+        intercept[SparkException] {
+          sql("SELECT * FROM range(8, 12, 1, 4)")
+            .write.format(dataSourceName)
+            .mode("append")
+            .save(path)
+        }
+        checkAnswer(
+          spark.read.text(path + "/failed.txt"),
+          Seq(Row("failed")))
+      }
+    }
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonDataSourceSuite.scala
@@ -661,6 +661,7 @@ class PythonDataSourceSuite extends QueryTest with SharedSparkSession {
     val dataSourceScript =
       s"""
          |import json
+         |import os
          |from dataclasses import dataclass
          |from pyspark import TaskContext
          |from pyspark.sql.datasource import DataSource, DataSourceWriter, WriterCommitMessage
@@ -679,7 +680,7 @@ class PythonDataSourceSuite extends QueryTest with SharedSparkSession {
          |    def write(self, iterator):
          |        context = TaskContext.get()
          |        partition_id = context.partitionId()
-         |        output_path = f"{self.path}/{partition_id}.json"
+         |        output_path = os.path.join(self.path, f"{partition_id}.json")
          |        cnt = 0
          |        with open(output_path, "w") as file:
          |            for row in iterator:
@@ -692,12 +693,12 @@ class PythonDataSourceSuite extends QueryTest with SharedSparkSession {
          |    def commit(self, messages) -> None:
          |        status = dict(num_files=len(messages), count=sum(m.count for m in messages))
          |
-         |        with open(f"{self.path}/success.json", "a") as file:
+         |        with open(os.path.join(self.path, "success.json"), "a") as file:
          |            file.write(json.dumps(status) + "\\n")
          |
          |    def abort(self, messages) -> None:
-         |        with open(f"{self.path}/failed.txt", "a") as file:
-         |            file.write("failed\\n")
+         |        with open(os.path.join(self.path, "failed.txt"), "a") as file:
+         |            file.write("failed")
          |
          |class SimpleDataSource(DataSource):
          |    def writer(self, schema, saveMode):


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR introduces support for the commit and abort APIs for Python data source write. After this PR, users can customize their implementations for committing and aborting write operations.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To support Python data source.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New unit tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No 