### PR TITLE
[MINOR][SQL] Check the NumericType in canImplicitlyCast is not needed.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/UnwrapCastInBinaryComparison.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/UnwrapCastInBinaryComparison.scala
@@ -452,9 +452,7 @@ object UnwrapCastInBinaryComparison extends Rule[LogicalPlan] {
       fromExp: Expression,
       toType: DataType,
       literalType: DataType): Boolean = {
-    DataTypeUtils.sameType(toType, literalType) &&
-      !fromExp.foldable &&
-      toType.isInstanceOf[NumericType] &&
+    DataTypeUtils.sameType(toType, literalType) && !fromExp.foldable &&
       canUnwrapCast(fromExp.dataType, toType)
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR propose to remove the check for `NumericType` in `canImplicitlyCast`.

In fact, all the caller already ensure the `NumericType`.
https://github.com/apache/spark/blob/8ea09de807f9f218d549ae179e09bd5219979e06/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/UnwrapCastInBinaryComparison.scala#L133
https://github.com/apache/spark/blob/8ea09de807f9f218d549ae179e09bd5219979e06/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/UnwrapCastInBinaryComparison.scala#L156
https://github.com/apache/spark/blob/8ea09de807f9f218d549ae179e09bd5219979e06/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/UnwrapCastInBinaryComparison.scala#L171


### Why are the changes needed?
Check the NumericType in canImplicitlyCast is not needed.


### Does this PR introduce _any_ user-facing change?
'No'.


### How was this patch tested?
GA tests.


### Was this patch authored or co-authored using generative AI tooling?
'No'.
