### PR TITLE
[SPARK-45917][PYTHON][SQL] Automatic registration of Python Data Source on startup

### DIFF
--- a/python/pyspark/sql/worker/lookup_data_sources.py
+++ b/python/pyspark/sql/worker/lookup_data_sources.py
@@ -28,6 +28,7 @@ from pyspark.serializers import (
     write_with_length,
     SpecialLengths,
 )
+from pyspark.sql.datasource import DataSource
 from pyspark.util import handle_worker_exception
 from pyspark.worker_util import (
     check_python_version,
@@ -65,7 +66,7 @@ def main(infile: IO, outfile: IO) -> None:
         for info in iter_modules():
             if info.name.startswith("pyspark_"):
                 mod = import_module(info.name)
-                if hasattr(mod, "DefaultSource"):
+                if hasattr(mod, "DefaultSource") and isinstance(mod.DefaultSource, DataSource):
                     infos[mod.DefaultSource.name()] = mod.DefaultSource
 
         # Writes name -> pickled data source to JVM side to be registered

--- a/python/pyspark/sql/worker/lookup_data_sources.py
+++ b/python/pyspark/sql/worker/lookup_data_sources.py
@@ -66,7 +66,7 @@ def main(infile: IO, outfile: IO) -> None:
         for info in iter_modules():
             if info.name.startswith("pyspark_"):
                 mod = import_module(info.name)
-                if hasattr(mod, "DefaultSource") and isinstance(mod.DefaultSource, DataSource):
+                if hasattr(mod, "DefaultSource") and issubclass(mod.DefaultSource, DataSource):
                     infos[mod.DefaultSource.name()] = mod.DefaultSource
 
         # Writes name -> pickled data source to JVM side to be registered

--- a/python/pyspark/sql/worker/lookup_data_sources.py
+++ b/python/pyspark/sql/worker/lookup_data_sources.py
@@ -1,0 +1,89 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from importlib import import_module
+from pkgutil import iter_modules
+import os
+import sys
+from typing import IO
+
+from pyspark.accumulators import _accumulatorRegistry
+from pyspark.java_gateway import local_connect_and_auth
+from pyspark.serializers import (
+    read_bool,
+    read_int,
+    write_int,
+    write_with_length,
+    SpecialLengths,
+)
+from pyspark.util import handle_worker_exception
+from pyspark.worker_util import (
+    check_python_version,
+    read_command,
+    pickleSer,
+    send_accumulator_updates,
+    setup_broadcasts,
+    setup_memory_limits,
+    setup_spark_files,
+    utf8_deserializer,
+)
+
+
+def main(infile: IO, outfile: IO) -> None:
+    try:
+        check_python_version(infile)
+
+        memory_limit_mb = int(os.environ.get("PYSPARK_PLANNER_MEMORY_MB", "-1"))
+        setup_memory_limits(memory_limit_mb)
+
+        setup_spark_files(infile)
+        setup_broadcasts(infile)
+
+        _accumulatorRegistry.clear()
+
+        infos = {}
+        for info in iter_modules():
+            if info.name.startswith("pyspark_"):
+                mod = import_module(info.name)
+                if hasattr(mod, "DefaultSource"):
+                    infos[mod.DefaultSource.name()] = mod.DefaultSource
+
+        write_int(len(infos), outfile)
+        for name, mod in infos:
+            write_with_length(name.encode("utf-8"), outfile)
+            pickleSer._write_with_length(mod.DefaultSource, outfile)
+
+    except BaseException as e:
+        handle_worker_exception(e, outfile)
+        sys.exit(-1)
+
+    send_accumulator_updates(outfile)
+
+    # check end of stream
+    if read_int(infile) == SpecialLengths.END_OF_STREAM:
+        write_int(SpecialLengths.END_OF_STREAM, outfile)
+    else:
+        # write a different value to tell JVM to not reuse this worker
+        write_int(SpecialLengths.END_OF_DATA_SECTION, outfile)
+        sys.exit(-1)
+
+
+if __name__ == "__main__":
+    # Read information about how to connect back to the JVM from the environment.
+    java_port = int(os.environ["PYTHON_WORKER_FACTORY_PORT"])
+    auth_secret = os.environ["PYTHON_WORKER_FACTORY_SECRET"]
+    (sock_file, _) = local_connect_and_auth(java_port, auth_secret)
+    main(sock_file, sock_file)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceManager.scala
@@ -32,8 +32,11 @@ import org.apache.spark.sql.execution.python.UserDefinedPythonDataSource
  * their short names or fully qualified names.
  */
 class DataSourceManager extends Logging {
-  private val dataSourceBuilders = new ConcurrentHashMap[String, UserDefinedPythonDataSource]()
-  dataSourceBuilders.putAll(DataSourceManager.initialDataSourceBuilders.asJava)
+  private lazy val dataSourceBuilders = {
+    val builders = new ConcurrentHashMap[String, UserDefinedPythonDataSource]()
+    builders.putAll(DataSourceManager.initialDataSourceBuilders.asJava)
+    builders
+  }
 
   private def normalize(name: String): String = name.toLowerCase(Locale.ROOT)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/UserDefinedPythonDataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/UserDefinedPythonDataSource.scala
@@ -450,7 +450,7 @@ class UserDefinedPythonDataSourceLookupRunner(lookupSources: PythonFunction)
 
     val shortNames = ArrayBuffer.empty[String]
     val pickledDataSources = ArrayBuffer.empty[Array[Byte]]
-    val numDataSources = dataIn.readInt()
+    val numDataSources = length
 
     for (_ <- 0 until numDataSources) {
       val shortName = PythonWorkerUtils.readUTF(dataIn)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/UserDefinedPythonDataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/UserDefinedPythonDataSource.scala
@@ -26,7 +26,7 @@ import net.razorvine.pickle.Pickler
 
 import org.apache.spark.{JobArtifactSet, SparkException}
 import org.apache.spark.api.python.{ChainedPythonFunctions, PythonEvalType, PythonFunction, PythonUtils, PythonWorkerUtils, SimplePythonFunction, SpecialLengths}
-import org.apache.spark.sql.{SaveMode, SparkSession}
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.PythonUDF
 import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
@@ -288,6 +288,7 @@ class PythonCustomTaskMetric(
  * @param dataSourceCls The Python data source class.
  */
 case class UserDefinedPythonDataSource(dataSourceCls: PythonFunction) {
+
   /**
    * (Driver-side) Run Python process, and get the pickled Python Data Source
    * instance and its schema.
@@ -427,7 +428,7 @@ case class PythonDataSourceCreationResult(
     schema: StructType)
 
 /**
- * A runner used to create a Python data source in a Python process and return the result.
+ * A runner used to look up Python Data Sources available in Python path.
  */
 class UserDefinedPythonDataSourceLookupRunner(lookupSources: PythonFunction)
     extends PythonPlannerRunner[PythonAllDataSourcesCreationResult](lookupSources) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonDataSourceSuite.scala
@@ -17,11 +17,15 @@
 
 package org.apache.spark.sql.execution.python
 
+import java.io.{File, FileWriter}
+
 import org.apache.spark.SparkException
+import org.apache.spark.api.python.PythonUtils
 import org.apache.spark.sql.{AnalysisException, IntegratedUDFTestUtils, QueryTest, Row}
 import org.apache.spark.sql.execution.datasources.v2.{BatchScanExec, DataSourceV2ScanRelation}
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.StructType
+import org.apache.spark.util.Utils
 
 class PythonDataSourceSuite extends QueryTest with SharedSparkSession {
   import IntegratedUDFTestUtils._
@@ -29,7 +33,7 @@ class PythonDataSourceSuite extends QueryTest with SharedSparkSession {
   setupTestData()
 
   private def dataSourceName = "SimpleDataSource"
-  private def simpleDataSourceReaderScript: String =
+  private val simpleDataSourceReaderScript: String =
     """
       |from pyspark.sql.datasource import DataSourceReader, InputPartition
       |class SimpleDataSourceReader(DataSourceReader):
@@ -40,6 +44,52 @@ class PythonDataSourceSuite extends QueryTest with SharedSparkSession {
       |        yield (1, partition.value)
       |        yield (2, partition.value)
       |""".stripMargin
+  private val staticSourceName = "custom_source"
+  private var tempDir: File = _
+
+  override def beforeAll(): Unit = {
+    // Create a Python Data Source package before starting up the Spark Session
+    // that triggers automatic registration of the Python Data Source.
+    val dataSourceScript =
+    s"""
+       |from pyspark.sql.datasource import DataSource, DataSourceReader
+       |$simpleDataSourceReaderScript
+       |
+       |class DefaultSource(DataSource):
+       |    def schema(self) -> str:
+       |        return "id INT, partition INT"
+       |
+       |    def reader(self, schema):
+       |        return SimpleDataSourceReader()
+       |
+       |    @classmethod
+       |    def name(cls):
+       |        return "$staticSourceName"
+       |""".stripMargin
+    tempDir = Utils.createTempDir()
+    // Write a temporary package to test.
+    // tmp/my_source
+    // tmp/my_source/__init__.py
+    val packageDir = new File(tempDir, "pyspark_mysource")
+    assert(packageDir.mkdir())
+    Utils.tryWithResource(
+      new FileWriter(new File(packageDir, "__init__.py")))(_.write(dataSourceScript))
+    // So Spark Session initialization can lookup this temporary directory.
+    PythonUtils.additionalTestingPath = Some(tempDir.toString)
+    super.beforeAll()
+  }
+
+  override def afterAll(): Unit = {
+    Utils.deleteRecursively(tempDir)
+    PythonUtils.additionalTestingPath = None
+    super.afterAll()
+  }
+
+  test("SPARK-45917: automatic registration of Python Data Source") {
+    assume(shouldTestPandasUDFs)
+    val df = spark.read.format(staticSourceName).load()
+    checkAnswer(df, Seq(Row(0, 0), Row(0, 1), Row(1, 0), Row(1, 1), Row(2, 0), Row(2, 1)))
+  }
 
   test("simple data source") {
     assume(shouldTestPandasUDFs)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to add the support of automatic Python Data Source registration.

**End user perspective:**

```bash
# Assume that `customsource` defined a short name as `custom` 
pip install pyspark_customsource
```

Users can directly use the Python Data Source

```python
df = spark.format("custom").load()
```

**Developer perspective:**

The packages should follow the structure below:
- The package name should start with `pyspark_` prefix
- `pyspark_*.DefaultSource` has to be defined that inherits `pyspark.sql.datasource.DataSource`

For example:

```
pyspark_customsource
├── __init__.py
 ...
```

`__init__.py`:

```python
from pyspark.sql.datasource import DataSource

class DefaultSource(Datasource):
    pass
```

### Why are the changes needed?

This allows the developers to release and maintain their 3rd party Python Data Sources separately (e.g., in PyPI), and end users can easily install the Python Data Source without doing anything other than just `pip install pyspark_their_source`

### Does this PR introduce _any_ user-facing change?

Yes, this allows users to `pip install pyspark_custom_source`, and automatically register it as Data Source available in Spark. 

### How was this patch tested?

Unittests were added.

Also manual test as below:

```bash
rm -fr pyspark_mysource
mkdir pyspark_mysource
cd pyspark_mysource
echo '
from pyspark.sql.datasource import DataSource, DataSourceReader, InputPartition

class TestDataSourceReader(DataSourceReader):
    def __init__(self, options):
        self.options = options
    def partitions(self):
        return [InputPartition(i) for i in range(3)]
    def read(self, partition):
        yield partition.value, str(partition.value)


class DefaultSource(DataSource):
    @classmethod
    def name(cls):
        return "test"
    def schema(self):
        return "x INT, y STRING"
    def reader(self, schema) -> "DataSourceReader":
        return TestDataSourceReader(self.options)
    @classmethod
    def name(cls):
        return "mysource"
' > __init__.py
cd ..
./bin/pyspark
```

```python
spark.read.format("mysource").load().show()
```

```
+---+---+
|  x|  y|
+---+---+
|  0|  0|
|  1|  1|
|  2|  2|
+---+---+
```

### Was this patch authored or co-authored using generative AI tooling?

No.