### PR TITLE
[MINOR][K8S] Remove an unused expression `None` from `KubernetesClientUtils#loadSparkConfDirFiles`

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientUtils.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientUtils.scala
@@ -135,7 +135,6 @@ private[spark] object KubernetesClientUtils extends Logging {
           case e: MalformedInputException =>
             logWarning(
               s"Unable to read a non UTF-8 encoded file ${file.getAbsolutePath}. Skipping...", e)
-            None
         } finally {
           source.close()
         }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr just remove an unused expression `None` from `KubernetesClientUtils#loadSparkConfDirFiles`

### Why are the changes needed?
Code cleanup


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No
