### PR TITLE
[SPARK-46530][PYTHON][SQL] Check Python executable when looking up available Data Sources

### DIFF
--- a/core/src/main/scala/org/apache/spark/TestUtils.scala
+++ b/core/src/main/scala/org/apache/spark/TestUtils.scala
@@ -34,7 +34,7 @@ import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 import scala.io.Source
 import scala.reflect.{classTag, ClassTag}
-import scala.sys.process.{Process, ProcessLogger}
+import scala.sys.process.Process
 import scala.util.Try
 
 import com.google.common.io.{ByteStreams, Files}
@@ -204,16 +204,7 @@ private[spark] object TestUtils extends SparkTestUtils {
   /**
    * Test if a command is available.
    */
-  def testCommandAvailable(command: String): Boolean = {
-    val attempt = if (Utils.isWindows) {
-      Try(Process(Seq(
-        "cmd.exe", "/C", s"where $command")).run(ProcessLogger(_ => ())).exitValue())
-    } else {
-      Try(Process(Seq(
-        "sh", "-c", s"command -v $command")).run(ProcessLogger(_ => ())).exitValue())
-    }
-    attempt.isSuccess && attempt.get == 0
-  }
+  def testCommandAvailable(command: String): Boolean = Utils.checkCommandAvailable(command)
 
   // SPARK-40053: This string needs to be updated when the
   // minimum python supported version changes.

--- a/core/src/main/scala/org/apache/spark/api/python/PythonUtils.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonUtils.scala
@@ -153,10 +153,10 @@ private[spark] object PythonUtils extends Logging {
   // Only for testing.
   private[spark] var additionalTestingPath: Option[String] = None
 
-  private[spark] def createPythonFunction(command: Array[Byte]): SimplePythonFunction = {
-    val pythonExec: String = sys.env.getOrElse(
-      "PYSPARK_DRIVER_PYTHON", sys.env.getOrElse("PYSPARK_PYTHON", "python3"))
+  private[spark] val defaultPythonExec: String = sys.env.getOrElse(
+    "PYSPARK_DRIVER_PYTHON", sys.env.getOrElse("PYSPARK_PYTHON", "python3"))
 
+  private[spark] def createPythonFunction(command: Array[Byte]): SimplePythonFunction = {
     val sourcePython = if (Utils.isTesting) {
       // Put PySpark source code instead of the build zip archive so we don't need
       // to build PySpark every time during development.
@@ -180,7 +180,7 @@ private[spark] object PythonUtils extends Logging {
 
     val pythonVer: String =
       Process(
-        Seq(pythonExec, "-c", "import sys; print('%d.%d' % sys.version_info[:2])"),
+        Seq(defaultPythonExec, "-c", "import sys; print('%d.%d' % sys.version_info[:2])"),
         None,
         "PYTHONPATH" -> pythonPath).!!.trim()
 
@@ -188,7 +188,7 @@ private[spark] object PythonUtils extends Logging {
       command = command.toImmutableArraySeq,
       envVars = mutable.Map("PYTHONPATH" -> pythonPath).asJava,
       pythonIncludes = List.empty.asJava,
-      pythonExec = pythonExec,
+      pythonExec = defaultPythonExec,
       pythonVer = pythonVer,
       broadcastVars = List.empty.asJava,
       accumulator = null)

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -3028,6 +3028,23 @@ private[spark] object Utils
   }
 
   /**
+   * Check if a command is available.
+   */
+  def checkCommandAvailable(command: String): Boolean = {
+    // To avoid conflicts with java.lang.Process
+    import scala.sys.process.{Process, ProcessLogger}
+
+    val attempt = if (Utils.isWindows) {
+      Try(Process(Seq(
+        "cmd.exe", "/C", s"where $command")).run(ProcessLogger(_ => ())).exitValue())
+    } else {
+      Try(Process(Seq(
+        "sh", "-c", s"command -v $command")).run(ProcessLogger(_ => ())).exitValue())
+    }
+    attempt.isSuccess && attempt.get == 0
+  }
+
+  /**
    * Return whether we are using G1GC or not
    */
   lazy val isG1GC: Boolean = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceManager.scala
@@ -17,8 +17,10 @@
 
 package org.apache.spark.sql.execution.datasources
 
+import java.io.File
 import java.util.Locale
 import java.util.concurrent.ConcurrentHashMap
+import java.util.regex.Pattern
 
 import scala.jdk.CollectionConverters._
 
@@ -26,6 +28,7 @@ import org.apache.spark.api.python.PythonUtils
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.execution.python.UserDefinedPythonDataSource
+import org.apache.spark.util.Utils
 
 
 /**
@@ -83,17 +86,28 @@ class DataSourceManager extends Logging {
 
 
 object DataSourceManager {
-  // Visiable for testing
+  // Visible for testing
   private[spark] var dataSourceBuilders: Option[Map[String, UserDefinedPythonDataSource]] = None
-  private def initialDataSourceBuilders = this.synchronized {
-    if (dataSourceBuilders.isEmpty) {
-      val result = UserDefinedPythonDataSource.lookupAllDataSourcesInPython()
-      val builders = result.names.zip(result.dataSources).map { case (name, dataSource) =>
-        name ->
-          UserDefinedPythonDataSource(PythonUtils.createPythonFunction(dataSource))
-      }.toMap
-      dataSourceBuilders = Some(builders)
+  private lazy val shouldLoadPythonDataSources: Boolean = {
+    Utils.checkCommandAvailable(PythonUtils.defaultPythonExec) &&
+      // Make sure PySpark zipped files also exist.
+      PythonUtils.sparkPythonPath
+        .split(Pattern.quote(File.separator)).forall(new File(_).exists())
+  }
+
+  private def initialDataSourceBuilders: Map[String, UserDefinedPythonDataSource] = {
+    if (Utils.isTesting || shouldLoadPythonDataSources) this.synchronized {
+      if (dataSourceBuilders.isEmpty) {
+        val result = UserDefinedPythonDataSource.lookupAllDataSourcesInPython()
+        val builders = result.names.zip(result.dataSources).map { case (name, dataSource) =>
+          name ->
+            UserDefinedPythonDataSource(PythonUtils.createPythonFunction(dataSource))
+        }.toMap
+        dataSourceBuilders = Some(builders)
+      }
+      dataSourceBuilders.get
+    } else {
+      Map.empty
     }
-    dataSourceBuilders.get
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceManager.scala
@@ -105,7 +105,8 @@ object DataSourceManager extends Logging {
             // Even if it fails for whatever reason, we shouldn't make the whole
             // application fail.
             logWarning(
-              s"Failed to execute Python worker: $e, giving up looking Python Data Sources")
+              "Skipping the lookup of Python Data Sources " +
+                s"as it failed to execute the Python worker: $e")
             None
         }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceManager.scala
@@ -105,8 +105,7 @@ object DataSourceManager extends Logging {
             // Even if it fails for whatever reason, we shouldn't make the whole
             // application fail.
             logWarning(
-              "Skipping the lookup of Python Data Sources " +
-                s"as it failed to execute the Python worker: $e")
+              s"Skipping the lookup of Python Data Sources due to the failure: $e")
             None
         }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a sort of followup of https://github.com/apache/spark/pull/44504 but addresses a separate issue. This PR proposes to check:
- if Python executable exists when looking up available Python Data Sources.
- if PySpark source and Py4J files exist - for the case users don't have them in their machine (and don't use PySpark).

### Why are the changes needed?

For some OSes such as Windows, or minimized Docker containers, there is no Python installed, and it will just fail even when users want to use Scala only. We should check the Python executable, and skip if that does not exist.

### Does this PR introduce _any_ user-facing change?

No because the main change has not been released out yet.

### How was this patch tested?

Manually tested.

### Was this patch authored or co-authored using generative AI tooling?

No.
