### PR TITLE
[SPARK-46531][BUILD] Move the dependency management of `datasketches-java` from `catalyst` to `parent`

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -107,7 +107,7 @@
     <dependency>
       <groupId>com.github.scopt</groupId>
       <artifactId>scopt_${scala.binary.version}</artifactId>
-      <version>3.7.1</version>
+      <version>4.1.0</version>
     </dependency>
   </dependencies>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -107,7 +107,7 @@
     <dependency>
       <groupId>com.github.scopt</groupId>
       <artifactId>scopt_${scala.binary.version}</artifactId>
-      <version>4.1.0</version>
+      <version>3.7.1</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -223,6 +223,7 @@
     <commons-cli.version>1.6.0</commons-cli.version>
     <bouncycastle.version>1.77</bouncycastle.version>
     <tink.version>1.9.0</tink.version>
+    <datasketches.version>3.3.0</datasketches.version>
     <netty.version>4.1.100.Final</netty.version>
     <netty-tcnative.version>2.0.61.Final</netty-tcnative.version>
     <!--
@@ -2836,6 +2837,12 @@
         <groupId>dev.ludovic.netlib</groupId>
         <artifactId>arpack</artifactId>
         <version>${netlib.ludovic.dev.version}</version>
+      </dependency>
+      <!-- SPARK-16484 add `datasketches-java` for support Datasketches HllSketch -->
+      <dependency>
+        <groupId>org.apache.datasketches</groupId>
+        <artifactId>datasketches-java</artifactId>
+        <version>${datasketches.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/sql/catalyst/pom.xml
+++ b/sql/catalyst/pom.xml
@@ -120,7 +120,6 @@
     <dependency>
       <groupId>org.apache.datasketches</groupId>
       <artifactId>datasketches-java</artifactId>
-      <version>3.3.0</version>
     </dependency>
   </dependencies>
   <build>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr move  the dependency management of `datasketches-java` from `catalyst/pom.xml` to `parent/pom.xml` and defined a new property xx to manage it's version.

### Why are the changes needed?
he management of dependencies with non-special versions should be placed in `parent.xml`.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions

### Was this patch authored or co-authored using generative AI tooling?
No