### PR TITLE
[SPARK-46534][SQL][HIVE] Skip initializing an unused hive client in HiveThriftServer2.startWithContext DeveloperApi

### DIFF
--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SharedThriftServer.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SharedThriftServer.scala
@@ -47,7 +47,7 @@ trait SharedThriftServer extends SharedSparkSession {
   protected val tempScratchDir: File = {
     val dir = Utils.createTempDir()
     dir.setWritable(true, false)
-    Utils.createTempDir(dir.getAbsolutePath)
+    Utils.deleteRecursively(dir)
     dir
   }
 
@@ -145,10 +145,6 @@ trait SharedThriftServer extends SharedSparkSession {
           logInfo(s"Started HiveThriftServer2: mode=$mode, port=$serverPort, attempt=$attempt")
         case _ =>
       }
-
-      // the scratch dir will be recreated after the probe sql `SELECT 1` executed, so we
-      // check it here first.
-      assert(!tempScratchDir.exists())
 
       // Wait for thrift server to be ready to serve the query, via executing simple query
       // till the query succeeds. See SPARK-30345 for more details.

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
@@ -330,30 +330,6 @@ private[spark] object HiveUtils extends Logging {
   }
 
   /**
-   * Create a [[HiveClient]] used for execution.
-   *
-   * Currently this must always be the Hive built-in version that packaged
-   * with Spark SQL. This copy of the client is used for execution related tasks like
-   * registering temporary functions or ensuring that the ThreadLocal SessionState is
-   * correctly populated.  This copy of Hive is *not* used for storing persistent metadata,
-   * and only point to a dummy metastore in a temporary directory.
-   */
-  protected[hive] def newClientForExecution(
-      conf: SparkConf,
-      hadoopConf: Configuration): HiveClientImpl = {
-    logInfo(s"Initializing execution hive, version $builtinHiveVersion")
-    val loader = new IsolatedClientLoader(
-      version = IsolatedClientLoader.hiveVersion(builtinHiveVersion),
-      sparkConf = conf,
-      execJars = Seq.empty,
-      hadoopConf = hadoopConf,
-      config = newTemporaryConfiguration(useInMemoryDerby = true),
-      isolationOn = false,
-      baseClassLoader = Utils.getContextOrSparkClassLoader)
-    loader.createClient().asInstanceOf[HiveClientImpl]
-  }
-
-  /**
    * Create a [[HiveClient]] used to retrieve metadata from the Hive MetaStore.
    *
    * The version of the Hive client that is used here must match the metastore that is configured


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR skips initializing an unused hive client in HiveThriftServer2.startWithContext DeveloperApi. Instead, we initialize the HiveConf instance directly.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Recently, `ThriftServerWithSparkContextInHttpSuite` is flakey. When the `SharedThriftServer` bootstrapping, it seems to not follow the preset configurations. 
The logs below show that
- `HIVE_SERVER2_TRANSPORT_MODE` is not respected as it logs `AbstractService: Service:ThriftBinaryCLIService is started`
- `HIVE_START_CLEANUP_SCRATCHDIR`is not respected as it should log `erverUtils: Cleaning scratchDir : ...` but didn't.

```java
03:58:57.265 pool-1-thread-1 INFO ThriftServerWithSparkContextInHttpSuite: Trying to start HiveThriftServer2: mode=http, attempt=0
03:58:57.265 pool-1-thread-1 INFO SharedState: Setting hive.metastore.warehouse.dir ('null') to the value of spark.sql.warehouse.dir.
03:58:57.265 pool-1-thread-1 INFO SharedState: Warehouse path is 'file:/home/runner/work/spark/spark/sql/hive-thriftserver/spark-warehouse/org.apache.spark.sql.hive.thriftserver.ThriftServerWithSparkContextInHttpSuite'.
03:58:57.266 pool-1-thread-1 INFO HiveUtils: Initializing execution hive, version 2.3.9
03:58:57.267 pool-1-thread-1 INFO HiveClientImpl: Warehouse location for Hive client (version 2.3.9) is file:/home/runner/work/spark/spark/sql/hive-thriftserver/spark-warehouse/org.apache.spark.sql.hive.thriftserver.ThriftServerWithSparkContextInHttpSuite
03:58:57.267 pool-1-thread-1 INFO SessionManager: Operation log root directory is created: /home/runner/work/spark/spark/target/tmp/runner/operation_logs
03:58:57.267 pool-1-thread-1 INFO SessionManager: HiveServer2: Background operation thread pool size: 100
03:58:57.267 pool-1-thread-1 INFO SessionManager: HiveServer2: Background operation thread wait queue size: 100
03:58:57.267 pool-1-thread-1 INFO SessionManager: HiveServer2: Background operation thread keepalive time: 10 seconds
03:58:57.267 pool-1-thread-1 INFO AbstractService: Service:OperationManager is inited.
03:58:57.267 pool-1-thread-1 INFO AbstractService: Service:SessionManager is inited.
03:58:57.267 pool-1-thread-1 INFO AbstractService: Service: CLIService is inited.
03:58:57.267 pool-1-thread-1 INFO AbstractService: Service:ThriftBinaryCLIService is inited.
03:58:57.267 pool-1-thread-1 INFO AbstractService: Service: HiveServer2 is inited.
03:58:57.268 pool-1-thread-1 INFO AbstractService: Service:OperationManager is started.
03:58:57.268 pool-1-thread-1 INFO AbstractService: Service:SessionManager is started.
03:58:57.268 pool-1-thread-1 INFO AbstractService: Service: CLIService is started.
03:58:57.268 pool-1-thread-1 INFO AbstractService: Service:ThriftBinaryCLIService is started.
03:58:57.268 pool-1-thread-1 INFO ThriftCLIService: Starting ThriftBinaryCLIService on port 10000 with 5...500 worker threads
03:58:57.268 pool-1-thread-1 INFO AbstractService: Service:HiveServer2 is started.
03:58:57.268 pool-1-thread-1 INFO HiveThriftServer2: HiveThriftServer2 started
03:58:57.268 pool-1-thread-1 INFO ThriftServerWithSparkContextInHttpSuite: Started HiveThriftServer2: mode=http, port=10000, attempt=0
03:58:57.269 pool-1-thread-1 ERROR ThriftServerWithSparkContextInHttpSuite: Error start hive server with Context 
org.scalatest.exceptions.TestFailedException: SharedThriftServer.this.tempScratchDir.exists() was true
	at org.scalatest.Assertions.newAssertionFailedException(Assertions.scala:472)
	at org.scalatest.Assertions.newAssertionFailedException$(Assertions.scala:471)
	at org.scalatest.Assertions$.newAssertionFailedException(Assertions.scala:1231)
	at org.scalatest.Assertions$AssertionsHelper.macroAssert(Assertions.scala:1295)
	at org.apache.spark.sql.hive.thriftserver.SharedThriftServer.startThriftServer(SharedThriftServer.scala:151)
	at org.apache.spark.sql.hive.thriftserver.SharedThriftServer.$anonfun$beforeAll$1(SharedThriftServer.scala:59)
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18)
	at scala.util.Try$.apply(Try.scala:210)
	at org.apache.spark.sql.hive.thriftserver.SharedThriftServer.beforeAll(SharedThriftServer.scala:59)
	at org.apache.spark.sql.hive.thriftserver.SharedThriftServer.beforeAll$(SharedThriftServer.scala:56)
	at org.apache.spark.sql.hive.thriftserver.ThriftServerWithSparkContextInHttpSuite.beforeAll(ThriftServerWithSparkContextSuite.scala:279)
	at org.scalatest.BeforeAndAfterAll.liftedTree1$1(BeforeAndAfterAll.scala:212)
	at org.scalatest.BeforeAndAfterAll.run(BeforeAndAfterAll.scala:210)
	at org.scalatest.BeforeAndAfterAll.run$(BeforeAndAfterAll.scala:208)
	at org.apache.spark.SparkFunSuite.run(SparkFunSuite.scala:69)
	at org.scalatest.tools.Framework.org$scalatest$tools$Framework$$runSuite(Framework.scala:321)
	at org.scalatest.tools.Framework$ScalaTestTask.execute(Framework.scala:517)
	at sbt.ForkMain$Run.lambda$runTest$1(ForkMain.java:414)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:840)
```

This PR is unsure to fix the flakiness of the test above. But after this simplification, we might be able to step closer.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

no

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Pass ThriftServerWithSparkContextSuite

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.

-->
no
