### PR TITLE
[SPARK-46397][PYTHON][CONNECT] Function `sha2`  should raise `PySparkValueError` for invalid `numBits`

### DIFF
--- a/python/pyspark/sql/connect/functions/builtin.py
+++ b/python/pyspark/sql/connect/functions/builtin.py
@@ -3684,6 +3684,14 @@ sha1.__doc__ = pysparkfuncs.sha1.__doc__
 
 
 def sha2(col: "ColumnOrName", numBits: int) -> Column:
+    if numBits not in [0, 224, 256, 384, 512]:
+        raise PySparkValueError(
+            error_class="VALUE_NOT_ALLOWED",
+            message_parameters={
+                "arg_name": "numBits",
+                "allowed_values": "[0, 224, 256, 384, 512]",
+            },
+        )
     return _invoke_function("sha2", _to_col(col), lit(numBits))
 
 

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -9112,6 +9112,14 @@ def sha2(col: "ColumnOrName", numBits: int) -> Column:
     |Bob  |cd9fb1e148ccd8442e5aa74904cc73bf6fb54d1d54d333bd596aa9bb4bb4e961|
     +-----+----------------------------------------------------------------+
     """
+    if numBits not in [0, 224, 256, 384, 512]:
+        raise PySparkValueError(
+            error_class="VALUE_NOT_ALLOWED",
+            message_parameters={
+                "arg_name": "numBits",
+                "allowed_values": "[0, 224, 256, 384, 512]",
+            },
+        )
     return _invoke_function("sha2", _to_java_column(col), numBits)
 
 

--- a/python/pyspark/sql/tests/connect/test_utils.py
+++ b/python/pyspark/sql/tests/connect/test_utils.py
@@ -14,16 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import unittest
 
 from pyspark.testing.connectutils import ReusedConnectTestCase
 from pyspark.sql.tests.test_utils import UtilsTestsMixin
 
 
 class ConnectUtilsTests(ReusedConnectTestCase, UtilsTestsMixin):
-    @unittest.skip("SPARK-46397: Different exception thrown")
-    def test_capture_illegalargument_exception(self):
-        super().test_capture_illegalargument_exception()
+    pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### What changes were proposed in this pull request?
Function `sha2`  should raise `PySparkValueError` for invalid `numBits`


### Why are the changes needed?
vanilla PySpark invokes the Scala side and raise an `IllegalArgumentException`
https://github.com/apache/spark/blob/fa4096eb6aba4c66f0d9c5dcbabdfc0804064fff/sql/core/src/main/scala/org/apache/spark/sql/functions.scala#L3212-L3217

while Python client won't do this check and raise an `AnalysisException`.

They should both raise a `PySparkValueError` for this case.


### Does this PR introduce _any_ user-facing change?
yes

```
In [1]: from pyspark.sql import functions as sf
   ...: spark.range(1).select(sf.sha2(sf.col("id"), 1024)).collect()
---------------------------------------------------------------------------
PySparkValueError                         Traceback (most recent call last)
<ipython-input-1-1ae9879dcc31> in ?()
      1 from pyspark.sql import functions as sf
----> 2 spark.range(1).select(sf.sha2(sf.col("id"), 1024)).collect()

~/Dev/spark/python/pyspark/sql/utils.py in ?(*args, **kwargs)
    190             from pyspark.sql.connect import functions
    191
    192             return getattr(functions, f.__name__)(*args, **kwargs)
    193         else:
--> 194             return f(*args, **kwargs)

~/Dev/spark/python/pyspark/sql/functions/builtin.py in ?(col, numBits)
   9112     |Bob  |cd9fb1e148ccd8442e5aa74904cc73bf6fb54d1d54d333bd596aa9bb4bb4e961|
   9113     +-----+----------------------------------------------------------------+
   9114     """
   9115     if numBits not in [0, 224, 256, 384, 512]:
-> 9116         raise PySparkValueError(
   9117             error_class="VALUE_NOT_ALLOWED",
   9118             message_parameters={
   9119                 "arg_name": "numBits",

PySparkValueError: [VALUE_NOT_ALLOWED] Value for `numBits` has to be amongst the following values: [0, 224, 256, 384, 512].
```


### How was this patch tested?
added ut


### Was this patch authored or co-authored using generative AI tooling?
no