### PR TITLE
[SPARK-46542][SQL] Remove the check for `c>=0` from `ExternalCatalogUtils#needsEscaping` as it is always true

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogUtils.scala
@@ -64,7 +64,7 @@ object ExternalCatalogUtils {
   }
 
   def needsEscaping(c: Char): Boolean = {
-    c >= 0 && c < charToEscape.size() && charToEscape.get(c)
+    c < charToEscape.size() && charToEscape.get(c)
   }
 
   def escapePathName(path: String): String = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr just remove the check for `c>=0` from `ExternalCatalogUtils#needsEscaping` since it is always true due to the numerical range of the `Char` type in Scala is unsigned integer.
```
scala> Char.char2long(Char.MinValue)
res2: Long = 0

scala> Char.char2long(Char.MaxValue)
res1: Long = 65535
```

### Why are the changes needed?
Remove constant condition


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No
