### PR TITLE
[SPARK-46545][INFRA] Pin `lxml==4.9.4`

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -253,7 +253,7 @@ jobs:
     - name: Install Python packages (Python 3.9)
       if: (contains(matrix.modules, 'sql') && !contains(matrix.modules, 'sql-')) || contains(matrix.modules, 'connect')
       run: |
-        python3.9 -m pip install 'numpy>=1.20.0' pyarrow pandas scipy unittest-xml-reporting 'grpcio==1.59.3' 'grpcio-status==1.59.3' 'protobuf==4.25.1'
+        python3.9 -m pip install 'numpy>=1.20.0' pyarrow pandas scipy unittest-xml-reporting 'lxml==4.9.4' 'grpcio==1.59.3' 'grpcio-status==1.59.3' 'protobuf==4.25.1'
         python3.9 -m pip list
     # Run the tests.
     - name: Run tests


### PR DESCRIPTION
### What changes were proposed in this pull request?
Pin 'lxml==4.9.4'


### Why are the changes needed?
it seems the newly released lxml 5.0.0 breaks the CI (the `Install Python packages (Python 3.9)` step for Spark SQL tests)

```
Collecting lxml (from unittest-xml-reporting)
  Downloading lxml-5.0.0.tar.gz (3.8 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 3.8/3.8 MB 17.4 MB/s eta 0:00:00
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'error'
  error: subprocess-exited-with-error
  
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [4 lines of output]
      <string>:67: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
      Building lxml version 5.0.0.
      Building without Cython.
      Error: Please make sure the libxml2 and libxslt development packages are installed.
      [end of output]
```

in the latest successful run, the version is 4.9.4:
```
Package                  Version
------------------------ ------------
googleapis-common-protos 1.62.0
grpcio                   1.59.3
grpcio-status            1.59.3
lxml                     4.9.4
numpy                    1.26.2
pandas                   2.1.4
pip                      23.0.1
protobuf                 4.25.1
pyarrow                  14.0.2
python-dateutil          2.8.2
pytz                     2023.3.post1
scipy                    1.11.4
setuptools               58.1.0
six                      1.16.0
tzdata                   2023.3
unittest-xml-reporting   3.2.0
```

`unittest-xml-reporting` requires `lxml` but without specified version 

```
name                    summary
----------------------  ------------------------------------------------------------------------------------------------
unittest-xml-reporting  unittest-based test runner with Ant/JUnit like XML reporting.
└── lxml                Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API.
```

### Does this PR introduce _any_ user-facing change?
no, infra only

### How was this patch tested?
ci

### Was this patch authored or co-authored using generative AI tooling?
no
