### PR TITLE
[WIP][SPARK-46549][INFRA] Cache the Python dependencies for SQL tests

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -250,10 +250,12 @@ jobs:
       with:
         python-version: '3.9'
         architecture: x64
+        cache: 'pip'
+        cache-dependency-path: 'dev/py-tests/requirements-sql.txt'
     - name: Install Python packages (Python 3.9)
       if: (contains(matrix.modules, 'sql') && !contains(matrix.modules, 'sql-')) || contains(matrix.modules, 'connect')
       run: |
-        python3.9 -m pip install 'numpy>=1.20.0' pyarrow pandas scipy unittest-xml-reporting 'lxml==4.9.4' 'grpcio==1.59.3' 'grpcio-status==1.59.3' 'protobuf==4.25.1'
+        python3.9 -m pip install -r dev/py-tests/requirements-sql.txt
         python3.9 -m pip list
     # Run the tests.
     - name: Run tests

--- a/dev/py-tests/requirements-sql.txt
+++ b/dev/py-tests/requirements-sql.txt
@@ -1,10 +1,10 @@
 # PySpark dependencies for SQL tests
 
-numpy>=1.20.0
-pyarrow
-pandas
-scipy
-unittest-xml-reporting
+numpy==1.26.2
+pyarrow==14.0.2
+pandas==2.1.4
+scipy==1.11.4
+unittest-xml-reporting==3.2.0
 lxml==4.9.4
 grpcio==1.59.3
 grpcio-status==1.59.3

--- a/dev/py-tests/requirements-sql.txt
+++ b/dev/py-tests/requirements-sql.txt
@@ -1,0 +1,11 @@
+# PySpark dependencies for SQL tests
+
+numpy>=1.20.0
+pyarrow
+pandas
+scipy
+unittest-xml-reporting
+lxml==4.9.4
+grpcio==1.59.3
+grpcio-status==1.59.3
+protobuf==4.25.1


### PR DESCRIPTION
### What changes were proposed in this pull request?
Enable the caching provided by [`setup-python`](https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#caching-packages)




### Why are the changes needed?
avoid downloading the Python dependencies if possible


### Does this PR introduce _any_ user-facing change?
no, infra-only


### How was this patch tested?
ci, manually check:

1, first run to cache the dependencies
https://github.com/zhengruifeng/spark/actions/runs/7363727839/job/20043467880

![image](https://github.com/apache/spark/assets/7322292/65ef7886-af2e-4b96-8bd1-493332adaee8)

![image](https://github.com/apache/spark/assets/7322292/5d8c2862-acc8-4e2e-b832-4e42027961f8)

2, second run to reuse the cache
https://github.com/zhengruifeng/spark/actions/runs/7367425047/job/20050701350

![image](https://github.com/apache/spark/assets/7322292/09a72a94-5221-4607-bc12-9ae73d5cc9df)




### Was this patch authored or co-authored using generative AI tooling?
no
