### PR TITLE
[SPARK-46561][UI] Use `exists` instead of `filter + nonEmpty` to check `showResourceColumn` in `MasterPage.scala`

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/master/ui/MasterPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/ui/MasterPage.scala
@@ -98,7 +98,7 @@ private[ui] class MasterPage(parent: MasterWebUI) extends WebUIPage("") {
   def render(request: HttpServletRequest): Seq[Node] = {
     val state = getMasterState
 
-    val showResourceColumn = state.workers.filter(_.resourcesInfoUsed.nonEmpty).nonEmpty
+    val showResourceColumn = state.workers.exists(_.resourcesInfoUsed.nonEmpty)
     val workerHeaders = if (showResourceColumn) {
       Seq("Worker Id", "Address", "State", "Cores", "Memory", "Resources")
     } else {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr just change to use `exists` instead of `filter + nonEmpty` to check `showResourceColumn` in `MasterPage.scala`:

```scala
state.workers.filter(_.resourcesInfoUsed.nonEmpty).nonEmpty
```

to

```scala
state.workers.exists(_.resourcesInfoUsed.nonEmpty)
```

### Why are the changes needed?
Simplify the code: compared to `filter + nonEmpty`, using `exists` has the opportunity to terminate the iteration over the collection early.



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No
