### PR TITLE
[SPARK-46567][CORE] Remove ThreadLocal for ReadAheadInputStream

### DIFF
--- a/core/src/main/java/org/apache/spark/io/ReadAheadInputStream.java
+++ b/core/src/main/java/org/apache/spark/io/ReadAheadInputStream.java
@@ -89,8 +89,6 @@ public class ReadAheadInputStream extends InputStream {
 
   private final Condition asyncReadComplete = stateChangeLock.newCondition();
 
-  private static final ThreadLocal<byte[]> oneByte = ThreadLocal.withInitial(() -> new byte[1]);
-
   /**
    * Creates a <code>ReadAheadInputStream</code> with the specified buffer size and read-ahead
    * threshold
@@ -247,7 +245,7 @@ public class ReadAheadInputStream extends InputStream {
       // short path - just get one byte.
       return activeBuffer.get() & 0xFF;
     } else {
-      byte[] oneByteArray = oneByte.get();
+      byte[] oneByteArray = new byte[1];
       return read(oneByteArray, 0, 1) == -1 ? -1 : oneByteArray[0] & 0xFF;
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR propose to remove `ThreadLocal` for `ReadAheadInputStream`.


### Why are the changes needed?
`ReadAheadInputStream` has a field `oneByte` declared as `TheadLocal`.
In fact, `oneByte` only used in read.
We can remove it by the way that the closure of local variables in instance methods can provide thread safety guarantees.

On the other hand, the `TheadLocal` occupies a certain amount of space in the heap and there are allocation and GC costs.

### Does this PR introduce _any_ user-facing change?
'No'.


### How was this patch tested?
Exists test cases.


### Was this patch authored or co-authored using generative AI tooling?
'No'.
