### PR TITLE
[SPARK-46570][INFRA] Run Python 3.11 and 3.12 tests independently

### DIFF
--- a/.github/workflows/build_python.yml
+++ b/.github/workflows/build_python.yml
@@ -27,7 +27,7 @@ jobs:
   run-build:
     strategy:
       matrix:
-        pyversion: ["pypy3,python3.10", "python3.11,python3.12"]
+        pyversion: ["pypy3,python3.10", "python3.11", "python3.12"]
     permissions:
       packages: write
     name: Run


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to run `Python 3.11` and `3.12` tests independently.

### Why are the changes needed?

Currently, the CI is broken. It's easier to split the versions to isolate and identify the Python version-related root cause.

![Screenshot 2024-01-02 at 12 44 29 PM](https://github.com/apache/spark/assets/9700541/f034dc60-ae45-4538-8c2a-55bc89904d1f)

Since Python 3.12 is relatively new than the other versions, it needs more attention.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

This should be tested after merging because `Python CI` is a daily test.

### Was this patch authored or co-authored using generative AI tooling?

No.