### PR TITLE
[SPARK-45338][TEST][SQL][FOLLOWUP] Use scala.jdk.javaapi.CollectionConverters in JavaHigherOrderFunctionsSuite

### DIFF
--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaHigherOrderFunctionsSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaHigherOrderFunctionsSuite.java
@@ -22,7 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import static java.util.stream.Collectors.toList;
 
-import scala.jdk.CollectionConverters;
+import scala.jdk.javaapi.CollectionConverters;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -222,10 +222,10 @@ public class JavaHigherOrderFunctionsSuite {
         checkAnswer(
             mapDf.select(transform_keys(col("x"), (k, v) -> k.plus(v))),
             toRows(
-                CollectionConverters.MapHasAsScala(new HashMap<Integer, Integer>() {{
+                CollectionConverters.asScala(new HashMap<Integer, Integer>() {{
                     put(2, 1);
                     put(4, 2);
-                }}).asScala(),
+                }}),
                 null
             )
         );
@@ -236,10 +236,10 @@ public class JavaHigherOrderFunctionsSuite {
         checkAnswer(
             mapDf.select(transform_values(col("x"), (k, v) -> k.plus(v))),
             toRows(
-                CollectionConverters.MapHasAsScala(new HashMap<Integer, Integer>() {{
+                CollectionConverters.asScala(new HashMap<Integer, Integer>() {{
                     put(1, 2);
                     put(2, 4);
-                }}).asScala(),
+                }}),
                 null
             )
         );
@@ -250,7 +250,7 @@ public class JavaHigherOrderFunctionsSuite {
         checkAnswer(
             mapDf.select(map_filter(col("x"), (k, v) -> lit(false))),
             toRows(
-                CollectionConverters.MapHasAsScala(new HashMap<Integer, Integer>()).asScala(),
+                CollectionConverters.asScala(new HashMap<Integer, Integer>()),
                 null
             )
         );
@@ -261,10 +261,10 @@ public class JavaHigherOrderFunctionsSuite {
         checkAnswer(
             mapDf.select(map_zip_with(col("x"), col("x"), (k, v1, v2) -> lit(false))),
             toRows(
-                CollectionConverters.MapHasAsScala(new HashMap<Integer, Boolean>() {{
+                CollectionConverters.asScala(new HashMap<Integer, Boolean>() {{
                     put(1, false);
                     put(2, false);
-                }}).asScala(),
+                }}),
                 null
             )
         );


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR proposes to use `scala.jdk.javaapi.CollectionConverters` intended for Java-interop in `JavaHigherOrderFunctionsSuite` instead of the original `scala.jdk.CollectionConverters`.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Simply Java test suite code by using the Scala standard library type intended for Java-interop.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Existing test suite `JavaHigherOrderFunctionsSuite`, as this is a test-only change that only affects this suite.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No