### PR TITLE
[SPARK-46571][PS][TEST] Re-enable TODOs that are resolved from recent Pandas

### DIFF
--- a/python/pyspark/pandas/tests/diff_frames_ops/test_groupby_rolling_adv.py
+++ b/python/pyspark/pandas/tests/diff_frames_ops/test_groupby_rolling_adv.py
@@ -33,7 +33,6 @@ class GroupByRollingAdvMixin(GroupByRollingTestingFuncMixin):
         super().tearDownClass()
 
     def test_groupby_rolling_std(self):
-        # TODO: `std` now raise error in pandas 1.0.0
         self._test_groupby_rolling_func("std")
 
     def test_groupby_rolling_var(self):

--- a/python/pyspark/pandas/tests/groupby/test_stat_func.py
+++ b/python/pyspark/pandas/tests/groupby/test_stat_func.py
@@ -91,8 +91,7 @@ class FuncTestsMixin(GroupbyStatTestingFuncMixin):
             check_exact=False,
         )
 
-        # TODO: fix bug of `sum` and re-enable the test below
-        # self._test_stat_func(lambda groupby_obj: groupby_obj.sum(), check_exact=False)
+        self._test_stat_func(lambda groupby_obj: groupby_obj.sum(), check_exact=False)
         self.assert_eq(
             psdf.groupby("A").sum().sort_index(),
             pdf.groupby("A").sum().sort_index(),

--- a/python/pyspark/pandas/tests/test_namespace.py
+++ b/python/pyspark/pandas/tests/test_namespace.py
@@ -393,7 +393,7 @@ class NamespaceTestsMixin:
         psdf3 = psdf.copy()
 
         columns = pd.MultiIndex.from_tuples([("X", "A"), ("X", "B"), ("Y", "C")])
-        # TODO: colums.names = ["XYZ", "ABC"]
+        columns.names = ["XYZ", "ABC"]
         pdf3.columns = columns
         psdf3.columns = columns
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to re-enable some tests that we can run our current build.

### Why are the changes needed?

Because the previous bugs are resolved from recent Pandas, so we can re-enable the tests.

### Does this PR introduce _any_ user-facing change?

No, it's test-only.

### How was this patch tested?

Manually tests from local build.

### Was this patch authored or co-authored using generative AI tooling?

No.