### PR TITLE
[SPARK-46573][K8S] Use `appId` instead of `conf.appId` in `LoggingPodStatusWatcherImpl`

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/LoggingPodStatusWatcher.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/LoggingPodStatusWatcher.scala
@@ -96,7 +96,7 @@ private[k8s] class LoggingPodStatusWatcherImpl(conf: KubernetesDriverConf)
   }
 
   override def watchOrStop(sId: String): Boolean = {
-    logInfo(s"Waiting for application ${conf.appName} with application ID ${conf.appId} " +
+    logInfo(s"Waiting for application ${conf.appName} with application ID $appId " +
       s"and submission ID $sId to finish...")
     val interval = conf.get(REPORT_INTERVAL)
     synchronized {
@@ -110,7 +110,7 @@ private[k8s] class LoggingPodStatusWatcherImpl(conf: KubernetesDriverConf)
       logInfo(
         pod.map { p => s"Container final statuses:\n\n${containersDescription(p)}" }
           .getOrElse("No containers were found in the driver pod."))
-      logInfo(s"Application ${conf.appName} with application ID ${conf.appId} " +
+      logInfo(s"Application ${conf.appName} with application ID $appId " +
         s"and submission ID $sId finished")
     }
     podCompleted


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR replaces the call to `conf.appId` with direct use of `appId` in `LoggingPodStatusWatcherImpl`, as it is already defined in `LoggingPodStatusWatcherImpl`:

https://github.com/apache/spark/blob/b74b1592c9ec07b3d29b6d4d900b1d3ba1417cd1/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/LoggingPodStatusWatcher.scala#L42

### Why are the changes needed?
Should use the already defined `val appId`


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No
