### PR TITLE
[SPARK-46566][SQL] Session level config was not loaded when isolation is enable.

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveContext.scala
@@ -80,6 +80,6 @@ object HiveContext {
   }
 
   def getSessionHiveConfBuffer(): ByteBuffer = {
-    sessionHiveConfBuffer.get
+    sessionHiveConfBuffer.get()
   }
 }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -186,10 +186,10 @@ private[hive] class HiveClientImpl(
   def conf: HiveConf = {
     val hiveConf = state.getConf
     // Load session-level config
-    val sessionHiveConfBuffer = HiveContext.getSessionHiveConfBuffer
+    val sessionHiveConfBuffer = HiveContext.getSessionHiveConfBuffer()
     if (sessionHiveConfBuffer != null) {
-      val buffer = new DataInputBuffer
-      buffer.reset(sessionHiveConfBuffer.array, 0, sessionHiveConfBuffer.limit)
+      val buffer = new DataInputBuffer()
+      buffer.reset(sessionHiveConfBuffer.array(), 0, sessionHiveConfBuffer.limit())
       hiveConf.readFields(buffer)
     }
     // Hive changed the default of datanucleus.schema.autoCreateAll from true to false


### PR DESCRIPTION
### What changes were proposed in this pull request?

Load session level config.

### Why are the changes needed?

I found session level hive config is missing when we use isolation client classloader for specified hive metastore version. 
For more information see: https://issues.apache.org/jira/browse/SPARK-46566

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

test in our prod yarn cluster.


### Was this patch authored or co-authored using generative AI tooling?

No.
