### PR TITLE
[SPARK-46569][SQL] Remove ThreadLocal due to SecureRandom is thread safe since JDK9

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/ExpressionImplUtils.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/ExpressionImplUtils.java
@@ -34,8 +34,7 @@ import java.security.spec.AlgorithmParameterSpec;
  * A utility class for constructing expressions.
  */
 public class ExpressionImplUtils {
-  private static final ThreadLocal<SecureRandom> threadLocalSecureRandom =
-          ThreadLocal.withInitial(SecureRandom::new);
+  private static final SecureRandom secureRandom = new SecureRandom();
 
   private static final int GCM_IV_LEN = 12;
   private static final int GCM_TAG_LEN = 128;
@@ -153,7 +152,7 @@ public class ExpressionImplUtils {
 
   private static byte[] generateIv(CipherMode mode) {
     byte[] iv = new byte[mode.ivLength];
-    threadLocalSecureRandom.get().nextBytes(iv);
+    secureRandom.nextBytes(iv);
     return iv;
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR propose to remove `ThreadLocal` due to `SecureRandom` is thread safe since JDK9.


### Why are the changes needed?
Spark already upgraded the JDK version to 17.
Before JDK9, we use `ThreadLocal` to keep the thread safe for `SecureRandom`.
There are some javadoc of `SecureRandom` since JDK9 show below.
![屏幕快照 2024-01-03 下午8 11 40](https://github.com/apache/spark/assets/8486025/5699624a-6aa4-4172-a07a-11cf7a3272d8)

Now, we can remove `ThreadLocal` due to `SecureRandom` is thread safe since JDK9.


### Does this PR introduce _any_ user-facing change?
'No'.


### How was this patch tested?
GA tests.


### Was this patch authored or co-authored using generative AI tooling?
'No'.
