### PR TITLE
[WIP][SPARK-46578][SQL] Remove ThreadLocal for fallbackConf

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -141,12 +141,7 @@ object SQLConf {
    * Default config. Only used when there is no active SparkSession for the thread.
    * See [[get]] for more information.
    */
-  private lazy val fallbackConf = new ThreadLocal[SQLConf] {
-    override def initialValue: SQLConf = new SQLConf
-  }
-
-  /** See [[get]] for more information. */
-  def getFallbackConf: SQLConf = fallbackConf.get()
+  def fallbackConf: SQLConf = new SQLConf
 
   private lazy val existingConf = new ThreadLocal[SQLConf] {
     override def initialValue: SQLConf = null
@@ -170,7 +165,7 @@ object SQLConf {
    * Defines a getter that returns the SQLConf within scope.
    * See [[get]] for more information.
    */
-  private val confGetter = new AtomicReference[() => SQLConf](() => fallbackConf.get())
+  private val confGetter = new AtomicReference[() => SQLConf](() => fallbackConf)
 
   /**
    * Sets the active config object within the current scope.

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -117,7 +117,7 @@ class SparkSession private(
   // If there is no active SparkSession, uses the default SQL conf. Otherwise, use the session's.
   SQLConf.setSQLConfGetter(() => {
     SparkSession.getActiveSession.filterNot(_.sparkContext.isStopped).map(_.sessionState.conf)
-      .getOrElse(SQLConf.getFallbackConf)
+      .getOrElse(SQLConf.fallbackConf)
   })
 
   /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfGetterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfGetterSuite.scala
@@ -27,7 +27,7 @@ class SQLConfGetterSuite extends SparkFunSuite with LocalSparkSession {
     assert(SQLConf.get eq spark.sessionState.conf,
       "SQLConf.get should get the conf from the active spark session.")
     spark.stop()
-    assert(SQLConf.get eq SQLConf.getFallbackConf,
+    assert(SQLConf.get eq SQLConf.fallbackConf,
       "SQLConf.get should not get conf from a stopped spark session.")
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR propose to remove `ThreadLocal` for `fallbackConf`.


### Why are the changes needed?
`SQLConf` have a field `fallbackConf` with `ThreadLocal`.
`fallbackConf` has some read operators, but no write operators.
In fact, we can simplify it by create `SQLConf`.


### Does this PR introduce _any_ user-facing change?
'No'.


### How was this patch tested?
GA tests.


### Was this patch authored or co-authored using generative AI tooling?
'No'.
