### PR TITLE
[SPARK-46589][CONNECT] Handle a non-existent error class

### DIFF
--- a/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/client/GrpcExceptionConverter.scala
+++ b/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/client/GrpcExceptionConverter.scala
@@ -392,7 +392,7 @@ private[client] object GrpcExceptionConverter {
     if (isValidErrorClass(params.errorClass)) {
       params.messageParameters
     } else {
-      Map("message" -> params.message)
+      Map("message" -> Option(params.message).getOrElse("No message"))
     }
   }
 

--- a/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/client/GrpcExceptionConverter.scala
+++ b/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/client/GrpcExceptionConverter.scala
@@ -370,9 +370,11 @@ private[client] object GrpcExceptionConverter {
   }
 
   private def isValidErrorClass(errorClass: Option[String]): Boolean = {
-    errorClass.map { ec =>
-      SparkThrowableHelper.isValidErrorClass(ec)
-    }.getOrElse(false)
+    errorClass
+      .map { ec =>
+        SparkThrowableHelper.isValidErrorClass(ec)
+      }
+      .getOrElse(false)
   }
 
   /**

--- a/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/client/GrpcExceptionConverter.scala
+++ b/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/client/GrpcExceptionConverter.scala
@@ -370,11 +370,7 @@ private[client] object GrpcExceptionConverter {
   }
 
   private def isValidErrorClass(errorClass: Option[String]): Boolean = {
-    errorClass
-      .map { ec =>
-        SparkThrowableHelper.isValidErrorClass(ec)
-      }
-      .getOrElse(false)
+    errorClass.exists(SparkThrowableHelper.isValidErrorClass)
   }
 
   /**

--- a/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/client/GrpcExceptionConverter.scala
+++ b/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/client/GrpcExceptionConverter.scala
@@ -392,7 +392,7 @@ private[client] object GrpcExceptionConverter {
     if (isValidErrorClass(params.errorClass)) {
       params.messageParameters
     } else {
-      Map("message" -> Option(params.message).getOrElse("No message"))
+      Map("message" -> params.message)
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to check existence of error class in Scala connect client while converting errors from proto to Spark exceptions. And when an error class doesn't exists, use some legacy error class.

### Why are the changes needed?
To avoid internal errors when the client receives non-existent error class from the connect server, for instance in the case `client 4.0` <-> `server 4.1` as new Spark versions might have new error classes that have been ported to old clients.

### Does this PR introduce _any_ user-facing change?
Yes. After the changes, the connect client (Scala client) won't fail w/ an internal error when it cannot find an error class.

### How was this patch tested?
By existing GAs.

### Was this patch authored or co-authored using generative AI tooling?
No.