### PR TITLE
[SPARK-46582][R][INFRA] Upgrade R Tools version from 4.0.2 to 4.3.2 in AppVeyor

### DIFF
--- a/dev/appveyor-install-dependencies.ps1
+++ b/dev/appveyor-install-dependencies.ps1
@@ -141,7 +141,7 @@ Pop-Location
 
 # ========================== R
 $rVer = "4.3.2"
-$rToolsVer = "4.0.2"
+$rToolsVer = "4.3.2"
 
 InstallR
 InstallRtools


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to upgrade R Tools version from 4.0.2 to 4.3.2 in AppVeyor

### Why are the changes needed?

R Tools 4.3.X is for R 4.3.X. We did not upgrade because of the test failure previously.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Checking the CI in this PR.

### Was this patch authored or co-authored using generative AI tooling?

No.