### PR TITLE
[SPARK-46587][SQL] XML: Fix XSD big integer conversion

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/xml/XSDToSchema.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/xml/XSDToSchema.scala
@@ -96,17 +96,18 @@ object XSDToSchema extends Logging{
                   case facet: XmlSchemaTotalDigitsFacet => facet.getValue.toString.toInt
                 }.getOrElse(38)
                 DecimalType(totalDigits, math.min(totalDigits, fracDigits))
-              case Constants.XSD_UNSIGNEDLONG => DecimalType(38, 0)
+              case Constants.XSD_UNSIGNEDLONG |
+                   Constants.XSD_INTEGER |
+                   Constants.XSD_NEGATIVEINTEGER |
+                   Constants.XSD_NONNEGATIVEINTEGER |
+                   Constants.XSD_NONPOSITIVEINTEGER |
+                   Constants.XSD_POSITIVEINTEGER => DecimalType(38, 0)
               case Constants.XSD_DOUBLE => DoubleType
               case Constants.XSD_FLOAT => FloatType
               case Constants.XSD_BYTE => ByteType
               case Constants.XSD_SHORT |
                    Constants.XSD_UNSIGNEDBYTE => ShortType
-              case Constants.XSD_INTEGER |
-                   Constants.XSD_NEGATIVEINTEGER |
-                   Constants.XSD_NONNEGATIVEINTEGER |
-                   Constants.XSD_NONPOSITIVEINTEGER |
-                   Constants.XSD_POSITIVEINTEGER |
+              case Constants.XSD_INT |
                    Constants.XSD_UNSIGNEDSHORT => IntegerType
               case Constants.XSD_LONG |
                    Constants.XSD_UNSIGNEDINT => LongType

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/util/XSDToSchemaSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/util/XSDToSchemaSuite.scala
@@ -23,7 +23,7 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.execution.datasources.xml.TestUtils._
 import org.apache.spark.sql.execution.datasources.xml.XSDToSchema
 import org.apache.spark.sql.test.SharedSparkSession
-import org.apache.spark.sql.types.{ArrayType, DecimalType, FloatType, LongType, StringType}
+import org.apache.spark.sql.types._
 
 class XSDToSchemaSuite extends SharedSparkSession {
 
@@ -182,5 +182,116 @@ class XSDToSchemaSuite extends SharedSparkSession {
     intercept[FileNotFoundException] {
       XSDToSchema.read(new Path("/path/not/found"))
     }
+  }
+
+  test("Basic DataTypes parsing") {
+    val xsdString =
+      """<?xml version="1.0" encoding="UTF-8" ?>
+        |<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+        |  <xs:element name="basket">
+        |    <xs:complexType>
+        |    <xs:sequence>
+        |      <xs:element name="xs_anyType" type="xs:anyType" />
+        |      <xs:element name="xs_anySimpleType" type="xs:anySimpleType" />
+        |      <xs:element name="xs_anyURI" type="xs:anyURI" />
+        |      <xs:element name="xs_base64Binary" type="xs:base64Binary" />
+        |      <xs:element name="xs_boolean" type="xs:boolean" />
+        |      <xs:element name="xs_byte" type="xs:byte" />
+        |      <xs:element name="xs_date" type="xs:date" />
+        |      <xs:element name="xs_dateTime" type="xs:dateTime" />
+        |      <xs:element name="xs_decimal" type="xs:decimal" />
+        |      <xs:element name="xs_double" type="xs:double" />
+        |      <xs:element name="xs_duration" type="xs:duration" />
+        |      <xs:element name="xs_ENTITIES" type="xs:ENTITIES" />
+        |      <xs:element name="xs_ENTITY" type="xs:ENTITY" />
+        |      <xs:element name="xs_float" type="xs:float" />
+        |      <xs:element name="xs_gDay" type="xs:gDay" />
+        |      <xs:element name="xs_gMonth" type="xs:gMonth" />
+        |      <xs:element name="xs_gMonthDay" type="xs:gMonthDay" />
+        |      <xs:element name="xs_gYear" type="xs:gYear" />
+        |      <xs:element name="xs_gYearMonth" type="xs:gYearMonth" />
+        |      <xs:element name="xs_hexBinary" type="xs:hexBinary" />
+        |      <xs:element name="xs_ID" type="xs:ID" />
+        |      <xs:element name="xs_IDREF" type="xs:IDREF" />
+        |      <xs:element name="xs_IDREFS" type="xs:IDREFS" />
+        |      <xs:element name="xs_int" type="xs:int" />
+        |      <xs:element name="xs_integer" type="xs:integer" />
+        |      <xs:element name="xs_language" type="xs:language" />
+        |      <xs:element name="xs_long" type="xs:long" />
+        |      <xs:element name="xs_Name" type="xs:Name" />
+        |      <xs:element name="xs_NCName" type="xs:NCName" />
+        |      <xs:element name="xs_negativeInteger" type="xs:negativeInteger" />
+        |      <xs:element name="xs_NMTOKEN" type="xs:NMTOKEN" />
+        |      <xs:element name="xs_NMTOKENS" type="xs:NMTOKENS" />
+        |      <xs:element name="xs_nonNegativeInteger" type="xs:nonNegativeInteger" />
+        |      <xs:element name="xs_nonPositiveInteger" type="xs:nonPositiveInteger" />
+        |      <xs:element name="xs_normalizedString" type="xs:normalizedString" />
+        |      <xs:element name="xs_NOTATION" type="xs:NOTATION" />
+        |      <xs:element name="xs_positiveInteger" type="xs:positiveInteger" />
+        |      <xs:element name="xs_QName" type="xs:QName" />
+        |      <xs:element name="xs_short" type="xs:short" />
+        |      <xs:element name="xs_string" type="xs:string" />
+        |      <xs:element name="xs_time" type="xs:time" />
+        |      <xs:element name="xs_token" type="xs:token" />
+        |      <xs:element name="xs_unsignedByte" type="xs:unsignedByte" />
+        |      <xs:element name="xs_unsignedInt" type="xs:unsignedInt" />
+        |      <xs:element name="xs_unsignedLong" type="xs:unsignedLong" />
+        |      <xs:element name="xs_unsignedShort" type="xs:unsignedShort" />
+        |    </xs:sequence>
+        |    </xs:complexType>
+        |  </xs:element>
+        |</xs:schema>
+        |""".stripMargin
+    val parsedSchema = XSDToSchema.read(xsdString)
+    val expectedSchema = StructType(StructField("basket",
+      StructType(
+        StructField("xs_anyType", StringType, false) ::
+          StructField("xs_anySimpleType", StringType, false) ::
+          StructField("xs_anyURI", StringType, false) ::
+          StructField("xs_base64Binary", StringType, false) ::
+          StructField("xs_boolean", BooleanType, false) ::
+          StructField("xs_byte", ByteType, false) ::
+          StructField("xs_date", DateType, false) ::
+          StructField("xs_dateTime", TimestampType, false) ::
+          StructField("xs_decimal", DecimalType(38, 18), false) ::
+          StructField("xs_double", DoubleType, false) ::
+          StructField("xs_duration", StringType, false) ::
+          StructField("xs_ENTITIES", StringType, false) ::
+          StructField("xs_ENTITY", StringType, false) ::
+          StructField("xs_float", FloatType, false) ::
+          StructField("xs_gDay", StringType, false) ::
+          StructField("xs_gMonth", StringType, false) ::
+          StructField("xs_gMonthDay", StringType, false) ::
+          StructField("xs_gYear", StringType, false) ::
+          StructField("xs_gYearMonth", StringType, false) ::
+          StructField("xs_hexBinary", StringType, false) ::
+          StructField("xs_ID", StringType, false) ::
+          StructField("xs_IDREF", StringType, false) ::
+          StructField("xs_IDREFS", StringType, false) ::
+          StructField("xs_int", IntegerType, false) ::
+          StructField("xs_integer", DecimalType(38, 0), false) ::
+          StructField("xs_language", StringType, false) ::
+          StructField("xs_long", LongType, false) ::
+          StructField("xs_Name", StringType, false) ::
+          StructField("xs_NCName", StringType, false) ::
+          StructField("xs_negativeInteger", DecimalType(38, 0), false) ::
+          StructField("xs_NMTOKEN", StringType, false) ::
+          StructField("xs_NMTOKENS", StringType, false) ::
+          StructField("xs_nonNegativeInteger", DecimalType(38, 0), false) ::
+          StructField("xs_nonPositiveInteger", DecimalType(38, 0), false) ::
+          StructField("xs_normalizedString", StringType, false) ::
+          StructField("xs_NOTATION", StringType, false) ::
+          StructField("xs_positiveInteger", DecimalType(38, 0), false) ::
+          StructField("xs_QName", StringType, false) ::
+          StructField("xs_short", ShortType, false) ::
+          StructField("xs_string", StringType, false) ::
+          StructField("xs_time", StringType, false) ::
+          StructField("xs_token", StringType, false) ::
+          StructField("xs_unsignedByte", ShortType, false) ::
+          StructField("xs_unsignedInt", LongType, false) ::
+          StructField("xs_unsignedLong", DecimalType(38, 0), false) ::
+          StructField("xs_unsignedShort", IntegerType, false) :: Nil),
+      false) :: Nil)
+    assert(parsedSchema === expectedSchema)
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix XSD type conversion for some big integer types in XSDToSchema helper utility.

NOTE: This is a deviation from spark-xml.

### Why are the changes needed?
To correctly map XSD data types to spark data types

### Does this PR introduce _any_ user-facing change?
Yes

### How was this patch tested?
Unit test

### Was this patch authored or co-authored using generative AI tooling?
No