### PR TITLE
[SPARK-46594][DOCS] The description of `spark.yarn.shuffle.server.recovery.disabled` should be in chapter `Configuring the External Shuffle Service`

### DIFF
--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -665,16 +665,6 @@ To use a custom metrics.properties for the application master and executors, upd
   </td>
   <td>3.0.0</td>
 </tr>
-<tr>
-  <td><code>spark.yarn.shuffle.server.recovery.disabled</code></td>
-  <td>false</td>
-  <td>
-    Set to true for applications that have higher security requirements and prefer that their
-    secret is not saved in the db. The shuffle data of such applications wll not be recovered after
-    the External Shuffle Service restarts.
-  </td>
-  <td>3.5.0</td>
-</tr>
 </table>
 
 #### Available patterns for SHS custom executor log URL
@@ -909,6 +899,16 @@ The following extra configuration options are available when the shuffle service
     created when switching storage types.
   </td>
   <td>3.4.0</td>
+</tr>
+<tr>
+  <td><code>spark.yarn.shuffle.server.recovery.disabled</code></td>
+  <td>false</td>
+  <td>
+    Set to true for applications that have higher security requirements and prefer that their
+    secret is not saved in the db. The shuffle data of such applications wll not be recovered after
+    the External Shuffle Service restarts.
+  </td>
+  <td>3.5.0</td>
 </tr>
 </table>
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to adjust the document(`running-on-yarn`) position of the description of `spark.yarn.shuffle.server.recovery.disabled`.
From the chapter `Spark Properties` to the chapter `Configuring the External Shuffle Service`.


### Why are the changes needed?
To improve documentation and facilitate users to quickly query configuration instructions.


### Does this PR introduce _any_ user-facing change?
Yes, the description of `spark.yarn.shuffle.server.recovery.disabled`, from the chapter `Spark Properties` to the chapter `Configuring the External Shuffle Service`.


### How was this patch tested?
Manually test.

### Was this patch authored or co-authored using generative AI tooling?
No.
