### PR TITLE
Revert "[SPARK-46593][PS][TESTS] Refactor `data_type_ops` tests"

### DIFF
--- a/python/pyspark/pandas/tests/connect/data_type_ops/test_parity_as_type.py
+++ b/python/pyspark/pandas/tests/connect/data_type_ops/test_parity_as_type.py
@@ -16,17 +16,19 @@
 #
 import unittest
 
+from pyspark import pandas as ps
 from pyspark.pandas.tests.data_type_ops.test_as_type import AsTypeTestsMixin
-from pyspark.pandas.tests.data_type_ops.testing_utils import OpsTestBase
+from pyspark.pandas.tests.connect.data_type_ops.testing_utils import OpsTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 from pyspark.testing.connectutils import ReusedConnectTestCase
 
 
 class AsTypeParityTests(
-    AsTypeTestsMixin,
-    OpsTestBase,
-    ReusedConnectTestCase,
+    AsTypeTestsMixin, PandasOnSparkTestUtils, OpsTestBase, ReusedConnectTestCase
 ):
-    pass
+    @property
+    def psdf(self):
+        return ps.from_pandas(self.pdf)
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/connect/data_type_ops/test_parity_base.py
+++ b/python/pyspark/pandas/tests/connect/data_type_ops/test_parity_base.py
@@ -20,10 +20,7 @@ from pyspark.pandas.tests.data_type_ops.test_base import BaseTestsMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase
 
 
-class BaseParityTests(
-    BaseTestsMixin,
-    ReusedConnectTestCase,
-):
+class BaseParityTests(BaseTestsMixin, ReusedConnectTestCase):
     pass
 
 

--- a/python/pyspark/pandas/tests/connect/data_type_ops/test_parity_binary_ops.py
+++ b/python/pyspark/pandas/tests/connect/data_type_ops/test_parity_binary_ops.py
@@ -17,14 +17,13 @@
 import unittest
 
 from pyspark.pandas.tests.data_type_ops.test_binary_ops import BinaryOpsTestsMixin
-from pyspark.pandas.tests.data_type_ops.testing_utils import OpsTestBase
+from pyspark.pandas.tests.connect.data_type_ops.testing_utils import OpsTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 from pyspark.testing.connectutils import ReusedConnectTestCase
 
 
 class BinaryOpsParityTests(
-    BinaryOpsTestsMixin,
-    OpsTestBase,
-    ReusedConnectTestCase,
+    BinaryOpsTestsMixin, PandasOnSparkTestUtils, OpsTestBase, ReusedConnectTestCase
 ):
     pass
 

--- a/python/pyspark/pandas/tests/connect/data_type_ops/test_parity_boolean_ops.py
+++ b/python/pyspark/pandas/tests/connect/data_type_ops/test_parity_boolean_ops.py
@@ -16,17 +16,19 @@
 #
 import unittest
 
+from pyspark import pandas as ps
 from pyspark.pandas.tests.data_type_ops.test_boolean_ops import BooleanOpsTestsMixin
-from pyspark.pandas.tests.data_type_ops.testing_utils import OpsTestBase
+from pyspark.pandas.tests.connect.data_type_ops.testing_utils import OpsTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 from pyspark.testing.connectutils import ReusedConnectTestCase
 
 
 class BooleanOpsParityTests(
-    BooleanOpsTestsMixin,
-    OpsTestBase,
-    ReusedConnectTestCase,
+    BooleanOpsTestsMixin, PandasOnSparkTestUtils, OpsTestBase, ReusedConnectTestCase
 ):
-    pass
+    @property
+    def psdf(self):
+        return ps.from_pandas(self.pdf)
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/connect/data_type_ops/test_parity_categorical_ops.py
+++ b/python/pyspark/pandas/tests/connect/data_type_ops/test_parity_categorical_ops.py
@@ -16,17 +16,19 @@
 #
 import unittest
 
+from pyspark import pandas as ps
 from pyspark.pandas.tests.data_type_ops.test_categorical_ops import CategoricalOpsTestsMixin
-from pyspark.pandas.tests.data_type_ops.testing_utils import OpsTestBase
+from pyspark.pandas.tests.connect.data_type_ops.testing_utils import OpsTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 from pyspark.testing.connectutils import ReusedConnectTestCase
 
 
 class CategoricalOpsParityTests(
-    CategoricalOpsTestsMixin,
-    OpsTestBase,
-    ReusedConnectTestCase,
+    CategoricalOpsTestsMixin, PandasOnSparkTestUtils, OpsTestBase, ReusedConnectTestCase
 ):
-    pass
+    @property
+    def psdf(self):
+        return ps.from_pandas(self.pdf)
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/connect/data_type_ops/test_parity_complex_ops.py
+++ b/python/pyspark/pandas/tests/connect/data_type_ops/test_parity_complex_ops.py
@@ -17,14 +17,13 @@
 import unittest
 
 from pyspark.pandas.tests.data_type_ops.test_complex_ops import ComplexOpsTestsMixin
-from pyspark.pandas.tests.data_type_ops.testing_utils import OpsTestBase
+from pyspark.pandas.tests.connect.data_type_ops.testing_utils import OpsTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 from pyspark.testing.connectutils import ReusedConnectTestCase
 
 
 class ComplexOpsParityTests(
-    ComplexOpsTestsMixin,
-    OpsTestBase,
-    ReusedConnectTestCase,
+    ComplexOpsTestsMixin, PandasOnSparkTestUtils, OpsTestBase, ReusedConnectTestCase
 ):
     pass
 

--- a/python/pyspark/pandas/tests/connect/data_type_ops/test_parity_date_ops.py
+++ b/python/pyspark/pandas/tests/connect/data_type_ops/test_parity_date_ops.py
@@ -16,17 +16,19 @@
 #
 import unittest
 
+from pyspark import pandas as ps
 from pyspark.pandas.tests.data_type_ops.test_date_ops import DateOpsTestsMixin
-from pyspark.pandas.tests.data_type_ops.testing_utils import OpsTestBase
+from pyspark.pandas.tests.connect.data_type_ops.testing_utils import OpsTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 from pyspark.testing.connectutils import ReusedConnectTestCase
 
 
 class DateOpsParityTests(
-    DateOpsTestsMixin,
-    OpsTestBase,
-    ReusedConnectTestCase,
+    DateOpsTestsMixin, PandasOnSparkTestUtils, OpsTestBase, ReusedConnectTestCase
 ):
-    pass
+    @property
+    def psdf(self):
+        return ps.from_pandas(self.pdf)
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/connect/data_type_ops/test_parity_datetime_ops.py
+++ b/python/pyspark/pandas/tests/connect/data_type_ops/test_parity_datetime_ops.py
@@ -16,17 +16,19 @@
 #
 import unittest
 
+from pyspark import pandas as ps
 from pyspark.pandas.tests.data_type_ops.test_datetime_ops import DatetimeOpsTestsMixin
-from pyspark.pandas.tests.data_type_ops.testing_utils import OpsTestBase
+from pyspark.pandas.tests.connect.data_type_ops.testing_utils import OpsTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 from pyspark.testing.connectutils import ReusedConnectTestCase
 
 
 class DatetimeOpsParityTests(
-    DatetimeOpsTestsMixin,
-    OpsTestBase,
-    ReusedConnectTestCase,
+    DatetimeOpsTestsMixin, PandasOnSparkTestUtils, OpsTestBase, ReusedConnectTestCase
 ):
-    pass
+    @property
+    def psdf(self):
+        return ps.from_pandas(self.pdf)
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/connect/data_type_ops/test_parity_null_ops.py
+++ b/python/pyspark/pandas/tests/connect/data_type_ops/test_parity_null_ops.py
@@ -17,14 +17,13 @@
 import unittest
 
 from pyspark.pandas.tests.data_type_ops.test_null_ops import NullOpsTestsMixin
-from pyspark.pandas.tests.data_type_ops.testing_utils import OpsTestBase
+from pyspark.pandas.tests.connect.data_type_ops.testing_utils import OpsTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 from pyspark.testing.connectutils import ReusedConnectTestCase
 
 
 class NullOpsParityTests(
-    NullOpsTestsMixin,
-    OpsTestBase,
-    ReusedConnectTestCase,
+    NullOpsTestsMixin, PandasOnSparkTestUtils, OpsTestBase, ReusedConnectTestCase
 ):
     pass
 

--- a/python/pyspark/pandas/tests/connect/data_type_ops/test_parity_num_arithmetic.py
+++ b/python/pyspark/pandas/tests/connect/data_type_ops/test_parity_num_arithmetic.py
@@ -16,17 +16,19 @@
 #
 import unittest
 
+from pyspark import pandas as ps
 from pyspark.pandas.tests.data_type_ops.test_num_arithmetic import ArithmeticTestsMixin
-from pyspark.pandas.tests.data_type_ops.testing_utils import OpsTestBase
+from pyspark.pandas.tests.connect.data_type_ops.testing_utils import OpsTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 from pyspark.testing.connectutils import ReusedConnectTestCase
 
 
 class ArithmeticParityTests(
-    ArithmeticTestsMixin,
-    OpsTestBase,
-    ReusedConnectTestCase,
+    ArithmeticTestsMixin, PandasOnSparkTestUtils, OpsTestBase, ReusedConnectTestCase
 ):
-    pass
+    @property
+    def psdf(self):
+        return ps.from_pandas(self.pdf)
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/connect/data_type_ops/test_parity_num_ops.py
+++ b/python/pyspark/pandas/tests/connect/data_type_ops/test_parity_num_ops.py
@@ -16,17 +16,19 @@
 #
 import unittest
 
+from pyspark import pandas as ps
 from pyspark.pandas.tests.data_type_ops.test_num_ops import NumOpsTestsMixin
-from pyspark.pandas.tests.data_type_ops.testing_utils import OpsTestBase
+from pyspark.pandas.tests.connect.data_type_ops.testing_utils import OpsTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 from pyspark.testing.connectutils import ReusedConnectTestCase
 
 
 class NumOpsParityTests(
-    NumOpsTestsMixin,
-    OpsTestBase,
-    ReusedConnectTestCase,
+    NumOpsTestsMixin, PandasOnSparkTestUtils, OpsTestBase, ReusedConnectTestCase
 ):
-    pass
+    @property
+    def psdf(self):
+        return ps.from_pandas(self.pdf)
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/connect/data_type_ops/test_parity_num_reverse.py
+++ b/python/pyspark/pandas/tests/connect/data_type_ops/test_parity_num_reverse.py
@@ -16,17 +16,19 @@
 #
 import unittest
 
+from pyspark import pandas as ps
 from pyspark.pandas.tests.data_type_ops.test_num_reverse import ReverseTestsMixin
-from pyspark.pandas.tests.data_type_ops.testing_utils import OpsTestBase
+from pyspark.pandas.tests.connect.data_type_ops.testing_utils import OpsTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 from pyspark.testing.connectutils import ReusedConnectTestCase
 
 
 class ReverseParityTests(
-    ReverseTestsMixin,
-    OpsTestBase,
-    ReusedConnectTestCase,
+    ReverseTestsMixin, PandasOnSparkTestUtils, OpsTestBase, ReusedConnectTestCase
 ):
-    pass
+    @property
+    def psdf(self):
+        return ps.from_pandas(self.pdf)
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/connect/data_type_ops/test_parity_string_ops.py
+++ b/python/pyspark/pandas/tests/connect/data_type_ops/test_parity_string_ops.py
@@ -16,17 +16,19 @@
 #
 import unittest
 
+from pyspark import pandas as ps
 from pyspark.pandas.tests.data_type_ops.test_string_ops import StringOpsTestsMixin
-from pyspark.pandas.tests.data_type_ops.testing_utils import OpsTestBase
+from pyspark.pandas.tests.connect.data_type_ops.testing_utils import OpsTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 from pyspark.testing.connectutils import ReusedConnectTestCase
 
 
 class StringOpsParityTests(
-    StringOpsTestsMixin,
-    OpsTestBase,
-    ReusedConnectTestCase,
+    StringOpsTestsMixin, PandasOnSparkTestUtils, OpsTestBase, ReusedConnectTestCase
 ):
-    pass
+    @property
+    def psdf(self):
+        return ps.from_pandas(self.pdf)
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/connect/data_type_ops/test_parity_timedelta_ops.py
+++ b/python/pyspark/pandas/tests/connect/data_type_ops/test_parity_timedelta_ops.py
@@ -16,17 +16,19 @@
 #
 import unittest
 
+import pyspark.pandas as ps
 from pyspark.pandas.tests.data_type_ops.test_timedelta_ops import TimedeltaOpsTestsMixin
-from pyspark.pandas.tests.data_type_ops.testing_utils import OpsTestBase
+from pyspark.pandas.tests.connect.data_type_ops.testing_utils import OpsTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 from pyspark.testing.connectutils import ReusedConnectTestCase
 
 
 class TimedeltaOpsParityTests(
-    TimedeltaOpsTestsMixin,
-    OpsTestBase,
-    ReusedConnectTestCase,
+    TimedeltaOpsTestsMixin, PandasOnSparkTestUtils, OpsTestBase, ReusedConnectTestCase
 ):
-    pass
+    @property
+    def psdf(self):
+        return ps.from_pandas(self.pdf)
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/connect/data_type_ops/test_parity_udt_ops.py
+++ b/python/pyspark/pandas/tests/connect/data_type_ops/test_parity_udt_ops.py
@@ -17,14 +17,13 @@
 import unittest
 
 from pyspark.pandas.tests.data_type_ops.test_udt_ops import UDTOpsTestsMixin
-from pyspark.pandas.tests.data_type_ops.testing_utils import OpsTestBase
+from pyspark.pandas.tests.connect.data_type_ops.testing_utils import OpsTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 from pyspark.testing.connectutils import ReusedConnectTestCase
 
 
 class UDTOpsParityTests(
-    UDTOpsTestsMixin,
-    OpsTestBase,
-    ReusedConnectTestCase,
+    UDTOpsTestsMixin, PandasOnSparkTestUtils, OpsTestBase, ReusedConnectTestCase
 ):
     pass
 

--- a/python/pyspark/pandas/tests/connect/data_type_ops/testing_utils.py
+++ b/python/pyspark/pandas/tests/connect/data_type_ops/testing_utils.py
@@ -27,7 +27,6 @@ from pyspark.pandas.typedef.typehints import (
     extension_float_dtypes_available,
     extension_object_dtypes_available,
 )
-from pyspark.testing.pandasutils import ComparisonTestBase
 
 if extension_dtypes_available:
     from pandas import Int8Dtype, Int16Dtype, Int32Dtype, Int64Dtype
@@ -39,7 +38,7 @@ if extension_object_dtypes_available:
     from pandas import BooleanDtype, StringDtype
 
 
-class OpsTestBase(ComparisonTestBase):
+class OpsTestBase:
     """The test base for arithmetic operations of different data types."""
 
     @property


### PR DESCRIPTION
### What changes were proposed in this pull request?
revert https://github.com/apache/spark/pull/44592 which happened to disable the parity tests 

they should be run on connect mode, but actually run on vanilla mode

