### PR TITLE
[SPARK-46604][SQL] Make `Literal.apply` support `s.c.immuable.ArraySeq`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
@@ -32,7 +32,7 @@ import java.time.{Duration, Instant, LocalDate, LocalDateTime, Period, ZoneOffse
 import java.util
 import java.util.Objects
 
-import scala.collection.mutable
+import scala.collection.{immutable, mutable}
 import scala.math.{BigDecimal, BigInt}
 import scala.reflect.runtime.universe.TypeTag
 import scala.util.Try
@@ -91,6 +91,7 @@ object Literal {
     case p: Period => Literal(periodToMonths(p), YearMonthIntervalType())
     case a: Array[Byte] => Literal(a, BinaryType)
     case a: mutable.ArraySeq[_] => apply(a.array)
+    case a: immutable.ArraySeq[_] => apply(a.unsafeArray)
     case a: Array[_] =>
       val elementType = componentTypeToDataType(a.getClass.getComponentType())
       val dataType = ArrayType(elementType)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/LiteralExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/LiteralExpressionSuite.scala
@@ -479,8 +479,7 @@ class LiteralExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
   }
 
   test("SPARK-46604: Literal support immutable ArraySeq") {
-    import org.apache.spark.util.ArrayImplicits._
-    val immArraySeq = Array(1.0, 4.0).toImmutableArraySeq
+    val immArraySeq = immutable.ArraySeq.unsafeWrapArray(Array(1.0, 4.0))
     val expected = toCatalyst(immArraySeq)
     checkEvaluation(Literal(immArraySeq), expected)
     checkEvaluation(Literal.create(immArraySeq), expected)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/LiteralExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/LiteralExpressionSuite.scala
@@ -479,7 +479,8 @@ class LiteralExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
   }
 
   test("SPARK-46604: Literal support immutable ArraySeq") {
-    val immArraySeq = immutable.ArraySeq.unsafeWrapArray(Array(1.0, 4.0))
+    import org.apache.spark.util.ArrayImplicits._
+    val immArraySeq = Array(1.0, 4.0).toImmutableArraySeq
     val expected = toCatalyst(immArraySeq)
     checkEvaluation(Literal(immArraySeq), expected)
     checkEvaluation(Literal.create(immArraySeq), expected)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/LiteralExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/LiteralExpressionSuite.scala
@@ -22,7 +22,7 @@ import java.time.{Duration, Instant, LocalDate, LocalDateTime, Period, ZoneOffse
 import java.time.temporal.ChronoUnit
 import java.util.TimeZone
 
-import scala.collection.mutable
+import scala.collection.{immutable, mutable}
 import scala.reflect.runtime.universe.TypeTag
 
 import org.apache.spark.{SparkException, SparkFunSuite}
@@ -476,5 +476,13 @@ class LiteralExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
     checkEvaluation(
       Literal.create(UTF8String.fromString("Spark SQL"), ObjectType(classOf[UTF8String])),
       UTF8String.fromString("Spark SQL"))
+  }
+
+  test("SPARK-46604: Literal support immutable ArraySeq") {
+    val immArraySeq = immutable.ArraySeq.unsafeWrapArray(Array(1.0, 4.0))
+    val expected = toCatalyst(immArraySeq)
+    checkEvaluation(Literal(immArraySeq), expected)
+    checkEvaluation(Literal.create(immArraySeq), expected)
+    checkEvaluation(Literal.create(immArraySeq, ArrayType(DoubleType)), expected)
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/LiteralExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/LiteralExpressionSuite.scala
@@ -22,7 +22,7 @@ import java.time.{Duration, Instant, LocalDate, LocalDateTime, Period, ZoneOffse
 import java.time.temporal.ChronoUnit
 import java.util.TimeZone
 
-import scala.collection.{immutable, mutable}
+import scala.collection.mutable
 import scala.reflect.runtime.universe.TypeTag
 
 import org.apache.spark.{SparkException, SparkFunSuite}
@@ -479,7 +479,8 @@ class LiteralExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
   }
 
   test("SPARK-46604: Literal support immutable ArraySeq") {
-    val immArraySeq = immutable.ArraySeq.unsafeWrapArray(Array(1.0, 4.0))
+    import org.apache.spark.util.ArrayImplicits._
+    val immArraySeq = Array(1.0, 4.0).toImmutableArraySeq
     val expected = toCatalyst(immArraySeq)
     checkEvaluation(Literal(immArraySeq), expected)
     checkEvaluation(Literal.create(immArraySeq), expected)


### PR DESCRIPTION
### What changes were proposed in this pull request?
The `Literal.create` function supports `immuable.ArraySeq`, but the `Literal.apply` function does not. So this pr make the `Literal.apply` function to also support `immuable.ArraySeq`.


### Why are the changes needed?
Make `Literal.apply` support `s.c.immuable.ArraySeq` as `Literal.create`


### Does this PR introduce _any_ user-facing change?
Yes, user can create `Literal` using the `Literal.apply` function with `s.c.immuable.ArraySeq` as input.


### How was this patch tested?
Add a new test


### Was this patch authored or co-authored using generative AI tooling?
No
