### PR TITLE
[SPARK-46607][PYTHON][TESTS] Check the testing mode

### DIFF
--- a/python/pyspark/pandas/tests/connect/groupby/test_parity_grouping.py
+++ b/python/pyspark/pandas/tests/connect/groupby/test_parity_grouping.py
@@ -19,10 +19,14 @@ import unittest
 
 from pyspark.pandas.tests.groupby.test_grouping import GroupingTestsMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase
-from pyspark.testing.pandasutils import PandasOnSparkTestCase
+from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
-class GroupingParityTests(GroupingTestsMixin, PandasOnSparkTestCase, ReusedConnectTestCase):
+class GroupingParityTests(
+    GroupingTestsMixin,
+    PandasOnSparkTestUtils,
+    ReusedConnectTestCase,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/connect/groupby/test_parity_missing.py
+++ b/python/pyspark/pandas/tests/connect/groupby/test_parity_missing.py
@@ -19,10 +19,14 @@ import unittest
 
 from pyspark.pandas.tests.groupby.test_missing import MissingTestsMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase
-from pyspark.testing.pandasutils import PandasOnSparkTestCase
+from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
-class MissingParityTests(MissingTestsMixin, PandasOnSparkTestCase, ReusedConnectTestCase):
+class MissingParityTests(
+    MissingTestsMixin,
+    PandasOnSparkTestUtils,
+    ReusedConnectTestCase,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/connect/groupby/test_parity_nlargest_nsmallest.py
+++ b/python/pyspark/pandas/tests/connect/groupby/test_parity_nlargest_nsmallest.py
@@ -19,11 +19,13 @@ import unittest
 
 from pyspark.pandas.tests.groupby.test_nlargest_nsmallest import NlargestNsmallestTestsMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase
-from pyspark.testing.pandasutils import PandasOnSparkTestCase
+from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
 class NlargestNsmallestParityTests(
-    NlargestNsmallestTestsMixin, PandasOnSparkTestCase, ReusedConnectTestCase
+    NlargestNsmallestTestsMixin,
+    PandasOnSparkTestUtils,
+    ReusedConnectTestCase,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/connect/groupby/test_parity_raises.py
+++ b/python/pyspark/pandas/tests/connect/groupby/test_parity_raises.py
@@ -19,10 +19,14 @@ import unittest
 
 from pyspark.pandas.tests.groupby.test_raises import RaisesTestsMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase
-from pyspark.testing.pandasutils import PandasOnSparkTestCase
+from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
-class RaisesParityTests(RaisesTestsMixin, PandasOnSparkTestCase, ReusedConnectTestCase):
+class RaisesParityTests(
+    RaisesTestsMixin,
+    PandasOnSparkTestUtils,
+    ReusedConnectTestCase,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/connect/groupby/test_parity_rank.py
+++ b/python/pyspark/pandas/tests/connect/groupby/test_parity_rank.py
@@ -19,10 +19,14 @@ import unittest
 
 from pyspark.pandas.tests.groupby.test_rank import RankTestsMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase
-from pyspark.testing.pandasutils import PandasOnSparkTestCase
+from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
-class RankParityTests(RankTestsMixin, PandasOnSparkTestCase, ReusedConnectTestCase):
+class RankParityTests(
+    RankTestsMixin,
+    PandasOnSparkTestUtils,
+    ReusedConnectTestCase,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/connect/groupby/test_parity_size.py
+++ b/python/pyspark/pandas/tests/connect/groupby/test_parity_size.py
@@ -19,10 +19,14 @@ import unittest
 
 from pyspark.pandas.tests.groupby.test_size import SizeTestsMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase
-from pyspark.testing.pandasutils import PandasOnSparkTestCase
+from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
-class SizeParityTests(SizeTestsMixin, PandasOnSparkTestCase, ReusedConnectTestCase):
+class SizeParityTests(
+    SizeTestsMixin,
+    PandasOnSparkTestUtils,
+    ReusedConnectTestCase,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/connect/groupby/test_parity_value_counts.py
+++ b/python/pyspark/pandas/tests/connect/groupby/test_parity_value_counts.py
@@ -19,10 +19,14 @@ import unittest
 
 from pyspark.pandas.tests.groupby.test_value_counts import ValueCountsTestsMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase
-from pyspark.testing.pandasutils import PandasOnSparkTestCase
+from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
-class ValueCountsParityTests(ValueCountsTestsMixin, PandasOnSparkTestCase, ReusedConnectTestCase):
+class ValueCountsParityTests(
+    ValueCountsTestsMixin,
+    PandasOnSparkTestUtils,
+    ReusedConnectTestCase,
+):
     pass
 
 

--- a/python/pyspark/testing/connectutils.py
+++ b/python/pyspark/testing/connectutils.py
@@ -192,3 +192,8 @@ class ReusedConnectTestCase(unittest.TestCase, SQLTestUtils, PySparkErrorTestUti
     def tearDownClass(cls):
         shutil.rmtree(cls.tempdir.name, ignore_errors=True)
         cls.spark.stop()
+
+    def test_assert_remote_mode(self):
+        from pyspark.sql import is_remote
+
+        self.assertTrue(is_remote())

--- a/python/pyspark/testing/utils.py
+++ b/python/pyspark/testing/utils.py
@@ -179,6 +179,11 @@ class ReusedPySparkTestCase(unittest.TestCase):
     def tearDownClass(cls):
         cls.sc.stop()
 
+    def test_assert_vanilla_mode(self):
+        from pyspark.sql import is_remote
+
+        self.assertFalse(is_remote())
+
 
 class ByteArrayOutput:
     def __init__(self):


### PR DESCRIPTION
### What changes were proposed in this pull request?
1, check the testing mode:

- `test_assert_vanilla_mode` in `ReusedPySparkTestCase`
- `test_assert_remote_mode` in `ReusedConnectTestCase`

use different function names in case a test suite inherit them both


2, fix the incorrect testing mode introduced in https://github.com/apache/spark/pull/44196

### Why are the changes needed?
incorrect usage of `PandasOnSparkTestCase` (subclass of `ReusedPySparkTestCase`) in parity tests cause test with vanilla Spark Session:
https://github.com/apache/spark/pull/44196
https://github.com/apache/spark/pull/44592



### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
ci, added UT


### Was this patch authored or co-authored using generative AI tooling?
no
