### PR TITLE
[SPARK-46613][SQL][PYTHON] Log full exception when failed to lookup Python Data Sources

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceManager.scala
@@ -103,7 +103,7 @@ object DataSourceManager extends Logging {
             // Even if it fails for whatever reason, we shouldn't make the whole
             // application fail.
             logWarning(
-              s"Skipping the lookup of Python Data Sources due to the failure: $e")
+              "Skipping the lookup of Python Data Sources due to the failure.", e)
             None
         }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to log full exception when failed to lookup Python Data Sources

### Why are the changes needed?

In my internal testing it logs something like:

```
...
24/01/05 03:49:49 WARN DataSourceManager: Skipping the lookup of Python Data Sources due to the failure: java.lang.StackOverflowError
24/01/05 03:49:49 WARN DataSourceManager: Skipping the lookup of Python Data Sources due to the failure: java.lang.StackOverflowError
24/01/05 03:49:49 WARN DataSourceManager: Skipping the lookup of Python Data Sources due to the failure: java.lang.StackOverflowError
24/01/05 03:49:49 WARN DataSourceManager: Skipping the lookup of Python Data Sources due to the failure: java.lang.StackOverflowError
24/01/05 03:49:49 WARN PythonWorkerFactory: Failed to open socket to Python daemon:
java.net.ConnectException: Connection refused
	at sun.nio.ch.Net.connect0(Native Method)
...
```

which is hard to debug. It should show the full error messages so developers can debug.

### Does this PR introduce _any_ user-facing change?

No, the main change has not been released out yet.

### How was this patch tested?

Manually.

### Was this patch authored or co-authored using generative AI tooling?

No.
