### PR TITLE
[SPARK-46611][CORE][FOLLOWUP] Correct new use of DateTimeFormat.withZone in UIUtils

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
@@ -147,30 +147,14 @@ private[spark] object UIUtils extends Logging {
       batchInterval: Long,
       showYYYYMMSS: Boolean = true,
       timezone: TimeZone = null): String = {
-    val oldTimezones = (batchTimeFormat.getZone, batchTimeFormatWithMilliseconds.getZone)
-    if (timezone != null) {
-      val zoneId = timezone.toZoneId
-      batchTimeFormat.withZone(zoneId)
-      batchTimeFormatWithMilliseconds.withZone(zoneId)
-    }
-    try {
-      val formattedBatchTime =
-        if (batchInterval < 1000) {
-          batchTimeFormatWithMilliseconds.format(Instant.ofEpochMilli(batchTime))
-        } else {
-          // If batchInterval >= 1 second, don't show milliseconds
-          batchTimeFormat.format(Instant.ofEpochMilli(batchTime))
-        }
-      if (showYYYYMMSS) {
-        formattedBatchTime
-      } else {
-        formattedBatchTime.substring(formattedBatchTime.indexOf(' ') + 1)
-      }
-    } finally {
-      if (timezone != null) {
-        batchTimeFormat.withZone(oldTimezones._1)
-        batchTimeFormatWithMilliseconds.withZone(oldTimezones._2)
-      }
+    // If batchInterval >= 1 second, don't show milliseconds
+    val format = if (batchInterval < 1000) batchTimeFormatWithMilliseconds else batchTimeFormat
+    val formatWithZone = if (timezone == null) format else format.withZone(timezone.toZoneId)
+    val formattedBatchTime = formatWithZone.format(Instant.ofEpochMilli(batchTime))
+    if (showYYYYMMSS) {
+      formattedBatchTime
+    } else {
+      formattedBatchTime.substring(formattedBatchTime.indexOf(' ') + 1)
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Simplify code and fix new use of DateTimeFormat.withZone introduced in https://github.com/apache/spark/pull/44613 ; need to use the new object copy this creates.

### Why are the changes needed?

Describing on mailing list from Janda Martin:

```
DateTimeFormatter is thread-safe and immutable according to JavaDoc so method DateTimeFormatter::withZone returns new instance when zone is changed.

Following code has no effect:
  val oldTimezones = (batchTimeFormat.getZone, batchTimeFormatWithMilliseconds.getZone)
  if (timezone != null) {
      val zoneId = timezone.toZoneId
      batchTimeFormat.withZone(zoneId)
      batchTimeFormatWithMilliseconds.withZone(zoneId)
    }

Suggested fix:
introduce local variables for "batchTimeFormat" and "batchTimeFormatWithMilliseconds" and remove "oldTimezones" and "finally" block.
```

### Does this PR introduce _any_ user-facing change?

Unlikely, the path in question is apparently test-only

### How was this patch tested?

Existing tests

### Was this patch authored or co-authored using generative AI tooling?

No