### PR TITLE
[WIP][SPARK-46620][PS][CONNECT] Implement `Frame.asfreq`

### DIFF
--- a/python/docs/source/reference/pyspark.pandas/frame.rst
+++ b/python/docs/source/reference/pyspark.pandas/frame.rst
@@ -261,6 +261,7 @@ Time series-related
 .. autosummary::
    :toctree: api/
 
+   DataFrame.asfreq
    DataFrame.resample
    DataFrame.shift
    DataFrame.first_valid_index

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -9479,7 +9479,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             pdf = pdf.drop(columns=[tmp_agg_column_name])
             pdf = pdf.set_index(tmp_idx_column_name, drop=True)
             pdf = pdf.sort_index()
-            pdf = pdf.asfreq(
+            pdf = pdf.asfreq(  # type: ignore[assignment]
                 freq=freq,
                 method=method,
                 how=how,
@@ -9493,7 +9493,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         output_df = output_df.set_index(tmp_idx_column_name)
         output_df.index.names = self.index.names
 
-        return output_df  # type: ignore[return-value]
+        return output_df
 
     def astype(self, dtype: Union[str, Dtype, Dict[Name, Union[str, Dtype]]]) -> "DataFrame":
         """

--- a/python/pyspark/pandas/missing/frame.py
+++ b/python/pyspark/pandas/missing/frame.py
@@ -34,7 +34,6 @@ class MissingPandasLikeDataFrame:
     # Documentation path: `python/docs/source/reference/pyspark.pandas/`.
 
     # Functions
-    asfreq = _unsupported_function("asfreq")
     asof = _unsupported_function("asof")
     combine = _unsupported_function("combine")
     compare = _unsupported_function("compare")


### PR DESCRIPTION
### What changes were proposed in this pull request?
Implement `Frame.asfreq`


### Why are the changes needed?
for feature parity


### Does this PR introduce _any_ user-facing change?
yes

```
In [1]: import pyspark.pandas as ps

In [2]: import pandas as pd

In [3]: index = pd.date_range('1/1/2000', periods=4, freq='min')

In [4]: series = pd.Series([0.0, None, 2.0, 3.0], index=index)

In [5]: pdf = pd.DataFrame({'s': series})

In [6]: psdf = ps.from_pandas(pdf)
24/01/08 17:25:19 WARN CheckAllocator: More than one DefaultAllocationManager on classpath. Choosing first found

In [7]: psdf.asfreq(freq='30s')
/Users/ruifeng.zheng/Dev/spark/python/pyspark/pandas/utils.py:1015: PandasAPIOnSparkAdviceWarning: `frame.asfreq` loads partial data into the driver's memory to infer the schema, and loads all data into one executor's memory to compute. It should only be used if the pandas DataFrame is expected to be small.
  warnings.warn(message, PandasAPIOnSparkAdviceWarning)
/Users/ruifeng.zheng/Dev/spark/python/pyspark/pandas/utils.py:1015: PandasAPIOnSparkAdviceWarning: If the type hints is not specified for `groupby.apply`, it is expensive to infer the data type internally.
  warnings.warn(message, PandasAPIOnSparkAdviceWarning)
Out[7]: 
                       s
2000-01-01 00:00:00  0.0
2000-01-01 00:00:30  NaN
2000-01-01 00:01:00  NaN
2000-01-01 00:01:30  NaN
2000-01-01 00:02:00  2.0
2000-01-01 00:02:30  NaN
2000-01-01 00:03:00  3.0

In [8]: psdf.asfreq(freq='30s', fill_value=9.0)
/Users/ruifeng.zheng/Dev/spark/python/pyspark/pandas/utils.py:1015: PandasAPIOnSparkAdviceWarning: `frame.asfreq` loads partial data into the driver's memory to infer the schema, and loads all data into one executor's memory to compute. It should only be used if the pandas DataFrame is expected to be small.
  warnings.warn(message, PandasAPIOnSparkAdviceWarning)
/Users/ruifeng.zheng/Dev/spark/python/pyspark/pandas/utils.py:1015: PandasAPIOnSparkAdviceWarning: If the type hints is not specified for `groupby.apply`, it is expensive to infer the data type internally.
  warnings.warn(message, PandasAPIOnSparkAdviceWarning)
Out[8]: 
                       s
2000-01-01 00:00:00  0.0
2000-01-01 00:00:30  9.0
2000-01-01 00:01:00  NaN
2000-01-01 00:01:30  9.0
2000-01-01 00:02:00  2.0
2000-01-01 00:02:30  9.0
2000-01-01 00:03:00  3.0

In [9]: psdf.asfreq(freq='30s', method='bfill')
/Users/ruifeng.zheng/Dev/spark/python/pyspark/pandas/utils.py:1015: PandasAPIOnSparkAdviceWarning: `frame.asfreq` loads partial data into the driver's memory to infer the schema, and loads all data into one executor's memory to compute. It should only be used if the pandas DataFrame is expected to be small.
  warnings.warn(message, PandasAPIOnSparkAdviceWarning)
/Users/ruifeng.zheng/Dev/spark/python/pyspark/pandas/utils.py:1015: PandasAPIOnSparkAdviceWarning: If the type hints is not specified for `groupby.apply`, it is expensive to infer the data type internally.
  warnings.warn(message, PandasAPIOnSparkAdviceWarning)
Out[9]: 
                       s
2000-01-01 00:00:00  0.0
2000-01-01 00:00:30  NaN
2000-01-01 00:01:00  NaN
2000-01-01 00:01:30  2.0
2000-01-01 00:02:00  2.0
2000-01-01 00:02:30  3.0
2000-01-01 00:03:00  3.0

```

### How was this patch tested?
doc test and ut

### Was this patch authored or co-authored using generative AI tooling?
no
