### PR TITLE
[SPARK-46617][SQL] Create-table-if-not-exists should not silently overwrite existing data-files

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/DataWritingCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/DataWritingCommand.scala
@@ -102,14 +102,17 @@ object DataWritingCommand {
   }
   /**
    * When execute CTAS operators, and the location is not empty, throw [[AnalysisException]].
-   * For CTAS, the SaveMode is always [[ErrorIfExists]]
+   * For CTAS, the SaveMode is always [[ErrorIfExists]].
+   * For Create-Table-If-Not-Exists, the SaveMode is [[Ignore]].
    *
    * @param tablePath Table location.
    * @param saveMode  Save mode of the table.
    * @param hadoopConf Configuration.
    */
   def assertEmptyRootPath(tablePath: URI, saveMode: SaveMode, hadoopConf: Configuration): Unit = {
-    if (saveMode == SaveMode.ErrorIfExists && !SQLConf.get.allowNonEmptyLocationInCTAS) {
+    if ((saveMode == SaveMode.ErrorIfExists && !SQLConf.get.allowNonEmptyLocationInCTAS) ||
+      saveMode == SaveMode.Ignore) {
+
       val filePath = new org.apache.hadoop.fs.Path(tablePath)
       val fs = filePath.getFileSystem(hadoopConf)
       if (fs.exists(filePath) &&


### PR DESCRIPTION
### What changes were proposed in this pull request?

**The bug:** If running `create table if not exists as select...` (or `SaveAsTable` using `SaveMode.Ignore`) and the table does not exist in the catalog, the data-files are always overwritten.

**Expected behavior:** Running `create table if not exists as select...` should not overwrite the existing data-files (more similar to the `create table as select` behavior).

For reference, the `create table as select` (or `SaveAsTable` using `SaveMode.ErrorIfExists`) statement just throws an exception instead of overwriting the data-files.

This expectation is in line with the documentation (https://spark.apache.org/docs/latest/api/java/index.html?org/apache/spark/sql/SaveMode.html):

> Ignore mode means that when saving a DataFrame to a data source, if data already exists, the save operation is expected to not save the contents of the DataFrame and to not change the existing data.

**The cause:** `DataWritingCommand.assertEmptyRootPath` verifies if the storage-location exists only if the `SaveMode` is `ErrorIfExists` (to know whether to save or throw exceptions in `create table as select` statements). When the `SaveMode` is `Ignore` (as is the case in `create table if not exists as select...` statements), the presence of files in the storage-location is not checked, so later the statement will force-overwrite the contents.

### Why are the changes needed?

It's a bug: inconsistent behavior depending on which case it is in the test-matrix:

```
+----------------------------+------------------------------------------+
|                            | Behavior when overwriting data-files     |
|    SQL statement           +-------------------+----------------------+
|                            | table in catalog  | table not in catalog |
+----------------------------+-------------------+----------------------+
| create-table               | exception (1)     | exception (2)        |
| create-table-if-not-exists | skip (3)          | OVERWRITE *BUG* (4)  |
+----------------------------+-------------------+----------------------+
```
Explained more in-depth in the jira ticket: https://issues.apache.org/jira/browse/SPARK-46617

### Does this PR introduce _any_ user-facing change?

create-table-if-not-exists statements will work in a more consistent manner.

### How was this patch tested?

* Went manually through the test-matrix again, checked that the table was not overwritten.
* Added unit-tests to automatically check for regressions.

### Was this patch authored or co-authored using generative AI tooling?

No
