### PR TITLE
[SPARK-46621][PYTHON] Address null from Exception.getMessage in Py4J captured exception

### DIFF
--- a/python/pyspark/errors/exceptions/captured.py
+++ b/python/pyspark/errors/exceptions/captured.py
@@ -59,6 +59,8 @@ class CapturedException(PySparkException):
         )
 
         self._desc = desc if desc is not None else cast(Py4JJavaError, origin).getMessage()
+        if self._desc is None:
+            self._desc = ""
         assert SparkContext._jvm is not None
         self._stackTrace = (
             stackTrace


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to address null from `Exception.getMessage` in Py4J captured exception. It returns an empty string.

### Why are the changes needed?

So whitelisted exceptions with an empty arguments are also covered.

### Does this PR introduce _any_ user-facing change?

Virtually no. It only happens when whitelisted exceptions are created without any argument so `null` is located in `message`.

### How was this patch tested?

Manually.

### Was this patch authored or co-authored using generative AI tooling?

No.