### PR TITLE
[SPARK-46622][CORE] Override `toString` method for `o.a.s.network.shuffledb.StoreVersion`

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/shuffledb/StoreVersion.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/shuffledb/StoreVersion.java
@@ -54,4 +54,9 @@ public class StoreVersion {
         result = 31 * result + minor;
         return result;
     }
+
+    @Override
+    public String toString() {
+      return "StoreVersion[" + major + "." + minor + ']';
+    }
 }

--- a/common/network-common/src/test/java/org/apache/spark/network/util/DBProviderSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/util/DBProviderSuite.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.network.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.lang3.SystemUtils;
+import org.apache.spark.network.shuffledb.DBBackend;
+import org.apache.spark.network.shuffledb.StoreVersion;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+
+public class DBProviderSuite {
+
+  @Test
+  public void testRockDBCheckVersionFailed() throws IOException {
+    testCheckVersionFailed(DBBackend.ROCKSDB, "rocksdb");
+  }
+
+  @Test
+  public void testLevelDBCheckVersionFailed() throws IOException {
+    assumeFalse(SystemUtils.IS_OS_MAC_OSX && SystemUtils.OS_ARCH.equals("aarch64"));
+    testCheckVersionFailed(DBBackend.LEVELDB, "leveldb");
+  }
+
+  private void testCheckVersionFailed(DBBackend dbBackend, String namePrefix) throws IOException {
+    String root = System.getProperty("java.io.tmpdir");
+    File dbFile = JavaUtils.createDirectory(root, namePrefix);
+    try {
+      StoreVersion v1 = new StoreVersion(1, 0);
+      ObjectMapper mapper = new ObjectMapper();
+      DBProvider.initDB(dbBackend, dbFile, v1, mapper).close();
+      StoreVersion v2 = new StoreVersion(2, 0);
+      IOException ioe = Assertions.assertThrows(IOException.class, () ->
+        DBProvider.initDB(dbBackend, dbFile, v2, mapper));
+      Assertions.assertTrue(
+        ioe.getMessage().contains("incompatible with current version StoreVersion[2.0]"));
+    } finally {
+      JavaUtils.deleteRecursively(dbFile);
+    }
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to override `toString` method for `o.a.s.network.shuffledb.StoreVersion`

### Why are the changes needed?
Avoid displaying `StoreVersion@hashCode` in the `IOException` thrown after the checkVersion check fails in RocksDBProvider/LevelDBProvider, show something like:

```
cannot read state DB with version org.apache.spark.network.shuffledb.StoreVersion@1f, incompatible with current version org.apache.spark.network.shuffledb.StoreVersion@3e
```


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Add new test


### Was this patch authored or co-authored using generative AI tooling?
No
