### PR TITLE
[SPARK-46624][BUILD] Upgrade joda-time to 2.12.6

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -136,7 +136,7 @@ jetty-util/9.4.53.v20231009//jetty-util-9.4.53.v20231009.jar
 jline/2.14.6//jline-2.14.6.jar
 jline/3.22.0//jline-3.22.0.jar
 jna/5.13.0//jna-5.13.0.jar
-joda-time/2.12.5//joda-time-2.12.5.jar
+joda-time/2.12.6//joda-time-2.12.6.jar
 jodd-core/3.5.2//jodd-core-3.5.2.jar
 jpam/1.1//jpam-1.1.jar
 json/1.8//json-1.8.jar

--- a/pom.xml
+++ b/pom.xml
@@ -208,7 +208,7 @@
       Because it transitions Jakarta REST API from javax to jakarta package.
     -->
     <jersey.version>2.41</jersey.version>
-    <joda.version>2.12.5</joda.version>
+    <joda.version>2.12.6</joda.version>
     <jodd.version>3.5.2</jodd.version>
     <jsr305.version>3.0.0</jsr305.version>
     <libthrift.version>0.12.0</libthrift.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to upgrade  joda-time  from 2.12.5 to 2.12.6

### Why are the changes needed?
The new version brings the following fixes:
- https://github.com/JodaOrg/joda-time/pull/733
- https://github.com/JodaOrg/joda-time/pull/755
- https://github.com/JodaOrg/joda-time/pull/731

The full release notes as follows:
- https://github.com/JodaOrg/joda-time/releases/tag/v2.12.6


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No