### PR TITLE
[MINOR][INFRA] Ensure that docs build successfully with SKIP_API=1

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -763,7 +763,9 @@ jobs:
       run: |
         # Build docs first with SKIP_API to ensure they are valid without requiring any
         # language docs to be built beforehand.
+        pushd docs
         SKIP_API=1 bundle exec jekyll build
+        popd
         if [ -f "./dev/is-changed.py" ]; then
           # Skip PySpark and SparkR docs while keeping Scala/Java/SQL docs
           pyspark_modules=`cd dev && python3.9 -c "import sparktestsupport.modules as m; print(','.join(m.name for m in m.all_modules if m.name.startswith('pyspark')))"`

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -761,11 +761,9 @@ jobs:
       run: ./dev/lint-r
     - name: Run documentation build
       run: |
-        # Build docs first with SKIP_API to ensure they are valid without requiring any
+        # Build docs first with SKIP_API to ensure they are buildable without requiring any
         # language docs to be built beforehand.
-        pushd docs
-        SKIP_API=1 bundle exec jekyll build
-        popd
+        cd docs; SKIP_API=1 bundle exec jekyll build; cd ..
         if [ -f "./dev/is-changed.py" ]; then
           # Skip PySpark and SparkR docs while keeping Scala/Java/SQL docs
           pyspark_modules=`cd dev && python3.9 -c "import sparktestsupport.modules as m; print(','.join(m.name for m in m.all_modules if m.name.startswith('pyspark')))"`

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -761,6 +761,9 @@ jobs:
       run: ./dev/lint-r
     - name: Run documentation build
       run: |
+        # Build docs first with SKIP_API to ensure they are valid without requiring any
+        # language docs to be built beforehand.
+        SKIP_API=1 bundle exec jekyll build
         if [ -f "./dev/is-changed.py" ]; then
           # Skip PySpark and SparkR docs while keeping Scala/Java/SQL docs
           pyspark_modules=`cd dev && python3.9 -c "import sparktestsupport.modules as m; print(','.join(m.name for m in m.all_modules if m.name.startswith('pyspark')))"`

--- a/docs/sql-ref-functions-builtin.md
+++ b/docs/sql-ref-functions-builtin.md
@@ -17,10 +17,15 @@ license: |
   limitations under the License.
 ---
 
+{% for static_file in site.static_files %}
+    {% if static_file.name == 'generated-agg-funcs-table.html' %}
 ### Aggregate Functions
 {% include_relative generated-agg-funcs-table.html %}
 #### Examples
 {% include_relative generated-agg-funcs-examples.html %}
+        {% break %}
+    {% endif %}
+{% endfor %}
 
 {% for static_file in site.static_files %}
     {% if static_file.name == 'generated-window-funcs-table.html' %}

--- a/docs/sql-ref-functions-builtin.md
+++ b/docs/sql-ref-functions-builtin.md
@@ -17,15 +17,10 @@ license: |
   limitations under the License.
 ---
 
-{% for static_file in site.static_files %}
-    {% if static_file.name == 'generated-agg-funcs-table.html' %}
 ### Aggregate Functions
 {% include_relative generated-agg-funcs-table.html %}
 #### Examples
 {% include_relative generated-agg-funcs-examples.html %}
-        {% break %}
-    {% endif %}
-{% endfor %}
 
 {% for static_file in site.static_files %}
     {% if static_file.name == 'generated-window-funcs-table.html' %}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR tweaks the docs build so that the general docs are first built with `SKIP_API=1` to ensure that the docs build works without any language being built beforehand.

### Why are the changes needed?

[Committers expect][1] docs to build with `SKIP_API=1` on a fresh checkout. Yet, our CI build does not ensure this. This PR corrects this gap.

[1]: https://github.com/apache/spark/pull/44393/files#r1444169083

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Via test commits against this PR.

[The build now fails][f] if the docs reference an include that has not been generated yet.

[f]: https://github.com/nchammas/spark/actions/runs/7450949388/job/20271048581#step:30:29

### Was this patch authored or co-authored using generative AI tooling?

No.