### PR TITLE
[SPARK-46626][DOCS] Bump jekyll to 4.3.3 to enable support for Ruby 3.3.0

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -17,7 +17,10 @@
 
 source "https://rubygems.org"
 
-# Reference: https://guides.rubygems.org/patterns/#declaring-dependencies
+# Keep these specifications as flexible as possible and leave it to Bundler
+# to pin versions in the lock file.
+# To update the lock file, run `bundle update`.
+# Version constraint reference: https://guides.rubygems.org/patterns/#declaring-dependencies
 gem "ffi", "1.15.5"
 gem "jekyll", "~> 4.3"
 gem "rouge", "3.26.0"

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -17,8 +17,9 @@
 
 source "https://rubygems.org"
 
+# Reference: https://guides.rubygems.org/patterns/#declaring-dependencies
 gem "ffi", "1.15.5"
-gem "jekyll", "4.3.2"
+gem "jekyll", "~> 4.3"
 gem "rouge", "3.26.0"
 gem "jekyll-redirect-from", "0.16.0"
 gem "webrick", "1.8.1"

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.5)
+    addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
     colorator (1.1.0)
     concurrent-ruby (1.2.2)
@@ -11,11 +11,11 @@ GEM
     eventmachine (1.2.7)
     ffi (1.15.5)
     forwardable-extended (2.6.0)
-    google-protobuf (3.24.2)
+    google-protobuf (3.25.1)
     http_parser.rb (0.8.0)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
-    jekyll (4.3.2)
+    jekyll (4.3.3)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)
@@ -48,20 +48,20 @@ GEM
     mercenary (0.4.0)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    public_suffix (5.0.3)
-    rake (13.0.6)
+    public_suffix (5.0.4)
+    rake (13.1.0)
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rexml (3.2.6)
     rouge (3.26.0)
     safe_yaml (1.0.5)
-    sass-embedded (1.63.6)
-      google-protobuf (~> 3.23)
+    sass-embedded (1.69.7)
+      google-protobuf (~> 3.25)
       rake (>= 13.0.0)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
-    unicode-display_width (2.4.2)
+    unicode-display_width (2.5.0)
     webrick (1.8.1)
 
 PLATFORMS
@@ -69,7 +69,7 @@ PLATFORMS
 
 DEPENDENCIES
   ffi (= 1.15.5)
-  jekyll (= 4.3.2)
+  jekyll (~> 4.3)
   jekyll-redirect-from (= 0.16.0)
   rouge (= 3.26.0)
   webrick (= 1.8.1)

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,12 +30,13 @@ whichever version of Spark you currently have checked out of revision control.
 
 The Spark documentation build uses a number of tools to build HTML docs and API docs in Scala, Java, Python, R, and SQL.
 
-You need to have [Ruby](https://www.ruby-lang.org/en/documentation/installation/) and
-[Python](https://docs.python.org/2/using/unix.html#getting-and-installing-the-latest-version-of-python)
-installed. Make sure the `bundle` command is available, if not install the Gem containing it:
+You need to have [Ruby][ruby] and [Python][python] installed. Make sure the `bundle` command is available. If not, install it as follows:
+
+[ruby]: https://www.ruby-lang.org/en/documentation/installation/
+[python]: https://www.python.org/downloads/
 
 ```sh
-$ sudo gem install bundler
+$ gem install bundler
 ```
 
 After this all the required ruby dependencies can be installed from the `docs/` directory via the Bundler:
@@ -44,8 +45,6 @@ After this all the required ruby dependencies can be installed from the `docs/` 
 $ cd docs
 $ bundle install
 ```
-
-Note: If you are on a system with both Ruby 1.9 and Ruby 2.0 you may need to replace gem with gem2.0.
 
 To generate the Python or R docs, you'll need to [install Pandoc](https://pandoc.org/installing.html).
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Bump jekyll to 4.3.3.
2. Loosen the dependency spec for jekyll to make updates easier.
3. Don't mention Ruby 1 or 2 in the docs.
4. Don't use `sudo` with `gem` in the docs.

### Why are the changes needed?

1. Jekyll 4.3.2 is [broken on Ruby 3.3.0][1]. Jekyll 4.3.3 [fixes the issue][2].
2. There is no need to pin Jekyll in the Gemfile since it gets pinned automatically for us in the lock file. This makes updating dependencies via `bundle update` easier.
3. Both Ruby 1 and 2 are [EOL][eol]. We should not use or reference them in the docs.
4. Installing stuff as the superuser is explicitly discouraged by both pip and gem. Pip issues this warning:

    > WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv

    And bundler issues this warning:

    > Don't run Bundler as root. Installing your bundle as root will break this application for all non-root users on this machine.

    We should not encourage this pattern in our docs.

[1]: https://github.com/jekyll/jekyll/pull/9510
[2]: https://github.com/jekyll/jekyll/releases/tag/v4.3.3
[eol]: https://www.ruby-lang.org/en/news/2022/04/12/ruby-2-7-6-released/

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Building the docs against Ruby 3.2.2 and 3.3.0.

### Was this patch authored or co-authored using generative AI tooling?

No.