### PR TITLE
[SPARK-46628][INFRA] Use SPDX short identifier in `license` name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
   <url>https://spark.apache.org/</url>
   <licenses>
     <license>
-      <name>Apache 2.0 License</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
       <distribution>repo</distribution>
     </license>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use SPDX short identifier as `license`'s `name` field.

- https://spdx.org/licenses/Apache-2.0.html

### Why are the changes needed?

SPDX short identifier is recommended as `name` field by `Apache Maven`.
- https://maven.apache.org/pom.html#Licenses

ASF pom file has been using it. This PR aims to match with ASF pom file.
- https://github.com/apache/maven-apache-parent/pull/118
- https://github.com/apache/maven-apache-parent/blob/7888bdb8ee653ecc03b5fee136540a607193c240/pom.xml#L46
```
<name>Apache-2.0</name>
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.