### PR TITLE
[SPARK-46630][SQL] XML: Validate XML element name on write

### DIFF
--- a/docs/sql-data-sources-xml.md
+++ b/docs/sql-data-sources-xml.md
@@ -94,7 +94,7 @@ Data source options of XML can be set via:
   <tr>
       <td><code>inferSchema</code></td>
       <td><code>true</code></td>
-      <td>If true, attempts to infer an appropriate type for each resulting DataFrame column. If false, all resulting columns are of string type. XML built-in functions ignore this option.</td>
+      <td>If true, attempts to infer an appropriate type for each resulting DataFrame column. If false, all resulting columns are of string type.</td>
       <td>read</td>
   </tr>
 

--- a/docs/sql-data-sources-xml.md
+++ b/docs/sql-data-sources-xml.md
@@ -94,7 +94,7 @@ Data source options of XML can be set via:
   <tr>
       <td><code>inferSchema</code></td>
       <td><code>true</code></td>
-      <td>If true, attempts to infer an appropriate type for each resulting DataFrame column. If false, all resulting columns are of string type. Default is true. XML built-in functions ignore this option.</td>
+      <td>If true, attempts to infer an appropriate type for each resulting DataFrame column. If false, all resulting columns are of string type. XML built-in functions ignore this option.</td>
       <td>read</td>
   </tr>
 
@@ -108,7 +108,7 @@ Data source options of XML can be set via:
   <tr>
     <td><code>attributePrefix</code></td>
     <td><code>_</code></td>
-    <td>The prefix for attributes to differentiate attributes from elements. This will be the prefix for field names. Default is _. Can be empty for reading XML, but not for writing.</td>
+    <td>The prefix for attributes to differentiate attributes from elements. This will be the prefix for field names. Can be empty for reading XML, but not for writing.</td>
     <td>read/write</td>
   </tr>
 
@@ -233,6 +233,13 @@ Data source options of XML can be set via:
     <td><code>none</code></td>
     <td>Compression codec to use when saving to file. This can be one of the known case-insensitive shortened names (none, bzip2, gzip, lz4, snappy and deflate). XML built-in functions ignore this option.</td>
     <td>write</td>
+  </tr>
+
+  <tr>
+      <td><code>validateName</code></td>
+      <td><code>true</code></td>
+      <td>If true, throws error on XML element name validation failure. For example, SQL field names can have spaces, but XML element names cannot.</td>
+      <td>write</td>
   </tr>
 
 </table>

--- a/python/pyspark/sql/connect/readwriter.py
+++ b/python/pyspark/sql/connect/readwriter.py
@@ -792,6 +792,7 @@ class DataFrameWriter(OptionUtils):
         timestampFormat: Optional[str] = None,
         compression: Optional[str] = None,
         encoding: Optional[str] = None,
+        validateName: Optional[bool] = None,
     ) -> None:
         self.mode(mode)
         self._set_opts(
@@ -806,6 +807,7 @@ class DataFrameWriter(OptionUtils):
             timestampFormat=timestampFormat,
             compression=compression,
             encoding=encoding,
+            validateName=validateName,
         )
         self.format("xml").save(path)
 

--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -2096,6 +2096,7 @@ class DataFrameWriter(OptionUtils):
         timestampFormat: Optional[str] = None,
         compression: Optional[str] = None,
         encoding: Optional[str] = None,
+        validateName: Optional[bool] = None,
     ) -> None:
         r"""Saves the content of the :class:`DataFrame` in XML format at the specified path.
 
@@ -2155,6 +2156,7 @@ class DataFrameWriter(OptionUtils):
             timestampFormat=timestampFormat,
             compression=compression,
             encoding=encoding,
+            validateName=validateName,
         )
         self._jwrite.xml(path)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/StaxXmlGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/StaxXmlGenerator.scala
@@ -65,6 +65,7 @@ class StaxXmlGenerator(
     val factory = XMLOutputFactory.newInstance()
     // to_xml disables structure validation to allow multiple root tags
     factory.setProperty(WstxOutputProperties.P_OUTPUT_VALIDATE_STRUCTURE, validateStructure)
+    factory.setProperty(WstxOutputProperties.P_OUTPUT_VALIDATE_NAMES, options.validateName)
     val xmlWriter = factory.createXMLStreamWriter(writer)
     if (!indentDisabled) {
       val indentingXmlWriter = new IndentingXMLStreamWriter(xmlWriter)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/XmlOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/XmlOptions.scala
@@ -107,6 +107,7 @@ class XmlOptions(
   // setting indent to "" disables indentation in the generated XML.
   // Each row will be written in a new line.
   val indent = parameters.getOrElse(INDENT, DEFAULT_INDENT)
+  val validateName = getBool(VALIDATE_NAME, true)
 
   /**
    * Infer columns with all valid date entries as date type (otherwise inferred as string or
@@ -210,6 +211,7 @@ object XmlOptions extends DataSourceOptions {
   val TIME_ZONE = newOption("timeZone")
   val INDENT = newOption("indent")
   val PREFERS_DECIMAL = newOption("prefersDecimal")
+  val VALIDATE_NAME = newOption("validateName")
   // Options with alternative
   val ENCODING = "encoding"
   val CHARSET = "charset"

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/XmlSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/XmlSuite.scala
@@ -23,14 +23,17 @@ import java.sql.{Date, Timestamp}
 import java.time.{Instant, LocalDateTime}
 import java.util.TimeZone
 import javax.xml.stream.XMLStreamException
+
 import scala.collection.immutable.ArraySeq
 import scala.collection.mutable
 import scala.io.Source
 import scala.jdk.CollectionConverters._
+
 import org.apache.commons.lang3.exception.ExceptionUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.io.{LongWritable, Text}
 import org.apache.hadoop.io.compress.GzipCodec
+
 import org.apache.spark.{SparkException, SparkFileNotFoundException}
 import org.apache.spark.sql.{AnalysisException, DataFrame, Dataset, Encoders, QueryTest, Row, SaveMode}
 import org.apache.spark.sql.catalyst.util._

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/XmlSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/XmlSuite.scala
@@ -2863,10 +2863,6 @@ class XmlSuite
                 .option("rowTag", "ROW")
                 .mode(SaveMode.Overwrite)
                 .xml(path)
-              val df2 = spark.read
-                .option("rowTag", "ROW")
-                .xml(path)
-              checkAnswer(df, df2)
             }
 
             assert(e.getCause.getCause.isInstanceOf[XMLStreamException])


### PR DESCRIPTION
### What changes were proposed in this pull request?
Validate XML element name on write. Spark SQL permits spaces in field names and they may even start with number or special characters. These field names cannot be converted to XML element names. This PR adds validation to throw error on non-compliant XML element names. 
This applies only to XML write. Validation is on by default. User can choose to disable this validation.

### Why are the changes needed?
Same as above

### Does this PR introduce _any_ user-facing change?
Yes

### How was this patch tested?
New unit test

### Was this patch authored or co-authored using generative AI tooling?
No