### PR TITLE
[SPARK-46650][CORE][SQL][YARN] Replace AtomicBoolean with volatile boolean

### DIFF
--- a/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnSchedulerBackend.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/scheduler/cluster/YarnSchedulerBackend.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.scheduler.cluster
 
 import java.util.EnumSet
-import java.util.concurrent.atomic.AtomicBoolean
 import javax.servlet.DispatcherType
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -47,7 +46,8 @@ private[spark] abstract class YarnSchedulerBackend(
     sc: SparkContext)
   extends CoarseGrainedSchedulerBackend(scheduler, sc.env.rpcEnv) {
 
-  private val stopped = new AtomicBoolean(false)
+  @volatile
+  private var stopped = false
 
   override val minRegisteredRatio =
     if (conf.get(config.SCHEDULER_MIN_REGISTERED_RESOURCES_RATIO).isEmpty) {
@@ -114,7 +114,7 @@ private[spark] abstract class YarnSchedulerBackend(
       requestTotalExecutors(Map.empty, Map.empty, Map.empty)
       super.stop()
     } finally {
-      stopped.set(true)
+      stopped = true
     }
   }
 
@@ -279,7 +279,7 @@ private[spark] abstract class YarnSchedulerBackend(
      */
     override def onDisconnected(rpcAddress: RpcAddress): Unit = {
       addressToExecutorId.get(rpcAddress).foreach { executorId =>
-        if (!stopped.get) {
+        if (!stopped) {
           if (disableExecutor(executorId)) {
             yarnSchedulerEndpoint.handleExecutorDisconnectedFromDriver(executorId, rpcAddress)
           }
@@ -342,7 +342,7 @@ private[spark] abstract class YarnSchedulerBackend(
         addWebUIFilter(filterName, filterParams, proxyBase)
 
       case r @ RemoveExecutor(executorId, reason) =>
-        if (!stopped.get) {
+        if (!stopped) {
           logWarning(s"Requesting driver to remove executor $executorId for reason $reason")
           driverEndpoint.send(r)
         }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR propose to replace `AtomicBoolean` with `volatile` boolean for some code.


### Why are the changes needed?
`volatile` could keep the visibility and is a lightweight synchronization method.
We should consider using volatile variables if the following requirements are met.

- The write operation on variables does not depend on the current value of the variable, or only a single thread updates the value of the variable.

- This variable will not be included in the invariant condition along with other state variables.

- No locking is required when accessing variables.


### Does this PR introduce _any_ user-facing change?
'No'.


### How was this patch tested?
GA tests.


### Was this patch authored or co-authored using generative AI tooling?
'No'.
