### PR TITLE
[SPARK-46736][PROTOBUF] retain empty message field in protobuf connector 

### DIFF
--- a/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/utils/ProtobufOptions.scala
+++ b/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/utils/ProtobufOptions.scala
@@ -208,9 +208,15 @@ private[sql] class ProtobufOptions(
   val unwrapWellKnownTypes: Boolean =
     parameters.getOrElse("unwrap.primitive.wrapper.types", false.toString).toBoolean
 
-  // Since Spark doesn't allow empty StructType, empty proto message type as field will be
+  // Since Spark doesn't allow writing empty StructType, empty proto message type will be
   // dropped by default. Setting this option to true will insert a dummy column to empty proto
   // message so that the empty message will be retained.
+  // Example: message A {} is an empty message.
+  // When used as field in another message: Message B {A a = 1, string name = 2}
+  // By default, in the spark schema field a will be dropped, which result in schema
+  // b struct<name: string>
+  // If retain.empty.message=true, field a will be retained by inserting a dummy subcolumn.
+  // b struct<name: string, a struct<__dummy_field_in_empty_struct: string>>
   val retainEmptyMessage: Boolean =
     parameters.getOrElse("retain.empty.message", false.toString).toBoolean
 }

--- a/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/utils/ProtobufOptions.scala
+++ b/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/utils/ProtobufOptions.scala
@@ -207,6 +207,12 @@ private[sql] class ProtobufOptions(
   //    nil => nil, Int32Value(0) => 0, Int32Value(100) => 100.
   val unwrapWellKnownTypes: Boolean =
     parameters.getOrElse("unwrap.primitive.wrapper.types", false.toString).toBoolean
+
+  // Since Spark doesn't allow empty StructType, empty proto message type as field will be
+  // dropped by default. Setting this option to true will insert a dummy column to empty proto
+  // message so that the empty message will be retained.
+  val retainEmptyMessage: Boolean =
+    parameters.getOrElse("retain.empty.message", false.toString).toBoolean
 }
 
 private[sql] object ProtobufOptions {

--- a/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/utils/ProtobufOptions.scala
+++ b/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/utils/ProtobufOptions.scala
@@ -211,15 +211,17 @@ private[sql] class ProtobufOptions(
   // Since Spark doesn't allow writing empty StructType, empty proto message type will be
   // dropped by default. Setting this option to true will insert a dummy column to empty proto
   // message so that the empty message will be retained.
-  // Example: message A {} is an empty message.
-  // When used as field in another message: Message B {A a = 1, string name = 2}
+  // For example, an empty message is used as field in another message:
+  //
+  // ```
+  // message A {}
+  // Message B {A a = 1, string name = 2}
+  // ```
+  //
   // By default, in the spark schema field a will be dropped, which result in schema
   // b struct<name: string>
-  // If retain.empty.message=true, field a will be retained by inserting a dummy subcolumn.
+  // If retain.empty.message.types=true, field a will be retained by inserting a dummy column.
   // b struct<name: string, a struct<__dummy_field_in_empty_struct: string>>
-  // Note: if the top level message is empty, a dummy column won't be inserted and data will have
-  // empty schema.
-  // message A{} will map to struct<>, which will cause analysis exception.
   val retainEmptyMessage: Boolean =
     parameters.getOrElse("retain.empty.message.types", false.toString).toBoolean
 }

--- a/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/utils/ProtobufOptions.scala
+++ b/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/utils/ProtobufOptions.scala
@@ -218,7 +218,7 @@ private[sql] class ProtobufOptions(
   // If retain.empty.message=true, field a will be retained by inserting a dummy subcolumn.
   // b struct<name: string, a struct<__dummy_field_in_empty_struct: string>>
   val retainEmptyMessage: Boolean =
-    parameters.getOrElse("retain.empty.message", false.toString).toBoolean
+    parameters.getOrElse("retain.empty.message.types", false.toString).toBoolean
 }
 
 private[sql] object ProtobufOptions {

--- a/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/utils/ProtobufOptions.scala
+++ b/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/utils/ProtobufOptions.scala
@@ -221,7 +221,7 @@ private[sql] class ProtobufOptions(
   // By default, in the spark schema field a will be dropped, which result in schema
   // b struct<name: string>
   // If retain.empty.message.types=true, field a will be retained by inserting a dummy column.
-  // b struct<name: string, a struct<__dummy_field_in_empty_struct: string>>
+  // b struct<a struct<__dummy_field_in_empty_struct: string>, name: string>
   val retainEmptyMessage: Boolean =
     parameters.getOrElse("retain.empty.message.types", false.toString).toBoolean
 }

--- a/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/utils/ProtobufOptions.scala
+++ b/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/utils/ProtobufOptions.scala
@@ -215,7 +215,7 @@ private[sql] class ProtobufOptions(
   //
   // ```
   // message A {}
-  // Message B {A a = 1, string name = 2}
+  // message B {A a = 1, string name = 2}
   // ```
   //
   // By default, in the spark schema field a will be dropped, which result in schema

--- a/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/utils/ProtobufOptions.scala
+++ b/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/utils/ProtobufOptions.scala
@@ -217,6 +217,9 @@ private[sql] class ProtobufOptions(
   // b struct<name: string>
   // If retain.empty.message=true, field a will be retained by inserting a dummy subcolumn.
   // b struct<name: string, a struct<__dummy_field_in_empty_struct: string>>
+  // Note: if the top level message is empty, a dummy column won't be inserted and data will have
+  // empty schema.
+  // message A{} will map to struct<>, which will cause analysis exception.
   val retainEmptyMessage: Boolean =
     parameters.getOrElse("retain.empty.message.types", false.toString).toBoolean
 }

--- a/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/utils/SchemaConverters.scala
+++ b/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/utils/SchemaConverters.scala
@@ -212,11 +212,17 @@ object SchemaConverters extends Logging {
           ).toSeq
           fields match {
             case Nil =>
-              log.info(
-                s"Dropping ${fd.getFullName} as it does not have any fields left " +
-                "likely due to recursive depth limit."
-              )
-              None
+              if (protobufOptions.retainEmptyMessage) {
+                // Insert a dummy column to retain the empty message because
+                // spark doesn't allow empty struct type.
+                Some(StructType(StructField("_dummy_field", StringType) :: Nil))
+              } else {
+                log.info(
+                  s"Dropping ${fd.getFullName} as it does not have any fields left " +
+                    "likely due to recursive depth limit."
+                )
+                None
+              }
             case fds => Some(StructType(fds))
           }
         }

--- a/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/utils/SchemaConverters.scala
+++ b/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/utils/SchemaConverters.scala
@@ -215,7 +215,9 @@ object SchemaConverters extends Logging {
               if (protobufOptions.retainEmptyMessage) {
                 // Insert a dummy column to retain the empty message because
                 // spark doesn't allow empty struct type.
-                Some(StructType(StructField("_dummy_field", StringType) :: Nil))
+                Some(
+                  StructType(StructField("_dummy_field_to_retain_empty_message", StringType) :: Nil)
+                )
               } else {
                 log.info(
                   s"Dropping ${fd.getFullName} as it does not have any fields left " +

--- a/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/utils/SchemaConverters.scala
+++ b/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/utils/SchemaConverters.scala
@@ -51,12 +51,13 @@ object SchemaConverters extends Logging {
   def toSqlTypeHelper(
       descriptor: Descriptor,
       protobufOptions: ProtobufOptions): SchemaType = {
-    SchemaType(
-      StructType(descriptor.getFields.asScala.flatMap(
-        structFieldFor(_,
-          Map(descriptor.getFullName -> 1),
-          protobufOptions: ProtobufOptions)).toArray),
-      nullable = true)
+    val fields = descriptor.getFields.asScala.flatMap(
+      structFieldFor(_,
+        Map(descriptor.getFullName -> 1),
+        protobufOptions: ProtobufOptions)).toSeq
+    if (fields.isEmpty && protobufOptions.retainEmptyMessage) {
+      SchemaType(convertEmptyProtoToStructWithDummyField(descriptor.getFullName), nullable = true)
+    } else SchemaType(StructType(fields), nullable = true)
   }
 
   // existingRecordNames: Map[String, Int] used to track the depth of recursive fields and to
@@ -213,15 +214,7 @@ object SchemaConverters extends Logging {
           fields match {
             case Nil =>
               if (protobufOptions.retainEmptyMessage) {
-                // Insert a dummy column to retain the empty message because
-                // spark doesn't allow empty struct type.
-                log.info(
-                  s"Keep ${fd.getFullName} which is empty struct by inserting a dummy field" +
-                    s" because retain.empty.message=true"
-                )
-                Some(
-                  StructType(StructField("__dummy_field_in_empty_struct", StringType) :: Nil)
-                )
+                Some(convertEmptyProtoToStructWithDummyField(fd.getFullName))
               } else {
                 log.info(
                   s"Dropping ${fd.getFullName} as it does not have any fields left " +
@@ -241,5 +234,12 @@ object SchemaConverters extends Logging {
         StructField(fd.getName, ArrayType(dt, containsNull = false))
       case dt => StructField(fd.getName, dt, nullable = !fd.isRequired)
     }
+  }
+
+  // Insert a dummy column to retain the empty message because
+  // spark doesn't allow empty struct type.
+  private def convertEmptyProtoToStructWithDummyField(desc: String): StructType = {
+    log.info(s"Keep $desc which is empty struct by inserting a dummy field.")
+    StructType(StructField("__dummy_field_in_empty_struct", StringType) :: Nil)
   }
 }

--- a/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/utils/SchemaConverters.scala
+++ b/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/utils/SchemaConverters.scala
@@ -215,8 +215,12 @@ object SchemaConverters extends Logging {
               if (protobufOptions.retainEmptyMessage) {
                 // Insert a dummy column to retain the empty message because
                 // spark doesn't allow empty struct type.
+                log.info(
+                  s"Keep ${fd.getFullName} which is empty struct by inserting a dummy field" +
+                    s" because retain.empty.message=true"
+                )
                 Some(
-                  StructType(StructField("_dummy_field_to_retain_empty_message", StringType) :: Nil)
+                  StructType(StructField("__dummy_field_in_empty_struct", StringType) :: Nil)
                 )
               } else {
                 log.info(

--- a/connector/protobuf/src/test/resources/protobuf/functions_suite.proto
+++ b/connector/protobuf/src/test/resources/protobuf/functions_suite.proto
@@ -269,6 +269,15 @@ message EventRecursiveB {
   OneOfEventWithRecursion recursiveOneOffInB = 3;
 }
 
+message EmptyProto {
+  // This is an empty proto
+}
+
+message EmptyProtoWrapper {
+  string name = 1;
+  EmptyProto empty_proto = 2;
+}
+
 message EmptyRecursiveProto {
   // This is a recursive proto with no fields. Used to test edge. Catalyst schema for this
   // should be "nothing" (i.e. completely dropped) irrespective of recursive limit.

--- a/connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufFunctionsSuite.scala
+++ b/connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufFunctionsSuite.scala
@@ -1230,14 +1230,32 @@ class ProtobufFunctionsSuite extends QueryTest with SharedSparkSession with Prot
     val emptyProtoSchema =
       StructType(StructField("__dummy_field_in_empty_struct", StringType) :: Nil)
     /*
-      Below is the expected schema.
-      root
-       |-- empty_proto: struct (nullable = true)
-       |    |-- recursive_field: struct (nullable = true)
-       |    |    |-- __dummy_field_in_empty_struct: string (nullable = true)
-       |    |-- recursive_array: array (nullable = true)
-       |    |    |-- element: struct (containsNull = false)
-       |    |    |    |-- __dummy_field_in_empty_struct: string (nullable = true)
+      The code below construct the expected schema with recursive depth set to 2.
+        root
+         |-- empty_proto: struct (nullable = true)
+         |    |-- recursive_field: struct (nullable = true)
+         |    |    |-- __dummy_field_in_empty_struct: string (nullable = true)
+         |    |-- recursive_array: array (nullable = true)
+         |    |    |-- element: struct (containsNull = false)
+         |    |    |    |-- __dummy_field_in_empty_struct: string (nullable = true)
+
+       Note: If recursive depth change, the resulting schema of empty recursive proto will change.
+       When recursive depth is 3, the schema will be
+        root
+         |-- empty_proto: struct (nullable = true)
+         |    |-- recursive_field: struct (nullable = true)
+         |    |    |-- recursive_field: struct (nullable = true)
+         |    |    |    |-- __dummy_field_in_empty_struct: string (nullable = true)
+         |    |    |-- recursive_array: array (nullable = true)
+         |    |    |    |-- element: struct (containsNull = false)
+         |    |    |    |    |-- __dummy_field_in_empty_struct: string (nullable = true)
+         |    |-- recursive_array: array (nullable = true)
+         |    |    |-- element: struct (containsNull = false)
+         |    |    |    |-- recursive_field: struct (nullable = true)
+         |    |    |    |    |-- __dummy_field_in_empty_struct: string (nullable = true)
+         |    |    |    |-- recursive_array: array (nullable = true)
+         |    |    |    |    |-- element: struct (containsNull = false)
+         |    |    |    |    |    |-- __dummy_field_in_empty_struct: string (nullable = true)
     */
     val expectedSchema = StructType(
       StructField("empty_proto",

--- a/connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufFunctionsSuite.scala
+++ b/connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufFunctionsSuite.scala
@@ -1124,7 +1124,7 @@ class ProtobufFunctionsSuite extends QueryTest with SharedSparkSession with Prot
     }
   }
 
-  test("retain empty proto fields") {
+  test("Retain empty proto fields when retain.empty.message.types=true") {
     // When retain.empty.message=true, empty proto like 'message A {}' can be retained as a field
     // by inserting a dummy column as sub column.
     val options = Map("recursive.fields.max.depth" -> "4", "retain.empty.message.types" -> "true")
@@ -1152,7 +1152,7 @@ class ProtobufFunctionsSuite extends QueryTest with SharedSparkSession with Prot
     }
   }
 
-  test("Write empty proto to parquet") {
+  test("Write empty proto to parquet when retain.empty.message.types=true") {
     // When retain.empty.message=true, empty proto like 'message A {}' can be retained as a field
     // by inserting a dummy column as sub column, such schema can be written to parquet.
     val options = Map("recursive.fields.max.depth" -> "4", "retain.empty.message.types" -> "true")
@@ -1202,7 +1202,7 @@ class ProtobufFunctionsSuite extends QueryTest with SharedSparkSession with Prot
     }
   }
 
-  test("Corner case: retain empty recursive proto fields") {
+  test("Retain empty recursive proto fields when retain.empty.message.types=true") {
     // This verifies that a empty proto like 'message A { A a = 1}' can be retained by
     // inserting a dumy field.
 

--- a/connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufFunctionsSuite.scala
+++ b/connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufFunctionsSuite.scala
@@ -1205,8 +1205,6 @@ class ProtobufFunctionsSuite extends QueryTest with SharedSparkSession with Prot
     val emptyProtoSchema =
       StructType(StructField("_dummy_field_to_retain_empty_message", StringType) :: Nil)
     val expectedSchema = StructType(
-      // DDL: "proto STRUCT<name: string, groups: map<
-      //    struct<name: string, group: map<struct<name: string>>>>>"
       StructField("empty_proto",
         StructType(
           StructField("recursive_field", emptyProtoSchema) ::

--- a/connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufFunctionsSuite.scala
+++ b/connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufFunctionsSuite.scala
@@ -1256,8 +1256,6 @@ class ProtobufFunctionsSuite extends QueryTest with SharedSparkSession with Prot
           from_protobuf_wrapper($"binary", name, descFilePathOpt, options).as("empty_proto")
         )
         assert(df.schema == expectedSchema)
-        logError("asdfunc")
-        df.printSchema()
     }
   }
 

--- a/connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufFunctionsSuite.scala
+++ b/connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufFunctionsSuite.scala
@@ -1159,7 +1159,7 @@ class ProtobufFunctionsSuite extends QueryTest with SharedSparkSession with Prot
     val options = Map("recursive.fields.max.depth" -> "4", "retain.empty.message.types" -> "true")
     withTempDir { file =>
       val binaryDF = Seq(
-        EmptyRecursiveProtoWrapper.newBuilder.setName("my_name").build().toByteArray)
+        EmptyProtoWrapper.newBuilder.setName("my_name").build().toByteArray)
         .toDF("binary")
       checkWithFileAndClassName("EmptyProtoWrapper") {
         case (name, descFilePathOpt) =>
@@ -1176,11 +1176,10 @@ class ProtobufFunctionsSuite extends QueryTest with SharedSparkSession with Prot
       checkAnswer(resultDF, Seq(Row(Row("my_name", null))))
     }
 
-    // Top level message can't be empty, otherwise AnalysisException will be thrown.
-    // Dummy column won't be inserted for top level struct when retain.empty.message.types=true.
+    // When top level message is empty, write to parquet.
     withTempDir { file =>
       val binaryDF = Seq(
-        EmptyRecursiveProto.newBuilder.build().toByteArray)
+        EmptyProto.newBuilder.build().toByteArray)
         .toDF("binary")
       checkWithFileAndClassName("EmptyProto") {
         case (name, descFilePathOpt) =>

--- a/connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufFunctionsSuite.scala
+++ b/connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufFunctionsSuite.scala
@@ -1229,6 +1229,16 @@ class ProtobufFunctionsSuite extends QueryTest with SharedSparkSession with Prot
 
     val emptyProtoSchema =
       StructType(StructField("__dummy_field_in_empty_struct", StringType) :: Nil)
+    /*
+      Below is the expected schema.
+      root
+       |-- empty_proto: struct (nullable = true)
+       |    |-- recursive_field: struct (nullable = true)
+       |    |    |-- __dummy_field_in_empty_struct: string (nullable = true)
+       |    |-- recursive_array: array (nullable = true)
+       |    |    |-- element: struct (containsNull = false)
+       |    |    |    |-- __dummy_field_in_empty_struct: string (nullable = true)
+    */
     val expectedSchema = StructType(
       StructField("empty_proto",
         StructType(
@@ -1246,6 +1256,8 @@ class ProtobufFunctionsSuite extends QueryTest with SharedSparkSession with Prot
           from_protobuf_wrapper($"binary", name, descFilePathOpt, options).as("empty_proto")
         )
         assert(df.schema == expectedSchema)
+        logError("asdfunc")
+        df.printSchema()
     }
   }
 

--- a/connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufFunctionsSuite.scala
+++ b/connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufFunctionsSuite.scala
@@ -1127,7 +1127,7 @@ class ProtobufFunctionsSuite extends QueryTest with SharedSparkSession with Prot
   test("Retain empty proto fields when retain.empty.message.types=true") {
     // When retain.empty.message.types=true, empty proto like 'message A {}' can be retained as
     // a field by inserting a dummy column as sub column.
-    val options = Map("recursive.fields.max.depth" -> "4", "retain.empty.message.types" -> "true")
+    val options = Map("retain.empty.message.types" -> "true")
 
     // EmptyProto at the top level. It will be an empty struct.
     checkWithFileAndClassName("EmptyProto") {

--- a/connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufFunctionsSuite.scala
+++ b/connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufFunctionsSuite.scala
@@ -1127,7 +1127,7 @@ class ProtobufFunctionsSuite extends QueryTest with SharedSparkSession with Prot
   test("retain empty proto fields") {
     // When retain.empty.message=true, empty proto like 'message A {}' can be retained as a field
     // by inserting a dummy column as sub column.
-    val options = Map("recursive.fields.max.depth" -> "4", "retain.empty.message" -> "true")
+    val options = Map("recursive.fields.max.depth" -> "4", "retain.empty.message.types" -> "true")
 
     // EmptyProto at the top level. It will be an empty struct.
     checkWithFileAndClassName("EmptyProto") {
@@ -1155,7 +1155,7 @@ class ProtobufFunctionsSuite extends QueryTest with SharedSparkSession with Prot
   test("Write empty proto to parquet") {
     // When retain.empty.message=true, empty proto like 'message A {}' can be retained as a field
     // by inserting a dummy column as sub column, such schema can be written to parquet.
-    val options = Map("recursive.fields.max.depth" -> "4", "retain.empty.message" -> "true")
+    val options = Map("recursive.fields.max.depth" -> "4", "retain.empty.message.types" -> "true")
     withTempDir { file =>
       val binaryDF = Seq(
         EmptyRecursiveProtoWrapper.newBuilder.setName("my_name").build().toByteArray)
@@ -1218,7 +1218,7 @@ class ProtobufFunctionsSuite extends QueryTest with SharedSparkSession with Prot
       ) :: Nil
     )
 
-    val options = Map("recursive.fields.max.depth" -> "2", "retain.empty.message" -> "true")
+    val options = Map("recursive.fields.max.depth" -> "2", "retain.empty.message.types" -> "true")
     checkWithFileAndClassName("EmptyRecursiveProto") {
       case (name, descFilePathOpt) =>
         val df = emptyBinaryDF.select(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Since Spark doesn't allow empty StructType, empty proto message type as field will be dropped by default. introduce an option to allow retaining an empty message field by inserting a dummy column.


### Why are the changes needed?
In protobuf, it is common to have empty message type without any field as a place holder, in some case people may not want to drop these empty message field.


### Does this PR introduce _any_ user-facing change?
Yes. The default behavior is still dropping an empty message field. The new option will enable customer to keep the empty message field though they will observe a dummy column. 


### How was this patch tested?
Unit test and integration test.


### Was this patch authored or co-authored using generative AI tooling?
No.
