### PR TITLE
[SPARK-46639][SQL] Add WindowExec SQLMetrics

### DIFF
--- a/sql/core/src/main/java/org/apache/spark/sql/execution/UnsafeKVExternalSorter.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/UnsafeKVExternalSorter.java
@@ -224,6 +224,13 @@ public final class UnsafeKVExternalSorter {
   }
 
   /**
+   * Return the total number of bytes that has been spilled into disk so far.
+   */
+  public long getSpillSizeOnDisk() {
+    return sorter.getSpillSizeOnDisk();
+  }
+
+  /**
    * Return the peak memory used so far, in bytes.
    */
   public long getPeakMemoryUsedBytes() {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/WindowInPandasExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/WindowInPandasExec.scala
@@ -76,7 +76,12 @@ case class WindowInPandasExec(
     child: SparkPlan)
   extends WindowExecBase with PythonSQLMetrics {
   override lazy val metrics: Map[String, SQLMetric] = pythonMetrics ++ Map(
-    "spillSize" -> SQLMetrics.createSizeMetric(sparkContext, "spill size")
+    "numOfOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"),
+    "numOfPartitions" -> SQLMetrics.createMetric(sparkContext, "number of partitions"),
+    "numOfWindowPartitions" -> SQLMetrics.createMetric(sparkContext, "number of window partitions"),
+    "spilledRows" -> SQLMetrics.createMetric(sparkContext, "spilled rows"),
+    "spillSize" -> SQLMetrics.createSizeMetric(sparkContext, "spill size in memory"),
+    "spillSizeOnDisk" -> SQLMetrics.createSizeMetric(sparkContext, "spill size on disk")
   )
 
   protected override def doExecute(): RDD[InternalRow] = {
@@ -87,6 +92,11 @@ case class WindowInPandasExec(
         orderSpec,
         child.output,
         longMetric("spillSize"),
+        longMetric("numOfOutputRows"),
+        longMetric("numOfPartitions"),
+        longMetric("spilledRows"),
+        longMetric("numOfWindowPartitions"),
+        longMetric("spillSizeOnDisk"),
         pythonMetrics,
         conf.pythonUDFProfiler)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/window/WindowExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/window/WindowExec.scala
@@ -91,7 +91,12 @@ case class WindowExec(
     child: SparkPlan)
   extends WindowExecBase {
   override lazy val metrics: Map[String, SQLMetric] = Map(
-    "spillSize" -> SQLMetrics.createSizeMetric(sparkContext, "spill size")
+    "numOfOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"),
+    "numOfPartitions" -> SQLMetrics.createMetric(sparkContext, "number of partitions"),
+    "spilledRows" -> SQLMetrics.createMetric(sparkContext, "spilled rows"),
+    "numOfWindowPartitions" -> SQLMetrics.createMetric(sparkContext, "number of window partitions"),
+    "spillSize" -> SQLMetrics.createSizeMetric(sparkContext, "spill size in memory"),
+    "spillSizeOnDisk" -> SQLMetrics.createSizeMetric(sparkContext, "spill size on disk")
   )
 
   protected override def doExecute(): RDD[InternalRow] = {
@@ -101,7 +106,12 @@ case class WindowExec(
         partitionSpec,
         orderSpec,
         child.output,
-        longMetric("spillSize"))
+        longMetric("spillSize"),
+        longMetric("numOfOutputRows"),
+        longMetric("numOfPartitions"),
+        longMetric("spilledRows"),
+        longMetric("numOfWindowPartitions"),
+        longMetric("spillSizeOnDisk"))
 
     // Start processing.
     if (conf.usePartitionEvaluator) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently, WindowExec Physical Operator does not have any SQLMetrics except spillSize (in-memory). This PR aims to add WindowExec SQLMetrics to provide following information from WindowExec usage during query execution:
```
numOfOutputRows: Number of total output rows.
numOfPartitions: Number of processed input partitions.
numOfWindowPartitions: Number of generated window partitions.
spilledRows: Number of total spilled rows.
spillSizeOnDisk: Total spilled data size on disk.
```

As an example use-case, WindowExec spilling behavior depends on multiple factors and it can sometime cause `SparkOutOfMemoryError` instead of spilling to disk so it is hard to track without SQL Metrics such as:
**1-** WindowExec creates ExternalAppendOnlyUnsafeRowArray (internal ArrayBuffer) per task (a.k.a child RDD partition)
**2-** When ExternalAppendOnlyUnsafeRowArray size exceeds spark.sql.windowExec.buffer.in.memory.threshold=4096, ExternalAppendOnlyUnsafeRowArray switches to UnsafeExternalSorter as spillableArray by moving its all buffered rows into UnsafeExternalSorter and ExternalAppendOnlyUnsafeRowArray (internal ArrayBuffer) is cleared. In this case, WindowExec starts to write UnsafeExternalSorter' s buffer (a.k.a UnsafeInMemorySorter).
**3-** UnsafeExternalSorter is being created per window partition. When UnsafeExternalSorter' buffer size exceeds spark.sql.windowExec.buffer.spill.threshold=Integer.MAX_VALUE, it starts to write to disk and get cleared all buffer (a.k.a UnsafeInMemorySorter) content. In this case, UnsafeExternalSorter will continue to buffer next records until exceeding spark.sql.windowExec.buffer.spill.threshold.

**New WindowExec SQLMetrics Sample Screenshot:**
<img width="237" alt="WindowExec SQLMetrics" src="https://github.com/apache/spark/assets/1437738/9f796ead-b619-40c3-81f7-62a6e94811d7">

### Why are the changes needed?
These SQLMetrics can help Spark users for better understanding about Window functions runtime results.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
New 4 Unit Test have been added.

### Was this patch authored or co-authored using generative AI tooling?
No