### PR TITLE
[MINOR][DOCS] Add license header at docs/_plugins

### DIFF
--- a/docs/_plugins/conditonal_includes.rb
+++ b/docs/_plugins/conditonal_includes.rb
@@ -1,3 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 module Jekyll
   # Tag for including a file if it exists.
   class IncludeRelativeIfExistsTag < Tags::IncludeRelativeTag

--- a/docs/_plugins/production_tag.rb
+++ b/docs/_plugins/production_tag.rb
@@ -1,3 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 module Jekyll
   class ProductionTag < Liquid::Block
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds license header to `docs/_plugins` files.

### Why are the changes needed?

To comply Apache License 2.0

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Existing CI should verify it e.g., linter.

### Was this patch authored or co-authored using generative AI tooling?

No.