### PR TITLE
[SPARK-46646][SQL][TESTS] Improve `TPCDSQueryBenchmark` to support other file formats

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/TPCDSQueryBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/TPCDSQueryBenchmark.scala
@@ -74,7 +74,8 @@ object TPCDSQueryBenchmark extends SqlBasedBenchmark with Logging {
     tables.map { tableName =>
       spark.sql(s"DROP TABLE IF EXISTS $tableName")
       val options = Map("path" -> s"$dataLocation/$tableName")
-      spark.catalog.createTable(tableName, "parquet", tableColumns(tableName), options)
+      val format = spark.conf.get("spark.sql.sources.default")
+      spark.catalog.createTable(tableName, format, tableColumns(tableName), options)
       // Recover partitions but don't fail if a table is not partitioned.
       Try {
         spark.sql(s"ALTER TABLE $tableName RECOVER PARTITIONS")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to improve `TPCDSQueryBenchmark` to support other file formats.

### Why are the changes needed?
 
Currently, `parquet` is a hard-coded because it's the default value of `spark.sql.sources.default`.

https://github.com/apache/spark/blob/48d22e9f876f070d35ff3dd011bfbd1b6bccb4ac/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/TPCDSQueryBenchmark.scala#L77

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Manual.

**BEFORE**
```
$ build/sbt "sql/Test/runMain org.apache.spark.sql.execution.benchmark.TPCDSQueryBenchmark --data-location /tmp/tpcds-sf-1-orc-snappy/"
...
[info] 18:36:39.698 ERROR org.apache.spark.executor.Executor: Exception in task 0.0 in stage 0.0 (TID 0)
[info] java.lang.RuntimeException: file:/tmp/tpcds-sf-1-orc-snappy/catalog_page/part-00000-40446d2a-f814-4e26-b3e1-664b833bf041-c000.snappy.orc is not a Parquet file. Expected magic number at tail, but found [79, 82, 67, 25]
[info] 	at org.apache.parquet.hadoop.ParquetFileReader.readFooter(ParquetFileReader.java:565)
...
```

**AFTER**
```
$ JDK_JAVA_OPTIONS='-Dspark.sql.sources.default=orc' \
build/sbt "sql/Test/runMain org.apache.spark.sql.execution.benchmark.TPCDSQueryBenchmark --data-location /tmp/tpcds-sf-1-orc-snappy/"
...
[info] Running benchmark: TPCDS Snappy
[info]   Running case: q1
[info]   Stopped after 6 iterations, 2028 ms
[info] OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Mac OS X 14.3
[info] Apple M1 Max
[info] TPCDS Snappy:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
[info] ------------------------------------------------------------------------------------------------------------------------
[info] q1                                                  305            338          24          1.5         660.4       1.0X
```

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
