### PR TITLE
[SPARK-46645][INFRA] Exclude unittest-xml-reporting in Python 3.12 image

### DIFF
--- a/dev/infra/Dockerfile
+++ b/dev/infra/Dockerfile
@@ -95,12 +95,12 @@ RUN curl -sS https://bootstrap.pypa.io/get-pip.py | pypy3
 RUN pypy3 -m pip install numpy 'six==1.16.0' 'pandas<=2.1.4' scipy coverage matplotlib lxml
 
 
-ARG BASIC_PIP_PKGS="numpy pyarrow>=14.0.0 six==1.16.0 pandas<=2.1.4 scipy unittest-xml-reporting plotly>=4.8 mlflow>=2.8.1 coverage matplotlib openpyxl memory-profiler>=0.61.0 scikit-learn>=1.3.2"
+ARG BASIC_PIP_PKGS="numpy pyarrow>=14.0.0 six==1.16.0 pandas<=2.1.4 scipy plotly>=4.8 mlflow>=2.8.1 coverage matplotlib openpyxl memory-profiler>=0.61.0 scikit-learn>=1.3.2"
 # Python deps for Spark Connect
 ARG CONNECT_PIP_PKGS="grpcio==1.59.3 grpcio-status==1.59.3 protobuf==4.25.1 googleapis-common-protos==1.56.4"
 
 
-RUN python3.9 -m pip install $BASIC_PIP_PKGS $CONNECT_PIP_PKGS
+RUN python3.9 -m pip install $BASIC_PIP_PKGS unittest-xml-reporting $CONNECT_PIP_PKGS
 # Add torch as a testing dependency for TorchDistributor and DeepspeedTorchDistributor
 RUN python3.9 -m pip install 'torch<=2.0.1' torchvision --index-url https://download.pytorch.org/whl/cpu
 RUN python3.9 -m pip install deepspeed torcheval
@@ -111,7 +111,7 @@ RUN apt-get update && apt-get install -y \
     python3.10 python3.10-distutils \
     && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.10
-RUN python3.10 -m pip install $BASIC_PIP_PKGS $CONNECT_PIP_PKGS
+RUN python3.10 -m pip install $BASIC_PIP_PKGS unittest-xml-reporting $CONNECT_PIP_PKGS
 RUN python3.10 -m pip install 'torch<=2.0.1' torchvision --index-url https://download.pytorch.org/whl/cpu
 RUN python3.10 -m pip install deepspeed torcheval
 
@@ -121,7 +121,7 @@ RUN apt-get update && apt-get install -y \
     python3.11 python3.11-distutils \
     && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.11
-RUN python3.11 -m pip install $BASIC_PIP_PKGS $CONNECT_PIP_PKGS
+RUN python3.11 -m pip install $BASIC_PIP_PKGS unittest-xml-reporting $CONNECT_PIP_PKGS
 RUN python3.11 -m pip install 'torch<=2.0.1' torchvision --index-url https://download.pytorch.org/whl/cpu
 RUN python3.11 -m pip install deepspeed torcheval
 
@@ -131,6 +131,7 @@ RUN apt-get update && apt-get install -y \
     python3.12 python3.12-distutils \
     && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.12
+# TODO(SPARK-46647) Add unittest-xml-reporting into Python 3.12 image when it supports Python 3.12
 RUN python3.12 -m pip install $BASIC_PIP_PKGS $CONNECT_PIP_PKGS
 # TODO(SPARK-46078) Use official one instead of nightly build when it's ready
 RUN python3.12 -m pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cpu


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to exclude unittest-xml-reporting in Python 3.12 image

### Why are the changes needed?

`unittest-xml-reporting` seems not supporting, and this seems hiding the real error:

```
  File "/__w/spark/spark/python/pyspark/streaming/tests/test_kinesis.py", line 118, in <module>
    unittest.main(testRunner=testRunner, verbosity=2)
  File "/usr/lib/python3.12/unittest/main.py", line 105, in __init__
    self.runTests()
  File "/usr/lib/python3.12/unittest/main.py", line 281, in runTests
    self.result = testRunner.run(self.test)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/xmlrunner/runner.py", line 67, in run
    test(result)
  File "/usr/lib/python3.12/unittest/suite.py", line 84, in __call__
    return self.run(*args, **kwds)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/unittest/suite.py", line 122, in run
    test(result)
  File "/usr/lib/python3.12/unittest/suite.py", line 84, in __call__
    return self.run(*args, **kwds)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/unittest/suite.py", line 122, in run
    test(result)
  File "/usr/lib/python3.12/unittest/case.py", line 692, in __call__
    return self.run(*args, **kwds)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/unittest/case.py", line 662, in run
    result.stopTest(self)
  File "/usr/local/lib/python3.12/dist-packages/xmlrunner/result.py", line 327, in stopTest
    self.callback()
  File "/usr/local/lib/python3.12/dist-packages/xmlrunner/result.py", line 235, in callback
    test_info.test_finished()
  File "/usr/local/lib/python3.12/dist-packages/xmlrunner/result.py", line 180, in test_finished
    self.test_result.stop_time - self.test_result.start_time
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: '_XMLTestResult' object has no attribute 'start_time'. Did you mean: 'stop_time'?
```

This is optional dependency in testing so we can exclude this (see https://github.com/apache/spark/actions/runs/7462843546/job/20306214215)

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

CI in this PR should test it out.

### Was this patch authored or co-authored using generative AI tooling?

Np.