### PR TITLE
[SPARK-46649][PYTHON][INFRA] Run PyPy 3 and Python 3.10 tests independently

### DIFF
--- a/.github/workflows/build_python.yml
+++ b/.github/workflows/build_python.yml
@@ -27,7 +27,7 @@ jobs:
   run-build:
     strategy:
       matrix:
-        pyversion: ["pypy3,python3.10", "python3.11", "python3.12"]
+        pyversion: ["pypy3", "python3.10", "python3.11", "python3.12"]
     permissions:
       packages: write
     name: Run


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to split PyPy 3 and Python 3.10 builds

### Why are the changes needed?

https://github.com/apache/spark/actions/runs/7462843546/job/20306241275

Seems like it terminates in the middle because of OOM. we should split

### Does this PR introduce _any_ user-facing change?

No, dev-only

### How was this patch tested?

CI should verify the change.

### Was this patch authored or co-authored using generative AI tooling?

No.