### PR TITLE
[SPARK-46642][PYTHON] Add `getMessageTemplate` to PySpark error framework

### DIFF
--- a/common/utils/src/main/java/org/apache/spark/SparkThrowable.java
+++ b/common/utils/src/main/java/org/apache/spark/SparkThrowable.java
@@ -54,5 +54,9 @@ public interface SparkThrowable {
     return new HashMap<>();
   }
 
+  default String getMessageTemplate() {
+    return SparkThrowableHelper.getMessageTemplate(this.getErrorClass());
+  }
+
   default QueryContext[] getQueryContext() { return new QueryContext[0]; }
 }

--- a/common/utils/src/main/scala/org/apache/spark/SparkThrowableHelper.scala
+++ b/common/utils/src/main/scala/org/apache/spark/SparkThrowableHelper.scala
@@ -70,6 +70,10 @@ private[spark] object SparkThrowableHelper {
     errorReader.getMessageParameters(errorClass)
   }
 
+  def getMessageTemplate(errorClass: String): String = {
+    errorReader.getMessageTemplate(errorClass)
+  }
+
   def isInternalError(errorClass: String): Boolean = {
     errorClass.startsWith("INTERNAL_ERROR")
   }

--- a/python/docs/source/reference/pyspark.errors.rst
+++ b/python/docs/source/reference/pyspark.errors.rst
@@ -72,5 +72,6 @@ Methods
     PySparkException.getErrorClass
     PySparkException.getMessage
     PySparkException.getMessageParameters
+    PySparkException.getMessageTemplate
     PySparkException.getQueryContext
     PySparkException.getSqlState

--- a/python/pyspark/errors/exceptions/base.py
+++ b/python/pyspark/errors/exceptions/base.py
@@ -64,6 +64,7 @@ class PySparkException(Exception):
         :meth:`PySparkException.getMessageParameters`
         :meth:`PySparkException.getQueryContext`
         :meth:`PySparkException.getSqlState`
+        :meth:`PySparkException.getMessageTemplate`
         """
         return self._error_class
 
@@ -79,8 +80,29 @@ class PySparkException(Exception):
         :meth:`PySparkException.getMessage`
         :meth:`PySparkException.getQueryContext`
         :meth:`PySparkException.getSqlState`
+        :meth:`PySparkException.getMessageTemplate`
         """
         return self._message_parameters
+
+    def getMessageTemplate(self) -> str:
+        """
+        Returns a message template as a string.
+
+        .. versionadded:: 4.0.0
+
+        See Also
+        --------
+        :meth:`PySparkException.getErrorClass`
+        :meth:`PySparkException.getMessage`
+        :meth:`PySparkException.getQueryContext`
+        :meth:`PySparkException.getSqlState`
+        :meth:`PySparkException.getMessageParameters`
+        """
+        return (
+            self._error_reader.get_message_template(self._error_class)
+            if self._error_class is not None
+            else ""
+        )
 
     def getSqlState(self) -> Optional[str]:
         """
@@ -96,6 +118,7 @@ class PySparkException(Exception):
         :meth:`PySparkException.getMessage`
         :meth:`PySparkException.getMessageParameters`
         :meth:`PySparkException.getQueryContext`
+        :meth:`PySparkException.getMessageTemplate`
         """
         return None
 
@@ -111,6 +134,7 @@ class PySparkException(Exception):
         :meth:`PySparkException.getMessageParameters`
         :meth:`PySparkException.getQueryContext`
         :meth:`PySparkException.getSqlState`
+        :meth:`PySparkException.getMessageTemplate`
         """
         return f"[{self.getErrorClass()}] {self._message}"
 
@@ -126,6 +150,7 @@ class PySparkException(Exception):
         :meth:`PySparkException.getMessageParameters`
         :meth:`PySparkException.getMessage`
         :meth:`PySparkException.getSqlState`
+        :meth:`PySparkException.getMessageTemplate`
         """
         return self._query_contexts
 

--- a/python/pyspark/errors/exceptions/captured.py
+++ b/python/pyspark/errors/exceptions/captured.py
@@ -112,6 +112,17 @@ class CapturedException(PySparkException):
         else:
             return None
 
+    def getMessageTemplate(self) -> str:
+        assert SparkContext._gateway is not None
+
+        gw = SparkContext._gateway
+        if self._origin is not None and is_instance_of(
+            gw, self._origin, "org.apache.spark.SparkThrowable"
+        ):
+            return self._origin.getMessageTemplate()
+        else:
+            return ""
+
     def getSqlState(self) -> Optional[str]:
         assert SparkContext._gateway is not None
         gw = SparkContext._gateway

--- a/python/pyspark/sql/tests/test_utils.py
+++ b/python/pyspark/sql/tests/test_utils.py
@@ -1750,6 +1750,10 @@ class UtilsTestsMixin:
         self.assertEqual(exception.getErrorClass(), "UNRESOLVED_COLUMN.WITHOUT_SUGGESTION")
         self.assertEqual(exception.getSqlState(), "42703")
         self.assertEqual(exception.getMessageParameters(), {"objectName": "`a`"})
+        self.assertEqual(
+            exception.getMessageTemplate(),
+            "A column, variable, or function parameter with name <objectName> cannot be resolved. ",
+        )
         self.assertIn(
             (
                 "[UNRESOLVED_COLUMN.WITHOUT_SUGGESTION] A column, variable, or function "


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to add `getMessageTemplate` to PySpark error framework.


### Why are the changes needed?

To provide users with a more flexible error message management method.


### Does this PR introduce _any_ user-facing change?

New API `getMessageTemplate` is added:
```python
try:
    spark.sql("""SELECT a""")
except AnalysisException as e:
    e.getMessageTemplate()
    // "A column, variable, or function parameter with name <objectName> cannot be resolved."
```


### How was this patch tested?

Added UT.


### Was this patch authored or co-authored using generative AI tooling?

No.
