### PR TITLE
[WIP][SQL][CONNECT] Resolve inappropriate use of AtomicInteger

### DIFF
--- a/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchSourceSuite.scala
+++ b/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchSourceSuite.scala
@@ -2681,7 +2681,7 @@ class KafkaSourceStressSuite extends KafkaSourceTest {
 
   import testImplicits._
 
-  val topicId = new AtomicInteger(1)
+  private val topicId = new AtomicInteger(1)
 
   @volatile var topics: Seq[String] = (1 to 5).map(_ => newStressTopic)
 

--- a/sql/api/src/main/scala/org/apache/spark/sql/util/ArrowUtils.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/util/ArrowUtils.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.sql.util
 
-import java.util.concurrent.atomic.AtomicInteger
-
 import scala.jdk.CollectionConverters._
 
 import org.apache.arrow.memory.RootAllocator
@@ -188,8 +186,12 @@ private[sql] object ArrowUtils {
         }
         val genNawName = st.names.groupBy(identity).map {
           case (name, names) if names.length > 1 =>
-            val i = new AtomicInteger()
-            name -> { () => s"${name}_${i.getAndIncrement()}" }
+            var i = 0
+            name -> { () =>
+              val id = i
+              i += 1
+              s"${name}_$id"
+            }
           case (name, _) => name -> { () => name }
         }
         st.names.map(genNawName(_)())

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/memory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/memory.scala
@@ -41,7 +41,6 @@ import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 object MemoryStream {
-  protected val currentBlockId = new AtomicInteger(0)
   protected val memoryStreamId = new AtomicInteger(0)
 
   def apply[A : Encoder](implicit sqlContext: SQLContext): MemoryStream[A] =

--- a/sql/core/src/test/scala/org/apache/spark/sql/ConfigBehaviorSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ConfigBehaviorSuite.scala
@@ -76,7 +76,7 @@ class ConfigBehaviorSuite extends QueryTest with SharedSparkSession {
     val numToTake = 50
     import scala.language.reflectiveCalls
     val jobCountListener = new SparkListener {
-      private var count: AtomicInteger = new AtomicInteger(0)
+      private val count: AtomicInteger = new AtomicInteger(0)
       def getCount: Int = count.get
       def reset(): Unit = count.set(0)
       override def onJobStart(jobStart: SparkListenerJobStart): Unit = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR propose to resolve inappropriate use of `AtomicInteger`.


### Why are the changes needed?
`AtomicInteger` itself is thread safe and is used to address the atomicity of operations such as increment or decrement.
This PR resolves some inappropriate case. such as:

- `AtomicInteger` used as a local variable.
- Decorate `AtomicInteger` with `var`.
- Some unused `AtomicInteger` variable.


### Does this PR introduce _any_ user-facing change?
'No'.


### How was this patch tested?
GA tests.


### Was this patch authored or co-authored using generative AI tooling?
'No'.
