### PR TITLE
[SPARK-46437][FOLLOWUP] Update configuration.md to use include_api_gen

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -3302,9 +3302,6 @@ Spark subsystems.
 
 ### Spark SQL
 
-{% for static_file in site.static_files %}
-    {% if static_file.name == 'generated-runtime-sql-config-table.html' %}
-
 #### Runtime SQL Configuration
 
 Runtime SQL configurations are per-session, mutable Spark SQL configurations. They can be set with initial values by the config file
@@ -3312,13 +3309,7 @@ and command-line options with `--conf/-c` prefixed, or by setting `SparkConf` th
 Also, they can be set and queried by SET commands and rest to their initial values by RESET command,
 or by `SparkSession.conf`'s setter and getter methods in runtime.
 
-{% include_relative generated-runtime-sql-config-table.html %}
-        {% break %}
-    {% endif %}
-{% endfor %}
-
-{% for static_file in site.static_files %}
-    {% if static_file.name == 'generated-static-sql-config-table.html' %}
+{% include_api_gen generated-runtime-sql-config-table.html %}
 
 #### Static SQL Configuration
 
@@ -3326,11 +3317,7 @@ Static SQL configurations are cross-session, immutable Spark SQL configurations.
 and command-line options with `--conf/-c` prefixed, or by setting `SparkConf` that are used to create `SparkSession`.
 External users can query the static sql config values via `SparkSession.conf` or via set command, e.g. `SET spark.sql.extensions;`, but cannot set/unset them.
 
-{% include_relative generated-static-sql-config-table.html %}
-        {% break %}
-    {% endif %}
-{% endfor %}
-
+{% include_api_gen generated-static-sql-config-table.html %}
 
 ### Spark Streaming
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

As part of #44630 I neglected to update some places that still use the following Liquid directive pattern:

```liquid
{% for static_file in site.static_files %}
    {% if static_file.name == 'generated-agg-funcs-table.html' %}
        {% include_relative generated-agg-funcs-table.html %}
        {% break %}
    {% endif %}
{% endfor %}
```

This PR replaces all remaining instances of this pattern with the new `include_api_gen` Jekyll tag.

### Why are the changes needed?

For consistency in how we build our docs.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manually building and reviewing the configuration docs.

### Was this patch authored or co-authored using generative AI tooling?

No.