### PR TITLE
[SPARK-46657][INFRA] Install `lxml` in Python 3.12

### DIFF
--- a/dev/infra/Dockerfile
+++ b/dev/infra/Dockerfile
@@ -132,7 +132,7 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.12
 # TODO(SPARK-46647) Add unittest-xml-reporting into Python 3.12 image when it supports Python 3.12
-RUN python3.12 -m pip install $BASIC_PIP_PKGS $CONNECT_PIP_PKGS
+RUN python3.12 -m pip install $BASIC_PIP_PKGS $CONNECT_PIP_PKGS lxml
 # TODO(SPARK-46078) Use official one instead of nightly build when it's ready
 RUN python3.12 -m pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cpu
 RUN python3.12 -m pip install torchvision --index-url https://download.pytorch.org/whl/cpu


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to install `lxml` in Python 3.12.

### Why are the changes needed?

- https://github.com/apache/spark/actions/runs/7476792796/job/20348097114
```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/__w/spark/spark/python/pyspark/sql/tests/test_session.py", line 22, in <module>
    from lxml import etree
ModuleNotFoundError: No module named 'lxml'
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs and daily `Python CI` should pass with Python 3.12.

### Was this patch authored or co-authored using generative AI tooling?

No.