### PR TITLE
[SPARK-46658][DOCS] Loosen Ruby dependency specification

### DIFF
--- a/docs/.bundle/config
+++ b/docs/.bundle/config
@@ -1,3 +1,4 @@
 ---
 BUNDLE_PATH: ".local_ruby_bundle"
+# See: https://issues.apache.org/jira/browse/SPARK-38488
 BUNDLE_BUILD__FFI: "--enable-libffi-alloc"

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -21,8 +21,12 @@ source "https://rubygems.org"
 # to pin versions in the lock file.
 # To update the lock file, run `bundle update`.
 # Version constraint reference: https://guides.rubygems.org/patterns/#declaring-dependencies
-gem "ffi", "1.15.5"
+
 gem "jekyll", "~> 4.3"
-gem "rouge", "3.26.0"
-gem "jekyll-redirect-from", "0.16.0"
-gem "webrick", "1.8.1"
+gem "jekyll-redirect-from", "~> 0.16"
+# Rouge 4.0 drops support for Ruby < 2.7, which is EOL.
+# See: https://github.com/rouge-ruby/rouge/blob/61bdda18f204a661413daa93d9624bc65ad219a5/CHANGELOG.md#version-400-2022-09-04
+gem "rouge", "~> 3.26"
+# This resolves a build issue on Apple Silicon.
+# See: https://issues.apache.org/jira/browse/SPARK-38488
+gem "ffi", "~> 1.15"

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -74,4 +74,4 @@ DEPENDENCIES
   rouge (~> 3.26)
 
 BUNDLED WITH
-   2.3.8
+   2.4.22

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -9,9 +9,9 @@ GEM
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
-    ffi (1.15.5)
+    ffi (1.16.3)
     forwardable-extended (2.6.0)
-    google-protobuf (3.25.1)
+    google-protobuf (3.25.2)
     http_parser.rb (0.8.0)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
@@ -54,7 +54,7 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rexml (3.2.6)
-    rouge (3.26.0)
+    rouge (3.30.0)
     safe_yaml (1.0.5)
     sass-embedded (1.69.7)
       google-protobuf (~> 3.25)
@@ -68,11 +68,10 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  ffi (= 1.15.5)
+  ffi (~> 1.15)
   jekyll (~> 4.3)
-  jekyll-redirect-from (= 0.16.0)
-  rouge (= 3.26.0)
-  webrick (= 1.8.1)
+  jekyll-redirect-from (~> 0.16)
+  rouge (~> 3.26)
 
 BUNDLED WITH
    2.3.8

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,7 +30,7 @@ whichever version of Spark you currently have checked out of revision control.
 
 The Spark documentation build uses a number of tools to build HTML docs and API docs in Scala, Java, Python, R, and SQL.
 
-You need to have [Ruby][ruby] and [Python][python] installed. Make sure the `bundle` command is available. If not, install it as follows:
+You need to have [Ruby 3][ruby] and [Python 3][python] installed. Make sure the `bundle` command is available. If not, install it as follows:
 
 [ruby]: https://www.ruby-lang.org/en/documentation/installation/
 [python]: https://www.python.org/downloads/

--- a/docs/_plugins/copy_api_dirs.rb
+++ b/docs/_plugins/copy_api_dirs.rb
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+# This include enables functions like `cd` and `cp_r`.
 require 'fileutils'
 include FileUtils
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

As [promised here][1], this change loosens our Ruby dependency specification so that Bundler can update transitive dependencies more easily.

Other changes included:
- Remove the direct dependency on webrick, because Jekyll [fixed the problem][2] that caused us to add it in the first place.
- Add explanatory comments to parts of the document generation process that are not obvious.

[1]: https://github.com/apache/spark/pull/44628#discussion_r1445151689
[2]: https://github.com/jekyll/jekyll/pull/8524

We can still build our docs using Ruby 2.7, but we should push devs to install Ruby 3 since Ruby 2 is [EOL][3] and we are unable to upgrade some of our doc dependencies until we're running Ruby 3.

[3]: https://www.ruby-lang.org/en/news/2022/04/12/ruby-2-7-6-released/

### Why are the changes needed?

Make the document building process more robust to future updates coming from the Ruby ecosystem.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

I built and reviewed the docs on both Ruby 2.7.8 and Ruby 3.3.0 using the following command:

```sh
SKIP_SCALADOC=1 SKIP_PYTHONDOC=1 SKIP_RDOC=1 bundle exec jekyll build
```

### Was this patch authored or co-authored using generative AI tooling?

No.