### PR TITLE
[SPARK-46660][CONNECT] ReattachExecute requests updates aliveness of SessionHolder

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SessionHolder.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SessionHolder.scala
@@ -214,9 +214,6 @@ case class SessionHolder(userId: String, sessionId: String, session: SparkSessio
     logInfo(s"Session $key accessed, time $lastAccessTimeMs.")
   }
 
-  // Exposed for testing.
-  private[connect] def getAccessTime(): Long = lastAccessTimeMs
-
   private[connect] def setCustomInactiveTimeoutMs(newInactiveTimeoutMs: Option[Long]): Unit = {
     customInactiveTimeoutMs = newInactiveTimeoutMs
     logInfo(s"Session $key inactive timout set to $customInactiveTimeoutMs ms.")

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SessionHolder.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SessionHolder.scala
@@ -214,6 +214,9 @@ case class SessionHolder(userId: String, sessionId: String, session: SparkSessio
     logInfo(s"Session $key accessed, time $lastAccessTimeMs.")
   }
 
+  // Exposed for testing.
+  private[connect] def getAccessTime(): Long = lastAccessTimeMs
+
   private[connect] def setCustomInactiveTimeoutMs(newInactiveTimeoutMs: Option[Long]): Unit = {
     customInactiveTimeoutMs = newInactiveTimeoutMs
     logInfo(s"Session $key inactive timout set to $customInactiveTimeoutMs ms.")

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectReattachExecuteHandler.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectReattachExecuteHandler.scala
@@ -33,22 +33,22 @@ class SparkConnectReattachExecuteHandler(
       .getIsolatedSession(SessionKey(v.getUserContext.getUserId, v.getSessionId))
 
     val executeHolder = sessionHolder.executeHolder(v.getOperationId).getOrElse {
-        if (SparkConnectService.executionManager
-            .getAbandonedTombstone(
-              ExecuteKey(v.getUserContext.getUserId, v.getSessionId, v.getOperationId))
-            .isDefined) {
-          logDebug(s"Reattach operation abandoned: ${v.getOperationId}")
-          throw new SparkSQLException(
-            errorClass = "INVALID_HANDLE.OPERATION_ABANDONED",
-            messageParameters = Map("handle" -> v.getOperationId))
+      if (SparkConnectService.executionManager
+          .getAbandonedTombstone(
+            ExecuteKey(v.getUserContext.getUserId, v.getSessionId, v.getOperationId))
+          .isDefined) {
+        logDebug(s"Reattach operation abandoned: ${v.getOperationId}")
+        throw new SparkSQLException(
+          errorClass = "INVALID_HANDLE.OPERATION_ABANDONED",
+          messageParameters = Map("handle" -> v.getOperationId))
 
-        } else {
-          logDebug(s"Reattach operation not found: ${v.getOperationId}")
-          throw new SparkSQLException(
-            errorClass = "INVALID_HANDLE.OPERATION_NOT_FOUND",
-            messageParameters = Map("handle" -> v.getOperationId))
-        }
+      } else {
+        logDebug(s"Reattach operation not found: ${v.getOperationId}")
+        throw new SparkSQLException(
+          errorClass = "INVALID_HANDLE.OPERATION_NOT_FOUND",
+          messageParameters = Map("handle" -> v.getOperationId))
       }
+    }
     if (!executeHolder.reattachable) {
       logWarning(s"Reattach to not reattachable operation.")
       throw new SparkSQLException(

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectReattachExecuteHandler.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectReattachExecuteHandler.scala
@@ -41,7 +41,6 @@ class SparkConnectReattachExecuteHandler(
         throw new SparkSQLException(
           errorClass = "INVALID_HANDLE.OPERATION_ABANDONED",
           messageParameters = Map("handle" -> v.getOperationId))
-
       } else {
         logDebug(s"Reattach operation not found: ${v.getOperationId}")
         throw new SparkSQLException(

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectReattachExecuteHandler.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectReattachExecuteHandler.scala
@@ -29,9 +29,10 @@ class SparkConnectReattachExecuteHandler(
     extends Logging {
 
   def handle(v: proto.ReattachExecuteRequest): Unit = {
-    val executeHolder = SparkConnectService.executionManager
-      .getExecuteHolder(ExecuteKey(v.getUserContext.getUserId, v.getSessionId, v.getOperationId))
-      .getOrElse {
+    val sessionHolder = SparkConnectService.sessionManager
+      .getIsolatedSession(SessionKey(v.getUserContext.getUserId, v.getSessionId))
+
+    val executeHolder = sessionHolder.executeHolder(v.getOperationId).getOrElse {
         if (SparkConnectService.executionManager
             .getAbandonedTombstone(
               ExecuteKey(v.getUserContext.getUserId, v.getSessionId, v.getOperationId))

--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/execution/ReattachableExecuteSuite.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/execution/ReattachableExecuteSuite.scala
@@ -394,4 +394,23 @@ class ReattachableExecuteSuite extends SparkConnectServerTest {
       assertEventuallyNoActiveExecutions()
     }
   }
+
+  test("SPARK-46660: reattach updates aliveness of session holder") {
+    withRawBlockingStub { stub =>
+      val operationId = UUID.randomUUID().toString
+      val iter = stub.executePlan(
+        buildExecutePlanRequest(buildPlan(MEDIUM_RESULTS_QUERY), operationId = operationId))
+      iter.next() // open the iterator, guarantees that the RPC reached the server
+
+      val executionHolder = getExecutionHolder
+      val lastAccessTime = executionHolder.sessionHolder.getAccessTime()
+
+      // send reattach
+      val iter2 = stub.reattachExecute(buildReattachExecuteRequest(operationId, None))
+      iter2.next() // open the iterator, guarantees that the RPC reached the server
+      val newAccessTime = executionHolder.sessionHolder.getAccessTime()
+
+      assert(newAccessTime > lastAccessTime, "reattach should update session holder access time")
+    }
+  }
 }

--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/execution/ReattachableExecuteSuite.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/execution/ReattachableExecuteSuite.scala
@@ -403,12 +403,12 @@ class ReattachableExecuteSuite extends SparkConnectServerTest {
       iter.next() // open the iterator, guarantees that the RPC reached the server
 
       val executionHolder = getExecutionHolder
-      val lastAccessTime = executionHolder.sessionHolder.getAccessTime()
+      val lastAccessTime = executionHolder.sessionHolder.getSessionHolderInfo.lastAccessTimeMs
 
       // send reattach
       val iter2 = stub.reattachExecute(buildReattachExecuteRequest(operationId, None))
       iter2.next() // open the iterator, guarantees that the RPC reached the server
-      val newAccessTime = executionHolder.sessionHolder.getAccessTime()
+      val newAccessTime = executionHolder.sessionHolder.getSessionHolderInfo.lastAccessTimeMs
 
       assert(newAccessTime > lastAccessTime, "reattach should update session holder access time")
     }

--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectServiceE2ESuite.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectServiceE2ESuite.scala
@@ -115,7 +115,7 @@ class SparkConnectServiceE2ESuite extends SparkConnectServerTest {
         }
         assert(
           queryAError.getMessage.contains("OPERATION_CANCELED") ||
-            queryAError.getMessage.contains("INVALID_HANDLE.OPERATION_ABANDONED"))
+            queryAError.getMessage.contains("INVALID_HANDLE.SESSION_CLOSED"))
 
         // B's query can run.
         while (queryB.hasNext) queryB.next()

--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectServiceE2ESuite.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectServiceE2ESuite.scala
@@ -66,22 +66,22 @@ class SparkConnectServiceE2ESuite extends SparkConnectServerTest {
       // query1 and query2 could get either an:
       // OPERATION_CANCELED if it happens fast - when closing the session interrupted the queries,
       // and that error got pushed to the client buffers before the client got disconnected.
-      // OPERATION_ABANDONED if it happens slow - when closing the session interrupted the client
-      // RPCs before it pushed out the error above. The client would then get an
+      // INVALID_HANDLE.SESSION_CLOSED if it happens slow - when closing the session interrupted the
+      // client RPCs before it pushed out the error above. The client would then get an
       // INVALID_CURSOR.DISCONNECTED, which it will retry with a ReattachExecute, and then get an
-      // INVALID_HANDLE.OPERATION_ABANDONED.
+      // INVALID_HANDLE.SESSION_CLOSED.
       val query1Error = intercept[SparkException] {
         while (query1.hasNext) query1.next()
       }
       assert(
         query1Error.getMessage.contains("OPERATION_CANCELED") ||
-          query1Error.getMessage.contains("INVALID_HANDLE.OPERATION_ABANDONED"))
+          query1Error.getMessage.contains("INVALID_HANDLE.SESSION_CLOSED"))
       val query2Error = intercept[SparkException] {
         while (query2.hasNext) query2.next()
       }
       assert(
         query2Error.getMessage.contains("OPERATION_CANCELED") ||
-          query2Error.getMessage.contains("INVALID_HANDLE.OPERATION_ABANDONED"))
+          query2Error.getMessage.contains("INVALID_HANDLE.SESSION_CLOSED"))
 
       // No other requests should be allowed in the session, failing with SESSION_CLOSED
       val requestError = intercept[SparkException] {

--- a/python/pyspark/sql/tests/connect/client/test_reattach.py
+++ b/python/pyspark/sql/tests/connect/client/test_reattach.py
@@ -97,14 +97,10 @@ class SparkConnectReattachTestCase(ReusedConnectTestCase, SQLTestUtils, PandasOn
 
         e = check_error(query1)
         self.assertIsNotNone(e, "An exception has to be thrown")
-        self.assertTrue(
-            "OPERATION_CANCELED" in str(e) or "INVALID_HANDLE.SESSION_CLOSED" in str(e)
-        )
+        self.assertTrue("OPERATION_CANCELED" in str(e) or "INVALID_HANDLE.SESSION_CLOSED" in str(e))
         e = check_error(query2)
         self.assertIsNotNone(e, "An exception has to be thrown")
-        self.assertTrue(
-            "OPERATION_CANCELED" in str(e) or "INVALID_HANDLE.SESSION_CLOSED" in str(e)
-        )
+        self.assertTrue("OPERATION_CANCELED" in str(e) or "INVALID_HANDLE.SESSION_CLOSED" in str(e))
 
         # query3 has not been submitted before, so it should now fail with SESSION_CLOSED
         e = check_error(query3)

--- a/python/pyspark/sql/tests/connect/client/test_reattach.py
+++ b/python/pyspark/sql/tests/connect/client/test_reattach.py
@@ -84,10 +84,10 @@ class SparkConnectReattachTestCase(ReusedConnectTestCase, SQLTestUtils, PandasOn
         # query1 and query2 could get either an:
         # OPERATION_CANCELED if it happens fast - when closing the session interrupted the queries,
         # and that error got pushed to the client buffers before the client got disconnected.
-        # OPERATION_ABANDONED if it happens slow - when closing the session interrupted the client
-        # RPCs before it pushed out the error above. The client would then get an
+        # INVALID_HANDLE.SESSION_CLOSED if it happens slow - when closing the session interrupted
+        # the client RPCs before it pushed out the error above. The client would then get an
         # INVALID_CURSOR.DISCONNECTED, which it will retry with a ReattachExecute, and then get an
-        # INVALID_HANDLE.OPERATION_ABANDONED.
+        # INVALID_HANDLE.SESSION_CLOSED.
 
         def check_error(q):
             try:
@@ -98,12 +98,12 @@ class SparkConnectReattachTestCase(ReusedConnectTestCase, SQLTestUtils, PandasOn
         e = check_error(query1)
         self.assertIsNotNone(e, "An exception has to be thrown")
         self.assertTrue(
-            "OPERATION_CANCELED" in str(e) or "INVALID_HANDLE.OPERATION_ABANDONED" in str(e)
+            "OPERATION_CANCELED" in str(e) or "INVALID_HANDLE.SESSION_CLOSED" in str(e)
         )
         e = check_error(query2)
         self.assertIsNotNone(e, "An exception has to be thrown")
         self.assertTrue(
-            "OPERATION_CANCELED" in str(e) or "INVALID_HANDLE.OPERATION_ABANDONED" in str(e)
+            "OPERATION_CANCELED" in str(e) or "INVALID_HANDLE.SESSION_CLOSED" in str(e)
         )
 
         # query3 has not been submitted before, so it should now fail with SESSION_CLOSED


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR makes `SparkConnectReattachExecuteHandler` fetch the `ExecuteHolder` via the`SessionHolder` which in turn refreshes it's aliveness. Further, this makes it consistent with `SparkConnectReleaseExecuteHandler`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Currently in ReattachExecute, we fetch the ExecuteHolder directly without going through the SessionHolder and hence the "aliveness" of the SessionHolder is not refreshed.

This would result in long-running queries (which do not send `ReleaseExecute` requests in specific) failing because the `SessionHolder` would expire from the cache during an active query execution.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, it fixes the bug where long-running may fail when their corresponding `SessionHolder` is expired during active query execution.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New unit test.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.
