### PR TITLE
[SPARK-46664][CORE] Improve `Master` to recover quickly in case of zero workers and apps

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -619,6 +619,9 @@ private[deploy] class Master(
         case e: Exception => logInfo("Worker " + worker.id + " had exception on reconnect")
       }
     }
+
+    // In case of zero workers and apps, we can complete recovery.
+    if (canCompleteRecovery) { completeRecovery() }
   }
 
   private def completeRecovery(): Unit = {

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -244,12 +244,13 @@ private[deploy] class Master(
       }
       logInfo("I have been elected leader! New state: " + state)
       if (state == RecoveryState.RECOVERING) {
-        beginRecovery(storedApps, storedDrivers, storedWorkers)
-        recoveryCompletionTask = forwardMessageThread.schedule(new Runnable {
-          override def run(): Unit = Utils.tryLogNonFatalError {
-            self.send(CompleteRecovery)
-          }
-        }, recoveryTimeoutMs, TimeUnit.MILLISECONDS)
+        if (beginRecovery(storedApps, storedDrivers, storedWorkers)) {
+          recoveryCompletionTask = forwardMessageThread.schedule(new Runnable {
+            override def run(): Unit = Utils.tryLogNonFatalError {
+              self.send(CompleteRecovery)
+            }
+          }, recoveryTimeoutMs, TimeUnit.MILLISECONDS)
+        }
       }
 
     case CompleteRecovery => completeRecovery()
@@ -590,7 +591,7 @@ private[deploy] class Master(
   private var recoveryStartTimeNs = 0L
 
   private def beginRecovery(storedApps: Seq[ApplicationInfo], storedDrivers: Seq[DriverInfo],
-      storedWorkers: Seq[WorkerInfo]): Unit = {
+      storedWorkers: Seq[WorkerInfo]): Boolean = {
     recoveryStartTimeNs = System.nanoTime()
     for (app <- storedApps) {
       logInfo("Trying to recover app: " + app.id)
@@ -621,7 +622,12 @@ private[deploy] class Master(
     }
 
     // In case of zero workers and apps, we can complete recovery.
-    if (canCompleteRecovery) { completeRecovery() }
+    if (canCompleteRecovery) {
+      completeRecovery()
+      false
+    } else {
+      true
+    }
   }
 
   private def completeRecovery(): Unit = {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to improve `Master` to recover quickly in case of zero workers and apps.

### Why are the changes needed?

This case happens on the initial cluster creation or during cluster restarting procedure.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs with the newly added test case.

### Was this patch authored or co-authored using generative AI tooling?

No.