### PR TITLE
[SPARK-46666][PYTHON][TESTS] Make lxml as an optional testing dependency in test_session

### DIFF
--- a/python/pyspark/sql/tests/test_session.py
+++ b/python/pyspark/sql/tests/test_session.py
@@ -19,7 +19,6 @@ import os
 import unittest
 import unittest.mock
 from io import StringIO
-from lxml import etree
 
 from pyspark import SparkConf, SparkContext
 from pyspark.errors import PySparkRuntimeError
@@ -121,9 +120,14 @@ class SparkSessionTests3(unittest.TestCase, PySparkErrorTestUtils):
             self.assertEqual(spark.range(3).count(), 3)
 
             try:
-                etree.parse(StringIO(spark._repr_html_()), etree.HTMLParser(recover=False))
-            except Exception as e:
-                self.fail(f"Generated HTML from `_repr_html_` was invalid: {e}")
+                from lxml import etree
+
+                try:
+                    etree.parse(StringIO(spark._repr_html_()), etree.HTMLParser(recover=False))
+                except Exception as e:
+                    self.fail(f"Generated HTML from `_repr_html_` was invalid: {e}")
+            except ImportError:
+                pass
 
             # SPARK-37516: Only plain column references work as variable in SQL.
             self.assertEqual(


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to make `lxml` as an optional testing dependency in the `test_session` test

### Why are the changes needed?

To make the tests pass without optional testing dependencies, see https://github.com/apache/spark/actions/runs/7476792796/job/20348097114

```
Starting test(python3.12): pyspark.sql.tests.test_session (temp output: /__w/spark/spark/python/target/5136bb6a-ba9d-4533-925c-adf338021fa0/python3.12__pyspark.sql.tests.test_session__yahhd4j3.log)
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/__w/spark/spark/python/pyspark/sql/tests/test_session.py", line 22, in <module>
    from lxml import etree
ModuleNotFoundError: No module named 'lxml'

```

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Manaully.

### Was this patch authored or co-authored using generative AI tooling?

No.
