### PR TITLE
[SPARK-46638][Python] Create Python UDTF API to acquire execution memory for function evaluation

### DIFF
--- a/python/pyspark/sql/udtf.py
+++ b/python/pyspark/sql/udtf.py
@@ -134,17 +134,17 @@ class AnalyzeResult:
         sort the input TABLE argument by. Note that the 'partitionBy' list must also be non-empty
         in this case.
     acquireExecutionMemoryMbRequested: long
-        If this is not None, this represents the amount of memory in megabytes that the UDTF should
-        request from each Spark executor that it runs on. Then the UDTF takes responsibility to use
-        at most this much memory, including all allocated objects. The purpose of this functionality
-        is to prevent executors from crashing by running out of memory due to the extra memory
-        consumption invoked by the UDTF's 'eval' and 'terminate' and 'cleanup' methods. Spark will
-        then call 'TaskMemoryManager.acquireExecutionMemory' with the requested number of megabytes.
+        If this is not None, this represents the amount of memory in MB that the UDTF should request
+        from each Spark executor that it runs on. Then the UDTF takes responsibility to use at most
+        this much memory, including all allocated objects. The purpose of this functionality is to
+        prevent executors from crashing by running out of memory due to the extra memory consumption
+        invoked by the UDTF's 'eval' and 'terminate' and 'cleanup' methods. Spark will then call
+        'TaskMemoryManager.acquireExecutionMemory' with the requested number of MB.
     acquireExecutionMemoryMbActual: long
-        If there is a task context available, Spark will assign this field to the number of
-        megabytes returned from the call to the TaskMemoryManager.acquireExecutionMemory' method, as
-        consumed by the UDTF's'__init__' method. Therefore, its 'eval' and 'terminate' and 'cleanup'
-        methods will know it thereafter and can ensure to bound memory usage to at most this number.
+        If there is a task context available, Spark will assign this field to the number of MB
+        returned from the call to the TaskMemoryManager.acquireExecutionMemory' method, as consumed
+        by the UDTF's'__init__' method. Therefore, its 'eval' and 'terminate' and 'cleanup' methods
+        will know it thereafter and can ensure to bound memory usage to at most this number.
         Note that there is no effect if the UDTF's 'analyze' method assigns a value to this; it will
         be overwritten.
     """
@@ -153,7 +153,7 @@ class AnalyzeResult:
     withSinglePartition: bool = False
     partitionBy: Sequence[PartitioningColumn] = field(default_factory=tuple)
     orderBy: Sequence[OrderingColumn] = field(default_factory=tuple)
-    acquireExecutionMemoryMbRequested: Optional[int] = None
+    acquireExecutionMemoryMbRequested: Optional[int] = 100
     acquireExecutionMemoryMbActual: Optional[int] = None
 
 

--- a/python/pyspark/sql/udtf.py
+++ b/python/pyspark/sql/udtf.py
@@ -140,6 +140,7 @@ class AnalyzeResult:
         prevent executors from crashing by running out of memory due to the extra memory consumption
         invoked by the UDTF's 'eval' and 'terminate' and 'cleanup' methods. Spark will then call
         'TaskMemoryManager.acquireExecutionMemory' with the requested number of MB.
+        We set a default of 100 MB here, which the UDTF may override to a more accurate number.
     acquireExecutionMemoryMbActual: long
         If there is a task context available, Spark will assign this field to the number of MB
         returned from the call to the TaskMemoryManager.acquireExecutionMemory' method, as consumed

--- a/python/pyspark/sql/worker/analyze_udtf.py
+++ b/python/pyspark/sql/worker/analyze_udtf.py
@@ -228,13 +228,17 @@ def main(infile: IO, outfile: IO) -> None:
                 write_int(2, outfile)
         # Return the requested amount of execution memory to acquire, if any.
         write_long(
-            0 if result.acquireExecutionMemoryMbRequested is None
+            0
+            if result.acquireExecutionMemoryMbRequested is None
             else result.acquireExecutionMemoryMbRequested,
-            outfile)
+            outfile,
+        )
         write_long(
-            0 if result.acquireExecutionMemoryMbActual is None
+            0
+            if result.acquireExecutionMemoryMbActual is None
             else result.acquireExecutionMemoryMbActual,
-            outfile)
+            outfile,
+        )
 
     except BaseException as e:
         handle_worker_exception(e, outfile)

--- a/python/pyspark/sql/worker/analyze_udtf.py
+++ b/python/pyspark/sql/worker/analyze_udtf.py
@@ -233,12 +233,6 @@ def main(infile: IO, outfile: IO) -> None:
             else result.acquireExecutionMemoryMbRequested,
             outfile,
         )
-        write_long(
-            0
-            if result.acquireExecutionMemoryMbActual is None
-            else result.acquireExecutionMemoryMbActual,
-            outfile,
-        )
 
     except BaseException as e:
         handle_worker_exception(e, outfile)

--- a/python/pyspark/sql/worker/analyze_udtf.py
+++ b/python/pyspark/sql/worker/analyze_udtf.py
@@ -28,6 +28,7 @@ from pyspark.serializers import (
     read_bool,
     read_int,
     write_int,
+    write_long,
     write_with_length,
     SpecialLengths,
 )
@@ -225,6 +226,15 @@ def main(infile: IO, outfile: IO) -> None:
                 write_int(1, outfile)
             else:
                 write_int(2, outfile)
+        # Return the requested amount of execution memory to acquire, if any.
+        write_long(
+            0 if result.acquireExecutionMemoryMbRequested is None
+            else result.acquireExecutionMemoryMbRequested,
+            outfile)
+        write_long(
+            0 if result.acquireExecutionMemoryMbActual is None
+            else result.acquireExecutionMemoryMbActual,
+            outfile)
 
     except BaseException as e:
         handle_worker_exception(e, outfile)

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -840,6 +840,9 @@ def read_udtf(pickleSer, infile, eval_type):
             f"The return type of a UDTF must be a struct type, but got {type(return_type)}."
         )
     udtf_name = utf8_deserializer.loads(infile)
+    udtf_acquired_execution_memory_mb = read_long(infile)
+    if udtf_acquired_execution_memory_mb > 0:
+        pickled_analyze_result.acquireExecutionMemoryMbActual = udtf_acquired_execution_memory_mb
 
     # Update the handler that creates a new UDTF instance to first try calling the UDTF constructor
     # with one argument containing the previous AnalyzeResult. If that fails, then try a constructor

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -2260,9 +2260,14 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
                 analyzeResult.applyToTableArgument(u.name, t)
               case c => c
             }
+            // Assign no partition column indexes for now upon initial construction of the
+            // 'PythonUDTF' class here; we may assign them later if necessary during query
+            // compilation.
+            val pythonUDTFPartitionColumnIndexes: Option[PythonUDTFPartitionColumnIndexes] = None
             PythonUDTF(
               u.name, u.func, analyzeResult.schema, Some(analyzeResult.pickledAnalyzeResult),
-              newChildren, u.evalType, u.udfDeterministic, u.resultId)
+              newChildren, u.evalType, u.udfDeterministic, u.resultId,
+              pythonUDTFPartitionColumnIndexes, analyzeResult.acquireMemoryMbRequested)
           }
         }
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/PythonUDF.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/PythonUDF.scala
@@ -174,8 +174,8 @@ abstract class UnevaluableGenerator extends Generator {
  * @param pythonUDTFPartitionColumnIndexes holds the zero-based indexes of the projected results of
  *                                         all PARTITION BY expressions within the TABLE argument of
  *                                         the Python UDTF call, if applicable
- * @param acquireMemoryMbRequested If this is not None, this represents the amount of memory in
- *                                 megabytes that the UDTF should request from each Spark executor
+ * @param acquireMemoryMbRequested If this is not None, this represents the amount of memory in MB
+ *                                 that the UDTF should request from each Spark executor
  *                                 that it runs on. Then the UDTF takes responsibility to use at
  *                                 most this much memory, including all allocated objects. The
  *                                 purpose of this functionality is to prevent executors from
@@ -183,7 +183,7 @@ abstract class UnevaluableGenerator extends Generator {
  *                                 consumption invoked by the UDTF's 'eval' and 'terminate' and
  *                                 'cleanup' methods. Spark will then call
  *                                 'TaskMemoryManager.acquireExecutionMemory' with the requested
- *                                 number of megabytes
+ *                                 number of MB
  */
 case class PythonUDTF(
     name: String,
@@ -211,7 +211,7 @@ case class PythonUDTF(
    * This eventually holds the result of 'TaskMemoryManager.acquireExecutionMemory' if and when we
    * call it with the argument of [[acquireMemoryMbRequested]]. That method returns an integer
    * indicating the number of bytes of memory actually acquired, which may range from zero to the
-   * number of bytes requested. We store this result here in order to propagate it back to the UDTF
+   * number of MB requested. We store this result here in order to propagate it back to the UDTF
    * execution and assign it to the 'acquireExecutionMemoryMb' field of the 'AnalyzeResult', so that
    * subsequent invocations of the 'eval' and 'terminate' and 'cleanup' methods can see it.
    */
@@ -267,12 +267,12 @@ case class UnresolvedPolymorphicPythonUDTF(
  * @param orderByExpressions if non-empty, this contains the list of ordering items that the
  *                           'analyze' method explicitly indicated that the UDTF call should consume
  *                           the input table rows by
- * @param acquireMemoryMbRequested If this is not None, this represents the amount of memory in
- *                                 megabytes that the UDTF should request from each Spark executor
- *                                 that it runs on (see this field in the 'PythonUDTF' class for
- *                                 more background)
+ * @param acquireMemoryMbRequested If this is not None, this represents the amount of memory in MB
+ *                                 that the UDTF should request from each Spark executor that it
+ *                                 runs on (see this field in the 'PythonUDTF' class for more
+ *                                 background)
  * @param acquireMemoryMbActual If this is not None, the UDTF's 'analyze' method assigned a positive
- *                              integer to this field as a minmium memory requirement signal wherein
+ *                              integer to this field as a minimum memory requirement signal wherein
  *                              Spark will return an error if the
  *                              'TaskMemoryManager.acquireExecutionMemory' method returns a smaller
  *                              value

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/PythonUDF.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/PythonUDF.scala
@@ -271,11 +271,6 @@ case class UnresolvedPolymorphicPythonUDTF(
  *                                 that the UDTF should request from each Spark executor that it
  *                                 runs on (see this field in the 'PythonUDTF' class for more
  *                                 background)
- * @param acquireMemoryMbActual If this is not None, the UDTF's 'analyze' method assigned a positive
- *                              integer to this field as a minimum memory requirement signal wherein
- *                              Spark will return an error if the
- *                              'TaskMemoryManager.acquireExecutionMemory' method returns a smaller
- *                              value
  * @param pickledAnalyzeResult this is the pickled 'AnalyzeResult' instance from the UDTF, which
  *                             contains all metadata returned by the Python UDTF 'analyze' method
  *                             including the result schema of the function call as well as optional
@@ -287,7 +282,6 @@ case class PythonUDTFAnalyzeResult(
     partitionByExpressions: Seq[Expression],
     orderByExpressions: Seq[SortOrder],
     acquireMemoryMbRequested: Option[Long],
-    acquireMemoryMbActual: Option[Long],
     pickledAnalyzeResult: Array[Byte]) {
   /**
    * Applies the requested properties from this analysis result to the target TABLE argument

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/BatchEvalPythonUDTFExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/BatchEvalPythonUDTFExec.scala
@@ -145,6 +145,7 @@ object PythonUDTFRunner {
     // Write the UDTF name.
     PythonWorkerUtils.writeUTF(udtf.name, dataOut)
     // Write the number of MB of acquired execution memory, if any.
+    print(s"@@@ write UDTF ${udtf.name}\n")
     dataOut.writeLong(udtf.acquireMemoryMbActual.getOrElse(0))
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/BatchEvalPythonUDTFExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/BatchEvalPythonUDTFExec.scala
@@ -144,7 +144,7 @@ object PythonUDTFRunner {
     PythonWorkerUtils.writeUTF(udtf.elementSchema.json, dataOut)
     // Write the UDTF name.
     PythonWorkerUtils.writeUTF(udtf.name, dataOut)
-    // Write the number of megabytes of acquired execution memory, if any.
+    // Write the number of MB of acquired execution memory, if any.
     dataOut.writeLong(udtf.acquireMemoryMbActual.getOrElse(0))
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/BatchEvalPythonUDTFExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/BatchEvalPythonUDTFExec.scala
@@ -144,5 +144,7 @@ object PythonUDTFRunner {
     PythonWorkerUtils.writeUTF(udtf.elementSchema.json, dataOut)
     // Write the UDTF name.
     PythonWorkerUtils.writeUTF(udtf.name, dataOut)
+    // Write the number of megabytes of acquired execution memory, if any.
+    dataOut.writeLong(udtf.acquireMemoryMbActual.getOrElse(0))
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/EvalPythonUDTFExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/EvalPythonUDTFExec.scala
@@ -165,29 +165,29 @@ trait EvalPythonUDTFExec extends UnaryExecNode {
  * and free the memory after the evaluation is over.
  *
  * Background: If the UDTF's 'analyze' method returns an 'AnalyzeResult' with a non-empty
- * 'acquireExecutionMemoryMb' value, this value represents the amount of memory in megabytes that
+ * 'acquireExecutionMemoryMb' value, this value represents the amount of memory in MB that
  * the UDTF should request from each Spark executor that it runs on. Then the UDTF takes
  * responsibility to use at most this much memory, including all allocated objects. The purpose of
  * this functionality is to prevent executors from crashing by running out of memory due to the
  * extra memory consumption invoked by the UDTF's 'eval' and 'terminate' and 'cleanup' methods.
  *
  * In this class, Spark calls 'TaskMemoryManager.acquireExecutionMemory' with the requested number
- * of megabytes, and when Spark calls __init__  of the UDTF later, it updates the
- * acquiredExecutionMemory integer passed into the UDTF constructor to the actual number returned
- * from 'TaskMemoryManager.acquireExecutionMemory', so the 'eval' and 'terminate' and 'cleanup'
- * methods know it and can ensure to bound memory usage to at most this number.
+ * of MB, and when Spark calls __init__  of the UDTF later, it updates the acquiredExecutionMemory
+ * integer passed into the UDTF constructor to the actual number returned from
+ * 'TaskMemoryManager.acquireExecutionMemory', so the 'eval' and 'terminate' and 'cleanup' methods
+ * know it and can ensure to bound memory usage to at most this number.
  */
 case class PythonUDTFMemoryConsumer(udtf: PythonUDTF)
   extends MemoryConsumer(TaskContext.get().taskMemoryManager(), MemoryMode.ON_HEAP) {
-  private val BYTES_PER_MEGABYTE = 1024 * 1024
+  private val BYTES_PER_MB = 1024 * 1024
   def acquireMemory(): Long = {
     udtf.acquireMemoryMbRequested.map { megabytes: Long =>
-      acquireMemory(megabytes * BYTES_PER_MEGABYTE) / BYTES_PER_MEGABYTE
+      acquireMemory(megabytes * BYTES_PER_MB) / BYTES_PER_MB
     }.getOrElse(0)
   }
   def freeMemory(): Unit = {
     udtf.acquireMemoryMbRequested.foreach { megabytes: Long =>
-      freeMemory(megabytes * BYTES_PER_MEGABYTE)
+      freeMemory(megabytes * BYTES_PER_MB)
     }
   }
   /** Return zero to indicate that we are not capable of spilling acquired memory to disk. */

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/UserDefinedPythonFunction.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/UserDefinedPythonFunction.scala
@@ -291,7 +291,6 @@ class UserDefinedPythonTableFunctionAnalyzeRunner(
       partitionByExpressions = partitionByExpressions.toSeq,
       orderByExpressions = orderBy.toSeq,
       acquireMemoryMbRequested = acquireExecutionMemoryMbRequested,
-      acquireMemoryMbActual = acquireExecutionMemoryMbActual,
       pickledAnalyzeResult = pickledAnalyzeResult)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/UserDefinedPythonFunction.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/UserDefinedPythonFunction.scala
@@ -281,10 +281,6 @@ class UserDefinedPythonTableFunctionAnalyzeRunner(
       val value = dataIn.readLong()
       if (value > 0) Some(value) else None
     }
-    val acquireExecutionMemoryMbActual = {
-      val value = dataIn.readLong()
-      if (value > 0) Some(value) else None
-    }
     PythonUDTFAnalyzeResult(
       schema = schema,
       withSinglePartition = withSinglePartition,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/UserDefinedPythonFunction.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/UserDefinedPythonFunction.scala
@@ -276,11 +276,22 @@ class UserDefinedPythonTableFunctionAnalyzeRunner(
         case 2 => orderBy.append(SortOrder(parsed, direction, NullsLast, Seq.empty))
       }
     }
+    // Receive the requested amount of execution memory to acquire, if any.
+    val acquireExecutionMemoryMbRequested = {
+      val value = dataIn.readLong()
+      if (value > 0) Some(value) else None
+    }
+    val acquireExecutionMemoryMbActual = {
+      val value = dataIn.readLong()
+      if (value > 0) Some(value) else None
+    }
     PythonUDTFAnalyzeResult(
       schema = schema,
       withSinglePartition = withSinglePartition,
       partitionByExpressions = partitionByExpressions.toSeq,
       orderByExpressions = orderBy.toSeq,
+      acquireMemoryMbRequested = acquireExecutionMemoryMbRequested,
+      acquireMemoryMbActual = acquireExecutionMemoryMbActual,
       pickledAnalyzeResult = pickledAnalyzeResult)
   }
 }

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/udtf/udtf.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/udtf/udtf.sql.out
@@ -479,6 +479,18 @@ org.apache.spark.sql.AnalysisException
 
 
 -- !query
+SELECT * FROM UDTFAcquireExecutionMemory(argument => 4, min_memory_mb => 0)
+-- !query analysis
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+SELECT * FROM UDTFAcquireExecutionMemory(argument => 4, min_memory_mb => 10)
+-- !query analysis
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
 SELECT * FROM InvalidEvalReturnsNoneToNonNullableColumnScalarType(TABLE(t2))
 -- !query analysis
 [Analyzer test output redacted due to nondeterminism]

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/udtf/udtf.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/udtf/udtf.sql.out
@@ -479,22 +479,6 @@ org.apache.spark.sql.AnalysisException
 
 
 -- !query
-SELECT * FROM UDTFAcquireExecutionMemory(
-    requested_memory_mb => 4,
-    min_memory_mb => 0)
--- !query analysis
-[Analyzer test output redacted due to nondeterminism]
-
-
--- !query
-SELECT * FROM UDTFAcquireExecutionMemory(
-    requested_memory_mb => 4,
-    min_memory_mb => 10)
--- !query analysis
-[Analyzer test output redacted due to nondeterminism]
-
-
--- !query
 SELECT * FROM InvalidEvalReturnsNoneToNonNullableColumnScalarType(TABLE(t2))
 -- !query analysis
 [Analyzer test output redacted due to nondeterminism]
@@ -819,6 +803,22 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
     "fragment" : "unparsable"
   } ]
 }
+
+
+-- !query
+SELECT * FROM UDTFAcquireExecutionMemory(
+    requested_memory_mb => 4,
+    min_memory_mb => 0)
+-- !query analysis
+[Analyzer test output redacted due to nondeterminism]
+
+
+-- !query
+SELECT * FROM UDTFAcquireExecutionMemory(
+    requested_memory_mb => 4,
+    min_memory_mb => 10)
+-- !query analysis
+[Analyzer test output redacted due to nondeterminism]
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/udtf/udtf.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/udtf/udtf.sql.out
@@ -479,13 +479,17 @@ org.apache.spark.sql.AnalysisException
 
 
 -- !query
-SELECT * FROM UDTFAcquireExecutionMemory(argument => 4, min_memory_mb => 0)
+SELECT * FROM UDTFAcquireExecutionMemory(
+    requested_memory_mb => 4,
+    min_memory_mb => 0)
 -- !query analysis
 [Analyzer test output redacted due to nondeterminism]
 
 
 -- !query
-SELECT * FROM UDTFAcquireExecutionMemory(argument => 4, min_memory_mb => 10)
+SELECT * FROM UDTFAcquireExecutionMemory(
+    requested_memory_mb => 4,
+    min_memory_mb => 10)
 -- !query analysis
 [Analyzer test output redacted due to nondeterminism]
 

--- a/sql/core/src/test/resources/sql-tests/inputs/udtf/udtf.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/udtf/udtf.sql
@@ -106,13 +106,6 @@ SELECT * FROM
     VALUES (0), (1) AS t(col)
     JOIN LATERAL
     UDTFInvalidOrderByWithoutPartitionBy(TABLE(t2) PARTITION BY partition_col);
--- The following UDTF calls exercise acquiring execution memory.
-SELECT * FROM UDTFAcquireExecutionMemory(
-    requested_memory_mb => 4,
-    min_memory_mb => 0);
-SELECT * FROM UDTFAcquireExecutionMemory(
-    requested_memory_mb => 4,
-    min_memory_mb => 10);
 -- The following UDTF calls should fail because the UDTF's 'eval' or 'terminate' method returns None
 -- to a non-nullable column, either directly or within an array/struct/map subfield.
 SELECT * FROM InvalidEvalReturnsNoneToNonNullableColumnScalarType(TABLE(t2));
@@ -143,6 +136,13 @@ SELECT * FROM UDTFWithSinglePartition(1, invalid_arg_name => 2);
 SELECT * FROM UDTFWithSinglePartition(1, initial_count => 2);
 SELECT * FROM UDTFWithSinglePartition(initial_count => 1, initial_count => 2);
 SELECT * FROM UDTFInvalidPartitionByOrderByParseError(TABLE(t2));
+-- The following UDTF calls exercise acquiring execution memory.
+SELECT * FROM UDTFAcquireExecutionMemory(
+    requested_memory_mb => 4,
+    min_memory_mb => 0);
+SELECT * FROM UDTFAcquireExecutionMemory(
+    requested_memory_mb => 4,
+    min_memory_mb => 10);
 
 -- cleanup
 DROP VIEW t1;

--- a/sql/core/src/test/resources/sql-tests/inputs/udtf/udtf.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/udtf/udtf.sql
@@ -107,8 +107,12 @@ SELECT * FROM
     JOIN LATERAL
     UDTFInvalidOrderByWithoutPartitionBy(TABLE(t2) PARTITION BY partition_col);
 -- The following UDTF calls exercise acquiring execution memory.
-SELECT * FROM UDTFAcquireExecutionMemory(argument => 4, min_memory_mb => 0);
-SELECT * FROM UDTFAcquireExecutionMemory(argument => 4, min_memory_mb => 10);
+SELECT * FROM UDTFAcquireExecutionMemory(
+    requested_memory_mb => 4,
+    min_memory_mb => 0);
+SELECT * FROM UDTFAcquireExecutionMemory(
+    requested_memory_mb => 4,
+    min_memory_mb => 10);
 -- The following UDTF calls should fail because the UDTF's 'eval' or 'terminate' method returns None
 -- to a non-nullable column, either directly or within an array/struct/map subfield.
 SELECT * FROM InvalidEvalReturnsNoneToNonNullableColumnScalarType(TABLE(t2));

--- a/sql/core/src/test/resources/sql-tests/inputs/udtf/udtf.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/udtf/udtf.sql
@@ -106,6 +106,9 @@ SELECT * FROM
     VALUES (0), (1) AS t(col)
     JOIN LATERAL
     UDTFInvalidOrderByWithoutPartitionBy(TABLE(t2) PARTITION BY partition_col);
+-- The following UDTF calls exercise acquiring execution memory.
+SELECT * FROM UDTFAcquireExecutionMemory(argument => 4, min_memory_mb => 0);
+SELECT * FROM UDTFAcquireExecutionMemory(argument => 4, min_memory_mb => 10);
 -- The following UDTF calls should fail because the UDTF's 'eval' or 'terminate' method returns None
 -- to a non-nullable column, either directly or within an array/struct/map subfield.
 SELECT * FROM InvalidEvalReturnsNoneToNonNullableColumnScalarType(TABLE(t2));

--- a/sql/core/src/test/resources/sql-tests/results/udtf/udtf.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udtf/udtf.sql.out
@@ -557,26 +557,6 @@ org.apache.spark.sql.AnalysisException
 
 
 -- !query
-SELECT * FROM UDTFAcquireExecutionMemory(
-    requested_memory_mb => 4,
-    min_memory_mb => 0)
--- !query schema
-struct<initial_request:bigint,acquired_memory:bigint,min_memory:bigint,status:string>
--- !query output
-4	4	0	OK
-
-
--- !query
-SELECT * FROM UDTFAcquireExecutionMemory(
-    requested_memory_mb => 4,
-    min_memory_mb => 10)
--- !query schema
-struct<initial_request:bigint,acquired_memory:bigint,min_memory:bigint,status:string>
--- !query output
-4	4	10	Insufficient memory
-
-
--- !query
 SELECT * FROM InvalidEvalReturnsNoneToNonNullableColumnScalarType(TABLE(t2))
 -- !query schema
 struct<>
@@ -967,6 +947,26 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
     "fragment" : "unparsable"
   } ]
 }
+
+
+-- !query
+SELECT * FROM UDTFAcquireExecutionMemory(
+    requested_memory_mb => 4,
+    min_memory_mb => 0)
+-- !query schema
+struct<initial_request:bigint,acquired_memory:bigint,min_memory:bigint,status:string>
+-- !query output
+4	4	0	OK
+
+
+-- !query
+SELECT * FROM UDTFAcquireExecutionMemory(
+    requested_memory_mb => 4,
+    min_memory_mb => 10)
+-- !query schema
+struct<initial_request:bigint,acquired_memory:bigint,min_memory:bigint,status:string>
+-- !query output
+4	4	10	Insufficient memory
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/udtf/udtf.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udtf/udtf.sql.out
@@ -557,7 +557,9 @@ org.apache.spark.sql.AnalysisException
 
 
 -- !query
-SELECT * FROM UDTFAcquireExecutionMemory(argument => 4, min_memory_mb => 0)
+SELECT * FROM UDTFAcquireExecutionMemory(
+    requested_memory_mb => 4,
+    min_memory_mb => 0)
 -- !query schema
 struct<initial_request:bigint,acquired_memory:bigint,min_memory:bigint,status:string>
 -- !query output
@@ -565,7 +567,9 @@ struct<initial_request:bigint,acquired_memory:bigint,min_memory:bigint,status:st
 
 
 -- !query
-SELECT * FROM UDTFAcquireExecutionMemory(argument => 4, min_memory_mb => 10)
+SELECT * FROM UDTFAcquireExecutionMemory(
+    requested_memory_mb => 4,
+    min_memory_mb => 10)
 -- !query schema
 struct<initial_request:bigint,acquired_memory:bigint,min_memory:bigint,status:string>
 -- !query output

--- a/sql/core/src/test/resources/sql-tests/results/udtf/udtf.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udtf/udtf.sql.out
@@ -557,6 +557,22 @@ org.apache.spark.sql.AnalysisException
 
 
 -- !query
+SELECT * FROM UDTFAcquireExecutionMemory(argument => 4, min_memory_mb => 0)
+-- !query schema
+struct<initial_request:bigint,acquired_memory:bigint,min_memory:bigint,status:string>
+-- !query output
+4	4	0	OK
+
+
+-- !query
+SELECT * FROM UDTFAcquireExecutionMemory(argument => 4, min_memory_mb => 10)
+-- !query schema
+struct<initial_request:bigint,acquired_memory:bigint,min_memory:bigint,status:string>
+-- !query output
+4	4	10	Insufficient memory
+
+
+-- !query
 SELECT * FROM InvalidEvalReturnsNoneToNonNullableColumnScalarType(TABLE(t2))
 -- !query schema
 struct<>

--- a/sql/core/src/test/scala/org/apache/spark/sql/IntegratedUDFTestUtils.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/IntegratedUDFTestUtils.scala
@@ -780,20 +780,22 @@ object IntegratedUDFTestUtils extends SQLHelper {
          |
          |    @staticmethod
          |    def analyze(**kwargs):
-         |        argument = kwargs.get("argument")
+         |        requested_memory_mb = kwargs.get("requested_memory_mb")
          |        min_memory_mb = kwargs.get("min_memory_mb").value
-         |        if argument is not None:
-         |            assert(argument.dataType == IntegerType() or argument.dataType == LongType())
-         |            argument_value = argument.value
+         |        if requested_memory_mb is not None:
+         |            assert(
+         |                requested_memory_mb.dataType == IntegerType() or
+         |                requested_memory_mb.dataType == LongType())
+         |            requested_memory_mb_value = requested_memory_mb.value
          |        else:
-         |            argument_value = None
+         |            requested_memory_mb_value = None
          |        return CustomAnalyzeResult(
          |            schema=StructType()
          |                .add("initial_request", LongType())
          |                .add("acquired_memory", LongType())
          |                .add("min_memory", LongType())
          |                .add("status", StringType()),
-         |            acquireExecutionMemoryMbRequested=argument_value,
+         |            acquireExecutionMemoryMbRequested=requested_memory_mb_value,
          |            # Set this field to some junk value to show that it has no effect and gets
          |            # overwritten with the actual number of execution MB acquired from the
          |            # 'TaskMemoryManager.acquireExecutionMemory' method.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR creates a Python UDTF API to acquire execution memory for future function evaluation in the 'eval' and 'terminate' and 'cleanup' methods.

For example, this UDTF accepts an argument representing the requested amount of memory to allocate (of which it will receive some subset), and a second argument containing the minimum memory allowed. It sets a status column to indicate an "out of memory" condition if the latter exceeds the memory allocated by Spark:

```
from dataclasses import dataclass
from pyspark.sql.functions import AnalyzeResult
from pyspark.sql.types import IntegerType, LongType, StringType, StructType

@dataclass
class CustomAnalyzeResult(AnalyzeResult):
    minMemoryMb: int = 0

class UDTFAcquireExecutionMemory:
    def __init__(self, analyze_result):
        self._analyze_result = analyze_result

    @staticmethod
    def analyze(**kwargs):
        requested_memory_mb = kwargs.get("requested_memory_mb")
        min_memory_mb = kwargs.get("min_memory_mb").value
        if requested_memory_mb is not None:
            assert(
                requested_memory_mb.dataType == IntegerType() or
                requested_memory_mb.dataType == LongType())
            requested_memory_mb_value = requested_memory_mb.value
        else:
            requested_memory_mb_value = None
        return CustomAnalyzeResult(
            schema=StructType()
                .add("initial_request", LongType())
                .add("acquired_memory", LongType())
                .add("min_memory", LongType())
                .add("status", StringType()),
            acquireExecutionMemoryMbRequested=requested_memory_mb_value,
            minMemoryMb=min_memory_mb)

    def eval(self, **kwargs):
        pass

    def terminate(self):
          yield (
              self._analyze_result.acquireExecutionMemoryMbRequested,
              self._analyze_result.acquireExecutionMemoryMbActual,
              self._analyze_result.minMemoryMb,
              "OK" if self._analyze_result.acquireExecutionMemoryMbActual >=
                  self._analyze_result.minMemoryMb else "Insufficient memory")
```

Invoking it yields the following:

```
SELECT * FROM UDTFAcquireExecutionMemory(
    requested_memory_mb_value => 4,
    min_memory_mb => 0)

> 4	4	0	OK

SELECT * FROM UDTFAcquireExecutionMemory(
    requested_memory_mb_value => 4,
    min_memory_mb => 10)

> 4	4	10	Insufficient memory
```

### Why are the changes needed?

Python UDTFs that import large libraries or otherwise use up a lot of memory from storing many input rows in memory need to register this memory usage with Spark executors in order to protect against OOM crashes.

### Does this PR introduce _any_ user-facing change?

Yes, see above.

### How was this patch tested?

This PR adds test coverage.

### Was this patch authored or co-authored using generative AI tooling?

No.