### PR TITLE
[SPARK-46668][DOCS] Parallelize Sphinx build of Python API docs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -750,7 +750,7 @@ jobs:
         Rscript -e "devtools::install_version('preferably', version='0.4', repos='https://cloud.r-project.org')"
     - name: Install dependencies for documentation generation
       run: |
-        python3.9 -m pip install 'sphinx==4.2.0' mkdocs 'pydata_sphinx_theme>=0.13' sphinx-copybutton nbsphinx numpydoc jinja2 markupsafe 'pyzmq<24.0.0'
+        python3.9 -m pip install 'sphinx==4.5.0' mkdocs 'pydata_sphinx_theme>=0.13' sphinx-copybutton nbsphinx numpydoc jinja2 markupsafe 'pyzmq<24.0.0'
         python3.9 -m pip install ipython_genutils # See SPARK-38517
         python3.9 -m pip install sphinx_plotly_directive 'numpy>=1.20.0' pyarrow pandas 'plotly>=4.8'
         python3.9 -m pip install 'docutils<0.18.0' # See SPARK-39421

--- a/dev/create-release/spark-rm/Dockerfile
+++ b/dev/create-release/spark-rm/Dockerfile
@@ -37,7 +37,7 @@ ENV DEBCONF_NONINTERACTIVE_SEEN true
 # These arguments are just for reuse and not really meant to be customized.
 ARG APT_INSTALL="apt-get install --no-install-recommends -y"
 
-ARG PIP_PKGS="sphinx==4.2.0 mkdocs==1.1.2 numpy==1.20.3 pydata_sphinx_theme==0.13.3 ipython==7.19.0 nbsphinx==0.8.0 numpydoc==1.1.0 jinja2==3.1.2 twine==3.4.1 sphinx-plotly-directive==0.1.3 sphinx-copybutton==0.5.2 pandas==1.5.3 pyarrow==3.0.0 plotly==5.4.0 markupsafe==2.0.1 docutils<0.17 grpcio==1.59.3 protobuf==4.21.6 grpcio-status==1.59.3 googleapis-common-protos==1.56.4"
+ARG PIP_PKGS="sphinx==4.5.0 mkdocs==1.1.2 numpy==1.20.3 pydata_sphinx_theme==0.13.3 ipython==7.19.0 nbsphinx==0.8.0 numpydoc==1.1.0 jinja2==3.1.2 twine==3.4.1 sphinx-plotly-directive==0.1.3 sphinx-copybutton==0.5.2 pandas==1.5.3 pyarrow==3.0.0 plotly==5.4.0 markupsafe==2.0.1 docutils<0.17 grpcio==1.59.3 protobuf==4.21.6 grpcio-status==1.59.3 googleapis-common-protos==1.56.4"
 ARG GEM_PKGS="bundler:2.3.8"
 
 # Install extra needed repos and refresh.

--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -36,7 +36,7 @@ ipython
 nbsphinx
 numpydoc
 jinja2
-sphinx==4.2.0
+sphinx==4.5.0
 sphinx-plotly-directive
 sphinx-copybutton
 docutils<0.18.0
@@ -67,4 +67,3 @@ torcheval
 
 # DeepspeedTorchDistributor dependencies
 deepspeed; sys_platform != 'darwin'
-

--- a/python/docs/Makefile
+++ b/python/docs/Makefile
@@ -16,7 +16,7 @@
 # Minimal makefile for Sphinx documentation
 
 # You can set these variables from the command line.
-SPHINXOPTS    ?= "-W"
+SPHINXOPTS    ?= "-W" "-j" "auto"
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     ?= source
 BUILDDIR      ?= build


### PR DESCRIPTION
### What changes were proposed in this pull request?

Upgrade to Sphinx 4.5.0, which is the [latest in the 4.x line][1] and includes the [fix for parallel builds on macOS][2].

Enable [parallel Sphinx workers][3] to build the Python API docs.

I experimented with a few different values, and `auto` seems to work best. Configuring 4 workers seems to yield the same improvement as `auto`, suggesting parallelization beyond that is ineffective due to some sort of resource contention. But I left it as `auto` since that's more dynamic and should work better across varied environments.

On my 16-core Intel workstation, the runtime of `make html` was cut by ~60%.

```sh
# `make html` @ master
real    43m51.167s
user    41m43.526s
sys     0m39.651s

# `make html` with parallel workers
real    17m8.424s
user    174m42.051s
sys     5m8.824s
```

[1]: https://www.sphinx-doc.org/en/master/changes.html#release-4-5-0-released-mar-28-2022
[2]: https://github.com/sphinx-doc/sphinx/pull/9793
[3]: https://www.sphinx-doc.org/en/master/man/sphinx-build.html#cmdoption-sphinx-build-j

Here on CI, the "Run documentation build" step seems also to have improved from the usual of [~50 minutes][5] down to [~31 minutes][6].

[5]: https://github.com/nchammas/spark/actions/runs/7477968036/job/20370932121#step:30:1
[6]: https://github.com/nchammas/spark/actions/runs/7484084658/job/20370406870#step:30:1

### Why are the changes needed?

This saves developer time and CI time.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

I manually built and reviewed the docs using:

```sh
SKIP_SCALADOC=1 SKIP_SQLDOC=1 SKIP_RDOC=1 time bundle exec jekyll build
```

### Was this patch authored or co-authored using generative AI tooling?

No.
