### PR TITLE
[SPARK-46672][BUILD] Upgrade log4j2 to 2.22.1

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -177,10 +177,10 @@ lapack/3.0.3//lapack-3.0.3.jar
 leveldbjni-all/1.8//leveldbjni-all-1.8.jar
 libfb303/0.9.3//libfb303-0.9.3.jar
 libthrift/0.12.0//libthrift-0.12.0.jar
-log4j-1.2-api/2.22.0//log4j-1.2-api-2.22.0.jar
-log4j-api/2.22.0//log4j-api-2.22.0.jar
-log4j-core/2.22.0//log4j-core-2.22.0.jar
-log4j-slf4j2-impl/2.22.0//log4j-slf4j2-impl-2.22.0.jar
+log4j-1.2-api/2.22.1//log4j-1.2-api-2.22.1.jar
+log4j-api/2.22.1//log4j-api-2.22.1.jar
+log4j-core/2.22.1//log4j-core-2.22.1.jar
+log4j-slf4j2-impl/2.22.1//log4j-slf4j2-impl-2.22.1.jar
 logging-interceptor/3.12.12//logging-interceptor-3.12.12.jar
 lz4-java/1.8.0//lz4-java-1.8.0.jar
 metrics-core/4.2.21//metrics-core-4.2.21.jar

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
     <sbt.project.name>spark</sbt.project.name>
     <asm.version>9.6</asm.version>
     <slf4j.version>2.0.10</slf4j.version>
-    <log4j.version>2.22.0</log4j.version>
+    <log4j.version>2.22.1</log4j.version>
     <!-- make sure to update IsolatedClientLoader whenever this version is changed -->
     <hadoop.version>3.3.6</hadoop.version>
     <!-- SPARK-41247: When updating `protobuf.version`, also need to update `protoVersion` in `SparkBuild.scala` -->


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to upgrade log4j2 from 2.22.0 to 2.22.1.

### Why are the changes needed?
The new version contains some bug fixes:
- [Fix NPE in CloseableThreadContext](https://github.com/apache/logging-log4j2/issues/1426) 
- [Fix NPE in RollingFileManager](https://github.com/apache/logging-log4j2/issues/1645) 

And 2.22.1 is generated using JDK 17, the full release note as follows:
- https://github.com/apache/logging-log4j2/releases/tag/rel%2F2.22.1


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No