### PR TITLE
[SPARK-46680][BUILD] Upgrade Apache commons-pool2 to 2.12.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -199,7 +199,7 @@
     <!-- org.apache.commons/commons-lang3/-->
     <commons-lang3.version>3.14.0</commons-lang3.version>
     <!-- org.apache.commons/commons-pool2/-->
-    <commons-pool2.version>2.11.1</commons-pool2.version>
+    <commons-pool2.version>2.12.0</commons-pool2.version>
     <datanucleus-core.version>4.1.17</datanucleus-core.version>
     <guava.version>14.0.1</guava.version>
     <janino.version>3.1.9</janino.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to upgrade Apache commons-pool2 from 2.11.1 to 2.12.0.

### Why are the changes needed?
The new version bring some bug fix like:

- [POOL-401](https://issues.apache.org/jira/browse/POOL-401):  Ensure that capacity freed by invalidateObject is available to all keyed pools.
- [POOL-391](https://issues.apache.org/jira/browse/POOL-391):  Ensure capacity freed by clear is made available to GKOP borrowers. 
- [POOL-402](https://issues.apache.org/jira/browse/POOL-402):  Check blockWhenExhausted in hasBorrowWaiters
- [POOL-405](https://issues.apache.org/jira/browse/POOL-405):  NullPointerException GenericKeyedObjectPool.invalidateObject(GenericKeyedObjectPool.java:1343)
- [POOL-393](https://issues.apache.org/jira/browse/POOL-393):  Improve BaseGenericObjectPool's JMX Register performance when creating many pools.
- [POOL-411](https://issues.apache.org/jira/browse/POOL-41):  Guard against NPE when deregistering a key at the end of borrow.

The full change we can refer to https://github.com/apache/commons-pool/blob/rel/commons-pool-2.12.0/RELEASE-NOTES.txt

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions

### Was this patch authored or co-authored using generative AI tooling?
No
