### PR TITLE
[SPARK-46667][SQL] XML: Throw error on multiple XML data source

### DIFF
--- a/common/utils/src/main/resources/error/error-classes.json
+++ b/common/utils/src/main/resources/error/error-classes.json
@@ -2664,7 +2664,8 @@
   "MULTIPLE_XML_DATA_SOURCE" : {
     "message" : [
       "Multiple sources found for <provider> (<sourceNames>). Please specify the fully qualified class name or remove <externalSource> from the classpath."
-    ]
+    ],
+    "sqlState" : "42000"
   },
   "MULTI_SOURCES_UNSUPPORTED_FOR_EXPRESSION" : {
     "message" : [

--- a/common/utils/src/main/resources/error/error-classes.json
+++ b/common/utils/src/main/resources/error/error-classes.json
@@ -2661,6 +2661,11 @@
     ],
     "sqlState" : "42K0E"
   },
+  "MULTIPLE_XML_DATA_SOURCE" : {
+    "message" : [
+      "Multiple sources found for <provider> (<sourceNames>). Please specify the fully qualified class name or remove <externalSource> from the classpath."
+    ]
+  },
   "MULTI_SOURCES_UNSUPPORTED_FOR_EXPRESSION" : {
     "message" : [
       "The expression <expr> does not support more than one source."

--- a/common/utils/src/main/resources/error/error-classes.json
+++ b/common/utils/src/main/resources/error/error-classes.json
@@ -2663,9 +2663,9 @@
   },
   "MULTIPLE_XML_DATA_SOURCE" : {
     "message" : [
-      "Multiple sources found for <provider> (<sourceNames>). Please specify the fully qualified class name or remove <externalSource> from the classpath."
+      "Detected multiple data sources with the name <provider> (<sourceNames>). Please specify the fully qualified class name or remove <externalSource> from the classpath."
     ],
-    "sqlState" : "42000"
+    "sqlState" : "42710"
   },
   "MULTI_SOURCES_UNSUPPORTED_FOR_EXPRESSION" : {
     "message" : [

--- a/docs/sql-error-conditions.md
+++ b/docs/sql-error-conditions.md
@@ -1505,6 +1505,12 @@ The query does not include a GROUP BY clause. Add GROUP BY or turn it into the w
 
 Cannot specify time travel in both the time travel clause and options.
 
+### MULTIPLE_XML_DATA_SOURCE
+
+[SQLSTATE: 42000](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Multiple sources found for `<provider>` (`<sourceNames>`). Please specify the fully qualified class name or remove `<externalSource>` from the classpath.
+
 ### MULTI_SOURCES_UNSUPPORTED_FOR_EXPRESSION
 
 [SQLSTATE: 42K0E](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)

--- a/docs/sql-error-conditions.md
+++ b/docs/sql-error-conditions.md
@@ -1507,9 +1507,9 @@ Cannot specify time travel in both the time travel clause and options.
 
 ### MULTIPLE_XML_DATA_SOURCE
 
-[SQLSTATE: 42000](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+[SQLSTATE: 42710](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
 
-Multiple sources found for `<provider>` (`<sourceNames>`). Please specify the fully qualified class name or remove `<externalSource>` from the classpath.
+Detected multiple data sources with the name `<provider>` (`<sourceNames>`). Please specify the fully qualified class name or remove `<externalSource>` from the classpath.
 
 ### MULTI_SOURCES_UNSUPPORTED_FOR_EXPRESSION
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -1644,17 +1644,6 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
         "sourceNames" -> sourceNames.mkString(", ")))
   }
 
-  def findMultipleXMLDataSourceError(provider: String,
-      sourceNames: Seq[String],
-      externalSource: String): Throwable = {
-    new AnalysisException(
-      errorClass = "MULTIPLE_XML_DATA_SOURCE",
-      messageParameters = Map("provider" -> provider,
-        "sourceNames" -> sourceNames.mkString(", "),
-        "externalSource" -> externalSource)
-    )
-  }
-
   def writeEmptySchemasUnsupportedByDataSourceError(): Throwable = {
     new AnalysisException(
       errorClass = "_LEGACY_ERROR_TEMP_1142",
@@ -3890,6 +3879,17 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
     new AnalysisException(
       errorClass = "FOUND_MULTIPLE_DATA_SOURCES",
       messageParameters = Map("provider" -> provider))
+  }
+
+  def foundMultipleXMLDataSourceError(provider: String,
+      sourceNames: Seq[String],
+      externalSource: String): Throwable = {
+    new AnalysisException(
+      errorClass = "MULTIPLE_XML_DATA_SOURCE",
+      messageParameters = Map("provider" -> provider,
+        "sourceNames" -> sourceNames.mkString(", "),
+        "externalSource" -> externalSource)
+    )
   }
 
   def xmlRowTagRequiredError(optionName: String): Throwable = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -1644,6 +1644,17 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
         "sourceNames" -> sourceNames.mkString(", ")))
   }
 
+  def findMultipleXMLDataSourceError(provider: String,
+      sourceNames: Seq[String],
+      externalSource: String): Throwable = {
+    new AnalysisException(
+      errorClass = "MULTIPLE_XML_DATA_SOURCE",
+      messageParameters = Map("provider" -> provider,
+        "sourceNames" -> sourceNames.mkString(", "),
+        "externalSource" -> externalSource)
+    )
+  }
+
   def writeEmptySchemasUnsupportedByDataSourceError(): Throwable = {
     new AnalysisException(
       errorClass = "_LEGACY_ERROR_TEMP_1142",

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -693,7 +693,7 @@ object DataSource extends Logging {
               .startsWith("org.apache.spark.sql.execution.datasources.xml.XmlFileFormat")
             ).head.getClass
             throw QueryCompilationErrors
-              .findMultipleXMLDataSourceError(provider1, sourceNames, externalSource.getName)
+              .foundMultipleXMLDataSourceError(provider1, sourceNames, externalSource.getName)
           } else if (internalSources.size == 1) {
             logWarning(s"Multiple sources found for $provider1 (${sourceNames.mkString(", ")}), " +
               s"defaulting to the internal datasource (${internalSources.head.getClass.getName}).")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -686,9 +686,15 @@ object DataSource extends Logging {
           // There are multiple registered aliases for the input. If there is single datasource
           // that has "org.apache.spark" package in the prefix, we use it considering it is an
           // internal datasource within Spark.
-          val sourceNames = sources.map(_.getClass.getName)
+          val sourceNames = sources.map(_.getClass.getName).sortBy(_.toString)
           val internalSources = sources.filter(_.getClass.getName.startsWith("org.apache.spark"))
-          if (internalSources.size == 1) {
+          if (provider.equalsIgnoreCase("xml") && sources.size == 2) {
+            val externalSource = sources.filterNot(_.getClass.getName
+              .startsWith("org.apache.spark.sql.execution.datasources.xml.XmlFileFormat")
+            ).head.getClass
+            throw QueryCompilationErrors
+              .findMultipleXMLDataSourceError(provider1, sourceNames, externalSource.getName)
+          } else if (internalSources.size == 1) {
             logWarning(s"Multiple sources found for $provider1 (${sourceNames.mkString(", ")}), " +
               s"defaulting to the internal datasource (${internalSources.head.getClass.getName}).")
             internalSources.head.getClass


### PR DESCRIPTION
### What changes were proposed in this pull request?
Spark-XML library users will notice some changes with built-in XML. Notably, some of the character data that was earlier dropped by spark-xml will be faithfully parsed by the built-in XML. Support for new data types like DecimalType, TimeStampNTZ, etc. have also been added. Few spark-xml users may still want to continue using the library. 

Rather than implicitly switching to the built-in XML, this PR throws an error when an external data source is detected for XML format.

Users can continue using the old spark-xml library by specifying the full package name. Alternatively, they can remove spark-xml from the classpath and switch to built-in XML.

### Why are the changes needed?
Same as above

### Does this PR introduce _any_ user-facing change?
Yes


### How was this patch tested?
New unit test


### Was this patch authored or co-authored using generative AI tooling?
No
