### PR TITLE
[SPARK-46676][SS] dropDuplicatesWithinWatermark should not fail on canonicalization of the plan

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/statefulOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/statefulOperators.scala
@@ -1097,39 +1097,19 @@ case class StreamingDeduplicateWithinWatermarkExec(
 
   protected val extraOptionOnStateStore: Map[String, String] = Map.empty
 
-  // Below three variables are Option as attributes in child won't have an event time column
-  // in the canonicalized plan. The executed plan will eventually call doExecute() and we can
-  // defer assertion of the existence of event time column at that time.
-  private val eventTimeColOpt: Option[Attribute] = WatermarkSupport.findEventTimeColumn(
-    child.output, allowMultipleEventTimeColumns = false)
-  private val delayThresholdMsOpt: Option[Long] = eventTimeColOpt.map(
-    _.metadata.getLong(EventTimeWatermark.delayKey))
-  private val eventTimeColOrdinalOpt: Option[Int] = eventTimeColOpt.map(child.output.indexOf)
-
-  // Below three variables will be set lazily when doExecute() is called.
-  private var eventTimeCol: Attribute = _
-  private var delayThresholdMs: Long = _
-  private var eventTimeColOrdinal: Int = _
+  // Below three variables are defined as lazy, as evaluating these variables does not work with
+  // canonicalized plan. Specifically, attributes in child won't have an event time column in
+  // the canonicalized plan. These variables are NOT referenced in canonicalized plan, hence
+  // defining these variables as lazy would avoid such error.
+  private lazy val eventTimeCol: Attribute = WatermarkSupport.findEventTimeColumn(child.output,
+    allowMultipleEventTimeColumns = false).get
+  private lazy val delayThresholdMs = eventTimeCol.metadata.getLong(EventTimeWatermark.delayKey)
+  private lazy val eventTimeColOrdinal: Int = child.output.indexOf(eventTimeCol)
 
   protected def initializeReusedDupInfoRow(): Option[UnsafeRow] = {
     val timeoutToUnsafeRow = UnsafeProjection.create(schemaForValueRow)
     val timeoutRow = timeoutToUnsafeRow(new SpecificInternalRow(schemaForValueRow))
     Some(timeoutRow)
-  }
-
-  override protected def doExecute(): RDD[InternalRow] = {
-    require(eventTimeColOpt.isDefined, "DataFrame should have defined an event time column to " +
-      "use the API `dropDuplicatesWithinWatermark`.")
-
-    // if event time column is available, all below must be available as well.
-    assert(delayThresholdMsOpt.isDefined)
-    assert(eventTimeColOrdinalOpt.isDefined)
-
-    eventTimeCol = eventTimeColOpt.get
-    delayThresholdMs = delayThresholdMsOpt.get
-    eventTimeColOrdinal = eventTimeColOrdinalOpt.get
-
-    super.doExecute()
   }
 
   protected def putDupInfoIntoState(

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingDeduplicationWithinWatermarkSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingDeduplicationWithinWatermarkSuite.scala
@@ -199,4 +199,27 @@ class StreamingDeduplicationWithinWatermarkSuite extends StateStoreMetricsTest {
       )
     }
   }
+
+  test("SPARK-46676: canonicalization of StreamingDeduplicateWithinWatermarkExec should work") {
+    withTempDir { checkpoint =>
+      val dedupeInputData = MemoryStream[(String, Int)]
+      val dedupe = dedupeInputData.toDS()
+        .withColumn("eventTime", timestamp_seconds($"_2"))
+        .withWatermark("eventTime", "10 second")
+        .dropDuplicatesWithinWatermark("_1")
+        .select($"_1", $"eventTime".cast("long").as[Long])
+
+      testStream(dedupe, Append)(
+        StartStream(checkpointLocation = checkpoint.getCanonicalPath),
+
+        AddData(dedupeInputData, "a" -> 1),
+        CheckNewAnswer("a" -> 1),
+
+        Execute { q =>
+          // This threw out error before SPARK-46676.
+          q.lastExecution.executedPlan.canonicalized
+        }
+      )
+    }
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingDeduplicationWithinWatermarkSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingDeduplicationWithinWatermarkSuite.scala
@@ -211,10 +211,8 @@ class StreamingDeduplicationWithinWatermarkSuite extends StateStoreMetricsTest {
 
       testStream(dedupe, Append)(
         StartStream(checkpointLocation = checkpoint.getCanonicalPath),
-
         AddData(dedupeInputData, "a" -> 1),
         CheckNewAnswer("a" -> 1),
-
         Execute { q =>
           // This threw out error before SPARK-46676.
           q.lastExecution.executedPlan.canonicalized


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to fix the bug on canonicalizing the plan which contains the physical node of dropDuplicatesWithinWatermark (`StreamingDeduplicateWithinWatermarkExec`).

### Why are the changes needed?

Canonicalization of the plan will replace the expressions (including attributes) to remove out cosmetic, including name, "and metadata", which denotes the event time column marker.

StreamingDeduplicateWithinWatermarkExec assumes that the input attributes of child node contain the event time column, and it is determined at the initialization of the node instance. Once canonicalization is being triggered, child node will lose the notion of event time column from its attributes, and copy of StreamingDeduplicateWithinWatermarkExec will be performed which instantiating a new node of `StreamingDeduplicateWithinWatermarkExec` with new child node, which no longer has an event time column, hence instantiation will fail.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

New UT added.

### Was this patch authored or co-authored using generative AI tooling?

No.