### PR TITLE
[SPARK-46681][CORE] Refactor `ExecutorFailureTracker#maxNumExecutorFailures` to avoid calculating `defaultMaxNumExecutorFailures` when `MAX_EXECUTOR_FAILURES` is configured

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/ExecutorFailureTracker.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/ExecutorFailureTracker.scala
@@ -84,18 +84,20 @@ object ExecutorFailureTracker {
   // Default to twice the number of executors (twice the maximum number of executors if dynamic
   // allocation is enabled), with a minimum of 3.
   def maxNumExecutorFailures(sparkConf: SparkConf): Int = {
-    val effectiveNumExecutors =
-      if (Utils.isStreamingDynamicAllocationEnabled(sparkConf)) {
-        sparkConf.get(STREAMING_DYN_ALLOCATION_MAX_EXECUTORS)
-      } else if (Utils.isDynamicAllocationEnabled(sparkConf)) {
-        sparkConf.get(DYN_ALLOCATION_MAX_EXECUTORS)
-      } else {
-        sparkConf.get(EXECUTOR_INSTANCES).getOrElse(0)
-      }
     // By default, effectiveNumExecutors is Int.MaxValue if dynamic allocation is enabled. We need
     // avoid the integer overflow here.
-    val defaultMaxNumExecutorFailures = math.max(3,
-      if (effectiveNumExecutors > Int.MaxValue / 2) Int.MaxValue else 2 * effectiveNumExecutors)
+    def defaultMaxNumExecutorFailures: Int = {
+      val effectiveNumExecutors =
+        if (Utils.isStreamingDynamicAllocationEnabled(sparkConf)) {
+          sparkConf.get(STREAMING_DYN_ALLOCATION_MAX_EXECUTORS)
+        } else if (Utils.isDynamicAllocationEnabled(sparkConf)) {
+          sparkConf.get(DYN_ALLOCATION_MAX_EXECUTORS)
+        } else {
+          sparkConf.get(EXECUTOR_INSTANCES).getOrElse(0)
+        }
+      math.max(3,
+        if (effectiveNumExecutors > Int.MaxValue / 2) Int.MaxValue else 2 * effectiveNumExecutors)
+    }
 
     sparkConf.get(MAX_EXECUTOR_FAILURES).getOrElse(defaultMaxNumExecutorFailures)
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to refactor `ExecutorFailureTracker#maxNumExecutorFailures` to avoid calculating `defaultMaxNumExecutorFailures` when `MAX_EXECUTOR_FAILURES` is configured.

### Why are the changes needed?
Avoid unnecessary computations:

https://github.com/apache/spark/blob/bfaf9e47b35b96be01962cce0670949901e171c3/core/src/main/scala/org/apache/spark/deploy/ExecutorFailureTracker.scala#L86-L100

The result of `defaultMaxNumExecutorFailures` is calculated first, even if MAX_EXECUTOR_FAILURES is configured now.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No