### PR TITLE
[SPARK-46664][CORE][TESTS][FOLLOWUP] Add a persistent `DriverInfo`

### DIFF
--- a/core/src/test/scala/org/apache/spark/deploy/master/MasterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/master/MasterSuite.scala
@@ -256,6 +256,18 @@ class MasterSuite extends SparkFunSuite
     conf.set(RECOVERY_MODE_FACTORY, classOf[FakeRecoveryModeFactory].getCanonicalName)
     conf.set(MASTER_REST_SERVER_ENABLED, false)
 
+    val fakeDriverInfo = new DriverInfo(
+      startTime = 0,
+      id = "test_driver",
+      desc = new DriverDescription(
+        jarUrl = "",
+        mem = 1024,
+        cores = 1,
+        supervise = false,
+        command = new Command("", Nil, Map.empty, Nil, Nil, Nil)),
+      submitDate = new Date())
+    FakeRecoveryModeFactory.persistentData.put(s"driver_${fakeDriverInfo.id}", fakeDriverInfo)
+
     var master: Master = null
     try {
       master = makeMaster(conf)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up of #44673 to fix the test case by adding a persistent `DriverInfo`.

### Why are the changes needed?

To make the test case fail without the main patch. Previously, this is missed. So, the test case succeeds without the main patch.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.