### PR TITLE
[SPARK-46682][BUILD] Upgrade `curator` to 5.6.0

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -51,9 +51,9 @@ commons-math3/3.6.1//commons-math3-3.6.1.jar
 commons-pool/1.5.4//commons-pool-1.5.4.jar
 commons-text/1.11.0//commons-text-1.11.0.jar
 compress-lzf/1.1.2//compress-lzf-1.1.2.jar
-curator-client/5.2.0//curator-client-5.2.0.jar
-curator-framework/5.2.0//curator-framework-5.2.0.jar
-curator-recipes/5.2.0//curator-recipes-5.2.0.jar
+curator-client/5.6.0//curator-client-5.6.0.jar
+curator-framework/5.6.0//curator-framework-5.6.0.jar
+curator-recipes/5.6.0//curator-recipes-5.6.0.jar
 datanucleus-api-jdo/4.2.4//datanucleus-api-jdo-4.2.4.jar
 datanucleus-core/4.1.17//datanucleus-core-4.1.17.jar
 datanucleus-rdbms/4.1.19//datanucleus-rdbms-4.1.19.jar

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
     <protoc-jar-maven-plugin.version>3.11.4</protoc-jar-maven-plugin.version>
     <yarn.version>${hadoop.version}</yarn.version>
     <zookeeper.version>3.9.1</zookeeper.version>
-    <curator.version>5.2.0</curator.version>
+    <curator.version>5.6.0</curator.version>
     <hive.group>org.apache.hive</hive.group>
     <hive.classifier>core</hive.classifier>
     <!-- Version used in Maven Hive dependency -->


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `curator` to 5.6.0.

### Why are the changes needed?

Apache Curator 5.6.0 is released on 2024-01-08.
- https://curator.apache.org/download#2024-01-08-release-560-available

This is the first community-blessed release for official `Java 17 and 21 Support` via the following.
- [CURATOR-691 Compatible with JDK 21](https://issues.apache.org/jira/browse/CURATOR-691)
- [CURATOR-672 Ensure JDK 17 support](https://issues.apache.org/jira/browse/CURATOR-672)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.