### PR TITLE
[SPARK-46684][PYTHON][CONNECT] Fix CoGroup.applyInPandas/Arrow to pass arguments properly

### DIFF
--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -1053,7 +1053,11 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         age  | 19
         name | This is a super l...
         """
+        print(self._show_string(n, truncate, vertical))
 
+    def _show_string(
+        self, n: int = 20, truncate: Union[bool, int] = True, vertical: bool = False
+    ) -> str:
         if not isinstance(n, int) or isinstance(n, bool):
             raise PySparkTypeError(
                 error_class="NOT_INT",
@@ -1067,7 +1071,7 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
             )
 
         if isinstance(truncate, bool) and truncate:
-            print(self._jdf.showString(n, 20, vertical))
+            return self._jdf.showString(n, 20, vertical)
         else:
             try:
                 int_truncate = int(truncate)
@@ -1080,7 +1084,7 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
                     },
                 )
 
-            print(self._jdf.showString(n, int_truncate, vertical))
+            return self._jdf.showString(n, int_truncate, vertical)
 
     def __repr__(self) -> str:
         if not self._support_repr_html and self.sparkSession._jconf.isReplEagerEvalEnabled():

--- a/python/pyspark/sql/tests/test_arrow_cogrouped_map.py
+++ b/python/pyspark/sql/tests/test_arrow_cogrouped_map.py
@@ -266,6 +266,41 @@ class CogroupedMapInArrowTestsMixin:
                 self.assertEqual(r.a, "hi")
                 self.assertEqual(r.b, 1)
 
+    def test_with_local_data(self):
+        df1 = self.spark.createDataFrame(
+            [(1, 1.0, "a"), (2, 2.0, "b"), (1, 3.0, "c"), (2, 4.0, "d")], ("id", "v1", "v2")
+        )
+        df2 = self.spark.createDataFrame([(1, "x"), (2, "y"), (1, "z")], ("id", "v3"))
+
+        def summarize(left, right):
+            return pa.Table.from_pydict(
+                {
+                    "left_rows": [left.num_rows],
+                    "left_columns": [left.num_columns],
+                    "right_rows": [right.num_rows],
+                    "right_columns": [right.num_columns],
+                }
+            )
+
+        df = (
+            df1.groupby("id")
+            .cogroup(df2.groupby("id"))
+            .applyInArrow(
+                summarize,
+                schema="left_rows long, left_columns long, right_rows long, right_columns long",
+            )
+        )
+
+        self.assertEqual(
+            df._show_string(),
+            "+---------+------------+----------+-------------+\n"
+            "|left_rows|left_columns|right_rows|right_columns|\n"
+            "+---------+------------+----------+-------------+\n"
+            "|        2|           3|         2|            2|\n"
+            "|        2|           3|         1|            2|\n"
+            "+---------+------------+----------+-------------+\n",
+        )
+
 
 class CogroupedMapInArrowTests(CogroupedMapInArrowTestsMixin, ReusedSQLTestCase):
     @classmethod


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix `CoGroup.applyInPandas/Arrow` to pass arguments properly.

### Why are the changes needed?

In Spark Connect, `CoGroup.applyInPandas/Arrow` doesn't take arguments properly, so the arguments of the UDF can be broken:

```py
>>> import pandas as pd
>>>
>>> df1 = spark.createDataFrame(
...     [(1, 1.0, "a"), (2, 2.0, "b"), (1, 3.0, "c"), (2, 4.0, "d")], ("id", "v1", "v2")
... )
>>> df2 = spark.createDataFrame([(1, "x"), (2, "y"), (1, "z")], ("id", "v3"))
>>>
>>> def summarize(left, right):
...     return pd.DataFrame(
...         {
...             "left_rows": [len(left)],
...             "left_columns": [len(left.columns)],
...             "right_rows": [len(right)],
...             "right_columns": [len(right.columns)],
...         }
...     )
...
>>> df = (
...     df1.groupby("id")
...     .cogroup(df2.groupby("id"))
...     .applyInPandas(
...         summarize,
...         schema="left_rows long, left_columns long, right_rows long, right_columns long",
...     )
... )
>>>
>>> df.show()
+---------+------------+----------+-------------+
|left_rows|left_columns|right_rows|right_columns|
+---------+------------+----------+-------------+
|        2|           1|         2|            1|
|        2|           1|         1|            1|
+---------+------------+----------+-------------+
```

The result should be:

```py
+---------+------------+----------+-------------+
|left_rows|left_columns|right_rows|right_columns|
+---------+------------+----------+-------------+
|        2|           3|         2|            2|
|        2|           3|         1|            2|
+---------+------------+----------+-------------+
```

### Does this PR introduce _any_ user-facing change?

This is a bug fix.

### How was this patch tested?

Added the related tests.

### Was this patch authored or co-authored using generative AI tooling?

No.
