### PR TITLE
[SPARK-46694][SQL][TESTS] Drop the assumptions of 'hive version < 2.0' in Hive version related tests

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HiveClientSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HiveClientSuite.scala
@@ -30,7 +30,7 @@ import org.apache.hadoop.security.UserGroupInformation
 
 import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
-import org.apache.spark.sql.catalyst.analysis.{DatabaseAlreadyExistsException, NoSuchDatabaseException, NoSuchPermanentFunctionException, PartitionsAlreadyExistException}
+import org.apache.spark.sql.catalyst.analysis.{DatabaseAlreadyExistsException, NoSuchDatabaseException, PartitionsAlreadyExistException}
 import org.apache.spark.sql.catalyst.catalog._
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, EqualTo, Literal}
 import org.apache.spark.sql.hive.HiveExternalCatalog
@@ -38,8 +38,7 @@ import org.apache.spark.sql.hive.test.TestHiveVersion
 import org.apache.spark.sql.types.{IntegerType, StructType}
 import org.apache.spark.util.{MutableURLClassLoader, Utils}
 
-class HiveClientSuite(version: String, allVersions: Seq[String])
-  extends HiveVersionSuite(version) {
+class HiveClientSuite(version: String) extends HiveVersionSuite(version) {
 
   private var versionSpark: TestHiveVersion = null
 
@@ -103,31 +102,29 @@ class HiveClientSuite(version: String, allVersions: Seq[String])
   }
 
   test("create/get/alter database should pick right user name as owner") {
-    if (version != "0.12") {
-      val currentUser = UserGroupInformation.getCurrentUser.getUserName
-      val ownerName = "SPARK_29425"
-      val db1 = "SPARK_29425_1"
-      val db2 = "SPARK_29425_2"
-      val ownerProps = Map("owner" -> ownerName)
+    val currentUser = UserGroupInformation.getCurrentUser.getUserName
+    val ownerName = "SPARK_29425"
+    val db1 = "SPARK_29425_1"
+    val db2 = "SPARK_29425_2"
+    val ownerProps = Map("owner" -> ownerName)
 
-      // create database with owner
-      val dbWithOwner = CatalogDatabase(db1, "desc", Utils.createTempDir().toURI, ownerProps)
-      client.createDatabase(dbWithOwner, ignoreIfExists = true)
-      val getDbWithOwner = client.getDatabase(db1)
-      assert(getDbWithOwner.properties("owner") === ownerName)
-      // alter database without owner
-      client.alterDatabase(getDbWithOwner.copy(properties = Map()))
-      assert(client.getDatabase(db1).properties("owner") === "")
+    // create database with owner
+    val dbWithOwner = CatalogDatabase(db1, "desc", Utils.createTempDir().toURI, ownerProps)
+    client.createDatabase(dbWithOwner, ignoreIfExists = true)
+    val getDbWithOwner = client.getDatabase(db1)
+    assert(getDbWithOwner.properties("owner") === ownerName)
+    // alter database without owner
+    client.alterDatabase(getDbWithOwner.copy(properties = Map()))
+    assert(client.getDatabase(db1).properties("owner") === "")
 
-      // create database without owner
-      val dbWithoutOwner = CatalogDatabase(db2, "desc", Utils.createTempDir().toURI, Map())
-      client.createDatabase(dbWithoutOwner, ignoreIfExists = true)
-      val getDbWithoutOwner = client.getDatabase(db2)
-      assert(getDbWithoutOwner.properties("owner") === currentUser)
-      // alter database with owner
-      client.alterDatabase(getDbWithoutOwner.copy(properties = ownerProps))
-      assert(client.getDatabase(db2).properties("owner") === ownerName)
-    }
+    // create database without owner
+    val dbWithoutOwner = CatalogDatabase(db2, "desc", Utils.createTempDir().toURI, Map())
+    client.createDatabase(dbWithoutOwner, ignoreIfExists = true)
+    val getDbWithoutOwner = client.getDatabase(db2)
+    assert(getDbWithoutOwner.properties("owner") === currentUser)
+    // alter database with owner
+    client.alterDatabase(getDbWithoutOwner.copy(properties = ownerProps))
+    assert(client.getDatabase(db2).properties("owner") === ownerName)
   }
 
   test("createDatabase with null description") {
@@ -336,30 +333,10 @@ class HiveClientSuite(version: String, allVersions: Seq[String])
   }
 
   test("dropTable") {
-    val versionsWithoutPurge =
-      if (allVersions.contains("0.14")) allVersions.takeWhile(_ != "0.14") else Nil
-    // First try with the purge option set. This should fail if the version is < 0.14, in which
-    // case we check the version and try without it.
-    try {
-      client.dropTable("default", tableName = "temporary", ignoreIfNotExists = false,
-        purge = true)
-      assert(!versionsWithoutPurge.contains(version))
-    } catch {
-      case _: UnsupportedOperationException =>
-        assert(versionsWithoutPurge.contains(version))
-        client.dropTable("default", tableName = "temporary", ignoreIfNotExists = false,
-          purge = false)
-    }
-    // Drop table with type CatalogTableType.VIEW.
-    try {
-      client.dropTable("default", tableName = "view1", ignoreIfNotExists = false,
-        purge = true)
-      assert(!versionsWithoutPurge.contains(version))
-    } catch {
-      case _: UnsupportedOperationException =>
-        client.dropTable("default", tableName = "view1", ignoreIfNotExists = false,
-          purge = false)
-    }
+    client.dropTable("default", tableName = "temporary", ignoreIfNotExists = false,
+      purge = true)
+    client.dropTable("default", tableName = "view1", ignoreIfNotExists = false,
+      purge = true)
     assert(client.listTables("default") === Seq("src"))
   }
 
@@ -416,13 +393,7 @@ class HiveClientSuite(version: String, allVersions: Seq[String])
     // Only one partition [1, 1] for key2 == 1
     val result = client.getPartitionsByFilter(client.getRawHiveTable("default", "src_part"),
       Seq(EqualTo(AttributeReference("key2", IntegerType)(), Literal(1))))
-
-    // Hive 0.12 doesn't support getPartitionsByFilter, it ignores the filter condition.
-    if (version != "0.12") {
-      assert(result.size == 1)
-    } else {
-      assert(result.size == testPartitionCount)
-    }
+    assert(result.size == 1)
   }
 
   test("getPartition") {
@@ -488,10 +459,7 @@ class HiveClientSuite(version: String, allVersions: Seq[String])
     val spec = Map("key1" -> "1", "key2" -> "2")
     val parameters = Map(StatsSetupConst.TOTAL_SIZE -> "0", StatsSetupConst.NUM_FILES -> "1")
     val newLocation = new URI(Utils.createTempDir().toURI.toString.stripSuffix("/"))
-    val storage = storageFormat.copy(
-      locationUri = Some(newLocation),
-      // needed for 0.12 alter partitions
-      serde = Some("org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe"))
+    val storage = storageFormat.copy(locationUri = Some(newLocation))
     val partition = CatalogTablePartition(spec, storage, parameters)
     client.alterPartitions("default", "src_part", Seq(partition))
     assert(client.getPartition("default", "src_part", spec)
@@ -502,21 +470,8 @@ class HiveClientSuite(version: String, allVersions: Seq[String])
 
   test("dropPartitions") {
     val spec = Map("key1" -> "1", "key2" -> "3")
-    val versionsWithoutPurge =
-      if (allVersions.contains("1.2")) allVersions.takeWhile(_ != "1.2") else Nil
-    // Similar to dropTable; try with purge set, and if it fails, make sure we're running
-    // with a version that is older than the minimum (1.2 in this case).
-    try {
-      client.dropPartitions("default", "src_part", Seq(spec), ignoreIfNotExists = true,
-        purge = true, retainData = false)
-      assert(!versionsWithoutPurge.contains(version))
-    } catch {
-      case _: UnsupportedOperationException =>
-        assert(versionsWithoutPurge.contains(version))
-        client.dropPartitions("default", "src_part", Seq(spec), ignoreIfNotExists = true,
-          purge = false, retainData = false)
-    }
-
+    client.dropPartitions("default", "src_part", Seq(spec), ignoreIfNotExists = true,
+      purge = true, retainData = false)
     assert(client.getPartitionOption("default", "src_part", spec).isEmpty)
   }
 
@@ -555,92 +510,42 @@ class HiveClientSuite(version: String, allVersions: Seq[String])
 
   test("createFunction") {
     val functionClass = "org.apache.spark.MyFunc1"
-    if (version == "0.12") {
-      // Hive 0.12 doesn't support creating permanent functions
-      intercept[AnalysisException] {
-        client.createFunction("default", function("func1", functionClass))
-      }
-    } else {
-      client.createFunction("default", function("func1", functionClass))
-    }
+    client.createFunction("default", function("func1", functionClass))
   }
 
   test("functionExists") {
-    if (version == "0.12") {
-      // Hive 0.12 doesn't allow customized permanent functions
-      assert(!client.functionExists("default", "func1"))
-    } else {
-      assert(client.functionExists("default", "func1"))
-    }
+    assert(client.functionExists("default", "func1"))
   }
 
   test("renameFunction") {
-    if (version == "0.12") {
-      // Hive 0.12 doesn't allow customized permanent functions
-      intercept[NoSuchPermanentFunctionException] {
-        client.renameFunction("default", "func1", "func2")
-      }
-    } else {
-      client.renameFunction("default", "func1", "func2")
-      assert(client.functionExists("default", "func2"))
-    }
+    client.renameFunction("default", "func1", "func2")
+    assert(client.functionExists("default", "func2"))
   }
 
   test("alterFunction") {
     val functionClass = "org.apache.spark.MyFunc2"
-    if (version == "0.12") {
-      // Hive 0.12 doesn't allow customized permanent functions
-      intercept[NoSuchPermanentFunctionException] {
-        client.alterFunction("default", function("func2", functionClass))
-      }
-    } else {
-      client.alterFunction("default", function("func2", functionClass))
-    }
+    client.alterFunction("default", function("func2", functionClass))
   }
 
   test("getFunction") {
-    if (version == "0.12") {
-      // Hive 0.12 doesn't allow customized permanent functions
-      intercept[NoSuchPermanentFunctionException] {
-        client.getFunction("default", "func2")
-      }
-    } else {
-      // No exception should be thrown
-      val func = client.getFunction("default", "func2")
-      assert(func.className == "org.apache.spark.MyFunc2")
-    }
+    // No exception should be thrown
+    val func = client.getFunction("default", "func2")
+    assert(func.className == "org.apache.spark.MyFunc2")
   }
 
   test("getFunctionOption") {
-    if (version == "0.12") {
-      // Hive 0.12 doesn't allow customized permanent functions
-      assert(client.getFunctionOption("default", "func2").isEmpty)
-    } else {
-      assert(client.getFunctionOption("default", "func2").isDefined)
-      assert(client.getFunctionOption("default", "the_func_not_exists").isEmpty)
-    }
+    assert(client.getFunctionOption("default", "func2").isDefined)
+    assert(client.getFunctionOption("default", "the_func_not_exists").isEmpty)
   }
 
   test("listFunctions") {
-    if (version == "0.12") {
-      // Hive 0.12 doesn't allow customized permanent functions
-      assert(client.listFunctions("default", "fun.*").isEmpty)
-    } else {
-      assert(client.listFunctions("default", "fun.*").size == 1)
-    }
+    assert(client.listFunctions("default", "fun.*").size == 1)
   }
 
   test("dropFunction") {
-    if (version == "0.12") {
-      // Hive 0.12 doesn't support creating permanent functions
-      intercept[NoSuchPermanentFunctionException] {
-        client.dropFunction("default", "func2")
-      }
-    } else {
-      // No exception should be thrown
-      client.dropFunction("default", "func2")
-      assert(client.listFunctions("default", "fun.*").isEmpty)
-    }
+    // No exception should be thrown
+    client.dropFunction("default", "func2")
+    assert(client.listFunctions("default", "fun.*").isEmpty)
   }
 
   ///////////////////////////////////////////////////////////////////////////
@@ -740,12 +645,7 @@ class HiveClientSuite(version: String, allVersions: Seq[String])
       assert(versionSpark.table("tbl").collect().toSeq == Seq(Row(1)))
       val tableMeta = versionSpark.sessionState.catalog.getTableMetadata(TableIdentifier("tbl"))
       val totalSize = tableMeta.stats.map(_.sizeInBytes)
-      // Except 0.12, all the following versions will fill the Hive-generated statistics
-      if (version == "0.12") {
-        assert(totalSize.isEmpty)
-      } else {
-        assert(totalSize.nonEmpty && totalSize.get > 0)
-      }
+      assert(totalSize.nonEmpty && totalSize.get > 0)
     }
   }
 
@@ -764,12 +664,7 @@ class HiveClientSuite(version: String, allVersions: Seq[String])
         TableIdentifier("tbl"), spec = Map("ds" -> "2")).parameters
       val totalSize = partMeta.get(StatsSetupConst.TOTAL_SIZE).map(_.toLong)
       val numFiles = partMeta.get(StatsSetupConst.NUM_FILES).map(_.toLong)
-      // Except 0.12, all the following versions will fill the Hive-generated statistics
-      if (version == "0.12") {
-        assert(totalSize.isEmpty && numFiles.isEmpty)
-      } else {
-        assert(totalSize.nonEmpty && numFiles.nonEmpty)
-      }
+      assert(totalSize.nonEmpty && numFiles.nonEmpty)
 
       versionSpark.sql(
         """
@@ -781,12 +676,7 @@ class HiveClientSuite(version: String, allVersions: Seq[String])
 
       val newTotalSize = newPartMeta.get(StatsSetupConst.TOTAL_SIZE).map(_.toLong)
       val newNumFiles = newPartMeta.get(StatsSetupConst.NUM_FILES).map(_.toLong)
-      // Except 0.12, all the following versions will fill the Hive-generated statistics
-      if (version == "0.12") {
-        assert(newTotalSize.isEmpty && newNumFiles.isEmpty)
-      } else {
-        assert(newTotalSize.nonEmpty && newNumFiles.nonEmpty)
-      }
+      assert(newTotalSize.nonEmpty && newNumFiles.nonEmpty)
     }
   }
 
@@ -808,10 +698,7 @@ class HiveClientSuite(version: String, allVersions: Seq[String])
           val filePaths = dir.map(_.getName).toList
           folders.flatMap(listFiles) ++: filePaths
         }
-        // expect 2 files left: `.part-00000-random-uuid.crc` and `part-00000-random-uuid`
-        // 0.12, 0.13, 1.0 and 1.1 also has another two more files ._SUCCESS.crc and _SUCCESS
-        val metadataFiles = Seq("._SUCCESS.crc", "_SUCCESS")
-        assert(listFiles(tmpDir).filterNot(metadataFiles.contains).length == 2)
+        assert(listFiles(tmpDir).length === 2)
       }
     }
   }
@@ -941,42 +828,16 @@ class HiveClientSuite(version: String, allVersions: Seq[String])
            """.stripMargin
         )
 
-        val errorMsg = "Cannot safely cast 'f0': decimal(2,1) to binary"
-
         if (isPartitioned) {
           val insertStmt = s"INSERT OVERWRITE TABLE $tableName partition (ds='a') SELECT 1.3"
-          if (version == "0.12" || version == "0.13") {
-            checkError(
-              exception = intercept[AnalysisException](versionSpark.sql(insertStmt)),
-              errorClass = "INCOMPATIBLE_DATA_FOR_TABLE.CANNOT_SAFELY_CAST",
-              parameters = Map(
-                "tableName" -> "`spark_catalog`.`default`.`tab1`",
-                "colName" -> "`f0`",
-                "srcType" -> "\"DECIMAL(2,1)\"",
-                "targetType" -> "\"BINARY\"")
-            )
-          } else {
-            versionSpark.sql(insertStmt)
-            assert(versionSpark.table(tableName).collect() ===
-              versionSpark.sql("SELECT 1.30, 'a'").collect())
-          }
+          versionSpark.sql(insertStmt)
+          assert(versionSpark.table(tableName).collect() ===
+            versionSpark.sql("SELECT 1.30, 'a'").collect())
         } else {
           val insertStmt = s"INSERT OVERWRITE TABLE $tableName SELECT 1.3"
-          if (version == "0.12" || version == "0.13") {
-            checkError(
-              exception = intercept[AnalysisException](versionSpark.sql(insertStmt)),
-              errorClass = "INCOMPATIBLE_DATA_FOR_TABLE.CANNOT_SAFELY_CAST",
-              parameters = Map(
-                "tableName" -> "`spark_catalog`.`default`.`tab1`",
-                "colName" -> "`f0`",
-                "srcType" -> "\"DECIMAL(2,1)\"",
-                "targetType" -> "\"BINARY\"")
-            )
-          } else {
-            versionSpark.sql(insertStmt)
-            assert(versionSpark.table(tableName).collect() ===
-              versionSpark.sql("SELECT 1.30").collect())
-          }
+          versionSpark.sql(insertStmt)
+          assert(versionSpark.table(tableName).collect() ===
+            versionSpark.sql("SELECT 1.30").collect())
         }
       }
     }
@@ -1025,7 +886,7 @@ class HiveClientSuite(version: String, allVersions: Seq[String])
 
   test("SPARK-17920: Insert into/overwrite avro table") {
     // skipped because it's failed in the condition on Windows
-    assume(!(Utils.isWindows && version == "0.12"))
+    assume(!Utils.isWindows)
     withTempDir { dir =>
       val avroSchema =
         """

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HiveClientSuites.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HiveClientSuites.scala
@@ -91,6 +91,6 @@ class HiveClientSuites extends SparkFunSuite with HiveClientVersions {
   }
 
   override def nestedSuites: IndexedSeq[Suite] = {
-    versions.map(new HiveClientSuite(_, versions))
+    versions.map(new HiveClientSuite(_))
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HivePartitionFilteringSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HivePartitionFilteringSuite.scala
@@ -49,13 +49,10 @@ class HivePartitionFilteringSuite(version: String)
   private val fallbackKey = SQLConf.HIVE_METASTORE_PARTITION_PRUNING_FALLBACK_ON_EXCEPTION.key
   private val pruningFastFallback = SQLConf.HIVE_METASTORE_PARTITION_PRUNING_FAST_FALLBACK.key
 
-  // Support default partition in metastoredirectsql since HIVE-11898(Hive 2.0.0).
-  private val defaultPartition = if (version >= "2.0") Some(DEFAULT_PARTITION_NAME) else None
-
   private val dsValue = 20170101 to 20170103
   private val hValue = 0 to 4
   private val chunkValue = Seq("aa", "ab", "ba", "bb")
-  private val dateValue = Seq("2019-01-01", "2019-01-02", "2019-01-03") ++ defaultPartition
+  private val dateValue = Seq("2019-01-01", "2019-01-02", "2019-01-03", DEFAULT_PARTITION_NAME)
   private val dateStrValue = Seq("2020-01-01", "2020-01-02", "2020-01-03", "20200104", "20200105")
   private val timestampStrValue = Seq("2021-01-01 00:00:00", "2021-01-02 00:00:00")
   private val testPartitionCount =


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Code clean-up following SPARK-45328, this PR drops the assumptions and workarounds in Hive version-related tests， which work for hive version < 2.0

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

clean dead codes

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
no

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

SPARK_TEST_HIVE_CLIENT_VERSIONS=3.1 ./build/sbt  -Phive -Phive-thriftserver "testOnly *HiveClientSuite*"

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
no