### PR TITLE
[SPARK-46586][SQL][TESTS][FOLLOWUP] Replace `appended` with `:+`

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/UDFSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/UDFSuite.scala
@@ -840,7 +840,7 @@ class UDFSuite extends QueryTest with SharedSparkSession {
     Row(ArrayBuffer(100)))
 
      val myUdf2 = udf((a: immutable.ArraySeq[Int]) =>
-      immutable.ArraySeq.unsafeWrapArray[Int](a.appended(5).appended(6).toArray))
+      immutable.ArraySeq.unsafeWrapArray[Int]((a :+ 5 :+ 6).toArray))
     checkAnswer(Seq(Array(1, 2, 3))
       .toDF("col")
       .select(myUdf2(Column("col"))),


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr is following up https://github.com/apache/spark/pull/44591.


### Why are the changes needed?
Fix issues in comments.
<img width="908" alt="image" src="https://github.com/apache/spark/assets/15246973/deec66a1-1bd1-44bc-9c16-f1fe8bbb14e8">


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
- Pass GA.
- Manually test.


### Was this patch authored or co-authored using generative AI tooling?
No.
