### PR TITLE
[MINOR][K8S] Remove unused local val `outstanding`  from `ExecutorPodsAllocator#onNewSnapshots`

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
@@ -366,7 +366,6 @@ class ExecutorPodsAllocator(
       // in the snapshot state. Since the messages are a little spammy, avoid them when we know
       // there are no useful updates.
       if (log.isDebugEnabled && snapshots.nonEmpty) {
-        val outstanding = pendingCountForRpId + newlyCreatedExecutorsForRpId.size
         if (currentRunningCount >= targetNum && !dynamicAllocationEnabled) {
           logDebug(s"Current number of running executors for ResourceProfile Id $rpId is " +
             "equal to the number of requested executors. Not scaling up further.")


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr just remove unused local `val outstanding`  from `ExecutorPodsAllocator#onNewSnapshots`, the `outstanding > 0` replaced by `newlyCreatedExecutorsForRpId.nonEmpty` after SPARK-36052 | https://github.com/apache/spark/pull/33492

### Why are the changes needed?
Remove unused local val


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No
