### PR TITLE
[SPARK-46696][CORE] In ResourceProfileManager, function calls should occur after variable declarations

### DIFF
--- a/core/src/main/scala/org/apache/spark/resource/ResourceProfileManager.scala
+++ b/core/src/main/scala/org/apache/spark/resource/ResourceProfileManager.scala
@@ -45,11 +45,6 @@ private[spark] class ResourceProfileManager(sparkConf: SparkConf,
     (lock.readLock(), lock.writeLock())
   }
 
-  private val defaultProfile = ResourceProfile.getOrCreateDefaultProfile(sparkConf)
-  addResourceProfile(defaultProfile)
-
-  def defaultResourceProfile: ResourceProfile = defaultProfile
-
   private val dynamicEnabled = Utils.isDynamicAllocationEnabled(sparkConf)
   private val master = sparkConf.getOption("spark.master")
   private val isYarn = master.isDefined && master.get.equals("yarn")
@@ -59,6 +54,11 @@ private[spark] class ResourceProfileManager(sparkConf: SparkConf,
     )
   private val notRunningUnitTests = !isTesting
   private val testExceptionThrown = sparkConf.get(RESOURCE_PROFILE_MANAGER_TESTING)
+
+  private val defaultProfile = ResourceProfile.getOrCreateDefaultProfile(sparkConf)
+  addResourceProfile(defaultProfile)
+
+  def defaultResourceProfile: ResourceProfile = defaultProfile
 
   /**
    * If we use anything except the default profile, it's supported on YARN, Kubernetes and

--- a/core/src/main/scala/org/apache/spark/resource/ResourceProfileManager.scala
+++ b/core/src/main/scala/org/apache/spark/resource/ResourceProfileManager.scala
@@ -58,7 +58,6 @@ private[spark] class ResourceProfileManager(sparkConf: SparkConf,
   private val defaultProfile = ResourceProfile.getOrCreateDefaultProfile(sparkConf)
   addResourceProfile(defaultProfile)
 
-
   def defaultResourceProfile: ResourceProfile = defaultProfile
 
   /**

--- a/core/src/main/scala/org/apache/spark/resource/ResourceProfileManager.scala
+++ b/core/src/main/scala/org/apache/spark/resource/ResourceProfileManager.scala
@@ -66,6 +66,7 @@ private[spark] class ResourceProfileManager(sparkConf: SparkConf,
    * disabled on Standalone. Throw an exception if not supported.
    */
   private[spark] def isSupported(rp: ResourceProfile): Boolean = {
+    assert(master != null)
     if (rp.isInstanceOf[TaskResourceProfile] && !dynamicEnabled) {
       if ((notRunningUnitTests || testExceptionThrown) &&
         !(isStandaloneOrLocalCluster || isYarn || isK8s)) {

--- a/core/src/main/scala/org/apache/spark/resource/ResourceProfileManager.scala
+++ b/core/src/main/scala/org/apache/spark/resource/ResourceProfileManager.scala
@@ -58,6 +58,7 @@ private[spark] class ResourceProfileManager(sparkConf: SparkConf,
   private val defaultProfile = ResourceProfile.getOrCreateDefaultProfile(sparkConf)
   addResourceProfile(defaultProfile)
 
+
   def defaultResourceProfile: ResourceProfile = defaultProfile
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?
In ResourceProfileManager, function calls should occur after variable declarations


### Why are the changes needed?
As the title suggests, in `ResourceProfileManager`, function calls should be made after variable declarations. When determining `isSupport`, all variables are uninitialized, with booleans defaulting to false and objects to null. While the end result is correct, the evaluation process is abnormal.
![image](https://github.com/apache/spark/assets/46274164/0e15b7e6-bd91-4d46-b220-758c131392c7)


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
through exists uts


### Was this patch authored or co-authored using generative AI tooling?
No
