### PR TITLE
[SPARK-46703][INFRA] Disable `fail-fast` in Python CI

### DIFF
--- a/.github/workflows/build_python.yml
+++ b/.github/workflows/build_python.yml
@@ -26,6 +26,7 @@ on:
 jobs:
   run-build:
     strategy:
+      fail-fast: false
       matrix:
         pyversion: ["pypy3", "python3.10", "python3.11", "python3.12"]
     permissions:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to disable `fail-fast` in Python CI.

### Why are the changes needed?

We need to disable `fail-fast` because each Python version test pipeline is independent from the others.

Currently, one failure cancelled all running pipelines.
- https://github.com/apache/spark/actions/runs/7503864095
<img width="302" alt="Screenshot 2024-01-12 at 11 42 18 AM" src="https://github.com/apache/spark/assets/9700541/7cfa97b0-e224-468b-b6fc-d5d8d49d4489">

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

This should be monitored after merging.

### Was this patch authored or co-authored using generative AI tooling?

No.