### PR TITLE
[SPARK-46708] Support message format in connect

### DIFF
--- a/common/utils/src/main/scala/org/apache/spark/SparkThrowableHelper.scala
+++ b/common/utils/src/main/scala/org/apache/spark/SparkThrowableHelper.scala
@@ -74,7 +74,11 @@ private[spark] object SparkThrowableHelper {
     errorClass.startsWith("INTERNAL_ERROR")
   }
 
-  def getMessage(e: SparkThrowable with Throwable, format: ErrorMessageFormat.Value, limit: Option[Int] = None): String = {
+  def getMessage(
+    e: SparkThrowable with Throwable,
+    format: ErrorMessageFormat.Value,
+    limit: Option[Int] = None
+  ): String = {
     import ErrorMessageFormat._
     val defaultMessage = limit.map(e.getMessage.take).getOrElse(e.getMessage)
     format match {

--- a/common/utils/src/main/scala/org/apache/spark/SparkThrowableHelper.scala
+++ b/common/utils/src/main/scala/org/apache/spark/SparkThrowableHelper.scala
@@ -74,17 +74,18 @@ private[spark] object SparkThrowableHelper {
     errorClass.startsWith("INTERNAL_ERROR")
   }
 
-  def getMessage(e: SparkThrowable with Throwable, format: ErrorMessageFormat.Value): String = {
+  def getMessage(e: SparkThrowable with Throwable, format: ErrorMessageFormat.Value, limit: Option[Int] = None): String = {
     import ErrorMessageFormat._
+    val defaultMessage = limit.map(e.getMessage.take).getOrElse(e.getMessage)
     format match {
-      case PRETTY => e.getMessage
+      case PRETTY => defaultMessage
       case MINIMAL | STANDARD if e.getErrorClass == null =>
         toJsonString { generator =>
           val g = generator.useDefaultPrettyPrinter()
           g.writeStartObject()
           g.writeStringField("errorClass", "LEGACY")
           g.writeObjectFieldStart("messageParameters")
-          g.writeStringField("message", e.getMessage)
+          g.writeStringField("message", defaultMessage)
           g.writeEndObject()
           g.writeEndObject()
         }

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
@@ -377,12 +377,13 @@ object SparkConnectService extends Logging {
   }
 
   def extractErrorMessage(st: Throwable, format: ErrorMessageFormat.Value): String = {
+    val limit = 2048
     val message = st match {
       case e: SparkThrowable =>
-        SparkThrowableHelper.getMessage(e, format)
+        SparkThrowableHelper.getMessage(e, format, limit)
       case _ =>
         st.getMessage
     }
-    Option(StringUtils.abbreviate(message, 2048)).getOrElse("")
+    Option(StringUtils.abbreviate(message, limit)).getOrElse("")
   }
 }

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
@@ -380,7 +380,7 @@ object SparkConnectService extends Logging {
     val limit = 2048
     val message = st match {
       case e: SparkThrowable =>
-        SparkThrowableHelper.getMessage(e, format, limit)
+        SparkThrowableHelper.getMessage(e, format, Some(limit))
       case _ =>
         st.getMessage
     }

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
@@ -381,9 +381,9 @@ object SparkConnectService extends Logging {
       case e: SparkThrowable =>
         SparkThrowableHelper.getMessage(e, format)
       case _ =>
-        StringUtils.abbreviate(st.getMessage, 2048)
+        st.getMessage
     }
-    convertNullString(message)
+    convertNullString(StringUtils.abbreviate(message, 2048))
   }
 
   def convertNullString(str: String): String = {

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
@@ -383,14 +383,6 @@ object SparkConnectService extends Logging {
       case _ =>
         st.getMessage
     }
-    convertNullString(StringUtils.abbreviate(message, 2048))
-  }
-
-  def convertNullString(str: String): String = {
-    if (str != null) {
-      str
-    } else {
-      ""
-    }
+    Option(StringUtils.abbreviate(message, 2048)).orElse("")
   }
 }

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
@@ -383,6 +383,6 @@ object SparkConnectService extends Logging {
       case _ =>
         st.getMessage
     }
-    Option(StringUtils.abbreviate(message, 2048)).orElse("")
+    Option(StringUtils.abbreviate(message, 2048)).getOrElse("")
   }
 }

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
@@ -31,7 +31,7 @@ import io.grpc.protobuf.services.ProtoReflectionService
 import io.grpc.stub.StreamObserver
 import org.apache.commons.lang3.StringUtils
 
-import org.apache.spark.{SparkContext, SparkEnv}
+import org.apache.spark.{ErrorMessageFormat, SparkContext, SparkEnv, SparkThrowable, SparkThrowableHelper}
 import org.apache.spark.connect.proto
 import org.apache.spark.connect.proto.{AddArtifactsRequest, AddArtifactsResponse, SparkConnectServiceGrpc}
 import org.apache.spark.connect.proto.SparkConnectServiceGrpc.AsyncService
@@ -376,8 +376,13 @@ object SparkConnectService extends Logging {
     uiTab.foreach(_.detach())
   }
 
-  def extractErrorMessage(st: Throwable): String = {
-    val message = StringUtils.abbreviate(st.getMessage, 2048)
+  def extractErrorMessage(st: Throwable, format: ErrorMessageFormat.Value): String = {
+    val message = st match {
+      case e: SparkThrowable =>
+        SparkThrowableHelper.getMessage(e, format)
+      case _ =>
+        StringUtils.abbreviate(st.getMessage, 2048)
+    }
     convertNullString(message)
   }
 

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/utils/ErrorUtils.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/utils/ErrorUtils.scala
@@ -218,9 +218,12 @@ private[connect] object ErrorUtils extends Logging {
       .newBuilder()
       .setCode(RPCCode.INTERNAL_VALUE)
       .addDetails(ProtoAny.pack(withStackTrace.build()))
-      .setMessage(SparkConnectService.extractErrorMessage(st, sessionHolderOpt.map(_.session.sessionState.conf.errorMessageFormat).getOrElse(
-        ErrorMessageFormat.withName(SparkEnv.get.conf.get(SQLConf.ERROR_MESSAGE_FORMAT))
-      )))
+      .setMessage(SparkConnectService.extractErrorMessage(
+        st,
+        sessionHolderOpt
+          .map(_.session.sessionState.conf.errorMessageFormat)
+          .getOrElse(
+            ErrorMessageFormat.withName(SparkEnv.get.conf.get(SQLConf.ERROR_MESSAGE_FORMAT)))))
       .build()
   }
 

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/utils/ErrorUtils.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/utils/ErrorUtils.scala
@@ -35,7 +35,7 @@ import org.apache.commons.lang3.exception.ExceptionUtils
 import org.json4s.JsonDSL._
 import org.json4s.jackson.JsonMethods
 
-import org.apache.spark.{SparkEnv, SparkException, SparkThrowable}
+import org.apache.spark.{ErrorMessageFormat, SparkEnv, SparkException, SparkThrowable}
 import org.apache.spark.api.python.PythonException
 import org.apache.spark.connect.proto.FetchErrorDetailsResponse
 import org.apache.spark.internal.Logging
@@ -218,7 +218,9 @@ private[connect] object ErrorUtils extends Logging {
       .newBuilder()
       .setCode(RPCCode.INTERNAL_VALUE)
       .addDetails(ProtoAny.pack(withStackTrace.build()))
-      .setMessage(SparkConnectService.extractErrorMessage(st))
+      .setMessage(SparkConnectService.extractErrorMessage(st, sessionHolderOpt.map(_.session.sessionState.conf.errorMessageFormat).getOrElse(
+        ErrorMessageFormat.withName(SparkEnv.get.conf.get(SQLConf.ERROR_MESSAGE_FORMAT))
+      )))
       .build()
   }
 

--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectServiceSuite.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectServiceSuite.scala
@@ -33,7 +33,7 @@ import org.mockito.Mockito.when
 import org.scalatest.Tag
 import org.scalatestplus.mockito.MockitoSugar
 
-import org.apache.spark.{ErrorMessageFormat, SparkContext, SparkException, SparkEnv}
+import org.apache.spark.{ErrorMessageFormat, SparkContext, SparkEnv, SparkException}
 import org.apache.spark.connect.proto
 import org.apache.spark.connect.proto.CreateDataFrameViewCommand
 import org.apache.spark.internal.Logging

--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectServiceSuite.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectServiceSuite.scala
@@ -70,7 +70,7 @@ class SparkConnectServiceSuite
     val message = SparkConnectService.extractErrorMessage(e, ErrorMessageFormat.STANDARD)
     assert(message.startsWith("{"))
     assert(message.endsWith("}"))
-    assert(message.contains(""""messageTemplate" : "test""""))
+    assert(message.contains(""""message" : "test""""))
   }
 
   test("Test schema in analyze response") {

--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectServiceSuite.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectServiceSuite.scala
@@ -33,7 +33,7 @@ import org.mockito.Mockito.when
 import org.scalatest.Tag
 import org.scalatestplus.mockito.MockitoSugar
 
-import org.apache.spark.{SparkContext, SparkEnv}
+import org.apache.spark.{ErrorMessageFormat, SparkContext, SparkException, SparkEnv}
 import org.apache.spark.connect.proto
 import org.apache.spark.connect.proto.CreateDataFrameViewCommand
 import org.apache.spark.internal.Logging
@@ -64,6 +64,14 @@ class SparkConnectServiceSuite
 
   private def sparkSessionHolder = SessionHolder.forTesting(spark)
   private def DEFAULT_UUID = UUID.fromString("89ea6117-1f45-4c03-ae27-f47c6aded093")
+
+  test("extractErrorMessage works with SparkThrowable") {
+    val e = new SparkException("test")
+    val message = SparkConnectService.extractErrorMessage(e, ErrorMessageFormat.STANDARD)
+    assert(message.startsWith("{"))
+    assert(message.endsWith("}"))
+    assert(message.contains(""""messageTemplate" : "test""""))
+  }
 
   test("Test schema in analyze response") {
     withTable("test") {

--- a/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
@@ -627,6 +627,9 @@ class SparkThrowableSuite extends SparkFunSuite {
           |  } ]
           |}""".stripMargin)
     // scalastyle:on line.size.limit
+    val e5 = new SparkException("*" * 10000)
+    val limit = 2048
+    assert(SparkThrowableHelper.getMessage(e5, PRETTY, Some(limit)).length === limit)
   }
 
   test("overwrite error classes") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
* spark connect does not properly support `spark.sql.error.messageFormat` which means spark exception messages don't change based on the format. This pr fixes that

* naturally a better option is if we could set the format as an argument similar to scala either via a helper or from the `getMessage` method
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
* adds parity with Better SQL Error Messages support. This already exists in spark so we need it in spark connect too
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
test:
<img width="805" alt="image" src="https://github.com/databricks/runtime/assets/110427462/0f624369-efdb-4cf0-a82f-1412841c7d55">

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
