### PR TITLE
[SPARK-46709][SS] Expose partition_id column for state data source

### DIFF
--- a/docs/structured-streaming-state-data-source.md
+++ b/docs/structured-streaming-state-data-source.md
@@ -96,9 +96,9 @@ Each row in the source has the following schema:
   <td></td>
 </tr>
 <tr>
-  <td>_partition_id</td>
+  <td>partition_id</td>
   <td>int</td>
-  <td>metadata column (hidden unless specified with SELECT)</td>
+  <td></td>
 </tr>
 </table>
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/state/StateDataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/state/StateDataSource.scala
@@ -35,7 +35,7 @@ import org.apache.spark.sql.execution.streaming.StreamingCheckpointConstants.{DI
 import org.apache.spark.sql.execution.streaming.StreamingSymmetricHashJoinHelper.{LeftSide, RightSide}
 import org.apache.spark.sql.execution.streaming.state.{StateSchemaCompatibilityChecker, StateStore, StateStoreConf, StateStoreId, StateStoreProviderId}
 import org.apache.spark.sql.sources.DataSourceRegister
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.types.{IntegerType, StructType}
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 /**
@@ -83,6 +83,7 @@ class StateDataSource extends TableProvider with DataSourceRegister {
       new StructType()
         .add("key", keySchema)
         .add("value", valueSchema)
+        .add("partition_id", IntegerType)
     } catch {
       case NonFatal(e) =>
         throw StateDataSourceErrors.failedToReadStateSchema(sourceOptions, e)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/state/StreamStreamJoinStatePartitionReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/state/StreamStreamJoinStatePartitionReader.scala
@@ -18,7 +18,7 @@ package org.apache.spark.sql.execution.datasources.v2.state
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{AttributeReference, GenericInternalRow, JoinedRow, Literal, UnsafeProjection, UnsafeRow}
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, GenericInternalRow, Literal, UnsafeProjection, UnsafeRow}
 import org.apache.spark.sql.catalyst.types.DataTypeUtils
 import org.apache.spark.sql.connector.read.{InputPartition, PartitionReader, PartitionReaderFactory}
 import org.apache.spark.sql.execution.datasources.v2.state.StateSourceOptions.JoinSideValues
@@ -148,18 +148,7 @@ class StreamStreamJoinStatePartitionReader(
     }
   }
 
-  private val joinedRow = new JoinedRow()
-
-  private def addMetadata(row: InternalRow): InternalRow = {
-    val metadataRow = new GenericInternalRow(
-      StateTable.METADATA_COLUMNS.map(_.name()).map {
-        case "_partition_id" => partition.partition.asInstanceOf[Any]
-      }.toArray
-    )
-    joinedRow.withLeft(row).withRight(metadataRow)
-  }
-
-  override def get(): InternalRow = addMetadata(current)
+  override def get(): InternalRow = current
 
   override def close(): Unit = {
     current = null
@@ -169,9 +158,10 @@ class StreamStreamJoinStatePartitionReader(
   }
 
   private def unifyStateRowPair(pair: (UnsafeRow, UnsafeRow)): InternalRow = {
-    val row = new GenericInternalRow(2)
+    val row = new GenericInternalRow(3)
     row.update(0, pair._1)
     row.update(1, pair._2)
+    row.update(2, partition.partition)
     row
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/state/StateDataSourceReadSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/state/StateDataSourceReadSuite.scala
@@ -687,7 +687,7 @@ abstract class StateDataSourceReadSuite extends StateDataSourceTestBase with Ass
     }
   }
 
-  test("metadata column") {
+  test("partition_id column") {
     withTempDir { tempDir =>
       import testImplicits._
       val stream = MemoryStream[Int]
@@ -735,7 +735,7 @@ abstract class StateDataSourceReadSuite extends StateDataSourceTestBase with Ass
     }
   }
 
-  test("metadata column with stream-stream join") {
+  test("partition_id column with stream-stream join") {
     val numShufflePartitions = spark.conf.get(SQLConf.SHUFFLE_PARTITIONS)
 
     withTempDir { tempDir =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/state/StateDataSourceReadSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/state/StateDataSourceReadSuite.scala
@@ -712,14 +712,11 @@ abstract class StateDataSourceReadSuite extends StateDataSourceTestBase with Ass
         // skip version and operator ID to test out functionalities
         .load()
 
-      assert(!stateReadDf.schema.exists(_.name == "_partition_id"),
-      "metadata column should not be exposed until it is explicitly specified!")
-
       val numShufflePartitions = spark.conf.get(SQLConf.SHUFFLE_PARTITIONS)
 
       val resultDf = stateReadDf
-        .selectExpr("key.value AS key_value", "value.count AS value_count", "_partition_id")
-        .where("_partition_id % 2 = 0")
+        .selectExpr("key.value AS key_value", "value.count AS value_count", "partition_id")
+        .where("partition_id % 2 = 0")
 
       // NOTE: This is a hash function of distribution for stateful operator.
       val hash = HashPartitioning(
@@ -744,11 +741,6 @@ abstract class StateDataSourceReadSuite extends StateDataSourceTestBase with Ass
     withTempDir { tempDir =>
       runStreamStreamJoinQueryWithOneThousandInputs(tempDir.getAbsolutePath)
 
-      def assertPartitionIdColumnIsNotExposedByDefault(df: DataFrame): Unit = {
-        assert(!df.schema.exists(_.name == "_partition_id"),
-          "metadata column should not be exposed until it is explicitly specified!")
-      }
-
       def assertPartitionIdColumn(df: DataFrame): Unit = {
         // NOTE: This is a hash function of distribution for stateful operator.
         // stream-stream join uses the grouping key for the equality match in the join condition.
@@ -759,8 +751,8 @@ abstract class StateDataSourceReadSuite extends StateDataSourceTestBase with Ass
           numShufflePartitions)
         val partIdExpr = hash.partitionIdExpression
 
-        val dfWithPartition = df.selectExpr("key.field0 As key_0", "_partition_id")
-          .where("_partition_id % 2 = 0")
+        val dfWithPartition = df.selectExpr("key.field0 As key_0", "partition_id")
+          .where("partition_id % 2 = 0")
 
         checkAnswer(dfWithPartition,
           Range.inclusive(2, 1000, 2).map { idx =>
@@ -778,8 +770,6 @@ abstract class StateDataSourceReadSuite extends StateDataSourceTestBase with Ass
           .option(StateSourceOptions.PATH, tempDir.getAbsolutePath)
           .option(StateSourceOptions.JOIN_SIDE, side)
           .load()
-
-        assertPartitionIdColumnIsNotExposedByDefault(stateReaderForLeft)
         assertPartitionIdColumn(stateReaderForLeft)
 
         val stateReaderForKeyToNumValues = spark.read
@@ -789,7 +779,7 @@ abstract class StateDataSourceReadSuite extends StateDataSourceTestBase with Ass
             s"$side-keyToNumValues")
           .load()
 
-        assertPartitionIdColumnIsNotExposedByDefault(stateReaderForKeyToNumValues)
+
         assertPartitionIdColumn(stateReaderForKeyToNumValues)
 
         val stateReaderForKeyWithIndexToValue = spark.read
@@ -799,7 +789,6 @@ abstract class StateDataSourceReadSuite extends StateDataSourceTestBase with Ass
             s"$side-keyWithIndexToValue")
           .load()
 
-        assertPartitionIdColumnIsNotExposedByDefault(stateReaderForKeyWithIndexToValue)
         assertPartitionIdColumn(stateReaderForKeyWithIndexToValue)
       }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Expose the partition_id column of state data source was hidden by default. 


### Why are the changes needed?
partition_id column is useful to users.


### Does this PR introduce _any_ user-facing change?
yes, Expose the partition_id column of state data source was hidden by default and modify the doc accordingly.


### How was this patch tested?
Modify existing integration test.


### Was this patch authored or co-authored using generative AI tooling?
No.
