### PR TITLE
[SPARK-46717][CORE] Simplify `ReloadingX509TrustManager` by the exit operation only depend on interrupt thread.

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/ssl/ReloadingX509TrustManager.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/ssl/ReloadingX509TrustManager.java
@@ -61,7 +61,6 @@ public final class ReloadingX509TrustManager
   protected volatile int needsReloadCheckCounts;
   private final AtomicReference<X509TrustManager> trustManagerRef;
 
-  private volatile boolean running;
   private Thread reloader;
 
   /**
@@ -98,7 +97,6 @@ public final class ReloadingX509TrustManager
   public void init() {
     reloader = new Thread(this, "Truststore reloader thread");
     reloader.setDaemon(true);
-    running = true;
     reloader.start();
   }
 
@@ -106,7 +104,6 @@ public final class ReloadingX509TrustManager
    * Stops the reloader thread.
    */
   public void destroy() throws InterruptedException {
-    running = false;
     reloader.interrupt();
     reloader.join();
   }
@@ -200,11 +197,12 @@ public final class ReloadingX509TrustManager
 
   @Override
   public void run() {
+    boolean running = true;
     while (running) {
       try {
         Thread.sleep(reloadInterval);
       } catch (InterruptedException e) {
-        //NOP
+        running = false;
       }
       try {
         if (running && needsReload()) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR propose to simplify the `ReloadingX509TrustManager`.


### Why are the changes needed?
Currently, close or destroy `ReloadingX509TrustManager` depend on interrupt thread and the volatile variable `running`.
In fact, we can change the `running` to a local variable on stack and let the close operation of `ReloadingX509TrustManager` only depend on interrupt thread.


### Does this PR introduce _any_ user-facing change?
'No'.


### How was this patch tested?
GA tests.


### Was this patch authored or co-authored using generative AI tooling?
'No'.
