### PR TITLE
[SPARK-46714][SQL] Overwrite a partition with custom location

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelationCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelationCommand.scala
@@ -299,7 +299,7 @@ case class InsertIntoHadoopFsRelationCommand(
       fs: FileSystem,
       table: CatalogTable,
       qualifiedOutputPath: Path,
-      partitions: Seq[CatalogTablePartition]) = {
+      partitions: Seq[CatalogTablePartition]): Map[TablePartitionSpec, String] = {
     partitions.flatMap { p =>
       val defaultLocation = qualifiedOutputPath.suffix(
         "/" + PartitioningUtils.getPathFragment(p.spec, table.partitionSchema)).toString

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelationCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelationCommand.scala
@@ -181,7 +181,10 @@ case class InsertIntoHadoopFsRelationCommand(
                 ifExists = true, purge = true,
                 retainData = false).run(sparkSession)
               AlterTableAddPartitionCommand(
-                catalogTable.get.identifier, movedPartitions.toSeq.map(p => (p, None)),
+                catalogTable.get.identifier, movedPartitions.toSeq.map(p => (p, Some(
+                  ExternalCatalogUtils.generatePartitionPath(
+                    p, catalogTable.get.partitionColumnNames, new Path(catalogTable.get.location)
+                  ).toString))),
                 ifNotExists = true).run(sparkSession)
             } else {
               // for other overwrite, old data has already deleted, so just set location

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -565,10 +565,7 @@ class HiveDDLSuite
       val basePath = new File(tmpDir.getCanonicalPath)
       val part1Path = new File(new File(basePath, "part10"), "part11")
       val part2Path = new File(new File(basePath, "part20"), "part21")
-      val part1NewPath = new File(new File(basePath, "ds=2008-04-08"), "hr=11")
-      val part2NewPath = new File(new File(basePath, "ds=2008-04-08"), "hr=12")
       val dirSet = part1Path :: part2Path :: Nil
-      val dirNewSet = part1NewPath :: part2NewPath :: Nil
 
       // Before data insertion, all the directory are empty
       assert(dirSet.forall(dir => dir.listFiles == null || dir.listFiles.isEmpty))
@@ -579,6 +576,11 @@ class HiveDDLSuite
              |CREATE TABLE $tab (key INT, value STRING)
              |PARTITIONED BY (ds STRING, hr STRING)
            """.stripMargin)
+        val newBasePath = new Path(spark.sessionState.conf.warehousePath, tab).toUri
+        val part1NewPath = new File(new File(newBasePath.getPath, "ds=2008-04-08"), "hr=11")
+        val part2NewPath = new File(new File(newBasePath.getPath, "ds=2008-04-08"), "hr=12")
+        val dirNewSet = part1NewPath :: part2NewPath :: Nil
+
         sql(
           s"""
              |ALTER TABLE $tab ADD

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/test/TestHive.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/test/TestHive.scala
@@ -66,6 +66,7 @@ object TestHive
         // Hive changed the default of hive.metastore.disallow.incompatible.col.type.changes
         // from false to true. For details, see the JIRA HIVE-12320 and HIVE-17764.
         .set("spark.hadoop.hive.metastore.disallow.incompatible.col.type.changes", "false")
+        .set("spark.hadoop.fs.mockFile.impl", classOf[MockCustomFileSystem].getName)
         // Disable ConvertToLocalRelation for better test coverage. Test cases built on
         // LocalRelation will exercise the optimization rules better by disabling it as
         // this rule may potentially block testing of other optimization rules such as


### PR DESCRIPTION
### What changes were proposed in this pull request?

Sometimes we use more than one filesystems for data warehouse, for example one for hot/warm data and another for cold data, with different storages to save total cost. But it seems after spark convert table writing into data source writing, it is not working as expected.

Before this patch, when overwrite a partition with custom location:
1. if the partition location is on same filesystem with its table, the partition location remain the same.
2. else, spark will throw an exception `java.lang.IllegalArgumentException: Wrong FS:`
After this patch, the behavior will align with Hive: the overwritten partition will be recreated under table location.

### Why are the changes needed?
1. to align behavior with Hive
2. support existing partitions on a separate filesystem from table location.

### Does this PR introduce _any_ user-facing change?

Yes.
Before this patch, when overwrite a partition with custom location:
1. if the partition location is on same filesystem with its table, the partition location remain the same.
2. else, spark will throw an exception `java.io.IOException: Wrong FS ...`
After this patch, the behavior will align with Hive: the overwritten partition will be recreated under table location.

### How was this patch tested?

Added a unit test case.

### Was this patch authored or co-authored using generative AI tooling?

No.