### PR TITLE
[MINOR][DOCS] Add missing part of RDD mapPartitions* docstrings

### DIFF
--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -733,6 +733,7 @@ class RDD(Generic[T_co]):
         preservesPartitioning : bool, optional, default False
             indicates whether the input function preserves the partitioner,
             which should be False unless this is a pair RDD and the input
+            function doesn't modify the keys
 
         Returns
         -------
@@ -774,6 +775,7 @@ class RDD(Generic[T_co]):
         preservesPartitioning : bool, optional, default False
             indicates whether the input function preserves the partitioner,
             which should be False unless this is a pair RDD and the input
+            function doesn't modify the keys
 
         Returns
         -------
@@ -816,6 +818,7 @@ class RDD(Generic[T_co]):
         preservesPartitioning : bool, optional, default False
             indicates whether the input function preserves the partitioner,
             which should be False unless this is a pair RDD and the input
+            function doesn't modify the keys
 
         Returns
         -------
@@ -862,6 +865,7 @@ class RDD(Generic[T_co]):
         preservesPartitioning : bool, optional, default False
             indicates whether the input function preserves the partitioner,
             which should be False unless this is a pair RDD and the input
+            function doesn't modify the keys
 
         Returns
         -------
@@ -907,6 +911,7 @@ class RDD(Generic[T_co]):
         preservesPartitioning : bool, optional, default False
             indicates whether the input function preserves the partitioner,
             which should be False unless this is a pair RDD and the input
+            function doesn't modify the keys
 
         Returns
         -------
@@ -5314,6 +5319,7 @@ class RDDBarrier(Generic[T]):
         preservesPartitioning : bool, optional, default False
             indicates whether the input function preserves the partitioner,
             which should be False unless this is a pair RDD and the input
+            function doesn't modify the keys
 
         Returns
         -------
@@ -5366,6 +5372,7 @@ class RDDBarrier(Generic[T]):
         preservesPartitioning : bool, optional, default False
             indicates whether the input function preserves the partitioner,
             which should be False unless this is a pair RDD and the input
+            function doesn't modify the keys
 
         Returns
         -------


### PR DESCRIPTION
### What changes were proposed in this pull request?

The original docstring is here: https://github.com/apache/spark/blob/5db7beb59a673f05e8f39aa9653cb0497a6c97cf/core/src/main/scala/org/apache/spark/rdd/RDD.scala#L847-L848

This docstring was copied incompletely to various RDD methods in the PySpark API.

### Why are the changes needed?

So the docstring is complete and coherent.

### Does this PR introduce _any_ user-facing change?

Yes, it changes the public API docstring.

### How was this patch tested?

Not tested.

### Was this patch authored or co-authored using generative AI tooling?

No.