### PR TITLE
[SPARK-46733][CORE] Simplify the BlockManager by the exit operation only depend on interrupt thread.

### DIFF
--- a/core/src/main/scala/org/apache/spark/ContextCleaner.scala
+++ b/core/src/main/scala/org/apache/spark/ContextCleaner.scala
@@ -116,6 +116,8 @@ private[spark] class ContextCleaner(
   private val blockOnShuffleCleanupTasks =
     sc.conf.get(CLEANER_REFERENCE_TRACKING_BLOCKING_SHUFFLE)
 
+  @volatile private var stopped = false
+
   /** Attach a listener object to get information of when objects are cleaned. */
   def attachListener(listener: CleanerListener): Unit = {
     listeners.add(listener)
@@ -134,6 +136,7 @@ private[spark] class ContextCleaner(
    * Stop the cleaning thread and wait until the thread has finished running its current task.
    */
   def stop(): Unit = {
+    stopped = true
     // Interrupt the cleaning thread, but wait until the current task has finished before
     // doing so. This guards against the race condition where a cleaning thread may
     // potentially clean similarly named variables created by a different SparkContext,
@@ -183,8 +186,7 @@ private[spark] class ContextCleaner(
 
   /** Keep cleaning RDD, shuffle, and broadcast state. */
   private def keepCleaning(): Unit = Utils.tryOrStopSparkContext(sc) {
-    var running = true
-    while (running) {
+    while (!stopped) {
       try {
         val reference = Option(referenceQueue.remove(ContextCleaner.REF_QUEUE_POLL_TIMEOUT))
           .map(_.asInstanceOf[CleanupTaskWeakReference])
@@ -210,8 +212,7 @@ private[spark] class ContextCleaner(
           }
         }
       } catch {
-        case ie: InterruptedException =>
-          running = false
+        case ie: InterruptedException if stopped => // ignore
         case e: Exception => logError("Error in cleaning thread", e)
       }
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR propose to simplify the `BlockManager`.


### Why are the changes needed?
Currently, close or destroy `BlockManager` depend on interrupt thread and the volatile variable `stopped`.
In fact, we can change the `stopped` to a local variable on stack and let the close operation of `BlockManager` only depend on interrupt thread.
For further optimization, this PR using `running` instead of `stopped`.


### Does this PR introduce _any_ user-facing change?
'No'.


### How was this patch tested?
GA tests.


### Was this patch authored or co-authored using generative AI tooling?
'No'.
