### PR TITLE
[SPARK-45827] Disallow partitioning on Variant column

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
@@ -564,7 +564,7 @@ object PartitioningUtils extends SQLConfHelper {
 
     partitionColumnsSchema(schema, partitionColumns).foreach {
       field => field.dataType match {
-        case _: AtomicType => // OK
+        case a: AtomicType if !a.isInstanceOf[VariantType] => // OK
         case _ => throw QueryCompilationErrors.cannotUseDataTypeForPartitionColumnError(field)
       }
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/rules.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/rules.scala
@@ -33,7 +33,7 @@ import org.apache.spark.sql.execution.command.DDLUtils
 import org.apache.spark.sql.execution.datasources.{CreateTable => CreateTableV1}
 import org.apache.spark.sql.execution.datasources.v2.FileDataSourceV2
 import org.apache.spark.sql.sources.InsertableRelation
-import org.apache.spark.sql.types.{AtomicType, StructType}
+import org.apache.spark.sql.types.{AtomicType, StructType, VariantType}
 import org.apache.spark.sql.util.PartitioningUtils.normalizePartitionSpec
 import org.apache.spark.sql.util.SchemaUtils
 import org.apache.spark.util.ArrayImplicits._
@@ -330,7 +330,8 @@ case class PreprocessTableCreation(catalog: SessionCatalog) extends Rule[Logical
     }
 
     schema.filter(f => normalizedPartitionCols.contains(f.name)).map(_.dataType).foreach {
-      case _: AtomicType => // OK
+      // VariantType values are not comparable, so can't be used as partition columns.
+      case a: AtomicType if !a.isInstanceOf[VariantType] => // OK
       case other => failAnalysis(s"Cannot use ${other.catalogString} for partition column")
     }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/VariantSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/VariantSuite.scala
@@ -151,7 +151,8 @@ class VariantSuite extends QueryTest with SharedSparkSession {
 
     // At this point, JSON parsing logic is not really implemented. We just construct some number
     // inputs that are also valid JSON. This exercises passing VariantVal throughout the system.
-    val query = spark.sql("select id, parse_json(repeat('1', id)) as v from range(1, 10)")
+    val queryString = "select id, parse_json(repeat('1', id)) as v from range(1, 10)"
+    val query = spark.sql(queryString)
     verifyResult(query)
 
     // Partition by another column should work.
@@ -166,6 +167,30 @@ class VariantSuite extends QueryTest with SharedSparkSession {
       val tempDir = new File(dir, "files").getCanonicalPath
       intercept[AnalysisException] {
         query.write.partitionBy("v").parquet(tempDir)
+      }
+    }
+
+    // Same as above, using saveAsTable
+    withTable("t") {
+      query.write.partitionBy("id").saveAsTable("t")
+      verifyResult(spark.sql("select * from t"))
+    }
+
+    withTable("t") {
+      intercept[AnalysisException] {
+        query.write.partitionBy("v").saveAsTable("t")
+      }
+    }
+
+    // Same as above, using SQL CTAS
+    withTable("t") {
+      spark.sql(s"CREATE TABLE t USING PARQUET PARTITIONED BY (id) AS $queryString")
+      verifyResult(spark.sql("select * from t"))
+    }
+
+    withTable("t") {
+      intercept[AnalysisException] {
+        spark.sql(s"CREATE TABLE t USING PARQUET PARTITIONED BY (v) AS $queryString")
       }
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Follow-up to https://github.com/apache/spark/pull/43984: we should not allow partitioning on VariantType. Even though it is is an atomic type, it represents a nested semi-structured value, so not partitioning is consistent with our decision to not allow partitioning on nested types. Also, for now at least, it is not even comparable, so attempting to partition fails with a confusing codegen error about a method named `compare` not being declared.

### Why are the changes needed?

Improves error message when attempting to partition on Variant, and explicitly forbids a case that we do not intend to support.

### Does this PR introduce _any_ user-facing change?

Improved error message if a user tries to partition on Variant.

### How was this patch tested?

Added unit test, which fails without the code change.

### Was this patch authored or co-authored using generative AI tooling?

No.