### PR TITLE
[SPARK-46744][SPARK-SHELL][SQL][CONNECT][PYTHON][R] Display clear `exit command` for all spark terminal

### DIFF
--- a/R/pkg/inst/profile/shell.R
+++ b/R/pkg/inst/profile/shell.R
@@ -45,5 +45,6 @@
 
   cat("\nSparkSession Web UI available at", SparkR::sparkR.uiWebUrl())
   cat("\nSparkSession available as 'spark'(master = ", unlist(SparkR::sparkR.conf("spark.master")),
-    ", app id = ", unlist(SparkR::sparkR.conf("spark.app.id")), ").", "\n", sep = "")
+    ", app id = ", unlist(SparkR::sparkR.conf("spark.app.id")), ").", sep = "")
+  cat("\nUse quit() or Ctrl-D (i.e. EOF) to exit.\n")
 }

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/application/ConnectRepl.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/application/ConnectRepl.scala
@@ -45,7 +45,8 @@ object ConnectRepl {
       | ___/ / /_/ / /_/ / /  / ,<    / /___/ /_/ / / / / / / /  __/ /__/ /_
       |/____/ .___/\__,_/_/  /_/|_|   \____/\____/_/ /_/_/ /_/\___/\___/\__/
       |    /_/
-      |""".stripMargin
+      |
+      |Use exit or Ctrl-D (i.e. EOF) to exit.""".stripMargin
 
   def main(args: Array[String]): Unit = doMain(args)
 

--- a/python/pyspark/shell.py
+++ b/python/pyspark/shell.py
@@ -113,6 +113,7 @@ else:
     )
 
 print("SparkSession available as 'spark'.")
+print("Use exit() or Ctrl-D (i.e. EOF) to exit.")
 
 # The ./bin/pyspark script stores the old PYTHONSTARTUP value in OLD_PYTHONSTARTUP,
 # which allows us to execute the user's PYTHONSTARTUP file:

--- a/repl/src/main/scala/org/apache/spark/repl/SparkILoop.scala
+++ b/repl/src/main/scala/org/apache/spark/repl/SparkILoop.scala
@@ -104,6 +104,7 @@ class SparkILoop(in0: BufferedReader, out: PrintWriter)
     echo(welcomeMsg)
     echo("Type in expressions to have them evaluated.")
     echo("Type :help for more information.")
+    echo("Use :quit or Ctrl-D (i.e. EOF) to exit.")
   }
 
   /** Available commands */

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
@@ -441,6 +441,7 @@ private[hive] class SparkSQLCLIDriver extends CliDriver with Logging {
       webUrl => console.printInfo(s"Spark Web UI available at $webUrl")
     }
     console.printInfo(s"Spark master: $master, Application Id: $appId")
+    console.printInfo("Use exit or quit or Ctrl-D (i.e. EOF) to exit.")
   }
 
   override def processCmd(cmd: String): Int = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to display clear `exit command` for all spark terminal, includes: 
`spark-shell`, `spark-sql`, `spark-connect-repl`, `pyspark` and `sparkR`.

### Why are the changes needed?
Because some `exit commands` are `different` across different terminals, in order to promote a better user experience.


### Does this PR introduce _any_ user-facing change?
Yes, when the user starts the terminal, they can clearly see `the exit command`.

### How was this patch tested?
Manually test.

### Was this patch authored or co-authored using generative AI tooling?
No.
