### PR TITLE
[SPARK-46749][DOCS] Document `SPARK_LOG_*` and `SPARK_PID_DIR`

### DIFF
--- a/docs/spark-standalone.md
+++ b/docs/spark-standalone.md
@@ -143,6 +143,18 @@ You can optionally configure the cluster further by setting environment variable
     </td>
   </tr>
   <tr>
+    <td><code>SPARK_LOG_DIR</code></td>
+    <td>Where log files are stored. (default: SPARK_HOME/logs).</td>
+  </tr>
+  <tr>
+    <td><code>SPARK_LOG_MAX_FILES</code></td>
+    <td>The maximum number of log files (default: 5).</td>
+  </tr>
+  <tr>
+    <td><code>SPARK_PID_DIR</code></td>
+    <td>Where pid files are stored. (default: /tmp).</td>
+  </tr>
+  <tr>
     <td><code>SPARK_WORKER_CORES</code></td>
     <td>Total number of cores to allow Spark applications to use on the machine (default: all available cores).</td>
   </tr>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to document the following three environment variables for `Spark Standalone` cluster.
- SPARK_LOG_DIR
- SPARK_LOG_MAX_FILES
- SPARK_PID_DIR

### Why are the changes needed?

So far, the users need to look at the `spark-env.sh.template` or `spark-daemon.sh` files to see the descriptions and the default values. We had better document it officially.

https://github.com/apache/spark/blob/9a2f39318e3af8b3817dc5e4baf52e548d82063c/conf/spark-env.sh.template#L67-L69

https://github.com/apache/spark/blob/9a2f39318e3af8b3817dc5e4baf52e548d82063c/sbin/spark-daemon.sh#L25-L28

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Generate HTML docs.

![Screenshot 2024-01-17 at 10 38 09 AM](https://github.com/apache/spark/assets/9700541/7b6106dc-5105-4653-94aa-0fc05af5a762)




### Was this patch authored or co-authored using generative AI tooling?

No.