### PR TITLE
[SPARK-46751][PYTHON][TESTS] Skip test_datasource if PyArrow is not installed

### DIFF
--- a/python/pyspark/sql/tests/test_python_datasource.py
+++ b/python/pyspark/sql/tests/test_python_datasource.py
@@ -29,11 +29,16 @@ from pyspark.sql.datasource import (
     CaseInsensitiveDict,
 )
 from pyspark.sql.types import Row, StructType
+from pyspark.testing.sqlutils import (
+    have_pyarrow,
+    pyarrow_requirement_message,
+)
 from pyspark.testing import assertDataFrameEqual
 from pyspark.testing.sqlutils import ReusedSQLTestCase
 from pyspark.testing.utils import SPARK_HOME
 
 
+@unittest.skipIf(not have_pyarrow, pyarrow_requirement_message)
 class BasePythonDataSourceTestsMixin:
     def test_basic_data_source_class(self):
         class MyDataSource(DataSource):


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to skip `test_datasource` if PyArrow is not installed because it requires `mapInArrow` that needs PyArrow.

### Why are the changes needed?

To make the build pass with the env that does not have PyArrow installed.

Currently scheduled job fails (with PyPy3): https://github.com/apache/spark/actions/runs/7557652490/job/20577472214

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Scheduled jobs should test it out. I also manually tested it.

### Was this patch authored or co-authored using generative AI tooling?

No.