### PR TITLE
[SPARK-46752][SQL][TESTS] Use default ORC compression in data source benchmarks

### DIFF
--- a/sql/core/benchmarks/BuiltInDataSourceWriteBenchmark-jdk21-results.txt
+++ b/sql/core/benchmarks/BuiltInDataSourceWriteBenchmark-jdk21-results.txt
@@ -2,69 +2,69 @@
 Parquet writer benchmark
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Parquet(PARQUET_1_0) writer benchmark:    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Output Single Int Column                           1641           1686          63          9.6         104.4       1.0X
-Output Single Double Column                        1991           2022          43          7.9         126.6       0.8X
-Output Int and String Column                       4249           4305          79          3.7         270.1       0.4X
-Output Partitions                                  3165           3189          33          5.0         201.3       0.5X
-Output Buckets                                     4429           4447          25          3.6         281.6       0.4X
+Output Single Int Column                           1677           1729          73          9.4         106.6       1.0X
+Output Single Double Column                        1879           1895          22          8.4         119.4       0.9X
+Output Int and String Column                       4135           4144          13          3.8         262.9       0.4X
+Output Partitions                                  3027           3042          21          5.2         192.4       0.6X
+Output Buckets                                     4258           4265          11          3.7         270.7       0.4X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Parquet(PARQUET_2_0) writer benchmark:    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Output Single Int Column                           1666           1688          32          9.4         105.9       1.0X
-Output Single Double Column                        1611           1627          24          9.8         102.4       1.0X
-Output Int and String Column                       4817           4829          17          3.3         306.2       0.3X
-Output Partitions                                  3210           3237          38          4.9         204.1       0.5X
-Output Buckets                                     4375           4384          13          3.6         278.2       0.4X
+Output Single Int Column                           1770           1797          38          8.9         112.5       1.0X
+Output Single Double Column                        1673           1703          43          9.4         106.3       1.1X
+Output Int and String Column                       4330           4337          10          3.6         275.3       0.4X
+Output Partitions                                  3129           3133           6          5.0         198.9       0.6X
+Output Buckets                                     4160           4192          46          3.8         264.5       0.4X
 
 
 ================================================================================================
 ORC writer benchmark
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 ORC writer benchmark:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Output Single Int Column                            915            945          28         17.2          58.2       1.0X
-Output Single Double Column                        1432           1445          18         11.0          91.0       0.6X
-Output Int and String Column                       3749           3771          31          4.2         238.3       0.2X
-Output Partitions                                  2458           2472          19          6.4         156.3       0.4X
-Output Buckets                                     3339           3358          27          4.7         212.3       0.3X
+Output Single Int Column                           1043           1057          20         15.1          66.3       1.0X
+Output Single Double Column                        2217           2243          37          7.1         141.0       0.5X
+Output Int and String Column                       4123           4151          40          3.8         262.1       0.3X
+Output Partitions                                  2399           2399           1          6.6         152.5       0.4X
+Output Buckets                                     3555           3589          48          4.4         226.0       0.3X
 
 
 ================================================================================================
 JSON writer benchmark
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 JSON writer benchmark:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Output Single Int Column                           1395           1431          51         11.3          88.7       1.0X
-Output Single Double Column                        2105           2128          33          7.5         133.8       0.7X
-Output Int and String Column                       3762           3773          16          4.2         239.2       0.4X
-Output Partitions                                  2937           2957          28          5.4         186.7       0.5X
-Output Buckets                                     3788           3822          48          4.2         240.9       0.4X
+Output Single Int Column                           1444           1452          11         10.9          91.8       1.0X
+Output Single Double Column                        2082           2090          11          7.6         132.4       0.7X
+Output Int and String Column                       3729           3779          71          4.2         237.1       0.4X
+Output Partitions                                  2781           2804          32          5.7         176.8       0.5X
+Output Buckets                                     3664           3901         335          4.3         233.0       0.4X
 
 
 ================================================================================================
 CSV writer benchmark
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 CSV writer benchmark:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Output Single Int Column                           3511           3524          19          4.5         223.2       1.0X
-Output Single Double Column                        4243           4250           9          3.7         269.8       0.8X
-Output Int and String Column                       6532           6557          37          2.4         415.3       0.5X
-Output Partitions                                  5369           5374           6          2.9         341.4       0.7X
-Output Buckets                                     6524           6531          10          2.4         414.8       0.5X
+Output Single Int Column                           3771           3793          31          4.2         239.7       1.0X
+Output Single Double Column                        4404           4419          21          3.6         280.0       0.9X
+Output Int and String Column                       6020           6031          16          2.6         382.7       0.6X
+Output Partitions                                  5232           5260          38          3.0         332.7       0.7X
+Output Buckets                                     6560           6576          23          2.4         417.1       0.6X
 
 

--- a/sql/core/benchmarks/BuiltInDataSourceWriteBenchmark-results.txt
+++ b/sql/core/benchmarks/BuiltInDataSourceWriteBenchmark-results.txt
@@ -2,69 +2,69 @@
 Parquet writer benchmark
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Parquet(PARQUET_1_0) writer benchmark:    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Output Single Int Column                           1673           1702          40          9.4         106.4       1.0X
-Output Single Double Column                        1728           1729           1          9.1         109.9       1.0X
-Output Int and String Column                       4300           4367          96          3.7         273.4       0.4X
-Output Partitions                                  3065           3156         129          5.1         194.9       0.5X
-Output Buckets                                     4114           4115           2          3.8         261.6       0.4X
+Output Single Int Column                           1663           1688          35          9.5         105.7       1.0X
+Output Single Double Column                        1748           1797          69          9.0         111.2       1.0X
+Output Int and String Column                       4313           4371          82          3.6         274.2       0.4X
+Output Partitions                                  3069           3124          77          5.1         195.1       0.5X
+Output Buckets                                     4149           4179          42          3.8         263.8       0.4X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Parquet(PARQUET_2_0) writer benchmark:    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Output Single Int Column                           1650           1661          15          9.5         104.9       1.0X
-Output Single Double Column                        1660           1670          14          9.5         105.6       1.0X
-Output Int and String Column                       4645           4655          14          3.4         295.3       0.4X
-Output Partitions                                  3083           3086           5          5.1         196.0       0.5X
-Output Buckets                                     3937           3975          53          4.0         250.3       0.4X
+Output Single Int Column                           1618           1619           1          9.7         102.9       1.0X
+Output Single Double Column                        1639           1646          10          9.6         104.2       1.0X
+Output Int and String Column                       4493           4493           1          3.5         285.7       0.4X
+Output Partitions                                  3086           3098          16          5.1         196.2       0.5X
+Output Buckets                                     4021           4054          47          3.9         255.7       0.4X
 
 
 ================================================================================================
 ORC writer benchmark
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 ORC writer benchmark:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Output Single Int Column                            918            929          10         17.1          58.4       1.0X
-Output Single Double Column                        1381           1382           2         11.4          87.8       0.7X
-Output Int and String Column                       3952           4028         108          4.0         251.2       0.2X
-Output Partitions                                  2315           2319           5          6.8         147.2       0.4X
-Output Buckets                                     2904           2915          15          5.4         184.6       0.3X
+Output Single Int Column                            870            873           4         18.1          55.3       1.0X
+Output Single Double Column                        2075           2104          40          7.6         132.0       0.4X
+Output Int and String Column                       4568           4576          11          3.4         290.4       0.2X
+Output Partitions                                  2489           2492           4          6.3         158.3       0.3X
+Output Buckets                                     3555           3566          16          4.4         226.0       0.2X
 
 
 ================================================================================================
 JSON writer benchmark
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 JSON writer benchmark:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Output Single Int Column                           1350           1358          11         11.6          85.8       1.0X
-Output Single Double Column                        2017           2045          39          7.8         128.2       0.7X
-Output Int and String Column                       3554           3593          56          4.4         225.9       0.4X
-Output Partitions                                  2809           2816          10          5.6         178.6       0.5X
-Output Buckets                                     3656           3667          15          4.3         232.4       0.4X
+Output Single Int Column                           1348           1354           8         11.7          85.7       1.0X
+Output Single Double Column                        1958           1970          18          8.0         124.5       0.7X
+Output Int and String Column                       4112           4116           5          3.8         261.5       0.3X
+Output Partitions                                  2983           3017          49          5.3         189.6       0.5X
+Output Buckets                                     3810           3821          15          4.1         242.2       0.4X
 
 
 ================================================================================================
 CSV writer benchmark
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 CSV writer benchmark:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Output Single Int Column                           3151           3153           3          5.0         200.3       1.0X
-Output Single Double Column                        3469           3470           1          4.5         220.6       0.9X
-Output Int and String Column                       5851           5860          13          2.7         372.0       0.5X
-Output Partitions                                  4830           4842          16          3.3         307.1       0.7X
-Output Buckets                                     6158           6181          32          2.6         391.5       0.5X
+Output Single Int Column                           2911           2970          85          5.4         185.0       1.0X
+Output Single Double Column                        3668           3676          12          4.3         233.2       0.8X
+Output Int and String Column                       5563           5564           1          2.8         353.7       0.5X
+Output Partitions                                  4608           4636          39          3.4         293.0       0.6X
+Output Buckets                                     5745           5771          38          2.7         365.2       0.5X
 
 

--- a/sql/core/benchmarks/DataSourceReadBenchmark-jdk21-results.txt
+++ b/sql/core/benchmarks/DataSourceReadBenchmark-jdk21-results.txt
@@ -2,430 +2,430 @@
 SQL Single Numeric Column Scan
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 SQL Single BOOLEAN Column Scan:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            7759           7796          53          2.0         493.3       1.0X
-SQL Json                                           7379           7417          54          2.1         469.1       1.1X
-SQL Parquet Vectorized: DataPageV1                   72             86          11        217.3           4.6     107.2X
-SQL Parquet Vectorized: DataPageV2                   55             65           7        287.6           3.5     141.9X
-SQL Parquet MR: DataPageV1                         1706           1710           6          9.2         108.5       4.5X
-SQL Parquet MR: DataPageV2                         1591           1591           0          9.9         101.2       4.9X
-SQL ORC Vectorized                                  112            124          11        139.9           7.1      69.0X
-SQL ORC MR                                         1465           1467           2         10.7          93.2       5.3X
+SQL CSV                                            7540           7568          39          2.1         479.4       1.0X
+SQL Json                                           7301           7365          91          2.2         464.2       1.0X
+SQL Parquet Vectorized: DataPageV1                   72             83           8        219.5           4.6     105.2X
+SQL Parquet Vectorized: DataPageV2                   52             59           5        304.7           3.3     146.1X
+SQL Parquet MR: DataPageV1                         1669           1685          22          9.4         106.1       4.5X
+SQL Parquet MR: DataPageV2                         1640           1643           4          9.6         104.3       4.6X
+SQL ORC Vectorized                                  113            121           9        139.6           7.2      66.9X
+SQL ORC MR                                         1464           1474          15         10.7          93.1       5.2X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Parquet Reader Single BOOLEAN Column Scan:   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized: DataPageV1                    37             39           2        421.2           2.4       1.0X
-ParquetReader Vectorized: DataPageV2                    27             28           1        575.3           1.7       1.4X
-ParquetReader Vectorized -> Row: DataPageV1             29             30           2        546.2           1.8       1.3X
-ParquetReader Vectorized -> Row: DataPageV2             18             20           2        862.2           1.2       2.0X
+ParquetReader Vectorized: DataPageV1                    34             34           1        468.1           2.1       1.0X
+ParquetReader Vectorized: DataPageV2                    24             24           1        667.2           1.5       1.4X
+ParquetReader Vectorized -> Row: DataPageV1             27             28           1        574.4           1.7       1.2X
+ParquetReader Vectorized -> Row: DataPageV2             17             20           6        902.8           1.1       1.9X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 SQL Single TINYINT Column Scan:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            9101           9111          14          1.7         578.6       1.0X
-SQL Json                                           8517           8528          16          1.8         541.5       1.1X
-SQL Parquet Vectorized: DataPageV1                   79             89           9        198.5           5.0     114.8X
-SQL Parquet Vectorized: DataPageV2                   78             90          10        201.8           5.0     116.8X
-SQL Parquet MR: DataPageV1                         1883           1885           4          8.4         119.7       4.8X
-SQL Parquet MR: DataPageV2                         1804           1813          13          8.7         114.7       5.0X
-SQL ORC Vectorized                                  136            144           7        115.3           8.7      66.7X
-SQL ORC MR                                         1523           1529           8         10.3          96.9       6.0X
+SQL CSV                                            9475           9483          11          1.7         602.4       1.0X
+SQL Json                                           8355           8358           5          1.9         531.2       1.1X
+SQL Parquet Vectorized: DataPageV1                   74             84           9        213.2           4.7     128.5X
+SQL Parquet Vectorized: DataPageV2                   73             83           9        216.9           4.6     130.7X
+SQL Parquet MR: DataPageV1                         1791           1791           0          8.8         113.9       5.3X
+SQL Parquet MR: DataPageV2                         1704           1726          32          9.2         108.3       5.6X
+SQL ORC Vectorized                                   79             86          11        199.2           5.0     120.0X
+SQL ORC MR                                         1482           1484           3         10.6          94.3       6.4X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Parquet Reader Single TINYINT Column Scan:   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized: DataPageV1                    55             56           1        284.8           3.5       1.0X
-ParquetReader Vectorized: DataPageV2                    55             56           1        285.1           3.5       1.0X
-ParquetReader Vectorized -> Row: DataPageV1             47             48           2        336.1           3.0       1.2X
-ParquetReader Vectorized -> Row: DataPageV2             47             48           1        335.8           3.0       1.2X
+ParquetReader Vectorized: DataPageV1                    76             79           2        208.1           4.8       1.0X
+ParquetReader Vectorized: DataPageV2                    75             79           2        208.5           4.8       1.0X
+ParquetReader Vectorized -> Row: DataPageV1             42             44           1        378.4           2.6       1.8X
+ParquetReader Vectorized -> Row: DataPageV2             42             44           1        376.9           2.7       1.8X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 SQL Single SMALLINT Column Scan:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            9505           9520          22          1.7         604.3       1.0X
-SQL Json                                           8821           8825           5          1.8         560.8       1.1X
-SQL Parquet Vectorized: DataPageV1                  100            112          12        157.2           6.4      95.0X
-SQL Parquet Vectorized: DataPageV2                  120            134          13        131.5           7.6      79.5X
-SQL Parquet MR: DataPageV1                         1901           1904           4          8.3         120.8       5.0X
-SQL Parquet MR: DataPageV2                         1974           2013          54          8.0         125.5       4.8X
-SQL ORC Vectorized                                  140            155          18        112.0           8.9      67.7X
-SQL ORC MR                                         1599           1610          16          9.8         101.6       5.9X
+SQL CSV                                           10097          10102           7          1.6         642.0       1.0X
+SQL Json                                           8401           8417          22          1.9         534.1       1.2X
+SQL Parquet Vectorized: DataPageV1                   99            114          16        159.3           6.3     102.3X
+SQL Parquet Vectorized: DataPageV2                  120            145          26        131.3           7.6      84.3X
+SQL Parquet MR: DataPageV1                         1894           1908          20          8.3         120.4       5.3X
+SQL Parquet MR: DataPageV2                         1825           1838          18          8.6         116.0       5.5X
+SQL ORC Vectorized                                  137            145          17        114.9           8.7      73.8X
+SQL ORC MR                                         1590           1592           3          9.9         101.1       6.4X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Parquet Reader Single SMALLINT Column Scan:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized: DataPageV1                   153            168           9        103.1           9.7       1.0X
-ParquetReader Vectorized: DataPageV2                   176            191           8         89.5          11.2       0.9X
-ParquetReader Vectorized -> Row: DataPageV1            142            148          10        110.4           9.1       1.1X
-ParquetReader Vectorized -> Row: DataPageV2            164            183          11         96.0          10.4       0.9X
+ParquetReader Vectorized: DataPageV1                   146            156           9        107.4           9.3       1.0X
+ParquetReader Vectorized: DataPageV2                   175            189           8         89.8          11.1       0.8X
+ParquetReader Vectorized -> Row: DataPageV1            141            146           7        111.9           8.9       1.0X
+ParquetReader Vectorized -> Row: DataPageV2            160            165           7         98.2          10.2       0.9X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 SQL Single INT Column Scan:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           10971          10979          11          1.4         697.5       1.0X
-SQL Json                                           9096           9096           1          1.7         578.3       1.2X
-SQL Parquet Vectorized: DataPageV1                   88             96           6        178.5           5.6     124.5X
-SQL Parquet Vectorized: DataPageV2                  157            173          19        100.0          10.0      69.7X
-SQL Parquet MR: DataPageV1                         2115           2121           9          7.4         134.4       5.2X
-SQL Parquet MR: DataPageV2                         1935           1940           8          8.1         123.0       5.7X
-SQL ORC Vectorized                                  131            138          11        120.0           8.3      83.7X
-SQL ORC MR                                         1610           1615           6          9.8         102.4       6.8X
+SQL CSV                                           11076          11105          41          1.4         704.2       1.0X
+SQL Json                                           8878           8879           2          1.8         564.4       1.2X
+SQL Parquet Vectorized: DataPageV1                   99            103           4        159.5           6.3     112.3X
+SQL Parquet Vectorized: DataPageV2                  174            177           3         90.5          11.0      63.8X
+SQL Parquet MR: DataPageV1                         1937           1981          63          8.1         123.1       5.7X
+SQL Parquet MR: DataPageV2                         1887           1899          16          8.3         120.0       5.9X
+SQL ORC Vectorized                                  198            207           8         79.6          12.6      56.0X
+SQL ORC MR                                         1676           1679           4          9.4         106.5       6.6X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Parquet Reader Single INT Column Scan:       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized: DataPageV1                   156            172          13        101.1           9.9       1.0X
-ParquetReader Vectorized: DataPageV2                   230            241           8         68.4          14.6       0.7X
-ParquetReader Vectorized -> Row: DataPageV1            139            144           6        113.3           8.8       1.1X
-ParquetReader Vectorized -> Row: DataPageV2            216            225          14         72.9          13.7       0.7X
+ParquetReader Vectorized: DataPageV1                   150            154           2        104.7           9.5       1.0X
+ParquetReader Vectorized: DataPageV2                   229            231           2         68.8          14.5       0.7X
+ParquetReader Vectorized -> Row: DataPageV1            121            130          10        129.7           7.7       1.2X
+ParquetReader Vectorized -> Row: DataPageV2            216            222           6         72.9          13.7       0.7X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 SQL Single BIGINT Column Scan:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           14745          14745           1          1.1         937.4       1.0X
-SQL Json                                          10039          10040           2          1.6         638.2       1.5X
-SQL Parquet Vectorized: DataPageV1                  120            159          20        131.0           7.6     122.8X
-SQL Parquet Vectorized: DataPageV2                  273            305          22         57.7          17.3      54.1X
-SQL Parquet MR: DataPageV1                         2258           2271          18          7.0         143.6       6.5X
-SQL Parquet MR: DataPageV2                         1964           1976          16          8.0         124.9       7.5X
-SQL ORC Vectorized                                  200            212          10         78.5          12.7      73.6X
-SQL ORC MR                                         1667           1686          26          9.4         106.0       8.8X
+SQL CSV                                           14952          15101         210          1.1         950.7       1.0X
+SQL Json                                          10191          10208          24          1.5         647.9       1.5X
+SQL Parquet Vectorized: DataPageV1                  132            137           5        119.0           8.4     113.1X
+SQL Parquet Vectorized: DataPageV2                  261            280          14         60.3          16.6      57.3X
+SQL Parquet MR: DataPageV1                         2374           2380           8          6.6         150.9       6.3X
+SQL Parquet MR: DataPageV2                         1990           1992           2          7.9         126.5       7.5X
+SQL ORC Vectorized                                  214            234          24         73.5          13.6      69.9X
+SQL ORC MR                                         1721           1737          22          9.1         109.4       8.7X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Parquet Reader Single BIGINT Column Scan:    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized: DataPageV1                   207            210           3         75.8          13.2       1.0X
-ParquetReader Vectorized: DataPageV2                   353            370          20         44.6          22.4       0.6X
-ParquetReader Vectorized -> Row: DataPageV1            167            172           5         94.2          10.6       1.2X
-ParquetReader Vectorized -> Row: DataPageV2            328            339          10         48.0          20.8       0.6X
+ParquetReader Vectorized: DataPageV1                   171            172           2         92.1          10.9       1.0X
+ParquetReader Vectorized: DataPageV2                   308            317           7         51.0          19.6       0.6X
+ParquetReader Vectorized -> Row: DataPageV1            162            167           6         97.3          10.3       1.1X
+ParquetReader Vectorized -> Row: DataPageV2            318            323           4         49.5          20.2       0.5X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 SQL Single FLOAT Column Scan:             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           11315          11446         186          1.4         719.4       1.0X
-SQL Json                                          11199          11243          63          1.4         712.0       1.0X
-SQL Parquet Vectorized: DataPageV1                   82             91           5        192.6           5.2     138.5X
-SQL Parquet Vectorized: DataPageV2                   86             92           6        183.1           5.5     131.7X
-SQL Parquet MR: DataPageV1                         1955           1957           2          8.0         124.3       5.8X
-SQL Parquet MR: DataPageV2                         1895           1907          18          8.3         120.5       6.0X
-SQL ORC Vectorized                                  265            274          12         59.4          16.8      42.7X
-SQL ORC MR                                         1716           1749          46          9.2         109.1       6.6X
+SQL CSV                                           11639          11735         136          1.4         740.0       1.0X
+SQL Json                                          11299          11315          23          1.4         718.4       1.0X
+SQL Parquet Vectorized: DataPageV1                   88             92           4        178.4           5.6     132.0X
+SQL Parquet Vectorized: DataPageV2                   87             91           3        180.0           5.6     133.2X
+SQL Parquet MR: DataPageV1                         1986           2000          20          7.9         126.3       5.9X
+SQL Parquet MR: DataPageV2                         1868           1894          37          8.4         118.7       6.2X
+SQL ORC Vectorized                                  263            273          11         59.9          16.7      44.3X
+SQL ORC MR                                         1684           1697          18          9.3         107.1       6.9X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Parquet Reader Single FLOAT Column Scan:     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized: DataPageV1                   131            135           6        119.7           8.4       1.0X
-ParquetReader Vectorized: DataPageV2                   130            132           1        121.2           8.3       1.0X
-ParquetReader Vectorized -> Row: DataPageV1            125            132           7        125.4           8.0       1.0X
-ParquetReader Vectorized -> Row: DataPageV2            125            133          11        125.9           7.9       1.1X
+ParquetReader Vectorized: DataPageV1                   158            161           2         99.8          10.0       1.0X
+ParquetReader Vectorized: DataPageV2                   156            161           3        101.1           9.9       1.0X
+ParquetReader Vectorized -> Row: DataPageV1            122            128           6        129.4           7.7       1.3X
+ParquetReader Vectorized -> Row: DataPageV2            122            131           9        128.6           7.8       1.3X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 SQL Single DOUBLE Column Scan:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           14813          14968         219          1.1         941.8       1.0X
-SQL Json                                          14256          14264          11          1.1         906.3       1.0X
-SQL Parquet Vectorized: DataPageV1                  133            140           5        118.2           8.5     111.3X
-SQL Parquet Vectorized: DataPageV2                  118            131          12        133.3           7.5     125.6X
-SQL Parquet MR: DataPageV1                         2248           2250           2          7.0         142.9       6.6X
-SQL Parquet MR: DataPageV2                         2134           2144          15          7.4         135.7       6.9X
-SQL ORC Vectorized                                  350            361          20         45.0          22.2      42.4X
-SQL ORC MR                                         1806           1809           3          8.7         114.8       8.2X
+SQL CSV                                           14922          15119         279          1.1         948.7       1.0X
+SQL Json                                          14012          14056          63          1.1         890.8       1.1X
+SQL Parquet Vectorized: DataPageV1                  117            134          14        133.9           7.5     127.0X
+SQL Parquet Vectorized: DataPageV2                  117            133          16        134.9           7.4     128.0X
+SQL Parquet MR: DataPageV1                         2237           2258          30          7.0         142.2       6.7X
+SQL Parquet MR: DataPageV2                         2138           2145          10          7.4         135.9       7.0X
+SQL ORC Vectorized                                  345            358          14         45.5          22.0      43.2X
+SQL ORC MR                                         1854           1871          24          8.5         117.8       8.1X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Parquet Reader Single DOUBLE Column Scan:    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized: DataPageV1                   178            188          11         88.3          11.3       1.0X
-ParquetReader Vectorized: DataPageV2                   177            188           7         88.8          11.3       1.0X
-ParquetReader Vectorized -> Row: DataPageV1            183            186           3         86.1          11.6       1.0X
-ParquetReader Vectorized -> Row: DataPageV2            169            180          12         93.3          10.7       1.1X
+ParquetReader Vectorized: DataPageV1                   164            172           6         96.1          10.4       1.0X
+ParquetReader Vectorized: DataPageV2                   165            176           9         95.1          10.5       1.0X
+ParquetReader Vectorized -> Row: DataPageV1            164            181          22         95.7          10.4       1.0X
+ParquetReader Vectorized -> Row: DataPageV2            174            179           4         90.4          11.1       0.9X
 
 
 ================================================================================================
 SQL Single Numeric Column Scan in Struct
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 SQL Single TINYINT Column Scan in Struct:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------
-SQL ORC MR                                                            2039           2047          12          7.7         129.7       1.0X
-SQL ORC Vectorized (Nested Column Disabled)                           2027           2028           2          7.8         128.8       1.0X
-SQL ORC Vectorized (Nested Column Enabled)                             254            267          30         61.9          16.2       8.0X
-SQL Parquet MR: DataPageV1                                            2366           2367           2          6.6         150.4       0.9X
-SQL Parquet Vectorized: DataPageV1 (Nested Column Disabled)           2672           2676           7          5.9         169.9       0.8X
-SQL Parquet Vectorized: DataPageV1 (Nested Column Enabled)             190            202           9         82.8          12.1      10.7X
-SQL Parquet MR: DataPageV2                                            2325           2328           5          6.8         147.8       0.9X
-SQL Parquet Vectorized: DataPageV2 (Nested Column Disabled)           2691           2706          22          5.8         171.1       0.8X
-SQL Parquet Vectorized: DataPageV2 (Nested Column Enabled)             188            218          20         83.6          12.0      10.8X
+SQL ORC MR                                                            2228           2250          31          7.1         141.6       1.0X
+SQL ORC Vectorized (Nested Column Disabled)                           2185           2189           6          7.2         138.9       1.0X
+SQL ORC Vectorized (Nested Column Enabled)                             192            202          14         81.9          12.2      11.6X
+SQL Parquet MR: DataPageV1                                            2314           2353          55          6.8         147.1       1.0X
+SQL Parquet Vectorized: DataPageV1 (Nested Column Disabled)           2736           2744          12          5.7         173.9       0.8X
+SQL Parquet Vectorized: DataPageV1 (Nested Column Enabled)              88             95           7        177.9           5.6      25.2X
+SQL Parquet MR: DataPageV2                                            2162           2171          13          7.3         137.4       1.0X
+SQL Parquet Vectorized: DataPageV2 (Nested Column Disabled)           2625           2675          72          6.0         166.9       0.8X
+SQL Parquet Vectorized: DataPageV2 (Nested Column Enabled)              88             97           6        179.6           5.6      25.4X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 SQL Single SMALLINT Column Scan in Struct:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------
-SQL ORC MR                                                            2167           2200          47          7.3         137.8       1.0X
-SQL ORC Vectorized (Nested Column Disabled)                           2168           2181          18          7.3         137.8       1.0X
-SQL ORC Vectorized (Nested Column Enabled)                             280            288           6         56.2          17.8       7.7X
-SQL Parquet MR: DataPageV1                                            2408           2416          12          6.5         153.1       0.9X
-SQL Parquet Vectorized: DataPageV1 (Nested Column Disabled)           2650           2675          35          5.9         168.5       0.8X
-SQL Parquet Vectorized: DataPageV1 (Nested Column Enabled)             101            108           7        155.3           6.4      21.4X
-SQL Parquet MR: DataPageV2                                            2349           2366          24          6.7         149.3       0.9X
-SQL Parquet Vectorized: DataPageV2 (Nested Column Disabled)           2566           2591          35          6.1         163.2       0.8X
-SQL Parquet Vectorized: DataPageV2 (Nested Column Enabled)             195            223          14         80.8          12.4      11.1X
+SQL ORC MR                                                            2323           2352          41          6.8         147.7       1.0X
+SQL ORC Vectorized (Nested Column Disabled)                           2328           2353          36          6.8         148.0       1.0X
+SQL ORC Vectorized (Nested Column Enabled)                             274            289          16         57.5          17.4       8.5X
+SQL Parquet MR: DataPageV1                                            2590           2595           6          6.1         164.7       0.9X
+SQL Parquet Vectorized: DataPageV1 (Nested Column Disabled)           3007           3028          30          5.2         191.2       0.8X
+SQL Parquet Vectorized: DataPageV1 (Nested Column Enabled)              94            113          16        166.9           6.0      24.7X
+SQL Parquet MR: DataPageV2                                            2384           2400          24          6.6         151.5       1.0X
+SQL Parquet Vectorized: DataPageV2 (Nested Column Disabled)           2733           2751          25          5.8         173.8       0.8X
+SQL Parquet Vectorized: DataPageV2 (Nested Column Enabled)             183            213          27         86.2          11.6      12.7X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 SQL Single INT Column Scan in Struct:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------
-SQL ORC MR                                                            2373           2375           2          6.6         150.9       1.0X
-SQL ORC Vectorized (Nested Column Disabled)                           2267           2272           7          6.9         144.1       1.0X
-SQL ORC Vectorized (Nested Column Enabled)                             299            309           7         52.6          19.0       7.9X
-SQL Parquet MR: DataPageV1                                            2442           2446           6          6.4         155.3       1.0X
-SQL Parquet Vectorized: DataPageV1 (Nested Column Disabled)           2928           2948          28          5.4         186.2       0.8X
-SQL Parquet Vectorized: DataPageV1 (Nested Column Enabled)              94             99           5        167.0           6.0      25.2X
-SQL Parquet MR: DataPageV2                                            2309           2338          42          6.8         146.8       1.0X
-SQL Parquet Vectorized: DataPageV2 (Nested Column Disabled)           2774           2788          19          5.7         176.4       0.9X
-SQL Parquet Vectorized: DataPageV2 (Nested Column Enabled)             260            271           7         60.5          16.5       9.1X
+SQL ORC MR                                                            2373           2384          15          6.6         150.9       1.0X
+SQL ORC Vectorized (Nested Column Disabled)                           2395           2399           6          6.6         152.3       1.0X
+SQL ORC Vectorized (Nested Column Enabled)                             299            313          26         52.7          19.0       7.9X
+SQL Parquet MR: DataPageV1                                            2629           2658          40          6.0         167.2       0.9X
+SQL Parquet Vectorized: DataPageV1 (Nested Column Disabled)           2993           3014          29          5.3         190.3       0.8X
+SQL Parquet Vectorized: DataPageV1 (Nested Column Enabled)              87            104          14        180.4           5.5      27.2X
+SQL Parquet MR: DataPageV2                                            2374           2380           9          6.6         150.9       1.0X
+SQL Parquet Vectorized: DataPageV2 (Nested Column Disabled)           2912           2914           3          5.4         185.2       0.8X
+SQL Parquet Vectorized: DataPageV2 (Nested Column Enabled)             222            234          15         70.9          14.1      10.7X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 SQL Single BIGINT Column Scan in Struct:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------
-SQL ORC MR                                                            2258           2301          60          7.0         143.6       1.0X
-SQL ORC Vectorized (Nested Column Disabled)                           2272           2293          29          6.9         144.5       1.0X
-SQL ORC Vectorized (Nested Column Enabled)                             322            335          16         48.8          20.5       7.0X
-SQL Parquet MR: DataPageV1                                            2666           2666           0          5.9         169.5       0.8X
-SQL Parquet Vectorized: DataPageV1 (Nested Column Disabled)           3376           3381           8          4.7         214.6       0.7X
-SQL Parquet Vectorized: DataPageV1 (Nested Column Enabled)             124            139          15        126.6           7.9      18.2X
-SQL Parquet MR: DataPageV2                                            2357           2360           4          6.7         149.8       1.0X
-SQL Parquet Vectorized: DataPageV2 (Nested Column Disabled)           2863           2935         102          5.5         182.0       0.8X
-SQL Parquet Vectorized: DataPageV2 (Nested Column Enabled)             303            321          12         51.9          19.3       7.5X
+SQL ORC MR                                                            2276           2330          77          6.9         144.7       1.0X
+SQL ORC Vectorized (Nested Column Disabled)                           2410           2412           3          6.5         153.2       0.9X
+SQL ORC Vectorized (Nested Column Enabled)                             330            349          13         47.6          21.0       6.9X
+SQL Parquet MR: DataPageV1                                            2693           2696           4          5.8         171.2       0.8X
+SQL Parquet Vectorized: DataPageV1 (Nested Column Disabled)           3188           3190           3          4.9         202.7       0.7X
+SQL Parquet Vectorized: DataPageV1 (Nested Column Enabled)             135            145           6        116.8           8.6      16.9X
+SQL Parquet MR: DataPageV2                                            2432           2436           7          6.5         154.6       0.9X
+SQL Parquet Vectorized: DataPageV2 (Nested Column Disabled)           2829           2847          26          5.6         179.9       0.8X
+SQL Parquet Vectorized: DataPageV2 (Nested Column Enabled)             324            332           6         48.5          20.6       7.0X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 SQL Single FLOAT Column Scan in Struct:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------
-SQL ORC MR                                                            2171           2179          12          7.2         138.0       1.0X
-SQL ORC Vectorized (Nested Column Disabled)                           2176           2194          26          7.2         138.3       1.0X
-SQL ORC Vectorized (Nested Column Enabled)                             369            387          14         42.6          23.5       5.9X
-SQL Parquet MR: DataPageV1                                            2268           2275           9          6.9         144.2       1.0X
-SQL Parquet Vectorized: DataPageV1 (Nested Column Disabled)           2657           2665          12          5.9         168.9       0.8X
-SQL Parquet Vectorized: DataPageV1 (Nested Column Enabled)              88             99           7        178.7           5.6      24.7X
-SQL Parquet MR: DataPageV2                                            2190           2193           4          7.2         139.3       1.0X
-SQL Parquet Vectorized: DataPageV2 (Nested Column Disabled)           2622           2630          11          6.0         166.7       0.8X
-SQL Parquet Vectorized: DataPageV2 (Nested Column Enabled)              89             99           6        177.3           5.6      24.5X
+SQL ORC MR                                                            2295           2417         173          6.9         145.9       1.0X
+SQL ORC Vectorized (Nested Column Disabled)                           2319           2329          14          6.8         147.4       1.0X
+SQL ORC Vectorized (Nested Column Enabled)                             366            375          10         42.9          23.3       6.3X
+SQL Parquet MR: DataPageV1                                            2346           2383          53          6.7         149.1       1.0X
+SQL Parquet Vectorized: DataPageV1 (Nested Column Disabled)           2913           2915           3          5.4         185.2       0.8X
+SQL Parquet Vectorized: DataPageV1 (Nested Column Enabled)              95            100           4        165.3           6.0      24.1X
+SQL Parquet MR: DataPageV2                                            2267           2287          29          6.9         144.1       1.0X
+SQL Parquet Vectorized: DataPageV2 (Nested Column Disabled)           2791           2812          29          5.6         177.5       0.8X
+SQL Parquet Vectorized: DataPageV2 (Nested Column Enabled)              95            101           6        166.1           6.0      24.2X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 SQL Single DOUBLE Column Scan in Struct:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------
-SQL ORC MR                                                            2358           2389          43          6.7         149.9       1.0X
-SQL ORC Vectorized (Nested Column Disabled)                           2340           2343           5          6.7         148.8       1.0X
-SQL ORC Vectorized (Nested Column Enabled)                             456            464           8         34.5          29.0       5.2X
-SQL Parquet MR: DataPageV1                                            2656           2660           5          5.9         168.9       0.9X
-SQL Parquet Vectorized: DataPageV1 (Nested Column Disabled)           3206           3212           9          4.9         203.8       0.7X
-SQL Parquet Vectorized: DataPageV1 (Nested Column Enabled)             134            141           4        117.5           8.5      17.6X
-SQL Parquet MR: DataPageV2                                            2573           2585          16          6.1         163.6       0.9X
-SQL Parquet Vectorized: DataPageV2 (Nested Column Disabled)           3103           3118          21          5.1         197.3       0.8X
-SQL Parquet Vectorized: DataPageV2 (Nested Column Enabled)             133            140           4        118.3           8.5      17.7X
+SQL ORC MR                                                            2536           2580          61          6.2         161.3       1.0X
+SQL ORC Vectorized (Nested Column Disabled)                           2554           2605          72          6.2         162.4       1.0X
+SQL ORC Vectorized (Nested Column Enabled)                             453            472          17         34.7          28.8       5.6X
+SQL Parquet MR: DataPageV1                                            2674           2678           6          5.9         170.0       0.9X
+SQL Parquet Vectorized: DataPageV1 (Nested Column Disabled)           3045           3067          31          5.2         193.6       0.8X
+SQL Parquet Vectorized: DataPageV1 (Nested Column Enabled)             123            144          11        127.5           7.8      20.6X
+SQL Parquet MR: DataPageV2                                            2575           2585          14          6.1         163.7       1.0X
+SQL Parquet Vectorized: DataPageV2 (Nested Column Disabled)           2998           3001           4          5.2         190.6       0.8X
+SQL Parquet Vectorized: DataPageV2 (Nested Column Enabled)             120            137          15        130.5           7.7      21.0X
 
 
 ================================================================================================
 SQL Nested Column Scan
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 SQL Nested Column Scan:                                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------
-SQL ORC MR                                                           12923          12980          39          0.1       12324.5       1.0X
-SQL ORC Vectorized (Nested Column Disabled)                          12954          13029          88          0.1       12354.4       1.0X
-SQL ORC Vectorized (Nested Column Enabled)                            7202           7236          26          0.1        6868.5       1.8X
-SQL Parquet MR: DataPageV1                                            9053           9151         102          0.1        8633.7       1.4X
-SQL Parquet Vectorized: DataPageV1 (Nested Column Disabled)           9342           9426          47          0.1        8909.5       1.4X
-SQL Parquet Vectorized: DataPageV1 (Nested Column Enabled)            6019           6059          30          0.2        5740.4       2.1X
-SQL Parquet MR: DataPageV2                                            9718           9850          74          0.1        9267.5       1.3X
-SQL Parquet Vectorized: DataPageV2 (Nested Column Disabled)          10073          10154          47          0.1        9606.0       1.3X
-SQL Parquet Vectorized: DataPageV2 (Nested Column Enabled)            5640           5726          39          0.2        5378.5       2.3X
+SQL ORC MR                                                           12626          12681          35          0.1       12041.3       1.0X
+SQL ORC Vectorized (Nested Column Disabled)                          12644          12692          56          0.1       12058.4       1.0X
+SQL ORC Vectorized (Nested Column Enabled)                            7113           7158          23          0.1        6783.6       1.8X
+SQL Parquet MR: DataPageV1                                            9071           9193          82          0.1        8650.8       1.4X
+SQL Parquet Vectorized: DataPageV1 (Nested Column Disabled)           8968           9026          30          0.1        8552.9       1.4X
+SQL Parquet Vectorized: DataPageV1 (Nested Column Enabled)            6002           6071          58          0.2        5723.6       2.1X
+SQL Parquet MR: DataPageV2                                            9651           9875          94          0.1        9204.3       1.3X
+SQL Parquet Vectorized: DataPageV2 (Nested Column Disabled)           9753          10071         180          0.1        9301.2       1.3X
+SQL Parquet Vectorized: DataPageV2 (Nested Column Enabled)            5521           5544          17          0.2        5265.3       2.3X
 
 
 ================================================================================================
 Int and String Scan
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Int and String Scan:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           10349          10355           9          1.0         986.9       1.0X
-SQL Json                                          10024          10046          31          1.0         956.0       1.0X
-SQL Parquet Vectorized: DataPageV1                 1648           1652           7          6.4         157.2       6.3X
-SQL Parquet Vectorized: DataPageV2                 1898           1916          25          5.5         181.0       5.5X
-SQL Parquet MR: DataPageV1                         4015           4028          19          2.6         382.9       2.6X
-SQL Parquet MR: DataPageV2                         3871           3874           4          2.7         369.2       2.7X
-SQL ORC Vectorized                                 1884           1886           4          5.6         179.6       5.5X
-SQL ORC MR                                         3405           3409           5          3.1         324.8       3.0X
+SQL CSV                                           10170          10172           3          1.0         969.9       1.0X
+SQL Json                                          10048          10052           6          1.0         958.2       1.0X
+SQL Parquet Vectorized: DataPageV1                 1623           1640          24          6.5         154.8       6.3X
+SQL Parquet Vectorized: DataPageV2                 1878           1893          20          5.6         179.1       5.4X
+SQL Parquet MR: DataPageV1                         3785           3797          18          2.8         360.9       2.7X
+SQL Parquet MR: DataPageV2                         3813           3826          18          2.8         363.6       2.7X
+SQL ORC Vectorized                                 1813           1828          21          5.8         172.9       5.6X
+SQL ORC MR                                         3449           3496          67          3.0         328.9       2.9X
 
 
 ================================================================================================
 Repeated String Scan
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Repeated String:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            5438           5462          34          1.9         518.6       1.0X
-SQL Json                                           6336           6347          15          1.7         604.3       0.9X
-SQL Parquet Vectorized: DataPageV1                  353            357           4         29.7          33.7      15.4X
-SQL Parquet Vectorized: DataPageV2                  350            358           8         30.0          33.3      15.6X
-SQL Parquet MR: DataPageV1                         1493           1502          13          7.0         142.4       3.6X
-SQL Parquet MR: DataPageV2                         1475           1480           6          7.1         140.7       3.7X
-SQL ORC Vectorized                                  368            373           5         28.5          35.1      14.8X
-SQL ORC MR                                         1627           1630           5          6.4         155.2       3.3X
+SQL CSV                                            5547           5552           6          1.9         529.0       1.0X
+SQL Json                                           6313           6324          16          1.7         602.0       0.9X
+SQL Parquet Vectorized: DataPageV1                  446            459          15         23.5          42.6      12.4X
+SQL Parquet Vectorized: DataPageV2                  446            462          14         23.5          42.5      12.4X
+SQL Parquet MR: DataPageV1                         1563           1595          45          6.7         149.1       3.5X
+SQL Parquet MR: DataPageV2                         1553           1553           1          6.8         148.1       3.6X
+SQL ORC Vectorized                                  370            375          10         28.4          35.2      15.0X
+SQL ORC MR                                         1682           1694          16          6.2         160.4       3.3X
 
 
 ================================================================================================
 Partitioned Table Scan
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Partitioned Table:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------
-Data column - CSV                                          14498          14503           7          1.1         921.7       1.0X
-Data column - Json                                         10115          10119           6          1.6         643.1       1.4X
-Data column - Parquet Vectorized: DataPageV1                 118            141          17        133.7           7.5     123.2X
-Data column - Parquet Vectorized: DataPageV2                 202            243          31         77.7          12.9      71.6X
-Data column - Parquet MR: DataPageV1                        2578           2609          44          6.1         163.9       5.6X
-Data column - Parquet MR: DataPageV2                        2193           2200          10          7.2         139.5       6.6X
-Data column - ORC Vectorized                                 173            195          22         90.7          11.0      83.6X
-Data column - ORC MR                                        2048           2054           9          7.7         130.2       7.1X
-Partition column - CSV                                      4442           4442           0          3.5         282.4       3.3X
-Partition column - Json                                     8948           9056         153          1.8         568.9       1.6X
-Partition column - Parquet Vectorized: DataPageV1             24             30           5        653.3           1.5     602.2X
-Partition column - Parquet Vectorized: DataPageV2             23             30           6        685.9           1.5     632.2X
-Partition column - Parquet MR: DataPageV1                   1186           1192           8         13.3          75.4      12.2X
-Partition column - Parquet MR: DataPageV2                   1174           1201          38         13.4          74.7      12.3X
-Partition column - ORC Vectorized                             24             29           5        663.7           1.5     611.8X
-Partition column - ORC MR                                   1241           1249          10         12.7          78.9      11.7X
-Both columns - CSV                                         14578          14580           3          1.1         926.9       1.0X
-Both columns - Json                                        10814          10828          19          1.5         687.5       1.3X
-Both columns - Parquet Vectorized: DataPageV1                164            173           4         96.0          10.4      88.5X
-Both columns - Parquet Vectorized: DataPageV2                239            258          28         65.7          15.2      60.6X
-Both columns - Parquet MR: DataPageV1                       2474           2490          23          6.4         157.3       5.9X
-Both columns - Parquet MR: DataPageV2                       2219           2244          35          7.1         141.1       6.5X
-Both columns - ORC Vectorized                                213            224          12         73.9          13.5      68.1X
-Both columns - ORC MR                                       2036           2041           7          7.7         129.5       7.1X
+Data column - CSV                                          14467          14620         216          1.1         919.8       1.0X
+Data column - Json                                         10116          10126          15          1.6         643.2       1.4X
+Data column - Parquet Vectorized: DataPageV1                 133            151          19        118.7           8.4     109.2X
+Data column - Parquet Vectorized: DataPageV2                 201            228          15         78.3          12.8      72.0X
+Data column - Parquet MR: DataPageV1                        2541           2554          17          6.2         161.6       5.7X
+Data column - Parquet MR: DataPageV2                        2271           2287          23          6.9         144.4       6.4X
+Data column - ORC Vectorized                                 194            210          18         81.2          12.3      74.7X
+Data column - ORC MR                                        2080           2087          10          7.6         132.3       7.0X
+Partition column - CSV                                      4074           4124          71          3.9         259.0       3.6X
+Partition column - Json                                     8412           8417           8          1.9         534.8       1.7X
+Partition column - Parquet Vectorized: DataPageV1             22             30           7        722.7           1.4     664.7X
+Partition column - Parquet Vectorized: DataPageV2             21             28           8        759.8           1.3     698.8X
+Partition column - Parquet MR: DataPageV1                   1190           1191           2         13.2          75.6      12.2X
+Partition column - Parquet MR: DataPageV2                   1209           1260          72         13.0          76.9      12.0X
+Partition column - ORC Vectorized                             21             26           6        742.4           1.3     682.9X
+Partition column - ORC MR                                   1255           1261           9         12.5          79.8      11.5X
+Both columns - CSV                                         14695          14705          14          1.1         934.3       1.0X
+Both columns - Json                                        10540          10554          21          1.5         670.1       1.4X
+Both columns - Parquet Vectorized: DataPageV1                153            177          19        103.0           9.7      94.8X
+Both columns - Parquet Vectorized: DataPageV2                233            253          14         67.5          14.8      62.1X
+Both columns - Parquet MR: DataPageV1                       2519           2634         162          6.2         160.1       5.7X
+Both columns - Parquet MR: DataPageV2                       2274           2298          34          6.9         144.6       6.4X
+Both columns - ORC Vectorized                                228            244          15         69.0          14.5      63.4X
+Both columns - ORC MR                                       2250           2252           3          7.0         143.0       6.4X
 
 
 ================================================================================================
 String with Nulls Scan
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 String with Nulls Scan (0.0%):            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            7138           7186          69          1.5         680.7       1.0X
-SQL Json                                           8395           8397           3          1.2         800.6       0.9X
-SQL Parquet Vectorized: DataPageV1                 1022           1036          19         10.3          97.5       7.0X
-SQL Parquet Vectorized: DataPageV2                 1292           1298           9          8.1         123.2       5.5X
-SQL Parquet MR: DataPageV1                         3263           3272          13          3.2         311.1       2.2X
-SQL Parquet MR: DataPageV2                         3228           3264          52          3.2         307.8       2.2X
-ParquetReader Vectorized: DataPageV1                704            708           4         14.9          67.1      10.1X
-ParquetReader Vectorized: DataPageV2               1044           1048           5         10.0          99.6       6.8X
-SQL ORC Vectorized                                  900            915          15         11.6          85.8       7.9X
-SQL ORC MR                                         2734           2743          14          3.8         260.7       2.6X
+SQL CSV                                            7048           7068          29          1.5         672.1       1.0X
+SQL Json                                           8609           8610           2          1.2         821.0       0.8X
+SQL Parquet Vectorized: DataPageV1                 1053           1055           2         10.0         100.5       6.7X
+SQL Parquet Vectorized: DataPageV2                 1373           1390          23          7.6         131.0       5.1X
+SQL Parquet MR: DataPageV1                         3412           3421          12          3.1         325.4       2.1X
+SQL Parquet MR: DataPageV2                         3547           3585          54          3.0         338.2       2.0X
+ParquetReader Vectorized: DataPageV1                700            712          11         15.0          66.8      10.1X
+ParquetReader Vectorized: DataPageV2               1016           1037          30         10.3          96.9       6.9X
+SQL ORC Vectorized                                  828            839          16         12.7          78.9       8.5X
+SQL ORC MR                                         2728           2748          29          3.8         260.2       2.6X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 String with Nulls Scan (50.0%):           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            5193           5195           3          2.0         495.2       1.0X
-SQL Json                                           7642           7646           5          1.4         728.8       0.7X
-SQL Parquet Vectorized: DataPageV1                  704            711          11         14.9          67.2       7.4X
-SQL Parquet Vectorized: DataPageV2                  937            959          33         11.2          89.3       5.5X
-SQL Parquet MR: DataPageV1                         2471           2482          16          4.2         235.6       2.1X
-SQL Parquet MR: DataPageV2                         2635           2648          18          4.0         251.3       2.0X
-ParquetReader Vectorized: DataPageV1                672            674           2         15.6          64.1       7.7X
-ParquetReader Vectorized: DataPageV2                850            864          14         12.3          81.1       6.1X
-SQL ORC Vectorized                                  966            979          16         10.9          92.1       5.4X
-SQL ORC MR                                         2597           2612          20          4.0         247.7       2.0X
+SQL CSV                                            5321           5335          20          2.0         507.4       1.0X
+SQL Json                                           7232           7241          14          1.5         689.7       0.7X
+SQL Parquet Vectorized: DataPageV1                  733            748          17         14.3          70.0       7.3X
+SQL Parquet Vectorized: DataPageV2                  933            949          19         11.2          89.0       5.7X
+SQL Parquet MR: DataPageV1                         2520           2533          19          4.2         240.3       2.1X
+SQL Parquet MR: DataPageV2                         2620           2621           1          4.0         249.9       2.0X
+ParquetReader Vectorized: DataPageV1                670            689          23         15.7          63.9       7.9X
+ParquetReader Vectorized: DataPageV2                896            909          22         11.7          85.4       5.9X
+SQL ORC Vectorized                                  976            984           8         10.7          93.1       5.5X
+SQL ORC MR                                         2696           2727          44          3.9         257.1       2.0X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 String with Nulls Scan (95.0%):           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            3813           3847          47          2.7         363.7       1.0X
-SQL Json                                           5464           5491          37          1.9         521.1       0.7X
-SQL Parquet Vectorized: DataPageV1                  150            156           6         70.1          14.3      25.5X
-SQL Parquet Vectorized: DataPageV2                  180            186           6         58.3          17.1      21.2X
-SQL Parquet MR: DataPageV1                         1574           1590          23          6.7         150.1       2.4X
-SQL Parquet MR: DataPageV2                         1559           1575          23          6.7         148.7       2.4X
-ParquetReader Vectorized: DataPageV1                140            142           3         74.9          13.4      27.2X
-ParquetReader Vectorized: DataPageV2                167            170           2         62.8          15.9      22.8X
-SQL ORC Vectorized                                  323            333           7         32.5          30.8      11.8X
-SQL ORC MR                                         1510           1539          41          6.9         144.0       2.5X
+SQL CSV                                            4117           4130          17          2.5         392.7       1.0X
+SQL Json                                           5173           5182          13          2.0         493.3       0.8X
+SQL Parquet Vectorized: DataPageV1                  157            163           5         66.8          15.0      26.2X
+SQL Parquet Vectorized: DataPageV2                  186            193           8         56.3          17.7      22.1X
+SQL Parquet MR: DataPageV1                         1588           1602          19          6.6         151.5       2.6X
+SQL Parquet MR: DataPageV2                         1557           1579          32          6.7         148.5       2.6X
+ParquetReader Vectorized: DataPageV1                169            172           2         61.9          16.1      24.3X
+ParquetReader Vectorized: DataPageV2                199            201           2         52.8          19.0      20.7X
+SQL ORC Vectorized                                  321            327           6         32.7          30.6      12.8X
+SQL ORC MR                                         1516           1527          15          6.9         144.6       2.7X
 
 
 ================================================================================================
 Single Column Scan From Wide Columns
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Single Column Scan from 10 columns:       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            1527           1533           8          0.7        1456.4       1.0X
-SQL Json                                           2009           2035          36          0.5        1916.2       0.8X
-SQL Parquet Vectorized: DataPageV1                   25             30           6         41.9          23.9      61.1X
-SQL Parquet Vectorized: DataPageV2                   36             39           4         29.1          34.4      42.4X
-SQL Parquet MR: DataPageV1                          171            179           6          6.1         163.1       8.9X
-SQL Parquet MR: DataPageV2                          149            170          35          7.1         141.6      10.3X
-SQL ORC Vectorized                                   31             37           6         33.4          29.9      48.7X
-SQL ORC MR                                          129            134           5          8.1         123.3      11.8X
+SQL CSV                                            1666           1668           3          0.6        1588.6       1.0X
+SQL Json                                           1824           1832          12          0.6        1739.3       0.9X
+SQL Parquet Vectorized: DataPageV1                   24             27           5         44.4          22.5      70.5X
+SQL Parquet Vectorized: DataPageV2                   34             44          22         30.5          32.8      48.4X
+SQL Parquet MR: DataPageV1                          169            175           5          6.2         161.2       9.9X
+SQL Parquet MR: DataPageV2                          148            154           7          7.1         140.9      11.3X
+SQL ORC Vectorized                                   31             36           6         34.3          29.1      54.5X
+SQL ORC MR                                          129            137           9          8.1         123.4      12.9X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Single Column Scan from 50 columns:       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            3360           3372          17          0.3        3203.9       1.0X
-SQL Json                                           7377           7426          70          0.1        7034.9       0.5X
-SQL Parquet Vectorized: DataPageV1                   32             37           6         32.4          30.9     103.7X
-SQL Parquet Vectorized: DataPageV2                   42             48           5         24.8          40.3      79.6X
-SQL Parquet MR: DataPageV1                          182            187           5          5.8         173.3      18.5X
-SQL Parquet MR: DataPageV2                          161            166           5          6.5         153.4      20.9X
-SQL ORC Vectorized                                   40             45           6         26.0          38.5      83.2X
-SQL ORC MR                                          144            148           3          7.3         137.4      23.3X
+SQL CSV                                            3691           3692           2          0.3        3519.7       1.0X
+SQL Json                                           6500           6536          51          0.2        6199.1       0.6X
+SQL Parquet Vectorized: DataPageV1                   31             36           7         34.2          29.2     120.5X
+SQL Parquet Vectorized: DataPageV2                   36             42           6         29.0          34.5     101.9X
+SQL Parquet MR: DataPageV1                          183            189           4          5.7         174.3      20.2X
+SQL Parquet MR: DataPageV2                          158            163           7          6.6         150.4      23.4X
+SQL ORC Vectorized                                   39             42           5         27.0          37.1      94.9X
+SQL ORC MR                                          142            145           4          7.4         135.1      26.0X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Single Column Scan from 100 columns:      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            5731           5732           2          0.2        5465.3       1.0X
-SQL Json                                          11202          11362         226          0.1       10682.7       0.5X
-SQL Parquet Vectorized: DataPageV1                   46             51           5         22.6          44.3     123.5X
-SQL Parquet Vectorized: DataPageV2                   52             58           6         20.1          49.7     110.0X
-SQL Parquet MR: DataPageV1                          203            208           5          5.2         193.3      28.3X
-SQL Parquet MR: DataPageV2                          182            186           4          5.8         173.2      31.6X
-SQL ORC Vectorized                                   52             60           9         20.2          49.5     110.4X
-SQL ORC MR                                          155            160           3          6.7         148.2      36.9X
+SQL CSV                                            6212           6336         175          0.2        5924.5       1.0X
+SQL Json                                          11851          11928         109          0.1       11302.0       0.5X
+SQL Parquet Vectorized: DataPageV1                   47             59          13         22.3          44.8     132.2X
+SQL Parquet Vectorized: DataPageV2                   50             59           9         20.9          47.9     123.7X
+SQL Parquet MR: DataPageV1                          198            207           6          5.3         188.4      31.5X
+SQL Parquet MR: DataPageV2                          179            182           3          5.8         170.9      34.7X
+SQL ORC Vectorized                                   50             57           6         21.2          47.3     125.4X
+SQL ORC MR                                          152            160          15          6.9         145.1      40.8X
 
 

--- a/sql/core/benchmarks/DataSourceReadBenchmark-results.txt
+++ b/sql/core/benchmarks/DataSourceReadBenchmark-results.txt
@@ -2,430 +2,430 @@
 SQL Single Numeric Column Scan
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 SQL Single BOOLEAN Column Scan:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           10079          10084           7          1.6         640.8       1.0X
-SQL Json                                           8230           8241          15          1.9         523.2       1.2X
-SQL Parquet Vectorized: DataPageV1                   71             81           9        222.9           4.5     142.8X
-SQL Parquet Vectorized: DataPageV2                   51             61           6        306.0           3.3     196.1X
-SQL Parquet MR: DataPageV1                         1782           1784           3          8.8         113.3       5.7X
-SQL Parquet MR: DataPageV2                         1685           1695          14          9.3         107.1       6.0X
-SQL ORC Vectorized                                  112            127          16        140.2           7.1      89.9X
-SQL ORC MR                                         1689           1692           3          9.3         107.4       6.0X
+SQL CSV                                           10647          10823         249          1.5         676.9       1.0X
+SQL Json                                           6941           7058         165          2.3         441.3       1.5X
+SQL Parquet Vectorized: DataPageV1                   69             81           7        226.7           4.4     153.4X
+SQL Parquet Vectorized: DataPageV2                   50             63           9        314.7           3.2     213.0X
+SQL Parquet MR: DataPageV1                         1829           1831           3          8.6         116.3       5.8X
+SQL Parquet MR: DataPageV2                         1654           1663          13          9.5         105.1       6.4X
+SQL ORC Vectorized                                  110            119          14        142.7           7.0      96.6X
+SQL ORC MR                                         1541           1546           7         10.2          98.0       6.9X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Parquet Reader Single BOOLEAN Column Scan:   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized: DataPageV1                    36             38           2        435.0           2.3       1.0X
-ParquetReader Vectorized: DataPageV2                    26             27           1        599.4           1.7       1.4X
-ParquetReader Vectorized -> Row: DataPageV1             29             30           1        536.9           1.9       1.2X
-ParquetReader Vectorized -> Row: DataPageV2             19             20           2        818.6           1.2       1.9X
+ParquetReader Vectorized: DataPageV1                    34             36           2        463.3           2.2       1.0X
+ParquetReader Vectorized: DataPageV2                    25             25           1        637.5           1.6       1.4X
+ParquetReader Vectorized -> Row: DataPageV1             27             29           1        576.5           1.7       1.2X
+ParquetReader Vectorized -> Row: DataPageV2             18             19           1        875.6           1.1       1.9X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 SQL Single TINYINT Column Scan:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           12081          12116          49          1.3         768.1       1.0X
-SQL Json                                           9405           9406           2          1.7         598.0       1.3X
-SQL Parquet Vectorized: DataPageV1                   78             89          11        200.4           5.0     154.0X
-SQL Parquet Vectorized: DataPageV2                   77             89          12        203.0           4.9     155.9X
-SQL Parquet MR: DataPageV1                         1876           1880           5          8.4         119.3       6.4X
-SQL Parquet MR: DataPageV2                         1782           1790          11          8.8         113.3       6.8X
-SQL ORC Vectorized                                  110            116           6        142.7           7.0     109.6X
-SQL ORC MR                                         1485           1489           5         10.6          94.4       8.1X
+SQL CSV                                           11525          11588          89          1.4         732.7       1.0X
+SQL Json                                           8941           8941           0          1.8         568.5       1.3X
+SQL Parquet Vectorized: DataPageV1                   74             83           8        212.7           4.7     155.8X
+SQL Parquet Vectorized: DataPageV2                   70             79           8        224.1           4.5     164.2X
+SQL Parquet MR: DataPageV1                         1878           1889          15          8.4         119.4       6.1X
+SQL Parquet MR: DataPageV2                         1761           1776          22          8.9         112.0       6.5X
+SQL ORC Vectorized                                  121            127           4        129.8           7.7      95.1X
+SQL ORC MR                                         1415           1416           2         11.1          90.0       8.1X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Parquet Reader Single TINYINT Column Scan:   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized: DataPageV1                    71             72           1        221.1           4.5       1.0X
-ParquetReader Vectorized: DataPageV2                    71             72           2        220.9           4.5       1.0X
-ParquetReader Vectorized -> Row: DataPageV1             51             52           1        307.5           3.3       1.4X
-ParquetReader Vectorized -> Row: DataPageV2             52             53           3        304.5           3.3       1.4X
+ParquetReader Vectorized: DataPageV1                    64             67           1        246.7           4.1       1.0X
+ParquetReader Vectorized: DataPageV2                    66             68           1        236.6           4.2       1.0X
+ParquetReader Vectorized -> Row: DataPageV1             46             48           1        339.0           2.9       1.4X
+ParquetReader Vectorized -> Row: DataPageV2             46             47           1        340.6           2.9       1.4X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 SQL Single SMALLINT Column Scan:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           12636          12666          43          1.2         803.4       1.0X
-SQL Json                                           9452           9455           5          1.7         600.9       1.3X
-SQL Parquet Vectorized: DataPageV1                   92             99           5        170.1           5.9     136.6X
-SQL Parquet Vectorized: DataPageV2                  112            118           8        140.7           7.1     113.1X
-SQL Parquet MR: DataPageV1                         2156           2161           7          7.3         137.0       5.9X
-SQL Parquet MR: DataPageV2                         1896           1926          42          8.3         120.5       6.7X
-SQL ORC Vectorized                                  142            146           4        111.1           9.0      89.2X
-SQL ORC MR                                         1584           1589           7          9.9         100.7       8.0X
+SQL CSV                                           12453          12512          82          1.3         791.8       1.0X
+SQL Json                                           8788           8809          30          1.8         558.7       1.4X
+SQL Parquet Vectorized: DataPageV1                   84             91           6        186.6           5.4     147.7X
+SQL Parquet Vectorized: DataPageV2                  109            116           6        144.9           6.9     114.7X
+SQL Parquet MR: DataPageV1                         1965           1971           8          8.0         124.9       6.3X
+SQL Parquet MR: DataPageV2                         2000           2004           6          7.9         127.1       6.2X
+SQL ORC Vectorized                                  141            146           4        111.2           9.0      88.0X
+SQL ORC MR                                         1615           1628          19          9.7         102.7       7.7X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Parquet Reader Single SMALLINT Column Scan:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized: DataPageV1                   147            148           1        107.1           9.3       1.0X
-ParquetReader Vectorized: DataPageV2                   164            165           2         96.1          10.4       0.9X
-ParquetReader Vectorized -> Row: DataPageV1            144            146           1        108.9           9.2       1.0X
-ParquetReader Vectorized -> Row: DataPageV2            162            163           1         97.1          10.3       0.9X
+ParquetReader Vectorized: DataPageV1                   136            138           1        115.9           8.6       1.0X
+ParquetReader Vectorized: DataPageV2                   162            165           1         96.9          10.3       0.8X
+ParquetReader Vectorized -> Row: DataPageV1            126            132           3        124.6           8.0       1.1X
+ParquetReader Vectorized -> Row: DataPageV2            152            157           3        103.6           9.7       0.9X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 SQL Single INT Column Scan:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           13705          13722          24          1.1         871.3       1.0X
-SQL Json                                           9745           9757          17          1.6         619.6       1.4X
-SQL Parquet Vectorized: DataPageV1                   84             89           5        188.0           5.3     163.8X
-SQL Parquet Vectorized: DataPageV2                  156            162           5        101.1           9.9      88.1X
-SQL Parquet MR: DataPageV1                         2152           2176          34          7.3         136.8       6.4X
-SQL Parquet MR: DataPageV2                         2001           2027          37          7.9         127.2       6.8X
-SQL ORC Vectorized                                  160            171          18         98.2          10.2      85.6X
-SQL ORC MR                                         1627           1635          11          9.7         103.4       8.4X
+SQL CSV                                           13049          13067          25          1.2         829.7       1.0X
+SQL Json                                           9333           9372          55          1.7         593.4       1.4X
+SQL Parquet Vectorized: DataPageV1                   82             86           3        191.4           5.2     158.8X
+SQL Parquet Vectorized: DataPageV2                  144            149           3        109.2           9.2      90.6X
+SQL Parquet MR: DataPageV1                         1899           1902           5          8.3         120.7       6.9X
+SQL Parquet MR: DataPageV2                         1811           1811           0          8.7         115.1       7.2X
+SQL ORC Vectorized                                  154            160           3        102.3           9.8      84.9X
+SQL ORC MR                                         1606           1616          15          9.8         102.1       8.1X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Parquet Reader Single INT Column Scan:       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized: DataPageV1                   137            138           1        114.7           8.7       1.0X
-ParquetReader Vectorized: DataPageV2                   209            211           1         75.2          13.3       0.7X
-ParquetReader Vectorized -> Row: DataPageV1            134            136           2        117.2           8.5       1.0X
-ParquetReader Vectorized -> Row: DataPageV2            209            219           9         75.3          13.3       0.7X
+ParquetReader Vectorized: DataPageV1                   137            139           2        114.4           8.7       1.0X
+ParquetReader Vectorized: DataPageV2                   204            205           1         77.1          13.0       0.7X
+ParquetReader Vectorized -> Row: DataPageV1            135            137           2        116.8           8.6       1.0X
+ParquetReader Vectorized -> Row: DataPageV2            204            206           2         77.2          13.0       0.7X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 SQL Single BIGINT Column Scan:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           17416          17550         189          0.9        1107.3       1.0X
-SQL Json                                          10793          10795           2          1.5         686.2       1.6X
-SQL Parquet Vectorized: DataPageV1                  134            145          10        117.3           8.5     129.9X
-SQL Parquet Vectorized: DataPageV2                  271            276           4         58.0          17.2      64.2X
-SQL Parquet MR: DataPageV1                         2321           2326           6          6.8         147.6       7.5X
-SQL Parquet MR: DataPageV2                         2066           2067           2          7.6         131.3       8.4X
-SQL ORC Vectorized                                  242            259          16         65.0          15.4      72.0X
-SQL ORC MR                                         1747           1761          20          9.0         111.1      10.0X
+SQL CSV                                           16969          17266         420          0.9        1078.9       1.0X
+SQL Json                                           9995          10082         123          1.6         635.5       1.7X
+SQL Parquet Vectorized: DataPageV1                  130            139           7        120.6           8.3     130.1X
+SQL Parquet Vectorized: DataPageV2                  217            223           6         72.6          13.8      78.3X
+SQL Parquet MR: DataPageV1                         2275           2284          12          6.9         144.7       7.5X
+SQL Parquet MR: DataPageV2                         2041           2066          36          7.7         129.7       8.3X
+SQL ORC Vectorized                                  228            236          11         69.0          14.5      74.4X
+SQL ORC MR                                         1749           1778          41          9.0         111.2       9.7X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Parquet Reader Single BIGINT Column Scan:    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized: DataPageV1                   186            189           4         84.6          11.8       1.0X
-ParquetReader Vectorized: DataPageV2                   325            339          28         48.4          20.6       0.6X
-ParquetReader Vectorized -> Row: DataPageV1            184            187           5         85.4          11.7       1.0X
-ParquetReader Vectorized -> Row: DataPageV2            322            327           5         48.9          20.4       0.6X
+ParquetReader Vectorized: DataPageV1                   186            190           2         84.4          11.8       1.0X
+ParquetReader Vectorized: DataPageV2                   270            275           4         58.3          17.1       0.7X
+ParquetReader Vectorized -> Row: DataPageV1            179            183           3         87.9          11.4       1.0X
+ParquetReader Vectorized -> Row: DataPageV2            264            268           3         59.6          16.8       0.7X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 SQL Single FLOAT Column Scan:             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           14078          14147          98          1.1         895.1       1.0X
-SQL Json                                          11715          11758          61          1.3         744.8       1.2X
-SQL Parquet Vectorized: DataPageV1                   83             97           8        189.0           5.3     169.2X
-SQL Parquet Vectorized: DataPageV2                   84             97           9        186.5           5.4     166.9X
-SQL Parquet MR: DataPageV1                         2043           2077          48          7.7         129.9       6.9X
-SQL Parquet MR: DataPageV2                         2000           2012          16          7.9         127.2       7.0X
-SQL ORC Vectorized                                  279            286           8         56.4          17.7      50.5X
-SQL ORC MR                                         1846           1850           6          8.5         117.4       7.6X
+SQL CSV                                           13601          13628          38          1.2         864.7       1.0X
+SQL Json                                          11414          11484          99          1.4         725.7       1.2X
+SQL Parquet Vectorized: DataPageV1                   82             95           8        192.3           5.2     166.3X
+SQL Parquet Vectorized: DataPageV2                   82             94           9        192.1           5.2     166.1X
+SQL Parquet MR: DataPageV1                         1933           1961          40          8.1         122.9       7.0X
+SQL Parquet MR: DataPageV2                         1826           1866          57          8.6         116.1       7.4X
+SQL ORC Vectorized                                  273            287           9         57.6          17.4      49.8X
+SQL ORC MR                                         1757           1759           4          9.0         111.7       7.7X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Parquet Reader Single FLOAT Column Scan:     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized: DataPageV1                   132            135           6        119.3           8.4       1.0X
-ParquetReader Vectorized: DataPageV2                   131            135           6        119.8           8.3       1.0X
-ParquetReader Vectorized -> Row: DataPageV1            146            153           6        107.5           9.3       0.9X
-ParquetReader Vectorized -> Row: DataPageV2            131            142          11        120.1           8.3       1.0X
+ParquetReader Vectorized: DataPageV1                   126            130           3        125.2           8.0       1.0X
+ParquetReader Vectorized: DataPageV2                   131            133           2        120.3           8.3       1.0X
+ParquetReader Vectorized -> Row: DataPageV1            142            147           5        110.9           9.0       0.9X
+ParquetReader Vectorized -> Row: DataPageV2            140            147           3        112.1           8.9       0.9X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 SQL Single DOUBLE Column Scan:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           18033          18103          99          0.9        1146.5       1.0X
-SQL Json                                          14967          14968           2          1.1         951.6       1.2X
-SQL Parquet Vectorized: DataPageV1                  134            143           9        117.8           8.5     135.0X
-SQL Parquet Vectorized: DataPageV2                  134            144          14        117.3           8.5     134.5X
-SQL Parquet MR: DataPageV1                         2394           2403          12          6.6         152.2       7.5X
-SQL Parquet MR: DataPageV2                         2219           2222           5          7.1         141.1       8.1X
-SQL ORC Vectorized                                  332            366          30         47.4          21.1      54.3X
-SQL ORC MR                                         1970           1977          10          8.0         125.3       9.2X
+SQL CSV                                           17938          18207         381          0.9        1140.5       1.0X
+SQL Json                                          13872          14036         232          1.1         882.0       1.3X
+SQL Parquet Vectorized: DataPageV1                  131            140           6        119.9           8.3     136.7X
+SQL Parquet Vectorized: DataPageV2                  136            141           4        116.0           8.6     132.3X
+SQL Parquet MR: DataPageV1                         2338           2340           2          6.7         148.7       7.7X
+SQL Parquet MR: DataPageV2                         2121           2149          40          7.4         134.8       8.5X
+SQL ORC Vectorized                                  317            338          17         49.6          20.2      56.6X
+SQL ORC MR                                         1740           1749          13          9.0         110.6      10.3X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Parquet Reader Single DOUBLE Column Scan:    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized: DataPageV1                   185            193          15         85.0          11.8       1.0X
-ParquetReader Vectorized: DataPageV2                   185            197           8         85.1          11.8       1.0X
-ParquetReader Vectorized -> Row: DataPageV1            184            190           7         85.3          11.7       1.0X
-ParquetReader Vectorized -> Row: DataPageV2            184            187           2         85.6          11.7       1.0X
+ParquetReader Vectorized: DataPageV1                   174            178           6         90.3          11.1       1.0X
+ParquetReader Vectorized: DataPageV2                   174            177           4         90.4          11.1       1.0X
+ParquetReader Vectorized -> Row: DataPageV1            173            178           4         90.9          11.0       1.0X
+ParquetReader Vectorized -> Row: DataPageV2            174            180           5         90.5          11.1       1.0X
 
 
 ================================================================================================
 SQL Single Numeric Column Scan in Struct
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 SQL Single TINYINT Column Scan in Struct:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------
-SQL ORC MR                                                            2203           2257          78          7.1         140.0       1.0X
-SQL ORC Vectorized (Nested Column Disabled)                           2319           2334          21          6.8         147.4       0.9X
-SQL ORC Vectorized (Nested Column Enabled)                             201            210          14         78.2          12.8      11.0X
-SQL Parquet MR: DataPageV1                                            2326           2353          39          6.8         147.9       0.9X
-SQL Parquet Vectorized: DataPageV1 (Nested Column Disabled)           2772           2783          15          5.7         176.2       0.8X
-SQL Parquet Vectorized: DataPageV1 (Nested Column Enabled)              90            113          16        175.4           5.7      24.6X
-SQL Parquet MR: DataPageV2                                            2293           2304          15          6.9         145.8       1.0X
-SQL Parquet Vectorized: DataPageV2 (Nested Column Disabled)           2733           2749          23          5.8         173.8       0.8X
-SQL Parquet Vectorized: DataPageV2 (Nested Column Enabled)              85             91           5        184.0           5.4      25.8X
+SQL ORC MR                                                            2120           2151          43          7.4         134.8       1.0X
+SQL ORC Vectorized (Nested Column Disabled)                           2067           2077          14          7.6         131.4       1.0X
+SQL ORC Vectorized (Nested Column Enabled)                             186            194           9         84.5          11.8      11.4X
+SQL Parquet MR: DataPageV1                                            2441           2474          47          6.4         155.2       0.9X
+SQL Parquet Vectorized: DataPageV1 (Nested Column Disabled)           2728           2741          18          5.8         173.5       0.8X
+SQL Parquet Vectorized: DataPageV1 (Nested Column Enabled)              92            103          10        171.1           5.8      23.1X
+SQL Parquet MR: DataPageV2                                            2236           2263          38          7.0         142.2       0.9X
+SQL Parquet Vectorized: DataPageV2 (Nested Column Disabled)           2527           2568          58          6.2         160.7       0.8X
+SQL Parquet Vectorized: DataPageV2 (Nested Column Enabled)              91             98           7        172.0           5.8      23.2X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 SQL Single SMALLINT Column Scan in Struct:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------
-SQL ORC MR                                                            2296           2373         110          6.9         145.9       1.0X
-SQL ORC Vectorized (Nested Column Disabled)                           2457           2499          59          6.4         156.2       0.9X
-SQL ORC Vectorized (Nested Column Enabled)                             279            287           5         56.3          17.8       8.2X
-SQL Parquet MR: DataPageV1                                            2521           2525           5          6.2         160.3       0.9X
-SQL Parquet Vectorized: DataPageV1 (Nested Column Disabled)           3105           3105           1          5.1         197.4       0.7X
-SQL Parquet Vectorized: DataPageV1 (Nested Column Enabled)              95            100           4        165.5           6.0      24.1X
-SQL Parquet MR: DataPageV2                                            2329           2332           5          6.8         148.1       1.0X
-SQL Parquet Vectorized: DataPageV2 (Nested Column Disabled)           2743           2754          15          5.7         174.4       0.8X
-SQL Parquet Vectorized: DataPageV2 (Nested Column Enabled)             235            248          13         66.8          15.0       9.8X
+SQL ORC MR                                                            1945           1969          34          8.1         123.6       1.0X
+SQL ORC Vectorized (Nested Column Disabled)                           1924           1936          17          8.2         122.3       1.0X
+SQL ORC Vectorized (Nested Column Enabled)                             254            265          13         62.0          16.1       7.7X
+SQL Parquet MR: DataPageV1                                            2379           2397          25          6.6         151.3       0.8X
+SQL Parquet Vectorized: DataPageV1 (Nested Column Disabled)           2750           2763          18          5.7         174.8       0.7X
+SQL Parquet Vectorized: DataPageV1 (Nested Column Enabled)              93            110          10        168.9           5.9      20.9X
+SQL Parquet MR: DataPageV2                                            2376           2379           4          6.6         151.1       0.8X
+SQL Parquet Vectorized: DataPageV2 (Nested Column Disabled)           2739           2757          26          5.7         174.2       0.7X
+SQL Parquet Vectorized: DataPageV2 (Nested Column Enabled)             241            249           8         65.2          15.3       8.1X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 SQL Single INT Column Scan in Struct:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------
-SQL ORC MR                                                            2232           2280          68          7.0         141.9       1.0X
-SQL ORC Vectorized (Nested Column Disabled)                           2095           2123          40          7.5         133.2       1.1X
-SQL ORC Vectorized (Nested Column Enabled)                             295            301           6         53.3          18.8       7.6X
-SQL Parquet MR: DataPageV1                                            2477           2486          12          6.3         157.5       0.9X
-SQL Parquet Vectorized: DataPageV1 (Nested Column Disabled)           2886           2945          84          5.5         183.5       0.8X
-SQL Parquet Vectorized: DataPageV1 (Nested Column Enabled)             108            121           9        145.2           6.9      20.6X
-SQL Parquet MR: DataPageV2                                            2410           2417           9          6.5         153.2       0.9X
-SQL Parquet Vectorized: DataPageV2 (Nested Column Disabled)           2741           2773          46          5.7         174.2       0.8X
-SQL Parquet Vectorized: DataPageV2 (Nested Column Enabled)             255            268          17         61.6          16.2       8.7X
+SQL ORC MR                                                            2021           2032          16          7.8         128.5       1.0X
+SQL ORC Vectorized (Nested Column Disabled)                           1999           2004           7          7.9         127.1       1.0X
+SQL ORC Vectorized (Nested Column Enabled)                             278            291          10         56.6          17.7       7.3X
+SQL Parquet MR: DataPageV1                                            2420           2436          24          6.5         153.8       0.8X
+SQL Parquet Vectorized: DataPageV1 (Nested Column Disabled)           2930           2933           3          5.4         186.3       0.7X
+SQL Parquet Vectorized: DataPageV1 (Nested Column Enabled)             108            120           6        145.2           6.9      18.7X
+SQL Parquet MR: DataPageV2                                            2343           2364          30          6.7         149.0       0.9X
+SQL Parquet Vectorized: DataPageV2 (Nested Column Disabled)           2739           2747          12          5.7         174.1       0.7X
+SQL Parquet Vectorized: DataPageV2 (Nested Column Enabled)             235            252          10         67.0          14.9       8.6X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 SQL Single BIGINT Column Scan in Struct:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------
-SQL ORC MR                                                            2268           2281          18          6.9         144.2       1.0X
-SQL ORC Vectorized (Nested Column Disabled)                           2284           2287           4          6.9         145.2       1.0X
-SQL ORC Vectorized (Nested Column Enabled)                             364            391          15         43.3          23.1       6.2X
-SQL Parquet MR: DataPageV1                                            2625           2629           5          6.0         166.9       0.9X
-SQL Parquet Vectorized: DataPageV1 (Nested Column Disabled)           3093           3113          28          5.1         196.6       0.7X
-SQL Parquet Vectorized: DataPageV1 (Nested Column Enabled)             148            155           7        106.1           9.4      15.3X
-SQL Parquet MR: DataPageV2                                            2406           2415          13          6.5         153.0       0.9X
-SQL Parquet Vectorized: DataPageV2 (Nested Column Disabled)           2780           2782           3          5.7         176.8       0.8X
-SQL Parquet Vectorized: DataPageV2 (Nested Column Enabled)             315            344          32         50.0          20.0       7.2X
+SQL ORC MR                                                            2543           2557          20          6.2         161.7       1.0X
+SQL ORC Vectorized (Nested Column Disabled)                           2473           2483          14          6.4         157.2       1.0X
+SQL ORC Vectorized (Nested Column Enabled)                             354            357           3         44.5          22.5       7.2X
+SQL Parquet MR: DataPageV1                                            2729           2736          10          5.8         173.5       0.9X
+SQL Parquet Vectorized: DataPageV1 (Nested Column Disabled)           3241           3261          29          4.9         206.0       0.8X
+SQL Parquet Vectorized: DataPageV1 (Nested Column Enabled)             151            162           7        103.9           9.6      16.8X
+SQL Parquet MR: DataPageV2                                            2381           2385           5          6.6         151.4       1.1X
+SQL Parquet Vectorized: DataPageV2 (Nested Column Disabled)           2881           2890          13          5.5         183.2       0.9X
+SQL Parquet Vectorized: DataPageV2 (Nested Column Enabled)             207            224          10         75.9          13.2      12.3X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 SQL Single FLOAT Column Scan in Struct:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------
-SQL ORC MR                                                            2334           2365          44          6.7         148.4       1.0X
-SQL ORC Vectorized (Nested Column Disabled)                           2352           2353           0          6.7         149.6       1.0X
-SQL ORC Vectorized (Nested Column Enabled)                             396            403           7         39.7          25.2       5.9X
-SQL Parquet MR: DataPageV1                                            2486           2519          46          6.3         158.0       0.9X
-SQL Parquet Vectorized: DataPageV1 (Nested Column Disabled)           2958           2972          19          5.3         188.1       0.8X
-SQL Parquet Vectorized: DataPageV1 (Nested Column Enabled)              91            109          13        173.1           5.8      25.7X
-SQL Parquet MR: DataPageV2                                            2385           2386           2          6.6         151.6       1.0X
-SQL Parquet Vectorized: DataPageV2 (Nested Column Disabled)           2848           2852           6          5.5         181.1       0.8X
-SQL Parquet Vectorized: DataPageV2 (Nested Column Enabled)              93            109          11        169.4           5.9      25.1X
+SQL ORC MR                                                            2340           2411         101          6.7         148.7       1.0X
+SQL ORC Vectorized (Nested Column Disabled)                           2339           2344           8          6.7         148.7       1.0X
+SQL ORC Vectorized (Nested Column Enabled)                             382            399          18         41.2          24.3       6.1X
+SQL Parquet MR: DataPageV1                                            2336           2337           1          6.7         148.5       1.0X
+SQL Parquet Vectorized: DataPageV1 (Nested Column Disabled)           2813           2846          47          5.6         178.8       0.8X
+SQL Parquet Vectorized: DataPageV1 (Nested Column Enabled)              86             90           3        182.7           5.5      27.2X
+SQL Parquet MR: DataPageV2                                            2185           2204          27          7.2         138.9       1.1X
+SQL Parquet Vectorized: DataPageV2 (Nested Column Disabled)           2668           2686          24          5.9         169.7       0.9X
+SQL Parquet Vectorized: DataPageV2 (Nested Column Enabled)              89            108          11        176.5           5.7      26.3X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 SQL Single DOUBLE Column Scan in Struct:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------
-SQL ORC MR                                                            2337           2430         132          6.7         148.6       1.0X
-SQL ORC Vectorized (Nested Column Disabled)                           2535           2543          11          6.2         161.2       0.9X
-SQL ORC Vectorized (Nested Column Enabled)                             498            514          11         31.6          31.6       4.7X
-SQL Parquet MR: DataPageV1                                            2585           2591           8          6.1         164.4       0.9X
-SQL Parquet Vectorized: DataPageV1 (Nested Column Disabled)           3113           3118           7          5.1         197.9       0.8X
-SQL Parquet Vectorized: DataPageV1 (Nested Column Enabled)             134            152          12        117.8           8.5      17.5X
-SQL Parquet MR: DataPageV2                                            2458           2468          13          6.4         156.3       1.0X
-SQL Parquet Vectorized: DataPageV2 (Nested Column Disabled)           2948           2953           8          5.3         187.4       0.8X
-SQL Parquet Vectorized: DataPageV2 (Nested Column Enabled)             139            150           9        112.8           8.9      16.8X
+SQL ORC MR                                                            2410           2470          85          6.5         153.3       1.0X
+SQL ORC Vectorized (Nested Column Disabled)                           2371           2416          64          6.6         150.7       1.0X
+SQL ORC Vectorized (Nested Column Enabled)                             436            444           5         36.0          27.7       5.5X
+SQL Parquet MR: DataPageV1                                            2594           2612          24          6.1         165.0       0.9X
+SQL Parquet Vectorized: DataPageV1 (Nested Column Disabled)           2974           2976           3          5.3         189.1       0.8X
+SQL Parquet Vectorized: DataPageV1 (Nested Column Enabled)             122            142          15        128.5           7.8      19.7X
+SQL Parquet MR: DataPageV2                                            2496           2535          56          6.3         158.7       1.0X
+SQL Parquet Vectorized: DataPageV2 (Nested Column Disabled)           2939           2956          25          5.4         186.8       0.8X
+SQL Parquet Vectorized: DataPageV2 (Nested Column Enabled)             123            134           8        127.6           7.8      19.5X
 
 
 ================================================================================================
 SQL Nested Column Scan
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 SQL Nested Column Scan:                                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------
-SQL ORC MR                                                           12672          12741         103          0.1       12085.3       1.0X
-SQL ORC Vectorized (Nested Column Disabled)                          12718          12778          83          0.1       12128.9       1.0X
-SQL ORC Vectorized (Nested Column Enabled)                            7075           7102          24          0.1        6747.5       1.8X
-SQL Parquet MR: DataPageV1                                            8766           8927         120          0.1        8359.9       1.4X
-SQL Parquet Vectorized: DataPageV1 (Nested Column Disabled)           9067           9195         118          0.1        8646.7       1.4X
-SQL Parquet Vectorized: DataPageV1 (Nested Column Enabled)            5850           5949          52          0.2        5578.9       2.2X
-SQL Parquet MR: DataPageV2                                            9363           9377          11          0.1        8929.6       1.4X
-SQL Parquet Vectorized: DataPageV2 (Nested Column Disabled)           9670           9694          15          0.1        9222.5       1.3X
-SQL Parquet Vectorized: DataPageV2 (Nested Column Enabled)            5684           5714          26          0.2        5420.3       2.2X
+SQL ORC MR                                                           12423          12679         228          0.1       11847.3       1.0X
+SQL ORC Vectorized (Nested Column Disabled)                          12318          12555         202          0.1       11747.0       1.0X
+SQL ORC Vectorized (Nested Column Enabled)                            6878           7081         141          0.2        6559.4       1.8X
+SQL Parquet MR: DataPageV1                                            8502           8686         140          0.1        8108.5       1.5X
+SQL Parquet Vectorized: DataPageV1 (Nested Column Disabled)           8877           9163         201          0.1        8465.5       1.4X
+SQL Parquet Vectorized: DataPageV1 (Nested Column Enabled)            5488           5609         113          0.2        5233.6       2.3X
+SQL Parquet MR: DataPageV2                                            9062           9238         146          0.1        8642.7       1.4X
+SQL Parquet Vectorized: DataPageV2 (Nested Column Disabled)           9379           9518         147          0.1        8944.5       1.3X
+SQL Parquet Vectorized: DataPageV2 (Nested Column Enabled)            5354           5459          95          0.2        5105.9       2.3X
 
 
 ================================================================================================
 Int and String Scan
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Int and String Scan:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           12234          12362         181          0.9        1166.7       1.0X
-SQL Json                                          10416          10419           4          1.0         993.3       1.2X
-SQL Parquet Vectorized: DataPageV1                 1754           1756           3          6.0         167.2       7.0X
-SQL Parquet Vectorized: DataPageV2                 1970           1979          13          5.3         187.9       6.2X
-SQL Parquet MR: DataPageV1                         3982           4007          35          2.6         379.8       3.1X
-SQL Parquet MR: DataPageV2                         3949           3978          42          2.7         376.6       3.1X
-SQL ORC Vectorized                                 1809           1816          10          5.8         172.5       6.8X
-SQL ORC MR                                         3531           3537           9          3.0         336.7       3.5X
+SQL CSV                                           12174          12192          25          0.9        1161.0       1.0X
+SQL Json                                           9906           9947          58          1.1         944.8       1.2X
+SQL Parquet Vectorized: DataPageV1                 1575           1609          48          6.7         150.2       7.7X
+SQL Parquet Vectorized: DataPageV2                 1728           1741          18          6.1         164.8       7.0X
+SQL Parquet MR: DataPageV1                         3713           3714           1          2.8         354.1       3.3X
+SQL Parquet MR: DataPageV2                         3775           3794          26          2.8         360.0       3.2X
+SQL ORC Vectorized                                 1848           1852           5          5.7         176.3       6.6X
+SQL ORC MR                                         3671           3703          45          2.9         350.1       3.3X
 
 
 ================================================================================================
 Repeated String Scan
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Repeated String:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            7196           7240          61          1.5         686.3       1.0X
-SQL Json                                           6584           6588           6          1.6         627.9       1.1X
-SQL Parquet Vectorized: DataPageV1                  368            377          10         28.5          35.1      19.5X
-SQL Parquet Vectorized: DataPageV2                  387            389           2         27.1          36.9      18.6X
-SQL Parquet MR: DataPageV1                         1802           1807           7          5.8         171.8       4.0X
-SQL Parquet MR: DataPageV2                         1717           1718           2          6.1         163.7       4.2X
-SQL ORC Vectorized                                  388            397           7         27.1          37.0      18.6X
-SQL ORC MR                                         1770           1775           8          5.9         168.8       4.1X
+SQL CSV                                            7541           7554          18          1.4         719.2       1.0X
+SQL Json                                           6087           6089           4          1.7         580.5       1.2X
+SQL Parquet Vectorized: DataPageV1                  361            369           7         29.0          34.5      20.9X
+SQL Parquet Vectorized: DataPageV2                  362            366           3         29.0          34.5      20.8X
+SQL Parquet MR: DataPageV1                         1861           1889          40          5.6         177.5       4.1X
+SQL Parquet MR: DataPageV2                         1867           1881          20          5.6         178.1       4.0X
+SQL ORC Vectorized                                  387            396           5         27.1          36.9      19.5X
+SQL ORC MR                                         1945           1971          38          5.4         185.4       3.9X
 
 
 ================================================================================================
 Partitioned Table Scan
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Partitioned Table:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------
-Data column - CSV                                          17659          17778         168          0.9        1122.7       1.0X
-Data column - Json                                         10769          10771           3          1.5         684.7       1.6X
-Data column - Parquet Vectorized: DataPageV1                 125            142          10        125.5           8.0     140.9X
-Data column - Parquet Vectorized: DataPageV2                 324            333           8         48.6          20.6      54.5X
-Data column - Parquet MR: DataPageV1                        2892           2916          33          5.4         183.9       6.1X
-Data column - Parquet MR: DataPageV2                        2587           2591           6          6.1         164.5       6.8X
-Data column - ORC Vectorized                                 225            251          25         69.8          14.3      78.4X
-Data column - ORC MR                                        2080           2100          29          7.6         132.2       8.5X
-Partition column - CSV                                      4417           4418           2          3.6         280.8       4.0X
-Partition column - Json                                     9255           9256           1          1.7         588.4       1.9X
-Partition column - Parquet Vectorized: DataPageV1             22             25           3        726.6           1.4     815.8X
-Partition column - Parquet Vectorized: DataPageV2             22             25           4        730.3           1.4     819.9X
-Partition column - Parquet MR: DataPageV1                   1244           1252          12         12.6          79.1      14.2X
-Partition column - Parquet MR: DataPageV2                   1237           1237           0         12.7          78.6      14.3X
-Partition column - ORC Vectorized                             23             27           4        689.5           1.5     774.1X
-Partition column - ORC MR                                   1269           1270           1         12.4          80.7      13.9X
-Both columns - CSV                                         17346          17353          10          0.9        1102.8       1.0X
-Both columns - Json                                        11289          11291           3          1.4         717.7       1.6X
-Both columns - Parquet Vectorized: DataPageV1                180            193          10         87.5          11.4      98.3X
-Both columns - Parquet Vectorized: DataPageV2                373            385          12         42.2          23.7      47.4X
-Both columns - Parquet MR: DataPageV1                       2619           2636          23          6.0         166.5       6.7X
-Both columns - Parquet MR: DataPageV2                       2377           2405          39          6.6         151.1       7.4X
-Both columns - ORC Vectorized                                228            239          19         69.1          14.5      77.6X
-Both columns - ORC MR                                       2075           2079           5          7.6         131.9       8.5X
+Data column - CSV                                          18182          18286         148          0.9        1155.9       1.0X
+Data column - Json                                          9913           9932          27          1.6         630.2       1.8X
+Data column - Parquet Vectorized: DataPageV1                 140            153          12        112.2           8.9     129.7X
+Data column - Parquet Vectorized: DataPageV2                 209            235          13         75.1          13.3      86.8X
+Data column - Parquet MR: DataPageV1                        2682           2702          28          5.9         170.5       6.8X
+Data column - Parquet MR: DataPageV2                        2365           2405          57          6.7         150.4       7.7X
+Data column - ORC Vectorized                                 253            271          13         62.3          16.1      72.0X
+Data column - ORC MR                                        2044           2058          19          7.7         130.0       8.9X
+Partition column - CSV                                      4172           4178           8          3.8         265.3       4.4X
+Partition column - Json                                     8800           8845          64          1.8         559.5       2.1X
+Partition column - Parquet Vectorized: DataPageV1             22             26           4        714.8           1.4     826.2X
+Partition column - Parquet Vectorized: DataPageV2             22             24           3        721.0           1.4     833.5X
+Partition column - Parquet MR: DataPageV1                   1239           1241           2         12.7          78.8      14.7X
+Partition column - Parquet MR: DataPageV2                   1194           1203          12         13.2          75.9      15.2X
+Partition column - ORC Vectorized                             22             25           4        727.0           1.4     840.3X
+Partition column - ORC MR                                   1207           1210           4         13.0          76.7      15.1X
+Both columns - CSV                                         17724          17883         225          0.9        1126.8       1.0X
+Both columns - Json                                        10325          10491         234          1.5         656.5       1.8X
+Both columns - Parquet Vectorized: DataPageV1                185            197          13         85.2          11.7      98.5X
+Both columns - Parquet Vectorized: DataPageV2                291            298           6         54.0          18.5      62.4X
+Both columns - Parquet MR: DataPageV1                       2669           2686          23          5.9         169.7       6.8X
+Both columns - Parquet MR: DataPageV2                       2285           2341          79          6.9         145.3       8.0X
+Both columns - ORC Vectorized                                260            279          25         60.5          16.5      70.0X
+Both columns - ORC MR                                       2067           2068           1          7.6         131.4       8.8X
 
 
 ================================================================================================
 String with Nulls Scan
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 String with Nulls Scan (0.0%):            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            8692           8725          47          1.2         828.9       1.0X
-SQL Json                                           8800           8809          12          1.2         839.3       1.0X
-SQL Parquet Vectorized: DataPageV1                 1181           1191          14          8.9         112.7       7.4X
-SQL Parquet Vectorized: DataPageV2                 1480           1483           5          7.1         141.1       5.9X
-SQL Parquet MR: DataPageV1                         3708           3720          17          2.8         353.6       2.3X
-SQL Parquet MR: DataPageV2                         3693           3770         108          2.8         352.2       2.4X
-ParquetReader Vectorized: DataPageV1                775            777           2         13.5          73.9      11.2X
-ParquetReader Vectorized: DataPageV2               1065           1067           2          9.8         101.6       8.2X
-SQL ORC Vectorized                                  882            899          18         11.9          84.1       9.9X
-SQL ORC MR                                         2876           2898          31          3.6         274.3       3.0X
+SQL CSV                                            8405           8412          10          1.2         801.5       1.0X
+SQL Json                                           8690           8735          64          1.2         828.8       1.0X
+SQL Parquet Vectorized: DataPageV1                 1016           1021           7         10.3          96.9       8.3X
+SQL Parquet Vectorized: DataPageV2                 1276           1285          14          8.2         121.7       6.6X
+SQL Parquet MR: DataPageV1                         3372           3374           2          3.1         321.6       2.5X
+SQL Parquet MR: DataPageV2                         3376           3459         116          3.1         322.0       2.5X
+ParquetReader Vectorized: DataPageV1                656            663           7         16.0          62.6      12.8X
+ParquetReader Vectorized: DataPageV2                858            874          15         12.2          81.8       9.8X
+SQL ORC Vectorized                                  965            988          28         10.9          92.0       8.7X
+SQL ORC MR                                         2970           3002          45          3.5         283.3       2.8X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 String with Nulls Scan (50.0%):           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            6208           6213           7          1.7         592.0       1.0X
-SQL Json                                           7652           7662          13          1.4         729.8       0.8X
-SQL Parquet Vectorized: DataPageV1                  821            830           8         12.8          78.3       7.6X
-SQL Parquet Vectorized: DataPageV2                 1011           1018          11         10.4          96.4       6.1X
-SQL Parquet MR: DataPageV1                         2756           2758           2          3.8         262.8       2.3X
-SQL Parquet MR: DataPageV2                         2948           2963          22          3.6         281.1       2.1X
-ParquetReader Vectorized: DataPageV1                783            784           1         13.4          74.7       7.9X
-ParquetReader Vectorized: DataPageV2                890            909          17         11.8          84.9       7.0X
-SQL ORC Vectorized                                  956            963           7         11.0          91.2       6.5X
-SQL ORC MR                                         2637           2651          19          4.0         251.5       2.4X
+SQL CSV                                            6260           6331         100          1.7         597.0       1.0X
+SQL Json                                           7294           7346          75          1.4         695.6       0.9X
+SQL Parquet Vectorized: DataPageV1                  699            712          13         15.0          66.6       9.0X
+SQL Parquet Vectorized: DataPageV2                  869            886          20         12.1          82.9       7.2X
+SQL Parquet MR: DataPageV1                         2630           2643          19          4.0         250.8       2.4X
+SQL Parquet MR: DataPageV2                         2789           2831          60          3.8         266.0       2.2X
+ParquetReader Vectorized: DataPageV1                695            703          10         15.1          66.3       9.0X
+ParquetReader Vectorized: DataPageV2                754            766          10         13.9          71.9       8.3X
+SQL ORC Vectorized                                 1008           1009           1         10.4          96.1       6.2X
+SQL ORC MR                                         2924           2930           8          3.6         278.8       2.1X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 String with Nulls Scan (95.0%):           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            4289           4308          28          2.4         409.0       1.0X
-SQL Json                                           5465           5466           1          1.9         521.1       0.8X
-SQL Parquet Vectorized: DataPageV1                  164            168           4         64.0          15.6      26.2X
-SQL Parquet Vectorized: DataPageV2                  186            190           2         56.3          17.8      23.0X
-SQL Parquet MR: DataPageV1                         1741           1744           5          6.0         166.0       2.5X
-SQL Parquet MR: DataPageV2                         1663           1670          10          6.3         158.6       2.6X
-ParquetReader Vectorized: DataPageV1                167            169           2         62.8          15.9      25.7X
-ParquetReader Vectorized: DataPageV2                189            191           3         55.5          18.0      22.7X
-SQL ORC Vectorized                                  298            299           2         35.2          28.4      14.4X
-SQL ORC MR                                         1563           1568           7          6.7         149.1       2.7X
+SQL CSV                                            4105           4121          22          2.6         391.5       1.0X
+SQL Json                                           5090           5132          60          2.1         485.4       0.8X
+SQL Parquet Vectorized: DataPageV1                  154            156           2         68.2          14.7      26.7X
+SQL Parquet Vectorized: DataPageV2                  176            179           3         59.6          16.8      23.3X
+SQL Parquet MR: DataPageV1                         1739           1741           2          6.0         165.9       2.4X
+SQL Parquet MR: DataPageV2                         1704           1706           3          6.2         162.5       2.4X
+ParquetReader Vectorized: DataPageV1                157            159           1         66.6          15.0      26.1X
+ParquetReader Vectorized: DataPageV2                171            174           1         61.4          16.3      24.0X
+SQL ORC Vectorized                                  313            320           6         33.5          29.9      13.1X
+SQL ORC MR                                         1567           1571           6          6.7         149.5       2.6X
 
 
 ================================================================================================
 Single Column Scan From Wide Columns
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Single Column Scan from 10 columns:       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            1642           1642           0          0.6        1566.3       1.0X
-SQL Json                                           2065           2066           2          0.5        1969.4       0.8X
-SQL Parquet Vectorized: DataPageV1                   26             29           3         40.9          24.5      64.0X
-SQL Parquet Vectorized: DataPageV2                   37             40           3         28.6          35.0      44.8X
-SQL Parquet MR: DataPageV1                          180            186           7          5.8         171.6       9.1X
-SQL Parquet MR: DataPageV2                          157            161           5          6.7         149.5      10.5X
-SQL ORC Vectorized                                   34             39           6         31.1          32.1      48.7X
-SQL ORC MR                                          130            133           2          8.1         124.1      12.6X
+SQL CSV                                            1593           1595           3          0.7        1519.2       1.0X
+SQL Json                                           1992           1992           0          0.5        1899.9       0.8X
+SQL Parquet Vectorized: DataPageV1                   25             28           4         41.6          24.0      63.2X
+SQL Parquet Vectorized: DataPageV2                   30             35           6         34.7          28.8      52.7X
+SQL Parquet MR: DataPageV1                          170            175           4          6.2         162.2       9.4X
+SQL Parquet MR: DataPageV2                          149            155           6          7.0         142.4      10.7X
+SQL ORC Vectorized                                   32             36           4         32.4          30.9      49.1X
+SQL ORC MR                                          126            130           3          8.3         119.9      12.7X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Single Column Scan from 50 columns:       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            3681           3707          36          0.3        3510.8       1.0X
-SQL Json                                           7350           7377          39          0.1        7009.2       0.5X
-SQL Parquet Vectorized: DataPageV1                   32             36           4         33.2          30.2     116.4X
-SQL Parquet Vectorized: DataPageV2                   43             49           5         24.3          41.2      85.2X
-SQL Parquet MR: DataPageV1                          193            195           2          5.4         183.7      19.1X
-SQL Parquet MR: DataPageV2                          170            173           3          6.2         162.3      21.6X
-SQL ORC Vectorized                                   42             45           4         25.1          39.8      88.3X
-SQL ORC MR                                          142            151          16          7.4         135.5      25.9X
+SQL CSV                                            3602           3616          20          0.3        3434.9       1.0X
+SQL Json                                           6952           7118         235          0.2        6629.8       0.5X
+SQL Parquet Vectorized: DataPageV1                   32             38           5         33.1          30.2     113.8X
+SQL Parquet Vectorized: DataPageV2                   37             41           5         28.5          35.1      97.8X
+SQL Parquet MR: DataPageV1                          183            187           2          5.7         174.8      19.6X
+SQL Parquet MR: DataPageV2                          163            168           4          6.4         155.7      22.1X
+SQL ORC Vectorized                                   41             44           4         25.6          39.1      87.9X
+SQL ORC MR                                          135            140           7          7.7         129.1      26.6X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Single Column Scan from 100 columns:      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            6277           6282           7          0.2        5986.3       1.0X
-SQL Json                                          13654          13947         415          0.1       13021.0       0.5X
-SQL Parquet Vectorized: DataPageV1                   45             51           6         23.4          42.8     139.8X
-SQL Parquet Vectorized: DataPageV2                   56             60           4         18.7          53.5     111.9X
-SQL Parquet MR: DataPageV1                          209            212           3          5.0         199.0      30.1X
-SQL Parquet MR: DataPageV2                          190            200           8          5.5         181.5      33.0X
-SQL ORC Vectorized                                   51             56           6         20.4          48.9     122.4X
-SQL ORC MR                                          150            152           2          7.0         142.9      41.9X
+SQL CSV                                            6136           6164          39          0.2        5852.1       1.0X
+SQL Json                                          12984          13108         175          0.1       12382.5       0.5X
+SQL Parquet Vectorized: DataPageV1                   47             51           5         22.3          44.8     130.7X
+SQL Parquet Vectorized: DataPageV2                   50             56           6         20.8          48.2     121.5X
+SQL Parquet MR: DataPageV1                          204            211           4          5.1         194.8      30.0X
+SQL Parquet MR: DataPageV2                          179            186           3          5.9         170.3      34.4X
+SQL ORC Vectorized                                   51             54           4         20.6          48.5     120.6X
+SQL ORC MR                                          146            155           8          7.2         139.4      42.0X
 
 

--- a/sql/core/benchmarks/FilterPushdownBenchmark-jdk21-results.txt
+++ b/sql/core/benchmarks/FilterPushdownBenchmark-jdk21-results.txt
@@ -2,733 +2,733 @@
 Pushdown for many distinct value case
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 0 string row (value IS NULL):      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                 6300           6424         117          2.5         400.6       1.0X
-Parquet Vectorized (Pushdown)                       302            320          11         52.1          19.2      20.9X
-Native ORC Vectorized                              5732           5796          88          2.7         364.4       1.1X
-Native ORC Vectorized (Pushdown)                    515            530           9         30.5          32.8      12.2X
+Parquet Vectorized                                 6598           6767         128          2.4         419.5       1.0X
+Parquet Vectorized (Pushdown)                       292            304          14         53.8          18.6      22.6X
+Native ORC Vectorized                              7341           7411          88          2.1         466.7       0.9X
+Native ORC Vectorized (Pushdown)                    282            291          10         55.7          18.0      23.4X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 0 string row ('7864320' < value < '7864320'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                            6320           6358          28          2.5         401.8       1.0X
-Parquet Vectorized (Pushdown)                                  284            298           7         55.4          18.0      22.3X
-Native ORC Vectorized                                         5825           5856          30          2.7         370.4       1.1X
-Native ORC Vectorized (Pushdown)                               494            515          21         31.9          31.4      12.8X
+Parquet Vectorized                                            6631           6653          20          2.4         421.6       1.0X
+Parquet Vectorized (Pushdown)                                  288            299          15         54.7          18.3      23.1X
+Native ORC Vectorized                                         7453           7468          19          2.1         473.8       0.9X
+Native ORC Vectorized (Pushdown)                               280            287           9         56.2          17.8      23.7X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 1 string row (value = '7864320'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                 6312           6338          22          2.5         401.3       1.0X
-Parquet Vectorized (Pushdown)                       272            279           6         57.7          17.3      23.2X
-Native ORC Vectorized                              5834           5845          12          2.7         370.9       1.1X
-Native ORC Vectorized (Pushdown)                    479            493           9         32.8          30.5      13.2X
+Parquet Vectorized                                 6635           6654          17          2.4         421.9       1.0X
+Parquet Vectorized (Pushdown)                       271            282           9         58.1          17.2      24.5X
+Native ORC Vectorized                              7482           7512          35          2.1         475.7       0.9X
+Native ORC Vectorized (Pushdown)                    268            277           4         58.6          17.1      24.7X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 1 string row (value <=> '7864320'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                  6305           6316          10          2.5         400.8       1.0X
-Parquet Vectorized (Pushdown)                        269            280           8         58.5          17.1      23.4X
-Native ORC Vectorized                               5782           5798          16          2.7         367.6       1.1X
-Native ORC Vectorized (Pushdown)                     471            486          13         33.4          29.9      13.4X
+Parquet Vectorized                                  6622           6633          10          2.4         421.0       1.0X
+Parquet Vectorized (Pushdown)                        262            270           9         60.1          16.6      25.3X
+Native ORC Vectorized                               7413           7429          15          2.1         471.3       0.9X
+Native ORC Vectorized (Pushdown)                     261            268           6         60.3          16.6      25.4X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 1 string row ('7864320' <= value <= '7864320'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                              6279           6293          12          2.5         399.2       1.0X
-Parquet Vectorized (Pushdown)                                    271            280           9         58.0          17.2      23.2X
-Native ORC Vectorized                                           5784           5795           7          2.7         367.8       1.1X
-Native ORC Vectorized (Pushdown)                                 477            483           5         33.0          30.3      13.2X
+Parquet Vectorized                                              6597           6632          34          2.4         419.4       1.0X
+Parquet Vectorized (Pushdown)                                    260            268           7         60.5          16.5      25.4X
+Native ORC Vectorized                                           7453           7467          11          2.1         473.9       0.9X
+Native ORC Vectorized (Pushdown)                                 261            270           7         60.3          16.6      25.3X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select all string rows (value IS NOT NULL):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                  12601          12652          32          1.2         801.1       1.0X
-Parquet Vectorized (Pushdown)                       12644          12659          19          1.2         803.9       1.0X
-Native ORC Vectorized                               12072          12079           8          1.3         767.5       1.0X
-Native ORC Vectorized (Pushdown)                    12213          12221           6          1.3         776.5       1.0X
+Parquet Vectorized                                  12805          12872          92          1.2         814.1       1.0X
+Parquet Vectorized (Pushdown)                       12833          12851          14          1.2         815.9       1.0X
+Native ORC Vectorized                               13594          13615          16          1.2         864.3       0.9X
+Native ORC Vectorized (Pushdown)                    13626          13637          11          1.2         866.3       0.9X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 0 int row (value IS NULL):         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                 6081           6223         134          2.6         386.6       1.0X
-Parquet Vectorized (Pushdown)                       289            310          22         54.3          18.4      21.0X
-Native ORC Vectorized                              5227           5248          39          3.0         332.3       1.2X
-Native ORC Vectorized (Pushdown)                    483            491           9         32.5          30.7      12.6X
+Parquet Vectorized                                 6401           6574         131          2.5         407.0       1.0X
+Parquet Vectorized (Pushdown)                       240            248           7         65.6          15.2      26.7X
+Native ORC Vectorized                              6666           6703          34          2.4         423.8       1.0X
+Native ORC Vectorized (Pushdown)                    262            269          10         60.0          16.7      24.4X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 0 int row (7864320 < value < 7864320):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                     6023           6036          17          2.6         382.9       1.0X
-Parquet Vectorized (Pushdown)                           245            262          14         64.1          15.6      24.5X
-Native ORC Vectorized                                  5191           5212          15          3.0         330.0       1.2X
-Native ORC Vectorized (Pushdown)                        472            482           9         33.3          30.0      12.8X
+Parquet Vectorized                                     6299           6330          35          2.5         400.5       1.0X
+Parquet Vectorized (Pushdown)                           238            251           9         66.0          15.2      26.4X
+Native ORC Vectorized                                  6662           6673          13          2.4         423.6       0.9X
+Native ORC Vectorized (Pushdown)                        256            268           9         61.3          16.3      24.6X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 1 int row (value = 7864320):       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                 6061           6083          22          2.6         385.4       1.0X
-Parquet Vectorized (Pushdown)                       241            246           4         65.2          15.3      25.1X
-Native ORC Vectorized                              5258           5264           6          3.0         334.3       1.2X
-Native ORC Vectorized (Pushdown)                    469            481           8         33.6          29.8      12.9X
+Parquet Vectorized                                 6374           6395          20          2.5         405.3       1.0X
+Parquet Vectorized (Pushdown)                       239            244           4         65.7          15.2      26.6X
+Native ORC Vectorized                              6699           6745          40          2.3         425.9       1.0X
+Native ORC Vectorized (Pushdown)                    255            262           7         61.6          16.2      25.0X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 1 int row (value <=> 7864320):     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                 6046           6073          20          2.6         384.4       1.0X
-Parquet Vectorized (Pushdown)                       241            247           4         65.4          15.3      25.1X
-Native ORC Vectorized                              5255           5264           9          3.0         334.1       1.2X
-Native ORC Vectorized (Pushdown)                    459            470           7         34.3          29.2      13.2X
+Parquet Vectorized                                 6363           6385          26          2.5         404.6       1.0X
+Parquet Vectorized (Pushdown)                       234            241           4         67.1          14.9      27.1X
+Native ORC Vectorized                              6725           6750          22          2.3         427.5       0.9X
+Native ORC Vectorized (Pushdown)                    265            273          14         59.3          16.9      24.0X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 1 int row (7864320 <= value <= 7864320):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                       6055           6084          20          2.6         385.0       1.0X
-Parquet Vectorized (Pushdown)                             242            251           8         65.1          15.4      25.1X
-Native ORC Vectorized                                    5245           5256          10          3.0         333.5       1.2X
-Native ORC Vectorized (Pushdown)                          463            468           3         33.9          29.5      13.1X
+Parquet Vectorized                                       6363           6399          37          2.5         404.5       1.0X
+Parquet Vectorized (Pushdown)                             236            241           5         66.7          15.0      27.0X
+Native ORC Vectorized                                    6762           6771          14          2.3         429.9       0.9X
+Native ORC Vectorized (Pushdown)                          246            256           4         63.9          15.7      25.8X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 1 int row (7864319 < value < 7864321):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                     6052           6057           5          2.6         384.8       1.0X
-Parquet Vectorized (Pushdown)                           240            247           4         65.6          15.2      25.2X
-Native ORC Vectorized                                  5215           5228          17          3.0         331.6       1.2X
-Native ORC Vectorized (Pushdown)                        460            475          10         34.2          29.3      13.2X
+Parquet Vectorized                                     6365           6401          38          2.5         404.7       1.0X
+Parquet Vectorized (Pushdown)                           236            240           5         66.8          15.0      27.0X
+Native ORC Vectorized                                  6734           6775          46          2.3         428.2       0.9X
+Native ORC Vectorized (Pushdown)                        250            255           4         62.8          15.9      25.4X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 10% int rows (value < 1572864):    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                 6601           6629          25          2.4         419.6       1.0X
-Parquet Vectorized (Pushdown)                      1408           1420          13         11.2          89.5       4.7X
-Native ORC Vectorized                              5816           5823           6          2.7         369.7       1.1X
-Native ORC Vectorized (Pushdown)                   1543           1554           9         10.2          98.1       4.3X
+Parquet Vectorized                                 6968           6990          14          2.3         443.0       1.0X
+Parquet Vectorized (Pushdown)                      1456           1487          42         10.8          92.6       4.8X
+Native ORC Vectorized                              7284           7290           5          2.2         463.1       1.0X
+Native ORC Vectorized (Pushdown)                   1488           1497           8         10.6          94.6       4.7X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 50% int rows (value < 7864320):    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                 8660           8668           7          1.8         550.6       1.0X
-Parquet Vectorized (Pushdown)                      5830           5868          44          2.7         370.7       1.5X
-Native ORC Vectorized                              7965           7974          10          2.0         506.4       1.1X
-Native ORC Vectorized (Pushdown)                   5673           5701          19          2.8         360.7       1.5X
+Parquet Vectorized                                 9072           9082          11          1.7         576.8       1.0X
+Parquet Vectorized (Pushdown)                      6042           6065          21          2.6         384.1       1.5X
+Native ORC Vectorized                              9554           9580          17          1.6         607.4       0.9X
+Native ORC Vectorized (Pushdown)                   6387           6400           9          2.5         406.1       1.4X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 90% int rows (value < 14155776):   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                10679          10694          14          1.5         679.0       1.0X
-Parquet Vectorized (Pushdown)                     10153          10162           8          1.5         645.5       1.1X
-Native ORC Vectorized                             10253          10275          16          1.5         651.9       1.0X
-Native ORC Vectorized (Pushdown)                   9945           9994          57          1.6         632.3       1.1X
+Parquet Vectorized                                11048          11091          76          1.4         702.4       1.0X
+Parquet Vectorized (Pushdown)                     10456          10495          33          1.5         664.8       1.1X
+Native ORC Vectorized                             11624          11645          27          1.4         739.0       1.0X
+Native ORC Vectorized (Pushdown)                  11056          11072          11          1.4         702.9       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select all int rows (value IS NOT NULL):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                11396          11401           4          1.4         724.5       1.0X
-Parquet Vectorized (Pushdown)                     11420          11450          24          1.4         726.1       1.0X
-Native ORC Vectorized                             10569          10579           8          1.5         672.0       1.1X
-Native ORC Vectorized (Pushdown)                  10721          10748          27          1.5         681.7       1.1X
+Parquet Vectorized                                11720          11747          45          1.3         745.1       1.0X
+Parquet Vectorized (Pushdown)                     11773          11808          35          1.3         748.5       1.0X
+Native ORC Vectorized                             12040          12062          31          1.3         765.5       1.0X
+Native ORC Vectorized (Pushdown)                  12157          12179          20          1.3         772.9       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select all int rows (value > -1):         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                11458          11469           9          1.4         728.5       1.0X
-Parquet Vectorized (Pushdown)                     11491          11531          40          1.4         730.6       1.0X
-Native ORC Vectorized                             10853          10866          10          1.4         690.0       1.1X
-Native ORC Vectorized (Pushdown)                  10985          11025          56          1.4         698.4       1.0X
+Parquet Vectorized                                11640          11661          14          1.4         740.0       1.0X
+Parquet Vectorized (Pushdown)                     11704          11712          12          1.3         744.1       1.0X
+Native ORC Vectorized                             12188          12198          15          1.3         774.9       1.0X
+Native ORC Vectorized (Pushdown)                  12278          12297          19          1.3         780.6       0.9X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select all int rows (value != -1):        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                11384          11417          22          1.4         723.8       1.0X
-Parquet Vectorized (Pushdown)                     11420          11460          25          1.4         726.1       1.0X
-Native ORC Vectorized                             10381          10403          15          1.5         660.0       1.1X
-Native ORC Vectorized (Pushdown)                  10567          10578           9          1.5         671.8       1.1X
+Parquet Vectorized                                11714          11733          34          1.3         744.7       1.0X
+Parquet Vectorized (Pushdown)                     11740          11770          32          1.3         746.4       1.0X
+Native ORC Vectorized                             12037          12052          21          1.3         765.3       1.0X
+Native ORC Vectorized (Pushdown)                  12147          12177          31          1.3         772.3       1.0X
 
 
 ================================================================================================
 Pushdown for few distinct value case (use dictionary encoding)
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 0 distinct string row (value IS NULL):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                     5431           5493          46          2.9         345.3       1.0X
-Parquet Vectorized (Pushdown)                           222            241          17         71.0          14.1      24.5X
-Native ORC Vectorized                                  6188           6207          24          2.5         393.4       0.9X
-Native ORC Vectorized (Pushdown)                        880            893          19         17.9          55.9       6.2X
+Parquet Vectorized                                     5614           5679          76          2.8         356.9       1.0X
+Parquet Vectorized (Pushdown)                           201            206           4         78.3          12.8      27.9X
+Native ORC Vectorized                                  8246           8272          28          1.9         524.3       0.7X
+Native ORC Vectorized (Pushdown)                        844            855          10         18.6          53.7       6.6X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 0 distinct string row ('100' < value < '100'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                             5477           5490          13          2.9         348.2       1.0X
-Parquet Vectorized (Pushdown)                                   212            218           4         74.3          13.5      25.9X
-Native ORC Vectorized                                          6376           6380           3          2.5         405.4       0.9X
-Native ORC Vectorized (Pushdown)                                875            884          11         18.0          55.6       6.3X
+Parquet Vectorized                                             5720           5730           7          2.7         363.7       1.0X
+Parquet Vectorized (Pushdown)                                   203            206           3         77.7          12.9      28.2X
+Native ORC Vectorized                                          8400           8420          18          1.9         534.0       0.7X
+Native ORC Vectorized (Pushdown)                                843            862          14         18.7          53.6       6.8X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 1 distinct string row (value = '100'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                     5441           5455          14          2.9         345.9       1.0X
-Parquet Vectorized (Pushdown)                           255            268          15         61.8          16.2      21.4X
-Native ORC Vectorized                                  6336           6358          24          2.5         402.8       0.9X
-Native ORC Vectorized (Pushdown)                        908            921          12         17.3          57.7       6.0X
+Parquet Vectorized                                     5644           5663          16          2.8         358.8       1.0X
+Parquet Vectorized (Pushdown)                           248            257           8         63.5          15.8      22.8X
+Native ORC Vectorized                                  8364           8388          32          1.9         531.8       0.7X
+Native ORC Vectorized (Pushdown)                        898            906           8         17.5          57.1       6.3X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 1 distinct string row (value <=> '100'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                       5446           5465          14          2.9         346.3       1.0X
-Parquet Vectorized (Pushdown)                             249            254           4         63.1          15.8      21.9X
-Native ORC Vectorized                                    6367           6375           7          2.5         404.8       0.9X
-Native ORC Vectorized (Pushdown)                          929            935           5         16.9          59.0       5.9X
+Parquet Vectorized                                       5656           5668          10          2.8         359.6       1.0X
+Parquet Vectorized (Pushdown)                             246            250           4         63.9          15.6      23.0X
+Native ORC Vectorized                                    8336           8349          13          1.9         530.0       0.7X
+Native ORC Vectorized (Pushdown)                          879            894          10         17.9          55.9       6.4X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 1 distinct string row ('100' <= value <= '100'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                               5535           5546           9          2.8         351.9       1.0X
-Parquet Vectorized (Pushdown)                                     259            273          24         60.6          16.5      21.3X
-Native ORC Vectorized                                            6423           6440          20          2.4         408.4       0.9X
-Native ORC Vectorized (Pushdown)                                  923            933          11         17.0          58.7       6.0X
+Parquet Vectorized                                               5758           5763           5          2.7         366.1       1.0X
+Parquet Vectorized (Pushdown)                                     247            252           4         63.6          15.7      23.3X
+Native ORC Vectorized                                            8398           8442          32          1.9         533.9       0.7X
+Native ORC Vectorized (Pushdown)                                  896            903           7         17.6          57.0       6.4X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select all distinct string rows (value IS NOT NULL):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                           12137          12183          32          1.3         771.6       1.0X
-Parquet Vectorized (Pushdown)                                12175          12193          16          1.3         774.1       1.0X
-Native ORC Vectorized                                        13243          13282          35          1.2         841.9       0.9X
-Native ORC Vectorized (Pushdown)                             13527          13579          55          1.2         860.0       0.9X
+Parquet Vectorized                                           12870          12960          99          1.2         818.2       1.0X
+Parquet Vectorized (Pushdown)                                12923          12937          14          1.2         821.6       1.0X
+Native ORC Vectorized                                        15635          15671          23          1.0         994.0       0.8X
+Native ORC Vectorized (Pushdown)                             15933          15960          23          1.0        1013.0       0.8X
 
 
 ================================================================================================
 Pushdown benchmark for StringStartsWith
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 StringStartsWith filter: (value like '10%'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                    6767           6953         134          2.3         430.2       1.0X
-Parquet Vectorized (Pushdown)                          911           1004          89         17.3          57.9       7.4X
-Native ORC Vectorized                                 5984           6035          69          2.6         380.5       1.1X
-Native ORC Vectorized (Pushdown)                      6119           6155          40          2.6         389.0       1.1X
+Parquet Vectorized                                    7008           7221         212          2.2         445.5       1.0X
+Parquet Vectorized (Pushdown)                          960            977          25         16.4          61.0       7.3X
+Native ORC Vectorized                                 7499           7570          65          2.1         476.8       0.9X
+Native ORC Vectorized (Pushdown)                      7600           7628          37          2.1         483.2       0.9X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 StringStartsWith filter: (value like '1000%'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                      6421           6436          17          2.4         408.2       1.0X
-Parquet Vectorized (Pushdown)                            274            281           8         57.5          17.4      23.5X
-Native ORC Vectorized                                   5776           5789          16          2.7         367.2       1.1X
-Native ORC Vectorized (Pushdown)                        5939           5953          18          2.6         377.6       1.1X
+Parquet Vectorized                                      6718           6731          17          2.3         427.1       1.0X
+Parquet Vectorized (Pushdown)                            251            259           4         62.6          16.0      26.7X
+Native ORC Vectorized                                   7306           7323          21          2.2         464.5       0.9X
+Native ORC Vectorized (Pushdown)                        7413           7433          17          2.1         471.3       0.9X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 StringStartsWith filter: (value like '786432%'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                        6414           6423           9          2.5         407.8       1.0X
-Parquet Vectorized (Pushdown)                              266            287          17         59.1          16.9      24.1X
-Native ORC Vectorized                                     5841           5850           6          2.7         371.3       1.1X
-Native ORC Vectorized (Pushdown)                          5952           5964          11          2.6         378.4       1.1X
+Parquet Vectorized                                        6723           6729           5          2.3         427.4       1.0X
+Parquet Vectorized (Pushdown)                              235            255          16         66.9          15.0      28.6X
+Native ORC Vectorized                                     7301           7326          17          2.2         464.2       0.9X
+Native ORC Vectorized (Pushdown)                          7396           7420          30          2.1         470.2       0.9X
 
 
 ================================================================================================
 Pushdown benchmark for StringEndsWith
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 StringEndsWith filter: (value like '%10'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                  5497           5632         102          2.9         349.5       1.0X
-Parquet Vectorized (Pushdown)                        337            377          48         46.7          21.4      16.3X
-Native ORC Vectorized                               6391           6417          31          2.5         406.3       0.9X
-Native ORC Vectorized (Pushdown)                    6730           6760          24          2.3         427.9       0.8X
+Parquet Vectorized                                  5893           6058         178          2.7         374.7       1.0X
+Parquet Vectorized (Pushdown)                        453            503          63         34.7          28.8      13.0X
+Native ORC Vectorized                               8333           8385          76          1.9         529.8       0.7X
+Native ORC Vectorized (Pushdown)                    8576           8630          43          1.8         545.3       0.7X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 StringEndsWith filter: (value like '%1000'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                    5405           5437          19          2.9         343.6       1.0X
-Parquet Vectorized (Pushdown)                          250            256           7         62.8          15.9      21.6X
-Native ORC Vectorized                                 6422           6467          49          2.4         408.3       0.8X
-Native ORC Vectorized (Pushdown)                      6700           6717          17          2.3         426.0       0.8X
+Parquet Vectorized                                    5719           5754          29          2.8         363.6       1.0X
+Parquet Vectorized (Pushdown)                          251            267          15         62.7          15.9      22.8X
+Native ORC Vectorized                                 8256           8276          16          1.9         524.9       0.7X
+Native ORC Vectorized (Pushdown)                      8540           8576          29          1.8         542.9       0.7X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 StringEndsWith filter: (value like '%786432'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                      5442           5455          16          2.9         346.0       1.0X
-Parquet Vectorized (Pushdown)                            246            259          11         63.9          15.7      22.1X
-Native ORC Vectorized                                   6362           6386          29          2.5         404.5       0.9X
-Native ORC Vectorized (Pushdown)                        6653           6667          15          2.4         423.0       0.8X
+Parquet Vectorized                                      5666           5698          22          2.8         360.2       1.0X
+Parquet Vectorized (Pushdown)                            253            270          20         62.1          16.1      22.4X
+Native ORC Vectorized                                   8236           8261          21          1.9         523.6       0.7X
+Native ORC Vectorized (Pushdown)                        8600           8616          22          1.8         546.8       0.7X
 
 
 ================================================================================================
 Pushdown benchmark for StringContains
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 StringContains filter: (value like '%10%'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                   5748           5835          78          2.7         365.4       1.0X
-Parquet Vectorized (Pushdown)                         762            795          42         20.6          48.4       7.5X
-Native ORC Vectorized                                6553           6590          27          2.4         416.6       0.9X
-Native ORC Vectorized (Pushdown)                     6822           6862          26          2.3         433.7       0.8X
+Parquet Vectorized                                   6068           6240         126          2.6         385.8       1.0X
+Parquet Vectorized (Pushdown)                         877            910          37         17.9          55.8       6.9X
+Native ORC Vectorized                                8457           8509          44          1.9         537.7       0.7X
+Native ORC Vectorized (Pushdown)                     8721           8783          44          1.8         554.5       0.7X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 StringContains filter: (value like '%1000%'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                     5453           5468          16          2.9         346.7       1.0X
-Parquet Vectorized (Pushdown)                           249            257           7         63.2          15.8      21.9X
-Native ORC Vectorized                                  6339           6359          15          2.5         403.0       0.9X
-Native ORC Vectorized (Pushdown)                       6610           6644          24          2.4         420.2       0.8X
+Parquet Vectorized                                     5705           5762          50          2.8         362.7       1.0X
+Parquet Vectorized (Pushdown)                           243            276          23         64.8          15.4      23.5X
+Native ORC Vectorized                                  8189           8238          53          1.9         520.7       0.7X
+Native ORC Vectorized (Pushdown)                       8491           8531          36          1.9         539.8       0.7X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 StringContains filter: (value like '%786432%'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                       5429           5450          22          2.9         345.2       1.0X
-Parquet Vectorized (Pushdown)                             245            250           4         64.2          15.6      22.2X
-Native ORC Vectorized                                    6306           6323          22          2.5         400.9       0.9X
-Native ORC Vectorized (Pushdown)                         6610           6623          10          2.4         420.3       0.8X
+Parquet Vectorized                                       5657           5683          17          2.8         359.7       1.0X
+Parquet Vectorized (Pushdown)                             242            253           6         64.9          15.4      23.4X
+Native ORC Vectorized                                    8180           8201          18          1.9         520.1       0.7X
+Native ORC Vectorized (Pushdown)                         8544           8562          24          1.8         543.2       0.7X
 
 
 ================================================================================================
 Pushdown benchmark for decimal
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 1 decimal(9, 2) row (value = 7864320):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                     2427           2431           5          6.5         154.3       1.0X
-Parquet Vectorized (Pushdown)                            67             71           5        236.4           4.2      36.5X
-Native ORC Vectorized                                  3726           3770          51          4.2         236.9       0.7X
-Native ORC Vectorized (Pushdown)                        147            154           5        106.6           9.4      16.5X
+Parquet Vectorized                                     2464           2482          18          6.4         156.7       1.0X
+Parquet Vectorized (Pushdown)                            68             88          17        230.1           4.3      36.0X
+Native ORC Vectorized                                  3692           3718          25          4.3         234.7       0.7X
+Native ORC Vectorized (Pushdown)                         61             69           8        257.5           3.9      40.3X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 10% decimal(9, 2) rows (value < 1572864):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                        3545           3578          22          4.4         225.4       1.0X
-Parquet Vectorized (Pushdown)                             1682           1710          17          9.3         107.0       2.1X
-Native ORC Vectorized                                     4927           4964          25          3.2         313.3       0.7X
-Native ORC Vectorized (Pushdown)                          2084           2097          10          7.5         132.5       1.7X
+Parquet Vectorized                                        3602           3616          11          4.4         229.0       1.0X
+Parquet Vectorized (Pushdown)                             1643           1658           9          9.6         104.5       2.2X
+Native ORC Vectorized                                     5031           5040          12          3.1         319.9       0.7X
+Native ORC Vectorized (Pushdown)                          2080           2094          10          7.6         132.2       1.7X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 50% decimal(9, 2) rows (value < 7864320):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                        7305           7335          32          2.2         464.4       1.0X
-Parquet Vectorized (Pushdown)                             7025           7045          18          2.2         446.6       1.0X
-Native ORC Vectorized                                     8973           8994          22          1.8         570.5       0.8X
-Native ORC Vectorized (Pushdown)                          8526           8537          15          1.8         542.1       0.9X
+Parquet Vectorized                                        7284           7316          28          2.2         463.1       1.0X
+Parquet Vectorized (Pushdown)                             6977           6988          12          2.3         443.6       1.0X
+Native ORC Vectorized                                     9436           9480          50          1.7         599.9       0.8X
+Native ORC Vectorized (Pushdown)                          8932           8962          31          1.8         567.9       0.8X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 90% decimal(9, 2) rows (value < 14155776):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                         8018           8036          17          2.0         509.8       1.0X
-Parquet Vectorized (Pushdown)                              8034           8082          32          2.0         510.8       1.0X
-Native ORC Vectorized                                     10178          10195          15          1.5         647.1       0.8X
-Native ORC Vectorized (Pushdown)                          10217          10299          90          1.5         649.6       0.8X
+Parquet Vectorized                                         8297           8307          11          1.9         527.5       1.0X
+Parquet Vectorized (Pushdown)                              8340           8355          14          1.9         530.2       1.0X
+Native ORC Vectorized                                     10148          10214          43          1.5         645.2       0.8X
+Native ORC Vectorized (Pushdown)                          10163          10210          61          1.5         646.1       0.8X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 1 decimal(18, 2) row (value = 7864320):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                      2611           2632          36          6.0         166.0       1.0X
-Parquet Vectorized (Pushdown)                             64             73          12        246.0           4.1      40.8X
-Native ORC Vectorized                                   3726           3743          16          4.2         236.9       0.7X
-Native ORC Vectorized (Pushdown)                         145            158          13        108.5           9.2      18.0X
+Parquet Vectorized                                      2629           2642           9          6.0         167.2       1.0X
+Parquet Vectorized (Pushdown)                             63             72          13        251.3           4.0      42.0X
+Native ORC Vectorized                                   3751           3775          34          4.2         238.5       0.7X
+Native ORC Vectorized (Pushdown)                          57             65           8        277.9           3.6      46.5X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 10% decimal(18, 2) rows (value < 1572864):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                         3208           3260          65          4.9         203.9       1.0X
-Parquet Vectorized (Pushdown)                               931            959          37         16.9          59.2       3.4X
-Native ORC Vectorized                                      4394           4409          16          3.6         279.4       0.7X
-Native ORC Vectorized (Pushdown)                           1171           1177           5         13.4          74.5       2.7X
+Parquet Vectorized                                         3244           3279          54          4.8         206.3       1.0X
+Parquet Vectorized (Pushdown)                               909            932          22         17.3          57.8       3.6X
+Native ORC Vectorized                                      4391           4412          17          3.6         279.2       0.7X
+Native ORC Vectorized (Pushdown)                           1056           1067          11         14.9          67.1       3.1X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 50% decimal(18, 2) rows (value < 7864320):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                         5628           5647          24          2.8         357.8       1.0X
-Parquet Vectorized (Pushdown)                              4377           4400          24          3.6         278.3       1.3X
-Native ORC Vectorized                                      7078           7100          14          2.2         450.0       0.8X
-Native ORC Vectorized (Pushdown)                           5330           5342           9          3.0         338.9       1.1X
+Parquet Vectorized                                         5593           5602           6          2.8         355.6       1.0X
+Parquet Vectorized (Pushdown)                              4337           4354          17          3.6         275.8       1.3X
+Native ORC Vectorized                                      6914           6923           9          2.3         439.6       0.8X
+Native ORC Vectorized (Pushdown)                           5069           5090          26          3.1         322.3       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 90% decimal(18, 2) rows (value < 14155776):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                          7950           7959          11          2.0         505.4       1.0X
-Parquet Vectorized (Pushdown)                               7745           7754           7          2.0         492.4       1.0X
-Native ORC Vectorized                                       9724           9738          17          1.6         618.2       0.8X
-Native ORC Vectorized (Pushdown)                            9414           9426          12          1.7         598.6       0.8X
+Parquet Vectorized                                          7837           7855          34          2.0         498.3       1.0X
+Parquet Vectorized (Pushdown)                               7559           7612          49          2.1         480.6       1.0X
+Native ORC Vectorized                                       9464           9474          15          1.7         601.7       0.8X
+Native ORC Vectorized (Pushdown)                            9134           9202         119          1.7         580.7       0.9X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 1 decimal(38, 2) row (value = 7864320):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                      3736           3751          23          4.2         237.6       1.0X
-Parquet Vectorized (Pushdown)                             69             74           6        226.4           4.4      53.8X
-Native ORC Vectorized                                   3725           3734          10          4.2         236.8       1.0X
-Native ORC Vectorized (Pushdown)                         141            148           6        111.4           9.0      26.5X
+Parquet Vectorized                                      3799           3823          28          4.1         241.5       1.0X
+Parquet Vectorized (Pushdown)                             68             71           5        232.0           4.3      56.0X
+Native ORC Vectorized                                   3709           3721           9          4.2         235.8       1.0X
+Native ORC Vectorized (Pushdown)                          54             60           6        288.9           3.5      69.8X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 10% decimal(38, 2) rows (value < 1572864):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                         4563           4587          21          3.4         290.1       1.0X
-Parquet Vectorized (Pushdown)                              1261           1262           1         12.5          80.2       3.6X
-Native ORC Vectorized                                      4513           4521          10          3.5         286.9       1.0X
-Native ORC Vectorized (Pushdown)                           1276           1281           4         12.3          81.1       3.6X
+Parquet Vectorized                                         4714           4767          68          3.3         299.7       1.0X
+Parquet Vectorized (Pushdown)                              1255           1274          15         12.5          79.8       3.8X
+Native ORC Vectorized                                      4555           4564           6          3.5         289.6       1.0X
+Native ORC Vectorized (Pushdown)                           1205           1219          15         13.1          76.6       3.9X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 50% decimal(38, 2) rows (value < 7864320):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                         7929           7940          12          2.0         504.1       1.0X
-Parquet Vectorized (Pushdown)                              6120           6132          19          2.6         389.1       1.3X
-Native ORC Vectorized                                      7692           7698           6          2.0         489.0       1.0X
-Native ORC Vectorized (Pushdown)                           5904           5921          10          2.7         375.4       1.3X
+Parquet Vectorized                                         7818           7851          33          2.0         497.0       1.0X
+Parquet Vectorized (Pushdown)                              5988           6007          18          2.6         380.7       1.3X
+Native ORC Vectorized                                      7704           7733          22          2.0         489.8       1.0X
+Native ORC Vectorized (Pushdown)                           5832           5840           6          2.7         370.8       1.3X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 90% decimal(38, 2) rows (value < 14155776):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                         11278          11296          14          1.4         717.0       1.0X
-Parquet Vectorized (Pushdown)                              10885          10916          25          1.4         692.1       1.0X
-Native ORC Vectorized                                      10743          10763          24          1.5         683.0       1.0X
-Native ORC Vectorized (Pushdown)                           10431          10442          17          1.5         663.2       1.1X
+Parquet Vectorized                                         10998          11020          27          1.4         699.2       1.0X
+Parquet Vectorized (Pushdown)                              10657          10675          26          1.5         677.6       1.0X
+Native ORC Vectorized                                      10900          10917          12          1.4         693.0       1.0X
+Native ORC Vectorized (Pushdown)                           10551          10654         141          1.5         670.8       1.0X
 
 
 ================================================================================================
 Pushdown benchmark for InSet -> InFilters
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 InSet -> InFilters (values count: 5, distribution: 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                               6169           6272          71          2.5         392.2       1.0X
-Parquet Vectorized (Pushdown)                                     257            263           5         61.2          16.3      24.0X
-Native ORC Vectorized                                            5242           5278          39          3.0         333.3       1.2X
-Native ORC Vectorized (Pushdown)                                  465            479           9         33.8          29.6      13.3X
+Parquet Vectorized                                               6434           6488          65          2.4         409.0       1.0X
+Parquet Vectorized (Pushdown)                                     253            260           5         62.1          16.1      25.4X
+Native ORC Vectorized                                            6805           6857          47          2.3         432.6       0.9X
+Native ORC Vectorized (Pushdown)                                  291            311          29         54.0          18.5      22.1X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 InSet -> InFilters (values count: 5, distribution: 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                               6135           6144           9          2.6         390.1       1.0X
-Parquet Vectorized (Pushdown)                                     255            260           3         61.7          16.2      24.1X
-Native ORC Vectorized                                            5246           5260          10          3.0         333.5       1.2X
-Native ORC Vectorized (Pushdown)                                  466            477           6         33.8          29.6      13.2X
+Parquet Vectorized                                               6435           6458          25          2.4         409.1       1.0X
+Parquet Vectorized (Pushdown)                                     249            254           3         63.2          15.8      25.9X
+Native ORC Vectorized                                            6793           6827          22          2.3         431.9       0.9X
+Native ORC Vectorized (Pushdown)                                  274            282           5         57.4          17.4      23.5X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 InSet -> InFilters (values count: 5, distribution: 90):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                               6131           6152          19          2.6         389.8       1.0X
-Parquet Vectorized (Pushdown)                                     256            261           3         61.4          16.3      23.9X
-Native ORC Vectorized                                            5273           5279           6          3.0         335.2       1.2X
-Native ORC Vectorized (Pushdown)                                  469            485          15         33.5          29.8      13.1X
+Parquet Vectorized                                               6419           6435          11          2.5         408.1       1.0X
+Parquet Vectorized (Pushdown)                                     249            254           5         63.2          15.8      25.8X
+Native ORC Vectorized                                            6772           6788          13          2.3         430.5       0.9X
+Native ORC Vectorized (Pushdown)                                  275            283           7         57.2          17.5      23.3X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 InSet -> InFilters (values count: 10, distribution: 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                6117           6136          24          2.6         388.9       1.0X
-Parquet Vectorized (Pushdown)                                      273            281           6         57.6          17.4      22.4X
-Native ORC Vectorized                                             5268           5277          12          3.0         334.9       1.2X
-Native ORC Vectorized (Pushdown)                                   481            493           7         32.7          30.6      12.7X
+Parquet Vectorized                                                6414           6431          11          2.5         407.8       1.0X
+Parquet Vectorized (Pushdown)                                      265            271           5         59.4          16.8      24.2X
+Native ORC Vectorized                                             6773           6794          32          2.3         430.6       0.9X
+Native ORC Vectorized (Pushdown)                                   298            301           2         52.8          18.9      21.5X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 InSet -> InFilters (values count: 10, distribution: 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                6114           6126          12          2.6         388.7       1.0X
-Parquet Vectorized (Pushdown)                                      273            278           3         57.7          17.3      22.4X
-Native ORC Vectorized                                             5269           5283          14          3.0         335.0       1.2X
-Native ORC Vectorized (Pushdown)                                   480            489           6         32.8          30.5      12.7X
+Parquet Vectorized                                                6448           6468          22          2.4         409.9       1.0X
+Parquet Vectorized (Pushdown)                                      266            270           3         59.2          16.9      24.3X
+Native ORC Vectorized                                             6780           6790          10          2.3         431.1       1.0X
+Native ORC Vectorized (Pushdown)                                   304            307           2         51.7          19.3      21.2X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 InSet -> InFilters (values count: 10, distribution: 90):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                6127           6153          33          2.6         389.5       1.0X
-Parquet Vectorized (Pushdown)                                      276            281           5         56.9          17.6      22.2X
-Native ORC Vectorized                                             5252           5266          10          3.0         333.9       1.2X
-Native ORC Vectorized (Pushdown)                                   480            491           7         32.8          30.5      12.8X
+Parquet Vectorized                                                6440           6458          19          2.4         409.4       1.0X
+Parquet Vectorized (Pushdown)                                      273            275           3         57.7          17.3      23.6X
+Native ORC Vectorized                                             6784           6807          18          2.3         431.3       0.9X
+Native ORC Vectorized (Pushdown)                                   303            306           2         51.8          19.3      21.2X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 InSet -> InFilters (values count: 50, distribution: 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                6319           6349          25          2.5         401.8       1.0X
-Parquet Vectorized (Pushdown)                                      796            810          15         19.8          50.6       7.9X
-Native ORC Vectorized                                             5467           5476           8          2.9         347.6       1.2X
-Native ORC Vectorized (Pushdown)                                   607            610           3         25.9          38.6      10.4X
+Parquet Vectorized                                                6621           6642          26          2.4         421.0       1.0X
+Parquet Vectorized (Pushdown)                                      854            858           5         18.4          54.3       7.8X
+Native ORC Vectorized                                             6976           6989          13          2.3         443.5       0.9X
+Native ORC Vectorized (Pushdown)                                   453            458           3         34.7          28.8      14.6X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 InSet -> InFilters (values count: 50, distribution: 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                6338           6362          21          2.5         403.0       1.0X
-Parquet Vectorized (Pushdown)                                     3212           3234          14          4.9         204.2       2.0X
-Native ORC Vectorized                                             5505           5510           5          2.9         350.0       1.2X
-Native ORC Vectorized (Pushdown)                                   628            635           5         25.0          39.9      10.1X
+Parquet Vectorized                                                6616           6630          19          2.4         420.6       1.0X
+Parquet Vectorized (Pushdown)                                     3434           3441          12          4.6         218.3       1.9X
+Native ORC Vectorized                                             6992           6996           4          2.2         444.6       0.9X
+Native ORC Vectorized (Pushdown)                                   497            501           3         31.7          31.6      13.3X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 InSet -> InFilters (values count: 50, distribution: 90):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                6344           6361          11          2.5         403.4       1.0X
-Parquet Vectorized (Pushdown)                                     5558           5580          16          2.8         353.3       1.1X
-Native ORC Vectorized                                             5439           5459          14          2.9         345.8       1.2X
-Native ORC Vectorized (Pushdown)                                   620            624           4         25.4          39.4      10.2X
+Parquet Vectorized                                                6601           6633          26          2.4         419.7       1.0X
+Parquet Vectorized (Pushdown)                                     5923           5947          16          2.7         376.6       1.1X
+Native ORC Vectorized                                             6976           6984           5          2.3         443.5       0.9X
+Native ORC Vectorized (Pushdown)                                   513            515           3         30.7          32.6      12.9X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 InSet -> InFilters (values count: 100, distribution: 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                 6284           6303          20          2.5         399.6       1.0X
-Parquet Vectorized (Pushdown)                                       841            846           4         18.7          53.5       7.5X
-Native ORC Vectorized                                              5414           5429          11          2.9         344.2       1.2X
-Native ORC Vectorized (Pushdown)                                    714            729          18         22.0          45.4       8.8X
+Parquet Vectorized                                                 6568           6590          35          2.4         417.6       1.0X
+Parquet Vectorized (Pushdown)                                       871            875           3         18.1          55.4       7.5X
+Native ORC Vectorized                                              6956           6967          11          2.3         442.3       0.9X
+Native ORC Vectorized (Pushdown)                                    616            624           7         25.5          39.2      10.7X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 InSet -> InFilters (values count: 100, distribution: 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                 6306           6319          15          2.5         400.9       1.0X
-Parquet Vectorized (Pushdown)                                      3267           3272           6          4.8         207.7       1.9X
-Native ORC Vectorized                                              5416           5430          12          2.9         344.3       1.2X
-Native ORC Vectorized (Pushdown)                                    776            784           9         20.3          49.4       8.1X
+Parquet Vectorized                                                 6577           6596          16          2.4         418.2       1.0X
+Parquet Vectorized (Pushdown)                                      3396           3412          17          4.6         215.9       1.9X
+Native ORC Vectorized                                              6955           6968          14          2.3         442.2       0.9X
+Native ORC Vectorized (Pushdown)                                    701            704           4         22.4          44.6       9.4X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 InSet -> InFilters (values count: 100, distribution: 90):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                 6308           6314           7          2.5         401.1       1.0X
-Parquet Vectorized (Pushdown)                                      5670           5705          34          2.8         360.5       1.1X
-Native ORC Vectorized                                              5447           5459          12          2.9         346.3       1.2X
-Native ORC Vectorized (Pushdown)                                    784            794           9         20.1          49.9       8.0X
+Parquet Vectorized                                                 6598           6624          21          2.4         419.5       1.0X
+Parquet Vectorized (Pushdown)                                      5917           5926          10          2.7         376.2       1.1X
+Native ORC Vectorized                                              6944           6967          19          2.3         441.5       1.0X
+Native ORC Vectorized (Pushdown)                                    739            744           7         21.3          47.0       8.9X
 
 
 ================================================================================================
 Pushdown benchmark for tinyint
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 1 tinyint row (value = CAST(63 AS tinyint)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                           2722           2744          17          5.8         173.1       1.0X
-Parquet Vectorized (Pushdown)                                  99            108          11        158.7           6.3      27.5X
-Native ORC Vectorized                                        2527           2559          41          6.2         160.7       1.1X
-Native ORC Vectorized (Pushdown)                              196            211          11         80.2          12.5      13.9X
+Parquet Vectorized                                           2844           2870          18          5.5         180.8       1.0X
+Parquet Vectorized (Pushdown)                                 100            107           6        156.7           6.4      28.3X
+Native ORC Vectorized                                        3000           3012          11          5.2         190.8       0.9X
+Native ORC Vectorized (Pushdown)                              118            128          14        133.4           7.5      24.1X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 10% tinyint rows (value < CAST(12 AS tinyint)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                              3226           3260          52          4.9         205.1       1.0X
-Parquet Vectorized (Pushdown)                                    867            885          18         18.1          55.1       3.7X
-Native ORC Vectorized                                           3020           3043          30          5.2         192.0       1.1X
-Native ORC Vectorized (Pushdown)                                 908            916           7         17.3          57.8       3.6X
+Parquet Vectorized                                              3311           3339          21          4.8         210.5       1.0X
+Parquet Vectorized (Pushdown)                                    878            894          20         17.9          55.8       3.8X
+Native ORC Vectorized                                           3457           3482          23          4.6         219.8       1.0X
+Native ORC Vectorized (Pushdown)                                 859            866           6         18.3          54.6       3.9X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 50% tinyint rows (value < CAST(63 AS tinyint)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                              5371           5386          10          2.9         341.5       1.0X
-Parquet Vectorized (Pushdown)                                   4083           4095          12          3.9         259.6       1.3X
-Native ORC Vectorized                                           5116           5141          24          3.1         325.3       1.0X
-Native ORC Vectorized (Pushdown)                                3985           3999          12          3.9         253.4       1.3X
+Parquet Vectorized                                              5458           5468          16          2.9         347.0       1.0X
+Parquet Vectorized (Pushdown)                                   4118           4131          16          3.8         261.8       1.3X
+Native ORC Vectorized                                           5476           5518          29          2.9         348.2       1.0X
+Native ORC Vectorized (Pushdown)                                4098           4111          11          3.8         260.6       1.3X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 90% tinyint rows (value < CAST(114 AS tinyint)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                               7456           7474          13          2.1         474.0       1.0X
-Parquet Vectorized (Pushdown)                                    7265           7275           9          2.2         461.9       1.0X
-Native ORC Vectorized                                            7198           7227          37          2.2         457.7       1.0X
-Native ORC Vectorized (Pushdown)                                 7027           7037           9          2.2         446.8       1.1X
+Parquet Vectorized                                               7540           7575          25          2.1         479.4       1.0X
+Parquet Vectorized (Pushdown)                                    7311           7335          35          2.2         464.8       1.0X
+Native ORC Vectorized                                            7353           7381          18          2.1         467.5       1.0X
+Native ORC Vectorized (Pushdown)                                 7174           7196          24          2.2         456.1       1.1X
 
 
 ================================================================================================
 Pushdown benchmark for Timestamp
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 1 timestamp stored as INT96 row (value = timestamp_seconds(7864320)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                                    2952           2962          10          5.3         187.7       1.0X
-Parquet Vectorized (Pushdown)                                                         2949           2969          17          5.3         187.5       1.0X
-Native ORC Vectorized                                                                 2551           2559          10          6.2         162.2       1.2X
-Native ORC Vectorized (Pushdown)                                                       119            127          10        132.4           7.6      24.8X
+Parquet Vectorized                                                                    3138           3181          68          5.0         199.5       1.0X
+Parquet Vectorized (Pushdown)                                                         3140           3157          23          5.0         199.6       1.0X
+Native ORC Vectorized                                                                 2460           2477          18          6.4         156.4       1.3X
+Native ORC Vectorized (Pushdown)                                                        40             47           8        397.1           2.5      79.2X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 10% timestamp stored as INT96 rows (value < timestamp_seconds(1572864)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                                       3558           3571          20          4.4         226.2       1.0X
-Parquet Vectorized (Pushdown)                                                            3554           3558           6          4.4         226.0       1.0X
-Native ORC Vectorized                                                                    3122           3133          11          5.0         198.5       1.1X
-Native ORC Vectorized (Pushdown)                                                          958            967          17         16.4          60.9       3.7X
+Parquet Vectorized                                                                       3696           3721          21          4.3         235.0       1.0X
+Parquet Vectorized (Pushdown)                                                            3682           3696          15          4.3         234.1       1.0X
+Native ORC Vectorized                                                                    3000           3018          21          5.2         190.8       1.2X
+Native ORC Vectorized (Pushdown)                                                          829            833           3         19.0          52.7       4.5X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 50% timestamp stored as INT96 rows (value < timestamp_seconds(7864320)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                                       5983           5996          12          2.6         380.4       1.0X
-Parquet Vectorized (Pushdown)                                                            5988           5998          10          2.6         380.7       1.0X
-Native ORC Vectorized                                                                    5411           5420           7          2.9         344.0       1.1X
-Native ORC Vectorized (Pushdown)                                                         4234           4240           7          3.7         269.2       1.4X
+Parquet Vectorized                                                                       5876           5898          17          2.7         373.6       1.0X
+Parquet Vectorized (Pushdown)                                                            5899           5939          48          2.7         375.1       1.0X
+Native ORC Vectorized                                                                    5113           5136          26          3.1         325.1       1.1X
+Native ORC Vectorized (Pushdown)                                                         3923           3927           4          4.0         249.4       1.5X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 90% timestamp stored as INT96 rows (value < timestamp_seconds(14155776)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                                        8153           8171          14          1.9         518.4       1.0X
-Parquet Vectorized (Pushdown)                                                             8167           8202          36          1.9         519.2       1.0X
-Native ORC Vectorized                                                                     7547           7553           5          2.1         479.8       1.1X
-Native ORC Vectorized (Pushdown)                                                          7313           7331          14          2.2         464.9       1.1X
+Parquet Vectorized                                                                        8235           8252          13          1.9         523.5       1.0X
+Parquet Vectorized (Pushdown)                                                             8227           8240          12          1.9         523.0       1.0X
+Native ORC Vectorized                                                                     7154           7166          19          2.2         454.9       1.2X
+Native ORC Vectorized (Pushdown)                                                          6978           7000          26          2.3         443.6       1.2X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 1 timestamp stored as TIMESTAMP_MICROS row (value = timestamp_seconds(7864320)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                                               2561           2573          11          6.1         162.8       1.0X
-Parquet Vectorized (Pushdown)                                                                      64             66           5        247.6           4.0      40.3X
-Native ORC Vectorized                                                                            2533           2544          13          6.2         161.1       1.0X
-Native ORC Vectorized (Pushdown)                                                                  117            121           5        134.9           7.4      22.0X
+Parquet Vectorized                                                                               2612           2622          10          6.0         166.0       1.0X
+Parquet Vectorized (Pushdown)                                                                      61             64           4        258.4           3.9      42.9X
+Native ORC Vectorized                                                                            2452           2464          13          6.4         155.9       1.1X
+Native ORC Vectorized (Pushdown)                                                                   39             43           5        404.8           2.5      67.2X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 10% timestamp stored as TIMESTAMP_MICROS rows (value < timestamp_seconds(1572864)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                                                  3154           3160           5          5.0         200.5       1.0X
-Parquet Vectorized (Pushdown)                                                                        910            914           4         17.3          57.8       3.5X
-Native ORC Vectorized                                                                               3111           3120           9          5.1         197.8       1.0X
-Native ORC Vectorized (Pushdown)                                                                     947            949           2         16.6          60.2       3.3X
+Parquet Vectorized                                                                                  3163           3176          24          5.0         201.1       1.0X
+Parquet Vectorized (Pushdown)                                                                        886            890           4         17.7          56.4       3.6X
+Native ORC Vectorized                                                                               2994           3004          10          5.3         190.3       1.1X
+Native ORC Vectorized (Pushdown)                                                                     829            831           3         19.0          52.7       3.8X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 50% timestamp stored as TIMESTAMP_MICROS rows (value < timestamp_seconds(7864320)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                                                  5578           5591          19          2.8         354.6       1.0X
-Parquet Vectorized (Pushdown)                                                                       4353           4361           7          3.6         276.7       1.3X
-Native ORC Vectorized                                                                               5322           5327           4          3.0         338.4       1.0X
-Native ORC Vectorized (Pushdown)                                                                    4142           4149           5          3.8         263.3       1.3X
+Parquet Vectorized                                                                                  5406           5418          18          2.9         343.7       1.0X
+Parquet Vectorized (Pushdown)                                                                       4167           4171           3          3.8         264.9       1.3X
+Native ORC Vectorized                                                                               5158           5176          23          3.0         327.9       1.0X
+Native ORC Vectorized (Pushdown)                                                                    3970           3983          11          4.0         252.4       1.4X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 90% timestamp stored as TIMESTAMP_MICROS rows (value < timestamp_seconds(14155776)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                                                   7889           7900          11          2.0         501.6       1.0X
-Parquet Vectorized (Pushdown)                                                                        7693           7701          13          2.0         489.1       1.0X
-Native ORC Vectorized                                                                                7652           7664           9          2.1         486.5       1.0X
-Native ORC Vectorized (Pushdown)                                                                     7451           7463           9          2.1         473.7       1.1X
+Parquet Vectorized                                                                                   7737           7762          30          2.0         491.9       1.0X
+Parquet Vectorized (Pushdown)                                                                        7521           7537          12          2.1         478.2       1.0X
+Native ORC Vectorized                                                                                7336           7361          28          2.1         466.4       1.1X
+Native ORC Vectorized (Pushdown)                                                                     7115           7123           9          2.2         452.4       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 1 timestamp stored as TIMESTAMP_MILLIS row (value = timestamp_seconds(7864320)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                                               2720           2734          12          5.8         172.9       1.0X
-Parquet Vectorized (Pushdown)                                                                      62             65           3        252.2           4.0      43.6X
-Native ORC Vectorized                                                                            2524           2529           5          6.2         160.5       1.1X
-Native ORC Vectorized (Pushdown)                                                                  116            122           8        135.7           7.4      23.5X
+Parquet Vectorized                                                                               2774           2798          24          5.7         176.4       1.0X
+Parquet Vectorized (Pushdown)                                                                      60             62           2        260.4           3.8      45.9X
+Native ORC Vectorized                                                                            2445           2459          11          6.4         155.4       1.1X
+Native ORC Vectorized (Pushdown)                                                                   38             41           4        416.4           2.4      73.5X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 10% timestamp stored as TIMESTAMP_MILLIS rows (value < timestamp_seconds(1572864)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                                                  3299           3306           9          4.8         209.7       1.0X
-Parquet Vectorized (Pushdown)                                                                        922            929           5         17.1          58.6       3.6X
-Native ORC Vectorized                                                                               3115           3119           5          5.0         198.0       1.1X
-Native ORC Vectorized (Pushdown)                                                                     936            943           6         16.8          59.5       3.5X
+Parquet Vectorized                                                                                  3316           3340          30          4.7         210.8       1.0X
+Parquet Vectorized (Pushdown)                                                                        885            888           4         17.8          56.3       3.7X
+Native ORC Vectorized                                                                               2994           3015          24          5.3         190.3       1.1X
+Native ORC Vectorized (Pushdown)                                                                     823            827           3         19.1          52.3       4.0X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 50% timestamp stored as TIMESTAMP_MILLIS rows (value < timestamp_seconds(7864320)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                                                  5600           5613          10          2.8         356.0       1.0X
-Parquet Vectorized (Pushdown)                                                                       4310           4315           5          3.6         274.0       1.3X
-Native ORC Vectorized                                                                               5331           5346          13          3.0         338.9       1.1X
-Native ORC Vectorized (Pushdown)                                                                    4149           4152           4          3.8         263.8       1.3X
+Parquet Vectorized                                                                                  5563           5567           4          2.8         353.7       1.0X
+Parquet Vectorized (Pushdown)                                                                       4249           4266          24          3.7         270.2       1.3X
+Native ORC Vectorized                                                                               5161           5178          30          3.0         328.1       1.1X
+Native ORC Vectorized (Pushdown)                                                                    3960           3969           9          4.0         251.7       1.4X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 90% timestamp stored as TIMESTAMP_MILLIS rows (value < timestamp_seconds(14155776)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                                                   8072           8090          19          1.9         513.2       1.0X
-Parquet Vectorized (Pushdown)                                                                        7817           7849          25          2.0         497.0       1.0X
-Native ORC Vectorized                                                                                7620           7625           6          2.1         484.5       1.1X
-Native ORC Vectorized (Pushdown)                                                                     7406           7425          12          2.1         470.9       1.1X
+Parquet Vectorized                                                                                   7933           7956          27          2.0         504.4       1.0X
+Parquet Vectorized (Pushdown)                                                                        7686           7708          24          2.0         488.6       1.0X
+Native ORC Vectorized                                                                                7289           7301           7          2.2         463.4       1.1X
+Native ORC Vectorized (Pushdown)                                                                     7042           7072          29          2.2         447.7       1.1X
 
 
 ================================================================================================
 Pushdown benchmark with many filters
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 1 row with 1 filters:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                   61            101          18          0.0    61097276.0       1.0X
-Parquet Vectorized (Pushdown)                        61             65           5          0.0    60998399.0       1.0X
-Native ORC Vectorized                                54             58           5          0.0    54404022.0       1.1X
-Native ORC Vectorized (Pushdown)                     56             61           8          0.0    56324331.0       1.1X
+Parquet Vectorized                                   61             76          18          0.0    61164974.0       1.0X
+Parquet Vectorized (Pushdown)                        62             64           3          0.0    61877349.0       1.0X
+Native ORC Vectorized                                55             57           3          0.0    54841404.0       1.1X
+Native ORC Vectorized (Pushdown)                     57             59           2          0.0    56948049.0       1.1X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 1 row with 250 filters:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                  369            382           9          0.0   369372167.0       1.0X
-Parquet Vectorized (Pushdown)                       364            372           9          0.0   363804742.0       1.0X
-Native ORC Vectorized                               352            361          10          0.0   352426312.0       1.0X
-Native ORC Vectorized (Pushdown)                    357            360           3          0.0   357114524.0       1.0X
+Parquet Vectorized                                  366            381          12          0.0   365962320.0       1.0X
+Parquet Vectorized (Pushdown)                       364            369           8          0.0   363522231.0       1.0X
+Native ORC Vectorized                               348            356           7          0.0   348403209.0       1.1X
+Native ORC Vectorized (Pushdown)                    354            361           6          0.0   354441093.0       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 1 row with 500 filters:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                 1900           1950          67          0.0  1899717601.0       1.0X
-Parquet Vectorized (Pushdown)                      1909           1922           8          0.0  1908868076.0       1.0X
-Native ORC Vectorized                              1886           1907          19          0.0  1885672723.0       1.0X
-Native ORC Vectorized (Pushdown)                   1893           1910          12          0.0  1893308293.0       1.0X
+Parquet Vectorized                                 1871           1886          20          0.0  1870961467.0       1.0X
+Parquet Vectorized (Pushdown)                      1895           1910          12          0.0  1895308352.0       1.0X
+Native ORC Vectorized                              1866           1894          23          0.0  1866186408.0       1.0X
+Native ORC Vectorized (Pushdown)                   1877           1923          36          0.0  1876971257.0       1.0X
 
 

--- a/sql/core/benchmarks/FilterPushdownBenchmark-results.txt
+++ b/sql/core/benchmarks/FilterPushdownBenchmark-results.txt
@@ -2,733 +2,733 @@
 Pushdown for many distinct value case
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 0 string row (value IS NULL):      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                 6712           6782          63          2.3         426.7       1.0X
-Parquet Vectorized (Pushdown)                       284            307          19         55.3          18.1      23.6X
-Native ORC Vectorized                              5685           5718          34          2.8         361.4       1.2X
-Native ORC Vectorized (Pushdown)                    532            543           8         29.6          33.8      12.6X
+Parquet Vectorized                                 6749           6806          48          2.3         429.1       1.0X
+Parquet Vectorized (Pushdown)                       293            314          18         53.8          18.6      23.1X
+Native ORC Vectorized                              7052           7090          35          2.2         448.3       1.0X
+Native ORC Vectorized (Pushdown)                    302            315           9         52.0          19.2      22.3X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 0 string row ('7864320' < value < '7864320'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                            6825           6859          39          2.3         433.9       1.0X
-Parquet Vectorized (Pushdown)                                  274            284           6         57.4          17.4      24.9X
-Native ORC Vectorized                                         5795           5802           7          2.7         368.4       1.2X
-Native ORC Vectorized (Pushdown)                               532            546          18         29.6          33.8      12.8X
+Parquet Vectorized                                            6821           6838          24          2.3         433.7       1.0X
+Parquet Vectorized (Pushdown)                                  278            286           7         56.6          17.7      24.6X
+Native ORC Vectorized                                         7166           7182          20          2.2         455.6       1.0X
+Native ORC Vectorized (Pushdown)                               308            321          11         51.0          19.6      22.1X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 1 string row (value = '7864320'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                 6788           6812          25          2.3         431.6       1.0X
-Parquet Vectorized (Pushdown)                       267            276          11         58.8          17.0      25.4X
-Native ORC Vectorized                              5761           5767           5          2.7         366.3       1.2X
-Native ORC Vectorized (Pushdown)                    517            529          17         30.4          32.9      13.1X
+Parquet Vectorized                                 6768           6779          11          2.3         430.3       1.0X
+Parquet Vectorized (Pushdown)                       266            275           9         59.2          16.9      25.5X
+Native ORC Vectorized                              7112           7122           9          2.2         452.2       1.0X
+Native ORC Vectorized (Pushdown)                    292            300           6         53.8          18.6      23.1X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 1 string row (value <=> '7864320'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                  6759           6788          37          2.3         429.7       1.0X
-Parquet Vectorized (Pushdown)                        261            274          16         60.3          16.6      25.9X
-Native ORC Vectorized                               5748           5767          31          2.7         365.5       1.2X
-Native ORC Vectorized (Pushdown)                     504            509           6         31.2          32.0      13.4X
+Parquet Vectorized                                  6772           6795          22          2.3         430.6       1.0X
+Parquet Vectorized (Pushdown)                        259            266           9         60.7          16.5      26.1X
+Native ORC Vectorized                               7112           7122           8          2.2         452.1       1.0X
+Native ORC Vectorized (Pushdown)                     289            295           8         54.5          18.4      23.4X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 1 string row ('7864320' <= value <= '7864320'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                              6755           6775          23          2.3         429.4       1.0X
-Parquet Vectorized (Pushdown)                                    258            268          13         61.0          16.4      26.2X
-Native ORC Vectorized                                           5765           5775           8          2.7         366.5       1.2X
-Native ORC Vectorized (Pushdown)                                 510            522          12         30.9          32.4      13.3X
+Parquet Vectorized                                              6792           6806          13          2.3         431.8       1.0X
+Parquet Vectorized (Pushdown)                                    257            266           6         61.2          16.3      26.4X
+Native ORC Vectorized                                           7143           7160          15          2.2         454.1       1.0X
+Native ORC Vectorized (Pushdown)                                 291            306          23         54.1          18.5      23.4X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select all string rows (value IS NOT NULL):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                  13064          13129          58          1.2         830.6       1.0X
-Parquet Vectorized (Pushdown)                       13138          13177          30          1.2         835.3       1.0X
-Native ORC Vectorized                               11736          11780          27          1.3         746.1       1.1X
-Native ORC Vectorized (Pushdown)                    11869          11909          41          1.3         754.6       1.1X
+Parquet Vectorized                                  13181          13240          54          1.2         838.0       1.0X
+Parquet Vectorized (Pushdown)                       13158          13186          32          1.2         836.5       1.0X
+Native ORC Vectorized                               13340          13367          27          1.2         848.1       1.0X
+Native ORC Vectorized (Pushdown)                    13454          13470          16          1.2         855.4       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 0 int row (value IS NULL):         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                 6357           6384          34          2.5         404.1       1.0X
-Parquet Vectorized (Pushdown)                       246            257          14         64.0          15.6      25.9X
-Native ORC Vectorized                              5158           5174          27          3.0         328.0       1.2X
-Native ORC Vectorized (Pushdown)                    481            486           4         32.7          30.6      13.2X
+Parquet Vectorized                                 6394           6412          26          2.5         406.5       1.0X
+Parquet Vectorized (Pushdown)                       240            249           9         65.5          15.3      26.6X
+Native ORC Vectorized                              6540           6566          19          2.4         415.8       1.0X
+Native ORC Vectorized (Pushdown)                    271            276           4         58.0          17.2      23.6X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 0 int row (7864320 < value < 7864320):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                     6353           6383          28          2.5         403.9       1.0X
-Parquet Vectorized (Pushdown)                           249            257          11         63.3          15.8      25.6X
-Native ORC Vectorized                                  5153           5159           8          3.1         327.6       1.2X
-Native ORC Vectorized (Pushdown)                        491            503           8         32.0          31.2      12.9X
+Parquet Vectorized                                     6396           6415          25          2.5         406.6       1.0X
+Parquet Vectorized (Pushdown)                           246            251           4         63.9          15.7      26.0X
+Native ORC Vectorized                                  6531           6542           8          2.4         415.2       1.0X
+Native ORC Vectorized (Pushdown)                        283            290           5         55.7          18.0      22.6X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 1 int row (value = 7864320):       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                 6386           6407          26          2.5         406.0       1.0X
-Parquet Vectorized (Pushdown)                       248            265          19         63.5          15.7      25.8X
-Native ORC Vectorized                              5216           5221           6          3.0         331.6       1.2X
-Native ORC Vectorized (Pushdown)                    482            492           8         32.6          30.7      13.2X
+Parquet Vectorized                                 6419           6432          11          2.5         408.1       1.0X
+Parquet Vectorized (Pushdown)                       241            250           8         65.1          15.4      26.6X
+Native ORC Vectorized                              6578           6595          14          2.4         418.2       1.0X
+Native ORC Vectorized (Pushdown)                    279            287           9         56.4          17.7      23.0X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 1 int row (value <=> 7864320):     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                 6378           6393           9          2.5         405.5       1.0X
-Parquet Vectorized (Pushdown)                       245            253           9         64.2          15.6      26.0X
-Native ORC Vectorized                              5203           5207           4          3.0         330.8       1.2X
-Native ORC Vectorized (Pushdown)                    470            488          11         33.5          29.9      13.6X
+Parquet Vectorized                                 6425           6447          22          2.4         408.5       1.0X
+Parquet Vectorized (Pushdown)                       243            249           3         64.8          15.4      26.5X
+Native ORC Vectorized                              6585           6604          27          2.4         418.7       1.0X
+Native ORC Vectorized (Pushdown)                    276            280           4         56.9          17.6      23.3X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 1 int row (7864320 <= value <= 7864320):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                       6405           6426          11          2.5         407.2       1.0X
-Parquet Vectorized (Pushdown)                             249            253           4         63.1          15.9      25.7X
-Native ORC Vectorized                                    5209           5225          20          3.0         331.2       1.2X
-Native ORC Vectorized (Pushdown)                          481            486           3         32.7          30.6      13.3X
+Parquet Vectorized                                       6409           6416           6          2.5         407.5       1.0X
+Parquet Vectorized (Pushdown)                             240            246           9         65.6          15.2      26.7X
+Native ORC Vectorized                                    6591           6614          21          2.4         419.0       1.0X
+Native ORC Vectorized (Pushdown)                          277            281           4         56.8          17.6      23.1X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 1 int row (7864319 < value < 7864321):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                     6405           6420          17          2.5         407.2       1.0X
-Parquet Vectorized (Pushdown)                           247            251           5         63.6          15.7      25.9X
-Native ORC Vectorized                                  5199           5202           3          3.0         330.5       1.2X
-Native ORC Vectorized (Pushdown)                        473            483           7         33.2          30.1      13.5X
+Parquet Vectorized                                     6418           6444          18          2.5         408.0       1.0X
+Parquet Vectorized (Pushdown)                           240            252          10         65.4          15.3      26.7X
+Native ORC Vectorized                                  6590           6596           8          2.4         419.0       1.0X
+Native ORC Vectorized (Pushdown)                        277            281           6         56.8          17.6      23.2X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 10% int rows (value < 1572864):    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                 6956           6998          34          2.3         442.3       1.0X
-Parquet Vectorized (Pushdown)                      1446           1460           9         10.9          91.9       4.8X
-Native ORC Vectorized                              5787           5811          31          2.7         367.9       1.2X
-Native ORC Vectorized (Pushdown)                   1556           1570          17         10.1          99.0       4.5X
+Parquet Vectorized                                 6948           6990          38          2.3         441.8       1.0X
+Parquet Vectorized (Pushdown)                      1397           1408           9         11.3          88.8       5.0X
+Native ORC Vectorized                              7143           7162          27          2.2         454.1       1.0X
+Native ORC Vectorized (Pushdown)                   1481           1485           4         10.6          94.1       4.7X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 50% int rows (value < 7864320):    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                 9092           9116          18          1.7         578.1       1.0X
-Parquet Vectorized (Pushdown)                      6057           6066          14          2.6         385.1       1.5X
-Native ORC Vectorized                              7813           7832          15          2.0         496.8       1.2X
-Native ORC Vectorized (Pushdown)                   5547           5573          26          2.8         352.7       1.6X
+Parquet Vectorized                                 8942           8964          27          1.8         568.5       1.0X
+Parquet Vectorized (Pushdown)                      5881           5896          15          2.7         373.9       1.5X
+Native ORC Vectorized                              9163           9187          24          1.7         582.6       1.0X
+Native ORC Vectorized (Pushdown)                   6061           6072          10          2.6         385.4       1.5X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 90% int rows (value < 14155776):   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                11287          11311          23          1.4         717.6       1.0X
-Parquet Vectorized (Pushdown)                     10721          10734           9          1.5         681.6       1.1X
-Native ORC Vectorized                             10111          10136          18          1.6         642.8       1.1X
-Native ORC Vectorized (Pushdown)                   9758           9811          58          1.6         620.4       1.2X
+Parquet Vectorized                                10822          10868          65          1.5         688.0       1.0X
+Parquet Vectorized (Pushdown)                     10247          10266          22          1.5         651.5       1.1X
+Native ORC Vectorized                             11298          11327          24          1.4         718.3       1.0X
+Native ORC Vectorized (Pushdown)                  10772          10799          21          1.5         684.9       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select all int rows (value IS NOT NULL):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                11735          11767          27          1.3         746.1       1.0X
-Parquet Vectorized (Pushdown)                     11786          11811          23          1.3         749.3       1.0X
-Native ORC Vectorized                             10467          10482          17          1.5         665.4       1.1X
-Native ORC Vectorized (Pushdown)                  10572          10594          13          1.5         672.2       1.1X
+Parquet Vectorized                                11362          11395          32          1.4         722.4       1.0X
+Parquet Vectorized (Pushdown)                     11403          11413          10          1.4         725.0       1.0X
+Native ORC Vectorized                             11499          11523          28          1.4         731.1       1.0X
+Native ORC Vectorized (Pushdown)                  11589          11610          13          1.4         736.8       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select all int rows (value > -1):         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                11728          11743          14          1.3         745.7       1.0X
-Parquet Vectorized (Pushdown)                     11766          11806          30          1.3         748.1       1.0X
-Native ORC Vectorized                             10330          10342          11          1.5         656.8       1.1X
-Native ORC Vectorized (Pushdown)                  10479          10501          23          1.5         666.2       1.1X
+Parquet Vectorized                                11452          11466          21          1.4         728.1       1.0X
+Parquet Vectorized (Pushdown)                     11506          11538          44          1.4         731.6       1.0X
+Native ORC Vectorized                             11663          11673          13          1.3         741.5       1.0X
+Native ORC Vectorized (Pushdown)                  11768          11784          14          1.3         748.2       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select all int rows (value != -1):        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                11646          11681          35          1.4         740.4       1.0X
-Parquet Vectorized (Pushdown)                     11690          11705          27          1.3         743.2       1.0X
-Native ORC Vectorized                             10348          10363          10          1.5         657.9       1.1X
-Native ORC Vectorized (Pushdown)                  10545          10553           8          1.5         670.5       1.1X
+Parquet Vectorized                                11388          11397           7          1.4         724.0       1.0X
+Parquet Vectorized (Pushdown)                     11427          11439           9          1.4         726.5       1.0X
+Native ORC Vectorized                             11600          11625          17          1.4         737.5       1.0X
+Native ORC Vectorized (Pushdown)                  11689          11707          12          1.3         743.1       1.0X
 
 
 ================================================================================================
 Pushdown for few distinct value case (use dictionary encoding)
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 0 distinct string row (value IS NULL):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                     5684           5718          30          2.8         361.4       1.0X
-Parquet Vectorized (Pushdown)                           208            215           7         75.5          13.2      27.3X
-Native ORC Vectorized                                  6361           6386          29          2.5         404.4       0.9X
-Native ORC Vectorized (Pushdown)                        903            913          10         17.4          57.4       6.3X
+Parquet Vectorized                                     5712           5740          30          2.8         363.2       1.0X
+Parquet Vectorized (Pushdown)                           207            212           4         76.0          13.2      27.6X
+Native ORC Vectorized                                  8321           8338          16          1.9         529.0       0.7X
+Native ORC Vectorized (Pushdown)                        881            883           2         17.8          56.0       6.5X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 0 distinct string row ('100' < value < '100'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                             5831           5851          20          2.7         370.7       1.0X
-Parquet Vectorized (Pushdown)                                   208            215           5         75.5          13.2      28.0X
-Native ORC Vectorized                                          6562           6570          12          2.4         417.2       0.9X
-Native ORC Vectorized (Pushdown)                                920            930           8         17.1          58.5       6.3X
+Parquet Vectorized                                             5823           5847          21          2.7         370.2       1.0X
+Parquet Vectorized (Pushdown)                                   209            216           7         75.1          13.3      27.8X
+Native ORC Vectorized                                          8528           8536          10          1.8         542.2       0.7X
+Native ORC Vectorized (Pushdown)                                884            897          14         17.8          56.2       6.6X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 1 distinct string row (value = '100'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                     5749           5772          33          2.7         365.5       1.0X
-Parquet Vectorized (Pushdown)                           253            259           5         62.1          16.1      22.7X
-Native ORC Vectorized                                  6567           6587          26          2.4         417.5       0.9X
-Native ORC Vectorized (Pushdown)                        963            971           8         16.3          61.2       6.0X
+Parquet Vectorized                                     5740           5746           6          2.7         364.9       1.0X
+Parquet Vectorized (Pushdown)                           254            259           3         61.9          16.2      22.6X
+Native ORC Vectorized                                  8463           8476          15          1.9         538.1       0.7X
+Native ORC Vectorized (Pushdown)                        937            956          32         16.8          59.6       6.1X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 1 distinct string row (value <=> '100'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                       5750           5765          22          2.7         365.6       1.0X
-Parquet Vectorized (Pushdown)                             253            257           6         62.2          16.1      22.7X
-Native ORC Vectorized                                    6571           6588          24          2.4         417.8       0.9X
-Native ORC Vectorized (Pushdown)                          958            964           7         16.4          60.9       6.0X
+Parquet Vectorized                                       5757           5766           9          2.7         366.0       1.0X
+Parquet Vectorized (Pushdown)                             253            259           6         62.1          16.1      22.7X
+Native ORC Vectorized                                    8502           8517          16          1.9         540.5       0.7X
+Native ORC Vectorized (Pushdown)                          938            941           2         16.8          59.6       6.1X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 1 distinct string row ('100' <= value <= '100'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                               5824           5850          44          2.7         370.3       1.0X
-Parquet Vectorized (Pushdown)                                     255            260           7         61.7          16.2      22.9X
-Native ORC Vectorized                                            6632           6641           8          2.4         421.7       0.9X
-Native ORC Vectorized (Pushdown)                                  966            978           7         16.3          61.4       6.0X
+Parquet Vectorized                                               5845           5850           3          2.7         371.6       1.0X
+Parquet Vectorized (Pushdown)                                     255            260           5         61.8          16.2      23.0X
+Native ORC Vectorized                                            8528           8540           8          1.8         542.2       0.7X
+Native ORC Vectorized (Pushdown)                                  942            959          27         16.7          59.9       6.2X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select all distinct string rows (value IS NOT NULL):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                           12450          12487          30          1.3         791.6       1.0X
-Parquet Vectorized (Pushdown)                                12503          12535          29          1.3         794.9       1.0X
-Native ORC Vectorized                                        13539          13565          22          1.2         860.8       0.9X
-Native ORC Vectorized (Pushdown)                             13836          13855          15          1.1         879.7       0.9X
+Parquet Vectorized                                           12457          12486          25          1.3         792.0       1.0X
+Parquet Vectorized (Pushdown)                                12527          12568          62          1.3         796.4       1.0X
+Native ORC Vectorized                                        15088          15111          19          1.0         959.3       0.8X
+Native ORC Vectorized (Pushdown)                             15393          15410          15          1.0         978.7       0.8X
 
 
 ================================================================================================
 Pushdown benchmark for StringStartsWith
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 StringStartsWith filter: (value like '10%'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                    6935           6979          80          2.3         440.9       1.0X
-Parquet Vectorized (Pushdown)                          867            871           6         18.2          55.1       8.0X
-Native ORC Vectorized                                 5915           5933          24          2.7         376.1       1.2X
-Native ORC Vectorized (Pushdown)                      6072           6081          13          2.6         386.1       1.1X
+Parquet Vectorized                                    6943           6978          46          2.3         441.4       1.0X
+Parquet Vectorized (Pushdown)                          870            875           7         18.1          55.3       8.0X
+Native ORC Vectorized                                 7381           7398          17          2.1         469.3       0.9X
+Native ORC Vectorized (Pushdown)                      7448           7479          17          2.1         473.6       0.9X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 StringStartsWith filter: (value like '1000%'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                      6772           6792          20          2.3         430.5       1.0X
-Parquet Vectorized (Pushdown)                            246            251           6         64.0          15.6      27.6X
-Native ORC Vectorized                                   5768           5774           4          2.7         366.7       1.2X
-Native ORC Vectorized (Pushdown)                        5934           5948          20          2.7         377.3       1.1X
+Parquet Vectorized                                      6796           6815          24          2.3         432.1       1.0X
+Parquet Vectorized (Pushdown)                            245            250           6         64.2          15.6      27.7X
+Native ORC Vectorized                                   7210           7223          19          2.2         458.4       0.9X
+Native ORC Vectorized (Pushdown)                        7302           7311           8          2.2         464.2       0.9X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 StringStartsWith filter: (value like '786432%'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                        6748           6766          14          2.3         429.0       1.0X
-Parquet Vectorized (Pushdown)                              237            244           5         66.3          15.1      28.5X
-Native ORC Vectorized                                     5836           5853          22          2.7         371.1       1.2X
-Native ORC Vectorized (Pushdown)                          5993           6007          19          2.6         381.0       1.1X
+Parquet Vectorized                                        6790           6800          18          2.3         431.7       1.0X
+Parquet Vectorized (Pushdown)                              238            243           8         66.1          15.1      28.5X
+Native ORC Vectorized                                     7203           7212          13          2.2         457.9       0.9X
+Native ORC Vectorized (Pushdown)                          7304           7317          17          2.2         464.4       0.9X
 
 
 ================================================================================================
 Pushdown benchmark for StringEndsWith
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 StringEndsWith filter: (value like '%10'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                  5726           5750          19          2.7         364.0       1.0X
-Parquet Vectorized (Pushdown)                        324            335          12         48.5          20.6      17.7X
-Native ORC Vectorized                               6519           6533          19          2.4         414.5       0.9X
-Native ORC Vectorized (Pushdown)                    6815           6822           8          2.3         433.3       0.8X
+Parquet Vectorized                                  5764           5780          14          2.7         366.5       1.0X
+Parquet Vectorized (Pushdown)                        329            336           8         47.8          20.9      17.5X
+Native ORC Vectorized                               8427           8443          18          1.9         535.7       0.7X
+Native ORC Vectorized (Pushdown)                    8730           8747          27          1.8         555.0       0.7X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 StringEndsWith filter: (value like '%1000'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                    5689           5704          14          2.8         361.7       1.0X
-Parquet Vectorized (Pushdown)                          237            240           2         66.2          15.1      24.0X
-Native ORC Vectorized                                 6478           6482           5          2.4         411.9       0.9X
-Native ORC Vectorized (Pushdown)                      6789           6802          20          2.3         431.6       0.8X
+Parquet Vectorized                                    5713           5725          11          2.8         363.2       1.0X
+Parquet Vectorized (Pushdown)                          238            243           4         66.2          15.1      24.0X
+Native ORC Vectorized                                 8400           8414          10          1.9         534.1       0.7X
+Native ORC Vectorized (Pushdown)                      8689           8699           7          1.8         552.4       0.7X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 StringEndsWith filter: (value like '%786432'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                      5694           5715          35          2.8         362.0       1.0X
-Parquet Vectorized (Pushdown)                            236            241           3         66.6          15.0      24.1X
-Native ORC Vectorized                                   6475           6481           8          2.4         411.7       0.9X
-Native ORC Vectorized (Pushdown)                        6784           6796          20          2.3         431.3       0.8X
+Parquet Vectorized                                      5716           5722           9          2.8         363.4       1.0X
+Parquet Vectorized (Pushdown)                            239            241           2         65.7          15.2      23.9X
+Native ORC Vectorized                                   8398           8415          15          1.9         533.9       0.7X
+Native ORC Vectorized (Pushdown)                        8681           8740          44          1.8         552.0       0.7X
 
 
 ================================================================================================
 Pushdown benchmark for StringContains
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 StringContains filter: (value like '%10%'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                   5914           5926          16          2.7         376.0       1.0X
-Parquet Vectorized (Pushdown)                         739            754          25         21.3          47.0       8.0X
-Native ORC Vectorized                                6673           6707          28          2.4         424.3       0.9X
-Native ORC Vectorized (Pushdown)                     6986           7001          17          2.3         444.2       0.8X
+Parquet Vectorized                                   5922           5931          13          2.7         376.5       1.0X
+Parquet Vectorized (Pushdown)                         736            738           3         21.4          46.8       8.0X
+Native ORC Vectorized                                8614           8629          13          1.8         547.7       0.7X
+Native ORC Vectorized (Pushdown)                     8951           8968          30          1.8         569.1       0.7X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 StringContains filter: (value like '%1000%'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                     5714           5738          22          2.8         363.3       1.0X
-Parquet Vectorized (Pushdown)                           238            245           7         66.0          15.2      24.0X
-Native ORC Vectorized                                  6529           6539           9          2.4         415.1       0.9X
-Native ORC Vectorized (Pushdown)                       6846           6857           7          2.3         435.3       0.8X
+Parquet Vectorized                                     5724           5730           5          2.7         363.9       1.0X
+Parquet Vectorized (Pushdown)                           235            254          29         67.0          14.9      24.4X
+Native ORC Vectorized                                  8450           8469          25          1.9         537.2       0.7X
+Native ORC Vectorized (Pushdown)                       8750           8756           6          1.8         556.3       0.7X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 StringContains filter: (value like '%786432%'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                       5706           5724          26          2.8         362.8       1.0X
-Parquet Vectorized (Pushdown)                             237            242           4         66.4          15.1      24.1X
-Native ORC Vectorized                                    6519           6538          17          2.4         414.5       0.9X
-Native ORC Vectorized (Pushdown)                         6806           6855          29          2.3         432.7       0.8X
+Parquet Vectorized                                       5710           5716           6          2.8         363.0       1.0X
+Parquet Vectorized (Pushdown)                             235            241           3         67.0          14.9      24.3X
+Native ORC Vectorized                                    8454           8487          39          1.9         537.5       0.7X
+Native ORC Vectorized (Pushdown)                         8752           8757           5          1.8         556.5       0.7X
 
 
 ================================================================================================
 Pushdown benchmark for decimal
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 1 decimal(9, 2) row (value = 7864320):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                     2767           2788          16          5.7         175.9       1.0X
-Parquet Vectorized (Pushdown)                            63             66           3        247.9           4.0      43.6X
-Native ORC Vectorized                                  3721           3740          27          4.2         236.6       0.7X
-Native ORC Vectorized (Pushdown)                        150            161          10        105.2           9.5      18.5X
+Parquet Vectorized                                     2801           2811           7          5.6         178.1       1.0X
+Parquet Vectorized (Pushdown)                            63             66           4        250.0           4.0      44.5X
+Native ORC Vectorized                                  3765           3779          11          4.2         239.4       0.7X
+Native ORC Vectorized (Pushdown)                         61             68           8        259.2           3.9      46.1X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 10% decimal(9, 2) rows (value < 1572864):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                        3873           3882          14          4.1         246.2       1.0X
-Parquet Vectorized (Pushdown)                             1714           1725          20          9.2         109.0       2.3X
-Native ORC Vectorized                                     4922           4937          15          3.2         312.9       0.8X
-Native ORC Vectorized (Pushdown)                          2086           2093          13          7.5         132.6       1.9X
+Parquet Vectorized                                        3895           3901           6          4.0         247.6       1.0X
+Parquet Vectorized (Pushdown)                             1718           1725           9          9.2         109.2       2.3X
+Native ORC Vectorized                                     5023           5043          20          3.1         319.3       0.8X
+Native ORC Vectorized (Pushdown)                          2037           2046           9          7.7         129.5       1.9X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 50% decimal(9, 2) rows (value < 7864320):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                        7610           7642          38          2.1         483.8       1.0X
-Parquet Vectorized (Pushdown)                             7267           7303          31          2.2         462.0       1.0X
-Native ORC Vectorized                                     8880           8898          16          1.8         564.6       0.9X
-Native ORC Vectorized (Pushdown)                          8442           8481          38          1.9         536.7       0.9X
+Parquet Vectorized                                        7610           7624          17          2.1         483.8       1.0X
+Parquet Vectorized (Pushdown)                             7263           7282          29          2.2         461.8       1.0X
+Native ORC Vectorized                                     9291           9304           9          1.7         590.7       0.8X
+Native ORC Vectorized (Pushdown)                          8822           8841          18          1.8         560.9       0.9X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 90% decimal(9, 2) rows (value < 14155776):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                         8654           8682          22          1.8         550.2       1.0X
-Parquet Vectorized (Pushdown)                              8683           8691           6          1.8         552.1       1.0X
-Native ORC Vectorized                                     10100          10129          32          1.6         642.1       0.9X
-Native ORC Vectorized (Pushdown)                          10050          10069          24          1.6         638.9       0.9X
+Parquet Vectorized                                         8676           8690          13          1.8         551.6       1.0X
+Parquet Vectorized (Pushdown)                              8706           8717          11          1.8         553.5       1.0X
+Native ORC Vectorized                                     10341          10355          11          1.5         657.4       0.8X
+Native ORC Vectorized (Pushdown)                          10323          10342          23          1.5         656.3       0.8X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 1 decimal(18, 2) row (value = 7864320):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                      2976           3003          28          5.3         189.2       1.0X
-Parquet Vectorized (Pushdown)                             62             64           2        252.1           4.0      47.7X
-Native ORC Vectorized                                   3715           3732          26          4.2         236.2       0.8X
-Native ORC Vectorized (Pushdown)                         147            154           7        107.0           9.3      20.2X
+Parquet Vectorized                                      3004           3025          13          5.2         191.0       1.0X
+Parquet Vectorized (Pushdown)                             62             65           5        255.0           3.9      48.7X
+Native ORC Vectorized                                   3771           3782          14          4.2         239.7       0.8X
+Native ORC Vectorized (Pushdown)                          56             58           2        281.4           3.6      53.7X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 10% decimal(18, 2) rows (value < 1572864):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                         3575           3591          17          4.4         227.3       1.0X
-Parquet Vectorized (Pushdown)                               943            947           3         16.7          60.0       3.8X
-Native ORC Vectorized                                      4362           4369           7          3.6         277.4       0.8X
-Native ORC Vectorized (Pushdown)                           1126           1136          14         14.0          71.6       3.2X
+Parquet Vectorized                                         3572           3591          24          4.4         227.1       1.0X
+Parquet Vectorized (Pushdown)                               891            897           3         17.6          56.7       4.0X
+Native ORC Vectorized                                      4409           4426          27          3.6         280.3       0.8X
+Native ORC Vectorized (Pushdown)                           1041           1048           9         15.1          66.2       3.4X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 50% decimal(18, 2) rows (value < 7864320):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                         5968           5986          16          2.6         379.4       1.0X
-Parquet Vectorized (Pushdown)                              4522           4531          14          3.5         287.5       1.3X
-Native ORC Vectorized                                      6853           6869          20          2.3         435.7       0.9X
-Native ORC Vectorized (Pushdown)                           5076           5088          21          3.1         322.7       1.2X
+Parquet Vectorized                                         5790           5807          21          2.7         368.1       1.0X
+Parquet Vectorized (Pushdown)                              4307           4315          11          3.7         273.8       1.3X
+Native ORC Vectorized                                      6926           6941          11          2.3         440.3       0.8X
+Native ORC Vectorized (Pushdown)                           5036           5041           8          3.1         320.2       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 90% decimal(18, 2) rows (value < 14155776):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                          8307           8320          23          1.9         528.2       1.0X
-Parquet Vectorized (Pushdown)                               8032           8047          17          2.0         510.6       1.0X
-Native ORC Vectorized                                       9259           9285          25          1.7         588.7       0.9X
-Native ORC Vectorized (Pushdown)                            8950           8963          13          1.8         569.0       0.9X
+Parquet Vectorized                                          7990           8014          42          2.0         508.0       1.0X
+Parquet Vectorized (Pushdown)                               7697           7721          24          2.0         489.4       1.0X
+Native ORC Vectorized                                       9375           9530         303          1.7         596.1       0.9X
+Native ORC Vectorized (Pushdown)                            9054           9060           6          1.7         575.6       0.9X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 1 decimal(38, 2) row (value = 7864320):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                      4191           4200          16          3.8         266.4       1.0X
-Parquet Vectorized (Pushdown)                             68             70           3        230.9           4.3      61.5X
-Native ORC Vectorized                                   3755           3761           6          4.2         238.7       1.1X
-Native ORC Vectorized (Pushdown)                         147            153           7        106.7           9.4      28.4X
+Parquet Vectorized                                      4220           4234          13          3.7         268.3       1.0X
+Parquet Vectorized (Pushdown)                             68             69           2        232.0           4.3      62.3X
+Native ORC Vectorized                                   3852           3861           8          4.1         244.9       1.1X
+Native ORC Vectorized (Pushdown)                          56             60           4        280.5           3.6      75.2X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 10% decimal(38, 2) rows (value < 1572864):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                         5028           5075          46          3.1         319.7       1.0X
-Parquet Vectorized (Pushdown)                              1283           1291           6         12.3          81.6       3.9X
-Native ORC Vectorized                                      4548           4561          18          3.5         289.2       1.1X
-Native ORC Vectorized (Pushdown)                           1291           1293           2         12.2          82.1       3.9X
+Parquet Vectorized                                         5039           5063          30          3.1         320.4       1.0X
+Parquet Vectorized (Pushdown)                              1303           1309           6         12.1          82.9       3.9X
+Native ORC Vectorized                                      4598           4608          13          3.4         292.4       1.1X
+Native ORC Vectorized (Pushdown)                           1174           1176           2         13.4          74.7       4.3X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 50% decimal(38, 2) rows (value < 7864320):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                         8244           8265          24          1.9         524.2       1.0X
-Parquet Vectorized (Pushdown)                              6195           6210          26          2.5         393.9       1.3X
-Native ORC Vectorized                                      7700           7717          21          2.0         489.5       1.1X
-Native ORC Vectorized (Pushdown)                           5907           5919          15          2.7         375.5       1.4X
+Parquet Vectorized                                         8371           8382          13          1.9         532.2       1.0X
+Parquet Vectorized (Pushdown)                              6298           6306           9          2.5         400.4       1.3X
+Native ORC Vectorized                                      7603           7610           6          2.1         483.4       1.1X
+Native ORC Vectorized (Pushdown)                           5661           5673           8          2.8         359.9       1.5X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 90% decimal(38, 2) rows (value < 14155776):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                         11459          11494          30          1.4         728.5       1.0X
-Parquet Vectorized (Pushdown)                              11024          11061          22          1.4         700.9       1.0X
-Native ORC Vectorized                                      10817          10848          40          1.5         687.8       1.1X
-Native ORC Vectorized (Pushdown)                           10480          10512          39          1.5         666.3       1.1X
+Parquet Vectorized                                         11641          11651          11          1.4         740.1       1.0X
+Parquet Vectorized (Pushdown)                              11260          11271          11          1.4         715.9       1.0X
+Native ORC Vectorized                                      10561          10591          28          1.5         671.5       1.1X
+Native ORC Vectorized (Pushdown)                           10288          10325          32          1.5         654.1       1.1X
 
 
 ================================================================================================
 Pushdown benchmark for InSet -> InFilters
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 InSet -> InFilters (values count: 5, distribution: 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                               6379           6393          17          2.5         405.6       1.0X
-Parquet Vectorized (Pushdown)                                     250            256           6         62.8          15.9      25.5X
-Native ORC Vectorized                                            5205           5237          35          3.0         330.9       1.2X
-Native ORC Vectorized (Pushdown)                                  481            500          21         32.7          30.6      13.3X
+Parquet Vectorized                                               6413           6428          14          2.5         407.7       1.0X
+Parquet Vectorized (Pushdown)                                     254            256           2         61.9          16.2      25.2X
+Native ORC Vectorized                                            6988           6997          13          2.3         444.3       0.9X
+Native ORC Vectorized (Pushdown)                                  291            297          11         54.1          18.5      22.1X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 InSet -> InFilters (values count: 5, distribution: 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                               6369           6390          13          2.5         405.0       1.0X
-Parquet Vectorized (Pushdown)                                     250            255           3         62.9          15.9      25.5X
-Native ORC Vectorized                                            5221           5239          18          3.0         332.0       1.2X
-Native ORC Vectorized (Pushdown)                                  487            495           8         32.3          31.0      13.1X
+Parquet Vectorized                                               6414           6431          26          2.5         407.8       1.0X
+Parquet Vectorized (Pushdown)                                     253            260          12         62.2          16.1      25.4X
+Native ORC Vectorized                                            6993           7001           8          2.2         444.6       0.9X
+Native ORC Vectorized (Pushdown)                                  293            298           9         53.7          18.6      21.9X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 InSet -> InFilters (values count: 5, distribution: 90):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                               6393           6404           6          2.5         406.5       1.0X
-Parquet Vectorized (Pushdown)                                     251            255           3         62.6          16.0      25.5X
-Native ORC Vectorized                                            5226           5242          16          3.0         332.2       1.2X
-Native ORC Vectorized (Pushdown)                                  487            497           7         32.3          31.0      13.1X
+Parquet Vectorized                                               6421           6425           7          2.4         408.2       1.0X
+Parquet Vectorized (Pushdown)                                     252            256           3         62.5          16.0      25.5X
+Native ORC Vectorized                                            6989           6995           4          2.3         444.4       0.9X
+Native ORC Vectorized (Pushdown)                                  293            294           1         53.7          18.6      21.9X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 InSet -> InFilters (values count: 10, distribution: 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                6379           6400          25          2.5         405.6       1.0X
-Parquet Vectorized (Pushdown)                                      268            274           7         58.7          17.0      23.8X
-Native ORC Vectorized                                             5238           5260          18          3.0         333.0       1.2X
-Native ORC Vectorized (Pushdown)                                   503            515          12         31.3          32.0      12.7X
+Parquet Vectorized                                                6438           6446           7          2.4         409.3       1.0X
+Parquet Vectorized (Pushdown)                                      268            274           4         58.7          17.0      24.0X
+Native ORC Vectorized                                             6993           7008          16          2.2         444.6       0.9X
+Native ORC Vectorized (Pushdown)                                   312            315           2         50.4          19.8      20.6X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 InSet -> InFilters (values count: 10, distribution: 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                6395           6435          38          2.5         406.6       1.0X
-Parquet Vectorized (Pushdown)                                      271            278           8         58.1          17.2      23.6X
-Native ORC Vectorized                                             5239           5246          11          3.0         333.1       1.2X
-Native ORC Vectorized (Pushdown)                                   507            513           5         31.0          32.2      12.6X
+Parquet Vectorized                                                6421           6432           7          2.4         408.3       1.0X
+Parquet Vectorized (Pushdown)                                      270            273           3         58.3          17.2      23.8X
+Native ORC Vectorized                                             7000           7006           5          2.2         445.1       0.9X
+Native ORC Vectorized (Pushdown)                                   318            321           2         49.5          20.2      20.2X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 InSet -> InFilters (values count: 10, distribution: 90):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                6394           6423          37          2.5         406.5       1.0X
-Parquet Vectorized (Pushdown)                                      269            273           3         58.5          17.1      23.8X
-Native ORC Vectorized                                             5237           5242           5          3.0         333.0       1.2X
-Native ORC Vectorized (Pushdown)                                   510            513           3         30.9          32.4      12.5X
+Parquet Vectorized                                                6431           6444           8          2.4         408.8       1.0X
+Parquet Vectorized (Pushdown)                                      269            274           3         58.5          17.1      23.9X
+Native ORC Vectorized                                             6992           7013          19          2.2         444.6       0.9X
+Native ORC Vectorized (Pushdown)                                   321            322           2         49.0          20.4      20.0X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 InSet -> InFilters (values count: 50, distribution: 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                6603           6641          28          2.4         419.8       1.0X
-Parquet Vectorized (Pushdown)                                      878            909          41         17.9          55.8       7.5X
-Native ORC Vectorized                                             5444           5454           7          2.9         346.1       1.2X
-Native ORC Vectorized (Pushdown)                                   623            648          30         25.2          39.6      10.6X
+Parquet Vectorized                                                6610           6628          18          2.4         420.2       1.0X
+Parquet Vectorized (Pushdown)                                      839            843           6         18.7          53.3       7.9X
+Native ORC Vectorized                                             7199           7205           7          2.2         457.7       0.9X
+Native ORC Vectorized (Pushdown)                                   482            485           3         32.6          30.7      13.7X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 InSet -> InFilters (values count: 50, distribution: 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                6591           6601          14          2.4         419.0       1.0X
-Parquet Vectorized (Pushdown)                                     3370           3393          23          4.7         214.3       2.0X
-Native ORC Vectorized                                             5441           5450           6          2.9         345.9       1.2X
-Native ORC Vectorized (Pushdown)                                   644            646           2         24.4          40.9      10.2X
+Parquet Vectorized                                                6617           6626          11          2.4         420.7       1.0X
+Parquet Vectorized (Pushdown)                                     3402           3409           6          4.6         216.3       1.9X
+Native ORC Vectorized                                             7239           7252           9          2.2         460.2       0.9X
+Native ORC Vectorized (Pushdown)                                   540            544           3         29.1          34.3      12.3X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 InSet -> InFilters (values count: 50, distribution: 90):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                6589           6614          22          2.4         418.9       1.0X
-Parquet Vectorized (Pushdown)                                     5987           6001          11          2.6         380.6       1.1X
-Native ORC Vectorized                                             5502           5508           6          2.9         349.8       1.2X
-Native ORC Vectorized (Pushdown)                                   661            663           1         23.8          42.0      10.0X
+Parquet Vectorized                                                6620           6633          11          2.4         420.9       1.0X
+Parquet Vectorized (Pushdown)                                     5296           5302           4          3.0         336.7       1.2X
+Native ORC Vectorized                                             7232           7237           4          2.2         459.8       0.9X
+Native ORC Vectorized (Pushdown)                                   532            538           8         29.6          33.8      12.4X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 InSet -> InFilters (values count: 100, distribution: 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                 6622           6637          14          2.4         421.0       1.0X
-Parquet Vectorized (Pushdown)                                       890            894           3         17.7          56.6       7.4X
-Native ORC Vectorized                                              5430           5455          15          2.9         345.2       1.2X
-Native ORC Vectorized (Pushdown)                                    736            747           9         21.4          46.8       9.0X
+Parquet Vectorized                                                 6578           6592          17          2.4         418.2       1.0X
+Parquet Vectorized (Pushdown)                                       877            881           5         17.9          55.7       7.5X
+Native ORC Vectorized                                              7191           7195           6          2.2         457.2       0.9X
+Native ORC Vectorized (Pushdown)                                    642            645           3         24.5          40.8      10.2X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 InSet -> InFilters (values count: 100, distribution: 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                 6610           6635          36          2.4         420.3       1.0X
-Parquet Vectorized (Pushdown)                                      3408           3423          11          4.6         216.7       1.9X
-Native ORC Vectorized                                              5455           5471          13          2.9         346.8       1.2X
-Native ORC Vectorized (Pushdown)                                    816            826          11         19.3          51.9       8.1X
+Parquet Vectorized                                                 6577           6593          15          2.4         418.1       1.0X
+Parquet Vectorized (Pushdown)                                      3323           3336          12          4.7         211.3       2.0X
+Native ORC Vectorized                                              7159           7164           6          2.2         455.2       0.9X
+Native ORC Vectorized (Pushdown)                                    762            764           4         20.6          48.5       8.6X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 InSet -> InFilters (values count: 100, distribution: 90):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                 6616           6632          22          2.4         420.6       1.0X
-Parquet Vectorized (Pushdown)                                      5960           5993          21          2.6         378.9       1.1X
-Native ORC Vectorized                                              5441           5448           8          2.9         345.9       1.2X
-Native ORC Vectorized (Pushdown)                                    799            804           6         19.7          50.8       8.3X
+Parquet Vectorized                                                 6576           6592          11          2.4         418.1       1.0X
+Parquet Vectorized (Pushdown)                                      5924           5941          12          2.7         376.6       1.1X
+Native ORC Vectorized                                              7165           7171           7          2.2         455.6       0.9X
+Native ORC Vectorized (Pushdown)                                    781            787           8         20.1          49.7       8.4X
 
 
 ================================================================================================
 Pushdown benchmark for tinyint
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 1 tinyint row (value = CAST(63 AS tinyint)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                           3057           3068          12          5.1         194.3       1.0X
-Parquet Vectorized (Pushdown)                                 102            105           5        154.8           6.5      30.1X
-Native ORC Vectorized                                        2565           2580          25          6.1         163.1       1.2X
-Native ORC Vectorized (Pushdown)                              205            211           9         76.7          13.0      14.9X
+Parquet Vectorized                                           3074           3086          16          5.1         195.5       1.0X
+Parquet Vectorized (Pushdown)                                  99            101           2        159.1           6.3      31.1X
+Native ORC Vectorized                                        3003           3008           6          5.2         190.9       1.0X
+Native ORC Vectorized (Pushdown)                              118            122           6        133.8           7.5      26.1X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 10% tinyint rows (value < CAST(12 AS tinyint)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                              3603           3613          11          4.4         229.1       1.0X
-Parquet Vectorized (Pushdown)                                    888            896          10         17.7          56.4       4.1X
-Native ORC Vectorized                                           3080           3099          23          5.1         195.8       1.2X
-Native ORC Vectorized (Pushdown)                                 929            935           6         16.9          59.1       3.9X
+Parquet Vectorized                                              3628           3646          26          4.3         230.7       1.0X
+Parquet Vectorized (Pushdown)                                    887            893           4         17.7          56.4       4.1X
+Native ORC Vectorized                                           3528           3534           4          4.5         224.3       1.0X
+Native ORC Vectorized (Pushdown)                                 887            890           3         17.7          56.4       4.1X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 50% tinyint rows (value < CAST(63 AS tinyint)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                              5788           5811          21          2.7         368.0       1.0X
-Parquet Vectorized (Pushdown)                                   4301           4309          13          3.7         273.5       1.3X
-Native ORC Vectorized                                           5246           5259          10          3.0         333.5       1.1X
-Native ORC Vectorized (Pushdown)                                4077           4095          26          3.9         259.2       1.4X
+Parquet Vectorized                                              5829           5839          12          2.7         370.6       1.0X
+Parquet Vectorized (Pushdown)                                   4311           4333          21          3.6         274.1       1.4X
+Native ORC Vectorized                                           5627           5642          15          2.8         357.7       1.0X
+Native ORC Vectorized (Pushdown)                                4146           4158          10          3.8         263.6       1.4X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 90% tinyint rows (value < CAST(114 AS tinyint)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                               7995           8066          43          2.0         508.3       1.0X
-Parquet Vectorized (Pushdown)                                    7760           7793          21          2.0         493.3       1.0X
-Native ORC Vectorized                                            7433           7449          20          2.1         472.6       1.1X
-Native ORC Vectorized (Pushdown)                                 7231           7245          17          2.2         459.7       1.1X
+Parquet Vectorized                                               7918           7922           4          2.0         503.4       1.0X
+Parquet Vectorized (Pushdown)                                    7637           7648          11          2.1         485.6       1.0X
+Native ORC Vectorized                                            7874           7878           4          2.0         500.6       1.0X
+Native ORC Vectorized (Pushdown)                                 7598           7617          16          2.1         483.1       1.0X
 
 
 ================================================================================================
 Pushdown benchmark for Timestamp
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 1 timestamp stored as INT96 row (value = timestamp_seconds(7864320)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                                    3210           3223          11          4.9         204.1       1.0X
-Parquet Vectorized (Pushdown)                                                         3210           3230          26          4.9         204.1       1.0X
-Native ORC Vectorized                                                                 2612           2630          24          6.0         166.1       1.2X
-Native ORC Vectorized (Pushdown)                                                       120            127           6        130.8           7.6      26.7X
+Parquet Vectorized                                                                    3213           3223          10          4.9         204.3       1.0X
+Parquet Vectorized (Pushdown)                                                         3213           3224           6          4.9         204.3       1.0X
+Native ORC Vectorized                                                                 2593           2641          88          6.1         164.8       1.2X
+Native ORC Vectorized (Pushdown)                                                        41             43           4        387.4           2.6      79.1X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 10% timestamp stored as INT96 rows (value < timestamp_seconds(1572864)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                                       3783           3807          24          4.2         240.5       1.0X
-Parquet Vectorized (Pushdown)                                                            3784           3795          16          4.2         240.6       1.0X
-Native ORC Vectorized                                                                    3153           3157           4          5.0         200.5       1.2X
-Native ORC Vectorized (Pushdown)                                                          907            914           5         17.3          57.7       4.2X
+Parquet Vectorized                                                                       3777           3783           7          4.2         240.2       1.0X
+Parquet Vectorized (Pushdown)                                                            3771           3780          18          4.2         239.8       1.0X
+Native ORC Vectorized                                                                    3163           3173          14          5.0         201.1       1.2X
+Native ORC Vectorized (Pushdown)                                                          851            853           2         18.5          54.1       4.4X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 50% timestamp stored as INT96 rows (value < timestamp_seconds(7864320)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                                       6098           6113          15          2.6         387.7       1.0X
-Parquet Vectorized (Pushdown)                                                            6107           6111           3          2.6         388.3       1.0X
-Native ORC Vectorized                                                                    5362           5380          14          2.9         340.9       1.1X
-Native ORC Vectorized (Pushdown)                                                         4138           4146           6          3.8         263.1       1.5X
+Parquet Vectorized                                                                       6095           6118          18          2.6         387.5       1.0X
+Parquet Vectorized (Pushdown)                                                            6108           6117          12          2.6         388.3       1.0X
+Native ORC Vectorized                                                                    5578           5594          18          2.8         354.6       1.1X
+Native ORC Vectorized (Pushdown)                                                         4239           4254          28          3.7         269.5       1.4X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 90% timestamp stored as INT96 rows (value < timestamp_seconds(14155776)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                                        8131           8146          14          1.9         516.9       1.0X
-Parquet Vectorized (Pushdown)                                                             8117           8144          28          1.9         516.1       1.0X
-Native ORC Vectorized                                                                     7621           7642          30          2.1         484.5       1.1X
-Native ORC Vectorized (Pushdown)                                                          7407           7443          34          2.1         471.0       1.1X
+Parquet Vectorized                                                                        8448           8452           3          1.9         537.1       1.0X
+Parquet Vectorized (Pushdown)                                                             8442           8448           6          1.9         536.7       1.0X
+Native ORC Vectorized                                                                     7778           7787          10          2.0         494.5       1.1X
+Native ORC Vectorized (Pushdown)                                                          7522           7534           9          2.1         478.2       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 1 timestamp stored as TIMESTAMP_MICROS row (value = timestamp_seconds(7864320)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                                               2945           2963          22          5.3         187.2       1.0X
-Parquet Vectorized (Pushdown)                                                                      62             64           2        253.4           3.9      47.4X
-Native ORC Vectorized                                                                            2603           2617          13          6.0         165.5       1.1X
-Native ORC Vectorized (Pushdown)                                                                  123            131           8        127.8           7.8      23.9X
+Parquet Vectorized                                                                               2981           2998          17          5.3         189.6       1.0X
+Parquet Vectorized (Pushdown)                                                                      62             65           7        255.7           3.9      48.5X
+Native ORC Vectorized                                                                            2589           2593           5          6.1         164.6       1.2X
+Native ORC Vectorized (Pushdown)                                                                   41             43           3        384.7           2.6      72.9X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 10% timestamp stored as TIMESTAMP_MICROS rows (value < timestamp_seconds(1572864)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                                                  3491           3498           5          4.5         221.9       1.0X
-Parquet Vectorized (Pushdown)                                                                        903            907           4         17.4          57.4       3.9X
-Native ORC Vectorized                                                                               3159           3171          10          5.0         200.8       1.1X
-Native ORC Vectorized (Pushdown)                                                                     916            919           3         17.2          58.2       3.8X
+Parquet Vectorized                                                                                  3550           3564          17          4.4         225.7       1.0X
+Parquet Vectorized (Pushdown)                                                                        922            925           3         17.1          58.6       3.9X
+Native ORC Vectorized                                                                               3168           3170           4          5.0         201.4       1.1X
+Native ORC Vectorized (Pushdown)                                                                     851            855           5         18.5          54.1       4.2X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 50% timestamp stored as TIMESTAMP_MICROS rows (value < timestamp_seconds(7864320)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                                                  5820           5840          15          2.7         370.0       1.0X
-Parquet Vectorized (Pushdown)                                                                       4379           4391          16          3.6         278.4       1.3X
-Native ORC Vectorized                                                                               5353           5384          31          2.9         340.3       1.1X
-Native ORC Vectorized (Pushdown)                                                                    4131           4135           5          3.8         262.7       1.4X
+Parquet Vectorized                                                                                  5856           5865           8          2.7         372.3       1.0X
+Parquet Vectorized (Pushdown)                                                                       4396           4408           8          3.6         279.5       1.3X
+Native ORC Vectorized                                                                               5570           5583           8          2.8         354.1       1.1X
+Native ORC Vectorized (Pushdown)                                                                    4208           4239          18          3.7         267.6       1.4X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 90% timestamp stored as TIMESTAMP_MICROS rows (value < timestamp_seconds(14155776)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                                                   7812           7870          67          2.0         496.7       1.0X
-Parquet Vectorized (Pushdown)                                                                        7546           7580          26          2.1         479.8       1.0X
-Native ORC Vectorized                                                                                7640           7656          16          2.1         485.7       1.0X
-Native ORC Vectorized (Pushdown)                                                                     7406           7448          32          2.1         470.9       1.1X
+Parquet Vectorized                                                                                   8213           8235          16          1.9         522.2       1.0X
+Parquet Vectorized (Pushdown)                                                                        7933           7943          10          2.0         504.4       1.0X
+Native ORC Vectorized                                                                                7754           7775          17          2.0         493.0       1.1X
+Native ORC Vectorized (Pushdown)                                                                     7517           7525           8          2.1         477.9       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 1 timestamp stored as TIMESTAMP_MILLIS row (value = timestamp_seconds(7864320)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                                               2959           2965           7          5.3         188.1       1.0X
-Parquet Vectorized (Pushdown)                                                                      64             66           3        247.6           4.0      46.6X
-Native ORC Vectorized                                                                            2619           2637          18          6.0         166.5       1.1X
-Native ORC Vectorized (Pushdown)                                                                  122            129          11        128.6           7.8      24.2X
+Parquet Vectorized                                                                               3006           3015          16          5.2         191.1       1.0X
+Parquet Vectorized (Pushdown)                                                                      61             63           2        256.7           3.9      49.1X
+Native ORC Vectorized                                                                            2592           2596           7          6.1         164.8       1.2X
+Native ORC Vectorized (Pushdown)                                                                   40             43           4        396.3           2.5      75.7X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 10% timestamp stored as TIMESTAMP_MILLIS rows (value < timestamp_seconds(1572864)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                                                  3519           3528           8          4.5         223.7       1.0X
-Parquet Vectorized (Pushdown)                                                                        903            907           3         17.4          57.4       3.9X
-Native ORC Vectorized                                                                               3158           3165           9          5.0         200.8       1.1X
-Native ORC Vectorized (Pushdown)                                                                     913            915           1         17.2          58.0       3.9X
+Parquet Vectorized                                                                                  3563           3568           5          4.4         226.5       1.0X
+Parquet Vectorized (Pushdown)                                                                        923            926           4         17.0          58.7       3.9X
+Native ORC Vectorized                                                                               3166           3171           5          5.0         201.3       1.1X
+Native ORC Vectorized (Pushdown)                                                                     852            852           1         18.5          54.1       4.2X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 50% timestamp stored as TIMESTAMP_MILLIS rows (value < timestamp_seconds(7864320)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                                                  5820           5828           7          2.7         370.0       1.0X
-Parquet Vectorized (Pushdown)                                                                       4393           4404           9          3.6         279.3       1.3X
-Native ORC Vectorized                                                                               5355           5362           7          2.9         340.4       1.1X
-Native ORC Vectorized (Pushdown)                                                                    4135           4154          19          3.8         262.9       1.4X
+Parquet Vectorized                                                                                  5867           5884          27          2.7         373.0       1.0X
+Parquet Vectorized (Pushdown)                                                                       4405           4431          41          3.6         280.1       1.3X
+Native ORC Vectorized                                                                               5578           5582           4          2.8         354.6       1.1X
+Native ORC Vectorized (Pushdown)                                                                    4238           4248          13          3.7         269.5       1.4X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 90% timestamp stored as TIMESTAMP_MILLIS rows (value < timestamp_seconds(14155776)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                                                   7836           7850          15          2.0         498.2       1.0X
-Parquet Vectorized (Pushdown)                                                                        7554           7597          30          2.1         480.3       1.0X
-Native ORC Vectorized                                                                                7578           7618          33          2.1         481.8       1.0X
-Native ORC Vectorized (Pushdown)                                                                     7359           7373          13          2.1         467.9       1.1X
+Parquet Vectorized                                                                                   8229           8242          13          1.9         523.2       1.0X
+Parquet Vectorized (Pushdown)                                                                        7962           7978          16          2.0         506.2       1.0X
+Native ORC Vectorized                                                                                7769           7774           6          2.0         493.9       1.1X
+Native ORC Vectorized (Pushdown)                                                                     7526           7543          13          2.1         478.5       1.1X
 
 
 ================================================================================================
 Pushdown benchmark with many filters
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 1 row with 1 filters:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                   63             68           7          0.0    63142926.0       1.0X
-Parquet Vectorized (Pushdown)                        63             65           2          0.0    63401097.0       1.0X
-Native ORC Vectorized                                57             60           5          0.0    56665343.0       1.1X
-Native ORC Vectorized (Pushdown)                     59             61           3          0.0    58755936.0       1.1X
+Parquet Vectorized                                   62             65           3          0.0    62150610.0       1.0X
+Parquet Vectorized (Pushdown)                        63             66           2          0.0    63083706.0       1.0X
+Native ORC Vectorized                                57             58           3          0.0    56557268.0       1.1X
+Native ORC Vectorized (Pushdown)                     59             61           3          0.0    59024556.0       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 1 row with 250 filters:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                  419            425           6          0.0   419072952.0       1.0X
-Parquet Vectorized (Pushdown)                       420            430          14          0.0   420272165.0       1.0X
-Native ORC Vectorized                               406            411           6          0.0   406166234.0       1.0X
-Native ORC Vectorized (Pushdown)                    411            413           3          0.0   410576777.0       1.0X
+Parquet Vectorized                                  412            429          12          0.0   412390252.0       1.0X
+Parquet Vectorized (Pushdown)                       415            431          14          0.0   414805619.0       1.0X
+Native ORC Vectorized                               407            412           6          0.0   406739635.0       1.0X
+Native ORC Vectorized (Pushdown)                    410            412           2          0.0   409671972.0       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 5.15.0-1053-azure
 AMD EPYC 7763 64-Core Processor
 Select 1 row with 500 filters:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                 2294           2309          15          0.0  2293689319.0       1.0X
-Parquet Vectorized (Pushdown)                      2310           2332          33          0.0  2309978022.0       1.0X
-Native ORC Vectorized                              2286           2303          13          0.0  2286096831.0       1.0X
-Native ORC Vectorized (Pushdown)                   2290           2313          15          0.0  2290237508.0       1.0X
+Parquet Vectorized                                 2259           2306          51          0.0  2258996833.0       1.0X
+Parquet Vectorized (Pushdown)                      2269           2297          18          0.0  2268640662.0       1.0X
+Native ORC Vectorized                              2250           2273          15          0.0  2249833411.0       1.0X
+Native ORC Vectorized (Pushdown)                   2276           2285          13          0.0  2275929767.0       1.0X
 
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/BuiltInDataSourceWriteBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/BuiltInDataSourceWriteBenchmark.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql.execution.benchmark
 import org.apache.parquet.column.ParquetProperties
 import org.apache.parquet.hadoop.ParquetOutputFormat
 
-import org.apache.spark.sql.execution.datasources.orc.OrcCompressionCodec
 import org.apache.spark.sql.execution.datasources.parquet.ParquetCompressionCodec
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.util.ArrayImplicits._
@@ -56,8 +55,6 @@ object BuiltInDataSourceWriteBenchmark extends DataSourceWriteBenchmark {
 
     spark.conf.set(SQLConf.PARQUET_COMPRESSION.key,
       ParquetCompressionCodec.SNAPPY.lowerCaseName())
-    spark.conf.set(SQLConf.ORC_COMPRESSION.key,
-      OrcCompressionCodec.SNAPPY.lowerCaseName())
 
     formats.foreach { format =>
       runBenchmark(s"$format writer benchmark") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/DataSourceReadBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/DataSourceReadBenchmark.scala
@@ -29,7 +29,6 @@ import org.apache.spark.benchmark.Benchmark
 import org.apache.spark.sql.{DataFrame, DataFrameWriter, Row, SparkSession}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.util.HadoopCompressionCodec.GZIP
-import org.apache.spark.sql.execution.datasources.orc.OrcCompressionCodec
 import org.apache.spark.sql.execution.datasources.parquet.{ParquetCompressionCodec, VectorizedParquetRecordReader}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
@@ -122,8 +121,7 @@ object DataSourceReadBenchmark extends SqlBasedBenchmark {
   }
 
   private def saveAsOrcTable(df: DataFrameWriter[Row], dir: String): Unit = {
-    df.mode("overwrite").option("compression",
-      OrcCompressionCodec.SNAPPY.lowerCaseName()).orc(dir)
+    df.mode("overwrite").orc(dir)
     spark.read.orc(dir).createOrReplaceTempView("orcTable")
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/FilterPushdownBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/FilterPushdownBenchmark.scala
@@ -24,7 +24,6 @@ import scala.util.Random
 import org.apache.spark.SparkConf
 import org.apache.spark.benchmark.Benchmark
 import org.apache.spark.sql.{DataFrame, SparkSession}
-import org.apache.spark.sql.execution.datasources.orc.OrcCompressionCodec
 import org.apache.spark.sql.execution.datasources.parquet.ParquetCompressionCodec
 import org.apache.spark.sql.functions.{monotonically_increasing_id, timestamp_seconds}
 import org.apache.spark.sql.internal.SQLConf
@@ -51,7 +50,6 @@ object FilterPushdownBenchmark extends SqlBasedBenchmark {
       .set("spark.master", "local[1]")
       .setIfMissing("spark.driver.memory", "3g")
       .setIfMissing("spark.executor.memory", "3g")
-      .setIfMissing("orc.compression", OrcCompressionCodec.SNAPPY.lowerCaseName())
       .setIfMissing("spark.sql.parquet.compression.codec",
         ParquetCompressionCodec.SNAPPY.lowerCaseName())
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use the default ORC compression in data source benchmarks.

### Why are the changes needed?

Apache ORC 2.0 and Apache Spark 4.0 will use ZStandard as the default ORC compression codec.
- https://github.com/apache/orc/pull/1733
- https://github.com/apache/spark/pull/44654

`OrcReadBenchmark` was switched to use ZStandard for comparision.
- #44761

And, this PR aims to change the remaining three data source benchmarks.
```
$ git grep OrcCompressionCodec | grep Benchmark
sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/BuiltInDataSourceWriteBenchmark.scala:import org.apache.spark.sql.execution.datasources.orc.OrcCompressionCodec
sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/BuiltInDataSourceWriteBenchmark.scala:      OrcCompressionCodec.SNAPPY.lowerCaseName())
sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/DataSourceReadBenchmark.scala:import org.apache.spark.sql.execution.datasources.orc.OrcCompressionCodec
sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/DataSourceReadBenchmark.scala:      OrcCompressionCodec.SNAPPY.lowerCaseName()).orc(dir)
sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/FilterPushdownBenchmark.scala:import org.apache.spark.sql.execution.datasources.orc.OrcCompressionCodec
sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/FilterPushdownBenchmark.scala:      .setIfMissing("orc.compression", OrcCompressionCodec.SNAPPY.lowerCaseName())
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.