### PR TITLE
[SPARK-46754][SQL][AVRO] Fix compression code resolution in avro table definition and write options

### DIFF
--- a/connector/avro/src/main/scala/org/apache/spark/sql/avro/AvroUtils.scala
+++ b/connector/avro/src/main/scala/org/apache/spark/sql/avro/AvroUtils.scala
@@ -109,7 +109,7 @@ private[sql] object AvroUtils extends Logging {
             job.getConfiguration.setBoolean("mapred.output.compress", false)
           case compressed =>
             job.getConfiguration.setBoolean("mapred.output.compress", true)
-            job.getConfiguration.set(AvroJob.CONF_OUTPUT_CODEC, codecName)
+            job.getConfiguration.set(AvroJob.CONF_OUTPUT_CODEC, compressed.getCodecName)
             if (compressed == DEFLATE) {
               val deflateLevel = sqlConf.avroDeflateLevel
               logInfo(s"Compressing Avro output using the $codecName codec at level $deflateLevel")

--- a/connector/avro/src/main/scala/org/apache/spark/sql/avro/AvroUtils.scala
+++ b/connector/avro/src/main/scala/org/apache/spark/sql/avro/AvroUtils.scala
@@ -30,7 +30,7 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.FileStatus
 import org.apache.hadoop.mapreduce.Job
 
-import org.apache.spark.SparkException
+import org.apache.spark.{SparkException, SparkIllegalArgumentException}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.avro.AvroCompressionCodec._
@@ -102,22 +102,25 @@ private[sql] object AvroUtils extends Logging {
 
     AvroJob.setOutputKeySchema(job, outputAvroSchema)
 
-    if (parsedOptions.compression == UNCOMPRESSED.lowerCaseName()) {
-      job.getConfiguration.setBoolean("mapred.output.compress", false)
-    } else {
-      job.getConfiguration.setBoolean("mapred.output.compress", true)
-      logInfo(s"Compressing Avro output using the ${parsedOptions.compression} codec")
-      val codec = AvroCompressionCodec.fromString(parsedOptions.compression) match {
-        case DEFLATE =>
-          val deflateLevel = sqlConf.avroDeflateLevel
-          logInfo(s"Avro compression level $deflateLevel will be used for " +
-            s"${DEFLATE.getCodecName()} codec.")
-          job.getConfiguration.setInt(AvroOutputFormat.DEFLATE_LEVEL_KEY, deflateLevel)
-          DEFLATE.getCodecName()
-        case codec @ (SNAPPY | BZIP2 | XZ | ZSTANDARD) => codec.getCodecName()
-        case unknown => throw new IllegalArgumentException(s"Invalid compression codec: $unknown")
-      }
-      job.getConfiguration.set(AvroJob.CONF_OUTPUT_CODEC, codec)
+    parsedOptions.compression.toLowerCase(Locale.ROOT) match {
+      case codecName if AvroCompressionCodec.values().exists(c => c.lowerCaseName() == codecName) =>
+        AvroCompressionCodec.fromString(codecName) match {
+          case UNCOMPRESSED =>
+            job.getConfiguration.setBoolean("mapred.output.compress", false)
+          case compressed =>
+            job.getConfiguration.setBoolean("mapred.output.compress", true)
+            job.getConfiguration.set(AvroJob.CONF_OUTPUT_CODEC, codecName)
+            if (compressed == DEFLATE) {
+              val deflateLevel = sqlConf.avroDeflateLevel
+              logInfo(s"Compressing Avro output using the $codecName codec at level $deflateLevel")
+              job.getConfiguration.setInt(AvroOutputFormat.DEFLATE_LEVEL_KEY, deflateLevel)
+            } else {
+              logInfo(s"Compressing Avro output using the $codecName codec")
+            }
+        }
+      case unknown =>
+        throw new SparkIllegalArgumentException(
+          "CODEC_SHORT_NAME_NOT_FOUND", Map("codecName" -> unknown))
     }
 
     new AvroOutputWriterFactory(dataSchema,

--- a/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroCodecSuite.scala
+++ b/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroCodecSuite.scala
@@ -47,7 +47,7 @@ class AvroCodecSuite extends FileSourceCodecSuite {
     }
   }
 
-  test("SPARK-46746: invalid compression codec name in avro table definition") {
+  test("SPARK-46754: invalid compression codec name in avro table definition") {
     checkError(
       exception = intercept[SparkIllegalArgumentException](
         sql(

--- a/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroCodecSuite.scala
+++ b/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroCodecSuite.scala
@@ -35,9 +35,8 @@ class AvroCodecSuite extends FileSourceCodecSuite {
       withTable("avro_t") {
         sql(
           s"""CREATE TABLE avro_t
-             | USING $format OPTIONS('compression'='$codec')
-             | AS SELECT 1 as id
-             | """.stripMargin)
+             |USING $format OPTIONS('compression'='$codec')
+             |AS SELECT 1 as id""".stripMargin)
         spark
           .table("avro_t")
           .inputFiles.foreach { f =>
@@ -52,9 +51,8 @@ class AvroCodecSuite extends FileSourceCodecSuite {
       exception = intercept[SparkIllegalArgumentException](
         sql(
           s"""CREATE TABLE avro_t
-             | USING $format OPTIONS('compression'='unsupported')
-             | AS SELECT 1 as id
-             | """.stripMargin)),
+             |USING $format OPTIONS('compression'='unsupported')
+             |AS SELECT 1 as id""".stripMargin)),
       errorClass = "CODEC_SHORT_NAME_NOT_FOUND",
       sqlState = Some("42704"),
       parameters = Map("codecName" -> "unsupported")

--- a/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroCodecSuite.scala
+++ b/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroCodecSuite.scala
@@ -17,6 +17,9 @@
 
 package org.apache.spark.sql.avro
 
+import java.util.Locale
+
+import org.apache.spark.SparkIllegalArgumentException
 import org.apache.spark.sql.execution.datasources.FileSourceCodecSuite
 import org.apache.spark.sql.internal.SQLConf
 
@@ -27,7 +30,7 @@ class AvroCodecSuite extends FileSourceCodecSuite {
   override protected def availableCodecs =
     AvroCompressionCodec.values().map(_.lowerCaseName()).iterator.to(Seq)
 
-  availableCodecs.foreach { codec =>
+  (availableCodecs ++ availableCodecs.map(_.capitalize)).foreach { codec =>
     test(s"SPARK-46746: attach codec name to avro files - codec $codec") {
       withTable("avro_t") {
         sql(
@@ -35,11 +38,26 @@ class AvroCodecSuite extends FileSourceCodecSuite {
              | USING $format OPTIONS('compression'='$codec')
              | AS SELECT 1 as id
              | """.stripMargin)
-        spark.table("avro_t")
-          .inputFiles.foreach { file =>
-            assert(file.endsWith(s"$codec.avro".stripPrefix("uncompressed")))
+        spark
+          .table("avro_t")
+          .inputFiles.foreach { f =>
+            assert(f.endsWith(s"$codec.avro".toLowerCase(Locale.ROOT).stripPrefix("uncompressed")))
           }
       }
     }
+  }
+
+  test("SPARK-46746: invalid compression codec name in avro table definition") {
+    checkError(
+      exception = intercept[SparkIllegalArgumentException](
+        sql(
+          s"""CREATE TABLE avro_t
+             | USING $format OPTIONS('compression'='unsupported')
+             | AS SELECT 1 as id
+             | """.stripMargin)),
+      errorClass = "CODEC_SHORT_NAME_NOT_FOUND",
+      sqlState = Some("42704"),
+      parameters = Map("codecName" -> "unsupported")
+    )
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR fixes the case sensitivity of 'compression' in the avro table definition and the write options, in order to make it consistent with other file sources. Also, the current logic for dealing invalid codec names is unreachable.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
bugfix

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

yes, 'compression'='Xz', 'compression'='XZ' now works as well as 'compression'='xz'
### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
new tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
no