### PR TITLE
[SPARK-46756][SQL] Add rule to rewrite null safe equality join keys

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -199,6 +199,9 @@ abstract class Optimizer(catalogManager: CatalogManager)
       RemoveRepetitionFromGroupExpressions) :: Nil ++
     operatorOptimizationBatch) :+
     Batch("Clean Up Temporary CTE Info", Once, CleanUpTempCTEInfo) :+
+    // This batch must run after batch which  may create join, e.g., `RewriteExceptAll`,
+    // `RewriteCorrelatedScalarSubquery`
+    Batch("Rewrite Null Safe Equality Join Keys", Once, RewriteNullSafeEqualityJoinKeys) :+
     // This batch rewrites plans after the operator optimization and
     // before any batches that depend on stats.
     Batch("Pre CBO Rules", Once, preCBORules: _*) :+
@@ -275,6 +278,7 @@ abstract class Optimizer(catalogManager: CatalogManager)
       NormalizeFloatingNumbers.ruleName ::
       ReplaceUpdateFieldsExpression.ruleName ::
       RewriteLateralSubquery.ruleName ::
+      RewriteNullSafeEqualityJoinKeys.ruleName ::
       OptimizeSubqueries.ruleName :: Nil
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteNullSafeEqualityJoinKeys.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteNullSafeEqualityJoinKeys.scala
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import org.apache.spark.sql.catalyst.expressions.{And, Coalesce, EqualNullSafe, EqualTo, IsNull, Literal, PredicateHelper}
+import org.apache.spark.sql.catalyst.plans.logical.{Join, LogicalPlan}
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.catalyst.trees.TreePattern.JOIN
+
+/**
+ * Rewrite the null-safe equality join keys.
+ *
+ * Input query:
+ * {{{
+ *    SELECT * FROM l JOIN r on l.c <=> r.c
+ * }}}
+ *
+ * Rewritten query:
+ * {{{
+ *    SELECT * FROM l JOIN r ON
+ *      COALESCE(l.c, default) = COALESCE(r.c, default) AND ISNULL(l.c) = ISNULL(r.c)
+ * }}}
+ */
+object RewriteNullSafeEqualityJoinKeys extends Rule[LogicalPlan] with PredicateHelper {
+  override def apply(plan: LogicalPlan): LogicalPlan = {
+    plan.transformWithPruning(_.containsPattern(JOIN)) {
+      case join @ Join(left, right, _, Some(condition), _) =>
+        val predicates = splitConjunctivePredicates(condition)
+        val newPredicates = predicates.map {
+          // Replace null with default value for joining key, then those rows with null in it could
+          // be joined together
+          case EqualNullSafe(l, r) if canEvaluate(l, left) && canEvaluate(r, right) =>
+            // (coalesce(l, default) = coalesce(r, default)) and (isnull(l) = isnull(r))
+            And(
+              EqualTo(
+                Coalesce(Seq(l, Literal.default(l.dataType))),
+                  Coalesce(Seq(r, Literal.default(r.dataType)))),
+              EqualTo(IsNull(l), IsNull(r))
+            )
+          // Same as above with left/right reversed.
+          case EqualNullSafe(l, r) if canEvaluate(l, right) && canEvaluate(r, left) =>
+            And(
+              EqualTo(
+                Coalesce(Seq(r, Literal.default(r.dataType))),
+                Coalesce(Seq(l, Literal.default(l.dataType)))),
+              EqualTo(IsNull(r), IsNull(l))
+            )
+          case other => other
+        }
+        if (predicates == newPredicates) {
+          join
+        } else {
+          join.copy(condition = Some(newPredicates.reduce(And)))
+        }
+    }
+  }
+}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteNullSafeEqualityJoinKeysSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteNullSafeEqualityJoinKeysSuite.scala
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.dsl.plans._
+import org.apache.spark.sql.catalyst.expressions.{And, Literal, Or}
+import org.apache.spark.sql.catalyst.plans.PlanTest
+import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan}
+import org.apache.spark.sql.catalyst.rules.RuleExecutor
+import org.apache.spark.sql.types.IntegerType
+
+class RewriteNullSafeEqualityJoinKeysSuite extends PlanTest with JoinSelectionHelper {
+
+  object Optimize extends RuleExecutor[LogicalPlan] {
+    val batches =
+      Batch("Rewrite Null Safe Equality Join Keys", Once, RewriteNullSafeEqualityJoinKeys) :: Nil
+  }
+
+  val t1 = LocalRelation($"a".int, $"b".int)
+  val t2 = LocalRelation($"x".int, $"y".int)
+
+  test("Rewrite for equi-join") {
+    val plan = t1.join(t2, condition = Some(And($"a" <=> $"x", $"b" === $"y"))).analyze
+    val rewrittenCondition = And(
+      And(
+        coalesce($"a", Literal.default(IntegerType)) ===
+          coalesce($"x", Literal.default(IntegerType)),
+        $"a".isNull === $"x".isNull
+      ),
+      $"b" === $"y"
+    )
+    val expected = t1.join(t2, condition = Some(rewrittenCondition)).analyze
+    comparePlans(Optimize.execute(plan), expected)
+  }
+
+  test("Do not rewrite for non-equi-join") {
+    val plan = t1.join(t2, condition = Some(Or($"a" <=> $"x", $"b" > $"y"))).analyze
+    comparePlans(Optimize.execute(plan), plan)
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This pr adds a new rule to pulls out the rewrite EqualNullSafe from `ExtractEquiJoinKeys`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
It's better to rewrite expression at logical side to make the planner simpler, and it's possible that there is a chance to optimize the rewritten expression in Optimizer.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
no

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
add tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
no