### PR TITLE
[MINOR][DOCS] Remove unneeded production tag block method

### DIFF
--- a/docs/_plugins/production_tag.rb
+++ b/docs/_plugins/production_tag.rb
@@ -14,13 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
 module Jekyll
   class ProductionTag < Liquid::Block
-
-    def initialize(tag_name, markup, tokens)
-      super
-    end
-
     def render(context)
       if ENV['PRODUCTION'] then super else "" end
     end


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove an unneeded method override in the definition of `ProductionTag`.

### Why are the changes needed?

It's just noise.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

I built the docs and confirmed that this script block shows up only when `PRODUCTION=1`: https://github.com/apache/spark/blob/71468ebcc85e2694935086dcf0b01bfe2bff745f/docs/_layouts/global.html#L35-L52

### Was this patch authored or co-authored using generative AI tooling?

No.