### PR TITLE
[SPARK-46769][SQL] Fix type inferring for timestamps without time zone in JSON/CSV

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVInferSchema.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVInferSchema.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.catalyst.expressions.ExprUtils
 import org.apache.spark.sql.catalyst.util.{DateFormatter, TimestampFormatter}
 import org.apache.spark.sql.catalyst.util.LegacyDateFormats.FAST_DATE_FORMAT
 import org.apache.spark.sql.errors.QueryExecutionErrors
-import org.apache.spark.sql.internal.{LegacyBehaviorPolicy, SQLConf}
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 
 class CSVInferSchema(val options: CSVOptions) extends Serializable {
@@ -202,11 +202,8 @@ class CSVInferSchema(val options: CSVOptions) extends Serializable {
     // We can only parse the value as TimestampNTZType if it does not have zone-offset or
     // time-zone component and can be parsed with the timestamp formatter.
     // Otherwise, it is likely to be a timestamp with timezone.
-    val timestampType = SQLConf.get.timestampType
-    if ((SQLConf.get.legacyTimeParserPolicy == LegacyBehaviorPolicy.LEGACY ||
-        timestampType == TimestampNTZType) &&
-        timestampNTZFormatter.parseWithoutTimeZoneOptional(field, false).isDefined) {
-      timestampType
+    if (timestampNTZFormatter.parseWithoutTimeZoneOptional(field, false).isDefined) {
+      SQLConf.get.timestampType
     } else {
       tryParseTimestamp(field)
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JsonInferSchema.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JsonInferSchema.scala
@@ -33,7 +33,7 @@ import org.apache.spark.sql.catalyst.json.JacksonUtils.nextUntil
 import org.apache.spark.sql.catalyst.util._
 import org.apache.spark.sql.catalyst.util.LegacyDateFormats.FAST_DATE_FORMAT
 import org.apache.spark.sql.errors.QueryExecutionErrors
-import org.apache.spark.sql.internal.{LegacyBehaviorPolicy, SQLConf}
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.util.ArrayImplicits._
 import org.apache.spark.util.Utils
@@ -159,13 +159,11 @@ class JsonInferSchema(options: JSONOptions) extends Serializable with Logging {
           val bigDecimal = decimalParser(field)
             DecimalType(bigDecimal.precision, bigDecimal.scale)
         }
-        val timestampType = SQLConf.get.timestampType
         if (options.prefersDecimal && decimalTry.isDefined) {
           decimalTry.get
-        } else if (options.inferTimestamp && (SQLConf.get.legacyTimeParserPolicy ==
-          LegacyBehaviorPolicy.LEGACY || timestampType == TimestampNTZType) &&
-            timestampNTZFormatter.parseWithoutTimeZoneOptional(field, false).isDefined) {
-          timestampType
+        } else if (options.inferTimestamp &&
+          timestampNTZFormatter.parseWithoutTimeZoneOptional(field, false).isDefined) {
+          SQLConf.get.timestampType
         } else if (options.inferTimestamp &&
             timestampFormatter.parseOptional(field).isDefined) {
           TimestampType

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/csv/CSVInferSchemaSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/csv/CSVInferSchemaSuite.scala
@@ -267,7 +267,9 @@ class CSVInferSchemaSuite extends SparkFunSuite with SQLHelper {
   test("SPARK-45433: inferring the schema when timestamps do not match specified timestampFormat" +
     " with only one row") {
     val options = new CSVOptions(
-      Map("timestampFormat" -> "yyyy-MM-dd'T'HH:mm:ss"),
+      Map(
+        "timestampFormat" -> "yyyy-MM-dd'T'HH:mm:ss",
+        "timestampNTZFormat" -> "yyyy-MM-dd HH:mm:ss"),
       columnPruning = false,
       defaultTimeZoneId = "UTC")
     val inferSchema = new CSVInferSchema(options)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/json/JsonInferSchemaSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/json/JsonInferSchemaSuite.scala
@@ -116,7 +116,10 @@ class JsonInferSchemaSuite extends SparkFunSuite with SQLHelper {
   test("SPARK-45433: inferring the schema when timestamps do not match specified timestampFormat" +
     " with only one row") {
     checkType(
-      Map("timestampFormat" -> "yyyy-MM-dd'T'HH:mm:ss", "inferTimestamp" -> "true"),
+      Map(
+        "timestampFormat" -> "yyyy-MM-dd'T'HH:mm:ss",
+        "timestampNTZFormat" -> "yyyy-MM-dd HH:mm:ss",
+        "inferTimestamp" -> "true"),
       """{"a": "2884-06-24T02:45:51.138"}""",
       StringType)
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to revert inferring of the `TIMESTAMP_NTZ` type in the CSV/JSON datasources before the PR https://github.com/apache/spark/pull/43243.

### Why are the changes needed?
After the PR https://github.com/apache/spark/pull/43243, the TIMESTAMP_NTZ type inference in CSV/JSON datasource got 2 new guards which means TIMESTAMP_NTZ should be inferred either if:
1. the SQL config `spark.sql.legacy.timeParserPolicy` is set to `LEGACY` or
2. `spark.sql.timestampType` is set to `TIMESTAMP_NTZ`.

otherwise CSV/JSON should try to infer `TIMESTAMP_LTZ`.

Both guards are unnecessary because:
1. when `spark.sql.legacy.timeParserPolicy` is `LEGACY` that only means Spark should use a legacy Java 7- parser: `FastDateFormat` or `SimpleDateFormat`. Both parsers are applicable for parsing `TIMESTAMP_NTZ`.
2. when `spark.sql.timestampType` is set to `TIMESTAMP_LTZ`, it doesn't mean that we should skip inferring of `TIMESTAMP_NTZ` types in CSV/JSON, and try to parse the timestamp string value w/o time zone like `2024-01-19T09:10:11.123` using a LTZ format **with timezone** like `yyyy-MM-dd'T'HH:mm:ss.SSSXXX`. _The last one cannot match any NTZ values for sure._

### Does this PR introduce _any_ user-facing change?
Yes, it could.

### How was this patch tested?
By running the modified test suites:
```
$ build/sbt "test:testOnly *JsonInferSchemaSuite"
```
and the affected test suites:
```
$ build/sbt "test:testOnly *CSVLegacyTimeParserSuite"
```

### Was this patch authored or co-authored using generative AI tooling?
No.