### PR TITLE
[SPARK-46768][BUILD] Upgrade Guava used by the connect module to 33.0-jre

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -291,8 +291,8 @@
     <spark.test.docker.removePulledImage>true</spark.test.docker.removePulledImage>
 
     <!-- Version used in Connect -->
-    <connect.guava.version>32.0.1-jre</connect.guava.version>
-    <guava.failureaccess.version>1.0.1</guava.failureaccess.version>
+    <connect.guava.version>33.0.0-jre</connect.guava.version>
+    <guava.failureaccess.version>1.0.2</guava.failureaccess.version>
     <io.grpc.version>1.59.0</io.grpc.version>
     <mima.version>1.1.3</mima.version>
     <tomcat.annotations.api.version>6.0.53</tomcat.annotations.api.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to upgrade Guava used by the `connect` module from 32.0.1-jre to 33.0-jre, at the same time, upgrade ·failureaccess·, which is used in conjunction with Guava, from version 1.01 to 1.02.


### Why are the changes needed?
The new version bring some changes as follows:
- net: Optimized InternetDomainName construction. (https://github.com/google/guava/commit/3a1d18fbefa10218988a0fbbb6e1fada012397bf, https://github.com/google/guava/commit/eaa62eb09548a6f1b7a757e21d8852724b631cab)
- util.concurrent: Changed our implementations to avoid eagerly initializing loggers during class loading. This can help performance. (https://github.com/google/guava/commit/4fe1df56bd74e9eec8847bdb15c5be51f528e8c8)

The full release notes as follows:
- https://github.com/google/guava/releases/tag/v32.1.2
- https://github.com/google/guava/releases/tag/v32.1.3
- https://github.com/google/guava/releases/tag/v33.0.0

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No