### PR TITLE
[SPARK-46780][K8S][TESTS] Support skipping R image build step in SBT

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -1005,8 +1005,8 @@ object KubernetesIntegrationTests {
         val cmd = Seq(dockerTool,
           "-r", imageRepo,
           "-t", imageTag.getOrElse("dev"),
-          "-p", pyDockerFile,
-          "-R", rDockerFile) ++
+          "-p", pyDockerFile) ++
+          (if (rDockerFile.isBlank) Seq.empty else Seq("-R", rDockerFile)) ++
           (if (deployMode != Some("minikube")) Seq.empty else Seq("-m")) ++
           extraOptions :+
           "build"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to allow the users to skip R image build step in SBT.

### Why are the changes needed?

In SBT K8s IT, we always build SparkR image. However, it's not needed when we exclude R tests.
```
build/sbt -Pkubernetes -Pkubernetes-integration-tests -Dtest.exclude.tags=minikube,local,r -Dspark.kubernetes.test.deployMode=docker-desktop -Dspark.kubernetes.test.rDockerFile= "kubernetes-integration-tests/test"
```

### Does this PR introduce _any_ user-facing change?

No. This is a developer feature.

### How was this patch tested?

Manually tests.

### Was this patch authored or co-authored using generative AI tooling?

No.