### PR TITLE
[SPARK-46785][K8S][TESTS][3.5] Split the local storage PVs test into driver and executor PV tests

### DIFF
--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/PVTestsSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/PVTestsSuite.scala
@@ -200,25 +200,41 @@ private[spark] trait PVTestsSuite { k8sSuite: KubernetesSuite =>
     }
   }
 
-  test("PVs with local storage", k8sTestTag, MinikubeTag) {
+  test("PVs with local storage - driver", k8sTestTag, MinikubeTag) {
     sparkAppConf
       .set(s"spark.kubernetes.driver.volumes.persistentVolumeClaim.data.mount.path",
         CONTAINER_MOUNT_PATH)
       .set(s"spark.kubernetes.driver.volumes.persistentVolumeClaim.data.options.claimName",
         PVC_NAME)
-      .set(s"spark.kubernetes.executor.volumes.persistentVolumeClaim.data.mount.path",
-        CONTAINER_MOUNT_PATH)
-      .set(s"spark.kubernetes.executor.volumes.persistentVolumeClaim.data.options.claimName",
-        PVC_NAME)
-    val file = Utils.createTempFile(FILE_CONTENTS, HOST_PATH)
     try {
       setupLocalStorage()
+      val file = Utils.createTempFile(FILE_CONTENTS, HOST_PATH)
       runDFSReadWriteAndVerifyCompletion(
         FILE_CONTENTS.split(" ").length,
         driverPodChecker = (driverPod: Pod) => {
           doBasicDriverPodCheck(driverPod)
           checkPVs(driverPod, file)
         },
+        appArgs = Array(s"$CONTAINER_MOUNT_PATH/$file", s"$CONTAINER_MOUNT_PATH"),
+        interval = Some(PV_TESTS_INTERVAL)
+      )
+    } finally {
+      // make sure this always runs
+      deleteLocalStorage()
+    }
+  }
+
+  test("PVs with local storage - executor", k8sTestTag, MinikubeTag) {
+    sparkAppConf
+      .set(s"spark.kubernetes.executor.volumes.persistentVolumeClaim.data.mount.path",
+        CONTAINER_MOUNT_PATH)
+      .set(s"spark.kubernetes.executor.volumes.persistentVolumeClaim.data.options.claimName",
+        PVC_NAME)
+    try {
+      setupLocalStorage()
+      val file = Utils.createTempFile(FILE_CONTENTS, HOST_PATH)
+      runDFSReadWriteAndVerifyCompletion(
+        FILE_CONTENTS.split(" ").length,
         executorPodChecker = (executorPod: Pod) => {
           doBasicExecutorPodCheck(executorPod)
           checkPVs(executorPod, file)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This aims to fix a test case bug which tries to mount one PV (and PVC) into two pods, `Driver` and `Executor`, at the same time.

### Why are the changes needed?

This bug was introduced at the initial test case creation via SPARK-24902.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass these tests with Volcano Scheduler 1.8.2.
Before this PR, the test case has been disabled at VolcanoSuite.

### Was this patch authored or co-authored using generative AI tooling?

No.