### PR TITLE
[SPARK-46787][CONNECT] `bloomFilter` function should throw `AnalysisException` for invalid input

### DIFF
--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
@@ -613,10 +613,6 @@ final class DataFrameStatFunctions private[sql] (sparkSession: SparkSession, roo
    * @since 3.5.0
    */
   def bloomFilter(col: Column, expectedNumItems: Long, fpp: Double): BloomFilter = {
-    if (fpp <= 0d || fpp >= 1d) {
-      throw new IllegalArgumentException(
-        "False positive probability must be within range (0.0, 1.0)")
-    }
     val numBits = BloomFilter.optimalNumOfBits(expectedNumItems, fpp)
     bloomFilter(col, expectedNumItems, numBits)
   }

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
@@ -613,6 +613,10 @@ final class DataFrameStatFunctions private[sql] (sparkSession: SparkSession, roo
    * @since 3.5.0
    */
   def bloomFilter(col: Column, expectedNumItems: Long, fpp: Double): BloomFilter = {
+    if (fpp <= 0d || fpp >= 1d) {
+      throw new IllegalArgumentException(
+        "False positive probability must be within range (0.0, 1.0)")
+    }
     val numBits = BloomFilter.optimalNumOfBits(expectedNumItems, fpp)
     bloomFilter(col, expectedNumItems, numBits)
   }

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientDataFrameStatSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientDataFrameStatSuite.scala
@@ -248,19 +248,19 @@ class ClientDataFrameStatSuite extends RemoteSparkSession {
 
   test("Bloom filter test invalid inputs") {
     val df = spark.range(1000).toDF("id")
-    val message1 = intercept[AnalysisException] {
+    val error1 = intercept[AnalysisException] {
       df.stat.bloomFilter("id", -1000, 100)
-    }.getMessage
-    assert(message1.contains("VALUE_OUT_OF_RANGE"))
+    }
+    assert(error1.getErrorClass === "VALUE_OUT_OF_RANGE")
 
-    val message2 = intercept[AnalysisException] {
+    val error2 = intercept[AnalysisException] {
       df.stat.bloomFilter("id", 1000, -100)
-    }.getMessage
-    assert(message2.contains("VALUE_OUT_OF_RANGE"))
+    }
+    assert(error2.getErrorClass === "VALUE_OUT_OF_RANGE")
 
-    val message3 = intercept[AnalysisException] {
+    val error3 = intercept[AnalysisException] {
       df.stat.bloomFilter("id", 1000, -1.0)
-    }.getMessage
-    assert(message3.contains("VALUE_OUT_OF_RANGE"))
+    }
+    assert(error3.getErrorClass === "VALUE_OUT_OF_RANGE")
   }
 }

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientDataFrameStatSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientDataFrameStatSuite.scala
@@ -21,7 +21,7 @@ import java.util.Random
 
 import org.scalatest.matchers.must.Matchers._
 
-import org.apache.spark.{SparkException, SparkIllegalArgumentException}
+import org.apache.spark.SparkIllegalArgumentException
 import org.apache.spark.sql.test.RemoteSparkSession
 
 class ClientDataFrameStatSuite extends RemoteSparkSession {
@@ -248,19 +248,19 @@ class ClientDataFrameStatSuite extends RemoteSparkSession {
 
   test("Bloom filter test invalid inputs") {
     val df = spark.range(1000).toDF("id")
-    val message1 = intercept[SparkException] {
+    val message1 = intercept[AnalysisException] {
       df.stat.bloomFilter("id", -1000, 100)
     }.getMessage
-    assert(message1.contains("Expected insertions must be positive"))
+    assert(message1.contains("VALUE_OUT_OF_RANGE"))
 
-    val message2 = intercept[SparkException] {
+    val message2 = intercept[AnalysisException] {
       df.stat.bloomFilter("id", 1000, -100)
     }.getMessage
-    assert(message2.contains("Number of bits must be positive"))
+    assert(message2.contains("VALUE_OUT_OF_RANGE"))
 
-    val message3 = intercept[SparkException] {
+    val message3 = intercept[AnalysisException] {
       df.stat.bloomFilter("id", 1000, -1.0)
     }.getMessage
-    assert(message3.contains("False positive probability must be within range (0.0, 1.0)"))
+    assert(message3.contains("VALUE_OUT_OF_RANGE"))
   }
 }

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientDataFrameStatSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientDataFrameStatSuite.scala
@@ -251,16 +251,16 @@ class ClientDataFrameStatSuite extends RemoteSparkSession {
     val error1 = intercept[AnalysisException] {
       df.stat.bloomFilter("id", -1000, 100)
     }
-    assert(error1.getErrorClass === "VALUE_OUT_OF_RANGE")
+    assert(error1.getErrorClass === "DATATYPE_MISMATCH.VALUE_OUT_OF_RANGE")
 
     val error2 = intercept[AnalysisException] {
       df.stat.bloomFilter("id", 1000, -100)
     }
-    assert(error2.getErrorClass === "VALUE_OUT_OF_RANGE")
+    assert(error2.getErrorClass === "DATATYPE_MISMATCH.VALUE_OUT_OF_RANGE")
 
     val error3 = intercept[AnalysisException] {
       df.stat.bloomFilter("id", 1000, -1.0)
     }
-    assert(error3.getErrorClass === "VALUE_OUT_OF_RANGE")
+    assert(error3.getErrorClass === "DATATYPE_MISMATCH.VALUE_OUT_OF_RANGE")
   }
 }

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -1805,31 +1805,8 @@ class SparkConnectPlanner(
       case "bloom_filter_agg" if fun.getArgumentsCount == 3 =>
         // [col, expectedNumItems: Long, numBits: Long]
         val children = fun.getArgumentsList.asScala.map(transformExpression)
-
-        // Check expectedNumItems is LongType and value greater than 0L
-        val expectedNumItemsExpr = children(1)
-        val expectedNumItems = expectedNumItemsExpr match {
-          case Literal(l: Long, LongType) => l
-          case _ =>
-            throw InvalidPlanInput("Expected insertions must be long literal.")
-        }
-        if (expectedNumItems <= 0L) {
-          throw InvalidPlanInput("Expected insertions must be positive.")
-        }
-
-        val numBitsExpr = children(2)
-        // Check numBits is LongType and value greater than 0L
-        numBitsExpr match {
-          case Literal(numBits: Long, LongType) =>
-            if (numBits <= 0L) {
-              throw InvalidPlanInput("Number of bits must be positive.")
-            }
-          case _ =>
-            throw InvalidPlanInput("Number of bits must be long literal.")
-        }
-
         Some(
-          new BloomFilterAggregate(children.head, expectedNumItemsExpr, numBitsExpr)
+          new BloomFilterAggregate(children(0), children(1), children(2))
             .toAggregateExpression())
 
       case "window" if Seq(2, 3, 4).contains(fun.getArgumentsCount) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
@@ -536,11 +536,6 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
    * @since 2.0.0
    */
   def bloomFilter(col: Column, expectedNumItems: Long, fpp: Double): BloomFilter = {
-    if (fpp <= 0D || fpp >= 1D) {
-      throw new IllegalArgumentException(
-        "False positive probability must be within range (0.0, 1.0)"
-      )
-    }
     val numBits = BloomFilter.optimalNumOfBits(expectedNumItems, fpp)
     bloomFilter(col, expectedNumItems, numBits)
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameStatFunctions.scala
@@ -536,6 +536,11 @@ final class DataFrameStatFunctions private[sql](df: DataFrame) {
    * @since 2.0.0
    */
   def bloomFilter(col: Column, expectedNumItems: Long, fpp: Double): BloomFilter = {
+    if (fpp <= 0D || fpp >= 1D) {
+      throw new IllegalArgumentException(
+        "False positive probability must be within range (0.0, 1.0)"
+      )
+    }
     val numBits = BloomFilter.optimalNumOfBits(expectedNumItems, fpp)
     bloomFilter(col, expectedNumItems, numBits)
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
`bloomFilter` function should throw `AnalysisException` for invalid input

### Why are the changes needed?

1. `BloomFilterAggregate` itself validates the input, and throws meaningful errors. we should not handle those invalid input and throw `InvalidPlanInput` in Planner.
2. to be consistent with vanilla Scala API and other functions

### Does this PR introduce _any_ user-facing change?
yes, `InvalidPlanInput` -> `AnalysisException`


### How was this patch tested?
updated CI


### Was this patch authored or co-authored using generative AI tooling?
no
