### PR TITLE
[SPARK-42332][SQL] Reverting an import change that shouldn't have been made

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.errors
 
 import org.apache.spark.{SPARK_DOC_ROOT, SparkIllegalArgumentException, SparkUnsupportedOperationException}
-import org.apache.spark.sql._
+import org.apache.spark.sql.{AnalysisException, ClassData, IntegratedUDFTestUtils, QueryTest, Row}
 import org.apache.spark.sql.api.java.{UDF1, UDF2, UDF23Test}
 import org.apache.spark.sql.catalyst.expressions.{Coalesce, Literal, UnsafeRow}
 import org.apache.spark.sql.catalyst.parser.ParseException


### PR DESCRIPTION
### What changes were proposed in this pull request?
I changed an import to an import all instead of import specifics. Per this comment: https://github.com/apache/spark/pull/44336#discussion_r1461103077

### Why are the changes needed?
Revert the import back

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
CICD tests


### Was this patch authored or co-authored using generative AI tooling?
No
