### PR TITLE
[SPARK-46738][CONNECT][PYTHON] Make the display of `cast` in `Regular Spark` and `Spark Connect` consistent

### DIFF
--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientE2ETestSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientE2ETestSuite.scala
@@ -1508,6 +1508,15 @@ class ClientE2ETestSuite extends RemoteSparkSession with SQLHelper with PrivateM
         (0 until 5).foreach(i => assert(row.get(i * 2) === row.get(i * 2 + 1)))
       }
   }
+
+  test("SPARK-46738: `cast` displayed different results between Regular Spark and Spark Connect") {
+    val df = spark.sql("select 'Spark SQL' as key")
+    val castDF = df.select(to_binary(df.col("key"), lit("utf-8")).cast("STRING"))
+    testCapturedStdOut(castDF.show(false), 5, 39,
+      "+-------------------------------------+",
+      "|CAST(to_binary(key, utf-8) AS STRING)|",
+      "|Spark SQL                            |")
+  }
 }
 
 private[sql] case class ClassData(a: String, b: Int)

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientE2ETestSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientE2ETestSuite.scala
@@ -1509,8 +1509,7 @@ class ClientE2ETestSuite extends RemoteSparkSession with SQLHelper with PrivateM
       }
   }
 
-  test(
-    "SPARK-46738: `cast` displayed different results between Regular Spark and Spark Connect") {
+  test("SPARK-46738: Make the display of cast in Regular Spark and Spark Connect consistent") {
     val df = spark.sql("select 'Spark SQL' as key")
     val castDF = df.select(to_binary(df.col("key"), lit("utf-8")).cast("STRING"))
     testCapturedStdOut(

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientE2ETestSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientE2ETestSuite.scala
@@ -1509,10 +1509,14 @@ class ClientE2ETestSuite extends RemoteSparkSession with SQLHelper with PrivateM
       }
   }
 
-  test("SPARK-46738: `cast` displayed different results between Regular Spark and Spark Connect") {
+  test(
+    "SPARK-46738: `cast` displayed different results between Regular Spark and Spark Connect") {
     val df = spark.sql("select 'Spark SQL' as key")
     val castDF = df.select(to_binary(df.col("key"), lit("utf-8")).cast("STRING"))
-    testCapturedStdOut(castDF.show(false), 5, 39,
+    testCapturedStdOut(
+      castDF.show(false),
+      5,
+      39,
       "+-------------------------------------+",
       "|CAST(to_binary(key, utf-8) AS STRING)|",
       "|Spark SQL                            |")

--- a/connector/connect/common/src/test/resources/query-tests/explain-results/function_atan2.explain
+++ b/connector/connect/common/src/test/resources/query-tests/explain-results/function_atan2.explain
@@ -1,2 +1,2 @@
-Project [ATAN2(cast(a#0 as double), b#0) AS ATAN2(a, b)#0]
+Project [ATAN2(cast(a#0 as double), b#0) AS ATAN2(CAST(a AS DOUBLE), b)#0]
 +- LocalRelation <empty>, [id#0L, a#0, b#0, d#0, e#0, f#0, g#0]

--- a/connector/connect/common/src/test/resources/query-tests/explain-results/function_base64.explain
+++ b/connector/connect/common/src/test/resources/query-tests/explain-results/function_base64.explain
@@ -1,2 +1,2 @@
-Project [base64(cast(g#0 as binary)) AS base64(g)#0]
+Project [base64(cast(g#0 as binary)) AS base64(CAST(g AS BINARY))#0]
 +- LocalRelation <empty>, [id#0L, a#0, b#0, d#0, e#0, f#0, g#0]

--- a/connector/connect/common/src/test/resources/query-tests/explain-results/function_crc32.explain
+++ b/connector/connect/common/src/test/resources/query-tests/explain-results/function_crc32.explain
@@ -1,2 +1,2 @@
-Project [crc32(cast(g#0 as binary)) AS crc32(g)#0L]
+Project [crc32(cast(g#0 as binary)) AS crc32(CAST(g AS BINARY))#0L]
 +- LocalRelation <empty>, [id#0L, a#0, b#0, d#0, e#0, f#0, g#0]

--- a/connector/connect/common/src/test/resources/query-tests/explain-results/function_decode.explain
+++ b/connector/connect/common/src/test/resources/query-tests/explain-results/function_decode.explain
@@ -1,2 +1,2 @@
-Project [decode(cast(g#0 as binary), UTF-8, false) AS decode(g, UTF-8)#0]
+Project [decode(cast(g#0 as binary), UTF-8, false) AS decode(CAST(g AS BINARY), UTF-8)#0]
 +- LocalRelation <empty>, [id#0L, a#0, b#0, d#0, e#0, f#0, g#0]

--- a/connector/connect/common/src/test/resources/query-tests/explain-results/function_md5.explain
+++ b/connector/connect/common/src/test/resources/query-tests/explain-results/function_md5.explain
@@ -1,2 +1,2 @@
-Project [md5(cast(g#0 as binary)) AS md5(g)#0]
+Project [md5(cast(g#0 as binary)) AS md5(CAST(g AS BINARY))#0]
 +- LocalRelation <empty>, [id#0L, a#0, b#0, d#0, e#0, f#0, g#0]

--- a/connector/connect/common/src/test/resources/query-tests/explain-results/function_sha1.explain
+++ b/connector/connect/common/src/test/resources/query-tests/explain-results/function_sha1.explain
@@ -1,2 +1,2 @@
-Project [sha1(cast(g#0 as binary)) AS sha1(g)#0]
+Project [sha1(cast(g#0 as binary)) AS sha1(CAST(g AS BINARY))#0]
 +- LocalRelation <empty>, [id#0L, a#0, b#0, d#0, e#0, f#0, g#0]

--- a/connector/connect/common/src/test/resources/query-tests/explain-results/function_sha2.explain
+++ b/connector/connect/common/src/test/resources/query-tests/explain-results/function_sha2.explain
@@ -1,2 +1,2 @@
-Project [sha2(cast(g#0 as binary), 512) AS sha2(g, 512)#0]
+Project [sha2(cast(g#0 as binary), 512) AS sha2(CAST(g AS BINARY), 512)#0]
 +- LocalRelation <empty>, [id#0L, a#0, b#0, d#0, e#0, f#0, g#0]

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -1452,8 +1452,8 @@ class SparkConnectPlanner(
   private def toNamedExpression(expr: Expression): NamedExpression = expr match {
     case named: NamedExpression => named
     case c: Cast =>
-      c.transformUp {
-        case c @ Cast(_: NamedExpression, _, _, _) => UnresolvedAlias(c)
+      c.transformUp { case c @ Cast(_: NamedExpression, _, _, _) =>
+        UnresolvedAlias(c)
       } match {
         case ne: NamedExpression => ne
         case _ => UnresolvedAlias(expr, Some(Column.generateAlias))

--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectProtoSuite.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectProtoSuite.scala
@@ -994,7 +994,7 @@ class SparkConnectProtoSuite extends PlanTest with SparkConnectPlanTest {
           transform(connectTestRelation.observe("my_metric", "id".protoAttr.cast("string"))))
       },
       errorClass = "INVALID_OBSERVED_METRICS.NON_AGGREGATE_FUNC_ARG_IS_ATTRIBUTE",
-      parameters = Map("expr" -> "\"id AS id\""))
+      parameters = Map("expr" -> "\"CAST(id AS STRING) AS id\""))
 
     val connectPlan2 =
       connectTestRelation.observe(

--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectProtoSuite.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectProtoSuite.scala
@@ -1025,7 +1025,7 @@ class SparkConnectProtoSuite extends PlanTest with SparkConnectPlanTest {
             connectTestRelation.observe(Observation("my_metric"), "id".protoAttr.cast("string"))))
       },
       errorClass = "INVALID_OBSERVED_METRICS.NON_AGGREGATE_FUNC_ARG_IS_ATTRIBUTE",
-      parameters = Map("expr" -> "\"id AS id\""))
+      parameters = Map("expr" -> "\"CAST(id AS STRING) AS id\""))
   }
 
   test("Test RandomSplit") {

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -18836,8 +18836,6 @@ def nvl2(col1: "ColumnOrName", col2: "ColumnOrName", col3: "ColumnOrName") -> Co
     return _invoke_function_over_columns("nvl2", col1, col2, col3)
 
 
-# TODO(SPARK-46738) Re-enable testing that includes the 'Cast' operation after
-#  fixing the display difference between Regular Spark and Spark Connect on `Cast`.
 @_try_remote_functions
 def aes_encrypt(
     input: "ColumnOrName",
@@ -18930,7 +18928,7 @@ def aes_encrypt(
     ... )
     >>> df.select(sf.aes_decrypt(sf.aes_encrypt(df.input, df.key, df.mode, df.padding),
     ...     df.key, df.mode, df.padding
-    ... ).cast("STRING")).show(truncate=False) # doctest: +SKIP
+    ... ).cast("STRING")).show(truncate=False)
     +---------------------------------------------------------------------------------------------+
     |CAST(aes_decrypt(aes_encrypt(input, key, mode, padding, , ), key, mode, padding, ) AS STRING)|
     +---------------------------------------------------------------------------------------------+
@@ -18946,7 +18944,7 @@ def aes_encrypt(
     ... )
     >>> df.select(sf.aes_decrypt(sf.aes_encrypt(df.input, df.key, df.mode),
     ...     df.key, df.mode
-    ... ).cast("STRING")).show(truncate=False) # doctest: +SKIP
+    ... ).cast("STRING")).show(truncate=False)
     +---------------------------------------------------------------------------------------------+
     |CAST(aes_decrypt(aes_encrypt(input, key, mode, DEFAULT, , ), key, mode, DEFAULT, ) AS STRING)|
     +---------------------------------------------------------------------------------------------+
@@ -18962,7 +18960,7 @@ def aes_encrypt(
     ... )
     >>> df.select(sf.aes_decrypt(
     ...     sf.unbase64(sf.base64(sf.aes_encrypt(df.input, df.key))), df.key
-    ... ).cast("STRING")).show(truncate=False) # doctest: +SKIP
+    ... ).cast("STRING")).show(truncate=False)
     +-------------------------------------------------------------------------------------------------------------+
     |CAST(aes_decrypt(unbase64(base64(aes_encrypt(input, key, GCM, DEFAULT, , ))), key, GCM, DEFAULT, ) AS STRING)|
     +-------------------------------------------------------------------------------------------------------------+
@@ -18976,8 +18974,6 @@ def aes_encrypt(
     return _invoke_function_over_columns("aes_encrypt", input, key, _mode, _padding, _iv, _aad)
 
 
-# TODO(SPARK-46738) Re-enable testing that includes the 'Cast' operation after
-#  fixing the display difference between Regular Spark and Spark Connect on `Cast`.
 @_try_remote_functions
 def aes_decrypt(
     input: "ColumnOrName",
@@ -19031,7 +19027,7 @@ def aes_decrypt(
     ... )
     >>> df.select(sf.aes_decrypt(
     ...     sf.unbase64(df.input), df.key, df.mode, df.padding, df.aad
-    ... ).cast("STRING")).show(truncate=False) # doctest: +SKIP
+    ... ).cast("STRING")).show(truncate=False)
     +---------------------------------------------------------------------+
     |CAST(aes_decrypt(unbase64(input), key, mode, padding, aad) AS STRING)|
     +---------------------------------------------------------------------+
@@ -19048,7 +19044,7 @@ def aes_decrypt(
     ... )
     >>> df.select(sf.aes_decrypt(
     ...     sf.unbase64(df.input), df.key, df.mode, df.padding
-    ... ).cast("STRING")).show(truncate=False) # doctest: +SKIP
+    ... ).cast("STRING")).show(truncate=False)
     +------------------------------------------------------------------+
     |CAST(aes_decrypt(unbase64(input), key, mode, padding, ) AS STRING)|
     +------------------------------------------------------------------+
@@ -19065,7 +19061,7 @@ def aes_decrypt(
     ... )
     >>> df.select(sf.aes_decrypt(
     ...     sf.unbase64(df.input), df.key, df.mode
-    ... ).cast("STRING")).show(truncate=False) # doctest: +SKIP
+    ... ).cast("STRING")).show(truncate=False)
     +------------------------------------------------------------------+
     |CAST(aes_decrypt(unbase64(input), key, mode, DEFAULT, ) AS STRING)|
     +------------------------------------------------------------------+
@@ -19082,7 +19078,7 @@ def aes_decrypt(
     ... )
     >>> df.select(sf.aes_decrypt(
     ...     sf.unhex(df.input), df.key
-    ... ).cast("STRING")).show(truncate=False) # doctest: +SKIP
+    ... ).cast("STRING")).show(truncate=False)
     +--------------------------------------------------------------+
     |CAST(aes_decrypt(unhex(input), key, GCM, DEFAULT, ) AS STRING)|
     +--------------------------------------------------------------+
@@ -19095,8 +19091,6 @@ def aes_decrypt(
     return _invoke_function_over_columns("aes_decrypt", input, key, _mode, _padding, _aad)
 
 
-# TODO(SPARK-46738) Re-enable testing that includes the 'Cast' operation after
-#  fixing the display difference between Regular Spark and Spark Connect on `Cast`.
 @_try_remote_functions
 def try_aes_decrypt(
     input: "ColumnOrName",
@@ -19152,7 +19146,7 @@ def try_aes_decrypt(
     ... )
     >>> df.select(sf.try_aes_decrypt(
     ...     sf.unbase64(df.input), df.key, df.mode, df.padding, df.aad
-    ... ).cast("STRING")).show(truncate=False) # doctest: +SKIP
+    ... ).cast("STRING")).show(truncate=False)
     +-------------------------------------------------------------------------+
     |CAST(try_aes_decrypt(unbase64(input), key, mode, padding, aad) AS STRING)|
     +-------------------------------------------------------------------------+
@@ -19170,7 +19164,7 @@ def try_aes_decrypt(
     ... )
     >>> df.select(sf.try_aes_decrypt(
     ...     sf.unbase64(df.input), df.key, df.mode, df.padding, df.aad
-    ... ).cast("STRING")).show(truncate=False) # doctest: +SKIP
+    ... ).cast("STRING")).show(truncate=False)
     +-------------------------------------------------------------------------+
     |CAST(try_aes_decrypt(unbase64(input), key, mode, padding, aad) AS STRING)|
     +-------------------------------------------------------------------------+
@@ -19187,7 +19181,7 @@ def try_aes_decrypt(
     ... )
     >>> df.select(sf.try_aes_decrypt(
     ...     sf.unbase64(df.input), df.key, df.mode, df.padding
-    ... ).cast("STRING")).show(truncate=False) # doctest: +SKIP
+    ... ).cast("STRING")).show(truncate=False)
     +----------------------------------------------------------------------+
     |CAST(try_aes_decrypt(unbase64(input), key, mode, padding, ) AS STRING)|
     +----------------------------------------------------------------------+
@@ -19204,7 +19198,7 @@ def try_aes_decrypt(
     ... )
     >>> df.select(sf.try_aes_decrypt(
     ...     sf.unbase64(df.input), df.key, df.mode
-    ... ).cast("STRING")).show(truncate=False) # doctest: +SKIP
+    ... ).cast("STRING")).show(truncate=False)
     +----------------------------------------------------------------------+
     |CAST(try_aes_decrypt(unbase64(input), key, mode, DEFAULT, ) AS STRING)|
     +----------------------------------------------------------------------+
@@ -19221,7 +19215,7 @@ def try_aes_decrypt(
     ... )
     >>> df.select(sf.try_aes_decrypt(
     ...     sf.unhex(df.input), df.key
-    ... ).cast("STRING")).show(truncate=False) # doctest: +SKIP
+    ... ).cast("STRING")).show(truncate=False)
     +------------------------------------------------------------------+
     |CAST(try_aes_decrypt(unhex(input), key, GCM, DEFAULT, ) AS STRING)|
     +------------------------------------------------------------------+


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to make the display of `cast` in `Spark Connect` more reasonable, and to make the display of `cast` in `Regular Spark` and `Spark Connect` consistent.

The original intention of this PR comes from: https://github.com/apache/spark/pull/44750#discussion_r1454457235


### Why are the changes needed?
- Before(inconsistent):
  Regular Spark:
  <img width="1000" alt="image" src="https://github.com/apache/spark/assets/15246973/def1f3e2-560d-4bf1-a546-c1a3993f1270">

  Spark Connect:
  <img width="557" alt="image" src="https://github.com/apache/spark/assets/15246973/e5f1f935-35b3-4c77-97c2-eec26830dd08">

- After(consistent):
  Spark Connect: 
  <img width="999" alt="image" src="https://github.com/apache/spark/assets/15246973/709f1268-1645-42b7-9905-c764306731f4">
  <img width="553" alt="image" src="https://github.com/apache/spark/assets/15246973/acf61f41-d3df-428f-b6e9-7d51d0c0e96e">


### Does this PR introduce _any_ user-facing change?
Yes, the display of `cast` in `Spark Connect` more reasonable.

### How was this patch tested?
- Add new UT & Pass GA.
- Manually test.


### Was this patch authored or co-authored using generative AI tooling?
No.
