### PR TITLE
[SPARK-46792][PYTHON][CONNECT] Refactor ChannelBuilder into DefaultChannelBuilder and ChannelBuilder

### DIFF
--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -15,7 +15,8 @@
 # limitations under the License.
 #
 __all__ = [
-    "ChannelBuilder",
+    "DefaultChannelBuilder",
+    "DefaultChannelBuilder",
     "SparkConnectClient",
 ]
 
@@ -100,17 +101,7 @@ class ChannelBuilder:
     This is a helper class that is used to create a GRPC channel based on the given
     connection string per the documentation of Spark Connect.
 
-    .. versionadded:: 3.4.0
-
-    Examples
-    --------
-    >>> cb =  ChannelBuilder("sc://localhost")
-    ... cb.endpoint
-    "localhost:15002"
-
-    >>> cb = ChannelBuilder("sc://localhost/;use_ssl=true;token=aaa")
-    ... cb.secure
-    True
+    The standard implementation is in DefaultChannelBuilder.
     """
 
     PARAM_USE_SSL = "use_ssl"
@@ -119,6 +110,173 @@ class ChannelBuilder:
     PARAM_USER_AGENT = "user_agent"
     PARAM_SESSION_ID = "session_id"
     MAX_MESSAGE_LENGTH = 128 * 1024 * 1024
+
+    GRPC_DEFAULT_OPTIONS = [
+        ("grpc.max_send_message_length", MAX_MESSAGE_LENGTH),
+        ("grpc.max_receive_message_length", MAX_MESSAGE_LENGTH),
+    ]
+
+    def __init__(
+        self,
+        channelOptions: Optional[List[Tuple[str, Any]]] = None,
+        params: Optional[Dict[str, str]] = None,
+    ):
+        self._interceptors: List[grpc.UnaryStreamClientInterceptor] = []
+        self._params: Dict[str, str] = params or dict()
+        self._channel_options: List[Tuple[str, Any]] = ChannelBuilder.GRPC_DEFAULT_OPTIONS
+
+        if channelOptions is not None:
+            self._channel_options = self._channel_options + channelOptions
+
+    def get(self, key: str) -> Any:
+        """
+        Parameters
+        ----------
+        key : str
+            Parameter key name.
+        Returns
+        -------
+        The parameter value if present, raises exception otherwise.
+        """
+        return self._params[key]
+
+    def getDefault(self, key: str, default: Any) -> Any:
+        return self._params.get(key, default)
+
+    def set(self, key: str, value: Any):
+        self._params[key] = value
+
+    def add_interceptor(self, interceptor: grpc.UnaryStreamClientInterceptor) -> None:
+        self._interceptors.append(interceptor)
+
+    def toChannel(self) -> grpc.Channel:
+        """
+        The actual channel builder implementations should implement this function
+        to return grpc Channel.
+        This function should generally use self._insecure_channel or
+        self._secure_channel so that configuration options are applied
+        appropriately.
+        """
+        raise NotImplementedError
+
+    def _insecure_channel(self, target, **kwargs):
+        channel = grpc.insecure_channel(target, options=self._channel_options, **kwargs)
+
+        if len(self._interceptors) > 0:
+            logger.info(f"Applying interceptors ({self._interceptors})")
+            channel = grpc.intercept_channel(channel, *self._interceptors)
+        return channel
+
+    def _secure_channel(self, target, credentials, **kwargs):
+        channel = grpc.secure_channel(target, credentials, options=self._channel_options, **kwargs)
+
+        if len(self._interceptors) > 0:
+            logger.info(f"Applying interceptors ({self._interceptors})")
+            channel = grpc.intercept_channel(channel, *self._interceptors)
+        return channel
+
+    @property
+    def userId(self) -> Optional[str]:
+        """
+        Returns
+        -------
+        The user_id (extracted from connection string or configured by other means).
+        """
+        return self._params.get(ChannelBuilder.PARAM_USER_ID, None)
+
+    @property
+    def token(self) -> Optional[str]:
+        return self._params.get(ChannelBuilder.PARAM_TOKEN, None)
+
+    def metadata(self) -> Iterable[Tuple[str, str]]:
+        """
+        Builds the GRPC specific metadata list to be injected into the request. All
+        parameters will be converted to metadata except ones that are explicitly used
+        by the channel.
+        Returns
+        -------
+        A list of tuples (key, value)
+        """
+        return [
+            (k, self._params[k])
+            for k in self._params
+            if k
+            not in [
+                ChannelBuilder.PARAM_TOKEN,
+                ChannelBuilder.PARAM_USE_SSL,
+                ChannelBuilder.PARAM_USER_ID,
+                ChannelBuilder.PARAM_USER_AGENT,
+                ChannelBuilder.PARAM_SESSION_ID,
+            ]
+        ]
+
+    @property
+    def session_id(self) -> Optional[str]:
+        """
+        Returns
+        -------
+        The session_id extracted from the parameters of the connection string or `None` if not
+        specified.
+        """
+        session_id = self._params.get(ChannelBuilder.PARAM_SESSION_ID, None)
+        if session_id is not None:
+            try:
+                uuid.UUID(session_id, version=4)
+            except ValueError as ve:
+                raise PySparkValueError(
+                    error_class="INVALID_SESSION_UUID_ID",
+                    message_parameters={"arg_name": "session_id", "origin": str(ve)},
+                )
+        return session_id
+
+    @property
+    def userAgent(self) -> str:
+        """
+        Returns
+        -------
+        user_agent : str
+            The user_agent parameter specified in the connection string,
+            or "_SPARK_CONNECT_PYTHON" when not specified.
+            The returned value will be percent encoded.
+        """
+        user_agent = self._params.get(
+            ChannelBuilder.PARAM_USER_AGENT,
+            os.getenv("SPARK_CONNECT_USER_AGENT", "_SPARK_CONNECT_PYTHON"),
+        )
+
+        ua_len = len(urllib.parse.quote(user_agent))
+        if ua_len > 2048:
+            raise SparkConnectException(
+                f"'user_agent' parameter should not exceed 2048 characters, found {len} characters."
+            )
+        return " ".join(
+            [
+                user_agent,
+                f"spark/{__version__}",
+                f"os/{platform.uname().system.lower()}",
+                f"python/{platform.python_version()}",
+            ]
+        )
+
+
+
+class DefaultChannelBuilder(ChannelBuilder):
+    """
+    This is a helper class that is used to create a GRPC channel based on the given
+    connection string per the documentation of Spark Connect.
+
+    .. versionadded:: 3.4.0
+
+    Examples
+    --------
+    >>> cb =  DefaultChannelBuilder("sc://localhost")
+    ... cb.endpoint
+    "localhost:15002"
+
+    >>> cb = DefaultChannelBuilder("sc://localhost/;use_ssl=true;token=aaa")
+    ... cb.secure
+    True
+    """
 
     @staticmethod
     def default_port() -> int:
@@ -159,39 +317,31 @@ class ChannelBuilder:
         channelOptions: list of tuple, optional
             Additional options that can be passed to the GRPC channel construction.
         """
+
+        super().__init__(channelOptions=channelOptions)
+
         # Explicitly check the scheme of the URL.
         if url[:5] != "sc://":
             raise PySparkValueError(
                 error_class="INVALID_CONNECT_URL",
                 message_parameters={
                     "detail": "The URL must start with 'sc://'. Please update the URL to "
-                    "follow the correct format, e.g., 'sc://hostname:port'.",
+                              "follow the correct format, e.g., 'sc://hostname:port'.",
                 },
             )
         # Rewrite the URL to use http as the scheme so that we can leverage
         # Python's built-in parser.
         tmp_url = "http" + url[2:]
         self.url = urllib.parse.urlparse(tmp_url)
-        self.params: Dict[str, str] = {}
         if len(self.url.path) > 0 and self.url.path != "/":
             raise PySparkValueError(
                 error_class="INVALID_CONNECT_URL",
                 message_parameters={
                     "detail": f"The path component '{self.url.path}' must be empty. Please update "
-                    f"the URL to follow the correct format, e.g., 'sc://hostname:port'.",
+                              f"the URL to follow the correct format, e.g., 'sc://hostname:port'.",
                 },
             )
         self._extract_attributes()
-
-        GRPC_DEFAULT_OPTIONS = [
-            ("grpc.max_send_message_length", ChannelBuilder.MAX_MESSAGE_LENGTH),
-            ("grpc.max_receive_message_length", ChannelBuilder.MAX_MESSAGE_LENGTH),
-        ]
-
-        if channelOptions is None:
-            self._channel_options = GRPC_DEFAULT_OPTIONS
-        else:
-            self._channel_options = GRPC_DEFAULT_OPTIONS + channelOptions
 
     def _extract_attributes(self) -> None:
         if len(self.url.params) > 0:
@@ -203,16 +353,16 @@ class ChannelBuilder:
                         error_class="INVALID_CONNECT_URL",
                         message_parameters={
                             "detail": f"Parameter '{p}' should be provided as a "
-                            f"key-value pair separated by an equal sign (=). Please update "
-                            f"the parameter to follow the correct format, e.g., 'key=value'.",
+                                      f"key-value pair separated by an equal sign (=). Please update "
+                                      f"the parameter to follow the correct format, e.g., 'key=value'.",
                         },
                     )
-                self.params[kv[0]] = urllib.parse.unquote(kv[1])
+                self.set(kv[0], urllib.parse.unquote(kv[1]))
 
         netloc = self.url.netloc.split(":")
         if len(netloc) == 1:
             self.host = netloc[0]
-            self.port = ChannelBuilder.default_port()
+            self.port = DefaultChannelBuilder.default_port()
         elif len(netloc) == 2:
             self.host = netloc[0]
             self.port = int(netloc[1])
@@ -221,119 +371,21 @@ class ChannelBuilder:
                 error_class="INVALID_CONNECT_URL",
                 message_parameters={
                     "detail": f"Target destination '{self.url.netloc}' should match the "
-                    f"'<host>:<port>' pattern. Please update the destination to follow "
-                    f"the correct format, e.g., 'hostname:port'.",
+                              f"'<host>:<port>' pattern. Please update the destination to follow "
+                              f"the correct format, e.g., 'hostname:port'.",
                 },
             )
 
-    def metadata(self) -> Iterable[Tuple[str, str]]:
-        """
-        Builds the GRPC specific metadata list to be injected into the request. All
-        parameters will be converted to metadata except ones that are explicitly used
-        by the channel.
-
-        Returns
-        -------
-        A list of tuples (key, value)
-        """
-        return [
-            (k, self.params[k])
-            for k in self.params
-            if k
-            not in [
-                ChannelBuilder.PARAM_TOKEN,
-                ChannelBuilder.PARAM_USE_SSL,
-                ChannelBuilder.PARAM_USER_ID,
-                ChannelBuilder.PARAM_USER_AGENT,
-                ChannelBuilder.PARAM_SESSION_ID,
-            ]
-        ]
-
     @property
     def secure(self) -> bool:
-        if self._token is not None:
-            return True
-
-        value = self.params.get(ChannelBuilder.PARAM_USE_SSL, "")
-        return value.lower() == "true"
+        return (
+            self.getDefault(ChannelBuilder.PARAM_USE_SSL, "").lower() == "true"
+            or self.token is not None
+        )
 
     @property
     def endpoint(self) -> str:
         return f"{self.host}:{self.port}"
-
-    @property
-    def _token(self) -> Optional[str]:
-        return self.params.get(ChannelBuilder.PARAM_TOKEN, None)
-
-    @property
-    def userId(self) -> Optional[str]:
-        """
-        Returns
-        -------
-        The user_id extracted from the parameters of the connection string or `None` if not
-        specified.
-        """
-        return self.params.get(ChannelBuilder.PARAM_USER_ID, None)
-
-    @property
-    def userAgent(self) -> str:
-        """
-        Returns
-        -------
-        user_agent : str
-            The user_agent parameter specified in the connection string,
-            or "_SPARK_CONNECT_PYTHON" when not specified.
-            The returned value will be percent encoded.
-        """
-        user_agent = self.params.get(
-            ChannelBuilder.PARAM_USER_AGENT,
-            os.getenv("SPARK_CONNECT_USER_AGENT", "_SPARK_CONNECT_PYTHON"),
-        )
-        ua_len = len(urllib.parse.quote(user_agent))
-        if ua_len > 2048:
-            raise SparkConnectException(
-                f"'user_agent' parameter should not exceed 2048 characters, found {len} characters."
-            )
-        return " ".join(
-            [
-                user_agent,
-                f"spark/{__version__}",
-                f"os/{platform.uname().system.lower()}",
-                f"python/{platform.python_version()}",
-            ]
-        )
-
-    def get(self, key: str) -> Any:
-        """
-        Parameters
-        ----------
-        key : str
-            Parameter key name.
-
-        Returns
-        -------
-        The parameter value if present, raises exception otherwise.
-        """
-        return self.params[key]
-
-    @property
-    def session_id(self) -> Optional[str]:
-        """
-        Returns
-        -------
-        The session_id extracted from the parameters of the connection string or `None` if not
-        specified.
-        """
-        session_id = self.params.get(ChannelBuilder.PARAM_SESSION_ID, None)
-        if session_id is not None:
-            try:
-                uuid.UUID(session_id, version=4)
-            except ValueError as ve:
-                raise PySparkValueError(
-                    error_class="INVALID_SESSION_UUID_ID",
-                    message_parameters={"arg_name": "session_id", "origin": str(ve)},
-                )
-        return session_id
 
     def toChannel(self) -> grpc.Channel:
         """
@@ -345,36 +397,20 @@ class ChannelBuilder:
         -------
         GRPC Channel instance.
         """
-        destination = f"{self.host}:{self.port}"
 
-        # Setting a token implicitly sets the `use_ssl` to True.
-        if not self.secure and self._token is not None:
-            use_secure = True
-        elif self.secure:
-            use_secure = True
+        if not self.secure:
+            return self._insecure_channel(self.endpoint)
         else:
-            use_secure = False
+            ssl_creds = grpc.ssl_channel_credentials()
 
-        if not use_secure:
-            return grpc.insecure_channel(destination, options=self._channel_options)
-        else:
-            # Default SSL Credentials.
-            opt_token = self.params.get(ChannelBuilder.PARAM_TOKEN, None)
-            # When a token is present, pass the token to the channel.
-            if opt_token is not None:
-                ssl_creds = grpc.ssl_channel_credentials()
-                composite_creds = grpc.composite_channel_credentials(
-                    ssl_creds, grpc.access_token_call_credentials(opt_token)
-                )
-                return grpc.secure_channel(
-                    destination, credentials=composite_creds, options=self._channel_options
-                )
+            if self.token is None:
+                creds = ssl_creds
             else:
-                return grpc.secure_channel(
-                    destination,
-                    credentials=grpc.ssl_channel_credentials(),
-                    options=self._channel_options,
+                creds = grpc.composite_channel_credentials(
+                    ssl_creds, grpc.access_token_call_credentials(self.token)
                 )
+
+            return self._secure_channel(self.endpoint, creds)
 
 
 class MetricValue:
@@ -450,18 +486,18 @@ class PlanObservedMetrics:
 
 class AnalyzeResult:
     def __init__(
-        self,
-        schema: Optional[DataType],
-        explain_string: Optional[str],
-        tree_string: Optional[str],
-        is_local: Optional[bool],
-        is_streaming: Optional[bool],
-        input_files: Optional[List[str]],
-        spark_version: Optional[str],
-        parsed: Optional[DataType],
-        is_same_semantics: Optional[bool],
-        semantic_hash: Optional[int],
-        storage_level: Optional[StorageLevel],
+            self,
+            schema: Optional[DataType],
+            explain_string: Optional[str],
+            tree_string: Optional[str],
+            is_local: Optional[bool],
+            is_streaming: Optional[bool],
+            input_files: Optional[List[str]],
+            spark_version: Optional[str],
+            parsed: Optional[DataType],
+            is_same_semantics: Optional[bool],
+            semantic_hash: Optional[int],
+            storage_level: Optional[StorageLevel],
     ):
         self.schema = schema
         self.explain_string = explain_string
@@ -552,19 +588,19 @@ class SparkConnectClient(object):
     """
 
     def __init__(
-        self,
-        connection: Union[str, ChannelBuilder],
-        user_id: Optional[str] = None,
-        channel_options: Optional[List[Tuple[str, Any]]] = None,
-        retry_policy: Optional[Dict[str, Any]] = None,
-        use_reattachable_execute: bool = True,
+            self,
+            connection: Union[str, DefaultChannelBuilder],
+            user_id: Optional[str] = None,
+            channel_options: Optional[List[Tuple[str, Any]]] = None,
+            retry_policy: Optional[Dict[str, Any]] = None,
+            use_reattachable_execute: bool = True,
     ):
         """
         Creates a new SparkSession for the Spark Connect interface.
 
         Parameters
         ----------
-        connection : str or :class:`ChannelBuilder`
+        connection : str or :class:`DefaultChannelBuilder`
             Connection string that is used to extract the connection parameters and configure
             the GRPC connection. Or instance of ChannelBuilder that creates GRPC connection.
             Defaults to `sc://localhost`.
@@ -599,8 +635,8 @@ class SparkConnectClient(object):
         # Parse the connection string.
         self._builder = (
             connection
-            if isinstance(connection, ChannelBuilder)
-            else ChannelBuilder(connection, channel_options)
+            if isinstance(connection, DefaultChannelBuilder)
+            else DefaultChannelBuilder(connection, channel_options)
         )
         self._user_id = None
         self._retry_policies: List[RetryPolicy] = []
@@ -666,12 +702,12 @@ class SparkConnectClient(object):
         return list(self._retry_policies)
 
     def register_udf(
-        self,
-        function: Any,
-        return_type: "DataTypeOrString",
-        name: Optional[str] = None,
-        eval_type: int = PythonEvalType.SQL_BATCHED_UDF,
-        deterministic: bool = True,
+            self,
+            function: Any,
+            return_type: "DataTypeOrString",
+            name: Optional[str] = None,
+            eval_type: int = PythonEvalType.SQL_BATCHED_UDF,
+            deterministic: bool = True,
     ) -> str:
         """
         Create a temporary UDF in the session catalog on the other side. We generate a
@@ -705,12 +741,12 @@ class SparkConnectClient(object):
         return name
 
     def register_udtf(
-        self,
-        function: Any,
-        return_type: Optional["DataTypeOrString"],
-        name: str,
-        eval_type: int = PythonEvalType.SQL_TABLE_UDF,
-        deterministic: bool = True,
+            self,
+            function: Any,
+            return_type: Optional["DataTypeOrString"],
+            name: str,
+            eval_type: int = PythonEvalType.SQL_TABLE_UDF,
+            deterministic: bool = True,
     ) -> str:
         """
         Register a user-defined table function (UDTF) in the session catalog
@@ -739,11 +775,11 @@ class SparkConnectClient(object):
         return name
 
     def register_java(
-        self,
-        name: str,
-        javaClassName: str,
-        return_type: Optional["DataTypeOrString"] = None,
-        aggregate: bool = False,
+            self,
+            name: str,
+            javaClassName: str,
+            return_type: Optional["DataTypeOrString"] = None,
+            aggregate: bool = False,
     ) -> None:
         # construct a JavaUDF
         if return_type is None:
@@ -780,12 +816,12 @@ class SparkConnectClient(object):
         return resources
 
     def _build_observed_metrics(
-        self, metrics: Sequence["pb2.ExecutePlanResponse.ObservedMetrics"]
+            self, metrics: Sequence["pb2.ExecutePlanResponse.ObservedMetrics"]
     ) -> Iterator[PlanObservedMetrics]:
         return (PlanObservedMetrics(x.name, [v for v in x.values], list(x.keys)) for x in metrics)
 
     def to_table_as_iterator(
-        self, plan: pb2.Plan, observations: Dict[str, Observation]
+            self, plan: pb2.Plan, observations: Dict[str, Observation]
     ) -> Iterator[Union[StructType, "pa.Table"]]:
         """
         Return given plan as a PyArrow Table iterator.
@@ -800,7 +836,7 @@ class SparkConnectClient(object):
                 yield pa.Table.from_batches([response])
 
     def to_table(
-        self, plan: pb2.Plan, observations: Dict[str, Observation]
+            self, plan: pb2.Plan, observations: Dict[str, Observation]
     ) -> Tuple["pa.Table", Optional[StructType]]:
         """
         Return given plan as a PyArrow Table.
@@ -936,7 +972,7 @@ class SparkConnectClient(object):
         return result
 
     def execute_command(
-        self, command: pb2.Command, observations: Optional[Dict[str, Observation]] = None
+            self, command: pb2.Command, observations: Optional[Dict[str, Observation]] = None
     ) -> Tuple[Optional[pd.DataFrame], Dict[str, Any]]:
         """
         Execute given command.
@@ -996,7 +1032,7 @@ class SparkConnectClient(object):
         The authentication bearer token during connection.
         If authentication is not using a bearer token, None will be returned.
         """
-        return self._builder._token
+        return self._builder.token
 
     def _execute_plan_request_with_metadata(self) -> pb2.ExecutePlanRequest:
         req = pb2.ExecutePlanRequest(
@@ -1138,7 +1174,7 @@ class SparkConnectClient(object):
             self._handle_error(error)
 
     def _execute_and_fetch_as_iterator(
-        self, req: pb2.ExecutePlanRequest, observations: Dict[str, Observation]
+            self, req: pb2.ExecutePlanRequest, observations: Dict[str, Observation]
     ) -> Iterator[
         Union[
             "pa.RecordBatch",
@@ -1153,7 +1189,7 @@ class SparkConnectClient(object):
         num_records = 0
 
         def handle_response(
-            b: pb2.ExecutePlanResponse,
+                b: pb2.ExecutePlanResponse,
         ) -> Iterator[
             Union[
                 "pa.RecordBatch",
@@ -1187,8 +1223,8 @@ class SparkConnectClient(object):
                             {
                                 key: LiteralExpression._to_value(metric)
                                 for key, metric in zip(
-                                    observed_metrics.keys, observed_metrics.metrics
-                                )
+                                observed_metrics.keys, observed_metrics.metrics
+                            )
                             }
                         )
                     yield observed_metrics
@@ -1224,8 +1260,8 @@ class SparkConnectClient(object):
                 )
 
                 if (
-                    b.arrow_batch.HasField("start_offset")
-                    and num_records != b.arrow_batch.start_offset
+                        b.arrow_batch.HasField("start_offset")
+                        and num_records != b.arrow_batch.start_offset
                 ):
                     raise SparkConnectException(
                         f"Expected arrow batch to start at row offset {num_records} in results, "
@@ -1264,10 +1300,10 @@ class SparkConnectClient(object):
             self._handle_error(error)
 
     def _execute_and_fetch(
-        self,
-        req: pb2.ExecutePlanRequest,
-        observations: Dict[str, Observation],
-        self_destruct: bool = False,
+            self,
+            req: pb2.ExecutePlanRequest,
+            observations: Dict[str, Observation],
+            self_destruct: bool = False,
     ) -> Tuple[
         Optional["pa.Table"],
         Optional[StructType],
@@ -1342,7 +1378,7 @@ class SparkConnectClient(object):
         return tuple(configs.get(key) for key in keys)
 
     def get_config_with_defaults(
-        self, *pairs: Tuple[str, Optional[str]]
+            self, *pairs: Tuple[str, Optional[str]]
     ) -> Tuple[Optional[str], ...]:
         op = pb2.ConfigRequest.Operation(
             get_with_default=pb2.ConfigRequest.GetWithDefault(
@@ -1378,7 +1414,7 @@ class SparkConnectClient(object):
             self._handle_error(error)
 
     def _interrupt_request(
-        self, interrupt_type: str, id_or_tag: Optional[str] = None
+            self, interrupt_type: str, id_or_tag: Optional[str] = None
     ) -> pb2.InterruptRequest:
         req = pb2.InterruptRequest()
         req.session_id = self._session_id
@@ -1626,17 +1662,17 @@ class SparkConnectClient(object):
         raise SparkConnectException("Invalid state during retry exception handling.")
 
     def _verify_response_integrity(
-        self,
-        response: Union[
-            pb2.ConfigResponse,
-            pb2.ExecutePlanResponse,
-            pb2.InterruptResponse,
-            pb2.ReleaseExecuteResponse,
-            pb2.AddArtifactsResponse,
-            pb2.AnalyzePlanResponse,
-            pb2.FetchErrorDetailsResponse,
-            pb2.ReleaseSessionResponse,
-        ],
+            self,
+            response: Union[
+                pb2.ConfigResponse,
+                pb2.ExecutePlanResponse,
+                pb2.InterruptResponse,
+                pb2.ReleaseExecuteResponse,
+                pb2.AddArtifactsResponse,
+                pb2.AnalyzePlanResponse,
+                pb2.FetchErrorDetailsResponse,
+                pb2.ReleaseSessionResponse,
+            ],
     ) -> None:
         """
         Verifies the integrity of the response. This method checks if the session ID and the
@@ -1652,8 +1688,8 @@ class SparkConnectClient(object):
             )
         if self._server_session_id is not None:
             if (
-                response.server_side_session_id
-                and response.server_side_session_id != self._server_session_id
+                    response.server_side_session_id
+                    and response.server_side_session_id != self._server_session_id
             ):
                 raise PySparkAssertionError(
                     "Received incorrect server side session identifier for request. "

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -143,7 +143,7 @@ class ChannelBuilder:
     def getDefault(self, key: str, default: Any) -> Any:
         return self._params.get(key, default)
 
-    def set(self, key: str, value: Any):
+    def set(self, key: str, value: Any) -> None:
         self._params[key] = value
 
     def add_interceptor(self, interceptor: grpc.UnaryStreamClientInterceptor) -> None:
@@ -159,7 +159,7 @@ class ChannelBuilder:
         """
         raise PySparkNotImplementedError
 
-    def _insecure_channel(self, target, **kwargs):
+    def _insecure_channel(self, target, **kwargs) -> grpc.Channel:
         channel = grpc.insecure_channel(target, options=self._channel_options, **kwargs)
 
         if len(self._interceptors) > 0:
@@ -167,7 +167,7 @@ class ChannelBuilder:
             channel = grpc.intercept_channel(channel, *self._interceptors)
         return channel
 
-    def _secure_channel(self, target, credentials, **kwargs):
+    def _secure_channel(self, target, credentials, **kwargs) -> grpc.Channel:
         channel = grpc.secure_channel(target, credentials, options=self._channel_options, **kwargs)
 
         if len(self._interceptors) > 0:

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -259,7 +259,6 @@ class ChannelBuilder:
         )
 
 
-
 class DefaultChannelBuilder(ChannelBuilder):
     """
     This is a helper class that is used to create a GRPC channel based on the given
@@ -326,7 +325,7 @@ class DefaultChannelBuilder(ChannelBuilder):
                 error_class="INVALID_CONNECT_URL",
                 message_parameters={
                     "detail": "The URL must start with 'sc://'. Please update the URL to "
-                              "follow the correct format, e.g., 'sc://hostname:port'.",
+                    "follow the correct format, e.g., 'sc://hostname:port'.",
                 },
             )
         # Rewrite the URL to use http as the scheme so that we can leverage
@@ -338,7 +337,7 @@ class DefaultChannelBuilder(ChannelBuilder):
                 error_class="INVALID_CONNECT_URL",
                 message_parameters={
                     "detail": f"The path component '{self.url.path}' must be empty. Please update "
-                              f"the URL to follow the correct format, e.g., 'sc://hostname:port'.",
+                    f"the URL to follow the correct format, e.g., 'sc://hostname:port'.",
                 },
             )
         self._extract_attributes()
@@ -353,8 +352,8 @@ class DefaultChannelBuilder(ChannelBuilder):
                         error_class="INVALID_CONNECT_URL",
                         message_parameters={
                             "detail": f"Parameter '{p}' should be provided as a "
-                                      f"key-value pair separated by an equal sign (=). Please update "
-                                      f"the parameter to follow the correct format, e.g., 'key=value'.",
+                            f"key-value pair separated by an equal sign (=). Please update "
+                            f"the parameter to follow the correct format, e.g., 'key=value'.",
                         },
                     )
                 self.set(kv[0], urllib.parse.unquote(kv[1]))
@@ -371,8 +370,8 @@ class DefaultChannelBuilder(ChannelBuilder):
                 error_class="INVALID_CONNECT_URL",
                 message_parameters={
                     "detail": f"Target destination '{self.url.netloc}' should match the "
-                              f"'<host>:<port>' pattern. Please update the destination to follow "
-                              f"the correct format, e.g., 'hostname:port'.",
+                    f"'<host>:<port>' pattern. Please update the destination to follow "
+                    f"the correct format, e.g., 'hostname:port'.",
                 },
             )
 
@@ -486,18 +485,18 @@ class PlanObservedMetrics:
 
 class AnalyzeResult:
     def __init__(
-            self,
-            schema: Optional[DataType],
-            explain_string: Optional[str],
-            tree_string: Optional[str],
-            is_local: Optional[bool],
-            is_streaming: Optional[bool],
-            input_files: Optional[List[str]],
-            spark_version: Optional[str],
-            parsed: Optional[DataType],
-            is_same_semantics: Optional[bool],
-            semantic_hash: Optional[int],
-            storage_level: Optional[StorageLevel],
+        self,
+        schema: Optional[DataType],
+        explain_string: Optional[str],
+        tree_string: Optional[str],
+        is_local: Optional[bool],
+        is_streaming: Optional[bool],
+        input_files: Optional[List[str]],
+        spark_version: Optional[str],
+        parsed: Optional[DataType],
+        is_same_semantics: Optional[bool],
+        semantic_hash: Optional[int],
+        storage_level: Optional[StorageLevel],
     ):
         self.schema = schema
         self.explain_string = explain_string
@@ -588,12 +587,12 @@ class SparkConnectClient(object):
     """
 
     def __init__(
-            self,
-            connection: Union[str, DefaultChannelBuilder],
-            user_id: Optional[str] = None,
-            channel_options: Optional[List[Tuple[str, Any]]] = None,
-            retry_policy: Optional[Dict[str, Any]] = None,
-            use_reattachable_execute: bool = True,
+        self,
+        connection: Union[str, DefaultChannelBuilder],
+        user_id: Optional[str] = None,
+        channel_options: Optional[List[Tuple[str, Any]]] = None,
+        retry_policy: Optional[Dict[str, Any]] = None,
+        use_reattachable_execute: bool = True,
     ):
         """
         Creates a new SparkSession for the Spark Connect interface.
@@ -702,12 +701,12 @@ class SparkConnectClient(object):
         return list(self._retry_policies)
 
     def register_udf(
-            self,
-            function: Any,
-            return_type: "DataTypeOrString",
-            name: Optional[str] = None,
-            eval_type: int = PythonEvalType.SQL_BATCHED_UDF,
-            deterministic: bool = True,
+        self,
+        function: Any,
+        return_type: "DataTypeOrString",
+        name: Optional[str] = None,
+        eval_type: int = PythonEvalType.SQL_BATCHED_UDF,
+        deterministic: bool = True,
     ) -> str:
         """
         Create a temporary UDF in the session catalog on the other side. We generate a
@@ -741,12 +740,12 @@ class SparkConnectClient(object):
         return name
 
     def register_udtf(
-            self,
-            function: Any,
-            return_type: Optional["DataTypeOrString"],
-            name: str,
-            eval_type: int = PythonEvalType.SQL_TABLE_UDF,
-            deterministic: bool = True,
+        self,
+        function: Any,
+        return_type: Optional["DataTypeOrString"],
+        name: str,
+        eval_type: int = PythonEvalType.SQL_TABLE_UDF,
+        deterministic: bool = True,
     ) -> str:
         """
         Register a user-defined table function (UDTF) in the session catalog
@@ -775,11 +774,11 @@ class SparkConnectClient(object):
         return name
 
     def register_java(
-            self,
-            name: str,
-            javaClassName: str,
-            return_type: Optional["DataTypeOrString"] = None,
-            aggregate: bool = False,
+        self,
+        name: str,
+        javaClassName: str,
+        return_type: Optional["DataTypeOrString"] = None,
+        aggregate: bool = False,
     ) -> None:
         # construct a JavaUDF
         if return_type is None:
@@ -816,12 +815,12 @@ class SparkConnectClient(object):
         return resources
 
     def _build_observed_metrics(
-            self, metrics: Sequence["pb2.ExecutePlanResponse.ObservedMetrics"]
+        self, metrics: Sequence["pb2.ExecutePlanResponse.ObservedMetrics"]
     ) -> Iterator[PlanObservedMetrics]:
         return (PlanObservedMetrics(x.name, [v for v in x.values], list(x.keys)) for x in metrics)
 
     def to_table_as_iterator(
-            self, plan: pb2.Plan, observations: Dict[str, Observation]
+        self, plan: pb2.Plan, observations: Dict[str, Observation]
     ) -> Iterator[Union[StructType, "pa.Table"]]:
         """
         Return given plan as a PyArrow Table iterator.
@@ -836,7 +835,7 @@ class SparkConnectClient(object):
                 yield pa.Table.from_batches([response])
 
     def to_table(
-            self, plan: pb2.Plan, observations: Dict[str, Observation]
+        self, plan: pb2.Plan, observations: Dict[str, Observation]
     ) -> Tuple["pa.Table", Optional[StructType]]:
         """
         Return given plan as a PyArrow Table.
@@ -972,7 +971,7 @@ class SparkConnectClient(object):
         return result
 
     def execute_command(
-            self, command: pb2.Command, observations: Optional[Dict[str, Observation]] = None
+        self, command: pb2.Command, observations: Optional[Dict[str, Observation]] = None
     ) -> Tuple[Optional[pd.DataFrame], Dict[str, Any]]:
         """
         Execute given command.
@@ -1174,7 +1173,7 @@ class SparkConnectClient(object):
             self._handle_error(error)
 
     def _execute_and_fetch_as_iterator(
-            self, req: pb2.ExecutePlanRequest, observations: Dict[str, Observation]
+        self, req: pb2.ExecutePlanRequest, observations: Dict[str, Observation]
     ) -> Iterator[
         Union[
             "pa.RecordBatch",
@@ -1189,7 +1188,7 @@ class SparkConnectClient(object):
         num_records = 0
 
         def handle_response(
-                b: pb2.ExecutePlanResponse,
+            b: pb2.ExecutePlanResponse,
         ) -> Iterator[
             Union[
                 "pa.RecordBatch",
@@ -1223,8 +1222,8 @@ class SparkConnectClient(object):
                             {
                                 key: LiteralExpression._to_value(metric)
                                 for key, metric in zip(
-                                observed_metrics.keys, observed_metrics.metrics
-                            )
+                                    observed_metrics.keys, observed_metrics.metrics
+                                )
                             }
                         )
                     yield observed_metrics
@@ -1260,8 +1259,8 @@ class SparkConnectClient(object):
                 )
 
                 if (
-                        b.arrow_batch.HasField("start_offset")
-                        and num_records != b.arrow_batch.start_offset
+                    b.arrow_batch.HasField("start_offset")
+                    and num_records != b.arrow_batch.start_offset
                 ):
                     raise SparkConnectException(
                         f"Expected arrow batch to start at row offset {num_records} in results, "
@@ -1300,10 +1299,10 @@ class SparkConnectClient(object):
             self._handle_error(error)
 
     def _execute_and_fetch(
-            self,
-            req: pb2.ExecutePlanRequest,
-            observations: Dict[str, Observation],
-            self_destruct: bool = False,
+        self,
+        req: pb2.ExecutePlanRequest,
+        observations: Dict[str, Observation],
+        self_destruct: bool = False,
     ) -> Tuple[
         Optional["pa.Table"],
         Optional[StructType],
@@ -1378,7 +1377,7 @@ class SparkConnectClient(object):
         return tuple(configs.get(key) for key in keys)
 
     def get_config_with_defaults(
-            self, *pairs: Tuple[str, Optional[str]]
+        self, *pairs: Tuple[str, Optional[str]]
     ) -> Tuple[Optional[str], ...]:
         op = pb2.ConfigRequest.Operation(
             get_with_default=pb2.ConfigRequest.GetWithDefault(
@@ -1414,7 +1413,7 @@ class SparkConnectClient(object):
             self._handle_error(error)
 
     def _interrupt_request(
-            self, interrupt_type: str, id_or_tag: Optional[str] = None
+        self, interrupt_type: str, id_or_tag: Optional[str] = None
     ) -> pb2.InterruptRequest:
         req = pb2.InterruptRequest()
         req.session_id = self._session_id
@@ -1662,17 +1661,17 @@ class SparkConnectClient(object):
         raise SparkConnectException("Invalid state during retry exception handling.")
 
     def _verify_response_integrity(
-            self,
-            response: Union[
-                pb2.ConfigResponse,
-                pb2.ExecutePlanResponse,
-                pb2.InterruptResponse,
-                pb2.ReleaseExecuteResponse,
-                pb2.AddArtifactsResponse,
-                pb2.AnalyzePlanResponse,
-                pb2.FetchErrorDetailsResponse,
-                pb2.ReleaseSessionResponse,
-            ],
+        self,
+        response: Union[
+            pb2.ConfigResponse,
+            pb2.ExecutePlanResponse,
+            pb2.InterruptResponse,
+            pb2.ReleaseExecuteResponse,
+            pb2.AddArtifactsResponse,
+            pb2.AnalyzePlanResponse,
+            pb2.FetchErrorDetailsResponse,
+            pb2.ReleaseSessionResponse,
+        ],
     ) -> None:
         """
         Verifies the integrity of the response. This method checks if the session ID and the
@@ -1688,8 +1687,8 @@ class SparkConnectClient(object):
             )
         if self._server_session_id is not None:
             if (
-                    response.server_side_session_id
-                    and response.server_side_session_id != self._server_session_id
+                response.server_side_session_id
+                and response.server_side_session_id != self._server_session_id
             ):
                 raise PySparkAssertionError(
                     "Received incorrect server side session identifier for request. "

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -101,7 +101,7 @@ class ChannelBuilder:
     This is a helper class that is used to create a GRPC channel based on the given
     connection string per the documentation of Spark Connect.
 
-    The standard implementation is in DefaultChannelBuilder.
+    The standard implementation is in :class:`DefaultChannelBuilder`.
     """
 
     PARAM_USE_SSL = "use_ssl"

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 __all__ = [
-    "DefaultChannelBuilder",
+    "ChannelBuilder",
     "DefaultChannelBuilder",
     "SparkConnectClient",
 ]

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -159,7 +159,7 @@ class ChannelBuilder:
         """
         raise PySparkNotImplementedError
 
-    def _insecure_channel(self, target, **kwargs) -> grpc.Channel:
+    def _insecure_channel(self, target: Any, **kwargs: Any) -> grpc.Channel:
         channel = grpc.insecure_channel(target, options=self._channel_options, **kwargs)
 
         if len(self._interceptors) > 0:
@@ -167,7 +167,7 @@ class ChannelBuilder:
             channel = grpc.intercept_channel(channel, *self._interceptors)
         return channel
 
-    def _secure_channel(self, target, credentials, **kwargs) -> grpc.Channel:
+    def _secure_channel(self, target: Any, credentials: Any, **kwargs: Any) -> grpc.Channel:
         channel = grpc.secure_channel(target, credentials, options=self._channel_options, **kwargs)
 
         if len(self._interceptors) > 0:

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -89,7 +89,7 @@ from pyspark.sql.pandas.types import _create_converter_to_pandas, from_arrow_sch
 from pyspark.sql.types import DataType, StructType, TimestampType, _has_type
 from pyspark.rdd import PythonEvalType
 from pyspark.storagelevel import StorageLevel
-from pyspark.errors import PySparkValueError, PySparkAssertionError
+from pyspark.errors import PySparkValueError, PySparkAssertionError, PySparkNotImplementedError
 
 if TYPE_CHECKING:
     from google.rpc.error_details_pb2 import ErrorInfo
@@ -157,7 +157,7 @@ class ChannelBuilder:
         self._secure_channel so that configuration options are applied
         appropriately.
         """
-        raise NotImplementedError
+        raise PySparkNotImplementedError
 
     def _insecure_channel(self, target, **kwargs):
         channel = grpc.insecure_channel(target, options=self._channel_options, **kwargs)
@@ -634,7 +634,7 @@ class SparkConnectClient(object):
         # Parse the connection string.
         self._builder = (
             connection
-            if isinstance(connection, DefaultChannelBuilder)
+            if isinstance(connection, ChannelBuilder)
             else DefaultChannelBuilder(connection, channel_options)
         )
         self._user_id = None

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -50,7 +50,7 @@ import urllib
 
 from pyspark import SparkContext, SparkConf, __version__
 from pyspark.loose_version import LooseVersion
-from pyspark.sql.connect.client import SparkConnectClient, ChannelBuilder
+from pyspark.sql.connect.client import SparkConnectClient, DefaultChannelBuilder
 from pyspark.sql.connect.conf import RuntimeConf
 from pyspark.sql.connect.dataframe import DataFrame
 from pyspark.sql.connect.plan import (
@@ -110,7 +110,7 @@ class SparkSession:
 
         def __init__(self) -> None:
             self._options: Dict[str, Any] = {}
-            self._channel_builder: Optional[ChannelBuilder] = None
+            self._channel_builder: Optional[DefaultChannelBuilder] = None
 
         @overload
         def config(self, key: str, value: Any) -> "SparkSession.Builder":
@@ -144,7 +144,7 @@ class SparkSession:
         def remote(self, location: str = "sc://localhost") -> "SparkSession.Builder":
             return self.config("spark.remote", location)
 
-        def channelBuilder(self, channelBuilder: ChannelBuilder) -> "SparkSession.Builder":
+        def channelBuilder(self, channelBuilder: DefaultChannelBuilder) -> "SparkSession.Builder":
             """Uses custom :class:`ChannelBuilder` implementation, when there is a need
             to customize the behavior for creation of GRPC connections.
 
@@ -232,7 +232,7 @@ class SparkSession:
 
     builder.__doc__ = PySparkSession.builder.__doc__
 
-    def __init__(self, connection: Union[str, ChannelBuilder], userId: Optional[str] = None):
+    def __init__(self, connection: Union[str, DefaultChannelBuilder], userId: Optional[str] = None):
         """
         Creates a new SparkSession for the Spark Connect interface.
 

--- a/python/pyspark/sql/tests/connect/client/test_artifact.py
+++ b/python/pyspark/sql/tests/connect/client/test_artifact.py
@@ -29,7 +29,7 @@ from pyspark.sql.functions import udf
 
 if should_test_connect:
     from pyspark.sql.connect.client.artifact import ArtifactManager
-    from pyspark.sql.connect.client import ChannelBuilder
+    from pyspark.sql.connect.client import DefaultChannelBuilder
 
 
 class ArtifactTestsMixin:
@@ -54,7 +54,7 @@ class ArtifactTestsMixin:
         # Test multi sessions. Should be able to add the same
         # file from different session.
         self.check_add_pyfile(
-            SparkSession.builder.remote(f"sc://localhost:{ChannelBuilder.default_port()}").create()
+            SparkSession.builder.remote(f"sc://localhost:{DefaultChannelBuilder.default_port()}").create()
         )
 
     def test_artifacts_cannot_be_overwritten(self):
@@ -100,7 +100,7 @@ class ArtifactTestsMixin:
         # Test multi sessions. Should be able to add the same
         # file from different session.
         self.check_add_zipped_package(
-            SparkSession.builder.remote(f"sc://localhost:{ChannelBuilder.default_port()}").create()
+            SparkSession.builder.remote(f"sc://localhost:{DefaultChannelBuilder.default_port()}").create()
         )
 
     def check_add_archive(self, spark_session):
@@ -134,7 +134,7 @@ class ArtifactTestsMixin:
         # Test multi sessions. Should be able to add the same
         # file from different session.
         self.check_add_archive(
-            SparkSession.builder.remote(f"sc://localhost:{ChannelBuilder.default_port()}").create()
+            SparkSession.builder.remote(f"sc://localhost:{DefaultChannelBuilder.default_port()}").create()
         )
 
     def check_add_file(self, spark_session):
@@ -162,7 +162,7 @@ class ArtifactTestsMixin:
         # Test multi sessions. Should be able to add the same
         # file from different session.
         self.check_add_file(
-            SparkSession.builder.remote(f"sc://localhost:{ChannelBuilder.default_port()}").create()
+            SparkSession.builder.remote(f"sc://localhost:{DefaultChannelBuilder.default_port()}").create()
         )
 
 

--- a/python/pyspark/sql/tests/connect/client/test_artifact.py
+++ b/python/pyspark/sql/tests/connect/client/test_artifact.py
@@ -54,7 +54,9 @@ class ArtifactTestsMixin:
         # Test multi sessions. Should be able to add the same
         # file from different session.
         self.check_add_pyfile(
-            SparkSession.builder.remote(f"sc://localhost:{DefaultChannelBuilder.default_port()}").create()
+            SparkSession.builder.remote(
+                f"sc://localhost:{DefaultChannelBuilder.default_port()}"
+            ).create()
         )
 
     def test_artifacts_cannot_be_overwritten(self):
@@ -100,7 +102,9 @@ class ArtifactTestsMixin:
         # Test multi sessions. Should be able to add the same
         # file from different session.
         self.check_add_zipped_package(
-            SparkSession.builder.remote(f"sc://localhost:{DefaultChannelBuilder.default_port()}").create()
+            SparkSession.builder.remote(
+                f"sc://localhost:{DefaultChannelBuilder.default_port()}"
+            ).create()
         )
 
     def check_add_archive(self, spark_session):
@@ -134,7 +138,9 @@ class ArtifactTestsMixin:
         # Test multi sessions. Should be able to add the same
         # file from different session.
         self.check_add_archive(
-            SparkSession.builder.remote(f"sc://localhost:{DefaultChannelBuilder.default_port()}").create()
+            SparkSession.builder.remote(
+                f"sc://localhost:{DefaultChannelBuilder.default_port()}"
+            ).create()
         )
 
     def check_add_file(self, spark_session):
@@ -162,7 +168,9 @@ class ArtifactTestsMixin:
         # Test multi sessions. Should be able to add the same
         # file from different session.
         self.check_add_file(
-            SparkSession.builder.remote(f"sc://localhost:{DefaultChannelBuilder.default_port()}").create()
+            SparkSession.builder.remote(
+                f"sc://localhost:{DefaultChannelBuilder.default_port()}"
+            ).create()
         )
 
 

--- a/python/pyspark/sql/tests/connect/client/test_client.py
+++ b/python/pyspark/sql/tests/connect/client/test_client.py
@@ -27,7 +27,7 @@ if should_test_connect:
     import grpc
     import pandas as pd
     import pyarrow as pa
-    from pyspark.sql.connect.client import SparkConnectClient, ChannelBuilder
+    from pyspark.sql.connect.client import SparkConnectClient, DefaultChannelBuilder
     from pyspark.sql.connect.client.retries import (
         Retrying,
         DefaultPolicy,
@@ -72,7 +72,7 @@ class SparkConnectClientTestCase(unittest.TestCase):
         self.assertIsNone(client.token)
 
     def test_channel_builder(self):
-        class CustomChannelBuilder(ChannelBuilder):
+        class CustomChannelBuilder(DefaultChannelBuilder):
             @property
             def userId(self) -> Optional[str]:
                 return "abc"
@@ -129,7 +129,7 @@ class SparkConnectClientTestCase(unittest.TestCase):
 
     def test_channel_builder_with_session(self):
         dummy = str(uuid.uuid4())
-        chan = ChannelBuilder(f"sc://foo/;session_id={dummy}")
+        chan = DefaultChannelBuilder(f"sc://foo/;session_id={dummy}")
         client = SparkConnectClient(chan)
         self.assertEqual(client._session_id, chan.session_id)
 

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -3548,6 +3548,7 @@ class SparkConnectSessionTests(ReusedConnectTestCase):
 
     def test_custom_channel_builder(self):
         channel = self.spark._client._channel
+
         class CustomChannelBuilder(ChannelBuilder):
             def toChannel(self):
                 return channel
@@ -3767,14 +3768,18 @@ class ChannelBuilderTests(unittest.TestCase):
         self.assertIsInstance(chan, grpc.Channel)
 
     def test_channel_properties(self):
-        chan = DefaultChannelBuilder("sc://host/;use_ssl=true;token=abc;user_agent=foo;param1=120%2021")
+        chan = DefaultChannelBuilder(
+            "sc://host/;use_ssl=true;token=abc;user_agent=foo;param1=120%2021"
+        )
         self.assertEqual("host:15002", chan.endpoint)
         self.assertIn("foo", chan.userAgent.split(" "))
         self.assertEqual(True, chan.secure)
         self.assertEqual("120 21", chan.get("param1"))
 
     def test_metadata(self):
-        chan = DefaultChannelBuilder("sc://host/;use_ssl=true;token=abc;param1=120%2021;x-my-header=abcd")
+        chan = DefaultChannelBuilder(
+            "sc://host/;use_ssl=true;token=abc;param1=120%2021;x-my-header=abcd"
+        )
         md = chan.metadata()
         self.assertEqual([("param1", "120 21"), ("x-my-header", "abcd")], md)
 
@@ -3783,7 +3788,9 @@ class ChannelBuilderTests(unittest.TestCase):
         chan = DefaultChannelBuilder(f"sc://host/;session_id={id}")
         self.assertEqual(id, chan.session_id)
 
-        chan = DefaultChannelBuilder(f"sc://host/;session_id={id};user_agent=acbd;token=abcd;use_ssl=true")
+        chan = DefaultChannelBuilder(
+            f"sc://host/;session_id={id};user_agent=acbd;token=abcd;use_ssl=true"
+        )
         md = chan.metadata()
         for kv in md:
             self.assertNotIn(

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -3547,15 +3547,15 @@ class SparkConnectSessionTests(ReusedConnectTestCase):
             self.assertEqual(exception.getMessageParameters(), {"objectName": "`a`"})
 
     def test_custom_channel_builder(self):
-        channel = self.spark._client._channel
+        # Access self.spark's DefaultChannelBuilder to reuse same endpoint
+        endpoint = self.spark._client._builder.endpoint
 
         class CustomChannelBuilder(ChannelBuilder):
             def toChannel(self):
-                return channel
+                return self._insecure_channel(endpoint)
 
         session = RemoteSparkSession.builder.channelBuilder(CustomChannelBuilder()).create()
         session.sql("select 1 + 1")
-        session.stop()
 
 
 class SparkConnectSessionWithOptionsTest(unittest.TestCase):

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -73,7 +73,7 @@ if should_test_connect:
     import numpy as np
     from pyspark.sql.connect.proto import Expression as ProtoExpression
     from pyspark.sql.connect.session import SparkSession as RemoteSparkSession
-    from pyspark.sql.connect.client import DefaultChannelBuilder
+    from pyspark.sql.connect.client import DefaultChannelBuilder, ChannelBuilder
     from pyspark.sql.connect.column import Column
     from pyspark.sql.connect.readwriter import DataFrameWriterV2
     from pyspark.sql.dataframe import DataFrame
@@ -3545,6 +3545,16 @@ class SparkConnectSessionTests(ReusedConnectTestCase):
 
             self.assertIsNotNone(exception)
             self.assertEqual(exception.getMessageParameters(), {"objectName": "`a`"})
+
+    def test_custom_channel_builder(self):
+        channel = self.spark._client._channel
+        class CustomChannelBuilder(ChannelBuilder):
+            def toChannel(self):
+                return channel
+
+        session = RemoteSparkSession.builder.channelBuilder(CustomChannelBuilder()).create()
+        session.sql("select 1 + 1")
+        session.stop()
 
 
 class SparkConnectSessionWithOptionsTest(unittest.TestCase):

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -3796,11 +3796,11 @@ class ChannelBuilderTests(unittest.TestCase):
             self.assertNotIn(
                 kv[0],
                 [
-                    DefaultChannelBuilder.PARAM_SESSION_ID,
-                    DefaultChannelBuilder.PARAM_TOKEN,
-                    DefaultChannelBuilder.PARAM_USER_ID,
-                    DefaultChannelBuilder.PARAM_USER_AGENT,
-                    DefaultChannelBuilder.PARAM_USE_SSL,
+                    ChannelBuilder.PARAM_SESSION_ID,
+                    ChannelBuilder.PARAM_TOKEN,
+                    ChannelBuilder.PARAM_USER_ID,
+                    ChannelBuilder.PARAM_USER_AGENT,
+                    ChannelBuilder.PARAM_USE_SSL,
                 ],
                 "Metadata must not contain fixed params",
             )

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -73,7 +73,7 @@ if should_test_connect:
     import numpy as np
     from pyspark.sql.connect.proto import Expression as ProtoExpression
     from pyspark.sql.connect.session import SparkSession as RemoteSparkSession
-    from pyspark.sql.connect.client import ChannelBuilder
+    from pyspark.sql.connect.client import DefaultChannelBuilder
     from pyspark.sql.connect.column import Column
     from pyspark.sql.connect.readwriter import DataFrameWriterV2
     from pyspark.sql.dataframe import DataFrame
@@ -3715,85 +3715,85 @@ class ChannelBuilderTests(unittest.TestCase):
             "sc://host/;parm1;param2",
         ]
         for i in invalid:
-            self.assertRaises(PySparkValueError, ChannelBuilder, i)
+            self.assertRaises(PySparkValueError, DefaultChannelBuilder, i)
 
     def test_sensible_defaults(self):
-        chan = ChannelBuilder("sc://host")
+        chan = DefaultChannelBuilder("sc://host")
         self.assertFalse(chan.secure, "Default URL is not secure")
 
-        chan = ChannelBuilder("sc://host/;token=abcs")
+        chan = DefaultChannelBuilder("sc://host/;token=abcs")
         self.assertTrue(chan.secure, "specifying a token must set the channel to secure")
         self.assertRegex(
             chan.userAgent, r"^_SPARK_CONNECT_PYTHON spark/[^ ]+ os/[^ ]+ python/[^ ]+$"
         )
-        chan = ChannelBuilder("sc://host/;use_ssl=abcs")
+        chan = DefaultChannelBuilder("sc://host/;use_ssl=abcs")
         self.assertFalse(chan.secure, "Garbage in, false out")
 
     def test_user_agent(self):
-        chan = ChannelBuilder("sc://host/;user_agent=Agent123%20%2F3.4")
+        chan = DefaultChannelBuilder("sc://host/;user_agent=Agent123%20%2F3.4")
         self.assertIn("Agent123 /3.4", chan.userAgent)
 
     def test_user_agent_len(self):
         user_agent = "x" * 2049
-        chan = ChannelBuilder(f"sc://host/;user_agent={user_agent}")
+        chan = DefaultChannelBuilder(f"sc://host/;user_agent={user_agent}")
         with self.assertRaises(SparkConnectException) as err:
             chan.userAgent
         self.assertRegex(err.exception._message, "'user_agent' parameter should not exceed")
 
         user_agent = "%C3%A4" * 341  # "%C3%A4" -> "ä"; (341 * 6 = 2046) < 2048
         expected = "ä" * 341
-        chan = ChannelBuilder(f"sc://host/;user_agent={user_agent}")
+        chan = DefaultChannelBuilder(f"sc://host/;user_agent={user_agent}")
         self.assertIn(expected, chan.userAgent)
 
     def test_valid_channel_creation(self):
-        chan = ChannelBuilder("sc://host").toChannel()
+        chan = DefaultChannelBuilder("sc://host").toChannel()
         self.assertIsInstance(chan, grpc.Channel)
 
         # Sets up a channel without tokens because ssl is not used.
-        chan = ChannelBuilder("sc://host/;use_ssl=true;token=abc").toChannel()
+        chan = DefaultChannelBuilder("sc://host/;use_ssl=true;token=abc").toChannel()
         self.assertIsInstance(chan, grpc.Channel)
 
-        chan = ChannelBuilder("sc://host/;use_ssl=true").toChannel()
+        chan = DefaultChannelBuilder("sc://host/;use_ssl=true").toChannel()
         self.assertIsInstance(chan, grpc.Channel)
 
     def test_channel_properties(self):
-        chan = ChannelBuilder("sc://host/;use_ssl=true;token=abc;user_agent=foo;param1=120%2021")
+        chan = DefaultChannelBuilder("sc://host/;use_ssl=true;token=abc;user_agent=foo;param1=120%2021")
         self.assertEqual("host:15002", chan.endpoint)
         self.assertIn("foo", chan.userAgent.split(" "))
         self.assertEqual(True, chan.secure)
         self.assertEqual("120 21", chan.get("param1"))
 
     def test_metadata(self):
-        chan = ChannelBuilder("sc://host/;use_ssl=true;token=abc;param1=120%2021;x-my-header=abcd")
+        chan = DefaultChannelBuilder("sc://host/;use_ssl=true;token=abc;param1=120%2021;x-my-header=abcd")
         md = chan.metadata()
         self.assertEqual([("param1", "120 21"), ("x-my-header", "abcd")], md)
 
     def test_metadata(self):
         id = str(uuid.uuid4())
-        chan = ChannelBuilder(f"sc://host/;session_id={id}")
+        chan = DefaultChannelBuilder(f"sc://host/;session_id={id}")
         self.assertEqual(id, chan.session_id)
 
-        chan = ChannelBuilder(f"sc://host/;session_id={id};user_agent=acbd;token=abcd;use_ssl=true")
+        chan = DefaultChannelBuilder(f"sc://host/;session_id={id};user_agent=acbd;token=abcd;use_ssl=true")
         md = chan.metadata()
         for kv in md:
             self.assertNotIn(
                 kv[0],
                 [
-                    ChannelBuilder.PARAM_SESSION_ID,
-                    ChannelBuilder.PARAM_TOKEN,
-                    ChannelBuilder.PARAM_USER_ID,
-                    ChannelBuilder.PARAM_USER_AGENT,
-                    ChannelBuilder.PARAM_USE_SSL,
+                    DefaultChannelBuilder.PARAM_SESSION_ID,
+                    DefaultChannelBuilder.PARAM_TOKEN,
+                    DefaultChannelBuilder.PARAM_USER_ID,
+                    DefaultChannelBuilder.PARAM_USER_AGENT,
+                    DefaultChannelBuilder.PARAM_USE_SSL,
                 ],
                 "Metadata must not contain fixed params",
             )
 
         with self.assertRaises(ValueError) as ve:
-            chan = ChannelBuilder("sc://host/;session_id=abcd")
+            chan = DefaultChannelBuilder("sc://host/;session_id=abcd")
             SparkConnectClient(chan)
         self.assertIn("Parameter value session_id must be a valid UUID format", str(ve.exception))
 
-        chan = ChannelBuilder("sc://host/")
+        chan = DefaultChannelBuilder("sc://host/")
         self.assertIsNone(chan.session_id)
 
 

--- a/python/pyspark/sql/tests/connect/test_session.py
+++ b/python/pyspark/sql/tests/connect/test_session.py
@@ -20,7 +20,7 @@ import unittest
 from typing import Optional
 
 from pyspark import InheritableThread, inheritable_thread_target
-from pyspark.sql.connect.client import ChannelBuilder
+from pyspark.sql.connect.client import DefaultChannelBuilder
 from pyspark.sql.connect.session import SparkSession as RemoteSparkSession
 from pyspark.testing.connectutils import should_test_connect
 
@@ -28,7 +28,7 @@ if should_test_connect:
     from pyspark.testing.connectutils import ReusedConnectTestCase
 
 
-class CustomChannelBuilder(ChannelBuilder):
+class CustomChannelBuilder(DefaultChannelBuilder):
     @property
     def userId(self) -> Optional[str]:
         return "abc"


### PR DESCRIPTION
### What changes were proposed in this pull request?

Refactor ChannelBuilder into ChannelBuilder and DefaultChannelBuilder. ChannelBuilder is a abstract class with certain base functionality other possible channel builders should inherit. DefaultChannelBuilder is the current implementation of ChannelBuilder.

### Why are the changes needed?

The concept of ChannelBuilder was introduced specifically so that different implementations of Channel Builder would exist. However, the current version makes it hard to actually implement custom functionality, because the interface of channel builder and it's standard implementation are tied so closely.

### Does this PR introduce _any_ user-facing change?

No


### How was this patch tested?

Existing tests; new e2e test.


### Was this patch authored or co-authored using generative AI tooling?
Nope :) 
