### PR TITLE
[SPARK-46797][CORE] Rename `spark.deploy.spreadOut` to `spark.deploy.spreadOutApps`

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/Deploy.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/Deploy.scala
@@ -97,8 +97,9 @@ private[spark] object Deploy {
     .intConf
     .createWithDefault(10)
 
-  val SPREAD_OUT_APPS = ConfigBuilder("spark.deploy.spreadOut")
+  val SPREAD_OUT_APPS = ConfigBuilder("spark.deploy.spreadOutApps")
     .version("0.6.1")
+    .withAlternative("spark.deploy.spreadOut")
     .booleanConf
     .createWithDefault(true)
 

--- a/docs/spark-standalone.md
+++ b/docs/spark-standalone.md
@@ -279,7 +279,7 @@ SPARK_MASTER_OPTS supports the following system properties:
   <td>1.1.0</td>
 </tr>
 <tr>
-  <td><code>spark.deploy.spreadOut</code></td>
+  <td><code>spark.deploy.spreadOutApps</code></td>
   <td>true</td>
   <td>
     Whether the standalone cluster manager should spread applications out across nodes or try


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to rename `spark.deploy.spreadOut` to `spark.deploy.spreadOutApps`.

### Why are the changes needed?

Although Apache Spark documentation clearly says it's about `applications`, this still misleads users to forget `Driver` JVMs which will be spread out always independently from this configuration.

https://github.com/apache/spark/blob/b80e8cb4552268b771fc099457b9186807081c4a/docs/spark-standalone.md?plain=1#L282-L285

### Does this PR introduce _any_ user-facing change?

No, the behavior is the same. Only it will show warnings for old config name usages.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.