### PR TITLE
[SPARK-46800][CORE] Support `spark.deploy.spreadOutDrivers`

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/Deploy.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/Deploy.scala
@@ -97,6 +97,11 @@ private[spark] object Deploy {
     .intConf
     .createWithDefault(10)
 
+  val SPREAD_OUT_DRIVERS = ConfigBuilder("spark.deploy.spreadOutDrivers")
+    .version("4.0.0")
+    .booleanConf
+    .createWithDefault(true)
+
   val SPREAD_OUT_APPS = ConfigBuilder("spark.deploy.spreadOutApps")
     .version("0.6.1")
     .withAlternative("spark.deploy.spreadOut")

--- a/docs/spark-standalone.md
+++ b/docs/spark-standalone.md
@@ -284,7 +284,7 @@ SPARK_MASTER_OPTS supports the following system properties:
   <td>
     Whether the standalone cluster manager should spread drivers out across nodes or try
     to consolidate them onto as few nodes as possible. Spreading out is usually better for
-    data locality in HDFS, but consolidating is more efficient for compute-intensive workloads. <br/>
+    data locality in HDFS, but consolidating is more efficient for compute-intensive workloads.
   </td>
   <td>4.0.0</td>
 </tr>

--- a/docs/spark-standalone.md
+++ b/docs/spark-standalone.md
@@ -279,6 +279,16 @@ SPARK_MASTER_OPTS supports the following system properties:
   <td>1.1.0</td>
 </tr>
 <tr>
+  <td><code>spark.deploy.spreadOutDrivers</code></td>
+  <td>true</td>
+  <td>
+    Whether the standalone cluster manager should spread drivers out across nodes or try
+    to consolidate them onto as few nodes as possible. Spreading out is usually better for
+    data locality in HDFS, but consolidating is more efficient for compute-intensive workloads. <br/>
+  </td>
+  <td>4.0.0</td>
+</tr>
+<tr>
   <td><code>spark.deploy.spreadOutApps</code></td>
   <td>true</td>
   <td>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `spark.deploy.spreadOutDrivers` like `spark.deploy.spreadOutApps`.

### Why are the changes needed?

To allow the users to control the Spark's JVM distributions inside their clusters

### Does this PR introduce _any_ user-facing change?

This is a new feature, but the default behavior is unchanged.

### How was this patch tested?

Pass the CIs with newly added test cases.

### Was this patch authored or co-authored using generative AI tooling?

No.