### PR TITLE
[SPARK-46803][BUILD] Remove scala-2.13 profile

### DIFF
--- a/connector/connect/bin/spark-connect
+++ b/connector/connect/bin/spark-connect
@@ -35,7 +35,7 @@ SCALA_ARG="-Pscala-${SCALA_BINARY_VER}"
 SCBUILD="${SCBUILD:-1}"
 if [ "$SCBUILD" -eq "1" ]; then
   # Build the jars needed for spark submit and spark connect
-  build/sbt "${SCALA_ARG}" -Phive -Pconnect package || exit 1
+  build/sbt -Phive -Pconnect package || exit 1
 fi
 
 # This jar is already in the classpath, but the submit commands wants a jar as the input.

--- a/connector/connect/bin/spark-connect-build
+++ b/connector/connect/bin/spark-connect-build
@@ -30,4 +30,4 @@ SCALA_VER=`grep "scala.version" "${SPARK_HOME}/pom.xml" | grep ${SCALA_BINARY_VE
 SCALA_ARG="-Pscala-${SCALA_BINARY_VER}"
 
 # Build the jars needed for spark submit and spark connect JVM client
-build/sbt "${SCALA_ARG}" -Phive -Pconnect package "connect-client-jvm/package" || exit 1
+build/sbt -Phive -Pconnect package "connect-client-jvm/package" || exit 1

--- a/connector/connect/bin/spark-connect-scala-client
+++ b/connector/connect/bin/spark-connect-scala-client
@@ -45,7 +45,7 @@ SCALA_ARG="-Pscala-${SCALA_BINARY_VER}"
 SCBUILD="${SCBUILD:-1}"
 if [ "$SCBUILD" -eq "1" ]; then
   # Build the jars needed for spark connect JVM client
-  build/sbt "${SCALA_ARG}" "connect-client-jvm/package" || exit 1
+  build/sbt "connect-client-jvm/package" || exit 1
 fi
 
 if [ -z "$SCCLASSPATH" ]; then

--- a/connector/connect/bin/spark-connect-scala-client-classpath
+++ b/connector/connect/bin/spark-connect-scala-client-classpath
@@ -29,6 +29,6 @@ SCALA_BINARY_VER=`grep "scala.binary.version" "${SPARK_HOME}/pom.xml" | head -n1
 SCALA_VER=`grep "scala.version" "${SPARK_HOME}/pom.xml" | grep ${SCALA_BINARY_VER} | head -n1 | awk -F '[<>]' '{print $3}'`
 SCALA_ARG="-Pscala-${SCALA_BINARY_VER}"
 
-CONNECT_CLASSPATH="$(build/sbt "${SCALA_ARG}" -DcopyDependencies=false "export connect-client-jvm/fullClasspath" | grep jar | tail -n1)"
+CONNECT_CLASSPATH="$(build/sbt -DcopyDependencies=false "export connect-client-jvm/fullClasspath" | grep jar | tail -n1)"
 
 echo "$CONNECT_CLASSPATH"

--- a/connector/connect/bin/spark-connect-shell
+++ b/connector/connect/bin/spark-connect-shell
@@ -33,7 +33,7 @@ SCALA_ARG="-Pscala-${SCALA_BINARY_VER}"
 SCBUILD="${SCBUILD:-1}"
 if [ "$SCBUILD" -eq "1" ]; then
   # Build the jars needed for spark submit and spark connect
-  build/sbt "${SCALA_ARG}" -Phive -Pconnect package || exit 1
+  build/sbt -Phive -Pconnect package || exit 1
 fi
 
 exec "${SPARK_HOME}"/bin/spark-shell --conf spark.plugins=org.apache.spark.sql.connect.SparkConnectPlugin "$@"

--- a/dev/lint-scala
+++ b/dev/lint-scala
@@ -24,7 +24,6 @@ SPARK_ROOT_DIR="$(dirname $SCRIPT_DIR)"
 
 # For Spark Connect, we actively enforce scalafmt and check that the produced diff is empty.
 ERRORS=$(./build/mvn \
-    -Pscala-2.13 \
     scalafmt:format \
     -Dscalafmt.skip=false \
     -Dscalafmt.validateOnly=true \

--- a/dev/scalafmt
+++ b/dev/scalafmt
@@ -18,5 +18,5 @@
 #
 
 VERSION="${@:-2.13}"
-./build/mvn -Pscala-$VERSION scalafmt:format -Dscalafmt.skip=false -Dscalafmt.validateOnly=false
+./build/mvn scalafmt:format -Dscalafmt.skip=false -Dscalafmt.validateOnly=false
 

--- a/resource-managers/kubernetes/integration-tests/dev/dev-run-integration-tests.sh
+++ b/resource-managers/kubernetes/integration-tests/dev/dev-run-integration-tests.sh
@@ -206,7 +206,6 @@ properties+=(
   ./build/mvn install \
     -pl resource-managers/kubernetes/integration-tests \
     $BUILD_DEPENDENCIES_MVN_FLAG \
-    -Pscala-$SCALA_VERSION \
     -P$HADOOP_PROFILE \
     -Pkubernetes \
     -Pkubernetes-integration-tests \


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to remove `scala-2.13 profile` from various compiled scripts.


### Why are the changes needed?
Because in `Spark 4.0`, `scala-2.13 profile` no longer exists.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
- Pass GA.
- Manually test.


### Was this patch authored or co-authored using generative AI tooling?
No.
