### PR TITLE
[SPARK-46805][BUILD] Upgrade `scalafmt` to 3.7.17

### DIFF
--- a/dev/.scalafmt.conf
+++ b/dev/.scalafmt.conf
@@ -32,4 +32,4 @@ fileOverride {
     runner.dialect = scala213
   }
 }
-version = 3.7.13
+version = 3.7.17


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade `scalafmt` from `3.7.13` to `3.7.17`.


### Why are the changes needed?
- Regular upgrade, the last upgrade occurred 5 months ago.

- The full release notes:
  https://github.com/scalameta/scalafmt/releases/tag/v3.7.17
  https://github.com/scalameta/scalafmt/releases/tag/v3.7.16
  https://github.com/scalameta/scalafmt/releases/tag/v3.7.15
  https://github.com/scalameta/scalafmt/releases/tag/v3.7.14

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
- Pass GA.
- Manually test.


### Was this patch authored or co-authored using generative AI tooling?
No.
