### PR TITLE
[SPARK-43403][UI] Ensure old SparkUI in HistoryServer has been detached before loading new one

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/ApplicationCache.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/ApplicationCache.scala
@@ -50,7 +50,7 @@ private[history] class ApplicationCache(
 
   /**
    * Keep track of SparkUIs in [[ApplicationCache#appCache]] and SparkUIs removed from
-   * [[ApplicationCache#appCache]] but not destroyed yet.
+   * [[ApplicationCache#appCache]] but not detached yet.
    */
   private val loadedApps = new ConcurrentHashMap[CacheKey, CountDownLatch]()
 

--- a/core/src/main/scala/org/apache/spark/deploy/history/ApplicationCache.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/ApplicationCache.scala
@@ -58,7 +58,7 @@ private[history] class ApplicationCache(
 
     /** the cache key doesn't match a cached entry, or the entry is out-of-date, so load it. */
     override def load(key: CacheKey): CacheEntry = {
-      // Ensure current SparkUI has been detached before trying to load new one.
+      // Ensure current SparkUI has been detached before loading new one.
       val removalLatch = loadedApps.get(key)
       if (removalLatch != null) {
         removalLatch.await()

--- a/core/src/main/scala/org/apache/spark/deploy/history/ApplicationCache.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/ApplicationCache.scala
@@ -58,7 +58,7 @@ private[history] class ApplicationCache(
 
     /** the cache key doesn't match a cached entry, or the entry is out-of-date, so load it. */
     override def load(key: CacheKey): CacheEntry = {
-      // Ensure current SparkUI has been detached before loading new one.
+      // Ensure old SparkUI has been detached before loading new one.
       val removalLatch = loadedApps.get(key)
       if (removalLatch != null) {
         removalLatch.await()

--- a/core/src/main/scala/org/apache/spark/deploy/history/ApplicationCache.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/ApplicationCache.scala
@@ -17,11 +17,12 @@
 
 package org.apache.spark.deploy.history
 
-import java.util.concurrent.{ConcurrentHashMap, CountDownLatch, ExecutionException}
+import java.util.concurrent.{ConcurrentHashMap, CountDownLatch, ExecutionException, TimeUnit}
 import javax.servlet.{DispatcherType, Filter, FilterChain, FilterConfig, ServletException, ServletRequest, ServletResponse}
 import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 
 import scala.jdk.CollectionConverters._
+import scala.concurrent.TimeoutException
 
 import com.codahale.metrics.{Counter, MetricRegistry, Timer}
 import com.google.common.cache.{CacheBuilder, CacheLoader, LoadingCache, RemovalListener, RemovalNotification}
@@ -61,7 +62,11 @@ private[history] class ApplicationCache(
       // Ensure old SparkUI has been detached before loading new one.
       val removalLatch = loadedApps.get(key)
       if (removalLatch != null) {
-        removalLatch.await()
+        // Old SparkUI is in the middle of detaching.
+        // Waiting 10 seconds should be enough since detaching usually takes less than 1 second.
+        if (!removalLatch.await(10, TimeUnit.SECONDS)) {
+          throw new TimeoutException("Timed out waiting for old SparkUI to be detached")
+        }
       }
       val entry = loadApplicationEntry(key.appId, key.attemptId)
       loadedApps.put(key, new CountDownLatch(1))

--- a/core/src/main/scala/org/apache/spark/deploy/history/ApplicationCache.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/ApplicationCache.scala
@@ -61,9 +61,6 @@ private[history] class ApplicationCache(
       // Ensure old SparkUI has been detached before loading new one.
       val removalLatch = loadedApps.get(key)
       if (removalLatch != null) {
-        // Not set a timeout because:
-        // 1. ApplicationCache#removalListener ensures each removalLatch will be counted down
-        // 2. SparkUI detaching time is not predictable
         removalLatch.await()
       }
       val entry = loadApplicationEntry(key.appId, key.attemptId)

--- a/core/src/main/scala/org/apache/spark/deploy/history/ApplicationCache.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/ApplicationCache.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.deploy.history
 
-import java.util.concurrent.{ConcurrentHashMap, CountDownLatch, ExecutionException, TimeUnit}
+import java.util.concurrent.{ConcurrentHashMap, CountDownLatch, ExecutionException, TimeoutException, TimeUnit}
 import javax.servlet.{DispatcherType, Filter, FilterChain, FilterConfig, ServletException, ServletRequest, ServletResponse}
 import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 

--- a/core/src/main/scala/org/apache/spark/deploy/history/ApplicationCache.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/ApplicationCache.scala
@@ -62,11 +62,10 @@ private[history] class ApplicationCache(
       // Ensure old SparkUI has been detached before loading new one.
       val removalLatch = loadedApps.get(key)
       if (removalLatch != null) {
-        // Old SparkUI is in the middle of detaching.
-        // Waiting 10 seconds should be enough since detaching usually takes less than 1 second.
-        if (!removalLatch.await(10, TimeUnit.SECONDS)) {
-          throw new TimeoutException("Timed out waiting for old SparkUI to be detached")
-        }
+        // Not set a timeout because:
+        // 1. ApplicationCache#removalListener ensures each removalLatch will be counted down
+        // 2. SparkUI detaching time is not predictable
+        removalLatch.await()
       }
       val entry = loadApplicationEntry(key.appId, key.attemptId)
       loadedApps.put(key, new CountDownLatch(1))

--- a/core/src/main/scala/org/apache/spark/deploy/history/ApplicationCache.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/ApplicationCache.scala
@@ -17,12 +17,11 @@
 
 package org.apache.spark.deploy.history
 
-import java.util.concurrent.{ConcurrentHashMap, CountDownLatch, ExecutionException, TimeoutException, TimeUnit}
+import java.util.concurrent.{ConcurrentHashMap, CountDownLatch, ExecutionException}
 import javax.servlet.{DispatcherType, Filter, FilterChain, FilterConfig, ServletException, ServletRequest, ServletResponse}
 import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 
 import scala.jdk.CollectionConverters._
-import scala.concurrent.TimeoutException
 
 import com.codahale.metrics.{Counter, MetricRegistry, Timer}
 import com.google.common.cache.{CacheBuilder, CacheLoader, LoadingCache, RemovalListener, RemovalNotification}

--- a/core/src/test/scala/org/apache/spark/deploy/history/ApplicationCacheSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/ApplicationCacheSuite.scala
@@ -405,17 +405,15 @@ class ApplicationCacheSuite extends SparkFunSuite with MockitoSugar with Matcher
     // Wait for old SparkUI being removed from cache
     awaitRemoval.await()
 
+    // Loading of new SparkUI is blocked because old one has not been detached.
     val t2 = new Thread(() => cache.get(appId))
     t2.start()
     t2.join(100)
-
-    // Loading of new SparkUI is blocked because old one has not been detached.
     assert(loadCount == metrics.loadCount.getCount)
 
     // Unblock detach action and wait for loading of new SparkUI to complete.
     blockDetach.countDown()
     t2.join()
-
     assert(loadCount + 1 == metrics.loadCount.getCount)
   }
 }

--- a/core/src/test/scala/org/apache/spark/deploy/history/ApplicationCacheSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/ApplicationCacheSuite.scala
@@ -18,11 +18,10 @@
 package org.apache.spark.deploy.history
 
 import java.util.{Date, NoSuchElementException}
-import java.util.concurrent.CountDownLatch
+import java.util.concurrent.{CountDownLatch, TimeoutException}
 import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 
 import scala.collection.mutable
-import scala.concurrent.TimeoutException
 
 import com.codahale.metrics.Counter
 import org.eclipse.jetty.servlet.ServletContextHandler


### PR DESCRIPTION
### What changes were proposed in this pull request?
Ensure old SparkUI in HistoryServer has been detached before loading new one.


### Why are the changes needed?
The error described in SPARK-43403 happened quite often when user opened SparkUIs of in-progress Apps frequently.

It happened when `FsHistoryProvider#onUIDetached` run (in thread-a) right after a new SparkUI with the same appId and attemptId was loaded (in thread-b).

To avoid this, we let loading of the new SparkUI wait until old SparkUI is detached.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Add test `Load new SparkUI during old one is detaching` in `ApplicationCacheSuite`
