### PR TITLE
[SPARK-46826][INFRA] Reset `grpcio` installation version of `Python linter dependencies for branch-3.4/branch-3.5`

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -687,14 +687,14 @@ jobs:
         # SPARK-44554: Copy from https://github.com/apache/spark/blob/a05c27e85829fe742c1828507a1fd180cdc84b54/.github/workflows/build_and_test.yml#L571-L578
         # Should delete this section after SPARK 3.4 EOL.
         python3.9 -m pip install 'flake8==3.9.0' pydata_sphinx_theme 'mypy==0.920' 'pytest==7.1.3' 'pytest-mypy-plugins==1.9.3' numpydoc 'jinja2<3.0.0' 'black==22.6.0'
-        python3.9 -m pip install 'pandas-stubs==1.2.0.53' ipython 'grpcio==1.59.3' 'grpc-stubs==1.24.11' 'googleapis-common-protos-stubs==2.2.0'
+        python3.9 -m pip install 'pandas-stubs==1.2.0.53' ipython 'grpcio==1.48.1' 'grpc-stubs==1.24.11' 'googleapis-common-protos-stubs==2.2.0'
     - name: Install Python linter dependencies for branch-3.5
       if: inputs.branch == 'branch-3.5'
       run: |
         # SPARK-45212: Copy from https://github.com/apache/spark/blob/555c8def51e5951c7bf5165a332795e9e330ec9d/.github/workflows/build_and_test.yml#L631-L638
         # Should delete this section after SPARK 3.5 EOL.
         python3.9 -m pip install 'flake8==3.9.0' pydata_sphinx_theme 'mypy==0.982' 'pytest==7.1.3' 'pytest-mypy-plugins==1.9.3' numpydoc 'jinja2<3.0.0' 'black==22.6.0'
-        python3.9 -m pip install 'pandas-stubs==1.2.0.53' ipython 'grpcio==1.59.3' 'grpc-stubs==1.24.11' 'googleapis-common-protos-stubs==2.2.0'
+        python3.9 -m pip install 'pandas-stubs==1.2.0.53' ipython 'grpcio==1.56.0' 'grpc-stubs==1.24.11' 'googleapis-common-protos-stubs==2.2.0'
     - name: Install Python dependencies for python linter and documentation generation
       if: inputs.branch != 'branch-3.4' && inputs.branch != 'branch-3.5'
       run: |


### PR DESCRIPTION
### What changes were proposed in this pull request?
https://github.com/apache/spark/pull/43942 upgraded the `grpcio` version and simultaneously upgraded the `grpcio` version installed in `Install Python linter dependencies for branch-3.4` and `Install Python linter dependencies for branch-3.5` in `build_and_test.yml`. These two steps are used to install Python linter dependencies for `branch-3.4/branch-3.5` in daily tests. They should use the same configuration as `branch-3.4/branch-3.5` for safety. So this pr reset the version of grpcio installed in these two steps:

- branch-3.4

https://github.com/apache/spark/blob/e56bd97c04c184104046e51e6759e616c86683fa/.github/workflows/build_and_test.yml#L588-L595

- branch-3.5

https://github.com/apache/spark/blob/0956db6901bf03d2d948b23f00bcd6e74a0c251b/.github/workflows/build_and_test.yml#L637-L644


### Why are the changes needed?
The versions of the dependencies installed in `Install Python linter dependencies for branch-3.4` and `Install Python linter dependencies for branch-3.5` should be consistent with `branch-3.4/branch-3.5`.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Monitor GA after merged


### Was this patch authored or co-authored using generative AI tooling?
No
