### PR TITLE
[SPARK-46827][CORE] Make `RocksDBPersistenceEngine` to support a symbolic link

### DIFF
--- a/core/src/test/scala/org/apache/spark/deploy/master/PersistenceEngineSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/master/PersistenceEngineSuite.scala
@@ -88,6 +88,21 @@ class PersistenceEngineSuite extends SparkFunSuite {
     }
   }
 
+  test("SPARK-46827: RocksDBPersistenceEngine with a symbolic link") {
+    withTempDir { dir =>
+      val target = Paths.get(dir.getAbsolutePath(), "target")
+      val link = Paths.get(dir.getAbsolutePath(), "symbolic_link");
+
+      Files.createDirectories(target)
+      Files.createSymbolicLink(link, target);
+
+      val conf = new SparkConf()
+      testPersistenceEngine(conf, serializer =>
+        new RocksDBPersistenceEngine(link.toAbsolutePath.toString, serializer)
+      )
+    }
+  }
+
   test("SPARK-46205: Support KryoSerializer in FileSystemPersistenceEngine") {
     withTempDir { dir =>
       val conf = new SparkConf()


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to make `RocksDBPersistenceEngine` to support a symbolic link location.

### Why are the changes needed?

To be consistent with `FileSystemPersistenceEngine` which supports symbolic link locations.

https://github.com/apache/spark/blob/7004dd9edcad32d34d0448df9498d32c444ab082/core/src/main/scala/org/apache/spark/deploy/master/FileSystemPersistenceEngine.scala#L45-L50

### Does this PR introduce _any_ user-facing change?

No. This is a new feature at 4.0.0.

### How was this patch tested?

Pass the CIs with a newly added test case.

### Was this patch authored or co-authored using generative AI tooling?

No.
