### PR TITLE
[SPARK-46846][CORE] Make `WorkerResourceInfo` extend `Serializable` explicitly

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/master/WorkerInfo.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/WorkerInfo.scala
@@ -25,7 +25,7 @@ import org.apache.spark.rpc.RpcEndpointRef
 import org.apache.spark.util.Utils
 
 private[spark] case class WorkerResourceInfo(name: String, addresses: Seq[String])
-  extends ResourceAllocator {
+  extends Serializable with ResourceAllocator {
 
   override protected def resourceName = this.name
   override protected def resourceAddresses = this.addresses


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to make `WorkerResourceInfo` extend `Serializable` interface explicitly.

- https://docs.oracle.com/en/java/javase/17/docs/specs/serialization/serial-arch.html
> A Serializable class must do the following:
>   - Implement the `java.io.Serializable` interface

### Why are the changes needed?

`WorkerInfo` extends `Serializable` and has `WorkerResourceInfo` as data.
https://github.com/apache/spark/blob/1f23edfa84aa3318791d5fbbbae22d479a49134a/core/src/main/scala/org/apache/spark/deploy/master/WorkerInfo.scala#L49-L58

`WorkerInfo` itself has no data field, but inherits `ResourceAllocator` which has data.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.