### PR TITLE
[SPARK-46808][PYTHON][FOLLOW-UP] Add a guide for automatic sorting in `test_error_classes_sorted`

### DIFF
--- a/python/pyspark/errors/tests/test_errors.py
+++ b/python/pyspark/errors/tests/test_errors.py
@@ -36,7 +36,7 @@ class ErrorsTest(unittest.TestCase):
                 f"after [{error_class_names[i + 1]}]."
                 "\n\nRun 'cd $SPARK_HOME; bin/pyspark' and "
                 "'from pyspark.errors.exceptions import _write_self; _write_self()' "
-                "to automatically sort them."
+                "to automatically sort them.",
             )
 
     def test_error_classes_duplicated(self):

--- a/python/pyspark/errors/tests/test_errors.py
+++ b/python/pyspark/errors/tests/test_errors.py
@@ -32,8 +32,11 @@ class ErrorsTest(unittest.TestCase):
         for i in range(len(error_class_names) - 1):
             self.assertTrue(
                 error_class_names[i] < error_class_names[i + 1],
-                f"Error class [{error_class_names[i]}] should place"
-                f"after [{error_class_names[i + 1]}]",
+                f"Error class [{error_class_names[i]}] should place "
+                f"after [{error_class_names[i + 1]}]."
+                "\n\nRun 'cd $SPARK_HOME; bin/pyspark' and "
+                "'from pyspark.errors.exceptions import _write_self; _write_self()' "
+                "to automatically sort them."
             )
 
     def test_error_classes_duplicated(self):


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/44848 that adds a bit of guide to sort the error classes.

### Why are the changes needed?

For developers to easily sort the error classes.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Manually.

### Was this patch authored or co-authored using generative AI tooling?

No.