### PR TITLE
[SPARK-46868][CORE] Support Spark Worker Log UI

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/worker/ui/LogPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/ui/LogPage.scala
@@ -75,7 +75,7 @@ private[ui] class LogPage(parent: WorkerWebUI) extends WebUIPage("logPage") with
       case (None, None, Some(d), None) =>
         (s"${workDir.getPath}/$d/", s"driverId=$d", d)
       case (None, None, None, Some(_)) =>
-        (s"${sys.env.getOrElse("SPARK_LOG_DIR", workDir.getPath)}/", "self", "")
+        (s"${sys.env.getOrElse("SPARK_LOG_DIR", workDir.getPath)}/", "self", "worker")
       case _ =>
         throw new Exception("Request must specify either application or driver identifiers")
     }

--- a/core/src/main/scala/org/apache/spark/deploy/worker/ui/LogPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/ui/LogPage.scala
@@ -30,23 +30,26 @@ import org.apache.spark.util.logging.RollingFileAppender
 private[ui] class LogPage(parent: WorkerWebUI) extends WebUIPage("logPage") with Logging {
   private val worker = parent.worker
   private val workDir = new File(parent.workDir.toURI.normalize().getPath)
-  private val supportedLogTypes = Set("stderr", "stdout")
+  private val supportedLogTypes = Set("stderr", "stdout", "out")
   private val defaultBytes = 100 * 1024
 
   def renderLog(request: HttpServletRequest): String = {
     val appId = Option(request.getParameter("appId"))
     val executorId = Option(request.getParameter("executorId"))
     val driverId = Option(request.getParameter("driverId"))
+    val self = Option(request.getParameter("self"))
     val logType = request.getParameter("logType")
     val offset = Option(request.getParameter("offset")).map(_.toLong)
     val byteLength = Option(request.getParameter("byteLength")).map(_.toInt)
       .getOrElse(defaultBytes)
 
-    val logDir = (appId, executorId, driverId) match {
-      case (Some(a), Some(e), None) =>
+    val logDir = (appId, executorId, driverId, self) match {
+      case (Some(a), Some(e), None, None) =>
         s"${workDir.getPath}/$a/$e/"
-      case (None, None, Some(d)) =>
+      case (None, None, Some(d), None) =>
         s"${workDir.getPath}/$d/"
+      case (None, None, None, Some(_)) =>
+        s"${sys.env.getOrElse("SPARK_LOG_DIR", workDir.getPath)}/"
       case _ =>
         throw new Exception("Request must specify either application or driver identifiers")
     }
@@ -60,16 +63,19 @@ private[ui] class LogPage(parent: WorkerWebUI) extends WebUIPage("logPage") with
     val appId = Option(request.getParameter("appId"))
     val executorId = Option(request.getParameter("executorId"))
     val driverId = Option(request.getParameter("driverId"))
+    val self = Option(request.getParameter("self"))
     val logType = request.getParameter("logType")
     val offset = Option(request.getParameter("offset")).map(_.toLong)
     val byteLength = Option(request.getParameter("byteLength")).map(_.toInt)
       .getOrElse(defaultBytes)
 
-    val (logDir, params, pageName) = (appId, executorId, driverId) match {
-      case (Some(a), Some(e), None) =>
+    val (logDir, params, pageName) = (appId, executorId, driverId, self) match {
+      case (Some(a), Some(e), None, None) =>
         (s"${workDir.getPath}/$a/$e/", s"appId=$a&executorId=$e", s"$a/$e")
-      case (None, None, Some(d)) =>
+      case (None, None, Some(d), None) =>
         (s"${workDir.getPath}/$d/", s"driverId=$d", d)
+      case (None, None, None, Some(_)) =>
+        (s"${sys.env.getOrElse("SPARK_LOG_DIR", workDir.getPath)}/", "self", "")
       case _ =>
         throw new Exception("Request must specify either application or driver identifiers")
     }
@@ -137,8 +143,16 @@ private[ui] class LogPage(parent: WorkerWebUI) extends WebUIPage("logPage") with
       return ("Error: invalid log directory " + logDirectory, 0, 0, 0)
     }
 
+    // Find a log file name
+    val fileName = if (logType.equals("out")) {
+      normalizedLogDir.listFiles.map(_.getName).filter(_.endsWith(".out"))
+        .headOption.getOrElse(logType)
+    } else {
+      logType
+    }
+
     try {
-      val files = RollingFileAppender.getSortedRolledOverFiles(logDirectory, logType)
+      val files = RollingFileAppender.getSortedRolledOverFiles(logDirectory, fileName)
       logDebug(s"Sorted log files of type $logType in $logDirectory:\n${files.mkString("\n")}")
 
       val fileLengths: Seq[Long] = files.map(Utils.getFileLength(_, worker.conf))

--- a/core/src/main/scala/org/apache/spark/deploy/worker/ui/LogPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/ui/LogPage.scala
@@ -143,15 +143,14 @@ private[ui] class LogPage(parent: WorkerWebUI) extends WebUIPage("logPage") with
       return ("Error: invalid log directory " + logDirectory, 0, 0, 0)
     }
 
-    // Find a log file name
-    val fileName = if (logType.equals("out")) {
-      normalizedLogDir.listFiles.map(_.getName).filter(_.endsWith(".out"))
-        .headOption.getOrElse(logType)
-    } else {
-      logType
-    }
-
     try {
+      // Find a log file name
+      val fileName = if (logType.equals("out")) {
+        normalizedLogDir.listFiles.map(_.getName).filter(_.endsWith(".out"))
+          .headOption.getOrElse(logType)
+      } else {
+        logType
+      }
       val files = RollingFileAppender.getSortedRolledOverFiles(logDirectory, fileName)
       logDebug(s"Sorted log files of type $logType in $logDirectory:\n${files.mkString("\n")}")
 

--- a/core/src/main/scala/org/apache/spark/deploy/worker/ui/WorkerPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/ui/WorkerPage.scala
@@ -78,11 +78,15 @@ private[ui] class WorkerPage(parent: WorkerWebUI) extends WebUIPage("") {
     // For now we only show driver information if the user has submitted drivers to the cluster.
     // This is until we integrate the notion of drivers and applications in the UI.
 
+    val workerUrlRef = UIUtils.makeHref(parent.worker.reverseProxy, workerState.workerId,
+      parent.webUrl)
     val content =
       <div class="row"> <!-- Worker Details -->
         <div class="col-12">
           <ul class="list-unstyled">
-            <li><strong>ID:</strong> {workerState.workerId}</li>
+            <li><strong>ID:</strong>
+              <a href={s"$workerUrlRef/logPage/?self&logType=out"}>{workerState.workerId}</a>
+            </li>
             <li><strong>
               Master URL:</strong> {workerState.masterUrl}
             </li>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `Spark Worker Log UI` when `SPARK_LOG_DIR` is under work directory.

### Why are the changes needed?

This is a new feature to allow the users to access the worker log like the following.

**BEFORE**

![Screenshot 2024-01-25 at 3 04 20 PM](https://github.com/apache/spark/assets/9700541/73ef33d5-9b56-4cca-83c2-9fd2e8ab5201)

**AFTER**

- Worker Page (Worker ID provides a new hyperlink for Log UI)
![Screenshot 2024-01-25 at 2 58 44 PM](https://github.com/apache/spark/assets/9700541/1de66eee-7b73-4be3-a12c-e008442b7b6c)

- Log UI
![Screenshot 2024-01-25 at 6 00 25 PM](https://github.com/apache/spark/assets/9700541/e20fde05-ce5e-42cb-9112-4a8d2ec69418)

### Does this PR introduce _any_ user-facing change?

To provide a better UX.

### How was this patch tested?

Manually.

```
$ sbin/start-master.sh
$ SPARK_LOG_DIR=$PWD/work/logs sbin/start-worker.sh spark://$(hostname):7077
```

### Was this patch authored or co-authored using generative AI tooling?

No.