### PR TITLE
[SPARK-46869][K8S] Add `logrotate` to Spark docker files

### DIFF
--- a/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile
+++ b/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile
@@ -30,7 +30,7 @@ ARG spark_uid=185
 RUN set -ex && \
     apt-get update && \
     ln -s /lib /lib64 && \
-    apt install -y bash tini libc6 libpam-modules krb5-user libnss3 procps net-tools && \
+    apt install -y bash tini libc6 libpam-modules krb5-user libnss3 procps net-tools logrotate && \
     mkdir -p /opt/spark && \
     mkdir -p /opt/spark/examples && \
     mkdir -p /opt/spark/work-dir && \


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `logrotate` to Spark docker files.

### Why are the changes needed?

To help a user to easily rotate the logs by configuration. Note that this is not for rigorous users who cannot allow log data loss. `logratate` is easy but is known to allow log loss during rotation.

### Does this PR introduce _any_ user-facing change?

The image size change is negligible.
```
$ docker images spark
REPOSITORY   TAG                IMAGE ID       CREATED        SIZE
spark        latest-logrotate   d843879458af   18 hours ago   657MB
spark        latest             0e281bd1fbe6   18 hours ago   657MB
```

### How was this patch tested?

Manually.
```
$ docker run -it --rm spark:latest-logrotate /usr/sbin/logrotate | tail -n7
logrotate 3.19.0 - Copyright (C) 1995-2001 Red Hat, Inc.
This may be freely redistributed under the terms of the GNU General Public License

Usage: logrotate [-dfv?] [-d|--debug] [-f|--force] [-m|--mail=command]
        [-s|--state=statefile] [--skip-state-lock] [-v|--verbose]
        [-l|--log=logfile] [--version] [-?|--help] [--usage]
        [OPTION...] <configfile>
```

### Was this patch authored or co-authored using generative AI tooling?

Pass the CIs.