### PR TITLE
[SPARK-46877][SQL] Remove unnecessary synchronized

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -1619,8 +1619,8 @@ class SessionCatalog(
    */
   def lookupBuiltinOrTempFunction(name: String): Option[ExpressionInfo] = {
     FunctionRegistry.builtinOperators.get(name.toLowerCase(Locale.ROOT)).orElse {
-      synchronized(lookupTempFuncWithViewContext(
-        name, FunctionRegistry.builtin.functionExists, functionRegistry.lookupFunction))
+      lookupTempFuncWithViewContext(
+        name, FunctionRegistry.builtin.functionExists, functionRegistry.lookupFunction)
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogManager.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogManager.scala
@@ -138,7 +138,7 @@ class CatalogManager(
   }
 
   def listCatalogs(pattern: Option[String]): Seq[String] = {
-    val allCatalogs = (synchronized(catalogs.keys.toSeq) :+ SESSION_CATALOG_NAME).distinct.sorted
+    val allCatalogs = (catalogs.keys.toSeq :+ SESSION_CATALOG_NAME).distinct.sorted
     pattern.map(StringUtils.filterPattern(allCatalogs, _)).getOrElse(allCatalogs)
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR propose to remove unnecessary `synchronized` for `SessionCatalog` and `CatalogManager`.


### Why are the changes needed?
I invested there are two synchronized is unnecessary due to the returned objects are always different.
`functionRegistry.lookupFunction` always return different Option object even if looks up the same function.
`catalogs.keys.toSeq` returns different object too.


### Does this PR introduce _any_ user-facing change?
'No'.


### How was this patch tested?
GA


### Was this patch authored or co-authored using generative AI tooling?
'No'.
