### PR TITLE
[SPARK-46871][PS][TESTS] Clean up the imports in `pyspark.pandas.tests.computation.*`

### DIFF
--- a/python/pyspark/pandas/tests/computation/test_any_all.py
+++ b/python/pyspark/pandas/tests/computation/test_any_all.py
@@ -20,7 +20,7 @@ import numpy as np
 import pandas as pd
 
 from pyspark import pandas as ps
-from pyspark.testing.pandasutils import ComparisonTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
 
 
@@ -149,7 +149,11 @@ class FrameAnyAllMixin:
             psdf.any(axis=1)
 
 
-class FrameAnyAllTests(FrameAnyAllMixin, ComparisonTestBase, SQLTestUtils):
+class FrameAnyAllTests(
+    FrameAnyAllMixin,
+    PandasOnSparkTestCase,
+    SQLTestUtils,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/computation/test_apply_func.py
+++ b/python/pyspark/pandas/tests/computation/test_apply_func.py
@@ -25,7 +25,7 @@ import pandas as pd
 from pyspark import pandas as ps
 from pyspark.loose_version import LooseVersion
 from pyspark.pandas.config import option_context
-from pyspark.testing.pandasutils import ComparisonTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
 
 
@@ -39,6 +39,10 @@ class FrameApplyFunctionMixin:
             {"a": [1, 2, 3, 4, 5, 6, 7, 8, 9], "b": [4, 5, 6, 3, 2, 1, 0, 0, 0]},
             index=np.random.rand(9),
         )
+
+    @property
+    def psdf(self):
+        return ps.from_pandas(self.pdf)
 
     def test_apply(self):
         pdf = pd.DataFrame(
@@ -553,7 +557,11 @@ class FrameApplyFunctionMixin:
         self.assertRaises(ValueError, lambda: psdf.agg(("sum", "min")))
 
 
-class FrameApplyFunctionTests(FrameApplyFunctionMixin, ComparisonTestBase, SQLTestUtils):
+class FrameApplyFunctionTests(
+    FrameApplyFunctionMixin,
+    PandasOnSparkTestCase,
+    SQLTestUtils,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/computation/test_binary_ops.py
+++ b/python/pyspark/pandas/tests/computation/test_binary_ops.py
@@ -21,7 +21,7 @@ import numpy as np
 import pandas as pd
 
 from pyspark import pandas as ps
-from pyspark.testing.pandasutils import ComparisonTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
 
 
@@ -34,6 +34,10 @@ class FrameBinaryOpsMixin:
             {"a": [1, 2, 3, 4, 5, 6, 7, 8, 9], "b": [4, 5, 6, 3, 2, 1, 0, 0, 0]},
             index=np.random.rand(9),
         )
+
+    @property
+    def psdf(self):
+        return ps.from_pandas(self.pdf)
 
     def test_binary_operators(self):
         pdf = pd.DataFrame(
@@ -207,7 +211,11 @@ class FrameBinaryOpsMixin:
         self.assert_eq(psdf.rfloordiv(10), expected_result)
 
 
-class FrameBinaryOpsTests(FrameBinaryOpsMixin, ComparisonTestBase, SQLTestUtils):
+class FrameBinaryOpsTests(
+    FrameBinaryOpsMixin,
+    PandasOnSparkTestCase,
+    SQLTestUtils,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/computation/test_combine.py
+++ b/python/pyspark/pandas/tests/computation/test_combine.py
@@ -20,7 +20,7 @@ import numpy as np
 import pandas as pd
 
 from pyspark import pandas as ps
-from pyspark.testing.pandasutils import ComparisonTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
 
 
@@ -588,7 +588,11 @@ class FrameCombineMixin:
         )
 
 
-class FrameCombineTests(FrameCombineMixin, ComparisonTestBase, SQLTestUtils):
+class FrameCombineTests(
+    FrameCombineMixin,
+    PandasOnSparkTestCase,
+    SQLTestUtils,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/computation/test_compute.py
+++ b/python/pyspark/pandas/tests/computation/test_compute.py
@@ -21,7 +21,7 @@ import pandas as pd
 
 from pyspark.sql import functions as sf
 from pyspark import pandas as ps
-from pyspark.testing.pandasutils import ComparisonTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
 
 
@@ -432,7 +432,11 @@ class FrameComputeMixin:
         self.assert_eq(pdf.prod(numeric_only=True), psdf.prod().sort_index(), check_exact=False)
 
 
-class FrameComputeTests(FrameComputeMixin, ComparisonTestBase, SQLTestUtils):
+class FrameComputeTests(
+    FrameComputeMixin,
+    PandasOnSparkTestCase,
+    SQLTestUtils,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/computation/test_corr.py
+++ b/python/pyspark/pandas/tests/computation/test_corr.py
@@ -206,7 +206,11 @@ class FrameCorrMixin:
             self.assert_eq(psdf.corr(), pdf.corr(numeric_only=True), check_exact=False)
 
 
-class FrameCorrTests(FrameCorrMixin, PandasOnSparkTestCase, SQLTestUtils):
+class FrameCorrTests(
+    FrameCorrMixin,
+    PandasOnSparkTestCase,
+    SQLTestUtils,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/computation/test_corrwith.py
+++ b/python/pyspark/pandas/tests/computation/test_corrwith.py
@@ -19,7 +19,7 @@ import unittest
 import numpy as np
 
 from pyspark import pandas as ps
-from pyspark.testing.pandasutils import ComparisonTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
 
 
@@ -64,7 +64,11 @@ class FrameCorrwithMixin:
                 self.assert_eq(p_corr.sort_index(), ps_corr.sort_index(), almost=True)
 
 
-class FrameCorrwithTests(FrameCorrwithMixin, ComparisonTestBase, SQLTestUtils):
+class FrameCorrwithTests(
+    FrameCorrwithMixin,
+    PandasOnSparkTestCase,
+    SQLTestUtils,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/computation/test_cov.py
+++ b/python/pyspark/pandas/tests/computation/test_cov.py
@@ -21,7 +21,7 @@ import numpy as np
 import pandas as pd
 
 from pyspark import pandas as ps
-from pyspark.testing.pandasutils import ComparisonTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
 
 
@@ -100,7 +100,11 @@ class FrameCovMixin:
         self.assert_eq(pdf.cov(numeric_only=True), psdf.cov())
 
 
-class FrameCovTests(FrameCovMixin, ComparisonTestBase, SQLTestUtils):
+class FrameCovTests(
+    FrameCovMixin,
+    PandasOnSparkTestCase,
+    SQLTestUtils,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/computation/test_cumulative.py
+++ b/python/pyspark/pandas/tests/computation/test_cumulative.py
@@ -20,7 +20,7 @@ import numpy as np
 import pandas as pd
 
 from pyspark import pandas as ps
-from pyspark.testing.pandasutils import ComparisonTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
 
 
@@ -110,7 +110,11 @@ class FrameCumulativeMixin:
         self._test_cumprod(pdf, psdf)
 
 
-class FrameCumulativeTests(FrameCumulativeMixin, ComparisonTestBase, SQLTestUtils):
+class FrameCumulativeTests(
+    FrameCumulativeMixin,
+    PandasOnSparkTestCase,
+    SQLTestUtils,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/computation/test_describe.py
+++ b/python/pyspark/pandas/tests/computation/test_describe.py
@@ -21,7 +21,7 @@ import numpy as np
 import pandas as pd
 
 from pyspark import pandas as ps
-from pyspark.testing.pandasutils import ComparisonTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
 
 
@@ -229,7 +229,11 @@ class FrameDescribeMixin:
         )
 
 
-class FrameDescribeTests(FrameDescribeMixin, ComparisonTestBase, SQLTestUtils):
+class FrameDescribeTests(
+    FrameDescribeMixin,
+    PandasOnSparkTestCase,
+    SQLTestUtils,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/computation/test_eval.py
+++ b/python/pyspark/pandas/tests/computation/test_eval.py
@@ -20,7 +20,7 @@ import unittest
 import pandas as pd
 
 from pyspark import pandas as ps
-from pyspark.testing.pandasutils import ComparisonTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
 
 
@@ -60,7 +60,11 @@ class FrameEvalMixin:
         self.assertRaises(TypeError, lambda: psdf.eval("x.a + y.b"))
 
 
-class FrameEvalTests(FrameEvalMixin, ComparisonTestBase, SQLTestUtils):
+class FrameEvalTests(
+    FrameEvalMixin,
+    PandasOnSparkTestCase,
+    SQLTestUtils,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/computation/test_melt.py
+++ b/python/pyspark/pandas/tests/computation/test_melt.py
@@ -20,7 +20,7 @@ import numpy as np
 import pandas as pd
 
 from pyspark import pandas as ps
-from pyspark.testing.pandasutils import ComparisonTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
 from pyspark.pandas.utils import name_like_string
 
@@ -173,7 +173,11 @@ class FrameMeltMixin:
         )
 
 
-class FrameMeltTests(FrameMeltMixin, ComparisonTestBase, SQLTestUtils):
+class FrameMeltTests(
+    FrameMeltMixin,
+    PandasOnSparkTestCase,
+    SQLTestUtils,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/computation/test_missing_data.py
+++ b/python/pyspark/pandas/tests/computation/test_missing_data.py
@@ -21,7 +21,7 @@ import numpy as np
 import pandas as pd
 
 from pyspark import pandas as ps
-from pyspark.testing.pandasutils import ComparisonTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
 
 
@@ -455,7 +455,11 @@ class FrameMissingDataMixin:
         self.assert_eq(pdf, psdf)
 
 
-class FrameMissingDataTests(FrameMissingDataMixin, ComparisonTestBase, SQLTestUtils):
+class FrameMissingDataTests(
+    FrameMissingDataMixin,
+    PandasOnSparkTestCase,
+    SQLTestUtils,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/computation/test_pivot.py
+++ b/python/pyspark/pandas/tests/computation/test_pivot.py
@@ -20,7 +20,7 @@ import numpy as np
 import pandas as pd
 
 from pyspark import pandas as ps
-from pyspark.testing.pandasutils import ComparisonTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
 
 
@@ -191,7 +191,7 @@ class FramePivotMixin:
 
 class FramePivotTests(
     FramePivotMixin,
-    ComparisonTestBase,
+    PandasOnSparkTestCase,
     SQLTestUtils,
 ):
     pass

--- a/python/pyspark/pandas/tests/computation/test_pivot_table.py
+++ b/python/pyspark/pandas/tests/computation/test_pivot_table.py
@@ -20,7 +20,7 @@ import numpy as np
 import pandas as pd
 
 from pyspark import pandas as ps
-from pyspark.testing.pandasutils import ComparisonTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
 
 
@@ -75,7 +75,7 @@ class PivotTableMixin:
 
 class PivotTableTests(
     PivotTableMixin,
-    ComparisonTestBase,
+    PandasOnSparkTestCase,
     SQLTestUtils,
 ):
     pass

--- a/python/pyspark/pandas/tests/computation/test_pivot_table_adv.py
+++ b/python/pyspark/pandas/tests/computation/test_pivot_table_adv.py
@@ -20,7 +20,7 @@ import numpy as np
 import pandas as pd
 
 from pyspark import pandas as ps
-from pyspark.testing.pandasutils import ComparisonTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
 
 
@@ -75,7 +75,7 @@ class PivotTableAdvMixin:
 
 class PivotTableAdvTests(
     PivotTableAdvMixin,
-    ComparisonTestBase,
+    PandasOnSparkTestCase,
     SQLTestUtils,
 ):
     pass

--- a/python/pyspark/pandas/tests/computation/test_pivot_table_multi_idx.py
+++ b/python/pyspark/pandas/tests/computation/test_pivot_table_multi_idx.py
@@ -20,7 +20,7 @@ import numpy as np
 import pandas as pd
 
 from pyspark import pandas as ps
-from pyspark.testing.pandasutils import ComparisonTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
 
 
@@ -73,7 +73,7 @@ class PivotTableMultiIdxMixin:
 
 class PivotTableMultiIdxTests(
     PivotTableMultiIdxMixin,
-    ComparisonTestBase,
+    PandasOnSparkTestCase,
     SQLTestUtils,
 ):
     pass

--- a/python/pyspark/pandas/tests/computation/test_pivot_table_multi_idx_adv.py
+++ b/python/pyspark/pandas/tests/computation/test_pivot_table_multi_idx_adv.py
@@ -20,7 +20,7 @@ import numpy as np
 import pandas as pd
 
 from pyspark import pandas as ps
-from pyspark.testing.pandasutils import ComparisonTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
 
 
@@ -75,7 +75,7 @@ class PivotTableMultiIdxAdvMixin:
 
 class PivotTableMultiIdxAdvTests(
     PivotTableMultiIdxAdvMixin,
-    ComparisonTestBase,
+    PandasOnSparkTestCase,
     SQLTestUtils,
 ):
     pass

--- a/python/pyspark/pandas/tests/computation/test_stats.py
+++ b/python/pyspark/pandas/tests/computation/test_stats.py
@@ -306,7 +306,11 @@ class StatsTestsMixin:
             psdf.s.sum()
 
 
-class StatsTests(StatsTestsMixin, PandasOnSparkTestCase, SQLTestUtils):
+class StatsTests(
+    StatsTestsMixin,
+    PandasOnSparkTestCase,
+    SQLTestUtils,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/connect/computation/test_parity_any_all.py
+++ b/python/pyspark/pandas/tests/connect/computation/test_parity_any_all.py
@@ -16,16 +16,17 @@
 #
 import unittest
 
-from pyspark import pandas as ps
 from pyspark.pandas.tests.computation.test_any_all import FrameAnyAllMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase
 from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
-class FrameParityAnyAllTests(FrameAnyAllMixin, PandasOnSparkTestUtils, ReusedConnectTestCase):
-    @property
-    def psdf(self):
-        return ps.from_pandas(self.pdf)
+class FrameParityAnyAllTests(
+    FrameAnyAllMixin,
+    PandasOnSparkTestUtils,
+    ReusedConnectTestCase,
+):
+    pass
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/connect/computation/test_parity_apply_func.py
+++ b/python/pyspark/pandas/tests/connect/computation/test_parity_apply_func.py
@@ -16,18 +16,17 @@
 #
 import unittest
 
-from pyspark import pandas as ps
 from pyspark.pandas.tests.computation.test_apply_func import FrameApplyFunctionMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase
 from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
 class FrameParityApplyFunctionTests(
-    FrameApplyFunctionMixin, PandasOnSparkTestUtils, ReusedConnectTestCase
+    FrameApplyFunctionMixin,
+    PandasOnSparkTestUtils,
+    ReusedConnectTestCase,
 ):
-    @property
-    def psdf(self):
-        return ps.from_pandas(self.pdf)
+    pass
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/connect/computation/test_parity_binary_ops.py
+++ b/python/pyspark/pandas/tests/connect/computation/test_parity_binary_ops.py
@@ -16,16 +16,17 @@
 #
 import unittest
 
-from pyspark import pandas as ps
 from pyspark.pandas.tests.computation.test_binary_ops import FrameBinaryOpsMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase
 from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
-class FrameParityBinaryOpsTests(FrameBinaryOpsMixin, PandasOnSparkTestUtils, ReusedConnectTestCase):
-    @property
-    def psdf(self):
-        return ps.from_pandas(self.pdf)
+class FrameParityBinaryOpsTests(
+    FrameBinaryOpsMixin,
+    PandasOnSparkTestUtils,
+    ReusedConnectTestCase,
+):
+    pass
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/connect/computation/test_parity_combine.py
+++ b/python/pyspark/pandas/tests/connect/computation/test_parity_combine.py
@@ -21,7 +21,11 @@ from pyspark.testing.connectutils import ReusedConnectTestCase
 from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
-class FrameParityCombineTests(FrameCombineMixin, PandasOnSparkTestUtils, ReusedConnectTestCase):
+class FrameParityCombineTests(
+    FrameCombineMixin,
+    PandasOnSparkTestUtils,
+    ReusedConnectTestCase,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/connect/computation/test_parity_compute.py
+++ b/python/pyspark/pandas/tests/connect/computation/test_parity_compute.py
@@ -21,7 +21,11 @@ from pyspark.testing.connectutils import ReusedConnectTestCase
 from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
-class FrameParityComputeTests(FrameComputeMixin, PandasOnSparkTestUtils, ReusedConnectTestCase):
+class FrameParityComputeTests(
+    FrameComputeMixin,
+    PandasOnSparkTestUtils,
+    ReusedConnectTestCase,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/connect/computation/test_parity_corr.py
+++ b/python/pyspark/pandas/tests/connect/computation/test_parity_corr.py
@@ -16,13 +16,16 @@
 #
 import unittest
 
-from pyspark import pandas as ps
 from pyspark.pandas.tests.computation.test_corr import FrameCorrMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase
 from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
-class FrameParityCorrTests(FrameCorrMixin, PandasOnSparkTestUtils, ReusedConnectTestCase):
+class FrameParityCorrTests(
+    FrameCorrMixin,
+    PandasOnSparkTestUtils,
+    ReusedConnectTestCase,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/connect/computation/test_parity_corrwith.py
+++ b/python/pyspark/pandas/tests/connect/computation/test_parity_corrwith.py
@@ -16,16 +16,17 @@
 #
 import unittest
 
-from pyspark import pandas as ps
 from pyspark.pandas.tests.computation.test_corrwith import FrameCorrwithMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase
 from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
-class FrameParityCorrwithTests(FrameCorrwithMixin, PandasOnSparkTestUtils, ReusedConnectTestCase):
-    @property
-    def psdf(self):
-        return ps.from_pandas(self.pdf)
+class FrameParityCorrwithTests(
+    FrameCorrwithMixin,
+    PandasOnSparkTestUtils,
+    ReusedConnectTestCase,
+):
+    pass
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/connect/computation/test_parity_cov.py
+++ b/python/pyspark/pandas/tests/connect/computation/test_parity_cov.py
@@ -16,16 +16,17 @@
 #
 import unittest
 
-from pyspark import pandas as ps
 from pyspark.pandas.tests.computation.test_cov import FrameCovMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase
 from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
-class FrameParityCovTests(FrameCovMixin, PandasOnSparkTestUtils, ReusedConnectTestCase):
-    @property
-    def psdf(self):
-        return ps.from_pandas(self.pdf)
+class FrameParityCovTests(
+    FrameCovMixin,
+    PandasOnSparkTestUtils,
+    ReusedConnectTestCase,
+):
+    pass
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/connect/computation/test_parity_cumulative.py
+++ b/python/pyspark/pandas/tests/connect/computation/test_parity_cumulative.py
@@ -16,18 +16,17 @@
 #
 import unittest
 
-from pyspark import pandas as ps
 from pyspark.pandas.tests.computation.test_cumulative import FrameCumulativeMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase
 from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
 class FrameParityCumulativeTests(
-    FrameCumulativeMixin, PandasOnSparkTestUtils, ReusedConnectTestCase
+    FrameCumulativeMixin,
+    PandasOnSparkTestUtils,
+    ReusedConnectTestCase,
 ):
-    @property
-    def psdf(self):
-        return ps.from_pandas(self.pdf)
+    pass
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/connect/computation/test_parity_describe.py
+++ b/python/pyspark/pandas/tests/connect/computation/test_parity_describe.py
@@ -16,16 +16,13 @@
 #
 import unittest
 
-from pyspark import pandas as ps
 from pyspark.pandas.tests.computation.test_describe import FrameDescribeMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase
 from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
 class FrameParityDescribeTests(FrameDescribeMixin, PandasOnSparkTestUtils, ReusedConnectTestCase):
-    @property
-    def psdf(self):
-        return ps.from_pandas(self.pdf)
+    pass
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/connect/computation/test_parity_eval.py
+++ b/python/pyspark/pandas/tests/connect/computation/test_parity_eval.py
@@ -16,16 +16,17 @@
 #
 import unittest
 
-from pyspark import pandas as ps
 from pyspark.pandas.tests.computation.test_eval import FrameEvalMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase
 from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
-class FrameParityEvalTests(FrameEvalMixin, PandasOnSparkTestUtils, ReusedConnectTestCase):
-    @property
-    def psdf(self):
-        return ps.from_pandas(self.pdf)
+class FrameParityEvalTests(
+    FrameEvalMixin,
+    PandasOnSparkTestUtils,
+    ReusedConnectTestCase,
+):
+    pass
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/connect/computation/test_parity_melt.py
+++ b/python/pyspark/pandas/tests/connect/computation/test_parity_melt.py
@@ -16,16 +16,17 @@
 #
 import unittest
 
-from pyspark import pandas as ps
 from pyspark.pandas.tests.computation.test_melt import FrameMeltMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase
 from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
-class FrameParityMeltTests(FrameMeltMixin, PandasOnSparkTestUtils, ReusedConnectTestCase):
-    @property
-    def psdf(self):
-        return ps.from_pandas(self.pdf)
+class FrameParityMeltTests(
+    FrameMeltMixin,
+    PandasOnSparkTestUtils,
+    ReusedConnectTestCase,
+):
+    pass
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/connect/computation/test_parity_missing_data.py
+++ b/python/pyspark/pandas/tests/connect/computation/test_parity_missing_data.py
@@ -16,18 +16,17 @@
 #
 import unittest
 
-from pyspark import pandas as ps
 from pyspark.pandas.tests.computation.test_missing_data import FrameMissingDataMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase
 from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
 class FrameParityMissingDataTests(
-    FrameMissingDataMixin, PandasOnSparkTestUtils, ReusedConnectTestCase
+    FrameMissingDataMixin,
+    PandasOnSparkTestUtils,
+    ReusedConnectTestCase,
 ):
-    @property
-    def psdf(self):
-        return ps.from_pandas(self.pdf)
+    pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### What changes were proposed in this pull request?
Clean up the imports in `pyspark.pandas.tests.computation.*`


### Why are the changes needed?
1, remove unused imports;
2, define the test dataset in the vanilla side, so that won't need to define it again in the parity tests;


### Does this PR introduce _any_ user-facing change?
no, test-only

### How was this patch tested?
ci

### Was this patch authored or co-authored using generative AI tooling?
no