### PR TITLE
[SPARK-46872][CORE] Recover `log-view.js` to be non-module

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/log-view.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/log-view.js
@@ -17,8 +17,6 @@
 
 /* global $ */
 
-import {getBaseURI} from "./utils.js";
-
 var baseParams;
 
 var curLogLength;
@@ -60,7 +58,7 @@ function getRESTEndPoint() {
   // If the worker is served from the master through a proxy (see doc on spark.ui.reverseProxy), 
   // we need to retain the leading ../proxy/<workerid>/ part of the URL when making REST requests.
   // Similar logic is contained in executorspage.js function createRESTEndPoint.
-  var words = getBaseURI().split('/');
+  var words = (document.baseURI || document.URL).split('/');
   var ind = words.indexOf("proxy");
   if (ind > 0) {
     return words.slice(0, ind + 2).join('/') + "/log";

--- a/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
@@ -220,7 +220,7 @@ private[spark] object UIUtils extends Logging {
     <script src={prependBaseUri(request, "/static/initialize-tooltips.js")}></script>
     <script src={prependBaseUri(request, "/static/table.js")}></script>
     <script src={prependBaseUri(request, "/static/timeline-view.js")}></script>
-    <script type="module" src={prependBaseUri(request, "/static/log-view.js")}></script>
+    <script src={prependBaseUri(request, "/static/log-view.js")}></script>
     <script src={prependBaseUri(request, "/static/webui.js")}></script>
     <script>setUIRoot('{UIUtils.uiRoot(request)}')</script>
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to recover `log-view.js` to be no-module to fix loading issue.

### Why are the changes needed?

- #43903

![Screenshot 2024-01-25 at 9 08 48 PM](https://github.com/apache/spark/assets/9700541/830fadc8-ab1c-4cf4-9e56-493f9553b3ae)

### Does this PR introduce _any_ user-facing change?

No. This is a recovery to the status before SPARK-46003 which is not released yet.

### How was this patch tested?

Manually.

- Checkout SPARK-46003 commit and build.
- Start Master and Worker.
- Open `Incognito` or `Private` mode browser and go to Worker Log.
- Check `initLogPage` error via the developer tools

### Was this patch authored or co-authored using generative AI tooling?

No.