### PR TITLE
[SPARK-46873][SS] Do not recreate new StreamingQueryManager for the same Spark Session

### DIFF
--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -65,6 +65,7 @@ from pyspark.sql.connect.plan import (
 from pyspark.sql.connect.profiler import ProfilerCollector
 from pyspark.sql.connect.readwriter import DataFrameReader
 from pyspark.sql.connect.streaming.readwriter import DataStreamReader
+from pyspark.sql.streaming import StreamingQueryManager
 from pyspark.sql.pandas.serializers import ArrowStreamPandasSerializer
 from pyspark.sql.pandas.types import to_arrow_schema, to_arrow_type, _deduplicate_field_names
 from pyspark.sql.session import classproperty, SparkSession as PySparkSession
@@ -703,8 +704,6 @@ class SparkSession:
 
     @property
     def streams(self) -> "StreamingQueryManager":
-        from pyspark.sql.streaming import StreamingQueryManager
-
         if hasattr(self, "_sqm"):
             return self._sqm
         self._sqm = StreamingQueryManager(self)

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -65,7 +65,6 @@ from pyspark.sql.connect.plan import (
 from pyspark.sql.connect.profiler import ProfilerCollector
 from pyspark.sql.connect.readwriter import DataFrameReader
 from pyspark.sql.connect.streaming.readwriter import DataStreamReader
-from pyspark.sql.connect.streaming.query import StreamingQueryManager
 from pyspark.sql.pandas.serializers import ArrowStreamPandasSerializer
 from pyspark.sql.pandas.types import to_arrow_schema, to_arrow_type, _deduplicate_field_names
 from pyspark.sql.session import classproperty, SparkSession as PySparkSession
@@ -704,7 +703,12 @@ class SparkSession:
 
     @property
     def streams(self) -> "StreamingQueryManager":
-        return StreamingQueryManager(self)
+        from pyspark.sql.streaming import StreamingQueryManager
+
+        if hasattr(self, "_sqm"):
+            return self._sqm
+        self._sqm = StreamingQueryManager(self)
+        return self._sqm
 
     streams.__doc__ = PySparkSession.streams.__doc__
 

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -65,7 +65,7 @@ from pyspark.sql.connect.plan import (
 from pyspark.sql.connect.profiler import ProfilerCollector
 from pyspark.sql.connect.readwriter import DataFrameReader
 from pyspark.sql.connect.streaming.readwriter import DataStreamReader
-from pyspark.sql.streaming import StreamingQueryManager
+from pyspark.sql.connect.streaming.query import StreamingQueryManager
 from pyspark.sql.pandas.serializers import ArrowStreamPandasSerializer
 from pyspark.sql.pandas.types import to_arrow_schema, to_arrow_type, _deduplicate_field_names
 from pyspark.sql.session import classproperty, SparkSession as PySparkSession

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -706,7 +706,7 @@ class SparkSession:
     def streams(self) -> "StreamingQueryManager":
         if hasattr(self, "_sqm"):
             return self._sqm
-        self._sqm = StreamingQueryManager(self)
+        self._sqm: StreamingQueryManager = StreamingQueryManager(self)
         return self._sqm
 
     streams.__doc__ = PySparkSession.streams.__doc__

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -1827,7 +1827,7 @@ class SparkSession(SparkConversionMixin):
 
         if hasattr(self, "_sqm"):
             return self._sqm
-        self._sqm = StreamingQueryManager(self._jsparkSession.streams())
+        self._sqm: StreamingQueryManager = StreamingQueryManager(self._jsparkSession.streams())
         return self._sqm
 
     def stop(self) -> None:

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -1825,7 +1825,10 @@ class SparkSession(SparkConversionMixin):
         """
         from pyspark.sql.streaming import StreamingQueryManager
 
-        return StreamingQueryManager(self._jsparkSession.streams())
+        if hasattr(self, "_sqm"):
+            return self._sqm
+        self._sqm = StreamingQueryManager(self._jsparkSession.streams())
+        return self._sqm
 
     def stop(self) -> None:
         """

--- a/python/pyspark/sql/tests/streaming/test_streaming.py
+++ b/python/pyspark/sql/tests/streaming/test_streaming.py
@@ -295,8 +295,8 @@ class StreamingTestsMixin:
         self._assert_exception_tree_contains_msg(exception, "ZeroDivisionError")
 
     def test_query_manager_no_recreation(self):
-        # SPARK-46873: There should not be a new StreamingQueryManager created every time spark.streams
-        # is called.
+        # SPARK-46873: There should not be a new StreamingQueryManager created every time
+        # spark.streams is called.
         for i in range(5):
             self.assertTrue(self.spark.streams == self.spark.streams)
 

--- a/python/pyspark/sql/tests/streaming/test_streaming.py
+++ b/python/pyspark/sql/tests/streaming/test_streaming.py
@@ -294,6 +294,12 @@ class StreamingTestsMixin:
         self.assertIsInstance(exception, StreamingQueryException)
         self._assert_exception_tree_contains_msg(exception, "ZeroDivisionError")
 
+    # [SPARK-46873] There should only be one StreamingQueryManager for the same spark session.
+    # There should not be a new manager created every time spark.streams is called.
+    def test_query_manager_no_recreation(self):
+        for i in range(5):
+            self.assertTrue(self.spark.streams == self.spark.streams)
+
     def test_query_manager_get(self):
         df = self.spark.readStream.format("rate").load()
         for q in self.spark.streams.active:

--- a/python/pyspark/sql/tests/streaming/test_streaming.py
+++ b/python/pyspark/sql/tests/streaming/test_streaming.py
@@ -294,10 +294,9 @@ class StreamingTestsMixin:
         self.assertIsInstance(exception, StreamingQueryException)
         self._assert_exception_tree_contains_msg(exception, "ZeroDivisionError")
 
-called.
     def test_query_manager_no_recreation(self):
-    # SPARK-46873: There should not be a new StreamingQueryManager created every time spark.streams
-    #   is called.
+        # SPARK-46873: There should not be a new StreamingQueryManager created every time spark.streams
+        # is called.
         for i in range(5):
             self.assertTrue(self.spark.streams == self.spark.streams)
 

--- a/python/pyspark/sql/tests/streaming/test_streaming.py
+++ b/python/pyspark/sql/tests/streaming/test_streaming.py
@@ -294,8 +294,7 @@ class StreamingTestsMixin:
         self.assertIsInstance(exception, StreamingQueryException)
         self._assert_exception_tree_contains_msg(exception, "ZeroDivisionError")
 
-    # [SPARK-46873] There should only be one StreamingQueryManager for the same spark session.
-    # There should not be a new manager created every time spark.streams is called.
+    # [SPARK-46873] # There should not be a new StreamingQueryManager created every time spark.streams is called.
     def test_query_manager_no_recreation(self):
         for i in range(5):
             self.assertTrue(self.spark.streams == self.spark.streams)

--- a/python/pyspark/sql/tests/streaming/test_streaming.py
+++ b/python/pyspark/sql/tests/streaming/test_streaming.py
@@ -294,7 +294,7 @@ class StreamingTestsMixin:
         self.assertIsInstance(exception, StreamingQueryException)
         self._assert_exception_tree_contains_msg(exception, "ZeroDivisionError")
 
-    # [SPARK-46873] # There should not be a new StreamingQueryManager created every time spark.streams is called.
+    # [SPARK-46873] There should not be a new StreamingQueryManager created every time spark.streams is called.
     def test_query_manager_no_recreation(self):
         for i in range(5):
             self.assertTrue(self.spark.streams == self.spark.streams)

--- a/python/pyspark/sql/tests/streaming/test_streaming.py
+++ b/python/pyspark/sql/tests/streaming/test_streaming.py
@@ -294,8 +294,10 @@ class StreamingTestsMixin:
         self.assertIsInstance(exception, StreamingQueryException)
         self._assert_exception_tree_contains_msg(exception, "ZeroDivisionError")
 
-    # [SPARK-46873] There should not be a new StreamingQueryManager created every time spark.streams is called.
+called.
     def test_query_manager_no_recreation(self):
+    # SPARK-46873: There should not be a new StreamingQueryManager created every time spark.streams
+    #   is called.
         for i in range(5):
             self.assertTrue(self.spark.streams == self.spark.streams)
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
In Scala, there is only one streaming query manager for one spark session:

```
scala> spark.streams
val res0: org.apache.spark.sql.streaming.StreamingQueryManager = org.apache.spark.sql.streaming.StreamingQueryManager@46bb8cba

scala> spark.streams
val res1: org.apache.spark.sql.streaming.StreamingQueryManager = org.apache.spark.sql.streaming.StreamingQueryManager@46bb8cba

scala> spark.streams
val res2: org.apache.spark.sql.streaming.StreamingQueryManager = org.apache.spark.sql.streaming.StreamingQueryManager@46bb8cba

scala> spark.streams
val res3: org.apache.spark.sql.streaming.StreamingQueryManager = org.apache.spark.sql.streaming.StreamingQueryManager@46bb8cba
```




In Python, this is currently false for both connect and vanilla spark:

```
>>> spark.streams
<pyspark.sql.connect.streaming.query.StreamingQueryManager object at 0x1011f7c10>
>>> spark.streams
<pyspark.sql.connect.streaming.query.StreamingQueryManager object at 0x1011f71f0>
>>> spark.streams
<pyspark.sql.connect.streaming.query.StreamingQueryManager object at 0x1011f7be0>
>>> spark.streams
<pyspark.sql.connect.streaming.query.StreamingQueryManager object at 0x1011f7c40>
```
This PR makes the spark session reuse existing streaming query manager

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Python should align Scala behavior. 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added unit test

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No