### PR TITLE
[SPARK-46911][SS] Adding deleteIfExists operator to StatefulProcessorHandleImpl

### DIFF
--- a/common/utils/src/main/resources/error/error-classes.json
+++ b/common/utils/src/main/resources/error/error-classes.json
@@ -3241,6 +3241,12 @@
     ],
     "sqlState" : "0A000"
   },
+  "STATE_STORE_CANNOT_REMOVE_DEFAULT_COLUMN_FAMILY" : {
+    "message" : [
+      "Failed to remove default column family with reserved name=<colFamilyName>."
+    ],
+    "sqlState" : "42802"
+  },
   "STATE_STORE_MULTIPLE_VALUES_PER_KEY" : {
     "message" : [
       "Store does not support multiple values per key"
@@ -3948,6 +3954,11 @@
       "STATE_STORE_MULTIPLE_COLUMN_FAMILIES" : {
         "message" : [
           "Creating multiple column families with <stateStoreProvider> is not supported."
+        ]
+      },
+      "STATE_STORE_REMOVING_COLUMN_FAMILIES" : {
+        "message" : [
+          "Removing column families with <stateStoreProvider> is not supported."
         ]
       },
       "TABLE_OPERATION" : {

--- a/docs/sql-error-conditions-unsupported-feature-error-class.md
+++ b/docs/sql-error-conditions-unsupported-feature-error-class.md
@@ -194,6 +194,10 @@ set PROPERTIES and DBPROPERTIES at the same time.
 
 Creating multiple column families with `<stateStoreProvider>` is not supported.
 
+## STATE_STORE_REMOVING_COLUMN_FAMILIES
+
+Removing column families with `<stateStoreProvider>` is not supported.
+
 ## TABLE_OPERATION
 
 Table `<tableName>` does not support `<operation>`. Please check the current catalog and namespace to make sure the qualified table name is expected, and also check the catalog implementation which is configured by "spark.sql.catalog".

--- a/docs/sql-error-conditions.md
+++ b/docs/sql-error-conditions.md
@@ -2025,6 +2025,12 @@ The SQL config `<sqlConf>` cannot be found. Please verify that the config exists
 
 Star (*) is not allowed in a select list when GROUP BY an ordinal position is used.
 
+### STATE_STORE_CANNOT_REMOVE_DEFAULT_COLUMN_FAMILY
+
+[SQLSTATE: 42802](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Failed to remove default column family with reserved name=`<colFamilyName>`.
+
 ### STATE_STORE_MULTIPLE_VALUES_PER_KEY
 
 [SQLSTATE: 42802](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)

--- a/sql/api/src/main/scala/org/apache/spark/sql/streaming/StatefulProcessorHandle.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/streaming/StatefulProcessorHandle.scala
@@ -41,8 +41,8 @@ private[sql] trait StatefulProcessorHandle extends Serializable {
   /** Function to return queryInfo for currently running task */
   def getQueryInfo(): QueryInfo
 
-  /** Function to delete and purge state variable if defined previously
+  /** Function to delete state info if it exists and return state that was previously there
    * @param stateName - name of the state variable
-   */
+   * */
   def deleteIfExists(stateName: String): Unit
 }

--- a/sql/api/src/main/scala/org/apache/spark/sql/streaming/StatefulProcessorHandle.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/streaming/StatefulProcessorHandle.scala
@@ -41,7 +41,8 @@ private[sql] trait StatefulProcessorHandle extends Serializable {
   /** Function to return queryInfo for currently running task */
   def getQueryInfo(): QueryInfo
 
-  /** Function to delete and purge state variable if defined previously
+  /**
+   * Function to delete and purge state variable if defined previously
    * @param stateName - name of the state variable
    */
   def deleteIfExists(stateName: String): Unit

--- a/sql/api/src/main/scala/org/apache/spark/sql/streaming/StatefulProcessorHandle.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/streaming/StatefulProcessorHandle.scala
@@ -41,8 +41,8 @@ private[sql] trait StatefulProcessorHandle extends Serializable {
   /** Function to return queryInfo for currently running task */
   def getQueryInfo(): QueryInfo
 
-  /** Function to delete state info if it exists and return state that was previously there
+  /** Function to delete and purge state variable if defined previously
    * @param stateName - name of the state variable
-   * */
+   */
   def deleteIfExists(stateName: String): Unit
 }

--- a/sql/api/src/main/scala/org/apache/spark/sql/streaming/StatefulProcessorHandle.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/streaming/StatefulProcessorHandle.scala
@@ -40,4 +40,9 @@ private[sql] trait StatefulProcessorHandle extends Serializable {
 
   /** Function to return queryInfo for currently running task */
   def getQueryInfo(): QueryInfo
+
+  /** Function to delete state info if it exists and return state that was previously there
+   * @param stateName - name of the state variable
+   * */
+  def deleteIfExists(stateName: String): Unit
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StatefulProcessorHandleImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StatefulProcessorHandleImpl.scala
@@ -122,4 +122,18 @@ class StatefulProcessorHandleImpl(
   }
 
   override def getQueryInfo(): QueryInfo = currQueryInfo
+
+  /** Function to delete state info if it exists and return state that was previously there
+   *
+   * @param stateName  - name of the state variable
+   * @param keyEncoder - Spark SQL Encoder for key
+   * @param K          - type of key
+   * @return - instance of ValueState of type T that can be used to store state persistently
+   * */
+  override def deleteIfExists(stateName: String): Unit = {
+    verify(currState == CREATED, s"Cannot delete state variable with name=$stateName after " +
+      "initialization is complete")
+    store.removeColFamilyIfExists(stateName)
+  }
+
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StatefulProcessorHandleImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StatefulProcessorHandleImpl.scala
@@ -123,10 +123,13 @@ class StatefulProcessorHandleImpl(
 
   override def getQueryInfo(): QueryInfo = currQueryInfo
 
-  /** Function to delete and purge state variable if defined previously
+  /** Function to delete state info if it exists and return state that was previously there
    *
-   * @param stateName - name of the state variable
-   */
+   * @param stateName  - name of the state variable
+   * @param keyEncoder - Spark SQL Encoder for key
+   * @param K          - type of key
+   * @return - instance of ValueState of type T that can be used to store state persistently
+   * */
   override def deleteIfExists(stateName: String): Unit = {
     verify(currState == CREATED, s"Cannot delete state variable with name=$stateName after " +
       "initialization is complete")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StatefulProcessorHandleImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StatefulProcessorHandleImpl.scala
@@ -126,9 +126,6 @@ class StatefulProcessorHandleImpl(
   /** Function to delete state info if it exists and return state that was previously there
    *
    * @param stateName  - name of the state variable
-   * @param keyEncoder - Spark SQL Encoder for key
-   * @param K          - type of key
-   * @return - instance of ValueState of type T that can be used to store state persistently
    * */
   override def deleteIfExists(stateName: String): Unit = {
     verify(currState == CREATED, s"Cannot delete state variable with name=$stateName after " +

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StatefulProcessorHandleImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StatefulProcessorHandleImpl.scala
@@ -123,10 +123,10 @@ class StatefulProcessorHandleImpl(
 
   override def getQueryInfo(): QueryInfo = currQueryInfo
 
-  /** Function to delete state info if it exists and return state that was previously there
+  /** Function to delete and purge state variable if defined previously
    *
-   * @param stateName  - name of the state variable
-   * */
+   * @param stateName - name of the state variable
+   */
   override def deleteIfExists(stateName: String): Unit = {
     verify(currState == CREATED, s"Cannot delete state variable with name=$stateName after " +
       "initialization is complete")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StatefulProcessorHandleImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StatefulProcessorHandleImpl.scala
@@ -123,7 +123,8 @@ class StatefulProcessorHandleImpl(
 
   override def getQueryInfo(): QueryInfo = currQueryInfo
 
-  /** Function to delete and purge state variable if defined previously
+  /**
+   * Function to delete and purge state variable if defined previously
    *
    * @param stateName - name of the state variable
    */

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
@@ -203,7 +203,7 @@ private[sql] class HDFSBackedStateStoreProvider extends StateStoreProvider with 
     }
 
     override def removeColFamilyIfExists(colFamilyName: String): Unit = {
-      throw new UnsupportedOperationException("Removing with " +
+      throw new UnsupportedOperationException("Removing columnFamily with " +
         "HDFSBackedStateStoreProvider is not supported")
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
@@ -203,8 +203,9 @@ private[sql] class HDFSBackedStateStoreProvider extends StateStoreProvider with 
     }
 
     override def removeColFamilyIfExists(colFamilyName: String): Unit = {
-      throw new UnsupportedOperationException("Removing columnFamily with " +
-        "HDFSBackedStateStoreProvider is not supported")
+      throw StateStoreErrors.removingColumnFamiliesNotSupported(
+        "HDFSBackedStateStoreProvider")
+
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
@@ -201,6 +201,11 @@ private[sql] class HDFSBackedStateStoreProvider extends StateStoreProvider with 
     override def toString(): String = {
       s"HDFSStateStore[id=(op=${id.operatorId},part=${id.partitionId}),dir=$baseDir]"
     }
+
+    override def removeColFamilyIfExists(colFamilyName: String): Unit = {
+      throw new UnsupportedOperationException("Removing multiple column families with " +
+        "HDFSBackedStateStoreProvider is not supported")
+    }
   }
 
   def getMetricsForProvider(): Map[String, Long] = synchronized {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
@@ -203,7 +203,7 @@ private[sql] class HDFSBackedStateStoreProvider extends StateStoreProvider with 
     }
 
     override def removeColFamilyIfExists(colFamilyName: String): Unit = {
-      throw new UnsupportedOperationException("Removing multiple column families with " +
+      throw new UnsupportedOperationException("Removing with " +
         "HDFSBackedStateStoreProvider is not supported")
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
@@ -203,7 +203,7 @@ private[sql] class HDFSBackedStateStoreProvider extends StateStoreProvider with 
     }
 
     override def removeColFamilyIfExists(colFamilyName: String): Unit = {
-      throw new UnsupportedOperationException("Removing with " +
+      throw new UnsupportedOperationException("Removing multiple column families with " +
         "HDFSBackedStateStoreProvider is not supported")
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -265,6 +265,23 @@ class RocksDB(
   }
 
   /**
+   * Remove RocksDB column family, if exists
+   */
+  def removeColFamilyIfExists(colFamilyName: String): Unit = {
+    if (colFamilyName == StateStore.DEFAULT_COL_FAMILY_NAME) {
+      throw new UnsupportedOperationException("Failed to remove column family with reserved " +
+        s"name=$colFamilyName")
+    }
+
+    if (checkColFamilyExists(colFamilyName)) {
+      assert(db != null)
+      val handle = colFamilyNameToHandleMap(colFamilyName)
+      db.dropColumnFamily(handle)
+      colFamilyNameToHandleMap.remove(colFamilyName)
+    }
+  }
+
+  /**
    * Get the value for the given key if present, or null.
    * @note This will return the last written value even if it was uncommitted.
    */

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -269,7 +269,7 @@ class RocksDB(
    */
   def removeColFamilyIfExists(colFamilyName: String): Unit = {
     if (colFamilyName == StateStore.DEFAULT_COL_FAMILY_NAME) {
-      throw new UnsupportedOperationException("Removing default column family is not allowed")
+      throw StateStoreErrors.cannotRemoveDefaultColumnFamily(colFamilyName)
     }
 
     if (checkColFamilyExists(colFamilyName)) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -269,8 +269,7 @@ class RocksDB(
    */
   def removeColFamilyIfExists(colFamilyName: String): Unit = {
     if (colFamilyName == StateStore.DEFAULT_COL_FAMILY_NAME) {
-      throw new UnsupportedOperationException("Failed to remove column family with reserved " +
-        s"name=$colFamilyName")
+      throw new UnsupportedOperationException("Removing default column family is not allowed")
     }
 
     if (checkColFamilyExists(colFamilyName)) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
@@ -192,7 +192,7 @@ private[sql] class RocksDBStateStoreProvider
 
     /** Remove column family if exists */
      override def removeColFamilyIfExists(colFamilyName: String): Unit = {
-      rocksDB.removeColFamilyIfExists(colFamilyName)
+       rocksDB.removeColFamilyIfExists(colFamilyName)
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
@@ -192,7 +192,7 @@ private[sql] class RocksDBStateStoreProvider
 
     /** Remove column family if exists */
      override def removeColFamilyIfExists(colFamilyName: String): Unit = {
-       rocksDB.removeColFamilyIfExists(colFamilyName)
+      rocksDB.removeColFamilyIfExists(colFamilyName)
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
@@ -189,6 +189,11 @@ private[sql] class RocksDBStateStoreProvider
 
     /** Return the [[RocksDB]] instance in this store. This is exposed mainly for testing. */
     def dbInstance(): RocksDB = rocksDB
+
+    /** Remove column family if exists */
+     override def removeColFamilyIfExists(colFamilyName: String): Unit = {
+      rocksDB.removeColFamilyIfExists(colFamilyName)
+    }
   }
 
   override def init(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
@@ -103,6 +103,10 @@ trait ReadStateStore {
  * double resource cleanup.
  */
 trait StateStore extends ReadStateStore {
+
+  /**
+   * Remove column family with given name, if present.
+   */
   def removeColFamilyIfExists(colFamilyName: String): Unit
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
@@ -103,6 +103,8 @@ trait ReadStateStore {
  * double resource cleanup.
  */
 trait StateStore extends ReadStateStore {
+  def removeColFamilyIfExists(colFamilyName: String): Unit
+
   /**
    * Create column family with given name, if absent.
    */

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
@@ -103,10 +103,6 @@ trait ReadStateStore {
  * double resource cleanup.
  */
 trait StateStore extends ReadStateStore {
-
-  /**
-   * Remove column family with given name, if present.
-   */
   def removeColFamilyIfExists(colFamilyName: String): Unit
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreErrors.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreErrors.scala
@@ -64,7 +64,7 @@ class StateStoreRemovingColumnFamiliesNotSupportedException(stateStoreProvider: 
     messageParameters = Map("stateStoreProvider" -> stateStoreProvider)
   )
 
-  class StateStoreCannotRemoveDefaultColumnFamily(colFamilyName: String)
+class StateStoreCannotRemoveDefaultColumnFamily(colFamilyName: String)
   extends SparkUnsupportedOperationException(
     errorClass = "STATE_STORE_CANNOT_REMOVE_DEFAULT_COLUMN_FAMILY",
     messageParameters = Map("colFamilyName" -> colFamilyName)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreErrors.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreErrors.scala
@@ -37,6 +37,16 @@ object StateStoreErrors {
       new StateStoreMultipleColumnFamiliesNotSupportedException(stateStoreProvider)
     }
 
+  def removingColumnFamiliesNotSupported(stateStoreProvider: String):
+    StateStoreRemovingColumnFamiliesNotSupportedException = {
+        new StateStoreRemovingColumnFamiliesNotSupportedException(stateStoreProvider)
+    }
+  
+  def cannotRemoveDefaultColumnFamily(colFamilyName: String):
+    StateStoreCannotRemoveDefaultColumnFamily = {
+        new StateStoreCannotRemoveDefaultColumnFamily(colFamilyName)
+    }
+  
   def unsupportedOperationException(operationName: String, entity: String):
     StateStoreUnsupportedOperationException = {
       new StateStoreUnsupportedOperationException(operationName, entity)
@@ -48,6 +58,18 @@ class StateStoreMultipleColumnFamiliesNotSupportedException(stateStoreProvider: 
     errorClass = "UNSUPPORTED_FEATURE.STATE_STORE_MULTIPLE_COLUMN_FAMILIES",
     messageParameters = Map("stateStoreProvider" -> stateStoreProvider)
   )
+class StateStoreRemovingColumnFamiliesNotSupportedException(stateStoreProvider: String)
+  extends SparkUnsupportedOperationException(
+    errorClass = "UNSUPPORTED_FEATURE.STATE_STORE_REMOVING_COLUMN_FAMILIES",
+    messageParameters = Map("stateStoreProvider" -> stateStoreProvider)
+  )
+
+  class StateStoreCannotRemoveDefaultColumnFamily(colFamilyName: String)
+  extends SparkUnsupportedOperationException(
+    errorClass = "STATE_STORE_CANNOT_REMOVE_DEFAULT_COLUMN_FAMILY",
+    messageParameters = Map("colFamilyName" -> colFamilyName)
+  )
+
 
 class StateStoreUnsupportedOperationException(operationType: String, entity: String)
   extends SparkUnsupportedOperationException(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreErrors.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreErrors.scala
@@ -41,12 +41,12 @@ object StateStoreErrors {
     StateStoreRemovingColumnFamiliesNotSupportedException = {
         new StateStoreRemovingColumnFamiliesNotSupportedException(stateStoreProvider)
     }
-  
+
   def cannotRemoveDefaultColumnFamily(colFamilyName: String):
     StateStoreCannotRemoveDefaultColumnFamily = {
         new StateStoreCannotRemoveDefaultColumnFamily(colFamilyName)
     }
-  
+
   def unsupportedOperationException(operationName: String, entity: String):
     StateStoreUnsupportedOperationException = {
       new StateStoreUnsupportedOperationException(operationName, entity)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/MemoryStateStore.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/MemoryStateStore.scala
@@ -34,7 +34,7 @@ class MemoryStateStore extends StateStore() {
   }
 
   override def removeColFamilyIfExists(colFamilyName: String): Unit = {
-    throw new UnsupportedOperationException("Doesn't support removing column families!")
+    throw StateStoreErrors.removingColumnFamiliesNotSupported("MemoryStateStoreProvider")
   }
 
   override def get(key: UnsafeRow, colFamilyName: String): UnsafeRow = map.get(key)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/MemoryStateStore.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/MemoryStateStore.scala
@@ -33,6 +33,10 @@ class MemoryStateStore extends StateStore() {
     throw StateStoreErrors.multipleColumnFamiliesNotSupported("MemoryStateStoreProvider")
   }
 
+  override def removeColFamilyIfExists(colFamilyName: String): Unit = {
+    throw new UnsupportedOperationException("Doesn't support removing column families!")
+  }
+
   override def get(key: UnsafeRow, colFamilyName: String): UnsafeRow = map.get(key)
 
   override def put(key: UnsafeRow, newValue: UnsafeRow, colFamilyName: String): Unit =

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateSuite.scala
@@ -23,7 +23,6 @@ import org.apache.spark.sql.{AnalysisException, SaveMode}
 import org.apache.spark.sql.execution.streaming._
 import org.apache.spark.sql.execution.streaming.state.{AlsoTestWithChangelogCheckpointingEnabled, RocksDBStateStoreProvider}
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.util.Utils
 
 object TransformWithStateSuiteUtils {
   val NUM_SHUFFLE_PARTITIONS = 5
@@ -71,10 +70,8 @@ class RunningCountMostRecentStatefulProcessor
       outputMode: OutputMode) : Unit = {
     _processorHandle = handle
     assert(handle.getQueryInfo().getBatchId >= 0)
-    _countState = _processorHandle.getValueState[String, Long]("countState",
-      Encoders.STRING)
-    _mostRecent = _processorHandle.getValueState[String, String]("mostRecent",
-      Encoders.STRING)
+    _countState = _processorHandle.getValueState[Long]("countState")
+    _mostRecent = _processorHandle.getValueState[String]("mostRecent")
   }
 
   override def handleInputRows(
@@ -108,8 +105,7 @@ class MostRecentStatefulProcessorWithDeletion
     _processorHandle = handle
     assert(handle.getQueryInfo().getBatchId >= 0)
     _processorHandle.deleteIfExists("countState")
-    _mostRecent = _processorHandle.getValueState[String, String]("mostRecent",
-      Encoders.STRING)
+    _mostRecent = _processorHandle.getValueState[String]("mostRecent")
   }
 
   override def handleInputRows(

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateSuite.scala
@@ -67,8 +67,8 @@ class RunningCountMostRecentStatefulProcessor
   @transient var _processorHandle: StatefulProcessorHandle = _
 
   override def init(
-    handle: StatefulProcessorHandle,
-    outputMode: OutputMode) : Unit = {
+      handle: StatefulProcessorHandle,
+      outputMode: OutputMode) : Unit = {
     _processorHandle = handle
     assert(handle.getQueryInfo().getBatchId >= 0)
     _countState = _processorHandle.getValueState[String, Long]("countState",
@@ -78,9 +78,9 @@ class RunningCountMostRecentStatefulProcessor
   }
 
   override def handleInputRows(
-    key: String,
-    inputRows: Iterator[(String, String)],
-    timerValues: TimerValues): Iterator[(String, String, String)] = {
+      key: String,
+      inputRows: Iterator[(String, String)],
+      timerValues: TimerValues): Iterator[(String, String, String)] = {
     val count = _countState.getOption().getOrElse(0L) + 1
     val mostRecent = _mostRecent.getOption().getOrElse("")
 
@@ -103,8 +103,8 @@ class MostRecentStatefulProcessorWithDeletion
   @transient var _processorHandle: StatefulProcessorHandle = _
 
   override def init(
-     handle: StatefulProcessorHandle,
-     outputMode: OutputMode) : Unit = {
+       handle: StatefulProcessorHandle,
+       outputMode: OutputMode) : Unit = {
     _processorHandle = handle
     assert(handle.getQueryInfo().getBatchId >= 0)
     _processorHandle.deleteIfExists("countState")

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateSuite.scala
@@ -61,14 +61,14 @@ class RunningCountStatefulProcessor extends StatefulProcessor[String, String, (S
 
 class RunningCountMostRecentStatefulProcessor
   extends StatefulProcessor[String, (String, String), (String, String, String)]
-    with Logging {
+  with Logging {
   @transient private var _countState: ValueState[Long] = _
   @transient private var _mostRecent: ValueState[String] = _
   @transient var _processorHandle: StatefulProcessorHandle = _
 
   override def init(
-       handle: StatefulProcessorHandle,
-       outputMode: OutputMode) : Unit = {
+    handle: StatefulProcessorHandle,
+    outputMode: OutputMode) : Unit = {
     _processorHandle = handle
     assert(handle.getQueryInfo().getBatchId >= 0)
     _countState = _processorHandle.getValueState[String, Long]("countState",
@@ -78,9 +78,9 @@ class RunningCountMostRecentStatefulProcessor
   }
 
   override def handleInputRows(
-      key: String,
-      inputRows: Iterator[(String, String)],
-      timerValues: TimerValues): Iterator[(String, String, String)] = {
+    key: String,
+    inputRows: Iterator[(String, String)],
+    timerValues: TimerValues): Iterator[(String, String, String)] = {
     val count = _countState.getOption().getOrElse(0L) + 1
     val mostRecent = _mostRecent.getOption().getOrElse("")
 
@@ -206,33 +206,35 @@ class TransformWithStateSuite extends StateStoreMetricsTest
       classOf[RocksDBStateStoreProvider].getName,
       SQLConf.SHUFFLE_PARTITIONS.key ->
         TransformWithStateSuiteUtils.NUM_SHUFFLE_PARTITIONS.toString) {
-      val chkptDir = Utils.createTempDir("streaming.metadata").getCanonicalPath
-      val inputData = MemoryStream[(String, String)]
-      val stream1 = inputData.toDS()
-        .groupByKey(x => x._1)
-        .transformWithState(new RunningCountMostRecentStatefulProcessor(),
-          TimeoutMode.NoTimeouts(),
-          OutputMode.Update())
+      withTempDir { chkptDir =>
+        val dirPath = chkptDir.getCanonicalPath
+        val inputData = MemoryStream[(String, String)]
+        val stream1 = inputData.toDS()
+          .groupByKey(x => x._1)
+          .transformWithState(new RunningCountMostRecentStatefulProcessor(),
+            TimeoutMode.NoTimeouts(),
+            OutputMode.Update())
 
-      val stream2 = inputData.toDS()
-        .groupByKey(x => x._1)
-        .transformWithState(new MostRecentStatefulProcessorWithDeletion(),
-          TimeoutMode.NoTimeouts(),
-          OutputMode.Update())
+        val stream2 = inputData.toDS()
+          .groupByKey(x => x._1)
+          .transformWithState(new MostRecentStatefulProcessorWithDeletion(),
+            TimeoutMode.NoTimeouts(),
+            OutputMode.Update())
 
-      testStream(stream1, OutputMode.Update())(
-        StartStream(checkpointLocation = chkptDir),
-        AddData(inputData, ("a", "str1")),
-        CheckNewAnswer(("a", "1", "")),
-        StopStream
-      )
-      testStream(stream2, OutputMode.Update())(
-        StartStream(checkpointLocation = chkptDir),
-        AddData(inputData, ("a", "str2"), ("b", "str3")),
-        CheckNewAnswer(("a", "str1"),
-          ("b", "")), // should not factor in previous count state
-        StopStream
-      )
+        testStream(stream1, OutputMode.Update())(
+          StartStream(checkpointLocation = dirPath),
+          AddData(inputData, ("a", "str1")),
+          CheckNewAnswer(("a", "1", "")),
+          StopStream
+        )
+        testStream(stream2, OutputMode.Update())(
+          StartStream(checkpointLocation = dirPath),
+          AddData(inputData, ("a", "str2"), ("b", "str3")),
+          CheckNewAnswer(("a", "str1"),
+            ("b", "")), // should not factor in previous count state
+          StopStream
+        )
+      }
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Adding the `deleteIfExists` method to the `StatefulProcessorHandle` in order to remove state variables from the State Store. Implemented only for RocksDBStateStoreProvider, as we do not currently support multiple column families for HDFS.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This functionality is needed to so users can remove state from the state store from the StatefulProcessorHandleImpl

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes - this functionality (removing column families) was previously not supported from our RocksDB client. 

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added a unit test that creates two streams with the same checkpoint directory. The second stream removes state that was created in the first stream upon initialization. We ensure that the state from the previous stream isn't kept. 

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
