### PR TITLE
[SPARK-46880][PYTHON][CONNECT][TESTS] Improve and test warning for Arrow-optimized Python UDF

### DIFF
--- a/python/pyspark/sql/connect/udf.py
+++ b/python/pyspark/sql/connect/udf.py
@@ -85,7 +85,8 @@ def _create_py_udf(
             eval_type = PythonEvalType.SQL_ARROW_BATCHED_UDF
         else:
             warnings.warn(
-                "Arrow optimization for Python UDFs cannot be enabled.",
+                "Arrow optimization for Python UDFs cannot be enabled for functions"
+                " without arguments.",
                 UserWarning,
             )
 

--- a/python/pyspark/sql/tests/test_arrow_python_udf.py
+++ b/python/pyspark/sql/tests/test_arrow_python_udf.py
@@ -188,6 +188,15 @@ class PythonUDFArrowTestsMixin(BaseUDFTestsMixin):
             },
         )
 
+    def test_warn_no_args(self):
+        with self.assertWarns(UserWarning) as w:
+            udf(lambda: print("do"), useArrow=True)
+        self.assertEqual(
+            str(w.warning),
+            "Arrow optimization for Python UDFs cannot be enabled for functions"
+            " without arguments.",
+        )
+
 
 class PythonUDFArrowTests(PythonUDFArrowTestsMixin, ReusedSQLTestCase):
     @classmethod

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -142,7 +142,8 @@ def _create_py_udf(
             eval_type = PythonEvalType.SQL_ARROW_BATCHED_UDF
         else:
             warnings.warn(
-                "Arrow optimization for Python UDFs cannot be enabled.",
+                "Arrow optimization for Python UDFs cannot be enabled for functions"
+                " without arguments.",
                 UserWarning,
             )
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Improve and test warning for Arrow-optimized Python UDF

### Why are the changes needed?
To improve usability and test coverage.


### Does this PR introduce _any_ user-facing change?
Only a user warning changed.

FROM
```
>>> udf(lambda: print("do"), useArrow=True)
UserWarning: Arrow optimization for Python UDFs cannot be enabled.
  warnings.warn(
<function <lambda> at ..>
```
TO
```
>>> udf(lambda: print("do"), useArrow=True)
UserWarning: Arrow optimization for Python UDFs cannot be enabled for functions without arguments.
  warnings.warn(
<function <lambda> at ..>
```

### How was this patch tested?
Unit test.

### Was this patch authored or co-authored using generative AI tooling?
No.