### PR TITLE
[SPARK-46881][CORE] Support `spark.deploy.workerSelectionPolicy`

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/Deploy.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/Deploy.scala
@@ -108,6 +108,24 @@ private[spark] object Deploy {
     .booleanConf
     .createWithDefault(true)
 
+  object WorkerSelectionPolicy extends Enumeration {
+    val CORES_FREE_ASC, CORES_FREE_DESC, MEMORY_FREE_ASC, MEMORY_FREE_DESC, WORKER_ID = Value
+  }
+
+  val WORKER_SELECTION_POLICY = ConfigBuilder("spark.deploy.workerSelectionPolicy")
+    .doc("A policy to assign executors on one of the assignable workers; " +
+      "CORES_FREE_ASC to choose a worker with the least free cores, " +
+      "CORES_FREE_DESC to choose a worker with the most free cores, " +
+      "MEMORY_FREE_ASC to choose a worker with the least free memory, " +
+      "MEMORY_FREE_DESC to choose a worker with the most free memory, " +
+      "WORKER_ID to choose a worker with the smallest worker id. " +
+      "CORES_FREE_DESC is the default behavior.")
+    .version("4.0.0")
+    .stringConf
+    .transform(_.toUpperCase(Locale.ROOT))
+    .checkValues(WorkerSelectionPolicy.values.map(_.toString))
+    .createWithDefault(WorkerSelectionPolicy.CORES_FREE_DESC.toString)
+
   val DEFAULT_CORES = ConfigBuilder("spark.deploy.defaultCores")
     .version("0.9.0")
     .intConf

--- a/core/src/test/scala/org/apache/spark/deploy/master/MasterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/master/MasterSuite.scala
@@ -44,6 +44,7 @@ import org.apache.spark.deploy._
 import org.apache.spark.deploy.DeployMessages._
 import org.apache.spark.internal.config._
 import org.apache.spark.internal.config.Deploy._
+import org.apache.spark.internal.config.Deploy.WorkerSelectionPolicy._
 import org.apache.spark.internal.config.UI._
 import org.apache.spark.internal.config.Worker._
 import org.apache.spark.io.LZ4CompressionCodec
@@ -659,6 +660,52 @@ class MasterSuite extends SparkFunSuite
 
   test("scheduling for app with multiple resource profiles with max cores") {
     scheduleExecutorsForAppWithMultiRPs(withMaxCores = true)
+  }
+
+
+  private val workerSelectionPolicyTestCases = Seq(
+    (CORES_FREE_ASC, true, List("10001", "10002")),
+    (CORES_FREE_ASC, false, List("10001")),
+    (CORES_FREE_DESC, true, List("10004", "10005")),
+    (CORES_FREE_DESC, false, List("10005")),
+    (MEMORY_FREE_ASC, true, List("10001", "10005")),
+    (MEMORY_FREE_ASC, false, List("10001")),
+    (MEMORY_FREE_DESC, true, List("10002", "10003")),
+    (MEMORY_FREE_DESC, false, Seq("10002")),
+    (WORKER_ID, true, Seq("10001", "10002")),
+    (WORKER_ID, false, Seq("10001")))
+
+  workerSelectionPolicyTestCases.foreach { case (policy, spreadOut, expected) =>
+    test(s"SPARK-XXX: scheduling with workerSelectionPolicy - $policy ($spreadOut)") {
+      val conf = new SparkConf()
+        .set(WORKER_SELECTION_POLICY.key, policy.toString)
+        .set(SPREAD_OUT_APPS.key, spreadOut.toString)
+      val master = makeAliveMaster(conf)
+
+      // Use different core and memory values to simplify the tests
+      MockWorker.counter.set(10000)
+      (1 to 5).map { idx =>
+        val worker = new MockWorker(master.self, conf)
+        worker.rpcEnv.setupEndpoint(s"worker-$idx", worker)
+        val workerReg = RegisterWorker(
+          worker.id,
+          "localhost",
+          worker.self.address.port,
+          worker.self,
+          idx * 10,
+          10240 * (if (idx < 2) idx else (6 - idx)),
+          "http://localhost:8080",
+          RpcAddress("localhost", 10000))
+        master.self.send(workerReg)
+        worker
+      }
+
+      // An application with two executors
+      val appInfo = makeAppInfo(1024, Some(2), Some(4))
+      master.registerApplication(appInfo)
+      startExecutorsOnWorkers(master)
+      assert(appInfo.executors.map(_._2.worker.id).toSeq.distinct.sorted === expected)
+    }
   }
 
   test("SPARK-45174: scheduling with max drivers") {

--- a/core/src/test/scala/org/apache/spark/deploy/master/MasterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/master/MasterSuite.scala
@@ -676,7 +676,7 @@ class MasterSuite extends SparkFunSuite
     (WORKER_ID, false, Seq("10001")))
 
   workerSelectionPolicyTestCases.foreach { case (policy, spreadOut, expected) =>
-    test(s"SPARK-XXX: scheduling with workerSelectionPolicy - $policy ($spreadOut)") {
+    test(s"SPARK-46881: scheduling with workerSelectionPolicy - $policy ($spreadOut)") {
       val conf = new SparkConf()
         .set(WORKER_SELECTION_POLICY.key, policy.toString)
         .set(SPREAD_OUT_APPS.key, spreadOut.toString)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to introduce a new configuration, `spark.deploy.workerSelectionPolicy`, in order to allow users to decide a
policy to assign executors on one of the assignable workers.
- `CORES_FREE_ASC`: Choose a worker with the least free cores
- `CORES_FREE_DESC`: Choose a worker with the most free cores (**default**)
- `MEMORY_FREE_ASC`: Choose a worker with the least free memory
- `MEMORY_FREE_DESC`: Choose a worker with the most free memory
- `WORKER_ID`: Choose a worker with the smallest worker id

### Why are the changes needed?

This is very helpful for users to manage Spark Standalone cluster dynamically based on their workload and underlying cluster management policy.

### Does this PR introduce _any_ user-facing change?

No. The default policy, `CORES_FREE_DESC`, follows the existing behavior.

### How was this patch tested?

Pass the CIs with the newly added test cases.

### Was this patch authored or co-authored using generative AI tooling?

No.