### PR TITLE
[SPARK-46882][SS][TEST] Replace unnecessary AtomicInteger with int

### DIFF
--- a/streaming/src/test/scala/org/apache/spark/streaming/util/WriteAheadLogSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/util/WriteAheadLogSuite.scala
@@ -20,7 +20,6 @@ import java.io._
 import java.nio.ByteBuffer
 import java.util.{Iterator => JIterator}
 import java.util.concurrent.{CountDownLatch, RejectedExecutionException, ThreadPoolExecutor, TimeUnit}
-import java.util.concurrent.atomic.AtomicInteger
 
 import scala.collection.mutable.ArrayBuffer
 import scala.concurrent._
@@ -238,14 +237,14 @@ class FileBasedWriteAheadLogSuite
     val executionContext = ExecutionContext.fromExecutorService(fpool)
 
     class GetMaxCounter {
-      private val value = new AtomicInteger()
+      private var value = 0
       @volatile private var max: Int = 0
       def increment(): Unit = synchronized {
-        val atInstant = value.incrementAndGet()
-        if (atInstant > max) max = atInstant
+        value = value + 1
+        if (value > max) max = value
       }
-      def decrement(): Unit = synchronized { value.decrementAndGet() }
-      def get(): Int = synchronized { value.get() }
+      def decrement(): Unit = synchronized { value = value - 1 }
+      def get(): Int = synchronized { value }
       def getMax(): Int = synchronized { max }
     }
     try {

--- a/streaming/src/test/scala/org/apache/spark/streaming/util/WriteAheadLogSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/util/WriteAheadLogSuite.scala
@@ -238,7 +238,7 @@ class FileBasedWriteAheadLogSuite
 
     class GetMaxCounter {
       private var value = 0
-      @volatile private var max: Int = 0
+      private var max: Int = 0
       def increment(): Unit = synchronized {
         value = value + 1
         if (value > max) max = value


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR propose to replace unnecessary `AtomicInteger` with int.


### Why are the changes needed?
The variable `value` of `GetMaxCounter` always guarded by itself. So we can replace the unnecessary `AtomicInteger` with int.


### Does this PR introduce _any_ user-facing change?
'No'.


### How was this patch tested?
GA.


### Was this patch authored or co-authored using generative AI tooling?
'No'.
