### PR TITLE
[SPARK-46883][CORE] Support `/json/clusterutilization` API

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/JsonProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/JsonProtocol.scala
@@ -299,4 +299,22 @@ private[deploy] object JsonProtocol {
     ("executors" -> obj.executors.map(writeExecutorRunner)) ~
     ("finishedexecutors" -> obj.finishedExecutors.map(writeExecutorRunner))
   }
+
+  /**
+   * Export the cluster utilization based on the [[MasterStateResponse]] to a Json object.
+   */
+  def writeClusterUtilization(obj: MasterStateResponse): JObject = {
+    val aliveWorkers = obj.workers.filter(_.isAlive())
+    val cores = aliveWorkers.map(_.cores).sum
+    val coresUsed = aliveWorkers.map(_.coresUsed).sum
+    val memory = aliveWorkers.map(_.memory).sum
+    val memoryUsed = aliveWorkers.map(_.memoryUsed).sum
+    ("waitingDrivers" -> obj.activeDrivers.count(_.state == DriverState.SUBMITTED)) ~
+    ("cores" -> cores) ~
+    ("coresused" -> coresUsed) ~
+    ("coresutilization" -> 100 * coresUsed / cores) ~
+    ("memory" -> memory) ~
+    ("memoryused" -> memoryUsed) ~
+    ("memoryutilization" -> 100 * memoryUsed / memory)
+  }
 }

--- a/core/src/main/scala/org/apache/spark/deploy/master/ui/MasterPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/ui/MasterPage.scala
@@ -41,6 +41,8 @@ private[ui] class MasterPage(parent: MasterWebUI) extends WebUIPage("") {
   override def renderJson(request: HttpServletRequest): JValue = {
     jsonFieldPattern.findFirstMatchIn(request.getRequestURI()) match {
       case None => JsonProtocol.writeMasterState(getMasterState)
+      case Some(m) if m.group(1) == "clusterutilization" =>
+        JsonProtocol.writeClusterUtilization(getMasterState)
       case Some(m) => JsonProtocol.writeMasterState(getMasterState, Some(m.group(1)))
     }
   }

--- a/core/src/test/scala/org/apache/spark/deploy/JsonProtocolSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/JsonProtocolSuite.scala
@@ -105,6 +105,20 @@ class JsonProtocolSuite extends SparkFunSuite with JsonTestUtils {
     assertValidDataInJson(output, JsonMethods.parse(JsonConstants.workerStateJsonStr))
   }
 
+  test("SPARK-46883: writeClusterUtilization") {
+    val workers = Array(createWorkerInfo(), createWorkerInfo())
+    val activeApps = Array(createAppInfo())
+    val completedApps = Array.empty[ApplicationInfo]
+    val activeDrivers = Array(createDriverInfo())
+    val completedDrivers = Array(createDriverInfo())
+    val stateResponse = new MasterStateResponse(
+      "host", 8080, None, workers, activeApps, completedApps,
+      activeDrivers, completedDrivers, RecoveryState.ALIVE)
+    val output = JsonProtocol.writeClusterUtilization(stateResponse)
+    assertValidJson(output)
+    assertValidDataInJson(output, JsonMethods.parse(JsonConstants.clusterUtilizationJsonStr))
+  }
+
   def assertValidJson(json: JValue): Unit = {
     try {
       JsonMethods.parse(JsonMethods.compact(json))
@@ -206,4 +220,11 @@ object JsonConstants {
       |"executors":[],
       |"finishedexecutors":[%s,%s]}
     """.format(executorRunnerJsonStr, executorRunnerJsonStr).stripMargin
+
+  val clusterUtilizationJsonStr =
+    """
+      |{"waitingDrivers":1,
+      |"cores":8,"coresused":0,"coresutilization":0,
+      |"memory":2468,"memoryused":0,"memoryutilization":0}
+    """.stripMargin
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support new `/json/clusterutilization` API in `Master` JSON endpoint

### Why are the changes needed?

The user can get CPU/Memory/Waiting apps in a single API call.
```
# Start Spark Cluster and Spark Shell
$ sbin/start-master.sh
$ sbin/start-worker.sh spark://$(hostname):7077;
$ bin/spark-shell --master spark://$(hostname):7077

# Check `Cluster Utilization API`
$ curl http://localhost:8080/json/clusterutilization
{
  "waitingDrivers" : 0,
  "cores" : 10,
  "coresused" : 10,
  "coresutilization" : 100,
  "memory" : 31744,
  "memoryused" : 1024,
  "memoryutilization" : 3
}
```

### Does this PR introduce _any_ user-facing change?

No. This is a newly added API.

### How was this patch tested?

Pass the CIs with the newly added test case.

### Was this patch authored or co-authored using generative AI tooling?

No.