### PR TITLE
[SPARK-46885][SQL] Push down filters through `TypedFilter`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1836,6 +1836,7 @@ object PushPredicateThroughNonJoin extends Rule[LogicalPlan] with PredicateHelpe
     case _: BatchEvalPython => true
     case _: ArrowEvalPython => true
     case _: Expand => true
+    case _: TypedFilter => true
     case _ => false
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR enhances `PushPredicateThroughNonJoin` to make it support pushing down filters through `TypedFilter`.

### Why are the changes needed?

Pushed filters can be pushed down to file scanning to improve query performance.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit test,

### Was this patch authored or co-authored using generative AI tooling?

No.
