### PR TITLE
[SPARK-46889][CORE] Validate `spark.master.ui.decommission.allow.mode` setting

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/UI.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/UI.scala
@@ -241,6 +241,7 @@ private[spark] object UI {
     .version("3.1.0")
     .stringConf
     .transform(_.toUpperCase(Locale.ROOT))
+    .checkValues(Set("ALLOW", "LOCAL", "DENY"))
     .createWithDefault("LOCAL")
 
   val UI_SQL_GROUP_SUB_EXECUTION_ENABLED = ConfigBuilder("spark.ui.groupSQLSubExecutionEnabled")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `checkValues` to `spark.master.ui.decommission.allow.mode` configuration to validate the setting as early as possible.

### Why are the changes needed?

To prevent misconfigured `Spark Master`s from running in the cluster.

**BEFORE (STARTED MASTER WITH NO WARNING)**
```
$ SPARK_NO_DAEMONIZE=1 SPARK_MASTER_OPTS="-Dspark.master.ui.decommission.allow.mode=ALLOWS" sbin/start-master.sh
...
24/01/27 22:14:25 INFO Master: I have been elected leader! New state: ALIVE
```

**AFTER (FAILURE)**
```
$ SPARK_NO_DAEMONIZE=1 SPARK_MASTER_OPTS="-Dspark.master.ui.decommission.allow.mode=ALLOWS" sbin/start-master.sh
...
java.lang.IllegalArgumentException: The value of spark.master.ui.decommission.allow.mode should be one of ALLOW, LOCAL, DENY, but was ALLOWS
```

### Does this PR introduce _any_ user-facing change?

Yes However, this prevents a user to start `Spark Master` with misconfiguration. So, it happens only at the first start of the migrated Spark master installation. So, this is going to be solved before running Spark Master successfully first time.

### How was this patch tested?

Manually.

### Was this patch authored or co-authored using generative AI tooling?

No.