### PR TITLE
[SPARK-46891][SQL] Allow injecting LogicalPlan Statistics visitor.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/BasicStatsPlanVisitor.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/BasicStatsPlanVisitor.scala
@@ -22,10 +22,11 @@ import org.apache.spark.sql.catalyst.plans.logical._
 /**
  * A [[LogicalPlanVisitor]] that computes the statistics for the cost-based optimizer.
  */
-object BasicStatsPlanVisitor extends LogicalPlanVisitor[Statistics] {
+case class BasicStatsPlanVisitor(delegate: LogicalPlanVisitor[Statistics])
+  extends LogicalPlanStatisticsVisitor {
 
   /** Falls back to the estimation computed by [[SizeInBytesOnlyStatsPlanVisitor]]. */
-  private def fallback(p: LogicalPlan): Statistics = SizeInBytesOnlyStatsPlanVisitor.visit(p)
+  private def fallback(p: LogicalPlan): Statistics = delegate.visit(p)
 
   override def default(p: LogicalPlan): Statistics = p match {
     case p: LeafNode => p.computeStats()

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/LogicalPlanStats.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/LogicalPlanStats.scala
@@ -32,9 +32,9 @@ trait LogicalPlanStats { self: LogicalPlan =>
    */
   def stats: Statistics = statsCache.getOrElse {
     if (conf.cboEnabled) {
-      statsCache = Option(BasicStatsPlanVisitor.visit(self))
+      statsCache = Option(LogicalPlanVisitor.cbo.visit(self))
     } else {
-      statsCache = Option(SizeInBytesOnlyStatsPlanVisitor.visit(self))
+      statsCache = Option(LogicalPlanVisitor.nonCbo.visit(self))
     }
     statsCache.get
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/SizeInBytesOnlyStatsPlanVisitor.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/SizeInBytesOnlyStatsPlanVisitor.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.catalyst.plans.logical._
 /**
  * An [[LogicalPlanVisitor]] that computes a single dimension for plan stats: size in bytes.
  */
-object SizeInBytesOnlyStatsPlanVisitor extends LogicalPlanVisitor[Statistics] {
+case class SizeInBytesOnlyStatsPlanVisitor() extends LogicalPlanStatisticsVisitor {
 
   /**
    * A default, commonly used estimation for unary nodes. We assume the input row number is the


### PR DESCRIPTION
### What changes were proposed in this pull request?
Adding ability to inject LogicalPlan statistics visitor. 
added a new interface: `LogicalPlanStatisticsVisitor` so the generic will not be in the user interface.


### Why are the changes needed?
the statistics calc does not cover all use cases so if a user has use-case the is not covered or produces incorrect prediction it can be changed.


### Does this PR introduce _any_ user-facing change?
it adds new configuration: `spark.sql.cbo.planStats.class` and `spark.sql.planStats.class`


### How was this patch tested?
with current tests.


### Was this patch authored or co-authored using generative AI tooling?
No
