### PR TITLE
[SPARK-46892][BUILD] Upgrade dropwizard metrics 4.2.25

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -185,11 +185,11 @@ log4j-core/2.22.1//log4j-core-2.22.1.jar
 log4j-slf4j2-impl/2.22.1//log4j-slf4j2-impl-2.22.1.jar
 logging-interceptor/3.12.12//logging-interceptor-3.12.12.jar
 lz4-java/1.8.0//lz4-java-1.8.0.jar
-metrics-core/4.2.21//metrics-core-4.2.21.jar
-metrics-graphite/4.2.21//metrics-graphite-4.2.21.jar
-metrics-jmx/4.2.21//metrics-jmx-4.2.21.jar
-metrics-json/4.2.21//metrics-json-4.2.21.jar
-metrics-jvm/4.2.21//metrics-jvm-4.2.21.jar
+metrics-core/4.2.25//metrics-core-4.2.25.jar
+metrics-graphite/4.2.25//metrics-graphite-4.2.25.jar
+metrics-jmx/4.2.25//metrics-jmx-4.2.25.jar
+metrics-json/4.2.25//metrics-json-4.2.25.jar
+metrics-jvm/4.2.25//metrics-jvm-4.2.25.jar
 minlog/1.3.0//minlog-1.3.0.jar
 netty-all/4.1.106.Final//netty-all-4.1.106.Final.jar
 netty-buffer/4.1.106.Final//netty-buffer-4.1.106.Final.jar

--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@
     If you change codahale.metrics.version, you also need to change
     the link to metrics.dropwizard.io in docs/monitoring.md.
     -->
-    <codahale.metrics.version>4.2.21</codahale.metrics.version>
+    <codahale.metrics.version>4.2.25</codahale.metrics.version>
     <!-- Should be consistent with SparkBuild.scala and docs -->
     <avro.version>1.11.3</avro.version>
     <aws.kinesis.client.version>1.12.0</aws.kinesis.client.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade dropwizard metrics from `4.2.21` to `4.2.25`.

### Why are the changes needed?
The last update occurred 3 months ago.

- The new version bringes some bug fixes:
  Fix IndexOutOfBoundsException in Jetty 9, 10, 11, 12 InstrumentedHandler https://github.com/dropwizard/metrics/pull/3912

- The full version release notes:
  https://github.com/dropwizard/metrics/releases/tag/v4.2.25
  https://github.com/dropwizard/metrics/releases/tag/v4.2.24
  https://github.com/dropwizard/metrics/releases/tag/v4.2.23
  https://github.com/dropwizard/metrics/releases/tag/v4.2.22

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
