### PR TITLE
[MINOR][DOCS] Remove unneeded comments from global.html

### DIFF
--- a/docs/_layouts/global.html
+++ b/docs/_layouts/global.html
@@ -1,9 +1,5 @@
-
 <!DOCTYPE html>
-<!--[if lt IE 7]>      <html class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>         <html class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html class="no-js"> <!--<![endif]-->
+<html class="no-js">
     <head>
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
@@ -53,12 +49,7 @@
 
     </head>
     <body class="global">
-        <!--[if lt IE 7]>
-            <p class="chromeframe">You are using an outdated browser. <a href="https://browsehappy.com/">Upgrade your browser today</a> or <a href="http://www.google.com/chromeframe/?redirect=true">install Google Chrome Frame</a> to better experience this site.</p>
-        <![endif]-->
-
         <!-- This code is taken from http://twitter.github.com/bootstrap/examples/hero.html -->
-
         <nav class="navbar navbar-expand-lg navbar-dark p-0 px-4 fixed-top" style="background: #1d6890;" id="topbar">
             <div class="navbar-brand"><a href="index.html">
                 <img src="img/spark-logo-rev.svg" width="141" height="72"/></a><span class="version">{{site.SPARK_VERSION_SHORT}}</span>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove some unneeded comments from global.html.

### Why are the changes needed?

They are just noise. They don't appear to do anything (they are not Jekyll directives).

For the record, Internet Explorer 8, 9, and 10 were [sunset in 2020][1]. Internet Explorer 7 was sunset [last year][2].

[1]: https://learn.microsoft.com/en-us/lifecycle/products/internet-explorer-10
[2]: https://learn.microsoft.com/en-us/lifecycle/products/internet-explorer-7

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

I built the docs with `SKIP_API=1` and confirmed nothing broke.

### Was this patch authored or co-authored using generative AI tooling?

No.