### PR TITLE
[SPARK-46896][PS][TESTS] Clean up the imports in `pyspark.pandas.tests.{frame, series, groupby}.*`

### DIFF
--- a/python/pyspark/pandas/tests/connect/frame/test_parity_attrs.py
+++ b/python/pyspark/pandas/tests/connect/frame/test_parity_attrs.py
@@ -16,16 +16,17 @@
 #
 import unittest
 
-from pyspark import pandas as ps
 from pyspark.pandas.tests.frame.test_attrs import FrameAttrsMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase
 from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
-class FrameParityAttrsTests(FrameAttrsMixin, PandasOnSparkTestUtils, ReusedConnectTestCase):
-    @property
-    def psdf(self):
-        return ps.from_pandas(self.pdf)
+class FrameParityAttrsTests(
+    FrameAttrsMixin,
+    PandasOnSparkTestUtils,
+    ReusedConnectTestCase,
+):
+    pass
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/connect/frame/test_parity_axis.py
+++ b/python/pyspark/pandas/tests/connect/frame/test_parity_axis.py
@@ -21,7 +21,11 @@ from pyspark.testing.connectutils import ReusedConnectTestCase
 from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
-class FrameParityAxisTests(FrameAxisMixin, PandasOnSparkTestUtils, ReusedConnectTestCase):
+class FrameParityAxisTests(
+    FrameAxisMixin,
+    PandasOnSparkTestUtils,
+    ReusedConnectTestCase,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/connect/frame/test_parity_constructor.py
+++ b/python/pyspark/pandas/tests/connect/frame/test_parity_constructor.py
@@ -22,7 +22,9 @@ from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
 class FrameParityConstructorTests(
-    FrameConstructorMixin, PandasOnSparkTestUtils, ReusedConnectTestCase
+    FrameConstructorMixin,
+    PandasOnSparkTestUtils,
+    ReusedConnectTestCase,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/connect/frame/test_parity_conversion.py
+++ b/python/pyspark/pandas/tests/connect/frame/test_parity_conversion.py
@@ -16,18 +16,17 @@
 #
 import unittest
 
-from pyspark import pandas as ps
 from pyspark.pandas.tests.frame.test_conversion import FrameConversionMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase
 from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
 class FrameParityConversionTests(
-    FrameConversionMixin, PandasOnSparkTestUtils, ReusedConnectTestCase
+    FrameConversionMixin,
+    PandasOnSparkTestUtils,
+    ReusedConnectTestCase,
 ):
-    @property
-    def psdf(self):
-        return ps.from_pandas(self.pdf)
+    pass
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/connect/frame/test_parity_reindexing.py
+++ b/python/pyspark/pandas/tests/connect/frame/test_parity_reindexing.py
@@ -16,18 +16,17 @@
 #
 import unittest
 
-from pyspark import pandas as ps
 from pyspark.pandas.tests.frame.test_reindexing import FrameReindexingMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase
 from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
 class FrameParityReindexingTests(
-    FrameReindexingMixin, PandasOnSparkTestUtils, ReusedConnectTestCase
+    FrameReindexingMixin,
+    PandasOnSparkTestUtils,
+    ReusedConnectTestCase,
 ):
-    @property
-    def psdf(self):
-        return ps.from_pandas(self.pdf)
+    pass
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/connect/frame/test_parity_reshaping.py
+++ b/python/pyspark/pandas/tests/connect/frame/test_parity_reshaping.py
@@ -21,7 +21,11 @@ from pyspark.testing.connectutils import ReusedConnectTestCase
 from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
-class FrameParityReshapingTests(FrameReshapingMixin, PandasOnSparkTestUtils, ReusedConnectTestCase):
+class FrameParityReshapingTests(
+    FrameReshapingMixin,
+    PandasOnSparkTestUtils,
+    ReusedConnectTestCase,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/connect/frame/test_parity_spark.py
+++ b/python/pyspark/pandas/tests/connect/frame/test_parity_spark.py
@@ -16,16 +16,17 @@
 #
 import unittest
 
-from pyspark import pandas as ps
 from pyspark.pandas.tests.frame.test_spark import FrameSparkMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase
 from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
-class FrameParitySparkTests(FrameSparkMixin, PandasOnSparkTestUtils, ReusedConnectTestCase):
-    @property
-    def psdf(self):
-        return ps.from_pandas(self.pdf)
+class FrameParitySparkTests(
+    FrameSparkMixin,
+    PandasOnSparkTestUtils,
+    ReusedConnectTestCase,
+):
+    pass
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/connect/frame/test_parity_time_series.py
+++ b/python/pyspark/pandas/tests/connect/frame/test_parity_time_series.py
@@ -16,18 +16,17 @@
 #
 import unittest
 
-from pyspark import pandas as ps
 from pyspark.pandas.tests.frame.test_time_series import FrameTimeSeriesMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase
 from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
 class FrameParityTimeSeriesTests(
-    FrameTimeSeriesMixin, PandasOnSparkTestUtils, ReusedConnectTestCase
+    FrameTimeSeriesMixin,
+    PandasOnSparkTestUtils,
+    ReusedConnectTestCase,
 ):
-    @property
-    def psdf(self):
-        return ps.from_pandas(self.pdf)
+    pass
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/connect/frame/test_parity_truncate.py
+++ b/python/pyspark/pandas/tests/connect/frame/test_parity_truncate.py
@@ -16,16 +16,17 @@
 #
 import unittest
 
-from pyspark import pandas as ps
 from pyspark.pandas.tests.frame.test_truncate import FrameTruncateMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase
 from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
-class FrameParityTruncateTests(FrameTruncateMixin, PandasOnSparkTestUtils, ReusedConnectTestCase):
-    @property
-    def psdf(self):
-        return ps.from_pandas(self.pdf)
+class FrameParityTruncateTests(
+    FrameTruncateMixin,
+    PandasOnSparkTestUtils,
+    ReusedConnectTestCase,
+):
+    pass
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/connect/groupby/test_parity_aggregate.py
+++ b/python/pyspark/pandas/tests/connect/groupby/test_parity_aggregate.py
@@ -22,7 +22,9 @@ from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
 class GroupbyParityAggregateTests(
-    GroupbyAggregateMixin, PandasOnSparkTestUtils, ReusedConnectTestCase
+    GroupbyAggregateMixin,
+    PandasOnSparkTestUtils,
+    ReusedConnectTestCase,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/connect/groupby/test_parity_apply_func.py
+++ b/python/pyspark/pandas/tests/connect/groupby/test_parity_apply_func.py
@@ -22,7 +22,9 @@ from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
 class GroupbyParityApplyFuncTests(
-    GroupbyApplyFuncMixin, PandasOnSparkTestUtils, ReusedConnectTestCase
+    GroupbyApplyFuncMixin,
+    PandasOnSparkTestUtils,
+    ReusedConnectTestCase,
 ):
     @unittest.skip("Test depends on SparkContext which is not supported from Spark Connect.")
     def test_apply_with_side_effect(self):

--- a/python/pyspark/pandas/tests/connect/groupby/test_parity_cumulative.py
+++ b/python/pyspark/pandas/tests/connect/groupby/test_parity_cumulative.py
@@ -22,7 +22,9 @@ from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
 class GroupbyParityCumulativeTests(
-    GroupbyCumulativeMixin, PandasOnSparkTestUtils, ReusedConnectTestCase
+    GroupbyCumulativeMixin,
+    PandasOnSparkTestUtils,
+    ReusedConnectTestCase,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/connect/groupby/test_parity_describe.py
+++ b/python/pyspark/pandas/tests/connect/groupby/test_parity_describe.py
@@ -22,7 +22,9 @@ from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
 class GroupbyParityDescribeTests(
-    GroupbyDescribeMixin, PandasOnSparkTestUtils, ReusedConnectTestCase
+    GroupbyDescribeMixin,
+    PandasOnSparkTestUtils,
+    ReusedConnectTestCase,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/connect/groupby/test_parity_groupby.py
+++ b/python/pyspark/pandas/tests/connect/groupby/test_parity_groupby.py
@@ -22,7 +22,10 @@ from pyspark.testing.pandasutils import PandasOnSparkTestUtils, TestUtils
 
 
 class GroupByParityTests(
-    GroupByTestsMixin, PandasOnSparkTestUtils, TestUtils, ReusedConnectTestCase
+    GroupByTestsMixin,
+    PandasOnSparkTestUtils,
+    TestUtils,
+    ReusedConnectTestCase,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/connect/groupby/test_parity_head_tail.py
+++ b/python/pyspark/pandas/tests/connect/groupby/test_parity_head_tail.py
@@ -22,7 +22,9 @@ from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
 class GroupbyParityHeadTailTests(
-    GroupbyHeadTailMixin, PandasOnSparkTestUtils, ReusedConnectTestCase
+    GroupbyHeadTailMixin,
+    PandasOnSparkTestUtils,
+    ReusedConnectTestCase,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/connect/groupby/test_parity_index.py
+++ b/python/pyspark/pandas/tests/connect/groupby/test_parity_index.py
@@ -21,7 +21,11 @@ from pyspark.testing.connectutils import ReusedConnectTestCase
 from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
-class GroupbyParityIndexTests(GroupbyIndexMixin, PandasOnSparkTestUtils, ReusedConnectTestCase):
+class GroupbyParityIndexTests(
+    GroupbyIndexMixin,
+    PandasOnSparkTestUtils,
+    ReusedConnectTestCase,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/connect/groupby/test_parity_missing_data.py
+++ b/python/pyspark/pandas/tests/connect/groupby/test_parity_missing_data.py
@@ -22,7 +22,9 @@ from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
 class GroupbyParityMissingDataTests(
-    GroupbyMissingDataMixin, PandasOnSparkTestUtils, ReusedConnectTestCase
+    GroupbyMissingDataMixin,
+    PandasOnSparkTestUtils,
+    ReusedConnectTestCase,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/connect/series/test_parity_all_any.py
+++ b/python/pyspark/pandas/tests/connect/series/test_parity_all_any.py
@@ -21,7 +21,11 @@ from pyspark.testing.connectutils import ReusedConnectTestCase
 from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
-class SeriesParityAllAnyTests(SeriesAllAnyMixin, PandasOnSparkTestUtils, ReusedConnectTestCase):
+class SeriesParityAllAnyTests(
+    SeriesAllAnyMixin,
+    PandasOnSparkTestUtils,
+    ReusedConnectTestCase,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/connect/series/test_parity_arg_ops.py
+++ b/python/pyspark/pandas/tests/connect/series/test_parity_arg_ops.py
@@ -21,7 +21,11 @@ from pyspark.testing.connectutils import ReusedConnectTestCase
 from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
-class SeriesParityArgOpsTests(SeriesArgOpsMixin, PandasOnSparkTestUtils, ReusedConnectTestCase):
+class SeriesParityArgOpsTests(
+    SeriesArgOpsMixin,
+    PandasOnSparkTestUtils,
+    ReusedConnectTestCase,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/connect/series/test_parity_as_of.py
+++ b/python/pyspark/pandas/tests/connect/series/test_parity_as_of.py
@@ -21,7 +21,11 @@ from pyspark.testing.connectutils import ReusedConnectTestCase
 from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
-class SeriesParityArgOpsTests(SeriesAsOfMixin, PandasOnSparkTestUtils, ReusedConnectTestCase):
+class SeriesParityArgOpsTests(
+    SeriesAsOfMixin,
+    PandasOnSparkTestUtils,
+    ReusedConnectTestCase,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/connect/series/test_parity_as_type.py
+++ b/python/pyspark/pandas/tests/connect/series/test_parity_as_type.py
@@ -21,7 +21,11 @@ from pyspark.testing.connectutils import ReusedConnectTestCase
 from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
-class SeriesParityAsTypeTests(SeriesAsTypeMixin, PandasOnSparkTestUtils, ReusedConnectTestCase):
+class SeriesParityAsTypeTests(
+    SeriesAsTypeMixin,
+    PandasOnSparkTestUtils,
+    ReusedConnectTestCase,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/connect/series/test_parity_compute.py
+++ b/python/pyspark/pandas/tests/connect/series/test_parity_compute.py
@@ -21,7 +21,11 @@ from pyspark.testing.connectutils import ReusedConnectTestCase
 from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
-class SeriesParityComputeTests(SeriesComputeMixin, PandasOnSparkTestUtils, ReusedConnectTestCase):
+class SeriesParityComputeTests(
+    SeriesComputeMixin,
+    PandasOnSparkTestUtils,
+    ReusedConnectTestCase,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/connect/series/test_parity_conversion.py
+++ b/python/pyspark/pandas/tests/connect/series/test_parity_conversion.py
@@ -22,7 +22,9 @@ from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
 class SeriesParityConversionTests(
-    SeriesConversionMixin, PandasOnSparkTestUtils, ReusedConnectTestCase
+    SeriesConversionMixin,
+    PandasOnSparkTestUtils,
+    ReusedConnectTestCase,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/connect/series/test_parity_cumulative.py
+++ b/python/pyspark/pandas/tests/connect/series/test_parity_cumulative.py
@@ -22,7 +22,9 @@ from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
 class SeriesParityCumulativeTests(
-    SeriesCumulativeMixin, PandasOnSparkTestUtils, ReusedConnectTestCase
+    SeriesCumulativeMixin,
+    PandasOnSparkTestUtils,
+    ReusedConnectTestCase,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/connect/series/test_parity_index.py
+++ b/python/pyspark/pandas/tests/connect/series/test_parity_index.py
@@ -21,7 +21,11 @@ from pyspark.testing.connectutils import ReusedConnectTestCase
 from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
-class SeriesParityIndexTests(SeriesIndexMixin, PandasOnSparkTestUtils, ReusedConnectTestCase):
+class SeriesParityIndexTests(
+    SeriesIndexMixin,
+    PandasOnSparkTestUtils,
+    ReusedConnectTestCase,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/connect/series/test_parity_missing_data.py
+++ b/python/pyspark/pandas/tests/connect/series/test_parity_missing_data.py
@@ -22,7 +22,9 @@ from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
 class SeriesParityMissingDataTests(
-    SeriesMissingDataMixin, PandasOnSparkTestUtils, ReusedConnectTestCase
+    SeriesMissingDataMixin,
+    PandasOnSparkTestUtils,
+    ReusedConnectTestCase,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/connect/series/test_parity_series.py
+++ b/python/pyspark/pandas/tests/connect/series/test_parity_series.py
@@ -21,7 +21,11 @@ from pyspark.testing.connectutils import ReusedConnectTestCase
 from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
-class SeriesParityTests(SeriesTestsMixin, PandasOnSparkTestUtils, ReusedConnectTestCase):
+class SeriesParityTests(
+    SeriesTestsMixin,
+    PandasOnSparkTestUtils,
+    ReusedConnectTestCase,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/connect/series/test_parity_sort.py
+++ b/python/pyspark/pandas/tests/connect/series/test_parity_sort.py
@@ -21,7 +21,11 @@ from pyspark.testing.connectutils import ReusedConnectTestCase
 from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
-class SeriesParitySortTests(SeriesSortMixin, PandasOnSparkTestUtils, ReusedConnectTestCase):
+class SeriesParitySortTests(
+    SeriesSortMixin,
+    PandasOnSparkTestUtils,
+    ReusedConnectTestCase,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/connect/series/test_parity_stat.py
+++ b/python/pyspark/pandas/tests/connect/series/test_parity_stat.py
@@ -21,7 +21,11 @@ from pyspark.testing.connectutils import ReusedConnectTestCase
 from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
-class SeriesParityStatTests(SeriesStatMixin, PandasOnSparkTestUtils, ReusedConnectTestCase):
+class SeriesParityStatTests(
+    SeriesStatMixin,
+    PandasOnSparkTestUtils,
+    ReusedConnectTestCase,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/connect/series/test_parity_string_ops_adv.py
+++ b/python/pyspark/pandas/tests/connect/series/test_parity_string_ops_adv.py
@@ -22,7 +22,9 @@ from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
 class SeriesParityStringOpsAdvTests(
-    SeriesStringOpsAdvMixin, PandasOnSparkTestUtils, ReusedConnectTestCase
+    SeriesStringOpsAdvMixin,
+    PandasOnSparkTestUtils,
+    ReusedConnectTestCase,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/connect/series/test_parity_string_ops_basic.py
+++ b/python/pyspark/pandas/tests/connect/series/test_parity_string_ops_basic.py
@@ -22,7 +22,9 @@ from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
 class SeriesStringOpsParityTests(
-    SeriesStringOpsMixin, PandasOnSparkTestUtils, ReusedConnectTestCase
+    SeriesStringOpsMixin,
+    PandasOnSparkTestUtils,
+    ReusedConnectTestCase,
 ):
     pass
 

--- a/python/pyspark/pandas/tests/frame/test_attrs.py
+++ b/python/pyspark/pandas/tests/frame/test_attrs.py
@@ -36,11 +36,13 @@ class FrameAttrsMixin:
         )
 
     @property
-    def psdf(self):
-        return ps.from_pandas(self.pdf)
+    def df_pair(self):
+        pdf = self.pdf
+        psdf = ps.from_pandas(pdf)
+        return pdf, psdf
 
     def test_column_names(self):
-        pdf, psdf = self.pdf, self.psdf
+        pdf, psdf = self.df_pair
 
         self.assert_eq(psdf.columns, pdf.columns)
         self.assert_eq(psdf[["b", "a"]].columns, pdf[["b", "a"]].columns)
@@ -170,7 +172,7 @@ class FrameAttrsMixin:
         self.assert_eq(pdf.axes, psdf.axes)
 
     def test_inplace(self):
-        pdf, psdf = self.pdf, self.psdf
+        pdf, psdf = self.df_pair
 
         pser = pdf.a
         psser = psdf.a
@@ -268,7 +270,7 @@ class FrameAttrsMixin:
         self.assertEqual(df._repr_html_(), df._to_pandas()._repr_html_())
 
     def test_assign(self):
-        pdf, psdf = self.pdf, self.psdf
+        pdf, psdf = self.df_pair
 
         psdf["w"] = 1.0
         pdf["w"] = 1.0

--- a/python/pyspark/pandas/tests/frame/test_attrs.py
+++ b/python/pyspark/pandas/tests/frame/test_attrs.py
@@ -36,6 +36,10 @@ class FrameAttrsMixin:
         )
 
     @property
+    def psdf(self):
+        return ps.from_pandas(self.pdf)
+
+    @property
     def df_pair(self):
         pdf = self.pdf
         psdf = ps.from_pandas(pdf)

--- a/python/pyspark/pandas/tests/frame/test_attrs.py
+++ b/python/pyspark/pandas/tests/frame/test_attrs.py
@@ -21,7 +21,7 @@ import numpy as np
 import pandas as pd
 
 from pyspark import pandas as ps
-from pyspark.testing.pandasutils import ComparisonTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
 
 
@@ -36,13 +36,11 @@ class FrameAttrsMixin:
         )
 
     @property
-    def df_pair(self):
-        pdf = self.pdf
-        psdf = ps.from_pandas(pdf)
-        return pdf, psdf
+    def psdf(self):
+        return ps.from_pandas(self.pdf)
 
     def test_column_names(self):
-        pdf, psdf = self.df_pair
+        pdf, psdf = self.pdf, self.psdf
 
         self.assert_eq(psdf.columns, pdf.columns)
         self.assert_eq(psdf[["b", "a"]].columns, pdf[["b", "a"]].columns)
@@ -172,7 +170,7 @@ class FrameAttrsMixin:
         self.assert_eq(pdf.axes, psdf.axes)
 
     def test_inplace(self):
-        pdf, psdf = self.df_pair
+        pdf, psdf = self.pdf, self.psdf
 
         pser = pdf.a
         psser = psdf.a
@@ -270,7 +268,7 @@ class FrameAttrsMixin:
         self.assertEqual(df._repr_html_(), df._to_pandas()._repr_html_())
 
     def test_assign(self):
-        pdf, psdf = self.df_pair
+        pdf, psdf = self.pdf, self.psdf
 
         psdf["w"] = 1.0
         pdf["w"] = 1.0
@@ -341,7 +339,11 @@ class FrameAttrsMixin:
         self.assert_eq(psdf[psdf["t"] != psdf["t"]].dtypes, pdf[pdf["t"] != pdf["t"]].dtypes)
 
 
-class FrameAttrsTests(FrameAttrsMixin, ComparisonTestBase, SQLTestUtils):
+class FrameAttrsTests(
+    FrameAttrsMixin,
+    PandasOnSparkTestCase,
+    SQLTestUtils,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/frame/test_axis.py
+++ b/python/pyspark/pandas/tests/frame/test_axis.py
@@ -20,7 +20,7 @@ import unittest
 import pandas as pd
 
 from pyspark import pandas as ps
-from pyspark.testing.pandasutils import ComparisonTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
 
 
@@ -119,7 +119,11 @@ class FrameAxisMixin:
             )
 
 
-class FrameAxisTests(FrameAxisMixin, ComparisonTestBase, SQLTestUtils):
+class FrameAxisTests(
+    FrameAxisMixin,
+    PandasOnSparkTestCase,
+    SQLTestUtils,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/frame/test_constructor.py
+++ b/python/pyspark/pandas/tests/frame/test_constructor.py
@@ -28,7 +28,7 @@ from pyspark.pandas.typedef.typehints import (
 )
 from pyspark.pandas.utils import is_testing
 
-from pyspark.testing.pandasutils import ComparisonTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
 
 
@@ -572,7 +572,11 @@ class FrameConstructorMixin:
         self.assert_eq(psdf.astype(astype), pdf.astype(astype))
 
 
-class FrameConstructorTests(FrameConstructorMixin, ComparisonTestBase, SQLTestUtils):
+class FrameConstructorTests(
+    FrameConstructorMixin,
+    PandasOnSparkTestCase,
+    SQLTestUtils,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/frame/test_conversion.py
+++ b/python/pyspark/pandas/tests/frame/test_conversion.py
@@ -20,7 +20,7 @@ import numpy as np
 import pandas as pd
 
 from pyspark import pandas as ps
-from pyspark.testing.pandasutils import ComparisonTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
 
 
@@ -33,6 +33,10 @@ class FrameConversionMixin:
             {"a": [1, 2, 3, 4, 5, 6, 7, 8, 9], "b": [4, 5, 6, 3, 2, 1, 0, 0, 0]},
             index=np.random.rand(9),
         )
+
+    @property
+    def psdf(self):
+        return ps.from_pandas(self.pdf)
 
     def test_astype(self):
         psdf = self.psdf
@@ -51,7 +55,11 @@ class FrameConversionMixin:
         self.assert_eq(psdf.isnull(), pdf.isnull())
 
 
-class FrameConversionTests(FrameConversionMixin, ComparisonTestBase, SQLTestUtils):
+class FrameConversionTests(
+    FrameConversionMixin,
+    PandasOnSparkTestCase,
+    SQLTestUtils,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/frame/test_interpolate.py
+++ b/python/pyspark/pandas/tests/frame/test_interpolate.py
@@ -70,7 +70,11 @@ class FrameInterpolateMixin:
         self._test_interpolate(pdf)
 
 
-class FrameInterpolateTests(FrameInterpolateMixin, PandasOnSparkTestCase, TestUtils):
+class FrameInterpolateTests(
+    FrameInterpolateMixin,
+    PandasOnSparkTestCase,
+    TestUtils,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/frame/test_reindexing.py
+++ b/python/pyspark/pandas/tests/frame/test_reindexing.py
@@ -23,7 +23,7 @@ from pandas.tseries.offsets import DateOffset
 from pyspark import pandas as ps
 from pyspark.errors import PySparkValueError
 from pyspark.pandas.config import option_context
-from pyspark.testing.pandasutils import ComparisonTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
 
 
@@ -842,7 +842,11 @@ class FrameReindexingMixin:
             psdf.sample(n=1)
 
 
-class FrameReidexingTests(FrameReindexingMixin, ComparisonTestBase, SQLTestUtils):
+class FrameReidexingTests(
+    FrameReindexingMixin,
+    PandasOnSparkTestCase,
+    SQLTestUtils,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/frame/test_reshaping.py
+++ b/python/pyspark/pandas/tests/frame/test_reshaping.py
@@ -22,7 +22,7 @@ import pandas as pd
 
 from pyspark import pandas as ps
 from pyspark.pandas.config import option_context
-from pyspark.testing.pandasutils import ComparisonTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
 
 
@@ -464,7 +464,11 @@ class FrameReshapingMixin:
             self.assert_eq(pdf.squeeze(axis), psdf.squeeze(axis))
 
 
-class FrameReshapingTests(FrameReshapingMixin, ComparisonTestBase, SQLTestUtils):
+class FrameReshapingTests(
+    FrameReshapingMixin,
+    PandasOnSparkTestCase,
+    SQLTestUtils,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/frame/test_spark.py
+++ b/python/pyspark/pandas/tests/frame/test_spark.py
@@ -29,7 +29,7 @@ from pyspark import pandas as ps
 from pyspark.pandas.frame import CachedDataFrame
 from pyspark.pandas.exceptions import PandasNotImplementedError
 from pyspark.pandas.missing.frame import MissingPandasLikeDataFrame
-from pyspark.testing.pandasutils import ComparisonTestBase, SPARK_CONF_ARROW_ENABLED
+from pyspark.testing.pandasutils import PandasOnSparkTestCase, SPARK_CONF_ARROW_ENABLED
 from pyspark.testing.sqlutils import SQLTestUtils
 
 
@@ -42,6 +42,10 @@ class FrameSparkMixin:
             {"a": [1, 2, 3, 4, 5, 6, 7, 8, 9], "b": [4, 5, 6, 3, 2, 1, 0, 0, 0]},
             index=np.random.rand(9),
         )
+
+    @property
+    def psdf(self):
+        return ps.from_pandas(self.pdf)
 
     def test_empty_dataframe(self):
         pdf = pd.DataFrame({"a": pd.Series([], dtype="i1"), "b": pd.Series([], dtype="str")})
@@ -287,7 +291,11 @@ class FrameSparkMixin:
                 getattr(psdf, name)
 
 
-class FrameSparkTests(FrameSparkMixin, ComparisonTestBase, SQLTestUtils):
+class FrameSparkTests(
+    FrameSparkMixin,
+    PandasOnSparkTestCase,
+    SQLTestUtils,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/frame/test_time_series.py
+++ b/python/pyspark/pandas/tests/frame/test_time_series.py
@@ -21,7 +21,7 @@ import numpy as np
 import pandas as pd
 
 from pyspark import pandas as ps
-from pyspark.testing.pandasutils import ComparisonTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
 
 
@@ -120,7 +120,11 @@ class FrameTimeSeriesMixin:
         self.assert_eq(pd.to_datetime(pdf), ps.to_datetime(psdf))
 
 
-class FrameTimeSeriesTests(FrameTimeSeriesMixin, ComparisonTestBase, SQLTestUtils):
+class FrameTimeSeriesTests(
+    FrameTimeSeriesMixin,
+    PandasOnSparkTestCase,
+    SQLTestUtils,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/frame/test_truncate.py
+++ b/python/pyspark/pandas/tests/frame/test_truncate.py
@@ -19,7 +19,7 @@ import unittest
 import pandas as pd
 
 from pyspark import pandas as ps
-from pyspark.testing.pandasutils import ComparisonTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
 
 
@@ -117,7 +117,7 @@ class FrameTruncateMixin:
             psdf.truncate("C", "B", axis=1)
 
 
-class FrameTruncateTests(FrameTruncateMixin, ComparisonTestBase, SQLTestUtils):
+class FrameTruncateTests(FrameTruncateMixin, PandasOnSparkTestCase, SQLTestUtils):
     pass
 
 

--- a/python/pyspark/pandas/tests/groupby/test_aggregate.py
+++ b/python/pyspark/pandas/tests/groupby/test_aggregate.py
@@ -19,7 +19,7 @@ import unittest
 import pandas as pd
 
 from pyspark import pandas as ps
-from pyspark.testing.pandasutils import ComparisonTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
 
 
@@ -270,7 +270,11 @@ class GroupbyAggregateMixin:
         self.assert_eq(agg_pdf, agg_psdf)
 
 
-class GroupbyAggregateTests(GroupbyAggregateMixin, ComparisonTestBase, SQLTestUtils):
+class GroupbyAggregateTests(
+    GroupbyAggregateMixin,
+    PandasOnSparkTestCase,
+    SQLTestUtils,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/groupby/test_apply_func.py
+++ b/python/pyspark/pandas/tests/groupby/test_apply_func.py
@@ -21,7 +21,7 @@ import pandas as pd
 
 from pyspark import pandas as ps
 from pyspark.pandas.config import option_context
-from pyspark.testing.pandasutils import ComparisonTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
 
 
@@ -487,7 +487,11 @@ class GroupbyApplyFuncMixin:
         )
 
 
-class GroupbyApplyFuncTests(GroupbyApplyFuncMixin, ComparisonTestBase, SQLTestUtils):
+class GroupbyApplyFuncTests(
+    GroupbyApplyFuncMixin,
+    PandasOnSparkTestCase,
+    SQLTestUtils,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/groupby/test_cumulative.py
+++ b/python/pyspark/pandas/tests/groupby/test_cumulative.py
@@ -21,7 +21,7 @@ import pandas as pd
 
 from pyspark import pandas as ps
 from pyspark.pandas.exceptions import DataError
-from pyspark.testing.pandasutils import ComparisonTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
 
 
@@ -388,7 +388,11 @@ class GroupbyCumulativeMixin:
         self.assertRaises(DataError, lambda: psdf.groupby(["A"])["B"].cumprod())
 
 
-class GroupbyCumulativeTests(GroupbyCumulativeMixin, ComparisonTestBase, SQLTestUtils):
+class GroupbyCumulativeTests(
+    GroupbyCumulativeMixin,
+    PandasOnSparkTestCase,
+    SQLTestUtils,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/groupby/test_describe.py
+++ b/python/pyspark/pandas/tests/groupby/test_describe.py
@@ -20,7 +20,7 @@ from itertools import product
 import pandas as pd
 
 from pyspark import pandas as ps
-from pyspark.testing.pandasutils import ComparisonTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
 
 
@@ -113,7 +113,11 @@ class GroupbyDescribeMixin:
         )
 
 
-class GroupbyDescribeTests(GroupbyDescribeMixin, ComparisonTestBase, SQLTestUtils):
+class GroupbyDescribeTests(
+    GroupbyDescribeMixin,
+    PandasOnSparkTestCase,
+    SQLTestUtils,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/groupby/test_groupby.py
+++ b/python/pyspark/pandas/tests/groupby/test_groupby.py
@@ -16,17 +16,11 @@
 #
 
 import unittest
-import inspect
 
 import numpy as np
 import pandas as pd
 
 from pyspark import pandas as ps
-from pyspark.pandas.exceptions import PandasNotImplementedError
-from pyspark.pandas.missing.groupby import (
-    MissingPandasLikeDataFrameGroupBy,
-    MissingPandasLikeSeriesGroupBy,
-)
 from pyspark.pandas.groupby import is_multi_agg_with_relabel, SeriesGroupBy
 from pyspark.testing.pandasutils import PandasOnSparkTestCase, TestUtils
 
@@ -458,7 +452,11 @@ class GroupByTestsMixin:
         )
 
 
-class GroupByTests(GroupByTestsMixin, PandasOnSparkTestCase, TestUtils):
+class GroupByTests(
+    GroupByTestsMixin,
+    PandasOnSparkTestCase,
+    TestUtils,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/groupby/test_grouping.py
+++ b/python/pyspark/pandas/tests/groupby/test_grouping.py
@@ -155,7 +155,10 @@ class GroupingTestsMixin:
         self.assertTrue(isinstance(psdf.groupby("a")["b"], SeriesGroupBy))
 
 
-class GroupingTests(GroupingTestsMixin, PandasOnSparkTestCase):
+class GroupingTests(
+    GroupingTestsMixin,
+    PandasOnSparkTestCase,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/groupby/test_head_tail.py
+++ b/python/pyspark/pandas/tests/groupby/test_head_tail.py
@@ -20,7 +20,7 @@ import numpy as np
 import pandas as pd
 
 from pyspark import pandas as ps
-from pyspark.testing.pandasutils import ComparisonTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
 
 
@@ -202,7 +202,11 @@ class GroupbyHeadTailMixin:
             )
 
 
-class GroupbyHeadTailTests(GroupbyHeadTailMixin, ComparisonTestBase, SQLTestUtils):
+class GroupbyHeadTailTests(
+    GroupbyHeadTailMixin,
+    PandasOnSparkTestCase,
+    SQLTestUtils,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/groupby/test_index.py
+++ b/python/pyspark/pandas/tests/groupby/test_index.py
@@ -19,7 +19,7 @@ import unittest
 import pandas as pd
 
 from pyspark import pandas as ps
-from pyspark.testing.pandasutils import ComparisonTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
 
 
@@ -164,7 +164,11 @@ class GroupbyIndexMixin:
         )
 
 
-class GroupbyIndexTests(GroupbyIndexMixin, ComparisonTestBase, SQLTestUtils):
+class GroupbyIndexTests(
+    GroupbyIndexMixin,
+    PandasOnSparkTestCase,
+    SQLTestUtils,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/groupby/test_missing.py
+++ b/python/pyspark/pandas/tests/groupby/test_missing.py
@@ -128,7 +128,10 @@ class MissingTestsMixin:
                 getattr(psdf.a.groupby(psdf.a), name)
 
 
-class MissingTests(MissingTestsMixin, PandasOnSparkTestCase):
+class MissingTests(
+    MissingTestsMixin,
+    PandasOnSparkTestCase,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/groupby/test_missing_data.py
+++ b/python/pyspark/pandas/tests/groupby/test_missing_data.py
@@ -21,7 +21,7 @@ import numpy as np
 import pandas as pd
 
 from pyspark import pandas as ps
-from pyspark.testing.pandasutils import ComparisonTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
 
 
@@ -303,7 +303,11 @@ class GroupbyMissingDataMixin:
                 self.assert_eq(sorted_stats_psdf, sorted_stats_pdf)
 
 
-class GroupbyMissingDataTests(GroupbyMissingDataMixin, ComparisonTestBase, SQLTestUtils):
+class GroupbyMissingDataTests(
+    GroupbyMissingDataMixin,
+    PandasOnSparkTestCase,
+    SQLTestUtils,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/groupby/test_nlargest_nsmallest.py
+++ b/python/pyspark/pandas/tests/groupby/test_nlargest_nsmallest.py
@@ -103,7 +103,10 @@ class NlargestNsmallestTestsMixin:
             psdf.set_index(["a", "b"]).groupby(["c"])["d"].nsmallest(1)
 
 
-class NlargestNsmallestTests(NlargestNsmallestTestsMixin, PandasOnSparkTestCase):
+class NlargestNsmallestTests(
+    NlargestNsmallestTestsMixin,
+    PandasOnSparkTestCase,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/groupby/test_raises.py
+++ b/python/pyspark/pandas/tests/groupby/test_raises.py
@@ -36,7 +36,10 @@ class RaisesTestsMixin:
         self.assertRaises(KeyError, lambda: psdf.groupby("a")[["b", "x"]])
 
 
-class RaisesTests(RaisesTestsMixin, PandasOnSparkTestCase):
+class RaisesTests(
+    RaisesTestsMixin,
+    PandasOnSparkTestCase,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/groupby/test_rank.py
+++ b/python/pyspark/pandas/tests/groupby/test_rank.py
@@ -75,7 +75,10 @@ class RankTestsMixin:
         )
 
 
-class RankTests(RankTestsMixin, PandasOnSparkTestCase):
+class RankTests(
+    RankTestsMixin,
+    PandasOnSparkTestCase,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/groupby/test_size.py
+++ b/python/pyspark/pandas/tests/groupby/test_size.py
@@ -54,7 +54,10 @@ class SizeTestsMixin:
         )
 
 
-class SizeTests(SizeTestsMixin, PandasOnSparkTestCase):
+class SizeTests(
+    SizeTestsMixin,
+    PandasOnSparkTestCase,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/groupby/test_value_counts.py
+++ b/python/pyspark/pandas/tests/groupby/test_value_counts.py
@@ -88,7 +88,10 @@ class ValueCountsTestsMixin:
         )
 
 
-class ValueCountsTests(ValueCountsTestsMixin, PandasOnSparkTestCase):
+class ValueCountsTests(
+    ValueCountsTestsMixin,
+    PandasOnSparkTestCase,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/series/test_all_any.py
+++ b/python/pyspark/pandas/tests/series/test_all_any.py
@@ -20,7 +20,7 @@ import numpy as np
 import pandas as pd
 
 from pyspark import pandas as ps
-from pyspark.testing.pandasutils import ComparisonTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
 
 
@@ -81,7 +81,11 @@ class SeriesAllAnyMixin:
             psser.any(axis=1)
 
 
-class SeriesAllAnyTests(SeriesAllAnyMixin, ComparisonTestBase, SQLTestUtils):
+class SeriesAllAnyTests(
+    SeriesAllAnyMixin,
+    PandasOnSparkTestCase,
+    SQLTestUtils,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/series/test_arg_ops.py
+++ b/python/pyspark/pandas/tests/series/test_arg_ops.py
@@ -20,7 +20,7 @@ import numpy as np
 import pandas as pd
 
 from pyspark import pandas as ps
-from pyspark.testing.pandasutils import ComparisonTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
 
 
@@ -173,7 +173,11 @@ class SeriesArgOpsMixin:
             psser.argmin(axis=1)
 
 
-class SeriesArgOpsTests(SeriesArgOpsMixin, ComparisonTestBase, SQLTestUtils):
+class SeriesArgOpsTests(
+    SeriesArgOpsMixin,
+    PandasOnSparkTestCase,
+    SQLTestUtils,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/series/test_as_of.py
+++ b/python/pyspark/pandas/tests/series/test_as_of.py
@@ -20,7 +20,7 @@ import numpy as np
 import pandas as pd
 
 from pyspark import pandas as ps
-from pyspark.testing.pandasutils import ComparisonTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
 
 
@@ -113,7 +113,11 @@ class SeriesAsOfMixin:
         self.assert_eq(psser.asof([10, np.nan]), pser.asof([10, np.nan]))
 
 
-class SeriesAsOfTests(SeriesAsOfMixin, ComparisonTestBase, SQLTestUtils):
+class SeriesAsOfTests(
+    SeriesAsOfMixin,
+    PandasOnSparkTestCase,
+    SQLTestUtils,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/series/test_as_type.py
+++ b/python/pyspark/pandas/tests/series/test_as_type.py
@@ -20,7 +20,7 @@ import numpy as np
 import pandas as pd
 
 from pyspark import pandas as ps
-from pyspark.testing.pandasutils import ComparisonTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
 from pyspark.pandas.typedef.typehints import (
     extension_dtypes_available,
@@ -160,7 +160,11 @@ class SeriesAsTypeMixin:
         self.assert_eq(psser, pser)
 
 
-class SeriesAsTypeTests(SeriesAsTypeMixin, ComparisonTestBase, SQLTestUtils):
+class SeriesAsTypeTests(
+    SeriesAsTypeMixin,
+    PandasOnSparkTestCase,
+    SQLTestUtils,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/series/test_compute.py
+++ b/python/pyspark/pandas/tests/series/test_compute.py
@@ -22,7 +22,7 @@ import pandas as pd
 
 from pyspark import pandas as ps
 from pyspark.errors import PySparkValueError
-from pyspark.testing.pandasutils import ComparisonTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
 
 
@@ -575,7 +575,11 @@ class SeriesComputeMixin:
         )
 
 
-class SeriesComputeTests(SeriesComputeMixin, ComparisonTestBase, SQLTestUtils):
+class SeriesComputeTests(
+    SeriesComputeMixin,
+    PandasOnSparkTestCase,
+    SQLTestUtils,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/series/test_conversion.py
+++ b/python/pyspark/pandas/tests/series/test_conversion.py
@@ -19,7 +19,7 @@ import unittest
 import pandas as pd
 
 from pyspark import pandas as ps
-from pyspark.testing.pandasutils import ComparisonTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
 from pyspark.testing.pandasutils import have_tabulate, tabulate_requirement_message
 
@@ -72,7 +72,11 @@ class SeriesConversionMixin:
         self.assert_eq(pser.to_markdown(), psser.to_markdown())
 
 
-class SeriesConversionTests(SeriesConversionMixin, ComparisonTestBase, SQLTestUtils):
+class SeriesConversionTests(
+    SeriesConversionMixin,
+    PandasOnSparkTestCase,
+    SQLTestUtils,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/series/test_cumulative.py
+++ b/python/pyspark/pandas/tests/series/test_cumulative.py
@@ -19,7 +19,7 @@ import unittest
 import pandas as pd
 
 from pyspark import pandas as ps
-from pyspark.testing.pandasutils import ComparisonTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
 
 
@@ -114,7 +114,11 @@ class SeriesCumulativeMixin:
             ps.Series(["a", "b", "c", "d"]).cumprod()
 
 
-class SeriesCumulativeTests(SeriesCumulativeMixin, ComparisonTestBase, SQLTestUtils):
+class SeriesCumulativeTests(
+    SeriesCumulativeMixin,
+    PandasOnSparkTestCase,
+    SQLTestUtils,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/series/test_index.py
+++ b/python/pyspark/pandas/tests/series/test_index.py
@@ -20,7 +20,7 @@ import numpy as np
 import pandas as pd
 
 from pyspark import pandas as ps
-from pyspark.testing.pandasutils import ComparisonTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
 
 
@@ -451,7 +451,11 @@ class SeriesIndexMixin:
         )
 
 
-class SeriesIndexTests(SeriesIndexMixin, ComparisonTestBase, SQLTestUtils):
+class SeriesIndexTests(
+    SeriesIndexMixin,
+    PandasOnSparkTestCase,
+    SQLTestUtils,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/series/test_missing_data.py
+++ b/python/pyspark/pandas/tests/series/test_missing_data.py
@@ -20,7 +20,7 @@ import numpy as np
 import pandas as pd
 
 from pyspark import pandas as ps
-from pyspark.testing.pandasutils import ComparisonTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
 
 
@@ -224,7 +224,11 @@ class SeriesMissingDataMixin:
         self.assert_eq(pdf, psdf)
 
 
-class SeriesMissingDataTests(SeriesMissingDataMixin, ComparisonTestBase, SQLTestUtils):
+class SeriesMissingDataTests(
+    SeriesMissingDataMixin,
+    PandasOnSparkTestCase,
+    SQLTestUtils,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/series/test_series.py
+++ b/python/pyspark/pandas/tests/series/test_series.py
@@ -774,7 +774,11 @@ class SeriesTestsMixin:
             psser.transform(lambda x: x + 1, axis=1)
 
 
-class SeriesTests(SeriesTestsMixin, PandasOnSparkTestCase, SQLTestUtils):
+class SeriesTests(
+    SeriesTestsMixin,
+    PandasOnSparkTestCase,
+    SQLTestUtils,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/series/test_sort.py
+++ b/python/pyspark/pandas/tests/series/test_sort.py
@@ -20,7 +20,7 @@ import numpy as np
 import pandas as pd
 
 from pyspark import pandas as ps
-from pyspark.testing.pandasutils import ComparisonTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
 
 
@@ -138,7 +138,11 @@ class SeriesSortMixin:
             ps.from_pandas(pser1).searchsorted(1.1, side="middle")
 
 
-class SeriesSortTests(SeriesSortMixin, ComparisonTestBase, SQLTestUtils):
+class SeriesSortTests(
+    SeriesSortMixin,
+    PandasOnSparkTestCase,
+    SQLTestUtils,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/series/test_stat.py
+++ b/python/pyspark/pandas/tests/series/test_stat.py
@@ -21,7 +21,7 @@ import numpy as np
 import pandas as pd
 
 from pyspark import pandas as ps
-from pyspark.testing.pandasutils import ComparisonTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
 
 
@@ -694,7 +694,11 @@ class SeriesStatMixin:
             ps.Series(["a", "b", "c"]).sem()
 
 
-class SeriesStatTests(SeriesStatMixin, ComparisonTestBase, SQLTestUtils):
+class SeriesStatTests(
+    SeriesStatMixin,
+    PandasOnSparkTestCase,
+    SQLTestUtils,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/series/test_string_ops_adv.py
+++ b/python/pyspark/pandas/tests/series/test_string_ops_adv.py
@@ -213,7 +213,11 @@ class SeriesStringOpsAdvMixin:
             self.check_func(lambda x: x.str.get_dummies())
 
 
-class SeriesStringOpsAdvTests(SeriesStringOpsAdvMixin, PandasOnSparkTestCase, SQLTestUtils):
+class SeriesStringOpsAdvTests(
+    SeriesStringOpsAdvMixin,
+    PandasOnSparkTestCase,
+    SQLTestUtils,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/series/test_string_ops_basic.py
+++ b/python/pyspark/pandas/tests/series/test_string_ops_basic.py
@@ -167,7 +167,11 @@ class SeriesStringOpsMixin:
         self.check_func(lambda x: x.str.count("WH", flags=re.IGNORECASE))
 
 
-class SeriesStringOpsTests(SeriesStringOpsMixin, PandasOnSparkTestCase, SQLTestUtils):
+class SeriesStringOpsTests(
+    SeriesStringOpsMixin,
+    PandasOnSparkTestCase,
+    SQLTestUtils,
+):
     pass
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
1, remove unused imports;
2, only define the test datasets once in the vanilla side, so that won't need to define it again in the parity tests;


### Why are the changes needed?
code clean up


### Does this PR introduce _any_ user-facing change?
no, test-only


### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no