### PR TITLE
[SPARK-46906][SS] Add a check for stateful operator change for streaming

### DIFF
--- a/common/utils/src/main/resources/error/error-classes.json
+++ b/common/utils/src/main/resources/error/error-classes.json
@@ -3313,7 +3313,7 @@
   },
   "STREAMING_STATEFUL_OPERATOR_NOT_MATCH_IN_STATE_METADATA" : {
     "message" : [
-      "Streaming stateful operator name does not match with the operator in state metadata. This likely to happen when user changes stateful operator of existing streaming query.",
+      "Streaming stateful operator name does not match with the operator in state metadata. This likely to happen when user adds/removes/changes stateful operator of existing streaming query.",
       "Stateful operators in the metadata: [<OpsInMetadataSeq>]; Stateful operators in current batch: [<OpsInCurBatchSeq>]."
     ],
     "sqlState" : "42K03"

--- a/common/utils/src/main/resources/error/error-classes.json
+++ b/common/utils/src/main/resources/error/error-classes.json
@@ -3314,7 +3314,7 @@
   "STREAMING_STATEFUL_OPERATOR_NOT_MATCH_IN_STATE_METADATA" : {
     "message" : [
       "Streaming stateful operator name does not match with the operator in state metadata. This likely to happen when user changes stateful operator of existing streaming query.",
-      "Stateful operators in the metadata: [<OpsInMetadataSeq>]; Stateful operators in current batch: [<OpsInCurBatchSeq>]"
+      "Stateful operators in the metadata: [<OpsInMetadataSeq>]; Stateful operators in current batch: [<OpsInCurBatchSeq>]."
     ],
     "sqlState" : "42K03"
   },

--- a/common/utils/src/main/resources/error/error-classes.json
+++ b/common/utils/src/main/resources/error/error-classes.json
@@ -3317,6 +3317,12 @@
     ],
     "sqlState" : "XXKST"
   },
+  "STREAMING_STATEFUL_OPERATOR_NOT_MATCH_IN_STATE_METADATA" : {
+    "message" : [
+      "Streaming stateful operator name does not match with the operator in state metadata with the same operator id (id: <operatorId>). Stateful Operator name for current batch: <currentOperatorName>; Operator name in the state metadata: <stateMetadataOperatorName>."
+    ],
+    "sqlState" : "55019"
+  },
   "SUM_OF_LIMIT_AND_OFFSET_EXCEEDS_MAX_INT" : {
     "message" : [
       "The sum of the LIMIT clause and the OFFSET clause must not be greater than the maximum 32-bit integer value (2,147,483,647) but found limit = <limit>, offset = <offset>."
@@ -7443,4 +7449,4 @@
     ],
     "sqlState" : "P0001"
   }
-}
+},

--- a/common/utils/src/main/resources/error/error-classes.json
+++ b/common/utils/src/main/resources/error/error-classes.json
@@ -3313,8 +3313,25 @@
   },
   "STREAMING_STATEFUL_OPERATOR_NOT_MATCH_IN_STATE_METADATA" : {
     "message" : [
-      "Streaming stateful operator name does not match with the operator in state metadata with the same operator id (id: <operatorId>). This likely to happen when user changes stateful operator of existing streaming query. Stateful Operator name for current batch: <currentOperatorName>; Operator name in the state metadata: <stateMetadataOperatorName>."
+      "Streaming stateful operator name does not match with the operator in state metadata. This likely to happen when user changes stateful operator of existing streaming query."
     ],
+    "subClass" : {
+      "MISS_IN_CURRENT_BATCH" : {
+        "message" : [
+          "Operator exists in state metadata but not in current batch. Likely user has removed an operator after restart. Stateful Operator id in state metadata: <operatorId>; Operator name in state metadata: <operatorName>. <hint>"
+        ]
+      },
+      "MISS_IN_METADATA" : {
+        "message" : [
+          "Operator exists in current batch but not in state metadata. Likely user added a new operator after restart. Stateful Operator id for current batch: <operatorId>; Operator name for current batch: <operatorName>. <hint>"
+        ]
+      },
+      "NAME_NOT_MATCH" : {
+        "message" : [
+          "Found operator id in state metadata, but name not match. Likely user replace the operator after restart. Stateful Operator id for current batch: <operatorId>; Operator name for current batch: <operatorName>. Operator name in the state metadata: <hint>."
+        ]
+      }
+    },
     "sqlState" : "42K03"
   },
   "STREAM_FAILED" : {

--- a/common/utils/src/main/resources/error/error-classes.json
+++ b/common/utils/src/main/resources/error/error-classes.json
@@ -3311,17 +3311,17 @@
     ],
     "sqlState" : "42601"
   },
+  "STREAMING_STATEFUL_OPERATOR_NOT_MATCH_IN_STATE_METADATA" : {
+    "message" : [
+      "Streaming stateful operator name does not match with the operator in state metadata with the same operator id (id: <operatorId>). This likely to happen when user changes stateful operator of existing streaming query. Stateful Operator name for current batch: <currentOperatorName>; Operator name in the state metadata: <stateMetadataOperatorName>."
+    ],
+    "sqlState" : "42K03"
+  },
   "STREAM_FAILED" : {
     "message" : [
       "Query [id = <id>, runId = <runId>] terminated with exception: <message>"
     ],
     "sqlState" : "XXKST"
-  },
-  "STREAMING_STATEFUL_OPERATOR_NOT_MATCH_IN_STATE_METADATA" : {
-    "message" : [
-      "Streaming stateful operator name does not match with the operator in state metadata with the same operator id (id: <operatorId>). Stateful Operator name for current batch: <currentOperatorName>; Operator name in the state metadata: <stateMetadataOperatorName>."
-    ],
-    "sqlState" : "42K03"
   },
   "SUM_OF_LIMIT_AND_OFFSET_EXCEEDS_MAX_INT" : {
     "message" : [
@@ -7449,4 +7449,4 @@
     ],
     "sqlState" : "P0001"
   }
-},
+}

--- a/common/utils/src/main/resources/error/error-classes.json
+++ b/common/utils/src/main/resources/error/error-classes.json
@@ -3321,7 +3321,7 @@
     "message" : [
       "Streaming stateful operator name does not match with the operator in state metadata with the same operator id (id: <operatorId>). Stateful Operator name for current batch: <currentOperatorName>; Operator name in the state metadata: <stateMetadataOperatorName>."
     ],
-    "sqlState" : "55019"
+    "sqlState" : "42K03"
   },
   "SUM_OF_LIMIT_AND_OFFSET_EXCEEDS_MAX_INT" : {
     "message" : [

--- a/common/utils/src/main/resources/error/error-classes.json
+++ b/common/utils/src/main/resources/error/error-classes.json
@@ -3313,25 +3313,9 @@
   },
   "STREAMING_STATEFUL_OPERATOR_NOT_MATCH_IN_STATE_METADATA" : {
     "message" : [
-      "Streaming stateful operator name does not match with the operator in state metadata. This likely to happen when user changes stateful operator of existing streaming query."
+      "Streaming stateful operator name does not match with the operator in state metadata. This likely to happen when user changes stateful operator of existing streaming query.",
+      "Stateful operators in the metadata: [<OpsInMetadataSeq>]; Stateful operators in current batch: [<OpsInCurBatchSeq>]"
     ],
-    "subClass" : {
-      "MISS_IN_CURRENT_BATCH" : {
-        "message" : [
-          "Operator exists in state metadata but not in current batch. Likely user has removed an operator after restart. Stateful Operator id in state metadata: <operatorId>; Operator name in state metadata: <operatorName>. <hint>"
-        ]
-      },
-      "MISS_IN_METADATA" : {
-        "message" : [
-          "Operator exists in current batch but not in state metadata. Likely user added a new operator after restart. Stateful Operator id for current batch: <operatorId>; Operator name for current batch: <operatorName>. <hint>"
-        ]
-      },
-      "NAME_NOT_MATCH" : {
-        "message" : [
-          "Found operator id in state metadata, but name not match. Likely user replace the operator after restart. Stateful Operator id for current batch: <operatorId>; Operator name for current batch: <operatorName>. Operator name in the state metadata: <hint>."
-        ]
-      }
-    },
     "sqlState" : "42K03"
   },
   "STREAM_FAILED" : {

--- a/docs/sql-error-conditions.md
+++ b/docs/sql-error-conditions.md
@@ -2085,11 +2085,13 @@ The checkpoint seems to be only run with older Spark version(s). Run the streami
 
 '`<optionName>`' must be specified.
 
-### STREAMING_STATEFUL_OPERATOR_NOT_MATCH_IN_STATE_METADATA
+### [STREAMING_STATEFUL_OPERATOR_NOT_MATCH_IN_STATE_METADATA](sql-error-conditions-streaming-stateful-operator-not-match-in-state-metadata-error-class.html)
 
 [SQLSTATE: 42K03](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
 
-Streaming stateful operator name does not match with the operator in state metadata with the same operator id (id: `<operatorId>`). This likely to happen when user changes stateful operator of existing streaming query. Stateful Operator name for current batch: `<currentOperatorName>`; Operator name in the state metadata: `<stateMetadataOperatorName>`.
+Streaming stateful operator name does not match with the operator in state metadata. This likely to happen when user changes stateful operator of existing streaming query.
+
+For more details see [STREAMING_STATEFUL_OPERATOR_NOT_MATCH_IN_STATE_METADATA](sql-error-conditions-streaming-stateful-operator-not-match-in-state-metadata-error-class.html)
 
 ### STREAM_FAILED
 

--- a/docs/sql-error-conditions.md
+++ b/docs/sql-error-conditions.md
@@ -2091,6 +2091,12 @@ The checkpoint seems to be only run with older Spark version(s). Run the streami
 
 Query [id = `<id>`, runId = `<runId>`] terminated with exception: `<message>`
 
+### STREAMING_STATEFUL_OPERATOR_NOT_MATCH_IN_STATE_METADATA
+
+* [SQLSTATE: 42K03](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Streaming stateful operator name does not match with the operator in state metadata with the same operator id (id: `<operatorId>`). Stateful Operator name for current batch: `<currentOperatorName>`; Operator name in the state metadata: `<stateMetadataOperatorName>`.
+
 ### SUM_OF_LIMIT_AND_OFFSET_EXCEEDS_MAX_INT
 
 [SQLSTATE: 22003](sql-error-conditions-sqlstates.html#class-22-data-exception)

--- a/docs/sql-error-conditions.md
+++ b/docs/sql-error-conditions.md
@@ -2085,17 +2085,17 @@ The checkpoint seems to be only run with older Spark version(s). Run the streami
 
 '`<optionName>`' must be specified.
 
+### STREAMING_STATEFUL_OPERATOR_NOT_MATCH_IN_STATE_METADATA
+
+[SQLSTATE: 42K03](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+Streaming stateful operator name does not match with the operator in state metadata with the same operator id (id: `<operatorId>`). This likely to happen when user changes stateful operator of existing streaming query. Stateful Operator name for current batch: `<currentOperatorName>`; Operator name in the state metadata: `<stateMetadataOperatorName>`.
+
 ### STREAM_FAILED
 
 [SQLSTATE: XXKST](sql-error-conditions-sqlstates.html#class-XX-internal-error)
 
 Query [id = `<id>`, runId = `<runId>`] terminated with exception: `<message>`
-
-### STREAMING_STATEFUL_OPERATOR_NOT_MATCH_IN_STATE_METADATA
-
-* [SQLSTATE: 42K03](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
-
-Streaming stateful operator name does not match with the operator in state metadata with the same operator id (id: `<operatorId>`). Stateful Operator name for current batch: `<currentOperatorName>`; Operator name in the state metadata: `<stateMetadataOperatorName>`.
 
 ### SUM_OF_LIMIT_AND_OFFSET_EXCEEDS_MAX_INT
 

--- a/docs/sql-error-conditions.md
+++ b/docs/sql-error-conditions.md
@@ -2085,13 +2085,12 @@ The checkpoint seems to be only run with older Spark version(s). Run the streami
 
 '`<optionName>`' must be specified.
 
-### [STREAMING_STATEFUL_OPERATOR_NOT_MATCH_IN_STATE_METADATA](sql-error-conditions-streaming-stateful-operator-not-match-in-state-metadata-error-class.html)
+### STREAMING_STATEFUL_OPERATOR_NOT_MATCH_IN_STATE_METADATA
 
 [SQLSTATE: 42K03](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
 
 Streaming stateful operator name does not match with the operator in state metadata. This likely to happen when user changes stateful operator of existing streaming query.
-
-For more details see [STREAMING_STATEFUL_OPERATOR_NOT_MATCH_IN_STATE_METADATA](sql-error-conditions-streaming-stateful-operator-not-match-in-state-metadata-error-class.html)
+Stateful operators in the metadata: [`<OpsInMetadataSeq>`]; Stateful operators in current batch: [`<OpsInCurBatchSeq>`]
 
 ### STREAM_FAILED
 

--- a/docs/sql-error-conditions.md
+++ b/docs/sql-error-conditions.md
@@ -2090,7 +2090,7 @@ The checkpoint seems to be only run with older Spark version(s). Run the streami
 [SQLSTATE: 42K03](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
 
 Streaming stateful operator name does not match with the operator in state metadata. This likely to happen when user changes stateful operator of existing streaming query.
-Stateful operators in the metadata: [`<OpsInMetadataSeq>`]; Stateful operators in current batch: [`<OpsInCurBatchSeq>`]
+Stateful operators in the metadata: [`<OpsInMetadataSeq>`]; Stateful operators in current batch: [`<OpsInCurBatchSeq>`].
 
 ### STREAM_FAILED
 

--- a/docs/sql-error-conditions.md
+++ b/docs/sql-error-conditions.md
@@ -2089,7 +2089,7 @@ The checkpoint seems to be only run with older Spark version(s). Run the streami
 
 [SQLSTATE: 42K03](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
 
-Streaming stateful operator name does not match with the operator in state metadata. This likely to happen when user changes stateful operator of existing streaming query.
+Streaming stateful operator name does not match with the operator in state metadata. This likely to happen when user adds/removes/changes stateful operator of existing streaming query.
 Stateful operators in the metadata: [`<OpsInMetadataSeq>`]; Stateful operators in current batch: [`<OpsInCurBatchSeq>`].
 
 ### STREAM_FAILED

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -1703,16 +1703,14 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
   }
 
   def statefulOperatorNotMatchInStateMetadataError(
-      subClass: String,
-      operatorId: Long,
-      operatorName: String, hint: String):
+      opsInMetadataSeq: Seq[String],
+      opsInCurBatchSeq: Seq[String]):
     SparkRuntimeException = {
       new SparkRuntimeException(
-        errorClass = s"STREAMING_STATEFUL_OPERATOR_NOT_MATCH_IN_STATE_METADATA.$subClass",
+        errorClass = s"STREAMING_STATEFUL_OPERATOR_NOT_MATCH_IN_STATE_METADATA",
         messageParameters = Map(
-          "operatorId" -> operatorId.toString,
-          "operatorName" -> operatorName,
-          "hint" -> hint)
+          "OpsInMetadataSeq" -> opsInMetadataSeq.mkString(", "),
+          "OpsInCurBatchSeq" -> opsInCurBatchSeq.mkString(", "))
       )
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -1703,15 +1703,16 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
   }
 
   def statefulOperatorNotMatchInStateMetadataError(
+      subClass: String,
       operatorId: Long,
-      currentOperatorName: String, stateMetadataOperatorName: String):
+      operatorName: String, hint: String):
     SparkRuntimeException = {
       new SparkRuntimeException(
-        errorClass = "STREAMING_STATEFUL_OPERATOR_NOT_MATCH_IN_STATE_METADATA",
+        errorClass = s"STREAMING_STATEFUL_OPERATOR_NOT_MATCH_IN_STATE_METADATA.$subClass",
         messageParameters = Map(
           "operatorId" -> operatorId.toString,
-          "currentOperatorName" -> currentOperatorName,
-          "stateMetadataOperatorName" -> stateMetadataOperatorName)
+          "operatorName" -> operatorName,
+          "hint" -> hint)
       )
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -1702,6 +1702,19 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
       new NoSuchElementException("State is either not defined or has already been removed")
   }
 
+  def statefulOperatorNotMatchInStateMetadataError(
+      operatorId: Long,
+      currentOperatorName: String, stateMetadataOperatorName: String):
+    SparkRuntimeException = {
+      new SparkRuntimeException(
+        errorClass = "STREAMING_STATEFUL_OPERATOR_NOT_MATCH_IN_STATE_METADATA",
+        messageParameters = Map(
+          "operatorId" -> operatorId.toString,
+          "currentOperatorName" -> currentOperatorName,
+          "stateMetadataOperatorName" -> stateMetadataOperatorName)
+      )
+  }
+
   def cannotSetTimeoutDurationError(): SparkUnsupportedOperationException = {
     new SparkUnsupportedOperationException(errorClass = "_LEGACY_ERROR_TEMP_2203")
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -1703,15 +1703,16 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
   }
 
   def statefulOperatorNotMatchInStateMetadataError(
-      opsInMetadataSeq: Seq[String],
-      opsInCurBatchSeq: Seq[String]):
-    SparkRuntimeException = {
-      new SparkRuntimeException(
-        errorClass = s"STREAMING_STATEFUL_OPERATOR_NOT_MATCH_IN_STATE_METADATA",
-        messageParameters = Map(
-          "OpsInMetadataSeq" -> opsInMetadataSeq.mkString(", "),
-          "OpsInCurBatchSeq" -> opsInCurBatchSeq.mkString(", "))
-      )
+    opsInMetadataSeq: Map[Long, String],
+    opsInCurBatchSeq: Map[Long, String]): SparkRuntimeException = {
+    def formatPairString(pair: (Long, String)): String
+    = s"(OperatorId: ${pair._1} -> OperatorName: ${pair._2})"
+    new SparkRuntimeException(
+      errorClass = s"STREAMING_STATEFUL_OPERATOR_NOT_MATCH_IN_STATE_METADATA",
+      messageParameters = Map(
+        "OpsInMetadataSeq" -> opsInMetadataSeq.map(formatPairString).mkString(", "),
+        "OpsInCurBatchSeq" -> opsInCurBatchSeq.map(formatPairString).mkString(", "))
+    )
   }
 
   def cannotSetTimeoutDurationError(): SparkUnsupportedOperationException = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -1703,8 +1703,8 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
   }
 
   def statefulOperatorNotMatchInStateMetadataError(
-    opsInMetadataSeq: Map[Long, String],
-    opsInCurBatchSeq: Map[Long, String]): SparkRuntimeException = {
+      opsInMetadataSeq: Map[Long, String],
+      opsInCurBatchSeq: Map[Long, String]): SparkRuntimeException = {
     def formatPairString(pair: (Long, String)): String
     = s"(OperatorId: ${pair._1} -> OperatorName: ${pair._2})"
     new SparkRuntimeException(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/state/metadata/StateMetadataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/state/metadata/StateMetadataSource.scala
@@ -186,7 +186,7 @@ class StateMetadataPartitionReader(
     } else Array.empty
   }
 
-  private def allOperatorStateMetadata: Array[OperatorStateMetadata] = {
+  private[sql] def allOperatorStateMetadata: Array[OperatorStateMetadata] = {
     val stateDir = new Path(checkpointLocation, "state")
     val opIds = fileManager
       .list(stateDir, pathNameCanBeParsedAsLongFilter).map(f => pathToLong(f.getPath)).sorted

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/statefulOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/statefulOperators.scala
@@ -240,7 +240,7 @@ trait StateStoreWriter extends StatefulOperator with PythonSQLMetrics { self: Sp
   }
 
   /** Name to output in [[StreamingOperatorProgress]] to identify operator type */
-  protected def shortName: String = "defaultName"
+  def shortName: String = "defaultName"
 
   /**
    * Should the MicroBatchExecution run another batch based on this stateful operator and the

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/OperatorStateMetadataSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/OperatorStateMetadataSuite.scala
@@ -274,7 +274,7 @@ class OperatorStateMetadataSuite extends StreamTest with SharedSparkSession {
         testStream(restartStream, Update)(
           StartStream(checkpointLocation = checkpointDir.toString),
           AddData(inputData, 3),
-          ExpectFailure[SparkRuntimeException] { t => {
+          ExpectFailure[SparkRuntimeException] { t =>
             def formatPairString(pair: (Long, String)): String =
               s"(OperatorId: ${pair._1} -> OperatorName: ${pair._2})"
 
@@ -286,7 +286,7 @@ class OperatorStateMetadataSuite extends StreamTest with SharedSparkSession {
                 "OpsInMetadataSeq" -> opsInMetadataSeq.map(formatPairString).mkString(", "),
                 "OpsInCurBatchSeq" -> opsInCurBatchSeq.map(formatPairString).mkString(", ")))
           }
-          })
+        )
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/OperatorStateMetadataSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/OperatorStateMetadataSuite.scala
@@ -29,7 +29,6 @@ import org.apache.spark.sql.streaming.OutputMode.{Complete, Update}
 import org.apache.spark.sql.test.SharedSparkSession
 
 class OperatorStateMetadataSuite extends StreamTest with SharedSparkSession {
-
   import testImplicits._
 
   private lazy val hadoopConf = spark.sessionState.newHadoopConf()
@@ -46,6 +45,7 @@ class OperatorStateMetadataSuite extends StreamTest with SharedSparkSession {
     assert(operatorMetadata.operatorInfo == expectedMetadata.operatorInfo &&
       operatorMetadata.stateStoreInfo.sameElements(expectedMetadata.stateStoreInfo))
   }
+
   test("Serialize and deserialize stateful operator metadata") {
     withTempDir { checkpointDir =>
       val statePath = new Path(checkpointDir.toString, "state/0")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/OperatorStateMetadataSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/OperatorStateMetadataSuite.scala
@@ -266,7 +266,7 @@ class OperatorStateMetadataSuite extends StreamTest with SharedSparkSession {
 
       def checkOpChangeError(opName: String, ex: Throwable): Unit = {
         checkError(ex.asInstanceOf[SparkRuntimeException],
-          "STREAMING_STATEFUL_OPERATOR_NOT_MATCH_IN_STATE_METADATA", "55019",
+          "STREAMING_STATEFUL_OPERATOR_NOT_MATCH_IN_STATE_METADATA", "42K03",
           Map("operatorId" -> 0.toString,
             "currentOperatorName" -> opName,
             "stateMetadataOperatorName" -> "dedupeWithinWatermark")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Currently user will get a misleading error as org.apache.spark.sql.execution.streaming.state.StateSchemaNotCompatible if restarting query in the same checkpoint location and changing their stateful operator. This PR catches such errors and throws a new error with informative message.

After physical planning, before execution phase, we will read from state metadata with the current operator id to fetch operator name of committed batch with the same operator id. If operator name does not match, throws the error.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
The current error message is misleading to users. We should provide users with message that can guide them to the real root cause of error.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Unit tests.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No