### PR TITLE
[SPARK-46904][UI] Fix display issue of History UI summary

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryPage.scala
@@ -86,7 +86,7 @@ private[history] class HistoryPage(parent: HistoryServer) extends WebUIPage("") 
       </div>
 
     val pageLink =
-      <div>
+      <div class="container-fluid">
         <a href={makePageLink(request, !requestedIncomplete)}>
           {
             if (requestedIncomplete) {

--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryPage.scala
@@ -35,69 +35,76 @@ private[history] class HistoryPage(parent: HistoryServer) extends WebUIPage("") 
     val eventLogsUnderProcessCount = parent.getEventLogsUnderProcess()
     val lastUpdatedTime = parent.getLastUpdatedTime()
     val providerConfig = parent.getProviderConfig()
-    val content =
-      <script type="module"
-              src={UIUtils.prependBaseUri(request, "/static/historypage-common.js")} /> ++
-      <script type="module" src={UIUtils.prependBaseUri(request, "/static/utils.js")} />
-      <div>
-          <div class="container-fluid">
-            <ul class="list-unstyled">
-              {providerConfig.map { case (k, v) => <li><strong>{k}:</strong> {v}</li> }}
-            </ul>
-            {
-            if (eventLogsUnderProcessCount > 0) {
-              <p>There are {eventLogsUnderProcessCount} event log(s) currently being
-                processed which may result in additional applications getting listed on this page.
-                Refresh the page to view updates. </p>
-            }
-            }
 
-            {
-            if (lastUpdatedTime > 0) {
-              <p>Last updated: <span id="last-updated">{lastUpdatedTime}</span></p>
-            }
-            }
+    val summary =
+      <div class="container-fluid">
+        <ul class="list-unstyled">
+          {providerConfig.map { case (k, v) => <li><strong>{k}:</strong> {v}</li> }}
+        </ul>
+        {
+          if (eventLogsUnderProcessCount > 0) {
+          <p>There are {eventLogsUnderProcessCount} event log(s) currently being
+            processed which may result in additional applications getting listed on this page.
+            Refresh the page to view updates. </p>
+          } else Seq.empty
 
-            {
-            <p>Client local time zone: <span id="time-zone"></span></p>
-            }
-
-            {
-            if (displayApplications) {
-              val js =
-                s"""
-                   |${formatImportJavaScript(request, "/static/historypage.js", "setAppLimit")}
-                   |
-                   |setAppLimit(${parent.maxApplications});
-                   |""".stripMargin
-              <script src={UIUtils.prependBaseUri(
-                request, "/static/dataTables.rowsGroup.js")}></script> ++
-                <div id="history-summary"></div> ++
-                <script type="module"
-                        src={UIUtils.prependBaseUri(request, "/static/historypage.js")}></script> ++
-                <script type="module">{Unparsed(js)}</script>
-            } else if (requestedIncomplete) {
-              <h4>No incomplete applications found!</h4>
-            } else if (eventLogsUnderProcessCount > 0) {
-              <h4>No completed applications found!</h4>
-            } else {
-              <h4>No completed applications found!</h4> ++ parent.emptyListingHtml()
-            }
-            }
-
-            <a href={makePageLink(request, !requestedIncomplete)}>
-              {
-              if (requestedIncomplete) {
-                "Back to completed applications"
-              } else {
-                "Show incomplete applications"
-              }
-              }
-            </a>
-            <p><a href={UIUtils.prependBaseUri(request, "/logPage/?self&logType=out")}>
-              Show server log</a></p>
-          </div>
+        }
+        {
+          if (lastUpdatedTime > 0) {
+            <p>Last updated: <span id="last-updated">{lastUpdatedTime}</span></p>
+          } else Seq.empty
+        }
+        {
+          <p>Client local time zone: <span id="time-zone"></span></p>
+        }
       </div>
+
+    val appList =
+      <div class="container-fluid">
+        {
+          val js =
+            s"""
+               |${formatImportJavaScript(request, "/static/historypage.js", "setAppLimit")}
+               |
+               |setAppLimit(${parent.maxApplications});
+               |""".stripMargin
+
+          if (displayApplications) {
+            <script src={UIUtils.prependBaseUri(
+              request, "/static/dataTables.rowsGroup.js")}></script> ++
+            <script type="module" src={UIUtils.prependBaseUri(
+              request, "/static/historypage.js")} ></script> ++
+            <script type="module">{Unparsed(js)}</script> ++ <div id="history-summary"></div>
+          } else if (requestedIncomplete) {
+            <h4>No incomplete applications found!</h4>
+          } else if (eventLogsUnderProcessCount > 0) {
+            <h4>No completed applications found!</h4>
+          } else {
+            <h4>No completed applications found!</h4> ++ parent.emptyListingHtml()
+          }
+        }
+      </div>
+
+    val pageLink =
+      <div>
+        <a href={makePageLink(request, !requestedIncomplete)}>
+          {
+            if (requestedIncomplete) {
+              "Back to completed applications"
+            } else {
+              "Show incomplete applications"
+            }
+          }
+        </a>
+        <p><a href={UIUtils.prependBaseUri(request, "/logPage/?self&logType=out")}>
+          Show server log</a></p>
+      </div>
+    val content =
+      <script type="module" src={UIUtils.prependBaseUri(
+        request, "/static/historypage-common.js")}></script> ++
+      <script type="module" src={UIUtils.prependBaseUri(
+        request, "/static/utils.js")}></script> ++
+      summary ++ appList ++ pageLink
     UIUtils.basicSparkPage(request, content, "History Server", true)
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR segments the content definition of the History Page into `summary/table/links` to make it much more elegant. The previous giant variable seems to be a perfect place for bugs to lurk. The problem here is a kinda upstream issue that rendered one single-tagged `<script .../>` wrongly to an unclosed paired tag `<script>,` which missed a close tag.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

bugfix
### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

no
### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
locally tested

![image](https://github.com/apache/spark/assets/8326978/b52c0e03-3890-4659-b457-0848aa45a6be)


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
no