### PR TITLE
[SPARK-46890][SQL] Fix CSV parsing bug with existence default values and column pruning

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
@@ -292,16 +292,12 @@ class CSVOptions(
    * We disable column pruning when there are any column defaults, instead preferring to reach in
    * each row and then post-process it to substitute the default values after.
    */
-  def isColumnPruningEnabled(schema: StructType): Boolean = {
-    var result = !multiLine && columnPruning
-    if (parameters != null) {
-      result = getBool(COLUMN_PRUNING, result)
-    }
-    if (schema.exists(_.metadata.contains(EXISTS_DEFAULT_COLUMN_METADATA_KEY))) {
-      result = false
-    }
-    result
-  }
+  def isColumnPruningEnabled(schema: StructType): Boolean =
+    isColumnPruningOptionEnabled &&
+      schema.exists(_.metadata.contains(EXISTS_DEFAULT_COLUMN_METADATA_KEY))
+
+  private val isColumnPruningOptionEnabled: Boolean =
+    getBool(COLUMN_PRUNING, !multiLine && columnPruning)
 
   def asWriterSettings: CsvWriterSettings = {
     val writerSettings = new CsvWriterSettings()

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
@@ -292,9 +292,16 @@ class CSVOptions(
    * We disable column pruning when there are any column defaults, instead preferring to reach in
    * each row and then post-process it to substitute the default values after.
    */
-  def isColumnPruningEnabled(schema: StructType): Boolean =
-    getBool(COLUMN_PRUNING, !multiLine && columnPruning) &&
-      !schema.exists(_.metadata.contains(EXISTS_DEFAULT_COLUMN_METADATA_KEY))
+  def isColumnPruningEnabled(schema: StructType): Boolean = {
+    var result = !multiLine && columnPruning
+    if (parameters != null) {
+      result = getBool(COLUMN_PRUNING, result)
+    }
+    if (schema.exists(_.metadata.contains(EXISTS_DEFAULT_COLUMN_METADATA_KEY))) {
+      result = false
+    }
+    result
+  }
 
   def asWriterSettings: CsvWriterSettings = {
     val writerSettings = new CsvWriterSettings()

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
@@ -280,23 +280,24 @@ class CSVOptions(
     .getOrElse(UNESCAPED_QUOTE_HANDLING, "STOP_AT_DELIMITER").toUpperCase(Locale.ROOT))
 
   /**
-   * The column pruning feature can be enabled either via the CSV option `columnPruning` or
-   * in non-multiline mode via initialization of CSV options by the SQL config:
-   * `spark.sql.csv.parser.columnPruning.enabled`.
-   * The feature is disabled in the `multiLine` mode because of the issue:
-   * https://github.com/uniVocity/univocity-parsers/issues/529
    */
   val isColumnPruningEnabled: Boolean = getBool(COLUMN_PRUNING, !multiLine && columnPruning)
 
   /**
    * Returns true if column pruning is enabled and there are no existence column default values in
-   * the [[schema]]. This is useful when we want to disable column pruning when there are such
-   * defaults, instead preferring to reach in each row and then post-process it to substitute the
-   * default values after.
+   * the [[schema]].
+   *
+   * The column pruning feature can be enabled either via the CSV option `columnPruning` or
+   * in non-multiline mode via initialization of CSV options by the SQL config:
+   * `spark.sql.csv.parser.columnPruning.enabled`.
+   * The feature is disabled in the `multiLine` mode because of the issue:
+   * https://github.com/uniVocity/univocity-parsers/issues/529
+   *
+   * We disable column pruning when there are any column defaults, instead preferring to reach in
+   * each row and then post-process it to substitute the default values after.
    */
-  def isColumnPruningEnabledAndNoColumnDefaults(schema: StructType): Boolean =
-    isColumnPruningEnabled &&
-      !schema.exists(_.metadata.contains(EXISTS_DEFAULT_COLUMN_METADATA_KEY))
+  def isColumnPruningEnabled(schema: StructType): Boolean = isColumnPruningEnabled &&
+    !schema.exists(_.metadata.contains(EXISTS_DEFAULT_COLUMN_METADATA_KEY))
 
   def asWriterSettings: CsvWriterSettings = {
     val writerSettings = new CsvWriterSettings()

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
@@ -280,10 +280,6 @@ class CSVOptions(
     .getOrElse(UNESCAPED_QUOTE_HANDLING, "STOP_AT_DELIMITER").toUpperCase(Locale.ROOT))
 
   /**
-   */
-  val isColumnPruningEnabled: Boolean = getBool(COLUMN_PRUNING, !multiLine && columnPruning)
-
-  /**
    * Returns true if column pruning is enabled and there are no existence column default values in
    * the [[schema]].
    *
@@ -296,8 +292,9 @@ class CSVOptions(
    * We disable column pruning when there are any column defaults, instead preferring to reach in
    * each row and then post-process it to substitute the default values after.
    */
-  def isColumnPruningEnabled(schema: StructType): Boolean = isColumnPruningEnabled &&
-    !schema.exists(_.metadata.contains(EXISTS_DEFAULT_COLUMN_METADATA_KEY))
+  def isColumnPruningEnabled(schema: StructType): Boolean =
+    getBool(COLUMN_PRUNING, !multiLine && columnPruning) &&
+      !schema.exists(_.metadata.contains(EXISTS_DEFAULT_COLUMN_METADATA_KEY))
 
   def asWriterSettings: CsvWriterSettings = {
     val writerSettings = new CsvWriterSettings()

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
@@ -294,7 +294,7 @@ class CSVOptions(
    */
   def isColumnPruningEnabled(schema: StructType): Boolean =
     isColumnPruningOptionEnabled &&
-      schema.exists(_.metadata.contains(EXISTS_DEFAULT_COLUMN_METADATA_KEY))
+      !schema.exists(_.metadata.contains(EXISTS_DEFAULT_COLUMN_METADATA_KEY))
 
   private val isColumnPruningOptionEnabled: Boolean =
     getBool(COLUMN_PRUNING, !multiLine && columnPruning)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/UnivocityParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/UnivocityParser.scala
@@ -29,7 +29,6 @@ import org.apache.spark.sql.catalyst.{InternalRow, NoopFilters, OrderedFilters}
 import org.apache.spark.sql.catalyst.expressions.{Cast, EmptyRow, ExprUtils, GenericInternalRow, Literal}
 import org.apache.spark.sql.catalyst.util._
 import org.apache.spark.sql.catalyst.util.LegacyDateFormats.FAST_DATE_FORMAT
-import org.apache.spark.sql.catalyst.util.ResolveDefaultColumns._
 import org.apache.spark.sql.errors.{ExecutionErrors, QueryExecutionErrors}
 import org.apache.spark.sql.internal.{LegacyBehaviorPolicy, SQLConf}
 import org.apache.spark.sql.sources.Filter
@@ -71,8 +70,8 @@ class UnivocityParser(
   // positions. Generally assigned by input configuration options, except when input column(s) have
   // default values, in which case we omit the explicit indexes in order to know how many tokens
   // were present in each line instead.
-  private def columnPruning: Boolean = options.isColumnPruningEnabled &&
-    !requiredSchema.exists(_.metadata.contains(EXISTS_DEFAULT_COLUMN_METADATA_KEY))
+  private def columnPruning: Boolean =
+    options.isColumnPruningEnabledAndNoColumnDefaults(requiredSchema)
 
   // When column pruning is enabled, the parser only parses the required columns based on
   // their positions in the data schema.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/UnivocityParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/UnivocityParser.scala
@@ -70,8 +70,7 @@ class UnivocityParser(
   // positions. Generally assigned by input configuration options, except when input column(s) have
   // default values, in which case we omit the explicit indexes in order to know how many tokens
   // were present in each line instead.
-  private def columnPruning: Boolean =
-    options.isColumnPruningEnabledAndNoColumnDefaults(requiredSchema)
+  private def columnPruning: Boolean = options.isColumnPruningEnabled(requiredSchema)
 
   // When column pruning is enabled, the parser only parses the required columns based on
   // their positions in the data schema.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVFileFormat.scala
@@ -128,8 +128,7 @@ class CSVFileFormat extends TextBasedFileFormat with DataSourceRegister {
       // Use column pruning when specified by Catalyst, except when one or more columns have
       // existence default value(s), since in that case we instruct the CSV parser to disable column
       // pruning and instead read each entire row in order to correctly assign the default value(s).
-      val useColumnPruningForCheckingHeader = isColumnPruningEnabled
-      val schema = if (useColumnPruningForCheckingHeader) actualRequiredSchema else actualDataSchema
+      val schema = if (isColumnPruningEnabled) actualRequiredSchema else actualDataSchema
       val isStartOfFile = file.start == 0
       val headerChecker = new CSVHeaderChecker(
         schema, parsedOptions, source = s"CSV file: ${file.urlEncodedPath}", isStartOfFile)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVFileFormat.scala
@@ -105,6 +105,8 @@ class CSVFileFormat extends TextBasedFileFormat with DataSourceRegister {
       sparkSession.sessionState.conf.csvColumnPruning,
       sparkSession.sessionState.conf.sessionLocalTimeZone,
       sparkSession.sessionState.conf.columnNameOfCorruptRecord)
+    val isColumnPruningEnabled = parsedOptions.isColumnPruningEnabled(requiredSchema)
+
     // Check a field requirement for corrupt records here to throw an exception in a driver side
     ExprUtils.verifyColumnNameOfCorruptRecord(dataSchema, parsedOptions.columnNameOfCorruptRecord)
     // Don't push any filter which refers to the "virtual" column which cannot present in the input.
@@ -126,7 +128,7 @@ class CSVFileFormat extends TextBasedFileFormat with DataSourceRegister {
       // Use column pruning when specified by Catalyst, except when one or more columns have
       // existence default value(s), since in that case we instruct the CSV parser to disable column
       // pruning and instead read each entire row in order to correctly assign the default value(s).
-      val useColumnPruningForCheckingHeader = parsedOptions.isColumnPruningEnabled(requiredSchema)
+      val useColumnPruningForCheckingHeader = isColumnPruningEnabled
       val schema = if (useColumnPruningForCheckingHeader) actualRequiredSchema else actualDataSchema
       val isStartOfFile = file.start == 0
       val headerChecker = new CSVHeaderChecker(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVFileFormat.scala
@@ -125,7 +125,12 @@ class CSVFileFormat extends TextBasedFileFormat with DataSourceRegister {
         actualRequiredSchema,
         parsedOptions,
         actualFilters)
-      val schema = if (isColumnPruningEnabled) actualRequiredSchema else actualDataSchema
+      // Use column pruning when specified by Catalyst, except when one or more columns have
+      // existence default value(s), since in that case we instruct the CSV parser to disable column
+      // pruning and instead read each entire row in order to correctly assign the default value(s).
+      val useColumnPruningForCheckingHeader =
+        parsedOptions.isColumnPruningEnabledAndNoColumnDefaults(actualRequiredSchema)
+      val schema = if (useColumnPruningForCheckingHeader) actualRequiredSchema else actualDataSchema
       val isStartOfFile = file.start == 0
       val headerChecker = new CSVHeaderChecker(
         schema, parsedOptions, source = s"CSV file: ${file.urlEncodedPath}", isStartOfFile)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/CSVFileFormat.scala
@@ -105,8 +105,6 @@ class CSVFileFormat extends TextBasedFileFormat with DataSourceRegister {
       sparkSession.sessionState.conf.csvColumnPruning,
       sparkSession.sessionState.conf.sessionLocalTimeZone,
       sparkSession.sessionState.conf.columnNameOfCorruptRecord)
-    val isColumnPruningEnabled = parsedOptions.isColumnPruningEnabled
-
     // Check a field requirement for corrupt records here to throw an exception in a driver side
     ExprUtils.verifyColumnNameOfCorruptRecord(dataSchema, parsedOptions.columnNameOfCorruptRecord)
     // Don't push any filter which refers to the "virtual" column which cannot present in the input.
@@ -128,8 +126,7 @@ class CSVFileFormat extends TextBasedFileFormat with DataSourceRegister {
       // Use column pruning when specified by Catalyst, except when one or more columns have
       // existence default value(s), since in that case we instruct the CSV parser to disable column
       // pruning and instead read each entire row in order to correctly assign the default value(s).
-      val useColumnPruningForCheckingHeader =
-        parsedOptions.isColumnPruningEnabledAndNoColumnDefaults(actualRequiredSchema)
+      val useColumnPruningForCheckingHeader = parsedOptions.isColumnPruningEnabled(requiredSchema)
       val schema = if (useColumnPruningForCheckingHeader) actualRequiredSchema else actualDataSchema
       val isStartOfFile = file.start == 0
       val headerChecker = new CSVHeaderChecker(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/csv/CSVPartitionReaderFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/csv/CSVPartitionReaderFactory.scala
@@ -58,7 +58,11 @@ case class CSVPartitionReaderFactory(
       actualReadDataSchema,
       options,
       filters)
-    val schema = if (options.isColumnPruningEnabled) actualReadDataSchema else actualDataSchema
+    val schema = if (options.isColumnPruningEnabled(readDataSchema)) {
+      actualReadDataSchema
+    } else {
+      actualDataSchema
+    }
     val isStartOfFile = file.start == 0
     val headerChecker = new CSVHeaderChecker(
       schema, options, source = s"CSV file: ${file.urlEncodedPath}", isStartOfFile)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -3268,37 +3268,23 @@ abstract class CSVSuite
            |  path "${testFile(carsFile)}"
            |)
        """.stripMargin)
+      val expected = Seq(
+        Row("No comment"),
+        Row("Go get one now they are going fast"))
       checkAnswer(
-        spark.table("CarsTable"),
-        Seq(
-          Row(2012, "Tesla", "S", "No comment", null),
-          Row(1997, "Ford", "E350", "Go get one now they are going fast", null),
-          Row(2015, "Chevy", "Volt", "", "")
-        ))
-    }
-    withTable("Products") {
-      spark.sql(
-        s"""
-           |CREATE TABLE IF NOT EXISTS Products (
-           |  product_id INT,
-           |  name STRING,
-           |  price FLOAT default 0.0,
-           |  quantity INT default 0
-           |)
-           |USING CSV
-           |OPTIONS (
-           |  header 'true',
-           |  inferSchema 'false',
-           |  enforceSchema 'false',
-           |  path "${testFile(productsFile)}"
-           |)
-       """.stripMargin)
+        sql("SELECT comment FROM CarsTable WHERE year < 2014"),
+        expected)
       checkAnswer(
-        spark.table("Products"),
-        Seq(
-          Row(1, "Apple", 0.50, 100),
-          Row(2, "Banana", 0.25, 200),
-          Row(3, "Orange", 0.75, 50)))
+        spark.read.format("csv")
+          .options(
+      Map(
+        "header" -> "true",
+        "inferSchema" -> "true",
+        "enforceSchema" -> "false"))
+        .load(testFile(carsFile))
+          .select("comment")
+          .where("year < 2014"),
+        expected)
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -3276,12 +3276,11 @@ abstract class CSVSuite
         expected)
       checkAnswer(
         spark.read.format("csv")
-          .options(
-      Map(
-        "header" -> "true",
-        "inferSchema" -> "true",
-        "enforceSchema" -> "false"))
-        .load(testFile(carsFile))
+          .options(Map(
+            "header" -> "true",
+            "inferSchema" -> "true",
+            "enforceSchema" -> "false"))
+          .load(testFile(carsFile))
           .select("comment")
           .where("year < 2014"),
         expected)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes a CSV parsing bug with existence default values and column pruning (https://issues.apache.org/jira/browse/SPARK-46890).

The bug fix includes disabling column pruning specifically when checking the CSV header schema against the required schema expected by Catalyst. This makes the expected schema match what the CSV parser provides, since later we also happen instruct the CSV parser to disable column pruning and instead read each entire row in order to correctly assign the default value(s) during execution.

### Why are the changes needed?

Before this change, queries from a subset of the columns in a CSV table whose `CREATE TABLE` statement contained default values would return an internal exception. For example:

```
CREATE TABLE IF NOT EXISTS products (
  product_id INT,
  name STRING,
  price FLOAT default 0.0,
  quantity INT default 0
)
USING CSV
OPTIONS (
  header 'true',
  inferSchema 'false',
  enforceSchema 'false',
  path '/Users/maximgekk/tmp/products.csv'
);
```

The CSV file products.csv:

```
product_id,name,price,quantity
1,Apple,0.50,100
2,Banana,0.25,200
3,Orange,0.75,50
```

The query fails:

```
spark-sql (default)> SELECT price FROM products;
24/01/28 11:43:09 ERROR Executor: Exception in task 0.0 in stage 8.0 (TID 6)
java.lang.IllegalArgumentException: Number of column in CSV header is not equal to number of fields in the schema:
 Header length: 4, schema size: 1
CSV file: file:///Users/Daniel.Tenedorio/tmp/products.csv
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

This PR adds test coverage.

### Was this patch authored or co-authored using generative AI tooling?

No.