### PR TITLE
[SPARK-46910][PYTHON] Eliminate JDK Requirement in PySpark Installation

### DIFF
--- a/bin/pyspark
+++ b/bin/pyspark
@@ -73,7 +73,8 @@ else
         export JAVA_HOME=$(PYTHONPATH="$TEMP_DIR" python -c 'import jdk; print(jdk.install("17"))')
         RUNNER="${JAVA_HOME}/bin/java"
         echo "Java was installed to the path \"$JAVA_HOME.\""\
-        "You can avoid having to re-install it by running \`export JAVA_HOME=\"$JAVA_HOME\"\`."
+        "You can avoid needing to re-install JAVA by setting your JAVA_HOME environment variable"\
+        "to \"/root/.jdk/jdk-17.0.9+9.\""
     else
         echo "JDK installation skipped."\
         "You can manually install JDK (17 or later) and set JAVA_HOME in your environment."

--- a/bin/pyspark
+++ b/bin/pyspark
@@ -48,6 +48,40 @@ export PYSPARK_PYTHON
 export PYSPARK_DRIVER_PYTHON
 export PYSPARK_DRIVER_PYTHON_OPTS
 
+# Attempt to find JAVA_HOME.
+# If JAVA_HOME not set, install JDK 17 and set JAVA_HOME using a temp dir, and adding the
+# temp dir to the PYTHONPATH.
+if [ -n "${JAVA_HOME}" ]; then
+  RUNNER="${JAVA_HOME}/bin/java"
+else
+  if [ "$(command -v java)" ]; then
+    RUNNER="java"
+  else
+    if ! command -v python &> /dev/null || ! command -v pip &> /dev/null; then
+        echo "Python or pip is not installed or not in the PATH."\
+        "You can manually install python and pip and retry."
+        exit 1
+    fi
+
+    echo "JAVA_HOME is not set. Would you like to install JDK 17 and set JAVA_HOME? (Y/N)" >&2
+
+    read -r input
+
+    if [[ "${input,,}" == "y" ]]; then
+        TEMP_DIR=$(mktemp -d)
+        $PYSPARK_DRIVER_PYTHON -m pip install --target="$TEMP_DIR" install-jdk
+        export JAVA_HOME=$(PYTHONPATH="$TEMP_DIR" python -c 'import jdk; print(jdk.install("17"))')
+        RUNNER="${JAVA_HOME}/bin/java"
+        echo "Java was installed to the path \"$JAVA_HOME.\""\
+        "You can avoid having to re-install it by running \`export JAVA_HOME=\"$JAVA_HOME\"\`."
+    else
+        echo "JDK installation skipped."\
+        "You can manually install JDK (17 or later) and set JAVA_HOME in your environment."
+        exit 1
+    fi
+  fi
+fi
+
 # Add the PySpark classes to the Python path:
 export PYTHONPATH="${SPARK_HOME}/python/:$PYTHONPATH"
 export PYTHONPATH="${SPARK_HOME}/python/lib/py4j-0.10.9.7-src.zip:$PYTHONPATH"

--- a/bin/pyspark
+++ b/bin/pyspark
@@ -57,12 +57,6 @@ else
   if [ "$(command -v java)" ]; then
     RUNNER="java"
   else
-    if ! command -v python &> /dev/null || ! command -v pip &> /dev/null; then
-        echo "Python or pip is not installed or not in the PATH."\
-        "You can manually install python and pip and retry."
-        exit 1
-    fi
-
     echo -n "JAVA_HOME is not set. Would you like to install JDK 17 and set JAVA_HOME? (Y/N) " >&2
 
     read -r input

--- a/bin/pyspark
+++ b/bin/pyspark
@@ -63,18 +63,18 @@ else
         exit 1
     fi
 
-    echo "JAVA_HOME is not set. Would you like to install JDK 17 and set JAVA_HOME? (Y/N)" >&2
+    echo -n "JAVA_HOME is not set. Would you like to install JDK 17 and set JAVA_HOME? (Y/N) " >&2
 
     read -r input
 
     if [[ "${input,,}" == "y" ]]; then
         TEMP_DIR=$(mktemp -d)
         $PYSPARK_DRIVER_PYTHON -m pip install --target="$TEMP_DIR" install-jdk
-        export JAVA_HOME=$(PYTHONPATH="$TEMP_DIR" python -c 'import jdk; print(jdk.install("17"))')
+        export JAVA_HOME=$(PYTHONPATH="$TEMP_DIR" $PYSPARK_DRIVER_PYTHON -c 'import jdk; print(jdk.install("17"))')
         RUNNER="${JAVA_HOME}/bin/java"
-        echo "Java was installed to the path \"$JAVA_HOME.\""\
-        "You can avoid needing to re-install JAVA by setting your JAVA_HOME environment variable"\
-        "to \"/root/.jdk/jdk-17.0.9+9.\""
+        echo "JDK was installed to the path \"$JAVA_HOME\""
+        echo "You can avoid needing to re-install JDK by setting your JAVA_HOME environment variable"\
+        "to \"$JAVA_HOME\""
     else
         echo "JDK installation skipped."\
         "You can manually install JDK (17 or later) and set JAVA_HOME in your environment."

--- a/bin/pyspark
+++ b/bin/pyspark
@@ -67,11 +67,9 @@ else
         export JAVA_HOME=$(PYTHONPATH="$TEMP_DIR" $PYSPARK_DRIVER_PYTHON -c 'import jdk; print(jdk.install("17"))')
         RUNNER="${JAVA_HOME}/bin/java"
         echo "JDK was installed to the path \"$JAVA_HOME\""
-        echo "You can avoid needing to re-install JDK by setting your JAVA_HOME environment variable"\
-        "to \"$JAVA_HOME\""
+        echo "You can avoid needing to re-install JDK by setting your JAVA_HOME environment variable to \"$JAVA_HOME\""
     else
-        echo "JDK installation skipped."\
-        "You can manually install JDK (17 or later) and set JAVA_HOME in your environment."
+        echo "JDK installation skipped. You can manually install JDK (17 or later) and set JAVA_HOME in your environment."
         exit 1
     fi
   fi

--- a/bin/spark-class
+++ b/bin/spark-class
@@ -44,13 +44,13 @@ else
     if [ "$input" == "Y" ] || [ "$input" == "y" ]; then
         TEMP_DIR=$(mktemp -d)
         pip install --target="$TEMP_DIR" install-jdk
-        export JAVA_HOME=$(PYTHONPATH="$TEMP_DIR":"$PYTHONPATH" python -c 'import jdk; print(jdk.install("17"))')
+        export JAVA_HOME=$(PYTHONPATH="$TEMP_DIR" python -c 'import jdk; print(jdk.install("17"))')
         RUNNER="${JAVA_HOME}/bin/java"
         echo "Java was installed to $JAVA_HOME."\
-        "You can avoid having to re-install it by running `export JAVA_HOME=<path>`."
+        "You can avoid having to re-install it by running \`export JAVA_HOME=\"$JAVA_HOME\"\`."
     else
         echo "JDK installation skipped."\
-        "You can manually install JDK (8 or later) and set JAVA_HOME in your environment."
+        "You can manually install JDK (17 or later) and set JAVA_HOME in your environment."
         exit 1
     fi
   fi

--- a/bin/spark-class
+++ b/bin/spark-class
@@ -30,12 +30,15 @@ else
   if [ "$(command -v java)" ]; then
     RUNNER="java"
   else
+<<<<<<< HEAD
     if ! command -v python &> /dev/null || ! command -v pip &> /dev/null; then
         echo "Python or pip is not installed or not in the PATH."\
         "You can manually install python and pip and retry."
         exit 1
     fi
 
+=======
+>>>>>>> 53fa541225d (add install jdk option to spark-class script)
     echo "JAVA_HOME is not set."\
     "Press Y to install JDK 17 and set JAVA_HOME, or any key to quit." >&2
 

--- a/bin/spark-class
+++ b/bin/spark-class
@@ -30,8 +30,29 @@ else
   if [ "$(command -v java)" ]; then
     RUNNER="java"
   else
-    echo "JAVA_HOME is not set" >&2
-    exit 1
+    if ! command -v python &> /dev/null || ! command -v pip &> /dev/null; then
+        echo "Python or pip is not installed or not in the PATH."\
+        "You can manually install python and pip and retry."
+        exit 1
+    fi
+
+    echo "JAVA_HOME is not set."\
+    "Press Y to install JDK 17 and set JAVA_HOME, or any key to quit." >&2
+
+    read -r input
+
+    if [ "$input" == "Y" ] || [ "$input" == "y" ]; then
+        TEMP_DIR=$(mktemp -d)
+        pip install --target="$TEMP_DIR" install-jdk
+        export JAVA_HOME=$(PYTHONPATH="$TEMP_DIR":"$PYTHONPATH" python -c 'import jdk; print(jdk.install("17"))')
+        RUNNER="${JAVA_HOME}/bin/java"
+        echo "Java was installed to $JAVA_HOME."\
+        "You can avoid having to re-install it by running `export JAVA_HOME=<path>`."
+    else
+        echo "JDK installation skipped."\
+        "You can manually install JDK (8 or later) and set JAVA_HOME in your environment."
+        exit 1
+    fi
   fi
 fi
 

--- a/bin/spark-class
+++ b/bin/spark-class
@@ -30,29 +30,8 @@ else
   if [ "$(command -v java)" ]; then
     RUNNER="java"
   else
-    if ! command -v python &> /dev/null || ! command -v pip &> /dev/null; then
-        echo "Python or pip is not installed or not in the PATH."\
-        "You can manually install python and pip and retry."
-        exit 1
-    fi
-
-    echo "JAVA_HOME is not set."\
-    "Press Y to install JDK 17 and set JAVA_HOME, or any key to quit." >&2
-
-    read -r input
-
-    if [ "$input" == "Y" ] || [ "$input" == "y" ]; then
-        TEMP_DIR=$(mktemp -d)
-        pip install --target="$TEMP_DIR" install-jdk
-        export JAVA_HOME=$(PYTHONPATH="$TEMP_DIR" python -c 'import jdk; print(jdk.install("17"))')
-        RUNNER="${JAVA_HOME}/bin/java"
-        echo "Java was installed to $JAVA_HOME."\
-        "You can avoid having to re-install it by running \`export JAVA_HOME=\"$JAVA_HOME\"\`."
-    else
-        echo "JDK installation skipped."\
-        "You can manually install JDK (17 or later) and set JAVA_HOME in your environment."
-        exit 1
-    fi
+    echo "JAVA_HOME is not set" >&2
+    exit 1
   fi
 fi
 

--- a/bin/spark-class
+++ b/bin/spark-class
@@ -30,15 +30,12 @@ else
   if [ "$(command -v java)" ]; then
     RUNNER="java"
   else
-<<<<<<< HEAD
     if ! command -v python &> /dev/null || ! command -v pip &> /dev/null; then
         echo "Python or pip is not installed or not in the PATH."\
         "You can manually install python and pip and retry."
         exit 1
     fi
 
-=======
->>>>>>> 53fa541225d (add install jdk option to spark-class script)
     echo "JAVA_HOME is not set."\
     "Press Y to install JDK 17 and set JAVA_HOME, or any key to quit." >&2
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Modifies the PySpark installation script to ask users to allow installation of the necessary JDK, if not already installed.


### Why are the changes needed?
Simplifying the PySpark installation process is a critical part of improving the new user onboarding experience. Many new PySpark users get blocked in the installation process, due to confusing errors from not having Java installed. This change simplifies the PySpark user onboarding process.


### Does this PR introduce _any_ user-facing change?
Yes, modifies the PySpark installation script.


### How was this patch tested?
Installing PySpark in virtual environments


### Was this patch authored or co-authored using generative AI tooling?
No
