### PR TITLE
[SPARK-46912] Use worker JAVA_HOME and SPARK_HOME instead of from submitter

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/worker/CommandUtils.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/CommandUtils.scala
@@ -78,12 +78,18 @@ object CommandUtils extends Logging {
     val libraryPathName = Utils.libraryPathEnvName
     val libraryPathEntries = command.libraryPathEntries
     val cmdLibraryPath = command.environment.get(libraryPathName)
+    val localEnvs = Map(
+      "JAVA_HOME" -> sys.env.getOrElse("JAVA_HOME", ""),
+      "SPARK_HOME" -> sys.env.getOrElse("SPARK_HOME", ""),
+    ).filterNot(_._2.isEmpty)
 
     var newEnvironment = if (libraryPathEntries.nonEmpty && libraryPathName.nonEmpty) {
       val libraryPaths = libraryPathEntries ++ cmdLibraryPath ++ env.get(libraryPathName)
-      command.environment ++ Map(libraryPathName -> libraryPaths.mkString(File.pathSeparator))
+      (command.environment
+        ++ Map(libraryPathName -> libraryPaths.mkString(File.pathSeparator))
+        ++ localEnvs)
     } else {
-      command.environment
+      command.environment ++ localEnvs
     }
 
     // set auth secret to env variable if needed


### PR DESCRIPTION
### What changes were proposed in this pull request?
Replace JAVA_HOME and SPARK_HOME from submitter by value of worker when building localCommand.


### Why are the changes needed?
There is a problem when submit a job in cluster mode to a standalone cluster. The worker start a java job using value from submitter JAVA_HOME instead of itself.


### Does this PR introduce _any_ user-facing change?
No


### Was this patch authored or co-authored using generative AI tooling?
No
