### PR TITLE
[SPARK-46916][PS][TESTS] Clean up `pyspark.pandas.tests.indexes.*`

### DIFF
--- a/python/pyspark/pandas/tests/connect/indexes/test_parity_align.py
+++ b/python/pyspark/pandas/tests/connect/indexes/test_parity_align.py
@@ -16,16 +16,17 @@
 #
 import unittest
 
-from pyspark import pandas as ps
 from pyspark.pandas.tests.indexes.test_align import FrameAlignMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase
 from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
-class FrameParityAlignTests(FrameAlignMixin, PandasOnSparkTestUtils, ReusedConnectTestCase):
-    @property
-    def psdf(self):
-        return ps.from_pandas(self.pdf)
+class FrameParityAlignTests(
+    FrameAlignMixin,
+    PandasOnSparkTestUtils,
+    ReusedConnectTestCase,
+):
+    pass
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/connect/indexes/test_parity_indexing.py
+++ b/python/pyspark/pandas/tests/connect/indexes/test_parity_indexing.py
@@ -16,16 +16,17 @@
 #
 import unittest
 
-from pyspark import pandas as ps
 from pyspark.pandas.tests.indexes.test_indexing import FrameIndexingMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase
 from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
-class FrameParityIndexingTests(FrameIndexingMixin, PandasOnSparkTestUtils, ReusedConnectTestCase):
-    @property
-    def psdf(self):
-        return ps.from_pandas(self.pdf)
+class FrameParityIndexingTests(
+    FrameIndexingMixin,
+    PandasOnSparkTestUtils,
+    ReusedConnectTestCase,
+):
+    pass
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/connect/indexes/test_parity_reindex.py
+++ b/python/pyspark/pandas/tests/connect/indexes/test_parity_reindex.py
@@ -16,16 +16,17 @@
 #
 import unittest
 
-from pyspark import pandas as ps
 from pyspark.pandas.tests.indexes.test_reindex import FrameReindexMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase
 from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
-class FrameParityReindexTests(FrameReindexMixin, PandasOnSparkTestUtils, ReusedConnectTestCase):
-    @property
-    def psdf(self):
-        return ps.from_pandas(self.pdf)
+class FrameParityReindexTests(
+    FrameReindexMixin,
+    PandasOnSparkTestUtils,
+    ReusedConnectTestCase,
+):
+    pass
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/connect/indexes/test_parity_rename.py
+++ b/python/pyspark/pandas/tests/connect/indexes/test_parity_rename.py
@@ -16,16 +16,17 @@
 #
 import unittest
 
-from pyspark import pandas as ps
 from pyspark.pandas.tests.indexes.test_rename import FrameRenameMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase
 from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
-class FrameParityRenameTests(FrameRenameMixin, PandasOnSparkTestUtils, ReusedConnectTestCase):
-    @property
-    def psdf(self):
-        return ps.from_pandas(self.pdf)
+class FrameParityRenameTests(
+    FrameRenameMixin,
+    PandasOnSparkTestUtils,
+    ReusedConnectTestCase,
+):
+    pass
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/connect/indexes/test_parity_reset_index.py
+++ b/python/pyspark/pandas/tests/connect/indexes/test_parity_reset_index.py
@@ -16,18 +16,17 @@
 #
 import unittest
 
-from pyspark import pandas as ps
 from pyspark.pandas.tests.indexes.test_reset_index import FrameResetIndexMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase
 from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
 class FrameParityResetIndexTests(
-    FrameResetIndexMixin, PandasOnSparkTestUtils, ReusedConnectTestCase
+    FrameResetIndexMixin,
+    PandasOnSparkTestUtils,
+    ReusedConnectTestCase,
 ):
-    @property
-    def psdf(self):
-        return ps.from_pandas(self.pdf)
+    pass
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/indexes/test_align.py
+++ b/python/pyspark/pandas/tests/indexes/test_align.py
@@ -19,7 +19,7 @@ import unittest
 import pandas as pd
 
 from pyspark import pandas as ps
-from pyspark.testing.pandasutils import ComparisonTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
 
 
@@ -70,7 +70,11 @@ class FrameAlignMixin:
             self.assert_eq(psdf_r.sort_index(), pdf_r.sort_index())
 
 
-class FrameAlignTests(FrameAlignMixin, ComparisonTestBase, SQLTestUtils):
+class FrameAlignTests(
+    FrameAlignMixin,
+    PandasOnSparkTestCase,
+    SQLTestUtils,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/indexes/test_asof.py
+++ b/python/pyspark/pandas/tests/indexes/test_asof.py
@@ -19,7 +19,7 @@ import unittest
 import pandas as pd
 
 import pyspark.pandas as ps
-from pyspark.testing.pandasutils import ComparisonTestBase, TestUtils
+from pyspark.testing.pandasutils import PandasOnSparkTestCase, TestUtils
 
 
 class IndexesAsOfMixin:
@@ -71,7 +71,7 @@ class IndexesAsOfMixin:
 
 class IndexesAsOfTests(
     IndexesAsOfMixin,
-    ComparisonTestBase,
+    PandasOnSparkTestCase,
     TestUtils,
 ):
     pass

--- a/python/pyspark/pandas/tests/indexes/test_astype.py
+++ b/python/pyspark/pandas/tests/indexes/test_astype.py
@@ -21,7 +21,7 @@ import numpy as np
 import pandas as pd
 
 import pyspark.pandas as ps
-from pyspark.testing.pandasutils import ComparisonTestBase, TestUtils
+from pyspark.testing.pandasutils import PandasOnSparkTestCase, TestUtils
 
 
 class IndexesAsTypeMixin:
@@ -86,7 +86,7 @@ class IndexesAsTypeMixin:
 
 class IndexesAsTypeTests(
     IndexesAsTypeMixin,
-    ComparisonTestBase,
+    PandasOnSparkTestCase,
     TestUtils,
 ):
     pass

--- a/python/pyspark/pandas/tests/indexes/test_datetime.py
+++ b/python/pyspark/pandas/tests/indexes/test_datetime.py
@@ -122,7 +122,11 @@ class DatetimeIndexTestsMixin(DatetimeIndexTestingFuncMixin):
             self.assertRaises(NotImplementedError, lambda: py_datetime - psidx)
 
 
-class DatetimeIndexTests(DatetimeIndexTestsMixin, PandasOnSparkTestCase, TestUtils):
+class DatetimeIndexTests(
+    DatetimeIndexTestsMixin,
+    PandasOnSparkTestCase,
+    TestUtils,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/indexes/test_delete.py
+++ b/python/pyspark/pandas/tests/indexes/test_delete.py
@@ -20,7 +20,7 @@ import unittest
 import pandas as pd
 
 import pyspark.pandas as ps
-from pyspark.testing.pandasutils import ComparisonTestBase, TestUtils
+from pyspark.testing.pandasutils import PandasOnSparkTestCase, TestUtils
 
 
 class IndexesDeleteMixin:
@@ -69,7 +69,7 @@ class IndexesDeleteMixin:
 
 class IndexesDeleteTests(
     IndexesDeleteMixin,
-    ComparisonTestBase,
+    PandasOnSparkTestCase,
     TestUtils,
 ):
     pass

--- a/python/pyspark/pandas/tests/indexes/test_diff.py
+++ b/python/pyspark/pandas/tests/indexes/test_diff.py
@@ -21,7 +21,7 @@ import numpy as np
 import pandas as pd
 
 import pyspark.pandas as ps
-from pyspark.testing.pandasutils import ComparisonTestBase, TestUtils
+from pyspark.testing.pandasutils import PandasOnSparkTestCase, TestUtils
 
 
 class IndexesDiffMixin:
@@ -108,7 +108,7 @@ class IndexesDiffMixin:
 
 class IndexesDiffTests(
     IndexesDiffMixin,
-    ComparisonTestBase,
+    PandasOnSparkTestCase,
     TestUtils,
 ):
     pass

--- a/python/pyspark/pandas/tests/indexes/test_drop.py
+++ b/python/pyspark/pandas/tests/indexes/test_drop.py
@@ -21,7 +21,7 @@ import numpy as np
 import pandas as pd
 
 import pyspark.pandas as ps
-from pyspark.testing.pandasutils import ComparisonTestBase, TestUtils
+from pyspark.testing.pandasutils import PandasOnSparkTestCase, TestUtils
 
 
 class IndexesDropMixin:
@@ -158,7 +158,7 @@ class IndexesDropMixin:
 
 class IndexesDropTests(
     IndexesDropMixin,
-    ComparisonTestBase,
+    PandasOnSparkTestCase,
     TestUtils,
 ):
     pass

--- a/python/pyspark/pandas/tests/indexes/test_indexing.py
+++ b/python/pyspark/pandas/tests/indexes/test_indexing.py
@@ -21,7 +21,7 @@ import pandas as pd
 
 from pyspark import pandas as ps
 from pyspark.pandas.config import option_context
-from pyspark.testing.pandasutils import ComparisonTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
 
 
@@ -34,6 +34,10 @@ class FrameIndexingMixin:
             {"a": [1, 2, 3, 4, 5, 6, 7, 8, 9], "b": [4, 5, 6, 3, 2, 1, 0, 0, 0]},
             index=np.random.rand(9),
         )
+
+    @property
+    def psdf(self):
+        return ps.from_pandas(self.pdf)
 
     @property
     def df_pair(self):
@@ -411,7 +415,11 @@ class FrameIndexingMixin:
             self.assert_eq(value_psdf, value_pdf)
 
 
-class FrameIndexingTests(FrameIndexingMixin, ComparisonTestBase, SQLTestUtils):
+class FrameIndexingTests(
+    FrameIndexingMixin,
+    PandasOnSparkTestCase,
+    SQLTestUtils,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/indexes/test_indexing_loc_multi_idx.py
+++ b/python/pyspark/pandas/tests/indexes/test_indexing_loc_multi_idx.py
@@ -16,7 +16,6 @@
 #
 import unittest
 
-import numpy as np
 import pandas as pd
 
 from pyspark import pandas as ps

--- a/python/pyspark/pandas/tests/indexes/test_insert.py
+++ b/python/pyspark/pandas/tests/indexes/test_insert.py
@@ -19,17 +19,10 @@ import unittest
 import pandas as pd
 
 import pyspark.pandas as ps
-from pyspark.testing.pandasutils import ComparisonTestBase, TestUtils
+from pyspark.testing.pandasutils import PandasOnSparkTestCase, TestUtils
 
 
 class IndexesInsertMixin:
-    @property
-    def pdf(self):
-        return pd.DataFrame(
-            {"a": [1, 2, 3, 4, 5, 6, 7, 8, 9], "b": [4, 5, 6, 3, 2, 1, 0, 0, 0]},
-            index=[0, 1, 3, 5, 6, 8, 9, 9, 9],
-        )
-
     def test_insert(self):
         # Integer
         pidx = pd.Index([1, 2, 3], name="Koalas")
@@ -128,7 +121,7 @@ class IndexesInsertMixin:
 
 class IndexesInsertTests(
     IndexesInsertMixin,
-    ComparisonTestBase,
+    PandasOnSparkTestCase,
     TestUtils,
 ):
     pass

--- a/python/pyspark/pandas/tests/indexes/test_map.py
+++ b/python/pyspark/pandas/tests/indexes/test_map.py
@@ -19,7 +19,7 @@ import unittest
 import pandas as pd
 
 import pyspark.pandas as ps
-from pyspark.testing.pandasutils import ComparisonTestBase, TestUtils
+from pyspark.testing.pandasutils import PandasOnSparkTestCase, TestUtils
 
 
 class IndexesMapMixin:
@@ -100,7 +100,7 @@ class IndexesMapMixin:
 
 class IndexesMapTests(
     IndexesMapMixin,
-    ComparisonTestBase,
+    PandasOnSparkTestCase,
     TestUtils,
 ):
     pass

--- a/python/pyspark/pandas/tests/indexes/test_reindex.py
+++ b/python/pyspark/pandas/tests/indexes/test_reindex.py
@@ -19,7 +19,7 @@ import unittest
 import pandas as pd
 
 from pyspark import pandas as ps
-from pyspark.testing.pandasutils import ComparisonTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
 
 
@@ -278,7 +278,11 @@ class FrameReindexMixin:
         )
 
 
-class FrameReindexTests(FrameReindexMixin, ComparisonTestBase, SQLTestUtils):
+class FrameReindexTests(
+    FrameReindexMixin,
+    PandasOnSparkTestCase,
+    SQLTestUtils,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/indexes/test_rename.py
+++ b/python/pyspark/pandas/tests/indexes/test_rename.py
@@ -20,7 +20,7 @@ import numpy as np
 import pandas as pd
 
 from pyspark import pandas as ps
-from pyspark.testing.pandasutils import ComparisonTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
 
 
@@ -298,7 +298,11 @@ class FrameRenameMixin:
         self.assertRaises(TypeError, lambda: psidx.rename(["x", "y"]))
 
 
-class FrameRenameTests(FrameRenameMixin, ComparisonTestBase, SQLTestUtils):
+class FrameRenameTests(
+    FrameRenameMixin,
+    PandasOnSparkTestCase,
+    SQLTestUtils,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/indexes/test_reset_index.py
+++ b/python/pyspark/pandas/tests/indexes/test_reset_index.py
@@ -20,7 +20,7 @@ import numpy as np
 import pandas as pd
 
 from pyspark import pandas as ps
-from pyspark.testing.pandasutils import ComparisonTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
 
 
@@ -144,7 +144,11 @@ class FrameResetIndexMixin:
         )
 
 
-class FrameResetIndexTests(FrameResetIndexMixin, ComparisonTestBase, SQLTestUtils):
+class FrameResetIndexTests(
+    FrameResetIndexMixin,
+    PandasOnSparkTestCase,
+    SQLTestUtils,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/indexes/test_sort.py
+++ b/python/pyspark/pandas/tests/indexes/test_sort.py
@@ -20,7 +20,7 @@ import unittest
 import pandas as pd
 
 import pyspark.pandas as ps
-from pyspark.testing.pandasutils import ComparisonTestBase, TestUtils
+from pyspark.testing.pandasutils import PandasOnSparkTestCase, TestUtils
 
 
 class IndexesSortMixin:
@@ -81,7 +81,7 @@ class IndexesSortMixin:
 
 class IndexesSortTests(
     IndexesSortMixin,
-    ComparisonTestBase,
+    PandasOnSparkTestCase,
     TestUtils,
 ):
     pass

--- a/python/pyspark/pandas/tests/indexes/test_symmetric_diff.py
+++ b/python/pyspark/pandas/tests/indexes/test_symmetric_diff.py
@@ -21,7 +21,7 @@ import pandas as pd
 
 import pyspark.pandas as ps
 from pyspark.loose_version import LooseVersion
-from pyspark.testing.pandasutils import ComparisonTestBase, TestUtils
+from pyspark.testing.pandasutils import PandasOnSparkTestCase, TestUtils
 
 
 class IndexesSymmetricDiffMixin:
@@ -107,7 +107,7 @@ class IndexesSymmetricDiffMixin:
 
 class IndexesSymmetricDiffTests(
     IndexesSymmetricDiffMixin,
-    ComparisonTestBase,
+    PandasOnSparkTestCase,
     TestUtils,
 ):
     pass

--- a/python/pyspark/pandas/tests/indexes/test_take.py
+++ b/python/pyspark/pandas/tests/indexes/test_take.py
@@ -20,7 +20,7 @@ import unittest
 import pandas as pd
 
 import pyspark.pandas as ps
-from pyspark.testing.pandasutils import ComparisonTestBase, TestUtils
+from pyspark.testing.pandasutils import PandasOnSparkTestCase, TestUtils
 
 
 class IndexesTakeMixin:
@@ -66,7 +66,7 @@ class IndexesTakeMixin:
 
 class IndexesTakeTests(
     IndexesTakeMixin,
-    ComparisonTestBase,
+    PandasOnSparkTestCase,
     TestUtils,
 ):
     pass

--- a/python/pyspark/pandas/tests/indexes/test_timedelta.py
+++ b/python/pyspark/pandas/tests/indexes/test_timedelta.py
@@ -106,7 +106,11 @@ class TimedeltaIndexTestsMixin:
         self.assert_eq(self.neg_psidx.microseconds, self.neg_pidx.microseconds)
 
 
-class TimedeltaIndexTests(TimedeltaIndexTestsMixin, PandasOnSparkTestCase, TestUtils):
+class TimedeltaIndexTests(
+    TimedeltaIndexTestsMixin,
+    PandasOnSparkTestCase,
+    TestUtils,
+):
     pass
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Clean up `pyspark.pandas.tests.indexes.*`:
1, delete unused imports, variables;
2, avoid double definition of the testing datasets; 


### Why are the changes needed?
code clean up

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no