### PR TITLE
[SPARK-46710][SQL] Clean up the broadcast data when sql execution ends

### DIFF
--- a/core/src/main/scala/org/apache/spark/broadcast/BroadcastManager.scala
+++ b/core/src/main/scala/org/apache/spark/broadcast/BroadcastManager.scala
@@ -18,22 +18,27 @@
 package org.apache.spark.broadcast
 
 import java.util.Collections
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicLong
 
+import scala.collection.mutable.ListBuffer
 import scala.reflect.ClassTag
 
 import org.apache.commons.collections4.map.AbstractReferenceMap.ReferenceStrength
 import org.apache.commons.collections4.map.ReferenceMap
+import org.apache.commons.lang3.StringUtils
 
 import org.apache.spark.SparkConf
 import org.apache.spark.api.python.PythonBroadcast
-import org.apache.spark.internal.Logging
+import org.apache.spark.internal.{config, Logging}
 
 private[spark] class BroadcastManager(
     val isDriver: Boolean, conf: SparkConf) extends Logging {
 
   private var initialized = false
   private var broadcastFactory: BroadcastFactory = null
+  private var cleanAfterExecutionEnabled = false
+  private val executionBroadcastIds = new ConcurrentHashMap[String, ListBuffer[Long]]()
 
   initialize()
 
@@ -43,6 +48,7 @@ private[spark] class BroadcastManager(
       if (!initialized) {
         broadcastFactory = new TorrentBroadcastFactory
         broadcastFactory.initialize(isDriver, conf)
+        cleanAfterExecutionEnabled = conf.get(config.CLEAN_BROADCAST_AFTER_EXECUTION_ENABLED)
         initialized = true
       }
     }
@@ -63,7 +69,8 @@ private[spark] class BroadcastManager(
   def newBroadcast[T: ClassTag](
       value_ : T,
       isLocal: Boolean,
-      serializedOnly: Boolean = false): Broadcast[T] = {
+      serializedOnly: Boolean = false,
+      sqlExecutionId: String = null): Broadcast[T] = {
     val bid = nextBroadcastId.getAndIncrement()
     value_ match {
       case pb: PythonBroadcast =>
@@ -75,10 +82,33 @@ private[spark] class BroadcastManager(
 
       case _ => // do nothing
     }
-    broadcastFactory.newBroadcast[T](value_, isLocal, bid, serializedOnly)
+    val broadcast = broadcastFactory.newBroadcast[T](value_, isLocal, bid, serializedOnly)
+    if(cleanAfterExecutionEnabled && StringUtils.isNotBlank(sqlExecutionId)) {
+      val broadcastIds = executionBroadcastIds.getOrDefault(sqlExecutionId, ListBuffer())
+      broadcastIds += bid
+      executionBroadcastIds.put(sqlExecutionId, broadcastIds)
+    }
+    broadcast
   }
 
   def unbroadcast(id: Long, removeFromDriver: Boolean, blocking: Boolean): Unit = {
     broadcastFactory.unbroadcast(id, removeFromDriver, blocking)
+  }
+
+  def unbroadcastByExecution(executionId: String,
+    removeFromDriver: Boolean, blocking: Boolean): Unit = {
+    if (executionBroadcastIds.containsKey(executionId)) {
+      executionBroadcastIds.get(executionId).foreach(broadcastId => {
+        unbroadcast(broadcastId, removeFromDriver, blocking)
+      })
+      executionBroadcastIds.remove(executionId)
+    }
+  }
+
+  /**
+   * Exposed for testing
+   */
+  def getExecutionBroadcastIds(): ConcurrentHashMap[String, ListBuffer[Long]] = {
+    executionBroadcastIds
   }
 }

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -2025,6 +2025,15 @@ package object config {
       .checkValue(v => v >= 0, "The threshold should be non-negative.")
       .createWithDefault(1L * 1024 * 1024)
 
+  private[spark] val CLEAN_BROADCAST_AFTER_EXECUTION_ENABLED =
+    ConfigBuilder("spark.broadcast.cleanAfterExecution.enabled")
+      .doc("Whether to enable clean broadcast data after SQL execution. If enabled, " +
+        "after the sql execution is completed, the broadcast data generated during " +
+        " the sql execution will be destroyed. This can reclaim memory as quickly as possible.")
+      .version("4.0.0")
+      .booleanConf
+      .createWithDefault(false)
+
   private[spark] val RDD_COMPRESS = ConfigBuilder("spark.rdd.compress")
     .doc("Whether to compress serialized RDD partitions " +
       "(e.g. for StorageLevel.MEMORY_ONLY_SER in Scala " +

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala
@@ -25,7 +25,7 @@ import scala.util.control.NonFatal
 import org.apache.spark.{ErrorMessageFormat, JobArtifactSet, SparkException, SparkThrowable, SparkThrowableHelper}
 import org.apache.spark.SparkContext.{SPARK_JOB_DESCRIPTION, SPARK_JOB_INTERRUPT_ON_CANCEL}
 import org.apache.spark.internal.Logging
-import org.apache.spark.internal.config.{SPARK_DRIVER_PREFIX, SPARK_EXECUTOR_PREFIX}
+import org.apache.spark.internal.config.{CLEAN_BROADCAST_AFTER_EXECUTION_ENABLED, SPARK_DRIVER_PREFIX, SPARK_EXECUTOR_PREFIX}
 import org.apache.spark.internal.config.Tests.IS_TESTING
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.execution.ui.{SparkListenerSQLExecutionEnd, SparkListenerSQLExecutionStart}
@@ -180,6 +180,9 @@ object SQLExecution extends Logging {
       }
     } finally {
       executionIdToQueryExecution.remove(executionId)
+      if(sc.conf.get(CLEAN_BROADCAST_AFTER_EXECUTION_ENABLED)) {
+        sc.cleanBroadcastByExecution(executionId.toString)
+      }
       sc.setLocalProperty(EXECUTION_ID_KEY, oldExecutionId)
       // Unset the "root" SQL Execution Id once the "root" SQL execution completes.
       // The current execution is the root execution if rootExecutionId == executionId.

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/CleanBroadcastAfterExecutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/CleanBroadcastAfterExecutionSuite.scala
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.joins
+
+import org.apache.spark.SparkEnv
+import org.apache.spark.internal.config.CLEAN_BROADCAST_AFTER_EXECUTION_ENABLED
+import org.apache.spark.sql.{QueryTest, SparkSession}
+import org.apache.spark.sql.test.SQLTestData.{TestData, TestData2}
+import org.apache.spark.sql.test.SQLTestUtils
+
+/**
+ * Test clean broadcast data after sql execution ends
+ * (if we set spark.broadcast.cleanAfterExecution.enabled=true).
+ */
+class CleanBroadcastAfterExecutionSuite extends QueryTest with SQLTestUtils {
+
+  import testImplicits._
+
+  var spark: SparkSession = null
+
+  override def beforeAll(): Unit = {
+    spark = SparkSession.builder()
+      .master("local")
+      .config(CLEAN_BROADCAST_AFTER_EXECUTION_ENABLED.key, "true")
+      .appName("testing")
+      .getOrCreate()
+  }
+
+  override def afterAll(): Unit = {
+    try {
+      spark.stop()
+      spark = null
+    } finally {
+      super.afterAll()
+    }
+  }
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    System.gc()
+  }
+
+  test("clean broadcast data after execution") {
+    val testDataDF = spark.sparkContext.parallelize(
+      (1 to 3).map(i => TestData(i, i.toString))).toDF()
+    testDataDF.createOrReplaceTempView("testData")
+    val testData2DF = spark.sparkContext.parallelize(
+      TestData2(1, 1) :: TestData2(2, 2) :: TestData2(3, 1) :: Nil, 2).toDF()
+    testData2DF.createOrReplaceTempView("testData2")
+    checkAnswer(sql("SELECT  /*+ BROADCASTJOIN  */ t1.* " +
+      " from testData t1 left join testData2 t2 ON t1.key = t2.a"), testDataDF)
+    assert(SparkEnv.get.broadcastManager.getExecutionBroadcastIds().isEmpty)
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add config `spark.broadcast.cleanAfterExecution.enabled`(default false) . Clean up the broadcast data generated when sql execution ends ( only suitable for long running Spark SQL services ). 
Before this PR: broadcast data cleaning can only rely on when GC is triggered, which may lead to a lot of waste of memory usage , and may also cause query instability if a single GC takes too long.
After this PR: after the execution of sql is completed, the broadcast data generated during the execution of the sql will be cleared.

Note: this parameter is only suitable for long running Spark SQL services. If this parameter is turned on and one dataframe is collected twice, the broadcast data will not be found during the second execution (because it has been cleaned).

### Why are the changes needed?
 Reduce memory load on driver and executor. This can make a long running spark service more stable. 


### Does this PR introduce _any_ user-facing change?
Add config `spark.broadcast.cleanAfterExecution.enabled`.
Default `false`,  If `true`, the broadcast data generated by the sql will be destroyed when it is completed.