### PR TITLE
[SPARK-46922][CORE][SQL] Do not wrap runtime user-facing errors

### DIFF
--- a/common/utils/src/main/resources/error/error-classes.json
+++ b/common/utils/src/main/resources/error/error-classes.json
@@ -1242,6 +1242,12 @@
     ],
     "sqlState" : "22018"
   },
+  "FAILED_READ_FILE" : {
+    "message" : [
+      "Encountered error while reading file <path>."
+    ],
+    "sqlState" : "KD001"
+  },
   "FAILED_REGISTER_CLASS_WITH_KRYO" : {
     "message" : [
       "Failed to register classes with Kryo."
@@ -5852,11 +5858,6 @@
   "_LEGACY_ERROR_TEMP_2063" : {
     "message" : [
       "Parquet column cannot be converted in file <filePath>. Column: <column>, Expected: <logicalType>, Found: <physicalType>."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_2064" : {
-    "message" : [
-      "Encountered error while reading file <path>. Details:"
     ]
   },
   "_LEGACY_ERROR_TEMP_2065" : {

--- a/common/utils/src/main/scala/org/apache/spark/SparkThrowableHelper.scala
+++ b/common/utils/src/main/scala/org/apache/spark/SparkThrowableHelper.scala
@@ -74,6 +74,26 @@ private[spark] object SparkThrowableHelper {
     errorClass.startsWith("INTERNAL_ERROR")
   }
 
+  def isRuntimeUserError(e: Throwable): Boolean = {
+    e match {
+      case st: SparkThrowable if st.getErrorClass != null =>
+        st.getErrorClass match {
+          case "DIVIDE_BY_ZERO" | "INTERVAL_DIVIDED_BY_ZERO" => true
+          case "ARITHMETIC_OVERFLOW" | "BINARY_ARITHMETIC_OVERFLOW" | "CAST_OVERFLOW" |
+               "CAST_OVERFLOW_IN_TABLE_INSERT" | "DATETIME_OVERFLOW" |
+               "INTERVAL_ARITHMETIC_OVERFLOW" => true
+          case "CAST_INVALID_INPUT" | "NUMERIC_VALUE_OUT_OF_RANGE" | "CANNOT_PARSE_TIMESTAMP" =>
+            true
+          case "INVALID_ARRAY_INDEX" | "INVALID_ARRAY_INDEX_IN_ELEMENT_AT" |
+               "INVALID_INDEX_OF_ZERO" => true
+          // TODO: add more user-facing runtime errors (mostly ANSI errors).
+          case _ => false
+        }
+
+      case _ => false
+    }
+  }
+
   def getMessage(e: SparkThrowable with Throwable, format: ErrorMessageFormat.Value): String = {
     import ErrorMessageFormat._
     format match {

--- a/common/utils/src/main/scala/org/apache/spark/SparkThrowableHelper.scala
+++ b/common/utils/src/main/scala/org/apache/spark/SparkThrowableHelper.scala
@@ -74,26 +74,6 @@ private[spark] object SparkThrowableHelper {
     errorClass.startsWith("INTERNAL_ERROR")
   }
 
-  def isRuntimeUserError(e: Throwable): Boolean = {
-    e match {
-      case st: SparkThrowable if st.getErrorClass != null =>
-        st.getErrorClass match {
-          case "DIVIDE_BY_ZERO" | "INTERVAL_DIVIDED_BY_ZERO" => true
-          case "ARITHMETIC_OVERFLOW" | "BINARY_ARITHMETIC_OVERFLOW" | "CAST_OVERFLOW" |
-               "CAST_OVERFLOW_IN_TABLE_INSERT" | "DATETIME_OVERFLOW" |
-               "INTERVAL_ARITHMETIC_OVERFLOW" => true
-          case "CAST_INVALID_INPUT" | "NUMERIC_VALUE_OUT_OF_RANGE" | "CANNOT_PARSE_TIMESTAMP" =>
-            true
-          case "INVALID_ARRAY_INDEX" | "INVALID_ARRAY_INDEX_IN_ELEMENT_AT" |
-               "INVALID_INDEX_OF_ZERO" => true
-          // TODO: add more user-facing runtime errors (mostly ANSI errors).
-          case _ => false
-        }
-
-      case _ => false
-    }
-  }
-
   def getMessage(e: SparkThrowable with Throwable, format: ErrorMessageFormat.Value): String = {
     import ErrorMessageFormat._
     format match {

--- a/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroLogicalTypeSuite.scala
+++ b/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroLogicalTypeSuite.scala
@@ -433,10 +433,12 @@ abstract class AvroLogicalTypeSuite extends QueryTest with SharedSparkSession {
       dataFileWriter.flush()
       dataFileWriter.close()
 
+      val ex = intercept[SparkException] {
+        spark.read.format("avro").load(s"$dir.avro").collect()
+      }
+      assert(ex.getErrorClass == "FAILED_READ_FILE")
       checkError(
-        exception = intercept[SparkException] {
-          spark.read.format("avro").load(s"$dir.avro").collect()
-        }.getCause.getCause.asInstanceOf[SparkArithmeticException],
+        exception = ex.getCause.asInstanceOf[SparkArithmeticException],
         errorClass = "NUMERIC_VALUE_OUT_OF_RANGE",
         parameters = Map(
           "value" -> "0",

--- a/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
+++ b/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
@@ -32,7 +32,6 @@ import org.apache.avro.file.{DataFileReader, DataFileWriter}
 import org.apache.avro.generic.{GenericData, GenericDatumReader, GenericDatumWriter, GenericRecord}
 import org.apache.avro.generic.GenericData.{EnumSymbol, Fixed}
 import org.apache.commons.io.FileUtils
-import org.apache.commons.lang3.exception.ExceptionUtils
 
 import org.apache.spark.{SPARK_VERSION_SHORT, SparkConf, SparkException, SparkUpgradeException}
 import org.apache.spark.TestUtils.assertExceptionMsg
@@ -862,23 +861,19 @@ abstract class AvroSuite
       sql("SELECT 13.1234567890 a").write.format("avro").save(path.toString)
       // With the flag disabled, we will throw an exception if there is a mismatch
       withSQLConf(confKey -> "false") {
-        val e = intercept[SparkException] {
+        val ex = intercept[SparkException] {
           spark.read.schema("a DECIMAL(4, 3)").format("avro").load(path.toString).collect()
         }
-        ExceptionUtils.getRootCause(e) match {
-          case ex: AnalysisException =>
-            checkError(
-              exception = ex,
-              errorClass = "AVRO_INCOMPATIBLE_READ_TYPE",
-              parameters = Map("avroPath" -> "field 'a'",
-                "sqlPath" -> "field 'a'",
-                "avroType" -> "decimal\\(12,10\\)",
-                "sqlType" -> "\"DECIMAL\\(4,3\\)\""),
-              matchPVals = true
-            )
-          case other =>
-            fail(s"Received unexpected exception", other)
-        }
+        assert(ex.getErrorClass == "FAILED_READ_FILE")
+        checkError(
+          exception = ex.getCause.asInstanceOf[AnalysisException],
+          errorClass = "AVRO_INCOMPATIBLE_READ_TYPE",
+          parameters = Map("avroPath" -> "field 'a'",
+            "sqlPath" -> "field 'a'",
+            "avroType" -> "decimal\\(12,10\\)",
+            "sqlType" -> "\"DECIMAL\\(4,3\\)\""),
+          matchPVals = true
+        )
       }
       // The following used to work, so it should still work with the flag enabled
       checkAnswer(
@@ -911,24 +906,19 @@ abstract class AvroSuite
 
       withSQLConf(confKey -> "false") {
         Seq("DATE", "TIMESTAMP", "TIMESTAMP_NTZ").foreach { sqlType =>
-          val e = intercept[SparkException] {
+          val ex = intercept[SparkException] {
             spark.read.schema(s"a $sqlType").format("avro").load(path.toString).collect()
           }
-
-          ExceptionUtils.getRootCause(e) match {
-            case ex: AnalysisException =>
-              checkError(
-                exception = ex,
-                errorClass = "AVRO_INCOMPATIBLE_READ_TYPE",
-                parameters = Map("avroPath" -> "field 'a'",
-                  "sqlPath" -> "field 'a'",
-                  "avroType" -> "interval day to second",
-                  "sqlType" -> s""""$sqlType""""),
-                matchPVals = true
-              )
-            case other =>
-              fail(s"Received unexpected exception", other)
-          }
+          assert(ex.getErrorClass == "FAILED_READ_FILE")
+          checkError(
+            exception = ex.getCause.asInstanceOf[AnalysisException],
+            errorClass = "AVRO_INCOMPATIBLE_READ_TYPE",
+            parameters = Map("avroPath" -> "field 'a'",
+              "sqlPath" -> "field 'a'",
+              "avroType" -> "interval day to second",
+              "sqlType" -> s""""$sqlType""""),
+            matchPVals = true
+          )
         }
       }
 
@@ -953,24 +943,19 @@ abstract class AvroSuite
 
       withSQLConf(confKey -> "false") {
         Seq("DATE", "TIMESTAMP", "TIMESTAMP_NTZ").foreach { sqlType =>
-          val e = intercept[SparkException] {
+          val ex = intercept[SparkException] {
             spark.read.schema(s"a $sqlType").format("avro").load(path.toString).collect()
           }
-
-          ExceptionUtils.getRootCause(e) match {
-            case ex: AnalysisException =>
-              checkError(
-                exception = ex,
-                errorClass = "AVRO_INCOMPATIBLE_READ_TYPE",
-                parameters = Map("avroPath" -> "field 'a'",
-                  "sqlPath" -> "field 'a'",
-                  "avroType" -> "interval year to month",
-                  "sqlType" -> s""""$sqlType""""),
-                matchPVals = true
-              )
-            case other =>
-              fail(s"Received unexpected exception", other)
-          }
+          assert(ex.getErrorClass == "FAILED_READ_FILE")
+          checkError(
+            exception = ex.getCause.asInstanceOf[AnalysisException],
+            errorClass = "AVRO_INCOMPATIBLE_READ_TYPE",
+            parameters = Map("avroPath" -> "field 'a'",
+              "sqlPath" -> "field 'a'",
+              "avroType" -> "interval year to month",
+              "sqlType" -> s""""$sqlType""""),
+            matchPVals = true
+          )
         }
       }
 
@@ -1465,13 +1450,15 @@ abstract class AvroSuite
       df.write.format("avro").option("avroSchema", avroSchema).save(tempSaveDir)
       checkAvroSchemaEquals(avroSchema, getAvroSchemaStringFromFiles(tempSaveDir))
 
-      val message = intercept[SparkException] {
+      val ex = intercept[SparkException] {
         spark.createDataFrame(spark.sparkContext.parallelize(Seq(Row(2, null))), catalystSchema)
           .write.format("avro").option("avroSchema", avroSchema)
           .save(s"$tempDir/${UUID.randomUUID()}")
-      }.getMessage
-      assert(message.contains("Caused by: java.lang.NullPointerException: "))
-      assert(message.contains("null value for (non-nullable) string at test_schema.Name"))
+      }
+      assert(ex.getErrorClass == "TASK_WRITE_FAILED")
+      assert(ex.getCause.isInstanceOf[java.lang.NullPointerException])
+      assert(ex.getCause.getMessage.contains(
+        "null value for (non-nullable) string at test_schema.Name"))
     }
   }
 
@@ -2380,7 +2367,8 @@ abstract class AvroSuite
             val e = intercept[SparkException] {
               df.write.format("avro").option("avroSchema", avroSchema).save(path3_x)
             }
-            assert(e.getCause.getCause.isInstanceOf[SparkUpgradeException])
+            assert(e.getErrorClass == "TASK_WRITE_FAILED")
+            assert(e.getCause.isInstanceOf[SparkUpgradeException])
           }
           checkDefaultLegacyRead(oldPath)
 
@@ -2405,10 +2393,6 @@ abstract class AvroSuite
       }
     }
 
-    def failInRead(path: String): Unit = {
-      val e = intercept[SparkException](spark.read.format("avro").load(path).collect())
-      assert(e.getCause.isInstanceOf[SparkUpgradeException])
-    }
     def successInRead(path: String): Unit = spark.read.format("avro").load(path).collect()
     Seq(
       // By default we should not fail to read ancient datetime values when parquet files don't
@@ -2638,7 +2622,8 @@ abstract class AvroSuite
           val e = intercept[SparkException] {
             df.write.format("avro").option("avroSchema", avroSchema).save(dir.getCanonicalPath)
           }
-          val errMsg = e.getCause.getCause.asInstanceOf[SparkUpgradeException].getMessage
+          assert(e.getErrorClass == "TASK_WRITE_FAILED")
+          val errMsg = e.getCause.asInstanceOf[SparkUpgradeException].getMessage
           assert(errMsg.contains("You may get a different result due to the upgrading"))
         }
       }
@@ -2648,7 +2633,8 @@ abstract class AvroSuite
         val e = intercept[SparkException] {
           df.write.format("avro").save(dir.getCanonicalPath)
         }
-        val errMsg = e.getCause.getCause.asInstanceOf[SparkUpgradeException].getMessage
+        assert(e.getErrorClass == "TASK_WRITE_FAILED")
+        val errMsg = e.getCause.asInstanceOf[SparkUpgradeException].getMessage
         assert(errMsg.contains("You may get a different result due to the upgrading"))
       }
     }
@@ -2659,11 +2645,10 @@ abstract class AvroSuite
         "before_1582_timestamp_micros_v2_4_5.avro",
         "before_1582_timestamp_millis_v2_4_5.avro"
       ).foreach { fileName =>
-        val e = intercept[SparkException] {
+        val e = intercept[SparkUpgradeException] {
           spark.read.format("avro").load(getResourceAvroFilePath(fileName)).collect()
         }
-        val errMsg = e.getCause.asInstanceOf[SparkUpgradeException].getMessage
-        assert(errMsg.contains("You may get a different result due to the upgrading"))
+        assert(e.getMessage.contains("You may get a different result due to the upgrading"))
       }
     }
   }

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/streaming/ClientStreamingQuerySuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/streaming/ClientStreamingQuerySuite.scala
@@ -207,9 +207,8 @@ class ClientStreamingQuerySuite extends QueryTest with SQLHelper with Logging {
       assert(!exception.getMessageParameters().get("endOffset").isEmpty)
       assert(exception.getCause.isInstanceOf[SparkException])
       assert(exception.getCause.getCause.isInstanceOf[SparkException])
-      assert(exception.getCause.getCause.getCause.isInstanceOf[SparkException])
       assert(
-        exception.getCause.getCause.getCause.getMessage
+        exception.getCause.getCause.getMessage
           .contains("java.lang.RuntimeException: Number 2 encountered!"))
     } finally {
       spark.streams.resetTerminated()
@@ -248,9 +247,8 @@ class ClientStreamingQuerySuite extends QueryTest with SQLHelper with Logging {
     assert(!exception.getMessageParameters().get("endOffset").isEmpty)
     assert(exception.getCause.isInstanceOf[SparkException])
     assert(exception.getCause.getCause.isInstanceOf[SparkException])
-    assert(exception.getCause.getCause.getCause.isInstanceOf[SparkException])
     assert(
-      exception.getCause.getCause.getCause.getMessage
+      exception.getCause.getCause.getMessage
         .contains("java.lang.RuntimeException: Number 2 encountered!"))
   }
 

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/OracleIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/OracleIntegrationSuite.scala
@@ -359,10 +359,9 @@ class OracleIntegrationSuite extends DockerJDBCIntegrationSuite with SharedSpark
 
   test("SPARK-20427/SPARK-20921: read table use custom schema by jdbc api") {
     // default will throw IllegalArgumentException
-    val e = intercept[org.apache.spark.SparkException] {
+    val e = intercept[org.apache.spark.SparkArithmeticException] {
       spark.read.jdbc(jdbcUrl, "tableWithCustomSchema", new Properties()).collect()
     }
-    assert(e.getCause().isInstanceOf[ArithmeticException])
     assert(e.getMessage.contains("Decimal precision 39 exceeds max precision 38"))
 
     // custom schema can read data

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -2832,8 +2832,8 @@ private[spark] class DAGScheduler(
     updateStageInfoForPushBasedShuffle(failedStage)
     for (job <- dependentJobs) {
       val finalException = exception.collect {
-        // If the error is well defined (has an error class and is not internal error), we treat
-        // it as user-facing, and expose this error to the end users directly.
+        // If the error is user-facing (defines error class and is not internal error), we don't
+        // wrap it with "Job aborted" and expose this error to the end users directly.
         case st: Exception with SparkThrowable if st.getErrorClass != null &&
             !SparkThrowableHelper.isInternalError(st.getErrorClass) =>
           st

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -2831,10 +2831,16 @@ private[spark] class DAGScheduler(
     failedStage.latestInfo.completionTime = Some(clock.getTimeMillis())
     updateStageInfoForPushBasedShuffle(failedStage)
     for (job <- dependentJobs) {
-      failJobAndIndependentStages(
-        job,
+      val finalException = exception.collect {
+        // If the error is well defined (has an error class and is not internal error), we treat
+        // it as user-facing, and expose this error to the end users directly.
+        case st: Exception with SparkThrowable if st.getErrorClass != null &&
+            !SparkThrowableHelper.isInternalError(st.getErrorClass) =>
+          st
+      }.getOrElse {
         new SparkException(s"Job aborted due to stage failure: $reason", cause = exception.orNull)
-      )
+      }
+      failJobAndIndependentStages(job, finalException)
     }
     if (dependentJobs.isEmpty) {
       logInfo("Ignoring failure of " + failedStage + " because all jobs depending on it are done")
@@ -2895,7 +2901,7 @@ private[spark] class DAGScheduler(
   /** Fails a job and all stages that are only used by that job, and cleans up relevant state. */
   private def failJobAndIndependentStages(
       job: ActiveJob,
-      error: SparkException): Unit = {
+      error: Exception): Unit = {
     if (cancelRunningIndependentStages(job, error.getMessage)) {
       // SPARK-15783 important to cleanup state first, just for tests where we have some asserts
       // against the state.  Otherwise we have a *little* bit of flakiness in the tests.

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -976,14 +976,6 @@ private[spark] class TaskSetManager(
             info.id, taskSet.id, tid, ef.description))
           return
         }
-        if (ef.exception.exists(SparkThrowableHelper.isRuntimeUserError)) {
-          // We should not re-try tasks for user-errors (e.g. arithmetic overflow), as the error is
-          // not transient and re-try won't help.
-          emptyTaskInfoAccumulablesAndNotifyDagScheduler(tid, tasks(index), reason, null,
-            accumUpdates, metricPeaks)
-          abort(s"$task throws a runtime user-error", ef.exception)
-          return
-        }
         val key = ef.description
         val now = clock.getTimeMillis()
         val (printFull, dupCount) = {

--- a/docs/sql-error-conditions.md
+++ b/docs/sql-error-conditions.md
@@ -726,6 +726,12 @@ For more details see [FAILED_JDBC](sql-error-conditions-failed-jdbc-error-class.
 
 Failed parsing struct: `<raw>`.
 
+### FAILED_READ_FILE
+
+SQLSTATE: KD001
+
+Encountered error while reading file `<path>`.
+
 ### FAILED_REGISTER_CLASS_WITH_KRYO
 
 SQLSTATE: KD000

--- a/mllib/src/test/scala/org/apache/spark/mllib/classification/NaiveBayesSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/classification/NaiveBayesSuite.scala
@@ -24,7 +24,7 @@ import breeze.stats.distributions.{Multinomial => BrzMultinomial}
 import breeze.stats.distributions.Rand.FixedSeed.randBasis
 import org.scalatest.exceptions.TestFailedException
 
-import org.apache.spark.{SparkException, SparkFunSuite}
+import org.apache.spark.{SparkException, SparkFunSuite, SparkRuntimeException}
 import org.apache.spark.mllib.linalg.{Vector, Vectors}
 import org.apache.spark.mllib.regression.LabeledPoint
 import org.apache.spark.mllib.util.{LocalClusterSparkContext, MLlibTestSparkContext}
@@ -253,7 +253,7 @@ class NaiveBayesSuite extends SparkFunSuite with MLlibTestSparkContext {
       LabeledPoint(0.0, Vectors.dense(-1.0)),
       LabeledPoint(1.0, Vectors.dense(1.0)),
       LabeledPoint(1.0, Vectors.dense(0.0)))
-    intercept[SparkException] {
+    intercept[SparkRuntimeException] {
       NaiveBayes.train(sc.makeRDD(dense, 2))
     }
     val sparse = Seq(
@@ -261,7 +261,7 @@ class NaiveBayesSuite extends SparkFunSuite with MLlibTestSparkContext {
       LabeledPoint(0.0, Vectors.sparse(1, Array(0), Array(-1.0))),
       LabeledPoint(1.0, Vectors.sparse(1, Array(0), Array(1.0))),
       LabeledPoint(1.0, Vectors.sparse(1, Array.empty, Array.empty)))
-    intercept[SparkException] {
+    intercept[SparkRuntimeException] {
       NaiveBayes.train(sc.makeRDD(sparse, 2))
     }
     val nan = Seq(
@@ -269,7 +269,7 @@ class NaiveBayesSuite extends SparkFunSuite with MLlibTestSparkContext {
       LabeledPoint(0.0, Vectors.sparse(1, Array(0), Array(Double.NaN))),
       LabeledPoint(1.0, Vectors.sparse(1, Array(0), Array(1.0))),
       LabeledPoint(1.0, Vectors.sparse(1, Array.empty, Array.empty)))
-    intercept[SparkException] {
+    intercept[SparkRuntimeException] {
       NaiveBayes.train(sc.makeRDD(nan, 2))
     }
   }
@@ -281,7 +281,7 @@ class NaiveBayesSuite extends SparkFunSuite with MLlibTestSparkContext {
       LabeledPoint(1.0, Vectors.dense(1.0)),
       LabeledPoint(1.0, Vectors.dense(0.0)))
 
-    intercept[SparkException] {
+    intercept[SparkRuntimeException] {
       NaiveBayes.train(sc.makeRDD(badTrain, 2), 1.0, Bernoulli)
     }
 

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -24,9 +24,7 @@ import math
 import re
 import unittest
 
-from py4j.protocol import Py4JJavaError
-
-from pyspark.errors import PySparkTypeError, PySparkValueError
+from pyspark.errors import PySparkTypeError, PySparkValueError, SparkRuntimeException
 from pyspark.sql import Row, Window, functions as F, types
 from pyspark.sql.column import Column
 from pyspark.testing.sqlutils import ReusedSQLTestCase, SQLTestUtils
@@ -1073,7 +1071,7 @@ class FunctionsTestsMixin:
         self.assertEqual(datetime.date(2017, 1, 22), parse_result["to_date(dateCol)"])
 
     def test_assert_true(self):
-        self.check_assert_true(Py4JJavaError)
+        self.check_assert_true(SparkRuntimeException)
 
     def check_assert_true(self, tpe):
         df = self.spark.range(3)
@@ -1099,7 +1097,7 @@ class FunctionsTestsMixin:
         )
 
     def test_raise_error(self):
-        self.check_raise_error(Py4JJavaError)
+        self.check_raise_error(SparkRuntimeException)
 
     def check_raise_error(self, tpe):
         df = self.spark.createDataFrame([Row(id="foobar")])

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/FailureSafeParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/FailureSafeParser.scala
@@ -78,8 +78,8 @@ class FailureSafeParser[IN](
             case StringAsDataTypeException(fieldName, fieldValue, dataType) =>
               throw QueryExecutionErrors.cannotParseStringAsDataTypeError(e.record().toString,
                 fieldName, fieldValue, dataType)
-            case _ => throw QueryExecutionErrors.malformedRecordsDetectedInRecordParsingError(
-              toResultRow(e.partialResults().headOption, e.record).toString, e)
+            case other => throw QueryExecutionErrors.malformedRecordsDetectedInRecordParsingError(
+              toResultRow(e.partialResults().headOption, e.record).toString, other)
           }
       }
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -42,7 +42,7 @@ import org.apache.spark.sql.catalyst.plans.JoinType
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.plans.logical.statsEstimation.ValueInterval
 import org.apache.spark.sql.catalyst.trees.{Origin, TreeNode}
-import org.apache.spark.sql.catalyst.util.{sideBySide, BadRecordException, DateTimeUtils, FailFastMode, MapData}
+import org.apache.spark.sql.catalyst.util.{sideBySide, DateTimeUtils, FailFastMode, MapData}
 import org.apache.spark.sql.connector.catalog.{CatalogNotFoundException, Table, TableProvider}
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
 import org.apache.spark.sql.connector.expressions.Transform
@@ -836,7 +836,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
       e: Throwable,
       path: String): Throwable = {
     new SparkException(
-      errorClass = "_LEGACY_ERROR_TEMP_2064",
+      errorClass = "FAILED_READ_FILE",
       messageParameters = Map("path" -> path),
       cause = e)
   }
@@ -1501,7 +1501,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
   }
 
   def malformedRecordsDetectedInRecordParsingError(
-      badRecord: String, e: BadRecordException): Throwable = {
+      badRecord: String, e: Throwable): Throwable = {
     new SparkException(
       errorClass = "MALFORMED_RECORD_IN_PARSING.WITHOUT_SUGGESTION",
       messageParameters = Map(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileScanRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileScanRDD.scala
@@ -20,11 +20,9 @@ package org.apache.spark.sql.execution.datasources
 import java.io.{Closeable, FileNotFoundException, IOException}
 import java.net.URI
 
-import scala.util.control.NonFatal
-
 import org.apache.hadoop.fs.Path
 
-import org.apache.spark.{Partition => RDDPartition, SparkUpgradeException, TaskContext}
+import org.apache.spark.{Partition => RDDPartition, TaskContext}
 import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.paths.SparkPath
 import org.apache.spark.rdd.{InputFileBlockHolder, RDD}
@@ -35,6 +33,7 @@ import org.apache.spark.sql.catalyst.types.PhysicalDataType
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.execution.datasources.FileFormat._
+import org.apache.spark.sql.execution.datasources.v2.FileDataSourceV2
 import org.apache.spark.sql.execution.vectorized.{ColumnVectorUtils, ConstantColumnVector}
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnVector}
@@ -122,12 +121,23 @@ class FileScanRDD(
         currentIterator = null
       }
 
+      // This is called by both `hasNext` and `nextIterator`. We do not merge it into `hasNext`,
+      // to make the error enhancement in `hasNext` only apply once in the recursion (`nextIterator`
+      // calls `hasNext0`).
+      private def hasNext0: Boolean = {
+        (currentIterator != null && currentIterator.hasNext) || nextIterator()
+      }
+
       def hasNext: Boolean = {
         // Kill the task in case it has been marked as killed. This logic is from
         // InterruptibleIterator, but we inline it here instead of wrapping the iterator in order
         // to avoid performance overhead.
         context.killTaskIfInterrupted()
-        (currentIterator != null && currentIterator.hasNext) || nextIterator()
+        try {
+          hasNext0
+        } catch {
+          case e: Throwable => throw FileDataSourceV2.attachFilePath(currentFile.urlEncodedPath, e)
+        }
       }
 
       ///////////////////////////
@@ -280,20 +290,7 @@ class FileScanRDD(
             currentIterator = readCurrentFile()
           }
 
-          try {
-            hasNext
-          } catch {
-            case e: SchemaColumnConvertNotSupportedException =>
-              throw QueryExecutionErrors.unsupportedSchemaColumnConvertError(
-                currentFile.urlEncodedPath, e.getColumn, e.getLogicalType, e.getPhysicalType, e)
-            case sue: SparkUpgradeException => throw sue
-            case NonFatal(e) =>
-              e.getCause match {
-                case sue: SparkUpgradeException => throw sue
-                case _ =>
-                  throw QueryExecutionErrors.cannotReadFilesError(e, currentFile.urlEncodedPath)
-              }
-          }
+          hasNext0
         } else {
           currentFile = null
           updateMetadataRow()

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileDataSourceV2.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileDataSourceV2.scala
@@ -19,12 +19,14 @@ package org.apache.spark.sql.execution.datasources.v2
 import java.util
 
 import scala.jdk.CollectionConverters._
+import scala.util.control.NonFatal
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 
+import org.apache.spark.{SparkException, SparkFileNotFoundException, SparkUpgradeException}
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.connector.catalog.{Table, TableProvider}
 import org.apache.spark.sql.connector.expressions.Transform
@@ -115,8 +117,29 @@ trait FileDataSourceV2 extends TableProvider with DataSourceRegister {
   }
 }
 
-private object FileDataSourceV2 {
+object FileDataSourceV2 {
   private lazy val objectMapper = new ObjectMapper().registerModule(DefaultScalaModule)
   private def readPathsToSeq(paths: String): Seq[String] =
     objectMapper.readValue(paths, classOf[Seq[String]])
+
+  def attachFilePath(filePath: => String, ex: Throwable): Throwable = {
+    ex match {
+      case e: SchemaColumnConvertNotSupportedException =>
+        throw QueryExecutionErrors.unsupportedSchemaColumnConvertError(
+          filePath, e.getColumn, e.getLogicalType, e.getPhysicalType, e)
+      case sue: SparkUpgradeException => throw sue
+      // the following exceptions already contains file path, we don't need to wrap it with
+      // `QueryExecutionErrors.cannotReadFilesError` to provide the file path.
+      case e: SparkFileNotFoundException => throw e
+      case e: SparkException if e.getErrorClass == "CANNOT_READ_FILE_FOOTER" => throw e
+      case NonFatal(e) =>
+        // TODO: do we need to check the cause?
+        e.getCause match {
+          case sue: SparkUpgradeException => throw sue
+          case e: SparkFileNotFoundException => throw e
+          case e: SparkException if e.getErrorClass == "CANNOT_READ_FILE_FOOTER" => throw e
+          case _ => throw QueryExecutionErrors.cannotReadFilesError(e, filePath)
+        }
+    }
+  }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FilePartitionReaderFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FilePartitionReaderFactory.scala
@@ -28,20 +28,14 @@ abstract class FilePartitionReaderFactory extends PartitionReaderFactory {
 
   override def createReader(partition: InputPartition): PartitionReader[InternalRow] = {
     assert(partition.isInstanceOf[FilePartition])
-    val filePartition = partition.asInstanceOf[FilePartition]
-    val iter = filePartition.files.iterator.map { file =>
-      PartitionedFileReader(file, buildReader(file))
-    }
-    new FilePartitionReader[InternalRow](iter, options)
+    val files = partition.asInstanceOf[FilePartition].files
+    new FilePartitionReader[InternalRow](files.iterator, buildReader, options)
   }
 
   override def createColumnarReader(partition: InputPartition): PartitionReader[ColumnarBatch] = {
     assert(partition.isInstanceOf[FilePartition])
-    val filePartition = partition.asInstanceOf[FilePartition]
-    val iter = filePartition.files.iterator.map { file =>
-      PartitionedFileReader(file, buildColumnarReader(file))
-    }
-    new FilePartitionReader[ColumnarBatch](iter, options)
+    val files = partition.asInstanceOf[FilePartition].files
+    new FilePartitionReader[ColumnarBatch](files.iterator, buildColumnarReader, options)
   }
 
   def buildReader(partitionedFile: PartitionedFile): PartitionReader[InternalRow]

--- a/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
@@ -26,7 +26,7 @@ import org.apache.hadoop.io.{LongWritable, Text}
 import org.apache.hadoop.mapreduce.lib.input.{TextInputFormat => NewTextInputFormat}
 import org.scalatest.matchers.should.Matchers._
 
-import org.apache.spark.{SparkException, SparkThrowable}
+import org.apache.spark.{SparkException, SparkRuntimeException}
 import org.apache.spark.sql.UpdateFieldsBenchmark._
 import org.apache.spark.sql.catalyst.expressions.{InSet, Literal, NamedExpression}
 import org.apache.spark.sql.catalyst.util.DateTimeTestUtils.{outstandingTimezonesIds, outstandingZoneIds}
@@ -2571,10 +2571,10 @@ class ColumnExpressionSuite extends QueryTest with SharedSparkSession {
       booleanDf.filter("cond = true").select(assert_true($"cond")),
       Row(null) :: Nil
     )
-    val e1 = intercept[SparkException] {
-      booleanDf.select(assert_true($"cond", lit(null.asInstanceOf[String]))).collect()
-    }
-    checkError(e1.getCause.asInstanceOf[SparkThrowable],
+    checkError(
+      exception = intercept[SparkRuntimeException] {
+        booleanDf.select(assert_true($"cond", lit(null.asInstanceOf[String]))).collect()
+      },
       errorClass = "USER_RAISED_EXCEPTION",
       parameters = Map("errorMessage" -> "null"))
 
@@ -2583,39 +2583,37 @@ class ColumnExpressionSuite extends QueryTest with SharedSparkSession {
       nullDf.filter("cond = true").select(assert_true($"cond", $"cond")),
       Row(null) :: Nil
     )
-    val e2 = intercept[SparkException] {
-      nullDf.select(assert_true($"cond", $"n")).collect()
-    }
-    checkError(e2.getCause.asInstanceOf[SparkThrowable],
+    checkError(
+      exception = intercept[SparkRuntimeException] {
+        nullDf.select(assert_true($"cond", $"n")).collect()
+      },
       errorClass = "USER_RAISED_EXCEPTION",
       parameters = Map("errorMessage" -> "first row"))
 
     // assert_true(condition)
     val intDf = Seq((0, 1)).toDF("a", "b")
     checkAnswer(intDf.select(assert_true($"a" < $"b")), Row(null) :: Nil)
-    val e3 = intercept[SparkException] {
+    val e3 = intercept[SparkRuntimeException] {
       intDf.select(assert_true($"a" > $"b")).collect()
     }
-
-    assert(e3.getCause.isInstanceOf[RuntimeException])
-    assert(e3.getCause.getMessage.matches(
+    assert(e3.getMessage.matches(
       "\\[USER_RAISED_EXCEPTION\\] '\\(a#\\d+ > b#\\d+\\)' is not true! SQLSTATE: P0001"))
   }
 
   test("raise_error") {
     val strDf = Seq(("hello")).toDF("a")
 
-    val e1 = intercept[SparkException] {
-      strDf.select(raise_error(lit(null.asInstanceOf[String]))).collect()
-    }
-    checkError(e1.getCause.asInstanceOf[SparkThrowable],
+    checkError(
+      exception = intercept[SparkRuntimeException] {
+        strDf.select(raise_error(lit(null.asInstanceOf[String]))).collect()
+      },
       errorClass = "USER_RAISED_EXCEPTION",
       parameters = Map("errorMessage" -> "null"))
 
-    val e2 = intercept[SparkException] {
-      strDf.select(raise_error($"a")).collect()
-    }
-    checkError(e2.getCause.asInstanceOf[SparkThrowable],
+    checkError(
+      exception = intercept[SparkRuntimeException] {
+        strDf.select(raise_error($"a")).collect()
+      },
       errorClass = "USER_RAISED_EXCEPTION",
       parameters = Map("errorMessage" -> "hello"))
   }
@@ -2653,13 +2651,12 @@ class ColumnExpressionSuite extends QueryTest with SharedSparkSession {
         }
       }
 
-      val e = intercept[SparkException] {
+      val e = intercept[ArithmeticException] {
         Seq((LocalDate.of(2021, 3, 11), Period.ofMonths(Int.MaxValue)))
           .toDF("date", "interval")
           .select($"date" + $"interval")
           .collect()
-      }.getCause
-      assert(e.isInstanceOf[ArithmeticException])
+      }
       assert(e.getMessage.contains("integer overflow"))
     }
   }
@@ -2683,13 +2680,12 @@ class ColumnExpressionSuite extends QueryTest with SharedSparkSession {
         }
       }
 
-      val e = intercept[SparkException] {
+      val e = intercept[ArithmeticException] {
         Seq((LocalDate.of(2021, 3, 11), Period.ofMonths(Int.MaxValue)))
           .toDF("date", "interval")
           .select($"date" - $"interval")
           .collect()
-      }.getCause
-      assert(e.isInstanceOf[ArithmeticException])
+      }
       assert(e.getMessage.contains("integer overflow"))
     }
   }
@@ -2917,22 +2913,19 @@ class ColumnExpressionSuite extends QueryTest with SharedSparkSession {
       Seq((Period.ofMonths(-1), BigDecimal(0.5))).toDF("i", "n").select($"i" / $"n"),
       Row(Period.ofMonths(-2)))
 
-    val e = intercept[SparkException] {
+    val e = intercept[ArithmeticException] {
       Seq((Period.ofYears(9999), 0)).toDF("i", "n").select($"i" / $"n").collect()
-    }.getCause
-    assert(e.isInstanceOf[ArithmeticException])
+    }
     assert(e.getMessage.contains("Division by zero"))
 
-    val e2 = intercept[SparkException] {
+    val e2 = intercept[ArithmeticException] {
       Seq((Period.ofYears(9999), 0d)).toDF("i", "n").select($"i" / $"n").collect()
-    }.getCause
-    assert(e2.isInstanceOf[ArithmeticException])
+    }
     assert(e2.getMessage.contains("Division by zero"))
 
-    val e3 = intercept[SparkException] {
+    val e3 = intercept[ArithmeticException] {
       Seq((Period.ofYears(9999), BigDecimal(0))).toDF("i", "n").select($"i" / $"n").collect()
-    }.getCause
-    assert(e3.isInstanceOf[ArithmeticException])
+    }
     assert(e3.getMessage.contains("Division by zero"))
   }
 
@@ -2964,22 +2957,19 @@ class ColumnExpressionSuite extends QueryTest with SharedSparkSession {
         .toDF("i", "n").select($"i" / $"n"),
       Row(Duration.of(-1, ChronoUnit.MICROS).multipliedBy(10000).dividedBy(100000001)))
 
-    val e = intercept[SparkException] {
+    val e = intercept[ArithmeticException] {
       Seq((Duration.ofDays(9999), 0)).toDF("i", "n").select($"i" / $"n").collect()
-    }.getCause
-    assert(e.isInstanceOf[ArithmeticException])
+    }
     assert(e.getMessage.contains("Division by zero"))
 
-    val e2 = intercept[SparkException] {
+    val e2 = intercept[ArithmeticException] {
       Seq((Duration.ofDays(9999), 0d)).toDF("i", "n").select($"i" / $"n").collect()
-    }.getCause
-    assert(e2.isInstanceOf[ArithmeticException])
+    }
     assert(e2.getMessage.contains("Division by zero"))
 
-    val e3 = intercept[SparkException] {
+    val e3 = intercept[ArithmeticException] {
       Seq((Duration.ofDays(9999), BigDecimal(0))).toDF("i", "n").select($"i" / $"n").collect()
-    }.getCause
-    assert(e3.isInstanceOf[ArithmeticException])
+    }
     assert(e3.getMessage.contains("Division by zero"))
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
@@ -179,12 +179,10 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSparkSession {
     )
 
     val df5 = Seq((Seq("a", null), Seq(1, 2))).toDF("k", "v")
-    val e1 = intercept[SparkException] {
-      df5.select(map_from_arrays($"k", $"v")).collect()
-    }
-    assert(e1.getCause.isInstanceOf[SparkRuntimeException])
     checkError(
-      exception = e1.getCause.asInstanceOf[SparkRuntimeException],
+      exception = intercept[SparkRuntimeException] {
+        df5.select(map_from_arrays($"k", $"v")).collect()
+      },
       errorClass = "NULL_MAP_KEY",
       parameters = Map.empty
     )
@@ -1242,8 +1240,8 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSparkSession {
       Row(null)
     )
 
-    intercept[SparkException](df1.selectExpr("map_concat(map1, map2)").collect())
-    intercept[SparkException](df1.select(map_concat($"map1", $"map2")).collect())
+    intercept[SparkRuntimeException](df1.selectExpr("map_concat(map1, map2)").collect())
+    intercept[SparkRuntimeException](df1.select(map_concat($"map1", $"map2")).collect())
     withSQLConf(SQLConf.MAP_KEY_DEDUP_POLICY.key -> SQLConf.MapKeyDedupPolicy.LAST_WIN.toString) {
       checkAnswer(df1.selectExpr("map_concat(map1, map2)"), expected1a)
       checkAnswer(df1.select(map_concat($"map1", $"map2")), expected1a)
@@ -3417,12 +3415,10 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSparkSession {
     )
     checkAnswer(df4.selectExpr("array_insert(a, b, c)"), Seq(Row(Seq(true, false, false))))
 
-    val e1 = intercept[SparkException] {
-      df5.selectExpr("array_insert(a, b, c)").show()
-    }
-    assert(e1.getCause.isInstanceOf[SparkRuntimeException])
     checkError(
-      exception = e1.getCause.asInstanceOf[SparkRuntimeException],
+      exception = intercept[SparkRuntimeException] {
+        df5.selectExpr("array_insert(a, b, c)").show()
+      },
       errorClass = "INVALID_INDEX_OF_ZERO",
       parameters = Map.empty,
       context = ExpectedContext(
@@ -4945,10 +4941,10 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSparkSession {
       checkAnswer(dfExample2.select(transform_keys(col("j"), (k, v) => k + v)),
         Seq(Row(Map(2.0 -> 1.0, 3.4 -> 1.4, 4.7 -> 1.7))))
 
-      intercept[SparkException] {
+      intercept[SparkRuntimeException] {
         dfExample3.selectExpr("transform_keys(x, (k, v) ->  k % 2 = 0 OR v)").collect()
       }
-      intercept[SparkException] {
+      intercept[SparkRuntimeException] {
         dfExample3.select(transform_keys(col("x"), (k, v) => k % 2 === 0 || v)).collect()
       }
       withSQLConf(SQLConf.MAP_KEY_DEDUP_POLICY.key -> SQLConf.MapKeyDedupPolicy.LAST_WIN.toString) {
@@ -5017,22 +5013,18 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSparkSession {
         stop = 35)
     )
 
-    val ex3 = intercept[SparkException] {
-      dfExample1.selectExpr("transform_keys(i, (k, v) -> v)").show()
-    }
-    assert(ex3.getCause.isInstanceOf[SparkRuntimeException])
     checkError(
-      exception = ex3.getCause.asInstanceOf[SparkRuntimeException],
+      exception = intercept[SparkRuntimeException] {
+        dfExample1.selectExpr("transform_keys(i, (k, v) -> v)").show()
+      },
       errorClass = "NULL_MAP_KEY",
       parameters = Map.empty
     )
 
-    val ex3a = intercept[Exception] {
-      dfExample1.select(transform_keys(col("i"), (k, v) => v)).show()
-    }
-    assert(ex3a.getCause.isInstanceOf[SparkRuntimeException])
     checkError(
-      exception = ex3a.getCause.asInstanceOf[SparkRuntimeException],
+      exception = intercept[SparkRuntimeException] {
+        dfExample1.select(transform_keys(col("i"), (k, v) => v)).show()
+      },
       errorClass = "NULL_MAP_KEY",
       parameters = Map.empty
     )
@@ -5659,12 +5651,10 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSparkSession {
 
   test("SPARK-24734: Fix containsNull of Concat for array type") {
     val df = Seq((Seq(1), Seq[Integer](null), Seq("a", "b"))).toDF("k1", "k2", "v")
-    val e1 = intercept[SparkException] {
-      df.select(map_from_arrays(concat($"k1", $"k2"), $"v")).show()
-    }
-    assert(e1.getCause.isInstanceOf[SparkRuntimeException])
     checkError(
-      exception = e1.getCause.asInstanceOf[SparkRuntimeException],
+      exception = intercept[SparkRuntimeException] {
+        df.select(map_from_arrays(concat($"k1", $"k2"), $"v")).show()
+      },
       errorClass = "NULL_MAP_KEY",
       parameters = Map.empty
     )
@@ -6023,7 +6013,7 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSparkSession {
     checkError(
       exception = intercept[SparkException] {
         df1.map(r => df2.count() * r.getInt(0)).collect()
-      }.getCause.asInstanceOf[SparkException],
+      },
       errorClass = "CANNOT_INVOKE_IN_TRANSFORMATIONS",
       parameters = Map.empty
     )

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -209,12 +209,11 @@ class DataFrameSuite extends QueryTest
     if (!ansiEnabled) {
       checkAnswer(df, expectedAnswer)
     } else {
-      val e = intercept[SparkException] {
+      val e = intercept[ArithmeticException] {
         df.collect()
       }
-      assert(e.getCause.isInstanceOf[ArithmeticException])
-      assert(e.getCause.getMessage.contains("cannot be represented as Decimal") ||
-        e.getCause.getMessage.contains("Overflow in sum of decimals"))
+      assert(e.getMessage.contains("cannot be represented as Decimal") ||
+        e.getMessage.contains("Overflow in sum of decimals"))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DateFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DateFunctionsSuite.scala
@@ -23,7 +23,7 @@ import java.time.{Instant, LocalDateTime, ZoneId}
 import java.util.{Locale, TimeZone}
 import java.util.concurrent.TimeUnit
 
-import org.apache.spark.{SPARK_DOC_ROOT, SparkConf, SparkException, SparkUpgradeException}
+import org.apache.spark.{SPARK_DOC_ROOT, SparkConf, SparkUpgradeException}
 import org.apache.spark.sql.catalyst.util.DateTimeTestUtils.{CEST, LA}
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.functions._
@@ -594,9 +594,9 @@ class DateFunctionsSuite extends QueryTest with SharedSparkSession {
   }
 
   def checkExceptionMessage(df: DataFrame): Unit = {
-    val message = intercept[SparkException] {
+    val message = intercept[SparkUpgradeException] {
       df.collect()
-    }.getCause.getMessage
+    }.getMessage
     assert(message.contains("Fail to parse"))
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/FileBasedDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/FileBasedDataSourceSuite.scala
@@ -251,9 +251,9 @@ class FileBasedDataSourceSuite extends QueryTest
               case _ => "_LEGACY_ERROR_TEMP_2055"
             }
             checkErrorMatchPVals(
-              exception = intercept[SparkException] {
+              exception = intercept[SparkFileNotFoundException] {
                 testIgnoreMissingFiles(options)
-              }.getCause.asInstanceOf[SparkFileNotFoundException],
+              },
               errorClass = errorClass,
               parameters = Map("message" -> ".*does not exist")
             )

--- a/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
@@ -23,8 +23,6 @@ import java.util.Locale
 
 import scala.jdk.CollectionConverters._
 
-import org.apache.commons.lang3.exception.ExceptionUtils
-
 import org.apache.spark.{SparkException, SparkRuntimeException}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Literal, StructsToJson}
@@ -837,18 +835,17 @@ class JsonFunctionsSuite extends QueryTest with SharedSparkSession {
         df.select(from_json($"value", schema, Map("mode" -> "PERMISSIVE"))),
         Row(Row(null, null, badRec)) :: Row(Row(2, 12, null)) :: Nil)
 
-      val exception1 = intercept[SparkException] {
-        df.select(from_json($"value", schema, Map("mode" -> "FAILFAST"))).collect()
-      }.getCause
       checkError(
-        exception = exception1.asInstanceOf[SparkException],
+        exception = intercept[SparkException] {
+          df.select(from_json($"value", schema, Map("mode" -> "FAILFAST"))).collect()
+        },
         errorClass = "MALFORMED_RECORD_IN_PARSING.WITHOUT_SUGGESTION",
         parameters = Map(
           "badRecord" -> "[null,null,{\"a\" 1, \"b\": 11}]",
           "failFastMode" -> "FAILFAST")
       )
 
-      val exception2 = intercept[SparkException] {
+      val exception2 = intercept[AnalysisException] {
         df.select(from_json($"value", schema, Map("mode" -> "DROPMALFORMED")))
           .collect()
       }.getMessage
@@ -871,19 +868,19 @@ class JsonFunctionsSuite extends QueryTest with SharedSparkSession {
         df.select(from_json($"value", schema, Map("mode" -> "PERMISSIVE"))),
         Row(Row(null, 11, badRec)) :: Row(Row(2, 12, null)) :: Nil)
 
-      val exception = intercept[SparkException] {
+      val ex = intercept[SparkException] {
         df.select(from_json($"value", schema, Map("mode" -> "FAILFAST"))).collect()
-      }.getCause
+      }
 
       checkError(
-        exception = exception.asInstanceOf[SparkException],
+        exception = ex,
         errorClass = "MALFORMED_RECORD_IN_PARSING.WITHOUT_SUGGESTION",
         parameters = Map(
           "badRecord" -> "[null,11,{\"a\": \"1\", \"b\": 11}]",
           "failFastMode" -> "FAILFAST")
       )
       checkError(
-        exception = ExceptionUtils.getRootCause(exception).asInstanceOf[SparkRuntimeException],
+        exception = ex.getCause.asInstanceOf[SparkRuntimeException],
         errorClass = "CANNOT_PARSE_JSON_FIELD",
         parameters = Map(
           "fieldName" -> toSQLValue("a", StringType),
@@ -1214,22 +1211,20 @@ class JsonFunctionsSuite extends QueryTest with SharedSparkSession {
         val badRec = """{"a" 1, "b": 11}"""
         val df = Seq(badRec, """{"a": 2, "b": 12}""").toDS()
 
-        val exception1 = intercept[SparkException] {
-          df.select(from_json($"value", schema, Map("mode" -> "FAILFAST"))("b")).collect()
-        }.getCause
         checkError(
-          exception = exception1.asInstanceOf[SparkException],
+          exception = intercept[SparkException] {
+            df.select(from_json($"value", schema, Map("mode" -> "FAILFAST"))("b")).collect()
+          },
           errorClass = "MALFORMED_RECORD_IN_PARSING.WITHOUT_SUGGESTION",
           parameters = Map(
             "badRecord" -> "[null,null]",
             "failFastMode" -> "FAILFAST")
         )
 
-        val exception2 = intercept[SparkException] {
-          df.select(from_json($"value", schema, Map("mode" -> "FAILFAST"))("a")).collect()
-        }.getCause
         checkError(
-          exception = exception2.asInstanceOf[SparkException],
+          exception = intercept[SparkException] {
+            df.select(from_json($"value", schema, Map("mode" -> "FAILFAST"))("a")).collect()
+          },
           errorClass = "MALFORMED_RECORD_IN_PARSING.WITHOUT_SUGGESTION",
           parameters = Map(
             "badRecord" -> "[null,null]",
@@ -1248,22 +1243,20 @@ class JsonFunctionsSuite extends QueryTest with SharedSparkSession {
         val badRec = """{"a" 1, "b": 11}"""
         val df = Seq(s"""[$badRec, {"a": 2, "b": 12}]""").toDS()
 
-        val exception1 = intercept[SparkException] {
-          df.select(from_json($"value", schema, Map("mode" -> "FAILFAST"))("b")).collect()
-        }.getCause
         checkError(
-          exception = exception1.asInstanceOf[SparkException],
+          exception = intercept[SparkException] {
+            df.select(from_json($"value", schema, Map("mode" -> "FAILFAST"))("b")).collect()
+          },
           errorClass = "MALFORMED_RECORD_IN_PARSING.WITHOUT_SUGGESTION",
           parameters = Map(
             "badRecord" -> "[null]",
             "failFastMode" -> "FAILFAST")
         )
 
-        val exception2 = intercept[SparkException] {
-          df.select(from_json($"value", schema, Map("mode" -> "FAILFAST"))("a")).collect()
-        }.getCause
         checkError(
-          exception = exception2.asInstanceOf[SparkException],
+          exception = intercept[SparkException] {
+            df.select(from_json($"value", schema, Map("mode" -> "FAILFAST"))("a")).collect()
+          },
           errorClass = "MALFORMED_RECORD_IN_PARSING.WITHOUT_SUGGESTION",
           parameters = Map(
             "badRecord" -> "[null]",

--- a/sql/core/src/test/scala/org/apache/spark/sql/MetadataCacheSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/MetadataCacheSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql
 
 import java.io.File
 
-import org.apache.spark.{SparkConf, SparkException}
+import org.apache.spark.{SparkConf, SparkFileNotFoundException}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 
@@ -52,10 +52,9 @@ abstract class MetadataCacheSuite extends QueryTest with SharedSparkSession {
       deleteOneFileInDirectory(location)
 
       // Read it again and now we should see a FileNotFoundException
-      val e = intercept[SparkException] {
+      val e = intercept[SparkFileNotFoundException] {
         df.count()
       }
-      assert(e.getMessage.contains("FileNotFoundException"))
       assert(e.getMessage.contains("recreating the Dataset/DataFrame involved"))
     }
   }
@@ -81,10 +80,9 @@ class MetadataCacheV1Suite extends MetadataCacheSuite {
       deleteOneFileInDirectory(location)
 
       // Read it again and now we should see a FileNotFoundException
-      val e = intercept[SparkException] {
+      val e = intercept[SparkFileNotFoundException] {
         sql("select count(*) from view_refresh").first()
       }
-      assert(e.getMessage.contains("FileNotFoundException"))
       assert(e.getMessage.contains("REFRESH"))
 
       // Refresh and we should be able to read it again.
@@ -107,7 +105,7 @@ class MetadataCacheV1Suite extends MetadataCacheSuite {
 
           // Delete a file
           deleteOneFileInDirectory(location)
-          intercept[SparkException](sql("select count(*) from view_refresh").first())
+          intercept[SparkFileNotFoundException](sql("select count(*) from view_refresh").first())
 
           // Refresh and we should be able to read it again.
           spark.catalog.refreshTable("vIeW_reFrEsH")

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -28,7 +28,7 @@ import scala.collection.mutable
 
 import org.apache.commons.io.FileUtils
 
-import org.apache.spark.{AccumulatorSuite, SPARK_DOC_ROOT, SparkException}
+import org.apache.spark.{AccumulatorSuite, SPARK_DOC_ROOT, SparkArithmeticException, SparkDateTimeException, SparkException, SparkNumberFormatException, SparkRuntimeException}
 import org.apache.spark.scheduler.{SparkListener, SparkListenerJobStart}
 import org.apache.spark.sql.catalyst.ExtendedAnalysisException
 import org.apache.spark.sql.catalyst.expressions.{GenericRow, Hex}
@@ -4466,7 +4466,7 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
           "select -i - j from t",
           "select i * j from t",
           "select i / (j - 10) from t").foreach { query =>
-          val msg = intercept[SparkException] {
+          val msg = intercept[SparkArithmeticException] {
             sql(query).collect()
           }.getMessage
           assert(msg.contains(query))
@@ -4490,10 +4490,13 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
           "select cast(s as date) from t",
           "select cast(s as timestamp) from t",
           "select cast(s as boolean) from t").foreach { query =>
-          val msg = intercept[SparkException] {
+          val ex = intercept[Exception] {
             sql(query).collect()
-          }.getMessage
-          assert(msg.contains(query))
+          }
+          assert(ex.isInstanceOf[SparkNumberFormatException] ||
+            ex.isInstanceOf[SparkDateTimeException] ||
+            ex.isInstanceOf[SparkRuntimeException])
+          assert(ex.getMessage.contains(query))
         }
       }
     }
@@ -4510,7 +4513,7 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
           "select d / 0.1 from t",
           "select sum(d) from t",
           "select avg(d) from t").foreach { query =>
-          val msg = intercept[SparkException] {
+          val msg = intercept[SparkArithmeticException] {
             sql(query).collect()
           }.getMessage
           assert(msg.contains(query))
@@ -4641,9 +4644,9 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
     withSQLConf(SQLConf.ANSI_ENABLED.key -> "true") {
       withTable("dt") {
         sql("create table dt using parquet as select 9000000000BD as d")
-        val msg = intercept[SparkException] {
+        val msg = intercept[SparkArithmeticException] {
           sql("select cast(cast(d as int) as long) from dt").collect()
-        }.getCause.getMessage
+        }.getMessage
         assert(msg.contains("[CAST_OVERFLOW]"))
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/UDFSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/UDFSuite.scala
@@ -802,12 +802,16 @@ class UDFSuite extends QueryTest with SharedSparkSession {
     val e1 = intercept[SparkException] {
       Seq("20").toDF("col").select(udf(f1).apply(Column("col"))).collect()
     }
-    assert(e1.getMessage.contains("UDFSuite$MalformedClassObject$MalformedNonPrimitiveFunction"))
+    assert(e1.getErrorClass == "FAILED_EXECUTE_UDF")
+    assert(e1.getCause.getStackTrace.head.toString.contains(
+      "UDFSuite$MalformedClassObject$MalformedNonPrimitiveFunction"))
 
     val e2 = intercept[SparkException] {
       Seq(20).toDF("col").select(udf(f2).apply(Column("col"))).collect()
     }
-    assert(e2.getMessage.contains("UDFSuite$MalformedClassObject$MalformedPrimitiveFunction"))
+    assert(e2.getErrorClass == "FAILED_EXECUTE_UDF")
+    assert(e2.getCause.getStackTrace.head.toString.contains(
+      "UDFSuite$MalformedClassObject$MalformedPrimitiveFunction"))
   }
 
   test("SPARK-32307: Aggregation that use map type input UDF as group expression") {
@@ -914,8 +918,9 @@ class UDFSuite extends QueryTest with SharedSparkSession {
     val overflowFunc = udf((l: java.time.LocalDateTime) => l.plusDays(Long.MaxValue))
     val e = intercept[SparkException] {
       input.select(overflowFunc($"dateTime")).collect()
-    }.getCause.getCause
-    assert(e.isInstanceOf[java.lang.ArithmeticException])
+    }
+    assert(e.getErrorClass == "FAILED_EXECUTE_UDF")
+    assert(e.getCause.isInstanceOf[java.lang.ArithmeticException])
   }
 
   test("SPARK-34663, SPARK-35730: using java.time.Duration in UDF") {
@@ -1028,8 +1033,9 @@ class UDFSuite extends QueryTest with SharedSparkSession {
     val overflowFunc = udf((d: java.time.Duration) => d.plusDays(Long.MaxValue))
     val e = intercept[SparkException] {
       input.select(overflowFunc($"d")).collect()
-    }.getCause.getCause
-    assert(e.isInstanceOf[java.lang.ArithmeticException])
+    }
+    assert(e.getErrorClass == "FAILED_EXECUTE_UDF")
+    assert(e.getCause.isInstanceOf[java.lang.ArithmeticException])
   }
 
   test("SPARK-34663, SPARK-35777: using java.time.Period in UDF") {
@@ -1075,8 +1081,9 @@ class UDFSuite extends QueryTest with SharedSparkSession {
     val overflowFunc = udf((p: java.time.Period) => p.plusYears(Long.MaxValue))
     val e = intercept[SparkException] {
       input.select(overflowFunc($"p")).collect()
-    }.getCause.getCause
-    assert(e.isInstanceOf[java.lang.ArithmeticException])
+    }
+    assert(e.getErrorClass == "FAILED_EXECUTE_UDF")
+    assert(e.getCause.isInstanceOf[java.lang.ArithmeticException])
   }
 
   test("SPARK-43099: UDF className is correctly populated") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/UrlFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/UrlFunctionsSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql
 
-import org.apache.spark.{SparkException, SparkThrowable}
+import org.apache.spark.SparkIllegalArgumentException
 import org.apache.spark.sql.catalyst.util.TypeUtils.toSQLConf
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
@@ -73,9 +73,9 @@ class UrlFunctionsSuite extends QueryTest with SharedSparkSession {
     withSQLConf(SQLConf.ANSI_ENABLED.key -> "true") {
       val url = "inva lid://user:pass@host/file;param?query;p2"
       checkError(
-        exception = intercept[SparkException] {
+        exception = intercept[SparkIllegalArgumentException] {
           sql(s"SELECT parse_url('$url', 'HOST')").collect()
-        }.getCause.asInstanceOf[SparkThrowable],
+        },
         errorClass = "INVALID_URL",
         parameters = Map(
           "url" -> url,

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/MergeIntoTableSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/MergeIntoTableSuiteBase.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.connector
 
-import org.apache.spark.SparkException
+import org.apache.spark.{SparkException, SparkRuntimeException}
 import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, EqualTo, In, Not}
 import org.apache.spark.sql.catalyst.optimizer.BuildLeft
@@ -1611,9 +1611,9 @@ abstract class MergeIntoTableSuiteBase extends RowLevelOperationSuiteBase {
   }
 
   private def assertCardinalityError(query: String): Unit = {
-    val e = intercept[SparkException] {
+    val e = intercept[SparkRuntimeException] {
       sql(query)
     }
-    assert(e.getCause.getMessage.contains("ON search condition of the MERGE statement"))
+    assert(e.getMessage.contains("ON search condition of the MERGE statement"))
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.execution
 
-import org.apache.spark.{SparkArithmeticException, SparkException, SparkFileNotFoundException}
+import org.apache.spark.{SparkArithmeticException, SparkFileNotFoundException}
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.expressions.{Add, Alias, Divide}
@@ -1066,9 +1066,9 @@ abstract class SQLViewSuite extends QueryTest with SQLTestUtils {
           sql("CREATE TEMPORARY VIEW v1 AS SELECT * FROM t")
           Seq(4, 6, 5).toDF("c1").write.mode("overwrite").format("parquet").saveAsTable("t")
           checkErrorMatchPVals(
-            exception = intercept[SparkException] {
+            exception = intercept[SparkFileNotFoundException] {
               sql("SELECT * FROM v1").collect()
-            }.getCause.asInstanceOf[SparkFileNotFoundException],
+            },
             errorClass = "_LEGACY_ERROR_TEMP_2055",
             parameters = Map("message" -> ".* does not exist")
           )
@@ -1086,9 +1086,9 @@ abstract class SQLViewSuite extends QueryTest with SQLTestUtils {
           sql("ALTER VIEW v1 AS SELECT * FROM t")
           Seq(2, 4, 6).toDF("c1").write.mode("overwrite").format("parquet").saveAsTable("t")
           checkErrorMatchPVals(
-            exception = intercept[SparkException] {
+            exception = intercept[SparkFileNotFoundException] {
               sql("SELECT * FROM v1").collect()
-            }.getCause.asInstanceOf[SparkFileNotFoundException],
+            },
             errorClass = "_LEGACY_ERROR_TEMP_2055",
             parameters = Map("message" -> ".* does not exist")
           )

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
@@ -480,8 +480,8 @@ class FileSourceStrategySuite extends QueryTest with SharedSparkSession {
         val e = intercept[SparkException] {
           spark.read.text(inputFile.toURI.toString).collect()
         }
-        assert(e.getCause.getCause.isInstanceOf[EOFException])
-        assert(e.getCause.getCause.getMessage === "Unexpected end of input stream")
+        assert(e.getCause.isInstanceOf[EOFException])
+        assert(e.getCause.getMessage === "Unexpected end of input stream")
       }
       withSQLConf(SQLConf.IGNORE_CORRUPT_FILES.key -> "true") {
         assert(spark.read.text(inputFile.toURI.toString).collect().isEmpty)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/binaryfile/BinaryFileFormatSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/binaryfile/BinaryFileFormatSuite.scala
@@ -366,7 +366,8 @@ class BinaryFileFormatSuite extends QueryTest with SharedSparkSession {
           checkAnswer(readContent(), expected)
         }
       }
-      assert(caught.getMessage.contains("exceeds the max length allowed"))
+      assert(caught.getErrorClass == "FAILED_READ_FILE")
+      assert(caught.getCause.getMessage.contains("exceeds the max length allowed"))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -29,7 +29,6 @@ import scala.jdk.CollectionConverters._
 import scala.util.Properties
 
 import com.univocity.parsers.common.TextParsingException
-import org.apache.commons.lang3.exception.ExceptionUtils
 import org.apache.commons.lang3.time.FastDateFormat
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.io.SequenceFile.CompressionType
@@ -372,16 +371,18 @@ abstract class CSVSuite
 
   test("test for FAILFAST parsing mode") {
     Seq(false, true).foreach { multiLine =>
-      val exception = intercept[SparkException] {
+      val e1 = intercept[SparkException] {
         spark.read
           .format("csv")
           .option("multiLine", multiLine)
           .options(Map("header" -> "true", "mode" -> "failfast"))
           .load(testFile(carsFile)).collect()
       }
-
+      assert(e1.getErrorClass == "FAILED_READ_FILE")
+      val e2 = e1.getCause.asInstanceOf[SparkException]
+      assert(e2.getErrorClass == "MALFORMED_RECORD_IN_PARSING.WITHOUT_SUGGESTION")
       checkError(
-        exception = ExceptionUtils.getRootCause(exception).asInstanceOf[SparkRuntimeException],
+        exception = e2.getCause.asInstanceOf[SparkRuntimeException],
         errorClass = "MALFORMED_CSV_RECORD",
         parameters = Map("badRecord" -> "2015,Chevy,Volt")
       )
@@ -1242,13 +1243,15 @@ abstract class CSVSuite
     val exp = spark.sql("select timestamp_ntz'2020-12-12 12:12:12' as col0")
     for (pattern <- patterns) {
       withTempPath { path =>
-        val err = intercept[SparkException] {
+        val ex = intercept[SparkException] {
           exp.write.format("csv").option("timestampNTZFormat", pattern).save(path.getAbsolutePath)
         }
+        assert(ex.getErrorClass == "TASK_WRITE_FAILED")
+        val msg = ex.getCause.getMessage
         assert(
-          err.getMessage.contains("Unsupported field: OffsetSeconds") ||
-          err.getMessage.contains("Unable to extract value") ||
-          err.getMessage.contains("Unable to extract ZoneId"))
+          msg.contains("Unsupported field: OffsetSeconds") ||
+          msg.contains("Unable to extract value") ||
+          msg.contains("Unable to extract ZoneId"))
       }
     }
   }
@@ -1475,8 +1478,8 @@ abstract class CSVSuite
         val e = intercept[SparkException] {
           spark.read.csv(inputFile.toURI.toString).collect()
         }
-        assert(e.getCause.getCause.isInstanceOf[EOFException])
-        assert(e.getCause.getCause.getMessage === "Unexpected end of input stream")
+        assert(e.getCause.isInstanceOf[EOFException])
+        assert(e.getCause.getMessage === "Unexpected end of input stream")
         val e2 = intercept[SparkException] {
           spark.read.option("multiLine", true).csv(inputFile.toURI.toString).collect()
         }
@@ -1497,11 +1500,10 @@ abstract class CSVSuite
       val df = spark.read.option("multiLine", true).csv(csvPath.toString)
       fs.delete(csvPath, true)
       withSQLConf(SQLConf.IGNORE_MISSING_FILES.key -> "false") {
-        val e = intercept[SparkException] {
+        val e = intercept[SparkFileNotFoundException] {
           df.collect()
         }
-        assert(e.getCause.isInstanceOf[SparkFileNotFoundException])
-        assert(e.getCause.getMessage.contains(".csv does not exist"))
+        assert(e.getMessage.contains(".csv does not exist"))
       }
 
       sampledTestData.write.csv(csvPath.toString)
@@ -1645,7 +1647,7 @@ abstract class CSVSuite
         .csv(Seq("10u12").toDS())
         .collect()
     }
-    assert(exception.getMessage.contains("""input string: "10u12""""))
+    assert(exception.getCause.getMessage.contains("""input string: "10u12""""))
 
     val count = spark.read.schema("a FLOAT")
       .option("mode", "DROPMALFORMED")
@@ -1923,7 +1925,8 @@ abstract class CSVSuite
             .csv(path.getCanonicalPath)
             .collect()
         }
-        assert(exception.getMessage.contains("CSV header does not conform to the schema"))
+        assert(exception.getErrorClass == "FAILED_READ_FILE")
+        assert(exception.getCause.getMessage.contains("CSV header does not conform to the schema"))
 
         val shortSchema = new StructType().add("f1", DoubleType)
         val exceptionForShortSchema = intercept[SparkException] {
@@ -1935,7 +1938,8 @@ abstract class CSVSuite
             .csv(path.getCanonicalPath)
             .collect()
         }
-        assert(exceptionForShortSchema.getMessage.contains(
+        assert(exception.getErrorClass == "FAILED_READ_FILE")
+        assert(exceptionForShortSchema.getCause.getMessage.contains(
           "Number of column in CSV header is not equal to number of fields in the schema"))
 
         val longSchema = new StructType()
@@ -1952,7 +1956,9 @@ abstract class CSVSuite
             .csv(path.getCanonicalPath)
             .collect()
         }
-        assert(exceptionForLongSchema.getMessage.contains("Header length: 2, schema size: 3"))
+        assert(exceptionForLongSchema.getErrorClass == "FAILED_READ_FILE")
+        assert(exceptionForLongSchema.getCause.getMessage.contains(
+          "Header length: 2, schema size: 3"))
 
         val caseSensitiveSchema = new StructType().add("F1", DoubleType).add("f2", DoubleType)
         val caseSensitiveException = intercept[SparkException] {
@@ -1964,7 +1970,8 @@ abstract class CSVSuite
             .csv(path.getCanonicalPath)
             .collect()
         }
-        assert(caseSensitiveException.getMessage.contains(
+        assert(caseSensitiveException.getErrorClass == "FAILED_READ_FILE")
+        assert(caseSensitiveException.getCause.getMessage.contains(
           "CSV header does not conform to the schema"))
       }
     }
@@ -2660,9 +2667,9 @@ abstract class CSVSuite
       .option("timestampFormat", "yyyy-MM-dd'T'HH:mm:ss.SSSz")
       .schema("t timestamp").csv(ds)
     withSQLConf(SQLConf.LEGACY_TIME_PARSER_POLICY.key -> "exception") {
-      val msg = intercept[SparkException] {
+      val msg = intercept[SparkUpgradeException] {
         csv.collect()
-      }.getCause.getMessage
+      }.getMessage
       assert(msg.contains("Fail to parse"))
     }
     withSQLConf(SQLConf.LEGACY_TIME_PARSER_POLICY.key -> "legacy") {
@@ -3016,10 +3023,9 @@ abstract class CSVSuite
         )
       )
 
-      val err = intercept[SparkException] {
+      intercept[SparkUpgradeException] {
         check("exception", Nil)
-      }.getCause
-      assert(err.isInstanceOf[SparkUpgradeException])
+      }
     }
   }
 
@@ -3296,16 +3302,16 @@ class CSVv1Suite extends CSVSuite {
 
   test("test for FAILFAST parsing mode on CSV v1") {
     Seq(false, true).foreach { multiLine =>
-      val exception = intercept[SparkException] {
+      val ex = intercept[SparkException] {
         spark.read
           .format("csv")
           .option("multiLine", multiLine)
           .options(Map("header" -> "true", "mode" -> "failfast"))
           .load(testFile(carsFile)).collect()
       }
-
+      assert(ex.getErrorClass == "FAILED_READ_FILE")
       checkError(
-        exception = exception.getCause.asInstanceOf[SparkException],
+        exception = ex.getCause.asInstanceOf[SparkException],
         errorClass = "MALFORMED_RECORD_IN_PARSING.WITHOUT_SUGGESTION",
         parameters = Map(
           "badRecord" -> "[2015,Chevy,Volt,null,null]",
@@ -3323,17 +3329,15 @@ class CSVv2Suite extends CSVSuite {
 
   test("test for FAILFAST parsing mode on CSV v2") {
     Seq(false, true).foreach { multiLine =>
-      val exception = intercept[SparkException] {
-        spark.read
-          .format("csv")
-          .option("multiLine", multiLine)
-          .options(Map("header" -> "true", "mode" -> "failfast"))
-          .load(testFile(carsFile)).collect()
-      }
-
       checkError(
-        exception = exception.getCause.asInstanceOf[SparkException],
-        errorClass = "_LEGACY_ERROR_TEMP_2064",
+        exception = intercept[SparkException] {
+          spark.read
+            .format("csv")
+            .option("multiLine", multiLine)
+            .options(Map("header" -> "true", "mode" -> "failfast"))
+            .load(testFile(carsFile)).collect()
+        },
+        errorClass = "FAILED_READ_FILE",
         parameters = Map("path" -> s".*$carsFile"),
         matchPVals = true
       )

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcFilterSuite.scala
@@ -27,7 +27,7 @@ import scala.jdk.CollectionConverters._
 import org.apache.hadoop.hive.ql.io.sarg.{PredicateLeaf, SearchArgument, SearchArgumentImpl}
 import org.apache.hadoop.hive.ql.io.sarg.SearchArgumentFactory.newBuilder
 
-import org.apache.spark.{SparkConf, SparkException}
+import org.apache.spark.{SparkConf, SparkException, SparkRuntimeException}
 import org.apache.spark.sql.{AnalysisException, Column, DataFrame, Row}
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.expressions._
@@ -703,10 +703,12 @@ class OrcFilterSuite extends OrcTest with SharedSparkSession {
                |CREATE TABLE $tableName (A LONG) USING ORC LOCATION '$tableDir1'
              """.stripMargin)
 
-          val e = intercept[SparkException] {
+          val ex = intercept[SparkException] {
             sql(s"select A from $tableName where A < 0").collect()
           }
-          assert(e.getCause.isInstanceOf[RuntimeException] && e.getCause.getMessage.contains(
+          assert(ex.getErrorClass == "FAILED_READ_FILE")
+          assert(ex.getCause.isInstanceOf[SparkRuntimeException])
+          assert(ex.getCause.getMessage.contains(
             """Found duplicate field(s) "A": [A, a] in case-insensitive mode"""))
         }
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcQuerySuite.scala
@@ -604,11 +604,17 @@ abstract class OrcQueryTest extends OrcTest {
       val e1 = intercept[SparkException] {
         testIgnoreCorruptFiles()
       }
-      assert(e1.getMessage.contains("Malformed ORC file"))
+      assert(e1.getErrorClass == "FAILED_READ_FILE" ||
+        // Hive ORC table scan uses a different code path and reports a different error.
+        e1.getErrorClass == "CANNOT_READ_FILE_FOOTER")
+      assert(e1.getCause.getMessage.contains("Malformed ORC file"))
       val e2 = intercept[SparkException] {
         testIgnoreCorruptFilesWithoutSchemaInfer()
       }
-      assert(e2.getMessage.contains("Malformed ORC file"))
+      assert(e2.getErrorClass == "FAILED_READ_FILE" ||
+        // Hive ORC table scan uses a different code path and reports a different error.
+        e2.getErrorClass == "CANNOT_READ_FILE_FOOTER")
+      assert(e2.getCause.getMessage.contains("Malformed ORC file"))
       checkError(
         exception = intercept[SparkException] {
           testAllCorruptFiles()
@@ -620,7 +626,10 @@ abstract class OrcQueryTest extends OrcTest {
       val e4 = intercept[SparkException] {
         testAllCorruptFilesWithoutSchemaInfer()
       }
-      assert(e4.getMessage.contains("Malformed ORC file"))
+      assert(e4.getErrorClass == "FAILED_READ_FILE" ||
+        // Hive ORC table scan uses a different code path and reports a different error.
+        e1.getErrorClass == "CANNOT_READ_FILE_FOOTER")
+      assert(e4.getCause.getMessage.contains("Malformed ORC file"))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcSourceSuite.scala
@@ -448,18 +448,11 @@ abstract class OrcSuite
 
       // with schema merging, there should throw exception
       withSQLConf(SQLConf.ORC_SCHEMA_MERGING_ENABLED.key -> "true") {
-        val exception = intercept[SparkException] {
+        val ex = intercept[SparkException] {
           spark.read.orc(basePath).columns.length
-        }.getCause
-
-        val innerException = orcImp match {
-          case "native" => exception
-          case "hive" => exception.getCause
-          case impl =>
-            throw new UnsupportedOperationException(s"Unknown ORC implementation: $impl")
         }
-
-        assert(innerException.asInstanceOf[SparkException].getErrorClass ===
+        assert(ex.getErrorClass == "CANNOT_MERGE_SCHEMAS")
+        assert(ex.getCause.asInstanceOf[SparkException].getErrorClass ===
           "CANNOT_MERGE_INCOMPATIBLE_DATA_TYPE")
       }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
@@ -1213,8 +1213,9 @@ class ParquetIOSuite extends QueryTest with ParquetTest with SharedSparkSession 
       withTempPath { dir =>
         val m1 = intercept[SparkException] {
           spark.range(1).coalesce(1).write.options(extraOptions).parquet(dir.getCanonicalPath)
-        }.getMessage
-        assert(m1.contains("Intentional exception for testing purposes"))
+        }
+        assert(m1.getErrorClass == "TASK_WRITE_FAILED")
+        assert(m1.getCause.getMessage.contains("Intentional exception for testing purposes"))
       }
 
       withTempPath { dir =>
@@ -1222,8 +1223,9 @@ class ParquetIOSuite extends QueryTest with ParquetTest with SharedSparkSession 
           val df = spark.range(1).select($"id" as Symbol("a"), $"id" as Symbol("b"))
             .coalesce(1)
           df.write.partitionBy("a").options(extraOptions).parquet(dir.getCanonicalPath)
-        }.getMessage
-        assert(m2.contains("Intentional exception for testing purposes"))
+        }
+        assert(m2.getErrorClass == "TASK_WRITE_FAILED")
+        assert(m2.getCause.getMessage.contains("Intentional exception for testing purposes"))
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetQuerySuite.scala
@@ -196,10 +196,11 @@ abstract class ParquetQuerySuite extends QueryTest with ParquetTest with SharedS
             val df = spark.createDataFrame(sparkContext.parallelize(data), actualSchema)
             df.write.parquet(file.getCanonicalPath)
             withAllParquetReaders {
-              val msg = intercept[SparkException] {
+              val e = intercept[SparkException] {
                 spark.read.schema(providedSchema).parquet(file.getCanonicalPath).collect()
-              }.getMessage
-              assert(msg.contains(
+              }
+              assert(e.getErrorClass == "FAILED_READ_FILE")
+              assert(e.getCause.getMessage.contains(
                 "Unable to create Parquet converter for data type \"timestamp_ntz\""))
             }
           }
@@ -373,11 +374,11 @@ abstract class ParquetQuerySuite extends QueryTest with ParquetTest with SharedS
         withSQLConf(SQLConf.IGNORE_CORRUPT_FILES.key -> "false") {
           val exception = intercept[SparkException] {
             testIgnoreCorruptFiles(options)
-          }
+          }.getCause
           assert(exception.getMessage().contains("is not a Parquet file"))
           val exception2 = intercept[SparkException] {
             testIgnoreCorruptFilesWithoutSchemaInfer(options)
-          }
+          }.getCause
           assert(exception2.getMessage().contains("is not a Parquet file"))
         }
       }
@@ -1056,7 +1057,7 @@ abstract class ParquetQuerySuite extends QueryTest with ParquetTest with SharedS
         Seq("a DECIMAL(3, 0)", "b DECIMAL(18, 1)", "c DECIMAL(37, 1)").foreach { schema =>
           val e = intercept[SparkException] {
             readParquet(schema, path).collect()
-          }.getCause.getCause
+          }.getCause
           assert(e.isInstanceOf[SchemaColumnConvertNotSupportedException])
         }
       }
@@ -1077,15 +1078,16 @@ abstract class ParquetQuerySuite extends QueryTest with ParquetTest with SharedS
         checkAnswer(readParquet("c DECIMAL(22, 0)", path), df.select("c"))
         val e = intercept[SparkException] {
           readParquet("d DECIMAL(3, 2)", path).collect()
-        }.getCause
-        assert(e.getMessage.contains("Please read this column/field as Spark BINARY type"))
+        }
+        assert(e.getErrorClass == "FAILED_READ_FILE")
+        assert(e.getCause.getMessage.contains("Please read this column/field as Spark BINARY type"))
       }
 
       withSQLConf(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> "true") {
         Seq("a DECIMAL(3, 2)", "c DECIMAL(18, 1)", "d DECIMAL(37, 1)").foreach { schema =>
           val e = intercept[SparkException] {
             readParquet(schema, path).collect()
-          }.getCause.getCause
+          }.getCause
           assert(e.isInstanceOf[SchemaColumnConvertNotSupportedException])
         }
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRebaseDatetimeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRebaseDatetimeSuite.scala
@@ -414,7 +414,8 @@ abstract class ParquetRebaseDatetimeSuite
         val e = intercept[SparkException] {
           df.write.parquet(dir.getCanonicalPath)
         }
-        val errMsg = e.getCause.getCause.asInstanceOf[SparkUpgradeException].getMessage
+        assert(e.getErrorClass == "TASK_WRITE_FAILED")
+        val errMsg = e.getCause.asInstanceOf[SparkUpgradeException].getMessage
         assert(errMsg.contains("You may get a different result due to the upgrading"))
       }
     }
@@ -430,7 +431,8 @@ abstract class ParquetRebaseDatetimeSuite
           val e = intercept[SparkException] {
             df.write.parquet(dir.getCanonicalPath)
           }
-          val errMsg = e.getCause.getCause.asInstanceOf[SparkUpgradeException].getMessage
+          assert(e.getErrorClass == "TASK_WRITE_FAILED")
+          val errMsg = e.getCause.asInstanceOf[SparkUpgradeException].getMessage
           assert(errMsg.contains("You may get a different result due to the upgrading"))
         }
       }
@@ -442,11 +444,10 @@ abstract class ParquetRebaseDatetimeSuite
     }
 
     def checkRead(fileName: String): Unit = {
-      val e = intercept[SparkException] {
+      val e = intercept[SparkUpgradeException] {
         spark.read.parquet(getResourceParquetFilePath("test-data/" + fileName)).collect()
       }
-      val errMsg = e.getCause.asInstanceOf[SparkUpgradeException].getMessage
-      assert(errMsg.contains("You may get a different result due to the upgrading"))
+      assert(e.getMessage.contains("You may get a different result due to the upgrading"))
     }
     withAllParquetWriters {
       withSQLConf(SQLConf.PARQUET_REBASE_MODE_IN_READ.key -> EXCEPTION.toString) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowIndexSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowIndexSuite.scala
@@ -25,6 +25,7 @@ import org.apache.parquet.column.ParquetProperties._
 import org.apache.parquet.hadoop.{ParquetFileReader, ParquetOutputFormat}
 import org.apache.parquet.hadoop.ParquetWriter.DEFAULT_BLOCK_SIZE
 
+import org.apache.spark.SparkException
 import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.execution.FileSourceScanExec
 import org.apache.spark.sql.execution.datasources.FileFormat
@@ -317,8 +318,10 @@ class ParquetRowIndexSuite extends QueryTest with SharedSparkSession {
             .schema(schemaWithRowIdx)
             .load(path.getAbsolutePath)
 
-          val exception = intercept[Exception](dfRead.collect())
-          assert(exception.getMessage.contains(ParquetFileFormat.ROW_INDEX_TEMPORARY_COLUMN_NAME))
+          val exception = intercept[SparkException](dfRead.collect())
+          assert(exception.getErrorClass == "FAILED_READ_FILE")
+          assert(exception.getCause.getMessage.contains(
+            ParquetFileFormat.ROW_INDEX_TEMPORARY_COLUMN_NAME))
         }
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetTypeWideningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetTypeWideningSuite.scala
@@ -75,9 +75,9 @@ class ParquetTypeWideningSuite
                 readParquetFiles(dir, toType).collect()
               }
               assert(
-                exception.getCause.getCause
+                exception.getCause
                   .isInstanceOf[SchemaColumnConvertNotSupportedException] ||
-                exception.getCause.getCause
+                exception.getCause
                   .isInstanceOf[org.apache.parquet.io.ParquetDecodingException] ||
                 exception.getCause.getMessage.contains(
                   "Unable to create Parquet converter for data type"))

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/ExecutorSideSQLConfSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/ExecutorSideSQLConfSuite.scala
@@ -21,7 +21,7 @@ import java.util.UUID
 
 import org.scalatest.Assertions._
 
-import org.apache.spark.{SparkException, SparkFunSuite, TaskContext}
+import org.apache.spark.{SparkFunSuite, SparkNoSuchElementException, TaskContext}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{Dataset, SparkSession}
 import org.apache.spark.sql.catalyst.InternalRow
@@ -127,8 +127,7 @@ class ExecutorSideSQLConfSuite extends SparkFunSuite with SQLTestUtils {
     }
     val dummyQueryExecution1 = FakeQueryExecution(spark, physicalPlan)
     // Without setting the configs assertions fail
-    val e = intercept[SparkException](dummyQueryExecution1.toRdd.collect())
-    assert(e.getCause.isInstanceOf[NoSuchElementException])
+    intercept[SparkNoSuchElementException](dummyQueryExecution1.toRdd.collect())
   }
 
   test("SPARK-30556 propagate local properties to subquery execution thread") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
@@ -2859,12 +2859,11 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
         checkAggregateRemoved(df, false)
         checkPushedInfo(df, "PushedAggregates: [COUNT(PRICE), SUM(PRICE)]")
         if (ansiEnabled) {
-          val e = intercept[SparkException] {
+          val e = intercept[ArithmeticException] {
             df.collect()
           }
-          assert(e.getCause.isInstanceOf[ArithmeticException])
-          assert(e.getCause.getMessage.contains("cannot be represented as Decimal") ||
-            e.getCause.getMessage.contains("Overflow in sum of decimals"))
+          assert(e.getMessage.contains("cannot be represented as Decimal") ||
+            e.getMessage.contains("Overflow in sum of decimals"))
         } else {
           checkAnswer(df, Seq(Row(null)))
         }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/EventTimeWatermarkSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/EventTimeWatermarkSuite.scala
@@ -28,7 +28,6 @@ import org.scalatest.BeforeAndAfter
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.matchers.should.Matchers._
 
-import org.apache.spark.SparkException
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{AnalysisException, DataFrame, Dataset}
 import org.apache.spark.sql.catalyst.plans.logical.EventTimeWatermark
@@ -652,10 +651,9 @@ class EventTimeWatermarkSuite extends StreamTest with BeforeAndAfter with Matche
           (input1, Seq(("A", 200L), ("B", 300L))),
           (input2, Seq(("A", 190L), ("C", 350L)))
         ),
-        ExpectFailure[SparkException](assertFailure = exc => {
-          val cause = exc.getCause
-          assert(cause.getMessage.contains("More than one event time columns are available."))
-          assert(cause.getMessage.contains(
+        ExpectFailure[AnalysisException](assertFailure = ex => {
+          assert(ex.getMessage.contains("More than one event time columns are available."))
+          assert(ex.getMessage.contains(
             "Please ensure there is at most one event time column per stream."))
         })
       )

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateSuite.scala
@@ -21,7 +21,7 @@ import org.apache.spark.SparkException
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{AnalysisException, SaveMode}
 import org.apache.spark.sql.execution.streaming._
-import org.apache.spark.sql.execution.streaming.state.{AlsoTestWithChangelogCheckpointingEnabled, RocksDBStateStoreProvider}
+import org.apache.spark.sql.execution.streaming.state.{AlsoTestWithChangelogCheckpointingEnabled, RocksDBStateStoreProvider, StateStoreMultipleColumnFamiliesNotSupportedException}
 import org.apache.spark.sql.internal.SQLConf
 
 object TransformWithStateSuiteUtils {
@@ -160,9 +160,8 @@ class TransformWithStateSuite extends StateStoreMetricsTest
 
       testStream(result, OutputMode.Update())(
         AddData(inputData, "a"),
-        ExpectFailure[SparkException] {
-          (t: Throwable) => { assert(t.getCause
-            .getMessage.contains("Cannot create state variable")) }
+        ExpectFailure[SparkException] { t =>
+          assert(t.getCause.getMessage.contains("Cannot create state variable"))
         }
       )
     }
@@ -360,8 +359,8 @@ class TransformWithStateValidationSuite extends StateStoreMetricsTest {
 
     testStream(result, OutputMode.Update())(
       AddData(inputData, "a"),
-      ExpectFailure[SparkException] {
-        (t: Throwable) => { assert(t.getCause.getMessage.contains("not supported")) }
+      ExpectFailure[StateStoreMultipleColumnFamiliesNotSupportedException] { t =>
+        assert(t.getMessage.contains("not supported"))
       }
     )
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/TestSQLContext.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/TestSQLContext.scala
@@ -25,8 +25,8 @@ import org.apache.spark.sql.internal.{SessionState, SessionStateBuilder, SQLConf
  * A special `SparkSession` prepared for testing.
  */
 private[spark] class TestSparkSession(sc: SparkContext) extends SparkSession(sc) { self =>
-  def this(sparkConf: SparkConf) = {
-    this(new SparkContext("local[2]", "test-sql-context",
+  def this(sparkConf: SparkConf, maxLocalTaskFailures: Int = 1, numCores: Int = 2) = {
+    this(new SparkContext(s"local[$numCores,$maxLocalTaskFailures]", "test-sql-context",
       sparkConf.set("spark.sql.testkey", "true")))
   }
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/HiveCharVarcharTestSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/HiveCharVarcharTestSuite.scala
@@ -87,17 +87,19 @@ class HiveCharVarcharTestSuite extends CharVarcharTestSuite with TestHiveSinglet
           checkAnswer(spark.table(tableName), Nil)
         }
 
-        val e1 = intercept[SparkException](sql(s"INSERT OVERWRITE $tableName VALUES ('1', 100000)"))
         checkError(
-          exception = e1.getCause.asInstanceOf[SparkException],
+          exception = intercept[SparkException] {
+            sql(s"INSERT OVERWRITE $tableName VALUES ('1', 100000)")
+          },
           errorClass = "TASK_WRITE_FAILED",
           parameters = Map("path" -> s".*$tableName.*"),
           matchPVals = true
         )
 
-        val e2 = intercept[SparkRuntimeException](sql("ALTER TABLE t DROP PARTITION(c=100000)"))
         checkError(
-          exception = e2,
+          exception = intercept[SparkRuntimeException] {
+            sql("ALTER TABLE t DROP PARTITION(c=100000)")
+          },
           errorClass = "EXCEED_LIMIT_LENGTH",
           parameters = Map("limit" -> "5")
         )

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveScriptTransformationSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveScriptTransformationSuite.scala
@@ -25,7 +25,7 @@ import org.apache.hadoop.hive.serde2.`lazy`.LazySimpleSerDe
 import org.scalatest.exceptions.TestFailedException
 
 import org.apache.spark.{SparkException, TestUtils}
-import org.apache.spark.sql.Row
+import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
 import org.apache.spark.sql.catalyst.util.DateTimeConstants
 import org.apache.spark.sql.execution._
@@ -381,7 +381,7 @@ class HiveScriptTransformationSuite extends BaseScriptTransformationSuite with T
       ).toDF("a", "b", "c")
       df.createTempView("v")
 
-      val e1 = intercept[SparkException] {
+      val e1 = intercept[AnalysisException] {
         val plan = createScriptTransformationExec(
           script = "cat",
           output = Seq(
@@ -393,7 +393,7 @@ class HiveScriptTransformationSuite extends BaseScriptTransformationSuite with T
       }.getMessage
       assert(e1.contains("interval cannot be converted to Hive TypeInfo"))
 
-      val e2 = intercept[SparkException] {
+      val e2 = intercept[AnalysisException] {
         val plan = createScriptTransformationExec(
           script = "cat",
           output = Seq(
@@ -417,7 +417,7 @@ class HiveScriptTransformationSuite extends BaseScriptTransformationSuite with T
       ).toDF("a", "b", "c")
       df.createTempView("v")
 
-      val e1 = intercept[SparkException] {
+      val e1 = intercept[AnalysisException] {
         sql(
           """
             |SELECT TRANSFORM(a, b) USING 'cat' AS (a, b)
@@ -426,7 +426,7 @@ class HiveScriptTransformationSuite extends BaseScriptTransformationSuite with T
       }.getMessage
       assert(e1.contains("interval cannot be converted to Hive TypeInfo"))
 
-      val e2 = intercept[SparkException] {
+      val e2 = intercept[AnalysisException] {
         sql(
           """
             |SELECT TRANSFORM(a, c) USING 'cat' AS (a, c)

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
@@ -746,9 +746,8 @@ class HiveUDFSuite extends QueryTest with TestHiveSingleton with SQLTestUtils {
       withTable("HiveGenericUDFTable") {
         sql(s"create table HiveGenericUDFTable as select false as v")
         val df = sql("SELECT CodeGenHiveGenericUDF(v) from HiveGenericUDFTable")
-        val e = intercept[SparkException](df.collect()).getCause.asInstanceOf[SparkException]
         checkError(
-          e,
+          intercept[SparkException](df.collect()),
           "FAILED_EXECUTE_UDF",
           parameters = Map(
             "functionName" ->
@@ -788,7 +787,7 @@ class HiveUDFSuite extends QueryTest with TestHiveSingleton with SQLTestUtils {
           .stripMargin.replaceAll("\n", " ").trim
 
         checkError(
-          exception = intercept[SparkException](df.collect()).getCause.asInstanceOf[SparkException],
+          exception = intercept[SparkException](df.collect()),
           errorClass = "FAILED_EXECUTE_UDF",
           parameters = Map(
             "functionName" ->


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
It's not user-friendly to always wrap task runtime errors with `SparkException("Job aborted ...")`, as users need to scroll down quite a bit to find the real error. This PR throws the user-facing runtime errors directly, which means the error defines error class and is not internal error.

This PR also fixes some error wrapping issues.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Report errors better.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, now users can see the actual error directly instead of looking for the cause of "job aborted" error.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
new test

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No