### PR TITLE
[SPARK-46924][CORE] Fix `Load New` button in `Master/HistoryServer` Log UI

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/Utils.scala
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.deploy
+
+import java.io.File
+import javax.servlet.http.HttpServletRequest
+
+import org.apache.spark.SparkConf
+import org.apache.spark.internal.Logging
+import org.apache.spark.ui.JettyUtils.createServletHandler
+import org.apache.spark.ui.WebUI
+import org.apache.spark.util.Utils.{getFileLength, offsetBytes}
+import org.apache.spark.util.logging.RollingFileAppender
+
+/**
+ * An object to provide utility methods for Spark deploy module.
+ */
+private[deploy] object Utils extends Logging {
+  val DEFAULT_BYTES = 100 * 1024
+
+  def addRenderLogHandler(page: WebUI, conf: SparkConf): Unit = {
+    page.attachHandler(createServletHandler("/log",
+      (request: HttpServletRequest) => renderLog(request, conf),
+      conf))
+  }
+
+  private def renderLog(request: HttpServletRequest, conf: SparkConf): String = {
+    val logDir = sys.env.getOrElse("SPARK_LOG_DIR", "logs/")
+    val logType = request.getParameter("logType")
+    val offset = Option(request.getParameter("offset")).map(_.toLong)
+    val byteLength = Option(request.getParameter("byteLength")).map(_.toInt)
+      .getOrElse(DEFAULT_BYTES)
+
+    val (logText, startByte, endByte, logLength) = getLog(conf, logDir, logType, offset, byteLength)
+    val pre = s"==== Bytes $startByte-$endByte of $logLength of $logDir$logType ====\n"
+    pre + logText
+  }
+
+  /** Get the part of the log files given the offset and desired length of bytes */
+  def getLog(
+      conf: SparkConf,
+      logDirectory: String,
+      logType: String,
+      offsetOption: Option[Long],
+      byteLength: Int): (String, Long, Long, Long) = {
+    try {
+      // Find a log file name
+      val fileName = if (logType.equals("out")) {
+        val normalizedUri = new File(logDirectory).toURI.normalize()
+        val normalizedLogDir = new File(normalizedUri.getPath)
+        normalizedLogDir.listFiles.map(_.getName).filter(_.endsWith(".out"))
+          .headOption.getOrElse(logType)
+      } else {
+        logType
+      }
+      val files = RollingFileAppender.getSortedRolledOverFiles(logDirectory, fileName)
+      logDebug(s"Sorted log files of type $logType in $logDirectory:\n${files.mkString("\n")}")
+
+      val fileLengths: Seq[Long] = files.map(getFileLength(_, conf))
+      val totalLength = fileLengths.sum
+      val offset = offsetOption.getOrElse(totalLength - byteLength)
+      val startIndex = {
+        if (offset < 0) {
+          0L
+        } else if (offset > totalLength) {
+          totalLength
+        } else {
+          offset
+        }
+      }
+      val endIndex = math.min(startIndex + byteLength, totalLength)
+      logDebug(s"Getting log from $startIndex to $endIndex")
+      val logText = offsetBytes(files, fileLengths, startIndex, endIndex)
+      logDebug(s"Got log of length ${logText.length} bytes")
+      (logText, startIndex, endIndex, totalLength)
+    } catch {
+      case e: Exception =>
+        logError(s"Error getting $logType logs from directory $logDirectory", e)
+        ("Error getting logs due to exception: " + e.getMessage, 0, 0, 0)
+    }
+  }
+}

--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.deploy.history
 
-import java.util.NoSuchElementException
 import java.util.zip.ZipOutputStream
 import javax.servlet.http.{HttpServlet, HttpServletRequest, HttpServletResponse}
 
@@ -28,6 +27,7 @@ import org.eclipse.jetty.servlet.{ServletContextHandler, ServletHolder}
 
 import org.apache.spark.{SecurityManager, SparkConf}
 import org.apache.spark.deploy.SparkHadoopUtil
+import org.apache.spark.deploy.Utils.addRenderLogHandler
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config._
 import org.apache.spark.internal.config.History
@@ -153,6 +153,7 @@ class HistoryServer(
     attachHandler(ApiRootResource.getServletHandler(this))
 
     addStaticHandler(SparkUI.STATIC_RESOURCE_DIR)
+    addRenderLogHandler(this, conf)
 
     val contextHandler = new ServletContextHandler
     contextHandler.setContextPath(HistoryServer.UI_PATH_PREFIX)

--- a/core/src/main/scala/org/apache/spark/deploy/history/LogPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/LogPage.scala
@@ -17,27 +17,24 @@
 
 package org.apache.spark.deploy.history
 
-import java.io.File
 import javax.servlet.http.HttpServletRequest
 
 import scala.xml.{Node, Unparsed}
 
 import org.apache.spark.SparkConf
+import org.apache.spark.deploy.Utils.{getLog, DEFAULT_BYTES}
 import org.apache.spark.internal.Logging
 import org.apache.spark.ui.{UIUtils, WebUIPage}
-import org.apache.spark.util.Utils
-import org.apache.spark.util.logging.RollingFileAppender
 
 private[history] class LogPage(conf: SparkConf) extends WebUIPage("logPage") with Logging {
-  private val defaultBytes = 100 * 1024
-
   def render(request: HttpServletRequest): Seq[Node] = {
     val logDir = sys.env.getOrElse("SPARK_LOG_DIR", "logs/")
     val logType = request.getParameter("logType")
     val offset = Option(request.getParameter("offset")).map(_.toLong)
     val byteLength = Option(request.getParameter("byteLength")).map(_.toInt)
-      .getOrElse(defaultBytes)
-    val (logText, startByte, endByte, logLength) = getLog(logDir, logType, offset, byteLength)
+      .getOrElse(DEFAULT_BYTES)
+    val (logText, startByte, endByte, logLength) =
+      getLog(conf, logDir, logType, offset, byteLength)
     val curLogLength = endByte - startByte
     val range =
       <span id="log-data">
@@ -78,49 +75,5 @@ private[history] class LogPage(conf: SparkConf) extends WebUIPage("logPage") wit
       </div>
 
     UIUtils.basicSparkPage(request, content, logType + " log page for history server")
-  }
-
-  /** Get the part of the log files given the offset and desired length of bytes */
-  private def getLog(
-      logDirectory: String,
-      logType: String,
-      offsetOption: Option[Long],
-      byteLength: Int
-    ): (String, Long, Long, Long) = {
-    try {
-      // Find a log file name
-      val fileName = if (logType.equals("out")) {
-        val normalizedUri = new File(logDirectory).toURI.normalize()
-        val normalizedLogDir = new File(normalizedUri.getPath)
-        normalizedLogDir.listFiles.map(_.getName).filter(_.endsWith(".out"))
-          .headOption.getOrElse(logType)
-      } else {
-        logType
-      }
-      val files = RollingFileAppender.getSortedRolledOverFiles(logDirectory, fileName)
-      logDebug(s"Sorted log files of type $logType in $logDirectory:\n${files.mkString("\n")}")
-
-      val fileLengths: Seq[Long] = files.map(Utils.getFileLength(_, conf))
-      val totalLength = fileLengths.sum
-      val offset = offsetOption.getOrElse(totalLength - byteLength)
-      val startIndex = {
-        if (offset < 0) {
-          0L
-        } else if (offset > totalLength) {
-          totalLength
-        } else {
-          offset
-        }
-      }
-      val endIndex = math.min(startIndex + byteLength, totalLength)
-      logDebug(s"Getting log from $startIndex to $endIndex")
-      val logText = Utils.offsetBytes(files, fileLengths, startIndex, endIndex)
-      logDebug(s"Got log of length ${logText.length} bytes")
-      (logText, startIndex, endIndex, totalLength)
-    } catch {
-      case e: Exception =>
-        logError(s"Error getting $logType logs from directory $logDirectory", e)
-        ("Error getting logs due to exception: " + e.getMessage, 0, 0, 0)
-    }
   }
 }

--- a/core/src/main/scala/org/apache/spark/deploy/master/ui/LogPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/ui/LogPage.scala
@@ -17,26 +17,23 @@
 
 package org.apache.spark.deploy.master.ui
 
-import java.io.File
 import javax.servlet.http.HttpServletRequest
 
 import scala.xml.{Node, Unparsed}
 
+import org.apache.spark.deploy.Utils.{getLog, DEFAULT_BYTES}
 import org.apache.spark.internal.Logging
 import org.apache.spark.ui.{UIUtils, WebUIPage}
-import org.apache.spark.util.Utils
-import org.apache.spark.util.logging.RollingFileAppender
 
 private[ui] class LogPage(parent: MasterWebUI) extends WebUIPage("logPage") with Logging {
-  private val defaultBytes = 100 * 1024
-
   def render(request: HttpServletRequest): Seq[Node] = {
     val logDir = sys.env.getOrElse("SPARK_LOG_DIR", "logs/")
     val logType = request.getParameter("logType")
     val offset = Option(request.getParameter("offset")).map(_.toLong)
     val byteLength = Option(request.getParameter("byteLength")).map(_.toInt)
-      .getOrElse(defaultBytes)
-    val (logText, startByte, endByte, logLength) = getLog(logDir, logType, offset, byteLength)
+      .getOrElse(DEFAULT_BYTES)
+    val (logText, startByte, endByte, logLength) =
+      getLog(parent.master.conf, logDir, logType, offset, byteLength)
     val curLogLength = endByte - startByte
     val range =
       <span id="log-data">
@@ -77,49 +74,5 @@ private[ui] class LogPage(parent: MasterWebUI) extends WebUIPage("logPage") with
       </div>
 
     UIUtils.basicSparkPage(request, content, logType + " log page for master")
-  }
-
-  /** Get the part of the log files given the offset and desired length of bytes */
-  private def getLog(
-      logDirectory: String,
-      logType: String,
-      offsetOption: Option[Long],
-      byteLength: Int
-    ): (String, Long, Long, Long) = {
-    try {
-      // Find a log file name
-      val fileName = if (logType.equals("out")) {
-        val normalizedUri = new File(logDirectory).toURI.normalize()
-        val normalizedLogDir = new File(normalizedUri.getPath)
-        normalizedLogDir.listFiles.map(_.getName).filter(_.endsWith(".out"))
-          .headOption.getOrElse(logType)
-      } else {
-        logType
-      }
-      val files = RollingFileAppender.getSortedRolledOverFiles(logDirectory, fileName)
-      logDebug(s"Sorted log files of type $logType in $logDirectory:\n${files.mkString("\n")}")
-
-      val fileLengths: Seq[Long] = files.map(Utils.getFileLength(_, parent.master.conf))
-      val totalLength = fileLengths.sum
-      val offset = offsetOption.getOrElse(totalLength - byteLength)
-      val startIndex = {
-        if (offset < 0) {
-          0L
-        } else if (offset > totalLength) {
-          totalLength
-        } else {
-          offset
-        }
-      }
-      val endIndex = math.min(startIndex + byteLength, totalLength)
-      logDebug(s"Getting log from $startIndex to $endIndex")
-      val logText = Utils.offsetBytes(files, fileLengths, startIndex, endIndex)
-      logDebug(s"Got log of length ${logText.length} bytes")
-      (logText, startIndex, endIndex, totalLength)
-    } catch {
-      case e: Exception =>
-        logError(s"Error getting $logType logs from directory $logDirectory", e)
-        ("Error getting logs due to exception: " + e.getMessage, 0, 0, 0)
-    }
   }
 }

--- a/core/src/main/scala/org/apache/spark/deploy/master/ui/MasterWebUI.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/ui/MasterWebUI.scala
@@ -21,6 +21,7 @@ import java.net.{InetAddress, NetworkInterface, SocketException}
 import javax.servlet.http.{HttpServlet, HttpServletRequest, HttpServletResponse}
 
 import org.apache.spark.deploy.DeployMessages.{DecommissionWorkersOnHosts, MasterStateResponse, RequestMasterState}
+import org.apache.spark.deploy.Utils.addRenderLogHandler
 import org.apache.spark.deploy.master.Master
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config.DECOMMISSION_ENABLED
@@ -54,6 +55,7 @@ class MasterWebUI(
     attachPage(new LogPage(this))
     attachPage(masterPage)
     addStaticHandler(MasterWebUI.STATIC_RESOURCE_DIR)
+    addRenderLogHandler(this, master.conf)
     if (killEnabled) {
       attachHandler(createRedirectHandler(
         "/app/kill", "/", masterPage.handleAppKillRequest, httpMethods = Set("POST")))


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `Load New` button in `Master/HistoryServer` Log UI which assumes `/log` API additionally. In addition, this PR refactors all related logics into new `Utils` object in `deploy` module.

### Why are the changes needed?

`log-view.js` assumes `/log` endpoints when a button is clicked.

https://github.com/apache/spark/blob/8e29c0d8c5cdc87d0a7358e090af864c4f03b1a8/core/src/main/resources/org/apache/spark/ui/static/log-view.js#L57-L67


To make `Load New` button work in `Master` and `History Server` like `Worker` or `Spark Driver` pages. Currently, we need to refresh the page to get a new result.

### Does this PR introduce _any_ user-facing change?

No, `Master` and `History Server` Log Page features are not released yet.

### How was this patch tested?

Manually.

### Was this patch authored or co-authored using generative AI tooling?

No.