### PR TITLE
[SPARK-46925][PYTHON][CONNECT] Add a warning that instructs to install memory_profiler for memory profiling

### DIFF
--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -951,8 +951,8 @@ class SparkSession:
             self._profiler_collector.show_memory_profiles(id)
         else:
             warnings.warn(
-                "Memory profiling is disabled. To enable it, install 'memory-profiler' from PyPI"
-                " (https://pypi.org/project/memory-profiler/).",
+                "Memory profiling is disabled. To enable it, install 'memory-profiler',"
+                " e.g., from PyPI (https://pypi.org/project/memory-profiler/).",
                 UserWarning,
             )
 

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -96,6 +96,14 @@ if TYPE_CHECKING:
     from pyspark.sql.connect.udtf import UDTFRegistration
 
 
+try:
+    import memory_profiler  # type: ignore # noqa: F401
+
+    has_memory_profiler = True
+except Exception:
+    has_memory_profiler = False
+
+
 class SparkSession:
     # The active SparkSession for the current thread
     _active_session: ClassVar[threading.local] = threading.local()
@@ -939,7 +947,14 @@ class SparkSession:
     showPerfProfiles.__doc__ = PySparkSession.showPerfProfiles.__doc__
 
     def showMemoryProfiles(self, id: Optional[int] = None) -> None:
-        self._profiler_collector.show_memory_profiles(id)
+        if has_memory_profiler:
+            self._profiler_collector.show_memory_profiles(id)
+        else:
+            warnings.warn(
+                "Memory profiling is disabled. To enable it, install 'memory-profiler' from PyPI"
+                " (https://pypi.org/project/memory-profiler/).",
+                UserWarning,
+            )
 
     showMemoryProfiles.__doc__ = PySparkSession.showMemoryProfiles.__doc__
 

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -81,6 +81,12 @@ if TYPE_CHECKING:
     # other dependencies so importing here is fine.
     from pyspark.sql.connect.client import SparkConnectClient
 
+try:
+    import memory_profiler  # type: ignore # noqa: F401
+
+    has_memory_profiler = True
+except Exception:
+    has_memory_profiler = False
 
 __all__ = ["SparkSession"]
 
@@ -2128,7 +2134,14 @@ class SparkSession(SparkConversionMixin):
     showPerfProfiles.__doc__ = ProfilerCollector.show_perf_profiles.__doc__
 
     def showMemoryProfiles(self, id: Optional[int] = None) -> None:
-        self._profiler_collector.show_memory_profiles(id)
+        if has_memory_profiler:
+            self._profiler_collector.show_memory_profiles(id)
+        else:
+            warnings.warn(
+                "Memory profiling is disabled. To enable it, install 'memory-profiler' from PyPI"
+                " (https://pypi.org/project/memory-profiler/).",
+                UserWarning,
+            )
 
     showMemoryProfiles.__doc__ = ProfilerCollector.show_memory_profiles.__doc__
 

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -2138,8 +2138,8 @@ class SparkSession(SparkConversionMixin):
             self._profiler_collector.show_memory_profiles(id)
         else:
             warnings.warn(
-                "Memory profiling is disabled. To enable it, install 'memory-profiler' from PyPI"
-                " (https://pypi.org/project/memory-profiler/).",
+                "Memory profiling is disabled. To enable it, install 'memory-profiler',"
+                " e.g., from PyPI (https://pypi.org/project/memory-profiler/).",
                 UserWarning,
             )
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add a warning that instructs to install memory_profiler for memory profiling.


### Why are the changes needed?
To inform users why calling a method like spark.showMemoryProfiles() would return empty results if the memory_profiler module isn't installed. 
Better usability. 


### Does this PR introduce _any_ user-facing change?
No behavior change, only a warning is added.

```python
>>> import memory_profiler
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ModuleNotFoundError: No module named 'memory_profiler']

... 

>>> spark.showMemoryProfiles()
UserWarning: Memory profiling is disabled. To enable it, install 'memory-profiler' from PyPI (https://pypi.org/project/memory-profiler/).
```

### How was this patch tested?
Manual tests.


### Was this patch authored or co-authored using generative AI tooling?
No.