### PR TITLE
[SPARK-46926][PS][CONNECT] Support `convert_dtypes` and `infer_objects` in fallback mode

### DIFF
--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -822,6 +822,8 @@ pyspark_pandas = Module(
         # fallback
         "pyspark.pandas.tests.frame.test_asfreq",
         "pyspark.pandas.tests.frame.test_asof",
+        "pyspark.pandas.tests.frame.test_convert_dtypes",
+        "pyspark.pandas.tests.frame.test_infer_objects",
     ],
     excluded_python_implementations=[
         "PyPy"  # Skip these tests under PyPy since they require numpy, pandas, and pyarrow and
@@ -1207,6 +1209,8 @@ pyspark_pandas_connect_part1 = Module(
         # fallback
         "pyspark.pandas.tests.connect.frame.test_parity_asfreq",
         "pyspark.pandas.tests.connect.frame.test_parity_asof",
+        "pyspark.pandas.tests.connect.frame.test_parity_convert_dtypes",
+        "pyspark.pandas.tests.connect.frame.test_parity_infer_objects",
     ],
     excluded_python_implementations=[
         "PyPy"  # Skip these tests under PyPy since they require numpy, pandas, and pyarrow and

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -25,7 +25,6 @@ import warnings
 import inspect
 import json
 import types
-import base64
 from functools import partial, reduce
 import sys
 from itertools import zip_longest, chain
@@ -68,7 +67,7 @@ from pandas.core.accessor import CachedAccessor
 from pandas.core.dtypes.inference import is_sequence
 
 from pyspark.errors import PySparkValueError
-from pyspark import StorageLevel, cloudpickle
+from pyspark import StorageLevel
 from pyspark.sql import Column as PySparkColumn, DataFrame as PySparkDataFrame, functions as F
 from pyspark.sql.functions import pandas_udf
 from pyspark.sql.types import (
@@ -13487,66 +13486,6 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         return _internal_fall_back_function
 
-    def _fall_back_frame_with_inferred_schema(self, method: str) -> Callable:
-        def _internal_fall_back_function(*inputs: Any, **kwargs: Any) -> "DataFrame":
-            log_advice(
-                f"`{method}` is executed in fallback mode. It first loads all the data into one"
-                f"executor's memory to infer the schema, and then loads all data into one executor's "
-                f"memory again to compute. It should only be used if the pandas DataFrame is expected "
-                f"to be small."
-            )
-
-            input_df = self.copy()
-            index_names = input_df.index.names
-
-            sdf = input_df._internal.spark_frame
-            tmp_agg_column_name = verify_temp_column_name(
-                sdf, f"__tmp_aggregate_col_for_frame_{method}__"
-            )
-            input_df[tmp_agg_column_name] = 0
-
-            tmp_idx_column_name = verify_temp_column_name(
-                sdf, f"__tmp_index_col_for_frame_{method}__"
-            )
-            input_df[tmp_idx_column_name] = input_df.index
-
-            def infer_schema(pdf: pd.DataFrame) -> ps.DataFrame[zip(["schema"], [str])]:
-                pdf = pdf.drop(columns=[tmp_agg_column_name])
-                pdf = pdf.set_index(tmp_idx_column_name, drop=True)
-                pdf = pdf.sort_index()
-                pdf = getattr(pdf, method)(*inputs, **kwargs)
-                pdf[tmp_idx_column_name] = pdf.index
-                pdf = pdf.reset_index(drop=True)
-                schema = (pdf.columns, pdf.dtypes)
-                schema_bytes = cloudpickle.dumps(schema)
-                schema_str = base64.b64encode(schema_bytes)
-                return pd.DataFrame(data=[schema_str], columns=["schema"])
-
-            output_df = input_df.groupby(tmp_agg_column_name).apply(infer_schema)
-
-            # note that the inferred schema may contain 'object' and fail following computation
-            schema_str = output_df["schema"].iloc[0]
-            schema_bytes = base64.b64decode(schema_str)
-            (inferred_columns, inferred_dtypes) = cloudpickle.loads(schema_bytes)
-
-            def compute_function(
-                pdf: pd.DataFrame,
-            ) -> ps.DataFrame[zip(inferred_columns, inferred_dtypes)]:
-                pdf = pdf.drop(columns=[tmp_agg_column_name])
-                pdf = pdf.set_index(tmp_idx_column_name, drop=True)
-                pdf = pdf.sort_index()
-                pdf = getattr(pdf, method)(*inputs, **kwargs)
-                pdf[tmp_idx_column_name] = pdf.index
-                return pdf.reset_index(drop=True)
-
-            output_df = input_df.groupby(tmp_agg_column_name).apply(compute_function)
-            output_df = output_df.set_index(tmp_idx_column_name)
-            output_df.index.names = index_names
-
-            return output_df
-
-        return _internal_fall_back_function
-
     def __getattr__(self, key: str) -> Any:
         if key.startswith("__"):
             raise AttributeError(key)
@@ -13557,10 +13496,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 "convert_dtypes",
                 "infer_objects",
             ] and get_option("compute.pandas_fallback"):
-                if key in ["asfreq", "asof"]:
-                    return self._fall_back_frame(key)
-                else:
-                    return self._fall_back_frame_with_inferred_schema(key)
+                return self._fall_back_frame(key)
 
             property_or_func = getattr(MissingPandasLikeDataFrame, key)
             if isinstance(property_or_func, property):

--- a/python/pyspark/pandas/tests/connect/frame/test_parity_convert_dtypes.py
+++ b/python/pyspark/pandas/tests/connect/frame/test_parity_convert_dtypes.py
@@ -1,0 +1,41 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import unittest
+
+from pyspark.pandas.tests.frame.test_convert_dtypes import ConvertDtypesMixin
+from pyspark.testing.connectutils import ReusedConnectTestCase
+from pyspark.testing.pandasutils import PandasOnSparkTestUtils
+
+
+class ConvertDtypesParityTests(
+    ConvertDtypesMixin,
+    PandasOnSparkTestUtils,
+    ReusedConnectTestCase,
+):
+    pass
+
+
+if __name__ == "__main__":
+    from pyspark.pandas.tests.connect.frame.test_parity_convert_dtypes import *  # noqa: F401
+
+    try:
+        import xmlrunner  # type: ignore[import]
+
+        testRunner = xmlrunner.XMLTestRunner(output="target/test-reports", verbosity=2)
+    except ImportError:
+        testRunner = None
+    unittest.main(testRunner=testRunner, verbosity=2)

--- a/python/pyspark/pandas/tests/connect/frame/test_parity_infer_objects.py
+++ b/python/pyspark/pandas/tests/connect/frame/test_parity_infer_objects.py
@@ -1,0 +1,41 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import unittest
+
+from pyspark.pandas.tests.frame.test_infer_objects import InferObjMixin
+from pyspark.testing.connectutils import ReusedConnectTestCase
+from pyspark.testing.pandasutils import PandasOnSparkTestUtils
+
+
+class InferObjParityTests(
+    InferObjMixin,
+    PandasOnSparkTestUtils,
+    ReusedConnectTestCase,
+):
+    pass
+
+
+if __name__ == "__main__":
+    from pyspark.pandas.tests.connect.frame.test_parity_infer_objects import *  # noqa: F401
+
+    try:
+        import xmlrunner  # type: ignore[import]
+
+        testRunner = xmlrunner.XMLTestRunner(output="target/test-reports", verbosity=2)
+    except ImportError:
+        testRunner = None
+    unittest.main(testRunner=testRunner, verbosity=2)

--- a/python/pyspark/pandas/tests/frame/test_convert_dtypes.py
+++ b/python/pyspark/pandas/tests/frame/test_convert_dtypes.py
@@ -1,0 +1,97 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import unittest
+
+import numpy as np
+import pandas as pd
+
+import pyspark.pandas as ps
+from pyspark.pandas.exceptions import PandasNotImplementedError
+from pyspark.testing.pandasutils import PandasOnSparkTestCase, TestUtils
+
+
+class ConvertDtypesMixin:
+    @property
+    def pdf(self):
+        return pd.DataFrame(
+            {
+                "a": pd.Series([1, 2, 3], dtype=np.dtype("int32")),
+                "b": pd.Series(["x", "y", "z"], dtype=np.dtype("O")),
+                "c": pd.Series([True, False, np.nan], dtype=np.dtype("O")),
+                "d": pd.Series(["h", "i", np.nan], dtype=np.dtype("O")),
+                "e": pd.Series([10, np.nan, 20], dtype=np.dtype("float")),
+                "f": pd.Series([np.nan, 100.5, 200], dtype=np.dtype("float")),
+            }
+        )
+
+    @property
+    def psdf(self):
+        return ps.from_pandas(self.pdf)
+
+    def test_disabled(self):
+        with self.assertRaises(PandasNotImplementedError):
+            self.psdf.infer_objects()
+
+    def test_fallback(self):
+        ps.set_option("compute.pandas_fallback", True)
+
+        pdf2 = self.pdf.convert_dtypes()
+        psdf2 = self.psdf.convert_dtypes()
+        self.assert_eq(pdf2, psdf2)
+        self.assert_eq(pdf2.dtypes, psdf2.dtypes)
+
+        # pdf2 = self.pdf.convert_dtypes(convert_string=False)
+        # psdf2 = self.psdf.convert_dtypes(convert_string=False)
+        # self.assert_eq(pdf2, psdf2)
+        # self.assert_eq(pdf2.dtypes, psdf2.dtypes)
+
+        pdf2 = self.pdf.convert_dtypes(convert_integer=False)
+        psdf2 = self.psdf.convert_dtypes(convert_integer=False)
+        self.assert_eq(pdf2, psdf2)
+        self.assert_eq(pdf2.dtypes, psdf2.dtypes)
+
+        # pdf2 = self.pdf.convert_dtypes(convert_boolean=False)
+        # psdf2 = self.psdf.convert_dtypes(convert_boolean=False)
+        # self.assert_eq(pdf2, psdf2)
+        # self.assert_eq(pdf2.dtypes, psdf2.dtypes)
+
+        pdf2 = self.pdf.convert_dtypes(convert_floating=False)
+        psdf2 = self.psdf.convert_dtypes(convert_floating=False)
+        self.assert_eq(pdf2, psdf2)
+        self.assert_eq(pdf2.dtypes, psdf2.dtypes)
+
+        ps.reset_option("compute.pandas_fallback")
+
+
+class ConvertDtypesTests(
+    ConvertDtypesMixin,
+    PandasOnSparkTestCase,
+    TestUtils,
+):
+    pass
+
+
+if __name__ == "__main__":
+    from pyspark.pandas.tests.frame.test_convert_dtypes import *  # noqa: F401
+
+    try:
+        import xmlrunner
+
+        testRunner = xmlrunner.XMLTestRunner(output="target/test-reports", verbosity=2)
+    except ImportError:
+        testRunner = None
+    unittest.main(testRunner=testRunner, verbosity=2)

--- a/python/pyspark/pandas/tests/frame/test_convert_dtypes.py
+++ b/python/pyspark/pandas/tests/frame/test_convert_dtypes.py
@@ -54,20 +54,20 @@ class ConvertDtypesMixin:
         self.assert_eq(pdf2, psdf2)
         self.assert_eq(pdf2.dtypes, psdf2.dtypes)
 
-        # pdf2 = self.pdf.convert_dtypes(convert_string=False)
-        # psdf2 = self.psdf.convert_dtypes(convert_string=False)
-        # self.assert_eq(pdf2, psdf2)
-        # self.assert_eq(pdf2.dtypes, psdf2.dtypes)
+        pdf2 = self.pdf.convert_dtypes(convert_string=False)
+        psdf2 = self.psdf.convert_dtypes(convert_string=False)
+        self.assert_eq(pdf2, psdf2)
+        self.assert_eq(pdf2.dtypes, psdf2.dtypes)
 
         pdf2 = self.pdf.convert_dtypes(convert_integer=False)
         psdf2 = self.psdf.convert_dtypes(convert_integer=False)
         self.assert_eq(pdf2, psdf2)
         self.assert_eq(pdf2.dtypes, psdf2.dtypes)
 
-        # pdf2 = self.pdf.convert_dtypes(convert_boolean=False)
-        # psdf2 = self.psdf.convert_dtypes(convert_boolean=False)
-        # self.assert_eq(pdf2, psdf2)
-        # self.assert_eq(pdf2.dtypes, psdf2.dtypes)
+        pdf2 = self.pdf.convert_dtypes(convert_boolean=False)
+        psdf2 = self.psdf.convert_dtypes(convert_boolean=False)
+        self.assert_eq(pdf2, psdf2)
+        self.assert_eq(pdf2.dtypes, psdf2.dtypes)
 
         pdf2 = self.pdf.convert_dtypes(convert_floating=False)
         psdf2 = self.psdf.convert_dtypes(convert_floating=False)

--- a/python/pyspark/pandas/tests/frame/test_infer_objects.py
+++ b/python/pyspark/pandas/tests/frame/test_infer_objects.py
@@ -1,0 +1,68 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import unittest
+
+import pandas as pd
+
+import pyspark.pandas as ps
+from pyspark.pandas.exceptions import PandasNotImplementedError
+from pyspark.testing.pandasutils import PandasOnSparkTestCase, TestUtils
+
+
+class InferObjMixin:
+    @property
+    def pdf(self):
+        df = pd.DataFrame({"A": ["a", 1, 2, 3]})
+        return df.iloc[1:]
+
+    @property
+    def psdf(self):
+        return ps.from_pandas(self.pdf)
+
+    def test_disabled(self):
+        with self.assertRaises(PandasNotImplementedError):
+            self.psdf.infer_objects()
+
+    def test_fallback(self):
+        ps.set_option("compute.pandas_fallback", True)
+
+        pdf2 = self.pdf.infer_objects()
+        psdf2 = self.psdf.infer_objects()
+        self.assert_eq(pdf2, psdf2)
+        self.assert_eq(pdf2.dtypes, psdf2.dtypes)
+
+        ps.reset_option("compute.pandas_fallback")
+
+
+class InferObjTests(
+    InferObjMixin,
+    PandasOnSparkTestCase,
+    TestUtils,
+):
+    pass
+
+
+if __name__ == "__main__":
+    from pyspark.pandas.tests.frame.test_infer_objects import *  # noqa: F401
+
+    try:
+        import xmlrunner
+
+        testRunner = xmlrunner.XMLTestRunner(output="target/test-reports", verbosity=2)
+    except ImportError:
+        testRunner = None
+    unittest.main(testRunner=testRunner, verbosity=2)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support `convert_dtypes` and `infer_objects` in fallback mode

### Why are the changes needed?
for parity


### Does this PR introduce _any_ user-facing change?
new functions support in fallback mode, disabled by default


### How was this patch tested?
added ut

### Was this patch authored or co-authored using generative AI tooling?
no
