### PR TITLE
[SPARK-46927][PYTHON] Make `assertDataFrameEqual` work properly without PyArrow

### DIFF
--- a/python/pyspark/testing/utils.py
+++ b/python/pyspark/testing/utils.py
@@ -789,29 +789,29 @@ def assertDataFrameEqual(
                 actual, expected, almost=True, rtol=rtol, atol=atol, check_row_order=checkRowOrder
             )
 
-        from pyspark.sql.utils import get_dataframe_class
+    from pyspark.sql.utils import get_dataframe_class
 
-        # if is_remote(), allow Connect DataFrame
-        SparkDataFrame = get_dataframe_class()
+    # if is_remote(), allow Connect DataFrame
+    SparkDataFrame = get_dataframe_class()
 
-        if not isinstance(actual, (DataFrame, SparkDataFrame, list)):
-            raise PySparkAssertionError(
-                error_class="INVALID_TYPE_DF_EQUALITY_ARG",
-                message_parameters={
-                    "expected_type": "Union[DataFrame, ps.DataFrame, List[Row]]",
-                    "arg_name": "actual",
-                    "actual_type": type(actual),
-                },
-            )
-        elif not isinstance(expected, (DataFrame, SparkDataFrame, list)):
-            raise PySparkAssertionError(
-                error_class="INVALID_TYPE_DF_EQUALITY_ARG",
-                message_parameters={
-                    "expected_type": "Union[DataFrame, ps.DataFrame, List[Row]]",
-                    "arg_name": "expected",
-                    "actual_type": type(expected),
-                },
-            )
+    if not isinstance(actual, (DataFrame, SparkDataFrame, list)):
+        raise PySparkAssertionError(
+            error_class="INVALID_TYPE_DF_EQUALITY_ARG",
+            message_parameters={
+                "expected_type": "Union[DataFrame, ps.DataFrame, List[Row]]",
+                "arg_name": "actual",
+                "actual_type": type(actual),
+            },
+        )
+    elif not isinstance(expected, (DataFrame, SparkDataFrame, list)):
+        raise PySparkAssertionError(
+            error_class="INVALID_TYPE_DF_EQUALITY_ARG",
+            message_parameters={
+                "expected_type": "Union[DataFrame, ps.DataFrame, List[Row]]",
+                "arg_name": "expected",
+                "actual_type": type(expected),
+            },
+        )
 
     if ignoreColumnOrder:
         actual = actual.select(*sorted(actual.columns))


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to fix `assertDataFrameEqual` to work properly without PyArrow


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
The current way does not work properly without PyArrow.


### Does this PR introduce _any_ user-facing change?

`assertDataFrameEqual` will raise proper error without PyArrow.

**Before**
```python
>>> from pyspark.testing.utils import assertDataFrameEqual
>>> dict1 = {"a": 1, "b": 2}
>>> dict2 = {"a": 1, "b": 2}
>>> assertDataFrameEqual(dict1, dict2)
AttributeError: 'dict' object has no attribute 'schema'
```

**After**
```python
>>> from pyspark.testing.utils import assertDataFrameEqual
>>> dict1 = {"a": 1, "b": 2}
>>> dict2 = {"a": 1, "b": 2}
>>> assertDataFrameEqual(dict1, dict2)
pyspark.errors.exceptions.base.PySparkAssertionError: [INVALID_TYPE_DF_EQUALITY_ARG] Expected type Union[DataFrame, ps.DataFrame, List[Row]] for `actual` but got type <class 'dict'>.
```


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
UT

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.
