### PR TITLE
[SPARK-46926][PS] Add `convert_dtypes`, `infer_objects` and `set_axis` in fallback list

### DIFF
--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -13490,7 +13490,13 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         if key.startswith("__"):
             raise AttributeError(key)
         if hasattr(MissingPandasLikeDataFrame, key):
-            if key in ["asfreq", "asof"] and get_option("compute.pandas_fallback"):
+            if key in [
+                "asfreq",
+                "asof",
+                "convert_dtypes",
+                "infer_objects",
+                "set_axis",
+            ] and get_option("compute.pandas_fallback"):
                 return self._fall_back_frame(key)
 
             property_or_func = getattr(MissingPandasLikeDataFrame, key)

--- a/python/pyspark/pandas/missing/frame.py
+++ b/python/pyspark/pandas/missing/frame.py
@@ -43,7 +43,6 @@ class MissingPandasLikeDataFrame:
     reorder_levels = _unsupported_function("reorder_levels")
     set_axis = _unsupported_function("set_axis")
     to_feather = _unsupported_function("to_feather")
-    to_gbq = _unsupported_function("to_gbq")
     to_hdf = _unsupported_function("to_hdf")
     to_period = _unsupported_function("to_period")
     to_sql = _unsupported_function("to_sql")
@@ -55,6 +54,9 @@ class MissingPandasLikeDataFrame:
     # Deprecated functions
     lookup = _unsupported_function(
         "lookup", deprecated=True, reason="Use DataFrame.melt and DataFrame.loc instead."
+    )
+    to_gbq = _unsupported_function(
+        "to_gbq", deprecated=True, reason="Use pandas_gbq.to_gbq instead."
     )
 
     # Functions we won't support.


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add `convert_dtypes`, `infer_objects` and `set_axis` in fallback list


### Why are the changes needed?
for pandas parity

### Does this PR introduce _any_ user-facing change?
these apis are disabled by default


### How was this patch tested?
manually check with the latest pandas examples


### Was this patch authored or co-authored using generative AI tooling?
no