### PR TITLE
[SPARK-46932] Clean up the imports in `pyspark.pandas.test_*`

### DIFF
--- a/python/pyspark/pandas/tests/connect/test_parity_categorical.py
+++ b/python/pyspark/pandas/tests/connect/test_parity_categorical.py
@@ -16,18 +16,18 @@
 #
 import unittest
 
-from pyspark import pandas as ps
 from pyspark.pandas.tests.test_categorical import CategoricalTestsMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase
 from pyspark.testing.pandasutils import PandasOnSparkTestUtils, TestUtils
 
 
 class CategoricalParityTests(
-    CategoricalTestsMixin, PandasOnSparkTestUtils, TestUtils, ReusedConnectTestCase
+    CategoricalTestsMixin,
+    PandasOnSparkTestUtils,
+    TestUtils,
+    ReusedConnectTestCase,
 ):
-    @property
-    def psdf(self):
-        return ps.from_pandas(self.pdf)
+    pass
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/connect/test_parity_extension.py
+++ b/python/pyspark/pandas/tests/connect/test_parity_extension.py
@@ -16,26 +16,17 @@
 #
 import unittest
 
-import pandas as pd
-import numpy as np
-
-from pyspark import pandas as ps
 from pyspark.pandas.tests.test_extension import ExtensionTestsMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase
 from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
-class ExtensionParityTests(ExtensionTestsMixin, PandasOnSparkTestUtils, ReusedConnectTestCase):
-    @property
-    def pdf(self):
-        return pd.DataFrame(
-            {"a": [1, 2, 3, 4, 5, 6, 7, 8, 9], "b": [4, 5, 6, 3, 2, 1, 0, 0, 0]},
-            index=np.random.rand(9),
-        )
-
-    @property
-    def psdf(self):
-        return ps.from_pandas(self.pdf)
+class ExtensionParityTests(
+    ExtensionTestsMixin,
+    PandasOnSparkTestUtils,
+    ReusedConnectTestCase,
+):
+    pass
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/connect/test_parity_numpy_compat.py
+++ b/python/pyspark/pandas/tests/connect/test_parity_numpy_compat.py
@@ -16,25 +16,17 @@
 #
 import unittest
 
-import pandas as pd
-
-from pyspark import pandas as ps
 from pyspark.pandas.tests.test_numpy_compat import NumPyCompatTestsMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase
 from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 
 
-class NumPyCompatParityTests(NumPyCompatTestsMixin, PandasOnSparkTestUtils, ReusedConnectTestCase):
-    @property
-    def pdf(self):
-        return pd.DataFrame(
-            {"a": [1, 2, 3, 4, 5, 6, 7, 8, 9], "b": [4, 5, 6, 3, 2, 1, 0, 0, 0]},
-            index=[0, 1, 3, 5, 6, 8, 9, 9, 9],
-        )
-
-    @property
-    def psdf(self):
-        return ps.from_pandas(self.pdf)
+class NumPyCompatParityTests(
+    NumPyCompatTestsMixin,
+    PandasOnSparkTestUtils,
+    ReusedConnectTestCase,
+):
+    pass
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/test_categorical.py
+++ b/python/pyspark/pandas/tests/test_categorical.py
@@ -20,7 +20,7 @@ import pandas as pd
 from pandas.api.types import CategoricalDtype
 
 import pyspark.pandas as ps
-from pyspark.testing.pandasutils import ComparisonTestBase, TestUtils
+from pyspark.testing.pandasutils import PandasOnSparkTestCase, TestUtils
 
 
 class CategoricalTestsMixin:
@@ -34,6 +34,10 @@ class CategoricalTestsMixin:
                 ),
             },
         )
+
+    @property
+    def psdf(self):
+        return ps.from_pandas(self.pdf)
 
     @property
     def df_pair(self):
@@ -658,7 +662,11 @@ class CategoricalTestsMixin:
         )
 
 
-class CategoricalTests(CategoricalTestsMixin, ComparisonTestBase, TestUtils):
+class CategoricalTests(
+    CategoricalTestsMixin,
+    PandasOnSparkTestCase,
+    TestUtils,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/test_extension.py
+++ b/python/pyspark/pandas/tests/test_extension.py
@@ -21,7 +21,7 @@ import numpy as np
 import pandas as pd
 
 from pyspark import pandas as ps
-from pyspark.testing.pandasutils import assert_produces_warning, ComparisonTestBase
+from pyspark.testing.pandasutils import assert_produces_warning, PandasOnSparkTestCase
 from pyspark.pandas.extensions import (
     register_dataframe_accessor,
     register_series_accessor,
@@ -73,6 +73,10 @@ class ExtensionTestsMixin:
             {"a": [1, 2, 3, 4, 5, 6, 7, 8, 9], "b": [4, 5, 6, 3, 2, 1, 0, 0, 0]},
             index=np.random.rand(9),
         )
+
+    @property
+    def psdf(self):
+        return ps.from_pandas(self.pdf)
 
     @property
     def accessor(self):
@@ -135,7 +139,10 @@ class ExtensionTestsMixin:
                 ps.Series([1, 2], dtype=object).bad
 
 
-class ExtensionTests(ExtensionTestsMixin, ComparisonTestBase):
+class ExtensionTests(
+    ExtensionTestsMixin,
+    PandasOnSparkTestCase,
+):
     pass
 
 

--- a/python/pyspark/pandas/tests/test_numpy_compat.py
+++ b/python/pyspark/pandas/tests/test_numpy_compat.py
@@ -20,7 +20,7 @@ import pandas as pd
 
 from pyspark import pandas as ps
 from pyspark.pandas import set_option, reset_option
-from pyspark.testing.pandasutils import ComparisonTestBase
+from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
 
 
@@ -45,6 +45,10 @@ class NumPyCompatTestsMixin:
             {"a": [1, 2, 3, 4, 5, 6, 7, 8, 9], "b": [4, 5, 6, 3, 2, 1, 0, 0, 0]},
             index=[0, 1, 3, 5, 6, 8, 9, 9, 9],
         )
+
+    @property
+    def psdf(self):
+        return ps.from_pandas(self.pdf)
 
     def test_np_add_series(self):
         psdf = self.psdf
@@ -178,7 +182,11 @@ class NumPyCompatTestsMixin:
             reset_option("compute.ops_on_diff_frames")
 
 
-class NumPyCompatTests(NumPyCompatTestsMixin, ComparisonTestBase, SQLTestUtils):
+class NumPyCompatTests(
+    NumPyCompatTestsMixin,
+    PandasOnSparkTestCase,
+    SQLTestUtils,
+):
     pass
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
1, remove unused import, variables
2, avoid double definition of variables


### Why are the changes needed?
code clean up


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
ci

### Was this patch authored or co-authored using generative AI tooling?
no