### PR TITLE
[SPARK-46933][SQL] Add query execution time metric to connectors which use JDBCRDD

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -122,7 +122,7 @@ case class RowDataSourceScanExec(
     )
 
     rdd match {
-      case sqlRdd: SQLRDD => (metrics ++ sqlRdd.metrics).toMap
+      case rddWithDSMetrics: DataSourceMetricsMixin => metrics ++ rddWithDSMetrics.getMetrics
       case _ => metrics
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -99,6 +99,10 @@ trait DataSourceScanExec extends LeafExecNode {
   def inputRDDs(): Seq[RDD[InternalRow]]
 }
 
+object DataSourceScanExec {
+  val numOutputRowsKey = "numOutputRows"
+}
+
 /** Physical plan node for scanning data from a relation. */
 case class RowDataSourceScanExec(
     output: Seq[Attribute],
@@ -111,8 +115,17 @@ case class RowDataSourceScanExec(
     tableIdentifier: Option[TableIdentifier])
   extends DataSourceScanExec with InputRDDCodegen {
 
-  override lazy val metrics =
-    Map("numOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"))
+  override lazy val metrics: Map[String, SQLMetric] = {
+    val metrics = Map(
+      DataSourceScanExec.numOutputRowsKey ->
+        SQLMetrics.createMetric(sparkContext, "number of output rows")
+    )
+
+    rdd match {
+      case sqlRdd: SQLRDD => (metrics ++ sqlRdd.metrics).toMap
+      case _ => metrics
+    }
+  }
 
   protected override def doExecute(): RDD[InternalRow] = {
     val numOutputRows = longMetric("numOutputRows")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceMetricsMixin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceMetricsMixin.scala
@@ -17,23 +17,8 @@
 
 package org.apache.spark.sql.execution.datasources
 
-import org.apache.spark.SparkContext
-import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
+import org.apache.spark.sql.execution.metric.SQLMetric
 
-/**
- * Class that is used as base class for all RDDs
- * that retrieves data from some external data source using SQL query
- */
-abstract class SQLRDD (sparkContext: SparkContext)
-  extends RDD[InternalRow](sparkContext, deps = Nil) {
-
-  val queryExecutionTimeMetric: SQLMetric = SQLMetrics.createNanoTimingMetric(
-    sparkContext,
-    name = "Query execution time")
-
-  val metrics: Seq[(String, SQLMetric)] = Seq(
-    "queryExecutionTime" -> queryExecutionTimeMetric
-  )
+trait DataSourceMetricsMixin {
+  def getMetrics: Seq[(String, SQLMetric)]
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/SQLRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/SQLRDD.scala
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources
+
+import org.apache.spark.SparkContext
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
+
+/**
+ * Class that is used as base class for all RDDs
+ * that retrieves data from some external data source using SQL query
+ */
+abstract class SQLRDD (sparkContext: SparkContext)
+  extends RDD[InternalRow](sparkContext, deps = Nil) {
+
+  val queryExecutionTimeMetric: SQLMetric = SQLMetrics.createNanoTimingMetric(
+    sparkContext,
+    name = "Query execution time")
+
+  val metrics: Seq[(String, SQLMetric)] = Seq(
+    "queryExecutionTime" -> queryExecutionTimeMetric
+  )
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
@@ -287,7 +287,6 @@ class JDBCRDD(
     val endTime = System.nanoTime
 
     val executionTime = endTime - startTime
-    logInfo(s"Query execution time = $executionTime ns")
     queryExecutionTimeMetric.add(executionTime)
 
     val rowsIterator =

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
@@ -180,7 +180,7 @@ class JDBCRDD(
    */
   val queryExecutionTimeMetric: SQLMetric = SQLMetrics.createNanoTimingMetric(
     sparkContext,
-    name = "Query execution time")
+    name = "JDBC query execution time")
 
   /**
    * Retrieve the list of partitions corresponding to this RDD.


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pull request should add measuring query execution time on external JDBC data source.
Another change is changing access right for JDBCRDD class, that is needed for adding another metric (SQL text) which will be done in some next PR.

### Why are the changes needed?
Query execution time is very important metric to have

### Does this PR introduce _any_ user-facing change?
User can see query execution time on SparkPlan graph under node metrics tab

### How was this patch tested?
Tested using custom image

### Was this patch authored or co-authored using generative AI tooling?
No
