### PR TITLE
[MINOR][SQL] Clean up outdated comments from `hash` function in `Metadata`

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/types/Metadata.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/Metadata.scala
@@ -208,8 +208,6 @@ object Metadata {
   /** Computes the hash code for the types we support. */
   private def hash(obj: Any): Int = {
     obj match {
-      // `map.mapValues` return `Map` in Scala 2.12 and return `MapView` in Scala 2.13, call
-      // `toMap` for Scala version compatibility.
       case map: Map[_, _] =>
         map.transform((_, v) => hash(v)).##
       case arr: Array[_] =>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr just clean up outdated comments from `hash` function in `Metadata`

### Why are the changes needed?
Clean up outdated comments


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions

### Was this patch authored or co-authored using generative AI tooling?
No