### PR TITLE
[SPARK-46942][CORE] Ignore --num-executors config if DYN_ALLOCATION_ENABLED is true and allow remove idle executors

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -2541,7 +2541,7 @@ private[spark] object Utils
       conf.get(DYN_ALLOCATION_INITIAL_EXECUTORS)).max
 
     logInfo(s"Using initial executors = $initialExecutors, max of " +
-      s"${DYN_ALLOCATION_INITIAL_EXECUTORS.key}, ${DYN_ALLOCATION_MIN_EXECUTORS.key}")
+      s"${DYN_ALLOCATION_INITIAL_EXECUTORS.key} and ${DYN_ALLOCATION_MIN_EXECUTORS.key}")
     initialExecutors
   }
 

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -2536,20 +2536,12 @@ private[spark] object Utils
           "please update your configs.")
     }
 
-    if (conf.get(EXECUTOR_INSTANCES).getOrElse(0) < conf.get(DYN_ALLOCATION_MIN_EXECUTORS)) {
-      logWarning(s"${EXECUTOR_INSTANCES.key} less than " +
-        s"${DYN_ALLOCATION_MIN_EXECUTORS.key} is invalid, ignoring its setting, " +
-          "please update your configs.")
-    }
-
     val initialExecutors = Seq(
       conf.get(DYN_ALLOCATION_MIN_EXECUTORS),
-      conf.get(DYN_ALLOCATION_INITIAL_EXECUTORS),
-      conf.get(EXECUTOR_INSTANCES).getOrElse(0)).max
+      conf.get(DYN_ALLOCATION_INITIAL_EXECUTORS)).max
 
     logInfo(s"Using initial executors = $initialExecutors, max of " +
-      s"${DYN_ALLOCATION_INITIAL_EXECUTORS.key}, ${DYN_ALLOCATION_MIN_EXECUTORS.key} and " +
-        s"${EXECUTOR_INSTANCES.key}")
+      s"${DYN_ALLOCATION_INITIAL_EXECUTORS.key}, ${DYN_ALLOCATION_MIN_EXECUTORS.key}")
     initialExecutors
   }
 

--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -948,10 +948,10 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties {
       conf.set(DYN_ALLOCATION_MIN_EXECUTORS, 3)) === 3)
     assert(Utils.getDynamicAllocationInitialExecutors( // should use minExecutors
       conf.set("spark.executor.instances", "2")) === 3)
-    assert(Utils.getDynamicAllocationInitialExecutors( // should use executor.instances
-      conf.set("spark.executor.instances", "4")) === 4)
-    assert(Utils.getDynamicAllocationInitialExecutors( // should use executor.instances
-      conf.set(DYN_ALLOCATION_INITIAL_EXECUTORS, 3)) === 4)
+    assert(Utils.getDynamicAllocationInitialExecutors( // should ignore executor.instances
+      conf.set("spark.executor.instances", "4")) === 3)
+    assert(Utils.getDynamicAllocationInitialExecutors( // should ignore executor.instances
+      conf.set(DYN_ALLOCATION_INITIAL_EXECUTORS, 3)) === 3)
     assert(Utils.getDynamicAllocationInitialExecutors( // should use initialExecutors
       conf.set(DYN_ALLOCATION_INITIAL_EXECUTORS, 5)) === 5)
     assert(Utils.getDynamicAllocationInitialExecutors( // should use minExecutors


### PR DESCRIPTION

### What changes were proposed in this pull request?

In https://issues.apache.org/jira/browse/SPARK-13723 , conf --num-executors will be used to compute initialExecutors and initial # of executors.

I think that may conflict to DYN_ALLOCATION_MIN_EXECUTORS and will not free the idle executors.

```
  private def removeExecutors(executors: Seq[(String, Int)]): Seq[String] = synchronized {
        if (newExecutorTotal - 1 < minNumExecutors) {
          logDebug(s"Not removing idle executor $executorIdToBeRemoved because there " +
            s"are only $newExecutorTotal executor(s) left (minimum number of executor limit " +
            s"$minNumExecutors)")
        } else if (newExecutorTotal - 1 < numExecutorsTargetPerResourceProfileId(rpId)) {
          logDebug(s"Not removing idle executor $executorIdToBeRemoved because there " +
            s"are only $newExecutorTotal executor(s) left (number of executor " +
            s"target ${numExecutorsTargetPerResourceProfileId(rpId)})")
        } else {
          executorIdsToBeRemoved += executorIdToBeRemoved
          numExecutorsTotalPerRpId(rpId) -= 1
        }
  }
```

### Why are the changes needed?

Remove the idle executors and improve the cluster resources utilization. 


### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Local test.

Before this PR:
```
24/01/27 02:41:20 INFO Utils: Using initial executors = 1000, max of spark.dynamicAllocation.initialExecutors, spark.dynamicAllocation.minExecutors and spark.executor.instances
```

After this PR:
```
24/01/27 02:51:20 INFO Utils: Using initial executors = 0, max of spark.dynamicAllocation.initialExecutors and spark.dynamicAllocation.minExecutors
```

### Was this patch authored or co-authored using generative AI tooling?

No
