### PR TITLE
[SPARK-46943][SQL] Support for configuring ShuffledHashJoin plan size Threshold

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
@@ -504,12 +504,14 @@ trait JoinSelectionHelper {
 
   /**
    * Matches a plan whose single partition should be small enough to build a hash table.
+   * And the data size of plan is smaller than SHUFFLE_HASH_JOIN_THRESHOLD.
    *
    * Note: this assume that the number of partition is fixed, requires additional work if it's
    * dynamic.
    */
   private def canBuildLocalHashMapBySize(plan: LogicalPlan, conf: SQLConf): Boolean = {
-    plan.stats.sizeInBytes < conf.autoBroadcastJoinThreshold * conf.numShufflePartitions
+    plan.stats.sizeInBytes < conf.autoBroadcastJoinThreshold * conf.numShufflePartitions &&
+      plan.stats.sizeInBytes < conf.getConf(SQLConf.SHUFFLE_HASH_JOIN_THRESHOLD)
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -591,6 +591,12 @@ object SQLConf {
     .bytesConf(ByteUnit.BYTE)
     .createWithDefaultString("10MB")
 
+  val SHUFFLE_HASH_JOIN_THRESHOLD = buildConf("spark.sql.shuffledHashJoinThreshold")
+    .doc("Configure the maximum size in bytes of the plan that performs shuffle hash join.")
+    .version("4.0.0")
+    .bytesConf(ByteUnit.BYTE)
+    .createWithDefault(Long.MaxValue)
+
   val SHUFFLE_HASH_JOIN_FACTOR = buildConf("spark.sql.shuffledHashJoinFactor")
     .doc("The shuffle hash join can be selected if the data size of small" +
       " side multiplied by this factor is still smaller than the large side.")

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/JoinSelectionHelperSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/JoinSelectionHelperSuite.scala
@@ -165,15 +165,32 @@ class JoinSelectionHelperSuite extends PlanTest with JoinSelectionHelper {
   }
 
   test("getShuffleHashJoinBuildSide (hintOnly = false) return BuildRight when right is smaller") {
-    val broadcastSide = getBroadcastBuildSide(
-      left,
-      right,
-      Inner,
-      JoinHint(None, None),
-      hintOnly = false,
-      SQLConf.get
-    )
-    assert(broadcastSide === Some(BuildRight))
+    withSQLConf(SQLConf.PREFER_SORTMERGEJOIN.key -> "false") {
+      val broadcastSide = getShuffleHashJoinBuildSide(
+        left,
+        right,
+        Inner,
+        JoinHint(None, None),
+        hintOnly = false,
+        SQLConf.get
+      )
+      assert(broadcastSide === Some(BuildRight))
+    }
+  }
+
+  test("getShuffleHashJoinBuildSide (hintOnly = false) return None when threshold is small") {
+    withSQLConf(SQLConf.PREFER_SORTMERGEJOIN.key -> "false",
+      SQLConf.SHUFFLE_HASH_JOIN_THRESHOLD.key -> "1") {
+      val broadcastSide = getShuffleHashJoinBuildSide(
+        left,
+        right,
+        Inner,
+        JoinHint(None, None),
+        hintOnly = false,
+        SQLConf.get
+      )
+      assert(broadcastSide === None)
+    }
   }
 
   test("getSmallerSide should return BuildRight") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Introduce the configuration `spark.sql.shuffledHashJoinThreshold`, the default is the maximum value of Long, which can limit the maximum value of the size converted to SHJ.

### Why are the changes needed?

When we enable `spark.sql.join.preferSortMergeJoin=false`, we may get the following error.

```java
org.apache.spark.SparkException: Can't acquire 1073741824 bytes memory to build hash relation, got 478549889 bytes
	at org.apache.spark.sql.errors.QueryExecutionErrors$.cannotAcquireMemoryToBuildLongHashedRelationError(QueryExecutionErrors.scala:795)
	at org.apache.spark.sql.execution.joins.LongToUnsafeRowMap.ensureAcquireMemory(HashedRelation.scala:581)
	at org.apache.spark.sql.execution.joins.LongToUnsafeRowMap.grow(HashedRelation.scala:813)
	at org.apache.spark.sql.execution.joins.LongToUnsafeRowMap.append(HashedRelation.scala:761)
	at org.apache.spark.sql.execution.joins.LongHashedRelation$.apply(HashedRelation.scala:1064)
	at org.apache.spark.sql.execution.joins.HashedRelation$.apply(HashedRelation.scala:153)
	at org.apache.spark.sql.execution.joins.ShuffledHashJoinExec.buildHashedRelation(ShuffledHashJoinExec.scala:75)
	at org.apache.spark.sql.catalyst.expressions.GeneratedClass$GeneratedIteratorForCodegenStage11.init(Unknown Source)
	at org.apache.spark.sql.execution.WholeStageCodegenExec.$anonfun$doExecute$6(WholeStageCodegenExec.scala:775)
	at org.apache.spark.sql.execution.WholeStageCodegenExec.$anonfun$doExecute$6$adapted(WholeStageCodegenExec.scala:771)
	at org.apache.spark.rdd.RDD.$anonfun$mapPartitionsWithIndex$2(RDD.scala:915)
```

Because when converting SMJ to SHJ, it only determines whether the size of the plan is smaller than `conf.autoBroadcastJoinThreshold * conf.numShufflePartitions`. 
When the configured `numShufflePartitions` is large enough, it is easy to convert to SHJ. The executor build hash relation fails due to insufficient memory.

https://github.com/apache/spark/blob/223afea9960c7ef1a4c8654e043e860f6c248185/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala#L505-L513


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Production environment verification

Add UT

### Was this patch authored or co-authored using generative AI tooling?
No
