### PR TITLE
[SPARK-46944] Follow up to SPARK-46792 (ChannelBuilder refactoring): Fix minor typing oversight

### DIFF
--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -159,6 +159,14 @@ class ChannelBuilder:
         """
         raise PySparkNotImplementedError
 
+    @property
+    def host(self) -> str:
+        """
+        The hostname where this client intends to connect.
+        This is used for end-user display purpose in REPL
+        """
+        raise PySparkNotImplementedError
+
     def _insecure_channel(self, target: Any, **kwargs: Any) -> grpc.Channel:
         channel = grpc.insecure_channel(target, options=self._channel_options, **kwargs)
 
@@ -360,11 +368,11 @@ class DefaultChannelBuilder(ChannelBuilder):
 
         netloc = self.url.netloc.split(":")
         if len(netloc) == 1:
-            self.host = netloc[0]
-            self.port = DefaultChannelBuilder.default_port()
+            self._host = netloc[0]
+            self._port = DefaultChannelBuilder.default_port()
         elif len(netloc) == 2:
-            self.host = netloc[0]
-            self.port = int(netloc[1])
+            self._host = netloc[0]
+            self._port = int(netloc[1])
         else:
             raise PySparkValueError(
                 error_class="INVALID_CONNECT_URL",
@@ -382,9 +390,16 @@ class DefaultChannelBuilder(ChannelBuilder):
             or self.token is not None
         )
 
+    def host(self) -> str:
+        """
+        The hostname where this client intends to connect.
+        """
+
+        return self._host
+
     @property
     def endpoint(self) -> str:
-        return f"{self.host}:{self.port}"
+        return f"{self._host}:{self._port}"
 
     def toChannel(self) -> grpc.Channel:
         """

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -390,6 +390,7 @@ class DefaultChannelBuilder(ChannelBuilder):
             or self.token is not None
         )
 
+    @property
     def host(self) -> str:
         """
         The hostname where this client intends to connect.

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -588,7 +588,7 @@ class SparkConnectClient(object):
 
     def __init__(
         self,
-        connection: Union[str, DefaultChannelBuilder],
+        connection: Union[str, ChannelBuilder],
         user_id: Optional[str] = None,
         channel_options: Optional[List[Tuple[str, Any]]] = None,
         retry_policy: Optional[Dict[str, Any]] = None,
@@ -599,7 +599,7 @@ class SparkConnectClient(object):
 
         Parameters
         ----------
-        connection : str or :class:`DefaultChannelBuilder`
+        connection : str or :class:`ChannelBuilder`
             Connection string that is used to extract the connection parameters and configure
             the GRPC connection. Or instance of ChannelBuilder that creates GRPC connection.
             Defaults to `sc://localhost`.

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -394,7 +394,6 @@ class DefaultChannelBuilder(ChannelBuilder):
         """
         The hostname where this client intends to connect.
         """
-
         return self._host
 
     @property


### PR DESCRIPTION
### What changes were proposed in this pull request?

The SparkConnectClient should take instance of `ChannelBuilder`, not `DefaultChannelBuilder`. 
Note there is no actual code difference, only typing declarations are changed.

### Why are the changes needed?

Minor fall out from previous pull request. https://github.com/apache/spark/pull/44832

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
N/A


### Was this patch authored or co-authored using generative AI tooling?
No