### PR TITLE
[MINOR][DOCS] Fix outgoing links from SELECT SQL reference page

### DIFF
--- a/docs/sql-ref-syntax-qry-select.md
+++ b/docs/sql-ref-syntax-qry-select.md
@@ -83,8 +83,8 @@ SELECT [ hints , ... ] [ ALL | DISTINCT ] { [ [ named_expression | regex_column_
      Specifies a source of input for the query. It can be one of the following:
      * Table relation
      * [Join relation](sql-ref-syntax-qry-select-join.html)
-     * [Pivot relation](sql-ref-syntax-qry-select-pivot.md)
-     * [Unpivot relation](sql-ref-syntax-qry-select-unpivot.md)
+     * [Pivot relation](sql-ref-syntax-qry-select-pivot.html)
+     * [Unpivot relation](sql-ref-syntax-qry-select-unpivot.html)
      * [Table-value function](sql-ref-syntax-qry-select-tvf.html)
      * [Inline table](sql-ref-syntax-qry-select-inline-table.html)
      * [ [LATERAL](sql-ref-syntax-qry-select-lateral-subquery.html) ] ( Subquery )


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix a couple of links that were pointing to the raw Markdown files (which doesn't work) rather than the compiled HTML files.

### Why are the changes needed?

Documentation links should work, especially internal links.

### Does this PR introduce _any_ user-facing change?

Yes, it changes the documentation.

### How was this patch tested?

I built the docs and confirmed the links work.

### Was this patch authored or co-authored using generative AI tooling?

No.