### PR TITLE
[SPARK-46949][SQL] Support CHAR/VARCHAR through ResolveDefaultColumns

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ResolveDefaultColumnsUtil.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ResolveDefaultColumnsUtil.scala
@@ -21,7 +21,7 @@ import scala.collection.mutable.ArrayBuffer
 
 import org.apache.spark.{SparkThrowable, SparkUnsupportedOperationException}
 import org.apache.spark.sql.AnalysisException
-import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.{InternalRow, SQLConfHelper}
 import org.apache.spark.sql.catalyst.analysis._
 import org.apache.spark.sql.catalyst.catalog.{CatalogDatabase, InMemoryCatalog, SessionCatalog}
 import org.apache.spark.sql.catalyst.expressions._
@@ -42,7 +42,9 @@ import org.apache.spark.util.ArrayImplicits._
 /**
  * This object contains fields to help process DEFAULT columns.
  */
-object ResolveDefaultColumns extends QueryErrorsBase with ResolveDefaultColumnsUtils {
+object ResolveDefaultColumns extends QueryErrorsBase
+  with ResolveDefaultColumnsUtils
+  with SQLConfHelper {
   // Name of attributes representing explicit references to the value stored in the above
   // CURRENT_DEFAULT_COLUMN_METADATA.
   val CURRENT_DEFAULT_COLUMN_NAME = "DEFAULT"
@@ -307,10 +309,11 @@ object ResolveDefaultColumns extends QueryErrorsBase with ResolveDefaultColumnsU
       statementType: String,
       colName: String,
       defaultSQL: String): Expression = {
+    val supplanted = CharVarcharUtils.replaceCharVarcharWithString(dataType)
     // Perform implicit coercion from the provided expression type to the required column type.
-    if (dataType == analyzed.dataType) {
+    val ret = if (supplanted == analyzed.dataType) {
       analyzed
-    } else if (Cast.canUpCast(analyzed.dataType, dataType)) {
+    } else if (Cast.canUpCast(analyzed.dataType, supplanted)) {
       Cast(analyzed, dataType)
     } else {
       // If the provided default value is a literal of a wider type than the target column, but the
@@ -318,14 +321,14 @@ object ResolveDefaultColumns extends QueryErrorsBase with ResolveDefaultColumnsU
       // boolean/array/struct/map types from consideration for this type coercion to avoid
       // surprising behavior like interpreting "false" as integer zero.
       val result = if (analyzed.isInstanceOf[Literal] &&
-        !Seq(dataType, analyzed.dataType).exists(_ match {
+        !Seq(supplanted, analyzed.dataType).exists(_ match {
           case _: BooleanType | _: ArrayType | _: StructType | _: MapType => true
           case _ => false
         })) {
         try {
-          val casted = Cast(analyzed, dataType, evalMode = EvalMode.TRY).eval()
+          val casted = Cast(analyzed, supplanted, evalMode = EvalMode.TRY).eval()
           if (casted != null) {
-            Some(Literal(casted, dataType))
+            Some(Literal(casted, supplanted))
           } else {
             None
           }
@@ -339,6 +342,10 @@ object ResolveDefaultColumns extends QueryErrorsBase with ResolveDefaultColumnsU
           statementType, colName, defaultSQL, dataType, analyzed.dataType)
       }
     }
+    if (!conf.charVarcharAsString && CharVarcharUtils.hasCharVarchar(dataType)) {
+      CharVarcharUtils.stringLengthCheck(ret, dataType).eval()
+    }
+    ret
   }
 
   /**
@@ -454,7 +461,8 @@ object ResolveDefaultColumns extends QueryErrorsBase with ResolveDefaultColumnsU
       throw QueryCompilationErrors.defaultValuesMayNotContainSubQueryExpressions(
         statement, colName, default.originalSQL)
     } else if (default.resolved) {
-      if (!Cast.canUpCast(default.child.dataType, targetType)) {
+      val dataType = CharVarcharUtils.replaceCharVarcharWithString(targetType)
+      if (!Cast.canUpCast(default.child.dataType, dataType)) {
         throw QueryCompilationErrors.defaultValuesDataTypeError(
           statement, colName, default.originalSQL, targetType, default.child.dataType)
       }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ResolveDefaultColumnsUtil.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ResolveDefaultColumnsUtil.scala
@@ -314,7 +314,7 @@ object ResolveDefaultColumns extends QueryErrorsBase
     val ret = if (supplanted == analyzed.dataType) {
       analyzed
     } else if (Cast.canUpCast(analyzed.dataType, supplanted)) {
-      Cast(analyzed, dataType)
+      Cast(analyzed, supplanted)
     } else {
       // If the provided default value is a literal of a wider type than the target column, but the
       // literal value fits within the narrower type, just coerce it for convenience. Exclude
@@ -343,7 +343,7 @@ object ResolveDefaultColumns extends QueryErrorsBase
       }
     }
     if (!conf.charVarcharAsString && CharVarcharUtils.hasCharVarchar(dataType)) {
-      CharVarcharUtils.stringLengthCheck(ret, dataType).eval()
+      CharVarcharUtils.stringLengthCheck(ret, dataType).eval(EmptyRow)
     }
     ret
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/ResolveDefaultColumnsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ResolveDefaultColumnsSuite.scala
@@ -241,4 +241,19 @@ class ResolveDefaultColumnsSuite extends QueryTest with SharedSparkSession {
         parameters = Map("limit" -> "3"))
     }
   }
+
+  test("SPARK-46949: DDL with default char/varchar values need padding") {
+    withTable("t") {
+      val ddl =
+        s"""
+           |CREATE TABLE t(
+           |  key int,
+           |  v VARCHAR(6) DEFAULT 'apache',
+           |  c CHAR(6) DEFAULT 'spark')
+           |USING parquet""".stripMargin
+      sql(ddl)
+      sql("INSERT INTO t (key) VALUES(1)")
+      checkAnswer(sql("select * from t"), Row(1, "apache", "spark "))
+    }
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/ResolveDefaultColumnsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ResolveDefaultColumnsSuite.scala
@@ -217,7 +217,7 @@ class ResolveDefaultColumnsSuite extends QueryTest with SharedSparkSession {
     }
   }
 
-  test("default values") {
+  test("SPARK-46949: DDL with valid default char/varchar values") {
     withTable("t") {
       val ddl =
         s"""
@@ -232,7 +232,7 @@ class ResolveDefaultColumnsSuite extends QueryTest with SharedSparkSession {
     }
   }
 
-  test("default values 2") {
+  test("SPARK-46949: DDL with invalid default char/varchar values") {
     Seq("CHAR", "VARCHAR").foreach { typeName =>
       checkError(
         exception = intercept[SparkRuntimeException](


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

We have issues resolving column definitions with default values, i.e., `c CHAR(5) DEFAULT 'foo'`, `v  VARCHAR(10) DEFAULT 'bar'`. The reason is that CAHR/VARCHAR types in schemas are not supplanted with STRING type to align with the value expression.

This PR fixes these issues in `ResolveDefaultColumns`, which seems to only cover the v1 tables. When I applied some related tests to v2 tables, they had the same issues. But beyond that, there are some other front-loading needs to be addressed. In this case, I'd like to separate v2 from the v1 PR.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

bugfix

```
spark-sql (default)> CREATE TABLE t( c CHAR(5) DEFAULT 'spark') USING parquet;
[INVALID_DEFAULT_VALUE.DATA_TYPE] Failed to execute CREATE TABLE command because the destination table column `c` has a DEFAULT value 'spark', which requires "CHAR(5)" type, but the statement provided a value of incompatible "STRING" type.
```
### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

no, bugfix
### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
new tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->no
