### PR TITLE
[SPARK-46952][SQL] XML: Limit size of corrupt record

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/StaxXmlParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/StaxXmlParser.scala
@@ -145,8 +145,7 @@ class StaxXmlParser(
   def doParseColumn(xml: String,
       parseMode: ParseMode,
       xsdSchema: Option[Schema]): Option[InternalRow] = {
-    // limit the size of the XML records to add in bad record exception
-    lazy val xmlRecord = UTF8String.fromString(xml.substring(0, math.min(xml.length, 1024 * 1024)))
+    lazy val xmlRecord = UTF8String.fromString(xml)
     try {
       xsdSchema.foreach { schema =>
         schema.newValidator().validate(new StreamSource(new StringReader(xml)))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/StaxXmlParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/StaxXmlParser.scala
@@ -145,7 +145,8 @@ class StaxXmlParser(
   def doParseColumn(xml: String,
       parseMode: ParseMode,
       xsdSchema: Option[Schema]): Option[InternalRow] = {
-    val xmlRecord = UTF8String.fromString(xml)
+    // limit the size of the XML records to add in bad record exception
+    lazy val xmlRecord = UTF8String.fromString(xml.substring(0, math.min(xml.length, 1024 * 1024)))
     try {
       xsdSchema.foreach { schema =>
         schema.newValidator().validate(new StreamSource(new StringReader(xml)))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/XmlSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/XmlSuite.scala
@@ -308,22 +308,6 @@ class XmlSuite
     assert(cars(2).toSeq.takeRight(3) === Seq("Chevy", "Volt", 2015))
   }
 
-  test("Limit size of corrupt records") {
-    val badRecordSizeLimit = 1024 * 1024;
-    val corruptXMLString = "<ROW><data>" + "a" * badRecordSizeLimit + "</data><s></ROW>"
-    val xmlRDD = spark.sparkContext.parallelize(Seq(corruptXMLString))
-    val ds = spark.createDataset(xmlRDD)(Encoders.STRING)
-    val df = spark.read
-      .schema("data string, _malformed_records string")
-      .option("rowTag", "ROW")
-      .option("mode", PermissiveMode.name)
-      .option("columnNameOfCorruptRecord", "_malformed_records")
-      .xml(ds)
-    val malformedRow = df.cache().select("_malformed_records").first().get(0).toString
-    val expectedMalformedRow = corruptXMLString.substring(0, badRecordSizeLimit)
-    assert(malformedRow === expectedMalformedRow)
-  }
-
   test("DSL test with empty file and known schema") {
     val results = spark.read
       .option("rowTag", "ROW")


### PR DESCRIPTION
### What changes were proposed in this pull request?
Limit the size of malformed XML string that gets stored in the corrupt column.

### Why are the changes needed?
A large corrupt XML record can be arbitrarily large and may cause OOM.

### Does this PR introduce _any_ user-facing change?
Yes

### How was this patch tested?
Unit test

### Was this patch authored or co-authored using generative AI tooling?
No