### PR TITLE
[SPARK-46964][SQL] Change the signature of the hllInvalidLgK query execution error to take an integer as 4th argument

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/datasketchesAggregates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/datasketchesAggregates.scala
@@ -196,7 +196,7 @@ object HllSketchAgg {
   def checkLgK(lgConfigK: Int): Unit = {
     if (lgConfigK < minLgConfigK || lgConfigK > maxLgConfigK) {
       throw QueryExecutionErrors.hllInvalidLgK(function = "hll_sketch_agg",
-        min = minLgConfigK, max = maxLgConfigK, value = lgConfigK.toString)
+        min = minLgConfigK, max = maxLgConfigK, value = lgConfigK)
     }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -2609,14 +2609,14 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
       cause = e)
   }
 
-  def hllInvalidLgK(function: String, min: Int, max: Int, value: String): Throwable = {
+  def hllInvalidLgK(function: String, min: Int, max: Int, value: Int): Throwable = {
     new SparkRuntimeException(
       errorClass = "HLL_INVALID_LG_K",
       messageParameters = Map(
         "function" -> toSQLId(function),
         "min" -> toSQLValue(min, IntegerType),
         "max" -> toSQLValue(max, IntegerType),
-        "value" -> value))
+        "value" -> toSQLValue(value, IntegerType)))
   }
 
   def hllInvalidInputSketchBuffer(function: String): Throwable = {


### PR DESCRIPTION
### What changes were proposed in this pull request?

The current signature of the `hllInvalidLgK` query execution error takes four arguments:
1. The SQL function (a string).
2. The minimum possible `lgk` value (an integer).
3. The maximum possible `lgk` value (an integer).
4. The actual invalid `lgk` value (a string).

There is no meaningful reason for the 4th argument to be a string. In this PR we change it to be an integer, just like the minimum and maximum valid values.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Seeking to make the signature of the `hllInvalidLgK` error more meaningful and self-consistent.

### Does this PR introduce _any_ user-facing change?

No, there is no user-facing changes because of this PR. This is just an internal change.

### How was this patch tested?

Existing tests suffice.

### Was this patch authored or co-authored using generative AI tooling?

No.