### PR TITLE
[SPARK-46956][SQL] Improve the error prompt when `SaveMode` is null in API `DataFrameWriter.mode`

### DIFF
--- a/common/utils/src/main/resources/error/error-classes.json
+++ b/common/utils/src/main/resources/error/error-classes.json
@@ -4083,17 +4083,22 @@
   },
   "UNSUPPORTED_SAVE_MODE" : {
     "message" : [
-      "The save mode <saveMode> is not supported for:"
+      "The save mode <saveMode> is not supported."
     ],
     "subClass" : {
       "EXISTENT_PATH" : {
         "message" : [
-          "an existent path."
+          "for an existent path."
         ]
       },
       "NON_EXISTENT_PATH" : {
         "message" : [
-          "a non-existent path."
+          "for a non-existent path."
+        ]
+      },
+      "WITHOUT_SUGGESTION" : {
+        "message" : [
+          ""
         ]
       }
     },

--- a/common/utils/src/main/resources/error/error-classes.json
+++ b/common/utils/src/main/resources/error/error-classes.json
@@ -4088,12 +4088,12 @@
     "subClass" : {
       "EXISTENT_PATH" : {
         "message" : [
-          "for an existent path."
+          "Because the path <path> is an existent path."
         ]
       },
       "NON_EXISTENT_PATH" : {
         "message" : [
-          "for a non-existent path."
+          "Because the path <path> is a non-existent path."
         ]
       },
       "WITHOUT_SUGGESTION" : {

--- a/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
@@ -560,20 +560,23 @@ class SparkThrowableSuite extends SparkFunSuite {
         |    "fragment" : "1 / 0"
         |  } ]
         |}""".stripMargin)
-      // scalastyle:on line.size.limit
+    // scalastyle:on line.size.limit
     // STANDARD w/ errorSubClass but w/o queryContext
     val e2 = new SparkIllegalArgumentException(
       errorClass = "UNSUPPORTED_SAVE_MODE.EXISTENT_PATH",
-      messageParameters = Map("saveMode" -> "UNSUPPORTED_MODE"))
+      messageParameters = Map("saveMode" -> "UNSUPPORTED_MODE", "path" -> "an existent path"))
+    // scalastyle:off line.size.limit
     assert(SparkThrowableHelper.getMessage(e2, STANDARD) ===
       """{
         |  "errorClass" : "UNSUPPORTED_SAVE_MODE.EXISTENT_PATH",
-        |  "messageTemplate" : "The save mode <saveMode> is not supported. for an existent path.",
+        |  "messageTemplate" : "The save mode <saveMode> is not supported. Because the path <path> is an existent path.",
         |  "sqlState" : "0A000",
         |  "messageParameters" : {
+        |    "path" : "an existent path",
         |    "saveMode" : "UNSUPPORTED_MODE"
         |  }
         |}""".stripMargin)
+    // scalastyle:on line.size.limit
     // Legacy mode when an exception does not have any error class
     class LegacyException extends Throwable with SparkThrowable {
       override def getErrorClass: String = null

--- a/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
@@ -568,7 +568,7 @@ class SparkThrowableSuite extends SparkFunSuite {
     assert(SparkThrowableHelper.getMessage(e2, STANDARD) ===
       """{
         |  "errorClass" : "UNSUPPORTED_SAVE_MODE.EXISTENT_PATH",
-        |  "messageTemplate" : "The save mode <saveMode> is not supported for: an existent path.",
+        |  "messageTemplate" : "The save mode <saveMode> is not supported. for an existent path.",
         |  "sqlState" : "0A000",
         |  "messageParameters" : {
         |    "saveMode" : "UNSUPPORTED_MODE"

--- a/docs/sql-error-conditions-unsupported-save-mode-error-class.md
+++ b/docs/sql-error-conditions-unsupported-save-mode-error-class.md
@@ -26,16 +26,20 @@ license: |
 
 [SQLSTATE: 0A000](sql-error-conditions-sqlstates.html#class-0A-feature-not-supported)
 
-The save mode `<saveMode>` is not supported for:
+The save mode `<saveMode>` is not supported.
 
 This error class has the following derived error classes:
 
 ## EXISTENT_PATH
 
-an existent path.
+for an existent path.
 
 ## NON_EXISTENT_PATH
 
-a non-existent path.
+for a non-existent path.
+
+## WITHOUT_SUGGESTION
+
+
 
 

--- a/docs/sql-error-conditions-unsupported-save-mode-error-class.md
+++ b/docs/sql-error-conditions-unsupported-save-mode-error-class.md
@@ -32,11 +32,11 @@ This error class has the following derived error classes:
 
 ## EXISTENT_PATH
 
-for an existent path.
+Because the path `<path>` is an existent path.
 
 ## NON_EXISTENT_PATH
 
-for a non-existent path.
+Because the path `<path>` is a non-existent path.
 
 ## WITHOUT_SUGGESTION
 

--- a/docs/sql-error-conditions.md
+++ b/docs/sql-error-conditions.md
@@ -2499,7 +2499,7 @@ For more details see [UNSUPPORTED_OVERWRITE](sql-error-conditions-unsupported-ov
 
 [SQLSTATE: 0A000](sql-error-conditions-sqlstates.html#class-0A-feature-not-supported)
 
-The save mode `<saveMode>` is not supported for:
+The save mode `<saveMode>` is not supported.
 
 For more details see [UNSUPPORTED_SAVE_MODE](sql-error-conditions-unsupported-save-mode-error-class.html)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -766,6 +766,12 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
       messageParameters = Map("message" -> e.getMessage))
   }
 
+  def saveModeUnsupportedError(saveMode: Any): Throwable = {
+    new SparkIllegalArgumentException(
+      errorClass = s"UNSUPPORTED_SAVE_MODE.WITHOUT_SUGGESTION",
+      messageParameters = Map("saveMode" -> toSQLValue(saveMode, StringType)))
+  }
+
   def saveModeUnsupportedError(saveMode: Any, pathExists: Boolean): Throwable = {
     val errorSubClass = if (pathExists) "EXISTENT_PATH" else "NON_EXISTENT_PATH"
     new SparkIllegalArgumentException(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -772,11 +772,13 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
       messageParameters = Map("saveMode" -> toSQLValue(saveMode, StringType)))
   }
 
-  def saveModeUnsupportedError(saveMode: Any, pathExists: Boolean): Throwable = {
+  def saveModeUnsupportedError(saveMode: Any, pathExists: Boolean, path: Path): Throwable = {
     val errorSubClass = if (pathExists) "EXISTENT_PATH" else "NON_EXISTENT_PATH"
     new SparkIllegalArgumentException(
       errorClass = s"UNSUPPORTED_SAVE_MODE.$errorSubClass",
-      messageParameters = Map("saveMode" -> toSQLValue(saveMode, StringType)))
+      messageParameters = Map(
+        "saveMode" -> toSQLValue(saveMode, StringType),
+        "path" -> path.toString))
   }
 
   def cannotClearOutputDirectoryError(staticPrefixPath: Path): Throwable = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -21,6 +21,7 @@ import java.util.{Locale, Properties}
 
 import scala.jdk.CollectionConverters._
 
+
 import org.apache.spark.annotation.Stable
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.{EliminateSubqueryAliases, NoSuchTableException, UnresolvedIdentifier, UnresolvedRelation}
@@ -31,7 +32,7 @@ import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
 import org.apache.spark.sql.connector.catalog.{CatalogPlugin, CatalogV2Implicits, CatalogV2Util, Identifier, SupportsCatalogOptions, Table, TableCatalog, TableProvider, V1Table}
 import org.apache.spark.sql.connector.catalog.TableCapability._
 import org.apache.spark.sql.connector.expressions.{FieldReference, IdentityTransform, Transform}
-import org.apache.spark.sql.errors.QueryCompilationErrors
+import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
 import org.apache.spark.sql.execution.QueryExecution
 import org.apache.spark.sql.execution.command.DDLUtils
 import org.apache.spark.sql.execution.datasources.{CreateTable, DataSource, DataSourceUtils, LogicalRelation}
@@ -67,6 +68,9 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) {
    * @since 1.4.0
    */
   def mode(saveMode: SaveMode): DataFrameWriter[T] = {
+    if (saveMode == null) {
+      throw QueryExecutionErrors.saveModeUnsupportedError(saveMode)
+    }
     this.mode = saveMode
     this
   }
@@ -83,6 +87,9 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) {
    * @since 1.4.0
    */
   def mode(saveMode: String): DataFrameWriter[T] = {
+    if (saveMode == null) {
+      throw QueryExecutionErrors.saveModeUnsupportedError(saveMode)
+    }
     saveMode.toLowerCase(Locale.ROOT) match {
       case "overwrite" => mode(SaveMode.Overwrite)
       case "append" => mode(SaveMode.Append)

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -21,7 +21,6 @@ import java.util.{Locale, Properties}
 
 import scala.jdk.CollectionConverters._
 
-
 import org.apache.spark.annotation.Stable
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.{EliminateSubqueryAliases, NoSuchTableException, UnresolvedIdentifier, UnresolvedRelation}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelationCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelationCommand.scala
@@ -136,7 +136,7 @@ case class InsertIntoHadoopFsRelationCommand(
         case (SaveMode.Ignore, exists) =>
           !exists
         case (s, exists) =>
-          throw QueryExecutionErrors.saveModeUnsupportedError(s, exists)
+          throw QueryExecutionErrors.saveModeUnsupportedError(s, exists, qualifiedOutputPath)
       }
     }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
@@ -505,7 +505,7 @@ class QueryExecutionErrorsSuite
       }
       checkError(
         exception = e1,
-        errorClass = "UNSUPPORTED_SAVE_MODE.NON_EXISTENT_PATH",
+        errorClass = "UNSUPPORTED_SAVE_MODE.WITHOUT_SUGGESTION",
         parameters = Map("saveMode" -> "NULL"))
 
       Utils.createDirectory(path)
@@ -516,7 +516,7 @@ class QueryExecutionErrorsSuite
       }
       checkError(
         exception = e2,
-        errorClass = "UNSUPPORTED_SAVE_MODE.EXISTENT_PATH",
+        errorClass = "UNSUPPORTED_SAVE_MODE.WITHOUT_SUGGESTION",
         parameters = Map("saveMode" -> "NULL"))
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to improve the `error prompt` when `SaveMode is null` in API `DataFrameWriter.mode`.

### Why are the changes needed?
When `mode is null` in API `DataFrameWriter.mode`, the prompt information is more reasonable and will not cause misunderstandings.
- Before:
  <img width="1175" alt="image" src="https://github.com/apache/spark/assets/15246973/e4428fc9-c47b-4a82-ae04-729ea7bdb44f">

- After:
  <img width="1012" alt="image" src="https://github.com/apache/spark/assets/15246973/fa82e472-8bc0-4af3-9f47-911edcd9ef3c">


### Does this PR introduce _any_ user-facing change?
Yes, make more reasonable error prompts to reduce misunderstandings.


### How was this patch tested?
- Update existed UT.
- Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
