### PR TITLE
[WIP][Spark 44646] Reduce usage of log4j core

### DIFF
--- a/common/utils/pom.xml
+++ b/common/utils/pom.xml
@@ -67,6 +67,7 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j2-impl</artifactId>
+<!--&lt;!&ndash;      <optional>True</optional>&ndash;&gt; it should be optional-->
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
@@ -75,6 +76,7 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
+<!--      <optional>True</optional>-->
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>

--- a/common/utils/src/main/scala/org/apache/spark/internal/Log4j2Utils.scala
+++ b/common/utils/src/main/scala/org/apache/spark/internal/Log4j2Utils.scala
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.internal
+
+import scala.collection.JavaConverters._
+
+import org.apache.logging.log4j.{Level, LogManager}
+import org.apache.logging.log4j.core.{Filter, LifeCycle, LogEvent, Logger => Log4jLogger, LoggerContext}
+import org.apache.logging.log4j.core.appender.ConsoleAppender
+import org.apache.logging.log4j.core.config.DefaultConfiguration
+import org.apache.logging.log4j.core.filter.AbstractFilter
+
+import org.apache.spark.util.SparkClassUtils
+
+object Log4j2Utils {
+  @volatile private[internal] var defaultSparkLog4jConfig = false
+  @volatile private[internal] var defaultRootLevel: Level = null
+
+  // Return true if the logger has custom configuration. It depends on:
+  // 1. If the logger isn't attached with root logger config (i.e., with custom configuration), or
+  // 2. the logger level is different to root config level (i.e., it is changed programmatically).
+  //
+  // Note that if a logger is programmatically changed log level but set to same level
+  // as root config level, we cannot tell if it is with custom configuration.
+  private def loggerWithCustomConfig(logger: Log4jLogger): Boolean = {
+    val rootConfig = LogManager.getRootLogger.asInstanceOf[Log4jLogger].get()
+    (logger.get() ne rootConfig) || (logger.getLevel != rootConfig.getLevel())
+  }
+
+  private[internal] def initializeLogging(isInterpreter: Boolean,
+                                          silent: Boolean,
+                                          logName: String): Unit = {
+    val rootLogger = LogManager.getRootLogger.asInstanceOf[Log4jLogger]
+
+    // If Log4j 2 is used but is initialized by default configuration,
+    // load a default properties file
+    // scalastyle:off println
+    if (islog4j2DefaultConfigured()) {
+      defaultSparkLog4jConfig = true
+      val defaultLogProps = "org/apache/spark/log4j2-defaults.properties"
+      Option(SparkClassUtils.getSparkClassLoader.getResource(defaultLogProps)) match {
+        case Some(url) =>
+          val context = LogManager.getContext(false).asInstanceOf[LoggerContext]
+          context.setConfigLocation(url.toURI)
+          if (!silent) {
+            System.err.println(s"Using Spark's default log4j profile: $defaultLogProps")
+            Logging.setLogLevelPrinted = true
+          }
+        case None =>
+          System.err.println(s"Spark was unable to load $defaultLogProps")
+      }
+    }
+
+    if (defaultRootLevel == null) {
+      defaultRootLevel = rootLogger.getLevel()
+    }
+
+    if (isInterpreter) {
+      // Use the repl's main class to define the default log level when running the shell,
+      // overriding the root logger's config if they're different.
+      val replLogger = LogManager.getLogger(logName).asInstanceOf[Log4jLogger]
+      val replLevel = if (loggerWithCustomConfig(replLogger)) {
+        replLogger.getLevel()
+      } else {
+        Level.WARN
+      }
+      // Update the consoleAppender threshold to replLevel
+      if (replLevel != rootLogger.getLevel()) {
+        if (!silent) {
+          System.err.printf("Setting default log level to \"%s\".\n", replLevel)
+          System.err.println("To adjust logging level use sc.setLogLevel(newLevel). " +
+            "For SparkR, use setLogLevel(newLevel).")
+          Logging.setLogLevelPrinted = true
+        }
+        Logging.sparkShellThresholdLevel = replLevel
+        rootLogger.getAppenders().asScala.foreach {
+          case (_, ca: ConsoleAppender) =>
+            ca.addFilter(new SparkShellLoggingFilter())
+          case _ => // no-op
+        }
+      }
+    }
+
+    // scalastyle:on println
+  }
+
+  private[internal] def setLogLevel(l: Level): Unit = {
+    val ctx = LogManager.getContext(false).asInstanceOf[LoggerContext]
+    val config = ctx.getConfiguration()
+    val loggerConfig = config.getLoggerConfig(LogManager.ROOT_LOGGER_NAME)
+    loggerConfig.setLevel(l)
+    ctx.updateLoggers()
+  }
+  private[internal] def uninitialize(): Unit = {
+    if (defaultSparkLog4jConfig) {
+      defaultSparkLog4jConfig = false
+      val context = LogManager.getContext(false).asInstanceOf[LoggerContext]
+      context.reconfigure()
+    } else {
+      val rootLogger = LogManager.getRootLogger().asInstanceOf[Log4jLogger]
+      rootLogger.setLevel(defaultRootLevel)
+      Logging.sparkShellThresholdLevel = null
+    }
+  }
+
+  /**
+   * Return true if log4j2 is initialized by default configuration which has one
+   * appender with error level. See `org.apache.logging.log4j.core.config.DefaultConfiguration`.
+   */
+  private[spark] def islog4j2DefaultConfigured(): Boolean = {
+    val rootLogger = LogManager.getRootLogger.asInstanceOf[Log4jLogger]
+    rootLogger.getAppenders.isEmpty ||
+      (rootLogger.getAppenders.size() == 1 &&
+        rootLogger.getLevel == Level.ERROR &&
+        LogManager.getContext.asInstanceOf[LoggerContext]
+          .getConfiguration.isInstanceOf[DefaultConfiguration])
+  }
+
+  private[spark] class SparkShellLoggingFilter extends AbstractFilter {
+    private var status = LifeCycle.State.INITIALIZING
+
+    /**
+     * If sparkShellThresholdLevel is not defined, this filter is a no-op.
+     * If log level of event is not equal to root level, the event is allowed. Otherwise,
+     * the decision is made based on whether the log came from root or some custom configuration
+     *
+     * @param loggingEvent
+     * @return decision for accept/deny log event
+     */
+    override def filter(logEvent: LogEvent): Filter.Result = {
+      if (Logging.sparkShellThresholdLevel == null) {
+        Filter.Result.NEUTRAL
+      } else if (logEvent.getLevel.isMoreSpecificThan(Logging.sparkShellThresholdLevel)) {
+        Filter.Result.NEUTRAL
+      } else {
+        val logger = LogManager.getLogger(logEvent.getLoggerName).asInstanceOf[Log4jLogger]
+        if (loggerWithCustomConfig(logger)) {
+          return Filter.Result.NEUTRAL
+        }
+        Filter.Result.DENY
+      }
+    }
+
+    override def getState: LifeCycle.State = status
+
+    override def initialize(): Unit = {
+      status = LifeCycle.State.INITIALIZED
+    }
+
+    override def start(): Unit = {
+      status = LifeCycle.State.STARTED
+    }
+
+    override def stop(): Unit = {
+      status = LifeCycle.State.STOPPED
+    }
+
+    override def isStarted: Boolean = status == LifeCycle.State.STARTED
+
+    override def isStopped: Boolean = status == LifeCycle.State.STOPPED
+  }
+}

--- a/common/utils/src/main/scala/org/apache/spark/internal/Logging.scala
+++ b/common/utils/src/main/scala/org/apache/spark/internal/Logging.scala
@@ -17,16 +17,9 @@
 
 package org.apache.spark.internal
 
-import scala.collection.JavaConverters._
-
-import org.apache.logging.log4j.{Level, LogManager}
-import org.apache.logging.log4j.core.{Filter, LifeCycle, LogEvent, Logger => Log4jLogger, LoggerContext}
-import org.apache.logging.log4j.core.appender.ConsoleAppender
-import org.apache.logging.log4j.core.config.DefaultConfiguration
-import org.apache.logging.log4j.core.filter.AbstractFilter
+import org.apache.logging.log4j.Level
 import org.slf4j.{Logger, LoggerFactory}
 
-import org.apache.spark.internal.Logging.SparkShellLoggingFilter
 import org.apache.spark.util.SparkClassUtils
 
 /**
@@ -126,57 +119,7 @@ trait Logging {
 
   private def initializeLogging(isInterpreter: Boolean, silent: Boolean): Unit = {
     if (Logging.isLog4j2()) {
-      val rootLogger = LogManager.getRootLogger.asInstanceOf[Log4jLogger]
-      // If Log4j 2 is used but is initialized by default configuration,
-      // load a default properties file
-      // scalastyle:off println
-      if (Logging.islog4j2DefaultConfigured()) {
-        Logging.defaultSparkLog4jConfig = true
-        val defaultLogProps = "org/apache/spark/log4j2-defaults.properties"
-        Option(SparkClassUtils.getSparkClassLoader.getResource(defaultLogProps)) match {
-          case Some(url) =>
-            val context = LogManager.getContext(false).asInstanceOf[LoggerContext]
-            context.setConfigLocation(url.toURI)
-            if (!silent) {
-              System.err.println(s"Using Spark's default log4j profile: $defaultLogProps")
-              Logging.setLogLevelPrinted = true
-            }
-          case None =>
-            System.err.println(s"Spark was unable to load $defaultLogProps")
-        }
-      }
-
-      if (Logging.defaultRootLevel == null) {
-        Logging.defaultRootLevel = rootLogger.getLevel()
-      }
-
-      if (isInterpreter) {
-        // Use the repl's main class to define the default log level when running the shell,
-        // overriding the root logger's config if they're different.
-        val replLogger = LogManager.getLogger(logName).asInstanceOf[Log4jLogger]
-        val replLevel = if (Logging.loggerWithCustomConfig(replLogger)) {
-          replLogger.getLevel()
-        } else {
-          Level.WARN
-        }
-        // Update the consoleAppender threshold to replLevel
-        if (replLevel != rootLogger.getLevel()) {
-          if (!silent) {
-            System.err.printf("Setting default log level to \"%s\".\n", replLevel)
-            System.err.println("To adjust logging level use sc.setLogLevel(newLevel). " +
-              "For SparkR, use setLogLevel(newLevel).")
-            Logging.setLogLevelPrinted = true
-          }
-          Logging.sparkShellThresholdLevel = replLevel
-          rootLogger.getAppenders().asScala.foreach {
-            case (_, ca: ConsoleAppender) =>
-              ca.addFilter(new SparkShellLoggingFilter())
-            case _ => // no-op
-          }
-        }
-      }
-
-      // scalastyle:on println
+      Log4j2Utils.initializeLogging(isInterpreter, silent, logName)
     }
     Logging.initialized = true
 
@@ -187,9 +130,7 @@ trait Logging {
 }
 
 private[spark] object Logging {
-  @volatile private var initialized = false
-  @volatile private var defaultRootLevel: Level = null
-  @volatile private var defaultSparkLog4jConfig = false
+  @volatile private[internal] var initialized = false
   @volatile private[spark] var sparkShellThresholdLevel: Level = null
   @volatile private[spark] var setLogLevelPrinted: Boolean = false
 
@@ -208,98 +149,33 @@ private[spark] object Logging {
   }
 
   /**
+   * configure a new logger level
+   */
+  def setLogLevel(l: Level): Unit = {
+    if (isLog4j2()) {
+      Log4j2Utils.setLogLevel(l)
+    }
+    // Setting threshold to null as rootLevel will define log level for spark-shell
+    sparkShellThresholdLevel = null
+  }
+
+  /**
    * Marks the logging system as not initialized. This does a best effort at resetting the
    * logging system to its initial state so that the next class to use logging triggers
    * initialization again.
    */
   def uninitialize(): Unit = initLock.synchronized {
     if (isLog4j2()) {
-      if (defaultSparkLog4jConfig) {
-        defaultSparkLog4jConfig = false
-        val context = LogManager.getContext(false).asInstanceOf[LoggerContext]
-        context.reconfigure()
-      } else {
-        val rootLogger = LogManager.getRootLogger().asInstanceOf[Log4jLogger]
-        rootLogger.setLevel(defaultRootLevel)
-        sparkShellThresholdLevel = null
-      }
+      Log4j2Utils.uninitialize()
     }
     this.initialized = false
   }
 
-  private def isLog4j2(): Boolean = {
+  private[spark] def isLog4j2(): Boolean = {
     // This distinguishes the log4j 1.2 binding, currently
     // org.slf4j.impl.Log4jLoggerFactory, from the log4j 2.0 binding, currently
     // org.apache.logging.slf4j.Log4jLoggerFactory
     "org.apache.logging.slf4j.Log4jLoggerFactory"
       .equals(LoggerFactory.getILoggerFactory.getClass.getName)
-  }
-
-  // Return true if the logger has custom configuration. It depends on:
-  // 1. If the logger isn't attached with root logger config (i.e., with custom configuration), or
-  // 2. the logger level is different to root config level (i.e., it is changed programmatically).
-  //
-  // Note that if a logger is programmatically changed log level but set to same level
-  // as root config level, we cannot tell if it is with custom configuration.
-  private def loggerWithCustomConfig(logger: Log4jLogger): Boolean = {
-    val rootConfig = LogManager.getRootLogger.asInstanceOf[Log4jLogger].get()
-    (logger.get() ne rootConfig) || (logger.getLevel != rootConfig.getLevel())
-  }
-
-  /**
-   * Return true if log4j2 is initialized by default configuration which has one
-   * appender with error level. See `org.apache.logging.log4j.core.config.DefaultConfiguration`.
-   */
-  private[spark] def islog4j2DefaultConfigured(): Boolean = {
-    val rootLogger = LogManager.getRootLogger.asInstanceOf[Log4jLogger]
-    rootLogger.getAppenders.isEmpty ||
-      (rootLogger.getAppenders.size() == 1 &&
-        rootLogger.getLevel == Level.ERROR &&
-        LogManager.getContext.asInstanceOf[LoggerContext]
-          .getConfiguration.isInstanceOf[DefaultConfiguration])
-  }
-
-
-  private[spark] class SparkShellLoggingFilter extends AbstractFilter {
-    private var status = LifeCycle.State.INITIALIZING
-
-    /**
-     * If sparkShellThresholdLevel is not defined, this filter is a no-op.
-     * If log level of event is not equal to root level, the event is allowed. Otherwise,
-     * the decision is made based on whether the log came from root or some custom configuration
-     * @param loggingEvent
-     * @return decision for accept/deny log event
-     */
-    override def filter(logEvent: LogEvent): Filter.Result = {
-      if (Logging.sparkShellThresholdLevel == null) {
-        Filter.Result.NEUTRAL
-      } else if (logEvent.getLevel.isMoreSpecificThan(Logging.sparkShellThresholdLevel)) {
-        Filter.Result.NEUTRAL
-      } else {
-        val logger = LogManager.getLogger(logEvent.getLoggerName).asInstanceOf[Log4jLogger]
-        if (loggerWithCustomConfig(logger)) {
-            return Filter.Result.NEUTRAL
-        }
-        Filter.Result.DENY
-      }
-    }
-
-    override def getState: LifeCycle.State = status
-
-    override def initialize(): Unit = {
-      status = LifeCycle.State.INITIALIZED
-    }
-
-    override def start(): Unit = {
-      status = LifeCycle.State.STARTED
-    }
-
-    override def stop(): Unit = {
-      status = LifeCycle.State.STOPPED
-    }
-
-    override def isStarted: Boolean = status == LifeCycle.State.STARTED
-
-    override def isStopped: Boolean = status == LifeCycle.State.STOPPED
   }
 }

--- a/core/src/main/scala/org/apache/spark/deploy/Client.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/Client.scala
@@ -25,7 +25,6 @@ import scala.reflect.ClassTag
 import scala.util.{Failure, Success}
 
 import org.apache.logging.log4j.LogManager
-import org.apache.logging.log4j.core.Logger
 
 import org.apache.spark.{SecurityManager, SparkConf}
 import org.apache.spark.deploy.DeployMessages._
@@ -278,11 +277,14 @@ object Client {
 private[spark] class ClientApp extends SparkApplication {
 
   override def start(args: Array[String], conf: SparkConf): Unit = {
+    import org.apache.logging.log4j.core.Logger
+
     val driverArgs = new ClientArguments(args)
 
     if (!conf.contains(RPC_ASK_TIMEOUT)) {
       conf.set(RPC_ASK_TIMEOUT, "10s")
     }
+
     LogManager.getRootLogger.asInstanceOf[Logger].setLevel(driverArgs.logLevel)
 
     val rpcEnv =

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -59,8 +59,7 @@ import org.apache.hadoop.ipc.CallerContext.{Builder => HadoopCallerContextBuilde
 import org.apache.hadoop.security.UserGroupInformation
 import org.apache.hadoop.util.{RunJar, StringUtils}
 import org.apache.hadoop.yarn.conf.YarnConfiguration
-import org.apache.logging.log4j.{Level, LogManager}
-import org.apache.logging.log4j.core.LoggerContext
+import org.apache.logging.log4j.Level
 import org.eclipse.jetty.util.MultiException
 import org.slf4j.Logger
 
@@ -2312,17 +2311,10 @@ private[spark] object Utils
   }
 
   /**
-   * configure a new log4j level
+   * configure a new logger level
    */
   def setLogLevel(l: Level): Unit = {
-    val ctx = LogManager.getContext(false).asInstanceOf[LoggerContext]
-    val config = ctx.getConfiguration()
-    val loggerConfig = config.getLoggerConfig(LogManager.ROOT_LOGGER_NAME)
-    loggerConfig.setLevel(l)
-    ctx.updateLoggers()
-
-    // Setting threshold to null as rootLevel will define log level for spark-shell
-    Logging.sparkShellThresholdLevel = null
+    Logging.setLogLevel(l)
   }
 
   /**

--- a/core/src/test/scala/org/apache/spark/internal/LoggingSuite.scala
+++ b/core/src/test/scala/org/apache/spark/internal/LoggingSuite.scala
@@ -23,7 +23,7 @@ import org.apache.logging.log4j.core.impl.Log4jLogEvent.Builder
 import org.apache.logging.log4j.message.SimpleMessage
 
 import org.apache.spark.SparkFunSuite
-import org.apache.spark.internal.Logging.SparkShellLoggingFilter
+import org.apache.spark.internal.Log4j2Utils.SparkShellLoggingFilter
 import org.apache.spark.util.Utils
 
 class LoggingSuite extends SparkFunSuite {

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/SparkRackResolver.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/SparkRackResolver.scala
@@ -27,7 +27,6 @@ import org.apache.hadoop.net._
 import org.apache.hadoop.util.ReflectionUtils
 import org.apache.hadoop.yarn.util.RackResolver
 import org.apache.logging.log4j.{Level, LogManager}
-import org.apache.logging.log4j.core.Logger
 
 import org.apache.spark.internal.Logging
 
@@ -40,8 +39,8 @@ private[spark] class SparkRackResolver(conf: Configuration) extends Logging {
 
   // RackResolver logs an INFO message whenever it resolves a rack, which is way too often.
   val logger = LogManager.getLogger(classOf[RackResolver])
-  if (logger.getLevel != Level.WARN) {
-    logger.asInstanceOf[Logger].setLevel(Level.WARN)
+  if (logger.getLevel != Level.WARN && logger.getLevel != Level.ERROR) {
+    Logging.setLogLevel(Level.WARN)
   }
 
   private val dnsToSwitchMapping: DNSToSwitchMapping = {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Reducing usage of Log4j2 core classes, and moving this usage to isolated classes which won't be loaded unless log4j2 is on classpath. For now Spark strongly needs `log4j-core` library, what may conflicts with other libraries.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To let user decide which framework for logging he/she can use.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Seems that no, but please verify.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
I tested builded `spark-common-utils` package locally against my test project.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.