### PR TITLE
[MINOR][DOCS] The default fractional numeric literal in SQL is a decimal

### DIFF
--- a/docs/sql-ref-literals.md
+++ b/docs/sql-ref-literals.md
@@ -275,6 +275,10 @@ E [ + | - ] digit [ ... ]
 
     Case insensitive, indicates `DECIMAL`, with the total number of digits as precision and the number of digits to right of decimal point as scale.
 
+* **default (no postfix)**
+
+    Indicates `DECIMAL`, same as the `BD` postfix.
+
 #### Fractional Literals Examples
 
 ```sql


### PR DESCRIPTION
### What changes were proposed in this pull request?

Explain that a number like `123.456`, without a postfix but with a decimal point, is a decimal literal.

### Why are the changes needed?

In Python (and I think Java too) fractional numeric literals are typically floats. To get decimals, you need to provide an explicit postfix or use an explicit class.

In Spark, it's the other way around. I found this surprising and couldn't find documentation about it.

I discovered this after reading SPARK-45786. I did a little searching and came across #10796, which shows that we used to default to floats as the fractional numeric literal, but then switched to decimals.

### Does this PR introduce _any_ user-facing change?

Yes, it adds a bit of documentation.

### How was this patch tested?

No testing.

### Was this patch authored or co-authored using generative AI tooling?

No.