### PR TITLE
[SPARK-46963] Verify AQE is not enabled for Structured Streaming

### DIFF
--- a/common/utils/src/main/resources/error/error-classes.json
+++ b/common/utils/src/main/resources/error/error-classes.json
@@ -3775,6 +3775,11 @@
           "The ANALYZE TABLE command does not support views."
         ]
       },
+      "AQE_STREAMING" : {
+        "message" : [
+          "Adaptive Query Execution is not supported in Structured Streaming. If you want to use AQE in streaming, please use ForeachBatch sink."
+        ]
+      },
       "CATALOG_OPERATION" : {
         "message" : [
           "Catalog <catalogName> does not support <operation>."
@@ -4098,19 +4103,6 @@
       }
     },
     "sqlState" : "0A000"
-  },
-  "UNSUPPORTED_FEATURE_FOR_STREAMING" : {
-    "message" : [
-      "<feature> is not supported in Structured Streaming."
-    ],
-    "subClass" : {
-      "AQE" : {
-        "message" : [
-          "If you want to use AQE in streaming, please use ForeachBatch sink."
-        ]
-      }
-    },
-    "sqlState" : "XXKST"
   },
   "UNSUPPORTED_SUBQUERY_EXPRESSION_CATEGORY" : {
     "message" : [

--- a/common/utils/src/main/resources/error/error-classes.json
+++ b/common/utils/src/main/resources/error/error-classes.json
@@ -4099,6 +4099,19 @@
     },
     "sqlState" : "0A000"
   },
+  "UNSUPPORTED_FEATURE_FOR_STREAMING" : {
+    "message" : [
+      "<feature> is not supported in Structured Streaming."
+    ],
+    "subClass" : {
+      "AQE" : {
+        "message" : [
+          "If you want to use AQE in streaming, please use ForeachBatch sink."
+        ]
+      }
+    },
+    "sqlState" : "XXKST"
+  },
   "UNSUPPORTED_SUBQUERY_EXPRESSION_CATEGORY" : {
     "message" : [
       "Unsupported subquery expression:"

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -3980,4 +3980,10 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
       origin = e.origin
     )
   }
+
+  def unsupportedFeatureForStreaming(feature: String, subClass: String): Throwable = {
+    throw new AnalysisException(
+      errorClass = s"UNSUPPORTED_FEATURE_FOR_STREAMING.$subClass",
+      messageParameters = Map("feature" -> feature))
+  }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -3981,9 +3981,9 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
     )
   }
 
-  def unsupportedFeatureForStreaming(feature: String, subClass: String): Throwable = {
+  def unsupportedAQEForStreaming(): Throwable = {
     throw new AnalysisException(
-      errorClass = s"UNSUPPORTED_FEATURE_FOR_STREAMING.$subClass",
-      messageParameters = Map("feature" -> feature))
+      errorClass = "UNSUPPORTED_FEATURE.AQE_STREAMING",
+      messageParameters = Map.empty)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MicroBatchExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MicroBatchExecution.scala
@@ -239,7 +239,7 @@ class MicroBatchExecution(
   private def verifyIfAQEIsDisabled(sink: Table, sparkSession: SparkSession): Unit = {
     if (!sink.isInstanceOf[ForeachBatchSink[_]] &&
       sparkSession.sessionState.conf.adaptiveExecutionEnabled) {
-      throw QueryCompilationErrors.unsupportedFeatureForStreaming("Adaptive Query Execution", "AQE")
+      throw QueryCompilationErrors.unsupportedAQEForStreaming()
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MicroBatchExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MicroBatchExecution.scala
@@ -27,13 +27,13 @@ import org.apache.spark.sql.catalyst.plans.logical.{LeafNode, LocalRelation, Log
 import org.apache.spark.sql.catalyst.streaming.{StreamingRelationV2, WriteToStream}
 import org.apache.spark.sql.catalyst.trees.TreePattern.CURRENT_LIKE
 import org.apache.spark.sql.catalyst.util.truncatedString
-import org.apache.spark.sql.connector.catalog.{SupportsRead, SupportsWrite, TableCapability}
+import org.apache.spark.sql.connector.catalog.{SupportsRead, SupportsWrite, Table, TableCapability}
 import org.apache.spark.sql.connector.read.streaming.{MicroBatchStream, Offset => OffsetV2, ReadLimit, SparkDataStream, SupportsAdmissionControl, SupportsTriggerAvailableNow}
-import org.apache.spark.sql.errors.QueryExecutionErrors
+import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
 import org.apache.spark.sql.execution.SQLExecution
 import org.apache.spark.sql.execution.datasources.LogicalRelation
 import org.apache.spark.sql.execution.datasources.v2.{DataSourceV2Relation, StreamingDataSourceV2Relation, StreamingDataSourceV2ScanRelation, StreamWriterCommitProgress, WriteToDataSourceV2Exec}
-import org.apache.spark.sql.execution.streaming.sources.{WriteToMicroBatchDataSource, WriteToMicroBatchDataSourceV1}
+import org.apache.spark.sql.execution.streaming.sources.{ForeachBatchSink, WriteToMicroBatchDataSource, WriteToMicroBatchDataSourceV1}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming.Trigger
 import org.apache.spark.util.{Clock, Utils}
@@ -114,6 +114,8 @@ class MicroBatchExecution(
 
     val disabledSources =
       Utils.stringToSeq(sparkSession.sessionState.conf.disabledV2StreamingMicroBatchReaders)
+
+    verifyIfAQEIsDisabled(sink, sparkSession)
 
     import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Implicits._
     val _logicalPlan = analyzedPlan.transform {
@@ -228,6 +230,16 @@ class MicroBatchExecution(
 
       case _ =>
         throw new IllegalArgumentException(s"unknown sink type for $sink")
+    }
+  }
+
+  /**
+   * Check if AQE is disabled for non-foreachBatch queries.
+   */
+  private def verifyIfAQEIsDisabled(sink: Table, sparkSession: SparkSession): Unit = {
+    if (!sink.isInstanceOf[ForeachBatchSink[_]] &&
+      sparkSession.sessionState.conf.adaptiveExecutionEnabled) {
+      throw QueryCompilationErrors.unsupportedFeatureForStreaming("Adaptive Query Execution", "AQE")
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/sources/ForeachBatchSinkSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/sources/ForeachBatchSinkSuite.scala
@@ -25,6 +25,7 @@ import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.apache.spark.sql.execution.SerializeFromObjectExec
 import org.apache.spark.sql.execution.streaming.MemoryStream
 import org.apache.spark.sql.functions._
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming._
 import org.apache.spark.util.ArrayImplicits._
 
@@ -187,7 +188,7 @@ class ForeachBatchSinkSuite extends StreamTest {
   }
 
   test("foreachBatch should not fail when AQE is enabled") {
-//    spark.conf.set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "true")
+    spark.conf.set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "true")
     val mem = MemoryStream[Int]
     val ds = mem.toDS().map(_ + 1)
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Added a check to verify AQE is not enabled for Structured Streaming, except for ForeachBatch sink.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To ensure AQE is not enabled for Structured Streaming to avoid indeterministic behavior.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, this change includes error message changes.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added unit tests.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No