### PR TITLE
[SPARK-46965][CORE] Check `logType` in `Utils.getLog`

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/Utils.scala
@@ -32,6 +32,7 @@ import org.apache.spark.util.logging.RollingFileAppender
  */
 private[deploy] object Utils extends Logging {
   val DEFAULT_BYTES = 100 * 1024
+  val SUPPORTED_LOG_TYPES = Set("stderr", "stdout", "out")
 
   def addRenderLogHandler(page: WebUI, conf: SparkConf): Unit = {
     page.attachHandler(createServletHandler("/log",
@@ -58,6 +59,9 @@ private[deploy] object Utils extends Logging {
       logType: String,
       offsetOption: Option[Long],
       byteLength: Int): (String, Long, Long, Long) = {
+    if (!SUPPORTED_LOG_TYPES.contains(logType)) {
+      return ("Error: Log type must be one of " + SUPPORTED_LOG_TYPES.mkString(", "), 0, 0, 0)
+    }
     try {
       // Find a log file name
       val fileName = if (logType.equals("out")) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to check `logType` in `Utils.getLog`.

### Why are the changes needed?

To prevent security vulnerability.

### Does this PR introduce _any_ user-facing change?

No. This is a new module which is not released yet.

### How was this patch tested?

Manually.

**BEFORE**
```
$ sbin/start-master.sh
$ curl -s 'http://localhost:8080/logPage/self?logType=../../../../../../etc/nfs.conf' | grep NFS
# nfs.conf: the NFS configuration file
```

**AFTER**
```
$ sbin/start-master.sh
$ curl -s 'http://localhost:8080/logPage/self?logType=../../../../../../etc/nfs.conf' | grep NFS
```

For `Spark History Server`, the same check with 18080 port.
```
$ curl -s 'http://localhost:18080/logPage/self?logType=../../../../../../../etc/nfs.conf' | grep NFS
```

### Was this patch authored or co-authored using generative AI tooling?

No