### PR TITLE
[SPARK-46967][CORE][UI] Hide `Thread Dump` and `Heap Histogram` of `Dead` executors in `Executors` UI

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/executorspage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/executorspage.js
@@ -587,14 +587,16 @@ $(document).ready(function () {
             {name: 'executorLogsCol', data: 'executorLogs', render: formatLogsCells},
             {
               name: 'threadDumpCol',
-              data: 'id', render: function (data, type) {
-                return type === 'display' ? ("<a href='threadDump/?executorId=" + data + "'>Thread Dump</a>" ) : data;
+              data: function (row) { return row.isActive ? row.id : '' },
+              render: function (data, type) {
+                return data != '' && type === 'display' ? ("<a href='threadDump/?executorId=" + data + "'>Thread Dump</a>" ) : data;
               }
             },
             {
               name: 'heapHistogramCol',
-              data: 'id', render: function (data, type) {
-                return type === 'display' ? ("<a href='heapHistogram/?executorId=" + data + "'>Heap Histogram</a>") : data;
+              data: function (row) { return row.isActive ? row.id : '' },
+              render: function (data, type) {
+                return data != '' && type === 'display' ? ("<a href='heapHistogram/?executorId=" + data + "'>Heap Histogram</a>") : data;
               }
             },
             {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to hide `Thread Dump` and `Heap Histogram` links of `Dead` executors in Spark Driver `Executors` UI.

**BEFORE**
![Screenshot 2024-02-02 at 11 40 46 PM](https://github.com/apache/spark/assets/9700541/9fb45667-b25c-44cc-9c7c-c2ff981c5a2f)

**AFTER**
![Screenshot 2024-02-02 at 11 40 03 PM](https://github.com/apache/spark/assets/9700541/9963452a-773c-4f8b-b025-9362853d3cae)

### Why are the changes needed?

Since both `Thread Dump` and `Heap Histogram` requires a live JVM, those links are broken and leads to the following pages.

**Broken Thread Dump Link**
![Screenshot 2024-02-02 at 11 36 55 PM](https://github.com/apache/spark/assets/9700541/2cfff1b1-dc00-4fef-ab68-5e3fad5df7a0)

**Broken Heap Histogram Link**
![Screenshot 2024-02-02 at 11 37 12 PM](https://github.com/apache/spark/assets/9700541/8450cb3e-3756-4755-896f-7ced682f09b0)

We had better hide them.



### Does this PR introduce _any_ user-facing change?

Yes, but this PR only hides the broken links.

### How was this patch tested?

Manual.

### Was this patch authored or co-authored using generative AI tooling?

No.