### PR TITLE
[SPARK-46969][SQL][TESTS] Recover `to_timestamp('366', 'DD')` test case of `datetime-parsing-invalid.sql`

### DIFF
--- a/sql/core/src/test/resources/sql-tests/analyzer-results/ansi/datetime-parsing-invalid.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/ansi/datetime-parsing-invalid.sql.out
@@ -56,6 +56,13 @@ Project [to_timestamp(9, Some(DD), TimestampType, Some(America/Los_Angeles), tru
 
 
 -- !query
+select to_timestamp('366', 'DD')
+-- !query analysis
+Project [to_timestamp(366, Some(DD), TimestampType, Some(America/Los_Angeles), true) AS to_timestamp(366, DD)#x]
++- OneRowRelation
+
+
+-- !query
 select to_timestamp('9', 'DDD')
 -- !query analysis
 Project [to_timestamp(9, Some(DDD), TimestampType, Some(America/Los_Angeles), true) AS to_timestamp(9, DDD)#x]

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/datetime-parsing-invalid.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/datetime-parsing-invalid.sql.out
@@ -56,6 +56,13 @@ Project [to_timestamp(9, Some(DD), TimestampType, Some(America/Los_Angeles), fal
 
 
 -- !query
+select to_timestamp('366', 'DD')
+-- !query analysis
+Project [to_timestamp(366, Some(DD), TimestampType, Some(America/Los_Angeles), false) AS to_timestamp(366, DD)#x]
++- OneRowRelation
+
+
+-- !query
 select to_timestamp('9', 'DDD')
 -- !query analysis
 Project [to_timestamp(9, Some(DDD), TimestampType, Some(America/Los_Angeles), false) AS to_timestamp(9, DDD)#x]

--- a/sql/core/src/test/resources/sql-tests/inputs/datetime-parsing-invalid.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/datetime-parsing-invalid.sql
@@ -14,8 +14,7 @@ select to_timestamp('366', 'D');
 select to_timestamp('9', 'DD');
 -- in java 8 this case is invalid, but valid in java 11, disabled for jenkins
 -- select to_timestamp('100', 'DD');
--- The error message is changed since Java 11+
--- select to_timestamp('366', 'DD');
+select to_timestamp('366', 'DD');
 select to_timestamp('9', 'DDD');
 select to_timestamp('99', 'DDD');
 select to_timestamp('30-365', 'dd-DDD');

--- a/sql/core/src/test/resources/sql-tests/results/ansi/datetime-parsing-invalid.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ansi/datetime-parsing-invalid.sql.out
@@ -122,6 +122,22 @@ org.apache.spark.SparkUpgradeException
 
 
 -- !query
+select to_timestamp('366', 'DD')
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.SparkDateTimeException
+{
+  "errorClass" : "CANNOT_PARSE_TIMESTAMP",
+  "sqlState" : "22007",
+  "messageParameters" : {
+    "ansiConfig" : "\"spark.sql.ansi.enabled\"",
+    "message" : "Invalid date 'DayOfYear 366' as '1970' is not a leap year"
+  }
+}
+
+
+-- !query
 select to_timestamp('9', 'DDD')
 -- !query schema
 struct<>

--- a/sql/core/src/test/resources/sql-tests/results/datetime-parsing-invalid.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/datetime-parsing-invalid.sql.out
@@ -106,6 +106,14 @@ org.apache.spark.SparkUpgradeException
 
 
 -- !query
+select to_timestamp('366', 'DD')
+-- !query schema
+struct<to_timestamp(366, DD):timestamp>
+-- !query output
+NULL
+
+
+-- !query
 select to_timestamp('9', 'DDD')
 -- !query schema
 struct<>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to recover a negative `to_timestamp` test case.

### Why are the changes needed?

From Apache Spark 4.0, all error messages are the same on Java 17+ environment.

### Does this PR introduce _any_ user-facing change?

No, this is a test-only PR.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.