### PR TITLE
[MINOR][DOCS] Remove Java 8/11 at `IgnoreUnrecognizedVMOptions` description

### DIFF
--- a/launcher/src/main/java/org/apache/spark/launcher/JavaModuleOptions.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/JavaModuleOptions.java
@@ -20,7 +20,7 @@ package org.apache.spark.launcher;
 /**
  * This helper class is used to place the all `--add-opens` options
  * required by Spark when using Java 17. `DEFAULT_MODULE_OPTIONS` has added
- * `-XX:+IgnoreUnrecognizedVMOptions` to be compatible with Java 8 and Java 11.
+ * `-XX:+IgnoreUnrecognizedVMOptions` to be robust.
  *
  * @since 3.3.0
  */

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -1031,8 +1031,7 @@ private[spark] class Client(
     javaOpts += s"-Djava.net.preferIPv6Addresses=${Utils.preferIPv6}"
 
     // SPARK-37106: To start AM with Java 17, `JavaModuleOptions.defaultModuleOptions`
-    // is added by default. It will not affect Java 8 and Java 11 due to existence of
-    // `-XX:+IgnoreUnrecognizedVMOptions`.
+    // is added by default.
     javaOpts += JavaModuleOptions.defaultModuleOptions()
 
     // Set the environment variable through a command prefix


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove old Java 8 and Java 11 from `IgnoreUnrecognizedVMOptions` JVM option description.

### Why are the changes needed?

From Apache Spark 4.0.0, we use `IgnoreUnrecognizedVMOptions` JVM option to be robust, not for Java 8 and Java 11 support.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.