### PR TITLE
[SPARK-46971][SQL] When the `compression` is null, a `NullPointException` should not be thrown

### DIFF
--- a/connector/avro/src/main/scala/org/apache/spark/sql/avro/AvroOptions.scala
+++ b/connector/avro/src/main/scala/org/apache/spark/sql/avro/AvroOptions.scala
@@ -27,6 +27,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.{DataSourceOptions, FileSourceOptions}
 import org.apache.spark.sql.catalyst.util.{CaseInsensitiveMap, FailFastMode, ParseMode}
+import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.internal.SQLConf
 
 /**
@@ -118,7 +119,11 @@ private[sql] class AvroOptions(
    * taken into account. If the former one is not set too, the `snappy` codec is used by default.
    */
   val compression: String = {
-    parameters.get(COMPRESSION).getOrElse(SQLConf.get.avroCompressionCodec)
+    val v = parameters.get(COMPRESSION).getOrElse(SQLConf.get.avroCompressionCodec)
+    if (v == null) {
+      throw QueryExecutionErrors.codecNotAvailableError(null, SQLConf.get.avroCompressionCodec)
+    }
+    v
   }
 
   val parseMode: ParseMode =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/CompressionCodecs.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/CompressionCodecs.scala
@@ -35,6 +35,10 @@ object CompressionCodecs {
    * If it is already a class name, just return it.
    */
   def getCodecClassName(name: String): String = {
+    if (name == null) {
+      throw QueryExecutionErrors.codecNotAvailableError(
+          null, shortCompressionCodecNames.keys.mkString(", "))
+    }
     val codecName = shortCompressionCodecNames.getOrElse(name.toLowerCase(Locale.ROOT), name)
     try {
       // Validate the codec name

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -2716,7 +2716,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
     new SparkIllegalArgumentException(
       errorClass = "CODEC_NOT_AVAILABLE.WITH_AVAILABLE_CODECS_SUGGESTION",
       messageParameters = Map(
-        "codecName" -> codecName,
+        "codecName" -> toSQLValue(codecName, StringType),
         "availableCodecs" -> availableCodecs))
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcOptions.scala
@@ -51,12 +51,13 @@ class OrcOptions(
       .get(COMPRESSION)
       .orElse(orcCompressionConf)
       .getOrElse(sqlConf.orcCompressionCodec)
-      .toLowerCase(Locale.ROOT)
-    if (!shortOrcCompressionCodecNames.contains(codecName)) {
+    val lowerCasedCodecName = if (codecName != null) codecName.toLowerCase(Locale.ROOT) else null
+    if (!shortOrcCompressionCodecNames.contains(lowerCasedCodecName)) {
       val availableCodecs = shortOrcCompressionCodecNames.keys.map(_.toLowerCase(Locale.ROOT))
-      throw QueryExecutionErrors.codecNotAvailableError(codecName, availableCodecs.mkString(", "))
+      throw QueryExecutionErrors.codecNotAvailableError(
+        lowerCasedCodecName, availableCodecs.mkString(", "))
     }
-    shortOrcCompressionCodecNames(codecName)
+    shortOrcCompressionCodecNames(lowerCasedCodecName)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetOptions.scala
@@ -52,14 +52,13 @@ class ParquetOptions(
       .get(COMPRESSION)
       .orElse(parquetCompressionConf)
       .getOrElse(sqlConf.parquetCompressionCodec)
-      .toLowerCase(Locale.ROOT)
-    if (!shortParquetCompressionCodecNames.contains(codecName)) {
-      val availableCodecs =
-        shortParquetCompressionCodecNames.keys.map(_.toLowerCase(Locale.ROOT))
+    val lowerCasedCodecName = if (codecName != null) codecName.toLowerCase(Locale.ROOT) else null
+    if (!shortParquetCompressionCodecNames.contains(lowerCasedCodecName)) {
+      val availableCodecs = shortParquetCompressionCodecNames.keys.map(_.toLowerCase(Locale.ROOT))
       throw QueryExecutionErrors.codecNotAvailableError(
-        codecName, availableCodecs.mkString(", "))
+        lowerCasedCodecName, availableCodecs.mkString(", "))
     }
-    shortParquetCompressionCodecNames(codecName).name()
+    shortParquetCompressionCodecNames(lowerCasedCodecName).name()
   }
 
   /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
@@ -1160,6 +1160,67 @@ class QueryExecutionErrorsSuite
       )
     )
   }
+
+  test("CODEC_NOT_AVAILABLE.WITH_AVAILABLE_CODECS_SUGGESTION: when compression is null") {
+    withTempPath { path =>
+      val df = (1 to 5).map(i => ((i % 2).toString)).toDF("a")
+
+      checkError(
+        exception = intercept[SparkIllegalArgumentException] {
+          df.write.option("compression", null).text(path.getAbsolutePath)
+        },
+        errorClass = "CODEC_NOT_AVAILABLE.WITH_AVAILABLE_CODECS_SUGGESTION",
+        parameters = Map(
+          "codecName" -> "NULL",
+          "availableCodecs" -> "bzip2, deflate, uncompressed, snappy, none, lz4, gzip"))
+
+      checkError(
+        exception = intercept[SparkIllegalArgumentException] {
+          df.write.option("compression", null).csv(path.getAbsolutePath)
+        },
+        errorClass = "CODEC_NOT_AVAILABLE.WITH_AVAILABLE_CODECS_SUGGESTION",
+        parameters = Map(
+          "codecName" -> "NULL",
+          "availableCodecs" -> "bzip2, deflate, uncompressed, snappy, none, lz4, gzip"))
+
+      checkError(
+        exception = intercept[SparkIllegalArgumentException] {
+          df.write.option("compression", null).json(path.getAbsolutePath)
+        },
+        errorClass = "CODEC_NOT_AVAILABLE.WITH_AVAILABLE_CODECS_SUGGESTION",
+        parameters = Map(
+          "codecName" -> "NULL",
+          "availableCodecs" -> "bzip2, deflate, uncompressed, snappy, none, lz4, gzip"))
+
+      checkError(
+        exception = intercept[SparkIllegalArgumentException] {
+          df.write.option("compression", null).xml(path.getAbsolutePath)
+        },
+        errorClass = "CODEC_NOT_AVAILABLE.WITH_AVAILABLE_CODECS_SUGGESTION",
+        parameters = Map(
+          "codecName" -> "NULL",
+          "availableCodecs" -> "bzip2, deflate, uncompressed, snappy, none, lz4, gzip"))
+
+      checkError(
+        exception = intercept[SparkIllegalArgumentException] {
+          df.write.option("compression", null).orc(path.getAbsolutePath)
+        },
+        errorClass = "CODEC_NOT_AVAILABLE.WITH_AVAILABLE_CODECS_SUGGESTION",
+        parameters = Map(
+          "codecName" -> "NULL",
+          "availableCodecs" -> "uncompressed, lz4, lzo, snappy, zlib, none, zstd"))
+
+      checkError(
+        exception = intercept[SparkIllegalArgumentException] {
+          df.write.option("compression", null).parquet(path.getAbsolutePath)
+        },
+        errorClass = "CODEC_NOT_AVAILABLE.WITH_AVAILABLE_CODECS_SUGGESTION",
+        parameters = Map(
+          "codecName" -> "NULL",
+          "availableCodecs" ->
+            ("brotli, uncompressed, lzo, snappy, lz4_raw, none, zstd, lz4, gzip")))
+    }
+  }
 }
 
 class FakeFileSystemSetPermission extends LocalFileSystem {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetCompressionCodecPrecedenceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetCompressionCodecPrecedenceSuite.scala
@@ -127,7 +127,7 @@ class ParquetCompressionCodecPrecedenceSuite extends ParquetTest with SharedSpar
         },
         errorClass = "CODEC_NOT_AVAILABLE.WITH_AVAILABLE_CODECS_SUGGESTION",
         parameters = Map(
-          "codecName" -> "aa",
+          "codecName" -> "'aa'",
           "availableCodecs" -> ("brotli, uncompressed, lzo, snappy, " +
             "lz4_raw, none, zstd, lz4, gzip")))
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/text/TextSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/text/TextSuite.scala
@@ -113,7 +113,7 @@ abstract class TextSuite extends QueryTest with SharedSparkSession with CommonFi
         },
         errorClass = "CODEC_NOT_AVAILABLE.WITH_AVAILABLE_CODECS_SUGGESTION",
         parameters = Map(
-          "codecName" -> "illegal",
+          "codecName" -> "'illegal'",
           "availableCodecs" -> "bzip2, deflate, uncompressed, snappy, none, lz4, gzip")
       )
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to provide better prompts when option's `compression` is null.


### Why are the changes needed?
In the original logic, if the `compression` is null, Spark will throw a `NullPointerException`, which is obviously unfriendly to the user.

```
val df = (1 to 5).map(i => ((i % 2).toString)).toDF("a")
df.write.option("compression", null).text("test1")
```
Before:
```
scala> df.write.option("compression", null).text("test1")
org.apache.spark.SparkException: [INTERNAL_ERROR] Eagerly executed command failed. You hit a bug in Spark or the Spark plugins you use. Please, report this bug to the corresponding communities or vendors, and provide the full stack trace. SQLSTATE: XX000
  at org.apache.spark.SparkException$.internalError(SparkException.scala:107)
  at org.apache.spark.sql.execution.QueryExecution$.toInternalError(QueryExecution.scala:550)
  at org.apache.spark.sql.execution.QueryExecution$.withInternalError(QueryExecution.scala:562)
  at org.apache.spark.sql.execution.QueryExecution$$anonfun$eagerlyExecuteCommands$1.applyOrElse(QueryExecution.scala:119)
  at org.apache.spark.sql.execution.QueryExecution$$anonfun$eagerlyExecuteCommands$1.applyOrElse(QueryExecution.scala:109)
  at org.apache.spark.sql.catalyst.trees.TreeNode.$anonfun$transformDownWithPruning$1(TreeNode.scala:442)
  at org.apache.spark.sql.catalyst.trees.CurrentOrigin$.withOrigin(origin.scala:83)
  at org.apache.spark.sql.catalyst.trees.TreeNode.transformDownWithPruning(TreeNode.scala:442)
  at org.apache.spark.sql.catalyst.plans.logical.LogicalPlan.org$apache$spark$sql$catalyst$plans$logical$AnalysisHelper$$super$transformDownWithPruning(LogicalPlan.scala:34)
  at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper.transformDownWithPruning(AnalysisHelper.scala:271)
  at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper.transformDownWithPruning$(AnalysisHelper.scala:267)
  at org.apache.spark.sql.catalyst.plans.logical.LogicalPlan.transformDownWithPruning(LogicalPlan.scala:34)
  at org.apache.spark.sql.catalyst.plans.logical.LogicalPlan.transformDownWithPruning(LogicalPlan.scala:34)
  at org.apache.spark.sql.catalyst.trees.TreeNode.transformDown(TreeNode.scala:418)
  at org.apache.spark.sql.execution.QueryExecution.eagerlyExecuteCommands(QueryExecution.scala:109)
  at org.apache.spark.sql.execution.QueryExecution.commandExecuted$lzycompute(QueryExecution.scala:96)
  at org.apache.spark.sql.execution.QueryExecution.commandExecuted(QueryExecution.scala:94)
  at org.apache.spark.sql.execution.QueryExecution.assertCommandExecuted(QueryExecution.scala:156)
  at org.apache.spark.sql.DataFrameWriter.runCommand(DataFrameWriter.scala:892)
  at org.apache.spark.sql.DataFrameWriter.saveToV1Source(DataFrameWriter.scala:389)
  at org.apache.spark.sql.DataFrameWriter.saveInternal(DataFrameWriter.scala:362)
  at org.apache.spark.sql.DataFrameWriter.save(DataFrameWriter.scala:240)
  at org.apache.spark.sql.DataFrameWriter.text(DataFrameWriter.scala:834)
  ... 42 elided
Caused by: java.lang.NullPointerException: Cannot invoke "String.toLowerCase(java.util.Locale)" because "name" is null
  at org.apache.spark.sql.catalyst.util.CompressionCodecs$.getCodecClassName(CompressionCodecs.scala:38)
  at org.apache.spark.sql.execution.datasources.text.TextOptions.$anonfun$compressionCodec$1(TextOptions.scala:38)
  at scala.Option.map(Option.scala:242)
  ... 17 elided and 62 more
```

After:
```
scala> df.write.option("compression", null).text("test1")
org.apache.spark.SparkIllegalArgumentException: [CODEC_NOT_AVAILABLE.WITH_AVAILABLE_CODECS_SUGGESTION] The codec NULL is not available. Available codecs are bzip2, deflate, uncompressed, snappy, none, lz4, gzip. SQLSTATE: 56038
  at org.apache.spark.sql.errors.QueryExecutionErrors$.codecNotAvailableError(QueryExecutionErrors.scala:2716)
  at org.apache.spark.sql.catalyst.util.CompressionCodecs$.getCodecClassName(CompressionCodecs.scala:40)
  at org.apache.spark.sql.execution.datasources.text.TextOptions.$anonfun$compressionCodec$1(TextOptions.scala:38)
  at scala.Option.map(Option.scala:242)
  ... 79 elided
```

### Does this PR introduce _any_ user-facing change?
Yes, when `compression` is null, will display better error prompts.


### How was this patch tested?
- Add new UT.
- Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
