### PR TITLE
[SPARK-42789][SQL] Rewrite multiple GetJsonObject that consumes same JSON to single JsonTuple

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -85,6 +85,7 @@ abstract class Optimizer(catalogManager: CatalogManager)
         LimitPushDown,
         LimitPushDownThroughWindow,
         ColumnPruning,
+        RewriteGetJsonObject,
         GenerateOptimization,
         // Operator combine
         CollapseRepartition,
@@ -220,8 +221,6 @@ abstract class Optimizer(catalogManager: CatalogManager)
     // aggregate distinct column
     Batch("Distinct Aggregate Rewrite", Once,
       RewriteDistinctAggregates) :+
-    Batch("Rewrite GetJsonObject", Once,
-      RewriteGetJsonObject) :+
     Batch("Object Expressions Optimization", fixedPoint,
       EliminateMapObjects,
       CombineTypedFilters,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -220,6 +220,8 @@ abstract class Optimizer(catalogManager: CatalogManager)
     // aggregate distinct column
     Batch("Distinct Aggregate Rewrite", Once,
       RewriteDistinctAggregates) :+
+    Batch("Rewrite GetJsonObject", Once,
+      RewriteGetJsonObject) :+
     Batch("Object Expressions Optimization", fixedPoint,
       EliminateMapObjects,
       CombineTypedFilters,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteGetJsonObject.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteGetJsonObject.scala
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import scala.collection.mutable
+
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression, GetJsonObject, JsonTuple, NamedExpression}
+import org.apache.spark.sql.catalyst.plans.logical.{Generate, LogicalPlan, Project}
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.catalyst.trees.TreePattern.GET_JSON_OBJECT
+import org.apache.spark.sql.types.StringType
+
+/**
+ * This rule rewrites multiple GetJsonObjects to a JsonTuple if their json expression is the same.
+ */
+object RewriteGetJsonObject extends Rule[LogicalPlan] {
+  def apply(plan: LogicalPlan): LogicalPlan = plan.transformUpWithPruning(
+    _.containsPattern(GET_JSON_OBJECT), ruleId) {
+    case p: Project =>
+      val getJsonObjects = p.projectList.flatMap {
+        _.collect {
+          case gjo: GetJsonObject if gjo.rewriteToJsonTuplePath.nonEmpty => gjo
+        }
+      }
+
+      val groupedGetJsonObjects = getJsonObjects.groupBy(_.json).filter(_._2.size > 1)
+      if (groupedGetJsonObjects.nonEmpty) {
+        var newChild = p.child
+        val keyValues = mutable.LinkedHashMap.empty[Expression, AttributeReference]
+        groupedGetJsonObjects.foreach {
+          case (json, getJsonObjects) =>
+            val generatorOutput = getJsonObjects.map { j =>
+              val attr = AttributeReference(j.rewriteToJsonTuplePath.get.toString, StringType)()
+              keyValues.put(j.canonicalized, attr)
+              attr
+            }
+            newChild = Generate(
+              JsonTuple(json +: getJsonObjects.flatMap(_.rewriteToJsonTuplePath)),
+              Nil,
+              outer = false,
+              Some(json.sql),
+              generatorOutput,
+              newChild)
+        }
+
+        val newProjectList = p.projectList.map {
+          _.transformUp {
+            case gjo: GetJsonObject => keyValues.getOrElse(gjo.canonicalized, gjo)
+          }.asInstanceOf[NamedExpression]
+        }
+        p.copy(newProjectList, newChild)
+      } else {
+        p
+      }
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleIdCollection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleIdCollection.scala
@@ -163,6 +163,7 @@ object RuleIdCollection {
       "org.apache.spark.sql.catalyst.optimizer.RewriteExceptAll" ::
       "org.apache.spark.sql.catalyst.optimizer.RewriteIntersectAll" ::
       "org.apache.spark.sql.catalyst.optimizer.RewriteAsOfJoin" ::
+      "org.apache.spark.sql.catalyst.optimizer.RewriteGetJsonObject" ::
       "org.apache.spark.sql.catalyst.optimizer.SimplifyBinaryComparison" ::
       "org.apache.spark.sql.catalyst.optimizer.SimplifyCaseConversionExpressions" ::
       "org.apache.spark.sql.catalyst.optimizer.SimplifyCasts" ::

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
@@ -50,6 +50,7 @@ object TreePattern extends Enumeration  {
   val FUNCTION_TABLE_RELATION_ARGUMENT_EXPRESSION: Value = Value
   val GENERATE: Value = Value
   val GENERATOR: Value = Value
+  val GET_JSON_OBJECT: Value = Value
   val HIGH_ORDER_FUNCTION: Value = Value
   val IF: Value = Value
   val IN: Value = Value

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -466,6 +466,17 @@ object SQLConf {
       .intConf
       .createWithDefault(100)
 
+  val REWRITE_TO_JSON_TUPLE_THRESHOLD =
+    buildConf("spark.sql.optimizer.rewriteGetJsonObjectToJsonTupleThreshold")
+      .internal()
+      .doc("When the number of GetJsonObject that consumes the same JSON as input exceeds " +
+        "the threshold, we rewrite those GetJsonObjects to a single JsonTuple to eliminate " +
+        "multiple time JSON parsing procedure. The threshold must be greater than 1.")
+      .version("4.0.0")
+      .intConf
+      .checkValue(t => t > 1, "The threshold must be greater than 1")
+      .createOptional
+
   val COMPRESS_CACHED = buildConf("spark.sql.inMemoryColumnarStorage.compressed")
     .doc("When set to true Spark SQL will automatically select a compression codec for each " +
       "column based on statistics of the data.")

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteGetJsonObjectSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteGetJsonObjectSuite.scala
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.dsl.plans._
+import org.apache.spark.sql.catalyst.expressions.{Concat, GetJsonObject, JsonTuple}
+import org.apache.spark.sql.catalyst.plans.PlanTest
+import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan}
+import org.apache.spark.sql.catalyst.rules.RuleExecutor
+
+class RewriteGetJsonObjectSuite extends PlanTest {
+
+  object Optimize extends RuleExecutor[LogicalPlan] {
+    val batches =
+      Batch("Rewrite GetJsonObject", Once,
+        RewriteGetJsonObject) :: Nil
+  }
+
+  private val testRelation = LocalRelation($"a".string, $"b".string, $"c".string)
+
+  test("Rewrite to a single JsonTuple") {
+    val query = testRelation
+      .select(
+        GetJsonObject($"a", stringToLiteral("$.c1")).as("c1"),
+        GetJsonObject($"a", stringToLiteral("$.c2")).as("c2"),
+        GetJsonObject($"a", stringToLiteral("$.c3")).as("c3"))
+
+    val correctAnswer = testRelation
+      .generate(
+        JsonTuple(Seq($"a", stringToLiteral("c1"), stringToLiteral("c2"), stringToLiteral("c3"))),
+        Nil,
+        alias = Some("a"),
+        outputNames = Seq("c1", "c2", "c3"))
+      .select($"c1".as("c1"), $"c2".as("c2"), $"c3".as("c3"))
+
+    val getJsonObjects = query.expressions.flatMap { _.collect {
+        case gjo: GetJsonObject if gjo.rewriteToJsonTuplePath.nonEmpty => gjo
+    }}
+    assert(getJsonObjects.forall(_.rewriteToJsonTuplePath.nonEmpty))
+    comparePlans(Optimize.execute(query.analyze), correctAnswer.analyze)
+  }
+
+  test("Rewrite to multiple JsonTuples") {
+    val query = testRelation
+      .select(
+        GetJsonObject($"a", stringToLiteral("$.c1")).as("c1"),
+        GetJsonObject($"a", stringToLiteral("$.c2")).as("c2"),
+        GetJsonObject($"b", stringToLiteral("$.c1")).as("c3"),
+        GetJsonObject($"b", stringToLiteral("$.c2")).as("c4"),
+        GetJsonObject($"c", stringToLiteral("$.c1")).as("c5"))
+
+    val correctAnswer = testRelation
+      .generate(
+        JsonTuple(Seq($"a", stringToLiteral("c1"), stringToLiteral("c2"))),
+        Nil,
+        alias = Some("a"),
+        outputNames = Seq("c1", "c2"))
+      .generate(
+        JsonTuple(Seq($"b", stringToLiteral("c1"), stringToLiteral("c2"))),
+        Nil,
+        alias = Some("b"),
+        outputNames = Seq("c1", "c2"))
+      .select(
+        $"a.c1".as("c1"), $"a.c2".as("c2"),
+        $"b.c1".as("c3"), $"b.c2".as("c4"),
+        GetJsonObject($"c", stringToLiteral("$.c1")).as("c5"))
+
+    val getJsonObjects = query.expressions.flatMap {
+      _.collect {
+        case gjo: GetJsonObject if gjo.rewriteToJsonTuplePath.nonEmpty => gjo
+      }
+    }
+    assert(getJsonObjects.forall(_.rewriteToJsonTuplePath.nonEmpty))
+    comparePlans(Optimize.execute(query.analyze), correctAnswer.analyze)
+  }
+
+  test("Rewrite GetJsonObject with other UDFs") {
+    val query = testRelation
+      .select(
+        Concat(Seq(GetJsonObject($"a", stringToLiteral("$.c1")),
+          GetJsonObject($"a", stringToLiteral("$.c2")),
+          GetJsonObject($"a", stringToLiteral("$.c3")))).as("c"))
+
+    val correctAnswer = testRelation
+      .generate(
+        JsonTuple(Seq($"a", stringToLiteral("c1"), stringToLiteral("c2"), stringToLiteral("c3"))),
+        Nil,
+        alias = Some("a"),
+        outputNames = Seq("c1", "c2", "c3"))
+      .select(Concat(Seq($"c1", $"c2", $"c3")).as("c"))
+
+    val getJsonObjects = query.expressions.flatMap {
+      _.collect {
+        case gjo: GetJsonObject if gjo.rewriteToJsonTuplePath.nonEmpty => gjo
+      }
+    }
+    assert(getJsonObjects.forall(_.rewriteToJsonTuplePath.nonEmpty))
+    comparePlans(Optimize.execute(query.analyze), correctAnswer.analyze)
+  }
+
+  test("Do not rewrite if parsed path is empty") {
+    val query = testRelation
+      .select(
+        GetJsonObject($"a", stringToLiteral("c1")).as("c1"),
+        GetJsonObject($"a", stringToLiteral("c2")).as("c2"),
+        GetJsonObject($"a", stringToLiteral("c3")).as("c3"))
+
+    val getJsonObjects = query.expressions.flatMap {
+      _.collect {
+        case gjo: GetJsonObject if gjo.rewriteToJsonTuplePath.nonEmpty => gjo
+      }
+    }
+    assert(getJsonObjects.forall(_.rewriteToJsonTuplePath.isEmpty))
+    comparePlans(Optimize.execute(query.analyze), query.analyze)
+  }
+
+  test("Do not rewrite if parsed path is not Key and Named") {
+    val query = testRelation
+      .select(
+        GetJsonObject($"a", stringToLiteral("$[0]")).as("c1"),
+        GetJsonObject($"a", stringToLiteral("$[1]")).as("c2"))
+
+    val getJsonObjects = query.expressions.flatMap {
+      _.collect {
+        case gjo: GetJsonObject if gjo.rewriteToJsonTuplePath.nonEmpty => gjo
+      }
+    }
+    assert(getJsonObjects.forall(_.rewriteToJsonTuplePath.isEmpty))
+    comparePlans(Optimize.execute(query.analyze), query.analyze)
+  }
+
+  test("Do not rewrite if parsed path contains multiple Named") {
+    val query = testRelation
+      .select(
+        GetJsonObject($"a", stringToLiteral("$.a.b")).as("c1"),
+        GetJsonObject($"a", stringToLiteral("$.c.d")).as("c2"))
+
+    val getJsonObjects = query.expressions.flatMap {
+      _.collect {
+        case gjo: GetJsonObject if gjo.rewriteToJsonTuplePath.nonEmpty => gjo
+      }
+    }
+    assert(getJsonObjects.forall(_.rewriteToJsonTuplePath.isEmpty))
+    comparePlans(Optimize.execute(query.analyze), query.analyze)
+  }
+}


### PR DESCRIPTION
This PR takes over https://github.com/apache/spark/pull/40419 as the original author @wangyum is busy with other works.

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR adds a new rule to rewrite multiple `GetJsonObject` to one `JsonTuple` if their json expressions are the same and the path is `.<name>`. For example:

```
=== Applying Rule org.apache.spark.sql.catalyst.optimizer.RewriteGetJsonObject ===
!Project [get_json_object(a#0, $.c1) AS c1#3, get_json_object(a#0, $.c2) AS c2#4, get_json_object(b#1, $.c1) AS c3#5, get_json_object(b#1, $.c2) AS c4#6, get_json_object(c#2, $.c1) AS c5#7]   Project [c1#13 AS c1#3, c2#14 AS c2#4, c1#15 AS c3#5, c2#16 AS c4#6, get_json_object(c#2, $.c1) AS c5#7]
!+- LocalRelation <empty>, [a#0, b#1, c#2]                                                                                                                                                      +- Generate json_tuple(b#1, c1, c2), false, b, [c1#15, c2#16]
!                                                                                                                                                                                                  +- Generate json_tuple(a#0, c1, c2), false, a, [c1#13, c2#14]
!                                                                                                                                                                                                     +- LocalRelation <empty>, [a#0, b#1, c#2]
```

Please note that it needs to rewrite the path, otherwise it will not get the correct value. For example:
```
spark-sql (default)> SELECT get_json_object('{"name": "alice", "age": 5}', '$.name') AS name;
alice
spark-sql (default)> SELECT name lateral view json_tuple('{"name": "alice", "age": 5}', '$.name') a AS name;
NULL
spark-sql (default)> select name lateral view json_tuple('{"name": "alice", "age": 5}', 'name') a AS name;
alice
```

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Improve query performance by eliminating multiple-time expensive JSON parsing.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
A new configuration `spark.sql.optimizer.rewriteGetJsonObjectToJsonTupleThreshold` is introduced, while the default value `None` keeps the current behavior.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Unit test and benchmark test.

Benchmark result:

No. of GetJsonObjects | Default(ms) | Rewrite to JsonTuple(ms) | Relative
-- | -- | -- | --
2 | 37914 | 24887 | 1.5X
3 | 52862 | 26752 | 2.0X
4 | 71680 | 28452 | 2.5X
5 | 108479 | 36830 | 2.9X
10 | 153952 | 32436 | 4.7X
15 | 224950 | 34806 | 6.5X
20 | 293155 | 38148 | 7.7X
25 | 366037 | 45725 | 8.0X
30 | 439567 | 52949 | 8.3X
35 | 526481 | 60586 | 8.7X

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.