### PR TITLE
[MINOR][DOCS] Clarify docs on default fractional numeric literals in SQL

### DIFF
--- a/docs/sql-ref-literals.md
+++ b/docs/sql-ref-literals.md
@@ -275,14 +275,6 @@ E [ + | - ] digit [ ... ]
 
     Case insensitive, indicates `DECIMAL`, with the total number of digits as precision and the number of digits to right of decimal point as scale.
 
-* **default (no postfix, no exponent)**
-
-    Indicates `DECIMAL`, same as the `BD` postfix.
-
-* **default (no postfix, with exponent)**
-
-    Indicates `DOUBLE`, same as the `D` postfix.
-
 #### Fractional Literals Examples
 
 ```sql

--- a/docs/sql-ref-literals.md
+++ b/docs/sql-ref-literals.md
@@ -275,15 +275,30 @@ E [ + | - ] digit [ ... ]
 
     Case insensitive, indicates `DECIMAL`, with the total number of digits as precision and the number of digits to right of decimal point as scale.
 
+* **default (no postfix, no exponent)**
+
+    Indicates `DECIMAL`, same as the `BD` postfix.
+
+* **default (no postfix, with exponent)**
+
+    Indicates `DOUBLE`, same as the `D` postfix.
+
 #### Fractional Literals Examples
 
 ```sql
-SELECT 12.578 AS col;
-+------+
-|   col|
-+------+
-|12.578|
-+------+
+SELECT 12.578 AS col, TYPEOF(12.578) AS type;
++------+------------+
+|   col|        type|
++------+------------+
+|12.578|decimal(5,3)|
++------+------------+
+
+SELECT 12.578E0 AS col, TYPEOF(12.578E0) AS type;
++------+------+
+|   col|  type|
++------+------+
+|12.578|double|
++------+------+
 
 SELECT -0.1234567 AS col;
 +----------+


### PR DESCRIPTION
### What changes were proposed in this pull request?

Provide examples showing what type literals like `123.456` and `123.456E0` have in SQL.

### Why are the changes needed?

In Python (and I think Java too) fractional numeric literals are typically floats. To get decimals, you need to provide an explicit postfix or use an explicit class. In Spark, it's the other way around. I found this surprising and couldn't find documentation about it.

I discovered this after reading [SPARK-45786](https://issues.apache.org/jira/browse/SPARK-45786). I did a little searching and came across https://github.com/apache/spark/pull/10796, which shows that we used to default to floats as the fractional numeric literal, but then switched to decimals.

There is an additional wrinkle I discovered in #45003. If the fractional literal has an exponent, then it's a double, not a decimal.

The existing syntax documents this, but that alone is not user-friendly. The new examples make this clearer.

### Does this PR introduce _any_ user-facing change?

Yes, it clarifies the user-facing documentation about fractional numeric literals.

### How was this patch tested?

No testing.

### Was this patch authored or co-authored using generative AI tooling?

No.