### PR TITLE
[SPARK-46976][PS] Implement `DataFrameGroupBy.corr`

### DIFF
--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -889,6 +889,7 @@ pyspark_pandas_slow = Module(
         "pyspark.pandas.tests.indexes.test_reset_index",
         "pyspark.pandas.tests.groupby.test_aggregate",
         "pyspark.pandas.tests.groupby.test_apply_func",
+        "pyspark.pandas.tests.groupby.test_corr",
         "pyspark.pandas.tests.groupby.test_cumulative",
         "pyspark.pandas.tests.groupby.test_describe",
         "pyspark.pandas.tests.groupby.test_groupby",

--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -1175,6 +1175,7 @@ pyspark_pandas_connect_part1 = Module(
         "pyspark.pandas.tests.connect.frame.test_parity_truncate",
         "pyspark.pandas.tests.connect.groupby.test_parity_aggregate",
         "pyspark.pandas.tests.connect.groupby.test_parity_apply_func",
+        "pyspark.pandas.tests.connect.groupby.test_parity_corr",
         "pyspark.pandas.tests.connect.groupby.test_parity_cumulative",
         "pyspark.pandas.tests.connect.groupby.test_parity_missing_data",
         "pyspark.pandas.tests.connect.groupby.test_parity_split_apply",

--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -3992,7 +3992,7 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
         2 B       NaN       NaN
           C       NaN       NaN
 
-        >>> psdf.groupby("A").corr(min_periods=2)
+        >>> df.groupby("A").corr(min_periods=2)
                     B         C
         A
         0 B  1.000000  0.720577

--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -66,7 +66,6 @@ from pyspark.pandas.internal import (
     HIDDEN_COLUMNS,
     NATURAL_ORDER_COLUMN_NAME,
     SPARK_INDEX_NAME_FORMAT,
-    SPARK_DEFAULT_INDEX_NAME,
     SPARK_DEFAULT_SERIES_NAME,
     SPARK_INDEX_NAME_PATTERN,
 )
@@ -4138,7 +4137,7 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
                 index_spark_columns=[
                     scol_for(sdf, key) for key in groupkey_names + [auxiliary_col_name]
                 ],
-                index_names=[(key,) for key in groupkey_names] + [("",)],
+                index_names=[(key,) for key in groupkey_names] + [(None,)],
                 column_labels=numeric_labels,
                 column_label_names=internal.column_label_names,
             )

--- a/python/pyspark/pandas/missing/groupby.py
+++ b/python/pyspark/pandas/missing/groupby.py
@@ -41,7 +41,6 @@ class MissingPandasLikeDataFrameGroupBy:
     # Documentation path: `python/docs/source/reference/pyspark.pandas/`.
 
     # Properties
-    corr = _unsupported_property("corr")
     corrwith = _unsupported_property("corrwith")
     cov = _unsupported_property("cov")
     dtypes = _unsupported_property("dtypes")

--- a/python/pyspark/pandas/tests/connect/groupby/test_parity_corr.py
+++ b/python/pyspark/pandas/tests/connect/groupby/test_parity_corr.py
@@ -1,0 +1,41 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import unittest
+
+from pyspark.pandas.tests.groupby.test_corr import CorrMixin
+from pyspark.testing.connectutils import ReusedConnectTestCase
+from pyspark.testing.pandasutils import PandasOnSparkTestUtils
+
+
+class CorrParityTests(
+    CorrMixin,
+    PandasOnSparkTestUtils,
+    ReusedConnectTestCase,
+):
+    pass
+
+
+if __name__ == "__main__":
+    from pyspark.pandas.tests.connect.groupby.test_parity_corr import *  # noqa: F401
+
+    try:
+        import xmlrunner  # type: ignore[import]
+
+        testRunner = xmlrunner.XMLTestRunner(output="target/test-reports", verbosity=2)
+    except ImportError:
+        testRunner = None
+    unittest.main(testRunner=testRunner, verbosity=2)

--- a/python/pyspark/pandas/tests/groupby/test_corr.py
+++ b/python/pyspark/pandas/tests/groupby/test_corr.py
@@ -1,0 +1,84 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import unittest
+
+import pandas as pd
+
+from pyspark import pandas as ps
+from pyspark.testing.pandasutils import PandasOnSparkTestCase
+from pyspark.testing.sqlutils import SQLTestUtils
+
+
+class CorrMixin:
+    @property
+    def pdf(self):
+        return pd.DataFrame(
+            {
+                "A": [0, 0, 0, 1, 1, 2],
+                "B": [-1, 2, 3, 5, 6, 0],
+                "C": [4, 6, 5, 1, 3, 0],
+            },
+            columns=["A", "B", "C"],
+        )
+
+    @property
+    def psdf(self):
+        return ps.from_pandas(self.pdf)
+
+    def test_corr(self):
+        for c in ["A", "B", "C"]:
+            self.assert_eq(
+                self.pdf.groupby(c).corr().sort_index(),
+                self.psdf.groupby(c).corr().sort_index(),
+                almost=True,
+            )
+
+    def test_method(self):
+        for m in ["pearson", "spearman", "kendall"]:
+            self.assert_eq(
+                self.pdf.groupby("A").corr(method=m).sort_index(),
+                self.psdf.groupby("A").corr(method=m).sort_index(),
+                almost=True,
+            )
+
+    def test_min_periods(self):
+        for m in [1, 2, 3]:
+            self.assert_eq(
+                self.pdf.groupby("A").corr(min_periods=m).sort_index(),
+                self.psdf.groupby("A").corr(min_periods=m).sort_index(),
+                almost=True,
+            )
+
+
+class CorrTests(
+    CorrMixin,
+    PandasOnSparkTestCase,
+    SQLTestUtils,
+):
+    pass
+
+
+if __name__ == "__main__":
+    from pyspark.pandas.tests.groupby.test_corr import *  # noqa: F401
+
+    try:
+        import xmlrunner
+
+        testRunner = xmlrunner.XMLTestRunner(output="target/test-reports", verbosity=2)
+    except ImportError:
+        testRunner = None
+    unittest.main(testRunner=testRunner, verbosity=2)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Implement `DataFrameGroupBy.corr`


### Why are the changes needed?
for pandas parity
 https://pandas.pydata.org/docs/reference/api/pandas.core.groupby.DataFrameGroupBy.corr.html


### Does this PR introduce _any_ user-facing change?
yes
```
In [5]: pdf = pd.DataFrame({'A': [0, 0, 0, 1, 1, 2], 'B': [-1, 2, 3, 5, 6, 0], 'C': [4, 6, 5, 1, 3, 0]}, columns=['A', 'B', 'C'])

In [6]: pdf.groupby("A").corr()
Out[6]: 
            B         C
A                      
0 B  1.000000  0.720577
  C  0.720577  1.000000
1 B  1.000000  1.000000
  C  1.000000  1.000000
2 B       NaN       NaN
  C       NaN       NaN

In [7]: psdf = ps.from_pandas(pdf)

In [8]: psdf.groupby("A").corr()
                                                                                
            B         C
A                      
0 B  1.000000  0.720577
  C  0.720577  1.000000
1 B  1.000000  1.000000
  C  1.000000  1.000000
2 B       NaN       NaN
  C       NaN       NaN
```

### How was this patch tested?
added tests


### Was this patch authored or co-authored using generative AI tooling?
no
