### PR TITLE
[SPARK-46977][CORE] A failed request to obtain a token from one NameNode should not skip subsequent token requests

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/security/HadoopFSDelegationTokenProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/security/HadoopFSDelegationTokenProvider.scala
@@ -31,6 +31,7 @@ import org.apache.spark.{SparkConf, SparkException}
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config._
 import org.apache.spark.security.HadoopDelegationTokenProvider
+import org.apache.spark.util.Utils
 
 private[deploy] class HadoopFSDelegationTokenProvider
     extends HadoopDelegationTokenProvider with Logging {
@@ -116,10 +117,10 @@ private[deploy] class HadoopFSDelegationTokenProvider
       if (fsToExclude.contains(fs.getUri.getHost)) {
         // YARN RM skips renewing token with empty renewer
         logInfo(s"getting token for: $fs with empty renewer to skip renewal")
-        fs.addDelegationTokens("", creds)
+        Utils.tryLogNonFatalError { fs.addDelegationTokens("", creds) }
       } else {
         logInfo(s"getting token for: $fs with renewer $renewer")
-        fs.addDelegationTokens(renewer, creds)
+        Utils.tryLogNonFatalError { fs.addDelegationTokens(renewer, creds) }
       }
     }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR enhances the `HadoopFSDelegationTokenProvider` to tolerate failures when fetching tokens from multiple NameNodes.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Let's say we are going to access 3 HDFS, `nn-1`, `nn-2`, `nn-3` in YARN cluster mode with TGT cache, while the `nn-1` is the `defaultFs` which is used by YARN to store aggregated logs, and there are issues in `nn-2` which can not issue the token.

```
spark-submit \
  --master yarn \
  --deployMode cluster \
  --conf spark.kerberos.access.hadoopFileSystems=hdfs://nn-1,hdfs://nn-2,hdfs://nn-3 \
  ...
```

During the submitting phase, Spark is going to call `HadoopFSDelegationTokenProvider` to fetch tokens from all declared NameNodes one by one, in **indeterminate** order (`HadoopFSDelegationTokenProvider.hadoopFSsToAccess` process and return a `Set[FileSystem]`), so the order may not respect the user declared order in `spark.kerberos.access.hadoopFileSystems`.

If the order is [`nn-1`, `nn-2`, `nn-3`], then we are going to request a token from `nn-1` successfully, but fail for `nn-2` with the below error, the left `nn-3` is going to be skipped. But such failure WON'T block the whole submitting process, the Spark app is going to be submitted with only `nn-1` token.
```
2024-01-03 12:41:36 [WARN] [main] org.apache.spark.deploy.security.HadoopFSDelegationTokenProvider#94 - Failed to get token from service hadoopfs
org.apache.hadoop.ipc.RemoteException: <Some Error Message>
  at org.apache.hadoop.ipc.Client.getRpcResponse(Client.java:1507) ~[hadoop-common-2.9.2.2.jar:?]
  ...
  at org.apache.hadoop.hdfs.DistributedFileSystem.addDelegationTokens(DistributedFileSystem.java:2604) ~[hadoop-hdfs-client-2.9.2.2.jar:?]
  at org.apache.spark.deploy.security.HadoopFSDelegationTokenProvider.$anonfun$fetchDelegationTokens$1(HadoopFSDelegationTokenProvider.scala:122) ~[spark-core_2.12-3.3.1.27.jar:3.3.1.27]
  at scala.collection.immutable.HashSet$HashSet1.foreach(HashSet.scala:335) ~[scala-library-2.12.15.jar:?]
  at scala.collection.immutable.HashSet$HashTrieSet.foreach(HashSet.scala:1111) ~[scala-library-2.12.15.jar:?]
  at scala.collection.immutable.HashSet$HashTrieSet.foreach(HashSet.scala:1111) ~[scala-library-2.12.15.jar:?]
  at org.apache.spark.deploy.security.HadoopFSDelegationTokenProvider.fetchDelegationTokens(HadoopFSDelegationTokenProvider.scala:115) ~[spark-core_2.12-3.3.1.27.jar:3.3.1.27]
  ...
  at org.apache.spark.deploy.security.HadoopDelegationTokenManager.obtainDelegationTokens(HadoopDelegationTokenManager.scala:146) ~[spark-core_2.12-3.3.1.27.jar:3.3.1.27]
  at org.apache.spark.deploy.yarn.Client.setupSecurityToken(Client.scala:352) ~[spark-yarn_2.12-3.3.1.27.jar:3.3.1.27]
  at org.apache.spark.deploy.yarn.Client.createContainerLaunchContext(Client.scala:1140) ~[spark-yarn_2.12-3.3.1.27.jar:3.3.1.27]
  ...
  at org.apache.spark.deploy.SparkSubmit.main(SparkSubmit.scala) ~[spark-core_2.12-3.3.1.27.jar:3.3.1.27]
```
when the Spark app access `nn-2` and `nn-3`, it will fail with `o.a.h.security.AccessControlException: Client cannot authenticate via:[TOKEN, KERBEROS]`

Things become worse if the FS order is [`nn-3`, `nn-2`, `nn-1`], the Spark app will be submitted to YARN with only `nn-3` token, it even has no chance to allow NodeManager to upload aggregated logs after the application exit because it requires the app to provide a token to access `nn-1`.

the log from NodeManager
```
2024-01-03 08:08:14,028 [3173570620] - WARN [NM ContainerManager dispatcher:Client$Connection1$772] - Exception encountered while connecting to the server
Caused by: org.apache.hadoop.security.AccessControlException: Client cannot authenticate via:[TOKEN, KERBEROS]
    at org.apache.hadoop.security.SaslRpcClient.selectSaslClient(SaslRpcClient.java:179)
    at org.apache.hadoop.security.SaslRpcClient.saslConnect(SaslRpcClient.java:392)
    ...
    at org.apache.hadoop.hdfs.DistributedFileSystem.getFileStatus(DistributedFileSystem.java:1768)
    ...
    at org.apache.hadoop.yarn.server.nodemanager.containermanager.logaggregation.LogAggregationService.createAppDir(LogAggregationService.java:404)
    at org.apache.hadoop.yarn.server.nodemanager.containermanager.logaggregation.LogAggregationService.initAppAggregator(LogAggregationService.java:273)
    ...
```

Without the logs, we even don't know what happened.

Eventually, due to the **indeterminate** order of NameNodes to request tokens, such a Job sometimes submitted successfully and sometimes failed without logs.

<img width="1903" alt="image" src="https://github.com/apache/spark/assets/26535726/7ca5c871-6399-4eae-b689-d6d741c1c373">

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, when the user configures `spark.kerberos.access.hadoopFileSystems` to access multiple Kerberized HDFS, and one or more NameNodes have issues, tokens are always fetched from the rest health NameNodes after this patch.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Tested in internal Kerberized cluster.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.