### PR TITLE
[SPARK-46934][SQL] Read/write roundtrip for struct type with special characters with HMS

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -1062,7 +1062,11 @@ private[hive] object HiveClientImpl extends Logging {
     // in `FieldSchema`, while the original form of the 2nd one, which from user API, is
     // struct<x:int,`y.z`:int>. Because  we use `CatalystSqlParser.parseDataType` to verify the
     // type, we need to covert the unquoted element names to quoted ones.
-    val typeStr = hc.getType.replaceAll("(?<=[<,])([^,:]+)(?=:)", "`$1`")
+    // Examples:
+    //   struct<x:int,y.z:int> -> struct<`x`:int,`y.z`:int>
+    //   array<struct<x:int,y.z:int>> -> array<struct<`x`:int,`y.z`:int>>
+    //   map<string,struct<x:int,y.z:int>> -> map<string,struct<`x`:int,`y.z`:int>>
+    val typeStr = hc.getType.replaceAll("(?<=struct<|,)([^,<:]+)(?=:)", "`$1`")
     try {
       CatalystSqlParser.parseDataType(typeStr)
     } catch {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -1056,11 +1056,18 @@ private[hive] object HiveClientImpl extends Logging {
 
   /** Get the Spark SQL native DataType from Hive's FieldSchema. */
   private def getSparkSQLDataType(hc: FieldSchema): DataType = {
+    // For struct types, Hive metastore API uses unquoted element names, so does the spark catalyst
+    // generates catalog string to conform with.
+    // For example, both struct<x:int,y.z:int> and struct<x:int,y.z:int> are valid cases
+    // in `FieldSchema`, while the original form of the 2nd one, which from user API, is
+    // struct<x:int,`y.z`:int>. Because  we use `CatalystSqlParser.parseDataType` to verify the
+    // type, we need to covert the unquoted element names to quoted ones.
+    val typeStr = hc.getType.replaceAll("(?<=[<,])([^,:]+)(?=:)", "`$1`")
     try {
-      CatalystSqlParser.parseDataType(hc.getType)
+      CatalystSqlParser.parseDataType(typeStr)
     } catch {
       case e: ParseException =>
-        throw QueryExecutionErrors.cannotRecognizeHiveTypeError(e, hc.getType, hc.getName)
+        throw QueryExecutionErrors.cannotRecognizeHiveTypeError(e, typeStr, hc.getName)
     }
   }
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveMetastoreCatalogSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveMetastoreCatalogSuite.scala
@@ -415,4 +415,43 @@ class DataSourceWithHiveMetastoreCatalogSuite
       })
     }
   }
+
+  test("SPARK-46934: Handle special characters in struct types") {
+    withTable("t") {
+      val schema =
+        "a struct<" +
+          "`a.a`:int," +
+          "`a.b`:struct<" +
+          "  `a^b.b`:array<string>," +
+          "  `a b c`:map<int, string>" +
+          "  >" +
+          ">"
+      sql("CREATE TABLE t(" + schema + ")")
+      assert(spark.table("t").schema === CatalystSqlParser.parseTableSchema(schema))
+    }
+  }
+
+  test("SPARK-46934: Handle special characters in struct types with CTAS") {
+    withTable("t") {
+      val schema = "`a.b` struct<`a.b.b`:array<string>, `a b c`:map<int, string>>"
+      sql("CREATE TABLE t AS " +
+        "SELECT named_struct('a.b.b', array('a'), 'a b c', map(1, 'a')) AS `a.b`")
+      assert(spark.table("t").schema === CatalystSqlParser.parseTableSchema(schema))
+    }
+  }
+
+  test("SPARK-46934: runhive") {
+    withTable("t") {
+      val schema =
+        "a struct<" +
+          "`a.a`:int," +
+          "`a.b`:struct<" +
+          "  `a.b.b`:array<string>," +
+          "  `a b c`:map<int, string>" +
+          "  >" +
+          ">"
+      sparkSession.metadataHive.runSqlHive(s"CREATE TABLE t($schema)")
+      assert(spark.table("t").schema === CatalystSqlParser.parseTableSchema(schema))
+    }
+  }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveMetastoreCatalogSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveMetastoreCatalogSuite.scala
@@ -422,7 +422,7 @@ class DataSourceWithHiveMetastoreCatalogSuite
         "a struct<" +
           "`a.a`:int," +
           "`a.b`:struct<" +
-          "  `a^b.b`:array<string>," +
+          "  `a b b`:array<string>," +
           "  `a b c`:map<int, string>" +
           "  >" +
           ">"

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveMetastoreCatalogSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveMetastoreCatalogSuite.scala
@@ -440,7 +440,7 @@ class DataSourceWithHiveMetastoreCatalogSuite
     }
   }
 
-  test("SPARK-46934: runhive") {
+  test("SPARK-46934: Handle special characters in struct types with hive DDL") {
     withTable("t") {
       val schema =
         "a struct<" +

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -174,7 +174,7 @@ class HiveDDLSuite
     testAddColumnPartitioned("orc")
   }
 
-  test("SPARK-46934: quote element name before parse struct") { //
+  test("SPARK-46934: quote element name before parsing struct") {
     withTable("t") {
       sql("CREATE TABLE t USING hive AS SELECT STRUCT('a' AS `$a`, 1 AS b) q")
       assert(spark.table("t").schema === CatalystSqlParser.parseTableSchema(
@@ -241,7 +241,7 @@ class HiveDDLSuite
     }
   }
 
-  test("SPARK-22431: negative alter table tests with nested types") {
+  test("SPARK-46934: alter table tests with nested types") {
     withTable("t1") {
       sql("CREATE TABLE t1 (q STRUCT<col1:INT, col2:STRING>, i1 INT) USING hive")
       sql("ALTER TABLE t1 ADD COLUMNS (newcol1 STRUCT<`$col1`:STRING, col2:Int>)")

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -174,21 +174,6 @@ class HiveDDLSuite
     testAddColumnPartitioned("orc")
   }
 
-  test("SPARK-22431: illegal hive type") {
-    try {
-      hiveClient.runSqlHive("CREATE TABLE t(foo UNIONTYPE<int, double>)")
-      val exception = intercept[SparkException](sql("SELECT * FROM t"))
-      checkError(
-        exception = exception.getCause.asInstanceOf[SparkException],
-        errorClass = "CANNOT_RECOGNIZE_HIVE_TYPE",
-        parameters = Map("fieldType" -> "\"UNIONTYPE<INT,DOUBLE>\"", "fieldName" -> "`foo`"))
-    } finally {
-      // USING hive to cleanup the table because Spark `DROP TABLE` will fail as it load the
-      // unrecognized schema too. bug?
-      hiveClient.runSqlHive("DROP TABLE IF EXIST t")
-    }
-  }
-
   test("SPARK-46934: quote element name before parse struct") { //
     withTable("t") {
       sql("CREATE TABLE t USING hive AS SELECT STRUCT('a' AS `$a`, 1 AS b) q")

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -184,7 +184,7 @@ class HiveDDLSuite
     withTable("t") {
       sql("CREATE TABLE t(q STRUCT<`$a`:INT, col2:STRING>, i1 INT) USING hive")
       assert(spark.table("t").schema === CatalystSqlParser.parseTableSchema(
-        "q STRUCT<`$A`:INT, COL2:STRING>"))
+        "q STRUCT<`$a`:INT, col2:STRING>, i1 INT"))
     }
 
     withView("v") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Hive metastore API uses unquoted element names for struct types, so the spark catalyst generates a catalog string to conform with.

For example, both `struct<x:int,y.z:int>` and `struct<x:int,y.z:int>` are valid cases in `FieldSchema`.
while the original form of the 2nd one, which is from user API, is ```struct<x:int,`y.z`:int>```. Because we use `CatalystSqlParser.parseDataType` to verify the type, we need to convert the unquoted element names to quoted ones.

- For verification
  - For the read path, a.k.a, getting an existing table from HMS. We need to convert `struct<x:int,y.z:int>` returned by HMS to ```struct<x:int,`y.z`:int>```.
  - For the write path, a.k.a, creating/altering a table to HMS. We need to convert `struct<x:int,y.z:int>` generated by Spark catalogString to ```struct<x:int,`y.z`:int>```.
- For HMS API calls
   - keep the `struct<x:int,y.z:int>` AS-IS to conform with HMS, as ```'`'``` can not be recognized by hive.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

bugfix
### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
yes, users can now read/write/define/delete tables with struct columns with pecial characters in their elements

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
new tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->no
