### PR TITLE
[SPARK-46984][PYTHON] Remove pyspark.copy_func

### DIFF
--- a/python/pyspark/__init__.py
+++ b/python/pyspark/__init__.py
@@ -47,8 +47,7 @@ Public classes:
 """
 
 from functools import wraps
-import types
-from typing import cast, Any, Callable, Optional, TypeVar, Union
+from typing import cast, Any, Callable, TypeVar, Union
 
 from pyspark.conf import SparkConf
 from pyspark.rdd import RDD, RDDBarrier
@@ -84,36 +83,6 @@ def since(version: Union[str, float]) -> Callable[[_F], _F]:
         return f
 
     return deco
-
-
-def copy_func(
-    f: _F,
-    name: Optional[str] = None,
-    sinceversion: Optional[Union[str, float]] = None,
-    doc: Optional[str] = None,
-) -> _F:
-    """
-    Returns a function with same code, globals, defaults, closure, and
-    name (or provide a new name).
-    """
-    # See
-    # http://stackoverflow.com/questions/6527633/how-can-i-make-a-deepcopy-of-a-function-in-python
-    assert isinstance(f, types.FunctionType)
-
-    fn = types.FunctionType(
-        f.__code__,
-        f.__globals__,
-        name or f.__name__,
-        f.__defaults__,
-        f.__closure__,
-    )
-    # in case f was given attrs (note this dict is a shallow copy):
-    fn.__dict__.update(f.__dict__)
-    if doc is not None:
-        fn.__doc__ = doc
-    if sinceversion is not None:
-        fn = since(sinceversion)(fn)
-    return cast(_F, fn)
 
 
 def keyword_only(func: _F) -> _F:

--- a/python/pyspark/pandas/correlation.py
+++ b/python/pyspark/pandas/correlation.py
@@ -125,7 +125,7 @@ def compute(sdf: SparkDataFrame, groupKeys: List[str], method: str) -> SparkData
                 )
             )
 
-        sdf = sdf.groupby(*groupKeys).agg(
+        sdf = sdf.groupby(groupKeys).agg(
             F.corr(CORRELATION_VALUE_1_COLUMN, CORRELATION_VALUE_2_COLUMN).alias(
                 CORRELATION_CORR_OUTPUT_COLUMN
             ),
@@ -220,7 +220,7 @@ def compute(sdf: SparkDataFrame, groupKeys: List[str], method: str) -> SparkData
         )
 
         sdf = (
-            sdf.groupby(*groupKeys)
+            sdf.groupby(groupKeys)
             .agg(
                 F.count(F.when(pair_cond & p_cond, 1)).alias(CORRELATION_KENDALL_P_COLUMN),
                 F.count(F.when(pair_cond & q_cond, 1)).alias(CORRELATION_KENDALL_Q_COLUMN),

--- a/python/pyspark/pandas/correlation.py
+++ b/python/pyspark/pandas/correlation.py
@@ -125,7 +125,7 @@ def compute(sdf: SparkDataFrame, groupKeys: List[str], method: str) -> SparkData
                 )
             )
 
-        sdf = sdf.groupby(groupKeys).agg(
+        sdf = sdf.groupby(*groupKeys).agg(
             F.corr(CORRELATION_VALUE_1_COLUMN, CORRELATION_VALUE_2_COLUMN).alias(
                 CORRELATION_CORR_OUTPUT_COLUMN
             ),
@@ -220,7 +220,7 @@ def compute(sdf: SparkDataFrame, groupKeys: List[str], method: str) -> SparkData
         )
 
         sdf = (
-            sdf.groupby(groupKeys)
+            sdf.groupby(*groupKeys)
             .agg(
                 F.count(F.when(pair_cond & p_cond, 1)).alias(CORRELATION_KENDALL_P_COLUMN),
                 F.count(F.when(pair_cond & q_cond, 1)).alias(CORRELATION_KENDALL_Q_COLUMN),

--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -33,7 +33,6 @@ from typing import (
 
 from py4j.java_gateway import JavaObject, JVMView
 
-from pyspark import copy_func
 from pyspark.context import SparkContext
 from pyspark.errors import PySparkAttributeError, PySparkTypeError, PySparkValueError
 from pyspark.sql.types import DataType
@@ -1230,7 +1229,13 @@ class Column:
                 )
             return Column(getattr(self._jc, "as")(_to_seq(sc, list(alias))))
 
-    name = copy_func(alias, sinceversion=2.0, doc=":func:`name` is an alias for :func:`alias`.")
+    def name(self, *alias: str, **kwargs: Any) -> "Column":
+        """
+        :func:`name` is an alias for :func:`alias`.
+
+        .. versionadded:: 2.0.0
+        """
+        return self.alias(self, *alias, **kwargs)
 
     def cast(self, dataType: Union[DataType, str]) -> "Column":
         """
@@ -1277,7 +1282,13 @@ class Column:
             )
         return Column(jc)
 
-    astype = copy_func(cast, sinceversion=1.4, doc=":func:`astype` is an alias for :func:`cast`.")
+    def astype(self, dataType: Union[DataType, str]) -> "Column":
+        """
+        :func:`astype` is an alias for :func:`cast`.
+
+        .. versionadded:: 1.4.0
+        """
+        return self.cast(self, dataType)
 
     def between(
         self,

--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -1235,7 +1235,7 @@ class Column:
 
         .. versionadded:: 2.0.0
         """
-        return self.alias(self, *alias, **kwargs)
+        return self.alias(*alias, **kwargs)
 
     def cast(self, dataType: Union[DataType, str]) -> "Column":
         """
@@ -1288,7 +1288,7 @@ class Column:
 
         .. versionadded:: 1.4.0
         """
-        return self.cast(self, dataType)
+        return self.cast(dataType)
 
     def between(
         self,

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -4005,6 +4005,10 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         return DataFrame(jdf, self.sparkSession)
 
     @overload
+    def groupBy(self, *cols: "ColumnOrNameOrOrdinal") -> "GroupedData":
+        ...
+
+    @overload
     def groupBy(self, __cols: Union[List[Column], List[str], List[int]]) -> "GroupedData":
         ...
 
@@ -6797,7 +6801,7 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
     def groupby(self, __cols: Union[List[Column], List[str], List[int]]) -> "GroupedData":
         ...
 
-    def groupby(self, *cols: "ColumnOrNameOrOrdinal") -> "GroupedData":
+    def groupby(self, *cols: "ColumnOrNameOrOrdinal") -> "GroupedData":  # type: ignore[misc]
         """
         :func:`groupby` is an alias for :func:`groupBy`.
 

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -4005,10 +4005,6 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         return DataFrame(jdf, self.sparkSession)
 
     @overload
-    def groupBy(self, *cols: "ColumnOrNameOrOrdinal") -> "GroupedData":
-        ...
-
-    @overload
     def groupBy(self, __cols: Union[List[Column], List[str], List[int]]) -> "GroupedData":
         ...
 
@@ -6793,6 +6789,14 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
     # make it "compatible" by adding aliases. Therefore, we stop adding such
     # aliases as of Spark 3.0. Two methods below remain just
     # for legacy users currently.
+    @overload
+    def groupby(self, *cols: "ColumnOrNameOrOrdinal") -> "GroupedData":
+        ...
+
+    @overload
+    def groupby(self, __cols: Union[List[Column], List[str], List[int]]) -> "GroupedData":
+        ...
+
     def groupby(self, *cols: "ColumnOrNameOrOrdinal") -> "GroupedData":
         """
         :func:`groupby` is an alias for :func:`groupBy`.

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -6793,7 +6793,7 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
     # make it "compatible" by adding aliases. Therefore, we stop adding such
     # aliases as of Spark 3.0. Two methods below remain just
     # for legacy users currently.
-    def groupby(self, *cols: "ColumnOrNameOrOrdinal") -> "GroupedData":  # type: ignore[misc]
+    def groupby(self, *cols: "ColumnOrNameOrOrdinal") -> "GroupedData":
         """
         :func:`groupby` is an alias for :func:`groupBy`.
 

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -40,7 +40,7 @@ from typing import (
 
 from py4j.java_gateway import JavaObject, JVMView
 
-from pyspark import copy_func, _NoValue
+from pyspark import _NoValue
 from pyspark._globals import _NoValueType
 from pyspark.context import SparkContext
 from pyspark.errors import (
@@ -6780,22 +6780,34 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         """
         return list(self._jdf.inputFiles())
 
-    where = copy_func(filter, sinceversion=1.3, doc=":func:`where` is an alias for :func:`filter`.")
+    def where(self, condition: "ColumnOrName") -> "DataFrame":
+        """
+        :func:`where` is an alias for :func:`filter`.
+
+        .. versionadded:: 1.3.0
+        """
+        return self.filter(condition)
 
     # Two aliases below were added for pandas compatibility many years ago.
     # There are too many differences compared to pandas and we cannot just
     # make it "compatible" by adding aliases. Therefore, we stop adding such
     # aliases as of Spark 3.0. Two methods below remain just
     # for legacy users currently.
-    groupby = copy_func(
-        groupBy, sinceversion=1.4, doc=":func:`groupby` is an alias for :func:`groupBy`."
-    )
+    def groupby(self, *cols: "ColumnOrNameOrOrdinal") -> "GroupedData":  # type: ignore[misc]
+        """
+        :func:`groupby` is an alias for :func:`groupBy`.
 
-    drop_duplicates = copy_func(
-        dropDuplicates,
-        sinceversion=1.4,
-        doc=":func:`drop_duplicates` is an alias for :func:`dropDuplicates`.",
-    )
+        .. versionadded:: 1.4.0
+        """
+        return self.groupBy(*cols)
+
+    def drop_duplicates(self, subset: Optional[List[str]] = None) -> "DataFrame":
+        """
+        :func:`drop_duplicates` is an alias for :func:`dropDuplicates`.
+
+        .. versionadded:: 1.4.0
+        """
+        return self.dropDuplicates(subset)
 
     def writeTo(self, table: str) -> DataFrameWriterV2:
         """


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR removes `pyspark.copy_func` but just explicitly define the aliases.

### Why are the changes needed?

- It needs more code than what it actually deduplicates.
- For consistency with other cases.
- Type hints can't be leveraged without this.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing unittests should cover.

### Was this patch authored or co-authored using generative AI tooling?

No.
