### PR TITLE
[SPARK-46985][PYTHON] Move pyspark._NoValue to pyspark.sql._NoValue

### DIFF
--- a/python/mypy.ini
+++ b/python/mypy.ini
@@ -35,7 +35,7 @@ disallow_untyped_defs = False
 [mypy-pyspark.find_spark_home]
 disallow_untyped_defs = False
 
-[mypy-pyspark._globals]
+[mypy-pyspark.sql._globals]
 disallow_untyped_defs = False
 
 [mypy-pyspark.install]

--- a/python/pyspark/__init__.py
+++ b/python/pyspark/__init__.py
@@ -62,7 +62,6 @@ from pyspark.serializers import MarshalSerializer, CPickleSerializer
 from pyspark.taskcontext import TaskContext, BarrierTaskContext, BarrierTaskInfo
 from pyspark.profiler import Profiler, BasicProfiler
 from pyspark.version import __version__
-from pyspark._globals import _NoValue  # noqa: F401
 
 _F = TypeVar("_F", bound=Callable)
 

--- a/python/pyspark/pandas/config.py
+++ b/python/pyspark/pandas/config.py
@@ -22,7 +22,7 @@ from contextlib import contextmanager
 import json
 from typing import Any, Callable, Dict, Iterator, List, Tuple, Union
 
-from pyspark._globals import _NoValue, _NoValueType
+from pyspark.sql._globals import _NoValue, _NoValueType
 from pyspark.pandas.utils import default_session
 
 

--- a/python/pyspark/pandas/indexes/datetimes.py
+++ b/python/pyspark/pandas/indexes/datetimes.py
@@ -22,7 +22,7 @@ from typing import Any, Optional, Union, cast, no_type_check
 import pandas as pd
 from pandas.api.types import is_hashable  # type: ignore[attr-defined]
 from pandas.tseries.offsets import DateOffset
-from pyspark._globals import _NoValue
+from pyspark.sql._globals import _NoValue
 
 from pyspark import pandas as ps
 from pyspark.pandas import DataFrame

--- a/python/pyspark/pandas/indexes/timedelta.py
+++ b/python/pyspark/pandas/indexes/timedelta.py
@@ -23,7 +23,7 @@ from pandas.api.types import is_hashable  # type: ignore[attr-defined]
 import numpy as np
 
 from pyspark import pandas as ps
-from pyspark._globals import _NoValue
+from pyspark.sql._globals import _NoValue
 from pyspark.pandas.indexes.base import Index
 from pyspark.pandas.missing.indexes import MissingPandasLikeTimedeltaIndex
 from pyspark.pandas.series import Series

--- a/python/pyspark/pandas/internal.py
+++ b/python/pyspark/pandas/internal.py
@@ -25,7 +25,7 @@ import numpy as np
 import pandas as pd
 from pandas.api.types import CategoricalDtype  # noqa: F401
 
-from pyspark._globals import _NoValue, _NoValueType
+from pyspark.sql._globals import _NoValue, _NoValueType
 from pyspark.sql import (
     functions as F,
     Column as PySparkColumn,

--- a/python/pyspark/sql/_globals.py
+++ b/python/pyspark/sql/_globals.py
@@ -23,8 +23,8 @@ way the identities of the classes defined here are fixed and will remain so
 even if pyspark itself is reloaded. In particular, a function like the following
 will still work correctly after pyspark is reloaded:
 
-    def foo(arg=pyspark._NoValue):
-        if arg is pyspark._NoValue:
+    def foo(arg=pyspark.sql._globals._NoValue):
+        if arg is pyspark._globals._NoValue:
             ...
 
 See gh-7844 for a discussion of the reload problem that motivated this module.
@@ -37,8 +37,7 @@ __ALL__ = ["_NoValue"]
 
 # Disallow reloading this module so as to preserve the identities of the
 # classes defined here.
-if "_is_loaded" in globals():
-    raise RuntimeError("Reloading pyspark._globals is not allowed")
+assert "_is_loaded" not in globals(), "Reloading pyspark.sql._globals is not allowed"
 _is_loaded = True
 
 

--- a/python/pyspark/sql/conf.py
+++ b/python/pyspark/sql/conf.py
@@ -20,8 +20,7 @@ from typing import Any, Optional, Union
 
 from py4j.java_gateway import JavaObject
 
-from pyspark import _NoValue
-from pyspark._globals import _NoValueType
+from pyspark.sql._globals import _NoValue, _NoValueType
 from pyspark.errors import PySparkTypeError
 
 

--- a/python/pyspark/sql/connect/conf.py
+++ b/python/pyspark/sql/connect/conf.py
@@ -22,8 +22,7 @@ check_dependencies(__name__)
 from typing import Any, Optional, Union, cast
 import warnings
 
-from pyspark import _NoValue
-from pyspark._globals import _NoValueType
+from pyspark.sql._globals import _NoValue, _NoValueType
 from pyspark.sql.conf import RuntimeConfig as PySparkRuntimeConfig
 from pyspark.sql.connect import proto
 from pyspark.sql.connect.client import SparkConnectClient

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -47,8 +47,7 @@ import json
 import warnings
 from collections.abc import Iterable
 
-from pyspark import _NoValue
-from pyspark._globals import _NoValueType
+from pyspark.sql._globals import _NoValue, _NoValueType
 from pyspark.sql.types import Row, StructType, _create_row
 from pyspark.sql.dataframe import (
     DataFrame as PySparkDataFrame,

--- a/python/pyspark/sql/context.py
+++ b/python/pyspark/sql/context.py
@@ -34,8 +34,7 @@ from typing import (
 
 from py4j.java_gateway import JavaObject
 
-from pyspark import _NoValue
-from pyspark._globals import _NoValueType
+from pyspark.sql._globals import _NoValue, _NoValueType
 from pyspark.sql.session import _monkey_patch_RDD, SparkSession
 from pyspark.sql.dataframe import DataFrame
 from pyspark.sql.readwriter import DataFrameReader

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -40,8 +40,8 @@ from typing import (
 
 from py4j.java_gateway import JavaObject, JVMView
 
-from pyspark import copy_func, _NoValue
-from pyspark._globals import _NoValueType
+from pyspark import copy_func
+from pyspark.sql._globals import _NoValue, _NoValueType
 from pyspark.context import SparkContext
 from pyspark.errors import (
     PySparkTypeError,


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to move `pyspark._NoValue` to `pyspark.sql._NoValue`.

### Why are the changes needed?

To decouple core from SQL. `_NoValue` is only used in SQL and pandas API on Spark (that is dependent on SQL).

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing unittests.

### Was this patch authored or co-authored using generative AI tooling?

No.
