### PR TITLE
[SPARK-46989][SQL][CONNECT] Improve concurrency performance for SparkSession

### DIFF
--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -930,11 +930,10 @@ object SparkSession extends Logging {
      * @since 3.5.0
      */
     def config(map: Map[String, Any]): Builder = {
-      map.foreach { kv: (String, Any) =>
-        {
-          options.put(kv._1, kv._2.toString)
-        }
-      }
+      val kvs = map.map { kv: (String, Any) =>
+        (kv._1, kv._2.toString)
+      }.asJava
+      options.putAll(kvs)
       this
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -1006,11 +1006,10 @@ object SparkSession extends Logging {
      * @since 3.4.0
      */
     def config(map: Map[String, Any]): Builder = {
-      map.foreach {
-        kv: (String, Any) => {
-          options.put(kv._1, kv._2.toString)
-        }
-      }
+      val kvs = map.map { kv: (String, Any) =>
+        (kv._1, kv._2.toString)
+      }.asJava
+      options.putAll(kvs)
       this
     }
 
@@ -1020,7 +1019,7 @@ object SparkSession extends Logging {
      *
      * @since 3.4.0
      */
-    def config(map: java.util.Map[String, Any]): Builder = synchronized {
+    def config(map: java.util.Map[String, Any]): Builder = {
       config(map.asScala.toMap)
     }
 
@@ -1030,7 +1029,8 @@ object SparkSession extends Logging {
      * @since 2.0.0
      */
     def config(conf: SparkConf): Builder = {
-      conf.getAll.foreach { case (k, v) => options.put(k, v) }
+      val map = conf.getAll.toMap
+      options.putAll(map.asJava)
       this
     }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR propose to improve concurrency performance for `SparkSession`.


### Why are the changes needed?
Currently, `SparkSession` adopted the mutable.Map caching the config infos. The `SparkSession` guarded by this so as ensure security under multithreading.
Because all the operation about config are not related to other operation, we can delegate security to `ConcurrentHashMap`.
`ConcurrentHashMap`  has higher concurrency activity and responsiveness.
After this change, `SparkSession` have better perf than before.


### Does this PR introduce _any_ user-facing change?
'No'.


### How was this patch tested?
GA.


### Was this patch authored or co-authored using generative AI tooling?
'No'.
