### PR TITLE
[MINOR][DOCS] Show sort order of NaN relative to infinity

### DIFF
--- a/docs/sql-ref-datatypes.md
+++ b/docs/sql-ref-datatypes.md
@@ -353,19 +353,24 @@ SELECT double('inf') = double('infinity') AS col;
 +----+
 
 CREATE TABLE test (c1 int, c2 double);
-INSERT INTO test VALUES (1, double('infinity'));
-INSERT INTO test VALUES (2, double('infinity'));
-INSERT INTO test VALUES (3, double('inf'));
-INSERT INTO test VALUES (4, double('-inf'));
-INSERT INTO test VALUES (5, double('NaN'));
-INSERT INTO test VALUES (6, double('NaN'));
-INSERT INTO test VALUES (7, double('-infinity'));
-SELECT COUNT(*), c2 FROM test GROUP BY c2;
+INSERT INTO test VALUES
+  (1, double('infinity')),
+  (2, double('infinity')),
+  (3, double('inf')),
+  (4, double('-inf')),
+  (5, double('NaN')),
+  (6, double('NaN')),
+  (7, double('-infinity'))
+;
+SELECT COUNT(*), c2
+FROM test
+GROUP BY c2
+ORDER BY c2;
 +---------+---------+
 | count(1)|       c2|
 +---------+---------+
-|        2|      NaN|
 |        2|-Infinity|
 |        3| Infinity|
+|        2|      NaN|
 +---------+---------+
 ```


### PR DESCRIPTION
### What changes were proposed in this pull request?

Tweak the examples in our documentation on NaN semantics to demonstrate how NaN sorts relative to infinity.

### Why are the changes needed?

The docs make an interesting point about how NaNs are sorted, but none of the examples that follow demonstrate this point.

https://github.com/apache/spark/blob/a6d5b6a2f89fb8aa8de835e7bf5c72b1bed32bf7/docs/sql-ref-datatypes.md#L294

### Does this PR introduce _any_ user-facing change?

Yes, it tweaks some documentation.

### How was this patch tested?

I ran the SQL I tweaked to confirm the output.

### Was this patch authored or co-authored using generative AI tooling?

No.