### PR TITLE
[SPARK-46689][SPARK-46690][PYTHON][CONNECT] Support v2 profiling in group/cogroup applyInPandas/applyInArrow

### DIFF
--- a/python/pyspark/sql/tests/test_udf_profiler.py
+++ b/python/pyspark/sql/tests/test_udf_profiler.py
@@ -393,10 +393,11 @@ class UDFProfiler2TestsMixin:
             self.assertRegex(
                 io.getvalue(), f"2.*{os.path.basename(inspect.getfile(_do_computation))}"
             )
+
     @unittest.skipIf(
         not have_pandas or not have_pyarrow,
         cast(str, pandas_requirement_message or pyarrow_requirement_message),
-        )
+    )
     def test_perf_profiler_group_apply_in_pandas(self):
         # FlatMapGroupsInBatchExec
         df = self.spark.createDataFrame(
@@ -437,7 +438,7 @@ class UDFProfiler2TestsMixin:
     @unittest.skipIf(
         not have_pandas or not have_pyarrow,
         cast(str, pandas_requirement_message or pyarrow_requirement_message),
-        )
+    )
     def test_perf_profiler_cogroup_apply_in_pandas(self):
         # FlatMapCoGroupsInBatchExec
         import pandas as pd

--- a/python/pyspark/sql/tests/test_udf_profiler.py
+++ b/python/pyspark/sql/tests/test_udf_profiler.py
@@ -498,8 +498,8 @@ class UDFProfiler2TestsMixin:
         df1 = self.spark.createDataFrame([(1, 1.0), (2, 2.0), (1, 3.0), (2, 4.0)], ("id", "v1"))
         df2 = self.spark.createDataFrame([(1, "x"), (2, "y")], ("id", "v2"))
 
-        def summarize(l, r):
-            return pa.Table.from_pydict({"left": [l.num_rows], "right": [r.num_rows]})
+        def summarize(left, right):
+            return pa.Table.from_pydict({"left": [left.num_rows], "right": [right.num_rows]})
 
         with self.sql_conf({"spark.sql.pyspark.udf.profiler": "perf"}):
             df1.groupby("id").cogroup(df2.groupby("id")).applyInArrow(

--- a/python/pyspark/sql/tests/test_udf_profiler.py
+++ b/python/pyspark/sql/tests/test_udf_profiler.py
@@ -393,6 +393,68 @@ class UDFProfiler2TestsMixin:
             self.assertRegex(
                 io.getvalue(), f"2.*{os.path.basename(inspect.getfile(_do_computation))}"
             )
+    @unittest.skipIf(
+        not have_pandas or not have_pyarrow,
+        cast(str, pandas_requirement_message or pyarrow_requirement_message),
+        )
+    def test_perf_profiler_group_apply_in_pandas(self):
+        # FlatMapGroupsInBatchExec
+        df = self.spark.createDataFrame(
+            [(1, 1.0), (1, 2.0), (2, 3.0), (2, 5.0), (2, 10.0)], ("id", "v")
+        )
+
+        def normalize(pdf):
+            v = pdf.v
+            return pdf.assign(v=(v - v.mean()) / v.std())
+
+        with self.sql_conf({"spark.sql.pyspark.udf.profiler": "perf"}):
+            df.groupby("id").applyInPandas(normalize, schema="id long, v double").show()
+
+        self.assertEqual(1, len(self.profile_results), str(self.profile_results.keys()))
+
+        for id in self.profile_results:
+            with self.trap_stdout() as io:
+                self.spark.showPerfProfiles(id)
+
+            self.assertIn(f"Profile of UDF<id={id}>", io.getvalue())
+            self.assertRegex(
+                io.getvalue(), f"2.*{os.path.basename(inspect.getfile(_do_computation))}"
+            )
+
+    @unittest.skipIf(
+        not have_pandas or not have_pyarrow,
+        cast(str, pandas_requirement_message or pyarrow_requirement_message),
+        )
+    def test_perf_profiler_cogroup_apply_in_pandas(self):
+        # FlatMapCoGroupsInBatchExec
+        import pandas as pd
+
+        df1 = self.spark.createDataFrame(
+            [(20000101, 1, 1.0), (20000101, 2, 2.0), (20000102, 1, 3.0), (20000102, 2, 4.0)],
+            ("time", "id", "v1"),
+        )
+        df2 = self.spark.createDataFrame(
+            [(20000101, 1, "x"), (20000101, 2, "y")], ("time", "id", "v2")
+        )
+
+        def asof_join(left, right):
+            return pd.merge_asof(left, right, on="time", by="id")
+
+        with self.sql_conf({"spark.sql.pyspark.udf.profiler": "perf"}):
+            df1.groupby("id").cogroup(df2.groupby("id")).applyInPandas(
+                asof_join, schema="time int, id int, v1 double, v2 string"
+            ).show()
+
+        self.assertEqual(1, len(self.profile_results), str(self.profile_results.keys()))
+
+        for id in self.profile_results:
+            with self.trap_stdout() as io:
+                self.spark.showPerfProfiles(id)
+
+            self.assertIn(f"Profile of UDF<id={id}>", io.getvalue())
+            self.assertRegex(
+                io.getvalue(), f"2.*{os.path.basename(inspect.getfile(_do_computation))}"
+            )
 
 
 class UDFProfiler2Tests(UDFProfiler2TestsMixin, ReusedSQLTestCase):

--- a/python/pyspark/sql/tests/test_udf_profiler.py
+++ b/python/pyspark/sql/tests/test_udf_profiler.py
@@ -422,19 +422,6 @@ class UDFProfiler2TestsMixin:
                 io.getvalue(), f"2.*{os.path.basename(inspect.getfile(_do_computation))}"
             )
 
-    @staticmethod
-    def apply_in_arrow_func(left, right):
-        import pyarrow as pa
-
-        left_ids = left.to_pydict()["id"]
-        right_ids = right.to_pydict()["id"]
-        result = {
-            "metric": ["min", "max", "len", "sum"],
-            "left": [min(left_ids), max(left_ids), len(left_ids), sum(left_ids)],
-            "right": [min(right_ids), max(right_ids), len(right_ids), sum(right_ids)],
-        }
-        return pa.Table.from_pydict(result)
-
     @unittest.skipIf(
         not have_pandas or not have_pyarrow,
         cast(str, pandas_requirement_message or pyarrow_requirement_message),

--- a/python/pyspark/tests/test_memory_profiler.py
+++ b/python/pyspark/tests/test_memory_profiler.py
@@ -508,41 +508,6 @@ class MemoryProfiler2TestsMixin:
         not have_pandas or not have_pyarrow,
         cast(str, pandas_requirement_message or pyarrow_requirement_message),
     )
-    def test_perf_profiler_cogroup_apply_in_pandas(self):
-        # FlatMapCoGroupsInBatchExec
-        import pandas as pd
-
-        df1 = self.spark.createDataFrame(
-            [(20000101, 1, 1.0), (20000101, 2, 2.0), (20000102, 1, 3.0), (20000102, 2, 4.0)],
-            ("time", "id", "v1"),
-        )
-        df2 = self.spark.createDataFrame(
-            [(20000101, 1, "x"), (20000101, 2, "y")], ("time", "id", "v2")
-        )
-
-        def asof_join(left, right):
-            return pd.merge_asof(left, right, on="time", by="id")
-
-        with self.sql_conf({"spark.sql.pyspark.udf.profiler": "memory"}):
-            df1.groupby("id").cogroup(df2.groupby("id")).applyInPandas(
-                asof_join, schema="time int, id int, v1 double, v2 string"
-            ).show()
-
-        self.assertEqual(1, len(self.profile_results), str(self.profile_results.keys()))
-
-        for id in self.profile_results:
-            with self.trap_stdout() as io:
-                self.spark.showPerfProfiles(id)
-
-            self.assertIn(f"Profile of UDF<id={id}>", io.getvalue())
-            self.assertRegex(
-                io.getvalue(), f"2.*{os.path.basename(inspect.getfile(_do_computation))}"
-            )
-
-    @unittest.skipIf(
-        not have_pandas or not have_pyarrow,
-        cast(str, pandas_requirement_message or pyarrow_requirement_message),
-    )
     def test_memory_profiler_group_apply_in_arrow(self):
         # FlatMapGroupsInBatchExec
         import pyarrow.compute as pc
@@ -570,34 +535,34 @@ class MemoryProfiler2TestsMixin:
                 io.getvalue(), f"Filename.*{os.path.basename(inspect.getfile(_do_computation))}"
             )
 
-        @unittest.skipIf(
-            not have_pandas or not have_pyarrow,
-            cast(str, pandas_requirement_message or pyarrow_requirement_message),
-        )
-        def test_memory_profiler_cogroup_apply_in_arrow(self):
-            import pyarrow as pa
+    @unittest.skipIf(
+        not have_pandas or not have_pyarrow,
+        cast(str, pandas_requirement_message or pyarrow_requirement_message),
+    )
+    def test_memory_profiler_cogroup_apply_in_arrow(self):
+        import pyarrow as pa
 
-            df1 = self.spark.createDataFrame([(1, 1.0), (2, 2.0), (1, 3.0), (2, 4.0)], ("id", "v1"))
-            df2 = self.spark.createDataFrame([(1, "x"), (2, "y")], ("id", "v2"))
+        df1 = self.spark.createDataFrame([(1, 1.0), (2, 2.0), (1, 3.0), (2, 4.0)], ("id", "v1"))
+        df2 = self.spark.createDataFrame([(1, "x"), (2, "y")], ("id", "v2"))
 
-            def summarize(l, r):
-                return pa.Table.from_pydict({"left": [l.num_rows], "right": [r.num_rows]})
+        def summarize(l, r):
+            return pa.Table.from_pydict({"left": [l.num_rows], "right": [r.num_rows]})
 
-            with self.sql_conf({"spark.sql.pyspark.udf.profiler": "memory"}):
-                df1.groupby("id").cogroup(df2.groupby("id")).applyInArrow(
-                    summarize, schema="left long, right long"
-                ).show()
+        with self.sql_conf({"spark.sql.pyspark.udf.profiler": "memory"}):
+            df1.groupby("id").cogroup(df2.groupby("id")).applyInArrow(
+                summarize, schema="left long, right long"
+            ).show()
 
-            self.assertEqual(1, len(self.profile_results), str(self.profile_results.keys()))
+        self.assertEqual(1, len(self.profile_results), str(self.profile_results.keys()))
 
-            for id in self.profile_results:
-                with self.trap_stdout() as io:
-                    self.spark.showMemoryProfiles(id)
+        for id in self.profile_results:
+            with self.trap_stdout() as io:
+                self.spark.showMemoryProfiles(id)
 
-                self.assertIn(f"Profile of UDF<id={id}>", io.getvalue())
-                self.assertRegex(
-                    io.getvalue(), f"Filename.*{os.path.basename(inspect.getfile(_do_computation))}"
-                )
+            self.assertIn(f"Profile of UDF<id={id}>", io.getvalue())
+            self.assertRegex(
+                io.getvalue(), f"Filename.*{os.path.basename(inspect.getfile(_do_computation))}"
+            )
 
 
 class MemoryProfiler2Tests(MemoryProfiler2TestsMixin, ReusedSQLTestCase):

--- a/python/pyspark/tests/test_memory_profiler.py
+++ b/python/pyspark/tests/test_memory_profiler.py
@@ -504,67 +504,71 @@ class MemoryProfiler2TestsMixin:
                 io.getvalue(), f"Filename.*{os.path.basename(inspect.getfile(_do_computation))}"
             )
 
-        def test_perf_profiler_cogroup_apply_in_pandas(self):
-            # FlatMapCoGroupsInBatchExec
-            import pandas as pd
+    @unittest.skipIf(
+        not have_pandas or not have_pyarrow,
+        cast(str, pandas_requirement_message or pyarrow_requirement_message),
+    )
+    def test_perf_profiler_cogroup_apply_in_pandas(self):
+        # FlatMapCoGroupsInBatchExec
+        import pandas as pd
 
-            df1 = self.spark.createDataFrame(
-                [(20000101, 1, 1.0), (20000101, 2, 2.0), (20000102, 1, 3.0), (20000102, 2, 4.0)],
-                ("time", "id", "v1"),
-            )
-            df2 = self.spark.createDataFrame(
-                [(20000101, 1, "x"), (20000101, 2, "y")], ("time", "id", "v2")
-            )
-
-            def asof_join(left, right):
-                return pd.merge_asof(left, right, on="time", by="id")
-
-            with self.sql_conf({"spark.sql.pyspark.udf.profiler": "memory"}):
-                df1.groupby("id").cogroup(df2.groupby("id")).applyInPandas(
-                    asof_join, schema="time int, id int, v1 double, v2 string"
-                ).show()
-
-            self.assertEqual(1, len(self.profile_results), str(self.profile_results.keys()))
-
-            for id in self.profile_results:
-                with self.trap_stdout() as io:
-                    self.spark.showPerfProfiles(id)
-
-                self.assertIn(f"Profile of UDF<id={id}>", io.getvalue())
-                self.assertRegex(
-                    io.getvalue(), f"2.*{os.path.basename(inspect.getfile(_do_computation))}"
-                )
-
-        @unittest.skipIf(
-            not have_pandas or not have_pyarrow,
-            cast(str, pandas_requirement_message or pyarrow_requirement_message),
+        df1 = self.spark.createDataFrame(
+            [(20000101, 1, 1.0), (20000101, 2, 2.0), (20000102, 1, 3.0), (20000102, 2, 4.0)],
+            ("time", "id", "v1"),
         )
-        def test_memory_profiler_group_apply_in_arrow(self):
-            # FlatMapGroupsInBatchExec
-            import pyarrow.compute as pc
+        df2 = self.spark.createDataFrame(
+            [(20000101, 1, "x"), (20000101, 2, "y")], ("time", "id", "v2")
+        )
 
-            df = self.spark.createDataFrame(
-                [(1, 1.0), (1, 2.0), (2, 3.0), (2, 5.0), (2, 10.0)], ("id", "v")
+        def asof_join(left, right):
+            return pd.merge_asof(left, right, on="time", by="id")
+
+        with self.sql_conf({"spark.sql.pyspark.udf.profiler": "memory"}):
+            df1.groupby("id").cogroup(df2.groupby("id")).applyInPandas(
+                asof_join, schema="time int, id int, v1 double, v2 string"
+            ).show()
+
+        self.assertEqual(1, len(self.profile_results), str(self.profile_results.keys()))
+
+        for id in self.profile_results:
+            with self.trap_stdout() as io:
+                self.spark.showPerfProfiles(id)
+
+            self.assertIn(f"Profile of UDF<id={id}>", io.getvalue())
+            self.assertRegex(
+                io.getvalue(), f"2.*{os.path.basename(inspect.getfile(_do_computation))}"
             )
 
-            def normalize(table):
-                v = table.column("v")
-                norm = pc.divide(pc.subtract(v, pc.mean(v)), pc.stddev(v, ddof=1))
-                return table.set_column(1, "v", norm)
+    @unittest.skipIf(
+        not have_pandas or not have_pyarrow,
+        cast(str, pandas_requirement_message or pyarrow_requirement_message),
+    )
+    def test_memory_profiler_group_apply_in_arrow(self):
+        # FlatMapGroupsInBatchExec
+        import pyarrow.compute as pc
 
-            with self.sql_conf({"spark.sql.pyspark.udf.profiler": "memory"}):
-                df.groupby("id").applyInArrow(normalize, schema="id long, v double").show()
+        df = self.spark.createDataFrame(
+            [(1, 1.0), (1, 2.0), (2, 3.0), (2, 5.0), (2, 10.0)], ("id", "v")
+        )
 
-            self.assertEqual(1, len(self.profile_results), str(self.profile_results.keys()))
+        def normalize(table):
+            v = table.column("v")
+            norm = pc.divide(pc.subtract(v, pc.mean(v)), pc.stddev(v, ddof=1))
+            return table.set_column(1, "v", norm)
 
-            for id in self.profile_results:
-                with self.trap_stdout() as io:
-                    self.spark.showMemoryProfiles(id)
+        with self.sql_conf({"spark.sql.pyspark.udf.profiler": "memory"}):
+            df.groupby("id").applyInArrow(normalize, schema="id long, v double").show()
 
-                self.assertIn(f"Profile of UDF<id={id}>", io.getvalue())
-                self.assertRegex(
-                    io.getvalue(), f"Filename.*{os.path.basename(inspect.getfile(_do_computation))}"
-                )
+        self.assertEqual(1, len(self.profile_results), str(self.profile_results.keys()))
+
+        for id in self.profile_results:
+            with self.trap_stdout() as io:
+                self.spark.showMemoryProfiles(id)
+
+            self.assertIn(f"Profile of UDF<id={id}>", io.getvalue())
+            self.assertRegex(
+                io.getvalue(), f"Filename.*{os.path.basename(inspect.getfile(_do_computation))}"
+            )
 
         @unittest.skipIf(
             not have_pandas or not have_pyarrow,

--- a/python/pyspark/tests/test_memory_profiler.py
+++ b/python/pyspark/tests/test_memory_profiler.py
@@ -545,8 +545,8 @@ class MemoryProfiler2TestsMixin:
         df1 = self.spark.createDataFrame([(1, 1.0), (2, 2.0), (1, 3.0), (2, 4.0)], ("id", "v1"))
         df2 = self.spark.createDataFrame([(1, "x"), (2, "y")], ("id", "v2"))
 
-        def summarize(l, r):
-            return pa.Table.from_pydict({"left": [l.num_rows], "right": [r.num_rows]})
+        def summarize(left, right):
+            return pa.Table.from_pydict({"left": [left.num_rows], "right": [right.num_rows]})
 
         with self.sql_conf({"spark.sql.pyspark.udf.profiler": "memory"}):
             df1.groupby("id").cogroup(df2.groupby("id")).applyInArrow(

--- a/python/pyspark/tests/test_memory_profiler.py
+++ b/python/pyspark/tests/test_memory_profiler.py
@@ -440,10 +440,12 @@ class MemoryProfiler2TestsMixin:
             self.assertRegex(
                 io.getvalue(), f"Filename.*{os.path.basename(inspect.getfile(_do_computation))}"
             )
+
+
 @unittest.skipIf(
     not have_pandas or not have_pyarrow,
     cast(str, pandas_requirement_message or pyarrow_requirement_message),
-    )
+)
 def test_memory_profiler_group_apply_in_pandas(self):
     # FlatMapGroupsInBatchExec
     df = self.spark.createDataFrame(
@@ -468,10 +470,11 @@ def test_memory_profiler_group_apply_in_pandas(self):
             io.getvalue(), f"Filename.*{os.path.basename(inspect.getfile(_do_computation))}"
         )
 
+
 @unittest.skipIf(
     not have_pandas or not have_pyarrow,
     cast(str, pandas_requirement_message or pyarrow_requirement_message),
-    )
+)
 def test_memory_profiler_cogroup_apply_in_pandas(self):
     # FlatMapCoGroupsInBatchExec
     import pandas as pd
@@ -480,9 +483,7 @@ def test_memory_profiler_cogroup_apply_in_pandas(self):
         [(20000101, 1, 1.0), (20000101, 2, 2.0), (20000102, 1, 3.0), (20000102, 2, 4.0)],
         ("time", "id", "v1"),
     )
-    df2 = self.spark.createDataFrame(
-        [(20000101, 1, "x"), (20000101, 2, "y")], ("time", "id", "v2")
-    )
+    df2 = self.spark.createDataFrame([(20000101, 1, "x"), (20000101, 2, "y")], ("time", "id", "v2"))
 
     def asof_join(left, right):
         return pd.merge_asof(left, right, on="time", by="id")

--- a/python/pyspark/tests/test_memory_profiler.py
+++ b/python/pyspark/tests/test_memory_profiler.py
@@ -503,6 +503,97 @@ def test_memory_profiler_cogroup_apply_in_pandas(self):
             io.getvalue(), f"Filename.*{os.path.basename(inspect.getfile(_do_computation))}"
         )
 
+    def test_perf_profiler_cogroup_apply_in_pandas(self):
+        # FlatMapCoGroupsInBatchExec
+        import pandas as pd
+
+        df1 = self.spark.createDataFrame(
+            [(20000101, 1, 1.0), (20000101, 2, 2.0), (20000102, 1, 3.0), (20000102, 2, 4.0)],
+            ("time", "id", "v1"),
+        )
+        df2 = self.spark.createDataFrame(
+            [(20000101, 1, "x"), (20000101, 2, "y")], ("time", "id", "v2")
+        )
+
+        def asof_join(left, right):
+            return pd.merge_asof(left, right, on="time", by="id")
+
+        with self.sql_conf({"spark.sql.pyspark.udf.profiler": "memory"}):
+            df1.groupby("id").cogroup(df2.groupby("id")).applyInPandas(
+                asof_join, schema="time int, id int, v1 double, v2 string"
+            ).show()
+
+        self.assertEqual(1, len(self.profile_results), str(self.profile_results.keys()))
+
+        for id in self.profile_results:
+            with self.trap_stdout() as io:
+                self.spark.showPerfProfiles(id)
+
+            self.assertIn(f"Profile of UDF<id={id}>", io.getvalue())
+            self.assertRegex(
+                io.getvalue(), f"2.*{os.path.basename(inspect.getfile(_do_computation))}"
+            )
+
+    @unittest.skipIf(
+        not have_pandas or not have_pyarrow,
+        cast(str, pandas_requirement_message or pyarrow_requirement_message),
+    )
+    def test_memory_profiler_group_apply_in_arrow(self):
+        # FlatMapGroupsInBatchExec
+        import pyarrow.compute as pc
+
+        df = self.spark.createDataFrame(
+            [(1, 1.0), (1, 2.0), (2, 3.0), (2, 5.0), (2, 10.0)], ("id", "v")
+        )
+
+        def normalize(table):
+            v = table.column("v")
+            norm = pc.divide(pc.subtract(v, pc.mean(v)), pc.stddev(v, ddof=1))
+            return table.set_column(1, "v", norm)
+
+        with self.sql_conf({"spark.sql.pyspark.udf.profiler": "memory"}):
+            df.groupby("id").applyInArrow(normalize, schema="id long, v double").show()
+
+        self.assertEqual(1, len(self.profile_results), str(self.profile_results.keys()))
+
+        for id in self.profile_results:
+            with self.trap_stdout() as io:
+                self.spark.showMemoryProfiles(id)
+
+            self.assertIn(f"Profile of UDF<id={id}>", io.getvalue())
+            self.assertRegex(
+                io.getvalue(), f"Filename.*{os.path.basename(inspect.getfile(_do_computation))}"
+            )
+
+    @unittest.skipIf(
+        not have_pandas or not have_pyarrow,
+        cast(str, pandas_requirement_message or pyarrow_requirement_message),
+    )
+    def test_memory_profiler_cogroup_apply_in_arrow(self):
+        import pyarrow as pa
+
+        df1 = self.spark.createDataFrame([(1, 1.0), (2, 2.0), (1, 3.0), (2, 4.0)], ("id", "v1"))
+        df2 = self.spark.createDataFrame([(1, "x"), (2, "y")], ("id", "v2"))
+
+        def summarize(l, r):
+            return pa.Table.from_pydict({"left": [l.num_rows], "right": [r.num_rows]})
+
+        with self.sql_conf({"spark.sql.pyspark.udf.profiler": "memory"}):
+            df1.groupby("id").cogroup(df2.groupby("id")).applyInArrow(
+                summarize, schema="left long, right long"
+            ).show()
+
+        self.assertEqual(1, len(self.profile_results), str(self.profile_results.keys()))
+
+        for id in self.profile_results:
+            with self.trap_stdout() as io:
+                self.spark.showMemoryProfiles(id)
+
+            self.assertIn(f"Profile of UDF<id={id}>", io.getvalue())
+            self.assertRegex(
+                io.getvalue(), f"Filename.*{os.path.basename(inspect.getfile(_do_computation))}"
+            )
+
 
 class MemoryProfiler2Tests(MemoryProfiler2TestsMixin, ReusedSQLTestCase):
     def setUp(self) -> None:

--- a/python/pyspark/tests/test_memory_profiler.py
+++ b/python/pyspark/tests/test_memory_profiler.py
@@ -440,6 +440,68 @@ class MemoryProfiler2TestsMixin:
             self.assertRegex(
                 io.getvalue(), f"Filename.*{os.path.basename(inspect.getfile(_do_computation))}"
             )
+@unittest.skipIf(
+    not have_pandas or not have_pyarrow,
+    cast(str, pandas_requirement_message or pyarrow_requirement_message),
+    )
+def test_memory_profiler_group_apply_in_pandas(self):
+    # FlatMapGroupsInBatchExec
+    df = self.spark.createDataFrame(
+        [(1, 1.0), (1, 2.0), (2, 3.0), (2, 5.0), (2, 10.0)], ("id", "v")
+    )
+
+    def normalize(pdf):
+        v = pdf.v
+        return pdf.assign(v=(v - v.mean()) / v.std())
+
+    with self.sql_conf({"spark.sql.pyspark.udf.profiler": "memory"}):
+        df.groupby("id").applyInPandas(normalize, schema="id long, v double").show()
+
+    self.assertEqual(1, len(self.profile_results), str(self.profile_results.keys()))
+
+    for id in self.profile_results:
+        with self.trap_stdout() as io:
+            self.spark.showMemoryProfiles(id)
+
+        self.assertIn(f"Profile of UDF<id={id}>", io.getvalue())
+        self.assertRegex(
+            io.getvalue(), f"Filename.*{os.path.basename(inspect.getfile(_do_computation))}"
+        )
+
+@unittest.skipIf(
+    not have_pandas or not have_pyarrow,
+    cast(str, pandas_requirement_message or pyarrow_requirement_message),
+    )
+def test_memory_profiler_cogroup_apply_in_pandas(self):
+    # FlatMapCoGroupsInBatchExec
+    import pandas as pd
+
+    df1 = self.spark.createDataFrame(
+        [(20000101, 1, 1.0), (20000101, 2, 2.0), (20000102, 1, 3.0), (20000102, 2, 4.0)],
+        ("time", "id", "v1"),
+    )
+    df2 = self.spark.createDataFrame(
+        [(20000101, 1, "x"), (20000101, 2, "y")], ("time", "id", "v2")
+    )
+
+    def asof_join(left, right):
+        return pd.merge_asof(left, right, on="time", by="id")
+
+    with self.sql_conf({"spark.sql.pyspark.udf.profiler": "memory"}):
+        df1.groupby("id").cogroup(df2.groupby("id")).applyInPandas(
+            asof_join, schema="time int, id int, v1 double, v2 string"
+        ).show()
+
+    self.assertEqual(1, len(self.profile_results), str(self.profile_results.keys()))
+
+    for id in self.profile_results:
+        with self.trap_stdout() as io:
+            self.spark.showMemoryProfiles(id)
+
+        self.assertIn(f"Profile of UDF<id={id}>", io.getvalue())
+        self.assertRegex(
+            io.getvalue(), f"Filename.*{os.path.basename(inspect.getfile(_do_computation))}"
+        )
 
 
 class MemoryProfiler2Tests(MemoryProfiler2TestsMixin, ReusedSQLTestCase):

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/FlatMapCoGroupsInBatchExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/FlatMapCoGroupsInBatchExec.scala
@@ -87,7 +87,7 @@ trait FlatMapCoGroupsInBatchExec extends SparkPlan with BinaryExecNode with Pyth
           pythonRunnerConf,
           pythonMetrics,
           jobArtifactUUID,
-          None) // TODO(SPARK-46690): Support profiling on FlatMapCoGroupsInBatchExec
+          conf.pythonUDFProfiler)
 
         executePython(data, output, runner)
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/FlatMapGroupsInBatchExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/FlatMapGroupsInBatchExec.scala
@@ -92,7 +92,7 @@ trait FlatMapGroupsInBatchExec extends SparkPlan with UnaryExecNode with PythonS
         pythonRunnerConf,
         pythonMetrics,
         jobArtifactUUID,
-        None) // TODO(SPARK-46689): Support profiling on FlatMapGroupsInBatchExec
+        conf.pythonUDFProfiler)
 
       executePython(data, output, runner)
     }}


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support v2 (perf, memory) profiling in group/cogroup applyInPandas/applyInArrow, which rely on physical plan nodes FlatMapGroupsInBatchExec and FlatMapCoGroupsInBatchExec.

### Why are the changes needed?
Complete v2 profiling support.

### Does this PR introduce _any_ user-facing change?
Yes. V2 profiling in group/cogroup applyInPandas/applyInArrow is supported.

### How was this patch tested?
Unit tests.

### Was this patch authored or co-authored using generative AI tooling?
No.