### PR TITLE
[SPARK-46993][SQL] Fix constant folding for session variables

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ColumnResolutionHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ColumnResolutionHelper.scala
@@ -312,14 +312,39 @@ trait ColumnResolutionHelper extends Logging with DataTypeErrorsBase {
       }.map(e => Alias(e, nameParts.last)())
     }
 
-    e.transformWithPruning(_.containsAnyPattern(UNRESOLVED_ATTRIBUTE, TEMP_RESOLVED_COLUMN)) {
-      case u: UnresolvedAttribute =>
-        resolve(u.nameParts).getOrElse(u)
-      // Re-resolves `TempResolvedColumn` as variable references if it has tried to be resolved with
-      // Aggregate but failed.
-      case t: TempResolvedColumn if t.hasTried =>
-        resolve(t.nameParts).getOrElse(t)
+    def innerResolve(e: Expression, isTopLevel: Boolean): Expression = withOrigin(e.origin) {
+      if (e.resolved) return e
+      val resolved = e match {
+        case u @ UnresolvedAttribute(nameParts) =>
+          val result = withPosition(u) {
+            resolve(nameParts).getOrElse(u) match {
+              // We trim unnecessary alias here. Note that, we cannot trim the alias at top-level,
+              // as we should resolve `UnresolvedAttribute` to a named expression. The caller side
+              // can trim the top-level alias if it's safe to do so. Since we will call
+              // CleanupAliases later in Analyzer, trim non top-level unnecessary alias is safe.
+              case Alias(child, _) if !isTopLevel => child
+              case other => other
+            }
+          }
+          result
+
+        // Re-resolves `TempResolvedColumn` if it has tried to be resolved with Aggregate
+        // but failed. If we still can't resolve it, we should keep it as `TempResolvedColumn`,
+        // so that it won't become a fresh `TempResolvedColumn` again.
+        case t: TempResolvedColumn if t.hasTried => withPosition(t) {
+          resolve(t.nameParts).getOrElse(t) match {
+            case _: UnresolvedAttribute => t
+            case other => other
+          }
+        }
+
+        case _ => e.mapChildren(innerResolve(_, isTopLevel = false))
+      }
+      resolved.copyTagsFrom(e)
+      resolved
     }
+
+    innerResolve(e, isTopLevel = true)
   }
 
   // Resolves `UnresolvedAttribute` to `TempResolvedColumn` via `plan.child.output` if plan is an

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/sql-session-variables.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/sql-session-variables.sql.out
@@ -74,7 +74,7 @@ CreateVariable defaultvalueexpression(null, null), false
 -- !query
 SELECT 'Expect: INT, NULL', typeof(var1), var1
 -- !query analysis
-Project [Expect: INT, NULL AS Expect: INT, NULL#x, typeof(variablereference(system.session.var1=CAST(NULL AS INT))) AS typeof(variablereference(system.session.var1=CAST(NULL AS INT)) AS var1)#x, variablereference(system.session.var1=CAST(NULL AS INT)) AS var1#x]
+Project [Expect: INT, NULL AS Expect: INT, NULL#x, typeof(variablereference(system.session.var1=CAST(NULL AS INT))) AS typeof(variablereference(system.session.var1=CAST(NULL AS INT)))#x, variablereference(system.session.var1=CAST(NULL AS INT)) AS var1#x]
 +- OneRowRelation
 
 
@@ -88,7 +88,7 @@ CreateVariable defaultvalueexpression(null, null), true
 -- !query
 SELECT 'Expect: DOUBLE, NULL', typeof(var1), var1
 -- !query analysis
-Project [Expect: DOUBLE, NULL AS Expect: DOUBLE, NULL#x, typeof(variablereference(system.session.var1=CAST(NULL AS DOUBLE))) AS typeof(variablereference(system.session.var1=CAST(NULL AS DOUBLE)) AS var1)#x, variablereference(system.session.var1=CAST(NULL AS DOUBLE)) AS var1#x]
+Project [Expect: DOUBLE, NULL AS Expect: DOUBLE, NULL#x, typeof(variablereference(system.session.var1=CAST(NULL AS DOUBLE))) AS typeof(variablereference(system.session.var1=CAST(NULL AS DOUBLE)))#x, variablereference(system.session.var1=CAST(NULL AS DOUBLE)) AS var1#x]
 +- OneRowRelation
 
 
@@ -108,7 +108,7 @@ DECLARE OR REPLACE VARIABLE var1 TIMESTAMP
 -- !query
 SELECT 'Expect: TIMESTAMP, NULL', typeof(var1), var1
 -- !query analysis
-Project [Expect: TIMESTAMP, NULL AS Expect: TIMESTAMP, NULL#x, typeof(variablereference(system.session.var1=CAST(NULL AS TIMESTAMP))) AS typeof(variablereference(system.session.var1=CAST(NULL AS TIMESTAMP)) AS var1)#x, variablereference(system.session.var1=CAST(NULL AS TIMESTAMP)) AS var1#x]
+Project [Expect: TIMESTAMP, NULL AS Expect: TIMESTAMP, NULL#x, typeof(variablereference(system.session.var1=CAST(NULL AS TIMESTAMP))) AS typeof(variablereference(system.session.var1=CAST(NULL AS TIMESTAMP)))#x, variablereference(system.session.var1=CAST(NULL AS TIMESTAMP)) AS var1#x]
 +- OneRowRelation
 
 
@@ -1969,21 +1969,21 @@ Project [variablereference(system.session.var1=1) AS var1#x]
 -- !query
 SELECT sum(var1) FROM VALUES(1)
 -- !query analysis
-Aggregate [sum(variablereference(system.session.var1=1)) AS sum(variablereference(system.session.var1=1) AS var1)#xL]
+Aggregate [sum(variablereference(system.session.var1=1)) AS sum(variablereference(system.session.var1=1))#xL]
 +- LocalRelation [col1#x]
 
 
 -- !query
 SELECT var1 + SUM(0) FROM VALUES(1)
 -- !query analysis
-Aggregate [(cast(variablereference(system.session.var1=1) as bigint) + sum(0)) AS (variablereference(system.session.var1=1) AS var1 + sum(0))#xL]
+Aggregate [(cast(variablereference(system.session.var1=1) as bigint) + sum(0)) AS (variablereference(system.session.var1=1) + sum(0))#xL]
 +- LocalRelation [col1#x]
 
 
 -- !query
 SELECT substr('12345', var1, 1)
 -- !query analysis
-Project [substr(12345, variablereference(system.session.var1=1), 1) AS substr(12345, variablereference(system.session.var1=1) AS var1, 1)#x]
+Project [substr(12345, variablereference(system.session.var1=1), 1) AS substr(12345, variablereference(system.session.var1=1), 1)#x]
 +- OneRowRelation
 
 
@@ -2031,7 +2031,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 -- !query
 SELECT array(1, 2, 4)[var1]
 -- !query analysis
-Project [array(1, 2, 4)[variablereference(system.session.var1=1)] AS array(1, 2, 4)[variablereference(system.session.var1=1) AS var1]#x]
+Project [array(1, 2, 4)[variablereference(system.session.var1=1)] AS array(1, 2, 4)[variablereference(system.session.var1=1)]#x]
 +- OneRowRelation
 
 
@@ -2124,6 +2124,35 @@ org.apache.spark.sql.AnalysisException
 DROP VIEW IF EXISTS V
 -- !query analysis
 DropTableCommand `spark_catalog`.`default`.`V`, true, true, false
+
+
+-- !query
+DROP TEMPORARY VARIABLE var1
+-- !query analysis
+DropVariable false
++- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.var1
+
+
+-- !query
+SET VARIABLE title = 'variable references -- test constant folding'
+-- !query analysis
+SetVariable [variablereference(system.session.title='variable references -- prohibited')]
++- Project [variable references -- test constant folding AS title#x]
+   +- OneRowRelation
+
+
+-- !query
+DECLARE OR REPLACE VARIABLE var1 STRING DEFAULT 'a INT'
+-- !query analysis
+CreateVariable defaultvalueexpression(cast(a INT as string), 'a INT'), true
++- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.var1
+
+
+-- !query
+SELECT from_json('{"a": 1}', var1)
+-- !query analysis
+Project [from_json(StructField(a,IntegerType,true), {"a": 1}, Some(America/Los_Angeles)) AS from_json({"a": 1})#x]
++- OneRowRelation
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/inputs/sql-session-variables.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/sql-session-variables.sql
@@ -375,3 +375,9 @@ CREATE OR REPLACE VIEW v AS SELECT var1 AS c1;
 DROP VIEW IF EXISTS V;
 
 DROP TEMPORARY VARIABLE var1;
+
+SET VARIABLE title = 'variable references -- test constant folding';
+
+DECLARE OR REPLACE VARIABLE var1 STRING DEFAULT 'a INT';
+SELECT from_json('{"a": 1}', var1);
+DROP TEMPORARY VARIABLE var1;

--- a/sql/core/src/test/resources/sql-tests/results/sql-session-variables.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/sql-session-variables.sql.out
@@ -82,7 +82,7 @@ struct<>
 -- !query
 SELECT 'Expect: INT, NULL', typeof(var1), var1
 -- !query schema
-struct<Expect: INT, NULL:string,typeof(variablereference(system.session.var1=CAST(NULL AS INT)) AS var1):string,var1:int>
+struct<Expect: INT, NULL:string,typeof(variablereference(system.session.var1=CAST(NULL AS INT))):string,var1:int>
 -- !query output
 Expect: INT, NULL	int	NULL
 
@@ -98,7 +98,7 @@ struct<>
 -- !query
 SELECT 'Expect: DOUBLE, NULL', typeof(var1), var1
 -- !query schema
-struct<Expect: DOUBLE, NULL:string,typeof(variablereference(system.session.var1=CAST(NULL AS DOUBLE)) AS var1):string,var1:double>
+struct<Expect: DOUBLE, NULL:string,typeof(variablereference(system.session.var1=CAST(NULL AS DOUBLE))):string,var1:double>
 -- !query output
 Expect: DOUBLE, NULL	double	NULL
 
@@ -122,7 +122,7 @@ struct<>
 -- !query
 SELECT 'Expect: TIMESTAMP, NULL', typeof(var1), var1
 -- !query schema
-struct<Expect: TIMESTAMP, NULL:string,typeof(variablereference(system.session.var1=CAST(NULL AS TIMESTAMP)) AS var1):string,var1:timestamp>
+struct<Expect: TIMESTAMP, NULL:string,typeof(variablereference(system.session.var1=CAST(NULL AS TIMESTAMP))):string,var1:timestamp>
 -- !query output
 Expect: TIMESTAMP, NULL	timestamp	NULL
 
@@ -2138,7 +2138,7 @@ struct<var1:int>
 -- !query
 SELECT sum(var1) FROM VALUES(1)
 -- !query schema
-struct<sum(variablereference(system.session.var1=1) AS var1):bigint>
+struct<sum(variablereference(system.session.var1=1)):bigint>
 -- !query output
 1
 
@@ -2146,7 +2146,7 @@ struct<sum(variablereference(system.session.var1=1) AS var1):bigint>
 -- !query
 SELECT var1 + SUM(0) FROM VALUES(1)
 -- !query schema
-struct<(variablereference(system.session.var1=1) AS var1 + sum(0)):bigint>
+struct<(variablereference(system.session.var1=1) + sum(0)):bigint>
 -- !query output
 1
 
@@ -2154,7 +2154,7 @@ struct<(variablereference(system.session.var1=1) AS var1 + sum(0)):bigint>
 -- !query
 SELECT substr('12345', var1, 1)
 -- !query schema
-struct<substr(12345, variablereference(system.session.var1=1) AS var1, 1):string>
+struct<substr(12345, variablereference(system.session.var1=1), 1):string>
 -- !query output
 1
 
@@ -2202,7 +2202,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 -- !query
 SELECT array(1, 2, 4)[var1]
 -- !query schema
-struct<array(1, 2, 4)[variablereference(system.session.var1=1) AS var1]:int>
+struct<array(1, 2, 4)[variablereference(system.session.var1=1)]:int>
 -- !query output
 2
 
@@ -2295,6 +2295,38 @@ DROP VIEW IF EXISTS V
 struct<>
 -- !query output
 
+
+
+-- !query
+DROP TEMPORARY VARIABLE var1
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+SET VARIABLE title = 'variable references -- test constant folding'
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+DECLARE OR REPLACE VARIABLE var1 STRING DEFAULT 'a INT'
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+SELECT from_json('{"a": 1}', var1)
+-- !query schema
+struct<from_json({"a": 1}):struct<a:int>>
+-- !query output
+{"a":1}
 
 
 -- !query


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Remove the unconditional Alias node generation when resolving a variable reference.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
An Alias that is not at the top level of an expression blocks constant folding.
Constant folding in turn is a requirement for variables to be usable as an argument to numerous functions, such as from_json().
It also has performance implications.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Existing regression tests in sql-session-variables.sql, added a test to validate the fix.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No