### PR TITLE
[SPARK-47002][Python] Return better error message if UDTF 'analyze' method 'orderBy' field accidentally returns a list of strings

### DIFF
--- a/python/pyspark/sql/worker/analyze_udtf.py
+++ b/python/pyspark/sql/worker/analyze_udtf.py
@@ -163,6 +163,18 @@ def main(infile: IO, outfile: IO) -> None:
                     but the 'schema' field had the wrong type: {type(result.schema)}"""
                 )
             )
+
+        def invalid_analyze_result_field(field_name: str, expected_field: str) -> PySparkValueError:
+            return PySparkValueError(
+                format_error(
+                    f"""
+                    {error_prefix} because the static 'analyze' method returned an
+                    'AnalyzeResult' object with the '{field_name}' field set to a value besides a
+                    list or tuple of '{expected_field}' objects. Please update the table function
+                    and then try the query again."""
+                )
+            )
+
         has_table_arg = any(arg.isTable for arg in args) or any(
             arg.isTable for arg in kwargs.values()
         )
@@ -190,19 +202,7 @@ def main(infile: IO, outfile: IO) -> None:
                     set to empty, and then try the query again."""
                 )
             )
-
-        def invalid_analyze_result_field(field_name: str, expected_field: str) -> PySparkValueError:
-            return PySparkValueError(
-                format_error(
-                    f"""
-                    {error_prefix} because the static 'analyze' method returned an
-                    'AnalyzeResult' object with the '{field_name}' field set to a value besides a
-                    list or tuple of '{expected_field}' objects. Please update the table function
-                    and then try the query again."""
-                )
-            )
-
-        if isinstance(result.partitionBy, (list, tuple)) and (
+        elif isinstance(result.partitionBy, (list, tuple)) and (
             len(result.partitionBy) > 0
             and not all([isinstance(val, PartitioningColumn) for val in result.partitionBy])
         ):

--- a/python/pyspark/sql/worker/analyze_udtf.py
+++ b/python/pyspark/sql/worker/analyze_udtf.py
@@ -202,19 +202,16 @@ def main(infile: IO, outfile: IO) -> None:
                     set to empty, and then try the query again."""
                 )
             )
-        elif isinstance(result.partitionBy, (list, tuple)) and (
-            len(result.partitionBy) > 0
-            and not all([isinstance(val, PartitioningColumn) for val in result.partitionBy])
+        elif not isinstance(result.partitionBy, (list, tuple)) or not all(
+            isinstance(val, PartitioningColumn) for val in result.partitionBy
         ):
             raise invalid_analyze_result_field("partitionBy", "PartitioningColumn")
-        elif isinstance(result.orderBy, (list, tuple)) and (
-            len(result.orderBy) > 0
-            and not all([isinstance(val, OrderingColumn) for val in result.orderBy])
+        elif not isinstance(result.orderBy, (list, tuple)) or not all(
+            isinstance(val, OrderingColumn) for val in result.orderBy
         ):
             raise invalid_analyze_result_field("orderBy", "OrderingColumn")
-        elif isinstance(result.select, (list, tuple)) and (
-            len(result.select) > 0
-            and not all([isinstance(val, SelectedColumn) for val in result.select])
+        elif not isinstance(result.select, (list, tuple)) or not all(
+            isinstance(val, SelectedColumn) for val in result.select
         ):
             raise invalid_analyze_result_field("select", "SelectedColumn")
 

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/udtf/udtf.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/udtf/udtf.sql.out
@@ -386,8 +386,21 @@ org.apache.spark.sql.AnalysisException
 -- !query
 SELECT * FROM UDTFInvalidOrderByStringList(TABLE(t2))
 -- !query analysis
-java.lang.NegativeArraySizeException
--2
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "TABLE_VALUED_FUNCTION_FAILED_TO_ANALYZE_IN_PYTHON",
+  "sqlState" : "38000",
+  "messageParameters" : {
+    "msg" : "Failed to evaluate the user-defined table function 'UDTFInvalidOrderByStringList' because the static 'analyze' method returned an 'AnalyzeResult' object with the 'orderBy' field set to a value besides a list or tuple of 'OrderingColumn' objects. Please update the table function and then try the query again."
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 15,
+    "stopIndex" : 53,
+    "fragment" : "UDTFInvalidOrderByStringList(TABLE(t2))"
+  } ]
+}
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/udtf/udtf.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/udtf/udtf.sql.out
@@ -125,13 +125,41 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
 -- !query
 SELECT * FROM UDTFWithSinglePartition(0, TABLE(t2))
 -- !query analysis
-[Analyzer test output redacted due to nondeterminism]
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "TABLE_VALUED_FUNCTION_FAILED_TO_ANALYZE_IN_PYTHON",
+  "sqlState" : "38000",
+  "messageParameters" : {
+    "msg" : "Traceback (most recent call last):\n  File \"/Users/Daniel.Tenedorio/spark-2/python/lib/pyspark.zip/pyspark/sql/worker/analyze_udtf.py\", line 206, in main\n    elif isinstance(result.select, (list, tuple)) and (\nAttributeError: 'AnalyzeResultWithBuffer' object has no attribute 'select'"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 15,
+    "stopIndex" : 51,
+    "fragment" : "UDTFWithSinglePartition(0, TABLE(t2))"
+  } ]
+}
 
 
 -- !query
 SELECT * FROM UDTFWithSinglePartition(1, TABLE(t2))
 -- !query analysis
-[Analyzer test output redacted due to nondeterminism]
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "TABLE_VALUED_FUNCTION_FAILED_TO_ANALYZE_IN_PYTHON",
+  "sqlState" : "38000",
+  "messageParameters" : {
+    "msg" : "Traceback (most recent call last):\n  File \"/Users/Daniel.Tenedorio/spark-2/python/lib/pyspark.zip/pyspark/sql/worker/analyze_udtf.py\", line 206, in main\n    elif isinstance(result.select, (list, tuple)) and (\nAttributeError: 'AnalyzeResultWithBuffer' object has no attribute 'select'"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 15,
+    "stopIndex" : 51,
+    "fragment" : "UDTFWithSinglePartition(1, TABLE(t2))"
+  } ]
+}
 
 
 -- !query
@@ -139,12 +167,10 @@ SELECT * FROM UDTFWithSinglePartition(0, TABLE(t2) WITH SINGLE PARTITION)
 -- !query analysis
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "TABLE_VALUED_FUNCTION_REQUIRED_METADATA_INCOMPATIBLE_WITH_CALL",
-  "sqlState" : "22023",
+  "errorClass" : "TABLE_VALUED_FUNCTION_FAILED_TO_ANALYZE_IN_PYTHON",
+  "sqlState" : "38000",
   "messageParameters" : {
-    "functionName" : "UDTFWithSinglePartition",
-    "invalidFunctionCallProperty" : "specified the WITH SINGLE PARTITION or PARTITION BY clause; please remove these clauses and retry the query again.",
-    "requestedMetadata" : "specified its own required partitioning of the input table"
+    "msg" : "Traceback (most recent call last):\n  File \"/Users/Daniel.Tenedorio/spark-2/python/lib/pyspark.zip/pyspark/sql/worker/analyze_udtf.py\", line 206, in main\n    elif isinstance(result.select, (list, tuple)) and (\nAttributeError: 'AnalyzeResultWithBuffer' object has no attribute 'select'"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -161,12 +187,10 @@ SELECT * FROM UDTFWithSinglePartition(0, TABLE(t2) PARTITION BY partition_col)
 -- !query analysis
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "TABLE_VALUED_FUNCTION_REQUIRED_METADATA_INCOMPATIBLE_WITH_CALL",
-  "sqlState" : "22023",
+  "errorClass" : "TABLE_VALUED_FUNCTION_FAILED_TO_ANALYZE_IN_PYTHON",
+  "sqlState" : "38000",
   "messageParameters" : {
-    "functionName" : "UDTFWithSinglePartition",
-    "invalidFunctionCallProperty" : "specified the WITH SINGLE PARTITION or PARTITION BY clause; please remove these clauses and retry the query again.",
-    "requestedMetadata" : "specified its own required partitioning of the input table"
+    "msg" : "Traceback (most recent call last):\n  File \"/Users/Daniel.Tenedorio/spark-2/python/lib/pyspark.zip/pyspark/sql/worker/analyze_udtf.py\", line 206, in main\n    elif isinstance(result.select, (list, tuple)) and (\nAttributeError: 'AnalyzeResultWithBuffer' object has no attribute 'select'"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -186,12 +210,10 @@ SELECT * FROM
 -- !query analysis
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "TABLE_VALUED_FUNCTION_REQUIRED_METADATA_INCOMPATIBLE_WITH_CALL",
-  "sqlState" : "22023",
+  "errorClass" : "TABLE_VALUED_FUNCTION_FAILED_TO_ANALYZE_IN_PYTHON",
+  "sqlState" : "38000",
   "messageParameters" : {
-    "functionName" : "UDTFWithSinglePartition",
-    "invalidFunctionCallProperty" : "specified the WITH SINGLE PARTITION or PARTITION BY clause; please remove these clauses and retry the query again.",
-    "requestedMetadata" : "specified its own required partitioning of the input table"
+    "msg" : "Traceback (most recent call last):\n  File \"/Users/Daniel.Tenedorio/spark-2/python/lib/pyspark.zip/pyspark/sql/worker/analyze_udtf.py\", line 206, in main\n    elif isinstance(result.select, (list, tuple)) and (\nAttributeError: 'AnalyzeResultWithBuffer' object has no attribute 'select'"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -302,6 +324,13 @@ org.apache.spark.sql.AnalysisException
     "fragment" : "UDTFInvalidOrderByAscKeyword(TABLE(t2))"
   } ]
 }
+
+
+-- !query
+SELECT * FROM UDTFInvalidOrderByStringList(TABLE(t2))
+-- !query analysis
+java.lang.NegativeArraySizeException
+-2
 
 
 -- !query
@@ -541,7 +570,21 @@ SELECT * FROM InvalidTerminateReturnsNoneToNonNullableColumnMapType(TABLE(t2))
 -- !query
 SELECT * FROM UDTFForwardStateFromAnalyzeWithKwargs()
 -- !query analysis
-[Analyzer test output redacted due to nondeterminism]
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "TABLE_VALUED_FUNCTION_FAILED_TO_ANALYZE_IN_PYTHON",
+  "sqlState" : "38000",
+  "messageParameters" : {
+    "msg" : "Traceback (most recent call last):\n  File \"/Users/Daniel.Tenedorio/spark-2/python/lib/pyspark.zip/pyspark/sql/worker/analyze_udtf.py\", line 206, in main\n    elif isinstance(result.select, (list, tuple)) and (\nAttributeError: 'AnalyzeResultWithBuffer' object has no attribute 'select'"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 15,
+    "stopIndex" : 53,
+    "fragment" : "UDTFForwardStateFromAnalyzeWithKwargs()"
+  } ]
+}
 
 
 -- !query
@@ -567,7 +610,21 @@ org.apache.spark.sql.AnalysisException
 -- !query
 SELECT * FROM UDTFForwardStateFromAnalyzeWithKwargs(invalid => 2)
 -- !query analysis
-[Analyzer test output redacted due to nondeterminism]
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "TABLE_VALUED_FUNCTION_FAILED_TO_ANALYZE_IN_PYTHON",
+  "sqlState" : "38000",
+  "messageParameters" : {
+    "msg" : "Traceback (most recent call last):\n  File \"/Users/Daniel.Tenedorio/spark-2/python/lib/pyspark.zip/pyspark/sql/worker/analyze_udtf.py\", line 206, in main\n    elif isinstance(result.select, (list, tuple)) and (\nAttributeError: 'AnalyzeResultWithBuffer' object has no attribute 'select'"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 15,
+    "stopIndex" : 65,
+    "fragment" : "UDTFForwardStateFromAnalyzeWithKwargs(invalid => 2)"
+  } ]
+}
 
 
 -- !query
@@ -674,7 +731,21 @@ org.apache.spark.sql.AnalysisException
 -- !query
 SELECT * FROM InvalidForwardStateFromAnalyzeTooManyInitArgs(TABLE(t2))
 -- !query analysis
-[Analyzer test output redacted due to nondeterminism]
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "TABLE_VALUED_FUNCTION_FAILED_TO_ANALYZE_IN_PYTHON",
+  "sqlState" : "38000",
+  "messageParameters" : {
+    "msg" : "Traceback (most recent call last):\n  File \"/Users/Daniel.Tenedorio/spark-2/python/lib/pyspark.zip/pyspark/sql/worker/analyze_udtf.py\", line 206, in main\n    elif isinstance(result.select, (list, tuple)) and (\nAttributeError: 'AnalyzeResultWithBuffer' object has no attribute 'select'"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 15,
+    "stopIndex" : 70,
+    "fragment" : "InvalidForwardStateFromAnalyzeTooManyInitArgs(TABLE(t2))"
+  } ]
+}
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/udtf/udtf.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/udtf/udtf.sql.out
@@ -125,41 +125,13 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
 -- !query
 SELECT * FROM UDTFWithSinglePartition(0, TABLE(t2))
 -- !query analysis
-org.apache.spark.sql.AnalysisException
-{
-  "errorClass" : "TABLE_VALUED_FUNCTION_FAILED_TO_ANALYZE_IN_PYTHON",
-  "sqlState" : "38000",
-  "messageParameters" : {
-    "msg" : "Traceback (most recent call last):\n  File \"/Users/Daniel.Tenedorio/spark-2/python/lib/pyspark.zip/pyspark/sql/worker/analyze_udtf.py\", line 206, in main\n    elif isinstance(result.select, (list, tuple)) and (\nAttributeError: 'AnalyzeResultWithBuffer' object has no attribute 'select'"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 15,
-    "stopIndex" : 51,
-    "fragment" : "UDTFWithSinglePartition(0, TABLE(t2))"
-  } ]
-}
+[Analyzer test output redacted due to nondeterminism]
 
 
 -- !query
 SELECT * FROM UDTFWithSinglePartition(1, TABLE(t2))
 -- !query analysis
-org.apache.spark.sql.AnalysisException
-{
-  "errorClass" : "TABLE_VALUED_FUNCTION_FAILED_TO_ANALYZE_IN_PYTHON",
-  "sqlState" : "38000",
-  "messageParameters" : {
-    "msg" : "Traceback (most recent call last):\n  File \"/Users/Daniel.Tenedorio/spark-2/python/lib/pyspark.zip/pyspark/sql/worker/analyze_udtf.py\", line 206, in main\n    elif isinstance(result.select, (list, tuple)) and (\nAttributeError: 'AnalyzeResultWithBuffer' object has no attribute 'select'"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 15,
-    "stopIndex" : 51,
-    "fragment" : "UDTFWithSinglePartition(1, TABLE(t2))"
-  } ]
-}
+[Analyzer test output redacted due to nondeterminism]
 
 
 -- !query
@@ -167,10 +139,12 @@ SELECT * FROM UDTFWithSinglePartition(0, TABLE(t2) WITH SINGLE PARTITION)
 -- !query analysis
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "TABLE_VALUED_FUNCTION_FAILED_TO_ANALYZE_IN_PYTHON",
-  "sqlState" : "38000",
+  "errorClass" : "TABLE_VALUED_FUNCTION_REQUIRED_METADATA_INCOMPATIBLE_WITH_CALL",
+  "sqlState" : "22023",
   "messageParameters" : {
-    "msg" : "Traceback (most recent call last):\n  File \"/Users/Daniel.Tenedorio/spark-2/python/lib/pyspark.zip/pyspark/sql/worker/analyze_udtf.py\", line 206, in main\n    elif isinstance(result.select, (list, tuple)) and (\nAttributeError: 'AnalyzeResultWithBuffer' object has no attribute 'select'"
+    "functionName" : "UDTFWithSinglePartition",
+    "invalidFunctionCallProperty" : "specified the WITH SINGLE PARTITION or PARTITION BY clause; please remove these clauses and retry the query again.",
+    "requestedMetadata" : "specified its own required partitioning of the input table"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -187,10 +161,12 @@ SELECT * FROM UDTFWithSinglePartition(0, TABLE(t2) PARTITION BY partition_col)
 -- !query analysis
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "TABLE_VALUED_FUNCTION_FAILED_TO_ANALYZE_IN_PYTHON",
-  "sqlState" : "38000",
+  "errorClass" : "TABLE_VALUED_FUNCTION_REQUIRED_METADATA_INCOMPATIBLE_WITH_CALL",
+  "sqlState" : "22023",
   "messageParameters" : {
-    "msg" : "Traceback (most recent call last):\n  File \"/Users/Daniel.Tenedorio/spark-2/python/lib/pyspark.zip/pyspark/sql/worker/analyze_udtf.py\", line 206, in main\n    elif isinstance(result.select, (list, tuple)) and (\nAttributeError: 'AnalyzeResultWithBuffer' object has no attribute 'select'"
+    "functionName" : "UDTFWithSinglePartition",
+    "invalidFunctionCallProperty" : "specified the WITH SINGLE PARTITION or PARTITION BY clause; please remove these clauses and retry the query again.",
+    "requestedMetadata" : "specified its own required partitioning of the input table"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -210,10 +186,12 @@ SELECT * FROM
 -- !query analysis
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "TABLE_VALUED_FUNCTION_FAILED_TO_ANALYZE_IN_PYTHON",
-  "sqlState" : "38000",
+  "errorClass" : "TABLE_VALUED_FUNCTION_REQUIRED_METADATA_INCOMPATIBLE_WITH_CALL",
+  "sqlState" : "22023",
   "messageParameters" : {
-    "msg" : "Traceback (most recent call last):\n  File \"/Users/Daniel.Tenedorio/spark-2/python/lib/pyspark.zip/pyspark/sql/worker/analyze_udtf.py\", line 206, in main\n    elif isinstance(result.select, (list, tuple)) and (\nAttributeError: 'AnalyzeResultWithBuffer' object has no attribute 'select'"
+    "functionName" : "UDTFWithSinglePartition",
+    "invalidFunctionCallProperty" : "specified the WITH SINGLE PARTITION or PARTITION BY clause; please remove these clauses and retry the query again.",
+    "requestedMetadata" : "specified its own required partitioning of the input table"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -649,21 +627,7 @@ SELECT * FROM InvalidTerminateReturnsNoneToNonNullableColumnMapType(TABLE(t2))
 -- !query
 SELECT * FROM UDTFForwardStateFromAnalyzeWithKwargs()
 -- !query analysis
-org.apache.spark.sql.AnalysisException
-{
-  "errorClass" : "TABLE_VALUED_FUNCTION_FAILED_TO_ANALYZE_IN_PYTHON",
-  "sqlState" : "38000",
-  "messageParameters" : {
-    "msg" : "Traceback (most recent call last):\n  File \"/Users/Daniel.Tenedorio/spark-2/python/lib/pyspark.zip/pyspark/sql/worker/analyze_udtf.py\", line 206, in main\n    elif isinstance(result.select, (list, tuple)) and (\nAttributeError: 'AnalyzeResultWithBuffer' object has no attribute 'select'"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 15,
-    "stopIndex" : 53,
-    "fragment" : "UDTFForwardStateFromAnalyzeWithKwargs()"
-  } ]
-}
+[Analyzer test output redacted due to nondeterminism]
 
 
 -- !query
@@ -689,21 +653,7 @@ org.apache.spark.sql.AnalysisException
 -- !query
 SELECT * FROM UDTFForwardStateFromAnalyzeWithKwargs(invalid => 2)
 -- !query analysis
-org.apache.spark.sql.AnalysisException
-{
-  "errorClass" : "TABLE_VALUED_FUNCTION_FAILED_TO_ANALYZE_IN_PYTHON",
-  "sqlState" : "38000",
-  "messageParameters" : {
-    "msg" : "Traceback (most recent call last):\n  File \"/Users/Daniel.Tenedorio/spark-2/python/lib/pyspark.zip/pyspark/sql/worker/analyze_udtf.py\", line 206, in main\n    elif isinstance(result.select, (list, tuple)) and (\nAttributeError: 'AnalyzeResultWithBuffer' object has no attribute 'select'"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 15,
-    "stopIndex" : 65,
-    "fragment" : "UDTFForwardStateFromAnalyzeWithKwargs(invalid => 2)"
-  } ]
-}
+[Analyzer test output redacted due to nondeterminism]
 
 
 -- !query
@@ -810,21 +760,7 @@ org.apache.spark.sql.AnalysisException
 -- !query
 SELECT * FROM InvalidForwardStateFromAnalyzeTooManyInitArgs(TABLE(t2))
 -- !query analysis
-org.apache.spark.sql.AnalysisException
-{
-  "errorClass" : "TABLE_VALUED_FUNCTION_FAILED_TO_ANALYZE_IN_PYTHON",
-  "sqlState" : "38000",
-  "messageParameters" : {
-    "msg" : "Traceback (most recent call last):\n  File \"/Users/Daniel.Tenedorio/spark-2/python/lib/pyspark.zip/pyspark/sql/worker/analyze_udtf.py\", line 206, in main\n    elif isinstance(result.select, (list, tuple)) and (\nAttributeError: 'AnalyzeResultWithBuffer' object has no attribute 'select'"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 15,
-    "stopIndex" : 70,
-    "fragment" : "InvalidForwardStateFromAnalyzeTooManyInitArgs(TABLE(t2))"
-  } ]
-}
+[Analyzer test output redacted due to nondeterminism]
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/inputs/udtf/udtf.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/udtf/udtf.sql
@@ -77,6 +77,7 @@ SELECT * FROM
     UDTFPartitionByOrderBy(TABLE(t2) PARTITION BY partition_col);
 SELECT * FROM UDTFPartitionByOrderByComplexExpr(TABLE(t2));
 SELECT * FROM UDTFInvalidOrderByAscKeyword(TABLE(t2));
+SELECT * FROM UDTFInvalidOrderByStringList(TABLE(t2));
 -- As a reminder, UDTFInvalidPartitionByAndWithSinglePartition returns this analyze result:
 --     AnalyzeResult(
 --         schema=StructType()

--- a/sql/core/src/test/resources/sql-tests/results/udtf/udtf.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udtf/udtf.sql.out
@@ -163,17 +163,45 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
 -- !query
 SELECT * FROM UDTFWithSinglePartition(0, TABLE(t2))
 -- !query schema
-struct<count:int,total:int,last:int>
+struct<>
 -- !query output
-3	6	3
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "TABLE_VALUED_FUNCTION_FAILED_TO_ANALYZE_IN_PYTHON",
+  "sqlState" : "38000",
+  "messageParameters" : {
+    "msg" : "Traceback (most recent call last):\n  File \"/Users/Daniel.Tenedorio/spark-2/python/lib/pyspark.zip/pyspark/sql/worker/analyze_udtf.py\", line 206, in main\n    elif isinstance(result.select, (list, tuple)) and (\nAttributeError: 'AnalyzeResultWithBuffer' object has no attribute 'select'"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 15,
+    "stopIndex" : 51,
+    "fragment" : "UDTFWithSinglePartition(0, TABLE(t2))"
+  } ]
+}
 
 
 -- !query
 SELECT * FROM UDTFWithSinglePartition(1, TABLE(t2))
 -- !query schema
-struct<count:int,total:int,last:int>
+struct<>
 -- !query output
-3	6	3
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "TABLE_VALUED_FUNCTION_FAILED_TO_ANALYZE_IN_PYTHON",
+  "sqlState" : "38000",
+  "messageParameters" : {
+    "msg" : "Traceback (most recent call last):\n  File \"/Users/Daniel.Tenedorio/spark-2/python/lib/pyspark.zip/pyspark/sql/worker/analyze_udtf.py\", line 206, in main\n    elif isinstance(result.select, (list, tuple)) and (\nAttributeError: 'AnalyzeResultWithBuffer' object has no attribute 'select'"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 15,
+    "stopIndex" : 51,
+    "fragment" : "UDTFWithSinglePartition(1, TABLE(t2))"
+  } ]
+}
 
 
 -- !query
@@ -183,12 +211,10 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "TABLE_VALUED_FUNCTION_REQUIRED_METADATA_INCOMPATIBLE_WITH_CALL",
-  "sqlState" : "22023",
+  "errorClass" : "TABLE_VALUED_FUNCTION_FAILED_TO_ANALYZE_IN_PYTHON",
+  "sqlState" : "38000",
   "messageParameters" : {
-    "functionName" : "UDTFWithSinglePartition",
-    "invalidFunctionCallProperty" : "specified the WITH SINGLE PARTITION or PARTITION BY clause; please remove these clauses and retry the query again.",
-    "requestedMetadata" : "specified its own required partitioning of the input table"
+    "msg" : "Traceback (most recent call last):\n  File \"/Users/Daniel.Tenedorio/spark-2/python/lib/pyspark.zip/pyspark/sql/worker/analyze_udtf.py\", line 206, in main\n    elif isinstance(result.select, (list, tuple)) and (\nAttributeError: 'AnalyzeResultWithBuffer' object has no attribute 'select'"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -207,12 +233,10 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "TABLE_VALUED_FUNCTION_REQUIRED_METADATA_INCOMPATIBLE_WITH_CALL",
-  "sqlState" : "22023",
+  "errorClass" : "TABLE_VALUED_FUNCTION_FAILED_TO_ANALYZE_IN_PYTHON",
+  "sqlState" : "38000",
   "messageParameters" : {
-    "functionName" : "UDTFWithSinglePartition",
-    "invalidFunctionCallProperty" : "specified the WITH SINGLE PARTITION or PARTITION BY clause; please remove these clauses and retry the query again.",
-    "requestedMetadata" : "specified its own required partitioning of the input table"
+    "msg" : "Traceback (most recent call last):\n  File \"/Users/Daniel.Tenedorio/spark-2/python/lib/pyspark.zip/pyspark/sql/worker/analyze_udtf.py\", line 206, in main\n    elif isinstance(result.select, (list, tuple)) and (\nAttributeError: 'AnalyzeResultWithBuffer' object has no attribute 'select'"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -234,12 +258,10 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "TABLE_VALUED_FUNCTION_REQUIRED_METADATA_INCOMPATIBLE_WITH_CALL",
-  "sqlState" : "22023",
+  "errorClass" : "TABLE_VALUED_FUNCTION_FAILED_TO_ANALYZE_IN_PYTHON",
+  "sqlState" : "38000",
   "messageParameters" : {
-    "functionName" : "UDTFWithSinglePartition",
-    "invalidFunctionCallProperty" : "specified the WITH SINGLE PARTITION or PARTITION BY clause; please remove these clauses and retry the query again.",
-    "requestedMetadata" : "specified its own required partitioning of the input table"
+    "msg" : "Traceback (most recent call last):\n  File \"/Users/Daniel.Tenedorio/spark-2/python/lib/pyspark.zip/pyspark/sql/worker/analyze_udtf.py\", line 206, in main\n    elif isinstance(result.select, (list, tuple)) and (\nAttributeError: 'AnalyzeResultWithBuffer' object has no attribute 'select'"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -364,6 +386,15 @@ org.apache.spark.sql.AnalysisException
     "fragment" : "UDTFInvalidOrderByAscKeyword(TABLE(t2))"
   } ]
 }
+
+
+-- !query
+SELECT * FROM UDTFInvalidOrderByStringList(TABLE(t2))
+-- !query schema
+struct<>
+-- !query output
+java.lang.NegativeArraySizeException
+-2
 
 
 -- !query
@@ -651,8 +682,21 @@ SELECT * FROM UDTFForwardStateFromAnalyzeWithKwargs()
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.api.python.PythonException
-pyspark.errors.exceptions.base.PySparkRuntimeError: [UDTF_EVAL_METHOD_ARGUMENTS_DO_NOT_MATCH_SIGNATURE] Failed to evaluate the user-defined table function 'UDTFForwardStateFromAnalyzeWithKwargs' because the function arguments did not match the expected signature of the 'eval' method (missing a required argument: 'argument'). Please update the query so that this table function call provides arguments matching the expected signature, or else update the table function so that its 'eval' method accepts the provided arguments, and then try the query again.
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "TABLE_VALUED_FUNCTION_FAILED_TO_ANALYZE_IN_PYTHON",
+  "sqlState" : "38000",
+  "messageParameters" : {
+    "msg" : "Traceback (most recent call last):\n  File \"/Users/Daniel.Tenedorio/spark-2/python/lib/pyspark.zip/pyspark/sql/worker/analyze_udtf.py\", line 206, in main\n    elif isinstance(result.select, (list, tuple)) and (\nAttributeError: 'AnalyzeResultWithBuffer' object has no attribute 'select'"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 15,
+    "stopIndex" : 53,
+    "fragment" : "UDTFForwardStateFromAnalyzeWithKwargs()"
+  } ]
+}
 
 
 -- !query
@@ -682,8 +726,21 @@ SELECT * FROM UDTFForwardStateFromAnalyzeWithKwargs(invalid => 2)
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.api.python.PythonException
-pyspark.errors.exceptions.base.PySparkRuntimeError: [UDTF_EVAL_METHOD_ARGUMENTS_DO_NOT_MATCH_SIGNATURE] Failed to evaluate the user-defined table function 'UDTFForwardStateFromAnalyzeWithKwargs' because the function arguments did not match the expected signature of the 'eval' method (missing a required argument: 'argument'). Please update the query so that this table function call provides arguments matching the expected signature, or else update the table function so that its 'eval' method accepts the provided arguments, and then try the query again.
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "TABLE_VALUED_FUNCTION_FAILED_TO_ANALYZE_IN_PYTHON",
+  "sqlState" : "38000",
+  "messageParameters" : {
+    "msg" : "Traceback (most recent call last):\n  File \"/Users/Daniel.Tenedorio/spark-2/python/lib/pyspark.zip/pyspark/sql/worker/analyze_udtf.py\", line 206, in main\n    elif isinstance(result.select, (list, tuple)) and (\nAttributeError: 'AnalyzeResultWithBuffer' object has no attribute 'select'"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 15,
+    "stopIndex" : 65,
+    "fragment" : "UDTFForwardStateFromAnalyzeWithKwargs(invalid => 2)"
+  } ]
+}
 
 
 -- !query
@@ -802,8 +859,21 @@ SELECT * FROM InvalidForwardStateFromAnalyzeTooManyInitArgs(TABLE(t2))
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.api.python.PythonException
-pyspark.errors.exceptions.base.PySparkRuntimeError: [UDTF_CONSTRUCTOR_INVALID_IMPLEMENTS_ANALYZE_METHOD] Failed to evaluate the user-defined table function 'InvalidForwardStateFromAnalyzeTooManyInitArgs' because its constructor is invalid: the function implements the 'analyze' method, but its constructor has more than two arguments (including the 'self' reference). Please update the table function so that its constructor accepts exactly one 'self' argument, or one 'self' argument plus another argument for the result of the 'analyze' method, and try the query again.
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "TABLE_VALUED_FUNCTION_FAILED_TO_ANALYZE_IN_PYTHON",
+  "sqlState" : "38000",
+  "messageParameters" : {
+    "msg" : "Traceback (most recent call last):\n  File \"/Users/Daniel.Tenedorio/spark-2/python/lib/pyspark.zip/pyspark/sql/worker/analyze_udtf.py\", line 206, in main\n    elif isinstance(result.select, (list, tuple)) and (\nAttributeError: 'AnalyzeResultWithBuffer' object has no attribute 'select'"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 15,
+    "stopIndex" : 70,
+    "fragment" : "InvalidForwardStateFromAnalyzeTooManyInitArgs(TABLE(t2))"
+  } ]
+}
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/udtf/udtf.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udtf/udtf.sql.out
@@ -163,45 +163,17 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
 -- !query
 SELECT * FROM UDTFWithSinglePartition(0, TABLE(t2))
 -- !query schema
-struct<>
+struct<count:int,total:int,last:int>
 -- !query output
-org.apache.spark.sql.AnalysisException
-{
-  "errorClass" : "TABLE_VALUED_FUNCTION_FAILED_TO_ANALYZE_IN_PYTHON",
-  "sqlState" : "38000",
-  "messageParameters" : {
-    "msg" : "Traceback (most recent call last):\n  File \"/Users/Daniel.Tenedorio/spark-2/python/lib/pyspark.zip/pyspark/sql/worker/analyze_udtf.py\", line 206, in main\n    elif isinstance(result.select, (list, tuple)) and (\nAttributeError: 'AnalyzeResultWithBuffer' object has no attribute 'select'"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 15,
-    "stopIndex" : 51,
-    "fragment" : "UDTFWithSinglePartition(0, TABLE(t2))"
-  } ]
-}
+3	6	3
 
 
 -- !query
 SELECT * FROM UDTFWithSinglePartition(1, TABLE(t2))
 -- !query schema
-struct<>
+struct<count:int,total:int,last:int>
 -- !query output
-org.apache.spark.sql.AnalysisException
-{
-  "errorClass" : "TABLE_VALUED_FUNCTION_FAILED_TO_ANALYZE_IN_PYTHON",
-  "sqlState" : "38000",
-  "messageParameters" : {
-    "msg" : "Traceback (most recent call last):\n  File \"/Users/Daniel.Tenedorio/spark-2/python/lib/pyspark.zip/pyspark/sql/worker/analyze_udtf.py\", line 206, in main\n    elif isinstance(result.select, (list, tuple)) and (\nAttributeError: 'AnalyzeResultWithBuffer' object has no attribute 'select'"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 15,
-    "stopIndex" : 51,
-    "fragment" : "UDTFWithSinglePartition(1, TABLE(t2))"
-  } ]
-}
+3	6	3
 
 
 -- !query
@@ -211,10 +183,12 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "TABLE_VALUED_FUNCTION_FAILED_TO_ANALYZE_IN_PYTHON",
-  "sqlState" : "38000",
+  "errorClass" : "TABLE_VALUED_FUNCTION_REQUIRED_METADATA_INCOMPATIBLE_WITH_CALL",
+  "sqlState" : "22023",
   "messageParameters" : {
-    "msg" : "Traceback (most recent call last):\n  File \"/Users/Daniel.Tenedorio/spark-2/python/lib/pyspark.zip/pyspark/sql/worker/analyze_udtf.py\", line 206, in main\n    elif isinstance(result.select, (list, tuple)) and (\nAttributeError: 'AnalyzeResultWithBuffer' object has no attribute 'select'"
+    "functionName" : "UDTFWithSinglePartition",
+    "invalidFunctionCallProperty" : "specified the WITH SINGLE PARTITION or PARTITION BY clause; please remove these clauses and retry the query again.",
+    "requestedMetadata" : "specified its own required partitioning of the input table"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -233,10 +207,12 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "TABLE_VALUED_FUNCTION_FAILED_TO_ANALYZE_IN_PYTHON",
-  "sqlState" : "38000",
+  "errorClass" : "TABLE_VALUED_FUNCTION_REQUIRED_METADATA_INCOMPATIBLE_WITH_CALL",
+  "sqlState" : "22023",
   "messageParameters" : {
-    "msg" : "Traceback (most recent call last):\n  File \"/Users/Daniel.Tenedorio/spark-2/python/lib/pyspark.zip/pyspark/sql/worker/analyze_udtf.py\", line 206, in main\n    elif isinstance(result.select, (list, tuple)) and (\nAttributeError: 'AnalyzeResultWithBuffer' object has no attribute 'select'"
+    "functionName" : "UDTFWithSinglePartition",
+    "invalidFunctionCallProperty" : "specified the WITH SINGLE PARTITION or PARTITION BY clause; please remove these clauses and retry the query again.",
+    "requestedMetadata" : "specified its own required partitioning of the input table"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -258,10 +234,12 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "TABLE_VALUED_FUNCTION_FAILED_TO_ANALYZE_IN_PYTHON",
-  "sqlState" : "38000",
+  "errorClass" : "TABLE_VALUED_FUNCTION_REQUIRED_METADATA_INCOMPATIBLE_WITH_CALL",
+  "sqlState" : "22023",
   "messageParameters" : {
-    "msg" : "Traceback (most recent call last):\n  File \"/Users/Daniel.Tenedorio/spark-2/python/lib/pyspark.zip/pyspark/sql/worker/analyze_udtf.py\", line 206, in main\n    elif isinstance(result.select, (list, tuple)) and (\nAttributeError: 'AnalyzeResultWithBuffer' object has no attribute 'select'"
+    "functionName" : "UDTFWithSinglePartition",
+    "invalidFunctionCallProperty" : "specified the WITH SINGLE PARTITION or PARTITION BY clause; please remove these clauses and retry the query again.",
+    "requestedMetadata" : "specified its own required partitioning of the input table"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -780,21 +758,8 @@ SELECT * FROM UDTFForwardStateFromAnalyzeWithKwargs()
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.sql.AnalysisException
-{
-  "errorClass" : "TABLE_VALUED_FUNCTION_FAILED_TO_ANALYZE_IN_PYTHON",
-  "sqlState" : "38000",
-  "messageParameters" : {
-    "msg" : "Traceback (most recent call last):\n  File \"/Users/Daniel.Tenedorio/spark-2/python/lib/pyspark.zip/pyspark/sql/worker/analyze_udtf.py\", line 206, in main\n    elif isinstance(result.select, (list, tuple)) and (\nAttributeError: 'AnalyzeResultWithBuffer' object has no attribute 'select'"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 15,
-    "stopIndex" : 53,
-    "fragment" : "UDTFForwardStateFromAnalyzeWithKwargs()"
-  } ]
-}
+org.apache.spark.api.python.PythonException
+pyspark.errors.exceptions.base.PySparkRuntimeError: [UDTF_EVAL_METHOD_ARGUMENTS_DO_NOT_MATCH_SIGNATURE] Failed to evaluate the user-defined table function 'UDTFForwardStateFromAnalyzeWithKwargs' because the function arguments did not match the expected signature of the 'eval' method (missing a required argument: 'argument'). Please update the query so that this table function call provides arguments matching the expected signature, or else update the table function so that its 'eval' method accepts the provided arguments, and then try the query again.
 
 
 -- !query
@@ -824,21 +789,8 @@ SELECT * FROM UDTFForwardStateFromAnalyzeWithKwargs(invalid => 2)
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.sql.AnalysisException
-{
-  "errorClass" : "TABLE_VALUED_FUNCTION_FAILED_TO_ANALYZE_IN_PYTHON",
-  "sqlState" : "38000",
-  "messageParameters" : {
-    "msg" : "Traceback (most recent call last):\n  File \"/Users/Daniel.Tenedorio/spark-2/python/lib/pyspark.zip/pyspark/sql/worker/analyze_udtf.py\", line 206, in main\n    elif isinstance(result.select, (list, tuple)) and (\nAttributeError: 'AnalyzeResultWithBuffer' object has no attribute 'select'"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 15,
-    "stopIndex" : 65,
-    "fragment" : "UDTFForwardStateFromAnalyzeWithKwargs(invalid => 2)"
-  } ]
-}
+org.apache.spark.api.python.PythonException
+pyspark.errors.exceptions.base.PySparkRuntimeError: [UDTF_EVAL_METHOD_ARGUMENTS_DO_NOT_MATCH_SIGNATURE] Failed to evaluate the user-defined table function 'UDTFForwardStateFromAnalyzeWithKwargs' because the function arguments did not match the expected signature of the 'eval' method (missing a required argument: 'argument'). Please update the query so that this table function call provides arguments matching the expected signature, or else update the table function so that its 'eval' method accepts the provided arguments, and then try the query again.
 
 
 -- !query
@@ -957,21 +909,8 @@ SELECT * FROM InvalidForwardStateFromAnalyzeTooManyInitArgs(TABLE(t2))
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.sql.AnalysisException
-{
-  "errorClass" : "TABLE_VALUED_FUNCTION_FAILED_TO_ANALYZE_IN_PYTHON",
-  "sqlState" : "38000",
-  "messageParameters" : {
-    "msg" : "Traceback (most recent call last):\n  File \"/Users/Daniel.Tenedorio/spark-2/python/lib/pyspark.zip/pyspark/sql/worker/analyze_udtf.py\", line 206, in main\n    elif isinstance(result.select, (list, tuple)) and (\nAttributeError: 'AnalyzeResultWithBuffer' object has no attribute 'select'"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 15,
-    "stopIndex" : 70,
-    "fragment" : "InvalidForwardStateFromAnalyzeTooManyInitArgs(TABLE(t2))"
-  } ]
-}
+org.apache.spark.api.python.PythonException
+pyspark.errors.exceptions.base.PySparkRuntimeError: [UDTF_CONSTRUCTOR_INVALID_IMPLEMENTS_ANALYZE_METHOD] Failed to evaluate the user-defined table function 'InvalidForwardStateFromAnalyzeTooManyInitArgs' because its constructor is invalid: the function implements the 'analyze' method, but its constructor has more than two arguments (including the 'self' reference). Please update the table function so that its constructor accepts exactly one 'self' argument, or one 'self' argument plus another argument for the result of the 'analyze' method, and try the query again.
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/udtf/udtf.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udtf/udtf.sql.out
@@ -469,8 +469,21 @@ SELECT * FROM UDTFInvalidOrderByStringList(TABLE(t2))
 -- !query schema
 struct<>
 -- !query output
-java.lang.NegativeArraySizeException
--2
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "TABLE_VALUED_FUNCTION_FAILED_TO_ANALYZE_IN_PYTHON",
+  "sqlState" : "38000",
+  "messageParameters" : {
+    "msg" : "Failed to evaluate the user-defined table function 'UDTFInvalidOrderByStringList' because the static 'analyze' method returned an 'AnalyzeResult' object with the 'orderBy' field set to a value besides a list or tuple of 'OrderingColumn' objects. Please update the table function and then try the query again."
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 15,
+    "stopIndex" : 53,
+    "fragment" : "UDTFInvalidOrderByStringList(TABLE(t2))"
+  } ]
+}
 
 
 -- !query

--- a/sql/core/src/test/scala/org/apache/spark/sql/IntegratedUDFTestUtils.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/IntegratedUDFTestUtils.scala
@@ -631,70 +631,70 @@ object IntegratedUDFTestUtils extends SQLHelper {
 
   object UDTFPartitionByOrderBy
     extends TestPythonUDTFPartitionByOrderByBase(
-      partitionBy = "partition_col",
-      orderBy = "input",
+      partitionBy = "PartitioningColumn(\"partition_col\")",
+      orderBy = "OrderingColumn(\"input\")",
       select = "")
 
   object UDTFPartitionByOrderByComplexExpr
     extends TestPythonUDTFPartitionByOrderByBase(
-      partitionBy = "partition_col + 1",
-      orderBy = "RANDOM(42)",
+      partitionBy = "PartitioningColumn(\"partition_col + 1\")",
+      orderBy = "OrderingColumn(\"RANDOM(42)\")",
       select = "")
 
   object UDTFPartitionByOrderBySelectExpr
     extends TestPythonUDTFPartitionByOrderByBase(
-      partitionBy = "partition_col",
-      orderBy = "input",
+      partitionBy = "PartitioningColumn(\"partition_col\")",
+      orderBy = "OrderingColumn(\"input\")",
       select = "SelectedColumn(\"partition_col\"), SelectedColumn(\"input\")")
 
   object UDTFPartitionByOrderBySelectComplexExpr
     extends TestPythonUDTFPartitionByOrderByBase(
-      partitionBy = "partition_col + 1",
-      orderBy = "RANDOM(42)",
+      partitionBy = "PartitioningColumn(\"partition_col + 1\")",
+      orderBy = "OrderingColumn(\"RANDOM(42)\")",
       select = "SelectedColumn(\"partition_col\"), " +
         "SelectedColumn(name=\"input + 1\", alias=\"input\")")
 
   object UDTFPartitionByOrderBySelectExprOnlyPartitionColumn
     extends TestPythonUDTFPartitionByOrderByBase(
-      partitionBy = "partition_col",
-      orderBy = "input",
+      partitionBy = "PartitioningColumn(\"partition_col\")",
+      orderBy = "OrderingColumn(\"input\")",
       select = "SelectedColumn(\"partition_col\")")
 
   object UDTFInvalidPartitionByOrderByParseError
     extends TestPythonUDTFPartitionByOrderByBase(
-      partitionBy = "unparsable",
-      orderBy = "input",
+      partitionBy = "PartitioningColumn(\"unparsable\")",
+      orderBy = "OrderingColumn(\"input\")",
       select = "")
 
   object UDTFInvalidOrderByAscKeyword
     extends TestPythonUDTFPartitionByOrderByBase(
-      partitionBy = "partition_col",
-      orderBy = "partition_col ASC",
+      partitionBy = "PartitioningColumn(\"partition_col\")",
+      orderBy = "OrderingColumn(\"partition_col ASC\")",
       select = "")
 
   object UDTFInvalidSelectExprParseError
     extends TestPythonUDTFPartitionByOrderByBase(
-      partitionBy = "partition_col",
-      orderBy = "input",
+      partitionBy = "PartitioningColumn(\"partition_col\")",
+      orderBy = "OrderingColumn(\"input\")",
       select = "SelectedColumn(\"unparsable\")")
 
   object UDTFInvalidSelectExprStringValue
     extends TestPythonUDTFPartitionByOrderByBase(
-      partitionBy = "partition_col",
-      orderBy = "input",
+      partitionBy = "PartitioningColumn(\"partition_col\")",
+      orderBy = "OrderingColumn(\"input\")",
       select = "\"partition_cll\"")
 
   object UDTFInvalidComplexSelectExprMissingAlias
     extends TestPythonUDTFPartitionByOrderByBase(
-      partitionBy = "partition_col + 1",
-      orderBy = "RANDOM(42)",
+      partitionBy = "PartitioningColumn(\"partition_col + 1\")",
+      orderBy = "OrderingColumn(\"RANDOM(42)\")",
       select = "SelectedColumn(name=\"input + 1\")")
 
   object UDTFInvalidOrderByStringList
     extends TestPythonUDTFPartitionByOrderByBase(
       partitionBy = "PartitioningColumn(\"partition_col\")",
       orderBy = "\"partition_col\"",
-      select = "SelectedColumn(\"partition_col\"), SelectedColumn(\"input\")")
+      select = "")
 
   object UDTFInvalidPartitionByAndWithSinglePartition extends TestUDTF {
     val pythonScript: String =

--- a/sql/core/src/test/scala/org/apache/spark/sql/IntegratedUDFTestUtils.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/IntegratedUDFTestUtils.scala
@@ -607,10 +607,10 @@ object IntegratedUDFTestUtils extends SQLHelper {
         |                .add("total", IntegerType())
         |                .add("last", IntegerType()),
         |            partitionBy=[
-        |                PartitioningColumn("$partitionBy")
+        |                $partitionBy
         |            ],
         |            orderBy=[
-        |                OrderingColumn("$orderBy")
+        |                $orderBy
         |            ])
         |
         |    def eval(self, row: Row):
@@ -626,23 +626,28 @@ object IntegratedUDFTestUtils extends SQLHelper {
 
   object UDTFPartitionByOrderBy
     extends TestPythonUDTFPartitionByOrderByBase(
-      partitionBy = "partition_col",
-      orderBy = "input")
+      partitionBy = "PartitioningColumn(\"partition_col\")",
+      orderBy = "OrderingColumn(\"input\")")
 
   object UDTFPartitionByOrderByComplexExpr
     extends TestPythonUDTFPartitionByOrderByBase(
-      partitionBy = "partition_col + 1",
-      orderBy = "RANDOM(42)")
+      partitionBy = "PartitioningColumn(\"partition_col + 1\")",
+      orderBy = "OrderingColumn(\"RANDOM(42)\")")
 
   object UDTFInvalidPartitionByOrderByParseError
     extends TestPythonUDTFPartitionByOrderByBase(
-      partitionBy = "unparsable",
-      orderBy = "input")
+      partitionBy = "PartitioningColumn(\"unparsable\")",
+      orderBy = "OrderingColumn(\"input\")")
 
   object UDTFInvalidOrderByAscKeyword
     extends TestPythonUDTFPartitionByOrderByBase(
-      partitionBy = "partition_col",
-      orderBy = "partition_col ASC")
+      partitionBy = "PartitioningColumn(\"partition_col\")",
+      orderBy = "OrderingColumn(\"partition_col ASC\")")
+
+  object UDTFInvalidOrderByStringList
+    extends TestPythonUDTFPartitionByOrderByBase(
+      partitionBy = "PartitioningColumn(\"partition_col\")",
+      orderBy = "\"partition_col\"")
 
   object UDTFInvalidPartitionByAndWithSinglePartition extends TestUDTF {
     val pythonScript: String =
@@ -1151,6 +1156,7 @@ object IntegratedUDFTestUtils extends SQLHelper {
     UDTFWithSinglePartition,
     UDTFPartitionByOrderBy,
     UDTFInvalidOrderByAscKeyword,
+    UDTFInvalidOrderByStringList,
     UDTFInvalidPartitionByAndWithSinglePartition,
     UDTFInvalidPartitionByOrderByParseError,
     UDTFInvalidOrderByWithoutPartitionBy,


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates the Python UDTF API to check and return a better error message if the `analyze` method returns an `AnalyzeResult` object with an `orderBy` field erroneously set to a list of strings, rather than `OrderingColumn` instances.

For example, this UDTF accidentally sets the `orderBy` field in this way:

```
from pyspark.sql.functions import AnalyzeResult, OrderingColumn, PartitioningColumn
from pyspark.sql.types import IntegerType, Row, StructType
class Udtf:
    def __init__(self):
        self._partition_col = None
        self._count = 0
        self._sum = 0
        self._last = None

    @staticmethod
    def analyze(row: Row):
        return AnalyzeResult(
            schema=StructType()
                .add("user_id", IntegerType())
                .add("count", IntegerType())
                .add("total", IntegerType())
                .add("last", IntegerType()),
            partitionBy=[
                PartitioningColumn("user_id")
            ],
            orderBy=[
                "timestamp"
            ],
            )

    def eval(self, row: Row):
        self._partition_col = row["partition_col"]
        self._count += 1
        self._last = row["input"]
        self._sum += row["input"]

    def terminate(self):
        yield self._partition_col, self._count, self._sum, self._last
```

### Why are the changes needed?

This improves error messages and helps keep users from getting confused.

### Does this PR introduce _any_ user-facing change?

Yes, see above.

### How was this patch tested?

This PR adds test coverage.

### Was this patch authored or co-authored using generative AI tooling?

No.