### PR TITLE
[MINOR][PYTHON][SQL][TESTS] Don't load Python Data Source when Python executable is not available even for testing

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceManager.scala
@@ -98,7 +98,7 @@ object DataSourceManager extends Logging {
   private def normalize(name: String): String = name.toLowerCase(Locale.ROOT)
 
   private def initialStaticDataSourceBuilders: Map[String, UserDefinedPythonDataSource] = {
-    if (Utils.isTesting || shouldLoadPythonDataSources) this.synchronized {
+    if (shouldLoadPythonDataSources) this.synchronized {
       if (dataSourceBuilders.isEmpty) {
         val maybeResult = try {
           Some(UserDefinedPythonDataSource.lookupAllDataSourcesInPython())


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to don't load Python Data Source Python executable is not available even for testing

### Why are the changes needed?

Whether if we're in test or not, it can't work loading Python Data Sources anyway.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Manually tested.

### Was this patch authored or co-authored using generative AI tooling?

No.