### PR TITLE
[SPARK-47011][MLLIB] Remove deprecated `BinaryClassificationMetrics.scoreLabelsWeight`

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/evaluation/BinaryClassificationMetrics.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/evaluation/BinaryClassificationMetrics.scala
@@ -46,9 +46,7 @@ class BinaryClassificationMetrics @Since("3.0.0") (
     @Since("1.3.0") val numBins: Int = 1000)
   extends Logging {
 
-  @deprecated("The variable `scoreLabelsWeight` should be private and " +
-    "will be removed in 4.0.0.", "3.4.0")
-  val scoreLabelsWeight: RDD[(Double, (Double, Double))] = scoreAndLabels.map {
+  private val scoreLabelsWeight: RDD[(Double, (Double, Double))] = scoreAndLabels.map {
     case (prediction: Double, label: Double, weight: Double) =>
       require(weight >= 0.0, s"instance weight, $weight has to be >= 0.0")
       (prediction, (label, weight))

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -77,7 +77,9 @@ object MimaExcludes {
     // SPARK-46410: Assign error classes/subclasses to JdbcUtils.classifyException
     ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.sql.jdbc.JdbcDialect.classifyException"),
     // [SPARK-464878][CORE][SQL] (false alert). Invalid rule for StringType extension.
-    ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.sql.types.StringType.this")
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.sql.types.StringType.this"),
+    // SPARK-47011: Remove deprecated BinaryClassificationMetrics.scoreLabelsWeight
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.mllib.evaluation.BinaryClassificationMetrics.scoreLabelsWeight")
   )
 
   // Default exclude rules


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to a planned removal of the deprecated `BinaryClassificationMetrics.scoreLabelsWeight`.

### Why are the changes needed?

Apache Spark 3.4.0 deprecated this via SPARK-39533 and announced the removal of this.
- #36926

https://github.com/apache/spark/blob/b7edc5fac0f4e479cbc869d54a9490c553ba2613/mllib/src/main/scala/org/apache/spark/mllib/evaluation/BinaryClassificationMetrics.scala#L49-L50

### Does this PR introduce _any_ user-facing change?

Yes, but this is a planned change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.