### PR TITLE
[SPARK-47014][PYTHON][CONNECT] Implement methods dumpPerfProfiles and dumpMemoryProfiles of SparkSession

### DIFF
--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -966,7 +966,7 @@ class SparkSession:
     def dumpMemoryProfiles(self, path: str, id: Optional[int] = None) -> None:
         self._profiler_collector.dump_memory_profiles(path, id)
 
-    dumpMemoryProfiles.__doc__ = PySparkSession.dump_memory_profiles.__doc__
+    dumpMemoryProfiles.__doc__ = PySparkSession.dumpMemoryprofiles.__doc__
 
 
 SparkSession.__doc__ = PySparkSession.__doc__

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -958,6 +958,11 @@ class SparkSession:
 
     showMemoryProfiles.__doc__ = PySparkSession.showMemoryProfiles.__doc__
 
+    def dumpPerfProfiles(self, path: str, id: Optional[int] = None) -> None:
+        self._profiler_collector.dump_perf_profiles(path, id)
+
+    dumpPerfProfiles.__doc__ = PySparkSession.dumpPerfProfiles.__doc__
+
 
 SparkSession.__doc__ = PySparkSession.__doc__
 

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -966,7 +966,7 @@ class SparkSession:
     def dumpMemoryProfiles(self, path: str, id: Optional[int] = None) -> None:
         self._profiler_collector.dump_memory_profiles(path, id)
 
-    dumpMemoryProfiles.__doc__ = PySparkSession.dumpMemoryprofiles.__doc__
+    dumpMemoryProfiles.__doc__ = PySparkSession.dumpMemoryProfiles.__doc__
 
 
 SparkSession.__doc__ = PySparkSession.__doc__

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -963,6 +963,11 @@ class SparkSession:
 
     dumpPerfProfiles.__doc__ = PySparkSession.dumpPerfProfiles.__doc__
 
+    def dumpMemoryProfiles(self, path: str, id: Optional[int] = None) -> None:
+        self._profiler_collector.dump_memory_profiles(path, id)
+
+    dumpMemoryProfiles.__doc__ = PySparkSession.dump_memory_profiles.__doc__
+
 
 SparkSession.__doc__ = PySparkSession.__doc__
 

--- a/python/pyspark/sql/profiler.py
+++ b/python/pyspark/sql/profiler.py
@@ -175,20 +175,20 @@ class ProfilerCollector(ABC):
         with self._lock:
             stats = self._perf_profile_results
 
-        def dump(path: str, id: int) -> None:
+        def dump(id: int) -> None:
             s = stats.get(id)
 
             if s is not None:
                 if not os.path.exists(path):
                     os.makedirs(path)
-                p = os.path.join(path, "udf_%d.pstats" % id)
+                p = os.path.join(path, f"udf_{id}_perf.pstats")
                 s.dump_stats(p)
 
         if id is not None:
-            dump(path, id)
+            dump(id)
         else:
             for id in sorted(stats.keys()):
-                dump(path, id)
+                dump(id)
 
     def dump_memory_profiles(self, path: str, id: Optional[int] = None) -> None:
         """
@@ -206,22 +206,22 @@ class ProfilerCollector(ABC):
         with self._lock:
             code_map = self._memory_profile_results
 
-        def dump(path: str, id: int) -> None:
+        def dump(id: int) -> None:
             cm = code_map.get(id)
 
             if cm is not None:
                 if not os.path.exists(path):
                     os.makedirs(path)
-                p = os.path.join(path, "udf_%d_memory.txt" % id)
+                p = os.path.join(path, f"udf_{id}_memory.txt")
 
                 with open(p, "w+") as f:
                     MemoryProfiler._show_results(cm, stream=f)
 
         if id is not None:
-            dump(path, id)
+            dump(id)
         else:
             for id in sorted(code_map.keys()):
-                dump(path, id)
+                dump(id)
 
 
 class AccumulatorProfilerCollector(ProfilerCollector):

--- a/python/pyspark/sql/profiler.py
+++ b/python/pyspark/sql/profiler.py
@@ -190,6 +190,39 @@ class ProfilerCollector(ABC):
             for id in sorted(stats.keys()):
                 dump(path, id)
 
+    def dump_memory_profiles(self, path: str, id: Optional[int] = None) -> None:
+        """
+        Dump the memory profile results into directory `path`.
+
+        .. versionadded:: 4.0.0
+
+        Parameters
+        ----------
+        path: str
+            A directory in which to dump the memory profile.
+        id : int, optional
+            A UDF ID to be shown. If not specified, all the results will be shown.
+        """
+        with self._lock:
+            code_map = self._memory_profile_results
+
+        def dump(path: str, id: int) -> None:
+            cm = code_map.get(id)
+
+            if cm is not None:
+                if not os.path.exists(path):
+                    os.makedirs(path)
+                p = os.path.join(path, "udf_%d_memory.txt" % id)
+
+                with open(p, "w+") as f:
+                    MemoryProfiler._show_results(cm, stream=f)
+
+        if id is not None:
+            dump(path, id)
+        else:
+            for id in sorted(code_map.keys()):
+                dump(path, id)
+
 
 class AccumulatorProfilerCollector(ProfilerCollector):
     def __init__(self) -> None:

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -2150,6 +2150,11 @@ class SparkSession(SparkConversionMixin):
 
     dumpPerfProfiles.__doc__ = ProfilerCollector.dump_perf_profiles.__doc__
 
+    def dumpMemoryProfiles(self, path: str, id: Optional[int] = None) -> None:
+        self._profiler_collector.dump_memory_profiles(path, id)
+
+    dumpMemoryProfiles.__doc__ = ProfilerCollector.dump_memory_profiles.__doc__
+
 
 def _test() -> None:
     import os

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -2145,6 +2145,11 @@ class SparkSession(SparkConversionMixin):
 
     showMemoryProfiles.__doc__ = ProfilerCollector.show_memory_profiles.__doc__
 
+    def dumpPerfProfiles(self, path: str, id: Optional[int] = None) -> None:
+        self._profiler_collector.dump_perf_profiles(path, id)
+
+    dumpPerfProfiles.__doc__ = ProfilerCollector.dump_perf_profiles.__doc__
+
 
 def _test() -> None:
     import os

--- a/python/pyspark/sql/tests/test_udf_profiler.py
+++ b/python/pyspark/sql/tests/test_udf_profiler.py
@@ -185,6 +185,9 @@ class UDFProfiler2TestsMixin:
         with self.trap_stdout() as io_all:
             self.spark.showPerfProfiles()
 
+        d = tempfile.gettempdir()
+        self.spark.dumpPerfProfiles(d)
+
         for id in self.profile_results:
             self.assertIn(f"Profile of UDF<id={id}>", io_all.getvalue())
 
@@ -195,6 +198,7 @@ class UDFProfiler2TestsMixin:
             self.assertRegex(
                 io.getvalue(), f"10.*{os.path.basename(inspect.getfile(_do_computation))}"
             )
+            self.assertTrue("udf_%d.pstats" % id in os.listdir(d))
 
     @unittest.skipIf(
         not have_pandas or not have_pyarrow,

--- a/python/pyspark/sql/tests/test_udf_profiler.py
+++ b/python/pyspark/sql/tests/test_udf_profiler.py
@@ -198,7 +198,7 @@ class UDFProfiler2TestsMixin:
                 self.assertRegex(
                     io.getvalue(), f"10.*{os.path.basename(inspect.getfile(_do_computation))}"
                 )
-                self.assertTrue("udf_%d.pstats" % id in os.listdir(d))
+                self.assertTrue(f"udf_{id}_perf.pstats" in os.listdir(d))
 
     @unittest.skipIf(
         not have_pandas or not have_pyarrow,

--- a/python/pyspark/sql/tests/test_udf_profiler.py
+++ b/python/pyspark/sql/tests/test_udf_profiler.py
@@ -185,20 +185,20 @@ class UDFProfiler2TestsMixin:
         with self.trap_stdout() as io_all:
             self.spark.showPerfProfiles()
 
-        d = tempfile.gettempdir()
-        self.spark.dumpPerfProfiles(d)
+        with tempfile.TemporaryDirectory() as d:
+            self.spark.dumpPerfProfiles(d)
 
-        for id in self.profile_results:
-            self.assertIn(f"Profile of UDF<id={id}>", io_all.getvalue())
+            for id in self.profile_results:
+                self.assertIn(f"Profile of UDF<id={id}>", io_all.getvalue())
 
-            with self.trap_stdout() as io:
-                self.spark.showPerfProfiles(id)
+                with self.trap_stdout() as io:
+                    self.spark.showPerfProfiles(id)
 
-            self.assertIn(f"Profile of UDF<id={id}>", io.getvalue())
-            self.assertRegex(
-                io.getvalue(), f"10.*{os.path.basename(inspect.getfile(_do_computation))}"
-            )
-            self.assertTrue("udf_%d.pstats" % id in os.listdir(d))
+                self.assertIn(f"Profile of UDF<id={id}>", io.getvalue())
+                self.assertRegex(
+                    io.getvalue(), f"10.*{os.path.basename(inspect.getfile(_do_computation))}"
+                )
+                self.assertTrue("udf_%d.pstats" % id in os.listdir(d))
 
     @unittest.skipIf(
         not have_pandas or not have_pyarrow,

--- a/python/pyspark/tests/test_memory_profiler.py
+++ b/python/pyspark/tests/test_memory_profiler.py
@@ -232,6 +232,9 @@ class MemoryProfiler2TestsMixin:
         with self.trap_stdout() as io_all:
             self.spark.showMemoryProfiles()
 
+        d = tempfile.gettempdir()
+        self.spark.dumpMemoryProfiles(d)
+
         for id in self.profile_results:
             self.assertIn(f"Profile of UDF<id={id}>", io_all.getvalue())
 
@@ -242,6 +245,7 @@ class MemoryProfiler2TestsMixin:
             self.assertRegex(
                 io.getvalue(), f"Filename.*{os.path.basename(inspect.getfile(_do_computation))}"
             )
+            self.assertTrue("udf_%d_memory.txt" % id in os.listdir(d))
 
     @unittest.skipIf(
         not have_pandas or not have_pyarrow,

--- a/python/pyspark/tests/test_memory_profiler.py
+++ b/python/pyspark/tests/test_memory_profiler.py
@@ -232,20 +232,20 @@ class MemoryProfiler2TestsMixin:
         with self.trap_stdout() as io_all:
             self.spark.showMemoryProfiles()
 
-        d = tempfile.gettempdir()
-        self.spark.dumpMemoryProfiles(d)
+        with tempfile.TemporaryDirectory() as d:
+            self.spark.dumpMemoryProfiles(d)
 
-        for id in self.profile_results:
-            self.assertIn(f"Profile of UDF<id={id}>", io_all.getvalue())
+            for id in self.profile_results:
+                self.assertIn(f"Profile of UDF<id={id}>", io_all.getvalue())
 
-            with self.trap_stdout() as io:
-                self.spark.showMemoryProfiles(id)
+                with self.trap_stdout() as io:
+                    self.spark.showMemoryProfiles(id)
 
-            self.assertIn(f"Profile of UDF<id={id}>", io.getvalue())
-            self.assertRegex(
-                io.getvalue(), f"Filename.*{os.path.basename(inspect.getfile(_do_computation))}"
-            )
-            self.assertTrue("udf_%d_memory.txt" % id in os.listdir(d))
+                self.assertIn(f"Profile of UDF<id={id}>", io.getvalue())
+                self.assertRegex(
+                    io.getvalue(), f"Filename.*{os.path.basename(inspect.getfile(_do_computation))}"
+                )
+                self.assertTrue("udf_%d_memory.txt" % id in os.listdir(d))
 
     @unittest.skipIf(
         not have_pandas or not have_pyarrow,

--- a/python/pyspark/tests/test_memory_profiler.py
+++ b/python/pyspark/tests/test_memory_profiler.py
@@ -108,7 +108,7 @@ class MemoryProfilerTests(PySparkTestCase):
 
         with tempfile.TemporaryDirectory() as d:
             self.sc.dump_profiles(d)
-            self.assertTrue("udf_%d_memory.txt" % id in os.listdir(d))
+            self.assertTrue(f"udf_{id}_memory.txt" in os.listdir(d))
 
     def test_profile_pandas_udf(self):
         udfs = [self.exec_pandas_udf_ser_to_ser, self.exec_pandas_udf_ser_to_scalar]
@@ -245,7 +245,7 @@ class MemoryProfiler2TestsMixin:
                 self.assertRegex(
                     io.getvalue(), f"Filename.*{os.path.basename(inspect.getfile(_do_computation))}"
                 )
-                self.assertTrue("udf_%d_memory.txt" % id in os.listdir(d))
+                self.assertTrue(f"udf_{id}_memory.txt" in os.listdir(d))
 
     @unittest.skipIf(
         not have_pandas or not have_pyarrow,


### PR DESCRIPTION
### What changes were proposed in this pull request?
Implement methods dumpPerfProfiles and dumpMemoryProfiles of SparkSession


### Why are the changes needed?
Complete support of (v2) SparkSession-based profiling.


### Does this PR introduce _any_ user-facing change?
Yes. dumpPerfProfiles and dumpMemoryProfiles of SparkSession are supported.

An example of dumpPerfProfiles is shown below.

```py
>>> @udf("long")
... def add(x):
...   return x + 1
... 
>>> spark.conf.set("spark.sql.pyspark.udf.profiler", "perf")
>>> spark.range(10).select(add("id")).collect()
...
>>> spark.dumpPerfProfiles("dummy_dir")
>>> os.listdir("dummy_dir")
['udf_2.pstats']
```

### How was this patch tested?
Unit tests.

### Was this patch authored or co-authored using generative AI tooling?
No.