### PR TITLE
[MINOR][DOCS] Remove outdated `antlr4` version comment in `pom.xml`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -212,7 +212,6 @@
     <jodd.version>3.5.2</jodd.version>
     <jsr305.version>3.0.0</jsr305.version>
     <libthrift.version>0.12.0</libthrift.version>
-    <!-- Please don't upgrade the version to 4.10+, it depends on JDK 11 -->
     <antlr4.version>4.13.1</antlr4.version>
     <jpam.version>1.1</jpam.version>
     <selenium.version>4.12.1</selenium.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove an outdated `antlr4` comment in `pom.xml`.

### Why are the changes needed?

This was missed when SPARK-44366 upgraded `antlr4` from 4.9.3 to 4.13.1.

- https://github.com/apache/spark/pull/43075

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.