### PR TITLE
[SPARK-47020][CORE][TESTS] Fix `RealBrowserUISeleniumSuite`

### DIFF
--- a/core/src/test/scala/org/apache/spark/ui/RealBrowserUISeleniumSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/RealBrowserUISeleniumSuite.scala
@@ -73,8 +73,8 @@ abstract class RealBrowserUISeleniumSuite(val driverProp: String)
 
         // Open DAG Viz.
         webDriver.findElement(By.id("job-dag-viz")).click()
-        val nodeDesc = webDriver.findElement(By.cssSelector("g[class='node_0 node']"))
-        nodeDesc.getAttribute("name") should include ("collect at &lt;console&gt;:25")
+        val nodeDesc = webDriver.findElement(By.cssSelector("g[id='node_0']"))
+        nodeDesc.getAttribute("innerHTML") should include ("collect at &lt;console&gt;:25")
       }
     }
   }
@@ -109,22 +109,20 @@ abstract class RealBrowserUISeleniumSuite(val driverProp: String)
         goToUi(sc, "/jobs/job/?id=0")
         webDriver.findElement(By.id("job-dag-viz")).click()
 
-        val stage0 = webDriver.findElement(By.cssSelector("g[id='graph_0']"))
-        val stage1 = webDriver.findElement(By.cssSelector("g[id='graph_1']"))
+        val stage0 = webDriver.findElement(By.cssSelector("g[id='graph_stage_0']"))
+          .findElement(By.xpath(".."))
+        val stage1 = webDriver.findElement(By.cssSelector("g[id='graph_stage_1']"))
+          .findElement(By.xpath(".."))
         val barrieredOps = webDriver.findElements(By.className("barrier-rdd")).iterator()
+        val id1 = barrieredOps.next().getAttribute("innerHTML")
+        val id2 = barrieredOps.next().getAttribute("innerHTML")
+        assert(!barrieredOps.hasNext())
 
-        while (barrieredOps.hasNext) {
-          val barrieredOpId = barrieredOps.next().getAttribute("innerHTML")
-          val foundInStage0 =
-            stage0.findElements(
-              By.cssSelector("g.barrier.cluster.cluster_" + barrieredOpId))
-          assert(foundInStage0.size === 1)
-
-          val foundInStage1 =
-            stage1.findElements(
-              By.cssSelector("g.barrier.cluster.cluster_" + barrieredOpId))
-          assert(foundInStage1.size === 0)
-        }
+        val prefix = "g[class='cluster barrier']#cluster_"
+        assert(stage0.findElements(By.cssSelector(s"${prefix}$id1")).size === 1)
+        assert(stage0.findElements(By.cssSelector(s"${prefix}$id2")).size === 1)
+        assert(stage1.findElements(By.cssSelector(s"${prefix}$id1")).size === 0)
+        assert(stage1.findElements(By.cssSelector(s"${prefix}$id2")).size === 1)
       }
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `RealBrowserUISeleniumSuite` which has been broken after SPARK-45274.

- #43053

### Why are the changes needed?

To recover `RealBrowserUISeleniumSuite` according to the latest HTML structure.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual
```
$ build/sbt -Dguava.version=32.1.2-jre \
-Dspark.test.webdriver.chrome.driver=/opt/homebrew/bin/chromedriver \
-Dtest.default.exclude.tags="" -Phive -Phive-thriftserver \
"core/testOnly org.apache.spark.ui.ChromeUISeleniumSuite"
```

**BEFORE**
```
[info] ChromeUISeleniumSuite:
[info] - SPARK-31534: text for tooltip should be escaped *** FAILED *** (12 seconds, 752 milliseconds)
[info] - SPARK-31882: Link URL for Stage DAGs should not depend on paged table. (2 seconds, 363 milliseconds)
[info] - SPARK-31886: Color barrier execution mode RDD correctly *** FAILED *** (12 seconds, 143 milliseconds)
[info] - Search text for paged tables should not be saved (3 seconds, 47 milliseconds)
[info] Run completed in 32 seconds, 54 milliseconds.
[info] Total number of tests run: 4
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 2, failed 2, canceled 0, ignored 0, pending 0
[info] *** 2 TESTS FAILED ***
[error] Failed tests:
[error] 	org.apache.spark.ui.ChromeUISeleniumSuite
[error] (core / Test / testOnly) sbt.TestsFailedException: Tests unsuccessful
[error] Total time: 42 s, completed Feb 9, 2024, 5:32:52 PM
```

**AFTER**
```
[info] ChromeUISeleniumSuite:
[info] - SPARK-31534: text for tooltip should be escaped (3 seconds, 135 milliseconds)
[info] - SPARK-31882: Link URL for Stage DAGs should not depend on paged table. (2 seconds, 395 milliseconds)
[info] - SPARK-31886: Color barrier execution mode RDD correctly (2 seconds, 144 milliseconds)
[info] - Search text for paged tables should not be saved (2 seconds, 958 milliseconds)
[info] Run completed in 12 seconds, 377 milliseconds.
[info] Total number of tests run: 4
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 4, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 22 s, completed Feb 9, 2024, 5:34:24 PM
```

### Was this patch authored or co-authored using generative AI tooling?

No.