### PR TITLE
[MINOR][SQL] Show only number of test blocks when there is a mismatch

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
@@ -622,9 +622,11 @@ class SQLQueryTestSuite extends QueryTest with SharedSparkSession with SQLHelper
       val segments = goldenOutput.split("-- !query.*\n")
 
       val numSegments = outputs.map(_.numSegments).sum + 1
-      assert(segments.size == numSegments,
-        s"Expected $numSegments blocks in result file but got " +
-          s"${segments.size}. Try regenerate the result files.")
+      assertResult(
+        numSegments,
+        s"blocks in result file '$resultFile'. Try regenerating the result files.") {
+        segments.size
+      }
       var curSegment = 0
 
       outputs.map { output =>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Instead of posting allllllllll of the expected test output, just show the path to the test file and the number of blocks.

### Why are the changes needed?

Compare the current behavior when an SQL test fails:

```
[info] - group-by.sql *** FAILED *** (2 seconds, 92 milliseconds)
[info]   group-by.sql
[info]   Array("-- Automatically generated by SQLQueryTestSuite
[info]   ", "CREATE OR REPLACE TEMPORARY VIEW testData AS SELECT * FROM VALUES
[info]   (1, 1), (1, 2), (2, 1), (2, 2), (3, 1), (3, 2), (null, 1), (3, null), (null, null)

[hundreds and hundreds of lines of SQL test output snipped]

[info]   0.0    2
[info]   Infinity       2
[info]   NaN    2
[info]   ") had size 259 instead of expected size 262 Expected 262 blocks in result file but got 259. Try regenerate the result files. (SQLQueryTestSuite.scala:625)
```

To the behavior after this patch:

```
[info] - group-by.sql *** FAILED *** (2 seconds, 10 milliseconds)
[info]   group-by.sql
[info]   Expected 262, but got 259 blocks in result file '.../spark/sql/core/src/test/resources/sql-tests/results/group-by.sql.out'. Try regenerating the result files. (SQLQueryTestSuite.scala:627)
```

Maybe I am missing something, but I don't think it helps anyone to see the whole test output file when the only things that are relevant are the file name and number of blocks.

Note also how the current error message on `master` repeats the expected and actual number of blocks.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

I ran some SQL tests from the sbt console:

```
~sql/testOnly org.apache.spark.sql.SQLQueryTestSuite -- -z "group-by"
```

### Was this patch authored or co-authored using generative AI tooling?

No.
