### PR TITLE
[SPARK-47025][BUILD][TESTS] Switch `Guava 19.0` dependency scope from `provided` to `test`

### DIFF
--- a/connector/docker-integration-tests/pom.xml
+++ b/connector/docker-integration-tests/pom.xml
@@ -50,6 +50,7 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>19.0</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to switch `Guava 19.0` dependency stop from `provided` to `test` in `docker-integration-tests` module.

### Why are the changes needed?

**BEFORE**
```
$ cd connector/docker-integration-tests
M3-Max docker-integration-tests:SPARK-47025 $ mvn dependency:tree | grep guava
[INFO] +- com.google.guava:guava:jar:19.0:provided
```

**AFTER**
```
$ cd connector/docker-integration-tests
$ mvn dependency:tree | grep guava
[INFO] +- com.google.guava:guava:jar:19.0:test
```

### Does this PR introduce _any_ user-facing change?

No. This is a test-only PR which touches the integration test module, `docker-integration-tests`.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.