### PR TITLE
[SPARK-47027][PYTHON][TESTS] Use temporary directories for profiler test outputs

### DIFF
--- a/python/pyspark/sql/tests/test_udf_profiler.py
+++ b/python/pyspark/sql/tests/test_udf_profiler.py
@@ -82,20 +82,20 @@ class UDFProfilerTests(unittest.TestCase):
         finally:
             sys.stdout = old_stdout
 
-        d = tempfile.gettempdir()
-        self.sc.dump_profiles(d)
+        with tempfile.TemporaryDirectory() as d:
+            self.sc.dump_profiles(d)
 
-        for i, udf_name in enumerate(["add1", "add2", "add1", "add2"]):
-            id, profiler, _ = profilers[i]
-            with self.subTest(id=id, udf_name=udf_name):
-                stats = profiler.stats()
-                self.assertTrue(stats is not None)
-                width, stat_list = stats.get_print_list([])
-                func_names = [func_name for fname, n, func_name in stat_list]
-                self.assertTrue(udf_name in func_names)
+            for i, udf_name in enumerate(["add1", "add2", "add1", "add2"]):
+                id, profiler, _ = profilers[i]
+                with self.subTest(id=id, udf_name=udf_name):
+                    stats = profiler.stats()
+                    self.assertTrue(stats is not None)
+                    width, stat_list = stats.get_print_list([])
+                    func_names = [func_name for fname, n, func_name in stat_list]
+                    self.assertTrue(udf_name in func_names)
 
-                self.assertTrue(udf_name in io.getvalue())
-                self.assertTrue("udf_%d.pstats" % id in os.listdir(d))
+                    self.assertTrue(udf_name in io.getvalue())
+                    self.assertTrue("udf_%d.pstats" % id in os.listdir(d))
 
     def test_custom_udf_profiler(self):
         class TestCustomProfiler(UDFBasicProfiler):

--- a/python/pyspark/tests/test_memory_profiler.py
+++ b/python/pyspark/tests/test_memory_profiler.py
@@ -106,9 +106,9 @@ class MemoryProfilerTests(PySparkTestCase):
             self.sc.show_profiles()
         self.assertTrue("plus_one" in fake_out.getvalue())
 
-        d = tempfile.gettempdir()
-        self.sc.dump_profiles(d)
-        self.assertTrue("udf_%d_memory.txt" % id in os.listdir(d))
+        with tempfile.TemporaryDirectory() as d:
+            self.sc.dump_profiles(d)
+            self.assertTrue("udf_%d_memory.txt" % id in os.listdir(d))
 
     def test_profile_pandas_udf(self):
         udfs = [self.exec_pandas_udf_ser_to_ser, self.exec_pandas_udf_ser_to_scalar]

--- a/python/pyspark/tests/test_profiler.py
+++ b/python/pyspark/tests/test_profiler.py
@@ -54,9 +54,9 @@ class ProfilerTests(PySparkTestCase):
         self.assertTrue("heavy_foo" in io.getvalue())
         sys.stdout = old_stdout
 
-        d = tempfile.gettempdir()
-        self.sc.dump_profiles(d)
-        self.assertTrue("rdd_%d.pstats" % id in os.listdir(d))
+        with tempfile.TemporaryDirectory() as d:
+            self.sc.dump_profiles(d)
+            self.assertTrue("rdd_%d.pstats" % id in os.listdir(d))
 
     def test_custom_profiler(self):
         class TestCustomProfiler(BasicProfiler):


### PR DESCRIPTION
### What changes were proposed in this pull request?

Use temporary directories for profiler test outputs instead of `tempfile.gettempdir()`.

### Why are the changes needed?

Directly using `tempfile.gettempdir()` can leave the files there after each test.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests.

### Was this patch authored or co-authored using generative AI tooling?

No.