### PR TITLE
[SPARK-47025][BUILD][TESTS] Upgrade `Guava` dependency in `docker-integration-tests` test module

### DIFF
--- a/connector/docker-integration-tests/pom.xml
+++ b/connector/docker-integration-tests/pom.xml
@@ -49,7 +49,8 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>19.0</version>
+      <version>33.0.0-jre</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -951,7 +951,7 @@ object Unsafe {
 object DockerIntegrationTests {
   // This serves to override the override specified in DependencyOverrides:
   lazy val settings = Seq(
-    dependencyOverrides += "com.google.guava" % "guava" % "19.0"
+    dependencyOverrides += "com.google.guava" % "guava" % "33.0.0-jre"
   )
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update `docker-integration-tests` test module to use the latest `Guava` test dependency. Specifically,
- Switch from `provided` dependency to `test` dependency
- Upgrade from version `19.0` to `33.0.0-jre`.

### Why are the changes needed?

Previously, `docker-integration-tests` uses `Guava 19.0` dependency as `provided` scope because `docker-java-core` is using `Guava 19.0` still.
 
- https://mvnrepository.com/artifact/com.github.docker-java/docker-java-core/3.3.4

### Does this PR introduce _any_ user-facing change?

No, `docker-integration-tests` is an integration test module.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.