### PR TITLE
[SPARK-47030][TESTS] Add `WebBrowserTest`

### DIFF
--- a/common/tags/src/test/java/org/apache/spark/tags/WebBrowserTest.java
+++ b/common/tags/src/test/java/org/apache/spark/tags/WebBrowserTest.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.tags;
+
+import java.lang.annotation.*;
+
+import org.scalatest.TagAnnotation;
+
+@TagAnnotation
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+public @interface WebBrowserTest { }

--- a/core/src/test/scala/org/apache/spark/deploy/history/ChromeUIHistoryServerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/ChromeUIHistoryServerSuite.scala
@@ -21,7 +21,7 @@ import org.openqa.selenium.WebDriver
 import org.openqa.selenium.chrome.{ChromeDriver, ChromeOptions}
 
 import org.apache.spark.internal.config.History.HybridStoreDiskBackend
-import org.apache.spark.tags.{ChromeUITest, ExtendedLevelDBTest}
+import org.apache.spark.tags.{ChromeUITest, ExtendedLevelDBTest, WebBrowserTest}
 
 
 /**
@@ -50,12 +50,14 @@ abstract class ChromeUIHistoryServerSuite
   }
 }
 
+@WebBrowserTest
 @ChromeUITest
 @ExtendedLevelDBTest
 class LevelDBBackendChromeUIHistoryServerSuite extends ChromeUIHistoryServerSuite {
   override protected def diskBackend: HybridStoreDiskBackend.Value = HybridStoreDiskBackend.LEVELDB
 }
 
+@WebBrowserTest
 @ChromeUITest
 class RocksDBBackendChromeUIHistoryServerSuite extends ChromeUIHistoryServerSuite {
   override protected def diskBackend: HybridStoreDiskBackend.Value = HybridStoreDiskBackend.ROCKSDB

--- a/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
@@ -49,7 +49,7 @@ import org.apache.spark.internal.config.Tests.IS_TESTING
 import org.apache.spark.internal.config.UI._
 import org.apache.spark.status.api.v1.ApplicationInfo
 import org.apache.spark.status.api.v1.JobData
-import org.apache.spark.tags.ExtendedLevelDBTest
+import org.apache.spark.tags.{ExtendedLevelDBTest, WebBrowserTest}
 import org.apache.spark.ui.SparkUI
 import org.apache.spark.util.{ResetSystemProperties, ShutdownHookManager, Utils}
 import org.apache.spark.util.ArrayImplicits._
@@ -797,12 +797,14 @@ object FakeAuthFilter {
   val FAKE_HTTP_USER = "HTTP_USER"
 }
 
+@WebBrowserTest
 @ExtendedLevelDBTest
 class LevelDBBackendHistoryServerSuite extends HistoryServerSuite {
   override protected def diskBackend: History.HybridStoreDiskBackend.Value =
     HybridStoreDiskBackend.LEVELDB
 }
 
+@WebBrowserTest
 class RocksDBBackendHistoryServerSuite extends HistoryServerSuite {
   override protected def diskBackend: History.HybridStoreDiskBackend.Value =
     HybridStoreDiskBackend.ROCKSDB

--- a/core/src/test/scala/org/apache/spark/ui/ChromeUISeleniumSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/ChromeUISeleniumSuite.scala
@@ -20,11 +20,12 @@ package org.apache.spark.ui
 import org.openqa.selenium.{JavascriptExecutor, WebDriver}
 import org.openqa.selenium.chrome.{ChromeDriver, ChromeOptions}
 
-import org.apache.spark.tags.ChromeUITest
+import org.apache.spark.tags.{ChromeUITest, WebBrowserTest}
 
 /**
  * Selenium tests for the Spark Web UI with Chrome.
  */
+@WebBrowserTest
 @ChromeUITest
 class ChromeUISeleniumSuite extends RealBrowserUISeleniumSuite("webdriver.chrome.driver") {
 

--- a/core/src/test/scala/org/apache/spark/ui/UISeleniumSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/UISeleniumSuite.scala
@@ -46,6 +46,7 @@ import org.apache.spark.internal.config.Status._
 import org.apache.spark.internal.config.UI._
 import org.apache.spark.shuffle.FetchFailedException
 import org.apache.spark.status.api.v1.{JacksonMessageWriter, RDDDataDistribution, StageStatus}
+import org.apache.spark.tags.WebBrowserTest
 import org.apache.spark.util.Utils
 
 private[spark] class SparkUICssErrorHandler extends DefaultCssErrorHandler {
@@ -80,6 +81,7 @@ private[spark] class SparkUICssErrorHandler extends DefaultCssErrorHandler {
 /**
  * Selenium tests for the Spark Web UI.
  */
+@WebBrowserTest
 class UISeleniumSuite extends SparkFunSuite with WebBrowser with Matchers {
 
   implicit var webDriver: WebDriver = _

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/UISeleniumSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/UISeleniumSuite.scala
@@ -30,8 +30,10 @@ import org.scalatestplus.selenium.WebBrowser
 
 import org.apache.spark.{SparkFunSuite, SparkRuntimeException}
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.tags.WebBrowserTest
 import org.apache.spark.ui.SparkUICssErrorHandler
 
+@WebBrowserTest
 class UISeleniumSuite extends SparkFunSuite with WebBrowser {
 
   private var spark: SparkSession = _

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/ui/UISeleniumSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/ui/UISeleniumSuite.scala
@@ -35,10 +35,11 @@ import org.apache.spark.sql.functions.{window => windowFn, _}
 import org.apache.spark.sql.internal.SQLConf.SHUFFLE_PARTITIONS
 import org.apache.spark.sql.internal.StaticSQLConf.ENABLED_STREAMING_UI_CUSTOM_METRIC_LIST
 import org.apache.spark.sql.streaming.{StreamingQueryException, Trigger}
-import org.apache.spark.tags.SlowSQLTest
+import org.apache.spark.tags.{SlowSQLTest, WebBrowserTest}
 import org.apache.spark.ui.SparkUICssErrorHandler
 import org.apache.spark.util.Utils
 
+@WebBrowserTest
 @SlowSQLTest
 class UISeleniumSuite extends SparkFunSuite with WebBrowser with Matchers {
 
@@ -182,6 +183,7 @@ class UISeleniumSuite extends SparkFunSuite with WebBrowser with Matchers {
   }
 }
 
+@WebBrowserTest
 @SlowSQLTest
 class UISeleniumWithRocksDBBackendSuite extends UISeleniumSuite {
   private val storePath = Utils.createTempDir()

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/UISeleniumSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/UISeleniumSuite.scala
@@ -33,8 +33,10 @@ import org.scalatest.matchers.should.Matchers._
 import org.scalatest.time.SpanSugar._
 import org.scalatestplus.selenium.WebBrowser
 
+import org.apache.spark.tags.WebBrowserTest
 import org.apache.spark.ui.SparkUICssErrorHandler
 
+@WebBrowserTest
 class UISeleniumSuite
   extends HiveThriftServer2TestBase
   with WebBrowser with Matchers with BeforeAndAfterAll {

--- a/streaming/src/test/scala/org/apache/spark/streaming/UISeleniumSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/UISeleniumSuite.scala
@@ -29,11 +29,13 @@ import org.scalatestplus.selenium.WebBrowser
 
 import org.apache.spark._
 import org.apache.spark.internal.config.UI.UI_ENABLED
+import org.apache.spark.tags.WebBrowserTest
 import org.apache.spark.ui.SparkUICssErrorHandler
 
 /**
  * Selenium tests for the Spark Streaming Web UI.
  */
+@WebBrowserTest
 class UISeleniumSuite extends SparkFunSuite with WebBrowser with Matchers with TestSuiteBase {
 
   implicit var webDriver: WebDriver = _


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add a new test tag, `WebBrowserTest`.

### Why are the changes needed?

Currently, several browser-based tests exist in multiple modules like the following. It's difficult to find and run them.

```
common/tags/src/test/java/org/apache/spark/tags/WebBrowserTest.java
core/src/test/scala/org/apache/spark/deploy/history/ChromeUIHistoryServerSuite.scala
core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
core/src/test/scala/org/apache/spark/ui/ChromeUISeleniumSuite.scala
core/src/test/scala/org/apache/spark/ui/UISeleniumSuite.scala
sql/core/src/test/scala/org/apache/spark/sql/execution/ui/UISeleniumSuite.scala
sql/core/src/test/scala/org/apache/spark/sql/streaming/ui/UISeleniumSuite.scala
sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/UISeleniumSuite.scala
streaming/src/test/scala/org/apache/spark/streaming/UISeleniumSuite.scala
```

In addition, the previous `ChromeUITest` is designed to disable `ChromeUI*` suite and doesn't cover all `WebBroser` based test suite.


### Does this PR introduce _any_ user-facing change?

No, this is a new test tag.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.