### PR TITLE
[SPARK-47040][CONNECT] Allow Spark Connect Server Script to wait

### DIFF
--- a/sbin/start-connect-server.sh
+++ b/sbin/start-connect-server.sh
@@ -38,4 +38,10 @@ fi
 
 . "${SPARK_HOME}/bin/load-spark-env.sh"
 
-exec "${SPARK_HOME}"/sbin/spark-daemon.sh submit $CLASS 1 --name "Spark Connect server" "$@"
+if [ "$1" == "--wait" ]; then
+  shift
+  exec "${SPARK_HOME}"/bin/spark-submit --class $CLASS 1 --name "Spark Connect Server" "$@"
+else
+  exec "${SPARK_HOME}"/sbin/spark-daemon.sh submit $CLASS 1 --name "Spark Connect server" "$@"
+fi
+


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add an option to the command line of `./sbin/start-connect-server.sh` that leaves it running in the foreground for easier debugging.

```
./sbin/start-connect-server.sh --wait
```

### Why are the changes needed?
Usability

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?
Manual

### Was this patch authored or co-authored using generative AI tooling?
No