### PR TITLE
[SS] Add MapState implementation for State API v2.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -354,18 +354,7 @@
     </dependency>
     <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
-      <artifactId>htmlunit-driver</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <!-- Coerce sbt into honoring these dependency updates: -->
-    <dependency>
-      <groupId>net.sourceforge.htmlunit</groupId>
-      <artifactId>htmlunit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>net.sourceforge.htmlunit</groupId>
-      <artifactId>htmlunit-core-js</artifactId>
+      <artifactId>htmlunit3-driver</artifactId>
       <scope>test</scope>
     </dependency>
     <!-- at least just for tests, coerce SBT to use the updated httpcore/client version -->
@@ -382,12 +371,6 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpcore</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <!-- Added for selenium: -->
-    <dependency>
-      <groupId>xml-apis</groupId>
-      <artifactId>xml-apis</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -354,7 +354,18 @@
     </dependency>
     <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
-      <artifactId>htmlunit3-driver</artifactId>
+      <artifactId>htmlunit-driver</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <!-- Coerce sbt into honoring these dependency updates: -->
+    <dependency>
+      <groupId>net.sourceforge.htmlunit</groupId>
+      <artifactId>htmlunit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>net.sourceforge.htmlunit</groupId>
+      <artifactId>htmlunit-core-js</artifactId>
       <scope>test</scope>
     </dependency>
     <!-- at least just for tests, coerce SBT to use the updated httpcore/client version -->
@@ -371,6 +382,12 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpcore</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <!-- Added for selenium: -->
+    <dependency>
+      <groupId>xml-apis</groupId>
+      <artifactId>xml-apis</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
@@ -561,7 +561,9 @@ abstract class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with
     // app is no longer incomplete
     listApplications(false) should not contain(appId)
 
-    assert(jobcount === getNumJobs("/jobs"))
+    eventually(stdTimeout, stdInterval) {
+      assert(jobcount === getNumJobs("/jobs"))
+    }
 
     // no need to retain the test dir now the tests complete
     ShutdownHookManager.registerShutdownDeleteDir(logDir)

--- a/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
@@ -561,9 +561,7 @@ abstract class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with
     // app is no longer incomplete
     listApplications(false) should not contain(appId)
 
-    eventually(stdTimeout, stdInterval) {
-      assert(jobcount === getNumJobs("/jobs"))
-    }
+    assert(jobcount === getNumJobs("/jobs"))
 
     // no need to retain the test dir now the tests complete
     ShutdownHookManager.registerShutdownDeleteDir(logDir)

--- a/core/src/test/scala/org/apache/spark/deploy/history/RealBrowserUIHistoryServerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/RealBrowserUIHistoryServerSuite.scala
@@ -22,8 +22,10 @@ import javax.servlet.http.HttpServletRequest
 import org.eclipse.jetty.proxy.ProxyServlet
 import org.eclipse.jetty.servlet.{ServletContextHandler, ServletHolder}
 import org.openqa.selenium.WebDriver
+import org.scalatest.concurrent.Eventually._
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.matchers.should.Matchers._
+import org.scalatest.time.SpanSugar._
 import org.scalatestplus.selenium.WebBrowser
 
 import org.apache.spark._
@@ -147,7 +149,9 @@ abstract class RealBrowserUIHistoryServerSuite(val driverProp: String)
 
       // there are at least some URL links that were generated via javascript,
       // and they all contain the spark.ui.proxyBase (uiRoot)
-      links.length should be > 4
+      eventually(timeout(10.seconds)) {
+        links.length should be > 4
+      }
       for (link <- links) {
         link should startWith(url + uiRoot)
       }

--- a/core/src/test/scala/org/apache/spark/deploy/history/RealBrowserUIHistoryServerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/RealBrowserUIHistoryServerSuite.scala
@@ -22,10 +22,8 @@ import javax.servlet.http.HttpServletRequest
 import org.eclipse.jetty.proxy.ProxyServlet
 import org.eclipse.jetty.servlet.{ServletContextHandler, ServletHolder}
 import org.openqa.selenium.WebDriver
-import org.scalatest.concurrent.Eventually._
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.matchers.should.Matchers._
-import org.scalatest.time.SpanSugar._
 import org.scalatestplus.selenium.WebBrowser
 
 import org.apache.spark._
@@ -149,9 +147,7 @@ abstract class RealBrowserUIHistoryServerSuite(val driverProp: String)
 
       // there are at least some URL links that were generated via javascript,
       // and they all contain the spark.ui.proxyBase (uiRoot)
-      eventually(timeout(10.seconds)) {
-        links.length should be > 4
-      }
+      links.length should be > 4
       for (link <- links) {
         link should startWith(url + uiRoot)
       }

--- a/core/src/test/scala/org/apache/spark/ui/UISeleniumSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/UISeleniumSuite.scala
@@ -24,9 +24,9 @@ import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 import scala.io.Source
 import scala.xml.Node
 
-import com.gargoylesoftware.css.parser.CSSParseException
-import com.gargoylesoftware.htmlunit.DefaultCssErrorHandler
 import org.glassfish.jersey.internal.util.collection.MultivaluedStringMap
+import org.htmlunit.DefaultCssErrorHandler
+import org.htmlunit.cssparser.parser.CSSParseException
 import org.json4s._
 import org.json4s.jackson.JsonMethods
 import org.openqa.selenium.{By, WebDriver}

--- a/core/src/test/scala/org/apache/spark/ui/UISeleniumSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/UISeleniumSuite.scala
@@ -24,9 +24,9 @@ import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 import scala.io.Source
 import scala.xml.Node
 
+import com.gargoylesoftware.css.parser.CSSParseException
+import com.gargoylesoftware.htmlunit.DefaultCssErrorHandler
 import org.glassfish.jersey.internal.util.collection.MultivaluedStringMap
-import org.htmlunit.DefaultCssErrorHandler
-import org.htmlunit.cssparser.parser.CSSParseException
 import org.json4s._
 import org.json4s.jackson.JsonMethods
 import org.openqa.selenium.{By, WebDriver}

--- a/pom.xml
+++ b/pom.xml
@@ -215,7 +215,8 @@
     <antlr4.version>4.13.1</antlr4.version>
     <jpam.version>1.1</jpam.version>
     <selenium.version>4.12.1</selenium.version>
-    <htmlunit3-driver.version>4.17.0</htmlunit3-driver.version>
+    <htmlunit-driver.version>4.12.0</htmlunit-driver.version>
+    <htmlunit.version>2.70.0</htmlunit.version>
     <maven-antrun.version>3.1.0</maven-antrun.version>
     <commons-crypto.version>1.1.0</commons-crypto.version>
     <commons-cli.version>1.6.0</commons-cli.version>
@@ -709,9 +710,28 @@
       </dependency>
       <dependency>
         <groupId>org.seleniumhq.selenium</groupId>
-        <artifactId>htmlunit3-driver</artifactId>
-        <version>${htmlunit3-driver.version}</version>
+        <artifactId>htmlunit-driver</artifactId>
+        <version>${htmlunit-driver.version}</version>
         <scope>test</scope>
+      </dependency>
+      <!-- Update htmlunit dependency that selenium uses for better JS support -->
+      <dependency>
+        <groupId>net.sourceforge.htmlunit</groupId>
+        <artifactId>htmlunit</artifactId>
+        <version>${htmlunit.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>net.sourceforge.htmlunit</groupId>
+        <artifactId>htmlunit-core-js</artifactId>
+        <version>${htmlunit.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <!-- Added for selenium only, and should match its dependent version: -->
+      <dependency>
+        <groupId>xml-apis</groupId>
+        <artifactId>xml-apis</artifactId>
+        <version>1.4.01</version>
       </dependency>
 
       <!-- log4j -->

--- a/pom.xml
+++ b/pom.xml
@@ -215,8 +215,7 @@
     <antlr4.version>4.13.1</antlr4.version>
     <jpam.version>1.1</jpam.version>
     <selenium.version>4.12.1</selenium.version>
-    <htmlunit-driver.version>4.12.0</htmlunit-driver.version>
-    <htmlunit.version>2.70.0</htmlunit.version>
+    <htmlunit3-driver.version>4.17.0</htmlunit3-driver.version>
     <maven-antrun.version>3.1.0</maven-antrun.version>
     <commons-crypto.version>1.1.0</commons-crypto.version>
     <commons-cli.version>1.6.0</commons-cli.version>
@@ -710,28 +709,9 @@
       </dependency>
       <dependency>
         <groupId>org.seleniumhq.selenium</groupId>
-        <artifactId>htmlunit-driver</artifactId>
-        <version>${htmlunit-driver.version}</version>
+        <artifactId>htmlunit3-driver</artifactId>
+        <version>${htmlunit3-driver.version}</version>
         <scope>test</scope>
-      </dependency>
-      <!-- Update htmlunit dependency that selenium uses for better JS support -->
-      <dependency>
-        <groupId>net.sourceforge.htmlunit</groupId>
-        <artifactId>htmlunit</artifactId>
-        <version>${htmlunit.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>net.sourceforge.htmlunit</groupId>
-        <artifactId>htmlunit-core-js</artifactId>
-        <version>${htmlunit.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <!-- Added for selenium only, and should match its dependent version: -->
-      <dependency>
-        <groupId>xml-apis</groupId>
-        <artifactId>xml-apis</artifactId>
-        <version>1.4.01</version>
       </dependency>
 
       <!-- log4j -->

--- a/sql/api/src/main/scala/org/apache/spark/sql/streaming/MapState.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/streaming/MapState.scala
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.streaming
+
+import org.apache.spark.annotation.{Evolving, Experimental}
+
+@Experimental
+@Evolving
+/**
+ * Interface used for arbitrary stateful operations with the v2 API to capture
+ * map value state.
+ */
+trait MapState[K, V] extends Serializable {
+  /** Whether state exists or not. */
+  def exists(): Boolean
+
+  /** Get the state value if it exists */
+  def getValue(key: K): V
+
+  /** Check if the user key is contained in the map */
+  def containsKey(key: K): Boolean
+
+  /** Update value for given user key */
+  def updateValue(key: K, value: V) : Unit
+
+  /** Get the map associated with grouping key */
+  def getMap(): Map[K, V]
+
+  /** Get the list of keys present in map associated with grouping key */
+  def getKeys(): Iterator[K]
+
+  /** Get the list of values present in map associated with grouping key */
+  def getValues(): Iterator[V]
+
+  /** Remove user key from map state */
+  def removeKey(key: K): Unit
+
+  /** Remove this state. */
+  def remove(): Unit
+}

--- a/sql/api/src/main/scala/org/apache/spark/sql/streaming/StatefulProcessorHandle.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/streaming/StatefulProcessorHandle.scala
@@ -46,4 +46,10 @@ private[sql] trait StatefulProcessorHandle extends Serializable {
    * @param stateName - name of the state variable
    */
   def deleteIfExists(stateName: String): Unit
+
+  /**
+   * Creates new or returns existing map state associated with stateName.
+   * The MapState persists Key-Value pairs of type [K, V].
+   */
+  def getMapState[K, V](stateName: String): MapState[K, V]
 }

--- a/sql/core/pom.xml
+++ b/sql/core/pom.xml
@@ -225,7 +225,7 @@
     </dependency>
     <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
-      <artifactId>htmlunit-driver</artifactId>
+      <artifactId>htmlunit3-driver</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/sql/core/pom.xml
+++ b/sql/core/pom.xml
@@ -225,7 +225,7 @@
     </dependency>
     <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
-      <artifactId>htmlunit3-driver</artifactId>
+      <artifactId>htmlunit-driver</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MapStateImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MapStateImpl.scala
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.streaming
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.execution.streaming.state.{StateStore, UnsafeRowPair}
+import org.apache.spark.sql.streaming.MapState
+
+class MapStateImpl[K, V](store: StateStore,
+                         stateName: String) extends MapState[K, V] with Logging {
+  store.setUseCompositeKey()
+
+  /** Whether state exists or not. */
+  override def exists(): Boolean = {
+    !store.prefixScan(StateEncoder.encodeKey(stateName), stateName).isEmpty
+  }
+
+  /** Get the state value if it exists */
+  override def getValue(key: K): V = {
+    require(key != null, "User key cannot be null.")
+    val encodedGroupingKey = StateEncoder.encodeKey(stateName)
+    val encodeUserKey = StateEncoder.encodeUserKey(key)
+    val unsafeRowValue = store.getWithCompositeKey(encodedGroupingKey, encodeUserKey, stateName)
+    if (unsafeRowValue == null) {
+      throw new UnsupportedOperationException(
+        "No value found for given grouping key and user key in the map.")
+    }
+    StateEncoder.decode(unsafeRowValue)
+  }
+
+  /** Check if the user key is contained in the map */
+  override def containsKey(key: K): Boolean = {
+    require(key != null, "User key cannot be null.")
+    try {
+      getValue(key) != null
+    } catch {
+      case _: Exception => false
+    }
+  }
+
+  /** Update value for given user key */
+  override def updateValue(key: K, value: V): Unit = {
+    require(key != null, "User key cannot be null.")
+    require(value != null, "Value put to map cannot be null.")
+    val encodedValue = StateEncoder.encodeValue(value)
+    val encodedKey = StateEncoder.encodeKey(stateName)
+    val encodedUserKey = StateEncoder.encodeUserKey(key)
+    store.putWithCompositeKey(encodedKey, encodedUserKey, encodedValue, stateName)
+  }
+
+  /** Get the map associated with grouping key */
+  override def getMap(): Map[K, V] = {
+    val encodedGroupingKey = StateEncoder.encodeKey(stateName)
+    store.prefixScan(encodedGroupingKey, stateName)
+      .map {
+        case iter: UnsafeRowPair =>
+          (StateEncoder.decode(iter.key), StateEncoder.decode(iter.value))
+      }.toMap
+  }
+
+  /** Get the list of keys present in map associated with grouping key */
+  override def getKeys(): Iterator[K] = {
+    getMap().keys.iterator
+  }
+
+  /** Get the list of values present in map associated with grouping key */
+  override def getValues(): Iterator[V] = {
+    getMap().values.iterator
+  }
+
+  /** Remove user key from map state */
+  override def removeKey(key: K): Unit = {
+    require(key != null, "User key cannot be null.")
+    val encodedKey = StateEncoder.encodeKey(stateName)
+    val encodedUserKey = StateEncoder.encodeUserKey(key)
+    store.removeWithCompositeKey(encodedKey, encodedUserKey, stateName)
+  }
+
+  /** Remove this state. */
+  override def remove(): Unit = {
+    getKeys().foreach { itr =>
+      removeKey(itr)
+    }
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StateEncoder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StateEncoder.scala
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.streaming
+
+import org.apache.commons.lang3.SerializationUtils
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
+import org.apache.spark.sql.catalyst.expressions.{UnsafeProjection, UnsafeRow}
+import org.apache.spark.sql.execution.streaming.state.StateStoreErrors
+import org.apache.spark.sql.types.{BinaryType, StructType}
+
+object StateEncoder {
+  private val schemaForKeyRow: StructType = new StructType().add("key", BinaryType)
+  private val keyEncoder = UnsafeProjection.create(schemaForKeyRow)
+
+  private val schemaForValueRow: StructType = new StructType().add("value", BinaryType)
+  private val valueEncoder = UnsafeProjection.create(schemaForValueRow)
+
+  // TODO: validate places that are trying to encode the key and check if we can eliminate/
+  // add caching for some of these calls.
+  def encodeKey(stateName: String, keyExprEnc: ExpressionEncoder[Any]): UnsafeRow = {
+    val keyOption = ImplicitGroupingKeyTracker.getImplicitKeyOption
+    if (!keyOption.isDefined) {
+      throw StateStoreErrors.implicitKeyNotFound(stateName)
+    }
+
+    val keySerializer = keyExprEnc.createSerializer()
+    val keyByteArr = keySerializer.apply(keyOption.get).asInstanceOf[UnsafeRow].getBytes()
+    val keyRow = keyEncoder(InternalRow(keyByteArr))
+    keyRow
+  }
+
+  def encodeUserKey[K](userKey: K): UnsafeRow = {
+    val schemaForKeyRow: StructType = new StructType().add("userKey", BinaryType)
+    val keyByteArr = SerializationUtils.serialize(userKey.asInstanceOf[Serializable])
+    val keyEncoder = UnsafeProjection.create(schemaForKeyRow)
+    val keyRow = keyEncoder(InternalRow(keyByteArr))
+    keyRow
+  }
+
+  def encodeValue[S] (value: S): UnsafeRow = {
+    val schemaForValueRow: StructType = new StructType().add("value", BinaryType)
+    val valueByteArr = SerializationUtils.serialize(value.asInstanceOf[Serializable])
+    val valueEncoder = UnsafeProjection.create(schemaForValueRow)
+    val valueRow = valueEncoder(InternalRow(valueByteArr))
+    valueRow
+  }
+
+  def decode[S](row: UnsafeRow): S = {
+    SerializationUtils
+      .deserialize(row.getBinary(0))
+      .asInstanceOf[S]
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StatefulProcessorHandleImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StatefulProcessorHandleImpl.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql.execution.streaming
 import java.util.UUID
 
 import org.apache.spark.TaskContext
-
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.apache.spark.sql.execution.streaming.state.StateStore
@@ -136,8 +135,7 @@ class StatefulProcessorHandleImpl(
   override def getMapState[K, V](stateName: String): MapState[K, V] = {
     verify(currState == CREATED, s"Cannot create state variable with name=$stateName after " +
       "initialization is complete")
-    store.createColFamilyIfAbsent(stateName)
-    val resultState = new MapStateImpl[K, V](store, stateName)
+    val resultState = new MapStateImpl[K, V](store, stateName, keyEncoder)
     resultState
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StatefulProcessorHandleImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StatefulProcessorHandleImpl.scala
@@ -19,10 +19,11 @@ package org.apache.spark.sql.execution.streaming
 import java.util.UUID
 
 import org.apache.spark.TaskContext
+
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.apache.spark.sql.execution.streaming.state.StateStore
-import org.apache.spark.sql.streaming.{QueryInfo, StatefulProcessorHandle, ValueState}
+import org.apache.spark.sql.streaming.{MapState, QueryInfo, StatefulProcessorHandle, ValueState}
 import org.apache.spark.util.Utils
 
 /**
@@ -130,6 +131,14 @@ class StatefulProcessorHandleImpl(
     verify(currState == CREATED, s"Cannot delete state variable with name=$stateName after " +
       "initialization is complete")
     store.removeColFamilyIfExists(stateName)
+  }
+
+  override def getMapState[K, V](stateName: String): MapState[K, V] = {
+    verify(currState == CREATED, s"Cannot create state variable with name=$stateName after " +
+      "initialization is complete")
+    store.createColFamilyIfAbsent(stateName)
+    val resultState = new MapStateImpl[K, V](store, stateName)
+    resultState
   }
 
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
@@ -84,8 +84,10 @@ private[sql] class HDFSBackedStateStoreProvider extends StateStoreProvider with 
       map.iterator()
     }
 
-    override def getWithCompositeKey(key: UnsafeRow, userKey: UnsafeRow,
-       colFamilyName: String): UnsafeRow = {
+    override def getWithCompositeKey(
+        key: UnsafeRow,
+        userKey: UnsafeRow,
+        colFamilyName: String): UnsafeRow = {
       throw new UnsupportedOperationException("Get with composite key is not supported for HDFS")
     }
 
@@ -131,8 +133,10 @@ private[sql] class HDFSBackedStateStoreProvider extends StateStoreProvider with 
       mapToUpdate.get(key)
     }
 
-    override def getWithCompositeKey(key: UnsafeRow, userKey: UnsafeRow,
-       colFamilyName: String): UnsafeRow = {
+    override def getWithCompositeKey(
+        key: UnsafeRow,
+        userKey: UnsafeRow,
+        colFamilyName: String): UnsafeRow = {
       throw new UnsupportedOperationException("Get with composite key is not supported for HDFS")
     }
 
@@ -145,8 +149,11 @@ private[sql] class HDFSBackedStateStoreProvider extends StateStoreProvider with 
       writeUpdateToDeltaFile(compressedStream, keyCopy, valueCopy)
     }
 
-    override def putWithCompositeKey(key: UnsafeRow, userKey: UnsafeRow, value: UnsafeRow,
-       colFamilyName: String): Unit = {
+    override def putWithCompositeKey(
+        key: UnsafeRow,
+        userKey: UnsafeRow,
+        value: UnsafeRow,
+        colFamilyName: String): Unit = {
       throw new UnsupportedOperationException("Put with composite key is not supported for HDFS")
     }
 
@@ -158,8 +165,10 @@ private[sql] class HDFSBackedStateStoreProvider extends StateStoreProvider with 
       }
     }
 
-    override def removeWithCompositeKey(key: UnsafeRow, userKey: UnsafeRow,
-       colFamilyName: String): Unit = {
+    override def removeWithCompositeKey(
+        key: UnsafeRow,
+        userKey: UnsafeRow,
+        colFamilyName: String): Unit = {
       throw new UnsupportedOperationException("Remove with composite key is not supported for HDFS")
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
@@ -84,6 +84,11 @@ private[sql] class HDFSBackedStateStoreProvider extends StateStoreProvider with 
       map.iterator()
     }
 
+    override def getWithCompositeKey(key: UnsafeRow, userKey: UnsafeRow,
+       colFamilyName: String): UnsafeRow = {
+      throw new UnsupportedOperationException("Get with composite key is not supported for HDFS")
+    }
+
     override def abort(): Unit = {}
 
     override def toString(): String = {
@@ -126,6 +131,11 @@ private[sql] class HDFSBackedStateStoreProvider extends StateStoreProvider with 
       mapToUpdate.get(key)
     }
 
+    override def getWithCompositeKey(key: UnsafeRow, userKey: UnsafeRow,
+       colFamilyName: String): UnsafeRow = {
+      throw new UnsupportedOperationException("Get with composite key is not supported for HDFS")
+    }
+
     override def put(key: UnsafeRow, value: UnsafeRow, colFamilyName: String): Unit = {
       require(value != null, "Cannot put a null value")
       verify(state == UPDATING, "Cannot put after already committed or aborted")
@@ -135,12 +145,22 @@ private[sql] class HDFSBackedStateStoreProvider extends StateStoreProvider with 
       writeUpdateToDeltaFile(compressedStream, keyCopy, valueCopy)
     }
 
+    override def putWithCompositeKey(key: UnsafeRow, userKey: UnsafeRow, value: UnsafeRow,
+       colFamilyName: String): Unit = {
+      throw new UnsupportedOperationException("Put with composite key is not supported for HDFS")
+    }
+
     override def remove(key: UnsafeRow, colFamilyName: String): Unit = {
       verify(state == UPDATING, "Cannot remove after already committed or aborted")
       val prevValue = mapToUpdate.remove(key)
       if (prevValue != null) {
         writeRemoveToDeltaFile(compressedStream, key)
       }
+    }
+
+    override def removeWithCompositeKey(key: UnsafeRow, userKey: UnsafeRow,
+       colFamilyName: String): Unit = {
+      throw new UnsupportedOperationException("Remove with composite key is not supported for HDFS")
     }
 
     /** Commit all the updates that have been made to the store, and return the new version. */

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateEncoder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateEncoder.scala
@@ -29,6 +29,14 @@ sealed trait RocksDBKeyStateEncoder {
 
   def encodeKey(row: UnsafeRow): Array[Byte]
   def decodeKey(keyBytes: Array[Byte]): UnsafeRow
+
+  def encodeCompositeKey(groupingKeyRow: UnsafeRow, userKeyRow: UnsafeRow): Array[Byte] = {
+    throw new UnsupportedOperationException("This encoder does not support composite key encoder")
+  }
+
+  def decodeCompositeKey(compositeKeyBytes: Array[Byte]): (UnsafeRow, UnsafeRow) = {
+    throw new UnsupportedOperationException("This encoder does not support composite key encoder")
+  }
 }
 
 sealed trait RocksDBValueStateEncoder {
@@ -203,6 +211,7 @@ class NoPrefixKeyStateEncoder(keySchema: StructType)
 
   // Reusable objects
   private val keyRow = new UnsafeRow(keySchema.size)
+  private val userKeyRow = new UnsafeRow(keySchema.size)
 
   override def encodeKey(row: UnsafeRow): Array[Byte] = encodeUnsafeRow(row)
 
@@ -221,8 +230,58 @@ class NoPrefixKeyStateEncoder(keySchema: StructType)
     throw new IllegalStateException("This encoder doesn't support prefix key!")
   }
 
+  /**
+   * Supports encoding grouping key as prefix of key in rocksDB.
+   * This is used for MapState.
+   * Grouping key is encoded as the following format:
+   * |---size(bytes)--|--unsafeRowEncodedBytes--|
+   * Size of byte array is stored as an Int.
+   */
   override def encodePrefixKey(prefixKey: UnsafeRow): Array[Byte] = {
-    throw new IllegalStateException("This encoder doesn't support prefix key!")
+    val prefixKeyEncoded = encodeUnsafeRow(prefixKey)
+    val prefix = new Array[Byte](prefixKeyEncoded.length + 4)
+    Platform.putInt(prefix, Platform.BYTE_ARRAY_OFFSET, prefixKeyEncoded.length)
+    Platform.copyMemory(prefixKeyEncoded, Platform.BYTE_ARRAY_OFFSET, prefix,
+      Platform.BYTE_ARRAY_OFFSET + 4, prefixKeyEncoded.length)
+    prefix
+  }
+
+  /**
+   * Supports encoding grouping key and user Key as a composite key in rocksDB.
+   * This is used for MapState.
+   * Composite key is encoded as the following format:
+   * |---size(EncodedGroupingKeyBytes)--|--EncodedGroupingKeyBytes--|--EncodedUserKeyBytes--|
+   * Size of byte array is stored as an Int.
+   */
+  override def encodeCompositeKey(groupingKeyRow: UnsafeRow, userKeyRow: UnsafeRow): Array[Byte] = {
+    val prefixKeyEncoded = encodeUnsafeRow(groupingKeyRow)
+    val remainingEncoded = encodeUnsafeRow(userKeyRow)
+    val encodedBytes = new Array[Byte](prefixKeyEncoded.length + remainingEncoded.length + 4)
+    Platform.putInt(encodedBytes, Platform.BYTE_ARRAY_OFFSET, prefixKeyEncoded.length)
+    Platform.copyMemory(prefixKeyEncoded, Platform.BYTE_ARRAY_OFFSET,
+      encodedBytes, Platform.BYTE_ARRAY_OFFSET + 4, prefixKeyEncoded.length)
+    Platform.copyMemory(remainingEncoded, Platform.BYTE_ARRAY_OFFSET,
+      encodedBytes, Platform.BYTE_ARRAY_OFFSET + 4 + prefixKeyEncoded.length,
+      remainingEncoded.length)
+    encodedBytes
+  }
+
+  override def decodeCompositeKey(compositeKeyBytes: Array[Byte]): (UnsafeRow, UnsafeRow) = {
+    val groupingKeyEncodedLen = Platform.getInt(compositeKeyBytes, Platform.BYTE_ARRAY_OFFSET)
+    val groupingKeyEncoded = new Array[Byte](groupingKeyEncodedLen)
+    Platform.copyMemory(compositeKeyBytes, Platform.BYTE_ARRAY_OFFSET + 4, groupingKeyEncoded,
+      Platform.BYTE_ARRAY_OFFSET, groupingKeyEncodedLen)
+
+    val remainingKeyEncodedLen = compositeKeyBytes.length - 4 - groupingKeyEncodedLen
+    val remainingKeyEncoded = new Array[Byte](remainingKeyEncodedLen)
+    Platform.copyMemory(compositeKeyBytes, Platform.BYTE_ARRAY_OFFSET + 4 +
+      groupingKeyEncodedLen, remainingKeyEncoded, Platform.BYTE_ARRAY_OFFSET,
+      remainingKeyEncodedLen)
+
+    val prefixKeyDecoded = decodeToUnsafeRow(groupingKeyEncoded, keyRow)
+    val remainingKeyDecoded = decodeToUnsafeRow(remainingKeyEncoded, userKeyRow)
+
+    (prefixKeyDecoded, remainingKeyDecoded)
   }
 }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
@@ -79,8 +79,10 @@ private[sql] class RocksDBStateStoreProvider
       value
     }
 
-    override def getWithCompositeKey(groupingKey: UnsafeRow,
-                                     userKey: UnsafeRow, colFamilyName: String): UnsafeRow = {
+    override def getWithCompositeKey(
+        groupingKey: UnsafeRow,
+        userKey: UnsafeRow,
+        colFamilyName: String): UnsafeRow = {
       verify(useCompositeKey, "Please setUseCompositeKey first")
       verify(groupingKey != null, "Grouping Key cannot be null")
       val kvEncoder = keyValueEncoderMap.get(colFamilyName)
@@ -94,7 +96,10 @@ private[sql] class RocksDBStateStoreProvider
       value
     }
 
-    override def putWithCompositeKey(groupingKey: UnsafeRow, userKey: UnsafeRow, value: UnsafeRow,
+    override def putWithCompositeKey(
+        groupingKey: UnsafeRow,
+        userKey: UnsafeRow,
+        value: UnsafeRow,
         colFamilyName: String = StateStore.DEFAULT_COL_FAMILY_NAME): Unit = {
       verify(useCompositeKey, "Please setUseCompositeKey first")
       verify(state == UPDATING, "Cannot put after already committed or aborted")
@@ -105,7 +110,9 @@ private[sql] class RocksDBStateStoreProvider
         kvEncoder._2.encodeValue(value), colFamilyName)
     }
 
-    override def removeWithCompositeKey(groupingKey: UnsafeRow, userKey: UnsafeRow,
+    override def removeWithCompositeKey(
+        groupingKey: UnsafeRow,
+        userKey: UnsafeRow,
         colFamilyName: String = StateStore.DEFAULT_COL_FAMILY_NAME): Unit = {
       verify(useCompositeKey, "Please setUseCompositeKey first")
       verify(state == UPDATING, "Cannot remove after already committed or aborted")
@@ -164,7 +171,7 @@ private[sql] class RocksDBStateStoreProvider
         val prefix = kvEncoder._1.encodePrefixKey(prefixKey)
         val rowPair = new UnsafeRowPair()
         rocksDB.prefixScan(prefix, colFamilyName).map { kv =>
-          rowPair.withRows(kvEncoder._1.decodeKey(kv.key),
+          rowPair.withRows(kvEncoder._1.decodeCompositeKey(kv.key)._2,
             kvEncoder._2.decodeValue(kv.value))
             rowPair
         }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
@@ -74,8 +74,10 @@ trait ReadStateStore {
   def get(key: UnsafeRow,
     colFamilyName: String = StateStore.DEFAULT_COL_FAMILY_NAME): UnsafeRow
 
-  def getWithCompositeKey(groupingKey: UnsafeRow, userKey: UnsafeRow,
-                          colFamilyName: String): UnsafeRow
+  def getWithCompositeKey(
+      groupingKey: UnsafeRow,
+      userKey: UnsafeRow,
+      colFamilyName: String): UnsafeRow
 
   /**
    * Return an iterator containing all the key-value pairs which are matched with

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
@@ -60,12 +60,22 @@ trait ReadStateStore {
   /** Version of the data in this store before committing updates. */
   def version: Long
 
+  /** Whether composite key is used for state store. */
+  var useCompositeKey: Boolean = false
+
+  def setUseCompositeKey(colFamilyName: String = StateStore.DEFAULT_COL_FAMILY_NAME): Unit = {
+    throw new UnsupportedOperationException("Set state store to use composite key is not supported")
+  }
+
   /**
    * Get the current value of a non-null key.
    * @return a non-null row if the key exists in the store, otherwise null.
    */
   def get(key: UnsafeRow,
     colFamilyName: String = StateStore.DEFAULT_COL_FAMILY_NAME): UnsafeRow
+
+  def getWithCompositeKey(groupingKey: UnsafeRow, userKey: UnsafeRow,
+                          colFamilyName: String): UnsafeRow
 
   /**
    * Return an iterator containing all the key-value pairs which are matched with
@@ -118,12 +128,21 @@ trait StateStore extends ReadStateStore {
       numColsPrefixKey: Int,
       valueSchema: StructType): Unit
 
+
+  def setUseCompositeKey(colFamilyName: String = StateStore.DEFAULT_COL_FAMILY_NAME): Unit
+
   /**
    * Put a new non-null value for a non-null key. Implementations must be aware that the UnsafeRows
    * in the params can be reused, and must make copies of the data as needed for persistence.
    */
   def put(key: UnsafeRow, value: UnsafeRow,
     colFamilyName: String = StateStore.DEFAULT_COL_FAMILY_NAME): Unit
+
+  def putWithCompositeKey(groupingKey: UnsafeRow, userKey: UnsafeRow, value: UnsafeRow,
+                          colFamilyName: String = StateStore.DEFAULT_COL_FAMILY_NAME): Unit
+
+  def removeWithCompositeKey(groupingKey: UnsafeRow, userKey: UnsafeRow,
+                             colFamilyName: String = StateStore.DEFAULT_COL_FAMILY_NAME): Unit
 
   /**
    * Remove a single non-null key.
@@ -182,6 +201,10 @@ class WrappedReadStateStore(store: StateStore) extends ReadStateStore {
   override def prefixScan(prefixKey: UnsafeRow,
     colFamilyName: String = StateStore.DEFAULT_COL_FAMILY_NAME): Iterator[UnsafeRowPair] =
     store.prefixScan(prefixKey, colFamilyName)
+
+  override def getWithCompositeKey(groupingKey: UnsafeRow, userKey: UnsafeRow,
+        colFamilyName: String = StateStore.DEFAULT_COL_FAMILY_NAME): UnsafeRow =
+    store.getWithCompositeKey(groupingKey, userKey, colFamilyName)
 }
 
 /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/MapStateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/MapStateSuite.scala
@@ -1,0 +1,202 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.streaming
+
+import org.apache.spark.SparkException
+import org.apache.spark.sql.execution.streaming.MemoryStream
+import org.apache.spark.sql.execution.streaming.state.RocksDBStateStoreProvider
+import org.apache.spark.sql.internal.SQLConf
+
+case class InputMapRow(key: String, action: String, value: (String, String))
+
+class TestMapStateProcessor
+  extends StatefulProcessor[String, InputMapRow, (String, String, String)] {
+
+  @transient var _processorHandle: StatefulProcessorHandle = _
+  @transient var _mapState: MapState[String, String] = _
+
+  override def init(handle: StatefulProcessorHandle, outputMode: OutputMode): Unit = {
+    _processorHandle = handle
+    _mapState = handle.getMapState("sessionState")
+  }
+
+  override def handleInputRows(key: String,
+                               inputRows: Iterator[InputMapRow],
+                               timerValues: TimerValues): Iterator[(String, String, String)] = {
+
+    var output = List[(String, String, String)]()
+
+    for (row <- inputRows) {
+      if (row.action == "exists") {
+        output = (key, "exists", _mapState.exists().toString) :: output
+      } else if (row.action == "getValue") {
+        output = (key, row.value._1, _mapState.getValue(row.value._1)) :: output
+      } else if (row.action == "containsKey") {
+        output = (key, row.value._1,
+          if (_mapState.containsKey(row.value._1)) "true" else "false") :: output
+      } else if (row.action == "updateValue") {
+        _mapState.updateValue(row.value._1, row.value._2)
+      } else if (row.action == "getMap") {
+        val res = _mapState.getMap()
+        res.foreach { pair =>
+          output = (key, pair._1, pair._2) :: output
+        }
+      } else if (row.action == "getKeys") {
+        _mapState.getKeys().foreach { key =>
+          output = (row.key, key, row.value._2) :: output
+        }
+      } else if (row.action == "getValues") {
+        _mapState.getValues().foreach { value =>
+          output = (row.key, row.value._1, value) :: output
+        }
+      } else if (row.action == "removeKey") {
+        _mapState.removeKey(row.value._1)
+      } else if (row.action == "remove") {
+        _mapState.remove()
+      }
+    }
+    output.iterator
+  }
+
+  override def close(): Unit = {}
+}
+
+class TransformWithMapStateSuite extends StreamTest {
+  import testImplicits._
+
+  private def testMapStateWithNullUserKey(inputMapRow: InputMapRow): Unit = {
+    withSQLConf(SQLConf.STATE_STORE_PROVIDER_CLASS.key ->
+      classOf[RocksDBStateStoreProvider].getName) {
+
+      val inputData = MemoryStream[InputMapRow]
+      val result = inputData.toDS()
+        .groupByKey(x => x.key)
+        .transformWithState(new TestMapStateProcessor(),
+          TimeoutMode.noTimeouts(),
+          OutputMode.Update())
+
+      testStream(result, OutputMode.Update())(
+        AddData(inputData, inputMapRow),
+        ExpectFailure[SparkException](e => {
+          assert(e.getMessage.contains("User key cannot be null"))
+        })
+      )
+    }
+  }
+
+  test("Test retrieving value with non-exist user key") {
+    withSQLConf(SQLConf.STATE_STORE_PROVIDER_CLASS.key ->
+      classOf[RocksDBStateStoreProvider].getName) {
+
+      val inputData = MemoryStream[InputMapRow]
+      val result = inputData.toDS()
+        .groupByKey(x => x.key)
+        .transformWithState(new TestMapStateProcessor(),
+          TimeoutMode.noTimeouts(),
+          OutputMode.Update())
+
+      testStream(result, OutputMode.Update())(
+        AddData(inputData, InputMapRow("k1", "getValue", ("v1", ""))),
+        ExpectFailure[SparkException](e => {
+          assert(e.getMessage.contains(
+            "No value found for given grouping key and user key in the map."))
+        })
+      )
+    }
+  }
+
+  Seq("getValue", "containsKey", "updateValue", "removeKey").foreach { mapImplFunc =>
+    test(s"Test $mapImplFunc with null user key") {
+      testMapStateWithNullUserKey(InputMapRow("k1", mapImplFunc, (null, "")))
+    }
+  }
+
+  test("Test put value with null value") {
+    withSQLConf(SQLConf.STATE_STORE_PROVIDER_CLASS.key ->
+      classOf[RocksDBStateStoreProvider].getName) {
+
+      val inputData = MemoryStream[InputMapRow]
+      val result = inputData.toDS()
+        .groupByKey(x => x.key)
+        .transformWithState(new TestMapStateProcessor(),
+          TimeoutMode.noTimeouts(),
+          OutputMode.Update())
+
+      testStream(result, OutputMode.Update())(
+        AddData(inputData, InputMapRow("k1", "updateValue", ("k1", null))),
+        ExpectFailure[SparkException](e => {
+          assert(e.getMessage.contains("Value put to map cannot be null."))
+        })
+      )
+    }
+  }
+
+  test("Test map state correctness") {
+    withSQLConf(SQLConf.STATE_STORE_PROVIDER_CLASS.key ->
+      classOf[RocksDBStateStoreProvider].getName) {
+      val inputData = MemoryStream[InputMapRow]
+      val result = inputData.toDS()
+        .groupByKey(x => x.key)
+        .transformWithState(new TestMapStateProcessor(),
+          TimeoutMode.noTimeouts(),
+          OutputMode.Append())
+      testStream(result, OutputMode.Append())(
+        // Test exists()
+        AddData(inputData, InputMapRow("k1", "updateValue", ("v1", "10"))),
+        AddData(inputData, InputMapRow("k1", "exists", ("", ""))),
+        AddData(inputData, InputMapRow("k2", "exists", ("", ""))),
+        CheckNewAnswer(("k1", "exists", "true"), ("k2", "exists", "false")),
+
+        // Test get and put with composite key
+        AddData(inputData, InputMapRow("k1", "updateValue", ("v2", "5"))),
+
+        AddData(inputData, InputMapRow("k2", "updateValue", ("v2", "3"))),
+        AddData(inputData, InputMapRow("k2", "updateValue", ("v2", "12"))),
+        AddData(inputData, InputMapRow("k2", "updateValue", ("v4", "1"))),
+
+        // Different grouping key, same user key
+        AddData(inputData, InputMapRow("k1", "getValue", ("v2", ""))),
+        CheckNewAnswer(("k1", "v2", "5")),
+        // Same grouping key, same user key, update value should reflect
+        AddData(inputData, InputMapRow("k2", "getValue", ("v2", ""))),
+        CheckNewAnswer(("k2", "v2", "12")),
+
+        // Test get full map for a given grouping key - prefixScan
+        AddData(inputData, InputMapRow("k2", "getMap", ("", ""))),
+        CheckNewAnswer(("k2", "v2", "12"), ("k2", "v4", "1")),
+
+        AddData(inputData, InputMapRow("k2", "getKeys", ("", ""))),
+        CheckNewAnswer(("k2", "v2", ""), ("k2", "v4", "")),
+
+        AddData(inputData, InputMapRow("k2", "getValues", ("", ""))),
+        CheckNewAnswer(("k2", "", "12"), ("k2", "", "1")),
+
+        // Test remove functionalities
+        AddData(inputData, InputMapRow("k1", "removeKey", ("v2", ""))),
+        AddData(inputData, InputMapRow("k1", "containsKey", ("v2", ""))),
+        CheckNewAnswer(("k1", "v2", "false")),
+
+        AddData(inputData, InputMapRow("k2", "remove", ("", ""))),
+        AddData(inputData, InputMapRow("k2", "getMap", ("", ""))),
+        CheckNewAnswer(),
+        AddData(inputData, InputMapRow("k2", "exists", ("", ""))),
+        CheckNewAnswer(("k2", "exists", "false"))
+      )
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/MemoryStateStore.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/MemoryStateStore.scala
@@ -42,6 +42,24 @@ class MemoryStateStore extends StateStore() {
     throw StateStoreErrors.removingColumnFamiliesNotSupported("MemoryStateStoreProvider")
   }
 
+  override def getWithCompositeKey(key: UnsafeRow, userKey: UnsafeRow,
+                                   colFamilyName: String): UnsafeRow = {
+    throw new UnsupportedOperationException(
+      "Get with composite key is not supported for Memory State")
+  }
+
+  def putWithCompositeKey(key: UnsafeRow, userKey: UnsafeRow, value: UnsafeRow,
+                          colFamilyName: String = StateStore.DEFAULT_COL_FAMILY_NAME): Unit = {
+    throw new UnsupportedOperationException(
+      "Put with composite key is not supported for Memory State")
+  }
+
+  def removeWithCompositeKey(key: UnsafeRow, userKey: UnsafeRow,
+                             colFamilyName: String = StateStore.DEFAULT_COL_FAMILY_NAME): Unit = {
+    throw new UnsupportedOperationException(
+      "Remove with composite key is not supported for Memory State")
+  }
+
   override def get(key: UnsafeRow, colFamilyName: String): UnsafeRow = map.get(key)
 
   override def put(key: UnsafeRow, newValue: UnsafeRow, colFamilyName: String): Unit =

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/MemoryStateStore.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/MemoryStateStore.scala
@@ -42,20 +42,26 @@ class MemoryStateStore extends StateStore() {
     throw StateStoreErrors.removingColumnFamiliesNotSupported("MemoryStateStoreProvider")
   }
 
-  override def getWithCompositeKey(key: UnsafeRow, userKey: UnsafeRow,
-                                   colFamilyName: String): UnsafeRow = {
+  override def getWithCompositeKey(
+      key: UnsafeRow,
+      userKey: UnsafeRow,
+      colFamilyName: String): UnsafeRow = {
     throw new UnsupportedOperationException(
       "Get with composite key is not supported for Memory State")
   }
 
-  def putWithCompositeKey(key: UnsafeRow, userKey: UnsafeRow, value: UnsafeRow,
-                          colFamilyName: String = StateStore.DEFAULT_COL_FAMILY_NAME): Unit = {
+  def putWithCompositeKey(
+      key: UnsafeRow,
+      userKey: UnsafeRow, value: UnsafeRow,
+      colFamilyName: String = StateStore.DEFAULT_COL_FAMILY_NAME): Unit = {
     throw new UnsupportedOperationException(
       "Put with composite key is not supported for Memory State")
   }
 
-  def removeWithCompositeKey(key: UnsafeRow, userKey: UnsafeRow,
-                             colFamilyName: String = StateStore.DEFAULT_COL_FAMILY_NAME): Unit = {
+  def removeWithCompositeKey(
+      key: UnsafeRow,
+      userKey: UnsafeRow,
+      colFamilyName: String = StateStore.DEFAULT_COL_FAMILY_NAME): Unit = {
     throw new UnsupportedOperationException(
       "Remove with composite key is not supported for Memory State")
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/TransformWithMapStateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/TransformWithMapStateSuite.scala
@@ -87,7 +87,7 @@ class TransformWithMapStateSuite extends StreamTest {
       val result = inputData.toDS()
         .groupByKey(x => x.key)
         .transformWithState(new TestMapStateProcessor(),
-          TimeoutMode.noTimeouts(),
+          TimeoutMode.NoTimeouts(),
           OutputMode.Update())
 
       testStream(result, OutputMode.Update())(
@@ -107,7 +107,7 @@ class TransformWithMapStateSuite extends StreamTest {
       val result = inputData.toDS()
         .groupByKey(x => x.key)
         .transformWithState(new TestMapStateProcessor(),
-          TimeoutMode.noTimeouts(),
+          TimeoutMode.NoTimeouts(),
           OutputMode.Update())
 
       testStream(result, OutputMode.Update())(
@@ -134,7 +134,7 @@ class TransformWithMapStateSuite extends StreamTest {
       val result = inputData.toDS()
         .groupByKey(x => x.key)
         .transformWithState(new TestMapStateProcessor(),
-          TimeoutMode.noTimeouts(),
+          TimeoutMode.NoTimeouts(),
           OutputMode.Update())
 
       testStream(result, OutputMode.Update())(
@@ -153,7 +153,7 @@ class TransformWithMapStateSuite extends StreamTest {
       val result = inputData.toDS()
         .groupByKey(x => x.key)
         .transformWithState(new TestMapStateProcessor(),
-          TimeoutMode.noTimeouts(),
+          TimeoutMode.NoTimeouts(),
           OutputMode.Append())
       testStream(result, OutputMode.Append())(
         // Test exists()

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/TransformWithMapStateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/TransformWithMapStateSuite.scala
@@ -35,9 +35,10 @@ class TestMapStateProcessor
     _mapState = handle.getMapState("sessionState")
   }
 
-  override def handleInputRows(key: String,
-                               inputRows: Iterator[InputMapRow],
-                               timerValues: TimerValues): Iterator[(String, String, String)] = {
+  override def handleInputRows(
+      key: String,
+      inputRows: Iterator[InputMapRow],
+      timerValues: TimerValues): Iterator[(String, String, String)] = {
 
     var output = List[(String, String, String)]()
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/UISeleniumSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/UISeleniumSuite.scala
@@ -22,7 +22,6 @@ import scala.jdk.CollectionConverters._
 
 import org.apache.commons.text.StringEscapeUtils.escapeJava
 import org.apache.commons.text.translate.EntityArrays._
-import org.openqa.selenium.By
 import org.openqa.selenium.htmlunit.HtmlUnitDriver
 import org.scalatest.concurrent.Eventually.eventually
 import org.scalatest.concurrent.Futures.{interval, timeout}
@@ -53,8 +52,7 @@ class UISeleniumSuite extends SparkFunSuite with WebBrowser {
     val webUrl = spark.sparkContext.uiWebUrl
     assert(webUrl.isDefined, "please turn on spark.ui.enabled")
     go to s"${webUrl.get}/SQL"
-    findAll(cssSelector("""#failed-table td .stacktrace-details"""))
-      .map(_.underlying.findElement(By.xpath("..")).getText).toList
+    findAll(cssSelector("""#failed-table td .stacktrace-details""")).map(_.text).toList
   }
 
   private def findErrorSummaryOnSQLUI(): String = {
@@ -106,13 +104,13 @@ class UISeleniumSuite extends SparkFunSuite with WebBrowser {
     eventually(timeout(10.seconds), interval(100.milliseconds)) {
       val sd = findErrorMessageOnSQLUI()
       assert(sd.size === 1, "Analyze fail shall show the query in failed table")
-      assert(sd.head.startsWith("TABLE_OR_VIEW_NOT_FOUND"))
+      assert(sd.head.startsWith("[TABLE_OR_VIEW_NOT_FOUND]"))
 
       val id = findExecutionIDOnSQLUI()
       // check query detail page
       go to s"${spark.sparkContext.uiWebUrl.get}/SQL/execution/?id=$id"
       val planDot = findAll(cssSelector(""".dot-file""")).map(_.text).toList
-      assert(planDot.size === 1)
+      assert(planDot.head.startsWith("digraph G {"))
       val planDetails = findAll(cssSelector("""#physical-plan-details""")).map(_.text).toList
       assert(planDetails.head.isEmpty)
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/UISeleniumSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/UISeleniumSuite.scala
@@ -22,6 +22,7 @@ import scala.jdk.CollectionConverters._
 
 import org.apache.commons.text.StringEscapeUtils.escapeJava
 import org.apache.commons.text.translate.EntityArrays._
+import org.openqa.selenium.By
 import org.openqa.selenium.htmlunit.HtmlUnitDriver
 import org.scalatest.concurrent.Eventually.eventually
 import org.scalatest.concurrent.Futures.{interval, timeout}
@@ -52,7 +53,8 @@ class UISeleniumSuite extends SparkFunSuite with WebBrowser {
     val webUrl = spark.sparkContext.uiWebUrl
     assert(webUrl.isDefined, "please turn on spark.ui.enabled")
     go to s"${webUrl.get}/SQL"
-    findAll(cssSelector("""#failed-table td .stacktrace-details""")).map(_.text).toList
+    findAll(cssSelector("""#failed-table td .stacktrace-details"""))
+      .map(_.underlying.findElement(By.xpath("..")).getText).toList
   }
 
   private def findErrorSummaryOnSQLUI(): String = {
@@ -104,13 +106,13 @@ class UISeleniumSuite extends SparkFunSuite with WebBrowser {
     eventually(timeout(10.seconds), interval(100.milliseconds)) {
       val sd = findErrorMessageOnSQLUI()
       assert(sd.size === 1, "Analyze fail shall show the query in failed table")
-      assert(sd.head.startsWith("[TABLE_OR_VIEW_NOT_FOUND]"))
+      assert(sd.head.startsWith("TABLE_OR_VIEW_NOT_FOUND"))
 
       val id = findExecutionIDOnSQLUI()
       // check query detail page
       go to s"${spark.sparkContext.uiWebUrl.get}/SQL/execution/?id=$id"
       val planDot = findAll(cssSelector(""".dot-file""")).map(_.text).toList
-      assert(planDot.head.startsWith("digraph G {"))
+      assert(planDot.size === 1)
       val planDetails = findAll(cssSelector("""#physical-plan-details""")).map(_.text).toList
       assert(planDetails.head.isEmpty)
     }

--- a/sql/hive-thriftserver/pom.xml
+++ b/sql/hive-thriftserver/pom.xml
@@ -103,7 +103,7 @@
     </dependency>
     <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
-      <artifactId>htmlunit-driver</artifactId>
+      <artifactId>htmlunit3-driver</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/sql/hive-thriftserver/pom.xml
+++ b/sql/hive-thriftserver/pom.xml
@@ -103,7 +103,7 @@
     </dependency>
     <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
-      <artifactId>htmlunit3-driver</artifactId>
+      <artifactId>htmlunit-driver</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/streaming/pom.xml
+++ b/streaming/pom.xml
@@ -113,7 +113,7 @@
     </dependency>
     <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
-      <artifactId>htmlunit-driver</artifactId>
+      <artifactId>htmlunit3-driver</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/streaming/pom.xml
+++ b/streaming/pom.xml
@@ -113,7 +113,7 @@
     </dependency>
     <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
-      <artifactId>htmlunit3-driver</artifactId>
+      <artifactId>htmlunit-driver</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR adds changes for MapState implementation in State Api v2. This implementation adds a new encoder/decoder to encode grouping key and user key into a composite key to be put into RocksDB so that we could retrieve key-value pair by user specified user key by one rocksdb get.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
These changes are needed to support map values in the State Store. The changes are part of the work around adding new stateful streaming operator for arbitrary state mgmt that provides a bunch of new features listed in the SPIP JIRA here - https://issues.apache.org/jira/browse/SPARK-45939

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes
This PR introduces a new state type (MapState) that users can use in their Spark streaming queries.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Unit tests in `TransforWithMapStateSuite`.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No