### PR TITLE
[SPARK-47039][TESTS] Add a checkstyle rule to ban `commons-lang` in Java code

### DIFF
--- a/dev/checkstyle-suppressions.xml
+++ b/dev/checkstyle-suppressions.xml
@@ -62,4 +62,6 @@
               files="sql/api/src/main/java/org/apache/spark/sql/streaming/Trigger.java"/>
     <suppress checks="LineLength"
               files="src/main/java/org/apache/spark/sql/api/java/*"/>
+    <suppress checks="IllegalImport"
+              files="src/test/java/org/apache/spark/sql/hive/test/Complex.java"/>
 </suppressions>

--- a/dev/checkstyle.xml
+++ b/dev/checkstyle.xml
@@ -186,6 +186,7 @@
         </module>
         <module name="IllegalImport">
             <property name="illegalPkgs" value="org.apache.log4j" />
+            <property name="illegalPkgs" value="org.apache.commons.lang" />
         </module>
     </module>
 </module>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add a checkstyle rule to ban `commons-lang` in Java code in favor of `commons-lang3`.

### Why are the changes needed?

SPARK-16129 banned `commons-lang` in Scala code since Apache Spark 2.0.0.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.