### PR TITLE
[SPARK-47041] PushDownUtils should support not only FileScanBuilder but any SupportsPushDownCatalystFilters

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushDownUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushDownUtils.scala
@@ -27,6 +27,7 @@ import org.apache.spark.sql.connector.expressions.filter.Predicate
 import org.apache.spark.sql.connector.read.{Scan, ScanBuilder, SupportsPushDownFilters, SupportsPushDownLimit, SupportsPushDownOffset, SupportsPushDownRequiredColumns, SupportsPushDownTableSample, SupportsPushDownTopN, SupportsPushDownV2Filters}
 import org.apache.spark.sql.execution.datasources.DataSourceStrategy
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.internal.connector.SupportsPushDownCatalystFilters
 import org.apache.spark.sql.sources
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.ArrayImplicits._
@@ -107,7 +108,7 @@ object PushDownUtils {
         (Right(r.pushedPredicates.toImmutableArraySeq),
           (postScanFilters ++ untranslatableExprs).toImmutableArraySeq)
 
-      case f: FileScanBuilder =>
+      case f: SupportsPushDownCatalystFilters =>
         val postScanFilters = f.pushFilters(filters)
         (Right(f.pushedFilters.toImmutableArraySeq), postScanFilters)
       case _ => (Left(Nil), filters)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Making the usage more flexible by migrating it to a trait.

### Why are the changes needed?

I want to implement a custom `ScanBuilder` supporting pushing predicates, but this code forces me to extend `FileScanBuilder`, though there is an interface exactly for that.

### Does this PR introduce _any_ user-facing change?

I guess, not.

### How was this patch tested?

Was not tested.

### Was this patch authored or co-authored using generative AI tooling?

No.
