### PR TITLE
[WIP][SPARK-47042][BUILD] add missing explicit dependency 'commons-lang3' to the module 'spark-common-utils'

### DIFF
--- a/common/utils/pom.xml
+++ b/common/utils/pom.xml
@@ -53,6 +53,10 @@
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
       <artifactId>commons-text</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to fix `spark-common-utils` module by adding explicit `commons-lang3` dependency. 

### Why are the changes needed?
`spark-common-utils` uses `commons-lang3` like the following, but we didn't declare it explicitly. 

[MavenUtils.scala](https://github.com/William1104/spark/blob/ad93dfb565ad2f6a04505365294bf1b1c603c2ce/common/utils/src/main/scala/org/apache/spark/util/MavenUtils.scala#L25)

[ClosureCleaner.scala]
(https://github.com/William1104/spark/blob/ad93dfb565ad2f6a04505365294bf1b1c603c2ce/common/utils/src/main/scala/org/apache/spark/util/ClosureCleaner.scala#L27)

[JavaUtils.java]
(https://github.com/William1104/spark/blob/ad93dfb565ad2f6a04505365294bf1b1c603c2ce/common/utils/src/main/java/org/apache/spark/network/util/JavaUtils.java#L31)

### How was this patch tested?
Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?
No.
