### PR TITLE
[SPARK-47044][SQL] Add executed query for JDBC external datasources to explain output

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -1000,12 +1000,10 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]]
 
     val str = if (verbose) {
       if (addSuffix) verboseStringWithSuffix(maxFields) else verboseString(maxFields)
+    } else if (printNodeId) {
+      simpleStringWithNodeId()
     } else {
-      if (printNodeId) {
-        simpleStringWithNodeId()
-      } else {
-        simpleString(maxFields)
-      }
+      simpleString(maxFields)
     }
     append(prefix)
     append(str)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -130,7 +130,7 @@ case class RowDataSourceScanExec(
   override def verboseStringWithOperatorId(): String = {
     super.verboseStringWithOperatorId() + (rdd match {
       case externalEngineDatasourceRdd: ExternalEngineDatasourceRDD =>
-        "Executed query: " +
+        "External engine query: " +
           externalEngineDatasourceRdd.getExternalEngineQuery +
           System.lineSeparator()
       case _ => ""

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -127,6 +127,16 @@ case class RowDataSourceScanExec(
     }
   }
 
+  override def verboseStringWithOperatorId(): String = {
+    super.verboseStringWithOperatorId() + (rdd match {
+      case externalEngineDatasourceRdd: ExternalEngineDatasourceRDD =>
+        "Executed query: " +
+          externalEngineDatasourceRdd.getExternalEngineQuery +
+          System.lineSeparator()
+      case _ => ""
+    })
+  }
+
   protected override def doExecute(): RDD[InternalRow] = {
     val numOutputRows = longMetric("numOutputRows")
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ExternalEngineDatasourceRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ExternalEngineDatasourceRDD.scala
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources
+
+/**
+ * Represents a trait that should be implemented by relations which
+ * access external database engines
+ */
+trait ExternalEngineDatasourceRDD {
+  def getExternalEngineQuery: String
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
@@ -26,7 +26,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.connector.expressions.filter.Predicate
-import org.apache.spark.sql.execution.datasources.DataSourceMetricsMixin
+import org.apache.spark.sql.execution.datasources.{DataSourceMetricsMixin, ExternalEngineDatasourceRDD}
 import org.apache.spark.sql.execution.datasources.v2.TableSampleInfo
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.sql.jdbc.{JdbcDialect, JdbcDialects}
@@ -173,7 +173,7 @@ class JDBCRDD(
     limit: Int,
     sortOrders: Array[String],
     offset: Int)
-  extends RDD[InternalRow](sc, Nil) with DataSourceMetricsMixin {
+  extends RDD[InternalRow](sc, Nil) with DataSourceMetricsMixin with ExternalEngineDatasourceRDD {
 
   /**
    * Execution time of the query issued to JDBC connection
@@ -182,10 +182,39 @@ class JDBCRDD(
     sparkContext,
     name = "JDBC query execution time")
 
+  private lazy val dialect = JdbcDialects.get(url)
+
+  def generateJdbcQuery(partition: Option[JDBCPartition]): String = {
+    // H2's JDBC driver does not support the setSchema() method.  We pass a
+    // fully-qualified table name in the SELECT statement.  I don't know how to
+    // talk about a table in a completely portable way.
+    var builder = dialect
+      .getJdbcSQLQueryBuilder(options)
+      .withColumns(columns)
+      .withPredicates(predicates, partition)
+      .withSortOrders(sortOrders)
+      .withLimit(limit)
+      .withOffset(offset)
+
+    groupByColumns.foreach { groupByKeys =>
+      builder = builder.withGroupByColumns(groupByKeys)
+    }
+
+    sample.foreach { tableSampleInfo =>
+      builder = builder.withTableSample(tableSampleInfo)
+    }
+
+    builder.build()
+  }
+
   /**
    * Retrieve the list of partitions corresponding to this RDD.
    */
   override def getPartitions: Array[Partition] = partitions
+
+  override def getExternalEngineQuery: String = {
+    generateJdbcQuery(partition = None)
+  }
 
   /**
    * Runs the SQL query against the JDBC driver.
@@ -236,7 +265,6 @@ class JDBCRDD(
     val inputMetrics = context.taskMetrics().inputMetrics
     val part = thePart.asInstanceOf[JDBCPartition]
     conn = getConnection(part.idx)
-    val dialect = JdbcDialects.get(url)
     import scala.jdk.CollectionConverters._
     dialect.beforeFetch(conn, options.asProperties.asScala.toMap)
 
@@ -256,27 +284,7 @@ class JDBCRDD(
       case None =>
     }
 
-    // H2's JDBC driver does not support the setSchema() method.  We pass a
-    // fully-qualified table name in the SELECT statement.  I don't know how to
-    // talk about a table in a completely portable way.
-
-    var builder = dialect
-      .getJdbcSQLQueryBuilder(options)
-      .withColumns(columns)
-      .withPredicates(predicates, part)
-      .withSortOrders(sortOrders)
-      .withLimit(limit)
-      .withOffset(offset)
-
-    groupByColumns.foreach { groupByKeys =>
-      builder = builder.withGroupByColumns(groupByKeys)
-    }
-
-    sample.foreach { tableSampleInfo =>
-      builder = builder.withTableSample(tableSampleInfo)
-    }
-
-    val sqlText = builder.build()
+    val sqlText = generateJdbcQuery(Some(part))
     stmt = conn.prepareStatement(sqlText,
         ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY)
     stmt.setFetchSize(options.fetchSize)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
@@ -190,14 +190,11 @@ class JDBCRDD(
     // talk about a table in a completely portable way.
     var builder = dialect
       .getJdbcSQLQueryBuilder(options)
+      .withPredicates(predicates, partition.getOrElse(JDBCPartition(whereClause = null, idx = 1)))
       .withColumns(columns)
       .withSortOrders(sortOrders)
       .withLimit(limit)
       .withOffset(offset)
-
-    if (partition.isDefined) {
-      builder = builder.withPredicates(predicates, partition.get)
-    }
 
     groupByColumns.foreach { groupByKeys =>
       builder = builder.withGroupByColumns(groupByKeys)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
@@ -191,10 +191,13 @@ class JDBCRDD(
     var builder = dialect
       .getJdbcSQLQueryBuilder(options)
       .withColumns(columns)
-      .withPredicates(predicates, partition)
       .withSortOrders(sortOrders)
       .withLimit(limit)
       .withOffset(offset)
+
+    if (partition.isDefined) {
+      builder = builder.withPredicates(predicates, partition.get)
+    }
 
     groupByColumns.foreach { groupByKeys =>
       builder = builder.withGroupByColumns(groupByKeys)

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcSQLQueryBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcSQLQueryBuilder.scala
@@ -81,21 +81,17 @@ class JdbcSQLQueryBuilder(dialect: JdbcDialect, options: JDBCOptions) {
   /**
    * Constructs the WHERE clause that following dialect's SQL syntax.
    */
-  def withPredicates(
-      predicates: Array[Predicate],
-      part: Option[JDBCPartition]): JdbcSQLQueryBuilder = {
+  def withPredicates(predicates: Array[Predicate], part: JDBCPartition): JdbcSQLQueryBuilder = {
     // `filters`, but as a WHERE clause suitable for injection into a SQL query.
     val filterWhereClause: String = {
       predicates.flatMap(dialect.compileExpression(_)).map(p => s"($p)").mkString(" AND ")
     }
 
-    val partitionWhereClause = part.map(p => p.whereClause).orNull
-
     // A WHERE clause representing both `filters`, if any, and the current partition.
-    whereClause = if (partitionWhereClause != null && filterWhereClause.length > 0) {
-      "WHERE " + s"($filterWhereClause)" + " AND " + s"(${partitionWhereClause})"
-    } else if (partitionWhereClause != null) {
-      "WHERE " + partitionWhereClause
+    whereClause = if (part.whereClause != null && filterWhereClause.length > 0) {
+      "WHERE " + s"($filterWhereClause)" + " AND " + s"(${part.whereClause})"
+    } else if (part.whereClause != null) {
+      "WHERE " + part.whereClause
     } else if (filterWhereClause.length > 0) {
       "WHERE " + filterWhereClause
     } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcSQLQueryBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcSQLQueryBuilder.scala
@@ -81,8 +81,9 @@ class JdbcSQLQueryBuilder(dialect: JdbcDialect, options: JDBCOptions) {
   /**
    * Constructs the WHERE clause that following dialect's SQL syntax.
    */
-  def withPredicates(predicates: Array[Predicate],
-                     part: Option[JDBCPartition]): JdbcSQLQueryBuilder = {
+  def withPredicates(
+      predicates: Array[Predicate],
+      part: Option[JDBCPartition]): JdbcSQLQueryBuilder = {
     // `filters`, but as a WHERE clause suitable for injection into a SQL query.
     val filterWhereClause: String = {
       predicates.flatMap(dialect.compileExpression(_)).map(p => s"($p)").mkString(" AND ")

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcSQLQueryBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcSQLQueryBuilder.scala
@@ -81,17 +81,20 @@ class JdbcSQLQueryBuilder(dialect: JdbcDialect, options: JDBCOptions) {
   /**
    * Constructs the WHERE clause that following dialect's SQL syntax.
    */
-  def withPredicates(predicates: Array[Predicate], part: JDBCPartition): JdbcSQLQueryBuilder = {
+  def withPredicates(predicates: Array[Predicate],
+                     part: Option[JDBCPartition]): JdbcSQLQueryBuilder = {
     // `filters`, but as a WHERE clause suitable for injection into a SQL query.
     val filterWhereClause: String = {
       predicates.flatMap(dialect.compileExpression(_)).map(p => s"($p)").mkString(" AND ")
     }
 
+    val partitionWhereClause = part.map(p => p.whereClause).orNull
+
     // A WHERE clause representing both `filters`, if any, and the current partition.
-    whereClause = if (part.whereClause != null && filterWhereClause.length > 0) {
-      "WHERE " + s"($filterWhereClause)" + " AND " + s"(${part.whereClause})"
-    } else if (part.whereClause != null) {
-      "WHERE " + part.whereClause
+    whereClause = if (partitionWhereClause != null && filterWhereClause.length > 0) {
+      "WHERE " + s"($filterWhereClause)" + " AND " + s"(${partitionWhereClause})"
+    } else if (partitionWhereClause != null) {
+      "WHERE " + partitionWhereClause
     } else if (filterWhereClause.length > 0) {
       "WHERE " + filterWhereClause
     } else {

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
@@ -34,6 +34,7 @@ import org.apache.spark.sql.connector.catalog.{Catalogs, Identifier, TableCatalo
 import org.apache.spark.sql.connector.catalog.functions.{ScalarFunction, UnboundFunction}
 import org.apache.spark.sql.connector.catalog.index.SupportsIndex
 import org.apache.spark.sql.connector.expressions.Expression
+import org.apache.spark.sql.execution.FormattedMode
 import org.apache.spark.sql.execution.datasources.v2.{DataSourceV2ScanRelation, V1ScanWrapper}
 import org.apache.spark.sql.execution.datasources.v2.jdbc.JDBCTableCatalog
 import org.apache.spark.sql.functions.{abs, acos, asin, atan, atan2, avg, ceil, coalesce, cos, cosh, cot, count, count_distinct, degrees, exp, floor, lit, log => logarithm, log10, not, pow, radians, round, signum, sin, sinh, sqrt, sum, tan, tanh, udf, when}
@@ -3020,5 +3021,11 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
       JdbcDialects.unregisterDialect(testH2Dialect)
       JdbcDialects.registerDialect(H2Dialect)
     }
+  }
+
+  test("Explain shows executed SQL query") {
+    val df = sql("SELECT max(id) FROM h2.test.people WHERE id > 1")
+    val explained = getNormalizedExplain(df, FormattedMode)
+    assert(explained.contains("Executed query:"))
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
@@ -3026,6 +3026,6 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
   test("Explain shows executed SQL query") {
     val df = sql("SELECT max(id) FROM h2.test.people WHERE id > 1")
     val explained = getNormalizedExplain(df, FormattedMode)
-    assert(explained.contains("Executed query:"))
+    assert(explained.contains("External engine query:"))
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add generated JDBC query to EXPLAIN FORMATTED command when physical Scan node should access to JDBC source to create RDD.

Output of Explain formatted with this change from newly added test.
```
== Physical Plan ==
* Project (2)
+- * Scan org.apache.spark.sql.execution.datasources.v2.jdbc.JDBCScan$$anon$1@4349389d  (1)


(1) Scan org.apache.spark.sql.execution.datasources.v2.jdbc.JDBCScan$$anon$1@4349389d  [codegen id : 1]
Output [1]: [MAX(ID)#x]
Arguments: [MAX(ID)#x], [StructField(MAX(ID),IntegerType,true)], PushedDownOperators(Some(org.apache.spark.sql.connector.expressions.aggregate.Aggregation@647d3279),None,None,None,List(),ArraySeq(ID IS NOT NULL, ID > 1)), JDBCRDD[0] at $anonfun$executePhase$2 at LexicalThreadLocal.scala:63, org.apache.spark.sql.execution.datasources.v2.jdbc.JDBCScan$$anon$1@4349389d, Statistics(sizeInBytes=8.0 EiB, ColumnStat: N/A)
External engine query: SELECT MAX("ID") FROM "test"."people"  WHERE ("ID" IS NOT NULL) AND ("ID" > 1)

(2) Project [codegen id : 1]
Output [1]: [MAX(ID)#x AS max(id)#x]
Input [1]: [MAX(ID)#x]
```

### Why are the changes needed?
This command will allow customers to see which query text is sent to external JDBC sources.

### Does this PR introduce _any_ user-facing change?
Yes
Customer will have another field in EXPLAIN FORMATTED command for RowDataSourceScanExec node.

### How was this patch tested?
Tested using JDBC V2 suite by new unit test.

### Was this patch authored or co-authored using generative AI tooling?
No
