### PR TITLE
[SPARK-47043][BUILD] add `jackson-core` and `jackson-annotations` dependencies to module `spark-common-utils`

### DIFF
--- a/common/utils/pom.xml
+++ b/common/utils/pom.xml
@@ -48,6 +48,14 @@
       <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>
       <artifactId>jackson-module-scala_${scala.binary.version}</artifactId>
     </dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to fix `spark-common-utils` module by adding explicit `jackson-core` and `jackson-annotations` dependencies. 

### Why are the changes needed?
`spark-common-utils` uses `jackson-core` and `jackson-annotations` like the following, but we didn't declare it explicitly. 

https://github.com/apache/spark/blob/a6bed5e9bcc54dac51421263d5ef73c0b6e0b12c/common/utils/src/main/scala/org/apache/spark/ErrorClassesJSONReader.scala#L26
https://github.com/apache/spark/blob/a6bed5e9bcc54dac51421263d5ef73c0b6e0b12c/common/utils/src/main/scala/org/apache/spark/ErrorClassesJSONReader.scala#L25
https://github.com/apache/spark/blob/a6bed5e9bcc54dac51421263d5ef73c0b6e0b12c/common/utils/src/main/scala/org/apache/spark/util/JsonUtils.scala#L23

### How was this patch tested?
Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?
No.
