### PR TITLE
[SPARK-47049][BUILD] Ban non-shaded Hadoop dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2869,6 +2869,10 @@
                   </requireJavaVersion>
                   <bannedDependencies>
                     <excludes>
+                      <exclude>org.apache.hadoop:hadoop-common</exclude>
+                      <exclude>org.apache.hadoop:hadoop-hdfs-client</exclude>
+                      <exclude>org.apache.hadoop:hadoop-mapreduce-client-core</exclude>
+                      <exclude>org.apache.hadoop:hadoop-mapreduce-client-jobclient</exclude>
                       <exclude>org.jboss.netty</exclude>
                       <exclude>org.codehaus.groovy</exclude>
                       <exclude>*:*_2.12</exclude>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to ban `non-shaded` Hadoop dependencies (including transitive ones).

### Why are the changes needed?

SPARK-33212 moved to shaded Hadoop dependencies at Apache Spark 3.2.0. This PR will make it sure that we don't have any accidental leftovers.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.