### PR TITLE
[SPARK-47051][INFRA] Create a new test pipeline for `yarn` and `connect`

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -147,8 +147,9 @@ jobs:
             mllib-local, mllib, graphx
           - >-
             streaming, sql-kafka-0-10, streaming-kafka-0-10, streaming-kinesis-asl,
-            yarn, kubernetes, hadoop-cloud, spark-ganglia-lgpl,
-            connect, protobuf
+            kubernetes, hadoop-cloud, spark-ganglia-lgpl, protobuf
+          - >-
+            yarn, connect
         # Here, we split Hive and SQL tests into some of slow ones and the rest of them.
         included-tags: [""]
         excluded-tags: [""]


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to spin off `yarn` and `connect` as a new test pipeline for the following:
- To stabilize more by off-loading
- To re-trigger easily in case of failures.
- To isolate `yarn` module change and avoid triggering other module's tests like Kafka module.
- To isolate `connect` module change and avoid triggering other module's tests like Kafka module.

### Why are the changes needed?
 
These two modules are known to be flaky in various GitHub Action CI pipelines.
- https://github.com/apache/spark/actions/runs/7905202256/job/21577289425 (`YarnClusterSuite`)
- https://github.com/apache/spark/actions/runs/7905202256/job/21585092863 (`SparkSessionE2ESuite`)
- https://github.com/apache/spark/actions/runs/7828944523/job/21359886644 (`SparkSessionE2ESuite`)
- https://github.com/apache/spark/actions/runs/7795415730/job/21258341216 (`SparkSessionE2ESuite`)
- https://github.com/apache/spark/actions/runs/7858754074/job/21444107806 (`SparkSessionE2ESuite`)
- https://github.com/apache/spark/actions/runs/7879934827/job/21501133320 (`SparkConnectServiceSuite`)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs in this PR.

![Screenshot 2024-02-14 at 15 44 56](https://github.com/apache/spark/assets/9700541/6e735420-914d-44d3-b037-112c3e98d0e6)

### Was this patch authored or co-authored using generative AI tooling?

No.