### PR TITLE
[SPARK-46687][TESTS][PYTHON][FOLLOW-UP] Skip MemoryProfilerParityTests when codecov enabled

### DIFF
--- a/python/pyspark/tests/test_memory_profiler.py
+++ b/python/pyspark/tests/test_memory_profiler.py
@@ -203,6 +203,9 @@ class MemoryProfilerTests(PySparkTestCase):
         df.mapInPandas(map, schema=df.schema).collect()
 
 
+@unittest.skipIf(
+    "COVERAGE_PROCESS_START" in os.environ, "Fails with coverage enabled, skipping for now."
+)
 @unittest.skipIf(not has_memory_profiler, "Must have memory-profiler installed.")
 class MemoryProfiler2TestsMixin:
     @contextmanager


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a followup of https://github.com/apache/spark/pull/44775 that skips the tests with codecov on. It fails now (https://github.com/apache/spark/actions/runs/7709423681/job/21010676103) and the coverage report is broken.

### Why are the changes needed?

To recover the test coverage report.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Manually tested.

### Was this patch authored or co-authored using generative AI tooling?

No.
