### PR TITLE
[SPARK-47056][TESTS] Add `scalastyle` and `checkstyle` rules to ban `FileBackedOutputStream`

### DIFF
--- a/dev/checkstyle.xml
+++ b/dev/checkstyle.xml
@@ -182,7 +182,7 @@
         </module>
         <module name="RegexpSinglelineJava">
             <property name="format" value="FileBackedOutputStream"/>
-            <property name="message" value="Avoid using FileBackedOutputStream due to the insecure use of temporary directory." />
+            <property name="message" value="Avoid using FileBackedOutputStream due to CVE-2023-2976." />
         </module>
         <module name="RegexpSinglelineJava">
             <property name="format" value="@Test\(expected"/>

--- a/dev/checkstyle.xml
+++ b/dev/checkstyle.xml
@@ -181,6 +181,10 @@
                 Use org.apache.spark.network.util.JavaUtils.createTempDir() instead." />
         </module>
         <module name="RegexpSinglelineJava">
+            <property name="format" value="FileBackedOutputStream"/>
+            <property name="message" value="Avoid using FileBackedOutputStream due to the insecure use of temporary directory." />
+        </module>
+        <module name="RegexpSinglelineJava">
             <property name="format" value="@Test\(expected"/>
             <property name="message" value="Please use the `assertThrows` method to test for exceptions." />
         </module>

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -464,7 +464,7 @@ This file is divided into 3 sections:
 
   <check customId="GuavaFileBackedOutputStream" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
     <parameters><parameter name="regex">FileBackedOutputStream</parameter></parameters>
-    <customMessage>Avoid using FileBackedOutputStream due to the insecure use of temporary directory.</customMessage>
+    <customMessage>Avoid using FileBackedOutputStream due to CVE-2023-2976.</customMessage>
   </check>
 
   <check customId="pathfromuri" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -462,6 +462,11 @@ This file is divided into 3 sections:
     </customMessage>
   </check>
 
+  <check customId="GuavaFileBackedOutputStream" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">FileBackedOutputStream</parameter></parameters>
+    <customMessage>Avoid using FileBackedOutputStream due to the insecure use of temporary directory.</customMessage>
+  </check>
+
   <check customId="pathfromuri" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
     <parameters><parameter name="regex">new Path\(new URI\(</parameter></parameters>
     <customMessage><![CDATA[


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `scalastyle` and `checkstyle` rules to ban `FileBackedOutputStream`.

### Why are the changes needed?

We don't use this but this will explicitly prevent any accidental usage of `FileBackedOutputStream` in the future.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.