### PR TITLE
[SPARK-47058][TESTS] Add `scalastyle` and `checkstyle` rules to ban `AtomicDoubleArray|CompoundOrdering`

### DIFF
--- a/dev/checkstyle.xml
+++ b/dev/checkstyle.xml
@@ -185,6 +185,14 @@
             <property name="message" value="Avoid using FileBackedOutputStream due to CVE-2023-2976." />
         </module>
         <module name="RegexpSinglelineJava">
+            <property name="format" value="AtomicDoubleArray"/>
+            <property name="message" value="Avoid using AtomicDoubleArray due to CVE-2018-10237." />
+        </module>
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="CompoundOrdering"/>
+            <property name="message" value="Avoid using CompoundOrdering due to CVE-2018-10237." />
+        </module>
+        <module name="RegexpSinglelineJava">
             <property name="format" value="@Test\(expected"/>
             <property name="message" value="Please use the `assertThrows` method to test for exceptions." />
         </module>

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -467,6 +467,16 @@ This file is divided into 3 sections:
     <customMessage>Avoid using FileBackedOutputStream due to CVE-2023-2976.</customMessage>
   </check>
 
+  <check customId="GuavaAtomicDoubleArray" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">AtomicDoubleArray</parameter></parameters>
+    <customMessage>Avoid using AtomicDoubleArray due to CVE-2018-10237.</customMessage>
+  </check>
+
+  <check customId="GuavaCompoundOrdering" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">CompoundOrdering</parameter></parameters>
+    <customMessage>Avoid using CompoundOrdering due to CVE-2018-10237.</customMessage>
+  </check>
+
   <check customId="pathfromuri" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
     <parameters><parameter name="regex">new Path\(new URI\(</parameter></parameters>
     <customMessage><![CDATA[


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `scalastyle` and `check style` rules to ban `AtomicDoubleArray|CompoundOrdering`.

### Why are the changes needed?

Although Apache Spark uses `com.google.common.util.concurrent.*` and `com.google.common.collect.*`, we don't use `AtomicDoubleArray` and `CompoundOrdering`. This PR will prevent any future accidental usage. 

```
$ git grep com.google.common.util.concurrent | wc -l
      18

$ git grep com.google.common.collect | wc -l
      84
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.