### PR TITLE
[SPARK-47059][SQL] Attach error context for ALTER COLUMN v1 command

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -2637,7 +2637,8 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
   def alterTableChangeColumnNotSupportedForColumnTypeError(
       tableName: String,
       originColumn: StructField,
-      newColumn: StructField): Throwable = {
+      newColumn: StructField,
+      origin: Origin): Throwable = {
     new AnalysisException(
       errorClass = "NOT_SUPPORTED_CHANGE_COLUMN",
       messageParameters = Map(
@@ -2645,7 +2646,9 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
         "originName" -> toSQLId(originColumn.name),
         "originType" -> toSQLType(originColumn.dataType),
         "newName" -> toSQLId(newColumn.name),
-        "newType"-> toSQLType(newColumn.dataType)))
+        "newType"-> toSQLType(newColumn.dataType)),
+      origin = origin
+    )
   }
 
   def cannotAlterPartitionColumn(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
@@ -390,7 +390,7 @@ case class AlterTableChangeColumnCommand(
     // Throw an AnalysisException if the column name/dataType is changed.
     if (!columnEqual(originColumn, newColumn, resolver)) {
       throw QueryCompilationErrors.alterTableChangeColumnNotSupportedForColumnTypeError(
-        toSQLId(table.identifier.nameParts), originColumn, newColumn)
+        toSQLId(table.identifier.nameParts), originColumn, newColumn, this.origin)
     }
 
     val newDataSchema = table.dataSchema.fields.map { field =>

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/change-column.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/change-column.sql.out
@@ -69,7 +69,14 @@ org.apache.spark.sql.AnalysisException
     "originName" : "`a`",
     "originType" : "\"INT\"",
     "table" : "`spark_catalog`.`default`.`test_change`"
-  }
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 1,
+    "stopIndex" : 44,
+    "fragment" : "ALTER TABLE test_change CHANGE a TYPE STRING"
+  } ]
 }
 
 

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/charvarchar.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/charvarchar.sql.out
@@ -133,7 +133,14 @@ org.apache.spark.sql.AnalysisException
     "originName" : "`c`",
     "originType" : "\"CHAR(5)\"",
     "table" : "`spark_catalog`.`default`.`char_tbl1`"
-  }
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 1,
+    "stopIndex" : 50,
+    "fragment" : "alter table char_tbl1 change column c type char(6)"
+  } ]
 }
 
 

--- a/sql/core/src/test/resources/sql-tests/results/change-column.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/change-column.sql.out
@@ -89,7 +89,14 @@ org.apache.spark.sql.AnalysisException
     "originName" : "`a`",
     "originType" : "\"INT\"",
     "table" : "`spark_catalog`.`default`.`test_change`"
-  }
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 1,
+    "stopIndex" : 44,
+    "fragment" : "ALTER TABLE test_change CHANGE a TYPE STRING"
+  } ]
 }
 
 

--- a/sql/core/src/test/resources/sql-tests/results/charvarchar.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/charvarchar.sql.out
@@ -268,7 +268,14 @@ org.apache.spark.sql.AnalysisException
     "originName" : "`c`",
     "originType" : "\"CHAR(5)\"",
     "table" : "`spark_catalog`.`default`.`char_tbl1`"
-  }
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 1,
+    "stopIndex" : 50,
+    "fragment" : "alter table char_tbl1 change column c type char(6)"
+  } ]
 }
 
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/CharVarcharDDLTestBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/CharVarcharDDLTestBase.scala
@@ -47,11 +47,11 @@ trait CharVarcharDDLTestBase extends QueryTest with SQLTestUtils {
   test("not allow to change column for char(x) to char(y), x != y") {
     withTable("t") {
       sql(s"CREATE TABLE t(i STRING, c CHAR(4)) USING $format")
-      val sql1 = "ALTER TABLE t CHANGE COLUMN c TYPE CHAR(5)"
+      val alterSQL = "ALTER TABLE t CHANGE COLUMN c TYPE CHAR(5)"
       val table = getTableName("t")
       checkError(
           exception = intercept[AnalysisException] {
-            sql(sql1)
+            sql(alterSQL)
           },
           errorClass = "NOT_SUPPORTED_CHANGE_COLUMN",
           parameters = Map(
@@ -60,10 +60,7 @@ trait CharVarcharDDLTestBase extends QueryTest with SQLTestUtils {
             "newName" -> "`c`",
             "originName" -> "`c`",
             "table" -> table),
-          queryContext = table match {
-            case "`spark_catalog`.`default`.`t`" => Array.empty
-            case _ => Array(ExpectedContext(fragment = sql1, start = 0, stop = 41))
-          }
+          queryContext = Array(ExpectedContext(fragment = alterSQL, start = 0, stop = 41))
       )
     }
   }
@@ -84,10 +81,7 @@ trait CharVarcharDDLTestBase extends QueryTest with SQLTestUtils {
             "newName" -> "`c`",
             "originName" -> "`c`",
             "table" -> table),
-          queryContext = table match {
-            case "`spark_catalog`.`default`.`t`" => Array.empty
-            case _ => Array(ExpectedContext(fragment = sql1, start = 0, stop = 41))
-          }
+          queryContext = Array(ExpectedContext(fragment = sql1, start = 0, stop = 41))
       )
     }
   }
@@ -108,10 +102,7 @@ trait CharVarcharDDLTestBase extends QueryTest with SQLTestUtils {
             "newName" -> "`i`",
             "originName" -> "`i`",
             "table" -> table),
-          queryContext = table match {
-            case "`spark_catalog`.`default`.`t`" => Array.empty
-            case _ => Array(ExpectedContext(fragment = sql1, start = 0, stop = 41))
-          }
+          queryContext = Array(ExpectedContext(fragment = sql1, start = 0, stop = 41))
       )
     }
   }
@@ -140,10 +131,7 @@ trait CharVarcharDDLTestBase extends QueryTest with SQLTestUtils {
             "newName" -> "`c`",
             "originName" -> "`c`",
             "table" -> table),
-          queryContext = table match {
-            case "`spark_catalog`.`default`.`t`" => Array.empty
-            case _ => Array(ExpectedContext(fragment = sql1, start = 0, stop = 44))
-          }
+          queryContext = Array(ExpectedContext(fragment = sql1, start = 0, stop = 44))
       )
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This is a small fix to improve the error message for ALTER COLUMN. We attach the error context for v1 command as well, making it consistent with v2 command.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
better error message

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
no

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
updated tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
no