### PR TITLE
[SPARK-47066][INFRA] Add `Apple Silicon` Maven build test to GitHub Action CI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -848,6 +848,62 @@ jobs:
         ./build/mvn $MAVEN_CLI_OPTS -DskipTests -Pyarn -Pkubernetes -Pvolcano -Phive -Phive-thriftserver -Phadoop-cloud -Djava.version=${JAVA_VERSION/-ea} install
         rm -rf ~/.m2/repository/org/apache/spark
 
+  apple-silicon:
+    needs: precondition
+    if: fromJson(needs.precondition.outputs.required).java-other-versions == 'true'
+    name: Apple Silicon build with Maven
+    strategy:
+      fail-fast: false
+      matrix:
+        java:
+          - 21
+    runs-on: macos-14
+    timeout-minutes: 300
+    steps:
+    - name: Checkout Spark repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        repository: apache/spark
+        ref: ${{ inputs.branch }}
+    - name: Sync the current branch with the latest in Apache Spark
+      if: github.repository != 'apache/spark'
+      run: |
+        git fetch https://github.com/$GITHUB_REPOSITORY.git ${GITHUB_REF#refs/heads/}
+        git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' merge --no-commit --progress --squash FETCH_HEAD
+        git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' commit -m "Merged commit" --allow-empty
+    - name: Cache Scala, SBT and Maven
+      uses: actions/cache@v4
+      with:
+        path: |
+          build/apache-maven-*
+          build/scala-*
+          build/*.jar
+          ~/.sbt
+        key: build-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
+        restore-keys: |
+          apple-silicon-build-
+    - name: Cache Maven local repository
+      uses: actions/cache@v4
+      with:
+        path: ~/.m2/repository
+        key: java${{ matrix.java }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          apple-silicon-${{ matrix.java }}-maven-
+    - name: Install Java ${{ matrix.java }}
+      uses: actions/setup-java@v4
+      with:
+        distribution: zulu
+        java-version: ${{ matrix.java }}
+    - name: Build with Maven
+      run: |
+        export MAVEN_OPTS="-Xss64m -Xmx2g -XX:ReservedCodeCacheSize=1g -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN"
+        export MAVEN_CLI_OPTS="--no-transfer-progress"
+        export JAVA_VERSION=${{ matrix.java }}
+        # It uses Maven's 'install' intentionally, see https://github.com/apache/spark/pull/26414.
+        ./build/mvn $MAVEN_CLI_OPTS -DskipTests -Pyarn -Pkubernetes -Pvolcano -Phive -Phive-thriftserver -Phadoop-cloud -Djava.version=${JAVA_VERSION/-ea} install
+        rm -rf ~/.m2/repository/org/apache/spark
+
   # Any TPC-DS related updates on this job need to be applied to tpcds-1g-gen job of benchmark.yml as well
   tpcds-1g:
     needs: precondition

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -850,7 +850,7 @@ jobs:
 
   apple-silicon:
     needs: precondition
-    if: fromJson(needs.precondition.outputs.required).java-other-versions == 'true'
+    if: fromJson(needs.precondition.outputs.required).build == 'true'
     name: Apple Silicon build with Maven
     strategy:
       fail-fast: false


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add a new maven build test pipeline on `Apple Silicon and MacOS 14` environment.

### Why are the changes needed?

To have a test coverage.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs. It passed already.

![Screenshot 2024-02-15 at 12 14 15](https://github.com/apache/spark/assets/9700541/814880d6-78ba-478d-963d-30c1a814016c)

![Screenshot 2024-02-15 at 12 24 52](https://github.com/apache/spark/assets/9700541/5def455a-8130-43bc-9a66-5d395dce0dac)



### Was this patch authored or co-authored using generative AI tooling?

No.