### PR TITLE
[SPARK-47067][INFRA] Add Daily Apple Silicon Github Action Job (Java/Scala)

### DIFF
--- a/.github/workflows/build_apple_silicon.yml
+++ b/.github/workflows/build_apple_silicon.yml
@@ -1,0 +1,47 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: "Build / Apple Silicon (master, JDK 21)"
+
+on:
+  schedule:
+    - cron: '0 20 * * *'
+
+jobs:
+  run-build:
+    permissions:
+      packages: write
+    name: Run
+    uses: ./.github/workflows/build_and_test.yml
+    runs-on: macos-14
+    if: github.repository == 'apache/spark'
+    with:
+      java: 21
+      branch: master
+      hadoop: hadoop3
+      envs: >-
+        {
+          "SKIP_MIMA": "true",
+          "SKIP_UNIDOC": "true",
+          "DEDICATED_JVM_SBT_TESTS": "org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormatV1Suite,org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormatV2Suite,org.apache.spark.sql.execution.datasources.orc.OrcSourceV1Suite,org.apache.spark.sql.execution.datasources.orc.OrcSourceV2Suite"
+        }
+      jobs: >-
+        {
+          "build": "true"
+        }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add a new `Daily Apple Silicon Github Action (Java/Scala)` job for Apache Spark 4.0.0.

### Why are the changes needed?

To have a test coverage for Apple Silicon environment in Java/Scala first.

For Python and R, we need more efforts due to their library dependencies.

We will add them separately.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unfortunately, this should be tested after merging.

### Was this patch authored or co-authored using generative AI tooling?

No.