### PR TITLE
[SPARK-47069][PYTHON][CONNECT] Introduce `spark.profile.show/dump` for SparkSession-based profiling

### DIFF
--- a/python/pyspark/sql/connect/profiler.py
+++ b/python/pyspark/sql/connect/profiler.py
@@ -16,7 +16,7 @@
 #
 from typing import TYPE_CHECKING
 
-from pyspark.sql.profiler import ProfilerCollector, ProfileResultsParam
+from pyspark.sql.profiler import Profile, ProfilerCollector, ProfileResultsParam
 
 if TYPE_CHECKING:
     from pyspark.sql._typing import ProfileResults
@@ -39,3 +39,14 @@ class ConnectProfilerCollector(ProfilerCollector):
     def _update(self, update: "ProfileResults") -> None:
         with self._lock:
             self._value = ProfileResultsParam.addInPlace(self._profile_results, update)
+
+
+class ConnectProfile(Profile):
+    """User-facing profile API for Spark Connect. This instance can be accessed by
+    :attr:`spark.profile`.
+
+    .. versionadded: 4.0.0
+    """
+
+    def __init__(self, profiler_collector: ConnectProfilerCollector):
+        self.profiler_collector = profiler_collector

--- a/python/pyspark/sql/connect/profiler.py
+++ b/python/pyspark/sql/connect/profiler.py
@@ -16,7 +16,7 @@
 #
 from typing import TYPE_CHECKING
 
-from pyspark.sql.profiler import Profile, ProfilerCollector, ProfileResultsParam
+from pyspark.sql.profiler import ProfilerCollector, ProfileResultsParam
 
 if TYPE_CHECKING:
     from pyspark.sql._typing import ProfileResults

--- a/python/pyspark/sql/connect/profiler.py
+++ b/python/pyspark/sql/connect/profiler.py
@@ -39,14 +39,3 @@ class ConnectProfilerCollector(ProfilerCollector):
     def _update(self, update: "ProfileResults") -> None:
         with self._lock:
             self._value = ProfileResultsParam.addInPlace(self._profile_results, update)
-
-
-class ConnectProfile(Profile):
-    """User-facing profile API for Spark Connect. This instance can be accessed by
-    :attr:`spark.profile`.
-
-    .. versionadded: 4.0.0
-    """
-
-    def __init__(self, profiler_collector: ConnectProfilerCollector):
-        self.profiler_collector = profiler_collector

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -68,7 +68,7 @@ from pyspark.sql.connect.streaming.readwriter import DataStreamReader
 from pyspark.sql.connect.streaming.query import StreamingQueryManager
 from pyspark.sql.pandas.serializers import ArrowStreamPandasSerializer
 from pyspark.sql.pandas.types import to_arrow_schema, to_arrow_type, _deduplicate_field_names
-from pyspark.sql.profile import Profile
+from pyspark.sql.profiler import Profile
 from pyspark.sql.session import classproperty, SparkSession as PySparkSession
 from pyspark.sql.types import (
     _infer_schema,

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -62,12 +62,13 @@ from pyspark.sql.connect.plan import (
     CachedRelation,
     CachedRemoteRelation,
 )
-from pyspark.sql.connect.profiler import ProfilerCollector, ConnectProfile
+from pyspark.sql.connect.profiler import ProfilerCollector
 from pyspark.sql.connect.readwriter import DataFrameReader
 from pyspark.sql.connect.streaming.readwriter import DataStreamReader
 from pyspark.sql.connect.streaming.query import StreamingQueryManager
 from pyspark.sql.pandas.serializers import ArrowStreamPandasSerializer
 from pyspark.sql.pandas.types import to_arrow_schema, to_arrow_type, _deduplicate_field_names
+from pyspark.sql.profile import Profile
 from pyspark.sql.session import classproperty, SparkSession as PySparkSession
 from pyspark.sql.types import (
     _infer_schema,
@@ -942,8 +943,8 @@ class SparkSession:
         return self._client._profiler_collector
 
     @property
-    def profile(self) -> ConnectProfile:
-        return ConnectProfile(self._client._profiler_collector)
+    def profile(self) -> Profile:
+        return Profile(self._client._profiler_collector)
 
 
 SparkSession.__doc__ = PySparkSession.__doc__

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -62,7 +62,7 @@ from pyspark.sql.connect.plan import (
     CachedRelation,
     CachedRemoteRelation,
 )
-from pyspark.sql.connect.profiler import ProfilerCollector
+from pyspark.sql.connect.profiler import ProfilerCollector, ConnectProfile
 from pyspark.sql.connect.readwriter import DataFrameReader
 from pyspark.sql.connect.streaming.readwriter import DataStreamReader
 from pyspark.sql.connect.streaming.query import StreamingQueryManager
@@ -941,32 +941,9 @@ class SparkSession:
     def _profiler_collector(self) -> ProfilerCollector:
         return self._client._profiler_collector
 
-    def showPerfProfiles(self, id: Optional[int] = None) -> None:
-        self._profiler_collector.show_perf_profiles(id)
-
-    showPerfProfiles.__doc__ = PySparkSession.showPerfProfiles.__doc__
-
-    def showMemoryProfiles(self, id: Optional[int] = None) -> None:
-        if has_memory_profiler:
-            self._profiler_collector.show_memory_profiles(id)
-        else:
-            warnings.warn(
-                "Memory profiling is disabled. To enable it, install 'memory-profiler',"
-                " e.g., from PyPI (https://pypi.org/project/memory-profiler/).",
-                UserWarning,
-            )
-
-    showMemoryProfiles.__doc__ = PySparkSession.showMemoryProfiles.__doc__
-
-    def dumpPerfProfiles(self, path: str, id: Optional[int] = None) -> None:
-        self._profiler_collector.dump_perf_profiles(path, id)
-
-    dumpPerfProfiles.__doc__ = PySparkSession.dumpPerfProfiles.__doc__
-
-    def dumpMemoryProfiles(self, path: str, id: Optional[int] = None) -> None:
-        self._profiler_collector.dump_memory_profiles(path, id)
-
-    dumpMemoryProfiles.__doc__ = PySparkSession.dumpMemoryProfiles.__doc__
+    @property
+    def profile(self) -> ConnectProfile:
+        return ConnectProfile(self._client._profiler_collector)
 
 
 SparkSession.__doc__ = PySparkSession.__doc__

--- a/python/pyspark/sql/profiler.py
+++ b/python/pyspark/sql/profiler.py
@@ -249,7 +249,7 @@ class Profile:
     .. versionadded: 4.0.0
     """
 
-    def __init__(self, profiler_collector: "ProfilerCollector"):
+    def __init__(self, profiler_collector: ProfilerCollector):
         self.profiler_collector = profiler_collector
 
     def show(self, id: Optional[int] = None, *, type: Optional[str] = None) -> None:

--- a/python/pyspark/sql/profiler.py
+++ b/python/pyspark/sql/profiler.py
@@ -31,7 +31,6 @@ from pyspark.profiler import CodeMapDict, MemoryProfiler, MemUsageParam, PStatsP
 
 if TYPE_CHECKING:
     from pyspark.sql._typing import ProfileResults
-    from pyspark.sql.session import SparkSession
 
 
 class _ProfileResultsParam(AccumulatorParam[Optional["ProfileResults"]]):

--- a/python/pyspark/sql/profiler.py
+++ b/python/pyspark/sql/profiler.py
@@ -250,10 +250,10 @@ class Profile:
     .. versionadded: 4.0.0
     """
 
-    def __init__(self, sparkSession: "SparkSession"):
-        self.sparkSession = sparkSession
+    def __init__(self, profiler_collector: "ProfilerCollector"):
+        self.profiler_collector = profiler_collector
 
-    def show(self, *, type: Optional[str] = None, id: Optional[int] = None) -> None:
+    def show(self, id: Optional[int] = None, *, type: Optional[str] = None) -> None:
         """
         Show the profile results.
 
@@ -261,17 +261,17 @@ class Profile:
 
         Parameters
         ----------
-        type : str, optional
-            The profiler type, which can be either "perf" or "memory".
         id : int, optional
             A UDF ID to be shown. If not specified, all the results will be shown.
+        type : str, optional
+            The profiler type, which can be either "perf" or "memory".
         """
         if type == "memory":
-            self.sparkSession.showMemoryProfiles(id)
+            self.profiler_collector.show_memory_profiles(id)
         elif type == "perf" or type is None:
-            self.sparkSession.showPerfProfiles(id)
+            self.profiler_collector.show_perf_profiles(id)
             if type is None:  # Show both perf and memory profiles
-                self.sparkSession.showMemoryProfiles(id)
+                self.profiler_collector.show_memory_profiles(id)
         else:
             raise PySparkValueError(
                 error_class="VALUE_NOT_ALLOWED",
@@ -281,7 +281,7 @@ class Profile:
                 },
             )
 
-    def dump(self, path: str, *, type: Optional[str] = None, id: Optional[int] = None) -> None:
+    def dump(self, path: str, id: Optional[int] = None, *, type: Optional[str] = None) -> None:
         """
         Dump the profile results into directory `path`.
 
@@ -291,17 +291,17 @@ class Profile:
         ----------
         path: str
             A directory in which to dump the profile.
-        type : str, optional
-            The profiler type, which can be either "perf" or "memory".
         id : int, optional
             A UDF ID to be shown. If not specified, all the results will be shown.
+        type : str, optional
+            The profiler type, which can be either "perf" or "memory".
         """
         if type == "memory":
-            self.sparkSession.dumpMemoryProfiles(path, id)
+            self.profiler_collector.dump_memory_profiles(path, id)
         elif type == "perf" or type is None:
-            self.sparkSession.dumpPerfProfiles(path, id)
+            self.profiler_collector.dump_perf_profiles(path, id)
             if type is None:  # Dump both perf and memory profiles
-                self.sparkSession.dumpMemoryProfiles(path, id)
+                self.profiler_collector.dump_memory_profiles(path, id)
         else:
             raise PySparkValueError(
                 error_class="VALUE_NOT_ALLOWED",

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -911,7 +911,7 @@ class SparkSession(SparkConversionMixin):
     def profile(self) -> "Profile":
         from pyspark.sql.profiler import Profile
 
-        return Profile(self)
+        return Profile(self._profiler_collector)
 
     def range(
         self,
@@ -2134,33 +2134,6 @@ class SparkSession(SparkConversionMixin):
             error_class="ONLY_SUPPORTED_WITH_SPARK_CONNECT",
             message_parameters={"feature": "SparkSession.clearTags"},
         )
-
-    def showPerfProfiles(self, id: Optional[int] = None) -> None:
-        self._profiler_collector.show_perf_profiles(id)
-
-    showPerfProfiles.__doc__ = ProfilerCollector.show_perf_profiles.__doc__
-
-    def showMemoryProfiles(self, id: Optional[int] = None) -> None:
-        if has_memory_profiler:
-            self._profiler_collector.show_memory_profiles(id)
-        else:
-            warnings.warn(
-                "Memory profiling is disabled. To enable it, install 'memory-profiler',"
-                " e.g., from PyPI (https://pypi.org/project/memory-profiler/).",
-                UserWarning,
-            )
-
-    showMemoryProfiles.__doc__ = ProfilerCollector.show_memory_profiles.__doc__
-
-    def dumpPerfProfiles(self, path: str, id: Optional[int] = None) -> None:
-        self._profiler_collector.dump_perf_profiles(path, id)
-
-    dumpPerfProfiles.__doc__ = ProfilerCollector.dump_perf_profiles.__doc__
-
-    def dumpMemoryProfiles(self, path: str, id: Optional[int] = None) -> None:
-        self._profiler_collector.dump_memory_profiles(path, id)
-
-    dumpMemoryProfiles.__doc__ = ProfilerCollector.dump_memory_profiles.__doc__
 
 
 def _test() -> None:

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -47,7 +47,7 @@ from pyspark.sql.conf import RuntimeConfig
 from pyspark.sql.dataframe import DataFrame
 from pyspark.sql.functions import lit
 from pyspark.sql.pandas.conversion import SparkConversionMixin
-from pyspark.sql.profiler import AccumulatorProfilerCollector
+from pyspark.sql.profiler import AccumulatorProfilerCollector, Profile
 from pyspark.sql.readwriter import DataFrameReader
 from pyspark.sql.sql_formatter import SQLStringFormatter
 from pyspark.sql.streaming import DataStreamReader
@@ -76,7 +76,6 @@ if TYPE_CHECKING:
     from pyspark.sql.udf import UDFRegistration
     from pyspark.sql.udtf import UDTFRegistration
     from pyspark.sql.datasource import DataSourceRegistration
-    from pyspark.sql.profiler import Profile
 
     # Running MyPy type checks will always require pandas and
     # other dependencies so importing here is fine.
@@ -908,9 +907,7 @@ class SparkSession(SparkConversionMixin):
         return DataSourceRegistration(self)
 
     @property
-    def profile(self) -> "Profile":
-        from pyspark.sql.profiler import Profile
-
+    def profile(self) -> Profile:
         return Profile(self._profiler_collector)
 
     def range(

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -76,6 +76,7 @@ if TYPE_CHECKING:
     from pyspark.sql.udf import UDFRegistration
     from pyspark.sql.udtf import UDTFRegistration
     from pyspark.sql.datasource import DataSourceRegistration
+    from pyspark.sql.profiler import Profile
 
     # Running MyPy type checks will always require pandas and
     # other dependencies so importing here is fine.
@@ -905,6 +906,12 @@ class SparkSession(SparkConversionMixin):
         from pyspark.sql.datasource import DataSourceRegistration
 
         return DataSourceRegistration(self)
+
+    @property
+    def profile(self) -> "Profile":
+        from pyspark.sql.profiler import Profile
+
+        return Profile(self)
 
     def range(
         self,

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -47,7 +47,7 @@ from pyspark.sql.conf import RuntimeConfig
 from pyspark.sql.dataframe import DataFrame
 from pyspark.sql.functions import lit
 from pyspark.sql.pandas.conversion import SparkConversionMixin
-from pyspark.sql.profiler import AccumulatorProfilerCollector, ProfilerCollector
+from pyspark.sql.profiler import AccumulatorProfilerCollector
 from pyspark.sql.readwriter import DataFrameReader
 from pyspark.sql.sql_formatter import SQLStringFormatter
 from pyspark.sql.streaming import DataStreamReader

--- a/python/pyspark/sql/tests/connect/test_parity_memory_profiler.py
+++ b/python/pyspark/sql/tests/connect/test_parity_memory_profiler.py
@@ -39,7 +39,7 @@ class MemoryProfilerParityTests(MemoryProfiler2TestsMixin, ReusedConnectTestCase
 
         for id in self.profile_results:
             with self.trap_stdout() as io:
-                self.spark.showMemoryProfiles(id)
+                self.spark.profile.show(id, type="memory")
 
             self.assertIn(f"Profile of UDF<id={id}>", io.getvalue())
             self.assertRegex(

--- a/python/pyspark/sql/tests/connect/test_parity_udf_profiler.py
+++ b/python/pyspark/sql/tests/connect/test_parity_udf_profiler.py
@@ -39,7 +39,7 @@ class UDFProfilerParityTests(UDFProfiler2TestsMixin, ReusedConnectTestCase):
 
         for id in self.profile_results:
             with self.trap_stdout() as io:
-                self.spark.showPerfProfiles(id)
+                self.spark.profile.show(id, type="perf")
 
             self.assertIn(f"Profile of UDF<id={id}>", io.getvalue())
             self.assertRegex(

--- a/python/pyspark/sql/tests/test_session.py
+++ b/python/pyspark/sql/tests/test_session.py
@@ -474,21 +474,23 @@ class SparkSessionBuilderTests(unittest.TestCase, PySparkErrorTestUtils):
 
 class SparkSessionProfileTests(unittest.TestCase, PySparkErrorTestUtils):
     def setUp(self):
-        self.mock_spark_session = unittest.mock.MagicMock()
-        self.profile = Profile(self.mock_spark_session)
+        self.profiler_collector_mock = unittest.mock.Mock()
+        self.profile = Profile(self.profiler_collector_mock)
 
     def test_show_memory_type(self):
         self.profile.show(type="memory")
-        self.mock_spark_session.showMemoryProfiles.assert_called_once()
+        self.profiler_collector_mock.show_memory_profiles.assert_called_with(None)
+        self.profiler_collector_mock.show_perf_profiles.assert_not_called()
 
     def test_show_perf_type(self):
         self.profile.show(type="perf")
-        self.mock_spark_session.showPerfProfiles.assert_called_once()
+        self.profiler_collector_mock.show_perf_profiles.assert_called_with(None)
+        self.profiler_collector_mock.show_memory_profiles.assert_not_called()
 
     def test_show_no_type(self):
         self.profile.show()
-        self.mock_spark_session.showPerfProfiles.assert_called_once()
-        self.mock_spark_session.showMemoryProfiles.assert_called_once()
+        self.profiler_collector_mock.show_perf_profiles.assert_called_with(None)
+        self.profiler_collector_mock.show_memory_profiles.assert_called_with(None)
 
     def test_show_invalid_type(self):
         with self.assertRaises(PySparkValueError) as e:
@@ -504,16 +506,18 @@ class SparkSessionProfileTests(unittest.TestCase, PySparkErrorTestUtils):
 
     def test_dump_memory_type(self):
         self.profile.dump("path/to/dump", type="memory")
-        self.mock_spark_session.dumpMemoryProfiles.assert_called_once_with("path/to/dump", None)
+        self.profiler_collector_mock.dump_memory_profiles.assert_called_with("path/to/dump", None)
+        self.profiler_collector_mock.dump_perf_profiles.assert_not_called()
 
     def test_dump_perf_type(self):
         self.profile.dump("path/to/dump", type="perf")
-        self.mock_spark_session.dumpPerfProfiles.assert_called_once_with("path/to/dump", None)
+        self.profiler_collector_mock.dump_perf_profiles.assert_called_with("path/to/dump", None)
+        self.profiler_collector_mock.dump_memory_profiles.assert_not_called()
 
     def test_dump_no_type(self):
         self.profile.dump("path/to/dump")
-        self.mock_spark_session.dumpPerfProfiles.assert_called_once_with("path/to/dump", None)
-        self.mock_spark_session.dumpMemoryProfiles.assert_called_once_with("path/to/dump", None)
+        self.profiler_collector_mock.dump_perf_profiles.assert_called_with("path/to/dump", None)
+        self.profiler_collector_mock.dump_memory_profiles.assert_called_with("path/to/dump", None)
 
     def test_dump_invalid_type(self):
         with self.assertRaises(PySparkValueError) as e:

--- a/python/pyspark/sql/tests/test_udf_profiler.py
+++ b/python/pyspark/sql/tests/test_udf_profiler.py
@@ -183,16 +183,16 @@ class UDFProfiler2TestsMixin:
         self.assertEqual(3, len(self.profile_results), str(list(self.profile_results)))
 
         with self.trap_stdout() as io_all:
-            self.spark.showPerfProfiles()
+            self.spark.profile.show(type="perf")
 
         with tempfile.TemporaryDirectory() as d:
-            self.spark.dumpPerfProfiles(d)
+            self.spark.profile.dump(d, type="perf")
 
             for id in self.profile_results:
                 self.assertIn(f"Profile of UDF<id={id}>", io_all.getvalue())
 
                 with self.trap_stdout() as io:
-                    self.spark.showPerfProfiles(id)
+                    self.spark.profile.show(id, type="perf")
 
                 self.assertIn(f"Profile of UDF<id={id}>", io.getvalue())
                 self.assertRegex(
@@ -212,7 +212,7 @@ class UDFProfiler2TestsMixin:
 
         for id in self.profile_results:
             with self.trap_stdout() as io:
-                self.spark.showPerfProfiles(id)
+                self.spark.profile.show(id, type="perf")
 
             self.assertIn(f"Profile of UDF<id={id}>", io.getvalue())
             self.assertRegex(
@@ -231,7 +231,7 @@ class UDFProfiler2TestsMixin:
 
         for id in self.profile_results:
             with self.trap_stdout() as io:
-                self.spark.showPerfProfiles(id)
+                self.spark.profile.show(id, type="perf")
 
             self.assertIn(f"Profile of UDF<id={id}>", io.getvalue())
             self.assertRegex(
@@ -252,7 +252,7 @@ class UDFProfiler2TestsMixin:
 
         for id in self.profile_results:
             with self.trap_stdout() as io:
-                self.spark.showPerfProfiles(id)
+                self.spark.profile.show(id, type="perf")
 
             self.assertIn(f"Profile of UDF<id={id}>", io.getvalue())
             self.assertRegex(
@@ -282,7 +282,7 @@ class UDFProfiler2TestsMixin:
 
         for id in self.profile_results:
             with self.trap_stdout() as io:
-                self.spark.showPerfProfiles(id)
+                self.spark.profile.show(id, type="perf")
 
             self.assertIn(f"Profile of UDF<id={id}>", io.getvalue())
             self.assertRegex(
@@ -315,7 +315,7 @@ class UDFProfiler2TestsMixin:
 
         for id in self.profile_results:
             with self.trap_stdout() as io:
-                self.spark.showPerfProfiles(id)
+                self.spark.profile.show(id, type="perf")
 
             self.assertIn(f"Profile of UDF<id={id}>", io.getvalue())
             self.assertRegex(
@@ -362,7 +362,7 @@ class UDFProfiler2TestsMixin:
 
         for id in self.profile_results:
             with self.trap_stdout() as io:
-                self.spark.showPerfProfiles(id)
+                self.spark.profile.show(id, type="perf")
 
             self.assertIn(f"Profile of UDF<id={id}>", io.getvalue())
             self.assertRegex(
@@ -391,7 +391,7 @@ class UDFProfiler2TestsMixin:
 
         for id in self.profile_results:
             with self.trap_stdout() as io:
-                self.spark.showPerfProfiles(id)
+                self.spark.profile.show(id, type="perf")
 
             self.assertIn(f"Profile of UDF<id={id}>", io.getvalue())
             self.assertRegex(
@@ -419,7 +419,7 @@ class UDFProfiler2TestsMixin:
 
         for id in self.profile_results:
             with self.trap_stdout() as io:
-                self.spark.showPerfProfiles(id)
+                self.spark.profile.show(id, type="perf")
 
             self.assertIn(f"Profile of UDF<id={id}>", io.getvalue())
             self.assertRegex(
@@ -454,7 +454,7 @@ class UDFProfiler2TestsMixin:
 
         for id in self.profile_results:
             with self.trap_stdout() as io:
-                self.spark.showPerfProfiles(id)
+                self.spark.profile.show(id, type="perf")
 
             self.assertIn(f"Profile of UDF<id={id}>", io.getvalue())
             self.assertRegex(
@@ -485,7 +485,7 @@ class UDFProfiler2TestsMixin:
 
         for id in self.profile_results:
             with self.trap_stdout() as io:
-                self.spark.showPerfProfiles(id)
+                self.spark.profile.show(id, type="perf")
 
             self.assertIn(f"Profile of UDF<id={id}>", io.getvalue())
             self.assertRegex(
@@ -514,7 +514,7 @@ class UDFProfiler2TestsMixin:
 
         for id in self.profile_results:
             with self.trap_stdout() as io:
-                self.spark.showPerfProfiles(id)
+                self.spark.profile.show(id, type="perf")
 
             self.assertIn(f"Profile of UDF<id={id}>", io.getvalue())
             self.assertRegex(

--- a/python/pyspark/tests/test_memory_profiler.py
+++ b/python/pyspark/tests/test_memory_profiler.py
@@ -233,16 +233,16 @@ class MemoryProfiler2TestsMixin:
         self.assertEqual(3, len(self.profile_results), str(list(self.profile_results)))
 
         with self.trap_stdout() as io_all:
-            self.spark.showMemoryProfiles()
+            self.spark.profile.show(type="memory")
 
         with tempfile.TemporaryDirectory() as d:
-            self.spark.dumpMemoryProfiles(d)
+            self.spark.profile.dump(d, type="memory")
 
             for id in self.profile_results:
                 self.assertIn(f"Profile of UDF<id={id}>", io_all.getvalue())
 
                 with self.trap_stdout() as io:
-                    self.spark.showMemoryProfiles(id)
+                    self.spark.profile.show(id, type="memory")
 
                 self.assertIn(f"Profile of UDF<id={id}>", io.getvalue())
                 self.assertRegex(
@@ -262,7 +262,7 @@ class MemoryProfiler2TestsMixin:
 
         for id in self.profile_results:
             with self.trap_stdout() as io:
-                self.spark.showMemoryProfiles(id)
+                self.spark.profile.show(id, type="memory")
 
             self.assertIn(f"Profile of UDF<id={id}>", io.getvalue())
             self.assertRegex(
@@ -281,7 +281,7 @@ class MemoryProfiler2TestsMixin:
 
         for id in self.profile_results:
             with self.trap_stdout() as io:
-                self.spark.showMemoryProfiles(id)
+                self.spark.profile.show(id, type="memory")
 
             self.assertIn(f"Profile of UDF<id={id}>", io.getvalue())
             self.assertRegex(
@@ -302,7 +302,7 @@ class MemoryProfiler2TestsMixin:
 
         for id in self.profile_results:
             with self.trap_stdout() as io:
-                self.spark.showMemoryProfiles(id)
+                self.spark.profile.show(id, type="memory")
 
             self.assertIn(f"Profile of UDF<id={id}>", io.getvalue())
             self.assertRegex(
@@ -332,7 +332,7 @@ class MemoryProfiler2TestsMixin:
 
         for id in self.profile_results:
             with self.trap_stdout() as io:
-                self.spark.showMemoryProfiles(id)
+                self.spark.profile.show(id, type="memory")
 
             self.assertIn(f"Profile of UDF<id={id}>", io.getvalue())
             self.assertRegex(
@@ -365,7 +365,7 @@ class MemoryProfiler2TestsMixin:
 
         for id in self.profile_results:
             with self.trap_stdout() as io:
-                self.spark.showMemoryProfiles(id)
+                self.spark.profile.show(id, type="memory")
 
             self.assertIn(f"Profile of UDF<id={id}>", io.getvalue())
             self.assertRegex(
@@ -412,7 +412,7 @@ class MemoryProfiler2TestsMixin:
 
         for id in self.profile_results:
             with self.trap_stdout() as io:
-                self.spark.showMemoryProfiles(id)
+                self.spark.profile.show(id, type="memory")
 
             self.assertIn(f"Profile of UDF<id={id}>", io.getvalue())
             self.assertRegex(
@@ -441,7 +441,7 @@ class MemoryProfiler2TestsMixin:
 
         for id in self.profile_results:
             with self.trap_stdout() as io:
-                self.spark.showMemoryProfiles(id)
+                self.spark.profile.show(id, type="memory")
 
             self.assertIn(f"Profile of UDF<id={id}>", io.getvalue())
             self.assertRegex(
@@ -469,7 +469,7 @@ class MemoryProfiler2TestsMixin:
 
         for id in self.profile_results:
             with self.trap_stdout() as io:
-                self.spark.showMemoryProfiles(id)
+                self.spark.profile.show(id, type="memory")
 
             self.assertIn(f"Profile of UDF<id={id}>", io.getvalue())
             self.assertRegex(
@@ -504,7 +504,7 @@ class MemoryProfiler2TestsMixin:
 
         for id in self.profile_results:
             with self.trap_stdout() as io:
-                self.spark.showMemoryProfiles(id)
+                self.spark.profile.show(id, type="memory")
 
             self.assertIn(f"Profile of UDF<id={id}>", io.getvalue())
             self.assertRegex(
@@ -535,7 +535,7 @@ class MemoryProfiler2TestsMixin:
 
         for id in self.profile_results:
             with self.trap_stdout() as io:
-                self.spark.showMemoryProfiles(id)
+                self.spark.profile.show(id, type="memory")
 
             self.assertIn(f"Profile of UDF<id={id}>", io.getvalue())
             self.assertRegex(
@@ -564,7 +564,7 @@ class MemoryProfiler2TestsMixin:
 
         for id in self.profile_results:
             with self.trap_stdout() as io:
-                self.spark.showMemoryProfiles(id)
+                self.spark.profile.show(id, type="memory")
 
             self.assertIn(f"Profile of UDF<id={id}>", io.getvalue())
             self.assertRegex(


### PR DESCRIPTION
### What changes were proposed in this pull request?
Introduce `spark.profile.show/dump` for SparkSession-based profiling for non-Spark-Connect. 

### Why are the changes needed?
SparkContext-based profiling has `sc.dump_profiles/show_profiles` for both perf and memory profiling.
Currently SparkSession-based has `spark.dump/showPerfProfiles` and `spark.dump/showMemoryProfiles` for perf and memory profiling separately.
It would be more consistent and user-friendly to consolidate them to a uniform interface as `spark.profile.dump/show`.

### Does this PR introduce _any_ user-facing change?
Yes. `spark.profile.show/dump` is supported, whereas (not-released yet) APIs below are removed
-`spark.dumpPerfProfiles`
-`spark.dumpMemoryProfiles`
-`spark.showPerfProfiles`
-`spark.showMemoryProfiles`

```py
>>> spark.conf.set("spark.sql.pyspark.udf.profiler", "perf")  # enable cProfiler
>>> 
>>> @udf("string")
... def f(x):
...       return str(x)
... 
>>> df = spark.range(10).select(f(col("id")))
>>> df.collect()
[Row(f(id)='0'), ...]
>>> spark.profile.show()
============================================================
Profile of UDF<id=2>
============================================================
...

>>> spark.profile.show(type="memory")
>>> spark.profile.show(type="perf")
============================================================
Profile of UDF<id=2>
============================================================
...

>>> spark.profile.show(2, type="perf")
============================================================
Profile of UDF<id=2>
============================================================
...

>>> spark.profile.show(2, type="memory")

```


### How was this patch tested?
Unit tests.


### Was this patch authored or co-authored using generative AI tooling?
No.