### PR TITLE
[SPARK-47057][PYTHON] Reeanble MyPy data test

### DIFF
--- a/dev/lint-python
+++ b/dev/lint-python
@@ -18,7 +18,7 @@
 # define test binaries + versions
 FLAKE8_BUILD="flake8"
 MINIMUM_FLAKE8="3.9.0"
-MINIMUM_MYPY="0.920"
+MINIMUM_MYPY="1.8.0"
 MYPY_BUILD="mypy"
 PYTEST_BUILD="pytest"
 

--- a/dev/lint-python
+++ b/dev/lint-python
@@ -221,10 +221,9 @@ function mypy_test {
     if [[ "$MYPY_EXAMPLES_TEST" == "true" ]]; then
         mypy_examples_test
     fi
-    # TODO(SPARK-47057): Reeanble MyPy data test
-    # if [[ "$MYPY_DATA_TEST" == "true" ]]; then
-    #     mypy_data_test
-    # fi
+    if [[ "$MYPY_DATA_TEST" == "true" ]]; then
+        mypy_data_test
+    fi
 }
 
 

--- a/python/pyspark/ml/tests/typing/test_classification.yml
+++ b/python/pyspark/ml/tests/typing/test_classification.yml
@@ -23,8 +23,8 @@
 
     # Should support
     OneVsRest(classifier=LogisticRegression())
-    OneVsRest(classifier=LogisticRegressionModel.load("/foo"))  # E: Argument "classifier" to "OneVsRest" has incompatible type "LogisticRegressionModel"; expected "Optional[Classifier[<nothing>]]"  [arg-type]
-    OneVsRest(classifier="foo")  # E: Argument "classifier" to "OneVsRest" has incompatible type "str"; expected "Optional[Classifier[<nothing>]]"  [arg-type]
+    OneVsRest(classifier=LogisticRegressionModel.load("/foo"))  # E: Argument "classifier" to "OneVsRest" has incompatible type "LogisticRegressionModel"; expected "Classifier[Never] | None"  [arg-type]
+    OneVsRest(classifier="foo")  # E: Argument "classifier" to "OneVsRest" has incompatible type "str"; expected "Classifier[Never] | None"  [arg-type]
 
 
 - case: fitFMClassifier

--- a/python/pyspark/ml/tests/typing/test_classification.yml
+++ b/python/pyspark/ml/tests/typing/test_classification.yml
@@ -23,8 +23,8 @@
 
     # Should support
     OneVsRest(classifier=LogisticRegression())
-    OneVsRest(classifier=LogisticRegressionModel.load("/foo"))  # E: Argument "classifier" to "OneVsRest" has incompatible type "LogisticRegressionModel"; expected "Classifier[Never] | None"  [arg-type]
-    OneVsRest(classifier="foo")  # E: Argument "classifier" to "OneVsRest" has incompatible type "str"; expected "Classifier[Never] | None"  [arg-type]
+    OneVsRest(classifier=LogisticRegressionModel.load("/foo"))  # E: Argument "classifier" to "OneVsRest" has incompatible type "LogisticRegressionModel"; expected "Optional[Classifier[Never]]"  [arg-type]
+    OneVsRest(classifier="foo")  # E: Argument "classifier" to "OneVsRest" has incompatible type "str"; expected "Optional[Classifier[Never]]"  [arg-type]
 
 
 - case: fitFMClassifier

--- a/python/pyspark/ml/tests/typing/test_feature.yml
+++ b/python/pyspark/ml/tests/typing/test_feature.yml
@@ -45,11 +45,11 @@
     StringIndexer(inputCols=["foo"], outputCol="bar")
 
   out: |
-    main:14: error: No overload variant of "StringIndexer" matches argument types "str", "List[str]"  [call-overload]
+    main:14: error: No overload variant of "StringIndexer" matches argument types "str", "list[str]"  [call-overload]
     main:14: note: Possible overload variants:
-    main:14: note:     def StringIndexer(self, *, inputCol: Optional[str] = ..., outputCol: Optional[str] = ..., handleInvalid: str = ..., stringOrderType: str = ...) -> StringIndexer
-    main:14: note:     def StringIndexer(self, *, inputCols: Optional[List[str]] = ..., outputCols: Optional[List[str]] = ..., handleInvalid: str = ..., stringOrderType: str = ...) -> StringIndexer
-    main:15: error: No overload variant of "StringIndexer" matches argument types "List[str]", "str"  [call-overload]
+    main:14: note:     def StringIndexer(self, *, inputCol: str | None = ..., outputCol: str | None = ..., handleInvalid: str = ..., stringOrderType: str = ...) -> StringIndexer
+    main:14: note:     def StringIndexer(self, *, inputCols: list[str] | None = ..., outputCols: list[str] | None = ..., handleInvalid: str = ..., stringOrderType: str = ...) -> StringIndexer
+    main:15: error: No overload variant of "StringIndexer" matches argument types "list[str]", "str"  [call-overload]
     main:15: note: Possible overload variants:
-    main:15: note:     def StringIndexer(self, *, inputCol: Optional[str] = ..., outputCol: Optional[str] = ..., handleInvalid: str = ..., stringOrderType: str = ...) -> StringIndexer
-    main:15: note:     def StringIndexer(self, *, inputCols: Optional[List[str]] = ..., outputCols: Optional[List[str]] = ..., handleInvalid: str = ..., stringOrderType: str = ...) -> StringIndexer
+    main:15: note:     def StringIndexer(self, *, inputCol: str | None = ..., outputCol: str | None = ..., handleInvalid: str = ..., stringOrderType: str = ...) -> StringIndexer
+    main:15: note:     def StringIndexer(self, *, inputCols: list[str] | None = ..., outputCols: list[str] | None = ..., handleInvalid: str = ..., stringOrderType: str = ...) -> StringIndexer

--- a/python/pyspark/ml/tests/typing/test_feature.yml
+++ b/python/pyspark/ml/tests/typing/test_feature.yml
@@ -47,9 +47,9 @@
   out: |
     main:14: error: No overload variant of "StringIndexer" matches argument types "str", "list[str]"  [call-overload]
     main:14: note: Possible overload variants:
-    main:14: note:     def StringIndexer(self, *, inputCol: str | None = ..., outputCol: str | None = ..., handleInvalid: str = ..., stringOrderType: str = ...) -> StringIndexer
-    main:14: note:     def StringIndexer(self, *, inputCols: list[str] | None = ..., outputCols: list[str] | None = ..., handleInvalid: str = ..., stringOrderType: str = ...) -> StringIndexer
+    main:14: note:     def StringIndexer(self, *, inputCol: Optional[str] = ..., outputCol: Optional[str] = ..., handleInvalid: str = ..., stringOrderType: str = ...) -> StringIndexer
+    main:14: note:     def StringIndexer(self, *, inputCols: Optional[list[str]] = ..., outputCols: Optional[list[str]] = ..., handleInvalid: str = ..., stringOrderType: str = ...) -> StringIndexer
     main:15: error: No overload variant of "StringIndexer" matches argument types "list[str]", "str"  [call-overload]
     main:15: note: Possible overload variants:
-    main:15: note:     def StringIndexer(self, *, inputCol: str | None = ..., outputCol: str | None = ..., handleInvalid: str = ..., stringOrderType: str = ...) -> StringIndexer
-    main:15: note:     def StringIndexer(self, *, inputCols: list[str] | None = ..., outputCols: list[str] | None = ..., handleInvalid: str = ..., stringOrderType: str = ...) -> StringIndexer
+    main:15: note:     def StringIndexer(self, *, inputCol: Optional[str] = ..., outputCol: Optional[str] = ..., handleInvalid: str = ..., stringOrderType: str = ...) -> StringIndexer
+    main:15: note:     def StringIndexer(self, *, inputCols: Optional[list[str]] = ..., outputCols: Optional[list[str]] = ..., handleInvalid: str = ..., stringOrderType: str = ...) -> StringIndexer

--- a/python/pyspark/sql/tests/typing/test_dataframe.yml
+++ b/python/pyspark/sql/tests/typing/test_dataframe.yml
@@ -37,8 +37,8 @@
   out: |
     main:16: error: No overload variant of "sample" of "DataFrame" matches argument type "bool"  [call-overload]
     main:16: note: Possible overload variants:
-    main:16: note:     def sample(self, fraction: float, seed: Optional[int] = ...) -> DataFrame
-    main:16: note:     def sample(self, withReplacement: Optional[bool], fraction: float, seed: Optional[int] = ...) -> DataFrame
+    main:16: note:     def sample(self, fraction: float, seed: int | None = ...) -> DataFrame
+    main:16: note:     def sample(self, withReplacement: bool | None, fraction: float, seed: int | None = ...) -> DataFrame
 
 
 - case: selectColumns
@@ -54,7 +54,7 @@
     df.select(["name", "age"])
     df.select([col("name"), col("age")])
 
-    df.select(["name", col("age")])  # E: Argument 1 to "select" of "DataFrame" has incompatible type "List[object]"; expected "Union[List[Column], List[str]]"  [arg-type]
+    df.select(["name", col("age")])  # E: Argument 1 to "select" of "DataFrame" has incompatible type "list[object]"; expected "list[Column] | list[str]"  [arg-type]
 
 
 - case: groupBy
@@ -71,7 +71,7 @@
     df.groupby(["name", "age"])
     df.groupBy([col("name"), col("age")])
     df.groupby([col("name"), col("age")])
-    df.groupBy(["name", col("age")])  # E: Argument 1 to "groupBy" of "DataFrame" has incompatible type "List[object]"; expected "Union[List[Column], List[str], List[int]]"  [arg-type]
+    df.groupBy(["name", col("age")])  # E: Argument 1 to "groupBy" of "DataFrame" has incompatible type "list[object]"; expected "list[Column] | list[str] | list[int]"  [arg-type]
 
 
 - case: rollup
@@ -88,7 +88,7 @@
     df.rollup([col("name"), col("age")])
 
 
-    df.rollup(["name", col("age")])  # E: Argument 1 to "rollup" of "DataFrame" has incompatible type "List[object]"; expected "Union[List[Column], List[str]]"  [arg-type]
+    df.rollup(["name", col("age")])  # E: Argument 1 to "rollup" of "DataFrame" has incompatible type "list[object]"; expected "list[Column] | list[str]"  [arg-type]
 
 
 - case: cube
@@ -105,7 +105,7 @@
     df.cube([col("name"), col("age")])
 
 
-    df.cube(["name", col("age")])  # E: Argument 1 to "cube" of "DataFrame" has incompatible type "List[object]"; expected "Union[List[Column], List[str]]"  [arg-type]
+    df.cube(["name", col("age")])  # E: Argument 1 to "cube" of "DataFrame" has incompatible type "list[object]"; expected "list[Column] | list[str]"  [arg-type]
 
 
 - case: dropColumns
@@ -124,7 +124,7 @@
   out: |
     main:10: error: No overload variant of "drop" of "DataFrame" matches argument types "Column", "Column"  [call-overload]
     main:10: note: Possible overload variants:
-    main:10: note:     def drop(self, cols: Union[Column, str]) -> DataFrame
+    main:10: note:     def drop(self, cols: Column | str) -> DataFrame
     main:10: note:     def drop(self, *cols: str) -> DataFrame
 
 

--- a/python/pyspark/sql/tests/typing/test_dataframe.yml
+++ b/python/pyspark/sql/tests/typing/test_dataframe.yml
@@ -37,8 +37,8 @@
   out: |
     main:16: error: No overload variant of "sample" of "DataFrame" matches argument type "bool"  [call-overload]
     main:16: note: Possible overload variants:
-    main:16: note:     def sample(self, fraction: float, seed: int | None = ...) -> DataFrame
-    main:16: note:     def sample(self, withReplacement: bool | None, fraction: float, seed: int | None = ...) -> DataFrame
+    main:16: note:     def sample(self, fraction: float, seed: Optional[int] = ...) -> DataFrame
+    main:16: note:     def sample(self, withReplacement: Optional[bool], fraction: float, seed: Optional[int] = ...) -> DataFrame
 
 
 - case: selectColumns
@@ -54,7 +54,7 @@
     df.select(["name", "age"])
     df.select([col("name"), col("age")])
 
-    df.select(["name", col("age")])  # E: Argument 1 to "select" of "DataFrame" has incompatible type "list[object]"; expected "list[Column] | list[str]"  [arg-type]
+    df.select(["name", col("age")])  # E: Argument 1 to "select" of "DataFrame" has incompatible type "list[object]"; expected "Union[list[Column], list[str]]"  [arg-type]
 
 
 - case: groupBy
@@ -71,7 +71,7 @@
     df.groupby(["name", "age"])
     df.groupBy([col("name"), col("age")])
     df.groupby([col("name"), col("age")])
-    df.groupBy(["name", col("age")])  # E: Argument 1 to "groupBy" of "DataFrame" has incompatible type "list[object]"; expected "list[Column] | list[str] | list[int]"  [arg-type]
+    df.groupBy(["name", col("age")])  # E: Argument 1 to "groupBy" of "DataFrame" has incompatible type "list[object]"; expected "Union[list[Column], list[str], list[int]]"  [arg-type]
 
 
 - case: rollup
@@ -88,7 +88,7 @@
     df.rollup([col("name"), col("age")])
 
 
-    df.rollup(["name", col("age")])  # E: Argument 1 to "rollup" of "DataFrame" has incompatible type "list[object]"; expected "list[Column] | list[str]"  [arg-type]
+    df.rollup(["name", col("age")])  # E: Argument 1 to "rollup" of "DataFrame" has incompatible type "list[object]"; expected "Union[list[Column], list[str]]"  [arg-type]
 
 
 - case: cube
@@ -105,7 +105,7 @@
     df.cube([col("name"), col("age")])
 
 
-    df.cube(["name", col("age")])  # E: Argument 1 to "cube" of "DataFrame" has incompatible type "list[object]"; expected "list[Column] | list[str]"  [arg-type]
+    df.cube(["name", col("age")])  # E: Argument 1 to "cube" of "DataFrame" has incompatible type "list[object]"; expected "Union[list[Column], list[str]]"  [arg-type]
 
 
 - case: dropColumns
@@ -124,7 +124,7 @@
   out: |
     main:10: error: No overload variant of "drop" of "DataFrame" matches argument types "Column", "Column"  [call-overload]
     main:10: note: Possible overload variants:
-    main:10: note:     def drop(self, cols: Column | str) -> DataFrame
+    main:10: note:     def drop(self, cols: Union[Column, str]) -> DataFrame
     main:10: note:     def drop(self, *cols: str) -> DataFrame
 
 

--- a/python/pyspark/sql/tests/typing/test_functions.yml
+++ b/python/pyspark/sql/tests/typing/test_functions.yml
@@ -69,33 +69,33 @@
   out: |
     main:29: error: No overload variant of "array" matches argument types "list[Column]", "list[Column]"  [call-overload]
     main:29: note: Possible overload variants:
-    main:29: note:     def array(*cols: Column | str) -> Column
-    main:29: note:     def [ColumnOrName_] array(list[ColumnOrName_] | tuple[ColumnOrName_, ...], /) -> Column
-    main:30: error: No overload variant of "create_map" matches argument types "list[Column]", "list[Column]"  [call-overload]
+    main:29: note:     def array(*cols: Union[Column, str]) -> Column
+    main:29: note:     def [ColumnOrName_] array(Union[list[ColumnOrName_], tuple[ColumnOrName_, ...]], /) -> Column
+    main:30: error: No overload variant of "create_map" matches argument types "list[Column]", "list[Col...
     main:30: note: Possible overload variants:
-    main:30: note:     def create_map(*cols: Column | str) -> Column
-    main:30: note:     def [ColumnOrName_] create_map(list[ColumnOrName_] | tuple[ColumnOrName_, ...], /) -> Column
-    main:31: error: No overload variant of "map_concat" matches argument types "list[Column]", "list[Column]"  [call-overload]
+    main:30: note:     def create_map(*cols: Union[Column, str]) -> Column
+    main:30: note:     def [ColumnOrName_] create_map(Union[list[ColumnOrName_], tuple[ColumnOrName_, ...]], /) -> Column
+    main:31: error: No overload variant of "map_concat" matches argument types "list[Column]", "list[Col...
     main:31: note: Possible overload variants:
-    main:31: note:     def map_concat(*cols: Column | str) -> Column
-    main:31: note:     def [ColumnOrName_] map_concat(list[ColumnOrName_] | tuple[ColumnOrName_, ...], /) -> Column
-    main:32: error: No overload variant of "struct" matches argument types "list[str]", "list[str]"  [call-overload]
+    main:31: note:     def map_concat(*cols: Union[Column, str]) -> Column
+    main:31: note:     def [ColumnOrName_] map_concat(Union[list[ColumnOrName_], tuple[ColumnOrName_, ...]], /) -> Column
+    main:32: error: No overload variant of "struct" matches argument types "list[str]", "list[str]"  [ca...
     main:32: note: Possible overload variants:
-    main:32: note:     def struct(*cols: Column | str) -> Column
-    main:32: note:     def [ColumnOrName_] struct(list[ColumnOrName_] | tuple[ColumnOrName_, ...], /) -> Column
-    main:33: error: No overload variant of "array" matches argument types "list[str]", "list[str]"  [call-overload]
+    main:32: note:     def struct(*cols: Union[Column, str]) -> Column
+    main:32: note:     def [ColumnOrName_] struct(Union[list[ColumnOrName_], tuple[ColumnOrName_, ...]], /) -> Column
+    main:33: error: No overload variant of "array" matches argument types "list[str]", "list[str]"  [cal...
     main:33: note: Possible overload variants:
-    main:33: note:     def array(*cols: Column | str) -> Column
-    main:33: note:     def [ColumnOrName_] array(list[ColumnOrName_] | tuple[ColumnOrName_, ...], /) -> Column
-    main:34: error: No overload variant of "create_map" matches argument types "list[str]", "list[str]"  [call-overload]
+    main:33: note:     def array(*cols: Union[Column, str]) -> Column
+    main:33: note:     def [ColumnOrName_] array(Union[list[ColumnOrName_], tuple[ColumnOrName_, ...]], /) -> Column
+    main:34: error: No overload variant of "create_map" matches argument types "list[str]", "list[str]" ...
     main:34: note: Possible overload variants:
-    main:34: note:     def create_map(*cols: Column | str) -> Column
-    main:34: note:     def [ColumnOrName_] create_map(list[ColumnOrName_] | tuple[ColumnOrName_, ...], /) -> Column
-    main:35: error: No overload variant of "map_concat" matches argument types "list[str]", "list[str]"  [call-overload]
+    main:34: note:     def create_map(*cols: Union[Column, str]) -> Column
+    main:34: note:     def [ColumnOrName_] create_map(Union[list[ColumnOrName_], tuple[ColumnOrName_, ...]], /) -> Column
+    main:35: error: No overload variant of "map_concat" matches argument types "list[str]", "list[str]" ...
     main:35: note: Possible overload variants:
-    main:35: note:     def map_concat(*cols: Column | str) -> Column
-    main:35: note:     def [ColumnOrName_] map_concat(list[ColumnOrName_] | tuple[ColumnOrName_, ...], /) -> Column
-    main:36: error: No overload variant of "struct" matches argument types "list[str]", "list[str]"  [call-overload]
+    main:35: note:     def map_concat(*cols: Union[Column, str]) -> Column
+    main:35: note:     def [ColumnOrName_] map_concat(Union[list[ColumnOrName_], tuple[ColumnOrName_, ...]], /) -> Column
+    main:36: error: No overload variant of "struct" matches argument types "list[str]", "list[str]"  [ca...
     main:36: note: Possible overload variants:
-    main:36: note:     def struct(*cols: Column | str) -> Column
-    main:36: note:     def [ColumnOrName_] struct(list[ColumnOrName_] | tuple[ColumnOrName_, ...], /) -> Column
+    main:36: note:     def struct(*cols: Union[Column, str]) -> Column
+    main:36: note:     def [ColumnOrName_] struct(Union[list[ColumnOrName_], tuple[ColumnOrName_, ...]], /) -> Column

--- a/python/pyspark/sql/tests/typing/test_functions.yml
+++ b/python/pyspark/sql/tests/typing/test_functions.yml
@@ -71,31 +71,31 @@
     main:29: note: Possible overload variants:
     main:29: note:     def array(*cols: Union[Column, str]) -> Column
     main:29: note:     def [ColumnOrName_] array(Union[list[ColumnOrName_], tuple[ColumnOrName_, ...]], /) -> Column
-    main:30: error: No overload variant of "create_map" matches argument types "list[Column]", "list[Col...
+    main:30: error: No overload variant of "create_map" matches argument types "list[Column]", "list[Column]"  [call-overload]
     main:30: note: Possible overload variants:
     main:30: note:     def create_map(*cols: Union[Column, str]) -> Column
     main:30: note:     def [ColumnOrName_] create_map(Union[list[ColumnOrName_], tuple[ColumnOrName_, ...]], /) -> Column
-    main:31: error: No overload variant of "map_concat" matches argument types "list[Column]", "list[Col...
+    main:31: error: No overload variant of "map_concat" matches argument types "list[Column]", "list[Column]"  [call-overload]
     main:31: note: Possible overload variants:
     main:31: note:     def map_concat(*cols: Union[Column, str]) -> Column
     main:31: note:     def [ColumnOrName_] map_concat(Union[list[ColumnOrName_], tuple[ColumnOrName_, ...]], /) -> Column
-    main:32: error: No overload variant of "struct" matches argument types "list[str]", "list[str]"  [ca...
+    main:32: error: No overload variant of "struct" matches argument types "list[str]", "list[str]"  [call-overload]
     main:32: note: Possible overload variants:
     main:32: note:     def struct(*cols: Union[Column, str]) -> Column
     main:32: note:     def [ColumnOrName_] struct(Union[list[ColumnOrName_], tuple[ColumnOrName_, ...]], /) -> Column
-    main:33: error: No overload variant of "array" matches argument types "list[str]", "list[str]"  [cal...
+    main:33: error: No overload variant of "array" matches argument types "list[str]", "list[str]"  [call-overload]
     main:33: note: Possible overload variants:
     main:33: note:     def array(*cols: Union[Column, str]) -> Column
     main:33: note:     def [ColumnOrName_] array(Union[list[ColumnOrName_], tuple[ColumnOrName_, ...]], /) -> Column
-    main:34: error: No overload variant of "create_map" matches argument types "list[str]", "list[str]" ...
+    main:34: error: No overload variant of "create_map" matches argument types "list[str]", "list[str]"  [call-overload]
     main:34: note: Possible overload variants:
     main:34: note:     def create_map(*cols: Union[Column, str]) -> Column
     main:34: note:     def [ColumnOrName_] create_map(Union[list[ColumnOrName_], tuple[ColumnOrName_, ...]], /) -> Column
-    main:35: error: No overload variant of "map_concat" matches argument types "list[str]", "list[str]" ...
+    main:35: error: No overload variant of "map_concat" matches argument types "list[str]", "list[str]"  [call-overload]
     main:35: note: Possible overload variants:
     main:35: note:     def map_concat(*cols: Union[Column, str]) -> Column
     main:35: note:     def [ColumnOrName_] map_concat(Union[list[ColumnOrName_], tuple[ColumnOrName_, ...]], /) -> Column
-    main:36: error: No overload variant of "struct" matches argument types "list[str]", "list[str]"  [ca...
+    main:36: error: No overload variant of "struct" matches argument types "list[str]", "list[str]"  [call-overload]
     main:36: note: Possible overload variants:
     main:36: note:     def struct(*cols: Union[Column, str]) -> Column
     main:36: note:     def [ColumnOrName_] struct(Union[list[ColumnOrName_], tuple[ColumnOrName_, ...]], /) -> Column

--- a/python/pyspark/sql/tests/typing/test_functions.yml
+++ b/python/pyspark/sql/tests/typing/test_functions.yml
@@ -67,35 +67,35 @@
     map_concat(col_objs)
 
   out: |
-    main:29: error: No overload variant of "array" matches argument types "List[Column]", "List[Column]"  [call-overload]
+    main:29: error: No overload variant of "array" matches argument types "list[Column]", "list[Column]"  [call-overload]
     main:29: note: Possible overload variants:
-    main:29: note:     def array(*cols: Union[Column, str]) -> Column
-    main:29: note:     def [ColumnOrName_] array(Union[List[ColumnOrName_], Tuple[ColumnOrName_, ...]]) -> Column
-    main:30: error: No overload variant of "create_map" matches argument types "List[Column]", "List[Column]"  [call-overload]
+    main:29: note:     def array(*cols: Column | str) -> Column
+    main:29: note:     def [ColumnOrName_] array(list[ColumnOrName_] | tuple[ColumnOrName_, ...], /) -> Column
+    main:30: error: No overload variant of "create_map" matches argument types "list[Column]", "list[Column]"  [call-overload]
     main:30: note: Possible overload variants:
-    main:30: note:     def create_map(*cols: Union[Column, str]) -> Column
-    main:30: note:     def [ColumnOrName_] create_map(Union[List[ColumnOrName_], Tuple[ColumnOrName_, ...]]) -> Column
-    main:31: error: No overload variant of "map_concat" matches argument types "List[Column]", "List[Column]"  [call-overload]
+    main:30: note:     def create_map(*cols: Column | str) -> Column
+    main:30: note:     def [ColumnOrName_] create_map(list[ColumnOrName_] | tuple[ColumnOrName_, ...], /) -> Column
+    main:31: error: No overload variant of "map_concat" matches argument types "list[Column]", "list[Column]"  [call-overload]
     main:31: note: Possible overload variants:
-    main:31: note:     def map_concat(*cols: Union[Column, str]) -> Column
-    main:31: note:     def [ColumnOrName_] map_concat(Union[List[ColumnOrName_], Tuple[ColumnOrName_, ...]]) -> Column
-    main:32: error: No overload variant of "struct" matches argument types "List[str]", "List[str]"  [call-overload]
+    main:31: note:     def map_concat(*cols: Column | str) -> Column
+    main:31: note:     def [ColumnOrName_] map_concat(list[ColumnOrName_] | tuple[ColumnOrName_, ...], /) -> Column
+    main:32: error: No overload variant of "struct" matches argument types "list[str]", "list[str]"  [call-overload]
     main:32: note: Possible overload variants:
-    main:32: note:     def struct(*cols: Union[Column, str]) -> Column
-    main:32: note:     def [ColumnOrName_] struct(Union[List[ColumnOrName_], Tuple[ColumnOrName_, ...]]) -> Column
-    main:33: error: No overload variant of "array" matches argument types "List[str]", "List[str]"  [call-overload]
+    main:32: note:     def struct(*cols: Column | str) -> Column
+    main:32: note:     def [ColumnOrName_] struct(list[ColumnOrName_] | tuple[ColumnOrName_, ...], /) -> Column
+    main:33: error: No overload variant of "array" matches argument types "list[str]", "list[str]"  [call-overload]
     main:33: note: Possible overload variants:
-    main:33: note:     def array(*cols: Union[Column, str]) -> Column
-    main:33: note:     def [ColumnOrName_] array(Union[List[ColumnOrName_], Tuple[ColumnOrName_, ...]]) -> Column
-    main:34: error: No overload variant of "create_map" matches argument types "List[str]", "List[str]"  [call-overload]
+    main:33: note:     def array(*cols: Column | str) -> Column
+    main:33: note:     def [ColumnOrName_] array(list[ColumnOrName_] | tuple[ColumnOrName_, ...], /) -> Column
+    main:34: error: No overload variant of "create_map" matches argument types "list[str]", "list[str]"  [call-overload]
     main:34: note: Possible overload variants:
-    main:34: note:     def create_map(*cols: Union[Column, str]) -> Column
-    main:34: note:     def [ColumnOrName_] create_map(Union[List[ColumnOrName_], Tuple[ColumnOrName_, ...]]) -> Column
-    main:35: error: No overload variant of "map_concat" matches argument types "List[str]", "List[str]"  [call-overload]
+    main:34: note:     def create_map(*cols: Column | str) -> Column
+    main:34: note:     def [ColumnOrName_] create_map(list[ColumnOrName_] | tuple[ColumnOrName_, ...], /) -> Column
+    main:35: error: No overload variant of "map_concat" matches argument types "list[str]", "list[str]"  [call-overload]
     main:35: note: Possible overload variants:
-    main:35: note:     def map_concat(*cols: Union[Column, str]) -> Column
-    main:35: note:     def [ColumnOrName_] map_concat(Union[List[ColumnOrName_], Tuple[ColumnOrName_, ...]]) -> Column
-    main:36: error: No overload variant of "struct" matches argument types "List[str]", "List[str]"  [call-overload]
+    main:35: note:     def map_concat(*cols: Column | str) -> Column
+    main:35: note:     def [ColumnOrName_] map_concat(list[ColumnOrName_] | tuple[ColumnOrName_, ...], /) -> Column
+    main:36: error: No overload variant of "struct" matches argument types "list[str]", "list[str]"  [call-overload]
     main:36: note: Possible overload variants:
-    main:36: note:     def struct(*cols: Union[Column, str]) -> Column
-    main:36: note:     def [ColumnOrName_] struct(Union[List[ColumnOrName_], Tuple[ColumnOrName_, ...]]) -> Column
+    main:36: note:     def struct(*cols: Column | str) -> Column
+    main:36: note:     def [ColumnOrName_] struct(list[ColumnOrName_] | tuple[ColumnOrName_, ...], /) -> Column

--- a/python/pyspark/sql/tests/typing/test_readwriter.yml
+++ b/python/pyspark/sql/tests/typing/test_readwriter.yml
@@ -26,8 +26,8 @@
 
     spark.read.load(foo=True)
 
-    spark.read.load(foo=["a"])  # E: Argument "foo" to "load" of "DataFrameReader" has incompatible type "List[str]"; expected "Union[bool, float, int, str, None]"  [arg-type]
-    spark.read.option("foo", (1, ))  # E: Argument 2 to "option" of "DataFrameReader" has incompatible type "Tuple[int]"; expected "Union[bool, float, int, str, None]"  [arg-type]
+    spark.read.load(foo=["a"])  # E: Argument "foo" to "load" of "DataFrameReader" has incompatible type "list[str]"; expected "bool | float | int | str | None"  [arg-type]
+    spark.read.option("foo", (1, ))  # E: Argument 2 to "option" of "DataFrameReader" has incompatible type "tuple[int]"; expected "bool | float | int | str | None"  [arg-type]
 
 
 - case: readStreamOptions

--- a/python/pyspark/sql/tests/typing/test_readwriter.yml
+++ b/python/pyspark/sql/tests/typing/test_readwriter.yml
@@ -26,8 +26,8 @@
 
     spark.read.load(foo=True)
 
-    spark.read.load(foo=["a"])  # E: Argument "foo" to "load" of "DataFrameReader" has incompatible type "list[str]"; expected "bool | float | int | str | None"  [arg-type]
-    spark.read.option("foo", (1, ))  # E: Argument 2 to "option" of "DataFrameReader" has incompatible type "tuple[int]"; expected "bool | float | int | str | None"  [arg-type]
+    spark.read.load(foo=["a"])  # E: Argument "foo" to "load" of "DataFrameReader" has incompatible type "list[str]"; expected "Union[bool, float, int, str, None]"  [arg-type]
+    spark.read.option("foo", (1, ))  # E: Argument 2 to "option" of "DataFrameReader" has incompatible type "tuple[int]"; expected "Union[bool, float, int, str, None]"  [arg-type]
 
 
 - case: readStreamOptions

--- a/python/pyspark/sql/tests/typing/test_session.yml
+++ b/python/pyspark/sql/tests/typing/test_session.yml
@@ -95,14 +95,14 @@
     main:14: error: Value of type variable "AtomicValue" of "createDataFrame" of "SparkSession" cannot be "tuple[str, int]"  [type-var]
     main:18: error: No overload variant of "createDataFrame" of "SparkSession" matches argument types "list[tuple[str, int]]", "StructType", "float"  [call-overload]
     main:18: note: Possible overload variants:
-    main:18: note:     def [RowLike in (list[Any], tuple[Any, ...], Row)] createDataFrame(self, data: Iterable[RowLike], schema: list[str] | tuple[str, ...] = ..., samplingRatio: float | None = ...) -> DataFrame
-    main:18: note:     def [RowLike in (list[Any], tuple[Any, ...], Row)] createDataFrame(self, data: RDD[RowLike], schema: list[str] | tuple[str, ...] = ..., samplingRatio: float | None = ...) -> DataFrame
-    main:18: note:     def [RowLike in (list[Any], tuple[Any, ...], Row)] createDataFrame(self, data: Iterable[RowLike], schema: StructType | str, *, verifySchema: bool = ...) -> DataFrame
-    main:18: note:     def [RowLike in (list[Any], tuple[Any, ...], Row)] createDataFrame(self, data: RDD[RowLike], schema: StructType | str, *, verifySchema: bool = ...) -> DataFrame
-    main:18: note:     def [AtomicValue in (datetime, date, Decimal, bool, str, int, float)] createDataFrame(self, data: RDD[AtomicValue], schema: AtomicType | str, verifySchema: bool = ...) -> DataFrame
-    main:18: note:     def [AtomicValue in (datetime, date, Decimal, bool, str, int, float)] createDataFrame(self, data: Iterable[AtomicValue], schema: AtomicType | str, verifySchema: bool = ...) -> DataFrame
-    main:18: note:     def createDataFrame(self, data: DataFrame, samplingRatio: float | None = ...) -> DataFrame
-    main:18: note:     def createDataFrame(self, data: DataFrame, schema: StructType | str, verifySchema: bool = ...) -> DataFrame
+    main:18: note:     def [RowLike in (list[Any], tuple[Any, ...], Row)] createDataFrame(self, data: Iterable[RowLike], schema: Union[list[str], tuple[str, ...]] = ..., samplingRatio: Optional[float] = ...) -> DataFrame
+    main:18: note:     def [RowLike in (list[Any], tuple[Any, ...], Row)] createDataFrame(self, data: RDD[RowLike], schema: Union[list[str], tuple[str, ...]] = ..., samplingRatio: Optional[float] = ...) -> DataFrame
+    main:18: note:     def [RowLike in (list[Any], tuple[Any, ...], Row)] createDataFrame(self, data: Iterable[RowLike], schema: Union[StructType, str], *, verifySchema: bool = ...) -> DataFrame
+    main:18: note:     def [RowLike in (list[Any], tuple[Any, ...], Row)] createDataFrame(self, data: RDD[RowLike], schema: Union[StructType, str], *, verifySchema: bool = ...) -> DataFrame
+    main:18: note:     def [AtomicValue in (datetime, date, Decimal, bool, str, int, float)] createDataFrame(self, data: RDD[AtomicValue], schema: Union[AtomicType, str], verifySchema: bool = ...) -> DataFrame
+    main:18: note:     def [AtomicValue in (datetime, date, Decimal, bool, str, int, float)] createDataFrame(self, data: Iterable[AtomicValue], schema: Union[AtomicType, str], verifySchema: bool = ...) -> DataFrame
+    main:18: note:     def createDataFrame(self, data: DataFrame, samplingRatio: Optional[float] = ...) -> DataFrame
+    main:18: note:     def createDataFrame(self, data: DataFrame, schema: Union[StructType, str], verifySchema: bool = ...) -> DataFrame
 
 - case: createDataFrameFromEmptyRdd
   main: |

--- a/python/pyspark/sql/tests/typing/test_session.yml
+++ b/python/pyspark/sql/tests/typing/test_session.yml
@@ -92,18 +92,17 @@
     spark.createDataFrame(data, schema, samplingRatio=0.1)
 
   out: |
-    main:14: error: Value of type variable "AtomicValue" of "createDataFrame" of "SparkSession" cannot be "Tuple[str, int]"  [type-var]
-    main:18: error: No overload variant of "createDataFrame" of "SparkSession" matches argument types "List[Tuple[str, int]]", "StructType", "float"  [call-overload]
+    main:14: error: Value of type variable "AtomicValue" of "createDataFrame" of "SparkSession" cannot be "tuple[str, int]"  [type-var]
+    main:18: error: No overload variant of "createDataFrame" of "SparkSession" matches argument types "list[tuple[str, int]]", "StructType", "float"  [call-overload]
     main:18: note: Possible overload variants:
-    main:18: note:     def [RowLike in (List[Any], Tuple[Any, ...], Row)] createDataFrame(self, data: Iterable[RowLike], schema: Union[List[str], Tuple[str, ...]] = ..., samplingRatio: Optional[float] = ...) -> DataFrame
-    main:18: note:     def [RowLike in (List[Any], Tuple[Any, ...], Row)] createDataFrame(self, data: RDD[RowLike], schema: Union[List[str], Tuple[str, ...]] = ..., samplingRatio: Optional[float] = ...) -> DataFrame
-    main:18: note:     def [RowLike in (List[Any], Tuple[Any, ...], Row)] createDataFrame(self, data: Iterable[RowLike], schema: Union[StructType, str], *, verifySchema: bool = ...) -> DataFrame
-    main:18: note:     def [RowLike in (List[Any], Tuple[Any, ...], Row)] createDataFrame(self, data: RDD[RowLike], schema: Union[StructType, str], *, verifySchema: bool = ...) -> DataFrame
-    main:18: note:     def [AtomicValue in (datetime, date, Decimal, bool, str, int, float)] createDataFrame(self, data: RDD[AtomicValue], schema: Union[AtomicType, str], verifySchema: bool = ...) -> DataFrame
-    main:18: note:     def [AtomicValue in (datetime, date, Decimal, bool, str, int, float)] createDataFrame(self, data: Iterable[AtomicValue], schema: Union[AtomicType, str], verifySchema: bool = ...) -> DataFrame
-    main:18: note:     def createDataFrame(self, data: DataFrame, samplingRatio: Optional[float] = ...) -> DataFrame
-    main:18: note:     def createDataFrame(self, data: DataFrame, schema: Union[StructType, str], verifySchema: bool = ...) -> DataFrame
-
+    main:18: note:     def [RowLike in (list[Any], tuple[Any, ...], Row)] createDataFrame(self, data: Iterable[RowLike], schema: list[str] | tuple[str, ...] = ..., samplingRatio: float | None = ...) -> DataFrame
+    main:18: note:     def [RowLike in (list[Any], tuple[Any, ...], Row)] createDataFrame(self, data: RDD[RowLike], schema: list[str] | tuple[str, ...] = ..., samplingRatio: float | None = ...) -> DataFrame
+    main:18: note:     def [RowLike in (list[Any], tuple[Any, ...], Row)] createDataFrame(self, data: Iterable[RowLike], schema: StructType | str, *, verifySchema: bool = ...) -> DataFrame
+    main:18: note:     def [RowLike in (list[Any], tuple[Any, ...], Row)] createDataFrame(self, data: RDD[RowLike], schema: StructType | str, *, verifySchema: bool = ...) -> DataFrame
+    main:18: note:     def [AtomicValue in (datetime, date, Decimal, bool, str, int, float)] createDataFrame(self, data: RDD[AtomicValue], schema: AtomicType | str, verifySchema: bool = ...) -> DataFrame
+    main:18: note:     def [AtomicValue in (datetime, date, Decimal, bool, str, int, float)] createDataFrame(self, data: Iterable[AtomicValue], schema: AtomicType | str, verifySchema: bool = ...) -> DataFrame
+    main:18: note:     def createDataFrame(self, data: DataFrame, samplingRatio: float | None = ...) -> DataFrame
+    main:18: note:     def createDataFrame(self, data: DataFrame, schema: StructType | str, verifySchema: bool = ...) -> DataFrame
 
 - case: createDataFrameFromEmptyRdd
   main: |

--- a/python/pyspark/tests/typing/test_rdd.yml
+++ b/python/pyspark/tests/typing/test_rdd.yml
@@ -102,10 +102,10 @@
   out: |
      main:11: note: Revealed type is "pyspark.rdd.RDD[builtins.str]"
      main:16: note: Revealed type is "pyspark.rdd.RDD[builtins.int]"
-     main:18: note: Revealed type is "pyspark.rdd.RDD[Tuple[builtins.str, builtins.int]]"
-     main:20: note: Revealed type is "Tuple[builtins.str, builtins.int]"
+     main:18: note: Revealed type is "pyspark.rdd.RDD[tuple[builtins.str, builtins.int]]"
+     main:20: note: Revealed type is "tuple[builtins.str, builtins.int]"
      main:22: note: Revealed type is "builtins.int"
-     main:34: note: Revealed type is "pyspark.rdd.RDD[Tuple[builtins.str, builtins.set[builtins.str]]]"
+     main:34: note: Revealed type is "pyspark.rdd.RDD[tuple[builtins.str, builtins.set[builtins.str]]]"
 
 - case: rddMethodsErrors
   main: |


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a followup of https://github.com/apache/spark/pull/45115 that enables MyPy data test.

### Why are the changes needed?

To reenable MyPy data test.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Manually ran the test via `./dev/lint-python`.

### Was this patch authored or co-authored using generative AI tooling?

No.
