### PR TITLE
[SPARK-47075][BUILD] Add `derby-provided` profile

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -251,6 +251,12 @@
 
     <!-- Profiles that disable inclusion of certain dependencies. -->
     <profile>
+      <id>derby-provided</id>
+      <properties>
+        <derby.deps.scope>provided</derby.deps.scope>
+      </properties>
+    </profile>
+    <profile>
       <id>hadoop-provided</id>
       <properties>
         <hadoop.deps.scope>provided</hadoop.deps.scope>

--- a/pom.xml
+++ b/pom.xml
@@ -266,6 +266,7 @@
       during compilation if the dependency is transitive (e.g. "graphx/" depending on "core/" and
       needing Hadoop classes in the classpath to compile).
     -->
+    <derby.deps.scope>compile</derby.deps.scope>
     <hadoop.deps.scope>compile</hadoop.deps.scope>
     <hive.deps.scope>compile</hive.deps.scope>
     <hive.storage.version>2.8.1</hive.storage.version>
@@ -936,11 +937,13 @@
         <groupId>org.apache.derby</groupId>
         <artifactId>derby</artifactId>
         <version>${derby.version}</version>
+        <scope>${derby.deps.scope}</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.derby</groupId>
         <artifactId>derbytools</artifactId>
         <version>${derby.version}</version>
+        <scope>${derby.deps.scope}</scope>
       </dependency>
       <dependency>
         <groupId>io.dropwizard.metrics</groupId>
@@ -3758,6 +3761,9 @@
       <properties>
         <spark.yarn.isHadoopProvided>true</spark.yarn.isHadoopProvided>
       </properties>
+    </profile>
+    <profile>
+      <id>derby-provided</id>
     </profile>
     <profile>
       <id>hive-provided</id>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `derby-provided` profile.

### Why are the changes needed?

To help the users add their custom Derby jar later.

For the record, currently, Apache Spark 4.0 allows Java 21 and Derby 10.17.1.0 combination build like the following.
```
$ dev/make-distribution.sh -Phive -Dderby.version=10.17.1.0 -Djava.version=21
$ cd dist/jars
$ ls derby*
derby-10.17.1.0.jar       derbyshared-10.17.1.0.jar derbytools-10.17.1.0.jar
```

### Does this PR introduce _any_ user-facing change?

No, this is a new additional profile.

### How was this patch tested?

Manual.

```
$ dev/make-distribution.sh -Phive,derby-provided
$ ls dist/jars/derby*
zsh: no matches found: dist/jars/derby*
```

### Was this patch authored or co-authored using generative AI tooling?

No.
