### PR TITLE
[SPARK-47077][BUILD][TEST] Fix sbt build Revert [SPARK-44445][BUILD][TESTS]

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -354,7 +354,18 @@
     </dependency>
     <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
-      <artifactId>htmlunit3-driver</artifactId>
+      <artifactId>htmlunit-driver</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <!-- Coerce sbt into honoring these dependency updates: -->
+    <dependency>
+      <groupId>net.sourceforge.htmlunit</groupId>
+      <artifactId>htmlunit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>net.sourceforge.htmlunit</groupId>
+      <artifactId>htmlunit-core-js</artifactId>
       <scope>test</scope>
     </dependency>
     <!-- at least just for tests, coerce SBT to use the updated httpcore/client version -->
@@ -371,6 +382,12 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpcore</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <!-- Added for selenium: -->
+    <dependency>
+      <groupId>xml-apis</groupId>
+      <artifactId>xml-apis</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
@@ -564,9 +564,7 @@ abstract class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with
     // app is no longer incomplete
     listApplications(false) should not contain(appId)
 
-    eventually(stdTimeout, stdInterval) {
-      assert(jobcount === getNumJobs("/jobs"))
-    }
+    assert(jobcount === getNumJobs("/jobs"))
 
     // no need to retain the test dir now the tests complete
     ShutdownHookManager.registerShutdownDeleteDir(logDir)

--- a/core/src/test/scala/org/apache/spark/deploy/history/RealBrowserUIHistoryServerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/RealBrowserUIHistoryServerSuite.scala
@@ -22,10 +22,8 @@ import javax.servlet.http.HttpServletRequest
 import org.eclipse.jetty.proxy.ProxyServlet
 import org.eclipse.jetty.servlet.{ServletContextHandler, ServletHolder}
 import org.openqa.selenium.WebDriver
-import org.scalatest.concurrent.Eventually._
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.matchers.should.Matchers._
-import org.scalatest.time.SpanSugar._
 import org.scalatestplus.selenium.WebBrowser
 
 import org.apache.spark._
@@ -149,9 +147,7 @@ abstract class RealBrowserUIHistoryServerSuite(val driverProp: String)
 
       // there are at least some URL links that were generated via javascript,
       // and they all contain the spark.ui.proxyBase (uiRoot)
-      eventually(timeout(10.seconds)) {
-        links.length should be > 4
-      }
+      links.length should be > 4
       for (link <- links) {
         link should startWith(url + uiRoot)
       }

--- a/core/src/test/scala/org/apache/spark/ui/UISeleniumSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/UISeleniumSuite.scala
@@ -24,9 +24,9 @@ import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 import scala.io.Source
 import scala.xml.Node
 
+import com.gargoylesoftware.css.parser.CSSParseException
+import com.gargoylesoftware.htmlunit.DefaultCssErrorHandler
 import org.glassfish.jersey.internal.util.collection.MultivaluedStringMap
-import org.htmlunit.DefaultCssErrorHandler
-import org.htmlunit.cssparser.parser.CSSParseException
 import org.json4s._
 import org.json4s.jackson.JsonMethods
 import org.openqa.selenium.{By, WebDriver}

--- a/pom.xml
+++ b/pom.xml
@@ -215,7 +215,8 @@
     <antlr4.version>4.13.1</antlr4.version>
     <jpam.version>1.1</jpam.version>
     <selenium.version>4.12.1</selenium.version>
-    <htmlunit3-driver.version>4.17.0</htmlunit3-driver.version>
+    <htmlunit-driver.version>4.12.0</htmlunit-driver.version>
+    <htmlunit.version>2.70.0</htmlunit.version>
     <maven-antrun.version>3.1.0</maven-antrun.version>
     <commons-crypto.version>1.1.0</commons-crypto.version>
     <commons-cli.version>1.6.0</commons-cli.version>
@@ -710,9 +711,28 @@
       </dependency>
       <dependency>
         <groupId>org.seleniumhq.selenium</groupId>
-        <artifactId>htmlunit3-driver</artifactId>
-        <version>${htmlunit3-driver.version}</version>
+        <artifactId>htmlunit-driver</artifactId>
+        <version>${htmlunit-driver.version}</version>
         <scope>test</scope>
+      </dependency>
+      <!-- Update htmlunit dependency that selenium uses for better JS support -->
+      <dependency>
+        <groupId>net.sourceforge.htmlunit</groupId>
+        <artifactId>htmlunit</artifactId>
+        <version>${htmlunit.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>net.sourceforge.htmlunit</groupId>
+        <artifactId>htmlunit-core-js</artifactId>
+        <version>${htmlunit.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <!-- Added for selenium only, and should match its dependent version: -->
+      <dependency>
+        <groupId>xml-apis</groupId>
+        <artifactId>xml-apis</artifactId>
+        <version>1.4.01</version>
       </dependency>
 
       <!-- log4j -->

--- a/sql/core/pom.xml
+++ b/sql/core/pom.xml
@@ -225,7 +225,7 @@
     </dependency>
     <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
-      <artifactId>htmlunit3-driver</artifactId>
+      <artifactId>htmlunit-driver</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/UISeleniumSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/UISeleniumSuite.scala
@@ -22,7 +22,6 @@ import scala.jdk.CollectionConverters._
 
 import org.apache.commons.text.StringEscapeUtils.escapeJava
 import org.apache.commons.text.translate.EntityArrays._
-import org.openqa.selenium.By
 import org.openqa.selenium.htmlunit.HtmlUnitDriver
 import org.scalatest.concurrent.Eventually.eventually
 import org.scalatest.concurrent.Futures.{interval, timeout}
@@ -53,8 +52,7 @@ class UISeleniumSuite extends SparkFunSuite with WebBrowser {
     val webUrl = spark.sparkContext.uiWebUrl
     assert(webUrl.isDefined, "please turn on spark.ui.enabled")
     go to s"${webUrl.get}/SQL"
-    findAll(cssSelector("""#failed-table td .stacktrace-details"""))
-      .map(_.underlying.findElement(By.xpath("..")).getText).toList
+    findAll(cssSelector("""#failed-table td .stacktrace-details""")).map(_.text).toList
   }
 
   private def findErrorSummaryOnSQLUI(): String = {
@@ -106,13 +104,13 @@ class UISeleniumSuite extends SparkFunSuite with WebBrowser {
     eventually(timeout(10.seconds), interval(100.milliseconds)) {
       val sd = findErrorMessageOnSQLUI()
       assert(sd.size === 1, "Analyze fail shall show the query in failed table")
-      assert(sd.head.startsWith("TABLE_OR_VIEW_NOT_FOUND"))
+      assert(sd.head.startsWith("[TABLE_OR_VIEW_NOT_FOUND]"))
 
       val id = findExecutionIDOnSQLUI()
       // check query detail page
       go to s"${spark.sparkContext.uiWebUrl.get}/SQL/execution/?id=$id"
       val planDot = findAll(cssSelector(""".dot-file""")).map(_.text).toList
-      assert(planDot.size === 1)
+      assert(planDot.head.startsWith("digraph G {"))
       val planDetails = findAll(cssSelector("""#physical-plan-details""")).map(_.text).toList
       assert(planDetails.head.isEmpty)
     }

--- a/sql/hive-thriftserver/pom.xml
+++ b/sql/hive-thriftserver/pom.xml
@@ -103,7 +103,7 @@
     </dependency>
     <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
-      <artifactId>htmlunit3-driver</artifactId>
+      <artifactId>htmlunit-driver</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/streaming/pom.xml
+++ b/streaming/pom.xml
@@ -113,7 +113,7 @@
     </dependency>
     <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
-      <artifactId>htmlunit3-driver</artifactId>
+      <artifactId>htmlunit-driver</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION


### What changes were proposed in this pull request?

This reverts commit f5b1e37c9e6a4ec2fd897f97cd4526415e6c0e49.



### Why are the changes needed?
Building with sbt & JDK11 or 17 (executed after reload & clean ;compile;catalyst/testOnly org.apache.spark.sql.catalyst.optimizer.FilterPushdownSuite) results in




 
[error] /home/holden/repos/spark/core/src/test/scala/org/apache/spark/deploy/history/ChromeUIHistoryServerSuite.scala:20:8: object WebDriver is not a member of package org.openqa.selenium
[error] import org.openqa.selenium.WebDriver
[error]        ^
[error] /home/holden/repos/spark/core/src/test/scala/org/apache/spark/deploy/history/ChromeUIHistoryServerSuite.scala:33:27: not found: type WebDriver
[error]   override var webDriver: WebDriver = _
[error]                           ^
[error] /home/holden/repos/spark/core/src/test/scala/org/apache/spark/deploy/history/ChromeUIHistoryServerSuite.scala:37:29: Class org.openqa.selenium.remote.AbstractDriverOptions not found - continuing with a stub.
[error]     val chromeOptions = new ChromeOptions
[error]                             ^
[error] /home/holden/repos/spark/core/src/test/scala/org/apache/spark/deploy/history/RealBrowserUIHistoryServerSuite.scala:24:8: object WebDriver is not a member of package org.openqa.selenium
[error] import org.openqa.selenium.WebDriver
[error]        ^
[error] /home/holden/repos/spark/core/src/test/scala/org/apache/spark/deploy/history/RealBrowserUIHistoryServerSuite.scala:43:27: not found: type WebDriver
[error]   implicit var webDriver: WebDriver
[error]                           ^
[error] /home/holden/repos/spark/core/src/test/scala/org/apache/spark/deploy/history/ChromeUIHistoryServerSuite.scala:39:21: Class org.openqa.selenium.remote.RemoteWebDriver not found - continuing with a stub.
[error]     webDriver = new ChromeDriver(chromeOptions)
[error]                     ^
[error] /home/holden/repos/spark/core/src/test/scala/org/apache/spark/deploy/history/ChromeUIHistoryServerSuite.scala:20:28: Unused import
[error] Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=unused-imports, site=org.apache.spark.deploy.history
[error] import org.openqa.selenium.WebDriver
[error]                            ^
[error] /home/holden/repos/spark/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala:36:8: object WebDriver is not a member of package org.openqa.selenium
[error] import org.openqa.selenium.WebDriver
[error]        ^
[error] /home/holden/repos/spark/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala:383:29: not found: type WebDriver
[error]     implicit val webDriver: WebDriver = new HtmlUnitDriver
[error]                             ^
[error] /home/holden/repos/spark/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala:37:8: Class org.openqa.selenium.WebDriver not found - continuing with a stub.
[error] import org.openqa.selenium.htmlunit.HtmlUnitDriver
[error]        ^
[error] /home/holden/repos/spark/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala:383:45: Class org.openqa.selenium.Capabilities not found - continuing with a stub.
[error]     implicit val webDriver: WebDriver = new HtmlUnitDriver
[error]                                             ^
[error] /home/holden/repos/spark/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala:470:9: Symbol 'type org.openqa.selenium.WebDriver' is missing from the classpath.
[error] This symbol is required by 'value org.scalatestplus.selenium.WebBrowser.go.driver'.
[error] Make sure that type WebDriver is in your classpath and check for conflicting dependencies with `-Ylog-classpath`.
[error] A full rebuild may help if 'WebBrowser.class' was compiled against an incompatible version of org.openqa.selenium.
[error]         go to target.toExternalForm
[error]         ^
[error] /home/holden/repos/spark/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala:470:12: could not find implicit value for parameter driver: org.openqa.selenium.WebDriver
[error]         go to target.toExternalForm
[error]            ^
[error] /home/holden/repos/spark/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala:36:28: Unused import
[error] Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=unused-imports, site=org.apache.spark.deploy.history
[error] import org.openqa.selenium.WebDriver
[error]                            ^
[error] /home/holden/repos/spark/core/src/test/scala/org/apache/spark/deploy/history/RealBrowserUIHistoryServerSuite.scala:24:28: Unused import
[error] Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=unused-imports, site=org.apache.spark.deploy.history
[error] import org.openqa.selenium.WebDriver
[error]                            ^
[error] /home/holden/repos/spark/core/src/test/scala/org/apache/spark/deploy/history/RealBrowserUIHistoryServerSuite.scala:27:47: Unused import
[error] Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=unused-imports, site=org.apache.spark.deploy.history
[error] import org.scalatest.matchers.should.Matchers._
[error]                                               ^
[error] /home/holden/repos/spark/core/src/test/scala/org/apache/spark/ui/ChromeUISeleniumSuite.scala:20:8: object JavascriptExecutor is not a member of package org.openqa.selenium
[error] import org.openqa.selenium.{JavascriptExecutor, WebDriver}
[error]        ^
[error] /home/holden/repos/spark/core/src/test/scala/org/apache/spark/ui/ChromeUISeleniumSuite.scala:32:27: not found: type WebDriver
[error]   override var webDriver: WebDriver with JavascriptExecutor = _
[error]                           ^
[error] /home/holden/repos/spark/core/src/test/scala/org/apache/spark/ui/ChromeUISeleniumSuite.scala:32:42: not found: type JavascriptExecutor
[error]   override var webDriver: WebDriver with JavascriptExecutor = _
[error]                                          ^
[error] /home/holden/repos/spark/core/src/test/scala/org/apache/spark/ui/RealBrowserUISeleniumSuite.scala:20:8: object By is not a member of package org.openqa.selenium
[error] import org.openqa.selenium.{By, JavascriptExecutor, WebDriver}
[error]        ^
[error] /home/holden/repos/spark/core/src/test/scala/org/apache/spark/ui/RealBrowserUISeleniumSuite.scala:39:27: not found: type WebDriver
[error]   implicit var webDriver: WebDriver with JavascriptExecutor
[error]                           ^
[error] /home/holden/repos/spark/core/src/test/scala/org/apache/spark/ui/RealBrowserUISeleniumSuite.scala:39:42: not found: type JavascriptExecutor
[error]   implicit var webDriver: WebDriver with JavascriptExecutor
[error]                                          ^
[error] /home/holden/repos/spark/core/src/test/scala/org/apache/spark/ui/ChromeUISeleniumSuite.scala:20:29: Unused import
[error] Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=unused-imports, site=org.apache.spark.ui
[error] import org.openqa.selenium.{JavascriptExecutor, WebDriver}
[error]                             ^
[error] /home/holden/repos/spark/core/src/test/scala/org/apache/spark/ui/ChromeUISeleniumSuite.scala:20:49: Unused import
[error] Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=unused-imports, site=org.apache.spark.ui
[error] import org.openqa.selenium.{JavascriptExecutor, WebDriver}
[error]                                                 ^
[error] /home/holden/repos/spark/core/src/test/scala/org/apache/spark/ui/RealBrowserUISeleniumSuite.scala:20:29: Unused import
[error] Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=unused-imports, site=org.apache.spark.ui
[error] import org.openqa.selenium.{By, JavascriptExecutor, WebDriver}
[error]                             ^
[error] /home/holden/repos/spark/core/src/test/scala/org/apache/spark/ui/RealBrowserUISeleniumSuite.scala:20:33: Unused import
[error] Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=unused-imports, site=org.apache.spark.ui
[error] import org.openqa.selenium.{By, JavascriptExecutor, WebDriver}
[error]                                 ^
[error] /home/holden/repos/spark/core/src/test/scala/org/apache/spark/ui/RealBrowserUISeleniumSuite.scala:20:53: Unused import
[error] Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=unused-imports, site=org.apache.spark.ui
[error] import org.openqa.selenium.{By, JavascriptExecutor, WebDriver}
[error]                                                     ^
[error] /home/holden/repos/spark/core/src/test/scala/org/apache/spark/ui/RealBrowserUISeleniumSuite.scala:23:47: Unused import
[error] Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=unused-imports, site=org.apache.spark.ui
[error] import org.scalatest.matchers.should.Matchers._
[error]                                               ^
[error] /home/holden/repos/spark/core/src/test/scala/org/apache/spark/ui/UISeleniumSuite.scala:32:8: object By is not a member of package org.openqa.selenium
[error] import org.openqa.selenium.{By, WebDriver}
[error]        ^
[error] /home/holden/repos/spark/core/src/test/scala/org/apache/spark/ui/UISeleniumSuite.scala:87:27: not found: type WebDriver
[error]   implicit var webDriver: WebDriver = _
[error]                           ^
[error] /home/holden/repos/spark/core/src/test/scala/org/apache/spark/ui/UISeleniumSuite.scala:21:18: Unused import
[error] Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=unused-imports, site=org.apache.spark.ui
[error] import java.util.Locale
[error]                  ^
[error] /home/holden/repos/spark/core/src/test/scala/org/apache/spark/ui/UISeleniumSuite.scala:32:29: Unused import
[error] Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=unused-imports, site=org.apache.spark.ui
[error] import org.openqa.selenium.{By, WebDriver}
[error]                             ^
[error] /home/holden/repos/spark/core/src/test/scala/org/apache/spark/ui/UISeleniumSuite.scala:32:33: Unused import
[error] Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=unused-imports, site=org.apache.spark.ui
[error] import org.openqa.selenium.{By, WebDriver}
[error]                                 ^
[error] /home/holden/repos/spark/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala: expected start of definition, but was Token(VAL,val,28273,val)
[warn] one warning found
[error] 33 errors found
[error] stack trace is suppressed; run last catalyst / scalaStyleOnTest for the full output
[error] (core / Test / compileIncremental) Compilation failed
[error] (catalyst / scalaStyleOnTest) Failing because of negative scalastyle result
[error] Total time: 16 s, completed Feb 16, 2024, 3:05:47 PM





### Does this PR introduce _any_ user-facing change?

Test only


### How was this patch tested?
Local sbt testing

### Was this patch authored or co-authored using generative AI tooling?
No