### PR TITLE
[SPARK-47001][SQL] Pushdown verification in optimizer

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1827,9 +1827,10 @@ object PushPredicateThroughNonJoin extends Rule[LogicalPlan] with PredicateHelpe
         if (e1c.semanticEquals(e2c)) {
           true
         } else if (e1c.isInstanceOf[NamedExpression] && e2c.isInstanceOf[NamedExpression]) {
-          if (e1c.asInstanceOf[NamedExpression].exprId == e2c.asInstanceOf[NamedExpression]) {
-            throw new Exception("sadness")
-            false
+          val named1 = e1c.asInstanceOf[NamedExpression]
+          val named2 = e2c.asInstanceOf[NamedExpression]
+          if (named1.exprId == named2.exprId) {
+            true
           } else {
             false
           }
@@ -1838,7 +1839,9 @@ object PushPredicateThroughNonJoin extends Rule[LogicalPlan] with PredicateHelpe
         }
       }
       def eligibleForPushdown(e: Expression): Boolean = {
-        e.deterministic && output.exists(e2 => semanticOrRefEqual(e, e2))
+        e.deterministic && e.references.forall { ref =>
+          output.exists(e2 => semanticOrRefEqual(ref, e2))
+        }
       }
       val (pushDown, stayUp) = splitConjunctivePredicates(condition).partition(eligibleForPushdown)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1817,14 +1817,9 @@ object PushPredicateThroughNonJoin extends Rule[LogicalPlan] with PredicateHelpe
 
     case filter @ Filter(condition, union: Union) =>
       // Union could change the rows, so non-deterministic predicate can't be pushed down
-      // We should also only push down filters which are equal (either ref or semantic) to an
-      // output of the union. We check referential equality since semantic equality of a named field
-      // may be false as the data type may have changed to include nullable during the union.
       val output = union.output
       def eligibleForPushdown(e: Expression): Boolean = {
-        e.deterministic && e.references.forall { ref =>
-          output.exists(e2 => ref.exprId == e2.exprId)
-        }
+        e.deterministic
       }
       val (pushDown, stayUp) = splitConjunctivePredicates(condition).partition(eligibleForPushdown)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1818,10 +1818,7 @@ object PushPredicateThroughNonJoin extends Rule[LogicalPlan] with PredicateHelpe
     case filter @ Filter(condition, union: Union) =>
       // Union could change the rows, so non-deterministic predicate can't be pushed down
       val output = union.output
-      def eligibleForPushdown(e: Expression): Boolean = {
-        e.deterministic
-      }
-      val (pushDown, stayUp) = splitConjunctivePredicates(condition).partition(eligibleForPushdown)
+      val (pushDown, stayUp) = splitConjunctivePredicates(condition).partition(_.deterministic)
 
       if (pushDown.nonEmpty) {
         val pushDownCond = pushDown.reduceLeft(And)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1817,7 +1817,6 @@ object PushPredicateThroughNonJoin extends Rule[LogicalPlan] with PredicateHelpe
 
     case filter @ Filter(condition, union: Union) =>
       // Union could change the rows, so non-deterministic predicate can't be pushed down
-      val output = union.output
       val (pushDown, stayUp) = splitConjunctivePredicates(condition).partition(_.deterministic)
 
       if (pushDown.nonEmpty) {
@@ -1825,6 +1824,7 @@ object PushPredicateThroughNonJoin extends Rule[LogicalPlan] with PredicateHelpe
         // The union is the child of the filter so it's children are grandchildren.
         // Moves filters down to the grandchild if there is an element in the grand child's
         // output which is semantically equal to the filter being evaluated.
+        val output = union.output
         val newGrandChildren = union.children.map { grandchild =>
           val newCond = pushDownCond transform {
             case a: Attribute if output.exists(_.exprId == a.exprId) =>

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
@@ -882,6 +882,25 @@ class FilterPushdownSuite extends PlanTest {
     comparePlans(optimized, correctAnswer)
   }
 
+  test("union part 2 electric razor idk") {
+    val nullableArray = StructFiled("c", ArrayType(IntegerType, true))
+    val testRelationNonNull = LocalRelation($"a".array(IntegerType), $"b".int)
+    val testRelationNull = LocalRelation(nullableArray, $"d".int)
+
+
+    val originalQuery = Union(Seq(testRelationNonNull, testRelationNull))
+      .where(IsNotNull($"a"))
+
+    val optimized = Optimize.execute(originalQuery.analyze)
+
+    val correctAnswer = Union(Seq(
+      testRelation.where(IsNotNull($"a")),
+      testRelation2.where(IsNotNull($"c"))
+      .analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
   test("expand") {
     val agg = testRelation
       .groupBy(Cube(Seq(Seq($"a"), Seq($"b"))))($"a", $"b", sum($"c"))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
@@ -882,7 +882,7 @@ class FilterPushdownSuite extends PlanTest {
     comparePlans(optimized, correctAnswer)
   }
 
-  test("union part 2 electric razor idk") {
+  test("union filter pushdown w/reference to grand-child field") {
     val nonNullableArray = StructField("a", ArrayType(IntegerType, false))
     val bField = StructField("b", IntegerType)
     val testRelationNonNull = LocalRelation(nonNullableArray, bField)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Changes how we evaluate & candidate elements for filter pushdown past unions.

### Why are the changes needed?

Unions type promotion combined with a reference to the head child dataframe can result in errors.

### Does this PR introduce _any_ user-facing change?

Yes: slightly more filters will be pushed down (these would have previously thrown an exception).

### How was this patch tested?

New test added.

### Was this patch authored or co-authored using generative AI tooling?

No