### PR TITLE
[SPARK-47080][CORE][TESTS] Fix `HistoryServerSuite` to use `constant value` and `getNumJobsRestful`

### DIFF
--- a/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
@@ -544,7 +544,6 @@ abstract class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with
     eventually(stdTimeout, stdInterval) {
       assert(4 === getNumJobsRestful(), s"two jobs back-to-back not updated, server=$server\n")
     }
-    val jobcount = getNumJobs("/jobs")
     assert(!isApplicationCompleted(provider.getListing().next()))
 
     listApplications(false) should contain(appId)
@@ -565,7 +564,7 @@ abstract class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with
     listApplications(false) should not contain(appId)
 
     eventually(stdTimeout, stdInterval) {
-      assert(jobcount === getNumJobs("/jobs"))
+      assert(4 === getNumJobsRestful())
     }
 
     // no need to retain the test dir now the tests complete


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `HistoryServerSuite` to use a constant value, `4`, and `getNumJobsRestful `.

### Why are the changes needed?

To remove flakiness. The test method `getNumJobsRestful()` is more robust than the test method `getNumJobs`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs and manual.

I verified this by repeating 100 times.
```
   test("incomplete apps get refreshed") {
+    (1 to 100).foreach { i =>
```

### Was this patch authored or co-authored using generative AI tooling?

No.