### PR TITLE
[SPARK-47082][SQL] Fix out-of-bounds error condition

### DIFF
--- a/python/pyspark/errors/error_classes.py
+++ b/python/pyspark/errors/error_classes.py
@@ -1105,7 +1105,7 @@ ERROR_CLASSES_JSON = '''
   },
   "VALUE_OUT_OF_BOUNDS": {
     "message": [
-      "Value for `<arg_name>` must be greater than <lower_bound> or less than <upper_bound>, got <actual>"
+      "Value for `<arg_name>` must be between <lower_bound> and <upper_bound> (inclusive), got <actual>"
     ]
   },
   "WRONG_NUM_ARGS_FOR_HIGHER_ORDER_FUNCTION": {

--- a/python/pyspark/errors/error_classes.py
+++ b/python/pyspark/errors/error_classes.py
@@ -1103,7 +1103,7 @@ ERROR_CLASSES_JSON = '''
       "Value for `<arg_name>` must be True, got '<arg_value>'."
     ]
   },
-  "VALUE_OUT_OF_BOUND": {
+  "VALUE_OUT_OF_BOUNDS": {
     "message": [
       "Value for `<arg_name>` must be greater than <lower_bound> or less than <upper_bound>, got <actual>"
     ]

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -2250,7 +2250,7 @@ def _make_type_verifier(
             verify_acceptable_types(obj)
             if obj < -128 or obj > 127:
                 raise PySparkValueError(
-                    error_class="VALUE_OUT_OF_BOUND",
+                    error_class="VALUE_OUT_OF_BOUNDS",
                     message_parameters={
                         "arg_name": "obj",
                         "lower_bound": "127",
@@ -2268,7 +2268,7 @@ def _make_type_verifier(
             verify_acceptable_types(obj)
             if obj < -32768 or obj > 32767:
                 raise PySparkValueError(
-                    error_class="VALUE_OUT_OF_BOUND",
+                    error_class="VALUE_OUT_OF_BOUNDS",
                     message_parameters={
                         "arg_name": "obj",
                         "lower_bound": "32767",
@@ -2286,7 +2286,7 @@ def _make_type_verifier(
             verify_acceptable_types(obj)
             if obj < -2147483648 or obj > 2147483647:
                 raise PySparkValueError(
-                    error_class="VALUE_OUT_OF_BOUND",
+                    error_class="VALUE_OUT_OF_BOUNDS",
                     message_parameters={
                         "arg_name": "obj",
                         "lower_bound": "2147483647",
@@ -2304,7 +2304,7 @@ def _make_type_verifier(
             verify_acceptable_types(obj)
             if obj < -9223372036854775808 or obj > 9223372036854775807:
                 raise PySparkValueError(
-                    error_class="VALUE_OUT_OF_BOUND",
+                    error_class="VALUE_OUT_OF_BOUNDS",
                     message_parameters={
                         "arg_name": "obj",
                         "lower_bound": "9223372036854775807",

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -2248,13 +2248,15 @@ def _make_type_verifier(
         def verify_byte(obj: Any) -> None:
             assert_acceptable_types(obj)
             verify_acceptable_types(obj)
-            if obj < -128 or obj > 127:
+            lower_bound = -128
+            upper_bound = 127
+            if obj < lower_bound or obj > upper_bound:
                 raise PySparkValueError(
                     error_class="VALUE_OUT_OF_BOUNDS",
                     message_parameters={
                         "arg_name": "obj",
-                        "lower_bound": "127",
-                        "upper_bound": "-127",
+                        "lower_bound": str(lower_bound),
+                        "upper_bound": str(upper_bound),
                         "actual": str(obj),
                     },
                 )
@@ -2266,13 +2268,15 @@ def _make_type_verifier(
         def verify_short(obj: Any) -> None:
             assert_acceptable_types(obj)
             verify_acceptable_types(obj)
-            if obj < -32768 or obj > 32767:
+            lower_bound = -32768
+            upper_bound = 32767
+            if obj < lower_bound or obj > upper_bound:
                 raise PySparkValueError(
                     error_class="VALUE_OUT_OF_BOUNDS",
                     message_parameters={
                         "arg_name": "obj",
-                        "lower_bound": "32767",
-                        "upper_bound": "-32768",
+                        "lower_bound": str(lower_bound),
+                        "upper_bound": str(upper_bound),
                         "actual": str(obj),
                     },
                 )
@@ -2284,13 +2288,15 @@ def _make_type_verifier(
         def verify_integer(obj: Any) -> None:
             assert_acceptable_types(obj)
             verify_acceptable_types(obj)
-            if obj < -2147483648 or obj > 2147483647:
+            lower_bound = -2147483648
+            upper_bound = 2147483647
+            if obj < lower_bound or obj > upper_bound:
                 raise PySparkValueError(
                     error_class="VALUE_OUT_OF_BOUNDS",
                     message_parameters={
                         "arg_name": "obj",
-                        "lower_bound": "2147483647",
-                        "upper_bound": "-2147483648",
+                        "lower_bound": str(lower_bound),
+                        "upper_bound": str(upper_bound),
                         "actual": str(obj),
                     },
                 )
@@ -2302,13 +2308,15 @@ def _make_type_verifier(
         def verify_long(obj: Any) -> None:
             assert_acceptable_types(obj)
             verify_acceptable_types(obj)
-            if obj < -9223372036854775808 or obj > 9223372036854775807:
+            lower_bound = -9223372036854775808
+            upper_bound = 9223372036854775807
+            if obj < lower_bound or obj > upper_bound:
                 raise PySparkValueError(
                     error_class="VALUE_OUT_OF_BOUNDS",
                     message_parameters={
                         "arg_name": "obj",
-                        "lower_bound": "9223372036854775807",
-                        "upper_bound": "-9223372036854775808",
+                        "lower_bound": str(lower_bound),
+                        "upper_bound": str(upper_bound),
                         "actual": str(obj),
                     },
                 )


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Correct the message for this condition to reflect the actual error.
- Adjust the name of the out-of-bounds error condition from `OUT_OF_BOUND` to `OUT_OF_BOUNDS`.

### Why are the changes needed?

The error message is currently incorrect. Here's the current message:

```
pyspark.errors.exceptions.base.PySparkValueError:
  [VALUE_OUT_OF_BOUND] Value for `obj` must be greater than 2147483647 or less than -2147483648,
    got 2147483648
```

Note how a) "greater" and "less" are in the wrong places, b) the min and max allowable values are not accurately represented, and  c) the condition should be "and", not "or".

It's been corrected to this:

```
pyspark.errors.exceptions.base.PySparkValueError:
  [VALUE_OUT_OF_BOUNDS] Value for `obj` must be between -2147483648 and 2147483647 (inclusive),
    got 2147483648
```

Also, the idiomatic adjective in English (at least American English) is ["out of bounds"][1], with an "s" at the end.

[1]: https://www.merriam-webster.com/dictionary/out-of-bounds

### Does this PR introduce _any_ user-facing change?

Yes, it changes a user-facing error condition.

### How was this patch tested?

Manual testing.

### Was this patch authored or co-authored using generative AI tooling?

No.