### PR TITLE
[SPARK-47090][INFRA] Skip JDK 17/21 Maven compilation in branch-3.4 job

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -790,7 +790,8 @@ jobs:
 
   maven-build:
     needs: precondition
-    if: fromJson(needs.precondition.outputs.required).maven-build == 'true'
+    # Skipped in branch-3.4, see SPARK-47090.
+    if: fromJson(needs.precondition.outputs.required).maven-build == 'true' && inputs.branch != 'branch-3.4'
     name: Java ${{ matrix.java }} build with Maven (${{ matrix.os }})
     strategy:
       fail-fast: false


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to skip JDK 17/21 Maven build for `branch-3.4`.

### Why are the changes needed?

- Spark 3.4.0 is actually built on JDK 8 but supports 11 and 17. 
- Official JDK support is 8/11/17 (https://spark.apache.org/docs/3.4.0/)

To fix up the build https://github.com/apache/spark/actions/runs/7928294496/job/21664443573

```
Error:  Failed to execute goal net.alchim31.maven:scala-maven-plugin:4.8.0:compile (scala-compile-first) on project spark-tags_2.12: Execution scala-compile-first of goal net.alchim31.maven:scala-maven-plugin:4.8.0:compile failed.: CompileFailed -> [Help 1]
Error:  
Error:  To see the full stack trace of the errors, re-run Maven with the -e switch.
Error:  Re-run Maven using the -X switch to enable full debug logging.
Error:  
Error:  For more information about the errors and possible solutions, please read the following articles:
Error:  [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/PluginExecutionException
Error:  
Error:  After correcting the problems, you can resume the build with the command
Error:    mvn <args> -rf :spark-tags_2.12
Error: Process completed with exit code 1.
```


### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Will be tested in this PR (as its negative condition to the scheduled build).

### Was this patch authored or co-authored using generative AI tooling?

No.
