### PR TITLE
[MINOR][INFRA] Rename build_maven.yml and build_maven_java21.yml

### DIFF
--- a/.github/workflows/build_maven.yml
+++ b/.github/workflows/build_maven.yml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-name: "Build using Maven (master, Scala 2.13, Hadoop 3, JDK 17)"
+name: "Build / Maven (master, Scala 2.13, Hadoop 3, JDK 17)"
 
 on:
   schedule:

--- a/.github/workflows/build_maven_java21.yml
+++ b/.github/workflows/build_maven_java21.yml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-name: "Build using Maven (master, Scala 2.13, Hadoop 3, JDK 21)"
+name: "Build / Maven (master, Scala 2.13, Hadoop 3, JDK 21)"
 
 on:
   schedule:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to change the name of `build_maven.yml` and `build_maven_java21.yml` from
- Build using Maven (master, Scala 2.13, Hadoop 3, JDK 17) -> Build \ Maven (master, Scala 2.13, Hadoop 3, JDK 17)
- Build using Maven (master, Scala 2.13, Hadoop 3, JDK 21) -> Build \ Maven (master, Scala 2.13, Hadoop 3, JDK 21)

### Why are the changes needed?

To make it easier to navigate, and to be consistent. By doing this, you don't have to click "Show more workloads" at https://github.com/apache/spark/actions

![Screenshot 2024-02-19 at 12 40 51 PM](https://github.com/apache/spark/assets/6477701/a7cba7c2-1264-40d1-b629-7713d22d6535)


### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Will be tested in this PR's GitHub Actions.

### Was this patch authored or co-authored using generative AI tooling?

No.