### PR TITLE
[MINOR][SQL] Remove `unsupportedOperationMsg` from `CaseInsensitiveStringMap`

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/util/CaseInsensitiveStringMap.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/util/CaseInsensitiveStringMap.java
@@ -45,8 +45,6 @@ import java.util.Set;
 public class CaseInsensitiveStringMap implements Map<String, String> {
   private static final Logger logger = LoggerFactory.getLogger(CaseInsensitiveStringMap.class);
 
-  private String unsupportedOperationMsg = "CaseInsensitiveStringMap is read-only.";
-
   public static CaseInsensitiveStringMap empty() {
     return new CaseInsensitiveStringMap(new HashMap<>(0));
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr remove unused private field `unsupportedOperationMsg` from `CaseInsensitiveStringMap`, it is replaced by `_LEGACY_ERROR_TEMP_3206` after https://github.com/apache/spark/pull/44549 is merged, 

### Why are the changes needed?
Remove unused private field.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No