### PR TITLE
[SPARK-47067][INFRA] Add Daily Apple Silicon Github Action Job with Maven (Java/Scala)

### DIFF
--- a/.github/workflows/build_maven_java21_macos14.yml
+++ b/.github/workflows/build_maven_java21_macos14.yml
@@ -1,0 +1,35 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: "Build / Maven (master, Scala 2.13, Hadoop 3, JDK 21, macos-14)"
+
+on:
+  schedule:
+    - cron: '0 20 * * *'
+
+jobs:
+  run-build:
+    permissions:
+      packages: write
+    name: Run
+    uses: ./.github/workflows/maven_test.yml
+    if: github.repository == 'apache/spark'
+    with:
+      java: 21
+      os: macos-14

--- a/.github/workflows/maven_test.yml
+++ b/.github/workflows/maven_test.yml
@@ -36,6 +36,11 @@ on:
         required: false
         type: string
         default: hadoop3
+      os:
+        description: OS to run this build.
+        required: false
+        type: string
+        default: ubuntu-22.04
       envs:
         description: Additional environment variables to set when running the tests. Should be in JSON format.
         required: false
@@ -45,7 +50,7 @@ jobs:
   # Build: build Spark and run the tests for specified modules using maven
   build:
     name: "Build modules using Maven: ${{ matrix.modules }} ${{ matrix.comment }}"
-    runs-on: ubuntu-22.04
+    runs-on: ${{ inputs.os }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add a new Maven build that uses Apple Silicon for Apache Spark 4.0.0.

### Why are the changes needed?

To have a test coverage for Apple Silicon environment.

For Python and R, we need more efforts due to their library dependencies.

We will add them separately.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unfortunately, this should be tested after merging.

### Was this patch authored or co-authored using generative AI tooling?

No.