### PR TITLE
[SPARK-44826][TEST][CONNECT] Re-enable `test_series_iloc_setitem`

### DIFF
--- a/python/pyspark/pandas/tests/connect/diff_frames_ops/test_parity_setitem_series.py
+++ b/python/pyspark/pandas/tests/connect/diff_frames_ops/test_parity_setitem_series.py
@@ -24,9 +24,7 @@ from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 class DiffFramesParitySetItemSeriesTests(
     DiffFramesSetItemSeriesMixin, PandasOnSparkTestUtils, ReusedConnectTestCase
 ):
-    @unittest.skip("TODO(SPARK-44826): Resolve testing timeout issue from Spark Connect.")
-    def test_series_iloc_setitem(self):
-        super().test_series_iloc_setitem()
+    pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to re-enable `test_series_iloc_setitem` test.


### Why are the changes needed?

To improve the test coverage. This test was disabled due to unknown timeout exception from Spark Connect for some reason, but it works well now.


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?

CI should pass.

### Was this patch authored or co-authored using generative AI tooling?
No.