### PR TITLE
[SPARK-37434][TESTS] Disable unsupported `ExtendedLevelDBTest` on `MacOS/aarch64`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3771,7 +3771,7 @@
     <profile>
       <id>sparkr</id>
     </profile>
-    <!-- use org.openlabtesting.leveldbjni on aarch64 platform -->
+    <!-- use org.openlabtesting.leveldbjni on aarch64 platform except MacOS -->
     <profile>
       <id>aarch64</id>
       <properties>
@@ -3780,6 +3780,18 @@
       <activation>
         <os>
           <family>linux</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+    </profile>
+    <profile>
+      <id>applesilicon</id>
+      <properties>
+        <test.default.exclude.tags>org.apache.spark.tags.ChromeUITest,org.apache.spark.tags.ExtendedLevelDBTest</test.default.exclude.tags>
+      </properties>
+      <activation>
+        <os>
+          <family>mac</family>
           <arch>aarch64</arch>
         </os>
       </activation>

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -1515,7 +1515,11 @@ object TestSettings {
   import BuildCommons._
   private val defaultExcludedTags = Seq("org.apache.spark.tags.ChromeUITest",
     "org.apache.spark.deploy.k8s.integrationtest.YuniKornTag",
-    "org.apache.spark.internal.io.cloud.IntegrationTestSuite")
+    "org.apache.spark.internal.io.cloud.IntegrationTestSuite") ++
+    (if (System.getProperty("os.name").startsWith("Mac OS X") &&
+        System.getProperty("os.arch").equals("aarch64")) {
+      Seq("org.apache.spark.tags.ExtendedLevelDBTest")
+    } else Seq.empty)
 
   lazy val settings = Seq (
     // Fork new JVMs for tests and set Java options for those


### PR DESCRIPTION
### What changes were proposed in this pull request?

This supercedes #34676 with the original authorship, @LuciferYang .

```
$ git log -n1
commit 561fb2968c188e002d5333469a9a5c02c08b8ab2 (HEAD -> SPARK-37434, dongjoon/SPARK-37434)
Author: yangjie01 <yangjie01@baidu.com>
Date:   Mon Feb 19 13:38:18 2024 -0800

    [SPARK-37434][TESTS] Disable unsupported `ExtendedLevelDBTest` on `MacOS/aarch64`
```

### Why are the changes needed?

#34676 initially proposed to disable both `LevelDB` and `RocksDB` related tests.
Now, we have `RocksDB` by default which supports all environments.
`LevelDB` code will be tested in the same way like before. 

In short, there is no test coverage loss.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs and manual tests.

### Was this patch authored or co-authored using generative AI tooling?

No.