### PR TITLE
[SPARK-47095][INFRA] Uses proper options for command script in macos-14 build

### DIFF
--- a/.github/workflows/maven_test.yml
+++ b/.github/workflows/maven_test.yml
@@ -171,7 +171,8 @@ jobs:
       # Run the tests.
       - name: Run tests
         env: ${{ fromJSON(inputs.envs) }}
-        shell: 'script -q -e -c "bash {0}"'
+        # The command script takes different options ubuntu vs macos-14, see also SPARK-47095.
+        shell: '[[ "${{ inputs.os }}" == *"ubuntu"* ]] && script -q -e -c "bash {0}" || script -q -e "bash {0}"'
         run: |
           # Fix for TTY related issues when launching the Ammonite REPL in tests.
           export TERM=vt100


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes `maven_test.yml` compatible with macos-14 by fixing `script` command options.

### Why are the changes needed?

https://github.com/apache/spark/actions/runs/7964626045/job/21742573399

It fails as below:

```
Run # Fix for TTY related issues when launching the Ammonite REPL in tests.
/usr/bin/script: illegal option -- c
usage: script [-aeFkpqr] [-t time] [file [command ...]]
       script -p [-deq] [-T fmt] [file]
Error: Process completed with exit code 1.
```

See https://man.freebsd.org/cgi/man.cgi?script(1)
https://man7.org/linux/man-pages/man1/script.1.html


### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Manually tested in my local.

### Was this patch authored or co-authored using generative AI tooling?

No.