### PR TITLE
[SPARK-47097][CONNECT][TESTS] Deflake interrupt tag at SparkSessionE2ESuite

### DIFF
--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/SparkSessionE2ESuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/SparkSessionE2ESuite.scala
@@ -128,9 +128,9 @@ class SparkSessionE2ESuite extends RemoteSparkSession {
       assert(spark.getTags() == Set("one"))
       try {
         spark
-          .range(10)
+          .range(start = 0, end = 10, step = 1, numPartitions = 2)
           .map(n => {
-            Thread.sleep(30000); n
+            Thread.sleep(40000); n
           })
           .collect()
       } finally {
@@ -146,9 +146,9 @@ class SparkSessionE2ESuite extends RemoteSparkSession {
       assert(spark.getTags() == Set("one", "two"))
       try {
         spark
-          .range(10)
+          .range(start = 0, end = 10, step = 1, numPartitions = 2)
           .map(n => {
-            Thread.sleep(30000); n
+            Thread.sleep(40000); n
           })
           .collect()
       } finally {
@@ -164,9 +164,9 @@ class SparkSessionE2ESuite extends RemoteSparkSession {
       assert(spark.getTags() == Set("two"))
       try {
         spark
-          .range(10)
+          .range(start = 0, end = 10, step = 1, numPartitions = 2)
           .map(n => {
-            Thread.sleep(30000); n
+            Thread.sleep(40000); n
           })
           .collect()
       } finally {
@@ -183,9 +183,9 @@ class SparkSessionE2ESuite extends RemoteSparkSession {
       assert(spark.getTags() == Set("one"))
       try {
         spark
-          .range(10)
+          .range(start = 0, end = 10, step = 1, numPartitions = 2)
           .map(n => {
-            Thread.sleep(30000); n
+            Thread.sleep(40000); n
           })
           .collect()
       } finally {
@@ -196,7 +196,7 @@ class SparkSessionE2ESuite extends RemoteSparkSession {
 
     // q2 and q3 should be cancelled
     interrupted.clear()
-    eventually(timeout(20.seconds), interval(1.seconds)) {
+    eventually(timeout(30.seconds), interval(1.seconds)) {
       val ids = spark.interruptTag("two")
       interrupted ++= ids
       assert(interrupted.length == 2, s"Interrupted operations: $interrupted.")
@@ -213,7 +213,7 @@ class SparkSessionE2ESuite extends RemoteSparkSession {
 
     // q1 and q4 should be cancelled
     interrupted.clear()
-    eventually(timeout(20.seconds), interval(1.seconds)) {
+    eventually(timeout(30.seconds), interval(1.seconds)) {
       val ids = spark.interruptTag("one")
       interrupted ++= ids
       assert(interrupted.length == 2, s"Interrupted operations: $interrupted.")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to deflake increase  interrupt tag at `SparkSessionE2ESuite` by:
- Increase timeout for interrupt tag at `SparkSessionE2ESuite`.
- Reduce the number of tasks in parallel.

### Why are the changes needed?

To fix the flakiness:

```
- interrupt tag *** FAILED ***
  The code passed to eventually never returned normally. Attempted 30 times over 20.037421464999998 seconds. Last failure message: ListBuffer("2beba4ac-a994-45f5-bd46-fca3e43fb5ef") had length 1 instead of expected length 2 Interrupted operations: ListBuffer(2beba4ac-a994-45f5-bd46-fca3e43fb5ef).. (SparkSessionE2ESuite.scala:216)
```

https://github.com/apache/spark/actions/runs/7959951623/job/21727929211

The test failed because the interruption took more than 20 seconds, and it launches too many tasks to run.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

CI in this PR should validate them. The flakiness can't easily be reproduced in my local.

### Was this patch authored or co-authored using generative AI tooling?

No.
