### PR TITLE
[SPARK-47016][BUILD] Upgrade scalatest related dependencies to the 3.2.18 series

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -214,7 +214,7 @@
     <libthrift.version>0.12.0</libthrift.version>
     <antlr4.version>4.13.1</antlr4.version>
     <jpam.version>1.1</jpam.version>
-    <selenium.version>4.12.1</selenium.version>
+    <selenium.version>4.17.0</selenium.version>
     <htmlunit3-driver.version>4.17.0</htmlunit3-driver.version>
     <maven-antrun.version>3.1.0</maven-antrun.version>
     <commons-crypto.version>1.1.0</commons-crypto.version>
@@ -403,7 +403,6 @@
     <dependency>
       <groupId>org.scalatest</groupId>
       <artifactId>scalatest_${scala.binary.version}</artifactId>
-      <version>3.2.18</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -418,7 +417,7 @@
     </dependency>
     <dependency>
       <groupId>org.scalatestplus</groupId>
-      <artifactId>selenium-4-12_${scala.binary.version}</artifactId>
+      <artifactId>selenium-4-17_${scala.binary.version}</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -1146,13 +1145,13 @@
       <dependency>
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest_${scala.binary.version}</artifactId>
-        <version>3.2.17</version>
+        <version>3.2.18</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.scalatestplus</groupId>
         <artifactId>scalacheck-1-17_${scala.binary.version}</artifactId>
-        <version>3.2.17.0</version>
+        <version>3.2.18.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -1163,8 +1162,8 @@
       </dependency>
       <dependency>
         <groupId>org.scalatestplus</groupId>
-        <artifactId>selenium-4-12_${scala.binary.version}</artifactId>
-        <version>3.2.17.0</version>
+        <artifactId>selenium-4-17_${scala.binary.version}</artifactId>
+        <version>3.2.18.0</version>
         <scope>test</scope>
         <exclusions>
           <exclusion>
@@ -1182,13 +1181,13 @@
       <dependency>
         <groupId>net.bytebuddy</groupId>
         <artifactId>byte-buddy</artifactId>
-        <version>1.14.10</version>
+        <version>1.14.11</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>net.bytebuddy</groupId>
         <artifactId>byte-buddy-agent</artifactId>
-        <version>1.14.10</version>
+        <version>1.14.11</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR upgrades the scalatest-related dependencies from the 3.2.17 series to the 3.2.18 series, including scalatest, scalatestplus-scalacheck, and scalatestplus-selenium. The upgrade for scalatestplus-mockito has already been completed in https://github.com/apache/spark/pull/45169.

### Why are the changes needed?

- scalatest: https://github.com/scalatest/scalatest/releases/tag/release-3.2.18
- scalatestplus-scalacheck: https://github.com/scalatest/scalatestplus-scalacheck/releases/tag/release-3.2.18.0-for-scalacheck-1.17
- scalatestplus-selenium: https://github.com/scalatest/scalatestplus-selenium/releases/tag/release-3.2.18.0-for-selenium-4.17


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass GitHub Actions
- Manual tests:

```
build/sbt clean -Dguava.version=33.0.0-jre -Dspark.test.webdriver.chrome.driver=/opt/homebrew/bin/chromedriver -Dtest.default.exclude.tags="org.apache.spark.tags.ExtendedLevelDBTest" -Phive -Phive-thriftserver \
"core/testOnly *HistoryServerSuite"
```

```
build/sbt clean  -Dguava.version=33.0.0-jre -Dspark.test.webdriver.chrome.driver=/opt/homebrew/bin/chromedriver -Dtest.default.exclude.tags="org.apache.spark.tags.ExtendedLevelDBTest" -Phive -Phive-thriftserver \
"core/testOnly *UISeleniumSuite"
```

```
build/sbt clean  -Dguava.version=33.0.0-jre -Dspark.test.webdriver.chrome.driver=/opt/homebrew/bin/chromedriver -Dtest.default.exclude.tags="org.apache.spark.tags.ExtendedLevelDBTest" -Phive -Phive-thriftserver \
"sql/testOnly *UISeleniumSuite"
```

```
build/sbt clean  -Dguava.version=33.0.0-jre -Dspark.test.webdriver.chrome.driver=/opt/homebrew/bin/chromedriver -Dtest.default.exclude.tags="org.apache.spark.tags.ExtendedLevelDBTest" -Phive -Phive-thriftserver \
"streaming/testOnly *UISeleniumSuite"
```

```
build/sbt clean  -Dguava.version=33.0.0-jre -Dspark.test.webdriver.chrome.driver=/opt/homebrew/bin/chromedriver -Dtest.default.exclude.tags="org.apache.spark.tags.ExtendedLevelDBTest" -Phive -Phive-thriftserver \
"hive-thriftserver/testOnly *UISeleniumSuite"
```

### Was this patch authored or co-authored using generative AI tooling?
No