### PR TITLE
[WIP][SPARK-47103][ML] Make the default storage level of intermediate datasets for MLlib configurable

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -29,7 +29,7 @@ import org.apache.spark.network.shuffledb.DBBackend
 import org.apache.spark.network.util.ByteUnit
 import org.apache.spark.scheduler.{EventLoggingListener, SchedulingMode}
 import org.apache.spark.shuffle.sort.io.LocalDiskShuffleDataIO
-import org.apache.spark.storage.{DefaultTopologyMapper, RandomBlockReplicationPolicy}
+import org.apache.spark.storage.{DefaultTopologyMapper, RandomBlockReplicationPolicy, StorageLevelMapper}
 import org.apache.spark.unsafe.array.ByteArrayMethods
 import org.apache.spark.util.{MavenUtils, Utils}
 import org.apache.spark.util.collection.unsafe.sort.UnsafeSorterSpillReader.MAX_BUFFER_SIZE_BYTES
@@ -2640,4 +2640,13 @@ package object config {
       .version("4.0.0")
       .booleanConf
       .createWithDefault(false)
+
+  private[spark] val DEFAULT_ML_INTERMEDIATE_STORAGE_LEVEL =
+    ConfigBuilder("spark.ml.defaultIntermediateStorageLevel")
+      .doc("The default storage level of intermediate datasets for MLlib. Cannot be 'NONE'.")
+      .version("4.0.0")
+      .stringConf
+      .transform(_.toUpperCase(Locale.ROOT))
+      .checkValues(StorageLevelMapper.values.map(_.name()).toSet - StorageLevelMapper.NONE.toString)
+      .createWithDefault(StorageLevelMapper.MEMORY_AND_DISK.name())
 }

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LogisticRegression.scala
@@ -507,8 +507,9 @@ class LogisticRegression @Since("1.2.0") (
         s"then cached during training. Be careful of double caching!")
     }
 
+    val sparkConf = dataset.rdd.sparkContext.getConf
     val intermediateRDDStorageLevel =
-      StorageLevel.fromString(dataset.sqlContext.getConf(DEFAULT_ML_INTERMEDIATE_STORAGE_LEVEL.key))
+      StorageLevel.fromString(sparkConf.get(DEFAULT_ML_INTERMEDIATE_STORAGE_LEVEL))
 
     val instances = dataset.select(
       checkClassificationLabels($(labelCol), None),


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Generally, the ML algorithms require multiple rounds of iterations, in the current implementation of MLlib(both `ml` and `mllib`), almost everywhere is hardcoded with `data.persist(StorageLevel.MEMORY_AND_DISK)` except to ALS which allows set intermediate RDD storage level via API.

```
  /**
   * Sets storage level for intermediate RDDs (user/product in/out links). The default value is
   * `MEMORY_AND_DISK`. Users can change it to a serialized storage, e.g., `MEMORY_AND_DISK_SER` and
   * set `spark.rdd.compress` to `true` to reduce the space requirement, at the cost of speed.
   */
  @Since("1.1.0")
  def setIntermediateRDDStorageLevel(storageLevel: StorageLevel): this.type = {
    require(storageLevel != StorageLevel.NONE,
      "ALS is not designed to run without persisting intermediate RDDs.")
    this.intermediateRDDStorageLevel = storageLevel
    this
  }
```

This PR introduces a configuration `spark.ml.defaultIntermediateStorageLevel` to make the default storage level of intermediate datasets for MLlib configurable.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

With storage level MEMORY_AND_DISK, once the executor that holds the RDD cached block is killed by the resource manager (e.g. OOM), the RDD cache becomes corrupt.

After SPARK-27677 (since 3.0), the External Shuffle Service could serve cached RDD block which persisted on the disk, so it would be helpful if we set the storage level of intermediate RDD to DISK.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No. The default value of `spark.ml.defaultIntermediateStorageLevel` is MEMORY_AND_DISK to keep the original behavior.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Pass GA.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.