### PR TITLE
[SPARK-47108][CORE] Set `derby.connection.requireAuthentication` to `false` explicitly in CLIs

### DIFF
--- a/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
@@ -305,6 +305,7 @@ class SparkSubmitCommandBuilder extends AbstractCommandBuilder {
 
     // SPARK-36796: Always add default `--add-opens` to submit command
     addOptionString(cmd, JavaModuleOptions.defaultModuleOptions());
+    addOptionString(cmd, "-Dderby.connection.requireAuthentication=false");
     cmd.add("org.apache.spark.deploy.SparkSubmit");
     cmd.addAll(buildSparkSubmitArgs());
     return cmd;


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to set `derby.connection.requireAuthentication` to `false` explicitly in CLIs by adding an option at `SparkSubmitCommandBuilder`.

### Why are the changes needed?

Not that the embedded `Apache Derby` is supposed to be used in a non-production environment only. However, it's used (or exposed) to the users when there is no reachable Hive MetaStores. For example, `spark-shell` and `spark-sql` and `Spark ThriftServer`.

https://github.com/apache/spark/blob/9d9675922543e3e5c3b01023e5a756462a1fd308/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala#L190

Although `derby.connection.requireAuthentication` is supposed to be `false` by default in Apache Derby, this PR aims to make it sure that Apache Spark doesn't use it always intentionally.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.