### PR TITLE
[SPARK-47112][INFRA] Write logs into a file in SparkR Windows build

### DIFF
--- a/.github/workflows/build_main.yml
+++ b/.github/workflows/build_main.yml
@@ -22,7 +22,7 @@ name: "Build"
 on:
   push:
     branches:
-    - '**'
+    - nonexistent
 
 jobs:
   call-build-and-test:

--- a/.github/workflows/build_main.yml
+++ b/.github/workflows/build_main.yml
@@ -22,7 +22,7 @@ name: "Build"
 on:
   push:
     branches:
-    - nonexistent
+    - '**'
 
 jobs:
   call-build-and-test:

--- a/.github/workflows/build_sparkr_window.yml
+++ b/.github/workflows/build_sparkr_window.yml
@@ -19,9 +19,8 @@
 name: "Build / SparkR-only (master, 4.3.2, windows-2019)"
 
 on:
-  push:
-    branches:
-    - '**'
+  schedule:
+    - cron: '0 17 * * *'
 
 jobs:
   build:

--- a/.github/workflows/build_sparkr_window.yml
+++ b/.github/workflows/build_sparkr_window.yml
@@ -72,7 +72,7 @@ jobs:
       run: |
         set HADOOP_HOME=%USERPROFILE%\hadoop-3.3.5
         set PATH=%HADOOP_HOME%\bin;%PATH%
-        .\bin\spark-submit2.cmd --verbose --driver-java-options "-Dlog4j.configuration=file:///%CD:\=/%/R/log4j2.properties" --conf spark.hadoop.fs.defaultFS="file:///" R\pkg\tests\run-all.R
+        .\bin\spark-submit2.cmd --driver-java-options "-Dlog4j.configurationFile=file:///%CD:\=/%/R/log4j2.properties" --conf spark.hadoop.fs.defaultFS="file:///" R\pkg\tests\run-all.R
       shell: cmd
       env:
         NOT_CRAN: true

--- a/.github/workflows/build_sparkr_window.yml
+++ b/.github/workflows/build_sparkr_window.yml
@@ -59,10 +59,6 @@ jobs:
         Rscript -e "install.packages(c('knitr', 'rmarkdown', 'testthat', 'e1071', 'survival', 'arrow', 'xml2'), repos='https://cloud.r-project.org/')"
         Rscript -e "pkg_list <- as.data.frame(installed.packages()[,c(1, 3:4)]); pkg_list[is.na(pkg_list$Priority), 1:2, drop = FALSE]"
       shell: cmd
-    - run: echo %CD:\=/%/R/log4j2.properties
-      shell: cmd
-    - run: dir %CD:\=/%/R/log4j2.properties
-      shell: cmd
     - name: Build Spark
       run: |
         rem 1. '-Djna.nosys=true' is required to avoid kernel32.dll load failure.
@@ -76,7 +72,7 @@ jobs:
       run: |
         set HADOOP_HOME=%USERPROFILE%\hadoop-3.3.5
         set PATH=%HADOOP_HOME%\bin;%PATH%
-        .\bin\spark-submit2.cmd --driver-java-options "-Dlog4j.configuration=file:///%CD:\=/%/R/log4j2.properties" --conf spark.hadoop.fs.defaultFS="file:///" R\pkg\tests\run-all.R
+        .\bin\spark-submit2.cmd --verbose --driver-java-options "-Dlog4j.configuration=file:///%CD:\=/%/R/log4j2.properties" --conf spark.hadoop.fs.defaultFS="file:///" R\pkg\tests\run-all.R
       shell: cmd
       env:
         NOT_CRAN: true

--- a/.github/workflows/build_sparkr_window.yml
+++ b/.github/workflows/build_sparkr_window.yml
@@ -19,8 +19,9 @@
 name: "Build / SparkR-only (master, 4.3.2, windows-2019)"
 
 on:
-  schedule:
-    - cron: '0 17 * * *'
+  push:
+    branches:
+    - '**'
 
 jobs:
   build:
@@ -57,6 +58,10 @@ jobs:
       run: |
         Rscript -e "install.packages(c('knitr', 'rmarkdown', 'testthat', 'e1071', 'survival', 'arrow', 'xml2'), repos='https://cloud.r-project.org/')"
         Rscript -e "pkg_list <- as.data.frame(installed.packages()[,c(1, 3:4)]); pkg_list[is.na(pkg_list$Priority), 1:2, drop = FALSE]"
+      shell: cmd
+    - run: echo %CD:\=/%/R/log4j2.properties
+      shell: cmd
+    - run: dir %CD:\=/%/R/log4j2.properties
       shell: cmd
     - name: Build Spark
       run: |


### PR DESCRIPTION
### What changes were proposed in this pull request?

We used to write Log4J logs into `target/unit-tests.log` instead of console. This seems to be broken in SparkR Windows job. This PR fixes it.

### Why are the changes needed?

https://github.com/apache/spark/actions/runs/7977185456/job/21779508822#step:10:89
This write too many logs, and difficult to see the real test cases. 

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

In my fork

### Was this patch authored or co-authored using generative AI tooling?

No.
