### PR TITLE
[SPARK-46938][BUILD] Remove `javax-servlet-api` exclusion rule for SBT

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -1192,7 +1192,6 @@ object YARN {
   lazy val settings = Seq(
     excludeDependencies --= Seq(
       ExclusionRule(organization = "com.sun.jersey"),
-      ExclusionRule("javax.servlet", "javax.servlet-api"),
       ExclusionRule("javax.ws.rs", "jsr311-api")),
     Compile / unmanagedResources :=
       (Compile / unmanagedResources).value.filter(!_.getName.endsWith(s"$propFileName")),

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -1075,7 +1075,6 @@ object ExcludedDependencies {
     // purpose only. Here we exclude them from the whole project scope and add them w/ yarn only.
     excludeDependencies ++= Seq(
       ExclusionRule(organization = "com.sun.jersey"),
-      ExclusionRule("javax.servlet", "javax.servlet-api"),
       ExclusionRule("javax.ws.rs", "jsr311-api"))
   )
 }
@@ -1192,6 +1191,7 @@ object YARN {
   lazy val settings = Seq(
     excludeDependencies --= Seq(
       ExclusionRule(organization = "com.sun.jersey"),
+      ExclusionRule("javax.servlet", "javax.servlet-api"),
       ExclusionRule("javax.ws.rs", "jsr311-api")),
     Compile / unmanagedResources :=
       (Compile / unmanagedResources).value.filter(!_.getName.endsWith(s"$propFileName")),


### PR DESCRIPTION
### What changes were proposed in this pull request?
* Update SBT build file to remove the exclusion rule for `javax-servlet-api` package.


### Why are the changes needed?


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
CI build

### Was this patch authored or co-authored using generative AI tooling?
No