### PR TITLE
[SPARK-47116][INFRA][R] Install proper Python version in SparkR Windows build to avoid warnings

### DIFF
--- a/.github/workflows/build_sparkr_window.yml
+++ b/.github/workflows/build_sparkr_window.yml
@@ -58,6 +58,15 @@ jobs:
         Rscript -e "install.packages(c('knitr', 'rmarkdown', 'testthat', 'e1071', 'survival', 'arrow', 'xml2'), repos='https://cloud.r-project.org/')"
         Rscript -e "pkg_list <- as.data.frame(installed.packages()[,c(1, 3:4)]); pkg_list[is.na(pkg_list$Priority), 1:2, drop = FALSE]"
       shell: cmd
+    # SparkR build does not need Python. However, it shows warnings when the Python version is too low during
+    # the attempt to look up Python Data Sources for session initialization. The Windows 2019 runner
+    # includes Python 3.7, which Spark does not support. Therefore, we simply install the proper Python
+    # for simplicity, see SPARK-47116.
+    - name: Install Python 3.11
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+        architecture: x64
     - name: Build Spark
       run: |
         rem 1. '-Djna.nosys=true' is required to avoid kernel32.dll load failure.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR installs Python 3.11 in SparkR build on Windows.

### Why are the changes needed?

To remove unrelated warnings: (https://github.com/HyukjinKwon/spark/actions/runs/7985005685/job/21802732830
)

```
Traceback (most recent call last):
  File "C:\hostedtoolcache\windows\Python\3.7.9\x64\lib\runpy.py", line 183, in _run_module_as_main
    mod_name, mod_spec, code = _get_module_details(mod_name, _Error)
  File "C:\hostedtoolcache\windows\Python\3.7.9\x64\lib\runpy.py", line 109, in _get_module_details
    __import__(pkg_name)
  File "D:\a\spark\spark\python\lib\pyspark.zip\pyspark\__init__.py", line [53](https://github.com/HyukjinKwon/spark/actions/runs/7985005685/job/21802732830#step:10:54), in <module>
  File "D:\a\spark\spark\python\lib\pyspark.zip\pyspark\rdd.py", line [54](https://github.com/HyukjinKwon/spark/actions/runs/7985005685/job/21802732830#step:10:55), in <module>
  File "D:\a\spark\spark\python\lib\pyspark.zip\pyspark\java_gateway.py", line 33, in <module>
  File "D:\a\spark\spark\python\lib\pyspark.zip\pyspark\serializers.py", line 69, in <module>
  File "D:\a\spark\spark\python\lib\pyspark.zip\pyspark\cloudpickle\__init__.py", line 1, in <module>
  File "D:\a\spark\spark\python\lib\pyspark.zip\pyspark\cloudpickle\cloudpickle.py", line 80, in <module>
ImportError: cannot import name 'CellType' from 'types' (C:\hostedtoolcache\windows\Python\3.7.9\x64\lib\types.py)
```

SparkR build does not need Python. However, it shows warnings when the Python version is too low during the attempt to look up Python Data Sources for session initialization. The Windows 2019 runner includes Python 3.7, which Spark does not support. Therefore, we simply install the proper Python for simplicity.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Manually

### Was this patch authored or co-authored using generative AI tooling?

No.