### PR TITLE
[SPARK-47104][SQL] `TakeOrderedAndProjectExec` should initialize the unsafe projection

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/TakeOrderedAndProjectSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/TakeOrderedAndProjectSuite.scala
@@ -21,7 +21,7 @@ import scala.util.Random
 
 import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.catalyst.dsl.expressions._
-import org.apache.spark.sql.catalyst.expressions.Literal
+import org.apache.spark.sql.catalyst.expressions.{Alias, Literal, Rand}
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
 
@@ -126,5 +126,31 @@ class TakeOrderedAndProjectSuite extends SparkPlanTest with SharedSparkSession {
           sortAnswers = false)
       }
     }
+  }
+
+  test("non-deterministic_issue") {
+    val expected = (input: SparkPlan) => {
+      GlobalLimitExec(limit,
+        LocalLimitExec(limit,
+          SortExec(sortOrder, true, input)))
+    }
+    val schema = StructType.fromDDL("a int, b int, c double")
+    val rdd = sparkContext.parallelize(
+      Seq(Row(1, 2, 0.0953472826424725d),
+        Row(2, 3, 0.5234194256885571d),
+        Row(3, 4, 0.7604953758285915d)), 1)
+    val df = spark.createDataFrame(rdd, schema)
+    df.show()
+    // val projection = df.queryExecution.sparkPlan.output ++ Seq(Alias(Uuid(Some(0)), "_uuid")())
+    val projection = df.queryExecution.sparkPlan.output.take(2) :+
+      Alias(Rand(Literal(0, IntegerType)), "_uuid")()
+    checkThatPlansAgree(
+      df,
+      input =>
+        TakeOrderedAndProjectExec(limit, sortOrder, projection,
+          SortExec(sortOrder, false, input)),
+
+      input => expected(input),
+      sortAnswers = false)
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Change `TakeOrderedAndProjectExec#executeCollect` and `TakeOrderedAndProjectExec#doExecute` to initialize the unsafe projection before using it to produce output rows.

### Why are the changes needed?

Because the unsafe projection is not initialized, non-deterministic expressions also don't get initialized. This results in errors when the projection contains non-deterministic expressions. For example:
```
create or replace temp view v1(id, name) as values
(1, "fred"),
(2, "bob");

cache table v1;

select name, uuid() as _iid from (
  select * from v1 order by name
)
limit 20;
```
This query produces the following error:
```
java.lang.NullPointerException: Cannot invoke "org.apache.spark.sql.catalyst.util.RandomUUIDGenerator.getNextUUIDUTF8String()" because "this.randomGen_0" is null
	at org.apache.spark.sql.catalyst.expressions.GeneratedClass$SpecificUnsafeProjection.apply(Unknown Source)
	at org.apache.spark.sql.execution.TakeOrderedAndProjectExec.$anonfun$executeCollect$6(limit.scala:297)
	at scala.collection.ArrayOps$.map$extension(ArrayOps.scala:934)
	at org.apache.spark.sql.execution.TakeOrderedAndProjectExec.$anonfun$executeCollect$1(limit.scala:297)
...
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

New test.

### Was this patch authored or co-authored using generative AI tooling?

No.
