### PR TITLE
[SPARK-47120][SQL] Null comparison push down data filter from subquery produces in NPE in Parquet filter

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -37,7 +37,7 @@ import org.apache.spark.sql.execution.datasources.v2.PushedDownOperators
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.sql.execution.vectorized.ConstantColumnVector
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.sources.{BaseRelation, Filter, GreaterThan, GreaterThanOrEqual, LessThan, LessThanOrEqual}
+import org.apache.spark.sql.sources.{BaseRelation, Filter}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.util.ArrayImplicits._
@@ -417,14 +417,6 @@ trait FileSourceScanLike extends DataSourceScanExec {
       case FileSourceConstantMetadataAttribute(_) => true
       case _ => false
     }).flatMap(DataSourceStrategy.translateFilter(_, supportNestedPredicatePushdown))
-    .filterNot {
-        // skip literal null comparisons as they're not compatible with parquet
-      case GreaterThanOrEqual(_, x) => x == null
-      case GreaterThan(_, x) => x == null
-      case LessThan(_, x) => x == null
-      case LessThanOrEqual(_, x) => x == null
-      case _ => false
-    }
   }
 
   // This field may execute subquery expressions and should not be accessed during planning.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -37,7 +37,7 @@ import org.apache.spark.sql.execution.datasources.v2.PushedDownOperators
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.sql.execution.vectorized.ConstantColumnVector
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.sources.{BaseRelation, Filter}
+import org.apache.spark.sql.sources.{BaseRelation, Filter, GreaterThan, GreaterThanOrEqual, LessThan, LessThanOrEqual}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.util.ArrayImplicits._
@@ -417,6 +417,14 @@ trait FileSourceScanLike extends DataSourceScanExec {
       case FileSourceConstantMetadataAttribute(_) => true
       case _ => false
     }).flatMap(DataSourceStrategy.translateFilter(_, supportNestedPredicatePushdown))
+    .filterNot {
+        // skip literal null comparisons as they're not compatible with parquet
+      case GreaterThanOrEqual(_, x) => x == null
+      case GreaterThan(_, x) => x == null
+      case LessThan(_, x) => x == null
+      case LessThanOrEqual(_, x) => x == null
+      case _ => false
+    }
   }
 
   // This field may execute subquery expressions and should not be accessed during planning.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilters.scala
@@ -609,8 +609,8 @@ class ParquetFilters(
 
   // Parquet's type in the given file should be matched to the value's type
   // in the pushed filter in order to push down the filter to Parquet.
-  private def valueCanMakeFilterOn(name: String, value: Any, allowNull: Boolean): Boolean = {
-    (value == null && allowNull) || (nameToParquetField(name).fieldType match {
+  private def valueCanMakeFilterOn(name: String, value: Any): Boolean = {
+    value == null || (nameToParquetField(name).fieldType match {
       case ParquetBooleanType => value.isInstanceOf[JBoolean]
       case ParquetIntegerType if value.isInstanceOf[Period] => true
       case ParquetByteType | ParquetShortType | ParquetIntegerType => value match {
@@ -649,8 +649,8 @@ class ParquetFilters(
     case _ => false
   }
 
-  private def canMakeFilterOn(name: String, value: Any, allowNull: Boolean = true): Boolean = {
-    nameToParquetField.contains(name) && valueCanMakeFilterOn(name, value, allowNull)
+  private def canMakeFilterOn(name: String, value: Any): Boolean = {
+    nameToParquetField.contains(name) && valueCanMakeFilterOn(name, value)
   }
 
   /**
@@ -700,19 +700,19 @@ class ParquetFilters(
         makeNotEq.lift(nameToParquetField(name).fieldType)
           .map(_(nameToParquetField(name).fieldNames, value))
 
-      case sources.LessThan(name, value) if canMakeFilterOn(name, value, allowNull = false) =>
+      case sources.LessThan(name, value) if (value != null) && canMakeFilterOn(name, value) =>
         makeLt.lift(nameToParquetField(name).fieldType)
           .map(_(nameToParquetField(name).fieldNames, value))
-      case sources.LessThanOrEqual(name, value)
-        if canMakeFilterOn(name, value, allowNull = false) =>
+      case sources.LessThanOrEqual(name, value) if (value != null) &&
+        canMakeFilterOn(name, value) =>
         makeLtEq.lift(nameToParquetField(name).fieldType)
           .map(_(nameToParquetField(name).fieldNames, value))
 
-      case sources.GreaterThan(name, value) if canMakeFilterOn(name, value, allowNull = false) =>
+      case sources.GreaterThan(name, value) if (value != null) && canMakeFilterOn(name, value) =>
         makeGt.lift(nameToParquetField(name).fieldType)
           .map(_(nameToParquetField(name).fieldNames, value))
-      case sources.GreaterThanOrEqual(name, value)
-        if canMakeFilterOn(name, value, allowNull = false) =>
+      case sources.GreaterThanOrEqual(name, value) if (value != null) &&
+        canMakeFilterOn(name, value) =>
         makeGtEq.lift(nameToParquetField(name).fieldType)
           .map(_(nameToParquetField(name).fieldNames, value))
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
@@ -2220,6 +2220,12 @@ abstract class ParquetFilterSuite extends QueryTest with ParquetTest with Shared
       Seq("=", ">", ">=", "<", "<=", "!=").foreach { op =>
         checkAnswer(sql(s"select * from t1 where 1=1 and d $op (select d from t2)"), Seq.empty)
       }
+      withSQLConf(SQLConf.OPTIMIZER_EXCLUDED_RULES.key ->
+        s"org.apache.spark.sql.catalyst.optimizer.NullPropagation") {
+        Seq("=", ">", ">=", "<", "<=", "!=").foreach { op =>
+          checkAnswer(sql(s"select * from t1 where d ${op} null"), Seq.empty)
+        }
+      }
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
@@ -2210,6 +2210,18 @@ abstract class ParquetFilterSuite extends QueryTest with ParquetTest with Shared
       }
     }
   }
+
+  test("SPARK-47120: subquery literal filter pushdown") {
+    withTable("t1", "t2") {
+      sql("create table t1(d date) using parquet")
+      sql("create table t2(d date) using parquet")
+      sql("insert into t1 values date'2021-01-01'")
+      sql("insert into t2 values (null)")
+      Seq("=", ">", ">=", "<", "<=", "!=").foreach { op =>
+        checkAnswer(sql(s"select * from t1 where 1=1 and d $op (select d from t2)"), Seq.empty)
+      }
+    }
+  }
 }
 
 @ExtendedSQLTest

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
@@ -2221,7 +2221,7 @@ abstract class ParquetFilterSuite extends QueryTest with ParquetTest with Shared
         checkAnswer(sql(s"select * from t1 where 1=1 and d $op (select d from t2)"), Seq.empty)
       }
       withSQLConf(SQLConf.OPTIMIZER_EXCLUDED_RULES.key ->
-        s"org.apache.spark.sql.catalyst.optimizer.NullPropagation") {
+        "org.apache.spark.sql.catalyst.optimizer.NullPropagation") {
         Seq("=", ">", ">=", "<", "<=", "!=").foreach { op =>
           checkAnswer(sql(s"select * from t1 where d ${op} null"), Seq.empty)
         }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

This issue has been introduced in https://github.com/apache/spark/pull/41088  where we convert scalar subqueries to literals and then convert the literals to org.apache.spark.sql.sources.Filters. These filters are then pushed down to parquet.

If the literal is a comparison with null then the parquet filter conversion code throws NPE. 

dateToDays does not expect null
https://github.com/apache/spark/blob/9b53b803998001e4b706666e37e5f86f900a7430/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilters.scala#L153

but Gt passes it directly
https://github.com/apache/spark/blob/9b53b803998001e4b706666e37e5f86f900a7430/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilters.scala#L403C29-L403C41


```
Caused by: scala.MatchError: null
	at org.apache.spark.sql.execution.datasources.parquet.ParquetFilters.org$apache$spark$sql$execution$datasources$parquet$ParquetFilters$$dateToDays(ParquetFilters.scala:168)
	at org.apache.spark.sql.execution.datasources.parquet.ParquetFilters$$anonfun$5.$anonfun$applyOrElse$73(ParquetFilters.scala:419)
	at org.apache.spark.sql.execution.datasources.parquet.ParquetFilters.$anonfun$createFilterHelper$9(ParquetFilters.scala:720)
	at scala.Option.map(Option.scala:230)
	at org.apache.spark.sql.execution.datasources.parquet.ParquetFilters.createFilterHelper(ParquetFilters.scala:720)
	at org.apache.spark.sql.execution.datasources.parquet.ParquetFilters.createFilter(ParquetFilters.scala:621)
	at org.apache.spark.sql.execution.datasources.parquet.ParquetFilterPredicateFactory.$anonfun$createFilter$2(ParquetFilters.scala:885)
	at scala.collection.immutable.List.flatMap(List.scala:366)
	at org.apache.spark.sql.execution.datasources.parquet.ParquetFilterPredicateFactory.createFilter(ParquetFilters.scala:885)
	at org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat$$anon$1.apply(ParquetFileFormat.scala:410)
	at org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat$$anon$1.apply(ParquetFileFormat.scala:265)
	at org.apache.spark.sql.execution.datasources.FileScanRDD$$anon$1$$anon$2.getNext(FileScanRDD.scala:601)
```

### Why are the changes needed?
NPE when subquery returns a NULL literal
NPE when comparing against a NULL literal with NullPropagation rule turned off.  

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
unit test


### Was this patch authored or co-authored using generative AI tooling?
No