### PR TITLE
[SPARK-47122][INFRA] Pin `buf-setup-action` to `v1.29.0`

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -574,8 +574,9 @@ jobs:
         git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' merge --no-commit --progress --squash FETCH_HEAD
         git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' commit -m "Merged commit" --allow-empty
     - name: Install Buf
-      uses: bufbuild/buf-setup-action@v1.29.0-1
+      uses: bufbuild/buf-setup-action@v1.29.0
       with:
+        version: 1.29.0
         github_token: ${{ secrets.GITHUB_TOKEN }}
     - name: Protocol Buffers Linter
       uses: bufbuild/buf-lint-action@v1

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -574,7 +574,7 @@ jobs:
         git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' merge --no-commit --progress --squash FETCH_HEAD
         git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' commit -m "Merged commit" --allow-empty
     - name: Install Buf
-      uses: bufbuild/buf-setup-action@v1
+      uses: bufbuild/buf-setup-action@v1.29.0-1
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
     - name: Protocol Buffers Linter


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to pin `bug-setup-action` to `v1.29.0`.

### Why are the changes needed?

To recover the broken CIs due to the latest `v1.29.0-1` issue.

- https://github.com/apache/spark/actions/runs/7995430821/job/21835769202

![Screenshot 2024-02-21 at 13 09 12](https://github.com/apache/spark/assets/9700541/4de2cbf9-bfb7-4f3c-9d77-dda043c36276)


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs on this PR. It passed already.

- https://github.com/dongjoon-hyun/spark/actions/runs/7995539640/job/21836175997

![Screenshot 2024-02-21 at 13 10 56](https://github.com/apache/spark/assets/9700541/f4ae4fa3-60c1-41f3-a839-bad8088badca)

![Screenshot 2024-02-21 at 13 12 02](https://github.com/apache/spark/assets/9700541/df5af647-5666-4fcb-b89f-c63fdcd90170)

### Was this patch authored or co-authored using generative AI tooling?

No.