### PR TITLE
[SPARK-47124][R][INFRA] Skip scheduled SparkR on Windows in fork repositories by default

### DIFF
--- a/.github/workflows/build_sparkr_window.yml
+++ b/.github/workflows/build_sparkr_window.yml
@@ -27,6 +27,7 @@ jobs:
     name: "Build module: sparkr"
     runs-on: windows-2019
     timeout-minutes: 300
+    if: github.repository == 'apache/spark'
     steps:
     - name: Download winutils Hadoop binary
       uses: actions/checkout@v4


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to skip scheduled SparkR on Windows in fork repositories by default

### Why are the changes needed?

To be consistent with other scheduled jobs. We encourage the contributors to turn this GitHub Actions on by default in forked repositories so we better disable them by default.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Manually. Uses https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idif to be consistent with other scheduled jobs.

### Was this patch authored or co-authored using generative AI tooling?

No.