### PR TITLE
[SPARK-47115][INFRA][FOLLOW-UP] Use larger runner for Maven build (macos-14-large)

### DIFF
--- a/.github/workflows/build_maven_java21_macos14.yml
+++ b/.github/workflows/build_maven_java21_macos14.yml
@@ -32,4 +32,4 @@ jobs:
     if: github.repository == 'apache/spark'
     with:
       java: 21
-      os: macos-14
+      os: macos-14-large


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR addresses https://github.com/apache/spark/pull/45195#pullrequestreview-1892229254 by using larger runner.
However, I do not change the memory at `.github/workflows/maven_test.yml` because that is shared by other standard runners.

We're using GitHub Enterprise so this runners are available.

### Why are the changes needed?

It still fails https://github.com/apache/spark/actions/runs/7994847558. My speculation is that it relates to the resources available.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Will monitor the scheduled jobs.

### Was this patch authored or co-authored using generative AI tooling?

No.