### PR TITLE
[SPARK-47127][INFRA] Update `SKIP_SPARK_RELEASE_VERSIONS` in Maven CIs

### DIFF
--- a/.github/workflows/build_maven.yml
+++ b/.github/workflows/build_maven.yml
@@ -33,5 +33,5 @@ jobs:
     with:
       envs: >-
         {
-          "SKIP_SPARK_RELEASE_VERSIONS": "3.4.2,3.5.0,3.5.1"
+          "SKIP_SPARK_RELEASE_VERSIONS": "3.4.2,3.5.1"
         }

--- a/.github/workflows/build_maven.yml
+++ b/.github/workflows/build_maven.yml
@@ -33,5 +33,5 @@ jobs:
     with:
       envs: >-
         {
-          "SKIP_SPARK_RELEASE_VERSIONS": "3.3.4,3.4.2,3.5.0"
+          "SKIP_SPARK_RELEASE_VERSIONS": "3.4.2,3.5.0,3.5.1"
         }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update `SKIP_SPARK_RELEASE_VERSIONS` in Maven CIs in order to prevent failures.

### Why are the changes needed?

- To skip newly released Apache Spark 3.5.1
- To remove deleted Apache Spark 3.3.4 and 3.5.0.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

This should be tested after merging.

### Was this patch authored or co-authored using generative AI tooling?

No.