### PR TITLE
[SPARK-47128][SQL] Improve `spark.sql.hive.metastore.sharedPrefixes` default value

### DIFF
--- a/docs/sql-data-sources-hive-tables.md
+++ b/docs/sql-data-sources-hive-tables.md
@@ -185,7 +185,9 @@ The following options can be used to configure the version of Hive that is used 
   </tr>
   <tr>
     <td><code>spark.sql.hive.metastore.sharedPrefixes</code></td>
-    <td><code>com.mysql.jdbc,<br/>org.postgresql,<br/>com.microsoft.sqlserver,<br/>oracle.jdbc</code></td>
+    <td><code>com.ibm.db2,<br/>com.microsoft.sqlserver,<br/>com.mysql.jdbc,
+      <br/>com.oracle.database.jdbc,<br/>oracle.jdbc,<br/>org.mariadb.jdbc,<br/>org.postgresql</code>
+    </td>
     <td>
       <p>
         A comma-separated list of class prefixes that should be loaded using the classloader that is

--- a/docs/sql-data-sources-hive-tables.md
+++ b/docs/sql-data-sources-hive-tables.md
@@ -186,7 +186,7 @@ The following options can be used to configure the version of Hive that is used 
   <tr>
     <td><code>spark.sql.hive.metastore.sharedPrefixes</code></td>
     <td><code>com.ibm.db2,<br/>com.microsoft.sqlserver,<br/>com.mysql.jdbc,
-      <br/>com.oracle.database.jdbc,<br/>oracle.jdbc,<br/>org.mariadb.jdbc,<br/>org.postgresql</code>
+      <br/>oracle.jdbc,<br/>org.mariadb.jdbc,<br/>org.postgresql</code>
     </td>
     <td>
       <p>

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
@@ -183,7 +183,13 @@ private[spark] object HiveUtils extends Logging {
     .createWithDefault(jdbcPrefixes)
 
   private def jdbcPrefixes = Seq(
-    "com.mysql.jdbc", "org.postgresql", "com.microsoft.sqlserver", "oracle.jdbc")
+    "com.ibm.db2",
+    "com.microsoft.sqlserver",
+    "com.mysql.jdbc",
+    "com.oracle.database.jdbc",
+    "oracle.jdbc",
+    "org.mariadb.jdbc",
+    "org.postgresql")
 
   val HIVE_METASTORE_BARRIER_PREFIXES = buildStaticConf("spark.sql.hive.metastore.barrierPrefixes")
     .doc("A comma separated list of class prefixes that should explicitly be reloaded for each " +

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
@@ -186,7 +186,6 @@ private[spark] object HiveUtils extends Logging {
     "com.ibm.db2",
     "com.microsoft.sqlserver",
     "com.mysql.jdbc",
-    "com.oracle.database.jdbc",
     "oracle.jdbc",
     "org.mariadb.jdbc",
     "org.postgresql")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to improve the default value of `spark.sql.hive.metastore.sharedPrefixes` configuration by enumerating the following JDBC prefixes.

- `com.ibm.db2` (Added, SPARK-31272)
- `com.microsoft.sqlserver` (Unchanged)
- `com.mysql.jdbc` (Unchanged)
- `oracle.jdbc` (Unchanged)
- `org.mariadb.jdbc` (Added, SPARK-31021)
- `org.postgresql` (Unchanged)

### Why are the changes needed?

Although Apache Spark maintains the test coverage of RDBMSes, some prefixes are missed.

For example, the latest `MariaDB` and `IBM` drivers are missing.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.