### PR TITLE
[SPARK-47127][INFRA][FOLLOWUP] Remove `3.5.1` from `SKIP_SPARK_RELEASE_VERSIONS` 

### DIFF
--- a/.github/workflows/build_maven.yml
+++ b/.github/workflows/build_maven.yml
@@ -33,5 +33,5 @@ jobs:
     with:
       envs: >-
         {
-          "SKIP_SPARK_RELEASE_VERSIONS": "3.4.2,3.5.1"
+          "SKIP_SPARK_RELEASE_VERSIONS": "3.4.2"
         }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to remove `3.5.1` from `SKIP_SPARK_RELEASE_VERSIONS(build_maven.yml)`  to restore test of `HiveExternalCatalogVersionsSuite` using maven with Spark 3.5.x.

### Why are the changes needed?
SPARK-46400 | https://github.com/apache/spark/pull/45017 has already merged into Spark 3.5.1, and the corresponding issue no longer exists for Spark 3.5.1 + 


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Monitor maven daily test after merged.


### Was this patch authored or co-authored using generative AI tooling?
NO
