### PR TITLE
[SPARK-43259][SQL][FOLLOWUP] Regenerate `sql-error-conditions.md` to recover `SparkThrowableSuite`

### DIFF
--- a/docs/sql-error-conditions.md
+++ b/docs/sql-error-conditions.md
@@ -1148,7 +1148,7 @@ Please increase executor memory using the --executor-memory option or "`<config>
 
 [SQLSTATE: 42001](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
 
-Found an invalid expression encoder. Expects an instance of `ExpressionEncoder` but got `<encoderType>`. For more information consult '`<docroot>`/api/java/index.html?org/apache/spark/sql/Encoder.html'.
+Found an invalid expression encoder. Expects an instance of ExpressionEncoder but got `<encoderType>`. For more information consult '`<docroot>`/api/java/index.html?org/apache/spark/sql/Encoder.html'.
 
 ### INVALID_EXTRACT_BASE_FIELD_TYPE
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up of #45095

### Why are the changes needed?

To recover the broken `master` branch.
- https://github.com/apache/spark/actions/runs/8008631301/job/21875499011

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

I manually verified like the following.
```
[info] SparkThrowableSuite:
[info] - No duplicate error classes (23 milliseconds)
[info] - Error classes are correctly formatted (37 milliseconds)
[info] - SQLSTATE is mandatory (1 millisecond)
[info] - Error category and error state / SQLSTATE invariants (21 milliseconds)
[info] - Message invariants (6 milliseconds)
[info] - Message format invariants (9 milliseconds)
[info] - Error classes match with document (54 milliseconds)
[info] - Round trip (23 milliseconds)
[info] - Error class names should contain only capital letters, numbers and underscores (5 milliseconds)
[info] - Check if error class is missing (14 milliseconds)
[info] - Check if message parameters match message format (2 milliseconds)
[info] - Error message is formatted (0 milliseconds)
[info] - Error message does not do substitution on values (0 milliseconds)
[info] - Try catching legacy SparkError (1 millisecond)
[info] - Try catching SparkError with error class (1 millisecond)
[info] - Try catching internal SparkError (1 millisecond)
[info] - Get message in the specified format (3 milliseconds)
[info] - overwrite error classes (47 milliseconds)
[info] - prohibit dots in error class names (15 milliseconds)
[info] Run completed in 1 second, 90 milliseconds.
[info] Total number of tests run: 19
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 19, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 7 s, completed Feb 22, 2024, 5:22:24 PM
```

### Was this patch authored or co-authored using generative AI tooling?

No.