### PR TITLE
[SPARK-47141][CORE] Support enabling migration of shuffle data directly to external storage using config parameter.

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkEnv.scala
+++ b/core/src/main/scala/org/apache/spark/SparkEnv.scala
@@ -390,6 +390,10 @@ object SparkEnv extends Logging {
       new MapOutputTrackerMasterEndpoint(
         rpcEnv, mapOutputTracker.asInstanceOf[MapOutputTrackerMaster], conf))
 
+    if (conf.get(STORAGE_FALLBACK_STORAGE_NUM_THREADS_FOR_SHUFFLE_READ).isEmpty) {
+      conf.set(STORAGE_FALLBACK_STORAGE_NUM_THREADS_FOR_SHUFFLE_READ, numUsableCores * 2)
+    }
+
     val blockManagerPort = if (isDriver) {
       conf.get(DRIVER_BLOCK_MANAGER_PORT)
     } else {

--- a/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
+++ b/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
@@ -314,6 +314,7 @@ private[spark] class CoarseGrainedExecutorBackend(
     logInfo(msg)
     try {
       decommissioned = true
+      val startTime = System.nanoTime()
       val migrationEnabled = env.conf.get(STORAGE_DECOMMISSION_ENABLED) &&
         (env.conf.get(STORAGE_DECOMMISSION_RDD_BLOCKS_ENABLED) ||
           env.conf.get(STORAGE_DECOMMISSION_SHUFFLE_BLOCKS_ENABLED))
@@ -354,7 +355,8 @@ private[spark] class CoarseGrainedExecutorBackend(
                 // We can only trust allBlocksMigrated boolean value if there were no tasks running
                 // since the start of computing it.
                 if (allBlocksMigrated && (migrationTime > lastTaskFinishTime.get())) {
-                  logInfo("No running tasks, all blocks migrated, stopping.")
+                  val timeTakenMs = (System.nanoTime() - startTime) / (1000 * 1000)
+                  logInfo(s"No running tasks, all blocks migrated in $timeTakenMs ms, stopping.")
                   exitExecutor(0, ExecutorLossMessage.decommissionFinished, notifyDriver = true)
                 } else {
                   logInfo("All blocks not yet migrated.")

--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -51,7 +51,7 @@ import org.apache.spark.scheduler._
 import org.apache.spark.serializer.SerializerHelper
 import org.apache.spark.shuffle.{FetchFailedException, ShuffleBlockPusher}
 import org.apache.spark.status.api.v1.ThreadStackTrace
-import org.apache.spark.storage.{StorageLevel, TaskResultBlockId}
+import org.apache.spark.storage.{FallbackStorage, StorageLevel, TaskResultBlockId}
 import org.apache.spark.util._
 import org.apache.spark.util.ArrayImplicits._
 
@@ -447,6 +447,7 @@ private[spark] class Executor(
           plugins.foreach(_.shutdown())
         }
       }
+      FallbackStorage.stopThreadPool(conf)
       if (!isLocal) {
         env.stop()
       }

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -552,16 +552,16 @@ package object config {
       .createOptional
 
   private[spark] val STORAGE_FALLBACK_STORAGE_NUM_THREADS_FOR_SHUFFLE_READ =
-    ConfigBuilder("spark.storage.fallbackStorage.num.threads.for.shuffle.read")
+    ConfigBuilder("spark.storage.fallbackStorage.numThreadsForShuffleRead")
       .doc("Number of threads to be used for reading shuffle data from external storage. If it" +
         " is not set, then number of cores set for executor will be used.")
       .version("4.0.0")
       .intConf
       .createOptional
 
-  private[spark] val STORAGE_DECOMMISSION_MIGRATE_TO_STORAGE =
-    ConfigBuilder("spark.storage.decommission.migrate.to.storage")
-      .doc("If true, Migrate the shuffle data directly to fallback storage during" +
+  private[spark] val STORAGE_DECOMMISSION_MIGRATE_TO_EXTERNAL_STORAGE =
+    ConfigBuilder("spark.storage.decommission.migrateToExternalStorage")
+      .doc("If true, Migrate the shuffle data directly to external storage during" +
         " node decommissioning.")
       .version("4.0.0")
       .booleanConf

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -551,6 +551,22 @@ package object config {
       .checkValue(_.endsWith(java.io.File.separator), "Path should end with separator.")
       .createOptional
 
+  private[spark] val STORAGE_FALLBACK_STORAGE_NUM_THREADS_FOR_SHUFFLE_READ =
+    ConfigBuilder("spark.storage.fallbackStorage.num.threads.for.shuffle.read")
+      .doc("Number of threads to be used for reading shuffle data from external storage. If it" +
+        " is not set, then number of cores set for executor will be used.")
+      .version("4.0.0")
+      .intConf
+      .createOptional
+
+  private[spark] val STORAGE_DECOMMISSION_MIGRATE_TO_STORAGE =
+    ConfigBuilder("spark.storage.decommission.migrate.to.storage")
+      .doc("If true, Migrate the shuffle data directly to fallback storage during" +
+        " node decommissioning.")
+      .version("4.0.0")
+      .booleanConf
+      .createWithDefault(false)
+
   private[spark] val STORAGE_DECOMMISSION_FALLBACK_STORAGE_CLEANUP =
     ConfigBuilder("spark.storage.decommission.fallbackStorage.cleanUp")
       .doc("If true, Spark cleans up its fallback storage data during shutting down.")

--- a/core/src/main/scala/org/apache/spark/storage/BlockManagerDecommissioner.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManagerDecommissioner.scala
@@ -309,7 +309,7 @@ private[storage] class BlockManagerDecommissioner(
     }
 
     // Update the threads doing migrations
-    if (conf.get(config.STORAGE_DECOMMISSION_MIGRATE_TO_STORAGE) &&
+    if (conf.get(config.STORAGE_DECOMMISSION_MIGRATE_TO_EXTERNAL_STORAGE) &&
       conf.get(config.STORAGE_DECOMMISSION_FALLBACK_STORAGE_PATH).isDefined) {
       val numThread = conf.get(config.STORAGE_DECOMMISSION_SHUFFLE_MAX_THREADS)
       logInfo(s"Migrating to external storage location " +

--- a/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
+++ b/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
@@ -373,7 +373,7 @@ final class ShuffleBlockFetcherIterator(
 
     if (req.address.executorId == FallbackStorage.FALLBACK_BLOCK_MANAGER_ID.executorId) {
       assert(fallbackStorage.isDefined)
-      fallbackStorage.get.fetchBlocks(blockManager, req.blocks, req.address, blockFetchingListener)
+      fallbackStorage.get.fetchBlocks(req.blocks, req.address, blockFetchingListener)
     }
     // Fetch remote shuffle blocks to disk when the request is too large. Since the shuffle data is
     // already encrypted and compressed over the wire(w.r.t. the related configs), we can just fetch

--- a/core/src/test/scala/org/apache/spark/shuffle/BlockStoreShuffleReaderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/shuffle/BlockStoreShuffleReaderSuite.scala
@@ -21,7 +21,7 @@ import java.io.{ByteArrayOutputStream, InputStream}
 import java.nio.ByteBuffer
 
 import org.mockito.ArgumentMatchers.{eq => meq}
-import org.mockito.Mockito.{mock, when}
+import org.mockito.Mockito.{doReturn, mock, when}
 
 import org.apache.spark._
 import org.apache.spark.internal.config
@@ -76,6 +76,7 @@ class BlockStoreShuffleReaderSuite extends SparkFunSuite with LocalSparkContext 
     // Make a mock BlockManager that will return RecordingManagedByteBuffers of data, so that we
     // can ensure retain() and release() are properly called.
     val blockManager = mock(classOf[BlockManager])
+    doReturn(testConf).when(blockManager).conf
 
     // Create a buffer with some randomly generated key-value pairs to use as the shuffle data
     // from each mappers (all mappers return the same shuffle data).

--- a/core/src/test/scala/org/apache/spark/storage/FallbackStorageSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/FallbackStorageSuite.scala
@@ -176,7 +176,7 @@ class FallbackStorageSuite extends SparkFunSuite with LocalSparkContext {
       val conf = new SparkConf(false)
         .set("spark.app.id", "testId")
         .set(STORAGE_DECOMMISSION_SHUFFLE_BLOCKS_ENABLED, true)
-        .set(STORAGE_DECOMMISSION_MIGRATE_TO_STORAGE, migrateToStorage)
+        .set(STORAGE_DECOMMISSION_MIGRATE_TO_EXTERNAL_STORAGE, migrateToStorage)
         .set(STORAGE_DECOMMISSION_FALLBACK_STORAGE_PATH,
           Files.createTempDirectory("tmp").toFile.getAbsolutePath + "/")
 

--- a/core/src/test/scala/org/apache/spark/storage/FallbackStorageSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/FallbackStorageSuite.scala
@@ -172,61 +172,64 @@ class FallbackStorageSuite extends SparkFunSuite with LocalSparkContext {
   }
 
   test("migrate shuffle data to fallback storage") {
-    val conf = new SparkConf(false)
-      .set("spark.app.id", "testId")
-      .set(STORAGE_DECOMMISSION_SHUFFLE_BLOCKS_ENABLED, true)
-      .set(STORAGE_DECOMMISSION_FALLBACK_STORAGE_PATH,
-        Files.createTempDirectory("tmp").toFile.getAbsolutePath + "/")
+    Seq(true, false).foreach { migrateToStorage =>
+      val conf = new SparkConf(false)
+        .set("spark.app.id", "testId")
+        .set(STORAGE_DECOMMISSION_SHUFFLE_BLOCKS_ENABLED, true)
+        .set(STORAGE_DECOMMISSION_MIGRATE_TO_STORAGE, migrateToStorage)
+        .set(STORAGE_DECOMMISSION_FALLBACK_STORAGE_PATH,
+          Files.createTempDirectory("tmp").toFile.getAbsolutePath + "/")
 
-    val ids = Set((1, 1L, 1))
-    val bm = mock(classOf[BlockManager])
-    val dbm = new DiskBlockManager(conf, deleteFilesOnStop = false, isDriver = false)
-    when(bm.diskBlockManager).thenReturn(dbm)
-    val indexShuffleBlockResolver = new IndexShuffleBlockResolver(conf, bm)
-    val indexFile = indexShuffleBlockResolver.getIndexFile(1, 1L)
-    val dataFile = indexShuffleBlockResolver.getDataFile(1, 1L)
-    indexFile.createNewFile()
-    dataFile.createNewFile()
+      val ids = Set((1, 1L, 1))
+      val bm = mock(classOf[BlockManager])
+      val dbm = new DiskBlockManager(conf, deleteFilesOnStop = false, isDriver = false)
+      when(bm.diskBlockManager).thenReturn(dbm)
+      val indexShuffleBlockResolver = new IndexShuffleBlockResolver(conf, bm)
+      val indexFile = indexShuffleBlockResolver.getIndexFile(1, 1L)
+      val dataFile = indexShuffleBlockResolver.getDataFile(1, 1L)
+      indexFile.createNewFile()
+      dataFile.createNewFile()
 
-    val resolver = mock(classOf[IndexShuffleBlockResolver])
-    when(resolver.getStoredShuffles())
-      .thenReturn(ids.map(triple => ShuffleBlockInfo(triple._1, triple._2)).toSeq)
-    ids.foreach { case (shuffleId: Int, mapId: Long, reduceId: Int) =>
-      when(resolver.getMigrationBlocks(mc.any()))
-        .thenReturn(List(
-          (ShuffleIndexBlockId(shuffleId, mapId, reduceId), mock(classOf[ManagedBuffer])),
-          (ShuffleDataBlockId(shuffleId, mapId, reduceId), mock(classOf[ManagedBuffer]))))
-      when(resolver.getIndexFile(shuffleId, mapId)).thenReturn(indexFile)
-      when(resolver.getDataFile(shuffleId, mapId)).thenReturn(dataFile)
-    }
-
-    when(bm.getPeers(mc.any()))
-      .thenReturn(Seq(FallbackStorage.FALLBACK_BLOCK_MANAGER_ID))
-    val bmm = new BlockManagerMaster(new NoopRpcEndpointRef(conf), null, conf, false)
-    when(bm.master).thenReturn(bmm)
-    val blockTransferService = mock(classOf[BlockTransferService])
-    when(blockTransferService.uploadBlockSync(mc.any(), mc.any(), mc.any(), mc.any(), mc.any(),
-      mc.any(), mc.any())).thenThrow(new IOException)
-    when(bm.blockTransferService).thenReturn(blockTransferService)
-    when(bm.migratableResolver).thenReturn(resolver)
-    when(bm.getMigratableRDDBlocks()).thenReturn(Seq())
-
-    val decommissioner = new BlockManagerDecommissioner(conf, bm)
-
-    try {
-      decommissioner.start()
-      val fallbackStorage = new FallbackStorage(conf)
-      eventually(timeout(10.second), interval(1.seconds)) {
-        // uploadBlockSync should not be used, verify that it is not called
-        verify(blockTransferService, never())
-          .uploadBlockSync(mc.any(), mc.any(), mc.any(), mc.any(), mc.any(), mc.any(), mc.any())
-
-        Seq("shuffle_1_1_0.index", "shuffle_1_1_0.data").foreach { filename =>
-          assert(fallbackStorage.exists(shuffleId = 1, filename))
-        }
+      val resolver = mock(classOf[IndexShuffleBlockResolver])
+      when(resolver.getStoredShuffles())
+        .thenReturn(ids.map(triple => ShuffleBlockInfo(triple._1, triple._2)).toSeq)
+      ids.foreach { case (shuffleId: Int, mapId: Long, reduceId: Int) =>
+        when(resolver.getMigrationBlocks(mc.any()))
+          .thenReturn(List(
+            (ShuffleIndexBlockId(shuffleId, mapId, reduceId), mock(classOf[ManagedBuffer])),
+            (ShuffleDataBlockId(shuffleId, mapId, reduceId), mock(classOf[ManagedBuffer]))))
+        when(resolver.getIndexFile(shuffleId, mapId)).thenReturn(indexFile)
+        when(resolver.getDataFile(shuffleId, mapId)).thenReturn(dataFile)
       }
-    } finally {
-      decommissioner.stop()
+
+      when(bm.getPeers(mc.any()))
+        .thenReturn(Seq(FallbackStorage.FALLBACK_BLOCK_MANAGER_ID))
+      val bmm = new BlockManagerMaster(new NoopRpcEndpointRef(conf), null, conf, false)
+      when(bm.master).thenReturn(bmm)
+      val blockTransferService = mock(classOf[BlockTransferService])
+      when(blockTransferService.uploadBlockSync(mc.any(), mc.any(), mc.any(), mc.any(), mc.any(),
+        mc.any(), mc.any())).thenThrow(new IOException)
+      when(bm.blockTransferService).thenReturn(blockTransferService)
+      when(bm.migratableResolver).thenReturn(resolver)
+      when(bm.getMigratableRDDBlocks()).thenReturn(Seq())
+
+      val decommissioner = new BlockManagerDecommissioner(conf, bm)
+
+      try {
+        decommissioner.start()
+        val fallbackStorage = FallbackStorage.getFallbackStorage(conf).get
+        eventually(timeout(10.second), interval(1.seconds)) {
+          // uploadBlockSync should not be used, verify that it is not called
+          verify(blockTransferService, never())
+            .uploadBlockSync(mc.any(), mc.any(), mc.any(), mc.any(), mc.any(), mc.any(), mc.any())
+
+          Seq("shuffle_1_1_0.index", "shuffle_1_1_0.data").foreach { filename =>
+            assert(fallbackStorage.exists(shuffleId = 1, filename))
+          }
+        }
+      } finally {
+        decommissioner.stop()
+      }
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
@@ -562,7 +562,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       // Make sure we release buffers when a wrapped input stream is closed.
       // for external storage shuffle, it is read directly from file and not using
       // mock transfer.
-      if (!blockId.name.startsWith("shuffle_0_5")) {
+      if (mergedExternalBlocks.keys.forall(_ != blockId)) {
         val mockBuf = allBlocks(blockId)
         verifyBufferRelease(mockBuf, inputStream)
       }

--- a/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
@@ -496,7 +496,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
     val mergedLocalBlocks = Map[BlockId, ManagedBuffer](
       ShuffleBlockBatchId(0, 0, 0, 3) -> createMockManagedBuffer())
     mergedLocalBlocks.foreach { case (blockId, buf) =>
-      doReturn(buf).when(blockManager).getLocalBlockData(meq(blockId))
+      doReturn(buf).when(blockManager).getLocalBlockData(blockId)
     }
 
     // Make sure remote blocks would return the merged block
@@ -549,9 +549,8 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       doBatchFetch = true
     )
 
-    // 3 local blocks fetched in initialization and one external
-    // storage batch fetched by thread pool
-    verify(blockManager, times(2)).getLocalBlockData(any())
+    // 3 local blocks batch fetched in initialization
+    verify(blockManager, times(1)).getLocalBlockData(any())
 
     val allBlocks = mergedLocalBlocks ++ mergedRemoteBlocks ++
       mergedHostLocalBlocks ++ mergedExternalBlocks


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
This PR exposes a config allowing user to migrate the shuffle data directly to external storage. Changes are made to migrate the data in multiple thread to reduce the migration time. Similarly, the reading of shuffle data from external storage is done using multiple thread. Configuration parameter is added to control the number of threads to be used for reading shuffle data.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
Currently Spark supports migration of shuffle data to peer nodes during node decommissioning. If peer nodes are not accessible, then Spark falls back to external storage. User needs to provide the storage location path. There are scenarios where user may want to migrate to external storage instead of peer nodes. This may be because of unstable nodes or due to the need of aggressive scale down. So, user should be able to configure to migrate the shuffle data directly to external storage if the use case permits. 
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, now user can enable migrating shuffle data directly to external storage and also control the number of threads used for reading shuffle data from external storage.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New Unit tests are added.
Made sure that existing tests are passing.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No