### PR TITLE
[SPARK-47143][CONNECT][TESTS] Improve `ArtifactSuite` to use unique `MavenCoordinate`s

### DIFF
--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/ArtifactSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/ArtifactSuite.scala
@@ -273,14 +273,14 @@ class ArtifactSuite extends ConnectFunSuite with BeforeAndAfterEach {
   }
 
   test("resolve ivy") {
-    val main = new MavenCoordinate("my.great.lib", "mylib", "0.1")
-    val dep = "my.great.dep:mydep:0.5"
+    val main = new MavenCoordinate("my.artifactsuite.lib", "mylib", "0.1")
+    val dep = "my.artifactsuite.dep:mydep:0.5"
     IvyTestUtils.withRepository(main, Some(dep), None) { repo =>
       val artifacts =
-        Artifact.newIvyArtifacts(URI.create(s"ivy://my.great.lib:mylib:0.1?repos=$repo"))
-      assert(artifacts.exists(_.path.toString.contains("jars/my.great.lib_mylib-0.1.jar")))
+        Artifact.newIvyArtifacts(URI.create(s"ivy://my.artifactsuite.lib:mylib:0.1?repos=$repo"))
+      assert(artifacts.exists(_.path.toString.contains("jars/my.artifactsuite.lib_mylib-0.1.jar")))
       // transitive dependency
-      assert(artifacts.exists(_.path.toString.contains("jars/my.great.dep_mydep-0.5.jar")))
+      assert(artifacts.exists(_.path.toString.contains("jars/my.artifactsuite.dep_mydep-0.5.jar")))
     }
 
   }

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/ArtifactSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/ArtifactSuite.scala
@@ -278,9 +278,11 @@ class ArtifactSuite extends ConnectFunSuite with BeforeAndAfterEach {
     IvyTestUtils.withRepository(main, Some(dep), None) { repo =>
       val artifacts =
         Artifact.newIvyArtifacts(URI.create(s"ivy://my.artifactsuite.lib:mylib:0.1?repos=$repo"))
-      assert(artifacts.exists(_.path.toString.contains("jars/my.artifactsuite.lib_mylib-0.1.jar")))
+      assert(
+        artifacts.exists(_.path.toString.contains("jars/my.artifactsuite.lib_mylib-0.1.jar")))
       // transitive dependency
-      assert(artifacts.exists(_.path.toString.contains("jars/my.artifactsuite.dep_mydep-0.5.jar")))
+      assert(
+        artifacts.exists(_.path.toString.contains("jars/my.artifactsuite.dep_mydep-0.5.jar")))
     }
 
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to improve `ArtifactSuite` to use unique `MavenCoordinate`s.

### Why are the changes needed?

`MavenCoordinate("my.great.lib", "mylib", "0.1")` is used in many places. However, `ArtifactSuite` uses it differently to check transitive dependencies. Sometimes, the other suites' leftover causes a test case failure. We had better use unique artifact name in this case in order to isolate completely.

```
$ git grep 'MavenCoordinate("my.great.lib", "mylib", "0.1")'
common/utils/src/test/scala/org/apache/spark/util/MavenUtilsSuite.scala:    val main = new MavenCoordinate("my.great.lib", "mylib", "0.1")
common/utils/src/test/scala/org/apache/spark/util/MavenUtilsSuite.scala:    val main = new MavenCoordinate("my.great.lib", "mylib", "0.1")
common/utils/src/test/scala/org/apache/spark/util/MavenUtilsSuite.scala:    val main = new MavenCoordinate("my.great.lib", "mylib", "0.1")
common/utils/src/test/scala/org/apache/spark/util/MavenUtilsSuite.scala:    val main = new MavenCoordinate("my.great.lib", "mylib", "0.1")
common/utils/src/test/scala/org/apache/spark/util/MavenUtilsSuite.scala:    val main = MavenCoordinate("my.great.lib", "mylib", "0.1")
connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/application/ReplE2ESuite.scala:    val main = MavenCoordinate("my.great.lib", "mylib", "0.1")
core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala:    val main = MavenCoordinate("my.great.lib", "mylib", "0.1")
core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala:    val main = MavenCoordinate("my.great.lib", "mylib", "0.1")
core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala:    val main = MavenCoordinate("my.great.lib", "mylib", "0.1")
core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala:    val main = MavenCoordinate("my.great.lib", "mylib", "0.1")
```

### Does this PR introduce _any_ user-facing change?

No. This is a test-case only change.

### How was this patch tested?

Manual review because this passed the CIs in general.

### Was this patch authored or co-authored using generative AI tooling?

No.