### PR TITLE
[SPARK-47099][SQL][FOLLOWUP] Regenerate `try_arithmetic.sql.out.java21`

### DIFF
--- a/sql/core/src/test/resources/sql-tests/results/try_arithmetic.sql.out.java21
+++ b/sql/core/src/test/resources/sql-tests/results/try_arithmetic.sql.out.java21
@@ -171,7 +171,7 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
   "messageParameters" : {
     "inputSql" : "\"INTERVAL '2' YEAR\"",
     "inputType" : "\"INTERVAL YEAR\"",
-    "paramIndex" : "1",
+    "paramIndex" : "first",
     "requiredType" : "\"(TIMESTAMP OR TIMESTAMP WITHOUT TIME ZONE)\"",
     "sqlExpr" : "\"INTERVAL '2' YEAR + INTERVAL '02' SECOND\""
   },


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up of #45177

### Why are the changes needed?

To recover Java 21 Daily CI.
- https://github.com/apache/spark/actions/workflows/build_maven_java21.yml
  - https://github.com/apache/spark/actions/runs/8020316098/job/21917446965

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manually with Java 21.

```
$ build/sbt "sql/testOnly *.SQLQueryTestSuite -- -z try_arithmetic"
Using /Users/dongjoon/.jenv/versions/21 as default JAVA_HOME.
Note, this will be overridden by -java-home if it is set.
Using SPARK_LOCAL_IP=localhost
[info] welcome to sbt 1.9.3 (Apple Inc. Java 21.0.2)
...
[info] SQLQueryTestSuite:
12:33:19.091 WARN org.apache.hadoop.util.NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
[info] - ansi/try_arithmetic.sql (1 second, 37 milliseconds)
[info] - ansi/try_arithmetic.sql_analyzer_test (114 milliseconds)
[info] - try_arithmetic.sql (688 milliseconds)
[info] - try_arithmetic.sql_analyzer_test (93 milliseconds)
12:33:24.980 WARN org.apache.spark.sql.SQLQueryTestSuite:
=== Metrics of Analyzer/Optimizer Rules ===
Total number of runs: 75794
Total time: 0.335704411 seconds

Rule                                                                                  Effective Time / Total Time                     Effective Runs / Total Runs

org.apache.spark.sql.catalyst.optimizer.ConstantFolding                               59501877 / 60217667                             108 / 336
org.apache.spark.sql.catalyst.analysis.An...
12:33:24.981 WARN org.apache.spark.sql.SQLQueryTestSuite:
=== Metrics of Whole-stage Codegen ===
Total code generation time: 0.051986919 seconds
Total compile time: 0.116905665 seconds

12:33:25.012 WARN org.apache.spark.sql.SQLQueryTestSuite:

===== POSSIBLE THREAD LEAK IN SUITE o.a.s.sql.SQLQueryTestSuite, threads: QueryStageCreator-0 (daemon=true), Idle Worker Monitor for python3 (daemon=true), rpc-boss-3-1 (daemon=true), process reaper (pid 15500) (daemon=true), ForkJoinPool.commonPool-worker-3 (daemon=true), ForkJoinPool.commonPool-worker-2 (daemon=true), shuffle-boss-6-1 (daemon=true), ForkJoinPool.commonPool-worker-1 (daemon=true) =====
[info] Run completed in 8 seconds, 79 milliseconds.
[info] Total number of tests run: 4
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 4, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 118 s (01:58), completed Feb 23, 2024, 12:33:25 PM
```

### Was this patch authored or co-authored using generative AI tooling?

No.
