### PR TITLE
[SPARK-47208][CORE] Allow overriding base overhead memory

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -375,7 +375,6 @@ package object config {
     .bytesConf(ByteUnit.MiB)
     .createOptional
 
-
   private[spark] val EXECUTOR_MEMORY_OVERHEAD_FACTOR =
     ConfigBuilder("spark.executor.memoryOverheadFactor")
       .doc("Fraction of executor memory to be allocated as additional non-heap memory per " +

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -117,6 +117,14 @@ package object config {
     .bytesConf(ByteUnit.MiB)
     .createOptional
 
+  private[spark] val DRIVER_MIN_MEMORY_OVERHEAD = ConfigBuilder("spark.driver.minMemoryOverhead")
+    .doc("The minimum amount of non-heap memory to be allocated per driver in cluster mode, " +
+      "in MiB unless otherwise specified. Overrides the default value of 384Mib." +
+      " This value is ignored if spark.driver.memoryOverhead is set directly.")
+    .version("3.5.0")
+    .bytesConf(ByteUnit.MiB)
+    .createOptional
+
   private[spark] val DRIVER_MEMORY_OVERHEAD_FACTOR =
     ConfigBuilder("spark.driver.memoryOverheadFactor")
       .doc("Fraction of driver memory to be allocated as additional non-heap memory per driver " +
@@ -357,6 +365,16 @@ package object config {
     .version("2.3.0")
     .bytesConf(ByteUnit.MiB)
     .createOptional
+
+  private[spark] val EXECUTOR_MIN_MEMORY_OVERHEAD =
+    ConfigBuilder("spark.executor.minMemoryOverhead")
+    .doc("The minimum amount of non-heap memory to be allocated per executor " +
+      "in MiB unless otherwise specified. Overrides the default value of 384Mib." +
+      " This value is ignored if spark.executor.memoryOverhead is set directly.")
+    .version("3.5.0")
+    .bytesConf(ByteUnit.MiB)
+    .createOptional
+
 
   private[spark] val EXECUTOR_MEMORY_OVERHEAD_FACTOR =
     ConfigBuilder("spark.executor.memoryOverheadFactor")

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -121,7 +121,7 @@ package object config {
     .doc("The minimum amount of non-heap memory to be allocated per driver in cluster mode, " +
       "in MiB unless otherwise specified. Overrides the default value of 384Mib." +
       " This value is ignored if spark.driver.memoryOverhead is set directly.")
-    .version("3.5.0")
+    .version("3.5.2")
     .bytesConf(ByteUnit.MiB)
     .createOptional
 
@@ -371,7 +371,7 @@ package object config {
     .doc("The minimum amount of non-heap memory to be allocated per executor " +
       "in MiB unless otherwise specified. Overrides the default value of 384Mib." +
       " This value is ignored if spark.executor.memoryOverhead is set directly.")
-    .version("3.5.0")
+    .version("3.5.2")
     .bytesConf(ByteUnit.MiB)
     .createOptional
 

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -119,11 +119,11 @@ package object config {
 
   private[spark] val DRIVER_MIN_MEMORY_OVERHEAD = ConfigBuilder("spark.driver.minMemoryOverhead")
     .doc("The minimum amount of non-heap memory to be allocated per driver in cluster mode, " +
-      "in MiB unless otherwise specified. Overrides the default value of 384Mib." +
-      " This value is ignored if spark.driver.memoryOverhead is set directly.")
-    .version("3.5.2")
+      "in MiB unless otherwise specified. This value is ignored if " +
+      "spark.driver.memoryOverhead is set directly.")
+    .version("4.0.0")
     .bytesConf(ByteUnit.MiB)
-    .createOptional
+    .createWithDefaultString("384m")
 
   private[spark] val DRIVER_MEMORY_OVERHEAD_FACTOR =
     ConfigBuilder("spark.driver.memoryOverheadFactor")
@@ -369,11 +369,11 @@ package object config {
   private[spark] val EXECUTOR_MIN_MEMORY_OVERHEAD =
     ConfigBuilder("spark.executor.minMemoryOverhead")
     .doc("The minimum amount of non-heap memory to be allocated per executor " +
-      "in MiB unless otherwise specified. Overrides the default value of 384Mib." +
-      " This value is ignored if spark.executor.memoryOverhead is set directly.")
-    .version("3.5.2")
+      "in MiB unless otherwise specified. This value is ignored if " +
+      "spark.executor.memoryOverhead is set directly.")
+    .version("4.0.0")
     .bytesConf(ByteUnit.MiB)
-    .createOptional
+    .createWithDefaultString("384m")
 
   private[spark] val EXECUTOR_MEMORY_OVERHEAD_FACTOR =
     ConfigBuilder("spark.executor.memoryOverheadFactor")

--- a/core/src/main/scala/org/apache/spark/resource/ResourceProfile.scala
+++ b/core/src/main/scala/org/apache/spark/resource/ResourceProfile.scala
@@ -489,13 +489,11 @@ object ResourceProfile extends Logging {
 
   private[spark] def calculateOverHeadMemory(
       overHeadMemFromConf: Option[Long],
-      minimumOverHeadMemoryFromConf: Option[Long],
+      minimumOverHeadMemoryFromConf: Long,
       executorMemoryMiB: Long,
       overheadFactor: Double): Long = {
-    val minMemoryOverhead =
-      minimumOverHeadMemoryFromConf.getOrElse(ResourceProfile.MEMORY_OVERHEAD_MIN_MIB);
     overHeadMemFromConf.getOrElse(math.max((overheadFactor * executorMemoryMiB).toInt,
-      minMemoryOverhead))
+      minimumOverHeadMemoryFromConf))
   }
 
   /**
@@ -507,7 +505,7 @@ object ResourceProfile extends Logging {
   private[spark] def getResourcesForClusterManager(
       rpId: Int,
       execResources: Map[String, ExecutorResourceRequest],
-      minimumOverheadMemory: Option[Long],
+      minimumOverheadMemory: Long,
       overheadFactor: Double,
       conf: SparkConf,
       isPythonApp: Boolean,

--- a/core/src/main/scala/org/apache/spark/resource/ResourceProfile.scala
+++ b/core/src/main/scala/org/apache/spark/resource/ResourceProfile.scala
@@ -489,10 +489,13 @@ object ResourceProfile extends Logging {
 
   private[spark] def calculateOverHeadMemory(
       overHeadMemFromConf: Option[Long],
+      minimumOverHeadMemoryFromConf: Option[Long],
       executorMemoryMiB: Long,
       overheadFactor: Double): Long = {
+    val minMemoryOverhead =
+      minimumOverHeadMemoryFromConf.getOrElse(ResourceProfile.MEMORY_OVERHEAD_MIN_MIB);
     overHeadMemFromConf.getOrElse(math.max((overheadFactor * executorMemoryMiB).toInt,
-        ResourceProfile.MEMORY_OVERHEAD_MIN_MIB))
+      minMemoryOverhead))
   }
 
   /**
@@ -504,6 +507,7 @@ object ResourceProfile extends Logging {
   private[spark] def getResourcesForClusterManager(
       rpId: Int,
       execResources: Map[String, ExecutorResourceRequest],
+      minimumOverheadMemory: Option[Long],
       overheadFactor: Double,
       conf: SparkConf,
       isPythonApp: Boolean,
@@ -515,7 +519,7 @@ object ResourceProfile extends Logging {
     var memoryOffHeapMiB = defaultResources.memoryOffHeapMiB
     var pysparkMemoryMiB = defaultResources.pysparkMemoryMiB.getOrElse(0L)
     var memoryOverheadMiB = calculateOverHeadMemory(defaultResources.memoryOverheadMiB,
-      executorMemoryMiB, overheadFactor)
+      minimumOverheadMemory, executorMemoryMiB, overheadFactor)
 
     val finalCustomResources = if (rpId != DEFAULT_RESOURCE_PROFILE_ID) {
       val customResources = new mutable.HashMap[String, ExecutorResourceRequest]

--- a/core/src/main/scala/org/apache/spark/resource/ResourceProfile.scala
+++ b/core/src/main/scala/org/apache/spark/resource/ResourceProfile.scala
@@ -352,8 +352,6 @@ object ResourceProfile extends Logging {
   val UNKNOWN_RESOURCE_PROFILE_ID = -1
   val DEFAULT_RESOURCE_PROFILE_ID = 0
 
-  private[spark] val MEMORY_OVERHEAD_MIN_MIB = 384L
-
   private lazy val nextProfileId = new AtomicInteger(0)
   private val DEFAULT_PROFILE_LOCK = new Object()
 

--- a/core/src/test/scala/org/apache/spark/resource/ResourceProfileSuite.scala
+++ b/core/src/test/scala/org/apache/spark/resource/ResourceProfileSuite.scala
@@ -98,7 +98,7 @@ class ResourceProfileSuite extends SparkFunSuite with MockitoSugar {
       new ExecutorResourceRequests().cores(4)
     val rp = rpBuilder.require(taskReq).require(execReq).build()
     val executorResourceForRp = ResourceProfile.getResourcesForClusterManager(
-      rp.id, rp.executorResources, Option.empty, 0.0, sparkConf, false, Map.empty)
+      rp.id, rp.executorResources, 500L, 0.0, sparkConf, false, Map.empty)
     // Standalone cluster only take cores and executor memory as built-in resources.
     assert(executorResourceForRp.cores.get === 4)
     assert(executorResourceForRp.executorMemoryMiB === 1024L)

--- a/core/src/test/scala/org/apache/spark/resource/ResourceProfileSuite.scala
+++ b/core/src/test/scala/org/apache/spark/resource/ResourceProfileSuite.scala
@@ -98,7 +98,7 @@ class ResourceProfileSuite extends SparkFunSuite with MockitoSugar {
       new ExecutorResourceRequests().cores(4)
     val rp = rpBuilder.require(taskReq).require(execReq).build()
     val executorResourceForRp = ResourceProfile.getResourcesForClusterManager(
-      rp.id, rp.executorResources, Option.empty, 0.0, sparkConf, isPythonApp = false, Map.empty)
+      rp.id, rp.executorResources, Option.empty, 0.0, sparkConf, false, Map.empty)
     // Standalone cluster only take cores and executor memory as built-in resources.
     assert(executorResourceForRp.cores.get === 4)
     assert(executorResourceForRp.executorMemoryMiB === 1024L)

--- a/core/src/test/scala/org/apache/spark/resource/ResourceProfileSuite.scala
+++ b/core/src/test/scala/org/apache/spark/resource/ResourceProfileSuite.scala
@@ -98,7 +98,7 @@ class ResourceProfileSuite extends SparkFunSuite with MockitoSugar {
       new ExecutorResourceRequests().cores(4)
     val rp = rpBuilder.require(taskReq).require(execReq).build()
     val executorResourceForRp = ResourceProfile.getResourcesForClusterManager(
-      rp.id, rp.executorResources, 0.0, sparkConf, false, Map.empty)
+      rp.id, rp.executorResources, Option.empty, 0.0, sparkConf, isPythonApp = false, Map.empty)
     // Standalone cluster only take cores and executor memory as built-in resources.
     assert(executorResourceForRp.cores.get === 4)
     assert(executorResourceForRp.executorMemoryMiB === 1024L)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -187,7 +187,7 @@ of the most common options to set are:
 </tr>
 <tr>
   <td><code>spark.driver.memoryOverhead</code></td>
-  <td>driverMemory * <code>spark.driver.memoryOverheadFactor</code>, with minimum of <code>spark.driver.minMemoryOverhead</code> or 384, if not defined </td>
+  <td>driverMemory * <code>spark.driver.memoryOverheadFactor</code>, with minimum of <code>spark.driver.minMemoryOverhead</code></td>
   <td>
     Amount of non-heap memory to be allocated per driver process in cluster mode, in MiB unless
     otherwise specified. This is memory that accounts for things like VM overheads, interned strings,
@@ -204,12 +204,12 @@ of the most common options to set are:
 </tr>
 <tr>
   <td><code>spark.driver.minMemoryOverhead</code></td>
-  <td>None</td>
+  <td>384Mib</td>
   <td>
     The minimum amount of non-heap memory to be allocated per driver process in cluster mode, in MiB unless otherwise specified, if <code>spark.driver.memoryOverhead</code> is not defined.
     This option is currently supported on YARN and Kubernetes.
   </td>
-  <td>3.5.2</td>
+  <td>4.0.0</td>
 </tr>
 <tr>
   <td><code>spark.driver.memoryOverheadFactor</code></td>
@@ -300,7 +300,7 @@ of the most common options to set are:
 </tr>
 <tr>
  <td><code>spark.executor.memoryOverhead</code></td>
-  <td>executorMemory * <code>spark.executor.memoryOverheadFactor</code>,  with minimum of <code>spark.executor.minMemoryOverhead</code> or 384, if not defined </td>
+  <td>executorMemory * <code>spark.executor.memoryOverheadFactor</code>, with minimum of <code>spark.executor.minMemoryOverhead</code></td>
   <td>
     Amount of additional memory to be allocated per executor process, in MiB unless otherwise specified.
     This is memory that accounts for things like VM overheads, interned strings, other native overheads, etc.
@@ -317,12 +317,12 @@ of the most common options to set are:
 </tr>
 <tr>
   <td><code>spark.driver.minMemoryOverhead</code></td>
-  <td>None</td>
+  <td>384Mib</td>
   <td>
     The minimum amount of non-heap memory to be allocated per executor process, in MiB unless otherwise specified, if <code>spark.executor.memoryOverhead</code> is not defined.
     This option is currently supported on YARN and Kubernetes.
   </td>
-  <td>3.5.2</td>
+  <td>4.0.0</td>
 </tr>
 <tr>
   <td><code>spark.executor.memoryOverheadFactor</code></td>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -187,7 +187,7 @@ of the most common options to set are:
 </tr>
 <tr>
   <td><code>spark.driver.memoryOverhead</code></td>
-  <td>driverMemory * <code>spark.driver.memoryOverheadFactor</code>, with minimum of 384 </td>
+  <td>driverMemory * <code>spark.driver.memoryOverheadFactor</code>, with minimum of <code>spark.driver.minMemoryOverhead</code> or 384, if not defined </td>
   <td>
     Amount of non-heap memory to be allocated per driver process in cluster mode, in MiB unless
     otherwise specified. This is memory that accounts for things like VM overheads, interned strings,
@@ -201,6 +201,15 @@ of the most common options to set are:
     and <code>spark.driver.memory</code>.
   </td>
   <td>2.3.0</td>
+</tr>
+<tr>
+  <td><code>spark.driver.minMemoryOverhead</code></td>
+  <td>None</td>
+  <td>
+    The minimum amount of non-heap memory to be allocated per driver process in cluster mode, in MiB unless otherwise specified, if <code>spark.driver.memoryOverhead</code> is not defined.
+    This option is currently supported on YARN and Kubernetes.
+  </td>
+  <td>3.5.0</td>
 </tr>
 <tr>
   <td><code>spark.driver.memoryOverheadFactor</code></td>
@@ -291,7 +300,7 @@ of the most common options to set are:
 </tr>
 <tr>
  <td><code>spark.executor.memoryOverhead</code></td>
-  <td>executorMemory * <code>spark.executor.memoryOverheadFactor</code>, with minimum of 384 </td>
+  <td>executorMemory * <code>spark.executor.memoryOverheadFactor</code>,  with minimum of <code>spark.executor.minMemoryOverhead</code> or 384, if not defined </td>
   <td>
     Amount of additional memory to be allocated per executor process, in MiB unless otherwise specified.
     This is memory that accounts for things like VM overheads, interned strings, other native overheads, etc.
@@ -305,6 +314,15 @@ of the most common options to set are:
     <code>spark.executor.pyspark.memory</code>.
   </td>
   <td>2.3.0</td>
+</tr>
+<tr>
+  <td><code>spark.driver.minMemoryOverhead</code></td>
+  <td>None</td>
+  <td>
+    The minimum amount of non-heap memory to be allocated per executor process, in MiB unless otherwise specified, if <code>spark.executor.memoryOverhead</code> is not defined.
+    This option is currently supported on YARN and Kubernetes.
+  </td>
+  <td>3.5.0</td>
 </tr>
 <tr>
   <td><code>spark.executor.memoryOverheadFactor</code></td>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -204,7 +204,7 @@ of the most common options to set are:
 </tr>
 <tr>
   <td><code>spark.driver.minMemoryOverhead</code></td>
-  <td>384Mib</td>
+  <td>384m</td>
   <td>
     The minimum amount of non-heap memory to be allocated per driver process in cluster mode, in MiB unless otherwise specified, if <code>spark.driver.memoryOverhead</code> is not defined.
     This option is currently supported on YARN and Kubernetes.
@@ -317,7 +317,7 @@ of the most common options to set are:
 </tr>
 <tr>
   <td><code>spark.driver.minMemoryOverhead</code></td>
-  <td>384Mib</td>
+  <td>384m</td>
   <td>
     The minimum amount of non-heap memory to be allocated per executor process, in MiB unless otherwise specified, if <code>spark.executor.memoryOverhead</code> is not defined.
     This option is currently supported on YARN and Kubernetes.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -209,7 +209,7 @@ of the most common options to set are:
     The minimum amount of non-heap memory to be allocated per driver process in cluster mode, in MiB unless otherwise specified, if <code>spark.driver.memoryOverhead</code> is not defined.
     This option is currently supported on YARN and Kubernetes.
   </td>
-  <td>3.5.0</td>
+  <td>3.5.2</td>
 </tr>
 <tr>
   <td><code>spark.driver.memoryOverheadFactor</code></td>
@@ -322,7 +322,7 @@ of the most common options to set are:
     The minimum amount of non-heap memory to be allocated per executor process, in MiB unless otherwise specified, if <code>spark.executor.memoryOverhead</code> is not defined.
     This option is currently supported on YARN and Kubernetes.
   </td>
-  <td>3.5.0</td>
+  <td>3.5.2</td>
 </tr>
 <tr>
   <td><code>spark.executor.memoryOverheadFactor</code></td>

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicDriverFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicDriverFeatureStep.scala
@@ -27,7 +27,6 @@ import org.apache.spark.deploy.k8s.Config._
 import org.apache.spark.deploy.k8s.Constants._
 import org.apache.spark.deploy.k8s.submit._
 import org.apache.spark.internal.config._
-import org.apache.spark.resource.ResourceProfile
 import org.apache.spark.ui.SparkUI
 import org.apache.spark.util.Utils
 
@@ -67,11 +66,7 @@ private[spark] class BasicDriverFeatureStep(conf: KubernetesDriverConf)
       conf.get(MEMORY_OVERHEAD_FACTOR)
     }
 
-  private val driverMinimumMemoryOverhead = if (conf.contains(DRIVER_MIN_MEMORY_OVERHEAD)) {
-    conf.get(DRIVER_MIN_MEMORY_OVERHEAD).get
-  } else {
-    ResourceProfile.MEMORY_OVERHEAD_MIN_MIB
-  }
+  private val driverMinimumMemoryOverhead = conf.get(DRIVER_MIN_MEMORY_OVERHEAD)
 
   // Prefer the driver memory overhead factor if set explicitly
   private val memoryOverheadFactor = if (conf.contains(DRIVER_MEMORY_OVERHEAD_FACTOR)) {

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStep.scala
@@ -59,6 +59,7 @@ private[spark] class BasicExecutorFeatureStep(
   private val isDefaultProfile = resourceProfile.id == ResourceProfile.DEFAULT_RESOURCE_PROFILE_ID
   private val isPythonApp = kubernetesConf.get(APP_RESOURCE_TYPE) == Some(APP_RESOURCE_TYPE_PYTHON)
   private val disableConfigMap = kubernetesConf.get(KUBERNETES_EXECUTOR_DISABLE_CONFIGMAP)
+  private val minimumMemoryOverhead = kubernetesConf.get(EXECUTOR_MIN_MEMORY_OVERHEAD)
   private val memoryOverheadFactor = if (kubernetesConf.contains(EXECUTOR_MEMORY_OVERHEAD_FACTOR)) {
     kubernetesConf.get(EXECUTOR_MEMORY_OVERHEAD_FACTOR)
   } else {
@@ -68,6 +69,7 @@ private[spark] class BasicExecutorFeatureStep(
   val execResources = ResourceProfile.getResourcesForClusterManager(
     resourceProfile.id,
     resourceProfile.executorResources,
+    minimumMemoryOverhead,
     memoryOverheadFactor,
     kubernetesConf.sparkConf,
     isPythonApp,

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicDriverFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicDriverFeatureStepSuite.scala
@@ -29,7 +29,7 @@ import org.apache.spark.deploy.k8s.features.KubernetesFeaturesTestUtils.TestReso
 import org.apache.spark.deploy.k8s.submit._
 import org.apache.spark.internal.config._
 import org.apache.spark.internal.config.UI._
-import org.apache.spark.resource.{ResourceID, ResourceProfile}
+import org.apache.spark.resource.ResourceID
 import org.apache.spark.resource.ResourceUtils._
 import org.apache.spark.util.Utils
 
@@ -205,7 +205,8 @@ class BasicDriverFeatureStepSuite extends SparkFunSuite {
     test(s"memory overhead factor new config: $name") {
       // Choose a driver memory where the default memory overhead is > MEMORY_OVERHEAD_MIN_MIB
       val driverMem =
-        ResourceProfile.MEMORY_OVERHEAD_MIN_MIB / DRIVER_MEMORY_OVERHEAD_FACTOR.defaultValue.get * 2
+        DRIVER_MIN_MEMORY_OVERHEAD.defaultValue.get /
+          DRIVER_MEMORY_OVERHEAD_FACTOR.defaultValue.get * 2
 
       // main app resource, overhead factor
       val sparkConf = new SparkConf(false)
@@ -235,7 +236,7 @@ class BasicDriverFeatureStepSuite extends SparkFunSuite {
     test(s"memory overhead factor old config: $name") {
       // Choose a driver memory where the default memory overhead is > MEMORY_OVERHEAD_MIN_MIB
       val driverMem =
-        ResourceProfile.MEMORY_OVERHEAD_MIN_MIB / MEMORY_OVERHEAD_FACTOR.defaultValue.get * 2
+        DRIVER_MIN_MEMORY_OVERHEAD.defaultValue.get / MEMORY_OVERHEAD_FACTOR.defaultValue.get * 2
 
       // main app resource, overhead factor
       val sparkConf = new SparkConf(false)
@@ -259,7 +260,8 @@ class BasicDriverFeatureStepSuite extends SparkFunSuite {
   test(s"SPARK-38194: memory overhead factor precendence") {
     // Choose a driver memory where the default memory overhead is > MEMORY_OVERHEAD_MIN_MIB
     val driverMem =
-      ResourceProfile.MEMORY_OVERHEAD_MIN_MIB / DRIVER_MEMORY_OVERHEAD_FACTOR.defaultValue.get * 2
+      DRIVER_MIN_MEMORY_OVERHEAD.defaultValue.get /
+        DRIVER_MEMORY_OVERHEAD_FACTOR.defaultValue.get * 2
 
     // main app resource, overhead factor
     val sparkConf = new SparkConf(false)
@@ -288,7 +290,8 @@ class BasicDriverFeatureStepSuite extends SparkFunSuite {
   test(s"SPARK-38194: old memory factor settings is applied if new one isn't given") {
     // Choose a driver memory where the default memory overhead is > MEMORY_OVERHEAD_MIN_MIB
     val driverMem =
-      ResourceProfile.MEMORY_OVERHEAD_MIN_MIB / DRIVER_MEMORY_OVERHEAD_FACTOR.defaultValue.get * 2
+      DRIVER_MIN_MEMORY_OVERHEAD.defaultValue.get /
+        DRIVER_MEMORY_OVERHEAD_FACTOR.defaultValue.get * 2
 
     // main app resource, overhead factor
     val sparkConf = new SparkConf(false)

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicDriverFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicDriverFeatureStepSuite.scala
@@ -372,7 +372,7 @@ class BasicDriverFeatureStepSuite extends SparkFunSuite {
       path.startsWith(FILE_UPLOAD_PATH) && path.endsWith("some-local-jar.jar")))
   }
 
-  test("SPARK-XXXXXX: User can override the minimum memory overhead of the driver") {
+  test("SPARK-47208: User can override the minimum memory overhead of the driver") {
     val sparkConf = new SparkConf()
       .set(KUBERNETES_DRIVER_POD_NAME, "spark-driver-pod")
       .set(DRIVER_MEMORY.key, "256M")
@@ -395,7 +395,7 @@ class BasicDriverFeatureStepSuite extends SparkFunSuite {
     assert(amountAndFormat(limits("memory")) === "756Mi")
   }
 
-  test("SPARK-XXXXXX: Explicit overhead takes precedence over minimum overhead") {
+  test("SPARK-47208: Explicit overhead takes precedence over minimum overhead") {
     val sparkConf = new SparkConf()
       .set(KUBERNETES_DRIVER_POD_NAME, "spark-driver-pod")
       .set(DRIVER_MEMORY.key, "256M")
@@ -419,7 +419,7 @@ class BasicDriverFeatureStepSuite extends SparkFunSuite {
     assert(amountAndFormat(limits("memory")) === "456Mi")
   }
 
-  test("SPARK-XXXXXX: Overhead is maximum between factor of memory and min base overhead") {
+  test("SPARK-47208: Overhead is maximum between factor of memory and min base overhead") {
     val sparkConf = new SparkConf()
       .set(KUBERNETES_DRIVER_POD_NAME, "spark-driver-pod")
       .set(DRIVER_MEMORY.key, "5000M")

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStepSuite.scala
@@ -524,7 +524,7 @@ class BasicExecutorFeatureStepSuite extends SparkFunSuite with BeforeAndAfter {
     assert(podConfigured1.container.getPorts.contains(ports))
   }
 
-  test("SPARK-XXXXXX: User can override the minimum memory overhead of the executor") {
+  test("SPARK-47208: User can override the minimum memory overhead of the executor") {
     // main app resource, overriding the minimum oberhead to 500Mb
     val sparkConf = new SparkConf(false)
       .set(CONTAINER_IMAGE, "spark-driver:latest")
@@ -543,7 +543,7 @@ class BasicExecutorFeatureStepSuite extends SparkFunSuite with BeforeAndAfter {
       .getLimits.get("memory")) === "1524Mi")
   }
 
-  test("SPARK-XXXXXX: Explicit overhead takes precedence over minimum overhead") {
+  test("SPARK-47208: Explicit overhead takes precedence over minimum overhead") {
     // main app resource, explicit overhead of 150MiB
     val sparkConf = new SparkConf(false)
       .set(CONTAINER_IMAGE, "spark-driver:latest")

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStepSuite.scala
@@ -460,7 +460,7 @@ class BasicExecutorFeatureStepSuite extends SparkFunSuite with BeforeAndAfter {
   test(s"SPARK-38194: memory overhead factor precendence") {
     // Choose an executor memory where the default memory overhead is > MEMORY_OVERHEAD_MIN_MIB
     val defaultFactor = EXECUTOR_MEMORY_OVERHEAD_FACTOR.defaultValue.get
-    val executorMem = ResourceProfile.MEMORY_OVERHEAD_MIN_MIB / defaultFactor * 2
+    val executorMem = EXECUTOR_MIN_MEMORY_OVERHEAD.defaultValue.get / defaultFactor * 2
 
     // main app resource, overhead factor
     val sparkConf = new SparkConf(false)
@@ -487,7 +487,7 @@ class BasicExecutorFeatureStepSuite extends SparkFunSuite with BeforeAndAfter {
   test(s"SPARK-38194: old memory factor settings is applied if new one isn't given") {
     // Choose an executor memory where the default memory overhead is > MEMORY_OVERHEAD_MIN_MIB
     val defaultFactor = EXECUTOR_MEMORY_OVERHEAD_FACTOR.defaultValue.get
-    val executorMem = ResourceProfile.MEMORY_OVERHEAD_MIN_MIB / defaultFactor * 2
+    val executorMem = EXECUTOR_MIN_MEMORY_OVERHEAD.defaultValue.get / defaultFactor * 2
 
     // main app resource, overhead factor
     val sparkConf = new SparkConf(false)

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -75,8 +75,7 @@ private[spark] class Client(
   private val yarnClient = YarnClient.createYarnClient
   private val hadoopConf = new YarnConfiguration(SparkHadoopUtil.newConfiguration(sparkConf))
 
-      private val isClusterMode = sparkConf.get(SUBMIT_DEPLOY_MODE) == "cluster"
-
+  private val isClusterMode = sparkConf.get(SUBMIT_DEPLOY_MODE) == "cluster"
   private val isClientUnmanagedAMEnabled = sparkConf.get(YARN_UNMANAGED_AM) && !isClusterMode
   private val statCachePreloadEnabled = sparkConf.get(YARN_CLIENT_STAT_CACHE_PRELOAD_ENABLED)
   private val statCachePreloadDirectoryCountThreshold: Int =
@@ -98,8 +97,8 @@ private[spark] class Client(
   }
 
   private val driverMinimumMemoryOverhead =
-    if (isClusterMode && sparkConf.contains(DRIVER_MIN_MEMORY_OVERHEAD)) {
-      sparkConf.get(DRIVER_MIN_MEMORY_OVERHEAD).get
+    if (isClusterMode) {
+      sparkConf.get(DRIVER_MIN_MEMORY_OVERHEAD)
     } else {
       ResourceProfile.MEMORY_OVERHEAD_MIN_MIB
     }
@@ -123,9 +122,10 @@ private[spark] class Client(
   protected val executorOffHeapMemory = Utils.executorOffHeapMemorySizeAsMb(sparkConf)
 
   private val executorMemoryOvereadFactor = sparkConf.get(EXECUTOR_MEMORY_OVERHEAD_FACTOR)
+  private val minMemoryOverhead = sparkConf.get(EXECUTOR_MIN_MEMORY_OVERHEAD)
   private val executorMemoryOverhead = sparkConf.get(EXECUTOR_MEMORY_OVERHEAD).getOrElse(
     math.max((executorMemoryOvereadFactor * executorMemory).toLong,
-      ResourceProfile.MEMORY_OVERHEAD_MIN_MIB)).toInt
+      minMemoryOverhead)).toInt
 
   private val isPython = sparkConf.get(IS_PYTHON_APP)
   private val pysparkWorkerMemory: Int = if (isPython) {

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -59,7 +59,6 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config._
 import org.apache.spark.internal.config.Python._
 import org.apache.spark.launcher.{JavaModuleOptions, LauncherBackend, SparkAppHandle, YarnCommandBuilderUtils}
-import org.apache.spark.resource.ResourceProfile
 import org.apache.spark.rpc.RpcEnv
 import org.apache.spark.util.{CallerContext, Utils, YarnContainerInfoHelper}
 import org.apache.spark.util.ArrayImplicits._
@@ -100,7 +99,7 @@ private[spark] class Client(
     if (isClusterMode) {
       sparkConf.get(DRIVER_MIN_MEMORY_OVERHEAD)
     } else {
-      ResourceProfile.MEMORY_OVERHEAD_MIN_MIB
+      384L
     }
 
   private val amMemoryOverhead = {

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnAllocator.scala
@@ -169,6 +169,8 @@ private[yarn] class YarnAllocator(
 
   private val isPythonApp = sparkConf.get(IS_PYTHON_APP)
 
+  private val minMemoryOverhead = sparkConf.get(EXECUTOR_MIN_MEMORY_OVERHEAD)
+
   private val memoryOverheadFactor = sparkConf.get(EXECUTOR_MEMORY_OVERHEAD_FACTOR)
 
   private val launcherPool = ThreadUtils.newDaemonCachedThreadPool(
@@ -313,7 +315,7 @@ private[yarn] class YarnAllocator(
 
       val resourcesWithDefaults =
         ResourceProfile.getResourcesForClusterManager(rp.id, rp.executorResources,
-          memoryOverheadFactor, sparkConf, isPythonApp, resourceNameMapping)
+          minMemoryOverhead, memoryOverheadFactor, sparkConf, isPythonApp, resourceNameMapping)
       val customSparkResources =
         resourcesWithDefaults.customResources.map { case (name, execReq) =>
           (name, execReq.amount.toString)

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ClientSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ClientSuite.scala
@@ -726,15 +726,15 @@ class ClientSuite extends SparkFunSuite
           new YarnClientApplication(getNewApplicationResponse, appContext),
           containerLaunchContext)
 
-        appContext.getApplicationName should be("foo-test-app")
+        appContext.getApplicationName should be ("foo-test-app")
         // flag should only work for cluster mode
-        if (deployMode=="cluster") {
+        if (deployMode == "cluster") {
           // 1Gb driver default + 500 overridden minimum default overhead
-          appContext.getResource should be(Resource.newInstance(1524L, 1))
+          appContext.getResource should be (Resource.newInstance(1524L, 1))
         } else {
           // 512 driver default (non-cluster) + 384 overhead default
           // that can't be changed in non cluster mode.
-          appContext.getResource should be(Resource.newInstance(896L, 1))
+          appContext.getResource should be (Resource.newInstance(896L, 1))
         }
       }
     }

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ClientSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ClientSuite.scala
@@ -733,7 +733,7 @@ class ClientSuite extends SparkFunSuite
           appContext.getResource should be(Resource.newInstance(1524L, 1))
         } else {
           // 512 driver default (non-cluster) + 384 overhead default
-          //  that can't be changed in non cluster mode.
+          // that can't be changed in non cluster mode.
           appContext.getResource should be(Resource.newInstance(896L, 1))
         }
       }

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ClientSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ClientSuite.scala
@@ -710,7 +710,7 @@ class ClientSuite extends SparkFunSuite
       "client",
       "cluster"
     ).foreach { case (deployMode) =>
-      test(s"SPARK-XXXXXX: minimum memory overhead is correctly set in ($deployMode mode)") {
+      test(s"SPARK-47208: minimum memory overhead is correctly set in ($deployMode mode)") {
         val sparkConf = new SparkConf()
           .set("spark.app.name", "foo-test-app")
           .set(SUBMIT_DEPLOY_MODE, deployMode)

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ClientSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ClientSuite.scala
@@ -706,6 +706,39 @@ class ClientSuite extends SparkFunSuite
     assert(client.getPreloadedStatCache(sparkConf.get(JARS_TO_DISTRIBUTE), mockFsLookup).size === 2)
   }
 
+  Seq(
+      "client",
+      "cluster"
+    ).foreach { case (deployMode) =>
+      test(s"SPARK-XXXXXX: minimum memory overhead is correctly set in ($deployMode mode)") {
+        val sparkConf = new SparkConf()
+          .set("spark.app.name", "foo-test-app")
+          .set(SUBMIT_DEPLOY_MODE, deployMode)
+          .set(DRIVER_MIN_MEMORY_OVERHEAD, 500L)
+        val args = new ClientArguments(Array())
+
+        val appContext = Records.newRecord(classOf[ApplicationSubmissionContext])
+        val getNewApplicationResponse = Records.newRecord(classOf[GetNewApplicationResponse])
+        val containerLaunchContext = Records.newRecord(classOf[ContainerLaunchContext])
+
+        val client = new Client(args, sparkConf, null)
+        client.createApplicationSubmissionContext(
+          new YarnClientApplication(getNewApplicationResponse, appContext),
+          containerLaunchContext)
+
+        appContext.getApplicationName should be("foo-test-app")
+        // flag should only work for cluster mode
+        if (deployMode=="cluster") {
+          // 1Gb driver default + 500 overriden minimum default
+          appContext.getResource should be(Resource.newInstance(1524L, 1))
+        } else {
+          // 512 driver default (non-cluster) + 384 overhead default
+          //  that can't be changed in non cluster mode.
+          appContext.getResource should be(Resource.newInstance(896L, 1))
+        }
+      }
+    }
+
   private val matching = Seq(
     ("files URI match test1", "file:///file1", "file:///file2"),
     ("files URI match test2", "file:///c:file1", "file://c:file2"),

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ClientSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ClientSuite.scala
@@ -729,7 +729,7 @@ class ClientSuite extends SparkFunSuite
         appContext.getApplicationName should be("foo-test-app")
         // flag should only work for cluster mode
         if (deployMode=="cluster") {
-          // 1Gb driver default + 500 overriden minimum default
+          // 1Gb driver default + 500 overridden minimum default overhead
           appContext.getResource should be(Resource.newInstance(1524L, 1))
         } else {
           // 512 driver default (non-cluster) + 384 overhead default

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnAllocatorSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnAllocatorSuite.scala
@@ -779,7 +779,7 @@ class YarnAllocatorSuite extends SparkFunSuite
     }
   }
 
-  test("SPARK-XXXXXX: User can override the minimum memory overhead of the executor") {
+  test("SPARK-47208: User can override the minimum memory overhead of the executor") {
     val executorMemory = sparkConf.get(EXECUTOR_MEMORY)
     try {
       sparkConf
@@ -795,7 +795,7 @@ class YarnAllocatorSuite extends SparkFunSuite
     }
   }
 
-  test("SPARK-XXXXXX: Explicit overhead takes precedence over minimum overhead") {
+  test("SPARK-47208: Explicit overhead takes precedence over minimum overhead") {
     val executorMemory = sparkConf.get(EXECUTOR_MEMORY)
     try {
       sparkConf

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnAllocatorSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnAllocatorSuite.scala
@@ -907,6 +907,4 @@ class YarnAllocatorSuite extends SparkFunSuite
     handler.getNumExecutorsRunning should be(0)
     handler.getNumExecutorsStarting should be(0)
   }
-
-
 }

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnAllocatorSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnAllocatorSuite.scala
@@ -731,6 +731,7 @@ class YarnAllocatorSuite extends SparkFunSuite
     val executorMemory = sparkConf.get(EXECUTOR_MEMORY).toInt
     val offHeapMemoryInMB = 1024L
     val offHeapMemoryInByte = offHeapMemoryInMB * 1024 * 1024
+    val clientModeMinOffHeapMemory = 384L
     try {
       sparkConf.set(MEMORY_OFFHEAP_ENABLED, true)
       sparkConf.set(MEMORY_OFFHEAP_SIZE, offHeapMemoryInByte)
@@ -739,7 +740,7 @@ class YarnAllocatorSuite extends SparkFunSuite
       val defaultResource = handler.rpIdToYarnResource.get(defaultRPId)
       val memory = defaultResource.getMemorySize
       assert(memory ==
-        executorMemory + offHeapMemoryInMB + ResourceProfile.MEMORY_OVERHEAD_MIN_MIB)
+        executorMemory + offHeapMemoryInMB + clientModeMinOffHeapMemory)
     } finally {
       sparkConf.set(MEMORY_OFFHEAP_ENABLED, originalOffHeapEnabled)
       sparkConf.set(MEMORY_OFFHEAP_SIZE, originalOffHeapSize)

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnAllocatorSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnAllocatorSuite.scala
@@ -128,9 +128,6 @@ class YarnAllocatorSuite extends SparkFunSuite
       .set(EXECUTOR_CORES, 5)
       .set(EXECUTOR_MEMORY, 2048L)
 
-    // scalastyle:off println
-    sparkConfClone.getAll.foreach(println)
-
     for ((name, value) <- additionalConfigs) {
       sparkConfClone.set(name, value)
     }
@@ -807,6 +804,8 @@ class YarnAllocatorSuite extends SparkFunSuite
       val memory = defaultResource.getMemorySize
       assert(memory == (executorMemory + 100))
     } finally {
+      sparkConf
+        .remove(EXECUTOR_MIN_MEMORY_OVERHEAD)
       sparkConf
         .remove(EXECUTOR_MIN_MEMORY_OVERHEAD)
     }

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnAllocatorSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnAllocatorSuite.scala
@@ -128,6 +128,9 @@ class YarnAllocatorSuite extends SparkFunSuite
       .set(EXECUTOR_CORES, 5)
       .set(EXECUTOR_MEMORY, 2048L)
 
+    // scalastyle:off println
+    sparkConfClone.getAll.foreach(println)
+
     for ((name, value) <- additionalConfigs) {
       sparkConfClone.set(name, value)
     }
@@ -772,6 +775,7 @@ class YarnAllocatorSuite extends SparkFunSuite
       assert(memory == (executorMemory * 1.4).toLong)
     } finally {
       sparkConf.set(EXECUTOR_MEMORY_OVERHEAD_FACTOR, 0.1)
+      sparkConf.remove(EXECUTOR_MEMORY_OVERHEAD)
     }
   }
 
@@ -787,7 +791,7 @@ class YarnAllocatorSuite extends SparkFunSuite
       assert(memory == (executorMemory + 500))
     } finally {
       sparkConf
-        .set(EXECUTOR_MIN_MEMORY_OVERHEAD, 384L)
+        .remove(EXECUTOR_MIN_MEMORY_OVERHEAD)
     }
   }
 
@@ -804,7 +808,7 @@ class YarnAllocatorSuite extends SparkFunSuite
       assert(memory == (executorMemory + 100))
     } finally {
       sparkConf
-        .set(EXECUTOR_MIN_MEMORY_OVERHEAD, 384L)
+        .remove(EXECUTOR_MIN_MEMORY_OVERHEAD)
     }
   }
 

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnAllocatorSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnAllocatorSuite.scala
@@ -788,8 +788,7 @@ class YarnAllocatorSuite extends SparkFunSuite
       val memory = defaultResource.getMemorySize
       assert(memory == (executorMemory + 500))
     } finally {
-      sparkConf
-        .remove(EXECUTOR_MIN_MEMORY_OVERHEAD)
+      sparkConf.remove(EXECUTOR_MIN_MEMORY_OVERHEAD)
     }
   }
 
@@ -805,10 +804,8 @@ class YarnAllocatorSuite extends SparkFunSuite
       val memory = defaultResource.getMemorySize
       assert(memory == (executorMemory + 100))
     } finally {
-      sparkConf
-        .remove(EXECUTOR_MIN_MEMORY_OVERHEAD)
-      sparkConf
-        .remove(EXECUTOR_MIN_MEMORY_OVERHEAD)
+      sparkConf.remove(EXECUTOR_MEMORY_OVERHEAD)
+      sparkConf.remove(EXECUTOR_MIN_MEMORY_OVERHEAD)
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
We can already select the desired overhead memory directly via the `spark.driver/executor.memoryOverhead` flags, however, if that flag is not present the overhead memory calculation goes as follows:

```
overhead_memory = Max(384, 'spark.driver/executor.memory' * 'spark.driver/executor.memoryOverheadFactor')

[where the 'memoryOverheadFactor' flag defaults to 0.1]
```

This PR adds two new spark configs: `spark.driver.minMemoryOverhead` and `spark.executor.minMemoryOverhead`, which can be used to override the 384Mib minimum value.

The memory overhead calculation will now be :

```
min_memory = sparkConf.get('spark.driver/executor.minMemoryOverhead') // has default of 384

overhead_memory = Max(min_memory, 'spark.driver/executor.memory' * 'spark.driver/executor.memoryOverheadFactor')
```

### Why are the changes needed?
There are certain times where being able to override the 384Mb minimum directly can be beneficial. We may have a scenario where a lot of off-heap operations are performed (ex: using package managers/native compression/decompression) where we don't have a need for a large JVM heap but we may still need a signficant amount of memory in the spark node. 

Using the `memoryOverheadFactor` config flag may not prove appropriate, since we may not want the overhead allocation to directly scale with JVM memory, as a cost saving/resource limitation problem.

### Does this PR introduce _any_ user-facing change?
Yes, as described above, two new flags have been added to the spark config. No break of existing behaviours.

### How was this patch tested?
Added tests for 3 cases:
- If `spark.driver/executor.memoryOverhead` is set, then the new changes have no effect.
- If  `spark.driver/executor.minMemoryOverhead` is set and its value is higher than  'spark.driver/executor.memory' * 'spark.driver/executor.memoryOverheadFactor', the total memory will be the allocated JVM memory + `spark.driver/executor.minMemoryOverhead`
- If  `spark.driver/executor.minMemoryOverhead` but its value is lower than 'spark.driver/executor.memory' * 'spark.driver/executor.memoryOverheadFactor', the total memory will be the allocated JVM memory + 'spark.driver/executor.memory' * 'spark.driver/executor.memoryOverheadFactor'.

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
No
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
