### PR TITLE
[SPARK-47152][SQL][BUILD][FOLLOWUP] Provide `CodeHaus Jackson` dependencies via a new optional directory

### DIFF
--- a/dev/make-distribution.sh
+++ b/dev/make-distribution.sh
@@ -192,7 +192,7 @@ cp "$SPARK_HOME"/assembly/target/scala*/jars/* "$DISTDIR/jars/"
 # Only create the hive-jackson directory if they exist.
 for f in "$DISTDIR"/jars/jackson-*-asl-*.jar; do
   mkdir -p "$DISTDIR"/hive-jackson
-  mv $f "$DISTDIR"/hive-jackson/
+  mv "$f" "$DISTDIR"/hive-jackson/
 done
 
 # Only create the yarn directory if the yarn artifacts were built.


### PR DESCRIPTION
### What changes were proposed in this pull request?
change `mv $f "$DISTDIR"/hive-jackson/` to `mv "$f" "$DISTDIR"/hive-jackson/`

### Why are the changes needed?
Always quote variables in shell scripts, especially when their content is unpredictable or when they are meant to represent file paths or names that could contain special characters. Quoting makes scripts more robust and prevents unexpected behavior caused by unusual filenames or input data.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA

### Was this patch authored or co-authored using generative AI tooling?
No.