### PR TITLE
[SPARK-47137][PYTHON][CONNECT][FOLLOW-UP] Uses assertEqual instead of assertEquals for Python 3.12 build

### DIFF
--- a/python/pyspark/sql/tests/test_conf.py
+++ b/python/pyspark/sql/tests/test_conf.py
@@ -89,7 +89,7 @@ class ConfTestsMixin:
             spark.conf.set("foo", "bar")
             updated = spark.conf.getAll
 
-            self.assertEquals(len(updated), len(all_confs) + 1)
+            self.assertEqual(len(updated), len(all_confs) + 1)
             self.assertIn("foo", updated)
         finally:
             spark.conf.unset("foo")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to uses `assertEqual` instead of` assertEquals` for Python 3.12 build.

### Why are the changes needed?

To fix up Python 3.12 build https://github.com/apache/spark/actions/runs/8021096275/job/21924086355. `assertEquals` was removed.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Manually.

### Was this patch authored or co-authored using generative AI tooling?

No.