### PR TITLE
[MINOR][CONNECT][TESTS] Chain waitFor after destroyForcibly in SparkConnectServerUtils

### DIFF
--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/test/RemoteSparkSession.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/test/RemoteSparkSession.scala
@@ -145,7 +145,7 @@ object SparkConnectServerUtils {
       consoleOut.flush()
       consoleOut.close()
       if (!sparkConnect.waitFor(2, TimeUnit.SECONDS)) {
-        sparkConnect.destroyForcibly()
+        sparkConnect.destroyForcibly().waitFor(2, TimeUnit.SECONDS)
       }
       val code = sparkConnect.exitValue()
       debug(s"Spark Connect Server is stopped with exit code: $code")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to wait 2 more seconds after `destroyForcibly` in `SparkConnectServerUtils`.

### Why are the changes needed?

To recover the build in https://github.com/apache/spark/actions/runs/8040413156/job/21958488885

```
Error:  Tests run: 3, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 19.71 s <<< FAILURE! -- in org.apache.spark.sql.JavaEncoderSuite
Error:  org.apache.spark.sql.JavaEncoderSuite -- Time elapsed: 19.71 s <<< ERROR!
java.lang.IllegalThreadStateException: process hasn't exited
	at java.base/java.lang.ProcessImpl.exitValue(ProcessImpl.java:452)
	at org.apache.spark.sql.test.SparkConnectServerUtils$.stop(RemoteSparkSession.scala:150)
	at org.apache.spark.sql.test.SparkConnectServerUtils.stop(RemoteSparkSession.scala)
	at org.apache.spark.sql.JavaEncoderSuite.tearDown(JavaEncoderSuite.java:49)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:75)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:52)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
	at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:156)
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptLifecycleMethod(TimeoutExtension.java:128)
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptAfterAllMethod(TimeoutExtension.java:118)
```

It fails because the process is still alive after `destroyForcibly`. This can happen according to the Java documentation (https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/Process.html#destroyForcibly())

> The process may not terminate immediately. i.e. isAlive() may return true for a brief period after destroyForcibly() is called. This method may be chained to waitFor() if needed.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Manually tested. A bit difficult to reproduce the env in https://github.com/apache/spark/actions/runs/8040413156/job/21958488885.

### Was this patch authored or co-authored using generative AI tooling?

No.
