### PR TITLE
[SPARK-46802][PYTHON][TESTS][FOLLOWUP] Remove obsolete comment in run-tests-with-coverage

### DIFF
--- a/python/run-tests-with-coverage
+++ b/python/run-tests-with-coverage
@@ -41,7 +41,7 @@ mkdir -p "$COVERAGE_DIR/coverage_data"
 # Current directory are added in the python path so that it doesn't refer our built
 # pyspark zip library first.
 export PYTHONPATH="$FWDIR:$PYTHONPATH"
-# Also, our sitecustomize.py and coverage_daemon.py are included in the path.
+# Also, our sitecustomize.py is included in the path.
 export PYTHONPATH="$COVERAGE_DIR:$PYTHONPATH"
 
 # This environment variable enables the coverage.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/44842 that removes obsolete comment in run-tests-with-coverage.

### Why are the changes needed?

To remove obsolete information.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

N/A

### Was this patch authored or co-authored using generative AI tooling?

No.