### PR TITLE
[SPARK-47159][INFRA] Set `OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES` in `MacOS` GitHub Action Job

### DIFF
--- a/.github/workflows/build_maven_java21_macos14.yml
+++ b/.github/workflows/build_maven_java21_macos14.yml
@@ -33,3 +33,7 @@ jobs:
     with:
       java: 21
       os: macos-14
+      envs: >-
+        {
+          "OBJC_DISABLE_INITIALIZE_FORK_SAFETY": "YES"
+        }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to set `OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES` in `MacOS` GitHub Action Job.
- https://github.com/apache/spark/actions/workflows/build_maven_java21_macos14.yml

### Why are the changes needed?

This is recommended for Python tests, but it seems that `Spark Connect` Python test suites are also related. We had better have this to be safe or isolate any issue.

https://github.com/apache/spark/blob/0ff18e579c2f4fc31f825a4acaea529b3d03945d/python/docs/source/development/testing.rst?plain=1#L39

### Does this PR introduce _any_ user-facing change?

No, this is a test infra-only change.

### How was this patch tested?

Manual review. This is tested by Daily CI after merging.

### Was this patch authored or co-authored using generative AI tooling?

No.