### PR TITLE
[SPARK-47160][K8S] Update K8s `Dockerfile` to include `hive-jackson` directory if exists

### DIFF
--- a/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile
+++ b/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile
@@ -42,6 +42,8 @@ RUN set -ex && \
     rm -rf /var/cache/apt/* && rm -rf /var/lib/apt/lists/*
 
 COPY jars /opt/spark/jars
+# Copy hive-jackson directory if exists
+COPY hive-jackso[n] /opt/spark/hive-jackson
 # Copy RELEASE file if exists
 COPY RELEAS[E] /opt/spark/RELEASE
 COPY bin /opt/spark/bin


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update K8s `Dockerfile` to include `hive-jackson` jar directory if exists.

### Why are the changes needed?

After SPARK-47152, we can have `hive-jackson` directory.

### Does this PR introduce _any_ user-facing change?

No, this is used by Spark internal by default.

### How was this patch tested?

Pass the CIs and manual check.

### Was this patch authored or co-authored using generative AI tooling?

No.