### PR TITLE
[SPARK-47161][INFRA][R] Uses hash key properly for SparkR build on Windows

### DIFF
--- a/.github/workflows/build_sparkr_window.yml
+++ b/.github/workflows/build_sparkr_window.yml
@@ -42,7 +42,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: ~/.m2/repository
-        key: build-sparkr-maven-${{ hashFiles('**/pom.xml') }}
+        key: build-sparkr-windows-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
           build-sparkr-windows-maven-
     - name: Install Java 17


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes the mistake in https://github.com/apache/spark/pull/45175 that sets the hash key wrongly for Maven cache.


### Why are the changes needed?

To use the cache properly. SparkR on Windows does not find its cache properly: https://github.com/apache/spark/actions/runs/8039485831/job/21956555533

![Screenshot 2024-02-26 at 2 48 07 PM](https://github.com/apache/spark/assets/6477701/1c151c04-c07c-4968-af3a-b745cc7af391)


### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Will monitor the CI.

### Was this patch authored or co-authored using generative AI tooling?

No.