### PR TITLE
[SPARK-47163][BUILD] Fix `make-distribution.sh` to check `jackson-core-asl-1.9.13.jar` existence first

### DIFF
--- a/dev/make-distribution.sh
+++ b/dev/make-distribution.sh
@@ -190,10 +190,12 @@ echo "Build flags: $@" >> "$DISTDIR/RELEASE"
 cp "$SPARK_HOME"/assembly/target/scala*/jars/* "$DISTDIR/jars/"
 
 # Only create the hive-jackson directory if they exist.
-for f in "$DISTDIR"/jars/jackson-*-asl-*.jar; do
-  mkdir -p "$DISTDIR"/hive-jackson
-  mv $f "$DISTDIR"/hive-jackson/
-done
+if [ -f "$DISTDIR"/jars/jackson-core-asl-1.9.13.jar ]; then
+  for f in "$DISTDIR"/jars/jackson-*-asl-*.jar; do
+    mkdir -p "$DISTDIR"/hive-jackson
+    mv $f "$DISTDIR"/hive-jackson/
+  done
+fi
 
 # Only create the yarn directory if the yarn artifacts were built.
 if [ -f "$SPARK_HOME"/common/network-yarn/target/scala*/spark-*-yarn-shuffle.jar ]; then


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `make-distribution.sh` script to check `jackson-*-asl-*.jar` existence first before copying.

### Why are the changes needed?

Currently, `make-distribution.sh` script fails if it builds without `hive-thriftserver`.

### Does this PR introduce _any_ user-facing change?

No, this bug is introduced by unreleased feature.

### How was this patch tested?

Pass the CIs and manually build without Hive like the following.

```
$ dev/make-distribution.sh
$ ls dist/
LICENSE    NOTICE     README.md  RELEASE    bin        conf       data       examples   jars       kubernetes licenses   python     sbin
```

```
$ dev/make-distribution.sh -Phive-thriftserver
$ ls dist
LICENSE      NOTICE       README.md    RELEASE      bin          conf         data         examples     hive-jackson jars         licenses     python       sbin
```

### Was this patch authored or co-authored using generative AI tooling?

No