### PR TITLE
[SPARK-47170][BUILD][CONNECT] Remove `jakarta.servlet-api` and `javax.servlet-api` dependency scope in `connect/server` module

### DIFF
--- a/connector/connect/server/pom.xml
+++ b/connector/connect/server/pom.xml
@@ -159,12 +159,10 @@
     <dependency>
       <groupId>jakarta.servlet</groupId>
       <artifactId>jakarta.servlet-api</artifactId>
-      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
-      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>


### PR DESCRIPTION


### What changes were proposed in this pull request?
This is a follow up change from https://github.com/apache/spark/pull/45154, to remove redundant `<scope>` for both servlet-api as `compile` is the default scope.


### Why are the changes needed?


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
CI build


### Was this patch authored or co-authored using generative AI tooling?
No
