### PR TITLE
[SPARK-46077][SQL] Consider the type generated by TimestampNTZConverter in JdbcDialect.compileValue.

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -289,6 +289,7 @@ abstract class JdbcDialect extends Serializable with Logging {
   def compileValue(value: Any): Any = value match {
     case stringValue: String => s"'${escapeSql(stringValue)}'"
     case timestampValue: Timestamp => "'" + timestampValue + "'"
+    case timestampValue: LocalDateTime => "'" + timestampValue + "'"
     case timestampValue: Instant =>
       val timestampFormatter = TimestampFormatter.getFractionFormatter(
         DateTimeUtils.getZoneId(SQLConf.get.sessionLocalTimeZone))

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -289,7 +289,10 @@ abstract class JdbcDialect extends Serializable with Logging {
   def compileValue(value: Any): Any = value match {
     case stringValue: String => s"'${escapeSql(stringValue)}'"
     case timestampValue: Timestamp => "'" + timestampValue + "'"
-    case timestampValue: LocalDateTime => "'" + timestampValue + "'"
+    case timestampValue: LocalDateTime =>
+      val timestampFormatter = TimestampFormatter.getFractionFormatter(
+        DateTimeUtils.getZoneId(SQLConf.get.sessionLocalTimeZone))
+      s"'${timestampFormatter.format(timestampValue)}'"
     case timestampValue: Instant =>
       val timestampFormatter = TimestampFormatter.getFractionFormatter(
         DateTimeUtils.getZoneId(SQLConf.get.sessionLocalTimeZone))

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -808,7 +808,7 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
       assert(doCompileFilter(LessThan(col0,
         Timestamp.valueOf("1995-11-21 00:00:00.0"))) === """"col0" < '1995-11-21 00:00:00.0'""")
       assert(doCompileFilter(LessThan(col0,
-        LocalDateTime.parse("2007-12-03T10:15:30"))) === """"col0" < '2007-12-03T10:15:30'""")
+        LocalDateTime.of(2007, 12, 3, 10, 15, 30))) === """"col0" < '2007-12-03 10:15:30'""")
       assert(doCompileFilter(LessThan(col0, Date.valueOf("1983-08-04")))
         === """"col0" < '1983-08-04'""")
       assert(doCompileFilter(LessThanOrEqual(col0, 5)) === """"col0" <= 5""")

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.jdbc
 import java.math.BigDecimal
 import java.sql.{Date, DriverManager, Timestamp}
 import java.time.{Instant, LocalDate, LocalDateTime}
+import java.time.format.DateTimeFormatter
 import java.util.{Calendar, GregorianCalendar, Properties, TimeZone}
 
 import scala.jdk.CollectionConverters._
@@ -808,7 +809,8 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
       assert(doCompileFilter(LessThan(col0,
         Timestamp.valueOf("1995-11-21 00:00:00.0"))) === """"col0" < '1995-11-21 00:00:00.0'""")
       assert(doCompileFilter(LessThan(col0,
-        Timestamp.valueOf("2007-12-03 10:15:30").toLocalDateTime))
+        LocalDateTime.parse("2007-12-03 10:15:30",
+          DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))))
         === """"col0" < '2007-12-03 10:15:30'""")
       assert(doCompileFilter(LessThan(col0, Date.valueOf("1983-08-04")))
         === """"col0" < '1983-08-04'""")

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -807,6 +807,8 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
       assert(doCompileFilter(LessThan(col0, 5)) === """"col0" < 5""")
       assert(doCompileFilter(LessThan(col0,
         Timestamp.valueOf("1995-11-21 00:00:00.0"))) === """"col0" < '1995-11-21 00:00:00.0'""")
+      assert(doCompileFilter(LessThan(col0,
+        LocalDateTime.parse("2007-12-03T10:15:30"))) === """"col0" < '2007-12-03T10:15:30'""")
       assert(doCompileFilter(LessThan(col0, Date.valueOf("1983-08-04")))
         === """"col0" < '1983-08-04'""")
       assert(doCompileFilter(LessThanOrEqual(col0, 5)) === """"col0" <= 5""")

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -808,7 +808,8 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
       assert(doCompileFilter(LessThan(col0,
         Timestamp.valueOf("1995-11-21 00:00:00.0"))) === """"col0" < '1995-11-21 00:00:00.0'""")
       assert(doCompileFilter(LessThan(col0,
-        LocalDateTime.of(2007, 12, 3, 10, 15, 30))) === """"col0" < '2007-12-03 10:15:30'""")
+        Timestamp.valueOf("2007-12-03 10:15:30").toLocalDateTime))
+        === """"col0" < '2007-12-03 10:15:30'""")
       assert(doCompileFilter(LessThan(col0, Date.valueOf("1983-08-04")))
         === """"col0" < '1983-08-04'""")
       assert(doCompileFilter(LessThanOrEqual(col0, 5)) === """"col0" <= 5""")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Considering the following case 

```
./bin/spark-shell --packages org.postgresql:postgresql:9.4.1211 --conf spark.sql.timestampType=TIMESTAMP_NTZ

spark.sql("create table tz3 using jdbc options('url' 'jdbc:postgresql://localhost:5432/postgres?user=postgres&password=postgres', 'dbtable' 'public.tz', 'driver' 'org.postgresql.Driver', 'preferTimestampNTZ' 'true') as select 1 as id, to_timestamp('2021-04-01 00:00:00', 'yyyy-MM-dd HH:mm:ss') as ts")

spark.sql("select * from tz3 where ts=to_timestamp('2021-04-01 00:00:00', 'yyyy-MM-dd HH:mm:ss')").show

```

The generated query is incorrect because the literal is not quoted

```
ERROR:  syntax error at or near "T00" at character 81
STATEMENT:  SELECT "id","ts" FROM public.tz  WHERE ("ts" IS NOT NULL) AND ("ts" = 2021-04-01T00:00)

```
TimestampNTZConverter generates a LocalDateTime value that we do not consider in JdbcDialect.compileValue


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
It solves the bug explained

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
With unit tests and manually

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No