### PR TITLE
[SPARK-47168][SQL] Disable parquet filter pushdown when working with non default collated strings

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/util/SchemaUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/util/SchemaUtils.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.catalyst.analysis._
 import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, NamedExpression}
 import org.apache.spark.sql.connector.expressions.{BucketTransform, FieldReference, NamedTransform, Transform}
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
-import org.apache.spark.sql.types.{ArrayType, DataType, MapType, StructField, StructType}
+import org.apache.spark.sql.types.{ArrayType, DataType, MapType, StringType, StructField, StructType}
 import org.apache.spark.util.ArrayImplicits._
 import org.apache.spark.util.SparkSchemaUtils
 
@@ -293,4 +293,14 @@ private[spark] object SchemaUtils {
    * @return The escaped string.
    */
   def escapeMetaCharacters(str: String): String = SparkSchemaUtils.escapeMetaCharacters(str)
+
+  /**
+   * Checks if a given data type has a non-default collation string type.
+   */
+  def hasNonDefaultCollatedString(dt: DataType): Boolean = {
+    dt.existsRecursively {
+      case st: StringType => !st.isDefaultCollation
+      case _ => false
+    }
+  }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/util/SchemaUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/util/SchemaUtils.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.catalyst.analysis._
 import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, NamedExpression}
 import org.apache.spark.sql.connector.expressions.{BucketTransform, FieldReference, NamedTransform, Transform}
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
-import org.apache.spark.sql.types.{ArrayType, DataType, MapType, StructField, StructType}
+import org.apache.spark.sql.types.{ArrayType, DataType, MapType, StringType, StructField, StructType}
 import org.apache.spark.util.ArrayImplicits._
 import org.apache.spark.util.SparkSchemaUtils
 
@@ -293,4 +293,14 @@ private[spark] object SchemaUtils {
    * @return The escaped string.
    */
   def escapeMetaCharacters(str: String): String = SparkSchemaUtils.escapeMetaCharacters(str)
+
+  /**
+   * Checks whether there are non default collated string types in the schema.
+   */
+  def containsNonDefaultCollatedString(schema: StructType): Boolean = {
+    schema.existsRecursively {
+      case st: StringType => !st.isDefaultCollation
+      case _ => false
+    }
+  }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/util/SchemaUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/util/SchemaUtils.scala
@@ -305,11 +305,8 @@ private[spark] object SchemaUtils {
   }
 
   /**
-   * Checks if a given data type satisfies a given condition.
-   *
-   * @param dt The data type to check.
-   * @param f  The condition to check for.
-   * @return True if the data type that satisfies the condition is found, false otherwise.
+   * Recursively checks whether a given predicate holds true for any data type
+   * within the specified data type.
    */
   def typeExistsRecursively(dt: DataType)(f: DataType => Boolean): Boolean = dt match {
       case struct: StructType => struct.existsRecursively(f)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/util/SchemaUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/util/SchemaUtils.scala
@@ -309,10 +309,13 @@ private[spark] object SchemaUtils {
    * within the specified data type.
    */
   def typeExistsRecursively(dt: DataType)(f: DataType => Boolean): Boolean = dt match {
-      case struct: StructType => struct.existsRecursively(f)
-      case arr: ArrayType => typeExistsRecursively(arr.elementType)(f)
+      case struct: StructType =>
+        f(struct) || struct.fields.exists(field => typeExistsRecursively(field.dataType)(f))
+      case arr: ArrayType =>
+        typeExistsRecursively(arr.elementType)(f)
       case map: MapType =>
         typeExistsRecursively(map.keyType)(f) || typeExistsRecursively(map.valueType)(f)
-      case other => f(other)
+      case other =>
+        f(other)
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/util/SchemaUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/util/SchemaUtils.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.catalyst.analysis._
 import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, NamedExpression}
 import org.apache.spark.sql.connector.expressions.{BucketTransform, FieldReference, NamedTransform, Transform}
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
-import org.apache.spark.sql.types.{ArrayType, DataType, MapType, StringType, StructField, StructType}
+import org.apache.spark.sql.types.{ArrayType, DataType, MapType, StructField, StructType}
 import org.apache.spark.util.ArrayImplicits._
 import org.apache.spark.util.SparkSchemaUtils
 
@@ -293,29 +293,4 @@ private[spark] object SchemaUtils {
    * @return The escaped string.
    */
   def escapeMetaCharacters(str: String): String = SparkSchemaUtils.escapeMetaCharacters(str)
-
-  /**
-   * Checks if a given data type has a non-default collation string type.
-   */
-  def hasNonDefaultCollatedString(dt: DataType): Boolean = {
-    typeExistsRecursively(dt) {
-      case st: StringType => !st.isDefaultCollation
-      case _ => false
-    }
-  }
-
-  /**
-   * Recursively checks whether a given predicate holds true for any data type
-   * within the specified data type.
-   */
-  def typeExistsRecursively(dt: DataType)(f: DataType => Boolean): Boolean = dt match {
-      case struct: StructType =>
-        f(struct) || struct.fields.exists(field => typeExistsRecursively(field.dataType)(f))
-      case arr: ArrayType =>
-        typeExistsRecursively(arr.elementType)(f)
-      case map: MapType =>
-        typeExistsRecursively(map.keyType)(f) || typeExistsRecursively(map.valueType)(f)
-      case other =>
-        f(other)
-  }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/util/SchemaUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/util/SchemaUtils.scala
@@ -298,7 +298,7 @@ private[spark] object SchemaUtils {
    * Checks if a given data type has a non-default collation string type.
    */
   def hasNonDefaultCollatedString(dt: DataType): Boolean = {
-    SchemaUtils.typeExistsRecursively(dt) {
+    typeExistsRecursively(dt) {
       case st: StringType => !st.isDefaultCollation
       case _ => false
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceUtils.scala
@@ -28,7 +28,7 @@ import org.json4s.jackson.Serialization
 import org.apache.spark.{SparkException, SparkUpgradeException}
 import org.apache.spark.sql.{SPARK_LEGACY_DATETIME_METADATA_KEY, SPARK_LEGACY_INT96_METADATA_KEY, SPARK_TIMEZONE_METADATA_KEY, SPARK_VERSION_METADATA_KEY}
 import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogUtils}
-import org.apache.spark.sql.catalyst.expressions.{AttributeReference, AttributeSet, Expression, ExpressionSet, PredicateHelper}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, AttributeSet, Expression, ExpressionSet, GetStructField, PredicateHelper}
 import org.apache.spark.sql.catalyst.util.RebaseDateTime
 import org.apache.spark.sql.catalyst.util.RebaseDateTime.RebaseSpec
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
@@ -36,7 +36,7 @@ import org.apache.spark.sql.execution.datasources.parquet.ParquetOptions
 import org.apache.spark.sql.internal.{LegacyBehaviorPolicy, SQLConf}
 import org.apache.spark.sql.sources.BaseRelation
 import org.apache.spark.sql.types._
-import org.apache.spark.sql.util.CaseInsensitiveStringMap
+import org.apache.spark.sql.util.{CaseInsensitiveStringMap, SchemaUtils}
 import org.apache.spark.util.Utils
 
 
@@ -278,5 +278,27 @@ object DataSourceUtils extends PredicateHelper {
     val extraPartitionFilter =
       dataFilters.flatMap(extractPredicatesWithinOutputSet(_, partitionSet))
     (ExpressionSet(partitionFilters ++ extraPartitionFilter).toSeq, dataFilters)
+  }
+
+  /**
+   * Determines whether a filter should be pushed down to the data source or not.
+   *
+   * @param expression The filter expression to be evaluated.
+   * @return A boolean indicating whether the filter should be pushed down or not.
+   */
+  def shouldPushFilter(expression: Expression): Boolean = {
+    def checkRecursive(expression: Expression): Boolean = expression match {
+      case _: Attribute | _: GetStructField =>
+        // don't push down filters for columns with non-default collation
+        // as it could lead to incorrect results
+        expression.dataType match {
+          case st: StringType => st.isDefaultCollation
+          case struct: StructType => !SchemaUtils.containsNonDefaultCollatedString(struct)
+          case _ => true
+        }
+      case _ => expression.children.forall(checkRecursive)
+    }
+
+    expression.deterministic && checkRecursive(expression)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceUtils.scala
@@ -289,13 +289,10 @@ object DataSourceUtils extends PredicateHelper {
   def shouldPushFilter(expression: Expression): Boolean = {
     def checkRecursive(expression: Expression): Boolean = expression match {
       case _: Attribute | _: GetStructField =>
-        // don't push down filters for columns with non-default collation
+        // don't push down filters for types with non-default collation
         // as it could lead to incorrect results
-        expression.dataType match {
-          case st: StringType => st.isDefaultCollation
-          case struct: StructType => !SchemaUtils.containsNonDefaultCollatedString(struct)
-          case _ => true
-        }
+        !SchemaUtils.hasNonDefaultCollatedString(expression.dataType)
+
       case _ => expression.children.forall(checkRecursive)
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceUtils.scala
@@ -36,7 +36,7 @@ import org.apache.spark.sql.execution.datasources.parquet.ParquetOptions
 import org.apache.spark.sql.internal.{LegacyBehaviorPolicy, SQLConf}
 import org.apache.spark.sql.sources.BaseRelation
 import org.apache.spark.sql.types._
-import org.apache.spark.sql.util.{CaseInsensitiveStringMap, SchemaUtils}
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.util.Utils
 
 
@@ -287,13 +287,16 @@ object DataSourceUtils extends PredicateHelper {
    * @return A boolean indicating whether the filter should be pushed down or not.
    */
   def shouldPushFilter(expression: Expression): Boolean = {
-    def checkRecursive(expression: Expression): Boolean = expression match {
-      case _: Attribute | _: GetStructField =>
+    def checkRecursive(expression: Expression): Boolean = !expression.exists {
+      case e @ (_: Attribute | _: GetStructField) =>
         // don't push down filters for types with non-default collation
         // as it could lead to incorrect results
-        !SchemaUtils.hasNonDefaultCollatedString(expression.dataType)
+        e.dataType.existsRecursively {
+          case st: StringType => !st.isDefaultCollation
+          case _ => false
+        }
 
-      case _ => expression.children.forall(checkRecursive)
+      case _ => false
     }
 
     expression.deterministic && checkRecursive(expression)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
@@ -160,8 +160,11 @@ object FileSourceStrategy extends Strategy with PredicateHelper with Logging {
       //  - filters that need to be evaluated again after the scan
       val filterSet = ExpressionSet(filters)
 
+      val filtersToPush = filters
+        .filter(f => DataSourceUtils.shouldPushFilter(f))
+
       val normalizedFilters = DataSourceStrategy.normalizeExprs(
-        filters.filter(_.deterministic), l.output)
+        filtersToPush, l.output)
 
       val partitionColumns =
         l.resolve(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
@@ -160,8 +160,7 @@ object FileSourceStrategy extends Strategy with PredicateHelper with Logging {
       //  - filters that need to be evaluated again after the scan
       val filterSet = ExpressionSet(filters)
 
-      val filtersToPush = filters
-        .filter(f => DataSourceUtils.shouldPushFilter(f))
+      val filtersToPush = filters.filter(f => DataSourceUtils.shouldPushFilter(f))
 
       val normalizedFilters = DataSourceStrategy.normalizeExprs(
         filtersToPush, l.output)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PruneFileSourcePartitions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PruneFileSourcePartitions.scala
@@ -63,7 +63,8 @@ private[sql] object PruneFileSourcePartitions extends Rule[LogicalPlan] {
             _))
         if filters.nonEmpty && fsRelation.partitionSchema.nonEmpty =>
       val normalizedFilters = DataSourceStrategy.normalizeExprs(
-        filters.filter(f => f.deterministic && !SubqueryExpression.hasSubquery(f)),
+        filters.filter(f => !SubqueryExpression.hasSubquery(f)
+          && DataSourceUtils.shouldPushFilter(f)),
         logicalRelation.output)
       val (partitionKeyFilters, _) = DataSourceUtils
         .getPartitionFiltersAndDataFilters(partitionSchema, normalizedFilters)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PruneFileSourcePartitions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PruneFileSourcePartitions.scala
@@ -63,7 +63,8 @@ private[sql] object PruneFileSourcePartitions extends Rule[LogicalPlan] {
             _))
         if filters.nonEmpty && fsRelation.partitionSchema.nonEmpty =>
       val normalizedFilters = DataSourceStrategy.normalizeExprs(
-        filters.filter(f => !SubqueryExpression.hasSubquery(f) && DataSourceUtils.shouldPushFilter(f)),
+        filters.filter(f =>
+          !SubqueryExpression.hasSubquery(f) && DataSourceUtils.shouldPushFilter(f)),
         logicalRelation.output)
       val (partitionKeyFilters, _) = DataSourceUtils
         .getPartitionFiltersAndDataFilters(partitionSchema, normalizedFilters)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PruneFileSourcePartitions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PruneFileSourcePartitions.scala
@@ -63,8 +63,7 @@ private[sql] object PruneFileSourcePartitions extends Rule[LogicalPlan] {
             _))
         if filters.nonEmpty && fsRelation.partitionSchema.nonEmpty =>
       val normalizedFilters = DataSourceStrategy.normalizeExprs(
-        filters.filter(f => !SubqueryExpression.hasSubquery(f)
-          && DataSourceUtils.shouldPushFilter(f)),
+        filters.filter(f => !SubqueryExpression.hasSubquery(f) && DataSourceUtils.shouldPushFilter(f)),
         logicalRelation.output)
       val (partitionKeyFilters, _) = DataSourceUtils
         .getPartitionFiltersAndDataFilters(partitionSchema, normalizedFilters)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileScanBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileScanBuilder.scala
@@ -70,9 +70,10 @@ abstract class FileScanBuilder(
   }
 
   override def pushFilters(filters: Seq[Expression]): Seq[Expression] = {
-    val (deterministicFilters, nonDeterminsticFilters) = filters.partition(_.deterministic)
+    val (filtersToPush, filtersToIgnore) = filters
+      .partition(DataSourceUtils.shouldPushFilter)
     val (partitionFilters, dataFilters) =
-      DataSourceUtils.getPartitionFiltersAndDataFilters(partitionSchema, deterministicFilters)
+      DataSourceUtils.getPartitionFiltersAndDataFilters(partitionSchema, filtersToPush)
     this.partitionFilters = partitionFilters
     this.dataFilters = dataFilters
     val translatedFilters = mutable.ArrayBuffer.empty[sources.Filter]
@@ -83,7 +84,7 @@ abstract class FileScanBuilder(
       }
     }
     pushedDataFilters = pushDataFilters(translatedFilters.toArray)
-    dataFilters ++ nonDeterminsticFilters
+    dataFilters ++ filtersToIgnore
   }
 
   override def pushedFilters: Array[Predicate] = pushedDataFilters.map(_.toV2)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileScanBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileScanBuilder.scala
@@ -70,8 +70,7 @@ abstract class FileScanBuilder(
   }
 
   override def pushFilters(filters: Seq[Expression]): Seq[Expression] = {
-    val (filtersToPush, filtersToIgnore) = filters
-      .partition(DataSourceUtils.shouldPushFilter)
+    val (filtersToPush, filtersToRemain) = filters.partition(DataSourceUtils.shouldPushFilter)
     val (partitionFilters, dataFilters) =
       DataSourceUtils.getPartitionFiltersAndDataFilters(partitionSchema, filtersToPush)
     this.partitionFilters = partitionFilters
@@ -84,7 +83,7 @@ abstract class FileScanBuilder(
       }
     }
     pushedDataFilters = pushDataFilters(translatedFilters.toArray)
-    dataFilters ++ filtersToIgnore
+    dataFilters ++ filtersToRemain
   }
 
   override def pushedFilters: Array[Predicate] = pushedDataFilters.map(_.toV2)

--- a/sql/core/src/test/resources/sql-tests/results/collations.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/collations.sql.out
@@ -72,6 +72,7 @@ select * from t1 where ucs_basic_lcase = 'aaa' collate 'ucs_basic_lcase'
 -- !query schema
 struct<ucs_basic:string,ucs_basic_lcase:string COLLATE 'UCS_BASIC_LCASE'>
 -- !query output
+AAA	AAA
 aaa	aaa
 
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/FileBasedDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/FileBasedDataSourceSuite.scala
@@ -33,7 +33,7 @@ import org.apache.spark.sql.catalyst.expressions.{AttributeReference, GreaterTha
 import org.apache.spark.sql.catalyst.expressions.IntegralLiteralTestUtils.{negativeInt, positiveInt}
 import org.apache.spark.sql.catalyst.plans.logical.Filter
 import org.apache.spark.sql.catalyst.types.DataTypeUtils
-import org.apache.spark.sql.execution.{FileSourceScanLike, SimpleMode}
+import org.apache.spark.sql.execution.{ExplainMode, FileSourceScanLike, SimpleMode}
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.execution.datasources.FilePartition
 import org.apache.spark.sql.execution.datasources.v2.{BatchScanExec, FileScan}
@@ -1243,6 +1243,50 @@ class FileBasedDataSourceSuite extends QueryTest
           }.flatten
           assert(filters.contains(GreaterThan(scan.logicalPlan.output.head, Literal(5L))))
         }
+      }
+    }
+  }
+
+  test("disable filter pushdown for collated strings") {
+    withTempPath { path =>
+      val collation = "'UCS_BASIC_LCASE'"
+      val df = sql(
+        s"""SELECT
+           |  COLLATE(c, $collation) as c1,
+           |  struct(COLLATE(c, $collation)) as str,
+           |  named_struct('f1', named_struct('f2', COLLATE(c, $collation), 'f3', 1)) as namedstr,
+           |  array(COLLATE(c, $collation)) as arr,
+           |  map(COLLATE(c, $collation), 1) as map1,
+           |  map(1, COLLATE(c, $collation)) as map2
+           |FROM VALUES ('aaa'), ('AAA'), ('bbb')
+           |as data(c)
+           |""".stripMargin)
+
+      df.write.parquet(path.getAbsolutePath)
+
+      // filter and expected result
+      val filters = Seq(
+        ("==", Seq(Row("aaa"), Row("AAA"))),
+        ("!=", Seq(Row("bbb"))),
+        ("<", Seq()),
+        ("<=", Seq(Row("aaa"), Row("AAA"))),
+        (">", Seq(Row("bbb"))),
+        (">=", Seq(Row("aaa"), Row("AAA"), Row("bbb"))))
+
+      filters.foreach { filter =>
+        val readback = spark.read
+          .parquet(path.getAbsolutePath)
+          .where(s"c1 ${filter._1} collate('aaa', $collation)")
+          .where(s"str ${filter._1} struct(collate('aaa', $collation))")
+          .where(s"namedstr.f1.f2 ${filter._1} collate('aaa', $collation)")
+          .where(s"arr ${filter._1} array(collate('aaa', $collation))")
+          .where(s"map_keys(map1) ${filter._1} array(collate('aaa', $collation))")
+          .where(s"map_values(map2) ${filter._1} array(collate('aaa', $collation))")
+          .select("c1")
+
+        val explain = readback.queryExecution.explainString(ExplainMode.fromString("extended"))
+        assert(explain.contains("PushedFilters: []"))
+        checkAnswer(readback, filter._2)
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/FileBasedDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/FileBasedDataSourceSuite.scala
@@ -1248,45 +1248,47 @@ class FileBasedDataSourceSuite extends QueryTest
   }
 
   test("disable filter pushdown for collated strings") {
-    withTempPath { path =>
-      val collation = "'UCS_BASIC_LCASE'"
-      val df = sql(
-        s"""SELECT
-           |  COLLATE(c, $collation) as c1,
-           |  struct(COLLATE(c, $collation)) as str,
-           |  named_struct('f1', named_struct('f2', COLLATE(c, $collation), 'f3', 1)) as namedstr,
-           |  array(COLLATE(c, $collation)) as arr,
-           |  map(COLLATE(c, $collation), 1) as map1,
-           |  map(1, COLLATE(c, $collation)) as map2
-           |FROM VALUES ('aaa'), ('AAA'), ('bbb')
-           |as data(c)
-           |""".stripMargin)
+    Seq("parquet").foreach { format =>
+      withTempPath { path =>
+        val collation = "'UCS_BASIC_LCASE'"
+        val df = sql(
+          s"""SELECT
+             |  COLLATE(c, $collation) as c1,
+             |  struct(COLLATE(c, $collation)) as str,
+             |  named_struct('f1', named_struct('f2', COLLATE(c, $collation), 'f3', 1)) as namedstr,
+             |  array(COLLATE(c, $collation)) as arr,
+             |  map(COLLATE(c, $collation), 1) as map1,
+             |  map(1, COLLATE(c, $collation)) as map2
+             |FROM VALUES ('aaa'), ('AAA'), ('bbb')
+             |as data(c)
+             |""".stripMargin)
 
-      df.write.parquet(path.getAbsolutePath)
+        df.write.format(format).save(path.getAbsolutePath)
 
-      // filter and expected result
-      val filters = Seq(
-        ("==", Seq(Row("aaa"), Row("AAA"))),
-        ("!=", Seq(Row("bbb"))),
-        ("<", Seq()),
-        ("<=", Seq(Row("aaa"), Row("AAA"))),
-        (">", Seq(Row("bbb"))),
-        (">=", Seq(Row("aaa"), Row("AAA"), Row("bbb"))))
+        // filter and expected result
+        val filters = Seq(
+          ("==", Seq(Row("aaa"), Row("AAA"))),
+          ("!=", Seq(Row("bbb"))),
+          ("<", Seq()),
+          ("<=", Seq(Row("aaa"), Row("AAA"))),
+          (">", Seq(Row("bbb"))),
+          (">=", Seq(Row("aaa"), Row("AAA"), Row("bbb"))))
 
-      filters.foreach { filter =>
-        val readback = spark.read
-          .parquet(path.getAbsolutePath)
-          .where(s"c1 ${filter._1} collate('aaa', $collation)")
-          .where(s"str ${filter._1} struct(collate('aaa', $collation))")
-          .where(s"namedstr.f1.f2 ${filter._1} collate('aaa', $collation)")
-          .where(s"arr ${filter._1} array(collate('aaa', $collation))")
-          .where(s"map_keys(map1) ${filter._1} array(collate('aaa', $collation))")
-          .where(s"map_values(map2) ${filter._1} array(collate('aaa', $collation))")
-          .select("c1")
+        filters.foreach { filter =>
+          val readback = spark.read
+            .parquet(path.getAbsolutePath)
+            .where(s"c1 ${filter._1} collate('aaa', $collation)")
+            .where(s"str ${filter._1} struct(collate('aaa', $collation))")
+            .where(s"namedstr.f1.f2 ${filter._1} collate('aaa', $collation)")
+            .where(s"arr ${filter._1} array(collate('aaa', $collation))")
+            .where(s"map_keys(map1) ${filter._1} array(collate('aaa', $collation))")
+            .where(s"map_values(map2) ${filter._1} array(collate('aaa', $collation))")
+            .select("c1")
 
-        val explain = readback.queryExecution.explainString(ExplainMode.fromString("extended"))
-        assert(explain.contains("PushedFilters: []"))
-        checkAnswer(readback, filter._2)
+          val explain = readback.queryExecution.explainString(ExplainMode.fromString("extended"))
+          assert(explain.contains("PushedFilters: []"))
+          checkAnswer(readback, filter._2)
+        }
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
@@ -2233,10 +2233,10 @@ abstract class ParquetFilterSuite extends QueryTest with ParquetTest with Shared
     withTempPath { path =>
       val collation = "'UCS_BASIC_LCASE'"
       val df = sql(
-        s""" SELECT
-           |COLLATE(c, $collation) as c1,
-           |struct(COLLATE(c, $collation)) as str,
-           |named_struct('f1', named_struct('f2', COLLATE(c, $collation), 'f3', 1)) as namedstr
+        s"""SELECT
+           |  COLLATE(c, $collation) as c1,
+           |  struct(COLLATE(c, $collation)) as str,
+           |  named_struct('f1', named_struct('f2', COLLATE(c, $collation), 'f3', 1)) as namedstr
            |FROM VALUES ('aaa'), ('AAA'), ('bbb')
            |as data(c)
            |""".stripMargin)
@@ -2250,11 +2250,11 @@ abstract class ParquetFilterSuite extends QueryTest with ParquetTest with Shared
         ("<", Seq()),
         ("<=", Seq(Row("aaa"), Row("AAA"))),
         (">", Seq(Row("bbb"))),
-        (">=", Seq(Row("aaa"), Row("AAA"), Row("bbb"))),
-      )
+        (">=", Seq(Row("aaa"), Row("AAA"), Row("bbb"))))
 
       filters.foreach { filter =>
-        val readback = spark.read.parquet(path.getAbsolutePath)
+        val readback = spark.read
+          .parquet(path.getAbsolutePath)
           .where(s"c1 ${filter._1} collate('aaa', $collation)")
           .where(s"str ${filter._1} struct(collate('aaa', $collation))")
           .where(s"namedstr.f1.f2 ${filter._1} collate('aaa', $collation)")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
@@ -2228,6 +2228,44 @@ abstract class ParquetFilterSuite extends QueryTest with ParquetTest with Shared
       }
     }
   }
+
+  test("disable filter pushdown for collated strings") {
+    withTempPath { path =>
+      val collation = "'UCS_BASIC_LCASE'"
+      val df = sql(
+        s""" SELECT
+           |COLLATE(c, $collation) as c1,
+           |struct(COLLATE(c, $collation)) as str,
+           |named_struct('f1', named_struct('f2', COLLATE(c, $collation), 'f3', 1)) as namedstr
+           |FROM VALUES ('aaa'), ('AAA'), ('bbb')
+           |as data(c)
+           |""".stripMargin)
+
+      df.write.parquet(path.getAbsolutePath)
+
+      // filter and expected result
+      val filters = Seq(
+        ("==", Seq(Row("aaa"), Row("AAA"))),
+        ("!=", Seq(Row("bbb"))),
+        ("<", Seq()),
+        ("<=", Seq(Row("aaa"), Row("AAA"))),
+        (">", Seq(Row("bbb"))),
+        (">=", Seq(Row("aaa"), Row("AAA"), Row("bbb"))),
+      )
+
+      filters.foreach { filter =>
+        val readback = spark.read.parquet(path.getAbsolutePath)
+          .where(s"c1 ${filter._1} collate('aaa', $collation)")
+          .where(s"str ${filter._1} struct(collate('aaa', $collation))")
+          .where(s"namedstr.f1.f2 ${filter._1} collate('aaa', $collation)")
+          .select("c1")
+
+        val explain = readback.queryExecution.explainString(ExplainMode.fromString("extended"))
+        assert(explain.contains("PushedFilters: []"))
+        checkAnswer(readback, filter._2)
+      }
+    }
+  }
 }
 
 @ExtendedSQLTest

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
@@ -2228,50 +2228,6 @@ abstract class ParquetFilterSuite extends QueryTest with ParquetTest with Shared
       }
     }
   }
-
-  test("disable filter pushdown for collated strings") {
-    withTempPath { path =>
-      val collation = "'UCS_BASIC_LCASE'"
-      val df = sql(
-        s"""SELECT
-           |  COLLATE(c, $collation) as c1,
-           |  struct(COLLATE(c, $collation)) as str,
-           |  named_struct('f1', named_struct('f2', COLLATE(c, $collation), 'f3', 1)) as namedstr,
-           |  array(COLLATE(c, $collation)) as arr,
-           |  map(COLLATE(c, $collation), 1) as map1,
-           |  map(1, COLLATE(c, $collation)) as map2
-           |FROM VALUES ('aaa'), ('AAA'), ('bbb')
-           |as data(c)
-           |""".stripMargin)
-
-      df.write.parquet(path.getAbsolutePath)
-
-      // filter and expected result
-      val filters = Seq(
-        ("==", Seq(Row("aaa"), Row("AAA"))),
-        ("!=", Seq(Row("bbb"))),
-        ("<", Seq()),
-        ("<=", Seq(Row("aaa"), Row("AAA"))),
-        (">", Seq(Row("bbb"))),
-        (">=", Seq(Row("aaa"), Row("AAA"), Row("bbb"))))
-
-      filters.foreach { filter =>
-        val readback = spark.read
-          .parquet(path.getAbsolutePath)
-          .where(s"c1 ${filter._1} collate('aaa', $collation)")
-          .where(s"str ${filter._1} struct(collate('aaa', $collation))")
-          .where(s"namedstr.f1.f2 ${filter._1} collate('aaa', $collation)")
-          .where(s"arr ${filter._1} array(collate('aaa', $collation))")
-          .where(s"map_keys(map1) ${filter._1} array(collate('aaa', $collation))")
-          .where(s"map_values(map2) ${filter._1} array(collate('aaa', $collation))")
-          .select("c1")
-
-        val explain = readback.queryExecution.explainString(ExplainMode.fromString("extended"))
-        assert(explain.contains("PushedFilters: []"))
-        checkAnswer(readback, filter._2)
-      }
-    }
-  }
 }
 
 @ExtendedSQLTest

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
@@ -2236,7 +2236,10 @@ abstract class ParquetFilterSuite extends QueryTest with ParquetTest with Shared
         s"""SELECT
            |  COLLATE(c, $collation) as c1,
            |  struct(COLLATE(c, $collation)) as str,
-           |  named_struct('f1', named_struct('f2', COLLATE(c, $collation), 'f3', 1)) as namedstr
+           |  named_struct('f1', named_struct('f2', COLLATE(c, $collation), 'f3', 1)) as namedstr,
+           |  array(COLLATE(c, $collation)) as arr,
+           |  map(COLLATE(c, $collation), 1) as map1,
+           |  map(1, COLLATE(c, $collation)) as map2
            |FROM VALUES ('aaa'), ('AAA'), ('bbb')
            |as data(c)
            |""".stripMargin)
@@ -2258,6 +2261,9 @@ abstract class ParquetFilterSuite extends QueryTest with ParquetTest with Shared
           .where(s"c1 ${filter._1} collate('aaa', $collation)")
           .where(s"str ${filter._1} struct(collate('aaa', $collation))")
           .where(s"namedstr.f1.f2 ${filter._1} collate('aaa', $collation)")
+          .where(s"arr ${filter._1} array(collate('aaa', $collation))")
+          .where(s"map_keys(map1) ${filter._1} array(collate('aaa', $collation))")
+          .where(s"map_values(map2) ${filter._1} array(collate('aaa', $collation))")
           .select("c1")
 
         val explain = readback.queryExecution.explainString(ExplainMode.fromString("extended"))


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Disable parquet filter pushdown when expression is referencing a non default collated column/field in a struct.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Because parquet min/max stats don't know about the concept of collation and data skipping based on them could lead to incorrect results for certain collation types (lowercase collation for example).

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Users should now always get the correct result when using collated string columns.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
With new UTs in `ParquetFilterSuite`

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No