### PR TITLE
[SPARK-45527][CORE][TESTS][FOLLOWUP] Reduce the number of threads from 1k to 100 in `TaskSchedulerImplSuite`

### DIFF
--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
@@ -2489,7 +2489,7 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext
     val taskCpus = 1
     val taskGpus = 0.3
     val executorGpus = 4
-    val executorCpus = 1000
+    val executorCpus = 100
 
     // each tasks require 0.3 gpu
     val taskScheduler = setupScheduler(numCores = executorCpus,


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a follow-up of #43494 in order to reduce the number of threads of SparkContext from 1k to 100 in the test environment.

### Why are the changes needed?

To reduce the test resource requirement. 1000 threads seem to be too large for some CI systems with a limited resource.
- https://github.com/apache/spark/actions/workflows/build_maven_java21_macos14.yml
  - https://github.com/apache/spark/actions/runs/8054862135/job/22000403549
```
Warning: [766.327s][warning][os,thread] Failed to start thread "Unknown thread" - pthread_create failed (EAGAIN) for attributes: stacksize: 4096k, guardsize: 16k, detached.
Warning: [766.327s][warning][os,thread] Failed to start the native thread for java.lang.Thread "dispatcher-event-loop-840"
*** RUN ABORTED ***
An exception or error caused a run to abort: unable to create native thread: possibly out of memory or process/resource limits reached 
  java.lang.OutOfMemoryError: unable to create native thread: possibly out of memory or process/resource limits reached
```

### Does this PR introduce _any_ user-facing change?

No, this is a test-case update.

### How was this patch tested?

Pass the CIs and monitor Daily Apple Silicon test.

### Was this patch authored or co-authored using generative AI tooling?

No.