### PR TITLE
[SPARK-47175][SS][TESTS] Remove ZOOKEEPER-1844 comment from `KafkaTestUtils`

### DIFF
--- a/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaTestUtils.scala
+++ b/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaTestUtils.scala
@@ -649,9 +649,6 @@ class KafkaTestUtils(
 
     def shutdown(): Unit = {
       factory.shutdown()
-      // The directories are not closed even if the ZooKeeper server is shut down.
-      // Please see ZOOKEEPER-1844, which is fixed in 3.4.6+. It leads to test failures
-      // on Windows if the directory deletion failure throws an exception.
       try {
         Utils.deleteRecursively(snapshotDir)
       } catch {

--- a/connector/kafka-0-10/src/test/scala/org/apache/spark/streaming/kafka010/KafkaTestUtils.scala
+++ b/connector/kafka-0-10/src/test/scala/org/apache/spark/streaming/kafka010/KafkaTestUtils.scala
@@ -331,9 +331,6 @@ private[kafka010] class KafkaTestUtils extends Logging {
 
     def shutdown(): Unit = {
       factory.shutdown()
-      // The directories are not closed even if the ZooKeeper server is shut down.
-      // Please see ZOOKEEPER-1844, which is fixed in 3.4.6+. It leads to test failures
-      // on Windows if the directory deletion failure throws an exception.
       try {
         Utils.deleteRecursively(snapshotDir)
       } catch {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove [ZOOKEEPER-1844](https://issues.apache.org/jira/browse/ZOOKEEPER-1844) comment from `KafkaTestUtils`.

### Why are the changes needed?

Apache Spark has been using Apache Zookeeper 3.4.6+ already since `Apache Spark 2.2.0` via SPARK-19464.

We don't need to remove the code itself. This PR simply aims to remove the resolved pointers.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

This is a removal of comment.

### Was this patch authored or co-authored using generative AI tooling?

No.