### PR TITLE
[SPARK-39771][CORE] Add a warning msg in `Dependency` when a too large number of shuffle blocks is to be created.

### DIFF
--- a/core/src/main/scala/org/apache/spark/Dependency.scala
+++ b/core/src/main/scala/org/apache/spark/Dependency.scala
@@ -214,9 +214,10 @@ class ShuffleDependency[K: ClassTag, V: ClassTag, C: ClassTag](
 
   if (numberOfShuffleBlocks > SHUFFLE_BLOCK_NUMBER_WARNING_THRESHOLD) {
     logWarning(
-      s"The number of shuffle blocks (${numberOfShuffleBlocks}) for ${_rdd} with ${numPartitions} " + 
-      "partitions is possibly too large, this could cause the driver to crash with an out-of-memory " + 
-      "error. Consider decreasing the number of partitions in this shuffle stage."
+      s"The number of shuffle blocks (${numberOfShuffleBlocks}) for ${_rdd} " +
+        "with ${numPartitions} partitions is possibly too large, " +
+        "this could cause the driver to crash with an out-of-memory error. " +
+        "Consider decreasing the number of partitions in this shuffle stage."
     )
   }
 

--- a/core/src/main/scala/org/apache/spark/Dependency.scala
+++ b/core/src/main/scala/org/apache/spark/Dependency.scala
@@ -206,17 +206,15 @@ class ShuffleDependency[K: ClassTag, V: ClassTag, C: ClassTag](
     finalizeTask = Option(task)
   }
 
-  private val numberOfShuffleBlocks = numPartitions.toLong * partitioner.numPartitions.toLong
-
   // Set the threshold to 1 billion which leads to an 128MB bitmap and
   // the actual size of `HighlyCompressedMapStatus` can be much larger than 128MB.
   // This may crash the driver with an OOM error.
-  if (numberOfShuffleBlocks > (1L << 30)) {
+  if (numPartitions.toLong * partitioner.numPartitions.toLong > (1L << 30)) {
     logWarning(
-      s"The number of shuffle blocks (${numberOfShuffleBlocks}) for shuffleId ${shuffleId} " +
-        s"for ${_rdd} with ${numPartitions} partitions is possibly too large, " +
-        "which could cause the driver to crash with an out-of-memory error. " +
-        "Consider decreasing the number of partitions in this shuffle stage."
+      s"The number of shuffle blocks (${numPartitions.toLong * partitioner.numPartitions.toLong})" +
+        s" for shuffleId ${shuffleId} for ${_rdd} with ${numPartitions} partitions" +
+        " is possibly too large, which could cause the driver to crash with an out-of-memory" +
+        " error. Consider decreasing the number of partitions in this shuffle stage."
     )
   }
 

--- a/core/src/main/scala/org/apache/spark/Dependency.scala
+++ b/core/src/main/scala/org/apache/spark/Dependency.scala
@@ -206,7 +206,7 @@ class ShuffleDependency[K: ClassTag, V: ClassTag, C: ClassTag](
     finalizeTask = Option(task)
   }
 
-  // Set the threshold to 1 billion which leads to an 125MB bitmap and
+  // Set the threshold to 1 billion which leads to an 128MB bitmap and
   // the actual size of `HighlyCompressedMapStatus` can be much larger than 125MB.
   // This may crash the driver with an OOM error.
   private val SHUFFLE_BLOCK_NUMBER_WARNING_THRESHOLD: Long = 1L << 30

--- a/core/src/main/scala/org/apache/spark/Dependency.scala
+++ b/core/src/main/scala/org/apache/spark/Dependency.scala
@@ -214,8 +214,8 @@ class ShuffleDependency[K: ClassTag, V: ClassTag, C: ClassTag](
 
   if (numberOfShuffleBlocks > SHUFFLE_BLOCK_NUMBER_WARNING_THRESHOLD) {
     logWarning(
-      s"The number of shuffle blocks (${numberOfShuffleBlocks}) for shuffleId ${shuffleId}" +
-        " for ${_rdd} with ${numPartitions} partitions is possibly too large, " +
+      s"The number of shuffle blocks (${numberOfShuffleBlocks}) for shuffleId ${shuffleId} " +
+        s"for ${_rdd} with ${numPartitions} partitions is possibly too large, " +
         "which could cause the driver to crash with an out-of-memory error. " +
         "Consider decreasing the number of partitions in this shuffle stage."
     )

--- a/core/src/main/scala/org/apache/spark/Dependency.scala
+++ b/core/src/main/scala/org/apache/spark/Dependency.scala
@@ -206,9 +206,9 @@ class ShuffleDependency[K: ClassTag, V: ClassTag, C: ClassTag](
     finalizeTask = Option(task)
   }
 
-  // Set the threshold to 1 billion which represents approximately 1GB of memory
-  // allocated to map output statuses.
-  // A large number of shuffle blocks may crash the driver with an OOM error.
+  // Set the threshold to 1 billion which leads to an 125MB bitmap and
+  // the actual size of `HighlyCompressedMapStatus` can be much larger than 125MB.
+  // This may crash the driver with an OOM error.
   private val SHUFFLE_BLOCK_NUMBER_WARNING_THRESHOLD: Long = 1L << 30
   private val numberOfShuffleBlocks = numPartitions.toLong * partitioner.numPartitions.toLong
 

--- a/core/src/main/scala/org/apache/spark/Dependency.scala
+++ b/core/src/main/scala/org/apache/spark/Dependency.scala
@@ -206,13 +206,12 @@ class ShuffleDependency[K: ClassTag, V: ClassTag, C: ClassTag](
     finalizeTask = Option(task)
   }
 
+  private val numberOfShuffleBlocks = numPartitions.toLong * partitioner.numPartitions.toLong
+
   // Set the threshold to 1 billion which leads to an 128MB bitmap and
   // the actual size of `HighlyCompressedMapStatus` can be much larger than 128MB.
   // This may crash the driver with an OOM error.
-  private val SHUFFLE_BLOCK_NUMBER_WARNING_THRESHOLD: Long = 1L << 30
-  private val numberOfShuffleBlocks = numPartitions.toLong * partitioner.numPartitions.toLong
-
-  if (numberOfShuffleBlocks > SHUFFLE_BLOCK_NUMBER_WARNING_THRESHOLD) {
+  if (numberOfShuffleBlocks > (1L << 30)) {
     logWarning(
       s"The number of shuffle blocks (${numberOfShuffleBlocks}) for shuffleId ${shuffleId} " +
         s"for ${_rdd} with ${numPartitions} partitions is possibly too large, " +

--- a/core/src/main/scala/org/apache/spark/Dependency.scala
+++ b/core/src/main/scala/org/apache/spark/Dependency.scala
@@ -207,7 +207,7 @@ class ShuffleDependency[K: ClassTag, V: ClassTag, C: ClassTag](
   }
 
   // Set the threshold to 1 billion which leads to an 128MB bitmap and
-  // the actual size of `HighlyCompressedMapStatus` can be much larger than 125MB.
+  // the actual size of `HighlyCompressedMapStatus` can be much larger than 128MB.
   // This may crash the driver with an OOM error.
   private val SHUFFLE_BLOCK_NUMBER_WARNING_THRESHOLD: Long = 1L << 30
   private val numberOfShuffleBlocks = numPartitions.toLong * partitioner.numPartitions.toLong

--- a/core/src/main/scala/org/apache/spark/Dependency.scala
+++ b/core/src/main/scala/org/apache/spark/Dependency.scala
@@ -209,14 +209,14 @@ class ShuffleDependency[K: ClassTag, V: ClassTag, C: ClassTag](
   // Set the threshold to 1 billion which represents approximately 1GB of memory
   // allocated to map output statuses.
   // A large number of shuffle blocks may crash the driver with an OOM error.
-  private val SHUFFLE_BLOCK_NUMBER_WARNING_THRESHOLD: Long = 1000000000L
+  private val SHUFFLE_BLOCK_NUMBER_WARNING_THRESHOLD: Long = 1L << 30
   private val numberOfShuffleBlocks = numPartitions.toLong * partitioner.numPartitions.toLong
 
   if (numberOfShuffleBlocks > SHUFFLE_BLOCK_NUMBER_WARNING_THRESHOLD) {
     logWarning(
-      s"The number of shuffle blocks (${numberOfShuffleBlocks}) for ${_rdd} " +
-        "with ${numPartitions} partitions is possibly too large, " +
-        "this could cause the driver to crash with an out-of-memory error. " +
+      s"The number of shuffle blocks (${numberOfShuffleBlocks}) for shuffleId ${shuffleId}" +
+        " for ${_rdd} with ${numPartitions} partitions is possibly too large, " +
+        "which could cause the driver to crash with an out-of-memory error. " +
         "Consider decreasing the number of partitions in this shuffle stage."
     )
   }

--- a/core/src/test/scala/org/apache/spark/ShuffleSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ShuffleSuite.scala
@@ -486,7 +486,7 @@ abstract class ShuffleSuite extends SparkFunSuite with Matchers with LocalRootDi
 
   test("SPARK-39771: warn when shuffle block number is too large") {
     sc = new SparkContext("local", "test", conf)
-    val logAppender = new LogAppender("deprecated Avro option 'ignoreExtension'")
+    val logAppender = new LogAppender("warn when shuffle block number is too large")
     withLogAppender(logAppender) {
       sc.parallelize(1 to 100000, 100000).map(x => (x, x)).reduceByKey(_ + _).toDebugString
     }

--- a/core/src/test/scala/org/apache/spark/ShuffleSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ShuffleSuite.scala
@@ -483,6 +483,17 @@ abstract class ShuffleSuite extends SparkFunSuite with Matchers with LocalRootDi
     }
     assert(e.getMessage.contains("corrupted due to DISK_ISSUE"))
   }
+
+  test("SPARK-39771: warn when shuffle block number is too large") {
+    sc = new SparkContext("local", "test", conf)
+    val logAppender = new LogAppender("deprecated Avro option 'ignoreExtension'")
+    withLogAppender(logAppender) {
+      sc.parallelize(1 to 100000, 100000).map(x => (x, x)).reduceByKey(_ + _).toDebugString
+    }
+    assert(logAppender
+      .loggingEvents
+      .count(_.getMessage.getFormattedMessage.contains(s"The number of shuffle blocks")) == 1)
+  }
 }
 
 /**


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Add a warning msg in `Dependency` when a large number of shuffle blocks is to be created which may crash the driver with OOM.

### Why are the changes needed?
Warn user ahead of a potential failure, and hint a possible solution.


### Does this PR introduce _any_ user-facing change?

User may see a warning message as above when the number of shuffle blocks exceeds our threshold. There is no change to the execution outcome.


### How was this patch tested?

I added an unit test to ensure the warning message will be logged.


### Was this patch authored or co-authored using generative AI tooling?
No