### PR TITLE
[SPARK-47178][PYTHON][TESTS] Add a test case for createDataFrame with dataclasses

### DIFF
--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -1299,7 +1299,7 @@ class SparkSession(SparkConversionMixin):
         ----------
         data : :class:`RDD` or iterable
             an RDD of any kind of SQL data representation (:class:`Row`,
-            :class:`tuple`, ``int``, ``boolean``, ``dict``` etc.), or :class:`list`,
+            :class:`tuple`, ``int``, ``boolean``, ``dict`` etc.), or :class:`list`,
             :class:`pandas.DataFrame` or :class:`numpy.ndarray`.
         schema : :class:`pyspark.sql.types.DataType`, str or list, optional
             a :class:`pyspark.sql.types.DataType` or a datatype string or a list of

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -1299,7 +1299,7 @@ class SparkSession(SparkConversionMixin):
         ----------
         data : :class:`RDD` or iterable
             an RDD of any kind of SQL data representation (:class:`Row`,
-            :class:`tuple`, ``int``, ``boolean``, ``dict`` etc.), or :class:`list`,
+            :class:`tuple`, ``int``, ``boolean``, ``dict``, etc.), or :class:`list`,
             :class:`pandas.DataFrame` or :class:`numpy.ndarray`.
         schema : :class:`pyspark.sql.types.DataType`, str or list, optional
             a :class:`pyspark.sql.types.DataType` or a datatype string or a list of

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -1299,7 +1299,7 @@ class SparkSession(SparkConversionMixin):
         ----------
         data : :class:`RDD` or iterable
             an RDD of any kind of SQL data representation (:class:`Row`,
-            :class:`tuple`, ``int``, ``boolean``, etc.), or :class:`list`,
+            :class:`tuple`, ``int``, ``boolean``, ``dict``` etc.), or :class:`list`,
             :class:`pandas.DataFrame` or :class:`numpy.ndarray`.
         schema : :class:`pyspark.sql.types.DataType`, str or list, optional
             a :class:`pyspark.sql.types.DataType` or a datatype string or a list of

--- a/python/pyspark/sql/tests/test_types.py
+++ b/python/pyspark/sql/tests/test_types.py
@@ -23,6 +23,7 @@ import os
 import pickle
 import sys
 import unittest
+from dataclasses import dataclass, asdict
 
 from pyspark.sql import Row
 from pyspark.sql import functions as F
@@ -411,6 +412,17 @@ class TypesTestsMixin:
     def test_create_dataframe_from_dict_respects_schema(self):
         df = self.spark.createDataFrame([{"a": 1}], ["b"])
         self.assertEqual(df.columns, ["b"])
+
+    def test_create_dataframe_from_dataclasses(self):
+        @dataclass
+        class User:
+            name: str
+            age: int
+            is_active: bool
+
+        user = User(name="John", age=30, is_active=True)
+        r = self.spark.createDataFrame([user]).first()
+        self.assertEqual(asdict(user), r.asDict())
 
     def test_negative_decimal(self):
         try:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds a test case for dataclasses with createDataFrame that is already supported:

```python
from dataclasses import dataclass

@dataclass
class User:
    name: str
    age: int
    is_active: bool

user = User(name="John", age=30, is_active=True)
spark.createDataFrame([user]).show()
```

### Why are the changes needed?

To make sure dataclasses work with PySpark.

### Does this PR introduce _any_ user-facing change?

No, test-only

### How was this patch tested?

Added test case.

### Was this patch authored or co-authored using generative AI tooling?

No.
