### PR TITLE
[SPARK-47179][SQL] Improve error message from SparkThrowableSuite for better debuggability

### DIFF
--- a/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
@@ -328,7 +328,9 @@ class SparkThrowableSuite extends SparkFunSuite {
         }
       } else {
         assert(subErrorDoc.trim == errorsInDoc.trim,
-          "The error class document is not up to date. Please regenerate it.")
+          "The error class document is not up to date. Please regenerate it by running " +
+            "SPARK_GENERATE_GOLDEN_FILES=1 build/sbt \"core/testOnly *SparkThrowableSuite -- -t " +
+            "\\\"Error classes match with document\\\"\"")
       }
     })
 
@@ -351,7 +353,9 @@ class SparkThrowableSuite extends SparkFunSuite {
       }
     } else {
       assert(sqlErrorParentDoc.trim == commonErrorsInDoc.trim,
-        "The error class document is not up to date. Please regenerate it.")
+        "The error class document is not up to date. Please regenerate it by running " +
+          "SPARK_GENERATE_GOLDEN_FILES=1 build/sbt \"core/testOnly *SparkThrowableSuite -- -t " +
+          "\\\"Error classes match with document\\\"\"")
     }
 
     val orphans = orphanedGoldenFiles()
@@ -368,7 +372,9 @@ class SparkThrowableSuite extends SparkFunSuite {
       }
     } else {
       assert(orphans.isEmpty,
-        "Exist orphaned error class documents. Please regenerate it.")
+        "Exist orphaned error class documents. Please regenerate it by running " +
+          "SPARK_GENERATE_GOLDEN_FILES=1 build/sbt \"core/testOnly *SparkThrowableSuite -- -t " +
+          "\\\"Error classes match with document\\\"\"")
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
@@ -329,8 +329,8 @@ class SparkThrowableSuite extends SparkFunSuite {
       } else {
         assert(subErrorDoc.trim == errorsInDoc.trim,
           "The error class document is not up to date. Please regenerate it by running " +
-            "SPARK_GENERATE_GOLDEN_FILES=1 build/sbt \"core/testOnly *SparkThrowableSuite -- -t " +
-            "\\\"Error classes match with document\\\"\"")
+            "`SPARK_GENERATE_GOLDEN_FILES=1 build/sbt \"core/testOnly *SparkThrowableSuite -- -t " +
+            "\\\"Error classes match with document\\\"\"`")
       }
     })
 
@@ -354,8 +354,8 @@ class SparkThrowableSuite extends SparkFunSuite {
     } else {
       assert(sqlErrorParentDoc.trim == commonErrorsInDoc.trim,
         "The error class document is not up to date. Please regenerate it by running " +
-          "SPARK_GENERATE_GOLDEN_FILES=1 build/sbt \"core/testOnly *SparkThrowableSuite -- -t " +
-          "\\\"Error classes match with document\\\"\"")
+          "`SPARK_GENERATE_GOLDEN_FILES=1 build/sbt \"core/testOnly *SparkThrowableSuite -- -t " +
+          "\\\"Error classes match with document\\\"\"`")
     }
 
     val orphans = orphanedGoldenFiles()
@@ -373,8 +373,8 @@ class SparkThrowableSuite extends SparkFunSuite {
     } else {
       assert(orphans.isEmpty,
         "Exist orphaned error class documents. Please regenerate it by running " +
-          "SPARK_GENERATE_GOLDEN_FILES=1 build/sbt \"core/testOnly *SparkThrowableSuite -- -t " +
-          "\\\"Error classes match with document\\\"\"")
+          "`SPARK_GENERATE_GOLDEN_FILES=1 build/sbt \"core/testOnly *SparkThrowableSuite -- -t " +
+          "\\\"Error classes match with document\\\"\"`")
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
@@ -42,7 +42,6 @@ import org.apache.spark.util.Utils
  * Test suite for Spark Throwables.
  */
 class SparkThrowableSuite extends SparkFunSuite {
-
   /* Used to regenerate the error class file. Run:
    {{{
       SPARK_GENERATE_GOLDEN_FILES=1 build/sbt \
@@ -51,10 +50,12 @@ class SparkThrowableSuite extends SparkFunSuite {
 
    To regenerate the error class document. Run:
    {{{
-      SPARK_GENERATE_GOLDEN_FILES=1 build/sbt \
-        "core/testOnly *SparkThrowableSuite -- -t \"Error classes match with document\""
+      $regenerateCommand
    }}}
    */
+  private val regenerateCommand = "SPARK_GENERATE_GOLDEN_FILES=1 build/sbt " +
+    "\"core/testOnly *SparkThrowableSuite -- -t \\\"Error classes match with document\\\"\""
+
   private val errorJsonFilePath = getWorkspaceFilePath(
     "common", "utils", "src", "main", "resources", "error", "error-classes.json")
 
@@ -328,9 +329,8 @@ class SparkThrowableSuite extends SparkFunSuite {
         }
       } else {
         assert(subErrorDoc.trim == errorsInDoc.trim,
-          "The error class document is not up to date. Please regenerate it by running " +
-            "`SPARK_GENERATE_GOLDEN_FILES=1 build/sbt \"core/testOnly *SparkThrowableSuite -- -t " +
-            "\\\"Error classes match with document\\\"\"`")
+          "The error class document is not up to date. " +
+            s"Please regenerate it by running `$regenerateCommand`")
       }
     })
 
@@ -353,9 +353,8 @@ class SparkThrowableSuite extends SparkFunSuite {
       }
     } else {
       assert(sqlErrorParentDoc.trim == commonErrorsInDoc.trim,
-        "The error class document is not up to date. Please regenerate it by running " +
-          "`SPARK_GENERATE_GOLDEN_FILES=1 build/sbt \"core/testOnly *SparkThrowableSuite -- -t " +
-          "\\\"Error classes match with document\\\"\"`")
+        "The error class document is not up to date. " +
+          s"Please regenerate it by running `$regenerateCommand`")
     }
 
     val orphans = orphanedGoldenFiles()
@@ -372,9 +371,8 @@ class SparkThrowableSuite extends SparkFunSuite {
       }
     } else {
       assert(orphans.isEmpty,
-        "Exist orphaned error class documents. Please regenerate it by running " +
-          "`SPARK_GENERATE_GOLDEN_FILES=1 build/sbt \"core/testOnly *SparkThrowableSuite -- -t " +
-          "\\\"Error classes match with document\\\"\"`")
+        "Exist orphaned error class documents. " +
+          s"Please regenerate it by running `$regenerateCommand`")
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
@@ -42,6 +42,7 @@ import org.apache.spark.util.Utils
  * Test suite for Spark Throwables.
  */
 class SparkThrowableSuite extends SparkFunSuite {
+
   /* Used to regenerate the error class file. Run:
    {{{
       SPARK_GENERATE_GOLDEN_FILES=1 build/sbt \
@@ -50,7 +51,8 @@ class SparkThrowableSuite extends SparkFunSuite {
 
    To regenerate the error class document. Run:
    {{{
-      $regenerateCommand
+      SPARK_GENERATE_GOLDEN_FILES=1 build/sbt \
+        "core/testOnly *SparkThrowableSuite -- -t \"Error classes match with document\""
    }}}
    */
   private val regenerateCommand = "SPARK_GENERATE_GOLDEN_FILES=1 build/sbt " +


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to improve error message from SparkThrowableSuite for better debuggability

### Why are the changes needed?

The current error message is not very actionable for developer who need regenerating the error class documentation.


### Does this PR introduce _any_ user-facing change?

No API change, but the error message is changed:

**Before**
```
The error class document is not up to date. Please regenerate it.
```

**After**
```
he error class document is not up to date. Please regenerate it by running `SPARK_GENERATE_GOLDEN_FILES=1 build/sbt "core/testOnly *SparkThrowableSuite -- -t \"Error classes match with document\""`
```

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
The existing CI should pass.

### Was this patch authored or co-authored using generative AI tooling?

No.