### PR TITLE
[MINOR][SS] Minor string representation improvement in AssertOnQuery

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamTest.scala
@@ -284,7 +284,11 @@ trait StreamTest extends QueryTest with SharedSparkSession with TimeLimits with 
   /** Assert that a condition on the active query is true */
   class AssertOnQuery(val condition: StreamExecution => Boolean, val message: String)
     extends StreamAction with StreamMustBeRunning {
-    override def toString: String = s"AssertOnQuery(<condition>, $message)"
+    override def toString: String = if (message == "") {
+      "AssertOnQuery(<condition>)"
+    } else {
+      s"AssertOnQuery(<condition>, $message)"
+    }
   }
 
   object AssertOnQuery {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR changes `AssertOnQuery(<condition>, )` to `AssertOnQuery(<condition>)` when the message is empty.

### Why are the changes needed?

Just to make it a little bit more prettier and readale.

### Does this PR introduce _any_ user-facing change?

No, dev-inly.

### How was this patch tested?

Manually.

### Was this patch authored or co-authored using generative AI tooling?

No.
