### PR TITLE
[SPARK-41873][PYTHON][CONNECT][TESTS] Enable `DataFrameParityTests.test_pandas_api`

### DIFF
--- a/python/pyspark/sql/tests/connect/test_parity_dataframe.py
+++ b/python/pyspark/sql/tests/connect/test_parity_dataframe.py
@@ -31,11 +31,6 @@ class DataFrameParityTests(DataFrameTestsMixin, ReusedConnectTestCase):
     def test_observe_str(self):
         super().test_observe_str()
 
-    # TODO(SPARK-41873): Implement DataFrame `pandas_api`
-    @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_pandas_api(self):
-        super().test_pandas_api()
-
     @unittest.skip("Spark Connect does not SparkContext but the tests depend on them.")
     def test_same_semantics_error(self):
         super().test_same_semantics_error()


### PR DESCRIPTION
### What changes were proposed in this pull request?
Enable `DataFrameParityTests.test_pandas_api`


### Why are the changes needed?
for testing parity, this method had already been implemented


### Does this PR introduce _any_ user-facing change?
no, test-only


### How was this patch tested?
enabled ut


### Was this patch authored or co-authored using generative AI tooling?
no