### PR TITLE
[SPARK-47183][PYTHON] Fix the error class for `sameSemantics`

### DIFF
--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -6711,7 +6711,7 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         """
         if not isinstance(other, DataFrame):
             raise PySparkTypeError(
-                error_class="NOT_STR",
+                error_class="NOT_DATAFRAME",
                 message_parameters={"arg_name": "other", "arg_type": type(other).__name__},
             )
         return self._jdf.sameSemantics(other._jdf)

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -1848,7 +1848,7 @@ class DataFrameTestsMixin:
 
             self.check_error(
                 exception=pe.exception,
-                error_class="NOT_STR",
+                error_class="NOT_DATAFRAME",
                 message_parameters={"arg_name": "other", "arg_type": "int"},
             )
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix the error class for `sameSemantics`

### Why are the changes needed?
the expected type should be `DataFrame`


### Does this PR introduce _any_ user-facing change?
yes


### How was this patch tested?
updated test

### Was this patch authored or co-authored using generative AI tooling?
no
