### PR TITLE
[SPARK-47185][SS][TESTS] Increase timeout between actions in KafkaContinuousSourceSuite

### DIFF
--- a/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaContinuousSourceSuite.scala
+++ b/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaContinuousSourceSuite.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.kafka010
 
 import org.apache.kafka.clients.producer.ProducerRecord
+import org.scalatest.time.SpanSugar._
 
 import org.apache.spark.sql.Dataset
 import org.apache.spark.sql.execution.datasources.v2.ContinuousScanExec
@@ -27,6 +28,8 @@ import org.apache.spark.sql.streaming.Trigger
 // Run tests in KafkaSourceSuiteBase in continuous execution mode.
 class KafkaContinuousSourceSuite extends KafkaSourceSuiteBase with KafkaContinuousTest {
   import testImplicits._
+
+  override val streamingTimeout = 60.seconds
 
   test("read Kafka transactional messages: read_committed") {
     val table = "kafka_continuous_source_test"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to increase the timeout between between actions in `KafkaContinuousSourceSuite`.

### Why are the changes needed?

In Mac OS build, those tests fail indeterministically, see
- https://github.com/apache/spark/actions/runs/8054862135/job/22000404856
- https://github.com/apache/spark/actions/runs/8040413156/job/21958488693
- https://github.com/apache/spark/actions/runs/8032862212/job/21942732320
- https://github.com/apache/spark/actions/runs/8024427919/job/21937366481

`KafkaContinuousSourceSuite` is specifically slow in Mac OS. Kafka producers send the messages correctly, but the consumers can't get the messages for some reasons. You can't get the offsets for long time. This is not an issue in micro batch but I fail to identify the difference.

I just decided to increase the timeout between actions for now. This is more just a workaround.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Manually tested in my Mac.

### Was this patch authored or co-authored using generative AI tooling?

No.