### PR TITLE
[SPARK-47186][DOCKER][TESTS] Add some timeouts options and logs to improve the debuggability for docker integration test

### DIFF
--- a/connector/docker-integration-tests/README.md
+++ b/connector/docker-integration-tests/README.md
@@ -108,4 +108,25 @@ The following are the available properties that can be passed to optimize testin
     </td>
     <td>true</td>
   </tr>
+  <tr>
+    <td><code>spark.test.docker.imagePullTimeout</code></td>
+    <td>
+      Timeout for pulling the Docker image before the tests start.
+    </td>
+    <td>5min</td>
+  </tr>
+  <tr>
+    <td><code>spark.test.docker.startContainerTimeout</code></td>
+    <td>
+      Timeout for container to spin up.
+    </td>
+    <td>5min</td>
+  </tr>
+  <tr>
+    <td><code>spark.test.docker.connectionTimeout</code></td>
+    <td>
+      Timeout for connecting the inner service in the container, such as JDBC services.
+    </td>
+    <td>5min(might get overridden by some inherits)</td>
+  </tr>
 </table>

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DockerJDBCIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DockerJDBCIntegrationSuite.scala
@@ -22,21 +22,23 @@ import java.sql.{Connection, DriverManager}
 import java.util.Properties
 import java.util.concurrent.TimeUnit
 
+import scala.concurrent.TimeoutException
 import scala.jdk.CollectionConverters._
 import scala.util.control.NonFatal
 
 import com.github.dockerjava.api.DockerClient
 import com.github.dockerjava.api.async.{ResultCallback, ResultCallbackTemplate}
-import com.github.dockerjava.api.command.CreateContainerResponse
+import com.github.dockerjava.api.command.{CreateContainerResponse, PullImageResultCallback}
 import com.github.dockerjava.api.exception.NotFoundException
 import com.github.dockerjava.api.model._
 import com.github.dockerjava.core.{DefaultDockerClientConfig, DockerClientImpl}
 import com.github.dockerjava.zerodep.ZerodepDockerHttpClient
-import org.scalatest.concurrent.Eventually
+import org.scalatest.concurrent.{Eventually, PatienceConfiguration}
 import org.scalatest.time.SpanSugar._
 
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.util.DockerUtils
+import org.apache.spark.util.Utils.{bytesToString, timeStringAsSeconds}
 
 abstract class DatabaseOnDocker {
   /**
@@ -101,11 +103,18 @@ abstract class DockerJDBCIntegrationSuite
 
   protected val dockerIp = DockerUtils.getDockerIp()
   val db: DatabaseOnDocker
-  val connectionTimeout = timeout(5.minutes)
   val keepContainer =
     sys.props.getOrElse("spark.test.docker.keepContainer", "false").toBoolean
   val removePulledImage =
     sys.props.getOrElse("spark.test.docker.removePulledImage", "true").toBoolean
+  protected val imagePullTimeout: Long =
+    timeStringAsSeconds(sys.props.getOrElse("spark.test.docker.imagePullTimeout", "5min"))
+  protected val startContainerTimeout: Long =
+    timeStringAsSeconds(sys.props.getOrElse("spark.test.docker.startContainerTimeout", "5min"))
+  protected val connectionTimeout: PatienceConfiguration.Timeout = {
+    val timeoutStr = sys.props.getOrElse("spark.test.docker.conn", "5min")
+    timeout(timeStringAsSeconds(timeoutStr).seconds)
+  }
 
   private var docker: DockerClient = _
   // Configure networking (necessary for boot2docker / Docker Machine)
@@ -142,10 +151,39 @@ abstract class DockerJDBCIntegrationSuite
       } catch {
         case e: NotFoundException =>
           log.warn(s"Docker image ${db.imageName} not found; pulling image from registry")
+          val callback = new PullImageResultCallback {
+            override def onNext(item: PullResponseItem): Unit = {
+              super.onNext(item)
+              if (item.getStatus != null) {
+                item.getStatus match {
+                  case s if item.getProgressDetail != null &&
+                      item.getProgressDetail.getCurrent != null &&
+                      item.getProgressDetail.getCurrent == item.getProgressDetail.getTotal =>
+                    // logging for final progress procedural status
+                    logInfo(s"$s ${item.getId} ${bytesToString(item.getProgressDetail.getTotal)}")
+                  case s if s != "Downloading" && s != "Extracting" =>
+                    logInfo(s"${item.getStatus} ${item.getId}")
+                  case _ =>
+                }
+              }
+            }
+
+            override def onComplete(): Unit = {
+              pulled = true
+            }
+
+            override def onError(throwable: Throwable): Unit = {
+              logError(s"Failed to pull Docker image ${db.imageName}", throwable)
+            }
+          }
+
           docker.pullImageCmd(db.imageName)
-            .start()
-            .awaitCompletion(connectionTimeout.value.toSeconds, TimeUnit.SECONDS)
-          pulled = true
+            .exec(callback)
+            .awaitCompletion(imagePullTimeout, TimeUnit.SECONDS)
+          if (!pulled) {
+            throw new TimeoutException(
+              s"Timeout('$imagePullTimeout secs') waiting for image ${db.imageName} to be pulled")
+          }
       }
 
       val hostConfig = HostConfig
@@ -176,7 +214,7 @@ abstract class DockerJDBCIntegrationSuite
       container = createContainerCmd.exec()
       // Start the container and wait until the database can accept JDBC connections:
       docker.startContainerCmd(container.getId).exec()
-      eventually(connectionTimeout, interval(1.second)) {
+      eventually(timeout(startContainerTimeout.seconds), interval(1.second)) {
         val response = docker.inspectContainerCmd(container.getId).exec()
         assert(response.getState.getRunning)
       }


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->


### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR adds test-scoped options:
  - Timeout for pulling the Docker image before the tests start. - `spark.test.docker.imagePullTimeout`
  - Timeout for container to spin up. - `spark.test.docker.startContainerTimeout`
  - Timeout for connecting the inner service in the container - `spark.test.docker.connectionTimeout`

This PR also adds loggings(excluding the downloading/extracting details) for the imaging pulling step which is time-consuming:

```
24/02/27 19:03:17.112 docker-java-stream--1665796424 INFO OracleIntegrationSuite: Pulling from gvenzl/oracle-free 23.3-slim
24/02/27 19:03:17.112 docker-java-stream--1665796424 INFO OracleIntegrationSuite: Pulling fs layer 5cbb6d705282
24/02/27 19:03:17.113 docker-java-stream--1665796424 INFO OracleIntegrationSuite: Pulling fs layer f1544b3116d0
24/02/27 19:03:17.113 docker-java-stream--1665796424 INFO OracleIntegrationSuite: Pulling fs layer 1dff807126c4
24/02/27 19:03:17.113 docker-java-stream--1665796424 INFO OracleIntegrationSuite: Pulling fs layer 603266ad0104
24/02/27 19:03:17.113 docker-java-stream--1665796424 INFO OracleIntegrationSuite: Pulling fs layer 10f286d1795c
24/02/27 19:03:17.113 docker-java-stream--1665796424 INFO OracleIntegrationSuite: Pulling fs layer 7c4de5471fcf
24/02/27 19:03:17.113 docker-java-stream--1665796424 INFO OracleIntegrationSuite: Waiting 603266ad0104
24/02/27 19:03:17.113 docker-java-stream--1665796424 INFO OracleIntegrationSuite: Waiting 10f286d1795c
24/02/27 19:03:17.113 docker-java-stream--1665796424 INFO OracleIntegrationSuite: Waiting 7c4de5471fcf
24/02/27 19:03:59.725 docker-java-stream--1665796424 INFO OracleIntegrationSuite: Verifying Checksum 5cbb6d705282
24/02/27 19:03:59.725 docker-java-stream--1665796424 INFO OracleIntegrationSuite: Download complete 5cbb6d705282
24/02/27 19:04:12.512 docker-java-stream--1665796424 INFO OracleIntegrationSuite: Extracting 5cbb6d705282 62.3 MiB
24/02/27 19:04:12.801 docker-java-stream--1665796424 INFO OracleIntegrationSuite: Pull complete 5cbb6d705282
24/02/27 19:04:25.905 docker-java-stream--1665796424 INFO OracleIntegrationSuite: Verifying Checksum f1544b3116d0
24/02/27 19:04:25.906 docker-java-stream--1665796424 INFO OracleIntegrationSuite: Download complete f1544b3116d0
24/02/27 19:04:39.533 docker-java-stream--1665796424 INFO OracleIntegrationSuite: Extracting f1544b3116d0 103.5 MiB
24/02/27 19:04:39.647 docker-java-stream--1665796424 INFO OracleIntegrationSuite: Pull complete f1544b3116d0
24/02/27 19:04:46.451 docker-java-stream--1665796424 INFO OracleIntegrationSuite: Verifying Checksum 10f286d1795c
24/02/27 19:04:46.452 docker-java-stream--1665796424 INFO OracleIntegrationSuite: Download complete 10f286d1795c
24/02/27 19:05:39.623 docker-java-stream--1665796424 INFO OracleIntegrationSuite: Verifying Checksum 7c4de5471fcf
24/02/27 19:05:39.623 docker-java-stream--1665796424 INFO OracleIntegrationSuite: Download complete 7c4de5471fcf
24/02/27 19:05:40.889 docker-java-stream--1665796424 INFO OracleIntegrationSuite: Verifying Checksum 1dff807126c4
24/02/27 19:05:40.890 docker-java-stream--1665796424 INFO OracleIntegrationSuite: Download complete 1dff807126c4
24/02/27 19:05:51.976 docker-java-stream--1665796424 INFO OracleIntegrationSuite: Verifying Checksum 603266ad0104
24/02/27 19:05:51.976 docker-java-stream--1665796424 INFO OracleIntegrationSuite: Download complete 603266ad0104
24/02/27 19:05:59.357 docker-java-stream--1665796424 INFO OracleIntegrationSuite: Extracting 1dff807126c4 178.3 MiB
24/02/27 19:05:59.429 docker-java-stream--1665796424 INFO OracleIntegrationSuite: Pull complete 1dff807126c4
24/02/27 19:06:10.751 docker-java-stream--1665796424 INFO OracleIntegrationSuite: Extracting 603266ad0104 110.2 MiB
24/02/27 19:06:11.117 docker-java-stream--1665796424 INFO OracleIntegrationSuite: Pull complete 603266ad0104
``` 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Some districts might suffer from network issues with the official docker registry

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
no, dev-only

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

docker it

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->no
