### PR TITLE
[SPARK-47033][SQL] Fix EXECUTE IMMEDIATE USING does not recognize session variable names

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/executeImmediate.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/executeImmediate.scala
@@ -123,7 +123,7 @@ class SubstituteExecuteImmediate(val catalogManager: CatalogManager)
           } else {
             val aliases = expressions.collect {
               case e: Alias => e
-              case u: UnresolvedAttribute => Alias(u, u.name)()
+              case u: UnresolvedAttribute => Alias(u, u.nameParts.last)()
             }
 
             if (aliases.size != expressions.size) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/executeImmediate.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/executeImmediate.scala
@@ -123,11 +123,7 @@ class SubstituteExecuteImmediate(val catalogManager: CatalogManager)
           } else {
             val aliases = expressions.collect {
               case (e: Alias) => e
-            }
-            val nonAliases = expressions.filter(!_.isInstanceOf[Alias])
-
-            if (nonAliases.nonEmpty) {
-              throw QueryCompilationErrors.invalidQueryAllParametersMustBeNamed(nonAliases)
+              case (u: UnresolvedAttribute) => new Alias(u, u.name)()
             }
 
             NameParameterizedQuery(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/executeImmediate.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/executeImmediate.scala
@@ -122,8 +122,15 @@ class SubstituteExecuteImmediate(val catalogManager: CatalogManager)
               resolveArguments(expressions))
           } else {
             val aliases = expressions.collect {
-              case (e: Alias) => e
-              case (u: UnresolvedAttribute) => new Alias(u, u.name)()
+              case e: Alias => e
+              case u: UnresolvedAttribute => Alias(u, u.name)()
+            }
+
+            if (aliases.size != expressions.size) {
+              val nonAliases = expressions.filter(attr =>
+                !attr.isInstanceOf[Alias] && !attr.isInstanceOf[UnresolvedAttribute])
+
+              throw QueryCompilationErrors.invalidQueryAllParametersMustBeNamed(nonAliases)
             }
 
             NameParameterizedQuery(

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/execute-immediate.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/execute-immediate.sql.out
@@ -750,6 +750,39 @@ org.apache.spark.sql.catalyst.parser.ParseException
 
 
 -- !query
+DECLARE p = 10
+-- !query analysis
+CreateVariable defaultvalueexpression(10, 10), false
++- ResolvedIdentifier org.apache.spark.sql.catalyst.analysis.FakeSystemCatalog$@xxxxxxxx, session.p
+
+
+-- !query
+EXECUTE IMMEDIATE 'SELECT id FROM tbl_view WHERE id = :p' USING p
+-- !query analysis
+Project [id#x]
++- Filter (id#x = variablereference(system.session.p=10))
+   +- SubqueryAlias tbl_view
+      +- View (`tbl_view`, [id#x, name#x, data#x])
+         +- Project [cast(id#x as int) AS id#x, cast(name#x as string) AS name#x, cast(data#x as struct<f1:int,s2:struct<f2:int,f3:string>>) AS data#x]
+            +- Project [id#x, name#x, data#x]
+               +- SubqueryAlias tbl_view
+                  +- LocalRelation [id#x, name#x, data#x]
+
+
+-- !query
+EXECUTE IMMEDIATE 'SELECT id FROM tbl_view WHERE id = :p' USING p, 'p'
+-- !query analysis
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "ALL_PARAMETERS_MUST_BE_NAMED",
+  "sqlState" : "07001",
+  "messageParameters" : {
+    "exprs" : "\"p\""
+  }
+}
+
+
+-- !query
 EXECUTE IMMEDIATE 'SELECT id, data.f1 FROM tbl_view WHERE id = 10' INTO res_id, res_id
 -- !query analysis
 org.apache.spark.sql.AnalysisException

--- a/sql/core/src/test/resources/sql-tests/inputs/execute-immediate.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/execute-immediate.sql
@@ -25,7 +25,7 @@ EXECUTE IMMEDIATE 'REFRESH TABLE IDENTIFIER(:tblName)' USING 'x' as tblName;
 EXECUTE IMMEDIATE sql_string;
 EXECUTE IMMEDIATE 'SELECT * from tbl_view where name = \'name1\'';
 
--- test positional paramete
+-- test positional parameters
 SET VAR sql_string = 'SELECT * from tbl_view where name = ? or name = ?';
 DECLARE a STRING;
 SET VAR a = 'name1';
@@ -34,7 +34,7 @@ EXECUTE IMMEDIATE sql_string USING a, 'name2';
 EXECUTE IMMEDIATE 'SELECT * from tbl_view where name = ? or name = ?' USING 'name1', 'name3';
 EXECUTE IMMEDIATE 'SELECT * from tbl_view where name = ? or name = ?' USING a, 'name2';
 EXECUTE IMMEDIATE 'SELECT * from tbl_view where name = ? or name = ?' USING (a, 'name2');
--- test positonal command
+-- test positional command
 EXECUTE IMMEDIATE 'INSERT INTO x VALUES(?)' USING 1;
 SELECT * from x;
 
@@ -128,6 +128,13 @@ EXECUTE IMMEDIATE 'SELECT id FROM tbl_view' INTO res_id, b;
 
 -- duplicate aliases
 EXECUTE IMMEDIATE 'SELECT id FROM tbl_view WHERE id = :first' USING 10 as first, 20 as first;
+
+-- no alias
+DECLARE p = 10;
+EXECUTE IMMEDIATE 'SELECT id FROM tbl_view WHERE id = :p' USING p;
+
+-- mixing literals and named parameters
+EXECUTE IMMEDIATE 'SELECT id FROM tbl_view WHERE id = :p' USING p, 'p';
 
 -- duplicate into entry
 EXECUTE IMMEDIATE 'SELECT id, data.f1 FROM tbl_view WHERE id = 10' INTO res_id, res_id;

--- a/sql/core/src/test/resources/sql-tests/results/execute-immediate.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/execute-immediate.sql.out
@@ -701,6 +701,37 @@ org.apache.spark.sql.catalyst.parser.ParseException
 
 
 -- !query
+DECLARE p = 10
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+EXECUTE IMMEDIATE 'SELECT id FROM tbl_view WHERE id = :p' USING p
+-- !query schema
+struct<id:int>
+-- !query output
+10
+
+
+-- !query
+EXECUTE IMMEDIATE 'SELECT id FROM tbl_view WHERE id = :p' USING p, 'p'
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "ALL_PARAMETERS_MUST_BE_NAMED",
+  "sqlState" : "07001",
+  "messageParameters" : {
+    "exprs" : "\"p\""
+  }
+}
+
+
+-- !query
 EXECUTE IMMEDIATE 'SELECT id, data.f1 FROM tbl_view WHERE id = 10' INTO res_id, res_id
 -- !query schema
 struct<>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ExecuteImmediateEndToEndSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ExecuteImmediateEndToEndSuite.scala
@@ -33,7 +33,7 @@ class ExecuteImmediateEndToEndSuite extends QueryTest with SharedSparkSession {
 
       checkAnswer(originalQuery, newQuery.collect().toIndexedSeq)
     } finally {
-      spark.sql("DROP TEMPORARY VARIABLE parm;")
+      spark.sql("DROP TEMPORARY VARIABLE IF EXISTS parm;")
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ExecuteImmediateEndToEndSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ExecuteImmediateEndToEndSuite.scala
@@ -33,7 +33,7 @@ class ExecuteImmediateEndToEndSuite extends QueryTest with SharedSparkSession {
 
       checkAnswer(originalQuery, newQuery.collect().toIndexedSeq)
     } finally {
-      spark.stop()
+      spark.sql("DROP TEMPORARY VARIABLE parm;")
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ExecuteImmediateEndToEndSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ExecuteImmediateEndToEndSuite.scala
@@ -22,14 +22,19 @@ import org.apache.spark.sql.test.SharedSparkSession
 class ExecuteImmediateEndToEndSuite extends QueryTest with SharedSparkSession {
 
   test("SPARK-47033: EXECUTE IMMEDIATE USING does not recognize session variable names") {
-    spark.sql("DECLARE parm = 'Hello';")
+    try {
+      spark.sql("DECLARE parm = 'Hello';")
 
-    val originalQuery = spark.sql(
-      "EXECUTE IMMEDIATE 'SELECT :parm' USING system.session.parm AS parm;")
-    val newQuery = spark.sql("EXECUTE IMMEDIATE 'SELECT :parm' USING system.session.parm;")
+      val originalQuery = spark.sql(
+        "EXECUTE IMMEDIATE 'SELECT :parm' USING system.session.parm AS parm;")
+      val newQuery = spark.sql("EXECUTE IMMEDIATE 'SELECT :parm' USING system.session.parm;")
 
-    assert(originalQuery.columns sameElements newQuery.columns)
+      assert(originalQuery.columns sameElements newQuery.columns)
 
-    checkAnswer(originalQuery, newQuery.collect().toIndexedSeq)
+      checkAnswer(originalQuery, newQuery.collect().toIndexedSeq)
+    }
+    finally {
+      super.spark.stop()
+    }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ExecuteImmediateEndToEndSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ExecuteImmediateEndToEndSuite.scala
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution
+
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.test.SharedSparkSession
+
+class ExecuteImmediateEndToEndSuite extends QueryTest with SharedSparkSession {
+
+  test("SPARK-47033: EXECUTE IMMEDIATE USING does not recognize session variable names") {
+    spark.sql("DECLARE parm = 'Hello';")
+
+    val originalQuery = spark.sql(
+      "EXECUTE IMMEDIATE 'SELECT :parm' USING system.session.parm AS parm;")
+    val newQuery = spark.sql("EXECUTE IMMEDIATE 'SELECT :parm' USING system.session.parm;")
+
+    assert(originalQuery.columns sameElements newQuery.columns)
+
+    checkAnswer(originalQuery, newQuery.collect().toIndexedSeq)
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ExecuteImmediateEndToEndSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ExecuteImmediateEndToEndSuite.scala
@@ -34,7 +34,7 @@ class ExecuteImmediateEndToEndSuite extends QueryTest with SharedSparkSession {
       checkAnswer(originalQuery, newQuery.collect().toIndexedSeq)
     }
     finally {
-      super.spark.stop()
+      spark.stop()
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ExecuteImmediateEndToEndSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ExecuteImmediateEndToEndSuite.scala
@@ -32,8 +32,7 @@ class ExecuteImmediateEndToEndSuite extends QueryTest with SharedSparkSession {
       assert(originalQuery.columns sameElements newQuery.columns)
 
       checkAnswer(originalQuery, newQuery.collect().toIndexedSeq)
-    }
-    finally {
+    } finally {
       spark.stop()
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/QueryExecutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/QueryExecutionSuite.scala
@@ -339,8 +339,9 @@ class QueryExecutionSuite extends SharedSparkSession {
   test("SPARK-47033: EXECUTE IMMEDIATE USING does not recognize session variable names") {
     spark.sql("DECLARE parm = 'Hello';")
 
-    val originalQuery = spark.sql("EXECUTE IMMEDIATE 'SELECT :parm' USING parm AS parm;")
-    val newQuery = spark.sql("EXECUTE IMMEDIATE 'SELECT :parm' USING parm;")
+    val originalQuery = spark.sql(
+      "EXECUTE IMMEDIATE 'SELECT :parm' USING system.session.parm AS parm;")
+    val newQuery = spark.sql("EXECUTE IMMEDIATE 'SELECT :parm' USING system.session.parm;")
 
     val columns = originalQuery.columns zip newQuery.columns
     assert(columns.count(x => x._1 != x._2) == 0)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/QueryExecutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/QueryExecutionSuite.scala
@@ -343,8 +343,7 @@ class QueryExecutionSuite extends SharedSparkSession {
       "EXECUTE IMMEDIATE 'SELECT :parm' USING system.session.parm AS parm;")
     val newQuery = spark.sql("EXECUTE IMMEDIATE 'SELECT :parm' USING system.session.parm;")
 
-    val columns = originalQuery.columns zip newQuery.columns
-    assert(columns.count(x => x._1 != x._2) == 0)
+    assert(originalQuery.columns sameElements newQuery.columns)
 
     assert(originalQuery.head() == newQuery.head())
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/QueryExecutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/QueryExecutionSuite.scala
@@ -336,6 +336,18 @@ class QueryExecutionSuite extends SharedSparkSession {
     }
   }
 
+  test("SPARK-47033: EXECUTE IMMEDIATE USING does not recognize session variable names") {
+    spark.sql("DECLARE parm = 'Hello';")
+
+    val originalQuery = spark.sql("EXECUTE IMMEDIATE 'SELECT :parm' USING parm AS parm;")
+    val newQuery = spark.sql("EXECUTE IMMEDIATE 'SELECT :parm' USING parm;")
+
+    val columns = originalQuery.columns zip newQuery.columns
+    assert(columns.count(x => x._1 != x._2) == 0)
+
+    assert(originalQuery.head() == newQuery.head())
+  }
+
   case class MockCallbackEagerCommand(
       var trackerAnalyzed: QueryPlanningTracker = null,
       var trackerReadyForExecution: QueryPlanningTracker = null)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/QueryExecutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/QueryExecutionSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.execution
 import scala.io.Source
 
 import org.apache.spark.sql.{AnalysisException, Dataset, FastOperator}
+import org.apache.spark.sql.QueryTest.checkAnswer
 import org.apache.spark.sql.catalyst.{QueryPlanningTracker, QueryPlanningTrackerCallback}
 import org.apache.spark.sql.catalyst.analysis.CurrentNamespace
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow
@@ -345,7 +346,7 @@ class QueryExecutionSuite extends SharedSparkSession {
 
     assert(originalQuery.columns sameElements newQuery.columns)
 
-    assert(originalQuery.head() == newQuery.head())
+    checkAnswer(originalQuery, newQuery.collect().toIndexedSeq)
   }
 
   case class MockCallbackEagerCommand(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/QueryExecutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/QueryExecutionSuite.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql.execution
 import scala.io.Source
 
 import org.apache.spark.sql.{AnalysisException, Dataset, FastOperator}
-import org.apache.spark.sql.QueryTest.checkAnswer
 import org.apache.spark.sql.catalyst.{QueryPlanningTracker, QueryPlanningTrackerCallback}
 import org.apache.spark.sql.catalyst.analysis.CurrentNamespace
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow
@@ -335,18 +334,6 @@ class QueryExecutionSuite extends SharedSparkSession {
         }
       }
     }
-  }
-
-  test("SPARK-47033: EXECUTE IMMEDIATE USING does not recognize session variable names") {
-    spark.sql("DECLARE parm = 'Hello';")
-
-    val originalQuery = spark.sql(
-      "EXECUTE IMMEDIATE 'SELECT :parm' USING system.session.parm AS parm;")
-    val newQuery = spark.sql("EXECUTE IMMEDIATE 'SELECT :parm' USING system.session.parm;")
-
-    assert(originalQuery.columns sameElements newQuery.columns)
-
-    checkAnswer(originalQuery, newQuery.collect().toIndexedSeq)
   }
 
   case class MockCallbackEagerCommand(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
In this PR, I propose to wrap unaliased params in aliases with the same name without introducing changes to the existing parser.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
By standard, this should work, but when using params without aliases it throws an error:
```
DECLARE parm = 'Hello';

--NOT OK
EXECUTE IMMEDIATE 'SELECT :parm' USING parm;
[ALL_PARAMETERS_MUST_BE_NAMED] Using name parameterized queries requires all parameters to be named. Parameters missing names: "parm". SQLSTATE: 07001

--OK
EXECUTE IMMEDIATE 'SELECT :parm' USING parm AS parm;
Hello
```

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Users could not previously use the above-mentioned command in Spark and needed to use `AS parm`. Now users do not need to use aliases for the parameters of the same name.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Unit test in a new suite `sql/core/src/test/scala/org/apache/spark/sql/execution/ExecuteImmediateEndToEndSuite.scala`.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No