### PR TITLE
[SPARK-47196][CORE][BUILD][3.4] Fix `core` module to succeed SBT tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -423,6 +423,12 @@
       <groupId>org.scalatestplus</groupId>
       <artifactId>selenium-4-7_${scala.binary.version}</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>net.bytebuddy</groupId>
+          <artifactId>byte-buddy</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -725,6 +731,12 @@
         <artifactId>htmlunit-driver</artifactId>
         <version>${htmlunit-driver.version}</version>
         <scope>test</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <!-- Update htmlunit dependency that selenium uses for better JS support -->
       <dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `core` module to succeed SBT tests by preserving `mockito-core`'s `byte-buddy` test dependency.

Currently, `Maven` respects `mockito-core`'s byte-buddy dependency while SBT doesn't.
**MAVEN**
```
$ build/mvn dependency:tree -pl core | grep byte-buddy
...
[INFO] |  +- net.bytebuddy:byte-buddy:jar:1.12.10:test
[INFO] |  +- net.bytebuddy:byte-buddy-agent:jar:1.12.10:test
```

**SBT**
```
$ build/sbt "core/test:dependencyTree" | grep byte-buddy
...
[info]   | | | | +-net.bytebuddy:byte-buddy:1.12.10 (evicted by: 1.12.18)
[info]   | | | | +-net.bytebuddy:byte-buddy:1.12.18
...
```

Note that this happens at `branch-3.4` from Apache Spark 3.4.0~3.4.2 only. branch-3.3/branch-3.5/master are okay.

### Why are the changes needed?

**BEFORE**
```
$ build/sbt "core/testOnly *.DAGSchedulerSuite"
[info] DAGSchedulerSuite:
[info] - [SPARK-3353] parent stage should have lower stage id *** FAILED *** (439 milliseconds)
[info]   java.lang.IllegalStateException: Could not initialize plugin: interface org.mockito.plugins.MockMaker (alternate: null)
...
[info] *** 1 SUITE ABORTED ***
[info] *** 118 TESTS FAILED ***
[error] Error during tests:
[error] 	org.apache.spark.scheduler.DAGSchedulerSuite
[error] (core / Test / testOnly) sbt.TestsFailedException: Tests unsuccessful
[error] Total time: 48 s, completed Feb 27, 2024, 1:26:27 PM
```

**AFTER**
```
$ build/sbt "core/testOnly *.DAGSchedulerSuite"
...
[info] All tests passed.
[success] Total time: 22 s, completed Feb 27, 2024, 1:24:34 PM
```

### Does this PR introduce _any_ user-facing change?

No, this is a test-only fix.

### How was this patch tested?

Pass the CIs and manual tests.

### Was this patch authored or co-authored using generative AI tooling?

No.