### PR TITLE
[SPARK-47201][PYTHON][CONNECT] `sameSemantics` checks input types

### DIFF
--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -2113,6 +2113,11 @@ class DataFrame:
     writeStream.__doc__ = PySparkDataFrame.writeStream.__doc__
 
     def sameSemantics(self, other: "DataFrame") -> bool:
+        if not isinstance(other, DataFrame):
+            raise PySparkTypeError(
+                error_class="NOT_DATAFRAME",
+                message_parameters={"arg_name": "other", "arg_type": type(other).__name__},
+            )
         self._check_same_session(other)
         return self._session.client.same_semantics(
             plan=self._plan.to_proto(self._session.client),

--- a/python/pyspark/sql/tests/connect/test_parity_dataframe.py
+++ b/python/pyspark/sql/tests/connect/test_parity_dataframe.py
@@ -31,10 +31,6 @@ class DataFrameParityTests(DataFrameTestsMixin, ReusedConnectTestCase):
     def test_observe_str(self):
         super().test_observe_str()
 
-    @unittest.skip("Spark Connect does not SparkContext but the tests depend on them.")
-    def test_same_semantics_error(self):
-        super().test_same_semantics_error()
-
     # Spark Connect throws `IllegalArgumentException` when calling `collect` instead of `sample`.
     def test_sample(self):
         super().test_sample()

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -1843,15 +1843,14 @@ class DataFrameTestsMixin:
         self.assertEqual(df.take(8), result)
 
     def test_same_semantics_error(self):
-        with QuietTest(self.sc):
-            with self.assertRaises(PySparkTypeError) as pe:
-                self.spark.range(10).sameSemantics(1)
+        with self.assertRaises(PySparkTypeError) as pe:
+            self.spark.range(10).sameSemantics(1)
 
-            self.check_error(
-                exception=pe.exception,
-                error_class="NOT_DATAFRAME",
-                message_parameters={"arg_name": "other", "arg_type": "int"},
-            )
+        self.check_error(
+            exception=pe.exception,
+            error_class="NOT_DATAFRAME",
+            message_parameters={"arg_name": "other", "arg_type": "int"},
+        )
 
     def test_input_files(self):
         tpath = tempfile.mkdtemp()


### PR DESCRIPTION
### What changes were proposed in this pull request?
`sameSemantics` checks input types in the same way as vanilla pyspark

### Why are the changes needed?
for parity


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
enabled ut


### Was this patch authored or co-authored using generative AI tooling?
no