### PR TITLE
[SPARK-47202][PYTHON] Fix typo breaking datetimes with tzinfo

### DIFF
--- a/python/pyspark/sql/pandas/types.py
+++ b/python/pyspark/sql/pandas/types.py
@@ -993,7 +993,7 @@ def _create_converter_from_pandas(
 
             def convert_timestamp(value: Any) -> Any:
                 if isinstance(value, datetime.datetime) and value.tzinfo is not None:
-                    ts = pd.Timstamp(value)
+                    ts = pd.Timestamp(value)
                 else:
                     ts = pd.Timestamp(value).tz_localize(timezone)
                 return ts.to_pydatetime()


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR fixes a bug caused due to a typo. 


### Why are the changes needed?
This bug is preventing users from having datetime.datetime objects with tzinfo when using the `TimestampType`

### Does this PR introduce _any_ user-facing change?
No, just a bug fix.

### How was this patch tested?
There ought to be CI that lints code and catches these simple errors at the time of opening the PR.


### Was this patch authored or co-authored using generative AI tooling?
No
